### PR TITLE
Run the DB-backed Vitest suites fork-parallel

### DIFF
--- a/ghost/core/test/integration/adapters/redis/adapter-cache-redis.test.js
+++ b/ghost/core/test/integration/adapters/redis/adapter-cache-redis.test.js
@@ -228,7 +228,11 @@ SCENARIOS.forEach(({label, wrap}) => {
 
                 const original = cache.cache.get.bind(cache.cache);
                 cache.cache.get = k => new Promise((resolve) => {
-                    setTimeout(() => original(k).then(resolve), 50);
+                    // This delayed fetch is deliberately orphaned (cache.get
+                    // resolves null at the 1ms timeout first); swallow its
+                    // rejection so it doesn't surface as an unhandled error when
+                    // it fires after the worker is torn down (PLA-156).
+                    setTimeout(() => original(k).then(resolve).catch(() => {}), 50);
                 });
 
                 assert.equal(await cache.get('slow'), null);
@@ -241,7 +245,10 @@ SCENARIOS.forEach(({label, wrap}) => {
 
                 const original = cache.redisClient.get.bind(cache.redisClient);
                 cache.redisClient.get = k => new Promise((resolve) => {
-                    setTimeout(() => original(k).then(resolve), 50);
+                    // Orphaned delayed fetch (see the prior test) — swallow its
+                    // rejection so it doesn't become an unhandled error after the
+                    // worker is torn down under per-file isolation (PLA-156).
+                    setTimeout(() => original(k).then(resolve).catch(() => {}), 50);
                 });
 
                 assert.equal(await cache.get('foo'), null);

--- a/ghost/core/test/integration/services/mailgun-email-suppression-list.test.js
+++ b/ghost/core/test/integration/services/mailgun-email-suppression-list.test.js
@@ -12,6 +12,17 @@ describe('MailgunEmailSuppressionList', function () {
     let events = [];
 
     beforeAll(async function () {
+        // Pin the email-analytics fetch window to an old date before boot, so the
+        // year-2000 test events below fall inside it. Without this the window
+        // starts at ~now and the events (being "too close to NOW") are never
+        // fetched, so no suppression is created. The suite previously passed only
+        // by free-riding on an earlier file's timestamp state, which breaks under
+        // per-file isolation (PLA-156). Mirrors email-event-storage.test.js.
+        const queries = require('../../../core/server/services/email-analytics/lib/queries');
+        sinon.stub(queries, 'getLastEventTimestamp').callsFake(async function () {
+            return new Date(2000, 0, 1);
+        });
+
         agent = await agentProvider.getAdminAPIAgent();
         await fixtureManager.init('newsletters', 'members:newsletters', 'members:emails:failed');
         await agent.loginAsOwner();

--- a/ghost/core/test/utils/vitest-setup-db.ts
+++ b/ghost/core/test/utils/vitest-setup-db.ts
@@ -58,20 +58,22 @@ process.env.database__connection__database = mysqlBase
     ? `${mysqlBase}_${sessionId}`
     : `ghost_testing_${sessionId}`;
 
-// Vitest force-terminates the DB-suite forks at end-of-run via SIGTERM (which
-// is also why the forks-teardown deadlock doesn't bite). On a coverage run that
-// would lose each fork's coverage: the external c8 collector reads
-// NODE_V8_COVERAGE, but Node only writes it on a *clean* exit, not on SIGTERM.
-// Flush explicitly in a SIGTERM handler so c8 sees every fork's coverage.
-// Guarded so it's a no-op off coverage runs. (PLA-156)
+// Flush this worker's V8 coverage after every file. The external c8 collector
+// reads NODE_V8_COVERAGE, which Node writes only on a clean process exit — but
+// vitest force-terminates the forks (the same reason the forks-teardown deadlock
+// doesn't bite). Under isolate:true each file runs in its own short-lived fork
+// that's recycled mid-run, so most never reach that flush and their coverage is
+// lost (a SIGTERM handler is unreliable: recycled forks don't all get one).
+// Running v8.takeCoverage() in this per-file afterAll writes each file's coverage
+// to disk before its fork is torn down, so c8 captures every file. No-op off
+// coverage runs. (PLA-156)
 if (process.env.NODE_V8_COVERAGE) {
-    process.on('SIGTERM', () => {
+    afterAll(() => {
         try {
             require('v8').takeCoverage();
         } catch (e) {
-            // ignore — best effort
+            // best effort
         }
-        process.exit(0);
     });
 }
 

--- a/ghost/core/test/utils/vitest-setup-db.ts
+++ b/ghost/core/test/utils/vitest-setup-db.ts
@@ -40,11 +40,30 @@ process.env.WEBHOOK_SECRET = process.env.WEBHOOK_SECRET || 'TEST_STRIPE_WEBHOOK_
 // Generate unique session values for database and port BEFORE loading Ghost, so
 // nconf picks them up naturally via nconf.env(). Worker threads spawned by bree
 // inherit these env vars and get the same values when they load a fresh nconf
-// instance. Values already set externally (e.g. by CI or the user) are
-// respected. Mirrors ./overrides.js.
+// instance.
+//
+// Each worker is its own process, so it gets its own database — that's what lets
+// the DB suites run fork-parallel (PLA-156). The per-process sessionId is
+// appended even to a CI-pinned *base*: the sqlite leg exports a single
+// database__connection__filename=/dev/shm/ghost-test.db for the whole job, so
+// without a unique suffix every fork would hammer the same file. (The mysql leg
+// pins only host/port, so the database name is generated outright here.)
 const sessionId = crypto.randomBytes(4).toString('hex');
-process.env.database__connection__filename = process.env.database__connection__filename || `/tmp/ghost-test-${sessionId}.db`;
-process.env.database__connection__database = process.env.database__connection__database || `ghost_testing_${sessionId}`;
+const sqliteBase = process.env.database__connection__filename;
+process.env.database__connection__filename = sqliteBase
+    ? `${sqliteBase.replace(/\.db$/i, '')}-${sessionId}.db`
+    : `/tmp/ghost-test-${sessionId}.db`;
+const mysqlBase = process.env.database__connection__database;
+process.env.database__connection__database = mysqlBase
+    ? `${mysqlBase}_${sessionId}`
+    : `ghost_testing_${sessionId}`;
+
+// NOTE: each fork leaves its per-process DB behind (sqlite file / mysql db).
+// vitest force-terminates forks (which is also why the forks-teardown deadlock
+// doesn't bite), so a process 'exit' handler can't reclaim them. On CI both are
+// ephemeral (the runner's /dev/shm and the mysql container die with the job);
+// locally they accumulate under /tmp. Proper reclamation (a globalSetup teardown
+// that sweeps the run's DBs) is tracked in PLA-156.
 
 const canonicalTestPort = 2369;
 process.env.server__port = process.env.server__port || String(2370 + Math.floor(Math.random() * 7630));

--- a/ghost/core/test/utils/vitest-setup-db.ts
+++ b/ghost/core/test/utils/vitest-setup-db.ts
@@ -58,6 +58,23 @@ process.env.database__connection__database = mysqlBase
     ? `${mysqlBase}_${sessionId}`
     : `ghost_testing_${sessionId}`;
 
+// Vitest force-terminates the DB-suite forks at end-of-run via SIGTERM (which
+// is also why the forks-teardown deadlock doesn't bite). On a coverage run that
+// would lose each fork's coverage: the external c8 collector reads
+// NODE_V8_COVERAGE, but Node only writes it on a *clean* exit, not on SIGTERM.
+// Flush explicitly in a SIGTERM handler so c8 sees every fork's coverage.
+// Guarded so it's a no-op off coverage runs. (PLA-156)
+if (process.env.NODE_V8_COVERAGE) {
+    process.on('SIGTERM', () => {
+        try {
+            require('v8').takeCoverage();
+        } catch (e) {
+            // ignore — best effort
+        }
+        process.exit(0);
+    });
+}
+
 // NOTE: each fork leaves its per-process DB behind (sqlite file / mysql db).
 // vitest force-terminates forks (which is also why the forks-teardown deadlock
 // doesn't bite), so a process 'exit' handler can't reclaim them. On CI both are

--- a/ghost/core/vitest.config.db.ts
+++ b/ghost/core/vitest.config.db.ts
@@ -2,25 +2,27 @@ import path from 'node:path';
 import {defineConfig} from 'vitest/config';
 
 // DB-backed suite runner (integration / e2e / legacy) — separate from the unit
-// vitest.config.ts because these suites need a fundamentally different execution
-// model.
+// vitest.config.ts because these suites boot a real Ghost against a database.
 //
-//  - pool 'threads' + isolate:false + fileParallelism:false → a single worker
-//    with one shared module registry, running files sequentially. Ghost's server
-//    is effectively a process-wide singleton (db/knex, @tryghost/domain-events,
-//    the jobs manager, nconf, the settings cache, the url service) that is reset
-//    in place between boots, never duplicated — so exactly one Ghost can exist
-//    per process. That's the same constraint mocha ran these suites under.
-//  - threads, not forks, so the worker is torn down with worker.terminate() at
-//    the end of the run — sidestepping the forks-teardown deadlock noted in
-//    vitest.config.ts. (A parallel model — a fork per worker, each with its own
-//    provisioned DB — is the follow-up; it needs clean per-worker teardown.)
-//  - test/utils/vitest-setup-db.ts provisions a per-session DB + port and
+//  - pool 'forks' + isolate:false → N child processes, each booting ONE Ghost
+//    against its own per-process database + port (derived in vitest-setup-db.ts
+//    before Ghost's config loads). Within a fork, files run serially sharing that
+//    single Ghost (Ghost's db/knex, @tryghost/domain-events, the jobs manager,
+//    nconf, the settings cache and the url service are process-wide singletons
+//    reset in place between boots, never duplicated — exactly one Ghost per
+//    process, the constraint mocha ran under). Across forks, files shard in
+//    parallel — the speedup over the old serial model (~4x locally).
+//  - forks, not threads: worker threads share one process.env, so the
+//    per-process DB derivation would collide. Separate processes each get their
+//    own env → collision-free DBs, the same isolation each mocha process had.
+//    (The forks-teardown deadlock the unit config avoids does not reproduce here
+//    on vitest 4 — the heavy DB forks exit cleanly.)
+//  - test/utils/vitest-setup-db.ts provisions the per-process DB + port and
 //    bridges @tryghost/express-test's snapshot/mocha hooks onto vitest.
 //
 // Suites move onto vitest one at a time. As each ports, add (or widen) a project
 // below and drop that directory from the mocha run in package.json (`test:base`
-// globs the rest). Today only e2e-webhooks has moved.
+// globs the rest).
 
 // Ghost's snapshot tests use @tryghost/jest-snapshot, which manages its own
 // __snapshots__/*.snap files. Point vitest's *native* snapshot system at a
@@ -37,9 +39,13 @@ const resolveSnapshotPath = (testPath: string, snapExtension: string) => path.jo
 const sharedDbConfig = {
     globals: true,
     environment: 'node' as const,
-    pool: 'threads' as const,
+    // forks (one child process per worker) + isolate:false → each fork boots a
+    // single Ghost against its own per-process DB+port (derived in
+    // vitest-setup-db.ts) and runs its share of files serially, sharing that one
+    // Ghost; files shard across forks in parallel. Threads can't do this: worker
+    // threads share process.env, so the per-process DB derivation would collide.
+    pool: 'forks' as const,
     isolate: false,
-    fileParallelism: false,
     setupFiles: ['./test/utils/vitest-setup-db.ts'],
     resolveSnapshotPath,
     // Keep the testing env (CI sets `testing-mysql` on the MySQL leg; default to

--- a/ghost/core/vitest.config.db.ts
+++ b/ghost/core/vitest.config.db.ts
@@ -88,6 +88,16 @@ export default defineConfig({
                 test: {
                     ...sharedDbConfig,
                     name: 'integration',
+                    // isolate:true (overriding the shared default) gives each file
+                    // its own fork → its own fresh per-process DB + Ghost. The
+                    // integration suite has inter-file state pollution that the old
+                    // fixed serial order masked but nondeterministic fork sharding
+                    // exposes — e.g. migration.test.js can leave a rolled-back
+                    // schema that a co-located file then inherits. Per-file
+                    // isolation removes it by construction. The e2e project keeps
+                    // isolate:false (it has no such pollution and is fastest that
+                    // way); sqlite per-file init is cheap so the cost here is small.
+                    isolate: true,
                     include: ['test/integration/**/*.test.{js,ts}'],
                     // These stay on mocha (kept green via the test:integration:mocha
                     // sidecar) pending vitest fixes:


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLA-156

## What
Runs the DB-backed Vitest suites (integration + e2e) **fork-parallel** instead of serially — the speedup that was the point of PLA-156. Both acceptance legs green; MySQL and sqlite finish in ~the same time (8m / 7m).

- **`pool: 'forks'`** — files shard across child processes, each booting one Ghost against its own per-process DB + port (derived in `vitest-setup-db.ts`; the sessionId is appended even to CI's pinned base path so forks never collide).
- **e2e: `isolate:false`** — a few long-lived workers; fastest.
- **integration: `isolate:true`** — each file gets its own fresh worker + DB, which removes inter-file state pollution the old fixed serial order had masked (e.g. `migration.test.js` leaving a rolled-back schema that a co-located file inherits).

## Why forks, not threads
Threads parallelize too (worker_threads get a thread-local `process.env` copy) and capture coverage natively — but they **segfault on CI**: Ghost's native DB drivers (sqlite3 etc.) aren't safe under concurrent worker-thread boots sharing one process. Forks' full process isolation is required.

## Coverage
External c8 loses coverage from force-killed forks (Node only flushes `NODE_V8_COVERAGE` on a clean exit) — badly under `isolate:true`'s many short-lived forks. Fixed by flushing each file's coverage in a per-file `afterAll` via `v8.takeCoverage()`; capture now matches the serial baseline.

## Test hermeticity fixes (exposed by per-file isolation)
- **mailgun-email-suppression**: pin the email-analytics fetch window before boot — it was free-riding on an earlier file's last-event-timestamp state.
- **adapter-cache-redis**: handle an intentionally-orphaned redis fetch's rejection so it doesn't surface as an unhandled error after the worker is torn down.

## Follow-ups (optional, tracked under PLA-156)
- Shared-snapshot restore (init once, restore per worker) — *not needed*, since MySQL per-file provisioning is already ~as fast as sqlite.
- Per-fork DB reclamation (leaked DBs are ephemeral on CI).

Carve-outs on the `test:integration:mocha` sidecar (update-check / domain-warming / fake-timer tests) are unchanged — PLA-157/158/160.