### PR TITLE
Fixed reauthentication flow failing to populate config

### DIFF
--- a/ghost/admin/app/services/config-manager.js
+++ b/ghost/admin/app/services/config-manager.js
@@ -10,6 +10,10 @@ export default class ConfigManagerService extends Service {
 
     @inject config;
 
+    // Lets re-auth paths that bypass `postAuthPreparation()` detect that the
+    // authenticated `/config` payload was never loaded for this app instance.
+    isConfigLoaded = false;
+
     fetch() {
         let promises = [];
 
@@ -40,5 +44,6 @@ export default class ConfigManagerService extends Service {
         const {config} = await this.ajax.request(configUrl);
 
         setProperties(this.config, config);
+        this.isConfigLoaded = true;
     }
 }

--- a/ghost/admin/app/services/session.js
+++ b/ghost/admin/app/services/session.js
@@ -1,8 +1,8 @@
+import * as Sentry from '@sentry/ember';
 import AuthConfiguration from 'ember-simple-auth/configuration';
 import ESASessionService from 'ember-simple-auth/services/session';
 import RSVP from 'rsvp';
 import windowProxy from 'ghost-admin/utils/window-proxy';
-import {configureScope} from '@sentry/ember';
 import {getOwner} from '@ember/application';
 import {inject} from 'ghost-admin/decorators/inject';
 import {run} from '@ember/runloop';
@@ -56,7 +56,7 @@ export default class SessionService extends ESASessionService {
 
         // update Sentry with the full Ghost version which we only get after authentication
         if (this.config.sentry_dsn) {
-            configureScope((scope) => {
+            Sentry.configureScope((scope) => {
                 scope.addEventProcessor((event) => {
                     return new Promise((resolve) => {
                         resolve({
@@ -75,6 +75,26 @@ export default class SessionService extends ESASessionService {
 
         // pre-emptively load editor code in the background to avoid loading state when opening editor
         this.koenig.fetch();
+    }
+
+    // Some re-auth paths (`setup()` restoring a session, or `this.user` already
+    // being populated) reach an authenticated state without running
+    // `postAuthPreparation()`, leaving `config`/`settings` unloaded until a
+    // refresh. Run it once if that happened.
+    async ensurePostAuthPreparation(source) {
+        if (this.configManager.isConfigLoaded) {
+            return;
+        }
+
+        Sentry.captureMessage('Ran postAuthPreparation after authentication bypassed it', {
+            tags: {source, ref: 'ONC-1774'}
+        });
+
+        try {
+            await this.postAuthPreparation();
+        } catch (err) {
+            // continue the retry even if prep fails, as it did before this repair
+        }
     }
 
     async handleAuthentication() {
@@ -120,6 +140,11 @@ export default class SessionService extends ESASessionService {
 
             if (this.user) {
                 await this.setup();
+
+                if (this.isAuthenticated) {
+                    await this.ensurePostAuthPreparation('requireAuthentication');
+                }
+
                 this.notifications.clearAll();
                 transition.retry();
             }
@@ -169,6 +194,8 @@ export default class SessionService extends ESASessionService {
             }
 
             yield this.postAuthPreparation();
+        } else {
+            yield this.ensurePostAuthPreparation('handleAuthentication');
         }
 
         callback();

--- a/ghost/admin/tests/unit/services/session-test.js
+++ b/ghost/admin/tests/unit/services/session-test.js
@@ -1,0 +1,131 @@
+import sinon from 'sinon';
+import {afterEach, beforeEach, describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupTest} from 'ember-mocha';
+
+describe('Unit: Service: session', function () {
+    setupTest();
+
+    let service, configManager;
+
+    beforeEach(function () {
+        service = this.owner.lookup('service:session');
+        configManager = this.owner.lookup('service:config-manager');
+
+        // Collaborators that hit the network/router are stubbed — these tests
+        // only assert the post-auth orchestration around config loading.
+        sinon.stub(service, 'postAuthPreparation').resolves();
+        sinon.stub(service, 'populateUser').resolves();
+        sinon.stub(service, 'invalidate').resolves();
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('#handleAuthenticationTask', function () {
+        it('populates the user and runs postAuthPreparation when no user is loaded', async function () {
+            service.user = null;
+
+            const callback = sinon.spy();
+            await service.handleAuthenticationTask.perform(callback);
+
+            expect(service.populateUser.calledOnce, 'populateUser').to.be.true;
+            expect(service.postAuthPreparation.calledOnce, 'postAuthPreparation').to.be.true;
+            expect(callback.calledOnce, 'callback').to.be.true;
+        });
+
+        it('runs postAuthPreparation when the user is set but config has not loaded', async function () {
+            // e.g. `setup()` restored the session (populating `this.user`) before
+            // authentication was handled here, so boot-time prep never ran
+            service.user = {id: 'me'};
+            configManager.isConfigLoaded = false;
+
+            const callback = sinon.spy();
+            await service.handleAuthenticationTask.perform(callback);
+
+            expect(service.populateUser.called, 'populateUser').to.be.false;
+            expect(service.postAuthPreparation.calledOnce, 'postAuthPreparation').to.be.true;
+            expect(callback.calledOnce, 'callback').to.be.true;
+        });
+
+        it('skips postAuthPreparation when the user is set and config has already loaded', async function () {
+            service.user = {id: 'me'};
+            configManager.isConfigLoaded = true;
+
+            const callback = sinon.spy();
+            await service.handleAuthenticationTask.perform(callback);
+
+            expect(service.postAuthPreparation.called, 'postAuthPreparation').to.be.false;
+            expect(callback.calledOnce, 'callback').to.be.true;
+        });
+
+        it('still runs the callback when prep fails during repair', async function () {
+            service.user = {id: 'me'};
+            configManager.isConfigLoaded = false;
+            service.postAuthPreparation.rejects(new Error('boom'));
+
+            const callback = sinon.spy();
+            await service.handleAuthenticationTask.perform(callback);
+
+            expect(service.postAuthPreparation.calledOnce, 'postAuthPreparation').to.be.true;
+            expect(callback.calledOnce, 'callback').to.be.true;
+        });
+    });
+
+    describe('#requireAuthentication', function () {
+        let transition;
+
+        beforeEach(function () {
+            // ESA's requireAuthentication asserts setup() was called
+            service._setupIsCalled = true;
+            sinon.stub(service.notifications, 'clearAll');
+            transition = {abort: sinon.spy(), retry: sinon.spy()};
+        });
+
+        it('runs postAuthPreparation when re-authenticating with config unloaded', async function () {
+            service.user = {id: 'me'};
+            configManager.isConfigLoaded = false;
+
+            let authenticated = false;
+            sinon.stub(service, 'isAuthenticated').get(() => authenticated);
+            sinon.stub(service, 'setup').callsFake(async () => {
+                authenticated = true;
+            });
+
+            await service.requireAuthentication(transition, () => {});
+
+            expect(service.setup.calledOnce, 'setup').to.be.true;
+            expect(service.postAuthPreparation.calledOnce, 'postAuthPreparation').to.be.true;
+            expect(transition.retry.calledOnce, 'retry').to.be.true;
+        });
+
+        it('does not run postAuthPreparation when config is already loaded', async function () {
+            service.user = {id: 'me'};
+            configManager.isConfigLoaded = true;
+
+            let authenticated = false;
+            sinon.stub(service, 'isAuthenticated').get(() => authenticated);
+            sinon.stub(service, 'setup').callsFake(async () => {
+                authenticated = true;
+            });
+
+            await service.requireAuthentication(transition, () => {});
+
+            expect(service.postAuthPreparation.called, 'postAuthPreparation').to.be.false;
+            expect(transition.retry.calledOnce, 'retry').to.be.true;
+        });
+
+        it('does not re-setup when there is no in-memory user', async function () {
+            service.user = null;
+            sinon.stub(service, 'isAuthenticated').get(() => false);
+            sinon.stub(service, 'setup').resolves();
+
+            await service.requireAuthentication(transition, () => {});
+
+            expect(service.setup.called, 'setup').to.be.false;
+            expect(service.postAuthPreparation.called, 'postAuthPreparation').to.be.false;
+            expect(transition.retry.called, 'retry').to.be.false;
+        });
+    });
+});


### PR DESCRIPTION
ref INC-303

Bug:
* Loading Ghost Admin, at least one of the requests in RSVP.all ([source](https://github.com/TryGhost/Ghost/blob/138c6608f33d79eeb6cccad263501bb65a4e2316/ghost/admin/app/services/session.js#L45)) fails with a 403 due to an expired session
* postAuthPreparation rejects, boot rejects. So now isAuthenticated = false, this.user is set, but config hasn't been written. So now we have no config
* on navigation we hit requireAuthentication, which does setup() but doesn't re-run postAuthenticationPreparation, so now we're authenticated but still don't have config.
* trying to publish a newsletter shows the "Setup Mailgun to send a newsletter" message

Fix:
* Ensure that postAuthenticationPreparation runs on the re-authentication flow in case config was never set