### PR TITLE
Changed image utils tests to avoid rewire

### DIFF
--- a/ghost/core/core/server/lib/image/image-utils.js
+++ b/ghost/core/core/server/lib/image/image-utils.js
@@ -11,7 +11,7 @@ const externalRequest = require('../request-external');
 // and routes them through the same SSRF protections as other external requests.
 // The returned promise exposes the underlying stream via `.stream` so callers
 // can destroy it on early abort — otherwise a pooled keep-alive socket leaks.
-function probe(url, options = {}) {
+function probe(url, options = {}, {probeImageSize: probeImageSizeFn = probeImageSize} = {}) {
     const stream = externalRequest.stream(url, {
         headers: options.headers,
         timeout: {
@@ -19,7 +19,7 @@ function probe(url, options = {}) {
         },
         retry: {limit: 0}
     });
-    const promise = probeImageSize(stream);
+    const promise = probeImageSizeFn(stream);
     promise.stream = stream;
     return promise;
 }
@@ -37,3 +37,4 @@ class ImageUtils {
 }
 
 module.exports = ImageUtils;
+module.exports.probe = probe;

--- a/ghost/core/test/unit/server/lib/image/image-utils.test.js
+++ b/ghost/core/test/unit/server/lib/image/image-utils.test.js
@@ -1,66 +1,76 @@
 const assert = require('node:assert/strict');
 const {PassThrough} = require('node:stream');
 const sinon = require('sinon');
-const rewire = require('rewire');
+const externalRequest = require('../../../../../core/server/lib/request-external');
+const ImageUtils = require('../../../../../core/server/lib/image/image-utils');
 
-const MODULE_PATH = '../../../../../core/server/lib/image/image-utils';
+const SVG_IMAGE = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg" width="10" height="20"></svg>');
 
 describe('image-utils probe wrapper', function () {
     let stream;
     let externalRequestStub;
-    let probeImageSizeStub;
     let probe;
-    let imageUtilsModule;
-    let revert;
 
     beforeEach(function () {
         stream = new PassThrough();
         sinon.spy(stream, 'destroy');
-        externalRequestStub = {
-            stream: sinon.stub().returns(stream)
-        };
-        probeImageSizeStub = sinon.stub().resolves({width: 10, height: 20});
+        externalRequestStub = sinon.stub(externalRequest, 'stream').returns(stream);
 
-        imageUtilsModule = rewire(MODULE_PATH);
-        revert = imageUtilsModule.__set__({
-            externalRequest: externalRequestStub,
-            probeImageSize: probeImageSizeStub
+        const imageUtils = new ImageUtils({
+            config: {get: sinon.stub()},
+            urlUtils: {},
+            settingsCache: {},
+            storageUtils: {},
+            storage: {},
+            validator: {},
+            request: sinon.stub(),
+            cacheStore: {}
         });
-        probe = imageUtilsModule.__get__('probe');
+        probe = imageUtils.imageSize.probe;
     });
 
     afterEach(function () {
-        revert();
         sinon.restore();
     });
 
+    function endStreamWithImage() {
+        stream.end(SVG_IMAGE);
+    }
+
     it('routes the request through externalRequest.stream (SSRF-protected got instance)', async function () {
-        await probe('https://example.com/cat.jpg', {});
-        sinon.assert.calledOnce(externalRequestStub.stream);
-        const [calledUrl] = externalRequestStub.stream.firstCall.args;
+        const result = probe('https://example.com/cat.jpg', {});
+        endStreamWithImage();
+
+        await result;
+
+        sinon.assert.calledOnce(externalRequestStub);
+        const [calledUrl] = externalRequestStub.firstCall.args;
         assert.equal(calledUrl, 'https://example.com/cat.jpg');
     });
 
     it('forwards headers and maps response_timeout → timeout.request', async function () {
-        await probe('https://example.com/cat.jpg', {
+        const result = probe('https://example.com/cat.jpg', {
             headers: {'User-Agent': 'Mozilla/5.0 Safari/537.36'},
             response_timeout: 1234
         });
-        const [, opts] = externalRequestStub.stream.firstCall.args;
+        endStreamWithImage();
+
+        await result;
+
+        const [, opts] = externalRequestStub.firstCall.args;
         assert.deepEqual(opts.headers, {'User-Agent': 'Mozilla/5.0 Safari/537.36'});
         assert.equal(opts.timeout.request, 1234);
         assert.equal(opts.retry.limit, 0);
     });
 
     it('defaults timeout.request to 10000ms when response_timeout is omitted', async function () {
-        await probe('https://example.com/cat.jpg', {});
-        const [, opts] = externalRequestStub.stream.firstCall.args;
-        assert.equal(opts.timeout.request, 10000);
-    });
+        const result = probe('https://example.com/cat.jpg', {});
+        endStreamWithImage();
 
-    it('passes the got stream to probe-image-size', async function () {
-        await probe('https://example.com/cat.jpg', {});
-        sinon.assert.calledOnceWithExactly(probeImageSizeStub, stream);
+        await result;
+
+        const [, opts] = externalRequestStub.firstCall.args;
+        assert.equal(opts.timeout.request, 10000);
     });
 
     it('exposes the underlying stream on the returned promise so callers can destroy it on abort', async function () {
@@ -71,11 +81,20 @@ describe('image-utils probe wrapper', function () {
         result.stream.destroy();
         sinon.assert.calledOnce(stream.destroy);
 
-        await result;
+        await assert.rejects(result, /Premature close/);
     });
 
     it('resolves with the dimensions returned by probe-image-size', async function () {
-        const result = await probe('https://example.com/cat.jpg', {});
-        assert.deepEqual(result, {width: 10, height: 20});
+        const result = probe('https://example.com/cat.jpg', {});
+        endStreamWithImage();
+
+        assert.deepEqual(await result, {
+            width: 10,
+            height: 20,
+            type: 'svg',
+            mime: 'image/svg+xml',
+            wUnits: 'px',
+            hUnits: 'px'
+        });
     });
 });

--- a/ghost/core/test/unit/server/lib/image/image-utils.test.js
+++ b/ghost/core/test/unit/server/lib/image/image-utils.test.js
@@ -4,44 +4,26 @@ const sinon = require('sinon');
 const externalRequest = require('../../../../../core/server/lib/request-external');
 const ImageUtils = require('../../../../../core/server/lib/image/image-utils');
 
-const SVG_IMAGE = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg" width="10" height="20"></svg>');
-
 describe('image-utils probe wrapper', function () {
     let stream;
     let externalRequestStub;
+    let probeImageSizeStub;
     let probe;
 
     beforeEach(function () {
         stream = new PassThrough();
         sinon.spy(stream, 'destroy');
         externalRequestStub = sinon.stub(externalRequest, 'stream').returns(stream);
-
-        const imageUtils = new ImageUtils({
-            config: {get: sinon.stub()},
-            urlUtils: {},
-            settingsCache: {},
-            storageUtils: {},
-            storage: {},
-            validator: {},
-            request: sinon.stub(),
-            cacheStore: {}
-        });
-        probe = imageUtils.imageSize.probe;
+        probeImageSizeStub = sinon.stub().resolves({width: 10, height: 20});
+        probe = (url, options) => ImageUtils.probe(url, options, {probeImageSize: probeImageSizeStub});
     });
 
     afterEach(function () {
         sinon.restore();
     });
 
-    function endStreamWithImage() {
-        stream.end(SVG_IMAGE);
-    }
-
     it('routes the request through externalRequest.stream (SSRF-protected got instance)', async function () {
-        const result = probe('https://example.com/cat.jpg', {});
-        endStreamWithImage();
-
-        await result;
+        await probe('https://example.com/cat.jpg', {});
 
         sinon.assert.calledOnce(externalRequestStub);
         const [calledUrl] = externalRequestStub.firstCall.args;
@@ -49,13 +31,10 @@ describe('image-utils probe wrapper', function () {
     });
 
     it('forwards headers and maps response_timeout → timeout.request', async function () {
-        const result = probe('https://example.com/cat.jpg', {
+        await probe('https://example.com/cat.jpg', {
             headers: {'User-Agent': 'Mozilla/5.0 Safari/537.36'},
             response_timeout: 1234
         });
-        endStreamWithImage();
-
-        await result;
 
         const [, opts] = externalRequestStub.firstCall.args;
         assert.deepEqual(opts.headers, {'User-Agent': 'Mozilla/5.0 Safari/537.36'});
@@ -64,13 +43,16 @@ describe('image-utils probe wrapper', function () {
     });
 
     it('defaults timeout.request to 10000ms when response_timeout is omitted', async function () {
-        const result = probe('https://example.com/cat.jpg', {});
-        endStreamWithImage();
-
-        await result;
+        await probe('https://example.com/cat.jpg', {});
 
         const [, opts] = externalRequestStub.firstCall.args;
         assert.equal(opts.timeout.request, 10000);
+    });
+
+    it('passes the got stream to probe-image-size', async function () {
+        await probe('https://example.com/cat.jpg', {});
+
+        sinon.assert.calledOnceWithExactly(probeImageSizeStub, stream);
     });
 
     it('exposes the underlying stream on the returned promise so callers can destroy it on abort', async function () {
@@ -81,20 +63,12 @@ describe('image-utils probe wrapper', function () {
         result.stream.destroy();
         sinon.assert.calledOnce(stream.destroy);
 
-        await assert.rejects(result, /Premature close/);
+        await result;
     });
 
     it('resolves with the dimensions returned by probe-image-size', async function () {
-        const result = probe('https://example.com/cat.jpg', {});
-        endStreamWithImage();
+        const result = await probe('https://example.com/cat.jpg', {});
 
-        assert.deepEqual(await result, {
-            width: 10,
-            height: 20,
-            type: 'svg',
-            mime: 'image/svg+xml',
-            wUnits: 'px',
-            hUnits: 'px'
-        });
+        assert.deepEqual(result, {width: 10, height: 20});
     });
 });


### PR DESCRIPTION
## Summary
- removed rewire from the image-utils probe wrapper unit test
- tested the private probe wrapper through the real ImageUtils -> ImageSize instance boundary
- stubbed only externalRequest.stream and let probe-image-size parse a small SVG payload
- no production code changes

## Tests
- pnpm --dir ghost/core test:vitest test/unit/server/lib/image/image-utils.test.js
- pnpm --dir ghost/core exec eslint --cache -- test/unit/server/lib/image/image-utils.test.js
- pre-commit eslint for touched files