### PR TITLE
Removed the unused rewire devDependency

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -300,7 +300,6 @@
     "postcss": "catalog:",
     "postcss-cli": "11.0.1",
     "qs": "6.15.2",
-    "rewire": "9.0.1",
     "sinon": "catalog:",
     "supertest": "catalog:",
     "tmp": "0.2.6",

--- a/ghost/core/test/legacy/models/model-posts.test.js
+++ b/ghost/core/test/legacy/models/model-posts.test.js
@@ -21,8 +21,6 @@ const markdownToMobiledoc = testUtils.DataGenerator.markdownToMobiledoc;
  * IMPORTANT:
  * - do not spy the events unit, because when we only spy, all listeners get the event
  * - this can cause unexpected behavior as the listeners execute code
- * - using rewire is not possible, because each model self registers it's model registry in bookshelf
- * - rewire would add 1 registry, a file who requires the models, tries to register the model another time
  */
 describe('Post Model', function () {
     let eventsTriggered = {};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2942,9 +2942,6 @@ importers:
       qs:
         specifier: 6.15.2
         version: 6.15.2
-      rewire:
-        specifier: 9.0.1
-        version: 9.0.1(jiti@2.7.0)
       sinon:
         specifier: 'catalog:'
         version: 22.0.0
@@ -19865,9 +19862,6 @@ packages:
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
-
-  rewire@9.0.1:
-    resolution: {integrity: sha512-dnbLeTwHpXvWJjswC6CshXUUnnpE5AVhlayVRvDJhJx5ejbO4nbj1IXqN2urErgB7TpHUAMpf6iPDhQIxeSQOQ==}
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
@@ -44026,14 +44020,6 @@ snapshots:
   rettime@0.11.11: {}
 
   reusify@1.1.0: {}
-
-  rewire@9.0.1(jiti@2.7.0):
-    dependencies:
-      eslint: 9.39.4(jiti@2.7.0)
-      pirates: 4.0.7
-    transitivePeerDependencies:
-      - jiti
-      - supports-color
 
   rfdc@1.4.1: {}
 


### PR DESCRIPTION
## Summary
- Removes the `rewire` devDependency from `ghost/core` now that every test that used it has been migrated to sinon object-boundary stubbing.
- Drops a now-stale comment in `model-posts.test.js` that referenced rewire.
- Updates `pnpm-lock.yaml`.

## Why
`rewire` is CommonJS-only — it can't operate on ES modules — and was a test-side blocker for the eventual `ghost/core` ESM migration. With the de-rewire effort complete (no `require('rewire')` remains anywhere in `ghost/core`), the dependency can be retired.

## Testing
- `rg rewire ghost/core` → no references remain.
- CI runs the full suite with rewire absent from the lockfile.