### PR TITLE
Fixed admin toolbar dev preview server being unreachable

### DIFF
--- a/apps/admin-toolbar/package.json
+++ b/apps/admin-toolbar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/admin-toolbar",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/admin-toolbar/vite.config.mjs
+++ b/apps/admin-toolbar/vite.config.mjs
@@ -10,7 +10,8 @@ export default defineConfig({
         'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'production')
     },
     preview: {
-        allowedHosts: true,
+        host: '0.0.0.0',
+        allowedHosts: true, // allows domain-name proxies to the preview server
         port: 4176
     },
     build: {


### PR DESCRIPTION
## Describe the problem you are solving
The admin-toolbar package's `vite.config.mjs` was missing `host: '0.0.0.0'` in its `preview` block, so the preview server bound to loopback (`[::1]`) only.

In the Docker dev setup, the Caddy gateway proxies the toolbar script via `host.docker.internal:4176`, which cannot reach a loopback-only bind. The result was a `502 Bad Gateway` on `admin-toolbar.min.js`, so the toolbar never loaded in local dev — even with a valid staff session and the activation cookie set.

## Changelog for devs

* Added `host: '0.0.0.0'` to the `preview` block in `apps/admin-toolbar/vite.config.mjs`

## Changelog for customers

* None (development-only change)

## Notes

* Every other public app — portal, comments-ui, sodo-search, signup-form, announcement-bar — already sets the identical line (with the same `// allows domain-name proxies to the preview server` comment). admin-toolbar shipped without it.
* **Dev-only.** Production serves the built UMD bundle from the CDN (`adminToolbar.url` in `defaults.json`); the `preview` block is only consumed by `vite preview` during `pnpm dev`. The shipped artifact is unaffected.

## Technical debt

* None.

## PR Scope (mark all that apply)

- [ ] Improves the user experience
- [ ] Enhances the readability of our code
- [x] Simplifies the maintenance of our software
- [x] Fixes a bug
- [ ] Provide a core layer to allow one of the points above

## Checklist before requesting a review (mark all that apply)

- [x] I have performed a self-review of my code
- [x] It's simple enough
- [x] The PR is not extensive
- [ ] It includes documentation
- [ ] I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
