### PR TITLE
Fixed method privacy type errors in comments service

### DIFF
--- a/ghost/core/core/server/services/comments/comments-service.js
+++ b/ghost/core/core/server/services/comments/comments-service.js
@@ -160,7 +160,6 @@ class CommentsService {
         }
     }
 
-    /** @private */
     async #withTransaction(options, operation) {
         if (options.transacting) {
             return await operation(options);
@@ -175,7 +174,6 @@ class CommentsService {
     }
 
     /**
-     * @private
      * Primary comment lookup: a single keyed fetch with the allowed statuses
      * applied in the query (`WHERE id = ? AND status IN (...)`), optionally locked
      * with `FOR UPDATE` inside a transaction. It deliberately does not load the
@@ -201,7 +199,6 @@ class CommentsService {
         return await model.fetch(getSafeFetchOptions(options, requiredColumns));
     }
 
-    /** @private */
     async #getPublishedCommentForAction(id, options = {}, requiredColumns = [], {forUpdate = false} = {}) {
         const model = await this.#fetchCommentByID(id, options, {
             requiredColumns,
@@ -219,7 +216,6 @@ class CommentsService {
     }
 
     /**
-     * @private
      * Member-facing read: goes through `findOne` (not the lean primitive) so the
      * serializer's default relation graph (member, counts, in_reply_to, replies)
      * is loaded. Readable statuses are constrained in the query via an NQL filter,
@@ -249,7 +245,6 @@ class CommentsService {
         return model;
     }
 
-    /** @private */
     async #getReplyParentCommentByID(id, options = {}) {
         // Deleted parent comments intentionally remain valid thread anchors: a reply
         // can still be posted under a top-level comment whose root was removed.
@@ -267,7 +262,6 @@ class CommentsService {
         return model;
     }
 
-    /** @private */
     async #getInReplyToCommentByID(id, parent, options = {}) {
         const model = await this.#fetchCommentByID(id, options, {
             requiredColumns: IN_REPLY_TO_REQUIRED_COLUMNS,
@@ -287,7 +281,6 @@ class CommentsService {
         return model;
     }
 
-    /** @private */
     async #assertCommentExists(commentId, options = {}) {
         const model = await this.#fetchCommentByID(commentId, options, {
             requiredColumns: ['id']
@@ -300,7 +293,6 @@ class CommentsService {
         }
     }
 
-    /** @private */
     async #getMemberCommentVotes({commentId, memberId, score}, options) {
         const collection = this.models.CommentLike.forge();
         collection.query((qb) => {
@@ -319,12 +311,10 @@ class CommentsService {
         return votes.models || [];
     }
 
-    /** @private */
     async #destroyCommentVotes(votes, options) {
         await Promise.all(votes.map(vote => vote.destroy(options)));
     }
 
-    /** @private */
     async #setCommentVote(commentId, member, targetScore, alreadyMessage, options = {}) {
         const memberModel = await this.models.Member.findOne({
             id: member.id
@@ -361,7 +351,6 @@ class CommentsService {
         });
     }
 
-    /** @private */
     async #clearCommentVote(commentId, member, targetScore, notFoundMessage, options = {}) {
         await this.#withTransaction(options, async (transactionOptions) => {
             await this.#getPublishedCommentForAction(commentId, transactionOptions, [], {forUpdate: true});


### PR DESCRIPTION
no ref

This only changes comments.

The `@private` directive is invalid in this code because it's redundant:

```javascript
class Foo {
    /** @private */
    #myMethod() {}
}
```

TypeScript will give this error:

> An accessibility modifier cannot be used with a private identifier.

Luckily, the solution is easy: just remove the directives.

(This cleanup is not related to any upcoming work. I just noticed it while working on something else.)
