### PR TITLE
Added automation publish confirmation modal

### DIFF
--- a/apps/posts/src/views/Automations/editor.tsx
+++ b/apps/posts/src/views/Automations/editor.tsx
@@ -182,6 +182,7 @@ const AutomationEditor: React.FC = () => {
         );
     };
 
+    const isConfirmPublishAlertOpen = editState.action === 'publish';
     const isConfirmUnpublishAlertOpen = editState.action === 'unpublish';
     const isConfirmRepublishAlertOpen = editState.action === 'republish';
     const isEditRequestActive = editState.phase === 'submitting';
@@ -189,12 +190,15 @@ const AutomationEditor: React.FC = () => {
     let saveButtonVariant: ButtonProps['variant'] = 'outline';
     let saveButtonChildren: React.ReactNode = 'Save';
     let isPublishButtonEnabled = !!draft && draft.actions.length > 0 && (draft.status === 'inactive' || hasUnsavedChanges);
-    let publishButtonVariant: ButtonProps['variant'] = 'default';
-    let publishButtonChildren: React.ReactNode = draft?.status === 'active'
+    const publishButtonVariant: ButtonProps['variant'] = 'default';
+    const publishButtonChildren: React.ReactNode = draft?.status === 'active'
         ? (hasUnsavedChanges ? 'Publish changes' : 'Published')
         : 'Publish';
     let isTurnOffButtonEnabled = true;
     let turnOffButtonChildren: React.ReactNode = 'Turn off';
+    let isPublishConfirmButtonEnabled = true;
+    let publishConfirmButtonVariant: ButtonProps['variant'] = 'default';
+    let publishConfirmButtonChildren: React.ReactNode = 'Publish';
     let isRepublishButtonEnabled = true;
     let republishButtonVariant: ButtonProps['variant'] = 'default';
     let republishButtonChildren: React.ReactNode = 'Publish changes';
@@ -216,7 +220,8 @@ const AutomationEditor: React.FC = () => {
             );
             break;
         case 'publish':
-            publishButtonChildren = (
+            isPublishConfirmButtonEnabled = false;
+            publishConfirmButtonChildren = (
                 <>
                     <LoadingIndicator color='light' size='sm' />
                     <span className='sr-only'>Publishing...</span>
@@ -244,6 +249,10 @@ const AutomationEditor: React.FC = () => {
         break;
     case 'confirming':
         switch (editState.action) {
+        case 'publish':
+            isSaveButtonEnabled = false;
+            isPublishButtonEnabled = false;
+            break;
         case 'republish':
             isPublishButtonEnabled = false;
             isTurnOffButtonEnabled = false;
@@ -262,8 +271,10 @@ const AutomationEditor: React.FC = () => {
             saveButtonChildren = 'Retry';
             break;
         case 'publish':
-            publishButtonVariant = 'destructive';
-            publishButtonChildren = 'Retry';
+            isSaveButtonEnabled = false;
+            isPublishButtonEnabled = false;
+            publishConfirmButtonVariant = 'destructive';
+            publishConfirmButtonChildren = 'Retry';
             break;
         case 'republish':
             isPublishButtonEnabled = false;
@@ -297,6 +308,20 @@ const AutomationEditor: React.FC = () => {
         });
     };
 
+    const onConfirmPublishOpenChange = (open: boolean): void => {
+        setEditState((oldEditState) => {
+            switch (oldEditState.phase) {
+            case 'confirming':
+            case 'failed':
+                return oldEditState.action === 'publish' && !open ? {phase: 'idle'} : oldEditState;
+            case 'idle':
+                return open ? {phase: 'confirming', action: 'publish'} : oldEditState;
+            default:
+                return oldEditState;
+            }
+        });
+    };
+
     const onConfirmRepublishOpenChange = (open: boolean): void => {
         setEditState((oldEditState) => {
             switch (oldEditState.phase) {
@@ -324,7 +349,10 @@ const AutomationEditor: React.FC = () => {
             setEditState({phase: 'confirming', action: 'republish'});
             break;
         case 'inactive':
-            save('active');
+            if (!validateActionErrors(draft, {phase: 'idle'})) {
+                return;
+            }
+            setEditState({phase: 'confirming', action: 'publish'});
             break;
         default: {
             const _exhaustive: never = draft.status;
@@ -387,6 +415,30 @@ const AutomationEditor: React.FC = () => {
                             onClick={() => navigationBlocker.proceed?.()}
                         >
                             Discard changes
+                        </Button>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+
+            <AlertDialog
+                open={isConfirmPublishAlertOpen}
+                onOpenChange={onConfirmPublishOpenChange}
+            >
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Start your automation?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            Once published, your automation goes live. Any member who meets the trigger will be enrolled automatically.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel disabled={isEditRequestActive}>Cancel</AlertDialogCancel>
+                        <Button
+                            disabled={!isPublishConfirmButtonEnabled}
+                            variant={publishConfirmButtonVariant}
+                            onClick={() => save('active')}
+                        >
+                            {publishConfirmButtonChildren}
                         </Button>
                     </AlertDialogFooter>
                 </AlertDialogContent>

--- a/apps/posts/src/views/Automations/types.ts
+++ b/apps/posts/src/views/Automations/types.ts
@@ -1,5 +1,5 @@
 type AutomationEditAction = 'save' | 'publish' | 'republish' | 'unpublish';
-type ConfirmableAutomationEditAction = 'republish' | 'unpublish';
+type ConfirmableAutomationEditAction = 'publish' | 'republish' | 'unpublish';
 
 export type AutomationEditState =
   | {phase: 'idle'; action?: undefined}

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -910,7 +910,7 @@ describe('AutomationEditor', () => {
         expect(screen.getByRole('button', {name: 'Publish'})).toBeDisabled();
     });
 
-    it('publishes an inactive automation when clicking Publish', () => {
+    it('confirms before publishing an inactive automation', async () => {
         mockUseReadAutomation.mockReturnValue({
             data: {automations: [{...automationDetail, status: 'inactive'}]},
             isLoading: false,
@@ -923,6 +923,13 @@ describe('AutomationEditor', () => {
         expect(button).not.toBeDisabled();
         fireEvent.click(button);
 
+        const dialog = await screen.findByRole('alertdialog', {name: 'Start your automation?'});
+        expect(within(dialog).getByText(/Once published, your automation goes live/)).toBeInTheDocument();
+        expect(within(dialog).getByText(/enrolled automatically/)).toBeInTheDocument();
+        expect(mockEditMutation.mutate).not.toHaveBeenCalled();
+
+        fireEvent.click(within(dialog).getByRole('button', {name: 'Publish'}));
+
         expect(mockEditMutation.mutate).toHaveBeenCalledWith(
             {
                 id: 'automation-id-1',
@@ -932,6 +939,27 @@ describe('AutomationEditor', () => {
             },
             expect.any(Object)
         );
+    });
+
+    it('closes the publish confirmation without publishing when cancelled', async () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [{...automationDetail, status: 'inactive'}]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        fireEvent.click(screen.getByRole('button', {name: 'Publish'}));
+
+        const dialog = await screen.findByRole('alertdialog', {name: 'Start your automation?'});
+        fireEvent.click(within(dialog).getByRole('button', {name: 'Cancel'}));
+
+        expect(mockEditMutation.mutate).not.toHaveBeenCalled();
+        await waitFor(() => {
+            expect(screen.queryByText('Start your automation?')).not.toBeInTheDocument();
+        });
+        expect(screen.getByRole('button', {name: 'Publish'})).toBeEnabled();
     });
 
     it('blocks publishing an inactive automation with an empty email body', () => {
@@ -945,7 +973,7 @@ describe('AutomationEditor', () => {
 
         fireEvent.click(screen.getByRole('button', {name: 'Publish'}));
 
-        expect(screen.queryByRole('alertdialog', {name: 'Publish automation with empty emails?'})).not.toBeInTheDocument();
+        expect(screen.queryByRole('alertdialog', {name: 'Start your automation?'})).not.toBeInTheDocument();
         expect(mockEditMutation.mutate).not.toHaveBeenCalled();
         expect(mockToastError).toHaveBeenCalledWith('Automation couldn’t be saved', {
             description: 'Fix the highlighted steps and try again.'
@@ -1029,7 +1057,7 @@ describe('AutomationEditor', () => {
         expect(screen.queryByRole('button', {name: 'Turn off'})).not.toBeInTheDocument();
     });
 
-    it('disables the publish button and shows loading UI while a publish request is in flight', () => {
+    it('disables the modal button and shows loading UI while a publish request is in flight', async () => {
         mockUseReadAutomation.mockReturnValue({
             data: {automations: [{...automationDetail, status: 'inactive'}]},
             isLoading: false,
@@ -1040,7 +1068,11 @@ describe('AutomationEditor', () => {
 
         fireEvent.click(screen.getByRole('button', {name: 'Publish'}));
 
-        const button = screen.getByRole('button', {name: 'Publishing...'});
+        const dialog = await screen.findByRole('alertdialog', {name: 'Start your automation?'});
+        fireEvent.click(within(dialog).getByRole('button', {name: 'Publish'}));
+
+        expect(within(dialog).getByRole('button', {name: 'Cancel'})).toBeDisabled();
+        const button = within(dialog).getByRole('button', {name: 'Publishing...'});
         expect(button).toBeDisabled();
         expect(button.querySelector('.animate-spin')).toBeInTheDocument();
     });
@@ -1064,7 +1096,7 @@ describe('AutomationEditor', () => {
         expect(turnOff.querySelector('.animate-spin')).toBeInTheDocument();
     });
 
-    it('shows a retry state when publishing fails', async () => {
+    it('shows a retry state and error in the modal when publishing fails', async () => {
         mockUseReadAutomation.mockReturnValue({
             data: {automations: [{...automationDetail, status: 'inactive'}]},
             isLoading: false,
@@ -1078,7 +1110,10 @@ describe('AutomationEditor', () => {
 
         fireEvent.click(screen.getByRole('button', {name: 'Publish'}));
 
-        const button = await screen.findByRole('button', {name: 'Retry'});
+        const dialog = await screen.findByRole('alertdialog', {name: 'Start your automation?'});
+        fireEvent.click(within(dialog).getByRole('button', {name: 'Publish'}));
+
+        const button = within(dialog).getByRole('button', {name: 'Retry'});
         expect(button).not.toBeDisabled();
         expect(button).toHaveClass('bg-destructive');
         expect(mockToastError).toHaveBeenCalledWith('Automation couldn’t be saved');
@@ -1350,7 +1385,8 @@ describe('AutomationEditor', () => {
         expect(within(emailStep).getByText('Add a subject line and email body.').closest('div')?.previousElementSibling).toHaveClass('mt-[3px]');
         expect(within(emailStep).getByText('Add a subject line and email body.')).toHaveClass('text-destructive');
         expect(within(emailStep).queryByText('Empty email body')).not.toBeInTheDocument();
-        expect(screen.getByRole('button', {name: 'Retry'})).toBeInTheDocument();
+        expect(screen.queryByRole('alertdialog', {name: 'Start your automation?'})).not.toBeInTheDocument();
+        expect(screen.getByRole('button', {name: 'Publish'})).toBeEnabled();
 
         // Filling only the subject leaves the body invalid, so the step stays blocked.
         const sidebar = screen.getByRole('complementary', {name: 'Step details'});
@@ -1371,6 +1407,8 @@ describe('AutomationEditor', () => {
         expect(within(emailStep).queryByText('Add an email body.')).not.toBeInTheDocument();
 
         fireEvent.click(screen.getByRole('button', {name: 'Publish'}));
+        const publishDialog = await screen.findByRole('alertdialog', {name: 'Start your automation?'});
+        fireEvent.click(within(publishDialog).getByRole('button', {name: 'Publish'}));
         expect(mockEditMutation.mutate).toHaveBeenCalledWith(
             expect.objectContaining({
                 status: 'active',
@@ -1665,6 +1703,9 @@ describe('AutomationEditor', () => {
         expect(publishButton).toBeEnabled();
         fireEvent.click(publishButton);
 
+        const dialog = await screen.findByRole('alertdialog', {name: 'Start your automation?'});
+        fireEvent.click(within(dialog).getByRole('button', {name: 'Publish'}));
+
         const mutateCall = mockEditMutation.mutate.mock.calls.at(-1)![0];
         expect(mutateCall.id).toBe('automation-id-1');
         expect(mutateCall.status).toBe('active');
@@ -1951,7 +1992,7 @@ describe('AutomationEditor', () => {
         expect(screen.getByRole('button', {name: 'Publish changes'})).toBeEnabled();
     });
 
-    it('clears the Retry state when the user stages another local edit after a failed publish', async () => {
+    it('clears the failed publish state when the confirmation modal is dismissed', async () => {
         mockUseReadAutomation.mockReturnValue({
             data: {automations: [{...automationDetail, status: 'inactive'}]},
             isLoading: false,
@@ -1964,13 +2005,17 @@ describe('AutomationEditor', () => {
         renderEditor();
 
         fireEvent.click(screen.getByRole('button', {name: 'Publish'}));
-        // After the failure, the button is the destructive Retry.
-        expect(await screen.findByRole('button', {name: 'Retry'})).toHaveClass('bg-destructive');
+        const dialog = await screen.findByRole('alertdialog', {name: 'Start your automation?'});
+        fireEvent.click(within(dialog).getByRole('button', {name: 'Publish'}));
 
-        // Staging another local edit clears the failure state; the button returns to plain Publish.
-        fireEvent.click(screen.getByTestId('add-step-tail-button'));
-        const picker = await screen.findByTestId('step-picker');
-        fireEvent.click(within(picker).getByText('Wait'));
+        // After the failure, the modal button is the destructive Retry.
+        expect(within(dialog).getByRole('button', {name: 'Retry'})).toHaveClass('bg-destructive');
+
+        // Dismissing the modal clears the failure; the toolbar button returns to plain Publish.
+        fireEvent.click(within(dialog).getByRole('button', {name: 'Cancel'}));
+        await waitFor(() => {
+            expect(screen.queryByRole('alertdialog', {name: 'Start your automation?'})).not.toBeInTheDocument();
+        });
 
         const recoveredButton = screen.getByRole('button', {name: 'Publish'});
         expect(recoveredButton).toBeEnabled();


### PR DESCRIPTION
closes [NY-1357](https://linear.app/ghost/issue/NY-1357)

Adds a confirmation modal when a user attempts to publish an automation.

<img width="1559" height="614" alt="Screenshot 2026-06-18 at 10 17 41 AM" src="https://github.com/user-attachments/assets/b5a6fde8-943f-457c-a39c-4103acbdad06" />
