### PR TITLE
Improved llms.txt and llms-full.txt content for AI consumers

### DIFF
--- a/ghost/core/core/frontend/services/llms/service.js
+++ b/ghost/core/core/frontend/services/llms/service.js
@@ -5,10 +5,12 @@ const {
 } = require('./markdown');
 
 const DEFAULT_BUDGET = 5 * 1024 * 1024;
-const TRUNCATION_FOOTER = '\n_Truncated after 5 MiB. Use `/llms.txt` for the complete index of older public content._\n';
-const RECENT_POSTS_FOOTER = '\n_Includes the latest 500 public posts. Use `/llms.txt` for the complete index of older public content._\n';
+const DEFAULT_INDEX_BUDGET = 50 * 1024;
+const TRUNCATION_FOOTER = '\n_Truncated after 5 MiB. Use `/sitemap.xml` for the complete archive of public content._\n';
+const RECENT_POSTS_FOOTER = '\n_Includes the latest 500 public posts. Use `/sitemap.xml` for the complete archive of public content._\n';
 const FULL_PAGE_SIZE = 100;
 const FULL_POST_LIMIT = 500;
+const PAGES_LIMIT = 20;
 
 function createLlmsService({settingsCache, labs, config, urlUtils, routing, api, fullTxtBudget}) {
     const footerBudget = Math.max(
@@ -16,6 +18,7 @@ function createLlmsService({settingsCache, labs, config, urlUtils, routing, api,
         Buffer.byteLength(RECENT_POSTS_FOOTER, 'utf8')
     );
     const BUDGET = (fullTxtBudget || DEFAULT_BUDGET) - footerBudget;
+
     function isEnabled() {
         return labs.isSet('llmsTxt') && !settingsCache.get('is_private') && settingsCache.get('llms_enabled') !== false;
     }
@@ -38,26 +41,30 @@ function createLlmsService({settingsCache, labs, config, urlUtils, routing, api,
             return null;
         }
 
-        const [pages, posts] = await Promise.all([
-            fetchIndexEntries('page'),
-            fetchIndexEntries('post')
-        ]);
+        const pages = await fetchIndexPages();
+        const pagesSection = buildIndexSection(pages);
+        const optionalSection = buildOptionalSection();
 
-        const sections = [
+        const scaffold = postsSection => [
             buildHeader(),
             'Public Ghost content for AI and LLM tooling. Use `/llms-full.txt` for consolidated page and post context.',
+            'Append `.md` to any post or page URL to get the content in Markdown (for example, `/example-post.md`).',
             '',
             '## Pages',
-            buildIndexSection(pages),
+            pagesSection,
             '',
             '## Posts',
-            buildIndexSection(posts),
+            postsSection,
             '',
             '## Optional',
-            buildOptionalSection()
+            optionalSection
         ];
 
-        return `${sections.join('\n').trim()}\n`;
+        const fixedBytes = Buffer.byteLength(scaffold('').join('\n'), 'utf8');
+        const postsBudget = Math.max(0, DEFAULT_INDEX_BUDGET - fixedBytes);
+        const postsSection = await buildBudgetedIndexPosts(postsBudget);
+
+        return `${scaffold(postsSection).join('\n').trim()}\n`;
     }
 
     async function getLlmsFullTxt() {
@@ -68,6 +75,7 @@ function createLlmsService({settingsCache, labs, config, urlUtils, routing, api,
         const header = [
             buildHeader(),
             'Public Ghost content for AI and LLM tooling. This file includes a bounded export of public pages first, then recent public posts.',
+            'Append `.md` to any post or page URL to get the content in Markdown (for example, `/example-post.md`).',
             ''
         ].join('\n');
 
@@ -75,7 +83,7 @@ function createLlmsService({settingsCache, labs, config, urlUtils, routing, api,
         let wasTruncated = false;
         let wasLimited = false;
 
-        const pageResult = await appendBoundedSectionPaginated(output, 'Pages', 'page');
+        const pageResult = await appendBoundedSectionPaginated(output, 'Pages', 'page', {maxEntries: PAGES_LIMIT});
         output = pageResult.output;
         wasTruncated = pageResult.wasTruncated;
 
@@ -169,21 +177,56 @@ function createLlmsService({settingsCache, labs, config, urlUtils, routing, api,
         ].join('\n');
     }
 
+    function buildIndexLine(entry) {
+        const description = truncateDescription(entry.custom_excerpt || entry.plaintext);
+        const linkLine = `- [${entry.title}](${getMarkdownUrl(entry.url)})`;
+
+        if (!description) {
+            return linkLine;
+        }
+
+        return `${linkLine} - ${description}`;
+    }
+
     function buildIndexSection(entries) {
         if (!entries.length) {
             return '_No public content available._';
         }
 
-        return entries.map((entry) => {
-            const description = truncateDescription(entry.custom_excerpt || entry.plaintext);
-            const linkLine = `- [${entry.title}](${getMarkdownUrl(entry.url)})`;
+        return entries.map(buildIndexLine).join('\n');
+    }
 
-            if (!description) {
-                return linkLine;
+    async function buildBudgetedIndexPosts(budgetBytes) {
+        const lines = [];
+        let usedBytes = 0;
+        let page = 1;
+        let hasMore = true;
+
+        while (hasMore) {
+            const {entries, pagination} = await browsePublicEntries('post', {
+                limit: FULL_PAGE_SIZE,
+                page,
+                fields: 'id,title,slug,custom_excerpt,featured,published_at,url',
+                formats: 'plaintext'
+            });
+            hasMore = Boolean(pagination && pagination.next);
+
+            for (const entry of entries) {
+                const line = buildIndexLine(entry);
+                const lineBytes = Buffer.byteLength(`${line}\n`, 'utf8');
+
+                if (usedBytes + lineBytes > budgetBytes) {
+                    return lines.length ? lines.join('\n') : '_No public content available._';
+                }
+
+                lines.push(line);
+                usedBytes += lineBytes;
             }
 
-            return `${linkLine} - ${description}`;
-        }).join('\n');
+            page += 1;
+        }
+
+        return lines.length ? lines.join('\n') : '_No public content available._';
     }
 
     function buildOptionalSection() {
@@ -195,6 +238,7 @@ function createLlmsService({settingsCache, labs, config, urlUtils, routing, api,
         }
 
         optionalLinks.push(`- [Sitemap](${urlUtils.urlFor({relativeUrl: '/sitemap.xml'}, true)})`);
+        optionalLinks.push(`- [Full content of pages and posts](${urlUtils.urlFor({relativeUrl: '/llms-full.txt'}, true)})`);
 
         return optionalLinks.join('\n');
     }
@@ -202,7 +246,17 @@ function createLlmsService({settingsCache, labs, config, urlUtils, routing, api,
     function buildFullEntry(entry) {
         const lastUpdated = entry.updated_at || entry.published_at || entry.created_at;
         const lastUpdatedLine = lastUpdated ? `Last updated: ${new Date(lastUpdated).toISOString()}` : null;
-        const markdownBody = renderEntryMarkdownBody(entry) || '_No content available._';
+
+        let markdownBody;
+        if (entry.visibility && entry.visibility !== 'public') {
+            const notice = (entry.visibility === 'paid' || entry.visibility === 'tiers')
+                ? 'This post is for paying subscribers only.'
+                : 'This post is for subscribers only.';
+            const excerpt = truncateDescription(entry.custom_excerpt);
+            markdownBody = excerpt ? `${excerpt}\n\n_${notice}_` : `_${notice}_`;
+        } else {
+            markdownBody = renderEntryMarkdownBody(entry) || '_No content available._';
+        }
 
         return [
             `### ${entry.title}`,
@@ -220,8 +274,8 @@ function createLlmsService({settingsCache, labs, config, urlUtils, routing, api,
         const response = await controller.browse({
             ...options,
             context: {member: null},
-            filter: 'status:published+visibility:public',
-            order: type === 'post' ? 'published_at desc' : 'id asc'
+            filter: 'status:published',
+            ...(type === 'page' ? {order: 'id asc'} : {})
         });
 
         const entries = (response?.[responseKey] || [])
@@ -230,20 +284,18 @@ function createLlmsService({settingsCache, labs, config, urlUtils, routing, api,
         return {entries, pagination: response?.meta?.pagination};
     }
 
-    async function fetchIndexEntries(type) {
+    async function fetchIndexPages() {
         // Without `fields` the content API selects every posts column (except
         // mobiledoc/lexical), pulling the full html of every post into memory.
         // The format columns (plaintext here) are appended to `fields` by the
         // input serializer, and `url` is resolved at serialization time.
-        const {entries} = await browsePublicEntries(type, {
-            limit: 'all',
+        const {entries} = await browsePublicEntries('page', {
+            limit: PAGES_LIMIT,
             fields: 'id,title,slug,custom_excerpt,featured,published_at,url',
             formats: 'plaintext'
         });
 
-        if (type === 'page') {
-            entries.sort((left, right) => left.url.localeCompare(right.url));
-        }
+        entries.sort((left, right) => left.url.localeCompare(right.url));
 
         return entries;
     }
@@ -252,7 +304,7 @@ function createLlmsService({settingsCache, labs, config, urlUtils, routing, api,
         const {entries, pagination} = await browsePublicEntries(type, {
             limit: FULL_PAGE_SIZE,
             page: pageNum,
-            fields: 'id,title,slug,featured,published_at,updated_at,created_at,url',
+            fields: 'id,title,slug,featured,published_at,updated_at,created_at,url,visibility,custom_excerpt',
             formats: 'html,plaintext'
         });
 

--- a/ghost/core/core/frontend/services/llms/service.js
+++ b/ghost/core/core/frontend/services/llms/service.js
@@ -4,20 +4,33 @@ const {
     truncateDescription
 } = require('./markdown');
 
-const DEFAULT_BUDGET = 5 * 1024 * 1024;
-const DEFAULT_INDEX_BUDGET = 50 * 1024;
-const TRUNCATION_FOOTER = '\n_Truncated after 5 MiB. Use `/sitemap.xml` for the complete archive of public content._\n';
-const RECENT_POSTS_FOOTER = '\n_Includes the latest 500 public posts. Use `/sitemap.xml` for the complete archive of public content._\n';
-const FULL_PAGE_SIZE = 100;
-const FULL_POST_LIMIT = 500;
+const LLMS_TXT_BUDGET = 50 * 1024;
+const LLMS_FULL_TXT_BUDGET = 5 * 1024 * 1024;
+const LLMS_FULL_TXT_POST_LIMIT = 500;
+const BROWSE_PAGE_SIZE = 100;
 const PAGES_LIMIT = 20;
+
+const LLMS_TXT_INTRO = 'Public Ghost content for AI and LLM tooling. Use `/llms-full.txt` for consolidated page and post context.';
+const LLMS_FULL_TXT_INTRO = 'Public Ghost content for AI and LLM tooling. This file includes a bounded export of public pages first, then recent public posts.';
+const MARKDOWN_DISCOVERABILITY = 'Append `.md` to any post or page URL to get the content in Markdown (for example, `/example-post.md`).';
+const MEMBERS_ONLY_NOTICE = 'This post is for subscribers only.';
+const PAID_MEMBERS_ONLY_NOTICE = 'This post is for paying subscribers only.';
+const EMPTY_SECTION = '_No public content available._';
+const LLMS_FULL_TXT_TRUNCATION_FOOTER = '\n_Truncated after 5 MiB. Use `/sitemap.xml` for the complete archive of public content._\n';
+const LLMS_FULL_TXT_RECENT_POSTS_FOOTER = '\n_Includes the latest 500 public posts. Use `/sitemap.xml` for the complete archive of public content._\n';
+
+// Narrow field lists stop the content API selecting every column (e.g. the full
+// html of every post). The requested `formats` columns are appended to the
+// select by the input serializer, and `url` is resolved at serialization time.
+const LLMS_TXT_FIELDS = 'id,title,slug,custom_excerpt,featured,published_at,url';
+const LLMS_FULL_TXT_FIELDS = 'id,title,slug,featured,published_at,updated_at,created_at,url,visibility,custom_excerpt';
 
 function createLlmsService({settingsCache, labs, config, urlUtils, routing, api, fullTxtBudget}) {
     const footerBudget = Math.max(
-        Buffer.byteLength(TRUNCATION_FOOTER, 'utf8'),
-        Buffer.byteLength(RECENT_POSTS_FOOTER, 'utf8')
+        Buffer.byteLength(LLMS_FULL_TXT_TRUNCATION_FOOTER, 'utf8'),
+        Buffer.byteLength(LLMS_FULL_TXT_RECENT_POSTS_FOOTER, 'utf8')
     );
-    const BUDGET = (fullTxtBudget || DEFAULT_BUDGET) - footerBudget;
+    const BUDGET = (fullTxtBudget || LLMS_FULL_TXT_BUDGET) - footerBudget;
 
     function isEnabled() {
         return labs.isSet('llmsTxt') && !settingsCache.get('is_private') && settingsCache.get('llms_enabled') !== false;
@@ -47,8 +60,8 @@ function createLlmsService({settingsCache, labs, config, urlUtils, routing, api,
 
         const scaffold = postsSection => [
             buildHeader(),
-            'Public Ghost content for AI and LLM tooling. Use `/llms-full.txt` for consolidated page and post context.',
-            'Append `.md` to any post or page URL to get the content in Markdown (for example, `/example-post.md`).',
+            LLMS_TXT_INTRO,
+            MARKDOWN_DISCOVERABILITY,
             '',
             '## Pages',
             pagesSection,
@@ -61,7 +74,7 @@ function createLlmsService({settingsCache, labs, config, urlUtils, routing, api,
         ];
 
         const fixedBytes = Buffer.byteLength(scaffold('').join('\n'), 'utf8');
-        const postsBudget = Math.max(0, DEFAULT_INDEX_BUDGET - fixedBytes);
+        const postsBudget = Math.max(0, LLMS_TXT_BUDGET - fixedBytes);
         const postsSection = await buildBudgetedIndexPosts(postsBudget);
 
         return `${scaffold(postsSection).join('\n').trim()}\n`;
@@ -74,8 +87,8 @@ function createLlmsService({settingsCache, labs, config, urlUtils, routing, api,
 
         const header = [
             buildHeader(),
-            'Public Ghost content for AI and LLM tooling. This file includes a bounded export of public pages first, then recent public posts.',
-            'Append `.md` to any post or page URL to get the content in Markdown (for example, `/example-post.md`).',
+            LLMS_FULL_TXT_INTRO,
+            MARKDOWN_DISCOVERABILITY,
             ''
         ].join('\n');
 
@@ -88,16 +101,16 @@ function createLlmsService({settingsCache, labs, config, urlUtils, routing, api,
         wasTruncated = pageResult.wasTruncated;
 
         if (!wasTruncated) {
-            const postResult = await appendBoundedSectionPaginated(output, 'Posts', 'post', {maxEntries: FULL_POST_LIMIT});
+            const postResult = await appendBoundedSectionPaginated(output, 'Posts', 'post', {maxEntries: LLMS_FULL_TXT_POST_LIMIT});
             output = postResult.output;
             wasTruncated = postResult.wasTruncated;
             wasLimited = postResult.wasLimited;
         }
 
         if (wasTruncated) {
-            output += TRUNCATION_FOOTER;
+            output += LLMS_FULL_TXT_TRUNCATION_FOOTER;
         } else if (wasLimited) {
-            output += RECENT_POSTS_FOOTER;
+            output += LLMS_FULL_TXT_RECENT_POSTS_FOOTER;
         }
 
         return output.trimEnd() + '\n';
@@ -124,7 +137,7 @@ function createLlmsService({settingsCache, labs, config, urlUtils, routing, api,
             hasMore = result.hasMore;
 
             if (!entries.length && page === 1) {
-                const emptySection = `${output}_No public content available._\n`;
+                const emptySection = `${output}${EMPTY_SECTION}\n`;
                 const emptySectionBytes = Buffer.byteLength(emptySection, 'utf8');
 
                 if (emptySectionBytes <= BUDGET) {
@@ -190,7 +203,7 @@ function createLlmsService({settingsCache, labs, config, urlUtils, routing, api,
 
     function buildIndexSection(entries) {
         if (!entries.length) {
-            return '_No public content available._';
+            return EMPTY_SECTION;
         }
 
         return entries.map(buildIndexLine).join('\n');
@@ -203,10 +216,10 @@ function createLlmsService({settingsCache, labs, config, urlUtils, routing, api,
         let hasMore = true;
 
         while (hasMore) {
-            const {entries, pagination} = await browsePublicEntries('post', {
-                limit: FULL_PAGE_SIZE,
+            const {entries, pagination} = await browsePublishedEntries('post', {
+                limit: BROWSE_PAGE_SIZE,
                 page,
-                fields: 'id,title,slug,custom_excerpt,featured,published_at,url',
+                fields: LLMS_TXT_FIELDS,
                 formats: 'plaintext'
             });
             hasMore = Boolean(pagination && pagination.next);
@@ -216,7 +229,7 @@ function createLlmsService({settingsCache, labs, config, urlUtils, routing, api,
                 const lineBytes = Buffer.byteLength(`${line}\n`, 'utf8');
 
                 if (usedBytes + lineBytes > budgetBytes) {
-                    return lines.length ? lines.join('\n') : '_No public content available._';
+                    return lines.length ? lines.join('\n') : EMPTY_SECTION;
                 }
 
                 lines.push(line);
@@ -226,7 +239,7 @@ function createLlmsService({settingsCache, labs, config, urlUtils, routing, api,
             page += 1;
         }
 
-        return lines.length ? lines.join('\n') : '_No public content available._';
+        return lines.length ? lines.join('\n') : EMPTY_SECTION;
     }
 
     function buildOptionalSection() {
@@ -243,20 +256,22 @@ function createLlmsService({settingsCache, labs, config, urlUtils, routing, api,
         return optionalLinks.join('\n');
     }
 
+    function buildMembersOnlyBody(entry) {
+        const notice = (entry.visibility === 'paid' || entry.visibility === 'tiers')
+            ? PAID_MEMBERS_ONLY_NOTICE
+            : MEMBERS_ONLY_NOTICE;
+        const excerpt = truncateDescription(entry.custom_excerpt);
+
+        return excerpt ? `${excerpt}\n\n_${notice}_` : `_${notice}_`;
+    }
+
     function buildFullEntry(entry) {
         const lastUpdated = entry.updated_at || entry.published_at || entry.created_at;
         const lastUpdatedLine = lastUpdated ? `Last updated: ${new Date(lastUpdated).toISOString()}` : null;
-
-        let markdownBody;
-        if (entry.visibility && entry.visibility !== 'public') {
-            const notice = (entry.visibility === 'paid' || entry.visibility === 'tiers')
-                ? 'This post is for paying subscribers only.'
-                : 'This post is for subscribers only.';
-            const excerpt = truncateDescription(entry.custom_excerpt);
-            markdownBody = excerpt ? `${excerpt}\n\n_${notice}_` : `_${notice}_`;
-        } else {
-            markdownBody = renderEntryMarkdownBody(entry) || '_No content available._';
-        }
+        const isMembersOnly = entry.visibility && entry.visibility !== 'public';
+        const markdownBody = isMembersOnly
+            ? buildMembersOnlyBody(entry)
+            : (renderEntryMarkdownBody(entry) || '_No content available._');
 
         return [
             `### ${entry.title}`,
@@ -267,7 +282,7 @@ function createLlmsService({settingsCache, labs, config, urlUtils, routing, api,
         ].filter(Boolean).join('\n');
     }
 
-    async function browsePublicEntries(type, options) {
+    async function browsePublishedEntries(type, options) {
         const controller = type === 'page' ? api.pagesPublic : api.postsPublic;
         const responseKey = type === 'page' ? 'pages' : 'posts';
 
@@ -285,13 +300,9 @@ function createLlmsService({settingsCache, labs, config, urlUtils, routing, api,
     }
 
     async function fetchIndexPages() {
-        // Without `fields` the content API selects every posts column (except
-        // mobiledoc/lexical), pulling the full html of every post into memory.
-        // The format columns (plaintext here) are appended to `fields` by the
-        // input serializer, and `url` is resolved at serialization time.
-        const {entries} = await browsePublicEntries('page', {
+        const {entries} = await browsePublishedEntries('page', {
             limit: PAGES_LIMIT,
-            fields: 'id,title,slug,custom_excerpt,featured,published_at,url',
+            fields: LLMS_TXT_FIELDS,
             formats: 'plaintext'
         });
 
@@ -301,10 +312,10 @@ function createLlmsService({settingsCache, labs, config, urlUtils, routing, api,
     }
 
     async function fetchFullEntries(type, pageNum) {
-        const {entries, pagination} = await browsePublicEntries(type, {
-            limit: FULL_PAGE_SIZE,
+        const {entries, pagination} = await browsePublishedEntries(type, {
+            limit: BROWSE_PAGE_SIZE,
             page: pageNum,
-            fields: 'id,title,slug,featured,published_at,updated_at,created_at,url,visibility,custom_excerpt',
+            fields: LLMS_FULL_TXT_FIELDS,
             formats: 'html,plaintext'
         });
 

--- a/ghost/core/test/e2e-frontend/llms-routes.test.js
+++ b/ghost/core/test/e2e-frontend/llms-routes.test.js
@@ -47,6 +47,10 @@ describe('llms.txt routing', function () {
         // descriptions come from plaintext, which is requested via `formats`
         // on top of the narrowed `fields`
         assert.match(res.text, /\[Start here for a quick overview of everything you need to know\]\([^)]+\) - We've crammed the most important information/);
+
+        // the .md discoverability line and the llms-full link in Optional
+        assert.match(res.text, /Append `\.md` to any post or page URL/);
+        assert.ok(res.text.includes(`[Full content of pages and posts](${siteUrl}/llms-full.txt)`), 'expected llms-full link in Optional');
     });
 
     it('serves llms-full.txt with entry bodies and absolute urls', async function () {
@@ -61,6 +65,12 @@ describe('llms.txt routing', function () {
         // entry bodies are rendered from html, which is requested via
         // `formats` on top of the narrowed `fields`
         assert.match(res.text, /An about page is a great example of one you might want to set up early on/);
+
+        // the .md discoverability line appears in both files
+        assert.match(res.text, /Append `\.md` to any post or page URL/);
+
+        // truncation footer (if present) points at the sitemap, not /llms.txt
+        assert.doesNotMatch(res.text, /Use `\/llms\.txt`/);
     });
 
     it('does not serve llms.txt when the labs flag is disabled', async function () {

--- a/ghost/core/test/unit/frontend/services/llms/service.test.js
+++ b/ghost/core/test/unit/frontend/services/llms/service.test.js
@@ -246,7 +246,7 @@ describe('Unit: frontend/services/llms/service', function () {
         assert.match(llmsFullTxt, /### Post 499/);
         assert.doesNotMatch(llmsFullTxt, /### Post 500/);
         assert.match(llmsFullTxt, /Includes the latest 500 public posts/);
-        assert.match(llmsFullTxt, /Use `\/llms\.txt` for the complete index/);
+        assert.match(llmsFullTxt, /Use `\/sitemap\.xml` for the complete archive of public content/);
     });
 
     it('computes fresh output on every call (no cache)', async function () {
@@ -410,11 +410,12 @@ describe('Unit: frontend/services/llms/service', function () {
 
         assert.ok(pageCall, 'expected pagesPublic.browse to be called');
         assert.ok(postCall, 'expected postsPublic.browse to be called');
-        assert.equal(pageCall.options.filter, 'status:published+visibility:public');
-        assert.equal(postCall.options.filter, 'status:published+visibility:public');
-        assert.equal(postCall.options.limit, 'all');
+        assert.equal(pageCall.options.filter, 'status:published');
+        assert.equal(postCall.options.filter, 'status:published');
+        assert.equal(pageCall.options.limit, 20);
+        assert.equal(postCall.options.limit, 100);
         assert.equal(pageCall.options.order, 'id asc');
-        assert.equal(postCall.options.order, 'published_at desc');
+        assert.equal(postCall.options.order, undefined);
         assert.deepEqual(pageCall.options.context, {member: null});
         assert.deepEqual(postCall.options.context, {member: null});
         assert.equal(postCall.options.formats, 'plaintext');
@@ -440,7 +441,116 @@ describe('Unit: frontend/services/llms/service', function () {
 
         assert.ok(postCall, 'expected postsPublic.browse to be called');
         assert.equal(postCall.options.formats, 'html,plaintext');
-        assert.equal(postCall.options.fields, 'id,title,slug,featured,published_at,updated_at,created_at,url');
+        assert.equal(postCall.options.fields, 'id,title,slug,featured,published_at,updated_at,created_at,url,visibility,custom_excerpt');
         assert.equal(postCall.options.limit, 100);
+    });
+
+    it('includes the .md discoverability line and llms-full link in llms.txt', async function () {
+        const service = createService({
+            pages: [{id: 'page-a', title: 'About', slug: 'about', type: 'page'}],
+            posts: [{id: 'post-a', title: 'Hello', slug: 'hello', type: 'post'}],
+            urlMap: {
+                'page-a': 'https://example.com/about/',
+                'post-a': 'https://example.com/hello/'
+            }
+        });
+
+        const llmsTxt = await service.getLlmsTxt();
+
+        assert.match(llmsTxt, /Append `\.md` to any post or page URL/);
+        assert.match(llmsTxt, /## Optional[\s\S]*\[Full content of pages and posts\]\(http:\/\/127\.0\.0\.1:\d+\/llms-full\.txt\)/m);
+    });
+
+    it('includes the .md discoverability line in llms-full.txt', async function () {
+        const service = createService({
+            pages: [],
+            posts: [{id: 'post-a', title: 'Hello', slug: 'hello', html: '<p>Body</p>', plaintext: 'Body', type: 'post'}],
+            urlMap: {'post-a': 'https://example.com/hello/'}
+        });
+
+        const llmsFullTxt = await service.getLlmsFullTxt();
+
+        assert.match(llmsFullTxt, /Append `\.md` to any post or page URL/);
+    });
+
+    it('keeps members-only posts in the llms.txt index with their public excerpt', async function () {
+        const service = createService({
+            pages: [],
+            posts: [{
+                id: 'post-m',
+                title: 'Members Post',
+                slug: 'members-post',
+                custom_excerpt: 'Public teaser',
+                plaintext: '',
+                visibility: 'members',
+                type: 'post'
+            }],
+            urlMap: {'post-m': 'https://example.com/members-post/'}
+        });
+
+        const llmsTxt = await service.getLlmsTxt();
+
+        assert.match(llmsTxt, /\[Members Post\]\(https:\/\/example\.com\/members-post\.md\) - Public teaser/);
+    });
+
+    it('cuts members-only post bodies off in llms-full.txt with a subscriber notice', async function () {
+        const service = createService({
+            pages: [],
+            posts: [
+                {
+                    id: 'post-m',
+                    title: 'Members Post',
+                    slug: 'members-post',
+                    custom_excerpt: 'Public teaser',
+                    html: '',
+                    plaintext: '',
+                    visibility: 'members',
+                    type: 'post'
+                },
+                {
+                    id: 'post-p',
+                    title: 'Paid Post',
+                    slug: 'paid-post',
+                    html: '',
+                    plaintext: '',
+                    visibility: 'paid',
+                    type: 'post'
+                }
+            ],
+            urlMap: {
+                'post-m': 'https://example.com/members-post/',
+                'post-p': 'https://example.com/paid-post/'
+            }
+        });
+
+        const llmsFullTxt = await service.getLlmsFullTxt();
+
+        assert.match(llmsFullTxt, /### Members Post[\s\S]*Public teaser[\s\S]*This post is for subscribers only\./);
+        assert.match(llmsFullTxt, /### Paid Post[\s\S]*This post is for paying subscribers only\./);
+    });
+
+    it('bounds the llms.txt index to the size budget', async function () {
+        // ~2KB of excerpt per post; 1000 posts would be ~2MB unbounded, but the
+        // index budget (~50KB) caps it well before that.
+        const posts = Array.from({length: 1000}, (_, index) => ({
+            id: `post-${index}`,
+            title: `Post ${index}`,
+            slug: `post-${index}`,
+            custom_excerpt: 'x'.repeat(280),
+            type: 'post'
+        }));
+        const urlMap = Object.fromEntries(posts.map(post => [
+            post.id,
+            `https://example.com/${post.slug}/`
+        ]));
+
+        const service = createService({pages: [], posts, urlMap});
+
+        const llmsTxt = await service.getLlmsTxt();
+
+        assert.ok(Buffer.byteLength(llmsTxt, 'utf8') <= 50 * 1024, `expected <= 50KB, got ${Buffer.byteLength(llmsTxt, 'utf8')}`);
+        // Optional section is always retained even when posts fill the budget.
+        assert.match(llmsTxt, /## Optional/);
+        assert.match(llmsTxt, /\[Sitemap\]/);
     });
 });


### PR DESCRIPTION
## Why

`/llms.txt` and `/llms-full.txt` are a machine-readable view of a Ghost site's public content for AI/LLM tooling, sitting alongside the per-post/page `.md` representations. This change reworks **what those two files contain** so they're genuinely useful to the tools that read them, rather than technically-complete files that nothing ingests. It's a content-design change only; the feature stays behind the `llmsTxt` flag and nothing here changes whether, or to whom, the files are served.

The design follows from research into how these files are actually consumed. A few principles did the deciding, and each one is why the resulting behaviour is what it is:

**Curated, not exhaustive.** Listing every URL on a site is already the sitemap's job, and an `llms.txt` that mirrors the sitemap is large, costly to generate, and — from the evidence we reviewed — not something consumers actually ingest. The value is a curated index a model can read in a single pass. So `llms.txt` is bounded to a ~50KB budget (pages, then newest posts until full) and links to the sitemap for the complete archive rather than trying to be it.

**Bounded by size, not by post count.** A count-based cap can't protect against a site whose posts are 40,000-word essays. Both files are bounded by a byte budget so the output stays ingestible regardless of individual post length, and when a file is deliberately cut short a truncation note says so — so a consumer doesn't wrongly infer the site only has N posts.

**Discoverability belongs in the file, not in headers.** We looked at `Link` / `X-Llms-Txt`-style discovery headers and found nothing reliably reads them. So the path to clean Markdown is stated inside both files, where a consumer reading the index will actually see it — and every index entry already links to the `.md` form, which both lands the reader on clean Markdown and demonstrates the "append `.md`" convention by example.

**Reflect the real public surface, and respect gating the same way the site does.** A members-only or paid post's existence and excerpt are already public, so the files should reflect that: those posts now appear in the index with their public excerpt, and in `llms-full.txt` their bodies are cut off to an excerpt-plus-notice. This mirrors exactly how the rest of the public site treats gated content, and it's achieved by browsing published content and letting the Content API's existing gating strip the bodies — not by re-implementing visibility rules in this service.

**Reproducible output.** Ordering follows the Content API's default (`published_at`, then `id`), so regenerating a file produces stable, diffable output.
