### PR TITLE
Changed gift-links service entry point to a lazy ESM binding

### DIFF
--- a/ghost/core/core/server/api/endpoints/gift-links.ts
+++ b/ghost/core/core/server/api/endpoints/gift-links.ts
@@ -1,13 +1,8 @@
-import type {GiftLinksService} from '../../services/gift-links/gift-links-service';
+import {service} from '../../services/gift-links';
 
-// The service is a boot singleton on a wrapper exported with `module.exports =`
-// (TS can't type a default import of that, and boot/the framework load it via
-// raw `require()`), so it's required and cast to the real service type.
-// `permissions` is untyped JS and required for the same reason.
-/* eslint-disable @typescript-eslint/no-require-imports */
-const giftLinks = require('../../services/gift-links') as {service: GiftLinksService};
+// `permissions` is untyped JS, so it's loaded via `require()`.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const permissionsService = require('../../services/permissions');
-/* eslint-enable @typescript-eslint/no-require-imports */
 
 interface Frame {
     options: {
@@ -55,7 +50,7 @@ const controller = {
             return assertCanManageGiftLink(frame);
         },
         query(frame: Frame) {
-            return giftLinks.service.getActive(frame.options.id, {context: frame.options.context});
+            return service!.getActive(frame.options.id, {context: frame.options.context});
         }
     },
 
@@ -79,7 +74,7 @@ const controller = {
             return assertCanManageGiftLink(frame);
         },
         query(frame: Frame) {
-            return giftLinks.service.upsert(frame.options.id, {context: frame.options.context});
+            return service!.upsert(frame.options.id, {context: frame.options.context});
         }
     },
 
@@ -102,7 +97,7 @@ const controller = {
             return assertCanManageGiftLink(frame);
         },
         query(frame: Frame) {
-            return giftLinks.service.reset(frame.options.id, {context: frame.options.context});
+            return service!.reset(frame.options.id, {context: frame.options.context});
         }
     },
 
@@ -117,7 +112,7 @@ const controller = {
         statusCode: 200,
         permissions: true,
         async query(frame: Frame) {
-            const count = await giftLinks.service.resetAll({context: frame.options.context});
+            const count = await service!.resetAll({context: frame.options.context});
             return {count};
         }
     }

--- a/ghost/core/core/server/services/gift-links/index.ts
+++ b/ghost/core/core/server/services/gift-links/index.ts
@@ -1,37 +1,26 @@
 import {GiftLinksService} from './gift-links-service';
 import {GiftLinkBookshelfRepository} from './gift-link-bookshelf-repository';
 
-/**
- * The one CJS bridge for the gift-links service: boot, the API endpoint and the
- * frontend reader all reach the singleton through `require()`, so this module
- * exports via `module.exports =`. Everything else in this directory is plain ESM
- * and imported directly above to stay typed.
- *
- * `init()` lazily wires the Bookshelf model into a repository so that requiring
- * this module doesn't trigger model loading.
- */
-class GiftLinksServiceWrapper {
-    service?: GiftLinksService;
+// Wired by init() at boot. Left undefined until then so that requiring this
+// module doesn't pull in the model layer (init lazily requires ../../models).
+// Consumers import this binding and assert it with `service!` (set before any
+// request is served).
+export let service: GiftLinksService | undefined;
 
-    init(): void {
-        if (this.service) {
-            return;
-        }
+export function init(): void {
+    if (service) {
+        return;
+    }
 
-        // `../../models` is untyped JS and only registers after boot, so it's
-        // required lazily rather than imported.
-        // eslint-disable-next-line @typescript-eslint/no-require-imports
-        const models = require('../../models');
+    // `../../models` is untyped JS and only registers after boot, so it's
+    // required lazily rather than imported.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const models = require('../../models');
 
-        const repository = new GiftLinkBookshelfRepository({
+    service = new GiftLinksService({
+        giftLinkRepository: new GiftLinkBookshelfRepository({
             GiftLinkModel: models.GiftLink,
             knex: models.Base.knex
-        });
-
-        this.service = new GiftLinksService({giftLinkRepository: repository});
-    }
+        })
+    });
 }
-
-// module.exports required - using `export` causes the module to fail to register
-// with the web framework as it's loaded via require()
-module.exports = new GiftLinksServiceWrapper();


### PR DESCRIPTION
## Problem

The gift-links service exposed its singleton through a wrapper object that was exported with CommonJS `module.exports`. Because of that, the admin API endpoint could not import the service as a typed value: it had to pull the wrapper in via `require()` and cast it to the service type by hand.

## Solution

The service entry point now exposes a lazily initialised `service` binding and an `init()` function as native ES exports. The boot process still wires the service via `init()` at startup, and the endpoint imports the `service` binding directly, so the require-and-cast is gone and there is no longer any CommonJS export in the service. Behaviour is unchanged; this is purely a typing and import cleanup.