### PR TITLE
Changed unit tests to avoid rewire seams

### DIFF
--- a/ghost/core/core/server/services/member-welcome-emails/member-welcome-email-renderer.js
+++ b/ghost/core/core/server/services/member-welcome-emails/member-welcome-email-renderer.js
@@ -7,7 +7,7 @@ const errors = require('@tryghost/errors');
 const {MESSAGES} = require('./constants');
 const {wrapReplacementStrings} = require('../koenig/render-utils/replacement-strings');
 const linkReplacer = require('../lib/link-replacer');
-const {getEmailDesign} = require('../email-rendering/email-design');
+const emailDesign = require('../email-rendering/email-design');
 const {registerHelpers} = require('../email-service/helpers/register-helpers');
 
 const REPLACEMENT_REGEX = /%%\{(\w+?)(?:,? *"(.*?)")?\}%%/g;
@@ -119,7 +119,7 @@ class MemberWelcomeEmailRenderer {
     async render({lexical, subject, designSettings, member, siteSettings}) {
         designSettings = designSettings || {};
 
-        const design = getEmailDesign({
+        const design = emailDesign.getEmailDesign({
             accentColor: siteSettings.accentColor,
             backgroundColor: designSettings.background_color,
             buttonColor: designSettings.button_color,

--- a/ghost/core/core/server/services/outbox/handlers/member-created.js
+++ b/ghost/core/core/server/services/outbox/handlers/member-created.js
@@ -6,83 +6,71 @@ const {MEMBER_WELCOME_EMAIL_SLUGS} = require('../../member-welcome-emails/consta
 
 const LOG_KEY = `${OUTBOX_LOG_KEY}[MEMBER-WELCOME-EMAIL]`;
 
-function createMemberCreatedHandler({
-    memberWelcomeEmailService: memberWelcomeEmailServiceDep = memberWelcomeEmailService,
-    Automation: AutomationDep = Automation,
-    AutomatedEmailRecipient: AutomatedEmailRecipientDep = AutomatedEmailRecipient
-} = {}) {
-    async function handle({payload}) {
-        await memberWelcomeEmailServiceDep.api.send({member: payload, memberStatus: payload.status});
+async function handle({payload}) {
+    await memberWelcomeEmailService.api.send({member: payload, memberStatus: payload.status});
 
-        try {
-            const slug = MEMBER_WELCOME_EMAIL_SLUGS[payload.status];
-            if (!slug) {
-                logging.warn({
-                    system: {
-                        event: 'outbox.member_created.no_slug_mapping',
-                        member_status: payload.status
-                    }
-                }, `${LOG_KEY} No automated email slug found for member status`);
-                return;
-            }
-
-            const automation = await AutomationDep.findOne({slug}, {withRelated: ['welcomeEmailAutomatedEmail']});
-            if (!automation) {
-                logging.warn({
-                    system: {
-                        event: 'outbox.member_created.no_automated_email',
-                        slug
-                    }
-                }, `${LOG_KEY} No automated email found for slug: ${slug}`);
-                return;
-            }
-
-            // NOTE(NY-1190): This naively assumes each drip sequence will have
-            // just one email. When we change that assumption, this line will need
-            // to change to something like:
-            //
-            // ```
-            // SELECT * FROM welcome_email_automated_emails
-            // WHERE welcome_email_automation_id IS ?
-            // AND id NOT IN (
-            //   SELECT next_id FROM welcome_email_automated_emails
-            //   WHERE next_id IS NOT NULL
-            //   AND welcome_email_automation_id IS ?
-            // );
-            // ```
-            const email = automation.related('welcomeEmailAutomatedEmail');
-            if (!email || !email.id) {
-                logging.warn({
-                    system: {
-                        event: 'outbox.member_created.no_automated_email',
-                        slug
-                    }
-                }, `${LOG_KEY} No automated email content found for slug: ${slug}`);
-                return;
-            }
-
-            await AutomatedEmailRecipientDep.add({
-                member_id: payload.memberId,
-                automated_email_id: email.id,
-                member_uuid: payload.uuid,
-                member_email: payload.email,
-                member_name: payload.name
-            });
-        } catch (err) {
-            logging.error({
+    try {
+        const slug = MEMBER_WELCOME_EMAIL_SLUGS[payload.status];
+        if (!slug) {
+            logging.warn({
                 system: {
-                    event: 'outbox.member_created.track_send_failed'
-                },
-                err
-            }, `${LOG_KEY} Failed to track automated email send`);
+                    event: 'outbox.member_created.no_slug_mapping',
+                    member_status: payload.status
+                }
+            }, `${LOG_KEY} No automated email slug found for member status`);
+            return;
         }
-    }
 
-    return {
-        handle,
-        getLogInfo,
-        LOG_KEY
-    };
+        const automation = await Automation.findOne({slug}, {withRelated: ['welcomeEmailAutomatedEmail']});
+        if (!automation) {
+            logging.warn({
+                system: {
+                    event: 'outbox.member_created.no_automated_email',
+                    slug
+                }
+            }, `${LOG_KEY} No automated email found for slug: ${slug}`);
+            return;
+        }
+
+        // NOTE(NY-1190): This naively assumes each drip sequence will have
+        // just one email. When we change that assumption, this line will need
+        // to change to something like:
+        //
+        // ```
+        // SELECT * FROM welcome_email_automated_emails
+        // WHERE welcome_email_automation_id IS ?
+        // AND id NOT IN (
+        //   SELECT next_id FROM welcome_email_automated_emails
+        //   WHERE next_id IS NOT NULL
+        //   AND welcome_email_automation_id IS ?
+        // );
+        // ```
+        const email = automation.related('welcomeEmailAutomatedEmail');
+        if (!email || !email.id) {
+            logging.warn({
+                system: {
+                    event: 'outbox.member_created.no_automated_email',
+                    slug
+                }
+            }, `${LOG_KEY} No automated email content found for slug: ${slug}`);
+            return;
+        }
+
+        await AutomatedEmailRecipient.add({
+            member_id: payload.memberId,
+            automated_email_id: email.id,
+            member_uuid: payload.uuid,
+            member_email: payload.email,
+            member_name: payload.name
+        });
+    } catch (err) {
+        logging.error({
+            system: {
+                event: 'outbox.member_created.track_send_failed'
+            },
+            err
+        }, `${LOG_KEY} Failed to track automated email send`);
+    }
 }
 
 function getLogInfo(payload) {
@@ -90,5 +78,8 @@ function getLogInfo(payload) {
     return payload?.name ? `${payload.name} (${email})` : email;
 }
 
-module.exports = createMemberCreatedHandler();
-module.exports.createMemberCreatedHandler = createMemberCreatedHandler;
+module.exports = {
+    handle,
+    getLogInfo,
+    LOG_KEY
+};

--- a/ghost/core/core/server/services/outbox/jobs/lib/process-entries.js
+++ b/ghost/core/core/server/services/outbox/jobs/lib/process-entries.js
@@ -40,8 +40,8 @@ async function markEntryCompleted({db, entryId}) {
         });
 }
 
-async function processEntry({db, entry, eventHandlers}) {
-    const handler = eventHandlers[entry.event_type];
+async function processEntry({db, entry}) {
+    const handler = EVENT_HANDLERS[entry.event_type];
     if (!handler) {
         logging.warn({
             system: {
@@ -98,23 +98,20 @@ async function processEntry({db, entry, eventHandlers}) {
     return {success: true};
 }
 
-function createProcessEntries({eventHandlers = EVENT_HANDLERS} = {}) {
-    return async function processEntries({db, entries}) {
-        let processed = 0;
-        let failed = 0;
+async function processEntries({db, entries}) {
+    let processed = 0;
+    let failed = 0;
 
-        for (const entry of entries) {
-            const result = await processEntry({db, entry, eventHandlers});
-            if (result.success) {
-                processed += 1;
-            } else {
-                failed += 1;
-            }
+    for (const entry of entries) {
+        const result = await processEntry({db, entry});
+        if (result.success) {
+            processed += 1;
+        } else {
+            failed += 1;
         }
+    }
 
-        return {processed, failed};
-    };
+    return {processed, failed};
 }
 
-module.exports = createProcessEntries();
-module.exports.createProcessEntries = createProcessEntries;
+module.exports = processEntries;

--- a/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
@@ -1,11 +1,12 @@
 const assert = require('node:assert/strict');
 const cheerio = require('cheerio');
 const sinon = require('sinon');
-const rewire = require('rewire');
 const errors = require('@tryghost/errors');
+const lexicalLib = require('../../../../../core/server/lib/lexical');
+const emailDesign = require('../../../../../core/server/services/email-rendering/email-design');
+const MemberWelcomeEmailRenderer = require('../../../../../core/server/services/member-welcome-emails/member-welcome-email-renderer');
 
 describe('MemberWelcomeEmailRenderer', function () {
-    let MemberWelcomeEmailRenderer;
     let lexicalRenderStub;
 
     const defaultSiteSettings = {
@@ -16,21 +17,23 @@ describe('MemberWelcomeEmailRenderer', function () {
     };
 
     beforeEach(function () {
-        lexicalRenderStub = sinon.stub().resolves('<p>Hello World</p>');
-
-        MemberWelcomeEmailRenderer = rewire('../../../../../core/server/services/member-welcome-emails/member-welcome-email-renderer');
-        MemberWelcomeEmailRenderer.__set__('lexicalLib', {
-            render: lexicalRenderStub
-        });
+        lexicalRenderStub = sinon.stub(lexicalLib, 'render').resolves('<p>Hello World</p>');
     });
 
     afterEach(function () {
         sinon.restore();
     });
 
+    function createRenderer(options = {}) {
+        return new MemberWelcomeEmailRenderer({
+            t: key => key,
+            ...options
+        });
+    }
+
     describe('render', function () {
         it('renders Lexical content to HTML via lexicalLib.render', async function () {
-            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+            const renderer = createRenderer();
             const lexicalJson = '{"root":{"children":[]}}';
 
             await renderer.render({
@@ -70,7 +73,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('substitutes member template variables', async function () {
             lexicalRenderStub.resolves('<p>Hello {name}, or {first_name}! Contact: {email}</p>');
-            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+            const renderer = createRenderer();
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -86,7 +89,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('substitutes site template variables', async function () {
             lexicalRenderStub.resolves('<p>Welcome to {site_title} at {site_url}</p>');
-            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+            const renderer = createRenderer();
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -101,7 +104,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('substitutes uuid replacement token', async function () {
             lexicalRenderStub.resolves('<p><a href="https://partner.transistor.fm/ghost/%%{uuid}%%">Listen</a></p>');
-            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+            const renderer = createRenderer();
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -119,7 +122,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('inlines accentColor into link styles', async function () {
             lexicalRenderStub.resolves('<p><a href="https://example.com">Click here</a></p>');
-            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+            const renderer = createRenderer();
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -134,7 +137,7 @@ describe('MemberWelcomeEmailRenderer', function () {
         });
 
         it('substitutes template variables in subject', async function () {
-            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+            const renderer = createRenderer();
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -148,7 +151,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('renders empty when member name is missing and no fallback specified', async function () {
             lexicalRenderStub.resolves('<p>Hello {name}!</p>');
-            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+            const renderer = createRenderer();
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -163,7 +166,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('uses custom fallback when member name is missing', async function () {
             lexicalRenderStub.resolves('<p>Hello {name, "there"}</p>');
-            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+            const renderer = createRenderer();
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -177,7 +180,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('uses custom fallback for first_name when missing', async function () {
             lexicalRenderStub.resolves('<p>Hey {first_name, "friend"}</p>');
-            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+            const renderer = createRenderer();
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -191,7 +194,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('ignores fallback when member name is present', async function () {
             lexicalRenderStub.resolves('<p>Hello {name, "there"}</p>');
-            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+            const renderer = createRenderer();
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -205,7 +208,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('renders empty when member email is missing', async function () {
             lexicalRenderStub.resolves('<p>Email: {email}!</p>');
-            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+            const renderer = createRenderer();
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -220,7 +223,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('extracts first name correctly from full name', async function () {
             lexicalRenderStub.resolves('<p>Hi {first_name}</p>');
-            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+            const renderer = createRenderer();
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -234,7 +237,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('handles whitespace in name when extracting first_name', async function () {
             lexicalRenderStub.resolves('<p>Hi {first_name, "friend"}</p>');
-            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+            const renderer = createRenderer();
 
             const paddedResult = await renderer.render({
                 lexical: '{}',
@@ -255,7 +258,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('wraps content in wrapper.hbs template', async function () {
             lexicalRenderStub.resolves('<p>Content</p>');
-            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+            const renderer = createRenderer();
             const year = new Date().getFullYear();
 
             const result = await renderer.render({
@@ -276,7 +279,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('preserves multiline code block whitespace in the shared email wrapper', async function () {
             lexicalRenderStub.resolves('<pre><code>const firstLine = 1;\nconst secondLine = 2;</code></pre>');
-            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+            const renderer = createRenderer();
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -293,7 +296,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('resolves relative portal links to absolute URLs', async function () {
             lexicalRenderStub.resolves('<table class="kg-card kg-button-card"><tbody><tr><td><table class="btn"><tbody><tr><td align="center"><a href="#/portal/support">Support us</a></td></tr></tbody></table></td></tr></tbody></table>');
-            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+            const renderer = createRenderer();
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -310,7 +313,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('generates plain text from HTML', async function () {
             lexicalRenderStub.resolves('<p>Hello World</p>');
-            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+            const renderer = createRenderer();
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -325,7 +328,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('throws IncorrectUsageError for invalid Lexical', async function () {
             lexicalRenderStub.rejects(new Error('Invalid JSON'));
-            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+            const renderer = createRenderer();
 
             await assert.rejects(renderer.render({
                 lexical: 'invalid',
@@ -337,7 +340,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('includes error context in IncorrectUsageError', async function () {
             lexicalRenderStub.rejects(new Error('Parse error'));
-            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+            const renderer = createRenderer();
 
             await assert.rejects(
                 renderer.render({
@@ -356,7 +359,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('escapes HTML in member values for body but not subject', async function () {
             lexicalRenderStub.resolves('<p>Hello {name}</p>');
-            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+            const renderer = createRenderer();
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -373,7 +376,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('uses &#39;, not &apos;, for Outlook support', async function () {
             lexicalRenderStub.resolves('<p>It\'s great to have you!</p>');
-            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+            const renderer = createRenderer();
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -388,7 +391,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('removes unknown tokens from output', async function () {
             lexicalRenderStub.resolves('<p>Hello {unknown_token} and {another}</p>');
-            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+            const renderer = createRenderer();
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -404,7 +407,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('removes code wrappers around replacement strings', async function () {
             lexicalRenderStub.resolves('<p>Hello <code>{first_name}</code></p>');
-            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+            const renderer = createRenderer();
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -420,7 +423,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('preserves code blocks that are not replacement strings', async function () {
             lexicalRenderStub.resolves('<p>Here is some code: <code>if (x) { return y; }</code> and a greeting for <code>{first_name}</code></p>');
-            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+            const renderer = createRenderer();
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -437,7 +440,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('removes code wrappers around replacement strings with fallback', async function () {
             lexicalRenderStub.resolves('<p>Hey <code>{first_name, "friend"}</code></p>');
-            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+            const renderer = createRenderer();
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -453,7 +456,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('removes code wrappers around replacement strings with fallback (no comma)', async function () {
             lexicalRenderStub.resolves('<p>Hey <code>{first_name "friend"}</code></p>');
-            const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+            const renderer = createRenderer();
 
             const result = await renderer.render({
                 lexical: '{}',
@@ -469,7 +472,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         it('translates footer text using the t helper', async function () {
             lexicalRenderStub.resolves('<p>Content</p>');
-            const renderer = new MemberWelcomeEmailRenderer({t: (key) => {
+            const renderer = createRenderer({t: (key) => {
                 if (key === 'Manage your preferences') {
                     return 'Gérer vos préférences';
                 }
@@ -490,10 +493,9 @@ describe('MemberWelcomeEmailRenderer', function () {
 
         describe('design customization', function () {
             it('builds the email design from database-backed design settings', async function () {
-                const getEmailDesignStub = sinon.stub().returns({accentColor: '#123456'});
-                MemberWelcomeEmailRenderer.__set__('getEmailDesign', getEmailDesignStub);
+                const getEmailDesignStub = sinon.stub(emailDesign, 'getEmailDesign').returns({accentColor: '#123456'});
 
-                const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+                const renderer = createRenderer();
                 const designSettings = {
                     background_color: '#111111',
                     button_color: '#222222',
@@ -537,7 +539,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
             it('passes header and footer settings through to the wrapper template', async function () {
                 lexicalRenderStub.resolves('<p>Content</p>');
-                const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+                const renderer = createRenderer();
 
                 const result = await renderer.render({
                     lexical: '{}',
@@ -560,7 +562,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
             it('renders the publication icon when enabled and a site icon exists', async function () {
                 lexicalRenderStub.resolves('<p>Content</p>');
-                const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+                const renderer = createRenderer();
 
                 const result = await renderer.render({
                     lexical: '{}',
@@ -581,7 +583,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
             it('does not render the publication icon when disabled', async function () {
                 lexicalRenderStub.resolves('<p>Content</p>');
-                const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+                const renderer = createRenderer();
 
                 const result = await renderer.render({
                     lexical: '{}',
@@ -602,7 +604,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
             it('does not render the publication icon when the site icon is missing', async function () {
                 lexicalRenderStub.resolves('<p>Content</p>');
-                const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+                const renderer = createRenderer();
 
                 const result = await renderer.render({
                     lexical: '{}',
@@ -626,7 +628,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
             it('uses the sans-serif content-shell class by default when design customization is enabled', async function () {
                 lexicalRenderStub.resolves('<p>Content</p>');
-                const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+                const renderer = createRenderer();
 
                 const result = await renderer.render({
                     lexical: '{}',
@@ -643,7 +645,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
             it('uses the serif content-shell class when a serif body font is explicitly configured', async function () {
                 lexicalRenderStub.resolves('<p>Content</p>');
-                const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+                const renderer = createRenderer();
 
                 const result = await renderer.render({
                     lexical: '{}',
@@ -663,7 +665,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
             it('applies custom link colors when design customization is enabled', async function () {
                 lexicalRenderStub.resolves('<p><a href="https://example.com">Custom link</a></p>');
-                const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+                const renderer = createRenderer();
 
                 const result = await renderer.render({
                     lexical: '{}',
@@ -681,7 +683,7 @@ describe('MemberWelcomeEmailRenderer', function () {
 
             it('applies header image styles and preserves header background color', async function () {
                 lexicalRenderStub.resolves('<p>Content</p>');
-                const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+                const renderer = createRenderer();
 
                 const result = await renderer.render({
                     lexical: '{}',
@@ -726,7 +728,7 @@ describe('MemberWelcomeEmailRenderer', function () {
                         <div class="kg-callout-text">Shared styles</div>
                     </div>
                 `);
-                const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+                const renderer = createRenderer();
 
                 const result = await renderer.render({
                     lexical: '{}',
@@ -755,7 +757,7 @@ describe('MemberWelcomeEmailRenderer', function () {
                         </tr>
                     </table>
                 `);
-                const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+                const renderer = createRenderer();
 
                 const result = await renderer.render({
                     lexical: '{}',
@@ -803,7 +805,7 @@ describe('MemberWelcomeEmailRenderer', function () {
                         <figcaption>Embed note</figcaption>
                     </figure>
                 `);
-                const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+                const renderer = createRenderer();
 
                 const result = await renderer.render({
                     lexical: '{}',
@@ -865,7 +867,7 @@ describe('MemberWelcomeEmailRenderer', function () {
                         </tr>
                     </table>
                 `);
-                const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+                const renderer = createRenderer();
 
                 const result = await renderer.render({
                     lexical: '{}',
@@ -901,7 +903,7 @@ describe('MemberWelcomeEmailRenderer', function () {
                         </tbody>
                     </table>
                 `);
-                const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+                const renderer = createRenderer();
 
                 const result = await renderer.render({
                     lexical: '{}',
@@ -924,7 +926,7 @@ describe('MemberWelcomeEmailRenderer', function () {
                         <figcaption>A caption</figcaption>
                     </figure>
                 `);
-                const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+                const renderer = createRenderer();
 
                 const result = await renderer.render({
                     lexical: '{}',
@@ -951,7 +953,7 @@ describe('MemberWelcomeEmailRenderer', function () {
                         <img src="https://example.com/photo.jpg" class="kg-image" alt="alt text" loading="lazy" width="600" height="400">
                     </figure>
                 `);
-                const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+                const renderer = createRenderer();
 
                 const result = await renderer.render({
                     lexical: '{}',
@@ -986,7 +988,7 @@ describe('MemberWelcomeEmailRenderer', function () {
                         </tbody>
                     </table>
                 `);
-                const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+                const renderer = createRenderer();
 
                 const result = await renderer.render({
                     lexical: '{}',
@@ -1019,7 +1021,7 @@ describe('MemberWelcomeEmailRenderer', function () {
                         </tbody>
                     </table>
                 `);
-                const renderer = new MemberWelcomeEmailRenderer({t: key => key});
+                const renderer = createRenderer();
 
                 const result = await renderer.render({
                     lexical: '{}',

--- a/ghost/core/test/unit/server/services/outbox/handlers/member-created.test.js
+++ b/ghost/core/test/unit/server/services/outbox/handlers/member-created.test.js
@@ -1,53 +1,46 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const {captureLoggerOutput, findByEvent} = require('../../../../../utils/logging-utils');
-const {createMemberCreatedHandler} = require('../../../../../../core/server/services/outbox/handlers/member-created.js');
+const handler = require('../../../../../../core/server/services/outbox/handlers/member-created.js');
+const memberWelcomeEmailService = require('../../../../../../core/server/services/member-welcome-emails/service');
+const {Automation, AutomatedEmailRecipient} = require('../../../../../../core/server/models');
 
 describe('member-created handler', function () {
-    let handler;
-    let memberWelcomeEmailServiceStub;
-    let AutomationStub;
-    let AutomatedEmailRecipientStub;
+    let memberWelcomeEmailServiceSendStub;
+    let AutomationFindOneStub;
+    let AutomatedEmailRecipientAddStub;
     let logCapture;
+    let originalMemberWelcomeEmailApi;
 
     beforeEach(function () {
-        memberWelcomeEmailServiceStub = {
-            api: {
-                send: sinon.stub().resolves()
-            }
+        memberWelcomeEmailServiceSendStub = sinon.stub().resolves();
+        originalMemberWelcomeEmailApi = memberWelcomeEmailService.api;
+        memberWelcomeEmailService.api = {
+            send: memberWelcomeEmailServiceSendStub
         };
 
-        AutomationStub = {
-            findOne: sinon.stub().resolves({
-                id: 'automation123',
-                related: sinon.stub().callsFake((relation) => {
-                    if (relation === 'welcomeEmailAutomatedEmail') {
-                        return {id: 'ae123'};
-                    }
-                })
+        AutomationFindOneStub = sinon.stub(Automation, 'findOne').resolves({
+            id: 'automation123',
+            related: sinon.stub().callsFake((relation) => {
+                if (relation === 'welcomeEmailAutomatedEmail') {
+                    return {id: 'ae123'};
+                }
             })
-        };
+        });
 
-        AutomatedEmailRecipientStub = {
-            add: sinon.stub().resolves()
-        };
+        AutomatedEmailRecipientAddStub = sinon.stub(AutomatedEmailRecipient, 'add').resolves();
 
         logCapture = captureLoggerOutput();
-
-        handler = createMemberCreatedHandler({
-            memberWelcomeEmailService: memberWelcomeEmailServiceStub,
-            Automation: AutomationStub,
-            AutomatedEmailRecipient: AutomatedEmailRecipientStub
-        });
     });
 
     afterEach(function () {
+        memberWelcomeEmailService.api = originalMemberWelcomeEmailApi;
         logCapture.restore();
         sinon.restore();
     });
 
     it('sends email even when tracking fails', async function () {
-        AutomatedEmailRecipientStub.add.rejects(new Error('Database error'));
+        AutomatedEmailRecipientAddStub.rejects(new Error('Database error'));
 
         await handler.handle({
             payload: {
@@ -59,12 +52,12 @@ describe('member-created handler', function () {
             }
         });
 
-        sinon.assert.calledOnce(memberWelcomeEmailServiceStub.api.send);
+        sinon.assert.calledOnce(memberWelcomeEmailServiceSendStub);
     });
 
     it('logs error when tracking fails', async function () {
         const dbError = new Error('Database connection failed');
-        AutomatedEmailRecipientStub.add.rejects(dbError);
+        AutomatedEmailRecipientAddStub.rejects(dbError);
 
         await handler.handle({
             payload: {
@@ -91,18 +84,18 @@ describe('member-created handler', function () {
             }
         });
 
-        sinon.assert.calledOnce(memberWelcomeEmailServiceStub.api.send);
+        sinon.assert.calledOnce(memberWelcomeEmailServiceSendStub);
         const warningLog = findByEvent(logCapture.output, 'outbox.member_created.no_slug_mapping');
         assert.ok(warningLog);
         assert.deepEqual(warningLog.system, {
             event: 'outbox.member_created.no_slug_mapping',
             member_status: 'comped'
         });
-        sinon.assert.notCalled(AutomatedEmailRecipientStub.add);
+        sinon.assert.notCalled(AutomatedEmailRecipientAddStub);
     });
 
     it('logs warning when no automated email found for slug', async function () {
-        AutomationStub.findOne.resolves(null);
+        AutomationFindOneStub.resolves(null);
 
         await handler.handle({
             payload: {
@@ -114,13 +107,13 @@ describe('member-created handler', function () {
             }
         });
 
-        sinon.assert.calledOnce(memberWelcomeEmailServiceStub.api.send);
+        sinon.assert.calledOnce(memberWelcomeEmailServiceSendStub);
         const warningLog = findByEvent(logCapture.output, 'outbox.member_created.no_automated_email');
         assert.ok(warningLog);
         assert.deepEqual(warningLog.system, {
             event: 'outbox.member_created.no_automated_email',
             slug: 'member-welcome-email-free'
         });
-        sinon.assert.notCalled(AutomatedEmailRecipientStub.add);
+        sinon.assert.notCalled(AutomatedEmailRecipientAddStub);
     });
 });

--- a/ghost/core/test/unit/server/services/outbox/jobs/lib/process-entries.test.js
+++ b/ghost/core/test/unit/server/services/outbox/jobs/lib/process-entries.test.js
@@ -1,12 +1,12 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const {captureLoggerOutput, findByEvent} = require('../../../../../../utils/logging-utils');
-const {createProcessEntries} = require('../../../../../../../core/server/services/outbox/jobs/lib/process-entries.js');
+const processEntries = require('../../../../../../../core/server/services/outbox/jobs/lib/process-entries.js');
+const memberCreatedHandler = require('../../../../../../../core/server/services/outbox/handlers/member-created');
 
 const MEMBER_CREATED_EVENT = 'MemberCreatedEvent';
 
 describe('processEntries', function () {
-    let processEntries;
     let handlerStub;
     let dbStub;
     let logCapture;
@@ -27,16 +27,9 @@ describe('processEntries', function () {
 
     beforeEach(function () {
         handlerStub = {
-            handle: sinon.stub().resolves(),
-            getLogInfo: sinon.stub().returns('test@example.com'),
-            LOG_KEY: '[OUTBOX][MEMBER-WELCOME-EMAIL]'
+            handle: sinon.stub(memberCreatedHandler, 'handle').resolves(),
+            getLogInfo: sinon.stub(memberCreatedHandler, 'getLogInfo').returns('test@example.com')
         };
-
-        processEntries = createProcessEntries({
-            eventHandlers: {
-                [MEMBER_CREATED_EVENT]: handlerStub
-            }
-        });
 
         dbStub = createDbStub();
 


### PR DESCRIPTION
## Summary
- removed rewire from the member welcome email renderer unit test using real object-boundary stubs
- changed the renderer's email design import to a module object so getEmailDesign can be stubbed without rewire
- reduced production seams added in #28647 by removing the member-created and process-entries factories
- updated the outbox tests to stub the real handler/model/service object boundaries instead

## Tests
- pnpm --dir ghost/core test:vitest test/unit/server/services/outbox/handlers/member-created.test.js test/unit/server/services/outbox/jobs/lib/process-entries.test.js test/unit/server/services/outbox/index.test.js test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
- pnpm --dir ghost/core exec eslint --cache -- core/server/services/member-welcome-emails/member-welcome-email-renderer.js test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js core/server/services/outbox/handlers/member-created.js core/server/services/outbox/jobs/lib/process-entries.js test/unit/server/services/outbox/handlers/member-created.test.js test/unit/server/services/outbox/jobs/lib/process-entries.test.js
- pre-commit eslint for touched files