### PR TITLE
Fixed admin-x-settings ESLint dependency resolution

### DIFF
--- a/apps/admin-x-settings/package.json
+++ b/apps/admin-x-settings/package.json
@@ -83,6 +83,8 @@
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@types/validator": "catalog:",
+    "@typescript-eslint/eslint-plugin": "catalog:",
+    "@typescript-eslint/parser": "catalog:",
     "@vitest/coverage-v8": "catalog:",
     "eslint": "catalog:",
     "eslint-plugin-react-hooks": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1054,6 +1054,12 @@ importers:
       '@types/validator':
         specifier: 'catalog:'
         version: 13.15.10
+      '@typescript-eslint/eslint-plugin':
+        specifier: 'catalog:'
+        version: 8.49.0(@typescript-eslint/parser@8.49.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser':
+        specifier: 'catalog:'
+        version: 8.49.0(eslint@8.57.1)(typescript@5.9.3)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.8(vitest@4.1.8)


### PR DESCRIPTION
## Summary
- Adds explicit catalog dev dependencies for @typescript-eslint/eslint-plugin and @typescript-eslint/parser in admin-x-settings
- Updates the lockfile importer entries for admin-x-settings

## Context
admin-x-settings extends the shared Ghost TypeScript ESLint config, but did not declare the TypeScript ESLint plugin/parser locally. This can allow pnpm to resolve a mismatched copy through another workspace package in some local installs.

## Testing
- CI=true pnpm install --frozen-lockfile --prefer-offline
- CI=true pnpm lint (from apps/admin-x-settings)
