### PR TITLE
Batched automation graph inserts and revision lookups

### DIFF
--- a/ghost/core/core/server/services/automations/database-automations-repository.ts
+++ b/ghost/core/core/server/services/automations/database-automations-repository.ts
@@ -111,6 +111,19 @@ type RevisionDataFor<ActionDataT> = {
 type WaitRevisionData = RevisionDataFor<WaitActionData>;
 type SendEmailRevisionData = RevisionDataFor<SendEmailActionData>;
 
+type ActionToInsert = {
+    id: string;
+    created_at: string;
+    updated_at: string;
+    automation_id: string;
+    type: AutomationAction['type'];
+};
+type ActionRevisionToInsert = {
+    actionId: string;
+    action: AutomationAction;
+    createdAt: string;
+};
+
 export function createDatabaseAutomationsRepository({
     knex,
     fakeWaitHoursMultiplier
@@ -259,22 +272,26 @@ async function ensureWelcomeEmailAction(trx: Knex.Transaction, automationId: str
     const now = toDatabaseDate(new Date());
     const actionId = ObjectId().toHexString();
 
-    await insertAction(trx, {
+    await insertActions(trx, [{
         id: actionId,
         created_at: now,
         updated_at: now,
         automation_id: automationId,
         type: 'send_email'
-    });
-    await insertActionRevision(trx, actionId, {
-        id: actionId,
-        type: 'send_email',
-        data: {
-            email_subject: email.subject,
-            email_lexical: email.lexical ?? '',
-            email_design_setting_id: email.email_design_setting_id
-        }
-    }, now, null);
+    }]);
+    await insertActionRevisions(trx, [{
+        actionId,
+        action: {
+            id: actionId,
+            type: 'send_email',
+            data: {
+                email_subject: email.subject,
+                email_lexical: email.lexical ?? '',
+                email_design_setting_id: email.email_design_setting_id
+            }
+        },
+        createdAt: getNextRevisionCreatedAt(null, now)
+    }]);
 }
 
 async function trigger(trx: Knex.Transaction, options: Readonly<{
@@ -717,18 +734,20 @@ async function updateAutomation(trx: Knex.Transaction, automation: AutomationRow
 }
 
 async function replaceAutomationGraph(trx: Knex.Transaction, automationId: string, submittedActions: AutomationAction[], edges: AutomationEdge[]): Promise<void> {
-    // TODO(NY-1340): This makes too many round-trips to the database. We should improve that.
     const existingActions = await loadAutomationActionRows(trx, automationId);
+    const existingActionById = new Map(existingActions.map(action => [action.id, action]));
     const actions = await resolveEmailDesignSettingIds(trx, submittedActions);
-    const existingActionIds = new Set(existingActions.map(action => action.id));
     const submittedActionIds = new Set(actions.map(action => action.id));
+    const actionIdsWithOwners = await loadActionIdsWithOwners(trx, [...submittedActionIds]);
+    const latestRevisionByActionId = new Map((await loadLatestActionRevisions(trx, [...submittedActionIds])).map(revision => [revision.action_id, revision]));
     const now = toDatabaseDate(new Date());
+    const actionsToInsert: ActionToInsert[] = [];
+    const revisionsToInsert: ActionRevisionToInsert[] = [];
 
     for (const action of actions) {
-        if (existingActionIds.has(action.id)) {
-            const existingAction = existingActions.find(({id}) => id === action.id);
-
-            if (existingAction?.type !== action.type) {
+        const existingAction = existingActionById.get(action.id);
+        if (existingAction) {
+            if (existingAction.type !== action.type) {
                 throw new errors.ValidationError({
                     message: tpl(messages.conflictingAutomationActionType, {
                         actionId: action.id
@@ -737,7 +756,7 @@ async function replaceAutomationGraph(trx: Knex.Transaction, automationId: strin
                 });
             }
         } else {
-            if (await loadActionOwner(trx, action.id)) {
+            if (actionIdsWithOwners.has(action.id)) {
                 throw new errors.ValidationError({
                     message: tpl(messages.conflictingAutomationActionId, {
                         actionId: action.id
@@ -746,7 +765,7 @@ async function replaceAutomationGraph(trx: Knex.Transaction, automationId: strin
                 });
             }
 
-            await insertAction(trx, {
+            actionsToInsert.push({
                 id: action.id,
                 created_at: now,
                 updated_at: now,
@@ -755,11 +774,18 @@ async function replaceAutomationGraph(trx: Knex.Transaction, automationId: strin
             });
         }
 
-        const latestRevision = await loadLatestActionRevision(trx, action.id);
+        const latestRevision = latestRevisionByActionId.get(action.id);
         if (shouldInsertActionRevision(action, latestRevision)) {
-            await insertActionRevision(trx, action.id, action, now, latestRevision);
+            revisionsToInsert.push({
+                actionId: action.id,
+                action,
+                createdAt: getNextRevisionCreatedAt(latestRevision?.created_at ?? null, now)
+            });
         }
     }
+
+    await insertActions(trx, actionsToInsert);
+    await insertActionRevisions(trx, revisionsToInsert);
 
     const actionIdsToSoftDelete = existingActions
         .filter(existingAction => !submittedActionIds.has(existingAction.id))
@@ -815,26 +841,24 @@ async function loadAutomationActionRows(trx: Knex.Transaction, automationId: str
         .whereNull('deleted_at');
 }
 
-async function loadActionOwner(trx: Knex.Transaction, actionId: string): Promise<string | null> {
-    const row = await trx('automation_actions')
-        .select('automation_id')
-        .where('id', actionId)
-        .first();
-
-    return row?.automation_id ?? null;
+async function loadActionIdsWithOwners(trx: Knex.Transaction, actionIds: ReadonlyArray<string>): Promise<Set<string>> {
+    if (actionIds.length === 0) {
+        return new Set();
+    }
+    const rows = await trx('automation_actions')
+        .select('id')
+        .whereIn('id', actionIds);
+    return new Set(rows.map(row => row.id));
 }
 
-async function insertAction(trx: Knex.Transaction, action: {
-    id: string;
-    created_at: string;
-    updated_at: string;
-    automation_id: string;
-    type: string;
-}) {
-    await trx('automation_actions').insert(action);
+async function insertActions(trx: Knex.Transaction, actions: ReadonlyArray<ActionToInsert>): Promise<void> {
+    if (actions.length === 0) {
+        return;
+    }
+    await trx('automation_actions').insert(actions);
 }
 
-function shouldInsertActionRevision(action: AutomationAction, latestRevision: ActionRevisionRow | null): boolean {
+function shouldInsertActionRevision(action: AutomationAction, latestRevision: ActionRevisionRow | undefined): boolean {
     if (!latestRevision) {
         return true;
     }
@@ -863,26 +887,34 @@ function buildRevisionActionData(action: AutomationAction, revision: ActionRevis
     }
 }
 
-async function loadLatestActionRevision(
+async function loadLatestActionRevisions(
     trx: Knex.Transaction,
-    actionId: string
-): Promise<ActionRevisionRow | null> {
-    const row = await trx('automation_action_revisions')
-        .select(
-            'action_id',
-            'created_at',
-            'wait_hours',
-            'email_subject',
-            'email_lexical',
-            'email_design_setting_id'
-        )
-        .where('action_id', actionId)
-        .where('created_at', trx('automation_action_revisions')
-            .max('created_at')
-            .where('action_id', actionId))
-        .first();
+    actionIds: ReadonlyArray<string>
+): Promise<ActionRevisionRow[]> {
+    if (actionIds.length === 0) {
+        return [];
+    }
 
-    return row ?? null;
+    const latestRevisionDates = trx('automation_action_revisions')
+        .select('action_id')
+        .max({created_at: 'created_at'})
+        .whereIn('action_id', actionIds)
+        .groupBy('action_id')
+        .as('latest_revision_dates');
+
+    return await trx('automation_action_revisions')
+        .select(
+            'automation_action_revisions.action_id',
+            'automation_action_revisions.created_at',
+            'automation_action_revisions.wait_hours',
+            'automation_action_revisions.email_subject',
+            'automation_action_revisions.email_lexical',
+            'automation_action_revisions.email_design_setting_id'
+        )
+        .innerJoin(latestRevisionDates, function () {
+            this.on('automation_action_revisions.action_id', 'latest_revision_dates.action_id')
+                .andOn('automation_action_revisions.created_at', 'latest_revision_dates.created_at');
+        });
 }
 
 async function softDeleteActions(
@@ -901,16 +933,16 @@ async function softDeleteActions(
         .whereIn('id', actionIds);
 }
 
-async function insertActionRevision(
+async function insertActionRevisions(
     trx: Knex.Transaction,
-    actionId: string,
-    action: AutomationAction,
-    createdAt: string,
-    latestRevision: ActionRevisionRow | null
+    revisions: ReadonlyArray<ActionRevisionToInsert>
 ): Promise<void> {
-    const revision = buildActionRevision(actionId, action, getNextRevisionCreatedAt(latestRevision?.created_at ?? null, createdAt));
-
-    await trx('automation_action_revisions').insert(revision);
+    if (revisions.length === 0) {
+        return;
+    }
+    await trx('automation_action_revisions').insert(
+        revisions.map(({actionId, action, createdAt}) => buildActionRevision(actionId, action, createdAt))
+    );
 }
 
 function getNextRevisionCreatedAt(latestCreatedAt: string | null, requestedCreatedAt: string) {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1340

This is a performance improvement that reduces trips to the database.
