### PR TITLE
Changed `pnpm setup` to also build workspace packages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,9 +45,11 @@ Two categories of apps:
 ### Development
 ```bash
 corepack enable pnpm           # Enable corepack to use the correct pnpm version
-pnpm run setup                 # First-time setup (installs deps + submodules)
+pnpm run setup                 # First-time setup (installs deps + submodules + builds workspace packages)
 pnpm dev                       # Start development (Docker backend + host frontend dev servers)
 ```
+
+> **Fresh worktree / first run — run `pnpm setup` before running tests or booting Ghost.** It installs deps, syncs submodules, and **builds the workspace packages** (Nx-cached, so it's fast). DB-backed tests and a real Ghost boot will not start until built deps like `@tryghost/parse-email-address` exist. If an incremental install over a branch switch leaves the dependency hoist tree incomplete (symptom: `Cannot find module '@tryghost/...'` at boot), do a clean reinstall with `pnpm fix`.
 
 ### Building
 ```bash

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "dev:status": "node scripts/dev-supervisor.js status",
     "fix": "pnpm store prune && rimraf -g '**/node_modules' && pnpm install && pnpm nx reset",
     "knex-migrator": "pnpm --filter ghost run knex-migrator",
-    "setup": "pnpm install && git submodule update --init --recursive",
+    "setup": "pnpm install && git submodule update --init --recursive && pnpm build",
     "reset:db": "docker exec ghost-dev bash -c 'cd /home/ghost/ghost/core && pnpm knex-migrator reset && pnpm knex-migrator init'",
     "reset:db:volume": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} down && docker volume rm ghost-dev_mysql-data",
     "reset:data": "docker exec ghost-dev bash -c 'cd /home/ghost/ghost/core && node index.js generate-data --clear-database --quantities members:1000,posts:100 --seed 123'",


### PR DESCRIPTION
## What
`pnpm setup` now runs `pnpm build` after `pnpm install` + submodule sync, so a fresh worktree or clone is actually ready to run tests and boot Ghost.

## Why
A fresh worktree could `pnpm install` without building, leaving built workspace deps missing — e.g. `@tryghost/parse-email-address` (`main` → `build/index.js`). Ghost's mail service `require`s it during boot, so a real boot — and therefore **every DB-backed test** — fails with `Cannot find module` until something builds it. `pnpm build` is Nx-cached (and Nx Cloud remote-cached): ~2s on a warm cache, and a one-time cost on a cold one, so `setup` now leaves a worktree genuinely ready.

Also documents the fresh-worktree flow in `AGENTS.md`, and points at `pnpm fix` for the incomplete-hoist case (the `@tryghost/tpl` phantom-dependency symptom — see PLA-155).