### PR TITLE
Added emails from automations to member activity feed

### DIFF
--- a/ghost/admin/app/components/member/activity-feed.hbs
+++ b/ghost/admin/app/components/member/activity-feed.hbs
@@ -24,7 +24,7 @@
                                                 <div class="gh-member-feed-event">
                                                     <span class="gh-member-feed-event-inner">
                                                         <span class="gh-members-activity-description feature-memberAttribution">
-                                                            <span class="gh-members-activity-event-text">{{capitalize-first-letter event.action}}</span>
+                                                            <span class="gh-members-activity-event-text" title={{event.actionTitle}}>{{capitalize-first-letter event.action}}</span>
                                                             {{#if event.info}}
                                                                 <span class="highlight">({{event.info}})</span>
                                                             {{/if}}
@@ -41,7 +41,7 @@
                                                         </span>
                                                         {{#if event.description}}
                                                             <div class="ghost-members-activity-event-description feature-memberAttribution">
-                                                                <div class="ghost-members-activity-event-url" {{on "mouseenter" this.enterLinkURL}} {{on "mouseleave" this.leaveLinkURL}}>
+                                                                <div class="ghost-members-activity-event-url" title={{event.descriptionTitle}} {{on "mouseenter" this.enterLinkURL}} {{on "mouseleave" this.leaveLinkURL}}>
                                                                     <span>{{event.description}}</span>
                                                                 </div>
                                                             </div>

--- a/ghost/admin/app/components/member/activity-feed.hbs
+++ b/ghost/admin/app/components/member/activity-feed.hbs
@@ -41,7 +41,7 @@
                                                         </span>
                                                         {{#if event.description}}
                                                             <div class="ghost-members-activity-event-description feature-memberAttribution">
-                                                                <div class="ghost-members-activity-event-url" title={{event.descriptionTitle}} {{on "mouseenter" this.enterLinkURL}} {{on "mouseleave" this.leaveLinkURL}}>
+                                                                <div class="ghost-members-activity-event-url" {{on "mouseenter" this.enterLinkURL}} {{on "mouseleave" this.leaveLinkURL}}>
                                                                     <span>{{event.description}}</span>
                                                                 </div>
                                                             </div>

--- a/ghost/admin/app/components/member/activity-feed.hbs
+++ b/ghost/admin/app/components/member/activity-feed.hbs
@@ -24,7 +24,7 @@
                                                 <div class="gh-member-feed-event">
                                                     <span class="gh-member-feed-event-inner">
                                                         <span class="gh-members-activity-description feature-memberAttribution">
-                                                            <span class="gh-members-activity-event-text" title={{event.actionTitle}}>{{capitalize-first-letter event.action}}</span>
+                                                            <span class="gh-members-activity-event-text" title={{capitalize-first-letter event.actionTitle}}>{{capitalize-first-letter event.action}}</span>
                                                             {{#if event.info}}
                                                                 <span class="highlight">({{event.info}})</span>
                                                             {{/if}}

--- a/ghost/admin/app/components/members-activity/table-row.hbs
+++ b/ghost/admin/app/components/members-activity/table-row.hbs
@@ -39,7 +39,7 @@
                     </span>
                     {{#if event.description}}
                         <div class="ghost-members-activity-event-description feature-memberAttribution">
-                            <div class="ghost-members-activity-event-url" title={{event.descriptionTitle}} {{on "mouseenter" this.enterLinkURL}} {{on "mouseleave" this.leaveLinkURL}}>
+                            <div class="ghost-members-activity-event-url" {{on "mouseenter" this.enterLinkURL}} {{on "mouseleave" this.leaveLinkURL}}>
                                 <span>{{event.description}}</span>
                             </div>
                         </div>

--- a/ghost/admin/app/components/members-activity/table-row.hbs
+++ b/ghost/admin/app/components/members-activity/table-row.hbs
@@ -20,7 +20,7 @@
                 <div class="gh-members-activity-icon">{{svg-jar event.icon}}</div>
                 <div class="gh-members-activity-event">
                     <span class="gh-members-activity-description feature-memberAttribution">
-                        <span class="gh-members-activity-event-text" title={{event.actionTitle}}>{{capitalize-first-letter event.action}}</span>
+                        <span class="gh-members-activity-event-text" title={{capitalize-first-letter event.actionTitle}}>{{capitalize-first-letter event.action}}</span>
                         {{#if event.info}}
                             <span class="highlight">({{event.info}})</span>
                         {{/if}}

--- a/ghost/admin/app/components/members-activity/table-row.hbs
+++ b/ghost/admin/app/components/members-activity/table-row.hbs
@@ -20,7 +20,7 @@
                 <div class="gh-members-activity-icon">{{svg-jar event.icon}}</div>
                 <div class="gh-members-activity-event">
                     <span class="gh-members-activity-description feature-memberAttribution">
-                        <span class="gh-members-activity-event-text">{{capitalize-first-letter event.action}}</span>
+                        <span class="gh-members-activity-event-text" title={{event.actionTitle}}>{{capitalize-first-letter event.action}}</span>
                         {{#if event.info}}
                             <span class="highlight">({{event.info}})</span>
                         {{/if}}
@@ -39,7 +39,7 @@
                     </span>
                     {{#if event.description}}
                         <div class="ghost-members-activity-event-description feature-memberAttribution">
-                            <div class="ghost-members-activity-event-url" {{on "mouseenter" this.enterLinkURL}} {{on "mouseleave" this.leaveLinkURL}}>
+                            <div class="ghost-members-activity-event-url" title={{event.descriptionTitle}} {{on "mouseenter" this.enterLinkURL}} {{on "mouseleave" this.leaveLinkURL}}>
                                 <span>{{event.description}}</span>
                             </div>
                         </div>

--- a/ghost/admin/app/helpers/parse-member-event.js
+++ b/ghost/admin/app/helpers/parse-member-event.js
@@ -22,6 +22,15 @@ export default class ParseMemberEventHelper extends Helper {
         return trimmed || null;
     }
 
+    truncateString(value, maxLength = 60) {
+        const trimmed = this.trimString(value);
+        if (!trimmed || trimmed.length <= maxLength) {
+            return trimmed;
+        }
+
+        return `${trimmed.slice(0, maxLength - 3)}...`;
+    }
+
     compute([event, hasMultipleNewsletters]) {
         let memberName = event.data.member?.name;
         memberName = this.trimString(memberName);
@@ -29,8 +38,10 @@ export default class ParseMemberEventHelper extends Helper {
         const subject = event.data.member ? (memberName || event.data.member.email) : (event.data.name || event.data.email || '');
         const icon = this.getIcon(event);
         const action = this.getAction(event, hasMultipleNewsletters);
+        const actionTitle = this.getActionTitle(event, hasMultipleNewsletters);
         const info = this.getInfo(event);
         const description = this.getDescription(event);
+        const descriptionTitle = this.getDescriptionTitle(event);
 
         const join = this.getJoin(event);
         const object = this.getObject(event);
@@ -53,11 +64,13 @@ export default class ParseMemberEventHelper extends Helper {
             icon,
             subject,
             action,
+            actionTitle,
             join,
             object,
             source,
             info,
             description,
+            descriptionTitle,
             url,
             route,
             timestamp
@@ -214,9 +227,18 @@ export default class ParseMemberEventHelper extends Helper {
         }
 
         if (event.type === 'automated_email_sent_event') {
-            const slug = event.data.automatedEmail?.slug || '';
-            const emailType = slug.includes('paid') ? 'Paid' : 'Free';
-            return `received welcome email (${emailType})`;
+            if (event.data.automatedEmail?.source !== 'automation_action_revision') {
+                const slug = event.data.automatedEmail?.slug || '';
+                const emailType = slug.includes('paid') ? 'Paid' : 'Free';
+                return `received welcome email (${emailType})`;
+            }
+
+            const subject = this.trimString(event.data.automatedEmail?.subject);
+            if (subject) {
+                return `received automated email: ${this.truncateString(subject)}`;
+            }
+
+            return 'received automated email';
         }
 
         if (event.type === 'email_delivered_event') {
@@ -284,6 +306,17 @@ export default class ParseMemberEventHelper extends Helper {
         if (event.type === 'gift_ended_event') {
             return 'gift subscription expired';
         }
+    }
+
+    getActionTitle(event, hasMultipleNewsletters) {
+        if (event.type === 'automated_email_sent_event' && event.data.automatedEmail?.source === 'automation_action_revision') {
+            const subject = this.trimString(event.data.automatedEmail?.subject);
+            if (subject) {
+                return `received automated email: ${subject}`;
+            }
+        }
+
+        return this.getAction(event, hasMultipleNewsletters);
     }
 
     /**
@@ -372,10 +405,18 @@ export default class ParseMemberEventHelper extends Helper {
             return event.data.tier_name;
         }
 
+        if (event.type === 'automated_email_sent_event') {
+            return;
+        }
+
         return;
     }
 
     getDescription(event) {
+        if (event.type === 'automated_email_sent_event') {
+            return;
+        }
+
         if (event.type === 'click_event') {
             // Clean URL
             try {
@@ -386,6 +427,12 @@ export default class ParseMemberEventHelper extends Helper {
             return event.data.link.to;
         }
         return;
+    }
+
+    getDescriptionTitle(event) {
+        if (event.type === 'automated_email_sent_event') {
+            return;
+        }
     }
 
     /**

--- a/ghost/admin/app/helpers/parse-member-event.js
+++ b/ghost/admin/app/helpers/parse-member-event.js
@@ -394,18 +394,10 @@ export default class ParseMemberEventHelper extends Helper {
             return event.data.tier_name;
         }
 
-        if (event.type === 'automated_email_sent_event') {
-            return;
-        }
-
         return;
     }
 
     getDescription(event) {
-        if (event.type === 'automated_email_sent_event') {
-            return;
-        }
-
         if (event.type === 'click_event') {
             // Clean URL
             try {

--- a/ghost/admin/app/helpers/parse-member-event.js
+++ b/ghost/admin/app/helpers/parse-member-event.js
@@ -22,15 +22,6 @@ export default class ParseMemberEventHelper extends Helper {
         return trimmed || null;
     }
 
-    truncateString(value, maxLength = 60) {
-        const trimmed = this.trimString(value);
-        if (!trimmed || trimmed.length <= maxLength) {
-            return trimmed;
-        }
-
-        return `${trimmed.slice(0, maxLength - 3)}...`;
-    }
-
     compute([event, hasMultipleNewsletters]) {
         let memberName = event.data.member?.name;
         memberName = this.trimString(memberName);
@@ -41,7 +32,6 @@ export default class ParseMemberEventHelper extends Helper {
         const actionTitle = this.getActionTitle(event, hasMultipleNewsletters);
         const info = this.getInfo(event);
         const description = this.getDescription(event);
-        const descriptionTitle = this.getDescriptionTitle(event);
 
         const join = this.getJoin(event);
         const object = this.getObject(event);
@@ -70,7 +60,6 @@ export default class ParseMemberEventHelper extends Helper {
             source,
             info,
             description,
-            descriptionTitle,
             url,
             route,
             timestamp
@@ -235,7 +224,7 @@ export default class ParseMemberEventHelper extends Helper {
 
             const subject = this.trimString(event.data.automatedEmail?.subject);
             if (subject) {
-                return `received automated email: ${this.truncateString(subject)}`;
+                return `received automated email: ${subject}`;
             }
 
             return 'received automated email';
@@ -427,12 +416,6 @@ export default class ParseMemberEventHelper extends Helper {
             return event.data.link.to;
         }
         return;
-    }
-
-    getDescriptionTitle(event) {
-        if (event.type === 'automated_email_sent_event') {
-            return;
-        }
     }
 
     /**

--- a/ghost/admin/app/helpers/parse-member-event.js
+++ b/ghost/admin/app/helpers/parse-member-event.js
@@ -222,12 +222,8 @@ export default class ParseMemberEventHelper extends Helper {
                 return `received welcome email (${emailType})`;
             }
 
-            const subject = this.trimString(event.data.automatedEmail?.subject);
-            if (subject) {
-                return `received automated email: ${subject}`;
-            }
-
-            return 'received automated email';
+            const subject = this.trimString(event.data.automatedEmail.subject);
+            return `received automated email: ${subject}`;
         }
 
         if (event.type === 'email_delivered_event') {
@@ -299,10 +295,8 @@ export default class ParseMemberEventHelper extends Helper {
 
     getActionTitle(event, hasMultipleNewsletters) {
         if (event.type === 'automated_email_sent_event' && event.data.automatedEmail?.source === 'automation_action_revision') {
-            const subject = this.trimString(event.data.automatedEmail?.subject);
-            if (subject) {
-                return `received automated email: ${subject}`;
-            }
+            const subject = this.trimString(event.data.automatedEmail.subject);
+            return `received automated email: ${subject}`;
         }
 
         return this.getAction(event, hasMultipleNewsletters);

--- a/ghost/admin/app/styles/layouts/member-activity.css
+++ b/ghost/admin/app/styles/layouts/member-activity.css
@@ -167,6 +167,7 @@
     font-size: 1.3rem;
     letter-spacing: 0;
     color: var(--middarkgrey);
+    white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
 }

--- a/ghost/admin/tests/unit/helpers/parse-member-event-test.js
+++ b/ghost/admin/tests/unit/helpers/parse-member-event-test.js
@@ -58,7 +58,6 @@ describe('Unit: Helper: parse-member-event', function () {
             expect(result.actionTitle).to.equal('received welcome email (Paid)');
             expect(result.info).to.equal(undefined);
             expect(result.description).to.equal(undefined);
-            expect(result.descriptionTitle).to.equal(undefined);
         });
 
         it('returns the email subject inline for automation action revision rows', function () {
@@ -78,10 +77,9 @@ describe('Unit: Helper: parse-member-event', function () {
             expect(result.actionTitle).to.equal('received automated email: Here is how to get started');
             expect(result.info).to.equal(undefined);
             expect(result.description).to.equal(undefined);
-            expect(result.descriptionTitle).to.equal(undefined);
         });
 
-        it('truncates long automation email subjects inline and keeps the full title', function () {
+        it('returns long automation email subjects inline for CSS truncation', function () {
             const subject = 'This is a very long automated email subject that should be truncated in the activity feed';
             const event = buildEvent({
                 type: 'automated_email_sent_event',
@@ -95,7 +93,7 @@ describe('Unit: Helper: parse-member-event', function () {
                 }
             });
             const result = helper.compute([event]);
-            expect(result.action).to.equal('received automated email: This is a very long automated email subject that should be...');
+            expect(result.action).to.equal(`received automated email: ${subject}`);
             expect(result.actionTitle).to.equal(`received automated email: ${subject}`);
         });
 
@@ -115,7 +113,6 @@ describe('Unit: Helper: parse-member-event', function () {
             expect(result.action).to.equal('received automated email');
             expect(result.actionTitle).to.equal('received automated email');
             expect(result.description).to.equal(undefined);
-            expect(result.descriptionTitle).to.equal(undefined);
         });
     });
 

--- a/ghost/admin/tests/unit/helpers/parse-member-event-test.js
+++ b/ghost/admin/tests/unit/helpers/parse-member-event-test.js
@@ -40,6 +40,85 @@ describe('Unit: Helper: parse-member-event', function () {
         });
     });
 
+    describe('automated_email_sent_event action', function () {
+        it('returns the welcome email label for welcome automation slugs', function () {
+            const event = buildEvent({
+                type: 'automated_email_sent_event',
+                data: {
+                    automatedEmail: {
+                        source: 'automated_email',
+                        slug: 'member-welcome-email-paid',
+                        name: 'Welcome Email (Paid)',
+                        subject: 'Welcome to the paid tier'
+                    }
+                }
+            });
+            const result = helper.compute([event]);
+            expect(result.action).to.equal('received welcome email (Paid)');
+            expect(result.actionTitle).to.equal('received welcome email (Paid)');
+            expect(result.info).to.equal(undefined);
+            expect(result.description).to.equal(undefined);
+            expect(result.descriptionTitle).to.equal(undefined);
+        });
+
+        it('returns the email subject inline for automation action revision rows', function () {
+            const event = buildEvent({
+                type: 'automated_email_sent_event',
+                data: {
+                    automatedEmail: {
+                        source: 'automation_action_revision',
+                        slug: 'member-welcome-email-free',
+                        name: 'New member onboarding',
+                        subject: 'Here is how to get started'
+                    }
+                }
+            });
+            const result = helper.compute([event]);
+            expect(result.action).to.equal('received automated email: Here is how to get started');
+            expect(result.actionTitle).to.equal('received automated email: Here is how to get started');
+            expect(result.info).to.equal(undefined);
+            expect(result.description).to.equal(undefined);
+            expect(result.descriptionTitle).to.equal(undefined);
+        });
+
+        it('truncates long automation email subjects inline and keeps the full title', function () {
+            const subject = 'This is a very long automated email subject that should be truncated in the activity feed';
+            const event = buildEvent({
+                type: 'automated_email_sent_event',
+                data: {
+                    automatedEmail: {
+                        source: 'automation_action_revision',
+                        slug: 'new-member-onboarding',
+                        name: 'New member onboarding',
+                        subject
+                    }
+                }
+            });
+            const result = helper.compute([event]);
+            expect(result.action).to.equal('received automated email: This is a very long automated email subject that should be...');
+            expect(result.actionTitle).to.equal(`received automated email: ${subject}`);
+        });
+
+        it('returns the fallback action for automation action revision rows without a subject', function () {
+            const event = buildEvent({
+                type: 'automated_email_sent_event',
+                data: {
+                    automatedEmail: {
+                        source: 'automation_action_revision',
+                        slug: 'new-member-onboarding',
+                        name: 'New member onboarding',
+                        subject: null
+                    }
+                }
+            });
+            const result = helper.compute([event]);
+            expect(result.action).to.equal('received automated email');
+            expect(result.actionTitle).to.equal('received automated email');
+            expect(result.description).to.equal(undefined);
+            expect(result.descriptionTitle).to.equal(undefined);
+        });
+    });
+
     describe('signup_event info', function () {
         it('returns null when created_with_status is "paid"', function () {
             const event = buildEvent({

--- a/ghost/admin/tests/unit/helpers/parse-member-event-test.js
+++ b/ghost/admin/tests/unit/helpers/parse-member-event-test.js
@@ -78,24 +78,6 @@ describe('Unit: Helper: parse-member-event', function () {
             expect(result.info).to.equal(undefined);
             expect(result.description).to.equal(undefined);
         });
-
-        it('returns long automation email subjects inline for CSS truncation', function () {
-            const subject = 'This is a very long automated email subject that should be truncated in the activity feed';
-            const event = buildEvent({
-                type: 'automated_email_sent_event',
-                data: {
-                    automatedEmail: {
-                        source: 'automation_action_revision',
-                        slug: 'new-member-onboarding',
-                        name: 'New member onboarding',
-                        subject
-                    }
-                }
-            });
-            const result = helper.compute([event]);
-            expect(result.action).to.equal(`received automated email: ${subject}`);
-            expect(result.actionTitle).to.equal(`received automated email: ${subject}`);
-        });
     });
 
     describe('signup_event info', function () {

--- a/ghost/admin/tests/unit/helpers/parse-member-event-test.js
+++ b/ghost/admin/tests/unit/helpers/parse-member-event-test.js
@@ -96,24 +96,6 @@ describe('Unit: Helper: parse-member-event', function () {
             expect(result.action).to.equal(`received automated email: ${subject}`);
             expect(result.actionTitle).to.equal(`received automated email: ${subject}`);
         });
-
-        it('returns the fallback action for automation action revision rows without a subject', function () {
-            const event = buildEvent({
-                type: 'automated_email_sent_event',
-                data: {
-                    automatedEmail: {
-                        source: 'automation_action_revision',
-                        slug: 'new-member-onboarding',
-                        name: 'New member onboarding',
-                        subject: null
-                    }
-                }
-            });
-            const result = helper.compute([event]);
-            expect(result.action).to.equal('received automated email');
-            expect(result.actionTitle).to.equal('received automated email');
-            expect(result.description).to.equal(undefined);
-        });
     });
 
     describe('signup_event info', function () {

--- a/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
@@ -1093,7 +1093,7 @@ module.exports = class EventRepository {
                     created_at: model.get('created_at'),
                     member: model.related('member').toJSON(),
                     automatedEmail: {
-                        id: automatedEmailId || automationActionRevisionId,
+                        id: automatedEmailId ?? automationActionRevisionId,
                         source: automatedEmailId ? 'automated_email' : 'automation_action_revision',
                         slug: automatedEmail.slug,
                         name: automatedEmail.name,

--- a/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
@@ -3,6 +3,7 @@ const nql = require('@tryghost/nql');
 const mingo = require('mingo');
 const {replaceFilters, expandFilters, splitFilter, getUsedKeys, chainTransformers, mapKeys, rejectStatements} = require('@tryghost/mongo-utils');
 const {default: ObjectID} = require('bson-objectid');
+const db = require('../../../../data/db');
 
 /**
  * This mongo transformer ignores the provided filter option and replaces the filter with a custom filter that was provided to the transformer. Allowing us to set a mongo filter instead of a string based NQL filter.
@@ -35,7 +36,8 @@ module.exports = class EventRepository {
         memberAttributionService,
         MemberEmailChangeEvent,
         AutomatedEmailRecipient,
-        Gift
+        Gift,
+        knex
     }) {
         this._DonationPaymentEvent = DonationPaymentEvent;
         this._MemberSubscribeEvent = MemberSubscribeEvent;
@@ -55,6 +57,7 @@ module.exports = class EventRepository {
         this._MemberEmailChangeEvent = MemberEmailChangeEvent;
         this._AutomatedEmailRecipient = AutomatedEmailRecipient;
         this._Gift = Gift;
+        this._knex = knex || db.knex;
     }
 
     async getEventTimeline(options = {}) {
@@ -1051,9 +1054,8 @@ module.exports = class EventRepository {
     async getAutomatedEmailSentEvents(options = {}, filter) {
         options = {
             ...options,
-            withRelated: ['member', 'automatedEmail.automation'],
-            // TODO(NY-1338): Handle rows where automated_email_id is null.
-            filter: 'automated_email_id:-null+custom:true',
+            withRelated: ['member'],
+            filter: 'custom:true',
             useBasicCount: true,
             mongoTransformer: chainTransformers(
                 replaceCustomFilterTransformer(filter),
@@ -1065,18 +1067,19 @@ module.exports = class EventRepository {
         };
 
         const {data: models, meta} = await this._AutomatedEmailRecipient.findPage(options);
+        const {
+            automatedEmailLabels,
+            automationActionRevisionLabels
+        } = await this.getAutomatedEmailSentEventLabels(models);
 
         const data = models.map((model) => {
-            const automatedEmail = model.related('automatedEmail');
-            if (!automatedEmail || !automatedEmail.id) {
-                // TODO(NY-1334) This won't necessarily be an error in the future.
-                throw new errors.InternalServerError({
-                    message: `Automated email recipient ${model.id} has no associated automated email`
-                });
-            }
+            const automatedEmailId = model.get('automated_email_id');
+            const automationActionRevisionId = model.get('automation_action_revision_id');
+            const automatedEmail = automatedEmailId
+                ? automatedEmailLabels.get(automatedEmailId)
+                : automationActionRevisionLabels.get(automationActionRevisionId);
 
-            const automation = automatedEmail.related('automation');
-            if (!automation || !automation.id) {
+            if (!automatedEmail) {
                 throw new errors.InternalServerError({
                     message: `Automated email recipient ${model.id} has no associated automation`
                 });
@@ -1090,8 +1093,11 @@ module.exports = class EventRepository {
                     created_at: model.get('created_at'),
                     member: model.related('member').toJSON(),
                     automatedEmail: {
-                        id: automatedEmail.id,
-                        slug: automation.get('slug')
+                        id: automatedEmailId || automationActionRevisionId,
+                        source: automatedEmailId ? 'automated_email' : 'automation_action_revision',
+                        slug: automatedEmail.slug,
+                        name: automatedEmail.name,
+                        subject: automatedEmail.subject
                     }
                 }
             };
@@ -1100,6 +1106,38 @@ module.exports = class EventRepository {
         return {
             data,
             meta
+        };
+    }
+
+    async getAutomatedEmailSentEventLabels(models) {
+        const automatedEmailIds = [...new Set(models.map(model => model.get('automated_email_id')).filter(Boolean))];
+        const automationActionRevisionIds = [...new Set(models.map(model => model.get('automation_action_revision_id')).filter(Boolean))];
+
+        const [automatedEmailRows, automationActionRevisionRows] = await Promise.all([
+            automatedEmailIds.length ? this._knex('welcome_email_automated_emails as email')
+                .select(
+                    'email.id as id',
+                    'automation.slug as slug',
+                    'automation.name as name',
+                    'email.subject as subject'
+                )
+                .innerJoin('automations as automation', 'automation.id', 'email.welcome_email_automation_id')
+                .whereIn('email.id', automatedEmailIds) : [],
+            automationActionRevisionIds.length ? this._knex('automation_action_revisions as revision')
+                .select(
+                    'revision.id as id',
+                    'automation.slug as slug',
+                    'automation.name as name',
+                    'revision.email_subject as subject'
+                )
+                .innerJoin('automation_actions as action', 'action.id', 'revision.action_id')
+                .innerJoin('automations as automation', 'automation.id', 'action.automation_id')
+                .whereIn('revision.id', automationActionRevisionIds) : []
+        ]);
+
+        return {
+            automatedEmailLabels: new Map(automatedEmailRows.map(row => [row.id, row])),
+            automationActionRevisionLabels: new Map(automationActionRevisionRows.map(row => [row.id, row]))
         };
     }
 

--- a/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
@@ -57,7 +57,7 @@ module.exports = class EventRepository {
         this._MemberEmailChangeEvent = MemberEmailChangeEvent;
         this._AutomatedEmailRecipient = AutomatedEmailRecipient;
         this._Gift = Gift;
-        this._knex = knex || db.knex;
+        this._knex = knex ?? db.knex;
     }
 
     async getEventTimeline(options = {}) {

--- a/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
@@ -1085,6 +1085,12 @@ module.exports = class EventRepository {
                 });
             }
 
+            if (!automatedEmailId && !automatedEmail.subject?.trim()) {
+                throw new errors.InternalServerError({
+                    message: `Automated email recipient ${model.id} has no associated automation email subject`
+                });
+            }
+
             return {
                 type: 'automated_email_sent_event',
                 data: {

--- a/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
@@ -36,8 +36,7 @@ module.exports = class EventRepository {
         memberAttributionService,
         MemberEmailChangeEvent,
         AutomatedEmailRecipient,
-        Gift,
-        knex
+        Gift
     }) {
         this._DonationPaymentEvent = DonationPaymentEvent;
         this._MemberSubscribeEvent = MemberSubscribeEvent;
@@ -57,7 +56,7 @@ module.exports = class EventRepository {
         this._MemberEmailChangeEvent = MemberEmailChangeEvent;
         this._AutomatedEmailRecipient = AutomatedEmailRecipient;
         this._Gift = Gift;
-        this._knex = knex ?? db.knex;
+        this._knex = db.knex;
     }
 
     async getEventTimeline(options = {}) {

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/event-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/event-repository.test.js
@@ -298,10 +298,21 @@ describe('EventRepository', function () {
     describe('getAutomatedEmailSentEvents', function () {
         let eventRepository;
         let fake;
+        let fakeKnex;
+        let models;
 
-        beforeAll(function () {
-            fake = sinon.fake.returns({data: [{
+        const makeAutomatedEmailRecipient = ({
+            automatedEmailId = 'ae123',
+            automationActionRevisionId = null
+        } = {}) => {
+            return {
                 get: (key) => {
+                    if (key === 'automated_email_id') {
+                        return automatedEmailId;
+                    }
+                    if (key === 'automation_action_revision_id') {
+                        return automationActionRevisionId;
+                    }
                     if (key === 'member_id') {
                         return '123';
                     }
@@ -313,22 +324,45 @@ describe('EventRepository', function () {
                     if (relation === 'member') {
                         return {toJSON: () => ({id: '123', email: 'test@example.com'})};
                     }
-                    if (relation === 'automatedEmail') {
-                        return {
-                            id: 'ae123',
-                            related: (rel) => {
-                                if (rel === 'automation') {
-                                    return {
-                                        id: 'auto123',
-                                        get: key => (key === 'slug' ? 'member-welcome-email-free' : undefined)
-                                    };
-                                }
-                            }
-                        };
-                    }
                 },
                 id: 'aer123'
-            }]});
+            };
+        };
+
+        beforeAll(function () {
+            models = [makeAutomatedEmailRecipient()];
+            fake = sinon.fake(() => ({data: models}));
+            fakeKnex = sinon.fake((tableName) => {
+                return {
+                    select() {
+                        return this;
+                    },
+                    innerJoin() {
+                        return this;
+                    },
+                    whereIn(_column, ids) {
+                        if (tableName === 'welcome_email_automated_emails as email') {
+                            return [{
+                                id: ids[0],
+                                slug: 'member-welcome-email-free',
+                                name: 'Welcome Email (Free)',
+                                subject: 'Welcome to the free tier'
+                            }];
+                        }
+
+                        if (tableName === 'automation_action_revisions as revision') {
+                            return [{
+                                id: ids[0],
+                                slug: 'member-welcome-email-free',
+                                name: 'New member onboarding',
+                                subject: 'Here is how to get started'
+                            }];
+                        }
+
+                        return [];
+                    }
+                };
+            });
             eventRepository = new EventRepository({
                 EmailRecipient: null,
                 MemberSubscribeEvent: null,
@@ -339,12 +373,15 @@ describe('EventRepository', function () {
                 labsService: null,
                 AutomatedEmailRecipient: {
                     findPage: fake
-                }
+                },
+                knex: fakeKnex
             });
         });
 
         afterEach(function () {
+            models = [makeAutomatedEmailRecipient()];
             fake.resetHistory();
+            fakeKnex.resetHistory();
         });
 
         it('works when setting no filters', async function () {
@@ -356,8 +393,8 @@ describe('EventRepository', function () {
             });
 
             sinon.assert.calledOnceWithMatch(fake, {
-                withRelated: ['member', 'automatedEmail.automation'],
-                filter: 'automated_email_id:-null+custom:true',
+                withRelated: ['member'],
+                filter: 'custom:true',
                 order: 'created_at desc, id desc'
             });
         });
@@ -370,8 +407,8 @@ describe('EventRepository', function () {
             });
 
             sinon.assert.calledOnceWithMatch(fake, {
-                withRelated: ['member', 'automatedEmail.automation'],
-                filter: 'automated_email_id:-null+custom:true',
+                withRelated: ['member'],
+                filter: 'custom:true',
                 order: 'created_at desc, id desc'
             });
         });
@@ -385,19 +422,9 @@ describe('EventRepository', function () {
             });
 
             sinon.assert.calledOnceWithMatch(fake, {
-                withRelated: ['member', 'automatedEmail.automation'],
-                filter: 'automated_email_id:-null+custom:true',
+                withRelated: ['member'],
+                filter: 'custom:true',
                 order: 'created_at desc, id desc'
-            });
-        });
-
-        it('excludes automation action revision recipients until they are supported in the activity feed', async function () {
-            await eventRepository.getAutomatedEmailSentEvents({
-                order: 'created_at desc, id desc'
-            }, {});
-
-            sinon.assert.calledOnceWithMatch(fake, {
-                filter: 'automated_email_id:-null+custom:true'
             });
         });
 
@@ -416,7 +443,39 @@ describe('EventRepository', function () {
                     member: {id: '123', email: 'test@example.com'},
                     automatedEmail: {
                         id: 'ae123',
-                        slug: 'member-welcome-email-free'
+                        source: 'automated_email',
+                        slug: 'member-welcome-email-free',
+                        name: 'Welcome Email (Free)',
+                        subject: 'Welcome to the free tier'
+                    }
+                }
+            });
+        });
+
+        it('returns correctly formatted automated_email_sent_event for automation action revision rows', async function () {
+            models = [makeAutomatedEmailRecipient({
+                automatedEmailId: null,
+                automationActionRevisionId: 'aar123'
+            })];
+
+            const result = await eventRepository.getAutomatedEmailSentEvents({
+                order: 'created_at desc, id desc'
+            }, {});
+
+            assert.equal(result.data.length, 1);
+            assert.deepEqual(result.data[0], {
+                type: 'automated_email_sent_event',
+                data: {
+                    id: 'aer123',
+                    member_id: '123',
+                    created_at: new Date('2024-01-01'),
+                    member: {id: '123', email: 'test@example.com'},
+                    automatedEmail: {
+                        id: 'aar123',
+                        source: 'automation_action_revision',
+                        slug: 'member-welcome-email-free',
+                        name: 'New member onboarding',
+                        subject: 'Here is how to get started'
                     }
                 }
             });

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/event-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/event-repository.test.js
@@ -300,6 +300,7 @@ describe('EventRepository', function () {
         let fake;
         let fakeKnex;
         let models;
+        let automationActionRevisionSubject;
 
         const makeAutomatedEmailRecipient = ({
             automatedEmailId = 'ae123',
@@ -331,6 +332,7 @@ describe('EventRepository', function () {
 
         beforeAll(function () {
             models = [makeAutomatedEmailRecipient()];
+            automationActionRevisionSubject = 'Here is how to get started';
             fake = sinon.fake(() => ({data: models}));
             fakeKnex = sinon.fake((tableName) => {
                 return {
@@ -355,7 +357,7 @@ describe('EventRepository', function () {
                                 id: ids[0],
                                 slug: 'member-welcome-email-free',
                                 name: 'New member onboarding',
-                                subject: 'Here is how to get started'
+                                subject: automationActionRevisionSubject
                             }];
                         }
 
@@ -380,6 +382,7 @@ describe('EventRepository', function () {
 
         afterEach(function () {
             models = [makeAutomatedEmailRecipient()];
+            automationActionRevisionSubject = 'Here is how to get started';
             fake.resetHistory();
             fakeKnex.resetHistory();
         });
@@ -479,6 +482,24 @@ describe('EventRepository', function () {
                     }
                 }
             });
+        });
+
+        it('throws when an automation action revision row has no subject', async function () {
+            models = [makeAutomatedEmailRecipient({
+                automatedEmailId: null,
+                automationActionRevisionId: 'aar123'
+            })];
+            automationActionRevisionSubject = null;
+
+            await assert.rejects(
+                () => eventRepository.getAutomatedEmailSentEvents({
+                    order: 'created_at desc, id desc'
+                }, {}),
+                {
+                    name: 'InternalServerError',
+                    message: 'Automated email recipient aer123 has no associated automation email subject'
+                }
+            );
         });
     });
 

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/event-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/event-repository.test.js
@@ -375,9 +375,9 @@ describe('EventRepository', function () {
                 labsService: null,
                 AutomatedEmailRecipient: {
                     findPage: fake
-                },
-                knex: fakeKnex
+                }
             });
+            eventRepository._knex = fakeKnex;
         });
 
         afterEach(function () {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1338/update-member-activity-feed-to-handle-reference-to-automation-revision
closes https://linear.app/ghost/issue/NY-1334/readwrite-automated-email-recipients-table-to-populate-member-details

## Summary
- Show automated email subjects in member activity for automation action revision rows
- Add tooltip titles for long action labels in member activity feeds
- Update event repository logic to resolve automated email labels from the new revision source

## Screenshots

For a member who received a (legacy) welcome email, nothing changes:
<img width="1508" height="254" alt="Screenshot 2026-06-16 at 18 16 08@2x" src="https://github.com/user-attachments/assets/a3702551-76af-4c0b-a4e3-935a4182c8d1" />

For a member who received an email via an automation, this will show in the activity feed:
<img width="1522" height="238" alt="Screenshot 2026-06-16 at 18 17 33@2x" src="https://github.com/user-attachments/assets/b23a5b14-69a5-4ce5-b2c8-2460d442f7b2" />

<img width="1518" height="294" alt="Screenshot 2026-06-16 at 18 18 09@2x" src="https://github.com/user-attachments/assets/0fc0371b-81e0-490d-8b1f-10a6221b4fb9" />

