### PR TITLE
Fixed admin dev target dependencies

### DIFF
--- a/apps/admin-x-design-system/package.json
+++ b/apps/admin-x-design-system/package.json
@@ -90,6 +90,11 @@
     },
     "nx": {
         "targets": {
+            "dev": {
+                "dependsOn": [
+                    "^build"
+                ]
+            },
             "build": {
                 "dependsOn": [
                     "^build"

--- a/apps/admin-x-framework/package.json
+++ b/apps/admin-x-framework/package.json
@@ -120,6 +120,11 @@
     },
     "nx": {
         "targets": {
+            "dev": {
+                "dependsOn": [
+                    "^build"
+                ]
+            },
             "build": {
                 "dependsOn": [
                     "^build"

--- a/apps/shade/package.json
+++ b/apps/shade/package.json
@@ -162,6 +162,11 @@
     },
     "nx": {
         "targets": {
+            "dev": {
+                "dependsOn": [
+                    "^build"
+                ]
+            },
             "build": {
                 "dependsOn": [
                     "^build"

--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -175,6 +175,16 @@
       "!ghost"
     ],
     "targets": {
+      "dev": {
+        "dependsOn": [
+          {
+            "projects": [
+              "@tryghost/admin-x-framework"
+            ],
+            "target": "build"
+          }
+        ]
+      },
       "build:dev": {
         "dependsOn": [
           "build:dev",


### PR DESCRIPTION
## Summary
- Updated admin support package dev targets to depend on finite builds instead of inherited continuous dev tasks.
- Added an explicit finite framework build prerequisite for ghost-admin:dev.
- Kept the top-level @tryghost/admin dev target responsible for starting Ember, Vite, and support package watches together.

## Verification
- CI=true pnpm install --frozen-lockfile --prefer-offline
- pnpm_config_verify_deps_before_run=false pnpm nx show project @tryghost/admin-x-framework --json
- pnpm_config_verify_deps_before_run=false pnpm nx show project @tryghost/admin-x-design-system --json
- pnpm_config_verify_deps_before_run=false pnpm nx show project @tryghost/shade --json
- pnpm_config_verify_deps_before_run=false pnpm nx show project ghost-admin --json
- pnpm_config_verify_deps_before_run=false pnpm nx show project @tryghost/admin --json
- In the original checkout, pnpm dev started listeners on 5174 and 4200 and http://localhost:2368/ghost/ returned 200