### PR TITLE
Moved the e2e-frontend suite onto Vitest

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -62,7 +62,7 @@
     "test:unit": "pnpm test:vitest",
     "test:integration": "pnpm test:base './test/integration' --timeout=10000",
     "test:e2e": "pnpm test:e2e:mocha && pnpm test:e2e:vitest",
-    "test:e2e:mocha": "pnpm test:base ./test/e2e-api ./test/e2e-frontend --timeout=15000",
+    "test:e2e:mocha": "pnpm test:base ./test/e2e-api --timeout=15000",
     "test:e2e:vitest": "vitest run -c vitest.config.db.ts --project e2e",
     "test:e2e:ci": "pnpm test:e2e:mocha -b && pnpm test:e2e:vitest",
     "test:legacy": "pnpm test:base './test/legacy' --timeout=60000",

--- a/ghost/core/test/e2e-frontend/advanced-url-config.test.js
+++ b/ghost/core/test/e2e-frontend/advanced-url-config.test.js
@@ -18,7 +18,7 @@ let request;
 
 describe('Advanced URL Configurations', function () {
     describe('Subdirectory config', function () {
-        before(async function () {
+        beforeAll(async function () {
             configUtils.set('url', 'http://localhost/blog/');
             urlUtils.stubUrlUtilsFromConfig();
             mockManager.mockMail();
@@ -28,7 +28,7 @@ describe('Advanced URL Configurations', function () {
             request = supertest.agent(configUtils.getServerUrl());
         });
 
-        after(async function () {
+        afterAll(async function () {
             await configUtils.restore();
             await urlUtils.restore();
             mockManager.restore();
@@ -85,7 +85,7 @@ describe('Advanced URL Configurations', function () {
         });
 
         describe('Preview routes', function () {
-            before(async function () {
+            beforeAll(async function () {
                 // NOTE: ideally we'd only insert the single draft post we want to test here
                 // but we don't have a way to do that just now and are already planning to
                 // replace the fixture system
@@ -101,7 +101,7 @@ describe('Advanced URL Configurations', function () {
     });
 
     describe('Subdirectory config: /ghost/ redirects with separate admin', function () {
-        before(async function () {
+        beforeAll(async function () {
             configUtils.set('url', 'http://localhost/blog/');
             configUtils.set('admin:redirects', true);
             configUtils.set('admin:url', 'http://admin.localhost/');
@@ -110,7 +110,7 @@ describe('Advanced URL Configurations', function () {
             request = supertest.agent(configUtils.getServerUrl());
         });
 
-        after(async function () {
+        afterAll(async function () {
             await urlUtils.restore();
             await configUtils.restore();
             await testUtils.startGhost();

--- a/ghost/core/test/e2e-frontend/custom-routes.test.js
+++ b/ghost/core/test/e2e-frontend/custom-routes.test.js
@@ -16,7 +16,7 @@ function assertCorrectFrontendHeaders(res) {
 describe('Custom Frontend routing', function () {
     let request;
 
-    before(async function () {
+    beforeAll(async function () {
         const routesFilePath = path.join(configUtils.config.get('paths:appRoot'), 'test/utils/fixtures/settings/newroutes.yaml');
 
         await testUtils.startGhost({
@@ -25,7 +25,7 @@ describe('Custom Frontend routing', function () {
         request = supertest.agent(configUtils.config.get('url'));
     });
 
-    after(function () {
+    afterAll(function () {
         return testUtils.stopGhost();
     });
 

--- a/ghost/core/test/e2e-frontend/default-routes.test.js
+++ b/ghost/core/test/e2e-frontend/default-routes.test.js
@@ -32,7 +32,7 @@ describe('Default Frontend routing', function () {
         sinon.restore();
     });
 
-    before(async function () {
+    beforeAll(async function () {
         await testUtils.startGhost();
         request = supertest.agent(configUtils.config.get('url'));
     });
@@ -117,7 +117,7 @@ describe('Default Frontend routing', function () {
     });
 
     describe('Gift preview routes', function () {
-        before(async function () {
+        beforeAll(async function () {
             await testUtils.createPost({
                 post: {
                     title: 'Gift a subscription',
@@ -194,14 +194,14 @@ describe('Default Frontend routing', function () {
         });
 
         describe('Admin Redirects Disabled', function () {
-            before(async function () {
+            beforeAll(async function () {
                 configUtils.set('admin:redirects', false);
 
                 await testUtils.startGhost();
                 request = supertest.agent(configUtils.config.get('url'));
             });
 
-            after(async function () {
+            afterAll(async function () {
                 await configUtils.restore();
 
                 await testUtils.startGhost();
@@ -219,7 +219,7 @@ describe('Default Frontend routing', function () {
 
     describe('/ghost/ redirects', function () {
         describe('with separate admin and admin:redirects=false', function () {
-            before(async function () {
+            beforeAll(async function () {
                 configUtils.set('admin:redirects', false);
                 configUtils.set('admin:url', 'http://localhost:9999');
 
@@ -227,7 +227,7 @@ describe('Default Frontend routing', function () {
                 request = supertest.agent(configUtils.config.get('url'));
             });
 
-            after(async function () {
+            afterAll(async function () {
                 await configUtils.restore();
 
                 await testUtils.startGhost();
@@ -250,7 +250,7 @@ describe('Default Frontend routing', function () {
         });
 
         describe('with separate admin and admin:redirects=true', function () {
-            before(async function () {
+            beforeAll(async function () {
                 configUtils.set('admin:redirects', true);
                 configUtils.set('admin:url', 'http://localhost:9999');
 
@@ -258,7 +258,7 @@ describe('Default Frontend routing', function () {
                 request = supertest.agent(configUtils.config.get('url'));
             });
 
-            after(async function () {
+            afterAll(async function () {
                 await configUtils.restore();
 
                 await testUtils.startGhost();
@@ -395,7 +395,7 @@ describe('Default Frontend routing', function () {
     });
 
     describe('Site Map', function () {
-        before(async function () {
+        beforeAll(async function () {
             await testUtils.teardownDb();
             await testUtils.initData();
             await testUtils.initFixtures('posts');

--- a/ghost/core/test/e2e-frontend/email-routes.test.js
+++ b/ghost/core/test/e2e-frontend/email-routes.test.js
@@ -15,7 +15,7 @@ describe('Frontend Routing: Email Routes', function () {
     let request;
     let emailPosts;
 
-    before(async function () {
+    beforeAll(async function () {
         await testUtils.startGhost({forceStart: true});
 
         request = supertest.agent(config.get('url'));
@@ -35,7 +35,7 @@ describe('Frontend Routing: Email Routes', function () {
         }]);
     });
 
-    after(function () {
+    afterAll(function () {
         sinon.restore();
     });
 

--- a/ghost/core/test/e2e-frontend/helpers/get.test.js
+++ b/ghost/core/test/e2e-frontend/helpers/get.test.js
@@ -48,7 +48,7 @@ describe('e2e {{#get}} helper', function () {
     let locals = {};
     let publicPost, membersPost, paidPost, basicTierPost;
 
-    before(async function () {
+    beforeAll(async function () {
         await testUtils.startGhost({
             backend: true,
             frontend: false

--- a/ghost/core/test/e2e-frontend/helpers/next-post.test.js
+++ b/ghost/core/test/e2e-frontend/helpers/next-post.test.js
@@ -30,7 +30,7 @@ describe('e2e {{#next_post}} helper', function () {
     let inverse;
     let publicPost, membersPost, paidPost, basicTierPost, publicPost2;
 
-    before(async function () {
+    beforeAll(async function () {
         await testUtils.startGhost({
             backend: true,
             frontend: false

--- a/ghost/core/test/e2e-frontend/llms-routes.test.js
+++ b/ghost/core/test/e2e-frontend/llms-routes.test.js
@@ -14,7 +14,7 @@ describe('llms.txt routing', function () {
     let request;
     let siteUrl;
 
-    before(async function () {
+    beforeAll(async function () {
         await testUtils.startGhost();
         siteUrl = configUtils.config.get('url').replace(/\/$/, '');
         request = supertest.agent(configUtils.config.get('url'));

--- a/ghost/core/test/e2e-frontend/members.test.js
+++ b/ghost/core/test/e2e-frontend/members.test.js
@@ -66,7 +66,7 @@ describe('Front-end members behavior', function () {
         return member;
     }
 
-    before(async function () {
+    beforeAll(async function () {
         const originalSettingsCacheGetFn = settingsCache.get;
 
         sinon.stub(settingsCache, 'get').callsFake(function (key, options) {
@@ -88,7 +88,7 @@ describe('Front-end members behavior', function () {
         request = supertest.agent(configUtils.config.get('url'));
     });
 
-    after(function () {
+    afterAll(function () {
         sinon.restore();
     });
 
@@ -544,7 +544,7 @@ describe('Front-end members behavior', function () {
         let labelPost;
         let productPost;
 
-        before(function () {
+        beforeAll(function () {
             publicPost = testUtils.DataGenerator.forKnex.createPost({
                 slug: 'free-to-see',
                 visibility: 'public',
@@ -786,7 +786,7 @@ describe('Front-end members behavior', function () {
         });
 
         describe('as free member', function () {
-            before(async function () {
+            beforeAll(async function () {
                 await loginAsMember('member1@test.com');
             });
 
@@ -839,7 +839,7 @@ describe('Front-end members behavior', function () {
 
         describe('as free member with vip label', function () {
             const email = 'vip@test.com';
-            before(async function () {
+            beforeAll(async function () {
                 await loginAsMember(email);
             });
 
@@ -869,7 +869,7 @@ describe('Front-end members behavior', function () {
 
         describe('as paid member', function () {
             const email = 'paid@test.com';
-            before(async function () {
+            beforeAll(async function () {
                 // Member should exist, because we are signin in
                 await models.Member.findOne({email}, {require: true});
 
@@ -1003,7 +1003,7 @@ describe('Front-end members behavior', function () {
         });
 
         describe('as comped member', function () {
-            before(async function () {
+            beforeAll(async function () {
                 await loginAsMember('comped@test.com');
             });
 
@@ -1044,7 +1044,7 @@ describe('Front-end members behavior', function () {
         });
 
         describe('as member with product', function () {
-            before(async function () {
+            beforeAll(async function () {
                 await loginAsMember('with-product@test.com');
             });
 

--- a/ghost/core/test/e2e-frontend/middleware.test.js
+++ b/ghost/core/test/e2e-frontend/middleware.test.js
@@ -8,7 +8,7 @@ describe('Middleware Execution', function () {
     let loadMemberSessionMiddlewareSpy;
     let request;
 
-    before(async function () {
+    beforeAll(async function () {
         loadMemberSessionMiddlewareSpy = sinon.spy(membersService.middleware, 'loadMemberSession');
 
         // Ensure we do a forced start so that spy is in place when the server starts
@@ -17,7 +17,7 @@ describe('Middleware Execution', function () {
         request = supertest.agent(configUtils.config.get('url'));
     });
 
-    after(async function () {
+    afterAll(async function () {
         sinon.restore();
 
         await testUtils.stopGhost();

--- a/ghost/core/test/e2e-frontend/preview-routes.test.js
+++ b/ghost/core/test/e2e-frontend/preview-routes.test.js
@@ -45,16 +45,16 @@ describe('Frontend Routing: Preview Routes', function () {
         sinon.restore();
     });
 
-    before(async function () {
+    beforeAll(async function () {
         await testUtils.startGhost();
         request = supertest.agent(config.get('url'));
     });
 
-    after(async function () {
+    afterAll(async function () {
         await testUtils.stopGhost();
     });
 
-    before(addPosts);
+    beforeAll(addPosts);
 
     it('should display draft posts accessed via uuid', async function () {
         await request.get('/p/d52c42ae-2755-455c-80ec-70b2ec55c903/')

--- a/ghost/core/test/e2e-frontend/rendered-content.test.js
+++ b/ghost/core/test/e2e-frontend/rendered-content.test.js
@@ -11,7 +11,7 @@ describe('Post Rendering', function () {
     let siteUrl;
     let request;
 
-    before(async function () {
+    beforeAll(async function () {
         await testUtils.startGhost();
         request = supertest.agent(config.get('url'));
         siteUrl = config.get('url');

--- a/ghost/core/test/e2e-frontend/site-id-middleware.test.js
+++ b/ghost/core/test/e2e-frontend/site-id-middleware.test.js
@@ -7,7 +7,7 @@ describe('Site id middleware execution', function () {
     let request;
 
     describe('Using site-id middleware', function () {
-        before(async function () {
+        beforeAll(async function () {
             configUtils.set('hostSettings:siteId', '123123');
 
             // Ensure we do a forced start so that spy is in place when the server starts
@@ -16,7 +16,7 @@ describe('Site id middleware execution', function () {
             request = supertest.agent(configUtils.config.get('url'));
         });
 
-        after(async function () {
+        afterAll(async function () {
             sinon.restore();
 
             configUtils.restore();
@@ -78,7 +78,7 @@ describe('Site id middleware execution', function () {
     });
 
     describe('Not using site-id middleware', function () {
-        before(async function () {
+        beforeAll(async function () {
             configUtils.set('hostSettings:siteId', undefined);
 
             // Ensure we do a forced start so that spy is in place when the server starts
@@ -87,7 +87,7 @@ describe('Site id middleware execution', function () {
             request = supertest.agent(configUtils.config.get('url'));
         });
 
-        after(async function () {
+        afterAll(async function () {
             sinon.restore();
 
             configUtils.restore();

--- a/ghost/core/test/e2e-frontend/static-files.test.js
+++ b/ghost/core/test/e2e-frontend/static-files.test.js
@@ -5,13 +5,13 @@ describe('Static files', function () {
     let frontendAgent;
     let ghostServer;
 
-    before(async function () {
+    beforeAll(async function () {
         const agents = await agentProvider.getAgentsWithFrontend();
         frontendAgent = agents.frontendAgent;
         ghostServer = agents.ghostServer;
     });
 
-    after(async function () {
+    afterAll(async function () {
         await ghostServer.stop();
     });
 

--- a/ghost/core/test/e2e-frontend/theme-i18n.test.js
+++ b/ghost/core/test/e2e-frontend/theme-i18n.test.js
@@ -51,7 +51,7 @@ describe('Theme i18n', function () {
             });
     }
 
-    before(async function () {
+    beforeAll(async function () {
         const agents = await agentProvider.getAgentsWithFrontend();
         frontendAgent = agents.frontendAgent;
         adminAgent = agents.adminAgent;
@@ -71,14 +71,14 @@ describe('Theme i18n', function () {
             .expectStatus(200);
     });
 
-    after(async function () {
+    afterAll(async function () {
         await adminAgent.put('themes/source/activate/');
         await setLocale('en', {});
         await ghostServer.stop();
     });
 
     describe('Legacy translation service (themeI18n)', function () {
-        before(async function () {
+        beforeAll(async function () {
             await setLocale('en', {themeTranslation: false});
         });
 
@@ -105,11 +105,11 @@ describe('Theme i18n', function () {
     });
 
     describe('New translation service (themeI18next)', function () {
-        before(async function () {
+        beforeAll(async function () {
             await setLocale('en', {themeTranslation: true});
         });
 
-        after(async function () {
+        afterAll(async function () {
             await setLocale('en', {});
         });
 

--- a/ghost/core/vitest.config.db.ts
+++ b/ghost/core/vitest.config.db.ts
@@ -67,10 +67,11 @@ export default defineConfig({
                 test: {
                     ...sharedDbConfig,
                     name: 'e2e',
-                    // Widens to e2e-api / e2e-frontend as they port.
+                    // Widens to e2e-api as it ports.
                     include: [
                         'test/e2e-webhooks/**/*.test.{js,ts}',
-                        'test/e2e-server/**/*.test.{js,ts}'
+                        'test/e2e-server/**/*.test.{js,ts}',
+                        'test/e2e-frontend/**/*.test.{js,ts}'
                     ],
                     exclude: ['**/node_modules/**'],
                     // Matches the mocha `--timeout=15000` for the e2e suites.


### PR DESCRIPTION
Ports `test/e2e-frontend` (15 files) onto the DB-backed Vitest runner. With this, only **e2e-api** remains on Mocha in the e2e lane.

ref https://linear.app/ghost/issue/PLA-151

## What
- Mechanical conversion: `before(`/`after(` → `beforeAll(`/`afterAll(` — including function-reference hooks like `before(addPosts)` (word-boundary replace, not literal-form; a literal `before(async function` sed silently misses those and the file fails to collect). Assertions unchanged.
- Moves the dir out of `test:e2e:mocha` (now just `./test/e2e-api`) into the Vitest `e2e` project. Coverage preserved via the shared c8.

## Notes
- **341 tests pass** across the e2e Vitest project (e2e-webhooks + e2e-server + e2e-frontend).
- Same real-server boot path as e2e-server (`getAgentsWithFrontend` / direct `startGhost`), runs fine under threads-serial.