### PR TITLE
Fixed admin-toolbar skipping publish step in CI

### DIFF
--- a/apps/admin-toolbar/package.json
+++ b/apps/admin-toolbar/package.json
@@ -21,7 +21,8 @@
     "build:watch": "pnpm exec vite build --watch",
     "dev": "concurrently --kill-others --names preview,build \"pnpm exec vite preview -l silent\" \"pnpm build:watch\"",
     "lint": "pnpm exec eslint src --ext .js --cache",
-    "test": "pnpm run build && pnpm exec mocha --exit --trace-warnings --timeout=60000 \"test/**/*.test.js\"",
+    "test": "pnpm test:unit",
+    "test:unit": "pnpm run build && pnpm exec mocha --exit --trace-warnings --timeout=60000 \"test/**/*.test.js\"",
     "preship": "pnpm lint",
     "ship": "node ../../.github/scripts/release-apps.js",
     "prepublishOnly": "pnpm build"


### PR DESCRIPTION
## Summary

- Added a `test:unit` script for `@tryghost/admin-toolbar`
- Kept `test` as an alias for `test:unit`

## Context

The admin toolbar package already had a Mocha test suite, but it did not expose a `test:unit` target for Nx. Toolbar-only changes could therefore skip the unit-test job, which caused the public app build/publish jobs to skip because they require unit tests to succeed.

## Validation

- `pnpm nx show projects --withTarget test:unit --sep=,` includes `@tryghost/admin-toolbar`
- `pnpm nx run @tryghost/admin-toolbar:test:unit` passes with 20 tests