### PR TITLE
Started using `@tryghost/errors` types

### DIFF
--- a/ghost/core/core/server/services/recommendations/service/libraries.d.ts
+++ b/ghost/core/core/server/services/recommendations/service/libraries.d.ts
@@ -1,4 +1,3 @@
-declare module '@tryghost/errors';
 declare module '@tryghost/tpl';
 declare module '@tryghost/logging';
 declare module '@tryghost/mongo-utils';


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1340

Depends on https://github.com/TryGhost/Ghost/pull/28648.

`@tryghost/errors` has types. Let's use them.

I think this change is useful on its own, but it's also useful for an upcoming change which uses these types.