### PR TITLE
Changed models listeners test to avoid rewire

### DIFF
--- a/ghost/core/core/server/models/base/listeners.js
+++ b/ghost/core/core/server/models/base/listeners.js
@@ -8,12 +8,7 @@ const {sequence} = require('@tryghost/promise');
 // Listen to settings.timezone.edited and settings.notifications.edited to bind extra logic to settings, similar to the bridge and member service
 const events = require('../../lib/common/events');
 
-/**
- * WHEN timezone changes, we will:
- * - reschedule all scheduled posts
- * - draft scheduled posts, when the published_at would be in the past
- */
-events.on('settings.timezone.edited', function (settingModel, options) {
+const onTimezoneEdited = function (settingModel, options) {
     options = options || {};
     options = _.merge({}, options, {context: {internal: true}});
 
@@ -81,14 +76,9 @@ events.on('settings.timezone.edited', function (settingModel, options) {
             }));
         }
     });
-});
+};
 
-/**
- * Remove all notifications, which are seen, older than 3 months.
- * No transaction, because notifications are not sensitive and we would have to add `forUpdate`
- * to the settings model to create real lock.
- */
-events.on('settings.notifications.edited', function (settingModel) {
+const onNotificationsEdited = function (settingModel) {
     let allNotifications = JSON.parse(settingModel.attributes.value || []);
     const options = {context: {internal: true}};
     let skip = true;
@@ -117,4 +107,26 @@ events.on('settings.notifications.edited', function (settingModel) {
     }, options).catch(function (err) {
         errors.logError(err);
     });
-});
+};
+
+const registerListeners = function (eventEmitter = events) {
+    /**
+     * WHEN timezone changes, we will:
+     * - reschedule all scheduled posts
+     * - draft scheduled posts, when the published_at would be in the past
+     */
+    eventEmitter.on('settings.timezone.edited', onTimezoneEdited);
+
+    /**
+     * Remove all notifications, which are seen, older than 3 months.
+     * No transaction, because notifications are not sensitive and we would have to add `forUpdate`
+     * to the settings model to create real lock.
+     */
+    eventEmitter.on('settings.notifications.edited', onNotificationsEdited);
+};
+
+registerListeners();
+
+module.exports = {
+    registerListeners
+};

--- a/ghost/core/test/legacy/models/base/listeners.test.js
+++ b/ghost/core/test/legacy/models/base/listeners.test.js
@@ -1,10 +1,10 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const moment = require('moment-timezone');
-const rewire = require('rewire');
 const _ = require('lodash');
 const events = require('../../../../core/server/lib/common/events');
 const models = require('../../../../core/server/models');
+const listeners = require('../../../../core/server/models/base/listeners');
 const testUtils = require('../../../utils');
 
 describe('Models: listeners', function () {
@@ -27,7 +27,7 @@ describe('Models: listeners', function () {
             eventsToRemember[eventName] = callback;
         });
 
-        rewire('../../../../core/server/models/base/listeners');
+        listeners.registerListeners(events);
     });
 
     afterEach(function () {


### PR DESCRIPTION
no ref

## Summary
- exposed `registerListeners` from the base model listeners module while preserving the existing top-level registration side effect
- updated the legacy listeners test to register against the real events object stub instead of using `rewire`
- avoided require cache reloading by using the exported registration boundary

## Tests
- `pnpm test:single test/legacy/models/base/listeners.test.js`
- `pnpm exec eslint --ignore-path .eslintignore core/server/models/base/listeners.js`
- `pnpm exec eslint -c test/.eslintrc.js --ignore-path test/.eslintignore test/legacy/models/base/listeners.test.js`