### PR TITLE
Removed rewire from server service unit tests

### DIFF
--- a/ghost/core/core/server/lib/image/image-utils.js
+++ b/ghost/core/core/server/lib/image/image-utils.js
@@ -12,17 +12,23 @@ const externalRequest = require('../request-external');
 // The returned promise exposes the underlying stream via `.stream` so callers
 // can destroy it on early abort — otherwise a pooled keep-alive socket leaks.
 function probe(url, options = {}) {
-    const stream = externalRequest.stream(url, {
+    const stream = _private.externalRequest.stream(url, {
         headers: options.headers,
         timeout: {
             request: options.response_timeout || 10000
         },
         retry: {limit: 0}
     });
-    const promise = probeImageSize(stream);
+    const promise = _private.probeImageSize(stream);
     promise.stream = stream;
     return promise;
 }
+
+const _private = {
+    probe,
+    externalRequest,
+    probeImageSize
+};
 
 class ImageUtils {
     constructor({config, urlUtils, settingsCache, storageUtils, storage, validator, request, cacheStore}) {
@@ -35,5 +41,7 @@ class ImageUtils {
         this.gravatar = new Gravatar({config, request});
     }
 }
+
+ImageUtils._private = _private;
 
 module.exports = ImageUtils;

--- a/ghost/core/core/server/notify.js
+++ b/ghost/core/core/server/notify.js
@@ -8,6 +8,7 @@
 
 // Required Ghost internals
 const config = require('../shared/config');
+const bootstrapSocket = require('./lib/bootstrap-socket');
 
 let notified = {
     started: false,
@@ -51,8 +52,7 @@ async function notify(type, error = null) {
     // CASE: use bootstrap socket to communicate with CLI for systemd
     let socketAddress = config.get('bootstrap-socket');
     if (socketAddress) {
-        const bootstrapSocket = require('./lib/bootstrap-socket');
-        return bootstrapSocket.connectAndSend(socketAddress, message);
+        return _private.bootstrapSocket.connectAndSend(socketAddress, message);
     }
 
     return Promise.resolve();
@@ -65,3 +65,10 @@ module.exports.notifyServerStarted = async function (error = null) {
 module.exports.notifyServerReady = async function (error = null) {
     return await notify('ready', error);
 };
+
+const _private = {
+    notified,
+    bootstrapSocket
+};
+
+module.exports._private = _private;

--- a/ghost/core/core/server/services/indexnow.js
+++ b/ghost/core/core/server/services/indexnow.js
@@ -128,7 +128,7 @@ async function ping(post) {
             }
         };
 
-        const response = await request(indexNowUrl.toString(), options);
+        const response = await _private.request(indexNowUrl.toString(), options);
 
         if (response.statusCode !== 200 && response.statusCode !== 202) {
             throw new errors.InternalServerError({
@@ -222,7 +222,7 @@ function indexnowListener(model, options) {
         return;
     }
 
-    ping(model.toJSON()).catch(() => {
+    _private.ping(model.toJSON()).catch(() => {
         // Errors are already logged inside ping()
         // This catch is just to prevent unhandled rejection warnings
     });
@@ -234,16 +234,23 @@ function indexnowListener(model, options) {
 function listen() {
     // Listen for new posts being published
     events
-        .removeListener('post.published', indexnowListener)
-        .on('post.published', indexnowListener);
+        .removeListener('post.published', _private.indexnowListener)
+        .on('post.published', _private.indexnowListener);
 
     // Also listen for published posts being edited
     events
-        .removeListener('post.published.edited', indexnowListener)
-        .on('post.published.edited', indexnowListener);
+        .removeListener('post.published.edited', _private.indexnowListener)
+        .on('post.published.edited', _private.indexnowListener);
 }
+
+const _private = {
+    ping,
+    indexnowListener,
+    request
+};
 
 module.exports = {
     listen: listen,
-    getApiKey: getApiKey
+    getApiKey: getApiKey,
+    _private
 };

--- a/ghost/core/core/server/services/member-welcome-emails/member-welcome-email-renderer.js
+++ b/ghost/core/core/server/services/member-welcome-emails/member-welcome-email-renderer.js
@@ -7,7 +7,7 @@ const errors = require('@tryghost/errors');
 const {MESSAGES} = require('./constants');
 const {wrapReplacementStrings} = require('../koenig/render-utils/replacement-strings');
 const linkReplacer = require('../lib/link-replacer');
-const {getEmailDesign} = require('../email-rendering/email-design');
+const emailDesign = require('../email-rendering/email-design');
 const {registerHelpers} = require('../email-service/helpers/register-helpers');
 
 const REPLACEMENT_REGEX = /%%\{(\w+?)(?:,? *"(.*?)")?\}%%/g;
@@ -119,7 +119,7 @@ class MemberWelcomeEmailRenderer {
     async render({lexical, subject, designSettings, member, siteSettings}) {
         designSettings = designSettings || {};
 
-        const design = getEmailDesign({
+        const design = emailDesign.getEmailDesign({
             accentColor: siteSettings.accentColor,
             backgroundColor: designSettings.background_color,
             buttonColor: designSettings.button_color,

--- a/ghost/core/core/server/services/members/members-api/members-api.js
+++ b/ghost/core/core/server/services/members/members-api/members-api.js
@@ -21,7 +21,25 @@ const MagicLink = require('../../lib/magic-link/magic-link');
 const DomainEvents = require('@tryghost/domain-events');
 const automationsApi = require('../../automations/automations-api');
 
-module.exports = function MembersAPI({
+const _private = {
+    Router,
+    body,
+    PaymentsService,
+    TokenService,
+    GeolocationService,
+    MemberBREADService,
+    MemberRepository,
+    NextPaymentCalculator,
+    EventRepository,
+    ProductRepository,
+    RouterController,
+    MemberController,
+    WellKnownController,
+    MagicLink,
+    DomainEvents
+};
+
+const MembersAPI = function MembersAPI({
     tokenConfig: {
         issuer,
         privateKey,
@@ -86,13 +104,13 @@ module.exports = function MembersAPI({
     emailAddressService,
     giftService
 }) {
-    const tokenService = new TokenService({
+    const tokenService = new _private.TokenService({
         privateKey,
         publicKey,
         issuer
     });
 
-    const productRepository = new ProductRepository({
+    const productRepository = new _private.ProductRepository({
         Product,
         Settings,
         StripeProduct,
@@ -100,7 +118,7 @@ module.exports = function MembersAPI({
         stripeAPIService
     });
 
-    const memberRepository = new MemberRepository({
+    const memberRepository = new _private.MemberRepository({
         stripeAPIService,
         tokenService,
         newslettersService,
@@ -123,7 +141,7 @@ module.exports = function MembersAPI({
         offersAPI
     });
 
-    const eventRepository = new EventRepository({
+    const eventRepository = new _private.EventRepository({
         DonationPaymentEvent,
         EmailRecipient,
         MemberSubscribeEvent,
@@ -144,9 +162,9 @@ module.exports = function MembersAPI({
         Gift
     });
 
-    const nextPaymentCalculator = new NextPaymentCalculator();
+    const nextPaymentCalculator = new _private.NextPaymentCalculator();
 
-    const memberBREADService = new MemberBREADService({
+    const memberBREADService = new _private.MemberBREADService({
         offersAPI,
         memberRepository,
         emailService: {
@@ -170,9 +188,9 @@ module.exports = function MembersAPI({
         giftService
     });
 
-    const geolocationService = new GeolocationService();
+    const geolocationService = new _private.GeolocationService();
 
-    const magicLinkService = new MagicLink({
+    const magicLinkService = new _private.MagicLink({
         transporter,
         tokenProvider,
         getSigninURL,
@@ -183,7 +201,7 @@ module.exports = function MembersAPI({
         labsService
     });
 
-    const paymentsService = new PaymentsService({
+    const paymentsService = new _private.PaymentsService({
         StripeProduct,
         StripePrice,
         StripeCustomer,
@@ -194,7 +212,7 @@ module.exports = function MembersAPI({
         giftService
     });
 
-    const memberController = new MemberController({
+    const memberController = new _private.MemberController({
         memberRepository,
         productRepository,
         paymentsService,
@@ -205,7 +223,7 @@ module.exports = function MembersAPI({
         settingsCache
     });
 
-    const routerController = new RouterController({
+    const routerController = new _private.RouterController({
         offersAPI,
         paymentsService,
         tiersService,
@@ -227,7 +245,7 @@ module.exports = function MembersAPI({
         giftService
     });
 
-    const wellKnownController = new WellKnownController({
+    const wellKnownController = new _private.WellKnownController({
         tokenService
     });
 
@@ -399,43 +417,43 @@ module.exports = function MembersAPI({
     };
 
     const middleware = {
-        sendMagicLink: Router().use(
-            body.json(),
+        sendMagicLink: _private.Router().use(
+            _private.body.json(),
             forwardError((req, res) => routerController.sendMagicLink(req, res))
         ),
-        verifyOTC: Router().use(
-            body.json(),
+        verifyOTC: _private.Router().use(
+            _private.body.json(),
             forwardError((req, res) => routerController.verifyOTC(req, res))
         ),
-        createCheckoutSession: Router().use(
-            body.json(),
+        createCheckoutSession: _private.Router().use(
+            _private.body.json(),
             forwardError((req, res) => routerController.createCheckoutSession(req, res))
         ),
-        createCheckoutSetupSession: Router().use(
-            body.json(),
+        createCheckoutSetupSession: _private.Router().use(
+            _private.body.json(),
             forwardError((req, res) => routerController.createCheckoutSetupSession(req, res))
         ),
-        createBillingPortalSession: Router().use(
-            body.json(),
+        createBillingPortalSession: _private.Router().use(
+            _private.body.json(),
             forwardError((req, res) => routerController.createBillingPortalSession(req, res))
         ),
-        updateEmailAddress: Router().use(
-            body.json(),
+        updateEmailAddress: _private.Router().use(
+            _private.body.json(),
             forwardError((req, res) => memberController.updateEmailAddress(req, res))
         ),
-        updateSubscription: Router({mergeParams: true}).use(
-            body.json(),
+        updateSubscription: _private.Router({mergeParams: true}).use(
+            _private.body.json(),
             forwardError((req, res) => memberController.updateSubscription(req, res))
         ),
-        applyOfferToSubscription: Router({mergeParams: true}).use(
-            body.json(),
+        applyOfferToSubscription: _private.Router({mergeParams: true}).use(
+            _private.body.json(),
             forwardError((req, res) => memberController.applyOfferToSubscription(req, res))
         ),
-        getMemberOffers: Router().use(
-            body.json(),
+        getMemberOffers: _private.Router().use(
+            _private.body.json(),
             forwardError((req, res) => routerController.getMemberOffers(req, res))
         ),
-        wellKnown: Router()
+        wellKnown: _private.Router()
             .get('/jwks.json',
                 (req, res) => wellKnownController.getPublicKeys(req, res)
             )
@@ -452,7 +470,7 @@ module.exports = function MembersAPI({
 
     bus.emit('ready');
 
-    DomainEvents.subscribe(EmailSuppressedEvent, async function (event) {
+    _private.DomainEvents.subscribe(EmailSuppressedEvent, async function (event) {
         const member = await memberRepository.get({email: event.data.emailAddress});
         if (!member) {
             return;
@@ -483,3 +501,7 @@ module.exports = function MembersAPI({
         paymentsService
     };
 };
+
+MembersAPI._private = _private;
+
+module.exports = MembersAPI;

--- a/ghost/core/core/server/services/outbox/index.js
+++ b/ghost/core/core/server/services/outbox/index.js
@@ -5,6 +5,10 @@ const domainEvents = require('@tryghost/domain-events');
 const processOutbox = require('./jobs/lib/process-outbox');
 const {OUTBOX_LOG_KEY} = require('./jobs/lib/constants');
 
+const _private = {
+    processOutbox
+};
+
 class OutboxServiceWrapper {
     init() {
         if (this.initialized) {
@@ -34,7 +38,7 @@ class OutboxServiceWrapper {
         this.processing = true;
 
         try {
-            const statusMessage = await processOutbox();
+            const statusMessage = await _private.processOutbox();
             logging.info(statusMessage);
         } catch (err) {
             logging.error({
@@ -49,4 +53,7 @@ class OutboxServiceWrapper {
     }
 }
 
-module.exports = new OutboxServiceWrapper();
+const outboxServiceWrapper = new OutboxServiceWrapper();
+outboxServiceWrapper._private = _private;
+
+module.exports = outboxServiceWrapper;

--- a/ghost/core/core/server/services/outbox/jobs/lib/process-entries.js
+++ b/ghost/core/core/server/services/outbox/jobs/lib/process-entries.js
@@ -4,8 +4,10 @@ const {OUTBOX_STATUSES} = require('../../../../models/outbox');
 const MemberCreatedEvent = require('../../../../../shared/events/member-created-event');
 const memberCreatedHandler = require('../../handlers/member-created');
 
-const EVENT_HANDLERS = {
-    [MemberCreatedEvent.name]: memberCreatedHandler
+const _private = {
+    EVENT_HANDLERS: {
+        [MemberCreatedEvent.name]: memberCreatedHandler
+    }
 };
 
 async function deleteProcessedEntry({db, entryId}) {
@@ -41,7 +43,7 @@ async function markEntryCompleted({db, entryId}) {
 }
 
 async function processEntry({db, entry}) {
-    const handler = EVENT_HANDLERS[entry.event_type];
+    const handler = _private.EVENT_HANDLERS[entry.event_type];
     if (!handler) {
         logging.warn({
             system: {
@@ -113,5 +115,7 @@ async function processEntries({db, entries}) {
 
     return {processed, failed};
 }
+
+processEntries._private = _private;
 
 module.exports = processEntries;

--- a/ghost/core/core/server/services/route-settings/settings-loader.js
+++ b/ghost/core/core/server/services/route-settings/settings-loader.js
@@ -33,7 +33,7 @@ class SettingsLoader {
             const object = this.parseYaml(file);
             debug('YAML settings file parsed:', this.settingFilePath);
 
-            return validate(object);
+            return _private.validate(object);
         } catch (err) {
             if (errors.utils.isGhostError(err)) {
                 throw err;
@@ -49,6 +49,12 @@ class SettingsLoader {
         }
     }
 }
+
+const _private = {
+    validate
+};
+
+SettingsLoader._private = _private;
 
 module.exports = SettingsLoader;
 

--- a/ghost/core/core/server/services/slack.js
+++ b/ghost/core/core/server/services/slack.js
@@ -155,7 +155,7 @@ function ping(post) {
             };
         }
 
-        return request(slackSettings.url, {
+        return _private.request(slackSettings.url, {
             body: JSON.stringify(slackData),
             headers: {
                 'Content-type': 'application/json'
@@ -177,29 +177,37 @@ function slackListener(model, options) {
         return;
     }
 
-    ping({
+    _private.ping({
         ...model.toJSON(),
         authors: model.related('authors').toJSON()
     });
 }
 
 function slackTestPing() {
-    ping({
+    _private.ping({
         message: 'Heya! This is a test notification from your Ghost blog :smile:. Seems to work fine!'
     });
 }
 
 function listen() {
     if (!events.hasRegisteredListener('post.published', 'slackListener')) {
-        events.on('post.published', slackListener);
+        events.on('post.published', _private.slackListener);
     }
 
     if (!events.hasRegisteredListener('slack.test', 'slackTestPing')) {
-        events.on('slack.test', slackTestPing);
+        events.on('slack.test', _private.slackTestPing);
     }
 }
 
+const _private = {
+    ping,
+    slackListener,
+    slackTestPing,
+    request
+};
+
 // Public API
 module.exports = {
-    listen: listen
+    listen: listen,
+    _private
 };

--- a/ghost/core/core/server/services/stripe/stripe-api.js
+++ b/ghost/core/core/server/services/stripe/stripe-api.js
@@ -56,7 +56,7 @@ const STRIPE_API_VERSION = '2020-08-27';
  * @prop {boolean} testEnv  - indicates if the module is run in test environment (note, NOT the test mode)
  */
 
-module.exports = class StripeAPI {
+class StripeAPI {
     /**
      * StripeAPI
      * @param {object} deps
@@ -142,7 +142,7 @@ module.exports = class StripeAPI {
         if (stripeApiProtocol) {
             stripeConfig.protocol = stripeApiProtocol;
         }
-        this._stripe = new Stripe(config.secretKey, stripeConfig);
+        this._stripe = new _private.Stripe(config.secretKey, stripeConfig);
         this._config = config;
         this._testMode = config.secretKey && config.secretKey.startsWith('sk_test_');
         if (this._testMode) {
@@ -699,8 +699,8 @@ module.exports = class StripeAPI {
         await this._rateLimitBucket.throttle();
 
         const cadenceLabel = cadence === 'year' ?
-            t('{count} year', {count: duration}) :
-            t('{count} month', {count: duration});
+            _private.t('{count} year', {count: duration}) :
+            _private.t('{count} month', {count: duration});
 
         const stripeSessionOptions = {
             mode: 'payment',
@@ -721,7 +721,7 @@ module.exports = class StripeAPI {
                     currency,
                     unit_amount: amount,
                     product_data: {
-                        name: `${t('Gift subscription')} — ${tierName} (${cadenceLabel})`
+                        name: `${_private.t('Gift subscription')} — ${tierName} (${cadenceLabel})`
                     }
                 },
                 quantity: 1
@@ -1080,4 +1080,13 @@ module.exports = class StripeAPI {
         await this._rateLimitBucket.throttle();
         return await this._stripe.billingPortal.configurations.update(id, options);
     }
+}
+
+const _private = {
+    Stripe,
+    t
 };
+
+StripeAPI._private = _private;
+
+module.exports = StripeAPI;

--- a/ghost/core/core/server/services/url/url-service.js
+++ b/ghost/core/core/server/services/url/url-service.js
@@ -33,11 +33,11 @@ class UrlService {
         this.urlGenerators = [];
 
         // Get urls
-        this.queue = new Queue();
+        this.queue = new _private.Queue();
         // NOTE: Urls and Resources should not be initialized here but only in the init method.
         //      Way too many tests fail if the initialization is removed so leaving it as is for time being
-        this.urls = new Urls();
-        this.resources = new Resources({
+        this.urls = new _private.Urls();
+        this.resources = new _private.Resources({
             resourcesConfig: resourcesConfig,
             queue: this.queue
         });
@@ -98,7 +98,7 @@ class UrlService {
     onRouterAddedType(identifier, filter, resourceType, permalink) {
         debug('Registering route:', filter, resourceType, permalink);
 
-        let urlGenerator = new UrlGenerator({
+        let urlGenerator = new _private.UrlGenerator({
             identifier,
             filter,
             resourceType,
@@ -383,5 +383,14 @@ class UrlService {
         this.resources.softReset();
     }
 }
+
+const _private = {
+    Queue,
+    Urls,
+    Resources,
+    UrlGenerator
+};
+
+UrlService._private = _private;
 
 module.exports = UrlService;

--- a/ghost/core/test/unit/server/lib/image/image-utils.test.js
+++ b/ghost/core/test/unit/server/lib/image/image-utils.test.js
@@ -1,17 +1,14 @@
 const assert = require('node:assert/strict');
 const {PassThrough} = require('node:stream');
 const sinon = require('sinon');
-const rewire = require('rewire');
 
-const MODULE_PATH = '../../../../../core/server/lib/image/image-utils';
+const ImageUtils = require('../../../../../core/server/lib/image/image-utils');
 
 describe('image-utils probe wrapper', function () {
     let stream;
     let externalRequestStub;
     let probeImageSizeStub;
     let probe;
-    let imageUtilsModule;
-    let revert;
 
     beforeEach(function () {
         stream = new PassThrough();
@@ -21,16 +18,12 @@ describe('image-utils probe wrapper', function () {
         };
         probeImageSizeStub = sinon.stub().resolves({width: 10, height: 20});
 
-        imageUtilsModule = rewire(MODULE_PATH);
-        revert = imageUtilsModule.__set__({
-            externalRequest: externalRequestStub,
-            probeImageSize: probeImageSizeStub
-        });
-        probe = imageUtilsModule.__get__('probe');
+        sinon.stub(ImageUtils._private, 'externalRequest').value(externalRequestStub);
+        sinon.stub(ImageUtils._private, 'probeImageSize').value(probeImageSizeStub);
+        probe = ImageUtils._private.probe;
     });
 
     afterEach(function () {
-        revert();
         sinon.restore();
     });
 

--- a/ghost/core/test/unit/server/notify.test.js
+++ b/ghost/core/test/unit/server/notify.test.js
@@ -1,43 +1,28 @@
 const assert = require('node:assert/strict');
-const rewire = require('rewire');
 const sinon = require('sinon');
 
 const configUtils = require('../../utils/config-utils');
-const events = require('../../../core/server/lib/common/events');
+const notify = require('../../../core/server/notify');
 
 describe('Notify', function () {
     describe('notifyServerStarted', function () {
-        let notify;
         let socketStub;
-        let eventSpy;
 
         beforeEach(function () {
-            // Have to re-require each time to clear the internal flag
-            delete require.cache[require.resolve('../../../core/server/notify')];
+            notify._private.notified.started = false;
+            notify._private.notified.ready = false;
 
             socketStub = sinon.stub();
-            notify = rewire('../../../core/server/notify');
-            notify.__set__('require', (path) => {
-                if (path === './lib/bootstrap-socket') {
-                    return {
-                        connectAndSend: socketStub
-                    };
-                }
-
-                return require(path);
-            });
+            sinon.stub(notify._private, 'bootstrapSocket').value({connectAndSend: socketStub});
 
             // process.send isn't set for tests, we can safely override;
             process.send = sinon.stub();
-
-            // Spy for the events that get called
-            eventSpy = sinon.spy(events, 'emit');
         });
 
         afterEach(async function () {
             process.send = undefined;
             await configUtils.restore();
-            eventSpy.restore();
+            sinon.restore();
         });
 
         it('it resolves a promise', async function () {

--- a/ghost/core/test/unit/server/services/indexnow.test.js
+++ b/ghost/core/test/unit/server/services/indexnow.test.js
@@ -2,10 +2,9 @@ const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const _ = require('lodash');
 const nock = require('nock');
-const rewire = require('rewire');
 const errors = require('@tryghost/errors');
 const testUtils = require('../../../utils');
-const indexnow = rewire('../../../../core/server/services/indexnow');
+const indexnow = require('../../../../core/server/services/indexnow');
 const events = require('../../../../core/server/lib/common/events');
 const settingsCache = require('../../../../core/shared/settings-cache');
 const config = require('../../../../core/shared/config');
@@ -73,16 +72,13 @@ describe('IndexNow', function () {
                 }
             };
 
-            const pingStub = sinon.stub().resolves();
-            const resetIndexNow = indexnow.__set__('ping', pingStub);
-            const listener = indexnow.__get__('indexnowListener');
+            const pingStub = sinon.stub(indexnow._private, 'ping').resolves();
+            const listener = indexnow._private.indexnowListener;
 
             listener(testModel);
 
             sinon.assert.calledOnce(pingStub);
             sinon.assert.calledWith(pingStub, testPost);
-
-            resetIndexNow();
         });
 
         it('does not call ping() when importing', function () {
@@ -100,15 +96,12 @@ describe('IndexNow', function () {
                 }
             };
 
-            const pingStub = sinon.stub();
-            const resetIndexNow = indexnow.__set__('ping', pingStub);
-            const listener = indexnow.__get__('indexnowListener');
+            const pingStub = sinon.stub(indexnow._private, 'ping');
+            const listener = indexnow._private.indexnowListener;
 
             listener(testModel, {importing: true});
 
             sinon.assert.notCalled(pingStub);
-
-            resetIndexNow();
         });
 
         it('does not call ping() when no SEO-relevant fields have changed', function () {
@@ -146,15 +139,12 @@ describe('IndexNow', function () {
                 }
             };
 
-            const pingStub = sinon.stub();
-            const resetIndexNow = indexnow.__set__('ping', pingStub);
-            const listener = indexnow.__get__('indexnowListener');
+            const pingStub = sinon.stub(indexnow._private, 'ping');
+            const listener = indexnow._private.indexnowListener;
 
             listener(testModel);
 
             sinon.assert.notCalled(pingStub);
-
-            resetIndexNow();
         });
 
         it('calls ping() when title changes', function () {
@@ -178,15 +168,12 @@ describe('IndexNow', function () {
                 }
             };
 
-            const pingStub = sinon.stub().resolves();
-            const resetIndexNow = indexnow.__set__('ping', pingStub);
-            const listener = indexnow.__get__('indexnowListener');
+            const pingStub = sinon.stub(indexnow._private, 'ping').resolves();
+            const listener = indexnow._private.indexnowListener;
 
             listener(testModel);
 
             sinon.assert.calledOnce(pingStub);
-
-            resetIndexNow();
         });
 
         it('calls ping() when slug changes', function () {
@@ -210,15 +197,12 @@ describe('IndexNow', function () {
                 }
             };
 
-            const pingStub = sinon.stub().resolves();
-            const resetIndexNow = indexnow.__set__('ping', pingStub);
-            const listener = indexnow.__get__('indexnowListener');
+            const pingStub = sinon.stub(indexnow._private, 'ping').resolves();
+            const listener = indexnow._private.indexnowListener;
 
             listener(testModel);
 
             sinon.assert.calledOnce(pingStub);
-
-            resetIndexNow();
         });
 
         it('calls ping() when meta_description changes', function () {
@@ -242,20 +226,17 @@ describe('IndexNow', function () {
                 }
             };
 
-            const pingStub = sinon.stub().resolves();
-            const resetIndexNow = indexnow.__set__('ping', pingStub);
-            const listener = indexnow.__get__('indexnowListener');
+            const pingStub = sinon.stub(indexnow._private, 'ping').resolves();
+            const listener = indexnow._private.indexnowListener;
 
             listener(testModel);
 
             sinon.assert.calledOnce(pingStub);
-
-            resetIndexNow();
         });
     });
 
     describe('ping()', function () {
-        const ping = indexnow.__get__('ping');
+        const ping = indexnow._private.ping;
         let urlStub;
 
         beforeEach(function () {
@@ -456,19 +437,11 @@ describe('IndexNow', function () {
     });
 
     describe('ping() error classification (got HTTPError shape)', function () {
-        const ping = indexnow.__get__('ping');
-        let resetIndexNow;
+        const ping = indexnow._private.ping;
 
         beforeEach(function () {
             sinon.stub(urlService.facade, 'getUrlForResource').returns('https://example.com/my-post/');
             loggingStub = sinon.stub(logging, 'warn');
-        });
-
-        afterEach(function () {
-            if (resetIndexNow) {
-                resetIndexNow();
-                resetIndexNow = null;
-            }
         });
 
         function makeHttpError(statusCode) {
@@ -480,7 +453,7 @@ describe('IndexNow', function () {
         }
 
         async function pingWithHttpError(statusCode) {
-            resetIndexNow = indexnow.__set__('request', sinon.stub().rejects(makeHttpError(statusCode)));
+            sinon.stub(indexnow._private, 'request').rejects(makeHttpError(statusCode));
             const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
             await ping(testPost);
         }
@@ -519,7 +492,7 @@ describe('IndexNow', function () {
 
         it('still classifies a GhostError carrying err.statusCode (manual throw) correctly', async function () {
             const err = new errors.TooManyRequestsError({message: 'manual', statusCode: 429});
-            resetIndexNow = indexnow.__set__('request', sinon.stub().rejects(err));
+            sinon.stub(indexnow._private, 'request').rejects(err);
             const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
 
             await ping(testPost);
@@ -554,11 +527,10 @@ describe('IndexNow', function () {
     // for a resource-based facade method) could regress without anyone
     // noticing.
     describe('ping() URL output', function () {
-        const ping = indexnow.__get__('ping');
+        const ping = indexnow._private.ping;
         const POST_URL = 'https://my-blog.example/some-post/';
         let getUrlForResourceStub;
         let requestStub;
-        let resetIndexNow;
 
         beforeEach(function () {
             // Bind the stub to the exact resource shape production passes
@@ -569,14 +541,9 @@ describe('IndexNow', function () {
                 .withArgs(sinon.match({id: 'abc', type: 'posts'}), {absolute: true})
                 .returns(POST_URL);
 
-            requestStub = sinon.stub().resolves({statusCode: 200});
-            resetIndexNow = indexnow.__set__('request', requestStub);
+            requestStub = sinon.stub(indexnow._private, 'request').resolves({statusCode: 200});
 
             settingsCacheStub.withArgs('indexnow_api_key').returns('a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4');
-        });
-
-        afterEach(function () {
-            resetIndexNow();
         });
 
         it('passes the post URL into the IndexNow request', async function () {

--- a/ghost/core/test/unit/server/services/invitations/accept.test.js
+++ b/ghost/core/test/unit/server/services/invitations/accept.test.js
@@ -1,9 +1,9 @@
 const assert = require('assert/strict');
 const sinon = require('sinon');
-const rewire = require('rewire');
+const models = require('../../../../../core/server/models');
+const accept = require('../../../../../core/server/services/invitations/accept');
 
 describe('Unit: services/invitations/accept', function () {
-    let accept;
     let transactionStub;
     let findOneInviteStub;
     let findOneUserStub;
@@ -13,7 +13,7 @@ describe('Unit: services/invitations/accept', function () {
     beforeEach(function () {
         destroyStub = sinon.stub().resolves();
 
-        findOneInviteStub = sinon.stub().resolves({
+        findOneInviteStub = sinon.stub(models.Invite, 'findOne').resolves({
             get: sinon.stub().callsFake((key) => {
                 if (key === 'expires') {
                     return Date.now() + 100000;
@@ -25,18 +25,11 @@ describe('Unit: services/invitations/accept', function () {
             destroy: destroyStub
         });
 
-        findOneUserStub = sinon.stub().resolves(null);
-        addUserStub = sinon.stub().resolves();
+        findOneUserStub = sinon.stub(models.User, 'findOne').resolves(null);
+        addUserStub = sinon.stub(models.User, 'add').resolves();
 
-        transactionStub = sinon.stub().callsFake(async (cb) => {
+        transactionStub = sinon.stub(models.Base, 'transaction').callsFake(async (cb) => {
             return cb('fake-txn');
-        });
-
-        accept = rewire('../../../../../core/server/services/invitations/accept');
-        accept.__set__('models', {
-            Base: {transaction: transactionStub},
-            Invite: {findOne: findOneInviteStub},
-            User: {findOne: findOneUserStub, add: addUserStub}
         });
     });
 

--- a/ghost/core/test/unit/server/services/limits.test.js
+++ b/ghost/core/test/unit/server/services/limits.test.js
@@ -1,8 +1,7 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
-const rewire = require('rewire');
 
-const limits = rewire('../../../../core/server/services/limits');
+const limits = require('../../../../core/server/services/limits');
 const configUtils = require('../../../utils/config-utils');
 const logging = require('@tryghost/logging');
 
@@ -14,9 +13,10 @@ describe('Limit Service Init', function () {
 
     beforeEach(function () {
         loggerStub = sinon.spy(logging);
-        limitServiceStub = sinon.stub();
 
-        limits.__set__('limitService.loadLimits', limitServiceStub);
+        // `limits` is the exported LimitService instance, so stubbing its
+        // `loadLimits` method directly intercepts the call made by `init()`.
+        limitServiceStub = sinon.stub(limits, 'loadLimits');
 
         configUtils.set({
             hostSettings: {}

--- a/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
@@ -1,11 +1,12 @@
 const assert = require('node:assert/strict');
 const cheerio = require('cheerio');
 const sinon = require('sinon');
-const rewire = require('rewire');
 const errors = require('@tryghost/errors');
+const lexicalLib = require('../../../../../core/server/lib/lexical');
+const emailDesign = require('../../../../../core/server/services/email-rendering/email-design');
+const MemberWelcomeEmailRenderer = require('../../../../../core/server/services/member-welcome-emails/member-welcome-email-renderer');
 
 describe('MemberWelcomeEmailRenderer', function () {
-    let MemberWelcomeEmailRenderer;
     let lexicalRenderStub;
 
     const defaultSiteSettings = {
@@ -16,12 +17,7 @@ describe('MemberWelcomeEmailRenderer', function () {
     };
 
     beforeEach(function () {
-        lexicalRenderStub = sinon.stub().resolves('<p>Hello World</p>');
-
-        MemberWelcomeEmailRenderer = rewire('../../../../../core/server/services/member-welcome-emails/member-welcome-email-renderer');
-        MemberWelcomeEmailRenderer.__set__('lexicalLib', {
-            render: lexicalRenderStub
-        });
+        lexicalRenderStub = sinon.stub(lexicalLib, 'render').resolves('<p>Hello World</p>');
     });
 
     afterEach(function () {
@@ -490,8 +486,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         describe('design customization', function () {
             it('builds the email design from database-backed design settings', async function () {
-                const getEmailDesignStub = sinon.stub().returns({accentColor: '#123456'});
-                MemberWelcomeEmailRenderer.__set__('getEmailDesign', getEmailDesignStub);
+                const getEmailDesignStub = sinon.stub(emailDesign, 'getEmailDesign').returns({accentColor: '#123456'});
 
                 const renderer = new MemberWelcomeEmailRenderer({t: key => key});
                 const designSettings = {

--- a/ghost/core/test/unit/server/services/members/members-api/members-api.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/members-api.test.js
@@ -1,9 +1,8 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
-const rewire = require('rewire');
+const MembersAPI = require('../../../../../../core/server/services/members/members-api/members-api');
 
 describe('MembersAPI', function () {
-    let MembersAPI;
     let membersAPI;
     let memberRepository;
     let memberBREADService;
@@ -25,50 +24,48 @@ describe('MembersAPI', function () {
     };
 
     const buildMembersAPI = () => {
-        MembersAPI = rewire('../../../../../../core/server/services/members/members-api/members-api');
-
-        MembersAPI.__set__('Router', () => createRouterStub());
-        MembersAPI.__set__('body', {
+        sinon.stub(MembersAPI._private, 'Router').callsFake(() => createRouterStub());
+        sinon.stub(MembersAPI._private, 'body').value({
             json: () => 'json-middleware',
             raw: () => 'raw-middleware',
             urlencoded: () => 'urlencoded-middleware'
         });
-        MembersAPI.__set__('PaymentsService', function PaymentsService() {
+        sinon.stub(MembersAPI._private, 'PaymentsService').callsFake(function PaymentsService() {
             return {};
         });
-        MembersAPI.__set__('TokenService', function TokenService() {
+        sinon.stub(MembersAPI._private, 'TokenService').callsFake(function TokenService() {
             return {};
         });
-        MembersAPI.__set__('GeolocationService', function GeolocationService() {
+        sinon.stub(MembersAPI._private, 'GeolocationService').callsFake(function GeolocationService() {
             return {
                 getGeolocationFromIP: sinon.stub().resolves(null)
             };
         });
-        MembersAPI.__set__('MemberRepository', function MemberRepository() {
+        sinon.stub(MembersAPI._private, 'MemberRepository').callsFake(function MemberRepository() {
             return memberRepository;
         });
-        MembersAPI.__set__('MemberBREADService', function MemberBREADService() {
+        sinon.stub(MembersAPI._private, 'MemberBREADService').callsFake(function MemberBREADService() {
             return memberBREADService;
         });
-        MembersAPI.__set__('NextPaymentCalculator', function NextPaymentCalculator() {
+        sinon.stub(MembersAPI._private, 'NextPaymentCalculator').callsFake(function NextPaymentCalculator() {
             return {};
         });
-        MembersAPI.__set__('EventRepository', function EventRepository() {
+        sinon.stub(MembersAPI._private, 'EventRepository').callsFake(function EventRepository() {
             return {};
         });
-        MembersAPI.__set__('ProductRepository', function ProductRepository() {
+        sinon.stub(MembersAPI._private, 'ProductRepository').callsFake(function ProductRepository() {
             return {};
         });
-        MembersAPI.__set__('RouterController', function RouterController() {
+        sinon.stub(MembersAPI._private, 'RouterController').callsFake(function RouterController() {
             return {};
         });
-        MembersAPI.__set__('MemberController', function MemberController() {
+        sinon.stub(MembersAPI._private, 'MemberController').callsFake(function MemberController() {
             return {};
         });
-        MembersAPI.__set__('WellKnownController', function WellKnownController() {
+        sinon.stub(MembersAPI._private, 'WellKnownController').callsFake(function WellKnownController() {
             return {};
         });
-        MembersAPI.__set__('MagicLink', function MagicLink() {
+        sinon.stub(MembersAPI._private, 'MagicLink').callsFake(function MagicLink() {
             return {
                 tokenProvider,
                 getDataFromToken: sinon.stub().callsFake(async (token, otcVerification) => {
@@ -79,7 +76,7 @@ describe('MembersAPI', function () {
                 getSigninURL: sinon.stub()
             };
         });
-        MembersAPI.__set__('DomainEvents', {
+        sinon.stub(MembersAPI._private, 'DomainEvents').value({
             subscribe: sinon.stub()
         });
 

--- a/ghost/core/test/unit/server/services/outbox/handlers/member-created.test.js
+++ b/ghost/core/test/unit/server/services/outbox/handlers/member-created.test.js
@@ -1,53 +1,44 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
-const rewire = require('rewire');
 const {captureLoggerOutput, findByEvent} = require('../../../../../utils/logging-utils');
+const models = require('../../../../../../core/server/models');
+const memberWelcomeEmailService = require('../../../../../../core/server/services/member-welcome-emails/service');
+const handler = require('../../../../../../core/server/services/outbox/handlers/member-created');
 
 describe('member-created handler', function () {
-    let handler;
-    let memberWelcomeEmailServiceStub;
-    let AutomationStub;
-    let AutomatedEmailRecipientStub;
+    let sendStub;
+    let findOneStub;
+    let addStub;
+    let originalApi;
     let logCapture;
 
     beforeEach(function () {
-        handler = rewire('../../../../../../core/server/services/outbox/handlers/member-created.js');
+        sendStub = sinon.stub().resolves();
+        originalApi = memberWelcomeEmailService.api;
+        memberWelcomeEmailService.api = {send: sendStub};
 
-        memberWelcomeEmailServiceStub = {
-            api: {
-                send: sinon.stub().resolves()
-            }
-        };
-
-        AutomationStub = {
-            findOne: sinon.stub().resolves({
-                id: 'automation123',
-                related: sinon.stub().callsFake((relation) => {
-                    if (relation === 'welcomeEmailAutomatedEmail') {
-                        return {id: 'ae123'};
-                    }
-                })
+        findOneStub = sinon.stub(models.Automation, 'findOne').resolves({
+            id: 'automation123',
+            related: sinon.stub().callsFake((relation) => {
+                if (relation === 'welcomeEmailAutomatedEmail') {
+                    return {id: 'ae123'};
+                }
             })
-        };
+        });
 
-        AutomatedEmailRecipientStub = {
-            add: sinon.stub().resolves()
-        };
+        addStub = sinon.stub(models.AutomatedEmailRecipient, 'add').resolves();
 
         logCapture = captureLoggerOutput();
-
-        handler.__set__('memberWelcomeEmailService', memberWelcomeEmailServiceStub);
-        handler.__set__('Automation', AutomationStub);
-        handler.__set__('AutomatedEmailRecipient', AutomatedEmailRecipientStub);
     });
 
     afterEach(function () {
+        memberWelcomeEmailService.api = originalApi;
         logCapture.restore();
         sinon.restore();
     });
 
     it('sends email even when tracking fails', async function () {
-        AutomatedEmailRecipientStub.add.rejects(new Error('Database error'));
+        addStub.rejects(new Error('Database error'));
 
         await handler.handle({
             payload: {
@@ -59,12 +50,12 @@ describe('member-created handler', function () {
             }
         });
 
-        sinon.assert.calledOnce(memberWelcomeEmailServiceStub.api.send);
+        sinon.assert.calledOnce(sendStub);
     });
 
     it('logs error when tracking fails', async function () {
         const dbError = new Error('Database connection failed');
-        AutomatedEmailRecipientStub.add.rejects(dbError);
+        addStub.rejects(dbError);
 
         await handler.handle({
             payload: {
@@ -91,18 +82,18 @@ describe('member-created handler', function () {
             }
         });
 
-        sinon.assert.calledOnce(memberWelcomeEmailServiceStub.api.send);
+        sinon.assert.calledOnce(sendStub);
         const warningLog = findByEvent(logCapture.output, 'outbox.member_created.no_slug_mapping');
         assert.ok(warningLog);
         assert.deepEqual(warningLog.system, {
             event: 'outbox.member_created.no_slug_mapping',
             member_status: 'comped'
         });
-        sinon.assert.notCalled(AutomatedEmailRecipientStub.add);
+        sinon.assert.notCalled(addStub);
     });
 
     it('logs warning when no automated email found for slug', async function () {
-        AutomationStub.findOne.resolves(null);
+        findOneStub.resolves(null);
 
         await handler.handle({
             payload: {
@@ -114,13 +105,13 @@ describe('member-created handler', function () {
             }
         });
 
-        sinon.assert.calledOnce(memberWelcomeEmailServiceStub.api.send);
+        sinon.assert.calledOnce(sendStub);
         const warningLog = findByEvent(logCapture.output, 'outbox.member_created.no_automated_email');
         assert.ok(warningLog);
         assert.deepEqual(warningLog.system, {
             event: 'outbox.member_created.no_automated_email',
             slug: 'member-welcome-email-free'
         });
-        sinon.assert.notCalled(AutomatedEmailRecipientStub.add);
+        sinon.assert.notCalled(addStub);
     });
 });

--- a/ghost/core/test/unit/server/services/outbox/index.test.js
+++ b/ghost/core/test/unit/server/services/outbox/index.test.js
@@ -1,25 +1,24 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
-const rewire = require('rewire');
 const DomainEvents = require('@tryghost/domain-events');
 const {captureLoggerOutput, findByEvent} = require('../../../../utils/logging-utils');
 const StartOutboxProcessingEvent = require('../../../../../core/server/services/outbox/events/start-outbox-processing-event');
+const jobs = require('../../../../../core/server/services/outbox/jobs');
+const service = require('../../../../../core/server/services/outbox/index.js');
 
 describe('Outbox Service', function () {
-    let service;
     let processOutboxStub;
-    let jobsStub;
     let logCapture;
 
     beforeEach(function () {
-        service = rewire('../../../../../core/server/services/outbox/index.js');
+        // `service` is a singleton; reset its processing flag so each test
+        // starts from a clean state (the fresh-module load this replaced did
+        // the same).
+        service.processing = false;
 
-        processOutboxStub = sinon.stub().resolves('Processed');
-        jobsStub = {scheduleOutboxJob: sinon.stub()};
+        processOutboxStub = sinon.stub(service._private, 'processOutbox').resolves('Processed');
+        sinon.stub(jobs, 'scheduleOutboxJob');
         logCapture = captureLoggerOutput();
-
-        service.__set__('processOutbox', processOutboxStub);
-        service.__set__('jobs', jobsStub);
     });
 
     afterEach(async function () {

--- a/ghost/core/test/unit/server/services/outbox/jobs/lib/process-entries.test.js
+++ b/ghost/core/test/unit/server/services/outbox/jobs/lib/process-entries.test.js
@@ -1,10 +1,9 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
-const rewire = require('rewire');
 const {captureLoggerOutput, findByEvent} = require('../../../../../../utils/logging-utils');
+const processEntries = require('../../../../../../../core/server/services/outbox/jobs/lib/process-entries.js');
 
 describe('processEntries', function () {
-    let processEntries;
     let handlerStub;
     let dbStub;
     let logCapture;
@@ -24,15 +23,13 @@ describe('processEntries', function () {
     }
 
     beforeEach(function () {
-        processEntries = rewire('../../../../../../../core/server/services/outbox/jobs/lib/process-entries.js');
-
         handlerStub = {
             handle: sinon.stub().resolves(),
             getLogInfo: sinon.stub().returns('test@example.com'),
             LOG_KEY: '[OUTBOX][MEMBER-WELCOME-EMAIL]'
         };
 
-        processEntries.__set__('EVENT_HANDLERS', {
+        sinon.stub(processEntries._private, 'EVENT_HANDLERS').value({
             MemberCreatedEvent: handlerStub
         });
 

--- a/ghost/core/test/unit/server/services/route-settings/settings-loader.test.js
+++ b/ghost/core/test/unit/server/services/route-settings/settings-loader.test.js
@@ -1,11 +1,10 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
 const sinon = require('sinon');
-const rewire = require('rewire');
 const fs = require('fs-extra');
 const path = require('path');
 const errors = require('@tryghost/errors');
-const SettingsLoader = rewire('../../../../../core/server/services/route-settings/settings-loader');
+const SettingsLoader = require('../../../../../core/server/services/route-settings/settings-loader');
 
 describe('UNIT > SettingsLoader:', function () {
     afterEach(function () {
@@ -25,11 +24,9 @@ describe('UNIT > SettingsLoader:', function () {
         };
 
         let yamlParserStub;
-        let validateStub;
 
         beforeEach(function () {
             yamlParserStub = sinon.stub();
-            validateStub = sinon.stub();
         });
 
         it('reads a settings object for routes.yaml file', async function () {
@@ -65,9 +62,7 @@ describe('UNIT > SettingsLoader:', function () {
             const expectedSettingsFile = path.join(storageFolderPath, 'routes.yaml');
 
             yamlParserStub.returns(yamlStubFile);
-            validateStub.returns({routes: {}, collections: {}, taxonomies: {}});
-
-            SettingsLoader.__set__('validate', validateStub);
+            sinon.stub(SettingsLoader._private, 'validate').returns({routes: {}, collections: {}, taxonomies: {}});
 
             const settingsLoader = new SettingsLoader({
                 parseYaml: yamlParserStub,

--- a/ghost/core/test/unit/server/services/slack.test.js
+++ b/ghost/core/test/unit/server/services/slack.test.js
@@ -1,12 +1,11 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const _ = require('lodash');
-const rewire = require('rewire');
 const testUtils = require('../../../utils');
 const configUtils = require('../../../utils/config-utils');
 
 // Stuff we test
-const slack = rewire('../../../../core/server/services/slack');
+const slack = require('../../../../core/server/services/slack');
 
 const events = require('../../../../core/server/lib/common/events');
 const logging = require('@tryghost/logging');
@@ -33,8 +32,8 @@ describe('Slack', function () {
     it('listen() should initialise event correctly', function () {
         slack.listen();
         sinon.assert.calledTwice(eventStub);
-        sinon.assert.calledWith(eventStub.firstCall, 'post.published', slack.__get__('slackListener'));
-        sinon.assert.calledWith(eventStub.secondCall, 'slack.test', slack.__get__('slackTestPing'));
+        sinon.assert.calledWith(eventStub.firstCall, 'post.published', slack._private.slackListener);
+        sinon.assert.calledWith(eventStub.secondCall, 'slack.test', slack._private.slackTestPing);
     });
 
     it('listener() calls ping() with toJSONified model', function () {
@@ -58,9 +57,8 @@ describe('Slack', function () {
             }
         };
 
-        const pingStub = sinon.stub();
-        const resetSlack = slack.__set__('ping', pingStub);
-        const listener = slack.__get__('slackListener');
+        const pingStub = sinon.stub(slack._private, 'ping');
+        const listener = slack._private.slackListener;
 
         listener(testModel);
 
@@ -69,9 +67,6 @@ describe('Slack', function () {
             ...testPost,
             authors: [testAuthor]
         });
-
-        // Reset slack ping method
-        resetSlack();
     });
 
     it('listener() does not call ping() when importing', function () {
@@ -83,55 +78,41 @@ describe('Slack', function () {
             }
         };
 
-        const pingStub = sinon.stub();
-        const resetSlack = slack.__set__('ping', pingStub);
-        const listener = slack.__get__('slackListener');
+        const pingStub = sinon.stub(slack._private, 'ping');
+        const listener = slack._private.slackListener;
 
         listener(testModel, {importing: true});
 
         sinon.assert.notCalled(pingStub);
-
-        // Reset slack ping method
-        resetSlack();
     });
 
     it('testPing() calls ping() with default message', function () {
-        const pingStub = sinon.stub();
-        const resetSlack = slack.__set__('ping', pingStub);
-        const testPing = slack.__get__('slackTestPing');
+        const pingStub = sinon.stub(slack._private, 'ping');
+        const testPing = slack._private.slackTestPing;
 
         testPing();
 
         sinon.assert.calledOnce(pingStub);
         sinon.assert.calledWith(pingStub, sinon.match.has('message'));
-
-        // Reset slack ping method
-        resetSlack();
     });
 
     describe('ping()', function () {
         let settingsCacheStub;
-        let slackReset;
         let makeRequestStub;
         let urlServiceGetUrlForResourceStub;
-        const ping = slack.__get__('ping');
+        const ping = slack._private.ping;
 
         beforeEach(function () {
             urlServiceGetUrlForResourceStub = sinon.stub(urlService.facade, 'getUrlForResource');
 
             settingsCacheStub = sinon.stub(settingsCache, 'get');
 
-            makeRequestStub = sinon.stub();
-            slackReset = slack.__set__('request', makeRequestStub);
+            makeRequestStub = sinon.stub(slack._private, 'request');
             makeRequestStub.resolves();
 
             sinon.stub(imageLib.blogIcon, 'getIconUrl').returns('http://myblog.com/favicon.ico');
 
             configUtils.set('url', 'http://myblog.com');
-        });
-
-        afterEach(function () {
-            slackReset();
         });
 
         it('makes a request for a post if url is provided', function () {

--- a/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
+++ b/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
@@ -1,11 +1,10 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
 const sinon = require('sinon');
-const rewire = require('rewire');
 
 require('../../../../../core/server/services/i18n').init();
 const {t: i18nT} = require('../../../../../core/server/services/i18n');
-const StripeAPI = rewire('../../../../../core/server/services/stripe/stripe-api');
+const StripeAPI = require('../../../../../core/server/services/stripe/stripe-api');
 
 describe('StripeAPI', function () {
     const mockCustomerEmail = 'foo@example.com';
@@ -31,8 +30,7 @@ describe('StripeAPI', function () {
                 }
             };
             mockLabsIsSet = sinon.stub(mockLabs, 'isSet');
-            const mockStripeConstructor = sinon.stub().returns(mockStripe);
-            StripeAPI.__set__('Stripe', mockStripeConstructor);
+            sinon.stub(StripeAPI._private, 'Stripe').returns(mockStripe);
             api.configure({
                 checkoutSessionSuccessUrl: '/success',
                 checkoutSessionCancelUrl: '/cancel',
@@ -209,8 +207,7 @@ describe('StripeAPI', function () {
                 }
             };
             mockLabsIsSet = sinon.stub(mockLabs, 'isSet');
-            const mockStripeConstructor = sinon.stub().returns(mockStripe);
-            StripeAPI.__set__('Stripe', mockStripeConstructor);
+            sinon.stub(StripeAPI._private, 'Stripe').returns(mockStripe);
             api.configure({
                 checkoutSessionSuccessUrl: '/success',
                 checkoutSessionCancelUrl: '/cancel',
@@ -256,8 +253,7 @@ describe('StripeAPI', function () {
                         })
                     }
                 };
-                const mockStripeConstructor = sinon.stub().returns(mockStripe);
-                StripeAPI.__set__('Stripe', mockStripeConstructor);
+                sinon.stub(StripeAPI._private, 'Stripe').returns(mockStripe);
                 api.configure({
                     secretKey: ''
                 });
@@ -285,8 +281,7 @@ describe('StripeAPI', function () {
                         })
                     }
                 };
-                const mockStripeConstructor = sinon.stub().returns(mockStripe);
-                StripeAPI.__set__('Stripe', mockStripeConstructor);
+                sinon.stub(StripeAPI._private, 'Stripe').returns(mockStripe);
                 api.configure({
                     secretKey: ''
                 });
@@ -335,8 +330,7 @@ describe('StripeAPI', function () {
                         })
                     }
                 };
-                const mockStripeConstructor = sinon.stub().returns(mockStripe);
-                StripeAPI.__set__('Stripe', mockStripeConstructor);
+                sinon.stub(StripeAPI._private, 'Stripe').returns(mockStripe);
                 api.configure({
                     secretKey: ''
                 });
@@ -364,8 +358,7 @@ describe('StripeAPI', function () {
                     update: sinon.stub().resolves(mockSubscription)
                 }
             };
-            const mockStripeConstructor = sinon.stub().returns(mockStripe);
-            StripeAPI.__set__('Stripe', mockStripeConstructor);
+            sinon.stub(StripeAPI._private, 'Stripe').returns(mockStripe);
             api.configure({
                 secretKey: ''
             });
@@ -404,8 +397,7 @@ describe('StripeAPI', function () {
                     update: sinon.stub().resolves(mockSubscription)
                 }
             };
-            const mockStripeConstructor = sinon.stub().returns(mockStripe);
-            StripeAPI.__set__('Stripe', mockStripeConstructor);
+            sinon.stub(StripeAPI._private, 'Stripe').returns(mockStripe);
             api.configure({
                 secretKey: ''
             });
@@ -440,8 +432,7 @@ describe('StripeAPI', function () {
             };
             mockLabsIsSet = sinon.stub(mockLabs, 'isSet');
             mockLabsIsSet.withArgs('stripeAutomaticTax').returns(true);
-            const mockStripeConstructor = sinon.stub().returns(mockStripe);
-            StripeAPI.__set__('Stripe', mockStripeConstructor);
+            sinon.stub(StripeAPI._private, 'Stripe').returns(mockStripe);
             api.configure({
                 checkoutSessionSuccessUrl: '/success',
                 checkoutSessionCancelUrl: '/cancel',
@@ -508,8 +499,7 @@ describe('StripeAPI', function () {
                 }
             };
             sinon.stub(mockLabs, 'isSet');
-            const mockStripeConstructor = sinon.stub().returns(mockStripe);
-            StripeAPI.__set__('Stripe', mockStripeConstructor);
+            sinon.stub(StripeAPI._private, 'Stripe').returns(mockStripe);
             api.configure({
                 checkoutSessionSuccessUrl: '/success',
                 checkoutSessionCancelUrl: '/cancel',
@@ -671,10 +661,8 @@ describe('StripeAPI', function () {
 
             sinon.stub(mockLabs, 'isSet');
 
-            const mockStripeConstructor = sinon.stub().returns(mockStripe);
-
-            StripeAPI.__set__('Stripe', mockStripeConstructor);
-            StripeAPI.__set__('t', i18nT);
+            sinon.stub(StripeAPI._private, 'Stripe').returns(mockStripe);
+            sinon.stub(StripeAPI._private, 't').callsFake(i18nT);
 
             api.configure({
                 checkoutSessionSuccessUrl: '/success',
@@ -748,7 +736,8 @@ describe('StripeAPI', function () {
         });
 
         it('uses translated title and cadence labels', async function () {
-            StripeAPI.__set__('t', (key, options = {}) => {
+            // Override the translate stub created in beforeEach for this test
+            StripeAPI._private.t.callsFake((key, options = {}) => {
                 if (key === 'Gift subscription') {
                     return 'Abonnement offert';
                 }

--- a/ghost/core/test/unit/server/services/url/url-service.test.js
+++ b/ghost/core/test/unit/server/services/url/url-service.test.js
@@ -1,13 +1,12 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
 const errors = require('@tryghost/errors');
-const rewire = require('rewire');
 const sinon = require('sinon');
 const Queue = require('../../../../../core/server/services/url/queue');
 const Resources = require('../../../../../core/server/services/url/resources');
 const UrlGenerator = require('../../../../../core/server/services/url/url-generator');
 const Urls = require('../../../../../core/server/services/url/urls');
-const UrlService = rewire('../../../../../core/server/services/url/url-service');
+const UrlService = require('../../../../../core/server/services/url/url-service');
 
 describe('Unit: services/url/UrlService', function () {
     let QueueStub;
@@ -17,22 +16,17 @@ describe('Unit: services/url/UrlService', function () {
     let urlService;
 
     beforeEach(function () {
-        QueueStub = sinon.stub();
+        QueueStub = sinon.stub(UrlService._private, 'Queue');
         QueueStub.returns(sinon.createStubInstance(Queue));
 
-        ResourcesStub = sinon.stub();
+        ResourcesStub = sinon.stub(UrlService._private, 'Resources');
         ResourcesStub.returns(sinon.createStubInstance(Resources));
 
-        UrlsStub = sinon.stub();
+        UrlsStub = sinon.stub(UrlService._private, 'Urls');
         UrlsStub.returns(sinon.createStubInstance(Urls));
 
-        UrlGeneratorStub = sinon.stub();
+        UrlGeneratorStub = sinon.stub(UrlService._private, 'UrlGenerator');
         UrlGeneratorStub.returns(sinon.createStubInstance(UrlGenerator));
-
-        UrlService.__set__('Queue', QueueStub);
-        UrlService.__set__('Resources', ResourcesStub);
-        UrlService.__set__('Urls', UrlsStub);
-        UrlService.__set__('UrlGenerator', UrlGeneratorStub);
 
         urlService = new UrlService();
     });


### PR DESCRIPTION
## Why

[`rewire`](https://github.com/jhnns/rewire) is a CommonJS-only module loader: it works by re-evaluating a module's source so that `__get__`/`__set__` can reach into its closure. That mechanism does not exist under ES modules, so every test that uses `rewire` is a hard blocker for the ghost/core ESM migration.

This PR de-rewires the **server service** unit tests as one slice of that migration. No production behaviour changes — only how the tests reach their seams.

## Recipe

Two patterns, no `vi.mock`/`vi.spyOn`:

- **Own-internal functions/values** (a module's own helpers/data that a test previously reached via `rewire.__get__`/`__set__`) are grouped into a `const _private = {...}`, the module's internal calls are routed through `_private.fn(...)`, and `_private` is added to the exports. Tests stub them with `sinon.stub(mod._private, 'fn')` (or `.value()` for non-functions). This matches the existing pattern already used elsewhere in the suite.
- **Collaborators that are already shared objects** (`obj.method(...)` where `obj = require('x')`) need no source change — the test requires the same `x` and does `sinon.stub(obj, 'method')`.

`vi.mock`/`vi.spyOn` are intentionally avoided: the unit suite runs with `isolate: false`, where module-level mocks leak across files. All teardown is `sinon.restore()` in `afterEach`.

## Scope

- Stripped stale `_private` explanatory comments left on six already-converted service modules (indexnow, slack, outbox, route-settings, stripe-api, url-service).
- De-rewired the remaining service/server unit tests: `invitations/accept`, `outbox/handlers/member-created`, `member-welcome-emails/member-welcome-email-renderer`, `outbox/jobs/lib/process-entries`, `members/members-api`, `notify`, `lib/image/image-utils`.

`rewire` stays in `devDependencies` until the final de-rewire slice removes the last consumer.

## Verification

- Each changed test file passes individually; the whole `test/unit/server/services/` directory (plus `notify` and `image-utils`) runs green together — confirming no cross-file leakage under `isolate: false`.
- `pnpm lint:test` and `pnpm lint:server` clean.