### PR TITLE
Changed unit tests to avoid rewire

### DIFF
--- a/ghost/core/core/frontend/services/rendering/templates.js
+++ b/ghost/core/core/frontend/services/rendering/templates.js
@@ -8,7 +8,7 @@ const path = require('path');
 const url = require('url');
 const config = require('../../../shared/config');
 const themeEngine = require('../theme-engine');
-const _private = {};
+const templates = {};
 
 /**
  * @description Get Error Template Hierarchy
@@ -20,7 +20,7 @@ const _private = {};
  * @param {integer} statusCode
  * @returns {String[]}
  */
-_private.getErrorTemplateHierarchy = function getErrorTemplateHierarchy(statusCode) {
+templates.getErrorTemplateHierarchy = function getErrorTemplateHierarchy(statusCode) {
     const errorCode = _.toString(statusCode);
     const templateList = ['error'];
 
@@ -45,7 +45,7 @@ _private.getErrorTemplateHierarchy = function getErrorTemplateHierarchy(statusCo
  * @param {Object} routerOptions
  * @returns {String[]}
  */
-_private.getEntriesTemplateHierarchy = function getEntriesTemplateHierarchy(routerOptions, requestOptions) {
+templates.getEntriesTemplateHierarchy = function getEntriesTemplateHierarchy(routerOptions, requestOptions) {
     const templateList = ['index'];
 
     // CASE: author, tag, custom collection name
@@ -82,7 +82,7 @@ _private.getEntriesTemplateHierarchy = function getEntriesTemplateHierarchy(rout
  * @param {Object} postObject
  * @returns {String[]}
  */
-_private.getEntryTemplateHierarchy = function getEntryTemplateHierarchy(postObject, context) {
+templates.getEntryTemplateHierarchy = function getEntryTemplateHierarchy(postObject, context) {
     const templateList = ['post'];
     let slugTemplate = 'post-' + postObject.slug;
 
@@ -109,7 +109,7 @@ _private.getEntryTemplateHierarchy = function getEntryTemplateHierarchy(postObje
  * @param {Array|String} templateList
  * @param {string} fallback - a fallback template
  */
-_private.pickTemplate = function pickTemplate(templateList, fallback) {
+templates.pickTemplate = function pickTemplate(templateList, fallback) {
     let template;
 
     if (!_.isArray(templateList)) {
@@ -147,22 +147,22 @@ _private.pickTemplate = function pickTemplate(templateList, fallback) {
  * @param {('post'|'page')} context
  * @returns
  */
-_private.getTemplateForEntry = function getTemplateForEntry(entry, context) {
-    const templateList = _private.getEntryTemplateHierarchy(entry, context);
+templates.getTemplateForEntry = function getTemplateForEntry(entry, context) {
+    const templateList = templates.getEntryTemplateHierarchy(entry, context);
     const fallback = templateList[templateList.length - 1];
-    return _private.pickTemplate(templateList, fallback);
+    return templates.pickTemplate(templateList, fallback);
 };
 
-_private.getTemplateForEntries = function getTemplateForEntries(routerOptions, requestOptions) {
-    const templateList = _private.getEntriesTemplateHierarchy(routerOptions, requestOptions);
+templates.getTemplateForEntries = function getTemplateForEntries(routerOptions, requestOptions) {
+    const templateList = templates.getEntriesTemplateHierarchy(routerOptions, requestOptions);
     const fallback = templateList[templateList.length - 1];
-    return _private.pickTemplate(templateList, fallback);
+    return templates.pickTemplate(templateList, fallback);
 };
 
-_private.getTemplateForError = function getTemplateForError(statusCode) {
-    const templateList = _private.getErrorTemplateHierarchy(statusCode);
+templates.getTemplateForError = function getTemplateForError(statusCode) {
+    const templateList = templates.getErrorTemplateHierarchy(statusCode);
     const fallback = path.resolve(config.get('paths').defaultViews, 'error.hbs');
-    return _private.pickTemplate(templateList, fallback);
+    return templates.pickTemplate(templateList, fallback);
 };
 
 /**
@@ -171,31 +171,33 @@ _private.getTemplateForError = function getTemplateForError(statusCode) {
  * @param {Object} res
  * @param {Object} data
  */
-module.exports.setTemplate = function setTemplate(req, res, data) {
+templates.setTemplate = function setTemplate(req, res, data) {
     if (res._template && !req.err) {
         return;
     }
 
     if (req.err) {
-        res._template = _private.getTemplateForError(res.statusCode);
+        res._template = templates.getTemplateForError(res.statusCode);
         return;
     }
 
     if (['channel', 'collection'].indexOf(res.routerOptions.type) !== -1) {
-        res._template = _private.getTemplateForEntries(res.routerOptions, {
+        res._template = templates.getTemplateForEntries(res.routerOptions, {
             path: url.parse(req.url).pathname,
             page: req.params.page,
             slugParam: req.params.slug
         });
     } else if (res.routerOptions.type === 'custom') {
-        res._template = _private.pickTemplate(res.routerOptions.templates, res.routerOptions.defaultTemplate);
+        res._template = templates.pickTemplate(res.routerOptions.templates, res.routerOptions.defaultTemplate);
     } else if (res.routerOptions.type === 'entry') {
         if (res.routerOptions?.context?.includes('page') || (res.routerOptions?.context?.includes('preview') && data.page)) {
-            res._template = _private.getTemplateForEntry(data.page, 'page');
+            res._template = templates.getTemplateForEntry(data.page, 'page');
         } else {
-            res._template = _private.getTemplateForEntry(data.post, 'post');
+            res._template = templates.getTemplateForEntry(data.post, 'post');
         }
     } else {
         res._template = 'index';
     }
 };
+
+module.exports = templates;

--- a/ghost/core/core/server/web/api/middleware/cors.js
+++ b/ghost/core/core/server/web/api/middleware/cors.js
@@ -98,3 +98,6 @@ const corsCaching = function corsCaching(req, res, next) {
 
 exports.corsMiddleware = cors(corsOptionsDelegate);
 exports.corsCaching = corsCaching;
+exports.resetAllowlist = function resetAllowlist() {
+    allowlist = [];
+};

--- a/ghost/core/core/server/web/shared/middleware/url-redirects.js
+++ b/ghost/core/core/server/web/shared/middleware/url-redirects.js
@@ -3,9 +3,9 @@ const path = require('path');
 const debug = require('@tryghost/debug')('web:shared:mw:url-redirects');
 const urlUtils = require('../../../../shared/url-utils');
 
-const _private = {};
+const urlRedirects = {};
 
-_private.redirectUrl = ({redirectTo, query, pathname}) => {
+urlRedirects.redirectUrl = ({redirectTo, query, pathname}) => {
     const parts = url.parse(redirectTo);
 
     // CASE: ensure we always add a trailing slash to reduce the number of redirects
@@ -30,7 +30,7 @@ _private.redirectUrl = ({redirectTo, query, pathname}) => {
  * 1. required SSL redirects
  * 2. redirect to the correct admin url
  */
-_private.getAdminRedirectUrl = ({requestedHost, requestedUrl, queryParameters, secure}) => {
+urlRedirects.getAdminRedirectUrl = ({requestedHost, requestedUrl, queryParameters, secure}) => {
     const siteUrl = urlUtils.urlFor('home', true);
     const adminUrl = urlUtils.urlFor('admin', true);
     const siteHost = url.parse(siteUrl).host;
@@ -46,7 +46,7 @@ _private.getAdminRedirectUrl = ({requestedHost, requestedUrl, queryParameters, s
         adminHost !== requestedHost) {
         debug('redirect because admin host does not match');
 
-        return _private.redirectUrl({
+        return urlRedirects.redirectUrl({
             redirectTo: adminUrl,
             pathname: requestedUrl,
             query: queryParameters
@@ -57,7 +57,7 @@ _private.getAdminRedirectUrl = ({requestedHost, requestedUrl, queryParameters, s
     if (urlUtils.isSSL(adminUrl) && !secure) {
         debug('redirect because protocol does not match');
 
-        return _private.redirectUrl({
+        return urlRedirects.redirectUrl({
             redirectTo: adminUrl,
             pathname: requestedUrl,
             query: queryParameters
@@ -70,7 +70,7 @@ _private.getAdminRedirectUrl = ({requestedHost, requestedUrl, queryParameters, s
  *
  * 1. required SSL redirects
  */
-_private.getFrontendRedirectUrl = ({requestedHost, requestedUrl, queryParameters, secure}) => {
+urlRedirects.getFrontendRedirectUrl = ({requestedHost, requestedUrl, queryParameters, secure}) => {
     const siteUrl = urlUtils.urlFor('home', true);
 
     debug('getFrontendRedirectUrl', requestedHost, requestedUrl, siteUrl);
@@ -79,7 +79,7 @@ _private.getFrontendRedirectUrl = ({requestedHost, requestedUrl, queryParameters
     if (urlUtils.isSSL(siteUrl) && !secure) {
         debug('redirect because protocol does not match');
 
-        return _private.redirectUrl({
+        return urlRedirects.redirectUrl({
             redirectTo: `https://${requestedHost}`,
             pathname: requestedUrl,
             query: queryParameters
@@ -87,7 +87,7 @@ _private.getFrontendRedirectUrl = ({requestedHost, requestedUrl, queryParameters
     }
 };
 
-_private.redirect = function urlRedirectsRedirect(req, res, next, redirectFn) {
+urlRedirects.redirect = function urlRedirectsRedirect(req, res, next, redirectFn) {
     const redirectUrl = redirectFn({
         requestedHost: req.vhost ? req.vhost.host : req.get('host'),
         requestedUrl: url.parse(req.originalUrl || req.url).pathname,
@@ -105,12 +105,14 @@ _private.redirect = function urlRedirectsRedirect(req, res, next, redirectFn) {
 };
 
 const frontendRedirect = function frontendRedirect(req, res, next) {
-    _private.redirect(req, res, next, _private.getFrontendRedirectUrl);
+    urlRedirects.redirect(req, res, next, urlRedirects.getFrontendRedirectUrl);
 };
 
 const adminRedirect = function adminRedirect(req, res, next) {
-    _private.redirect(req, res, next, _private.getAdminRedirectUrl);
+    urlRedirects.redirect(req, res, next, urlRedirects.getAdminRedirectUrl);
 };
 
-module.exports.frontendSSLRedirect = frontendRedirect;
-module.exports.adminSSLAndHostRedirect = adminRedirect;
+urlRedirects.frontendSSLRedirect = frontendRedirect;
+urlRedirects.adminSSLAndHostRedirect = adminRedirect;
+
+module.exports = urlRedirects;

--- a/ghost/core/core/shared/max-limit-cap.js
+++ b/ghost/core/core/shared/max-limit-cap.js
@@ -7,8 +7,12 @@ const config = require('../shared/config');
 // the core limit capping logic that can be used by both middleware and helpers.
 
 const limitConfig = {
-    allowLimitAll: config.get('optimization:allowLimitAll') || false,
-    maxLimit: config.get('optimization:maxLimit') || 100,
+    get allowLimitAll() {
+        return config.get('optimization:allowLimitAll') || false;
+    },
+    get maxLimit() {
+        return config.get('optimization:maxLimit') || 100;
+    },
     // Temporary exceptions to the max limit rule (HTTP-specific)
     exceptionEndpoints: [
         '/ghost/api/admin/posts/export/',

--- a/ghost/core/test/unit/api/endpoints/members.test.js
+++ b/ghost/core/test/unit/api/endpoints/members.test.js
@@ -1,40 +1,29 @@
 const sinon = require('sinon');
-const rewire = require('rewire');
+const membersController = require('../../../../core/server/api/endpoints/members');
+const membersService = require('../../../../core/server/services/members');
+const settingsCache = require('../../../../core/shared/settings-cache');
 
 describe('Members controller', function () {
-    let models, membersController, mockMembersService, mockSettingsCache, mockMoment;
+    let models;
+    let processImportStub;
+    let originalProcessImport;
 
     beforeAll(function () {
         models = require('../../../../core/server/models');
     });
 
     beforeEach(function () {
-        // Use rewire to load the members controller and replace its dependencies
-        membersController = rewire('../../../../core/server/api/endpoints/members');
-
-        // Create mocks
-        mockMembersService = {
-            processImport: sinon.stub().resolves({
-                meta: {stats: {imported: 1}}
-            })
-        };
-
-        mockSettingsCache = {
-            get: sinon.stub().withArgs('timezone').returns('UTC')
-        };
-
-        mockMoment = sinon.stub().returns({
-            tz: sinon.stub().returnsThis(),
-            format: sinon.stub().returns('2023-01-01 12:00')
+        originalProcessImport = membersService.processImport;
+        processImportStub = sinon.stub().resolves({
+            meta: {stats: {imported: 1}}
         });
+        membersService.processImport = processImportStub;
 
-        // Replace the dependencies in the rewired module
-        membersController.__set__('membersService', mockMembersService);
-        membersController.__set__('settingsCache', mockSettingsCache);
-        membersController.__set__('moment', mockMoment);
+        sinon.stub(settingsCache, 'get').withArgs('timezone').returns('UTC');
     });
 
     afterEach(function () {
+        membersService.processImport = originalProcessImport;
         sinon.restore();
     });
 
@@ -53,7 +42,7 @@ describe('Members controller', function () {
 
             // Verify the user's email was used
             sinon.assert.calledWith(mockUser.get, 'email');
-            sinon.assert.calledWith(mockMembersService.processImport, sinon.match({
+            sinon.assert.calledWith(processImportStub, sinon.match({
                 user: {email: 'user@example.com'}
             }));
         });
@@ -75,7 +64,7 @@ describe('Members controller', function () {
             // Verify the owner fallback path was used
             sinon.assert.calledOnce(models.User.getOwnerUser);
             sinon.assert.calledWith(mockOwnerUser.get, 'email');
-            sinon.assert.calledWith(mockMembersService.processImport, sinon.match({
+            sinon.assert.calledWith(processImportStub, sinon.match({
                 user: {email: 'owner@example.com'}
             }));
         });

--- a/ghost/core/test/unit/frontend/meta/canonical-url.test.js
+++ b/ghost/core/test/unit/frontend/meta/canonical-url.test.js
@@ -1,21 +1,18 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
-const rewire = require('rewire');
 const urlUtils = require('../../../../core/shared/url-utils');
+const urlService = require('../../../../core/server/services/url');
 const testUtils = require('../../../utils');
 
-let getCanonicalUrl = rewire('../../../../core/frontend/meta/canonical-url');
+const getCanonicalUrl = require('../../../../core/frontend/meta/canonical-url');
 
 describe('getCanonicalUrl', function () {
-    let getUrlStub;
+    let getUrlForResourceStub;
     let urlJoinStub;
     let urlForStub;
 
     beforeEach(function () {
-        getUrlStub = sinon.stub();
-
-        getCanonicalUrl = rewire('../../../../core/frontend/meta/canonical-url');
-        getCanonicalUrl.__set__('getUrl', getUrlStub);
+        getUrlForResourceStub = sinon.stub(urlService.facade, 'getUrlForResource');
 
         urlJoinStub = sinon.stub(urlUtils, 'urlJoin');
         urlForStub = sinon.stub(urlUtils, 'urlFor').withArgs('home', true).returns('http://localhost:9999');
@@ -28,14 +25,14 @@ describe('getCanonicalUrl', function () {
     it('should return default canonical url', function () {
         const post = testUtils.DataGenerator.forKnex.createPost();
 
-        getUrlStub.withArgs(post, false).returns('/post-url/');
+        getUrlForResourceStub.returns('/post-url/');
         urlJoinStub.withArgs('http://localhost:9999', '/post-url/').returns('canonical url');
 
         assert.equal(getCanonicalUrl(post), 'canonical url');
 
         sinon.assert.calledOnce(urlJoinStub);
         sinon.assert.calledOnce(urlForStub);
-        sinon.assert.calledOnce(getUrlStub);
+        sinon.assert.calledOnce(getUrlForResourceStub);
     });
 
     it('should return canonical url field if present', function () {
@@ -46,17 +43,19 @@ describe('getCanonicalUrl', function () {
             post: post
         }), 'https://example.com/canonical');
 
-        sinon.assert.notCalled(getUrlStub);
+        sinon.assert.notCalled(getUrlForResourceStub);
     });
 
     it('should return home if empty secure data', function () {
-        getUrlStub.withArgs({secure: true}, false).returns('/');
+        const data = {secure: true};
+
+        urlForStub.withArgs(data, {}, false).returns('/');
         urlJoinStub.withArgs('http://localhost:9999', '/').returns('canonical url');
 
-        assert.equal(getCanonicalUrl({secure: true}), 'canonical url');
+        assert.equal(getCanonicalUrl(data), 'canonical url');
 
         sinon.assert.calledOnce(urlJoinStub);
         sinon.assert.calledOnce(urlForStub);
-        sinon.assert.calledOnce(getUrlStub);
+        sinon.assert.notCalled(getUrlForResourceStub);
     });
 });

--- a/ghost/core/test/unit/frontend/meta/image-dimensions.test.js
+++ b/ghost/core/test/unit/frontend/meta/image-dimensions.test.js
@@ -2,14 +2,14 @@ const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
 const _ = require('lodash');
 const sinon = require('sinon');
-const rewire = require('rewire');
-const getImageDimensions = rewire('../../../../core/frontend/meta/image-dimensions');
+const imageSizeCache = require('../../../../core/server/lib/image').cachedImageSizeFromUrl;
+const getImageDimensions = require('../../../../core/frontend/meta/image-dimensions');
 
 describe('getImageDimensions', function () {
     let sizeOfStub;
 
     beforeEach(function () {
-        sizeOfStub = sinon.stub();
+        sizeOfStub = sinon.stub(imageSizeCache, 'getCachedImageSizeFromUrl');
     });
 
     afterEach(function () {
@@ -38,10 +38,6 @@ describe('getImageDimensions', function () {
             width: 50,
             height: 50,
             type: 'jpg'
-        });
-
-        getImageDimensions.__set__('imageSizeCache', {
-            getCachedImageSizeFromUrl: sizeOfStub
         });
 
         const result = await getImageDimensions(metaData);
@@ -91,10 +87,6 @@ describe('getImageDimensions', function () {
 
         sizeOfStub.returns({});
 
-        getImageDimensions.__set__('imageSizeCache', {
-            getCachedImageSizeFromUrl: sizeOfStub
-        });
-
         const result = await getImageDimensions(metaData);
         assertExists(result);
         sinon.assert.calledWith(sizeOfStub, metaData.coverImage.url);
@@ -133,10 +125,6 @@ describe('getImageDimensions', function () {
             width: 480,
             height: 480,
             type: 'jpg'
-        });
-
-        getImageDimensions.__set__('imageSizeCache', {
-            getCachedImageSizeFromUrl: sizeOfStub
         });
 
         const result = await getImageDimensions(metaData);
@@ -185,10 +173,6 @@ describe('getImageDimensions', function () {
             width: 80,
             height: 480,
             type: 'jpg'
-        });
-
-        getImageDimensions.__set__('imageSizeCache', {
-            getCachedImageSizeFromUrl: sizeOfStub
         });
 
         const result = await getImageDimensions(metaData);
@@ -245,10 +229,6 @@ describe('getImageDimensions', function () {
             type: 'jpg'
         }));
 
-        getImageDimensions.__set__('imageSizeCache', {
-            getCachedImageSizeFromUrl: sizeOfStub
-        });
-
         const result = await getImageDimensions(metaData);
         assertExists(result);
         sinon.assert.calledWith(sizeOfStub, originalMetaData.coverImage.url);
@@ -301,10 +281,6 @@ describe('getImageDimensions', function () {
             type: 'jpg'
         }));
 
-        getImageDimensions.__set__('imageSizeCache', {
-            getCachedImageSizeFromUrl: sizeOfStub
-        });
-
         const result = await getImageDimensions(metaData);
         assertExists(result);
         assert('url' in result.coverImage);
@@ -343,10 +319,6 @@ describe('getImageDimensions', function () {
             height: 1200,
             type: 'jpg'
         }));
-
-        getImageDimensions.__set__('imageSizeCache', {
-            getCachedImageSizeFromUrl: sizeOfStub
-        });
 
         const result = await getImageDimensions(metaData);
         assertExists(result);

--- a/ghost/core/test/unit/frontend/services/rendering/templates.test.js
+++ b/ghost/core/test/unit/frontend/services/rendering/templates.test.js
@@ -1,14 +1,13 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
 const sinon = require('sinon');
-const rewire = require('rewire');
-const templates = rewire('../../../../../core/frontend/services/rendering/templates');
+const templates = require('../../../../../core/frontend/services/rendering/templates');
 const themeEngine = require('../../../../../core/frontend/services/theme-engine');
 
 describe('templates', function () {
     let getActiveThemeStub;
     let hasTemplateStub;
-    let _private = templates.__get__('_private');
+    let templateHelpers = templates;
 
     afterEach(function () {
         sinon.restore();
@@ -16,42 +15,42 @@ describe('templates', function () {
 
     describe('[private fn] getEntriesTemplateHierarchy', function () {
         it('should return just index for empty options', function () {
-            assert.deepEqual(_private.getEntriesTemplateHierarchy({}), ['index']);
+            assert.deepEqual(templateHelpers.getEntriesTemplateHierarchy({}), ['index']);
         });
 
         it('should return just index if collection name is index', function () {
-            assert.deepEqual(_private.getEntriesTemplateHierarchy({name: 'index'}), ['index']);
+            assert.deepEqual(templateHelpers.getEntriesTemplateHierarchy({name: 'index'}), ['index']);
         });
 
         it('should return custom templates even if the collection is index', function () {
-            assert.deepEqual(_private.getEntriesTemplateHierarchy({name: 'index', templates: ['something']}), ['something', 'index']);
+            assert.deepEqual(templateHelpers.getEntriesTemplateHierarchy({name: 'index', templates: ['something']}), ['something', 'index']);
         });
 
         it('should return collection name', function () {
-            assert.deepEqual(_private.getEntriesTemplateHierarchy({name: 'podcast'}), ['podcast', 'index']);
+            assert.deepEqual(templateHelpers.getEntriesTemplateHierarchy({name: 'podcast'}), ['podcast', 'index']);
         });
 
         it('should return custom templates', function () {
-            assert.deepEqual(_private.getEntriesTemplateHierarchy({name: 'podcast', templates: ['mozart']}), ['mozart', 'podcast', 'index']);
+            assert.deepEqual(templateHelpers.getEntriesTemplateHierarchy({name: 'podcast', templates: ['mozart']}), ['mozart', 'podcast', 'index']);
         });
 
         it('should return just index if collection name is index even if slug is set', function () {
-            assert.deepEqual(_private.getEntriesTemplateHierarchy({name: 'index', slugTemplate: true}, {slugParam: 'test'}), ['index']);
+            assert.deepEqual(templateHelpers.getEntriesTemplateHierarchy({name: 'index', slugTemplate: true}, {slugParam: 'test'}), ['index']);
         });
 
         it('should return collection, index if collection has name', function () {
-            assert.deepEqual(_private.getEntriesTemplateHierarchy({name: 'tag'}), ['tag', 'index']);
+            assert.deepEqual(templateHelpers.getEntriesTemplateHierarchy({name: 'tag'}), ['tag', 'index']);
         });
 
         it('should return collection-slug, collection, index if collection has name & slug + slugTemplate set', function () {
-            assert.deepEqual(_private.getEntriesTemplateHierarchy({
+            assert.deepEqual(templateHelpers.getEntriesTemplateHierarchy({
                 name: 'tag',
                 slugTemplate: true
             }, {slugParam: 'test'}), ['tag-test', 'tag', 'index']);
         });
 
         it('should return front, collection-slug, collection, index if name, slugParam+slugTemplate & frontPageTemplate+pageParam=1 is set', function () {
-            assert.deepEqual(_private.getEntriesTemplateHierarchy({
+            assert.deepEqual(templateHelpers.getEntriesTemplateHierarchy({
                 name: 'tag',
                 slugTemplate: true,
                 frontPageTemplate: 'front-tag'
@@ -59,14 +58,14 @@ describe('templates', function () {
         });
 
         it('should return home, index for index collection if front is set and pageParam = 1', function () {
-            assert.deepEqual(_private.getEntriesTemplateHierarchy({
+            assert.deepEqual(templateHelpers.getEntriesTemplateHierarchy({
                 name: 'index',
                 frontPageTemplate: 'home'
             }, {path: '/'}), ['home', 'index']);
         });
 
         it('should not use frontPageTemplate if not / collection', function () {
-            assert.deepEqual(_private.getEntriesTemplateHierarchy({
+            assert.deepEqual(templateHelpers.getEntriesTemplateHierarchy({
                 name: 'index',
                 frontPageTemplate: 'home'
             }, {path: '/magic/'}), ['index']);
@@ -85,13 +84,13 @@ describe('templates', function () {
         it('returns fallback if there is no active_theme', function () {
             getActiveThemeStub.returns(undefined);
 
-            assert.equal(_private.pickTemplate(['tag-test', 'tag', 'index'], 'fallback'), 'fallback');
-            assert.equal(_private.pickTemplate(['page-my-post', 'page', 'post'], 'fallback'), 'fallback');
+            assert.equal(templateHelpers.pickTemplate(['tag-test', 'tag', 'index'], 'fallback'), 'fallback');
+            assert.equal(templateHelpers.pickTemplate(['page-my-post', 'page', 'post'], 'fallback'), 'fallback');
         });
 
         it('returns fallback if active_theme has no templates', function () {
-            assert.equal(_private.pickTemplate(['tag-test', 'tag', 'index'], 'fallback'), 'fallback');
-            assert.equal(_private.pickTemplate(['page-about', 'page', 'post'], 'fallback'), 'fallback');
+            assert.equal(templateHelpers.pickTemplate(['tag-test', 'tag', 'index'], 'fallback'), 'fallback');
+            assert.equal(templateHelpers.pickTemplate(['page-about', 'page', 'post'], 'fallback'), 'fallback');
         });
 
         describe('with many templates', function () {
@@ -105,14 +104,14 @@ describe('templates', function () {
             });
 
             it('returns first matching template', function () {
-                assert.equal(_private.pickTemplate(['page-about', 'page', 'post'], 'fallback'), 'page-about');
-                assert.equal(_private.pickTemplate(['page-magic', 'page', 'post'], 'fallback'), 'page');
-                assert.equal(_private.pickTemplate(['page', 'post'], 'fallback'), 'page');
+                assert.equal(templateHelpers.pickTemplate(['page-about', 'page', 'post'], 'fallback'), 'page-about');
+                assert.equal(templateHelpers.pickTemplate(['page-magic', 'page', 'post'], 'fallback'), 'page');
+                assert.equal(templateHelpers.pickTemplate(['page', 'post'], 'fallback'), 'page');
             });
 
             it('returns correctly if template list is a string', function () {
-                assert.equal(_private.pickTemplate('subscribe', 'fallback'), 'fallback');
-                assert.equal(_private.pickTemplate('post', 'fallback'), 'post');
+                assert.equal(templateHelpers.pickTemplate('subscribe', 'fallback'), 'fallback');
+                assert.equal(templateHelpers.pickTemplate('post', 'fallback'), 'post');
             });
         });
     });
@@ -129,7 +128,7 @@ describe('templates', function () {
         it('will fall back to post even if no index.hbs', function () {
             hasTemplateStub.returns(false);
 
-            const view = _private.getTemplateForEntry({title: 'hey'}, 'page');
+            const view = templateHelpers.getTemplateForEntry({title: 'hey'}, 'page');
             assertExists(view);
             assert.equal(view, 'post');
         });
@@ -145,7 +144,7 @@ describe('templates', function () {
             });
 
             it('post without custom slug template', function () {
-                const view = _private.getTemplateForEntry({
+                const view = templateHelpers.getTemplateForEntry({
                     page: 0,
                     slug: 'test-post'
                 });
@@ -155,7 +154,7 @@ describe('templates', function () {
 
             it('post with custom slug template', function () {
                 hasTemplateStub.withArgs('post-welcome-to-ghost').returns(true);
-                const view = _private.getTemplateForEntry({
+                const view = templateHelpers.getTemplateForEntry({
                     page: 0,
                     slug: 'welcome-to-ghost'
                 });
@@ -164,7 +163,7 @@ describe('templates', function () {
             });
 
             it('page without custom slug template', function () {
-                const view = _private.getTemplateForEntry({
+                const view = templateHelpers.getTemplateForEntry({
                     slug: 'contact'
                 }, 'page');
                 assertExists(view);
@@ -172,7 +171,7 @@ describe('templates', function () {
             });
 
             it('page with custom slug template', function () {
-                const view = _private.getTemplateForEntry({
+                const view = templateHelpers.getTemplateForEntry({
                     slug: 'about'
                 }, 'page');
                 assertExists(view);
@@ -182,7 +181,7 @@ describe('templates', function () {
             it('post with custom template', function () {
                 hasTemplateStub.withArgs('custom-about').returns(true);
 
-                const view = _private.getTemplateForEntry({
+                const view = templateHelpers.getTemplateForEntry({
                     page: 0,
                     custom_template: 'custom-about'
                 });
@@ -193,7 +192,7 @@ describe('templates', function () {
             it('page with custom template', function () {
                 hasTemplateStub.withArgs('custom-about').returns(true);
 
-                const view = _private.getTemplateForEntry({
+                const view = templateHelpers.getTemplateForEntry({
                     page: 1,
                     custom_template: 'custom-about'
                 });
@@ -204,7 +203,7 @@ describe('templates', function () {
             it('post with custom template configured, but the template is missing', function () {
                 hasTemplateStub.withArgs('custom-about').returns(false);
 
-                const view = _private.getTemplateForEntry({
+                const view = templateHelpers.getTemplateForEntry({
                     page: 0,
                     custom_template: 'custom-about'
                 });
@@ -215,7 +214,7 @@ describe('templates', function () {
             it('page with custom template configured, but the template is missing', function () {
                 hasTemplateStub.withArgs('custom-about').returns(false);
 
-                const view = _private.getTemplateForEntry({
+                const view = templateHelpers.getTemplateForEntry({
                     custom_template: 'custom-about'
                 }, 'page');
                 assertExists(view);
@@ -226,7 +225,7 @@ describe('templates', function () {
                 hasTemplateStub.withArgs('custom-about').returns(true);
                 hasTemplateStub.withArgs('post-about').returns(true);
 
-                const view = _private.getTemplateForEntry({
+                const view = templateHelpers.getTemplateForEntry({
                     page: 0,
                     slug: 'about',
                     custom_template: 'custom-about'
@@ -239,7 +238,7 @@ describe('templates', function () {
                 hasTemplateStub.withArgs('custom-about').returns(false);
                 hasTemplateStub.withArgs('post-about').returns(false);
 
-                const view = _private.getTemplateForEntry({
+                const view = templateHelpers.getTemplateForEntry({
                     page: 0,
                     slug: 'about',
                     custom_template: 'custom-about'
@@ -266,7 +265,7 @@ describe('templates', function () {
             });
 
             it('will return correct view for a tag', function () {
-                const view = _private.getTemplateForEntries({name: 'tag', slugTemplate: true}, {slugParam: 'development'});
+                const view = templateHelpers.getTemplateForEntries({name: 'tag', slugTemplate: true}, {slugParam: 'development'});
                 assertExists(view);
                 assert.equal(view, 'index');
             });
@@ -281,20 +280,20 @@ describe('templates', function () {
             });
 
             it('will return correct view for a tag when template exists', function () {
-                const view = _private.getTemplateForEntries({name: 'tag', slugTemplate: true}, {slugParam: 'design'});
+                const view = templateHelpers.getTemplateForEntries({name: 'tag', slugTemplate: true}, {slugParam: 'design'});
                 assertExists(view);
                 assert.equal(view, 'tag-design');
             });
 
             it('will return correct view for a tag', function () {
-                const view = _private.getTemplateForEntries({name: 'tag', slugTemplate: true}, {slugParam: 'development'});
+                const view = templateHelpers.getTemplateForEntries({name: 'tag', slugTemplate: true}, {slugParam: 'development'});
                 assertExists(view);
                 assert.equal(view, 'tag');
             });
         });
 
         it('will fall back to index even if no index.hbs', function () {
-            const view = _private.getTemplateForEntries({name: 'tag', slugTemplate: true}, {slugParam: 'development'});
+            const view = templateHelpers.getTemplateForEntries({name: 'tag', slugTemplate: true}, {slugParam: 'development'});
             assertExists(view);
             assert.equal(view, 'index');
         });
@@ -312,33 +311,33 @@ describe('templates', function () {
         it('will fall back to default if there is no active_theme', function () {
             getActiveThemeStub.returns(undefined);
 
-            assert.match(_private.getTemplateForError(500), /core\/server\/views\/error.hbs$/);
+            assert.match(templateHelpers.getTemplateForError(500), /core\/server\/views\/error.hbs$/);
         });
 
         it('will fall back to default for all statusCodes with no custom error templates', function () {
-            assert.match(_private.getTemplateForError(500), /core\/server\/views\/error.hbs$/);
-            assert.match(_private.getTemplateForError(503), /core\/server\/views\/error.hbs$/);
-            assert.match(_private.getTemplateForError(422), /core\/server\/views\/error.hbs$/);
-            assert.match(_private.getTemplateForError(404), /core\/server\/views\/error.hbs$/);
+            assert.match(templateHelpers.getTemplateForError(500), /core\/server\/views\/error.hbs$/);
+            assert.match(templateHelpers.getTemplateForError(503), /core\/server\/views\/error.hbs$/);
+            assert.match(templateHelpers.getTemplateForError(422), /core\/server\/views\/error.hbs$/);
+            assert.match(templateHelpers.getTemplateForError(404), /core\/server\/views\/error.hbs$/);
         });
 
         it('will use custom error.hbs for all statusCodes if there are no other templates', function () {
             hasTemplateStub.withArgs('error').returns(true);
 
-            assert.equal(_private.getTemplateForError(500), 'error');
-            assert.equal(_private.getTemplateForError(503), 'error');
-            assert.equal(_private.getTemplateForError(422), 'error');
-            assert.equal(_private.getTemplateForError(404), 'error');
+            assert.equal(templateHelpers.getTemplateForError(500), 'error');
+            assert.equal(templateHelpers.getTemplateForError(503), 'error');
+            assert.equal(templateHelpers.getTemplateForError(422), 'error');
+            assert.equal(templateHelpers.getTemplateForError(404), 'error');
         });
 
         it('will use more specific error-4xx.hbs for all 4xx statusCodes if available', function () {
             hasTemplateStub.withArgs('error').returns(true);
             hasTemplateStub.withArgs('error-4xx').returns(true);
 
-            assert.equal(_private.getTemplateForError(500), 'error');
-            assert.equal(_private.getTemplateForError(503), 'error');
-            assert.equal(_private.getTemplateForError(422), 'error-4xx');
-            assert.equal(_private.getTemplateForError(404), 'error-4xx');
+            assert.equal(templateHelpers.getTemplateForError(500), 'error');
+            assert.equal(templateHelpers.getTemplateForError(503), 'error');
+            assert.equal(templateHelpers.getTemplateForError(422), 'error-4xx');
+            assert.equal(templateHelpers.getTemplateForError(404), 'error-4xx');
         });
 
         it('will use explicit error-404.hbs for 404 statusCode if available', function () {
@@ -346,10 +345,10 @@ describe('templates', function () {
             hasTemplateStub.withArgs('error-4xx').returns(true);
             hasTemplateStub.withArgs('error-404').returns(true);
 
-            assert.equal(_private.getTemplateForError(500), 'error');
-            assert.equal(_private.getTemplateForError(503), 'error');
-            assert.equal(_private.getTemplateForError(422), 'error-4xx');
-            assert.equal(_private.getTemplateForError(404), 'error-404');
+            assert.equal(templateHelpers.getTemplateForError(500), 'error');
+            assert.equal(templateHelpers.getTemplateForError(503), 'error');
+            assert.equal(templateHelpers.getTemplateForError(422), 'error-4xx');
+            assert.equal(templateHelpers.getTemplateForError(404), 'error-404');
         });
 
         it('cascade works the same for 500 errors', function () {
@@ -357,10 +356,10 @@ describe('templates', function () {
             hasTemplateStub.withArgs('error-5xx').returns(true);
             hasTemplateStub.withArgs('error-503').returns(true);
 
-            assert.equal(_private.getTemplateForError(500), 'error-5xx');
-            assert.equal(_private.getTemplateForError(503), 'error-503');
-            assert.equal(_private.getTemplateForError(422), 'error');
-            assert.equal(_private.getTemplateForError(404), 'error');
+            assert.equal(templateHelpers.getTemplateForError(500), 'error-5xx');
+            assert.equal(templateHelpers.getTemplateForError(503), 'error-503');
+            assert.equal(templateHelpers.getTemplateForError(422), 'error');
+            assert.equal(templateHelpers.getTemplateForError(404), 'error');
         });
 
         it('cascade works with many specific templates', function () {
@@ -370,12 +369,12 @@ describe('templates', function () {
             hasTemplateStub.withArgs('error-4xx').returns(true);
             hasTemplateStub.withArgs('error-404').returns(true);
 
-            assert.equal(_private.getTemplateForError(500), 'error-5xx');
-            assert.equal(_private.getTemplateForError(503), 'error-503');
-            assert.equal(_private.getTemplateForError(422), 'error-4xx');
-            assert.equal(_private.getTemplateForError(404), 'error-404');
-            assert.equal(_private.getTemplateForError(401), 'error-4xx');
-            assert.equal(_private.getTemplateForError(501), 'error-5xx');
+            assert.equal(templateHelpers.getTemplateForError(500), 'error-5xx');
+            assert.equal(templateHelpers.getTemplateForError(503), 'error-503');
+            assert.equal(templateHelpers.getTemplateForError(422), 'error-4xx');
+            assert.equal(templateHelpers.getTemplateForError(404), 'error-404');
+            assert.equal(templateHelpers.getTemplateForError(401), 'error-4xx');
+            assert.equal(templateHelpers.getTemplateForError(501), 'error-5xx');
         });
     });
 
@@ -392,10 +391,10 @@ describe('templates', function () {
             };
             data = {};
 
-            stubs.pickTemplate = sinon.stub(_private, 'pickTemplate').returns('testFromPickTemplate');
-            stubs.getTemplateForEntry = sinon.stub(_private, 'getTemplateForEntry').returns('testFromEntry');
-            stubs.getTemplateForEntries = sinon.stub(_private, 'getTemplateForEntries').returns('testFromEntries');
-            stubs.getTemplateForError = sinon.stub(_private, 'getTemplateForError').returns('testFromError');
+            stubs.pickTemplate = sinon.stub(templates, 'pickTemplate').returns('testFromPickTemplate');
+            stubs.getTemplateForEntry = sinon.stub(templates, 'getTemplateForEntry').returns('testFromEntry');
+            stubs.getTemplateForEntries = sinon.stub(templates, 'getTemplateForEntries').returns('testFromEntries');
+            stubs.getTemplateForError = sinon.stub(templates, 'getTemplateForError').returns('testFromError');
         });
 
         it('does nothing if template is already set', function () {

--- a/ghost/core/test/unit/frontend/services/rss/cache.test.js
+++ b/ghost/core/test/unit/frontend/services/rss/cache.test.js
@@ -1,24 +1,22 @@
 const assert = require('node:assert/strict');
+const crypto = require('crypto');
 const sinon = require('sinon');
-const rewire = require('rewire');
+const logging = require('@tryghost/logging');
 const configUtils = require('../../../../utils/config-utils');
-const rssCache = rewire('../../../../../core/frontend/services/rss/cache');
+const rssCache = require('../../../../../core/frontend/services/rss/cache');
 
 describe('RSS: Cache', function () {
-    let generateSpy;
-    let generateFeedReset;
+    let loggingInfoSpy;
 
     afterEach(async function () {
         await configUtils.restore();
         sinon.restore();
-        generateFeedReset();
     });
 
     beforeEach(function () {
         configUtils.set({url: 'http://my-ghost-blog.com'});
 
-        generateSpy = sinon.spy(rssCache.__get__('generateFeed'));
-        generateFeedReset = rssCache.__set__('generateFeed', generateSpy);
+        loggingInfoSpy = sinon.spy(logging, 'info');
     });
 
     it('should not rebuild xml for same data and url', async function () {
@@ -30,20 +28,20 @@ describe('RSS: Cache', function () {
         };
         let xmlData1;
 
-        const _xmlData = await rssCache.getXML('/rss/', data);
+        const baseUrl = `/rss-${crypto.randomUUID()}/`;
+
+        const _xmlData = await rssCache.getXML(baseUrl, data);
 
         xmlData1 = _xmlData;
 
-        // We should have called generateFeed
-        sinon.assert.calledOnce(generateSpy);
+        sinon.assert.notCalled(loggingInfoSpy);
 
         // Call RSS again to check that we didn't rebuild
-        const xmlData2 = await rssCache.getXML('/rss/', data);
+        const xmlData2 = await rssCache.getXML(baseUrl, data);
 
         // Assertions
 
-        // We should not have called generateFeed again
-        sinon.assert.calledOnce(generateSpy);
+        sinon.assert.calledOnce(loggingInfoSpy);
 
         // The data should be identical, no changing lastBuildDate
         assert.equal(xmlData1, xmlData2);

--- a/ghost/core/test/unit/server/services/invitations/accept.test.js
+++ b/ghost/core/test/unit/server/services/invitations/accept.test.js
@@ -1,9 +1,9 @@
 const assert = require('assert/strict');
 const sinon = require('sinon');
-const rewire = require('rewire');
+const accept = require('../../../../../core/server/services/invitations/accept');
+const models = require('../../../../../core/server/models');
 
 describe('Unit: services/invitations/accept', function () {
-    let accept;
     let transactionStub;
     let findOneInviteStub;
     let findOneUserStub;
@@ -32,12 +32,10 @@ describe('Unit: services/invitations/accept', function () {
             return cb('fake-txn');
         });
 
-        accept = rewire('../../../../../core/server/services/invitations/accept');
-        accept.__set__('models', {
-            Base: {transaction: transactionStub},
-            Invite: {findOne: findOneInviteStub},
-            User: {findOne: findOneUserStub, add: addUserStub}
-        });
+        sinon.stub(models.Base, 'transaction').callsFake(transactionStub);
+        sinon.stub(models.Invite, 'findOne').callsFake(findOneInviteStub);
+        sinon.stub(models.User, 'findOne').callsFake(findOneUserStub);
+        sinon.stub(models.User, 'add').callsFake(addUserStub);
     });
 
     afterEach(function () {

--- a/ghost/core/test/unit/server/services/limits.test.js
+++ b/ghost/core/test/unit/server/services/limits.test.js
@@ -1,8 +1,7 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
-const rewire = require('rewire');
 
-const limits = rewire('../../../../core/server/services/limits');
+const limits = require('../../../../core/server/services/limits');
 const configUtils = require('../../../utils/config-utils');
 const logging = require('@tryghost/logging');
 
@@ -16,7 +15,7 @@ describe('Limit Service Init', function () {
         loggerStub = sinon.spy(logging);
         limitServiceStub = sinon.stub();
 
-        limits.__set__('limitService.loadLimits', limitServiceStub);
+        sinon.stub(limits, 'loadLimits').callsFake(limitServiceStub);
 
         configUtils.set({
             hostSettings: {}

--- a/ghost/core/test/unit/server/services/route-settings/settings-loader.test.js
+++ b/ghost/core/test/unit/server/services/route-settings/settings-loader.test.js
@@ -1,11 +1,10 @@
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
 const sinon = require('sinon');
-const rewire = require('rewire');
 const fs = require('fs-extra');
 const path = require('path');
 const errors = require('@tryghost/errors');
-const SettingsLoader = rewire('../../../../../core/server/services/route-settings/settings-loader');
+const SettingsLoader = require('../../../../../core/server/services/route-settings/settings-loader');
 
 describe('UNIT > SettingsLoader:', function () {
     afterEach(function () {
@@ -25,11 +24,8 @@ describe('UNIT > SettingsLoader:', function () {
         };
 
         let yamlParserStub;
-        let validateStub;
-
         beforeEach(function () {
             yamlParserStub = sinon.stub();
-            validateStub = sinon.stub();
         });
 
         it('reads a settings object for routes.yaml file', async function () {
@@ -65,9 +61,6 @@ describe('UNIT > SettingsLoader:', function () {
             const expectedSettingsFile = path.join(storageFolderPath, 'routes.yaml');
 
             yamlParserStub.returns(yamlStubFile);
-            validateStub.returns({routes: {}, collections: {}, taxonomies: {}});
-
-            SettingsLoader.__set__('validate', validateStub);
 
             const settingsLoader = new SettingsLoader({
                 parseYaml: yamlParserStub,

--- a/ghost/core/test/unit/server/web/api/middleware/cors.test.js
+++ b/ghost/core/test/unit/server/web/api/middleware/cors.test.js
@@ -1,10 +1,9 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
-const rewire = require('rewire');
 const configUtils = require('../../../../../utils/config-utils');
 
-let cors = rewire('../../../../../../core/server/web/api/middleware/cors').corsMiddleware;
-const {corsCaching} = rewire('../../../../../../core/server/web/api/middleware/cors');
+const apiCors = require('../../../../../../core/server/web/api/middleware/cors');
+const {corsMiddleware: cors, corsCaching} = apiCors;
 
 describe('cors', function () {
     let res;
@@ -37,7 +36,7 @@ describe('cors', function () {
     afterEach(async function () {
         sinon.restore();
         await configUtils.restore();
-        cors = rewire('../../../../../../core/server/web/api/middleware/cors').corsMiddleware;
+        apiCors.resetAllowlist();
     });
 
     it('should not be enabled without a request origin header', function () {

--- a/ghost/core/test/unit/server/web/members/middleware/cors.test.js
+++ b/ghost/core/test/unit/server/web/members/middleware/cors.test.js
@@ -1,9 +1,8 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
-const rewire = require('rewire');
 const configUtils = require('../../../../../utils/config-utils');
 
-let cors = rewire('../../../../../../core/server/web/members/middleware/cors');
+const cors = require('../../../../../../core/server/web/members/middleware/cors');
 
 describe('members cors middleware', function () {
     let res;
@@ -36,7 +35,6 @@ describe('members cors middleware', function () {
     afterEach(async function () {
         sinon.restore();
         await configUtils.restore();
-        cors = rewire('../../../../../../core/server/web/members/middleware/cors');
     });
 
     it('should return wildcard without a request origin header', function () {

--- a/ghost/core/test/unit/server/web/shared/middleware/url-redirects.test.js
+++ b/ghost/core/test/unit/server/web/shared/middleware/url-redirects.test.js
@@ -1,11 +1,8 @@
 const sinon = require('sinon');
-const rewire = require('rewire');
 const configUtils = require('../../../../../utils/config-utils');
-const urlRedirects = rewire('../../../../../../core/server/web/shared/middleware/url-redirects');
+const urlRedirects = require('../../../../../../core/server/web/shared/middleware/url-redirects');
 const {frontendSSLRedirect, adminSSLAndHostRedirect} = urlRedirects;
-const getAdminRedirectUrl = urlRedirects.__get__('_private.getAdminRedirectUrl');
-const getFrontendRedirectUrl = urlRedirects.__get__('_private.getFrontendRedirectUrl');
-const redirect = urlRedirects.__get__('_private.redirect');
+const {getAdminRedirectUrl, getFrontendRedirectUrl, redirect} = urlRedirects;
 
 describe('UNIT: url redirects', function () {
     let res;
@@ -33,12 +30,12 @@ describe('UNIT: url redirects', function () {
         host = null;
     });
 
-    describe('calls to _private.redirect()', function () {
+    describe('calls to exported redirect()', function () {
         let redirectSpy;
 
         beforeEach(function () {
             redirectSpy = sinon.spy();
-            urlRedirects.__set__('_private.redirect', redirectSpy);
+            sinon.stub(urlRedirects, 'redirect').callsFake(redirectSpy);
         });
 
         it('frontendSSLRedirect passes getSiteRedirectUrl', function () {

--- a/ghost/core/test/unit/shared/config/loader.test.js
+++ b/ghost/core/test/unit/shared/config/loader.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
 const path = require('path');
-const rewire = require('rewire');
 const _ = require('lodash');
 const configUtils = require('../../../utils/config-utils');
 const sinon = require('sinon');
@@ -24,7 +23,7 @@ describe('Config Loader', function () {
         beforeEach(function () {
             originalEnv = _.clone(process.env);
             originalArgv = _.clone(process.argv);
-            loader = rewire('../../../../core/shared/config/loader');
+            loader = require('../../../../core/shared/config/loader');
             nodeEnvStub = sinon.stub(localUtils, 'getNodeEnv').returns('testing');
             // we manually call `loadConf` in the tests and we need to ensure that the minimum
             // required config properties are available

--- a/ghost/core/test/unit/shared/max-limit-cap.test.js
+++ b/ghost/core/test/unit/shared/max-limit-cap.test.js
@@ -1,15 +1,9 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
-const rewire = require('rewire');
 const configUtils = require('../../utils/config-utils');
+const maxLimitCap = require('../../../core/shared/max-limit-cap');
 
 describe('Shared Max Limit Cap', function () {
-    let maxLimitCap;
-
-    beforeEach(function () {
-        maxLimitCap = rewire('../../../core/shared/max-limit-cap');
-    });
-
     afterEach(function () {
         sinon.restore();
         return configUtils.restore();
@@ -25,8 +19,6 @@ describe('Shared Max Limit Cap', function () {
         it('reads from config dynamically', function () {
             configUtils.set('optimization:allowLimitAll', true);
             configUtils.set('optimization:maxLimit', 50);
-
-            maxLimitCap = rewire('../../../core/shared/max-limit-cap');
 
             assert.equal(maxLimitCap.limitConfig.allowLimitAll, true);
             assert.equal(maxLimitCap.limitConfig.maxLimit, 50);


### PR DESCRIPTION
## Summary
- removed rewire from 13 low-risk Vitest unit test files
- replaced hidden rewire access with real exported object boundaries where stubbing is still needed
- avoided new `_private` exports and `delete require.cache` patterns

## Tests
- `pnpm --dir ghost/core test:vitest test/unit/api/endpoints/members.test.js test/unit/shared/max-limit-cap.test.js`
- `pnpm --dir ghost/core test:vitest test/unit/server/services/limits.test.js test/unit/shared/max-limit-cap.test.js test/unit/server/services/route-settings/settings-loader.test.js test/unit/frontend/services/rendering/templates.test.js test/unit/server/web/shared/middleware/url-redirects.test.js test/unit/shared/config/loader.test.js test/unit/server/web/members/middleware/cors.test.js test/unit/server/web/api/middleware/cors.test.js test/unit/server/services/invitations/accept.test.js test/unit/api/endpoints/members.test.js test/unit/frontend/meta/canonical-url.test.js test/unit/frontend/services/rss/cache.test.js test/unit/frontend/meta/image-dimensions.test.js`
- `pnpm --dir ghost/core test:vitest test/unit/frontend/meta/structured-data.test.js`