### PR TITLE
Fixed type errors in redirects service

### DIFF
--- a/ghost/core/core/server/services/custom-redirects/redirects-service.ts
+++ b/ghost/core/core/server/services/custom-redirects/redirects-service.ts
@@ -4,6 +4,7 @@ import * as errors from '@tryghost/errors';
 
 import DynamicRedirectManager from '../lib/dynamic-redirect-manager';
 import type {RedirectConfig, RedirectsStore} from './types';
+import {errify} from '../../../shared/errify';
 
 const messages = {
     redirectsRegister: 'Could not register custom redirects.',
@@ -121,12 +122,13 @@ export class RedirectsService {
                     throw this._buildRejectedError(redirect);
                 }
                 loaded += 1;
-            } catch (err) {
+            } catch (rawError) {
                 if (failFast) {
-                    throw err;
+                    throw rawError;
                 }
+                const err = errify(rawError);
                 logging.error(new errors.IncorrectUsageError({
-                    message: tpl(messages.skippedInvalidRedirect, {context: (err as Error).message}),
+                    message: tpl(messages.skippedInvalidRedirect, {context: err.message}),
                     err
                 }));
             }
@@ -146,9 +148,8 @@ export class RedirectsService {
                 from: redirect.from,
                 to: redirect.to
             }),
-            context: redirect,
             help: tpl(messages.redirectsHelp),
-            ...(cause !== undefined ? {err: cause} : {})
+            ...(cause !== undefined ? {err: errify(cause)} : {})
         });
     }
 
@@ -163,13 +164,14 @@ export class RedirectsService {
     async init(): Promise<void> {
         try {
             await this.activate();
-        } catch (err) {
+        } catch (rawError) {
+            const err = errify(rawError);
             if (errors.utils.isGhostError(err)) {
                 logging.error(err);
             } else {
                 logging.error(new errors.IncorrectUsageError({
                     message: tpl(messages.redirectsRegister),
-                    context: (err as Error).message,
+                    context: err.message,
                     help: tpl(messages.redirectsHelp),
                     err
                 }));

--- a/ghost/core/core/shared/errify.ts
+++ b/ghost/core/core/shared/errify.ts
@@ -1,0 +1,34 @@
+/* eslint-disable ghost/ghost-custom/no-native-error */
+
+/**
+ * Converts an unknown value to an Error object, if it isn't already.
+ */
+export const errify = (value: unknown): Error => {
+    if (value instanceof Error) {
+        return value;
+    }
+
+    if ((value === null) || (value === undefined)) {
+        return new Error();
+    }
+
+    const valuesSeen = new Set<unknown>();
+    while (
+        !valuesSeen.has(value) &&
+        value &&
+        typeof value === 'object' &&
+        'message' in value
+    ) {
+        value = value.message;
+        valuesSeen.add(value);
+    }
+
+    let message: string;
+    try {
+        message = String(value);
+    } catch {
+        message = Object.prototype.toString.call(value);
+    }
+
+    return new Error(message);
+};

--- a/ghost/core/core/shared/errify.ts
+++ b/ghost/core/core/shared/errify.ts
@@ -12,15 +12,12 @@ export const errify = (value: unknown): Error => {
         return new Error();
     }
 
-    const valuesSeen = new Set<unknown>();
-    while (
-        !valuesSeen.has(value) &&
+    if (
         value &&
         typeof value === 'object' &&
         'message' in value
     ) {
         value = value.message;
-        valuesSeen.add(value);
     }
 
     let message: string;

--- a/ghost/core/test/unit/shared/errify.test.ts
+++ b/ghost/core/test/unit/shared/errify.test.ts
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import {errify} from '../../../core/shared/errify';
+
+const assertError = (value: unknown, expectedMessage: string) => {
+    assert(value instanceof Error);
+    assert.equal(value.message, expectedMessage);
+};
+
+describe('errify', function () {
+    it('returns the value unchanged if it is already an error', function () {
+        const error = new Error('Test error');
+        assert.equal(errify(error), error);
+    });
+
+    it('returns the value unchanged if it is an error subclass', function () {
+        class CustomError extends Error {}
+        const error = new CustomError('Test error');
+        assert.equal(errify(error), error);
+    });
+
+    it('converts null to an error with no message', function () {
+        assertError(errify(null), '');
+    });
+
+    it('converts undefined to an error with no message', function () {
+        assertError(errify(undefined), '');
+    });
+
+    it('converts strings to errors with the string as the message', function () {
+        assertError(errify('Test error'), 'Test error');
+    });
+
+    it('converts other primitive types to an error with their values stringified', function () {
+        assertError(errify(false), 'false');
+        assertError(errify(42), '42');
+        assertError(errify(42n), '42');
+        assertError(errify(Symbol('test')), 'Symbol(test)');
+    });
+
+    it('converts objects with messages to errors with the message property as the message', function () {
+        assertError(errify({message: 'Test error'}), 'Test error');
+        assertError(errify({message: 42}), '42');
+    });
+
+    it('converts objects without messages to errors with the object stringified as the message', function () {
+        assertError(errify({foo: 'bar'}), '[object Object]');
+        assertError(errify(Object.create(null)), '[object Object]');
+        assertError(errify([1, 2, 3]), '1,2,3');
+        assertError(errify({[Symbol.toPrimitive]: () => 'test'}), 'test');
+        assertError(errify({toString: () => 'test'}), 'test');
+    });
+
+    it('handles failures to convert to string gracefully', function () {
+        const explode = () => {
+            assert.fail('Failed to convert');
+        };
+        assertError(errify({[Symbol.toPrimitive]: explode}), '[object Object]');
+        assertError(errify({toString: explode}), '[object Object]');
+    });
+
+    it('handles strange objects with circular messages', function () {
+        const obj: Record<string, unknown> = {};
+        obj.message = obj;
+        assertError(errify(obj), '[object Object]');
+    });
+});

--- a/ghost/core/test/unit/shared/errify.test.ts
+++ b/ghost/core/test/unit/shared/errify.test.ts
@@ -42,6 +42,10 @@ describe('errify', function () {
         assertError(errify({message: 42}), '42');
     });
 
+    it('does not use nested message properties', function () {
+        assertError(errify({message: {message: 'Test error'}}), '[object Object]');
+    });
+
     it('converts objects without messages to errors with the object stringified as the message', function () {
         assertError(errify({foo: 'bar'}), '[object Object]');
         assertError(errify(Object.create(null)), '[object Object]');


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1340
ref https://github.com/TryGhost/Ghost/pull/28644

This change should have no user impact.

`RedirectsService` had a few type errors:

- A number of errors weren't necessarily `Error`s. I added a function, `errify` to convert `unknown` to `Error`. (I think this function will be useful elsewhere.)

- A `ValidationError` was being created with an invalid `context`.

I think these are useful improvements on their own, but it'll also unblock [an upcoming change][0] in a seemingly-unrelated area.

[0]: https://github.com/TryGhost/Ghost/pull/28644
