### PR TITLE
Gift links: Admin Integration access

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.46/2026-06-17-10-00-00-add-gift-links-permission-to-admin-integration.js
+++ b/ghost/core/core/server/data/migrations/versions/6.46/2026-06-17-10-00-00-add-gift-links-permission-to-admin-integration.js
@@ -1,0 +1,10 @@
+const {addPermissionToRole} = require('../../utils');
+
+// Follow-up to the gift-links data foundation: grant Admin Integration (API
+// keys) the same per-post `manage` permission Editors/Authors have, so gift
+// links can be created/reset programmatically over the Admin API. The
+// site-wide `resetAll` kill switch stays Administrator-only.
+module.exports = addPermissionToRole({
+    permission: 'Manage gift links',
+    role: 'Admin Integration'
+});

--- a/ghost/core/core/server/data/schema/fixtures/fixtures.json
+++ b/ghost/core/core/server/data/schema/fixtures/fixtures.json
@@ -1028,7 +1028,8 @@
                     "collection": "all",
                     "recommendation": "all",
                     "automation": ["browse", "read", "edit"],
-                    "member_signin_url": "read"
+                    "member_signin_url": "read",
+                    "gift_link": "manage"
                 },
                 "Super Editor": {
                     "notification": "all",

--- a/ghost/core/test/integration/migrations/migration.test.js
+++ b/ghost/core/test/integration/migrations/migration.test.js
@@ -111,7 +111,7 @@ describe('Migrations', function () {
             assertHavePermission(permissions, 'Delete posts', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration', 'Super Editor']);
             assertHavePermission(permissions, 'Publish posts', ['Administrator', 'Editor', 'Admin Integration', 'Scheduler Integration', 'Super Editor']);
             assertHavePermission(permissions, 'Flush gift reminders', ['Scheduler Integration']);
-            assertHavePermission(permissions, 'Manage gift links', ['Administrator', 'Editor', 'Author', 'Super Editor']);
+            assertHavePermission(permissions, 'Manage gift links', ['Administrator', 'Editor', 'Author', 'Admin Integration', 'Super Editor']);
             assertHavePermission(permissions, 'Reset all gift links', ['Administrator']);
 
             assertHavePermission(permissions, 'Browse settings', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration', 'Super Editor']);

--- a/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
+++ b/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
@@ -398,7 +398,7 @@ describe('Migration Fixture Utils', function () {
             const rolesAllStub = sinon.stub(models.Role, 'findAll').returns(Promise.resolve(dataMethodStub));
 
             const result = await fixtureManager.addFixturesForRelation(fixtures.relations[0]);
-            const FIXTURE_COUNT = 147;
+            const FIXTURE_COUNT = 148;
             assertExists(result);
             assert(_.isPlainObject(result));
             assert.equal(result.expected, FIXTURE_COUNT);

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -36,7 +36,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = 'd13d76b072adfe28a355834180b013aa';
-    const currentFixturesHash = 'bdb2c8c05b925a76d4e89e72ff58cace';
+    const currentFixturesHash = '353da9c0389256cfae495bbf05350911';
     const currentSettingsHash = '397be8628c753b1959b8954d5610f83f';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 

--- a/ghost/core/test/utils/fixtures/fixtures.json
+++ b/ghost/core/test/utils/fixtures/fixtures.json
@@ -1182,7 +1182,8 @@
                     "mention": "browse",
                     "collection": "all",
                     "recommendation": "all",
-                    "automation": ["browse", "read", "edit"]
+                    "automation": ["browse", "read", "edit"],
+                    "gift_link": "manage"
                 },
                 "Editor": {
                     "notification": "all",


### PR DESCRIPTION
Fast-follow to the merged gift-links data foundation (#28626), addressing Kevin's review question:

> Non-blocker: Should Admin integrations have access to gift links so there is programmatic access/management?

ref https://linear.app/ghost/issue/BER-3739/admin-integration-access-to-gift-links

## What

Grants the **Admin Integration** role the existing `Manage gift links` (`gift_link: manage`) permission, so gift links can be created / ensured / reset programmatically over the Admin API.

## Why this scope

- **`manage` only, not `all`.** Mirrors Editor / Author / Super Editor. The endpoint's own `edit.post` ownership check still applies — Admin Integrations hold `post: all`, so they pass it for any post.
- **Site-wide `resetAll` stays Administrator-only.** A leaked integration key should not be able to deactivate every active gift link site-wide in one call.
- Still gated behind the off-by-default `giftLinks` labs flag, so this is inert until the rest of the stack lands and the flag is enabled.

## Changes

- New `6.46` migration linking `Manage gift links` → `Admin Integration` (down removes it)
- `gift_link: manage` added to Admin Integration in both `fixtures.json` files (fresh installs)
- Updated `migration.test.js`, `fixture-manager.test.js` (147 → 148), and the integrity fixtures hash

Migration + fixture + integrity tests pass locally.