### PR TITLE
Moved the e2e-server suite onto Vitest

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -62,7 +62,7 @@
     "test:unit": "pnpm test:vitest",
     "test:integration": "pnpm test:base './test/integration' --timeout=10000",
     "test:e2e": "pnpm test:e2e:mocha && pnpm test:e2e:vitest",
-    "test:e2e:mocha": "pnpm test:base ./test/e2e-api ./test/e2e-server ./test/e2e-frontend --timeout=15000",
+    "test:e2e:mocha": "pnpm test:base ./test/e2e-api ./test/e2e-frontend --timeout=15000",
     "test:e2e:vitest": "vitest run -c vitest.config.db.ts --project e2e",
     "test:e2e:ci": "pnpm test:e2e:mocha -b && pnpm test:e2e:vitest",
     "test:legacy": "pnpm test:base './test/legacy' --timeout=60000",

--- a/ghost/core/test/e2e-server/1-options-requests.test.js
+++ b/ghost/core/test/e2e-server/1-options-requests.test.js
@@ -10,7 +10,7 @@ describe('OPTIONS requests', function () {
     let contentAPIAgent;
     let ghostServer;
 
-    before(async function () {
+    beforeAll(async function () {
         const agents = await agentProvider.getAgentsWithFrontend();
         adminAgent = agents.adminAgent;
         membersAgent = agents.membersAgent;
@@ -19,7 +19,7 @@ describe('OPTIONS requests', function () {
         ghostServer = agents.ghostServer;
     });
 
-    after(async function () {
+    afterAll(async function () {
         await ghostServer.stop();
     });
 

--- a/ghost/core/test/e2e-server/admin.test.js
+++ b/ghost/core/test/e2e-server/admin.test.js
@@ -22,7 +22,7 @@ function assertCorrectHeaders(res) {
 }
 
 describe('Admin Routing', function () {
-    before(async function () {
+    beforeAll(async function () {
         adminUtils.stubAdminFiles();
 
         await testUtils.startGhost();
@@ -46,7 +46,7 @@ describe('Admin Routing', function () {
     });
 
     describe('Auth Frame', function () {
-        before(function () {
+        beforeAll(function () {
             // ensure the admin-auth folder exists so serveStatic doesn't fall through
             adminUtils.stubAuthFrameFiles(configUtils.config.getContentPath('public'));
         });
@@ -81,7 +81,7 @@ describe('Admin Routing', function () {
 
     // we'll use X-Forwarded-Proto: https to simulate an 'https://' request behind a proxy
     describe('Require HTTPS - redirect', function () {
-        before(async function () {
+        beforeAll(async function () {
             configUtils.set('url', 'https://localhost:2390');
             urlUtils.stubUrlUtilsFromConfig();
 
@@ -89,7 +89,7 @@ describe('Admin Routing', function () {
             request = supertest.agent(configUtils.getServerUrl());
         });
 
-        after(async function () {
+        afterAll(async function () {
             await urlUtils.restore();
             await configUtils.restore();
         });

--- a/ghost/core/test/e2e-server/click-tracking.test.js
+++ b/ghost/core/test/e2e-server/click-tracking.test.js
@@ -11,7 +11,7 @@ describe('Click Tracking', function () {
     let ghostServer;
     let webhookMockReceiver;
 
-    before(async function () {
+    beforeAll(async function () {
         ({adminAgent: agent, ghostServer} = await agentProvider.getAgentsWithFrontend());
         await fixtureManager.init('newsletters', 'members:newsletters', 'integrations');
         await agent.loginAsOwner();
@@ -28,7 +28,7 @@ describe('Click Tracking', function () {
         mockManager.restore();
     });
 
-    after(async function () {
+    afterAll(async function () {
         await ghostServer.stop();
     });
 

--- a/ghost/core/test/e2e-server/services/member-attribution.test.js
+++ b/ghost/core/test/e2e-server/services/member-attribution.test.js
@@ -7,7 +7,7 @@ const memberAttributionService = require('../../../core/server/services/member-a
 const urlUtils = require('../../../core/shared/url-utils');
 
 describe('Member Attribution Service', function () {
-    before(async function () {
+    beforeAll(async function () {
         await agentProvider.getAdminAPIAgent();
         await fixtureManager.init('posts');
     });

--- a/ghost/core/test/e2e-server/services/mentions.test.js
+++ b/ghost/core/test/e2e-server/services/mentions.test.js
@@ -42,7 +42,7 @@ function addMentionMocks() {
 }
 
 describe('Mentions Service', function () {
-    before(async function () {
+    beforeAll(async function () {
         agent = await agentProvider.getAdminAPIAgent();
         await fixtureManager.init('users');
         await agent.loginAsAdmin();

--- a/ghost/core/test/e2e-server/services/milestones.test.js
+++ b/ghost/core/test/e2e-server/services/milestones.test.js
@@ -150,7 +150,7 @@ describe('Milestones Service', function () {
         minDaysSinceLastEmail: 14
     };
 
-    before(async function () {
+    beforeAll(async function () {
         agent = await agentProvider.getAdminAPIAgent();
         await fixtureManager.init('newsletters');
         await agent.loginAsOwner();

--- a/ghost/core/test/e2e-server/services/recommendation-emails.test.js
+++ b/ghost/core/test/e2e-server/services/recommendation-emails.test.js
@@ -11,7 +11,7 @@ const Mention = require('../../../core/server/services/mentions/mention');
 describe('Incoming Recommendation Emails', function () {
     let emailMockReceiver;
 
-    before(async function () {
+    beforeAll(async function () {
         agent = await agentProvider.getAdminAPIAgent();
         await fixtureManager.init('users');
         await agent.loginAsAdmin();

--- a/ghost/core/test/e2e-server/services/stats/mrr-stats-service.test.js
+++ b/ghost/core/test/e2e-server/services/stats/mrr-stats-service.test.js
@@ -36,7 +36,7 @@ async function createMemberWithSubscription(interval, amount, currency, date) {
 }
 
 describe('MRR Stats Service', function () {
-    before(async function () {
+    beforeAll(async function () {
         agent = await agentProvider.getAdminAPIAgent();
         await fixtureManager.init();
         await agent.loginAsOwner();

--- a/ghost/core/test/e2e-server/well-known.test.js
+++ b/ghost/core/test/e2e-server/well-known.test.js
@@ -4,11 +4,11 @@ const {anyString, anyEtag} = matchers;
 describe('.well-known', function () {
     let agentGhostAPI;
 
-    before(async function () {
+    beforeAll(async function () {
         agentGhostAPI = await agentProvider.getGhostAPIAgent();
     });
 
-    after(function () {
+    afterAll(function () {
         mockManager.restore();
     });
 

--- a/ghost/core/vitest.config.db.ts
+++ b/ghost/core/vitest.config.db.ts
@@ -67,8 +67,11 @@ export default defineConfig({
                 test: {
                     ...sharedDbConfig,
                     name: 'e2e',
-                    // Widens to e2e-api / e2e-server / e2e-frontend as they port.
-                    include: ['test/e2e-webhooks/**/*.test.{js,ts}'],
+                    // Widens to e2e-api / e2e-frontend as they port.
+                    include: [
+                        'test/e2e-webhooks/**/*.test.{js,ts}',
+                        'test/e2e-server/**/*.test.{js,ts}'
+                    ],
                     exclude: ['**/node_modules/**'],
                     // Matches the mocha `--timeout=15000` for the e2e suites.
                     testTimeout: 15000


### PR DESCRIPTION
Second slice of the ghost/core Mocha→Vitest DB migration, on top of the basis (#28682). Ports `test/e2e-server` (9 files) onto the DB-backed Vitest runner; e2e-api / e2e-frontend stay on Mocha for now.

ref https://linear.app/ghost/issue/PLA-151

## What
- Mechanical conversion: `before(`/`after(` → `beforeAll(`/`afterAll(`. Assertions (`node:assert` + `sinon` + supertest) unchanged.
- Moves the dir out of `test:e2e:mocha` into the Vitest `e2e` project. Coverage is preserved — `test:ci:e2e` wraps both runners under one `c8` (c8 captures Vitest's worker-thread coverage).

## Notes
- These suites boot a **real HTTP server** (`getAgentsWithFrontend` → `server: true` → port bind) with `ghostServer.stop()` teardown — runs fine under the threads-serial model (per-session port from the setup file).
- **70 e2e-server tests pass** (108 with e2e-webhooks in the same project).

e2e-frontend follows in a stacked PR.