### PR TITLE
Changed IndexNow tests to avoid rewire

### DIFF
--- a/ghost/core/core/server/services/indexnow.js
+++ b/ghost/core/core/server/services/indexnow.js
@@ -245,5 +245,6 @@ function listen() {
 
 module.exports = {
     listen: listen,
+    ping: ping,
     getApiKey: getApiKey
 };

--- a/ghost/core/test/unit/server/services/indexnow.test.js
+++ b/ghost/core/test/unit/server/services/indexnow.test.js
@@ -2,10 +2,8 @@ const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const _ = require('lodash');
 const nock = require('nock');
-const rewire = require('rewire');
-const errors = require('@tryghost/errors');
 const testUtils = require('../../../utils');
-const indexnow = rewire('../../../../core/server/services/indexnow');
+const indexnow = require('../../../../core/server/services/indexnow');
 const events = require('../../../../core/server/lib/common/events');
 const settingsCache = require('../../../../core/shared/settings-cache');
 const config = require('../../../../core/shared/config');
@@ -48,6 +46,18 @@ describe('IndexNow', function () {
     });
 
     describe('listener()', function () {
+        let listener;
+        let urlStub;
+
+        beforeEach(function () {
+            urlStub = sinon.stub(urlService.facade, 'getUrlForResource').returns('https://example.com/my-post/');
+            settingsCacheStub.withArgs('indexnow_api_key').returns(null);
+            loggingStub = sinon.stub(logging, 'warn');
+
+            indexnow.listen();
+            listener = eventStub.firstCall.args[1];
+        });
+
         it('calls ping() with toJSONified model when content changed', function () {
             const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
 
@@ -73,16 +83,10 @@ describe('IndexNow', function () {
                 }
             };
 
-            const pingStub = sinon.stub().resolves();
-            const resetIndexNow = indexnow.__set__('ping', pingStub);
-            const listener = indexnow.__get__('indexnowListener');
-
             listener(testModel);
 
-            sinon.assert.calledOnce(pingStub);
-            sinon.assert.calledWith(pingStub, testPost);
-
-            resetIndexNow();
+            sinon.assert.calledOnce(urlStub);
+            sinon.assert.calledWith(urlStub, sinon.match({...testPost, type: 'posts'}), {absolute: true});
         });
 
         it('does not call ping() when importing', function () {
@@ -100,15 +104,9 @@ describe('IndexNow', function () {
                 }
             };
 
-            const pingStub = sinon.stub();
-            const resetIndexNow = indexnow.__set__('ping', pingStub);
-            const listener = indexnow.__get__('indexnowListener');
-
             listener(testModel, {importing: true});
 
-            sinon.assert.notCalled(pingStub);
-
-            resetIndexNow();
+            sinon.assert.notCalled(urlStub);
         });
 
         it('does not call ping() when no SEO-relevant fields have changed', function () {
@@ -146,15 +144,9 @@ describe('IndexNow', function () {
                 }
             };
 
-            const pingStub = sinon.stub();
-            const resetIndexNow = indexnow.__set__('ping', pingStub);
-            const listener = indexnow.__get__('indexnowListener');
-
             listener(testModel);
 
-            sinon.assert.notCalled(pingStub);
-
-            resetIndexNow();
+            sinon.assert.notCalled(urlStub);
         });
 
         it('calls ping() when title changes', function () {
@@ -178,15 +170,9 @@ describe('IndexNow', function () {
                 }
             };
 
-            const pingStub = sinon.stub().resolves();
-            const resetIndexNow = indexnow.__set__('ping', pingStub);
-            const listener = indexnow.__get__('indexnowListener');
-
             listener(testModel);
 
-            sinon.assert.calledOnce(pingStub);
-
-            resetIndexNow();
+            sinon.assert.calledOnce(urlStub);
         });
 
         it('calls ping() when slug changes', function () {
@@ -210,15 +196,9 @@ describe('IndexNow', function () {
                 }
             };
 
-            const pingStub = sinon.stub().resolves();
-            const resetIndexNow = indexnow.__set__('ping', pingStub);
-            const listener = indexnow.__get__('indexnowListener');
-
             listener(testModel);
 
-            sinon.assert.calledOnce(pingStub);
-
-            resetIndexNow();
+            sinon.assert.calledOnce(urlStub);
         });
 
         it('calls ping() when meta_description changes', function () {
@@ -242,20 +222,13 @@ describe('IndexNow', function () {
                 }
             };
 
-            const pingStub = sinon.stub().resolves();
-            const resetIndexNow = indexnow.__set__('ping', pingStub);
-            const listener = indexnow.__get__('indexnowListener');
-
             listener(testModel);
 
-            sinon.assert.calledOnce(pingStub);
-
-            resetIndexNow();
+            sinon.assert.calledOnce(urlStub);
         });
     });
 
     describe('ping()', function () {
-        const ping = indexnow.__get__('ping');
         let urlStub;
 
         beforeEach(function () {
@@ -269,7 +242,7 @@ describe('IndexNow', function () {
                 .reply(200);
             const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
 
-            await ping(testPost);
+            await indexnow.ping(testPost);
 
             sinon.assert.calledOnce(loggingStub);
             assert.equal(loggingStub.args[0][0].event.name, 'indexnow.pinged');
@@ -284,7 +257,7 @@ describe('IndexNow', function () {
                 .reply(200);
             const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
 
-            await ping(testPost);
+            await indexnow.ping(testPost);
 
             assert.equal(pingRequest.isDone(), false);
             sinon.assert.calledOnce(loggingStub);
@@ -303,7 +276,7 @@ describe('IndexNow', function () {
 
             testPost.slug = 'welcome';
 
-            await ping(testPost);
+            await indexnow.ping(testPost);
 
             assert.equal(pingRequest.isDone(), false);
         });
@@ -314,7 +287,7 @@ describe('IndexNow', function () {
                 .reply(200);
             const testPage = _.clone(testUtils.DataGenerator.Content.posts[5]);
 
-            await ping(testPage);
+            await indexnow.ping(testPage);
 
             assert.equal(pingRequest.isDone(), false);
         });
@@ -327,7 +300,7 @@ describe('IndexNow', function () {
                 .reply(200);
             const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
 
-            await ping(testPost);
+            await indexnow.ping(testPost);
 
             assert.equal(pingRequest.isDone(), false);
         });
@@ -340,7 +313,7 @@ describe('IndexNow', function () {
                 .reply(200);
             const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
 
-            await ping(testPost);
+            await indexnow.ping(testPost);
 
             assert.equal(pingRequest.isDone(), false);
         });
@@ -353,7 +326,7 @@ describe('IndexNow', function () {
                 .reply(200);
             const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
 
-            await ping(testPost);
+            await indexnow.ping(testPost);
 
             assert.equal(pingRequest.isDone(), false);
         });
@@ -367,7 +340,7 @@ describe('IndexNow', function () {
                 .reply(200);
             const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
 
-            await ping(testPost);
+            await indexnow.ping(testPost);
 
             // Should NOT have made the ping request
             assert.equal(pingRequest.isDone(), false);
@@ -384,7 +357,7 @@ describe('IndexNow', function () {
                 .reply(202);
             const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
 
-            await ping(testPost);
+            await indexnow.ping(testPost);
 
             assert.equal(pingRequest.isDone(), true);
             sinon.assert.calledOnce(loggingStub);
@@ -399,7 +372,7 @@ describe('IndexNow', function () {
                 .reply(400);
             const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
 
-            await ping(testPost);
+            await indexnow.ping(testPost);
 
             assert.equal(pingRequest.isDone(), true);
             sinon.assert.calledOnce(loggingStub);
@@ -414,7 +387,7 @@ describe('IndexNow', function () {
                 .reply(422);
             const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
 
-            await ping(testPost);
+            await indexnow.ping(testPost);
 
             assert.equal(pingRequest.isDone(), true);
             sinon.assert.calledOnce(loggingStub);
@@ -429,7 +402,7 @@ describe('IndexNow', function () {
                 .reply(429);
             const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
 
-            await ping(testPost);
+            await indexnow.ping(testPost);
 
             assert.equal(pingRequest.isDone(), true);
             sinon.assert.calledOnce(loggingStub);
@@ -446,7 +419,7 @@ describe('IndexNow', function () {
                 .reply(204);
             const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
 
-            await ping(testPost);
+            await indexnow.ping(testPost);
 
             assert.equal(pingRequest.isDone(), true);
             sinon.assert.calledOnce(loggingStub);
@@ -456,33 +429,17 @@ describe('IndexNow', function () {
     });
 
     describe('ping() error classification (got HTTPError shape)', function () {
-        const ping = indexnow.__get__('ping');
-        let resetIndexNow;
-
         beforeEach(function () {
             sinon.stub(urlService.facade, 'getUrlForResource').returns('https://example.com/my-post/');
             loggingStub = sinon.stub(logging, 'warn');
         });
 
-        afterEach(function () {
-            if (resetIndexNow) {
-                resetIndexNow();
-                resetIndexNow = null;
-            }
-        });
-
-        function makeHttpError(statusCode) {
-            const err = new Error(`Response code ${statusCode}`);
-            err.name = 'HTTPError';
-            err.code = 'ERR_NON_2XX_3XX_RESPONSE';
-            err.response = {statusCode};
-            return err;
-        }
-
         async function pingWithHttpError(statusCode) {
-            resetIndexNow = indexnow.__set__('request', sinon.stub().rejects(makeHttpError(statusCode)));
+            nock('https://api.indexnow.org')
+                .get(/\/indexnow/)
+                .reply(statusCode);
             const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
-            await ping(testPost);
+            await indexnow.ping(testPost);
         }
 
         it('classifies a 429 (status on err.response.statusCode) as rate_limited', async function () {
@@ -516,18 +473,6 @@ describe('IndexNow', function () {
             assert.equal(loggingStub.args[0][0].event.name, 'indexnow.ping_failed');
             assert.equal(loggingStub.args[0][0].http.response.status_code, 503);
         });
-
-        it('still classifies a GhostError carrying err.statusCode (manual throw) correctly', async function () {
-            const err = new errors.TooManyRequestsError({message: 'manual', statusCode: 429});
-            resetIndexNow = indexnow.__set__('request', sinon.stub().rejects(err));
-            const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
-
-            await ping(testPost);
-
-            sinon.assert.calledOnce(loggingStub);
-            assert.equal(loggingStub.args[0][0].event.name, 'indexnow.rate_limited');
-            assert.equal(loggingStub.args[0][0].http.response.status_code, 429);
-        });
     });
 
     describe('getApiKey()', function () {
@@ -554,11 +499,9 @@ describe('IndexNow', function () {
     // for a resource-based facade method) could regress without anyone
     // noticing.
     describe('ping() URL output', function () {
-        const ping = indexnow.__get__('ping');
         const POST_URL = 'https://my-blog.example/some-post/';
         let getUrlForResourceStub;
-        let requestStub;
-        let resetIndexNow;
+        let pingRequest;
 
         beforeEach(function () {
             // Bind the stub to the exact resource shape production passes
@@ -569,25 +512,23 @@ describe('IndexNow', function () {
                 .withArgs(sinon.match({id: 'abc', type: 'posts'}), {absolute: true})
                 .returns(POST_URL);
 
-            requestStub = sinon.stub().resolves({statusCode: 200});
-            resetIndexNow = indexnow.__set__('request', requestStub);
+            pingRequest = nock('https://api.indexnow.org')
+                .get('/indexnow')
+                .query((query) => {
+                    return query.url === POST_URL;
+                })
+                .reply(200);
 
             settingsCacheStub.withArgs('indexnow_api_key').returns('a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4');
-        });
-
-        afterEach(function () {
-            resetIndexNow();
         });
 
         it('passes the post URL into the IndexNow request', async function () {
             const post = {id: 'abc', slug: 'some-post', type: 'post'};
 
-            await ping(post);
+            await indexnow.ping(post);
 
             sinon.assert.calledOnce(getUrlForResourceStub);
-            sinon.assert.calledOnce(requestStub);
-            const indexNowUrl = new URL(requestStub.firstCall.args[0]);
-            assert.equal(indexNowUrl.searchParams.get('url'), POST_URL);
+            assert.equal(pingRequest.isDone(), true);
         });
     });
 });


### PR DESCRIPTION
## Summary
- exported IndexNow ping as a real service boundary
- updated IndexNow unit tests to require the service normally instead of using rewire
- exercised listener behavior through registered event handlers and HTTP behavior through nock

## Tests
- pnpm test:vitest test/unit/server/services/indexnow.test.js
- pnpm test:single test/unit/server/services/indexnow.test.js
- pnpm exec eslint --ignore-path .eslintignore core/server/services/indexnow.js --cache
- pnpm exec eslint -c test/.eslintrc.js --ignore-path test/.eslintignore test/unit/server/services/indexnow.test.js --cache