### PR TITLE
Fixed broken analytics layout on mobile devices

### DIFF
--- a/apps/shade/src/components/ui/metric-value.tsx
+++ b/apps/shade/src/components/ui/metric-value.tsx
@@ -50,7 +50,7 @@ const MetricValue = React.forwardRef<HTMLDivElement, MetricValueProps>(
                         {label}
                     </div>
                 )}
-                <div className='flex flex-col items-start gap-2 lg:flex-row xl:gap-3'>
+                <div className='flex flex-row flex-wrap items-center gap-2 xl:gap-3'>
                     <div
                         className={metricValueNumberVariants({size})}
                         data-slot='metric-value-number'

--- a/apps/stats/src/components/layout/main-layout.tsx
+++ b/apps/stats/src/components/layout/main-layout.tsx
@@ -4,7 +4,7 @@ const MainLayout: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children, .
     return (
         <div className='size-full'>
             <div className='relative size-full' {...props}>
-                <div className='mx-auto flex size-full max-w-page flex-col'>
+                <div className='mx-auto flex size-full max-w-page min-w-0 flex-col'>
                     {children}
                 </div>
             </div>

--- a/apps/stats/src/views/Stats/Growth/components/growth-kpis.tsx
+++ b/apps/stats/src/views/Stats/Growth/components/growth-kpis.tsx
@@ -248,7 +248,7 @@ const GrowthKPIs: React.FC<{
         );
     }
 
-    const areaChartClassname = '-mb-3 h-[16vw] max-h-[320px] w-full min-h-[180px]';
+    const areaChartClassname = '-mb-3 h-[16vw] max-h-[320px] w-full min-w-0 min-h-[180px]';
 
     return (
         <Tabs defaultValue={validatedInitialTab} variant='kpis'>
@@ -355,7 +355,7 @@ const GrowthKPIs: React.FC<{
                     </DropdownMenuContent>
                 </DropdownMenu>
             }
-            <div className='my-4 [&_.recharts-cartesian-axis-tick-value]:fill-gray-500'>
+            <div className='my-4 min-w-0 [&_.recharts-cartesian-axis-tick-value]:fill-gray-500'>
                 <GhAreaChart
                     className={areaChartClassname}
                     color={tabConfig[currentTab].color}

--- a/apps/stats/src/views/Stats/Growth/components/new-subscribers-cadence.tsx
+++ b/apps/stats/src/views/Stats/Growth/components/new-subscribers-cadence.tsx
@@ -232,15 +232,15 @@ const NewSubscribersCadence: React.FC<NewSubscribersCadenceProps> = ({isLoading,
     const hasData = chartData.length > 0 && totalSignups > 0;
 
     return (
-        <Card>
+        <Card className='w-full max-w-full min-w-0'>
             <CardHeader>
-                <div className="flex items-start justify-between gap-1.5">
-                    <div className='flex flex-col gap-1.5'>
+                <div className="flex min-w-0 flex-wrap items-start justify-between gap-1.5">
+                    <div className='flex min-w-0 flex-col gap-1.5'>
                         <CardTitle>Paid subscription breakdown</CardTitle>
                         <CardDescription>New paid subscriptions {getPeriodText(range)}</CardDescription>
                     </div>
                     {availableTiers.length > 1 && (
-                        <div>
+                        <div className='shrink-0'>
                             <Select value={breakdownType} onValueChange={value => setBreakdownType(value as BreakdownType)}>
                                 <SelectTrigger className="w-full">
                                     <SelectValue />
@@ -254,11 +254,11 @@ const NewSubscribersCadence: React.FC<NewSubscribersCadenceProps> = ({isLoading,
                     )}
                 </div>
             </CardHeader>
-            <CardContent>
+            <CardContent className='min-w-0'>
                 {hasData ? (
                     <>
                         <ChartContainer
-                            className="mx-auto aspect-square h-[250px] min-h-[250px] w-full"
+                            className="mx-auto aspect-square h-[250px] min-h-[250px] w-full min-w-0"
                             config={chartConfig}
                         >
                             <Recharts.PieChart>

--- a/apps/stats/src/views/Stats/Growth/components/paid-subscription-change-chart.tsx
+++ b/apps/stats/src/views/Stats/Growth/components/paid-subscription-change-chart.tsx
@@ -344,15 +344,15 @@ const PaidMembersChangeChart: React.FC<PaidMembersChangeChartProps> = ({
     };
 
     return (
-        <Card data-testid='paid-members-change-card'>
+        <Card className='w-full max-w-full min-w-0' data-testid='paid-members-change-card'>
             <CardHeader>
-                <div className="flex items-start justify-between gap-1.5">
-                    <div className='flex flex-col gap-1.5'>
+                <div className="flex min-w-0 flex-wrap items-start justify-between gap-1.5">
+                    <div className='flex min-w-0 flex-col gap-1.5'>
                         <CardTitle>Paid subscriptions</CardTitle>
                         <CardDescription>New and cancelled paid subscriptions {getPeriodText(range)}</CardDescription>
                     </div>
                     {availableResolutions.length > 1 && (
-                        <div>
+                        <div className='shrink-0'>
                             <Select value={selectedResolution} onValueChange={value => setSelectedResolution(value as ResolutionOption)}>
                                 <SelectTrigger className="w-[110px]">
                                     <SelectValue />
@@ -369,10 +369,10 @@ const PaidMembersChangeChart: React.FC<PaidMembersChangeChartProps> = ({
                     )}
                 </div>
             </CardHeader>
-            <CardContent>
+            <CardContent className='min-w-0'>
                 {hasData ? (
-                    <div>
-                        <ChartContainer className='aspect-auto h-[200px] w-full md:h-[220px] xl:h-[260px]' config={paidChangeChartConfig}>
+                    <div className='min-w-0'>
+                        <ChartContainer className='aspect-auto h-[200px] w-full min-w-0 md:h-[220px] xl:h-[260px]' config={paidChangeChartConfig}>
                             <Recharts.BarChart
                                 data={paidChangeChartData}
                                 stackOffset='sign'
@@ -498,7 +498,7 @@ const PaidMembersChangeChart: React.FC<PaidMembersChangeChartProps> = ({
                                 />
                             </Recharts.BarChart>
                         </ChartContainer>
-                        <div className='mt-3 flex items-center justify-center gap-6 text-sm text-muted-foreground'>
+                        <div className='mt-3 flex flex-wrap items-center justify-center gap-x-6 gap-y-1 text-sm text-muted-foreground'>
                             <div className='flex items-center gap-2'>
                                 <span className='size-2 rounded-full opacity-50'
                                     style={{

--- a/apps/stats/src/views/Stats/Growth/growth.tsx
+++ b/apps/stats/src/views/Stats/Growth/growth.tsx
@@ -149,8 +149,8 @@ const Growth: React.FC = () => {
                 </NavbarActions>
             </StatsHeader>
             <StatsView data={isPageLoading ? undefined : chartData} isLoading={false} loadingComponent={<></>}>
-                <Card data-testid='total-members-card'>
-                    <CardContent>
+                <Card className='w-full max-w-full min-w-0' data-testid='total-members-card'>
+                    <CardContent className='min-w-0'>
                         <GrowthKPIs
                             chartData={chartData}
                             currencySymbol={currencySymbol}
@@ -162,7 +162,7 @@ const Growth: React.FC = () => {
                     </CardContent>
                 </Card>
                 {appSettings?.paidMembersEnabled && currentKpiTab === 'paid-members' && (
-                    <div className='grid grid-cols-1 gap-6 lg:grid-cols-2 xl:grid-cols-[2fr_minmax(460px,1fr)]'>
+                    <div className='grid min-w-0 grid-cols-1 gap-6 lg:grid-cols-2 xl:grid-cols-[2fr_minmax(460px,1fr)]'>
                         <PaidMembersChangeChart
                             isLoading={isPageLoading}
                             memberData={chartData}
@@ -172,12 +172,12 @@ const Growth: React.FC = () => {
                         <NewSubscribersCadence isLoading={isPageLoading} range={range} />
                     </div>
                 )}
-                <Card className='w-full overflow-x-auto' data-testid='top-content-card'>
+                <Card className='w-full max-w-full min-w-0 overflow-x-auto' data-testid='top-content-card'>
                     <CardHeader>
                         <CardTitle>{getContentTitle(selectedContentType)}</CardTitle>
                         <CardDescription>{getGrowthContentDescription(selectedContentType, range, getPeriodText)}</CardDescription>
                     </CardHeader>
-                    <CardContent>
+                    <CardContent className='min-w-0'>
                         <Table>
                             <TableHeader>
                                 <TableRow className='[&>th]:h-auto [&>th]:pt-0 [&>th]:pb-2'>

--- a/apps/stats/src/views/Stats/Locations/components/locations-card.tsx
+++ b/apps/stats/src/views/Stats/Locations/components/locations-card.tsx
@@ -173,14 +173,14 @@ const LocationsCard: React.FC<LocationsCardProps> = ({data, isLoading, range, on
     };
 
     return (
-        <Card className='p-0'>
+        <Card className='w-full max-w-full min-w-0 p-0'>
             <CardHeader className='border-b'>
                 <CardTitle>Top Locations</CardTitle>
                 <CardDescription>A geographic breakdown of your readers {getPeriodText(range)}</CardDescription>
             </CardHeader>
-            <CardContent className='p-0'>
-                <div className='flex flex-col lg:grid lg:grid-cols-2 lg:items-stretch'>
-                    <div className='svg-map-container relative mx-auto w-full max-w-[740px] px-8 py-12 [&_.svg-map]:stroke-background'>
+            <CardContent className='min-w-0 p-0'>
+                <div className='flex min-w-0 flex-col lg:grid lg:grid-cols-2 lg:items-stretch'>
+                    <div className='svg-map-container relative mx-auto w-full max-w-[740px] min-w-0 px-8 py-12 [&_.svg-map]:stroke-background'>
                         <SVGMap
                             locationClassName={getLocationClassName}
                             map={World}
@@ -208,7 +208,7 @@ const LocationsCard: React.FC<LocationsCardProps> = ({data, isLoading, range, on
                             </div>
                         )}
                     </div>
-                    <div className='group/datalist flex flex-col justify-between overflow-hidden px-6' data-testid='visitors-card'>
+                    <div className='group/datalist flex min-w-0 flex-col justify-between overflow-hidden px-6' data-testid='visitors-card'>
                         <DataList className='mb-6 grow lg:ml-4'>
                             <DataListHeader className='px-0 pt-8'>
                                 <DataListHead>Country</DataListHead>

--- a/apps/stats/src/views/Stats/Newsletters/components/newsletters-kpis.tsx
+++ b/apps/stats/src/views/Stats/Newsletters/components/newsletters-kpis.tsx
@@ -319,10 +319,10 @@ const NewsletterKPIs: React.FC<{
                     }
                 </DropdownMenuContent>
             </DropdownMenu>
-            <div className='my-4 [&_.recharts-cartesian-axis-tick-value]:fill-gray-500'>
+            <div className='my-4 min-w-0 [&_.recharts-cartesian-axis-tick-value]:fill-gray-500'>
                 {(currentTab === 'total-subscribers') &&
                     <GhAreaChart
-                        className='-mb-3 h-[16vw] max-h-[320px] min-h-[180px] w-full'
+                        className='-mb-3 h-[16vw] max-h-[320px] min-h-[180px] w-full min-w-0'
                         color={tabConfig['total-subscribers'].color}
                         data={subscribersData}
                         id="mrr"
@@ -339,7 +339,7 @@ const NewsletterKPIs: React.FC<{
                             :
                             avgsData && avgsData.length > 0 ?
                                 <>
-                                    <ChartContainer className='aspect-auto h-[200px] w-full md:h-[220px] xl:h-[320px]' config={barChartConfig}>
+                                    <ChartContainer className='aspect-auto h-[200px] w-full min-w-0 md:h-[220px] xl:h-[320px]' config={barChartConfig}>
                                         <Recharts.BarChart
                                             className={isHoveringClickable ? 'cursor-pointer!' : ''}
                                             data={avgsData}

--- a/apps/stats/src/views/Stats/Newsletters/newsletters.tsx
+++ b/apps/stats/src/views/Stats/Newsletters/newsletters.tsx
@@ -204,8 +204,8 @@ const TopNewslettersTable: React.FC<{
     const [sortBy, setSortBy] = useState<TopNewslettersOrder>('open_rate desc');
 
     return (
-        <Card className='w-full max-w-[calc(100vw-64px)] overflow-x-auto sidebar:max-w-[calc(100vw-64px-280px)]' data-testid='top-newsletters-card'>
-            <CardContent>
+        <Card className='w-full max-w-full min-w-0 overflow-x-auto' data-testid='top-newsletters-card'>
+            <CardContent className='min-w-0'>
                 <Table>
                     <NewsletterTableHeader range={range} setSortBy={setSortBy} sortBy={sortBy} />
                     <TableBody>
@@ -383,8 +383,8 @@ const Newsletters: React.FC = () => {
             </StatsHeader>
             <StatsView isLoading={false} loadingComponent={<></>}>
                 <>
-                    <Card data-testid='newsletters-card'>
-                        <CardContent>
+                    <Card className='w-full max-w-full min-w-0' data-testid='newsletters-card'>
+                        <CardContent className='min-w-0'>
                             <NewsletterKPIs
                                 avgsData={avgsData}
                                 initialTab={initialTab}

--- a/apps/stats/src/views/Stats/Overview/components/latest-post.tsx
+++ b/apps/stats/src/views/Stats/Overview/components/latest-post.tsx
@@ -59,21 +59,21 @@ const LatestPost: React.FC<LatestPostProps> = ({
     const shouldGoToEditor = postDestination.startsWith('/editor/');
 
     return (
-        <Card className='group/card bg-gradient-to-tr from-muted/40 to-muted/0 to-50%' data-testid='latest-post'>
+        <Card className='group/card w-full max-w-full min-w-0 bg-gradient-to-tr from-muted/40 to-muted/0 to-50%' data-testid='latest-post'>
             <CardHeader>
                 <CardTitle className='flex items-baseline justify-between leading-snug font-medium text-muted-foreground'>
                     Latest post performance
                 </CardTitle>
                 <CardDescription className='hidden'>How your last post did</CardDescription>
             </CardHeader>
-            <CardContent className='flex flex-col gap-6 px-0 lg:flex-row xl:grid xl:grid-cols-3'>
+            <CardContent className='flex min-w-0 flex-col gap-6 px-0 lg:flex-row xl:grid xl:grid-cols-3'>
                 {isLoading &&
                     <>
-                        <div className='flex w-full items-center gap-6 px-6 xl:col-span-2'>
-                            <div className='w-full max-w-[232px] grow'>
+                        <div className='flex w-full min-w-0 items-center gap-6 px-6 xl:col-span-2'>
+                            <div className='w-full max-w-[232px] min-w-0 grow'>
                                 <Skeleton className='aspect-[16/10] rounded-md' />
                             </div>
-                            <div className='w-full grow'>
+                            <div className='w-full min-w-0 grow'>
                                 <Skeleton className='w-full max-w-[420px]' />
                                 <Skeleton className='w-1/2' />
                             </div>
@@ -102,21 +102,21 @@ const LatestPost: React.FC<LatestPostProps> = ({
                 }
                 {!isLoading && latestPostStats && metricsToShow ? (
                     <>
-                        <div className='flex flex-col gap-6 px-6 transition-all md:flex-row md:items-start xl:col-span-2'>
+                        <div className='flex min-w-0 flex-col gap-6 px-6 transition-all md:flex-row md:items-start xl:col-span-2'>
                             {latestPostStats.feature_image &&
                                     <div className='aspect-[16/10] w-full min-w-[100px] rounded-sm bg-cover bg-center sm:max-w-[170px] lg:max-w-[170px] xl:max-w-[232px]' style={{
                                         backgroundImage: `url(${latestPostStats.feature_image})`
                                     }}></div>
                             }
-                            <div className='flex grow flex-col items-start justify-center self-stretch'>
-                                <div className='text-md leading-tighter font-semibold tracking-tight hover:cursor-pointer hover:opacity-75' onClick={() => {
+                            <div className='flex min-w-0 grow flex-col items-start justify-center self-stretch'>
+                                <div className='max-w-full text-md leading-tighter font-semibold tracking-tight break-words hover:cursor-pointer hover:opacity-75' onClick={() => {
                                     if (!isLoading && latestPostStats) {
                                         navigate(postDestination, {crossApp: true});
                                     }
                                 }}>
                                     {latestPostStats.title}
                                 </div>
-                                <div className='mt-1 text-muted-foreground'>
+                                <div className='mt-1 max-w-full text-muted-foreground'>
                                     {latestPostStats.authors && latestPostStats.authors.length > 0 && (
                                         <div>
                                             By {latestPostStats.authors.map(author => author.name).join(', ')} &ndash; {formatDisplayDate(latestPostStats.published_at, siteTimezone)}
@@ -126,7 +126,7 @@ const LatestPost: React.FC<LatestPostProps> = ({
                                         {getPostStatusText(latestPostStats)}
                                     </div>
                                 </div>
-                                <div className='mt-6 flex items-center gap-2'>
+                                <div className='mt-6 flex max-w-full flex-wrap items-center gap-2'>
                                     {!latestPostStats.email_only && (
                                         <PostShareModal
                                             author={latestPostStats.authors?.map(author => author.name).join(', ') || ''}
@@ -169,8 +169,8 @@ const LatestPost: React.FC<LatestPostProps> = ({
                             </div>
                         </div>
 
-                        <div className='-ml-4 flex w-full flex-col items-stretch gap-2 pr-6 xl:h-full xl:max-w-none'>
-                            <div className='grid grid-cols-2 gap-6 pl-10 lg:border-l xl:h-full'>
+                        <div className='flex w-full min-w-0 flex-col items-stretch gap-2 px-6 lg:-ml-4 lg:pr-6 lg:pl-0 xl:h-full xl:max-w-none'>
+                            <div className='grid min-w-0 grid-cols-2 gap-6 lg:border-l lg:pl-10 xl:h-full'>
                                 {/* Web metrics - only for published posts */}
                                 {metricsToShow.showWebMetrics && webAnalytics &&
                                     <div className={metricClassName} data-testid='latest-post-visitors' onClick={() => {

--- a/apps/stats/src/views/Stats/Overview/components/overview-kpis.tsx
+++ b/apps/stats/src/views/Stats/Overview/components/overview-kpis.tsx
@@ -71,13 +71,13 @@ const OverviewKPICard: React.FC<OverviewKPICardProps> = ({
     }, [diffDirection, diffValue, trendingFromValue, formattedValue, range]);
 
     return (
-        <Card className='group' data-testid={title}>
+        <Card className='group w-full max-w-full min-w-0' data-testid={title}>
             <CardHeader className='hidden'>
                 <CardTitle>{title}</CardTitle>
                 <CardDescription>{description}</CardDescription>
             </CardHeader>
             <KpiCardHeader className='relative flex grow flex-row items-start justify-between gap-5 border-none pb-2 xl:pb-4'>
-                <div className='flex grow flex-col gap-1.5 border-none pb-0'>
+                <div className='flex min-w-0 grow flex-col gap-1.5 border-none pb-0'>
                     <KpiCardHeaderLabel className={onClick && 'transition-all group-hover:text-foreground'}>
                         {color && <span className='inline-block size-2 rounded-full opacity-50' style={{backgroundColor: color}}></span>}
                         {IconComponent && <IconComponent size={16} strokeWidth={1.5} />}
@@ -94,7 +94,7 @@ const OverviewKPICard: React.FC<OverviewKPICardProps> = ({
                     <Button className='absolute right-6 translate-x-10 opacity-0 transition-all duration-200 group-hover:translate-x-0 group-hover:opacity-100' size='sm' variant='outline' onClick={onClick}>View more</Button>
                 }
             </KpiCardHeader>
-            <CardContent>
+            <CardContent className='min-w-0'>
                 {children}
             </CardContent>
         </Card>
@@ -160,7 +160,7 @@ const OverviewKPIs:React.FC<OverviewKPIsProps> = ({
     const containerClass = `flex flex-col lg:grid ${cols} gap-6`;
 
     return (
-        <div className={containerClass}>
+        <div className={`${containerClass} min-w-0`}>
             {showWebAnalytics && !showUpgradeCTA &&
                 <OverviewKPICard
                     description='Number of individual people who visited your website'

--- a/apps/stats/src/views/Stats/Overview/components/top-posts.tsx
+++ b/apps/stats/src/views/Stats/Overview/components/top-posts.tsx
@@ -1,7 +1,7 @@
 import FeatureImagePlaceholder from '../../components/feature-image-placeholder';
 import React from 'react';
 import {Card, CardContent, CardDescription, CardHeader, CardTitle, EmptyIndicator, SkeletonTable} from '@tryghost/shade/components';
-import {LucideIcon, abbreviateNumber, cn, formatDisplayDate, formatNumber} from '@tryghost/shade/utils';
+import {LucideIcon, abbreviateNumber, formatDisplayDate, formatNumber} from '@tryghost/shade/utils';
 import {TopPostViewsStats} from '@tryghost/admin-x-framework/api/stats';
 import {getPeriodText} from '@src/utils/chart-helpers';
 import {getPostDestination} from '@src/utils/url-helpers';
@@ -16,19 +16,15 @@ interface PostlistTooptipProps {
         label: string;
         metric: React.ReactNode;
     }>
-    className?: string;
 };
 
 const PostListTooltip:React.FC<PostlistTooptipProps> = ({
-    className,
     metrics,
     title
 }) => {
     return (
         <>
-            <div className={
-                cn('pointer-events-none absolute bottom-[calc(100%+2px)] left-1/2 z-50 min-w-[160px] -translate-x-1/2 rounded-md bg-background p-3 text-sm opacity-0 shadow-md transition-all group-hover/tooltip:bottom-[calc(100%+12px)] group-hover/tooltip:opacity-100', className)
-            }>
+            <div className='pointer-events-none absolute right-0 bottom-[calc(100%+2px)] left-auto z-50 min-w-[160px] translate-x-0 rounded-md bg-background p-3 text-sm opacity-0 shadow-md transition-all group-hover/tooltip:bottom-[calc(100%+12px)] group-hover/tooltip:opacity-100'>
                 <div className='mb-1.5 border-b pr-10 pb-1.5 font-medium whitespace-nowrap text-muted-foreground'>{title}</div>
                 <div className="flex flex-col gap-1.5">
                     {metrics?.map(metric => (
@@ -77,14 +73,14 @@ const TopPosts: React.FC<TopPostsProps> = ({
     const metricClass = 'flex items-center justify-end gap-1 rounded-md px-2 py-1 font-mono text-gray-800 hover:bg-muted-foreground/10 group-hover:text-foreground';
 
     return (
-        <Card className='group/card w-full lg:col-span-2' data-testid='top-posts-card'>
+        <Card className='group/card w-full max-w-full min-w-0 lg:col-span-2' data-testid='top-posts-card'>
             <CardHeader>
                 <CardTitle className='flex items-baseline justify-between leading-snug  font-medium text-muted-foreground'>
                     Top posts {getPeriodText(range)}
                 </CardTitle>
                 <CardDescription className='hidden'>Most viewed posts in this period</CardDescription>
             </CardHeader>
-            <CardContent>
+            <CardContent className='min-w-0'>
                 {isLoading ?
                     <SkeletonTable className='mt-6' />
                     :
@@ -92,8 +88,8 @@ const TopPosts: React.FC<TopPostsProps> = ({
                         {
                             topPostsData?.stats?.map((post: TopPostViewsStats) => {
                                 return (
-                                    <div key={post.post_id} className='group relative flex w-full items-start justify-between gap-5 border-t border-border/50 py-4 before:absolute before:-inset-x-4 before:inset-y-0 before:z-0 before:hidden before:rounded-md before:bg-accent before:opacity-80 before:content-[""] first:border-border! hover:cursor-pointer hover:border-transparent hover:before:block md:items-center dark:before:bg-accent/50 [&+div]:hover:border-transparent'>
-                                        <div className='z-10 flex min-w-[160px] grow items-start gap-4 md:items-center lg:min-w-[320px]' onClick={() => {
+                                    <div key={post.post_id} className='group relative flex w-full min-w-0 items-start justify-between gap-5 border-t border-border/50 py-4 before:absolute before:-inset-x-4 before:inset-y-0 before:z-0 before:hidden before:rounded-md before:bg-accent before:opacity-80 before:content-[""] first:border-border! hover:cursor-pointer hover:border-transparent hover:before:block md:items-center dark:before:bg-accent/50 [&+div]:hover:border-transparent'>
+                                        <div className='z-10 flex min-w-0 grow items-start gap-4 md:items-center lg:min-w-[320px]' onClick={() => {
                                             navigate(getPostDestination({
                                                 postId: post.post_id,
                                                 hasEmailData: post.sent_count !== null,
@@ -110,7 +106,7 @@ const TopPosts: React.FC<TopPostsProps> = ({
                                                 :
                                                 <FeatureImagePlaceholder className='hidden aspect-[16/10] w-[80px] shrink-0 group-hover:bg-muted-foreground/10 sm:visible! sm:flex! lg:w-[100px]' />
                                             }
-                                            <div className='flex flex-col gap-0.5'>
+                                            <div className='flex min-w-0 flex-col gap-0.5'>
                                                 <span className='line-clamp-2 text-md font-semibold'>{post.title}</span>
                                                 <span className='text text-muted-foreground'>
                                                     By {post.authors} &ndash; {formatDisplayDate(post.published_at, siteTimezone)}
@@ -120,7 +116,7 @@ const TopPosts: React.FC<TopPostsProps> = ({
                                                 </span>
                                             </div>
                                         </div>
-                                        <div className='z-10 flex flex-col items-end justify-center gap-0.5 text-sm md:flex-row md:items-center md:justify-end md:gap-3'>
+                                        <div className='z-10 flex shrink-0 flex-col items-end justify-center gap-0.5 text-sm md:flex-row md:items-center md:justify-end md:gap-3'>
                                             {showWebAnalytics &&
                                                 <div className='group/tooltip relative flex w-[66px] lg:w-[92px]' data-testid='statistics-visitors' onClick={(e) => {
                                                     e.stopPropagation();
@@ -148,7 +144,6 @@ const TopPosts: React.FC<TopPostsProps> = ({
                                                     navigate(`/posts/analytics/${post.post_id}/newsletter`, {crossApp: true});
                                                 }}>
                                                     <PostListTooltip
-                                                        className={`${!membersTrackSources ? 'right-0 left-auto translate-x-0' : ''}`}
                                                         metrics={[
                                                             // Always show sent
                                                             {
@@ -209,7 +204,6 @@ const TopPosts: React.FC<TopPostsProps> = ({
                                                     navigate(`/posts/analytics/${post.post_id}/growth`, {crossApp: true});
                                                 }}>
                                                     <PostListTooltip
-                                                        className='right-0 left-auto translate-x-0'
                                                         metrics={[
                                                             {
                                                                 icon: <LucideIcon.User className='shrink-0 text-muted-foreground' size={16} strokeWidth={1.5} />,

--- a/apps/stats/src/views/Stats/Overview/overview.tsx
+++ b/apps/stats/src/views/Stats/Overview/overview.tsx
@@ -40,9 +40,9 @@ export const HelpCard: React.FC<HelpCardProps> = ({
             'block rounded-xl border bg-card p-6 transition-all hover:shadow-xs hover:bg-accent/50 group/card',
             className
         )} href={url} rel='noreferrer' target='_blank'>
-            <div className='flex items-center gap-6'>
+            <div className='flex min-w-0 items-center gap-6'>
                 {children}
-                <div className='flex flex-col gap-0.5 leading-tight'>
+                <div className='flex min-w-0 flex-col gap-0.5 leading-tight'>
                     <span className='text-base font-semibold'>{title}</span>
                     <span className='text-sm font-normal text-gray-700'>{description}</span>
                 </div>
@@ -224,13 +224,13 @@ const Overview: React.FC = () => {
                     isLoading={isTopPostsLoading}
                     topPostsData={topPostsData}
                 />
-                <div className='grid grid-cols-1 gap-6 lg:grid-cols-2'>
+                <div className='grid min-w-0 grid-cols-1 gap-6 lg:grid-cols-2'>
                     <H3 className='mt-4 -mb-4 lg:col-span-2'>Grow your audience</H3>
                     <HelpCard
                         description='Find out how to review the performance of your content and get the most out of post analytics in Ghost.'
                         title='Understanding analytics in Ghost'
                         url='https://ghost.org/help/native-analytics'>
-                        <div className='flex h-18 w-[100px] min-w-[100px] items-center justify-center rounded-md bg-gradient-to-tr from-[#14B8FF]/20 to-[#00BBA7]/20 p-4 opacity-80 transition-all group-hover/card:opacity-100'>
+                        <div className='flex h-18 w-[100px] shrink-0 items-center justify-center rounded-md bg-gradient-to-tr from-[#14B8FF]/20 to-[#00BBA7]/20 p-4 opacity-80 transition-all group-hover/card:opacity-100'>
                             <LucideIcon.ChartColumnIncreasing className='text-[#00BBA7]' size={20} strokeWidth={1.5} />
                         </div>
                     </HelpCard>
@@ -238,7 +238,7 @@ const Overview: React.FC = () => {
                         description='Use these content distribution tactics to get more people to discover your work and increase engagement.'
                         title='How to get your content seen online'
                         url='https://ghost.org/resources/content-distribution/'>
-                        <div className='flex h-18 w-[100px] min-w-[100px] items-center justify-center rounded-md bg-gradient-to-tl from-[#FDC700]/20 to-[#FF2056]/20 p-4 opacity-80 transition-all group-hover/card:opacity-100'>
+                        <div className='flex h-18 w-[100px] shrink-0 items-center justify-center rounded-md bg-gradient-to-tl from-[#FDC700]/20 to-[#FF2056]/20 p-4 opacity-80 transition-all group-hover/card:opacity-100'>
                             <LucideIcon.Globe className='text-[#FE9A00]' size={20} strokeWidth={1.5} />
                         </div>
                     </HelpCard>

--- a/apps/stats/src/views/Stats/Web/components/sources-card.tsx
+++ b/apps/stats/src/views/Stats/Web/components/sources-card.tsx
@@ -129,15 +129,15 @@ export const SourcesCard: React.FC<SourcesCardProps> = ({
     const description = `How readers found your ${range ? 'site' : 'post'} ${getPeriodText(range)}`;
 
     return (
-        <Card className='group/datalist' data-testid='top-sources-card'>
-            <div className='flex items-center justify-between gap-6 px-6 pt-6 pb-5'>
-                <CardHeader className='p-0'>
+        <Card className='group/datalist w-full max-w-full min-w-0' data-testid='top-sources-card'>
+            <div className='flex min-w-0 items-center justify-between gap-6 px-6 pt-6 pb-5'>
+                <CardHeader className='min-w-0 p-0'>
                     <CardTitle>{title}</CardTitle>
                     <CardDescription>{description}</CardDescription>
                 </CardHeader>
             </div>
-            <CardContent className='overflow-hidden'>
-                <div className='mb-2 flex h-6 items-center justify-between'>
+            <CardContent className='min-w-0 overflow-hidden'>
+                <div className='mb-2 flex h-6 min-w-0 items-center justify-between'>
                     <div className='text-xs font-medium tracking-wide text-muted-foreground uppercase'>Source</div>
                     <div className='text-xs font-medium tracking-wide text-muted-foreground uppercase'>Visitors</div>
                 </div>

--- a/apps/stats/src/views/Stats/Web/components/top-content.tsx
+++ b/apps/stats/src/views/Stats/Web/components/top-content.tsx
@@ -148,15 +148,15 @@ const TopContent: React.FC<TopContentProps> = ({range, totalVisitors, audience, 
     const topContent = transformedData?.slice(0, 6) || [];
 
     return (
-        <Card className='group/datalist' data-testid='top-content-card'>
-            <div className='flex items-center justify-between gap-6 px-6 pt-6 pb-5'>
-                <CardHeader className='p-0'>
+        <Card className='group/datalist w-full max-w-full min-w-0' data-testid='top-content-card'>
+            <div className='flex min-w-0 items-center justify-between gap-6 px-6 pt-6 pb-5'>
+                <CardHeader className='min-w-0 p-0'>
                     <CardTitle>{getContentTitle(selectedContentType)}</CardTitle>
                     <CardDescription>{getContentDescription(selectedContentType, range, getPeriodText)}</CardDescription>
                 </CardHeader>
             </div>
-            <CardContent className='overflow-hidden'>
-                <div className='mb-2 flex items-center justify-between'>
+            <CardContent className='min-w-0 overflow-hidden'>
+                <div className='mb-2 flex min-w-0 items-center justify-between'>
                     <Tabs defaultValue={selectedContentType} variant='button-sm' onValueChange={(value: string) => {
                         setSelectedContentType(value as ContentType);
                     }}>

--- a/apps/stats/src/views/Stats/Web/components/web-kpis.tsx
+++ b/apps/stats/src/views/Stats/Web/components/web-kpis.tsx
@@ -86,7 +86,7 @@ const WebKPIs: React.FC<WebKPIsProps> = ({data, range, isLoading}) => {
     }
 
     return (
-        <Tabs data-testid='web-graph' defaultValue="visits" variant='kpis'>
+        <Tabs className='min-w-0' data-testid='web-graph' defaultValue="visits" variant='kpis'>
             <TabsList className="-mx-6 hidden grid-cols-2 md:visible! md:grid!">
                 <KpiTabTrigger value="visits" onClick={() => setCurrentTab('visits')}>
                     <KpiTabValue color='var(--chart-blue)' label="Unique visitors" value={kpiValues.visits} />
@@ -111,9 +111,9 @@ const WebKPIs: React.FC<WebKPIsProps> = ({data, range, isLoading}) => {
                     <DropdownMenuItem onClick={() => setCurrentTab('views')}>Total views</DropdownMenuItem>
                 </DropdownMenuContent>
             </DropdownMenu>
-            <div className='my-4 [&_.recharts-cartesian-axis-tick-value]:fill-gray-500'>
+            <div className='my-4 min-w-0 [&_.recharts-cartesian-axis-tick-value]:fill-gray-500'>
                 <GhAreaChart
-                    className='-mb-3 h-[16vw] max-h-[320px] min-h-[180px] w-full'
+                    className='-mb-3 h-[16vw] max-h-[320px] min-h-[180px] w-full min-w-0'
                     color={currentMetric.chartColor}
                     data={chartData}
                     id="mrr"

--- a/apps/stats/src/views/Stats/Web/web.tsx
+++ b/apps/stats/src/views/Stats/Web/web.tsx
@@ -204,8 +204,8 @@ const Web: React.FC = () => {
                 </NavbarActions>
             </StatsHeader>
             <StatsView isLoading={isPageLoading} loadingComponent={<></>}>
-                <Card>
-                    <CardContent>
+                <Card className='w-full max-w-full min-w-0'>
+                    <CardContent className='min-w-0'>
                         <WebKPIs
                             data={kpiData as KpiDataItem[] | null}
                             isLoading={kpiLoading}
@@ -213,7 +213,7 @@ const Web: React.FC = () => {
                         />
                     </CardContent>
                 </Card>
-                <div className='flex grid-cols-2 flex-col gap-6 lg:grid'>
+                <div className='flex min-w-0 grid-cols-2 flex-col gap-6 lg:grid'>
                     <TopContent
                         audience={audience}
                         filterParams={filterParams}

--- a/apps/stats/src/views/Stats/layout/stats-content.tsx
+++ b/apps/stats/src/views/Stats/layout/stats-content.tsx
@@ -3,7 +3,7 @@ import {cn} from '@tryghost/shade/utils';
 
 const StatsContent: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({children, className, ...props}) => {
     return (
-        <section className={cn('flex grow flex-col items-stretch gap-6 w-full pb-8', className)} {...props}>
+        <section className={cn('flex grow flex-col items-stretch gap-6 w-full min-w-0 pb-8', className)} {...props}>
             {children}
         </section>
     );

--- a/apps/stats/src/views/Stats/layout/stats-layout.tsx
+++ b/apps/stats/src/views/Stats/layout/stats-layout.tsx
@@ -5,8 +5,8 @@ const StatsLayout = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivEleme
     ({children}, ref) => {
         return (
             <MainLayout>
-                <div ref={ref} className='grid w-full grow'>
-                    <div className='flex h-full flex-col px-6'>
+                <div ref={ref} className='grid w-full min-w-0 grow'>
+                    <div className='flex h-full min-w-0 flex-col px-6'>
                         {children}
                     </div>
                 </div>


### PR DESCRIPTION
Closes https://linear.app/ghost/issue/DES-1209/analytics-breaks-layout-on-mobile-devices

Analytics cards and charts could force the app wider than the mobile viewport because their flex/grid parents and chart containers were not consistently allowed to shrink. This keeps the analytics layout width-contained across Overview, Web traffic, Newsletters, Growth, and Locations while preserving table scrolling where needed.

The change to `MetricValue` removes the column layout when it could be row without breaking any layouts.