### PR TITLE
Changed importer tests to avoid rewire

### DIFF
--- a/ghost/core/test/unit/server/data/importer/index.test.js
+++ b/ghost/core/test/unit/server/data/importer/index.test.js
@@ -2,7 +2,6 @@ const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../utils/assertions');
 const errors = require('@tryghost/errors');
 const sinon = require('sinon');
-const rewire = require('rewire');
 const _ = require('lodash');
 const testUtils = require('../../../../utils');
 const moment = require('moment');
@@ -13,11 +12,22 @@ const fs = require('fs-extra');
 const ImportManager = require('../../../../../core/server/data/importer');
 
 const JSONHandler = require('../../../../../core/server/data/importer/handlers/json');
-let ImageHandler = rewire('../../../../../core/server/data/importer/handlers/image');
+const ImageHandler = Object.assign({}, require('../../../../../core/server/data/importer/handlers/image'));
 const MarkdownHandler = require('../../../../../core/server/data/importer/handlers/markdown');
 const RevueHandler = require('../../../../../core/server/data/importer/handlers/revue');
 const DataImporter = require('../../../../../core/server/data/importer/importers/data');
 const RevueImporter = require('../../../../../core/server/data/importer/importers/importer-revue');
+const UsersImporter = require('../../../../../core/server/data/importer/importers/data/users-importer');
+const RolesImporter = require('../../../../../core/server/data/importer/importers/data/roles-importer');
+const TagsImporter = require('../../../../../core/server/data/importer/importers/data/tags-importer');
+const NewslettersImporter = require('../../../../../core/server/data/importer/importers/data/newsletters-importer');
+const SettingsImporter = require('../../../../../core/server/data/importer/importers/data/settings-importer');
+const ProductsImporter = require('../../../../../core/server/data/importer/importers/data/products-importer');
+const StripeProductsImporter = require('../../../../../core/server/data/importer/importers/data/stripe-products-importer');
+const StripePricesImporter = require('../../../../../core/server/data/importer/importers/data/stripe-prices-importer');
+const PostsImporter = require('../../../../../core/server/data/importer/importers/data/posts-importer');
+const CustomThemeSettingsImporter = require('../../../../../core/server/data/importer/importers/data/custom-theme-settings-importer');
+const RevueSubscriberImporter = require('../../../../../core/server/data/importer/importers/data/revue-subscriber-importer');
 const models = require('../../../../../core/server/models');
 const configUtils = require('../../../../utils/config-utils');
 const logging = require('@tryghost/logging');
@@ -25,7 +35,6 @@ const logging = require('@tryghost/logging');
 describe('Importer', function () {
     afterEach(async function () {
         sinon.restore();
-        ImageHandler = rewire('../../../../../core/server/data/importer/handlers/image');
         await configUtils.restore();
     });
 
@@ -685,34 +694,37 @@ describe('Importer', function () {
         });
 
         it('rejects with a DataImportError carrying the importer errors when the import fails', async function () {
-            const RewiredDataImporter = rewire('../../../../../core/server/data/importer/importers/data/data-importer');
             const importError = new errors.ValidationError({
                 message: 'Value in [posts.title] exceeds maximum length of 2000 characters.',
                 context: '{"title":"..."}'
             });
 
-            const fakeImporter = (importerErrors = []) => ({
-                options: {requiredImportedData: [], requiredExistingData: []},
-                fetchExisting: sinon.stub().resolves(),
-                beforeImport: sinon.stub().resolves(),
-                replaceIdentifiers: sinon.stub().resolves(),
-                doImport: sinon.stub().resolves(),
-                errors: importerErrors,
-                problems: [],
-                importedData: []
+            [
+                UsersImporter,
+                RolesImporter,
+                TagsImporter,
+                NewslettersImporter,
+                SettingsImporter,
+                ProductsImporter,
+                StripeProductsImporter,
+                StripePricesImporter,
+                PostsImporter,
+                CustomThemeSettingsImporter,
+                RevueSubscriberImporter
+            ].forEach((Importer) => {
+                sinon.stub(Importer.prototype, 'fetchExisting').resolves();
+                sinon.stub(Importer.prototype, 'beforeImport').resolves();
+                sinon.stub(Importer.prototype, 'replaceIdentifiers').resolves();
+                sinon.stub(Importer.prototype, 'doImport').resolves();
             });
 
             sinon.stub(models.Base, 'transaction').callsFake(fn => fn({fake: 'transacting'}));
-            sinon.stub(RewiredDataImporter, 'init').callsFake(function (importData) {
-                RewiredDataImporter.__set__('importers', {
-                    posts: fakeImporter([importError]),
-                    products: fakeImporter(),
-                    stripe_prices: fakeImporter()
-                });
-                return importData;
+            PostsImporter.prototype.doImport.restore();
+            sinon.stub(PostsImporter.prototype, 'doImport').callsFake(function () {
+                this.errors.push(importError);
             });
 
-            await assert.rejects(RewiredDataImporter.doImport({meta: {version: '4.0.0'}, data: {}}, {}), (err) => {
+            await assert.rejects(DataImporter.doImport({meta: {version: '4.0.0'}, data: {}}, {}), (err) => {
                 assert(err instanceof Error);
                 assert(err instanceof errors.DataImportError);
                 assert.equal(err.message, importError.message);

--- a/ghost/core/test/unit/server/data/importer/index.test.js
+++ b/ghost/core/test/unit/server/data/importer/index.test.js
@@ -708,7 +708,6 @@ describe('Importer', function () {
                 ProductsImporter,
                 StripeProductsImporter,
                 StripePricesImporter,
-                PostsImporter,
                 CustomThemeSettingsImporter,
                 RevueSubscriberImporter
             ].forEach((Importer) => {
@@ -718,11 +717,14 @@ describe('Importer', function () {
                 sinon.stub(Importer.prototype, 'doImport').resolves();
             });
 
-            sinon.stub(models.Base, 'transaction').callsFake(fn => fn({fake: 'transacting'}));
-            PostsImporter.prototype.doImport.restore();
+            sinon.stub(PostsImporter.prototype, 'fetchExisting').resolves();
+            sinon.stub(PostsImporter.prototype, 'beforeImport').resolves();
+            sinon.stub(PostsImporter.prototype, 'replaceIdentifiers').resolves();
             sinon.stub(PostsImporter.prototype, 'doImport').callsFake(function () {
                 this.errors.push(importError);
             });
+
+            sinon.stub(models.Base, 'transaction').callsFake(fn => fn({fake: 'transacting'}));
 
             await assert.rejects(DataImporter.doImport({meta: {version: '4.0.0'}, data: {}}, {}), (err) => {
                 assert(err instanceof Error);


### PR DESCRIPTION
## Summary
- Removed rewire from the importer unit test
- Replaced rewired DataImporter internals with stubs on real importer class prototypes
- Kept importer production code unchanged

## Tests
- pnpm test:vitest test/unit/server/data/importer/index.test.js
- pnpm exec eslint -c test/.eslintrc.js --ignore-path test/.eslintignore test/unit/server/data/importer/index.test.js