### PR TITLE
Fixed browser back handling in automation email editor

### DIFF
--- a/apps/posts/src/views/Automations/components/email-modal/email-content-modal.tsx
+++ b/apps/posts/src/views/Automations/components/email-modal/email-content-modal.tsx
@@ -99,6 +99,9 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({initialMode = 'edi
     const dropdownRef = useRef<HTMLDivElement>(null);
     const normalizedLexical = useRef<string>(initialLexical || '');
     const hasEditorBeenFocused = useRef(false);
+    const hasModalHistoryEntry = useRef(false);
+    const pendingDiscardPoppedHistory = useRef(false);
+    const onCloseRef = useRef(onClose);
     const handleError = useHandleError();
     const automatedEmails = automatedEmailsData?.automated_emails || [];
     const {resolvedSenderName, resolvedSenderEmail, resolvedReplyToEmail, hasDistinctReplyTo} = useEmailSenderDetails(automatedEmails);
@@ -147,15 +150,70 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({initialMode = 'edi
     }, [enterPreview, formState, initialMode]);
 
     const isDirty = saveState === 'unsaved';
+    const isDirtyRef = useRef(isDirty);
+
+    useEffect(() => {
+        onCloseRef.current = onClose;
+    }, [onClose]);
+
+    useEffect(() => {
+        isDirtyRef.current = isDirty;
+    }, [isDirty]);
+
+    const pushModalHistoryEntry = useCallback(() => {
+        const modalHistoryState = {
+            ...(window.history.state ?? {}),
+            automationEmailModal: true
+        };
+        window.history.pushState(modalHistoryState, '', window.location.href);
+        hasModalHistoryEntry.current = true;
+    }, []);
+
+    const closeModal = useCallback(() => {
+        if (hasModalHistoryEntry.current) {
+            hasModalHistoryEntry.current = false;
+            window.history.back();
+        }
+        onCloseRef.current();
+    }, []);
 
     // Single close funnel: Esc, overlay click, and the Close button all route here.
     const attemptClose = useCallback(() => {
-        if (isDirty) {
+        if (isDirtyRef.current) {
             setConfirmDiscardOpen(true);
         } else {
-            onClose();
+            closeModal();
         }
-    }, [isDirty, onClose]);
+    }, [closeModal]);
+
+    useEffect(() => {
+        pushModalHistoryEntry();
+
+        const handlePopState = () => {
+            if (!hasModalHistoryEntry.current) {
+                return;
+            }
+
+            hasModalHistoryEntry.current = false;
+            if (isDirtyRef.current) {
+                pendingDiscardPoppedHistory.current = true;
+            }
+            attemptClose();
+        };
+
+        window.addEventListener('popstate', handlePopState);
+        return () => {
+            window.removeEventListener('popstate', handlePopState);
+        };
+    }, [attemptClose, pushModalHistoryEntry]);
+
+    const handleConfirmDiscardOpenChange = useCallback((open: boolean) => {
+        setConfirmDiscardOpen(open);
+        if (!open && pendingDiscardPoppedHistory.current) {
+            pendingDiscardPoppedHistory.current = false;
+            pushModalHistoryEntry();
+        }
+    }, [pushModalHistoryEntry]);
 
     // Commit to the automation draft. The Close button is the only way out of the modal.
     const handleSaveClick = useCallback(async () => {
@@ -359,7 +417,7 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({initialMode = 'edi
                     </EmailPreviewModalContent>
                 </DialogContent>
             </Dialog>
-            <AlertDialog open={confirmDiscardOpen} onOpenChange={setConfirmDiscardOpen}>
+            <AlertDialog open={confirmDiscardOpen} onOpenChange={handleConfirmDiscardOpenChange}>
                 <AlertDialogContent>
                     <AlertDialogHeader>
                         <AlertDialogTitle>Discard changes?</AlertDialogTitle>
@@ -370,8 +428,9 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({initialMode = 'edi
                         <Button
                             variant='destructive'
                             onClick={() => {
+                                pendingDiscardPoppedHistory.current = false;
                                 setConfirmDiscardOpen(false);
-                                onClose();
+                                closeModal();
                             }}
                         >
                             Discard

--- a/apps/posts/src/views/Automations/components/email-modal/email-content-modal.tsx
+++ b/apps/posts/src/views/Automations/components/email-modal/email-content-modal.tsx
@@ -101,6 +101,7 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({initialMode = 'edi
     const hasEditorBeenFocused = useRef(false);
     const hasModalHistoryEntry = useRef(false);
     const pendingDiscardPoppedHistory = useRef(false);
+    const isClosingFromModalHistory = useRef(false);
     const onCloseRef = useRef(onClose);
     const handleError = useHandleError();
     const automatedEmails = automatedEmailsData?.automated_emails || [];
@@ -160,34 +161,47 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({initialMode = 'edi
         isDirtyRef.current = isDirty;
     }, [isDirty]);
 
-    const pushModalHistoryEntry = useCallback(() => {
+    const pushModalHistoryEntry = () => {
+        if (hasModalHistoryEntry.current) {
+            return;
+        }
+
         const modalHistoryState = {
             ...(window.history.state ?? {}),
             automationEmailModal: true
         };
         window.history.pushState(modalHistoryState, '', window.location.href);
         hasModalHistoryEntry.current = true;
-    }, []);
+    };
 
-    const closeModal = useCallback(() => {
-        if (hasModalHistoryEntry.current) {
-            hasModalHistoryEntry.current = false;
-            window.history.back();
+    const closeModal = () => {
+        if (!hasModalHistoryEntry.current) {
+            onCloseRef.current();
+            return;
         }
-        onCloseRef.current();
-    }, []);
+
+        isClosingFromModalHistory.current = true;
+        window.history.back();
+    };
 
     // Single close funnel: Esc, overlay click, and the Close button all route here.
-    const attemptClose = useCallback(() => {
+    const attemptClose = () => {
         if (isDirtyRef.current) {
             setConfirmDiscardOpen(true);
         } else {
             closeModal();
         }
-    }, [closeModal]);
+    };
 
     useEffect(() => {
-        pushModalHistoryEntry();
+        if (!hasModalHistoryEntry.current) {
+            const modalHistoryState = {
+                ...(window.history.state ?? {}),
+                automationEmailModal: true
+            };
+            window.history.pushState(modalHistoryState, '', window.location.href);
+            hasModalHistoryEntry.current = true;
+        }
 
         const handlePopState = () => {
             if (!hasModalHistoryEntry.current) {
@@ -195,25 +209,35 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({initialMode = 'edi
             }
 
             hasModalHistoryEntry.current = false;
+            if (isClosingFromModalHistory.current) {
+                isClosingFromModalHistory.current = false;
+                onCloseRef.current();
+                return;
+            }
+
             if (isDirtyRef.current) {
                 pendingDiscardPoppedHistory.current = true;
             }
-            attemptClose();
+            if (isDirtyRef.current) {
+                setConfirmDiscardOpen(true);
+            } else {
+                onCloseRef.current();
+            }
         };
 
         window.addEventListener('popstate', handlePopState);
         return () => {
             window.removeEventListener('popstate', handlePopState);
         };
-    }, [attemptClose, pushModalHistoryEntry]);
+    }, []);
 
-    const handleConfirmDiscardOpenChange = useCallback((open: boolean) => {
+    const handleConfirmDiscardOpenChange = (open: boolean) => {
         setConfirmDiscardOpen(open);
         if (!open && pendingDiscardPoppedHistory.current) {
             pendingDiscardPoppedHistory.current = false;
             pushModalHistoryEntry();
         }
-    }, [pushModalHistoryEntry]);
+    };
 
     // Commit to the automation draft. The Close button is the only way out of the modal.
     const handleSaveClick = useCallback(async () => {

--- a/apps/posts/src/views/Automations/components/email-modal/email-content-modal.tsx
+++ b/apps/posts/src/views/Automations/components/email-modal/email-content-modal.tsx
@@ -175,6 +175,10 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({initialMode = 'edi
     };
 
     const closeModal = () => {
+        if (isClosingFromModalHistory.current) {
+            return;
+        }
+
         if (!hasModalHistoryEntry.current) {
             onCloseRef.current();
             return;

--- a/e2e/helpers/pages/admin/automations/automation-editor-page.ts
+++ b/e2e/helpers/pages/admin/automations/automation-editor-page.ts
@@ -11,6 +11,9 @@ export class AutomationEditorPage extends AdminPage {
     readonly editEmailContentButton: Locator;
     readonly emailContentModal: Locator;
     readonly emailEditor: Locator;
+    readonly emailEditorSaveButton: Locator;
+    readonly emailEditorSavedButton: Locator;
+    readonly emailEditorCloseButton: Locator;
     readonly discardEmailChangesDialog: Locator;
     readonly discardEmailChangesButton: Locator;
     readonly discardAutomationChangesDialog: Locator;
@@ -26,6 +29,9 @@ export class AutomationEditorPage extends AdminPage {
         this.editEmailContentButton = this.stepSidebar.getByRole('button', {name: 'Edit email content'});
         this.emailContentModal = page.getByRole('dialog', {name: 'Edit email'});
         this.emailEditor = this.emailContentModal.getByTestId('email-editor').getByRole('textbox').first();
+        this.emailEditorSaveButton = this.emailContentModal.getByRole('button', {name: 'Save'});
+        this.emailEditorSavedButton = this.emailContentModal.getByRole('button', {name: 'Saved'});
+        this.emailEditorCloseButton = this.emailContentModal.getByRole('button', {name: 'Close'});
         this.discardEmailChangesDialog = page.getByRole('alertdialog', {name: 'Discard changes?'});
         this.discardEmailChangesButton = this.discardEmailChangesDialog.getByRole('button', {name: 'Discard'});
         this.discardAutomationChangesDialog = page.getByRole('alertdialog', {name: 'Discard unsaved changes?'});
@@ -60,5 +66,16 @@ export class AutomationEditorPage extends AdminPage {
         await this.page.keyboard.press('ControlOrMeta+a');
         await this.page.keyboard.press('Backspace');
         await this.emailEditor.type(content);
+    }
+
+    async updateSelectedEmailSubject(subject: string): Promise<void> {
+        await this.stepSidebar.getByPlaceholder('Subject line').fill(subject);
+    }
+
+    async saveAndCloseEmailContentEditor(): Promise<void> {
+        await this.emailEditorSaveButton.click();
+        await this.emailEditorSavedButton.waitFor({state: 'visible'});
+        await this.emailEditorCloseButton.click();
+        await this.emailContentModal.waitFor({state: 'hidden'});
     }
 }

--- a/e2e/helpers/pages/admin/automations/automation-editor-page.ts
+++ b/e2e/helpers/pages/admin/automations/automation-editor-page.ts
@@ -1,0 +1,64 @@
+import {AdminPage} from '@/admin-pages';
+import {Locator, Page} from '@playwright/test';
+
+export class AutomationEditorPage extends AdminPage {
+    readonly editor: Locator;
+    readonly addTailStepButton: Locator;
+    readonly stepPicker: Locator;
+    readonly waitStep: Locator;
+    readonly sendEmailStep: Locator;
+    readonly stepSidebar: Locator;
+    readonly editEmailContentButton: Locator;
+    readonly emailContentModal: Locator;
+    readonly emailEditor: Locator;
+    readonly discardEmailChangesDialog: Locator;
+    readonly discardEmailChangesButton: Locator;
+    readonly discardAutomationChangesDialog: Locator;
+
+    constructor(page: Page) {
+        super(page);
+        this.editor = page.getByTestId('automation-editor');
+        this.addTailStepButton = page.getByTestId('add-step-tail-button');
+        this.stepPicker = page.getByTestId('step-picker');
+        this.waitStep = page.getByRole('button', {name: /^Wait:/});
+        this.sendEmailStep = page.getByRole('button', {name: /^Send email:/});
+        this.stepSidebar = page.getByRole('complementary', {name: 'Step details'});
+        this.editEmailContentButton = this.stepSidebar.getByRole('button', {name: 'Edit email content'});
+        this.emailContentModal = page.getByRole('dialog', {name: 'Edit email'});
+        this.emailEditor = this.emailContentModal.getByTestId('email-editor').getByRole('textbox').first();
+        this.discardEmailChangesDialog = page.getByRole('alertdialog', {name: 'Discard changes?'});
+        this.discardEmailChangesButton = this.discardEmailChangesDialog.getByRole('button', {name: 'Discard'});
+        this.discardAutomationChangesDialog = page.getByRole('alertdialog', {name: 'Discard unsaved changes?'});
+    }
+
+    async gotoAutomation(automationId: string): Promise<void> {
+        await this.goto(`/ghost/#/automations/${automationId}`);
+        await this.editor.waitFor({state: 'visible'});
+    }
+
+    async addWaitStepAtTail(): Promise<void> {
+        await this.addTailStepButton.click();
+        await this.stepPicker.getByRole('button', {name: 'Wait Wait a set amount of time'}).click();
+        await this.waitStep.waitFor({state: 'visible'});
+    }
+
+    async addEmailStepAtTail(): Promise<void> {
+        await this.addTailStepButton.click();
+        await this.stepPicker.getByRole('button', {name: 'Email Send an email'}).click();
+        await this.sendEmailStep.waitFor({state: 'visible'});
+    }
+
+    async openEmailContentEditor(): Promise<void> {
+        await this.sendEmailStep.click();
+        await this.editEmailContentButton.click();
+        await this.emailContentModal.waitFor({state: 'visible'});
+        await this.emailEditor.waitFor({state: 'visible'});
+    }
+
+    async replaceEmailBody(content: string): Promise<void> {
+        await this.emailEditor.click();
+        await this.page.keyboard.press('ControlOrMeta+a');
+        await this.page.keyboard.press('Backspace');
+        await this.emailEditor.type(content);
+    }
+}

--- a/e2e/helpers/pages/admin/automations/automations-page.ts
+++ b/e2e/helpers/pages/admin/automations/automations-page.ts
@@ -1,0 +1,19 @@
+import {AdminPage} from '@/admin-pages';
+import {Locator, Page} from '@playwright/test';
+
+export class AutomationsPage extends AdminPage {
+    readonly pageTitle: Locator;
+    readonly automationsList: Locator;
+
+    constructor(page: Page) {
+        super(page);
+        this.pageUrl = '/ghost/#/automations';
+        this.pageTitle = page.getByRole('heading', {name: 'Automations'});
+        this.automationsList = page.getByTestId('automations-list');
+    }
+
+    async waitUntilLoaded(): Promise<void> {
+        await this.pageTitle.waitFor({state: 'visible'});
+        await this.automationsList.waitFor({state: 'visible'});
+    }
+}

--- a/e2e/helpers/pages/admin/automations/automations-page.ts
+++ b/e2e/helpers/pages/admin/automations/automations-page.ts
@@ -4,16 +4,24 @@ import {Locator, Page} from '@playwright/test';
 export class AutomationsPage extends AdminPage {
     readonly pageTitle: Locator;
     readonly automationsList: Locator;
+    readonly freeWelcomeAutomationLink: Locator;
 
     constructor(page: Page) {
         super(page);
         this.pageUrl = '/ghost/#/automations';
         this.pageTitle = page.getByRole('heading', {name: 'Automations'});
         this.automationsList = page.getByTestId('automations-list');
+        this.freeWelcomeAutomationLink = this.automationsList.getByRole('link', {name: 'Welcome Email (Free)'});
     }
 
     async waitUntilLoaded(): Promise<void> {
         await this.pageTitle.waitFor({state: 'visible'});
         await this.automationsList.waitFor({state: 'visible'});
+    }
+
+    async openFreeWelcomeAutomation(): Promise<void> {
+        await this.goto();
+        await this.waitUntilLoaded();
+        await this.freeWelcomeAutomationLink.click();
     }
 }

--- a/e2e/helpers/pages/admin/automations/index.ts
+++ b/e2e/helpers/pages/admin/automations/index.ts
@@ -1,0 +1,2 @@
+export * from './automations-page';
+export * from './automation-editor-page';

--- a/e2e/helpers/pages/admin/index.ts
+++ b/e2e/helpers/pages/admin/index.ts
@@ -13,3 +13,4 @@ export * from './tags';
 export * from './sidebar';
 export * from './billing';
 export * from './comments';
+export * from './automations';

--- a/e2e/tests/admin/automations/editor.test.ts
+++ b/e2e/tests/admin/automations/editor.test.ts
@@ -1,15 +1,15 @@
-import {AutomationEditorPage} from '@/admin-pages';
+import {AutomationEditorPage, AutomationsPage} from '@/admin-pages';
 import {type Page} from '@playwright/test';
 import {expect, test} from '@/helpers/playwright';
 
-interface Automation {
+type Automation = {
     id: string;
     slug: string;
-}
+};
 
-interface AutomationsResponse {
+type AutomationsResponse = {
     automations: Automation[];
-}
+};
 
 async function getFreeWelcomeAutomationId(page: Page): Promise<string> {
     const response = await page.request.get('/ghost/api/admin/automations/');
@@ -27,9 +27,11 @@ test.describe('Ghost Admin - Automation Editor', () => {
 
     test('browser back from a dirty email editor - discards only email edits', async ({page}) => {
         const automationEditorPage = new AutomationEditorPage(page);
+        const automationsPage = new AutomationsPage(page);
         const automationId = await getFreeWelcomeAutomationId(page);
 
-        await automationEditorPage.gotoAutomation(automationId);
+        await automationsPage.openFreeWelcomeAutomation();
+        await automationEditorPage.editor.waitFor({state: 'visible'});
         await automationEditorPage.addWaitStepAtTail();
         await automationEditorPage.addEmailStepAtTail();
         await automationEditorPage.openEmailContentEditor();
@@ -44,5 +46,24 @@ test.describe('Ghost Admin - Automation Editor', () => {
         await expect(automationEditorPage.editor).toBeVisible();
         await expect(automationEditorPage.waitStep).toBeVisible();
         await expect(page).toHaveURL(new RegExp(`/ghost/#/automations/${automationId}$`));
+    });
+
+    test('browser back after saving and closing email editor - is not swallowed by modal history', async ({page}) => {
+        const automationEditorPage = new AutomationEditorPage(page);
+        const automationsPage = new AutomationsPage(page);
+
+        await automationsPage.openFreeWelcomeAutomation();
+        await automationEditorPage.editor.waitFor({state: 'visible'});
+        await automationEditorPage.addWaitStepAtTail();
+        await automationEditorPage.addEmailStepAtTail();
+        await automationEditorPage.updateSelectedEmailSubject('Back button regression email');
+        await automationEditorPage.openEmailContentEditor();
+        await automationEditorPage.replaceEmailBody('Saved email body edit');
+        await automationEditorPage.saveAndCloseEmailContentEditor();
+
+        await page.goBack();
+
+        await expect(automationsPage.pageTitle).toBeVisible();
+        await expect(automationEditorPage.editor).toBeHidden();
     });
 });

--- a/e2e/tests/admin/automations/editor.test.ts
+++ b/e2e/tests/admin/automations/editor.test.ts
@@ -1,0 +1,48 @@
+import {AutomationEditorPage} from '@/admin-pages';
+import {type Page} from '@playwright/test';
+import {expect, test} from '@/helpers/playwright';
+
+interface Automation {
+    id: string;
+    slug: string;
+}
+
+interface AutomationsResponse {
+    automations: Automation[];
+}
+
+async function getFreeWelcomeAutomationId(page: Page): Promise<string> {
+    const response = await page.request.get('/ghost/api/admin/automations/');
+    expect(response.ok()).toBe(true);
+
+    const {automations} = await response.json() as AutomationsResponse;
+    const freeWelcomeAutomation = automations.find(automation => automation.slug === 'member-welcome-email-free');
+    expect(freeWelcomeAutomation).toBeDefined();
+
+    return freeWelcomeAutomation!.id;
+}
+
+test.describe('Ghost Admin - Automation Editor', () => {
+    test.use({labs: {automations: true}});
+
+    test('browser back from a dirty email editor - discards only email edits', async ({page}) => {
+        const automationEditorPage = new AutomationEditorPage(page);
+        const automationId = await getFreeWelcomeAutomationId(page);
+
+        await automationEditorPage.gotoAutomation(automationId);
+        await automationEditorPage.addWaitStepAtTail();
+        await automationEditorPage.addEmailStepAtTail();
+        await automationEditorPage.openEmailContentEditor();
+        await automationEditorPage.replaceEmailBody('Temporary email body edit');
+
+        await page.goBack();
+        await expect(automationEditorPage.discardEmailChangesDialog).toBeVisible();
+        await expect(automationEditorPage.discardAutomationChangesDialog).toBeHidden();
+        await automationEditorPage.discardEmailChangesButton.click();
+
+        await expect(automationEditorPage.emailContentModal).toBeHidden();
+        await expect(automationEditorPage.editor).toBeVisible();
+        await expect(automationEditorPage.waitStep).toBeVisible();
+        await expect(page).toHaveURL(new RegExp(`/ghost/#/automations/${automationId}$`));
+    });
+});


### PR DESCRIPTION
closes [NY-1353](https://linear.app/ghost/issue/NY-1353/back-button-from-email-editor-closes-and-discards-changes-from-entire)

## Summary

* Fixes a back-button bug in the automation email editor where browser Back could leave the entire automation builder and discard all unsaved automation changes.
* Gives the email content modal its own same-URL history entry so browser Back is handled like closing the modal.
* Ensures closing the email editor after saving consumes that modal history entry, so the next Back press is not swallowed by duplicate history.
* Adds Playwright e2e coverage for the dirty-email and saved-email back-button flows.

## Original bug

When editing email content inside an automation, the email editor was only local modal state. It did not have a browser history entry of its own.

That meant pressing browser Back from the email editor went straight to the previous app route, usually the Automations list. Because the automation editor owns the route-level unsaved-changes blocker, the user saw a discard warning that looked related to the email editor, but confirming it actually proceeded away from the whole automation editor. Any unsaved automation draft changes, such as newly added wait steps or email steps, were lost.

This was especially risky after saving the email content to the local automation draft: the email looked saved, but browser Back could still discard the larger unsaved automation draft.

## Follow-up issue found

Adding modal history fixed the original dirty-editor Back path, but exposed a second history edge case: after saving and closing the email editor normally, the modal could leave a duplicate same-route history entry behind. The next Back press could then appear to do nothing because it only consumed that leftover modal entry.

## Why this fix

The email editor behaves like a full-screen nested editing surface, so browser Back should first unwind that nested surface before it navigates away from the automation route.

This fix adds a same-URL history entry when the email modal opens. When Back is pressed:

* if the email has unsaved modal edits, the existing email-level discard confirmation is shown;
* confirming discard closes only the email modal;
* cancelling the discard restores the modal history entry so the next Back still targets the modal first;
* the automation editor route remains mounted, preserving unsaved automation draft changes.

For normal modal close, including save-and-close, the modal now waits for the `popstate` caused by its own `history.back()` before unmounting. It also guards against pushing more than one modal history entry. That prevents duplicate same-route entries from being left on the stack, so the next Back press behaves immediately.

This keeps the behavior aligned with the modal Close button and avoids turning an email-level discard decision into an automation-level discard.

## Testing

* Added an e2e regression that opens an automation, adds a wait step and an email step, edits email content, presses browser Back, discards the email edit, and verifies the automation editor and unsaved wait step are still present.
* Added an e2e regression that saves and closes the email editor, then verifies the next Back press is not swallowed by leftover modal history.
* Verified with:
  * `pnpm --dir e2e test tests/admin/automations/editor.test.ts`
  * `pnpm --dir e2e lint`
  * `pnpm --dir e2e test:types`
  * `pnpm --dir apps/posts test:unit -- test/unit/views/automations/automation-editor.test.tsx`
  * `pnpm --dir apps/posts build`
