### PR TITLE
Fixed sign-in auth errors showing as toasts

### DIFF
--- a/apps/admin-x-design-system/src/providers/design-system-provider.tsx
+++ b/apps/admin-x-design-system/src/providers/design-system-provider.tsx
@@ -45,7 +45,7 @@ const DesignSystemProvider: React.FC<DesignSystemProviderProps> = ({fetchKoenigL
     return (
         <DesignSystemContext.Provider value={{isAnyTextFieldFocused, setFocusState, fetchKoenigLexical, darkMode}}>
             <GlobalDirtyStateProvider>
-                <Toaster containerClassName="toast-outlet-react-hot-toast" />
+                <Toaster />
                 <NiceModal.Provider>
                     {children}
                 </NiceModal.Provider>

--- a/apps/admin-x-framework/package.json
+++ b/apps/admin-x-framework/package.json
@@ -112,7 +112,6 @@
         "react": "catalog:",
         "react-dom": "catalog:",
         "react-hot-toast": "catalog:",
-        "sonner": "catalog:",
         "react-router": "catalog:"
     },
     "peerDependencies": {

--- a/apps/admin-x-framework/src/hooks/use-handle-error.ts
+++ b/apps/admin-x-framework/src/hooks/use-handle-error.ts
@@ -1,31 +1,16 @@
 import * as Sentry from '@sentry/react';
 import {showToast} from '@tryghost/admin-x-design-system';
-import {toast as sonnerToast} from 'sonner';
 import {useCallback} from 'react';
 import toast from 'react-hot-toast';
 import {useFramework} from '../providers/framework-provider';
 import {APIError, getErrorMessage} from '../utils/errors';
 
-// Stale toasts can cover UI and block clicks, especially in tests
-function dismissToasts() {
-    toast.remove();
-    sonnerToast.dismiss();
-}
-
-// There are two toast outlets: admin-x-design-system's DesignSystemProvider
-// renders react-hot-toast (marked with this class), shade's ShadeProvider
-// renders sonner - and the React shell can mount both at once. The marker's
-// presence in the DOM picks the library to emit to.
 function showErrorToast(message: React.ReactNode) {
-    dismissToasts();
-    if (document.querySelector('.toast-outlet-react-hot-toast')) {
-        showToast({
-            message,
-            type: 'error'
-        });
-    } else {
-        sonnerToast.error(message);
-    }
+    toast.remove();
+    showToast({
+        message,
+        type: 'error'
+    });
 }
 
 /**
@@ -65,7 +50,7 @@ const useHandleError = () => {
             // We use this status in tests to indicate the API request was not mocked -
             // don't show a toast because it may block clicking things in the test,
             // but still clear lingering toasts that would block clicks the same way
-            dismissToasts();
+            toast.remove();
         } else if (error instanceof APIError) {
             showErrorToast(getErrorMessage(error, error.message));
         } else {

--- a/apps/admin-x-framework/test/unit/hooks/use-handle-error.test.tsx
+++ b/apps/admin-x-framework/test/unit/hooks/use-handle-error.test.tsx
@@ -24,19 +24,11 @@ vi.mock('react-hot-toast', () => ({
     }
 }));
 
-vi.mock('sonner', () => ({
-    toast: {
-        error: vi.fn(),
-        dismiss: vi.fn()
-    }
-}));
-
 const mockShowToast = vi.fn();
 const mockToastRemove = vi.fn();
 
 import * as Sentry from '@sentry/react';
 import {showToast} from '@tryghost/admin-x-design-system';
-import {toast as sonnerToast} from 'sonner';
 import toast from 'react-hot-toast';
 
 const createWrapper = (sentryDSN?: string): React.FC<{children: ReactNode}> => {
@@ -159,7 +151,7 @@ describe('useHandleError', () => {
 
         result.current(error);
 
-        expect(sonnerToast.dismiss).toHaveBeenCalled();
+        expect(toast.remove).toHaveBeenCalled();
     });
 
     it('does not show toast when withToast is false', () => {
@@ -170,7 +162,6 @@ describe('useHandleError', () => {
         result.current(error, {withToast: false});
 
         expect(showToast).not.toHaveBeenCalled();
-        expect(sonnerToast.error).not.toHaveBeenCalled();
     });
 
     it('does not show toast for 418 status (test indicator)', () => {
@@ -183,7 +174,6 @@ describe('useHandleError', () => {
         result.current(error);
 
         expect(showToast).not.toHaveBeenCalled();
-        expect(sonnerToast.error).not.toHaveBeenCalled();
     });
 
     it('still clears lingering toasts for 418 status', () => {
@@ -198,28 +188,6 @@ describe('useHandleError', () => {
         // A stale toast can cover UI and block clicks in tests, so the
         // unmocked-request path must clear toasts even without showing one
         expect(toast.remove).toHaveBeenCalled();
-        expect(sonnerToast.dismiss).toHaveBeenCalled();
-    });
-
-    it('routes toasts to react-hot-toast when its outlet is mounted', () => {
-        const outlet = document.createElement('div');
-        outlet.className = 'toast-outlet-react-hot-toast';
-        document.body.appendChild(outlet);
-
-        try {
-            const wrapper = createWrapper();
-            const {result} = renderHook(() => useHandleError(), {wrapper});
-
-            result.current(new Error('Test error'));
-
-            expect(showToast).toHaveBeenCalledWith({
-                message: 'Something went wrong, please try again.',
-                type: 'error'
-            });
-            expect(sonnerToast.error).not.toHaveBeenCalled();
-        } finally {
-            outlet.remove();
-        }
     });
 
     it('shows validation error message from context', () => {
@@ -245,8 +213,10 @@ describe('useHandleError', () => {
 
         result.current(error);
 
-        expect(sonnerToast.error).toHaveBeenCalledWith('This field must be filled out');
-        expect(showToast).not.toHaveBeenCalled();
+        expect(showToast).toHaveBeenCalledWith({
+            message: 'This field must be filled out',
+            type: 'error'
+        });
     });
 
     it('shows validation error message when no context available', () => {
@@ -272,7 +242,10 @@ describe('useHandleError', () => {
 
         result.current(error);
 
-        expect(sonnerToast.error).toHaveBeenCalledWith('Field is required');
+        expect(showToast).toHaveBeenCalledWith({
+            message: 'Field is required',
+            type: 'error'
+        });
     });
 
     it('shows API error message', () => {
@@ -283,7 +256,10 @@ describe('useHandleError', () => {
 
         result.current(error);
 
-        expect(sonnerToast.error).toHaveBeenCalledWith('API Error occurred');
+        expect(showToast).toHaveBeenCalledWith({
+            message: 'API Error occurred',
+            type: 'error'
+        });
     });
 
     it('shows generic error message for unknown errors', () => {
@@ -294,7 +270,10 @@ describe('useHandleError', () => {
 
         result.current(error);
 
-        expect(sonnerToast.error).toHaveBeenCalledWith('Something went wrong, please try again.');
+        expect(showToast).toHaveBeenCalledWith({
+            message: 'Something went wrong, please try again.',
+            type: 'error'
+        });
     });
 
     it('handles string errors', () => {
@@ -304,7 +283,10 @@ describe('useHandleError', () => {
         result.current('String error');
 
         expect(console.error).toHaveBeenCalledWith('String error'); // eslint-disable-line no-console
-        expect(sonnerToast.error).toHaveBeenCalledWith('Something went wrong, please try again.');
+        expect(showToast).toHaveBeenCalledWith({
+            message: 'Something went wrong, please try again.',
+            type: 'error'
+        });
     });
 
     it('handles null/undefined errors', () => {
@@ -314,6 +296,9 @@ describe('useHandleError', () => {
         result.current(null);
 
         expect(console.error).toHaveBeenCalledWith(null); // eslint-disable-line no-console
-        expect(sonnerToast.error).toHaveBeenCalledWith('Something went wrong, please try again.');
+        expect(showToast).toHaveBeenCalledWith({
+            message: 'Something went wrong, please try again.',
+            type: 'error'
+        });
     });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -860,9 +860,6 @@ importers:
       react-router:
         specifier: 'catalog:'
         version: 7.14.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      sonner:
-        specifier: 'catalog:'
-        version: 2.0.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@playwright/test':
         specifier: 'catalog:'


### PR DESCRIPTION
## Summary
- reverted the PR commit that routed shared admin error toasts through sonner when no react-hot-toast outlet marker was present
- removed the react-hot-toast marker class from the design-system provider
- removed sonner from admin-x-framework dependencies and restored tests to assert the existing admin-x toast path

## Why
The sonner fallback caused unauthenticated admin bootstrap errors, including "Unable to determine the authenticated user or integration.", to show as toasts on the sign-in screen.

ref https://app.incident.io/ghost/incidents/304

## Testing
- pnpm install --lockfile-only
- pnpm --filter @tryghost/admin-x-framework test:unit -- test/unit/hooks/use-handle-error.test.tsx
- pnpm --filter @tryghost/admin-x-framework test:types
- git diff --check
- pre-commit lint-staged hook