### PR TITLE
Fixed a settings-cache calculated-field listener leak

### DIFF
--- a/ghost/core/core/shared/settings-cache/cache-manager.js
+++ b/ghost/core/core/shared/settings-cache/cache-manager.js
@@ -322,6 +322,7 @@ class CacheManager {
         });
 
         this.calculatedFields = [];
+        this._calculatedFieldHandlers.clear();
     }
 }
 

--- a/ghost/core/core/shared/settings-cache/cache-manager.js
+++ b/ghost/core/core/shared/settings-cache/cache-manager.js
@@ -78,6 +78,12 @@ class CacheManager {
         this.settingsOverrides = {};
         this.publicSettings = publicSettings;
         this.calculatedFields = [];
+        // Memoized per-field calculated-field listeners, so reset() can remove the
+        // exact function reference init() added. _updateCalculatedField() returns a
+        // fresh closure each call, so the old removeListener() never matched and the
+        // listeners leaked across every boot (harmless in production — boot happens
+        // once — but accumulates in test runs that boot repeatedly).
+        this._calculatedFieldHandlers = new Map();
 
         this.get = this.get.bind(this);
         this.set = this.set.bind(this);
@@ -101,6 +107,15 @@ class CacheManager {
             debug('Auto updating', field.key);
             this.set(field.key, field.getSetting());
         };
+    }
+
+    // Stable per-field handler so events.on()/removeListener() use the same
+    // function reference (otherwise calculated-field listeners leak across boots).
+    _getCalculatedFieldHandler(field) {
+        if (!this._calculatedFieldHandlers.has(field)) {
+            this._calculatedFieldHandlers.set(field, this._updateCalculatedField(field));
+        }
+        return this._calculatedFieldHandlers.get(field);
     }
 
     _doGet(key, options) {
@@ -279,7 +294,7 @@ class CacheManager {
         this.calculatedFields.forEach((field) => {
             this._updateCalculatedField(field)();
             field.dependents.forEach((dependent) => {
-                events.on(`settings.${dependent}.edited`, this._updateCalculatedField(field));
+                events.on(`settings.${dependent}.edited`, this._getCalculatedFieldHandler(field));
             });
         });
 
@@ -302,7 +317,7 @@ class CacheManager {
         //unbind calculated fields
         this.calculatedFields.forEach((field) => {
             field.dependents.forEach((dependent) => {
-                events.removeListener(`settings.${dependent}.edited`, this._updateCalculatedField(field));
+                events.removeListener(`settings.${dependent}.edited`, this._getCalculatedFieldHandler(field));
             });
         });
 

--- a/ghost/core/test/unit/shared/settings-cache.test.js
+++ b/ghost/core/test/unit/shared/settings-cache.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {EventEmitter} = require('node:events');
 const sinon = require('sinon');
 const _ = require('lodash');
 const events = require('../../../core/server/lib/common/events');
@@ -232,5 +233,32 @@ describe('UNIT: settings cache', function () {
         });
         sinon.assert.callCount(setSpy, 4);
         assert.equal(cache.get('key1'), 'second edit');
+    });
+
+    it('.reset() removes calculated field listeners and handlers', function () {
+        const localEvents = new EventEmitter();
+        const localCache = new CacheManager({
+            publicSettings
+        });
+        const settingsCollection = {
+            models: []
+        };
+        const createCalculatedField = value => ({
+            key: 'calculated_key',
+            dependents: ['dependent_key'],
+            getSetting: () => ({value})
+        });
+
+        for (let i = 0; i < 5; i += 1) {
+            localCache.init(localEvents, settingsCollection, [createCalculatedField(i)], new InMemoryCache());
+
+            assert.equal(localEvents.listenerCount('settings.dependent_key.edited'), 1);
+            assert.equal(localCache._calculatedFieldHandlers.size, 1);
+        }
+
+        localCache.reset(localEvents);
+
+        assert.equal(localEvents.listenerCount('settings.dependent_key.edited'), 0);
+        assert.equal(localCache._calculatedFieldHandlers.size, 0);
     });
 });


### PR DESCRIPTION
`SettingsCacheManager` leaked event listeners on every boot.

`init()` registered calculated-field listeners with `events.on('settings.<dep>.edited', this._updateCalculatedField(field))`, and `reset()` tried to remove them with the same expression — but `_updateCalculatedField(field)` returns a **new closure each call**, so `removeListener` never matched the added handler. The listeners were never removed.

## Impact
Harmless in production (Ghost boots once). But anything that boots Ghost repeatedly accumulates them — a serial DB-backed Vitest run (`isolate:false`, 35+ boots) reaches the `101 settings.*.edited listeners` MaxListeners warning, and the stale listeners fire on settings changes → order-dependent state pollution that makes boot-heavy test suites flaky. Surfaced while migrating the integration/legacy suites to Vitest (ref [PLA-159](https://linear.app/ghost/issue/PLA-159)).

## Fix
Memoize a stable per-field handler so `on()` and `removeListener()` use the same function reference. The set of *active* listeners after `init()` is unchanged — so production behaviour is identical — only the leaked stale ones are now removed.

settings-cache unit tests pass (13); lint clean.