### PR TITLE
Removed unused reference to outbox from member repo

### DIFF
--- a/ghost/core/core/server/services/members/api.js
+++ b/ghost/core/core/server/services/members/api.js
@@ -239,7 +239,6 @@ function createApiInstance(config) {
             Comment: models.Comment,
             MemberFeedback: models.MemberFeedback,
             EmailSpamComplaintEvent: models.EmailSpamComplaintEvent,
-            Outbox: models.Outbox,
             Automation: models.Automation,
             WelcomeEmailAutomationRun: models.WelcomeEmailAutomationRun,
             AutomatedEmailRecipient: models.AutomatedEmailRecipient,

--- a/ghost/core/core/server/services/members/members-api/members-api.js
+++ b/ghost/core/core/server/services/members/members-api/members-api.js
@@ -65,7 +65,6 @@ module.exports = function MembersAPI({
         Settings,
         Comment,
         MemberFeedback,
-        Outbox,
         Automation,
         WelcomeEmailAutomationRun,
         AutomatedEmailRecipient,
@@ -119,7 +118,6 @@ module.exports = function MembersAPI({
         OfferRedemption,
         StripeCustomer,
         StripeCustomerSubscription,
-        Outbox,
         offersAPI
     });
 

--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -64,7 +64,6 @@ module.exports = class MemberRepository {
      * @param {any} deps.StripeCustomer
      * @param {any} deps.StripeCustomerSubscription
      * @param {any} deps.OfferRedemption
-     * @param {any} deps.Outbox
      * @param {import('../../../stripe/stripe-api')} deps.stripeAPIService
      * @param {any} deps.productRepository
      * @param {any} deps.offersAPI
@@ -86,7 +85,6 @@ module.exports = class MemberRepository {
         StripeCustomer,
         StripeCustomerSubscription,
         OfferRedemption,
-        Outbox,
         stripeAPIService,
         productRepository,
         offersAPI,
@@ -105,7 +103,6 @@ module.exports = class MemberRepository {
         this._MemberStatusEvent = MemberStatusEvent;
         this._MemberProductEvent = MemberProductEvent;
         this._OfferRedemption = OfferRedemption;
-        this._Outbox = Outbox;
         this._StripeCustomer = StripeCustomer;
         this._StripeCustomerSubscription = StripeCustomerSubscription;
         this._stripeAPIService = stripeAPIService;

--- a/ghost/core/test/unit/server/services/members/members-api/members-api.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/members-api.test.js
@@ -65,7 +65,6 @@ describe('MembersAPI', function () {
                 Settings: {},
                 Comment: {},
                 MemberFeedback: {},
-                Outbox: {},
                 Automation: {},
                 AutomatedEmailRecipient: {},
                 Gift: {}

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
@@ -17,7 +17,6 @@ describe('MemberRepository', function () {
     let MemberStatusEvent;
     let MemberSubscribeEvent;
     let mockOfferRedemption;
-    let Outbox;
     let StripeCustomer;
     let StripeCustomerSubscription;
     let WelcomeEmailAutomationRun;
@@ -44,7 +43,6 @@ describe('MemberRepository', function () {
         MemberStatusEvent,
         MemberSubscribeEventModel: MemberSubscribeEvent,
         OfferRedemption: mockOfferRedemption,
-        Outbox,
         StripeCustomer,
         StripeCustomerSubscription,
         WelcomeEmailAutomationRun,
@@ -123,10 +121,6 @@ describe('MemberRepository', function () {
         };
 
         MemberProductEvent = {
-            add: sinon.stub().resolves()
-        };
-
-        Outbox = {
             add: sinon.stub().resolves()
         };
 
@@ -1732,7 +1726,6 @@ describe('MemberRepository', function () {
             it('creates automation run for free member signup (free welcome email)', async function () {
                 const repo = buildRepo({
                     Member,
-                    Outbox,
                     WelcomeEmailAutomationRun,
                     MemberStatusEvent,
                     MemberSubscribeEventModel: MemberSubscribeEvent,
@@ -1759,7 +1752,6 @@ describe('MemberRepository', function () {
 
                 const repo = buildRepo({
                     Member,
-                    Outbox,
                     WelcomeEmailAutomationRun,
                     MemberStatusEvent,
                     MemberSubscribeEventModel: MemberSubscribeEvent,
@@ -1783,7 +1775,6 @@ describe('MemberRepository', function () {
             it('does not create automation run for disallowed sources', async function () {
                 const repo = buildRepo({
                     Member,
-                    Outbox,
                     WelcomeEmailAutomationRun,
                     MemberStatusEvent,
                     MemberSubscribeEventModel: MemberSubscribeEvent,
@@ -1808,7 +1799,6 @@ describe('MemberRepository', function () {
             it('passes transaction to automation run creation', async function () {
                 const repo = buildRepo({
                     Member,
-                    Outbox,
                     WelcomeEmailAutomationRun,
                     MemberStatusEvent,
                     MemberSubscribeEventModel: MemberSubscribeEvent,
@@ -1842,7 +1832,6 @@ describe('MemberRepository', function () {
 
                 const repo = buildRepo({
                     Member,
-                    Outbox,
                     WelcomeEmailAutomationRun,
                     MemberStatusEvent,
                     MemberSubscribeEventModel: MemberSubscribeEvent,
@@ -1859,7 +1848,6 @@ describe('MemberRepository', function () {
             it('does NOT create automation run when member is signing up for a paid subscription (stripeCustomer is present)', async function () {
                 const repo = buildRepo({
                     Member,
-                    Outbox,
                     WelcomeEmailAutomationRun,
                     MemberStatusEvent,
                     MemberSubscribeEventModel: MemberSubscribeEvent,
@@ -1962,10 +1950,6 @@ describe('MemberRepository', function () {
                     attributes: {},
                     _previousAttributes: {}
                 })
-            };
-
-            Outbox = {
-                add: sinon.stub().resolves()
             };
 
             WelcomeEmailAutomationRun = {
@@ -2098,7 +2082,6 @@ describe('MemberRepository', function () {
 
                 const repo = buildRepo({
                     Member,
-                    Outbox,
                     WelcomeEmailAutomationRun,
                     MemberPaidSubscriptionEvent,
                     StripeCustomerSubscription,
@@ -2147,7 +2130,6 @@ describe('MemberRepository', function () {
 
                 const repo = buildRepo({
                     Member,
-                    Outbox,
                     WelcomeEmailAutomationRun,
                     MemberPaidSubscriptionEvent,
                     StripeCustomerSubscription,
@@ -2193,7 +2175,6 @@ describe('MemberRepository', function () {
 
                 const repo = buildRepo({
                     Member,
-                    Outbox,
                     WelcomeEmailAutomationRun,
                     MemberPaidSubscriptionEvent,
                     StripeCustomerSubscription,
@@ -2258,7 +2239,6 @@ describe('MemberRepository', function () {
 
                 const repo = buildRepo({
                     Member,
-                    Outbox,
                     WelcomeEmailAutomationRun,
                     MemberPaidSubscriptionEvent,
                     StripeCustomerSubscription,
@@ -2297,7 +2277,6 @@ describe('MemberRepository', function () {
 
                 const repo = buildRepo({
                     Member,
-                    Outbox,
                     WelcomeEmailAutomationRun,
                     MemberPaidSubscriptionEvent,
                     StripeCustomerSubscription,


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1220

This change should have no user impact.

`MemberRepository` took a reference to `Outbox`, which it no longer uses. Let's remove it.
