### PR TITLE
Deduped some automations test fixtures

### DIFF
--- a/ghost/core/test/e2e-api/admin/automations.test.js
+++ b/ghost/core/test/e2e-api/admin/automations.test.js
@@ -6,7 +6,7 @@ const models = require('../../../core/server/models');
 const {getSignedAdminToken} = require('../../../core/server/adapters/scheduling/utils');
 const {MEMBER_WELCOME_EMAIL_SLUGS} = require('../../../core/server/services/member-welcome-emails/constants');
 const {agentProvider, fixtureManager, matchers, assertions} = require('../../utils/e2e-framework');
-const {cleanupAutomationsFixture, setupAutomationsFixture, TEST_EMAIL_DESIGN_SETTING_ID} = require('../../utils/automations-fixtures');
+const {cleanupAutomationsFixture, NON_EMPTY_EMAIL_LEXICAL, setupAutomationsFixture, TEST_EMAIL_DESIGN_SETTING_ID} = require('../../utils/automations-fixtures');
 const StartAutomationsPollEvent = require('../../../core/server/services/automations/events/start-automations-poll-event');
 
 const {anyContentVersion, anyEtag, anyErrorId, anyISODateTime, anyObjectId} = matchers;
@@ -65,10 +65,6 @@ const buildLinearEdges = actions => actions.slice(1).map((action, index) => ({
 
 const EMPTY_EMAIL_LEXICAL = JSON.stringify({
     root: {children: [], direction: null, format: '', indent: 0, type: 'root', version: 1}
-});
-
-const NON_EMPTY_EMAIL_LEXICAL = JSON.stringify({
-    root: {children: [{type: 'paragraph', children: [{type: 'text', text: 'Lorem ipsum.'}]}], direction: null, format: '', indent: 0, type: 'root', version: 1}
 });
 
 const buildSendEmailAction = (dataOverrides = {}) => ({

--- a/ghost/core/test/e2e-api/admin/automations.test.js
+++ b/ghost/core/test/e2e-api/admin/automations.test.js
@@ -6,7 +6,7 @@ const models = require('../../../core/server/models');
 const {getSignedAdminToken} = require('../../../core/server/adapters/scheduling/utils');
 const {MEMBER_WELCOME_EMAIL_SLUGS} = require('../../../core/server/services/member-welcome-emails/constants');
 const {agentProvider, fixtureManager, matchers, assertions} = require('../../utils/e2e-framework');
-const {cleanupAutomationsFixture, NON_EMPTY_EMAIL_LEXICAL, setupAutomationsFixture, TEST_EMAIL_DESIGN_SETTING_ID} = require('../../utils/automations-fixtures');
+const {cleanupAutomationsFixture, EMPTY_EMAIL_LEXICAL, NON_EMPTY_EMAIL_LEXICAL, setupAutomationsFixture, TEST_EMAIL_DESIGN_SETTING_ID} = require('../../utils/automations-fixtures');
 const StartAutomationsPollEvent = require('../../../core/server/services/automations/events/start-automations-poll-event');
 
 const {anyContentVersion, anyEtag, anyErrorId, anyISODateTime, anyObjectId} = matchers;
@@ -62,10 +62,6 @@ const buildLinearEdges = actions => actions.slice(1).map((action, index) => ({
     source_action_id: actions[index].id,
     target_action_id: action.id
 }));
-
-const EMPTY_EMAIL_LEXICAL = JSON.stringify({
-    root: {children: [], direction: null, format: '', indent: 0, type: 'root', version: 1}
-});
 
 const buildSendEmailAction = (dataOverrides = {}) => ({
     id: ObjectId().toHexString(),

--- a/ghost/core/test/unit/server/services/automations/automations-api.test.js
+++ b/ghost/core/test/unit/server/services/automations/automations-api.test.js
@@ -2,13 +2,10 @@ const assert = require('node:assert/strict');
 const ObjectId = require('bson-objectid').default;
 
 const automationsApi = require('../../../../../core/server/services/automations/automations-api');
+const {NON_EMPTY_EMAIL_LEXICAL} = require('../../../../utils/automations-fixtures');
 
 const EMPTY_EMAIL_LEXICAL = JSON.stringify({
     root: {children: [], direction: null, format: '', indent: 0, type: 'root', version: 1}
-});
-
-const NON_EMPTY_EMAIL_LEXICAL = JSON.stringify({
-    root: {children: [{type: 'paragraph', children: [{type: 'text', text: 'Lorem ipsum.'}]}], direction: null, format: '', indent: 0, type: 'root', version: 1}
 });
 
 const buildSendEmailAction = (dataOverrides = {}) => ({

--- a/ghost/core/test/unit/server/services/automations/automations-api.test.js
+++ b/ghost/core/test/unit/server/services/automations/automations-api.test.js
@@ -2,11 +2,7 @@ const assert = require('node:assert/strict');
 const ObjectId = require('bson-objectid').default;
 
 const automationsApi = require('../../../../../core/server/services/automations/automations-api');
-const {NON_EMPTY_EMAIL_LEXICAL} = require('../../../../utils/automations-fixtures');
-
-const EMPTY_EMAIL_LEXICAL = JSON.stringify({
-    root: {children: [], direction: null, format: '', indent: 0, type: 'root', version: 1}
-});
+const {EMPTY_EMAIL_LEXICAL, NON_EMPTY_EMAIL_LEXICAL} = require('../../../../utils/automations-fixtures');
 
 const buildSendEmailAction = (dataOverrides = {}) => ({
     id: ObjectId().toHexString(),

--- a/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
+++ b/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
@@ -3,27 +3,12 @@ import errors from '@tryghost/errors';
 import ObjectId from 'bson-objectid';
 import createKnex, {type Knex} from 'knex';
 import moment from 'moment';
+import {NON_EMPTY_EMAIL_LEXICAL} from '../../../../utils/automations-fixtures';
 import {createDatabaseAutomationsRepository} from '../../../../../core/server/services/automations/database-automations-repository';
 import type {AutomationAction, AutomationsRepository, AutomationStepToRun} from '../../../../../core/server/services/automations/automations-repository';
 
 const HOUR_MS = 60 * 60 * 1000;
 const DATABASE_DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss';
-const NON_EMPTY_EMAIL_LEXICAL = JSON.stringify({
-    root: {
-        children: [{
-            type: 'paragraph',
-            children: [{
-                type: 'text',
-                text: 'Lorem ipsum.'
-            }]
-        }],
-        direction: null,
-        format: '',
-        indent: 0,
-        type: 'root',
-        version: 1
-    }
-});
 
 const toDatabaseDate = (date: Date | string): string => moment(date).format(DATABASE_DATE_FORMAT);
 const toRepositoryDateISOString = (date: Date | string): string => new Date(toDatabaseDate(date)).toISOString();

--- a/ghost/core/test/utils/automations-fixtures.ts
+++ b/ghost/core/test/utils/automations-fixtures.ts
@@ -11,6 +11,10 @@ const TEST_AUTOMATION_SLUGS = [
     MEMBER_WELCOME_EMAIL_SLUGS.paid
 ];
 
+export const EMPTY_EMAIL_LEXICAL = JSON.stringify({
+    root: {children: [], direction: null, format: '', indent: 0, type: 'root', version: 1}
+});
+
 export const NON_EMPTY_EMAIL_LEXICAL = JSON.stringify({
     root: {children: [{type: 'paragraph', children: [{type: 'text', text: 'Lorem ipsum.'}]}], direction: null, format: '', indent: 0, type: 'root', version: 1}
 });

--- a/ghost/core/test/utils/automations-fixtures.ts
+++ b/ghost/core/test/utils/automations-fixtures.ts
@@ -11,7 +11,7 @@ const TEST_AUTOMATION_SLUGS = [
     MEMBER_WELCOME_EMAIL_SLUGS.paid
 ];
 
-const NON_EMPTY_EMAIL_LEXICAL = JSON.stringify({
+export const NON_EMPTY_EMAIL_LEXICAL = JSON.stringify({
     root: {children: [{type: 'paragraph', children: [{type: 'text', text: 'Lorem ipsum.'}]}], direction: null, format: '', indent: 0, type: 'root', version: 1}
 });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/NY-1284

This is a test-only change, made commit-by-commit.

`NON_EMPTY_EMAIL_LEXICAL` and `EMPTY_EMAIL_LEXICAL` were defined in multiple places. Let's define them once.
