### PR TITLE
Prevent Tinybird polling when analytics is disabled

### DIFF
--- a/apps/admin-x-framework/src/hooks/use-tinybird-query.ts
+++ b/apps/admin-x-framework/src/hooks/use-tinybird-query.ts
@@ -14,9 +14,8 @@ export interface UseTinybirdQueryOptions {
 // Wrapper around Tinybird's useQuery hook that handles the token loading state
 export const useTinybirdQuery = (options: UseTinybirdQueryOptions) => {
     const {statsConfig, endpoint, params, enabled = true} = options;
-    // Web analytics is a global kill-switch, read from context rather than
-    // threaded through every call site. When it's off, shouldQuery collapses to
-    // false and the hook returns an empty state (no token, no query, no stale data).
+    // Web analytics kill-switch, read from context so no call site threads it.
+    // When off, shouldQuery is false and the hook returns empty state.
     const webAnalyticsEnabled = useWebAnalyticsEnabled();
 
     const shouldQuery = Boolean(enabled && webAnalyticsEnabled && statsConfig && endpoint);

--- a/apps/admin-x-framework/src/hooks/use-tinybird-query.ts
+++ b/apps/admin-x-framework/src/hooks/use-tinybird-query.ts
@@ -2,6 +2,7 @@ import {useQuery} from '@tinybirdco/charts';
 import {useTinybirdToken} from './use-tinybird-token';
 import {StatsConfig} from '../providers/framework-provider';
 import {getStatEndpointUrl} from '../utils/stats-config';
+import {useWebAnalyticsEnabled} from '../providers/app-provider';
 
 export interface UseTinybirdQueryOptions {
     statsConfig?: StatsConfig | null;
@@ -13,8 +14,12 @@ export interface UseTinybirdQueryOptions {
 // Wrapper around Tinybird's useQuery hook that handles the token loading state
 export const useTinybirdQuery = (options: UseTinybirdQueryOptions) => {
     const {statsConfig, endpoint, params, enabled = true} = options;
+    // Web analytics is a global kill-switch, read from context rather than
+    // threaded through every call site. When it's off, shouldQuery collapses to
+    // false and the hook returns an empty state (no token, no query, no stale data).
+    const webAnalyticsEnabled = useWebAnalyticsEnabled();
 
-    const shouldQuery = Boolean(enabled && statsConfig && endpoint);
+    const shouldQuery = Boolean(enabled && webAnalyticsEnabled && statsConfig && endpoint);
     const tokenQuery = useTinybirdToken({enabled: shouldQuery});
     const endpointUrl = shouldQuery && statsConfig ? getStatEndpointUrl(statsConfig, endpoint) : undefined;
 

--- a/apps/admin-x-framework/src/hooks/use-tinybird-query.ts
+++ b/apps/admin-x-framework/src/hooks/use-tinybird-query.ts
@@ -12,11 +12,11 @@ export interface UseTinybirdQueryOptions {
 
 // Wrapper around Tinybird's useQuery hook that handles the token loading state
 export const useTinybirdQuery = (options: UseTinybirdQueryOptions) => {
-    const tokenQuery = useTinybirdToken();
     const {statsConfig, endpoint, params, enabled = true} = options;
 
-    const shouldQuery = enabled && statsConfig && endpoint;
-    const endpointUrl = shouldQuery ? getStatEndpointUrl(statsConfig, endpoint) : undefined;
+    const shouldQuery = Boolean(enabled && statsConfig && endpoint);
+    const tokenQuery = useTinybirdToken({enabled: shouldQuery});
+    const endpointUrl = shouldQuery && statsConfig ? getStatEndpointUrl(statsConfig, endpoint) : undefined;
 
     // Set the endpoint to undefined if:
     // - Token is not loaded (prevents 403 errors)
@@ -25,14 +25,14 @@ export const useTinybirdQuery = (options: UseTinybirdQueryOptions) => {
     // - No endpoint specified
     const {data, meta, loading, error} = useQuery({
         endpoint: (!tokenQuery.isLoading && tokenQuery.token && shouldQuery) ? endpointUrl : undefined,
-        token: tokenQuery.token,
+        token: shouldQuery ? tokenQuery.token : undefined,
         params: params
     });
 
     return {
-        data,
-        meta,
-        loading: tokenQuery.isLoading || loading,
-        error: error ?? tokenQuery.error
+        data: shouldQuery ? data : null,
+        meta: shouldQuery ? meta : null,
+        loading: shouldQuery ? tokenQuery.isLoading || loading : false,
+        error: shouldQuery ? error ?? tokenQuery.error : null
     };
 };

--- a/apps/admin-x-framework/src/hooks/use-tinybird-token.ts
+++ b/apps/admin-x-framework/src/hooks/use-tinybird-token.ts
@@ -17,17 +17,14 @@ let hasLoggedConfigWarning = false;
 
 export const useTinybirdToken = (options: UseTinybirdTokenOptions = {}): UseTinybirdTokenResult => {
     const {enabled = true} = options;
-    // Web analytics is a global kill-switch: never load a token when it's off,
-    // regardless of what a caller passes. Read from context so no call site has
-    // to thread the flag through.
+    // Web analytics is a global kill-switch read from context, so no call site threads it.
     const webAnalyticsEnabled = useWebAnalyticsEnabled();
     const effectiveEnabled = enabled && webAnalyticsEnabled;
     const tinybirdQuery = getTinybirdToken({enabled: effectiveEnabled});
 
-    // A disabled React Query (v4) that has never run still reports isLoading:true
-    // and can retain previously cached data/errors. Normalize to an idle result so
-    // direct consumers (GlobalDataProvider, PostAnalyticsProvider) don't get stuck
-    // on a loading placeholder and no stale token/error leaks through when off.
+    // A disabled React Query (v4) still reports isLoading:true and can keep cached
+    // data/errors, so return an idle result — else direct consumers (the providers)
+    // hang on a loading placeholder or leak a stale token.
     if (!effectiveEnabled) {
         return {
             token: undefined,

--- a/apps/admin-x-framework/src/hooks/use-tinybird-token.ts
+++ b/apps/admin-x-framework/src/hooks/use-tinybird-token.ts
@@ -1,4 +1,5 @@
 import {getTinybirdToken} from '../api/tinybird';
+import {useWebAnalyticsEnabled} from '../providers/app-provider';
 
 export interface UseTinybirdTokenResult {
     token: string | undefined;
@@ -16,7 +17,12 @@ let hasLoggedConfigWarning = false;
 
 export const useTinybirdToken = (options: UseTinybirdTokenOptions = {}): UseTinybirdTokenResult => {
     const {enabled = true} = options;
-    const tinybirdQuery = getTinybirdToken({enabled});
+    // Web analytics is a global kill-switch: never load a token when it's off,
+    // regardless of what a caller passes. Read from context so no call site has
+    // to thread the flag through.
+    const webAnalyticsEnabled = useWebAnalyticsEnabled();
+    const effectiveEnabled = enabled && webAnalyticsEnabled;
+    const tinybirdQuery = getTinybirdToken({enabled: effectiveEnabled});
 
     const apiToken = tinybirdQuery.data?.tinybird?.token;
     
@@ -25,7 +31,7 @@ export const useTinybirdToken = (options: UseTinybirdTokenOptions = {}): UseTiny
     const error = tinybirdQuery.error as Error | null;
     
     // Log a warning ONCE if we got a response but no valid token (likely misconfiguration)
-    if (!tinybirdQuery.isLoading && enabled && tinybirdQuery.data && !apiToken && !hasLoggedConfigWarning) {
+    if (!tinybirdQuery.isLoading && effectiveEnabled && tinybirdQuery.data && !apiToken && !hasLoggedConfigWarning) {
         // eslint-disable-next-line no-console
         console.warn('Tinybird analytics: No valid token received. Check your Tinybird configuration (workspaceId and adminToken must be non-empty strings).');
         hasLoggedConfigWarning = true;

--- a/apps/admin-x-framework/src/hooks/use-tinybird-token.ts
+++ b/apps/admin-x-framework/src/hooks/use-tinybird-token.ts
@@ -24,6 +24,19 @@ export const useTinybirdToken = (options: UseTinybirdTokenOptions = {}): UseTiny
     const effectiveEnabled = enabled && webAnalyticsEnabled;
     const tinybirdQuery = getTinybirdToken({enabled: effectiveEnabled});
 
+    // A disabled React Query (v4) that has never run still reports isLoading:true
+    // and can retain previously cached data/errors. Normalize to an idle result so
+    // direct consumers (GlobalDataProvider, PostAnalyticsProvider) don't get stuck
+    // on a loading placeholder and no stale token/error leaks through when off.
+    if (!effectiveEnabled) {
+        return {
+            token: undefined,
+            isLoading: false,
+            error: null,
+            refetch: tinybirdQuery.refetch
+        };
+    }
+
     const apiToken = tinybirdQuery.data?.tinybird?.token;
     
     // Only treat actual API errors as errors, not null/undefined tokens
@@ -31,7 +44,7 @@ export const useTinybirdToken = (options: UseTinybirdTokenOptions = {}): UseTiny
     const error = tinybirdQuery.error as Error | null;
     
     // Log a warning ONCE if we got a response but no valid token (likely misconfiguration)
-    if (!tinybirdQuery.isLoading && effectiveEnabled && tinybirdQuery.data && !apiToken && !hasLoggedConfigWarning) {
+    if (!tinybirdQuery.isLoading && tinybirdQuery.data && !apiToken && !hasLoggedConfigWarning) {
         // eslint-disable-next-line no-console
         console.warn('Tinybird analytics: No valid token received. Check your Tinybird configuration (workspaceId and adminToken must be non-empty strings).');
         hasLoggedConfigWarning = true;

--- a/apps/admin-x-framework/src/index.ts
+++ b/apps/admin-x-framework/src/index.ts
@@ -4,7 +4,7 @@ export {FrameworkProvider, useFramework} from './providers/framework-provider';
 
 // App Context
 export type {AppSettings, BaseAppProps, AppContextType, AppProviderProps} from './providers/app-provider';
-export {AppContext, AppProvider, useAppContext} from './providers/app-provider';
+export {AppContext, AppProvider, useAppContext, useWebAnalyticsEnabled} from './providers/app-provider';
 
 // Hooks
 export {useActiveVisitors} from './hooks/use-active-visitors';

--- a/apps/admin-x-framework/src/providers/app-provider.tsx
+++ b/apps/admin-x-framework/src/providers/app-provider.tsx
@@ -62,22 +62,18 @@ export const useAppContext = () => {
     return context;
 };
 
-// Single source of truth for the web analytics kill-switch.
-//
-// Unlike useAppContext, this reads the context without throwing so it can be
-// consumed by framework-level data hooks (e.g. the Tinybird hooks) that may
-// render in standalone/Ember-embedded trees without an AppProvider mounted.
+// Single source of truth for the web analytics kill-switch. Reads context without
+// throwing (unlike useAppContext) so framework data hooks (e.g. Tinybird) can call
+// it even when rendered without an AppProvider.
 export const useWebAnalyticsEnabled = (): boolean => {
     const context = useContext(AppContext);
 
-    // No provider at all (standalone/Ember embed, tests): preserve the legacy
-    // behaviour where analytics simply runs — the gate can't know otherwise.
+    // No provider (standalone/Ember embed, tests): default to on — can't know otherwise.
     if (!context) {
         return true;
     }
 
-    // Provider mounted: only enabled when the setting is explicitly on. While
-    // settings are still resolving (appSettings undefined), treat as disabled so
-    // we don't fire Tinybird requests before the real value is known.
+    // Provider mounted: on only when explicitly true. Unresolved settings
+    // (appSettings undefined) count as off, so we don't query before it's known.
     return context.appSettings?.analytics?.webAnalytics === true;
 };

--- a/apps/admin-x-framework/src/providers/app-provider.tsx
+++ b/apps/admin-x-framework/src/providers/app-provider.tsx
@@ -67,10 +67,17 @@ export const useAppContext = () => {
 // Unlike useAppContext, this reads the context without throwing so it can be
 // consumed by framework-level data hooks (e.g. the Tinybird hooks) that may
 // render in standalone/Ember-embedded trees without an AppProvider mounted.
-// It defaults to `true` when no provider is present so those trees keep their
-// existing behaviour — the gate only ever suppresses when we positively know
-// web analytics is turned off.
 export const useWebAnalyticsEnabled = (): boolean => {
     const context = useContext(AppContext);
-    return context?.appSettings?.analytics?.webAnalytics ?? true;
+
+    // No provider at all (standalone/Ember embed, tests): preserve the legacy
+    // behaviour where analytics simply runs — the gate can't know otherwise.
+    if (!context) {
+        return true;
+    }
+
+    // Provider mounted: only enabled when the setting is explicitly on. While
+    // settings are still resolving (appSettings undefined), treat as disabled so
+    // we don't fire Tinybird requests before the real value is known.
+    return context.appSettings?.analytics?.webAnalytics === true;
 };

--- a/apps/admin-x-framework/src/providers/app-provider.tsx
+++ b/apps/admin-x-framework/src/providers/app-provider.tsx
@@ -61,3 +61,16 @@ export const useAppContext = () => {
     }
     return context;
 };
+
+// Single source of truth for the web analytics kill-switch.
+//
+// Unlike useAppContext, this reads the context without throwing so it can be
+// consumed by framework-level data hooks (e.g. the Tinybird hooks) that may
+// render in standalone/Ember-embedded trees without an AppProvider mounted.
+// It defaults to `true` when no provider is present so those trees keep their
+// existing behaviour — the gate only ever suppresses when we positively know
+// web analytics is turned off.
+export const useWebAnalyticsEnabled = (): boolean => {
+    const context = useContext(AppContext);
+    return context?.appSettings?.analytics?.webAnalytics ?? true;
+};

--- a/apps/admin-x-framework/test/unit/hooks/use-active-visitors.test.ts
+++ b/apps/admin-x-framework/test/unit/hooks/use-active-visitors.test.ts
@@ -25,6 +25,11 @@ import {useTinybirdToken} from '../../../src/hooks/use-tinybird-token';
 const mockUseQuery = vi.mocked(useQuery);
 const mockGetStatEndpointUrl = vi.mocked(getStatEndpointUrl);
 const mockUseTinybirdToken = vi.mocked(useTinybirdToken);
+const statsConfig = {
+    id: 'test-site-id',
+    endpoint: 'https://api.test.com',
+    token: 'test-token'
+};
 
 describe('useActiveVisitors', () => {
     let queryClient: QueryClient;
@@ -66,7 +71,7 @@ describe('useActiveVisitors', () => {
     });
 
     it('returns initial state when enabled is true', () => {
-        const {result} = renderHook(() => useActiveVisitors({enabled: true}), {wrapper});
+        const {result} = renderHook(() => useActiveVisitors({statsConfig, enabled: true}), {wrapper});
 
         expect(result.current).toEqual({
             activeVisitors: 0,
@@ -97,7 +102,7 @@ describe('useActiveVisitors', () => {
             refresh: vi.fn()
         });
 
-        const {result} = renderHook(() => useActiveVisitors({enabled: true}), {wrapper});
+        const {result} = renderHook(() => useActiveVisitors({statsConfig, enabled: true}), {wrapper});
 
         // Should show loading on initial load when no lastKnownCount exists
         expect(result.current.isLoading).toBe(true);
@@ -117,7 +122,7 @@ describe('useActiveVisitors', () => {
             refresh: vi.fn()
         });
 
-        const {result, rerender} = renderHook(() => useActiveVisitors({enabled: true}), {wrapper});
+        const {result, rerender} = renderHook(() => useActiveVisitors({statsConfig, enabled: true}), {wrapper});
         expect(result.current.activeVisitors).toBe(25);
 
         // Second render with loading but data should not show loading
@@ -150,7 +155,7 @@ describe('useActiveVisitors', () => {
             refresh: vi.fn()
         });
 
-        const {result} = renderHook(() => useActiveVisitors({enabled: true}), {wrapper});
+        const {result} = renderHook(() => useActiveVisitors({statsConfig, enabled: true}), {wrapper});
 
         expect(result.current.activeVisitors).toBe(42);
         expect(result.current.isLoading).toBe(false);
@@ -169,37 +174,31 @@ describe('useActiveVisitors', () => {
             refresh: vi.fn()
         });
 
-        const {result} = renderHook(() => useActiveVisitors({enabled: true}), {wrapper});
+        const {result} = renderHook(() => useActiveVisitors({statsConfig, enabled: true}), {wrapper});
 
         expect(result.current.error).toBe(mockError);
     });
 
     it('calls getStatEndpointUrl with correct parameters and uses tinybirdToken', () => {
-        const statsConfig = {
-            id: 'test-site-id',
-            endpoint: 'https://api.test.com',
-            token: 'test-token'
-        };
-
         renderHook(() => useActiveVisitors({statsConfig, enabled: true}), {wrapper});
 
         expect(mockGetStatEndpointUrl).toHaveBeenCalledWith(statsConfig, 'api_active_visitors');
         expect(mockUseTinybirdToken).toHaveBeenCalled();
     });
 
-    it('calls useTinybirdQuery with undefined endpoint when no statsConfig and uses tinybirdToken', () => {
+    it('calls useTinybirdQuery with undefined endpoint and token when no statsConfig', () => {
         renderHook(() => useActiveVisitors({enabled: true}), {wrapper});
 
         expect(mockUseQuery).toHaveBeenCalledWith(
             expect.objectContaining({
                 endpoint: undefined,
-                token: 'mock-token',
+                token: undefined,
                 params: expect.objectContaining({
                     site_uuid: ''
                 })
             })
         );
-        expect(mockUseTinybirdToken).toHaveBeenCalled();
+        expect(mockUseTinybirdToken).toHaveBeenCalledWith({enabled: false});
     });
 
     it('sets up 60-second interval when enabled', () => {
@@ -273,12 +272,6 @@ describe('useActiveVisitors', () => {
     });
 
     it('uses statsConfig for site_uuid', () => {
-        const statsConfig = {
-            id: 'test-site-id',
-            endpoint: 'https://api.test.com',
-            token: 'test-token'
-        };
-
         renderHook(() => useActiveVisitors({statsConfig, enabled: true}), {wrapper});
 
         expect(mockUseQuery).toHaveBeenCalledWith(
@@ -315,7 +308,7 @@ describe('useActiveVisitors', () => {
             refresh: vi.fn()
         });
 
-        const {result, rerender} = renderHook(() => useActiveVisitors({enabled: true}), {wrapper});
+        const {result, rerender} = renderHook(() => useActiveVisitors({statsConfig, enabled: true}), {wrapper});
         expect(result.current.activeVisitors).toBe(25);
 
         // Simulate refresh with loading state but no new data
@@ -395,7 +388,7 @@ describe('useActiveVisitors', () => {
             refresh: vi.fn()
         });
 
-        const {result, rerender} = renderHook(() => useActiveVisitors({enabled: true}), {wrapper});
+        const {result, rerender} = renderHook(() => useActiveVisitors({statsConfig, enabled: true}), {wrapper});
         expect(result.current.activeVisitors).toBe(0);
 
         // Provide valid data
@@ -439,7 +432,7 @@ describe('useActiveVisitors', () => {
         };
 
         const {rerender} = renderHook(
-            ({statsConfig}) => useActiveVisitors({statsConfig, enabled: true}),
+            ({statsConfig: currentStatsConfig}) => useActiveVisitors({statsConfig: currentStatsConfig, enabled: true}),
             {initialProps: {statsConfig: initialStatsConfig}, wrapper}
         );
 
@@ -473,7 +466,7 @@ describe('useActiveVisitors', () => {
         });
 
         const {result, rerender} = renderHook(
-            ({enabled}) => useActiveVisitors({enabled}),
+            ({enabled}) => useActiveVisitors({statsConfig, enabled}),
             {initialProps: {enabled: true}, wrapper}
         );
 
@@ -539,7 +532,7 @@ describe('useActiveVisitors', () => {
         mockUseQuery.mockClear();
 
         // Render the hook
-        renderHook(() => useActiveVisitors({enabled: true}), {wrapper});
+        renderHook(() => useActiveVisitors({statsConfig, enabled: true}), {wrapper});
 
         // EXPECTED: useQuery should be called with undefined endpoint when token is loading
         // This prevents HTTP requests by disabling the SWR query entirely
@@ -564,7 +557,7 @@ describe('useActiveVisitors', () => {
         mockUseQuery.mockClear();
 
         // Render the hook
-        renderHook(() => useActiveVisitors({enabled: true}), {wrapper});
+        renderHook(() => useActiveVisitors({statsConfig, enabled: true}), {wrapper});
 
         // Should call useQuery with the valid token
         expect(mockUseQuery).toHaveBeenCalledWith(
@@ -584,7 +577,7 @@ describe('useActiveVisitors', () => {
         });
 
         // Render the hook
-        const {rerender} = renderHook(() => useActiveVisitors({enabled: true}), {wrapper});
+        const {rerender} = renderHook(() => useActiveVisitors({statsConfig, enabled: true}), {wrapper});
 
         // Verify first call with undefined token (due to tokenLoading: true)
         expect(mockUseQuery).toHaveBeenLastCalledWith(
@@ -636,7 +629,7 @@ describe('useActiveVisitors', () => {
             refresh: vi.fn()
         });
 
-        const {result} = renderHook(() => useActiveVisitors({enabled: true}), {wrapper});
+        const {result} = renderHook(() => useActiveVisitors({statsConfig, enabled: true}), {wrapper});
 
         // Should show loading because token is loading and no lastKnownCount
         expect(result.current.isLoading).toBe(true);

--- a/apps/admin-x-framework/test/unit/hooks/use-tinybird-query.test.ts
+++ b/apps/admin-x-framework/test/unit/hooks/use-tinybird-query.test.ts
@@ -85,6 +85,58 @@ describe('useTinybirdQuery', () => {
         }));
     });
 
+    it('should not fetch a token or query Tinybird when disabled', () => {
+        const mockError = new Error('Token error');
+        mockUseTinybirdToken.mockReturnValue({
+            token: 'mock-token',
+            isLoading: true,
+            error: mockError,
+            refetch: vi.fn()
+        });
+        mockUseQuery.mockReturnValue({
+            data: [{visits: 1}],
+            loading: true,
+            error: 'Query error',
+            meta: [{name: 'visits'}],
+            statistics: null,
+            endpoint: 'https://api.example.com/test',
+            token: 'mock-token',
+            refresh: vi.fn()
+        });
+
+        const {result} = renderHook(() => useTinybirdQuery({
+            statsConfig: {id: '123'},
+            endpoint: 'test',
+            params: {},
+            enabled: false
+        }), {wrapper});
+
+        expect(mockUseTinybirdToken).toHaveBeenCalledWith({enabled: false});
+        expect(mockGetStatEndpointUrl).not.toHaveBeenCalled();
+        expect(mockUseQuery).toHaveBeenCalledWith(expect.objectContaining({
+            endpoint: undefined,
+            token: undefined
+        }));
+        expect(result.current.loading).toBe(false);
+        expect(result.current.error).toBe(null);
+        expect(result.current.data).toBe(null);
+        expect(result.current.meta).toBe(null);
+    });
+
+    it('should not fetch a token or query Tinybird without statsConfig', () => {
+        renderHook(() => useTinybirdQuery({
+            endpoint: 'test',
+            params: {}
+        }), {wrapper});
+
+        expect(mockUseTinybirdToken).toHaveBeenCalledWith({enabled: false});
+        expect(mockGetStatEndpointUrl).not.toHaveBeenCalled();
+        expect(mockUseQuery).toHaveBeenCalledWith(expect.objectContaining({
+            endpoint: undefined,
+            token: undefined
+        }));
+    });
+
     it('should call useQuery with the correct token', () => {
         mockUseTinybirdToken.mockReturnValue({
             token: 'mock-token',

--- a/apps/admin-x-framework/test/unit/hooks/use-tinybird-query.test.ts
+++ b/apps/admin-x-framework/test/unit/hooks/use-tinybird-query.test.ts
@@ -97,7 +97,7 @@ describe('useTinybirdQuery', () => {
             data: [{visits: 1}],
             loading: true,
             error: 'Query error',
-            meta: [{name: 'visits'}],
+            meta: [{name: 'visits', type: 'UInt64'}],
             statistics: null,
             endpoint: 'https://api.example.com/test',
             token: 'mock-token',

--- a/apps/admin-x-framework/test/unit/hooks/use-tinybird-query.test.ts
+++ b/apps/admin-x-framework/test/unit/hooks/use-tinybird-query.test.ts
@@ -1,7 +1,20 @@
 import {renderHook} from '@testing-library/react';
+import {AppProvider, AppSettings} from '../../../src/providers/app-provider';
 import {useTinybirdQuery} from '../../../src/hooks/use-tinybird-query';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import React from 'react';
+
+const buildAppSettings = (webAnalytics: boolean): AppSettings => ({
+    paidMembersEnabled: true,
+    newslettersEnabled: true,
+    analytics: {
+        emailTrackOpens: true,
+        emailTrackClicks: true,
+        membersTrackSources: true,
+        outboundLinkTagging: true,
+        webAnalytics
+    }
+});
 
 vi.mock('@tinybirdco/charts', () => ({
     useQuery: vi.fn()
@@ -249,5 +262,73 @@ describe('useTinybirdQuery', () => {
         }), {wrapper});
 
         expect(result.current.error).toBe(mockError);
+    });
+
+    describe('web analytics gate', () => {
+        const withAppSettings = (webAnalytics: boolean): React.FC<{children: React.ReactNode}> =>
+            ({children}) => React.createElement(
+                QueryClientProvider,
+                {client: queryClient},
+                React.createElement(AppProvider, {appSettings: buildAppSettings(webAnalytics)}, children)
+            );
+
+        it('noops without a per-call flag when web analytics is disabled', () => {
+            mockUseTinybirdToken.mockReturnValue({
+                token: 'mock-token',
+                isLoading: false,
+                error: null,
+                refetch: vi.fn()
+            });
+            mockUseQuery.mockReturnValue({
+                data: [{visits: 1}],
+                loading: true,
+                error: 'Query error',
+                meta: [{name: 'visits', type: 'UInt64'}],
+                statistics: null,
+                endpoint: 'https://api.example.com/test',
+                token: 'mock-token',
+                refresh: vi.fn()
+            });
+
+            // enabled defaults to true and statsConfig/endpoint are provided —
+            // only the context flag should suppress the query.
+            const {result} = renderHook(() => useTinybirdQuery({
+                statsConfig: {id: '123'},
+                endpoint: 'test',
+                params: {}
+            }), {wrapper: withAppSettings(false)});
+
+            expect(mockGetStatEndpointUrl).not.toHaveBeenCalled();
+            expect(mockUseTinybirdToken).toHaveBeenCalledWith({enabled: false});
+            expect(mockUseQuery).toHaveBeenCalledWith(expect.objectContaining({
+                endpoint: undefined,
+                token: undefined
+            }));
+            expect(result.current.data).toBe(null);
+            expect(result.current.meta).toBe(null);
+            expect(result.current.loading).toBe(false);
+            expect(result.current.error).toBe(null);
+        });
+
+        it('queries normally when web analytics is enabled', () => {
+            mockUseTinybirdToken.mockReturnValue({
+                token: 'mock-token',
+                isLoading: false,
+                error: null,
+                refetch: vi.fn()
+            });
+
+            renderHook(() => useTinybirdQuery({
+                statsConfig: {id: '123'},
+                endpoint: 'test',
+                params: {}
+            }), {wrapper: withAppSettings(true)});
+
+            expect(mockUseTinybirdToken).toHaveBeenCalledWith({enabled: true});
+            expect(mockUseQuery).toHaveBeenCalledWith(expect.objectContaining({
+                endpoint: 'https://api.example.com/test',
+                token: 'mock-token'
+            }));
+        });
     });
 });

--- a/apps/admin-x-framework/test/unit/hooks/use-tinybird-token.test.tsx
+++ b/apps/admin-x-framework/test/unit/hooks/use-tinybird-token.test.tsx
@@ -312,6 +312,23 @@ describe('useTinybirdToken', () => {
             expect(mockGetTinybirdToken).toHaveBeenCalledWith({enabled: false});
         });
 
+        it('returns an idle result when disabled, even if the query reports loading/error', () => {
+            // A disabled React Query still reports isLoading:true and may retain a
+            // cached error — the hook must normalize this so providers don't hang.
+            mockGetTinybirdToken.mockReturnValue({
+                data: {tinybird: {token: 'stale-token'}},
+                isLoading: true,
+                error: new Error('stale error'),
+                refetch: vi.fn()
+            } as any);
+
+            const {result} = renderHook(() => useTinybirdToken({enabled: true}), {wrapper: withAppSettings(false)});
+
+            expect(result.current.isLoading).toBe(false);
+            expect(result.current.error).toBe(null);
+            expect(result.current.token).toBeUndefined();
+        });
+
         it('loads a token when web analytics is enabled', () => {
             renderHook(() => useTinybirdToken({enabled: true}), {wrapper: withAppSettings(true)});
 

--- a/apps/admin-x-framework/test/unit/hooks/use-tinybird-token.test.tsx
+++ b/apps/admin-x-framework/test/unit/hooks/use-tinybird-token.test.tsx
@@ -1,8 +1,21 @@
 import {renderHook} from '@testing-library/react';
+import {AppProvider, AppSettings} from '../../../src/providers/app-provider';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {useTinybirdToken} from '../../../src/hooks/use-tinybird-token';
 import {getTinybirdToken} from '../../../src/api/tinybird';
 import React from 'react';
+
+const buildAppSettings = (webAnalytics: boolean): AppSettings => ({
+    paidMembersEnabled: true,
+    newslettersEnabled: true,
+    analytics: {
+        emailTrackOpens: true,
+        emailTrackClicks: true,
+        membersTrackSources: true,
+        outboundLinkTagging: true,
+        webAnalytics
+    }
+});
 
 // Mock the getTinybirdToken API
 vi.mock('../../../src/api/tinybird', () => ({
@@ -274,5 +287,47 @@ describe('useTinybirdToken', () => {
 
         expect(result.current.token).toBe('default-token');
         expect(mockGetTinybirdToken).toHaveBeenCalledWith({enabled: true});
+    });
+
+    describe('web analytics gate', () => {
+        const withAppSettings = (webAnalytics: boolean): React.FC<{children: React.ReactNode}> =>
+            ({children}) => React.createElement(
+                QueryClientProvider,
+                {client: queryClient},
+                React.createElement(AppProvider, {appSettings: buildAppSettings(webAnalytics)}, children)
+            );
+
+        beforeEach(() => {
+            mockGetTinybirdToken.mockReturnValue({
+                data: {tinybird: {token: 'test-token'}},
+                isLoading: false,
+                error: null,
+                refetch: vi.fn()
+            } as any);
+        });
+
+        it('never loads a token when web analytics is disabled, even if enabled is true', () => {
+            renderHook(() => useTinybirdToken({enabled: true}), {wrapper: withAppSettings(false)});
+
+            expect(mockGetTinybirdToken).toHaveBeenCalledWith({enabled: false});
+        });
+
+        it('loads a token when web analytics is enabled', () => {
+            renderHook(() => useTinybirdToken({enabled: true}), {wrapper: withAppSettings(true)});
+
+            expect(mockGetTinybirdToken).toHaveBeenCalledWith({enabled: true});
+        });
+
+        it('stays disabled when web analytics is on but the caller passes enabled false', () => {
+            renderHook(() => useTinybirdToken({enabled: false}), {wrapper: withAppSettings(true)});
+
+            expect(mockGetTinybirdToken).toHaveBeenCalledWith({enabled: false});
+        });
+
+        it('defaults to enabled when no AppProvider is mounted (preserves standalone behavior)', () => {
+            renderHook(() => useTinybirdToken({enabled: true}), {wrapper});
+
+            expect(mockGetTinybirdToken).toHaveBeenCalledWith({enabled: true});
+        });
     });
 });

--- a/apps/admin-x-framework/test/unit/hooks/use-tinybird-token.test.tsx
+++ b/apps/admin-x-framework/test/unit/hooks/use-tinybird-token.test.tsx
@@ -346,5 +346,17 @@ describe('useTinybirdToken', () => {
 
             expect(mockGetTinybirdToken).toHaveBeenCalledWith({enabled: true});
         });
+
+        it('stays disabled while settings are still loading (provider mounted, appSettings undefined)', () => {
+            const loadingWrapper: React.FC<{children: React.ReactNode}> = ({children}) => React.createElement(
+                QueryClientProvider,
+                {client: queryClient},
+                React.createElement(AppProvider, {appSettings: undefined}, children)
+            );
+
+            renderHook(() => useTinybirdToken({enabled: true}), {wrapper: loadingWrapper});
+
+            expect(mockGetTinybirdToken).toHaveBeenCalledWith({enabled: false});
+        });
     });
 });

--- a/apps/posts/src/app.tsx
+++ b/apps/posts/src/app.tsx
@@ -27,10 +27,8 @@ const App: React.FC<AppProps> = ({framework, designSystem, fromAnalytics = false
                 refetchOnWindowFocus: false // Disable window focus refetch (Ember admin doesn't have this)
             }}
         >
-            {/* Populate the framework AppContext so framework-level hooks (e.g. the
-                Tinybird hooks) can read appSettings. PostsAppContextProvider layers its
-                app-specific `fromAnalytics` on top. This mirrors the stats app and paves
-                the way for posts/stats to converge on a single app context. */}
+            {/* Populate the framework AppContext so framework hooks (e.g. Tinybird) can
+                read appSettings; PostsAppContextProvider adds fromAnalytics on top. */}
             <AppProvider appSettings={appSettings}>
                 <PostsAppContextProvider value={appContextValue}>
                     <RouterProvider prefix={APP_ROUTE_PREFIX} routes={routes}>

--- a/apps/posts/src/app.tsx
+++ b/apps/posts/src/app.tsx
@@ -2,7 +2,7 @@ import PostsAppContextProvider, {PostsAppContextType} from './providers/posts-ap
 import PostsErrorBoundary from '@components/errors/posts-error-boundary';
 import React from 'react';
 import {APP_ROUTE_PREFIX, routes} from '@src/routes';
-import {BaseAppProps, FrameworkProvider, Outlet, RouterProvider} from '@tryghost/admin-x-framework';
+import {AppProvider, BaseAppProps, FrameworkProvider, Outlet, RouterProvider} from '@tryghost/admin-x-framework';
 import {ShadeApp} from '@tryghost/shade/app';
 
 interface AppProps extends BaseAppProps {
@@ -27,15 +27,21 @@ const App: React.FC<AppProps> = ({framework, designSystem, fromAnalytics = false
                 refetchOnWindowFocus: false // Disable window focus refetch (Ember admin doesn't have this)
             }}
         >
-            <PostsAppContextProvider value={appContextValue}>
-                <RouterProvider prefix={APP_ROUTE_PREFIX} routes={routes}>
-                    <PostsErrorBoundary>
-                        <ShadeApp className="shade-posts app-container" darkMode={designSystem.darkMode} fetchKoenigLexical={null}>
-                            <Outlet />
-                        </ShadeApp>
-                    </PostsErrorBoundary>
-                </RouterProvider>
-            </PostsAppContextProvider>
+            {/* Populate the framework AppContext so framework-level hooks (e.g. the
+                Tinybird hooks) can read appSettings. PostsAppContextProvider layers its
+                app-specific `fromAnalytics` on top. This mirrors the stats app and paves
+                the way for posts/stats to converge on a single app context. */}
+            <AppProvider appSettings={appSettings}>
+                <PostsAppContextProvider value={appContextValue}>
+                    <RouterProvider prefix={APP_ROUTE_PREFIX} routes={routes}>
+                        <PostsErrorBoundary>
+                            <ShadeApp className="shade-posts app-container" darkMode={designSystem.darkMode} fetchKoenigLexical={null}>
+                                <Outlet />
+                            </ShadeApp>
+                        </PostsErrorBoundary>
+                    </RouterProvider>
+                </PostsAppContextProvider>
+            </AppProvider>
         </FrameworkProvider>
     );
 };

--- a/apps/posts/src/providers/post-analytics-context.tsx
+++ b/apps/posts/src/providers/post-analytics-context.tsx
@@ -74,9 +74,8 @@ const PostAnalyticsProvider = ({children}: { children: ReactNode }) => {
     const [range, setRange] = useState(STATS_RANGES.LAST_30_DAYS.value);
     const settings = useBrowseSettings();
     
-    // Only fetch Tinybird token if stats config is present. The web analytics
-    // kill-switch is applied inside useTinybirdToken, so it noops here too when
-    // the setting is off.
+    // Fetch the token only when stats config is present; the web analytics
+    // kill-switch is applied inside useTinybirdToken.
     const hasStatsConfig = Boolean(config.data?.config?.stats);
     const tinybirdTokenQuery = useTinybirdToken({enabled: hasStatsConfig});
 

--- a/apps/posts/src/providers/post-analytics-context.tsx
+++ b/apps/posts/src/providers/post-analytics-context.tsx
@@ -4,6 +4,7 @@ import {Post as PostBase, useBrowsePosts} from '@tryghost/admin-x-framework/api/
 import {ReactNode, createContext, useContext, useState} from 'react';
 import {Setting, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
 import {StatsConfig, useTinybirdToken} from '@tryghost/admin-x-framework';
+import {useAppContext} from '@src/providers/posts-app-context';
 import {useBrowseSite} from '@tryghost/admin-x-framework/api/site';
 import {useParams} from '@tryghost/admin-x-framework';
 
@@ -62,6 +63,7 @@ export const useGlobalData = () => {
 };
 
 const PostAnalyticsProvider = ({children}: { children: ReactNode }) => {
+    const {appSettings} = useAppContext();
     const {postId} = useParams();
     
     // Validate that postId exists - the app cannot function without it
@@ -76,7 +78,8 @@ const PostAnalyticsProvider = ({children}: { children: ReactNode }) => {
     
     // Only fetch Tinybird token if stats config is present
     const hasStatsConfig = Boolean(config.data?.config?.stats);
-    const tinybirdTokenQuery = useTinybirdToken({enabled: hasStatsConfig});
+    const shouldLoadTinybirdToken = hasStatsConfig && appSettings?.analytics?.webAnalytics === true;
+    const tinybirdTokenQuery = useTinybirdToken({enabled: shouldLoadTinybirdToken});
 
     // Fetch post data with all required includes. The gift-link modal reuses
     // POST_ANALYTICS_INCLUDE for the same query key, so both read one cached post.
@@ -90,12 +93,12 @@ const PostAnalyticsProvider = ({children}: { children: ReactNode }) => {
     // Check for errors in the ghost requests
     const ghostRequests = [config, site, settings];
     const ghostError = ghostRequests.map(request => request.error).find(Boolean);
-    const tinybirdError = hasStatsConfig ? tinybirdTokenQuery.error : null;
+    const tinybirdError = shouldLoadTinybirdToken ? tinybirdTokenQuery.error : null;
     const error = ghostError || tinybirdError;
     
     // Check loading states
     const isGhostLoading = ghostRequests.some(request => request.isLoading);
-    const isTinybirdLoading = hasStatsConfig ? tinybirdTokenQuery.isLoading : false;
+    const isTinybirdLoading = shouldLoadTinybirdToken ? tinybirdTokenQuery.isLoading : false;
     const isLoading = isGhostLoading || isTinybirdLoading;
 
     if (error) {

--- a/apps/posts/src/providers/post-analytics-context.tsx
+++ b/apps/posts/src/providers/post-analytics-context.tsx
@@ -4,7 +4,6 @@ import {Post as PostBase, useBrowsePosts} from '@tryghost/admin-x-framework/api/
 import {ReactNode, createContext, useContext, useState} from 'react';
 import {Setting, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
 import {StatsConfig, useTinybirdToken} from '@tryghost/admin-x-framework';
-import {useAppContext} from '@src/providers/posts-app-context';
 import {useBrowseSite} from '@tryghost/admin-x-framework/api/site';
 import {useParams} from '@tryghost/admin-x-framework';
 
@@ -63,7 +62,6 @@ export const useGlobalData = () => {
 };
 
 const PostAnalyticsProvider = ({children}: { children: ReactNode }) => {
-    const {appSettings} = useAppContext();
     const {postId} = useParams();
     
     // Validate that postId exists - the app cannot function without it
@@ -76,10 +74,11 @@ const PostAnalyticsProvider = ({children}: { children: ReactNode }) => {
     const [range, setRange] = useState(STATS_RANGES.LAST_30_DAYS.value);
     const settings = useBrowseSettings();
     
-    // Only fetch Tinybird token if stats config is present
+    // Only fetch Tinybird token if stats config is present. The web analytics
+    // kill-switch is applied inside useTinybirdToken, so it noops here too when
+    // the setting is off.
     const hasStatsConfig = Boolean(config.data?.config?.stats);
-    const shouldLoadTinybirdToken = hasStatsConfig && appSettings?.analytics?.webAnalytics === true;
-    const tinybirdTokenQuery = useTinybirdToken({enabled: shouldLoadTinybirdToken});
+    const tinybirdTokenQuery = useTinybirdToken({enabled: hasStatsConfig});
 
     // Fetch post data with all required includes. The gift-link modal reuses
     // POST_ANALYTICS_INCLUDE for the same query key, so both read one cached post.
@@ -93,12 +92,12 @@ const PostAnalyticsProvider = ({children}: { children: ReactNode }) => {
     // Check for errors in the ghost requests
     const ghostRequests = [config, site, settings];
     const ghostError = ghostRequests.map(request => request.error).find(Boolean);
-    const tinybirdError = shouldLoadTinybirdToken ? tinybirdTokenQuery.error : null;
+    const tinybirdError = hasStatsConfig ? tinybirdTokenQuery.error : null;
     const error = ghostError || tinybirdError;
-    
+
     // Check loading states
     const isGhostLoading = ghostRequests.some(request => request.isLoading);
-    const isTinybirdLoading = shouldLoadTinybirdToken ? tinybirdTokenQuery.isLoading : false;
+    const isTinybirdLoading = hasStatsConfig ? tinybirdTokenQuery.isLoading : false;
     const isLoading = isGhostLoading || isTinybirdLoading;
 
     if (error) {

--- a/apps/posts/src/views/PostAnalytics/Overview/overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/overview.tsx
@@ -27,6 +27,7 @@ const Overview: React.FC = () => {
     const {totals, isLoading: isTotalsLoading, currencySymbol} = usePostReferrers(postId);
     const {appSettings} = useAppContext();
     const {emailTrackClicks: emailTrackClicksEnabled, emailTrackOpens: emailTrackOpensEnabled} = appSettings?.analytics || {};
+    const webAnalyticsEnabled = appSettings?.analytics?.webAnalytics === true;
 
     // Gift link card: only for eligible posts. Read the active link (without
     // minting) to scope the usage count to the current token, matching the modal.
@@ -68,8 +69,9 @@ const Overview: React.FC = () => {
 
     const {data: chartData, loading: chartLoading} = useTinybirdQuery({
         endpoint: 'api_kpis',
-        statsConfig: statsConfig || {id: ''},
-        params: params
+        statsConfig,
+        params: params,
+        enabled: webAnalyticsEnabled
     });
 
     // Calculate total visitors as a number for WebOverview component
@@ -98,8 +100,9 @@ const Overview: React.FC = () => {
     // Get sources data
     const {data: sourcesData, loading: isSourcesLoading} = useTinybirdQuery({
         endpoint: 'api_top_sources',
-        statsConfig: statsConfig || {id: ''},
-        params: params
+        statsConfig,
+        params: params,
+        enabled: webAnalyticsEnabled
     });
 
     const kpiIsLoading = isConfigLoading || isTotalsLoading || isPostLoading || chartLoading;
@@ -107,17 +110,17 @@ const Overview: React.FC = () => {
 
     // Use the utility function from admin-x-framework
     const showNewsletterSection = hasBeenEmailed(post as Post) && emailTrackOpensEnabled && emailTrackClicksEnabled;
-    const showWebSection = !post?.email_only && appSettings?.analytics.webAnalytics;
+    const showWebSection = !post?.email_only && webAnalyticsEnabled;
     const showGrowthSection = appSettings?.analytics.membersTrackSources;
     const showGiftLinkCard = Boolean(canManageGiftLink && post && appSettings?.analytics.webAnalytics);
 
     // Redirect to Growth tab if this is a published-only post with web analytics disabled
     // Only redirect if Growth section is available
     useEffect(() => {
-        if (!isPostLoading && post && isPublishedOnly(post as Post) && !appSettings?.analytics.webAnalytics && showGrowthSection) {
+        if (!isPostLoading && post && isPublishedOnly(post as Post) && !webAnalyticsEnabled && showGrowthSection) {
             navigate(`/posts/analytics/${postId}/growth`, {replace: true});
         }
-    }, [isPostLoading, post, appSettings?.analytics.webAnalytics, navigate, postId, showGrowthSection]);
+    }, [isPostLoading, post, webAnalyticsEnabled, navigate, postId, showGrowthSection]);
 
     // First we have to wait for the post to be loaded to determine what sections (web, newsletter etc.) should be displayed
     if (isPostLoading) {

--- a/apps/posts/src/views/PostAnalytics/Overview/overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/overview.tsx
@@ -70,8 +70,7 @@ const Overview: React.FC = () => {
     const {data: chartData, loading: chartLoading} = useTinybirdQuery({
         endpoint: 'api_kpis',
         statsConfig,
-        params: params,
-        enabled: webAnalyticsEnabled
+        params: params
     });
 
     // Calculate total visitors as a number for WebOverview component
@@ -101,8 +100,7 @@ const Overview: React.FC = () => {
     const {data: sourcesData, loading: isSourcesLoading} = useTinybirdQuery({
         endpoint: 'api_top_sources',
         statsConfig,
-        params: params,
-        enabled: webAnalyticsEnabled
+        params: params
     });
 
     const kpiIsLoading = isConfigLoading || isTotalsLoading || isPostLoading || chartLoading;

--- a/apps/posts/src/views/PostAnalytics/Web/web.tsx
+++ b/apps/posts/src/views/PostAnalytics/Web/web.tsx
@@ -6,7 +6,7 @@ import PostAnalyticsHeader from '../components/post-analytics-header';
 import Sources from './components/sources';
 import StatsFilter from '../components/stats-filter';
 import {BarChartLoadingIndicator, Card, CardContent, EmptyIndicator, NavbarActions} from '@tryghost/shade/components';
-import {BaseSourceData, Navigate, useNavigate, useParams, useTinybirdQuery, useWebAnalyticsEnabled} from '@tryghost/admin-x-framework';
+import {BaseSourceData, Navigate, useNavigate, useParams, useTinybirdQuery} from '@tryghost/admin-x-framework';
 import {KpiDataItem, getWebKpiValues} from '@src/utils/kpi-helpers';
 import {LucideIcon, getScrollParent} from '@tryghost/shade/utils';
 import {STATS_RANGES, UNKNOWN_LOCATION_VALUES} from '@src/utils/constants';
@@ -14,6 +14,7 @@ import {createFilter} from '@tryghost/shade/patterns';
 import {formatQueryDate, getRangeDates, getRangeForStartDate} from '@tryghost/shade/app';
 import {getAudienceFromFilterValues, getAudienceQueryParam} from '@src/utils/audience';
 import {getPeriodText} from '@src/utils/chart-helpers';
+import {useAppContext} from '@src/providers/posts-app-context';
 import {useCallback, useEffect, useMemo, useRef} from 'react';
 import {useFilterParams} from '@src/hooks/use-filter-params';
 import {useGlobalData} from '@src/providers/post-analytics-context';
@@ -31,7 +32,7 @@ const Web: React.FC<postAnalyticsProps> = () => {
     const navigate = useNavigate();
     const {postId} = useParams();
     const {statsConfig, isLoading: isConfigLoading, range, data: globalData, post, isPostLoading} = useGlobalData();
-    const webAnalyticsEnabled = useWebAnalyticsEnabled();
+    const {appSettings} = useAppContext();
     const containerRef = useRef<HTMLElement>(null);
 
     // Use URL-synced filter state for bookmarking and sharing
@@ -213,7 +214,9 @@ const Web: React.FC<postAnalyticsProps> = () => {
     // Web analytics is disabled: this tab is hidden in the UI, but a direct link or
     // bookmark can still land here. Redirect to Overview instead of rendering the
     // empty "No visitors" state, which misrepresents a disabled feature as zero traffic.
-    if (!webAnalyticsEnabled) {
+    // Only redirect once settings have loaded and analytics is explicitly off, so
+    // enabled sites aren't bounced away while appSettings is still resolving.
+    if (appSettings && !appSettings.analytics?.webAnalytics) {
         return <Navigate to={`/posts/analytics/${postId}`} replace />;
     }
 

--- a/apps/posts/src/views/PostAnalytics/Web/web.tsx
+++ b/apps/posts/src/views/PostAnalytics/Web/web.tsx
@@ -14,6 +14,7 @@ import {createFilter} from '@tryghost/shade/patterns';
 import {formatQueryDate, getRangeDates, getRangeForStartDate} from '@tryghost/shade/app';
 import {getAudienceFromFilterValues, getAudienceQueryParam} from '@src/utils/audience';
 import {getPeriodText} from '@src/utils/chart-helpers';
+import {useAppContext} from '@src/providers/posts-app-context';
 import {useCallback, useEffect, useMemo, useRef} from 'react';
 import {useFilterParams} from '@src/hooks/use-filter-params';
 import {useGlobalData} from '@src/providers/post-analytics-context';
@@ -31,6 +32,8 @@ const Web: React.FC<postAnalyticsProps> = () => {
     const navigate = useNavigate();
     const {postId} = useParams();
     const {statsConfig, isLoading: isConfigLoading, range, data: globalData, post, isPostLoading} = useGlobalData();
+    const {appSettings} = useAppContext();
+    const webAnalyticsEnabled = appSettings?.analytics?.webAnalytics === true;
     const containerRef = useRef<HTMLElement>(null);
 
     // Use URL-synced filter state for bookmarking and sharing
@@ -143,22 +146,25 @@ const Web: React.FC<postAnalyticsProps> = () => {
     // Get web kpi data
     const {data: kpiData, loading: isKpisLoading} = useTinybirdQuery({
         endpoint: 'api_kpis',
-        statsConfig: statsConfig || {id: ''},
-        params: params
+        statsConfig,
+        params: params,
+        enabled: webAnalyticsEnabled
     });
 
     // Get locations data
     const {data: locationsData, loading: isLocationsLoading} = useTinybirdQuery({
         endpoint: 'api_top_locations',
-        statsConfig: statsConfig || {id: ''},
-        params: params
+        statsConfig,
+        params: params,
+        enabled: webAnalyticsEnabled
     });
 
     // Get sources data
     const {data: sourcesData, loading: isSourcesLoading} = useTinybirdQuery({
         endpoint: 'api_top_sources',
-        statsConfig: statsConfig || {id: ''},
-        params: params
+        statsConfig,
+        params: params,
+        enabled: webAnalyticsEnabled
     });
 
     // Calculate total visits for percentage calculation

--- a/apps/posts/src/views/PostAnalytics/Web/web.tsx
+++ b/apps/posts/src/views/PostAnalytics/Web/web.tsx
@@ -211,11 +211,9 @@ const Web: React.FC<postAnalyticsProps> = () => {
     // Check if filters are applied
     const hasFilters = analyticsFilters.length > 0;
 
-    // Web analytics is disabled: this tab is hidden in the UI, but a direct link or
-    // bookmark can still land here. Redirect to Overview instead of rendering the
-    // empty "No visitors" state, which misrepresents a disabled feature as zero traffic.
-    // Only redirect once settings have loaded and analytics is explicitly off, so
-    // enabled sites aren't bounced away while appSettings is still resolving.
+    // The Web tab is hidden when analytics is off, but a direct link can still land
+    // here — redirect to Overview instead of an empty "No visitors" state. Only once
+    // settings have loaded, else enabled sites get bounced mid-load.
     if (appSettings && !appSettings.analytics?.webAnalytics) {
         return <Navigate to={`/posts/analytics/${postId}`} replace />;
     }

--- a/apps/posts/src/views/PostAnalytics/Web/web.tsx
+++ b/apps/posts/src/views/PostAnalytics/Web/web.tsx
@@ -6,7 +6,7 @@ import PostAnalyticsHeader from '../components/post-analytics-header';
 import Sources from './components/sources';
 import StatsFilter from '../components/stats-filter';
 import {BarChartLoadingIndicator, Card, CardContent, EmptyIndicator, NavbarActions} from '@tryghost/shade/components';
-import {BaseSourceData, useNavigate, useParams, useTinybirdQuery} from '@tryghost/admin-x-framework';
+import {BaseSourceData, Navigate, useNavigate, useParams, useTinybirdQuery, useWebAnalyticsEnabled} from '@tryghost/admin-x-framework';
 import {KpiDataItem, getWebKpiValues} from '@src/utils/kpi-helpers';
 import {LucideIcon, getScrollParent} from '@tryghost/shade/utils';
 import {STATS_RANGES, UNKNOWN_LOCATION_VALUES} from '@src/utils/constants';
@@ -31,6 +31,7 @@ const Web: React.FC<postAnalyticsProps> = () => {
     const navigate = useNavigate();
     const {postId} = useParams();
     const {statsConfig, isLoading: isConfigLoading, range, data: globalData, post, isPostLoading} = useGlobalData();
+    const webAnalyticsEnabled = useWebAnalyticsEnabled();
     const containerRef = useRef<HTMLElement>(null);
 
     // Use URL-synced filter state for bookmarking and sharing
@@ -208,6 +209,13 @@ const Web: React.FC<postAnalyticsProps> = () => {
 
     // Check if filters are applied
     const hasFilters = analyticsFilters.length > 0;
+
+    // Web analytics is disabled: this tab is hidden in the UI, but a direct link or
+    // bookmark can still land here. Redirect to Overview instead of rendering the
+    // empty "No visitors" state, which misrepresents a disabled feature as zero traffic.
+    if (!webAnalyticsEnabled) {
+        return <Navigate to={`/posts/analytics/${postId}`} replace />;
+    }
 
     return (
         <>

--- a/apps/posts/src/views/PostAnalytics/Web/web.tsx
+++ b/apps/posts/src/views/PostAnalytics/Web/web.tsx
@@ -14,7 +14,6 @@ import {createFilter} from '@tryghost/shade/patterns';
 import {formatQueryDate, getRangeDates, getRangeForStartDate} from '@tryghost/shade/app';
 import {getAudienceFromFilterValues, getAudienceQueryParam} from '@src/utils/audience';
 import {getPeriodText} from '@src/utils/chart-helpers';
-import {useAppContext} from '@src/providers/posts-app-context';
 import {useCallback, useEffect, useMemo, useRef} from 'react';
 import {useFilterParams} from '@src/hooks/use-filter-params';
 import {useGlobalData} from '@src/providers/post-analytics-context';
@@ -32,8 +31,6 @@ const Web: React.FC<postAnalyticsProps> = () => {
     const navigate = useNavigate();
     const {postId} = useParams();
     const {statsConfig, isLoading: isConfigLoading, range, data: globalData, post, isPostLoading} = useGlobalData();
-    const {appSettings} = useAppContext();
-    const webAnalyticsEnabled = appSettings?.analytics?.webAnalytics === true;
     const containerRef = useRef<HTMLElement>(null);
 
     // Use URL-synced filter state for bookmarking and sharing
@@ -147,24 +144,21 @@ const Web: React.FC<postAnalyticsProps> = () => {
     const {data: kpiData, loading: isKpisLoading} = useTinybirdQuery({
         endpoint: 'api_kpis',
         statsConfig,
-        params: params,
-        enabled: webAnalyticsEnabled
+        params: params
     });
 
     // Get locations data
     const {data: locationsData, loading: isLocationsLoading} = useTinybirdQuery({
         endpoint: 'api_top_locations',
         statsConfig,
-        params: params,
-        enabled: webAnalyticsEnabled
+        params: params
     });
 
     // Get sources data
     const {data: sourcesData, loading: isSourcesLoading} = useTinybirdQuery({
         endpoint: 'api_top_sources',
         statsConfig,
-        params: params,
-        enabled: webAnalyticsEnabled
+        params: params
     });
 
     // Calculate total visits for percentage calculation

--- a/apps/posts/src/views/PostAnalytics/components/stats-filter.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/stats-filter.tsx
@@ -213,6 +213,7 @@ function StatsFilter({filters, onChange, ...props}: StatsFilterProps) {
     const {post} = useGlobalData();
     const postUuid = post?.uuid;
     const {isEnabled: giftLinksEnabled} = useFeatureFlag('giftLinks', '/analytics/');
+    const webAnalyticsEnabled = appSettings?.analytics?.webAnalytics === true;
 
     // Track which filter field is currently being selected (lazy loading)
     const [activeFilterField, setActiveFilterField] = useState<string | null>(null);
@@ -257,14 +258,14 @@ function StatsFilter({filters, onChange, ...props}: StatsFilterProps) {
     // Fetch options for all Tinybird-backed fields using the generic hook
     // Options are contextual - filtered based on currently applied filters and post_uuid
     // Lazy loading: only fetch when field is active or has applied filter
-    const {options: utmSourceOptions, loading: utmSourceLoading} = useTinybirdFilterOptions('utm_source', filters, postUuid, {enabled: shouldFetchOptions('utm_source')});
-    const {options: utmMediumOptions, loading: utmMediumLoading} = useTinybirdFilterOptions('utm_medium', filters, postUuid, {enabled: shouldFetchOptions('utm_medium')});
-    const {options: utmCampaignOptions, loading: utmCampaignLoading} = useTinybirdFilterOptions('utm_campaign', filters, postUuid, {enabled: shouldFetchOptions('utm_campaign')});
-    const {options: utmContentOptions, loading: utmContentLoading} = useTinybirdFilterOptions('utm_content', filters, postUuid, {enabled: shouldFetchOptions('utm_content')});
-    const {options: utmTermOptions, loading: utmTermLoading} = useTinybirdFilterOptions('utm_term', filters, postUuid, {enabled: shouldFetchOptions('utm_term')});
-    const {options: sourceOptions, loading: sourceLoading} = useTinybirdFilterOptions('source', filters, postUuid, {enabled: shouldFetchOptions('source')});
-    const {options: deviceOptions, loading: deviceLoading} = useTinybirdFilterOptions('device', filters, postUuid, {enabled: shouldFetchOptions('device')});
-    const {options: locationOptions, loading: locationLoading} = useTinybirdFilterOptions('location', filters, postUuid, {enabled: shouldFetchOptions('location')});
+    const {options: utmSourceOptions, loading: utmSourceLoading} = useTinybirdFilterOptions('utm_source', filters, postUuid, {enabled: webAnalyticsEnabled && shouldFetchOptions('utm_source')});
+    const {options: utmMediumOptions, loading: utmMediumLoading} = useTinybirdFilterOptions('utm_medium', filters, postUuid, {enabled: webAnalyticsEnabled && shouldFetchOptions('utm_medium')});
+    const {options: utmCampaignOptions, loading: utmCampaignLoading} = useTinybirdFilterOptions('utm_campaign', filters, postUuid, {enabled: webAnalyticsEnabled && shouldFetchOptions('utm_campaign')});
+    const {options: utmContentOptions, loading: utmContentLoading} = useTinybirdFilterOptions('utm_content', filters, postUuid, {enabled: webAnalyticsEnabled && shouldFetchOptions('utm_content')});
+    const {options: utmTermOptions, loading: utmTermLoading} = useTinybirdFilterOptions('utm_term', filters, postUuid, {enabled: webAnalyticsEnabled && shouldFetchOptions('utm_term')});
+    const {options: sourceOptions, loading: sourceLoading} = useTinybirdFilterOptions('source', filters, postUuid, {enabled: webAnalyticsEnabled && shouldFetchOptions('source')});
+    const {options: deviceOptions, loading: deviceLoading} = useTinybirdFilterOptions('device', filters, postUuid, {enabled: webAnalyticsEnabled && shouldFetchOptions('device')});
+    const {options: locationOptions, loading: locationLoading} = useTinybirdFilterOptions('location', filters, postUuid, {enabled: webAnalyticsEnabled && shouldFetchOptions('location')});
 
     // Note: Only 'is' operator supported - Tinybird pipes only support exact match
     const supportedOperators = useMemo(() => [

--- a/apps/posts/src/views/PostAnalytics/components/stats-filter.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/stats-filter.tsx
@@ -213,7 +213,6 @@ function StatsFilter({filters, onChange, ...props}: StatsFilterProps) {
     const {post} = useGlobalData();
     const postUuid = post?.uuid;
     const {isEnabled: giftLinksEnabled} = useFeatureFlag('giftLinks', '/analytics/');
-    const webAnalyticsEnabled = appSettings?.analytics?.webAnalytics === true;
 
     // Track which filter field is currently being selected (lazy loading)
     const [activeFilterField, setActiveFilterField] = useState<string | null>(null);
@@ -258,14 +257,14 @@ function StatsFilter({filters, onChange, ...props}: StatsFilterProps) {
     // Fetch options for all Tinybird-backed fields using the generic hook
     // Options are contextual - filtered based on currently applied filters and post_uuid
     // Lazy loading: only fetch when field is active or has applied filter
-    const {options: utmSourceOptions, loading: utmSourceLoading} = useTinybirdFilterOptions('utm_source', filters, postUuid, {enabled: webAnalyticsEnabled && shouldFetchOptions('utm_source')});
-    const {options: utmMediumOptions, loading: utmMediumLoading} = useTinybirdFilterOptions('utm_medium', filters, postUuid, {enabled: webAnalyticsEnabled && shouldFetchOptions('utm_medium')});
-    const {options: utmCampaignOptions, loading: utmCampaignLoading} = useTinybirdFilterOptions('utm_campaign', filters, postUuid, {enabled: webAnalyticsEnabled && shouldFetchOptions('utm_campaign')});
-    const {options: utmContentOptions, loading: utmContentLoading} = useTinybirdFilterOptions('utm_content', filters, postUuid, {enabled: webAnalyticsEnabled && shouldFetchOptions('utm_content')});
-    const {options: utmTermOptions, loading: utmTermLoading} = useTinybirdFilterOptions('utm_term', filters, postUuid, {enabled: webAnalyticsEnabled && shouldFetchOptions('utm_term')});
-    const {options: sourceOptions, loading: sourceLoading} = useTinybirdFilterOptions('source', filters, postUuid, {enabled: webAnalyticsEnabled && shouldFetchOptions('source')});
-    const {options: deviceOptions, loading: deviceLoading} = useTinybirdFilterOptions('device', filters, postUuid, {enabled: webAnalyticsEnabled && shouldFetchOptions('device')});
-    const {options: locationOptions, loading: locationLoading} = useTinybirdFilterOptions('location', filters, postUuid, {enabled: webAnalyticsEnabled && shouldFetchOptions('location')});
+    const {options: utmSourceOptions, loading: utmSourceLoading} = useTinybirdFilterOptions('utm_source', filters, postUuid, {enabled: shouldFetchOptions('utm_source')});
+    const {options: utmMediumOptions, loading: utmMediumLoading} = useTinybirdFilterOptions('utm_medium', filters, postUuid, {enabled: shouldFetchOptions('utm_medium')});
+    const {options: utmCampaignOptions, loading: utmCampaignLoading} = useTinybirdFilterOptions('utm_campaign', filters, postUuid, {enabled: shouldFetchOptions('utm_campaign')});
+    const {options: utmContentOptions, loading: utmContentLoading} = useTinybirdFilterOptions('utm_content', filters, postUuid, {enabled: shouldFetchOptions('utm_content')});
+    const {options: utmTermOptions, loading: utmTermLoading} = useTinybirdFilterOptions('utm_term', filters, postUuid, {enabled: shouldFetchOptions('utm_term')});
+    const {options: sourceOptions, loading: sourceLoading} = useTinybirdFilterOptions('source', filters, postUuid, {enabled: shouldFetchOptions('source')});
+    const {options: deviceOptions, loading: deviceLoading} = useTinybirdFilterOptions('device', filters, postUuid, {enabled: shouldFetchOptions('device')});
+    const {options: locationOptions, loading: locationLoading} = useTinybirdFilterOptions('location', filters, postUuid, {enabled: shouldFetchOptions('location')});
 
     // Note: Only 'is' operator supported - Tinybird pipes only support exact match
     const supportedOperators = useMemo(() => [

--- a/apps/stats/src/providers/global-data-provider.tsx
+++ b/apps/stats/src/providers/global-data-provider.tsx
@@ -38,9 +38,8 @@ const GlobalDataProvider = ({children}: { children: ReactNode }) => {
     const config = useBrowseConfig();
     // config.data is ConfigResponseType which has shape { config: Config }
     const configData = config.data?.config;
-    // Only load the Tinybird token when Tinybird is provisioned for this
-    // deployment. The web analytics kill-switch is applied inside
-    // useTinybirdToken, so it noops here too when the setting is off.
+    // Load the token only when Tinybird is provisioned; the web analytics
+    // kill-switch is applied inside useTinybirdToken.
     const hasStatsConfig = Boolean(configData?.stats);
     const tinybirdTokenQuery = useTinybirdToken({enabled: hasStatsConfig});
     const [range, setRange] = useState(STATS_RANGE_OPTIONS[STATS_DEFAULT_RANGE_KEY].value);

--- a/apps/stats/src/providers/global-data-provider.tsx
+++ b/apps/stats/src/providers/global-data-provider.tsx
@@ -2,7 +2,7 @@ import {Config, useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
 import {ReactNode, createContext, useContext, useState} from 'react';
 import {STATS_DEFAULT_RANGE_KEY, STATS_RANGE_OPTIONS} from '@src/utils/constants';
 import {Setting, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
-import {StatsConfig, useAppContext, useTinybirdToken} from '@tryghost/admin-x-framework';
+import {StatsConfig, useTinybirdToken} from '@tryghost/admin-x-framework';
 import {useBrowseSite} from '@tryghost/admin-x-framework/api/site';
 
 interface GlobalData {
@@ -33,27 +33,28 @@ export const useGlobalData = () => {
 };
 
 const GlobalDataProvider = ({children}: { children: ReactNode }) => {
-    const {appSettings} = useAppContext();
     const settings = useBrowseSettings();
     const site = useBrowseSite();
     const config = useBrowseConfig();
     // config.data is ConfigResponseType which has shape { config: Config }
     const configData = config.data?.config;
+    // Only load the Tinybird token when Tinybird is provisioned for this
+    // deployment. The web analytics kill-switch is applied inside
+    // useTinybirdToken, so it noops here too when the setting is off.
     const hasStatsConfig = Boolean(configData?.stats);
-    const shouldLoadTinybirdToken = hasStatsConfig && appSettings?.analytics?.webAnalytics === true;
-    const tinybirdTokenQuery = useTinybirdToken({enabled: shouldLoadTinybirdToken});
+    const tinybirdTokenQuery = useTinybirdToken({enabled: hasStatsConfig});
     const [range, setRange] = useState(STATS_RANGE_OPTIONS[STATS_DEFAULT_RANGE_KEY].value);
     const [selectedNewsletterId, setSelectedNewsletterId] = useState<string | null>(null);
 
     // Check for errors in the main requests
     const ghostRequests = [config, settings, site];
     const ghostError = ghostRequests.map(request => request.error).find(Boolean);
-    const tinybirdError = shouldLoadTinybirdToken ? tinybirdTokenQuery.error : null;
+    const tinybirdError = hasStatsConfig ? tinybirdTokenQuery.error : null;
     const error = ghostError || tinybirdError;
-    
+
     // Check loading states
     const isGhostLoading = ghostRequests.some(request => request.isLoading);
-    const isTinybirdLoading = shouldLoadTinybirdToken ? tinybirdTokenQuery.isLoading : false;
+    const isTinybirdLoading = hasStatsConfig ? tinybirdTokenQuery.isLoading : false;
     const isLoading = isGhostLoading || isTinybirdLoading;
 
     if (error) {

--- a/apps/stats/src/providers/global-data-provider.tsx
+++ b/apps/stats/src/providers/global-data-provider.tsx
@@ -2,7 +2,7 @@ import {Config, useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
 import {ReactNode, createContext, useContext, useState} from 'react';
 import {STATS_DEFAULT_RANGE_KEY, STATS_RANGE_OPTIONS} from '@src/utils/constants';
 import {Setting, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
-import {StatsConfig, useTinybirdToken} from '@tryghost/admin-x-framework';
+import {StatsConfig, useAppContext, useTinybirdToken} from '@tryghost/admin-x-framework';
 import {useBrowseSite} from '@tryghost/admin-x-framework/api/site';
 
 interface GlobalData {
@@ -33,25 +33,27 @@ export const useGlobalData = () => {
 };
 
 const GlobalDataProvider = ({children}: { children: ReactNode }) => {
+    const {appSettings} = useAppContext();
     const settings = useBrowseSettings();
     const site = useBrowseSite();
     const config = useBrowseConfig();
     // config.data is ConfigResponseType which has shape { config: Config }
     const configData = config.data?.config;
     const hasStatsConfig = Boolean(configData?.stats);
-    const tinybirdTokenQuery = useTinybirdToken({enabled: hasStatsConfig});
+    const shouldLoadTinybirdToken = hasStatsConfig && appSettings?.analytics?.webAnalytics === true;
+    const tinybirdTokenQuery = useTinybirdToken({enabled: shouldLoadTinybirdToken});
     const [range, setRange] = useState(STATS_RANGE_OPTIONS[STATS_DEFAULT_RANGE_KEY].value);
     const [selectedNewsletterId, setSelectedNewsletterId] = useState<string | null>(null);
 
     // Check for errors in the main requests
     const ghostRequests = [config, settings, site];
     const ghostError = ghostRequests.map(request => request.error).find(Boolean);
-    const tinybirdError = hasStatsConfig ? tinybirdTokenQuery.error : null;
+    const tinybirdError = shouldLoadTinybirdToken ? tinybirdTokenQuery.error : null;
     const error = ghostError || tinybirdError;
     
     // Check loading states
     const isGhostLoading = ghostRequests.some(request => request.isLoading);
-    const isTinybirdLoading = hasStatsConfig ? tinybirdTokenQuery.isLoading : false;
+    const isTinybirdLoading = shouldLoadTinybirdToken ? tinybirdTokenQuery.isLoading : false;
     const isLoading = isGhostLoading || isTinybirdLoading;
 
     if (error) {

--- a/apps/stats/src/views/Stats/Overview/overview.tsx
+++ b/apps/stats/src/views/Stats/Overview/overview.tsx
@@ -71,6 +71,7 @@ type GrowthChartDataItem = {
 const Overview: React.FC = () => {
     const {appSettings} = useAppContext();
     const {statsConfig, isLoading: isConfigLoading, range} = useGlobalData();
+    const webAnalyticsEnabled = appSettings?.analytics?.webAnalytics === true;
     const {startDate, endDate, timezone} = getRangeDates(range);
     const {isLoading: isGrowthStatsLoading, chartData: growthChartData, totals: growthTotals, currencySymbol} = useGrowthStats(range);
     const {data: latestPostStats, isLoading: isLatestPostLoading} = useLatestPostStats();
@@ -80,7 +81,8 @@ const Overview: React.FC = () => {
             date_to: formatQueryDate(endDate),
             limit: '5',
             timezone
-        }
+        },
+        enabled: webAnalyticsEnabled
     });
 
     /* Get visitors
@@ -96,7 +98,8 @@ const Overview: React.FC = () => {
     const {data: visitorsData, loading: isVisitorsLoading} = useTinybirdQuery({
         endpoint: 'api_kpis',
         statsConfig,
-        params: visitorsParams
+        params: visitorsParams,
+        enabled: webAnalyticsEnabled
     });
 
     const visitorsChartData = useMemo(() => {

--- a/apps/stats/src/views/Stats/Overview/overview.tsx
+++ b/apps/stats/src/views/Stats/Overview/overview.tsx
@@ -98,8 +98,7 @@ const Overview: React.FC = () => {
     const {data: visitorsData, loading: isVisitorsLoading} = useTinybirdQuery({
         endpoint: 'api_kpis',
         statsConfig,
-        params: visitorsParams,
-        enabled: webAnalyticsEnabled
+        params: visitorsParams
     });
 
     const visitorsChartData = useMemo(() => {

--- a/apps/stats/src/views/Stats/Web/web.tsx
+++ b/apps/stats/src/views/Stats/Web/web.tsx
@@ -57,6 +57,7 @@ const Web: React.FC = () => {
     const {statsConfig, isLoading: isConfigLoading, range, data} = useGlobalData();
     const {startDate, endDate, timezone} = getRangeDates(range);
     const {appSettings} = useAppContext();
+    const webAnalyticsEnabled = appSettings?.analytics?.webAnalytics === true;
 
     const containerRef = useRef<HTMLDivElement>(null);
 
@@ -155,21 +156,24 @@ const Web: React.FC = () => {
     const {data: kpiData, loading: kpiLoading} = useTinybirdQuery({
         endpoint: 'api_kpis',
         statsConfig,
-        params
+        params,
+        enabled: webAnalyticsEnabled
     });
 
     // Get top sources data
     const {data: sourcesData, loading: isSourcesLoading} = useTinybirdQuery({
         endpoint: 'api_top_sources',
         statsConfig,
-        params
+        params,
+        enabled: webAnalyticsEnabled
     });
 
     // Get top locations data
     const {data: locationsData, loading: isLocationsLoading} = useTinybirdQuery({
         endpoint: 'api_top_locations',
         statsConfig,
-        params
+        params,
+        enabled: webAnalyticsEnabled
     });
 
     // Get total visitors for table
@@ -178,7 +182,7 @@ const Web: React.FC = () => {
     // Calculate combined loading state
     const isPageLoading = isConfigLoading;
 
-    if (!appSettings?.analytics.webAnalytics) {
+    if (!webAnalyticsEnabled) {
         return (
             <Navigate to='/' />
         );

--- a/apps/stats/src/views/Stats/Web/web.tsx
+++ b/apps/stats/src/views/Stats/Web/web.tsx
@@ -156,24 +156,21 @@ const Web: React.FC = () => {
     const {data: kpiData, loading: kpiLoading} = useTinybirdQuery({
         endpoint: 'api_kpis',
         statsConfig,
-        params,
-        enabled: webAnalyticsEnabled
+        params
     });
 
     // Get top sources data
     const {data: sourcesData, loading: isSourcesLoading} = useTinybirdQuery({
         endpoint: 'api_top_sources',
         statsConfig,
-        params,
-        enabled: webAnalyticsEnabled
+        params
     });
 
     // Get top locations data
     const {data: locationsData, loading: isLocationsLoading} = useTinybirdQuery({
         endpoint: 'api_top_locations',
         statsConfig,
-        params,
-        enabled: webAnalyticsEnabled
+        params
     });
 
     // Get total visitors for table

--- a/apps/stats/src/views/Stats/components/stats-filter.tsx
+++ b/apps/stats/src/views/Stats/components/stats-filter.tsx
@@ -286,6 +286,7 @@ const usePostOptions = (currentFilters: Filter[] = [], config: UsePostOptionsCon
 function StatsFilter({filters, onChange, ...props}: StatsFilterProps) {
     const {appSettings} = useAppContext();
     const giftLinksEnabled = useLabsFlag('giftLinks');
+    const webAnalyticsEnabled = appSettings?.analytics?.webAnalytics === true;
 
     // Track which filter field is currently being selected (lazy loading)
     const [activeFilterField, setActiveFilterField] = useState<string | null>(null);
@@ -330,17 +331,17 @@ function StatsFilter({filters, onChange, ...props}: StatsFilterProps) {
     // Fetch options for all Tinybird-backed fields using the generic hook
     // Options are contextual - filtered based on currently applied filters
     // Lazy loading: only fetch when field is active or has applied filter
-    const {options: utmSourceOptions, loading: utmSourceLoading} = useTinybirdFilterOptions('utm_source', filters, {enabled: shouldFetchOptions('utm_source')});
-    const {options: utmMediumOptions, loading: utmMediumLoading} = useTinybirdFilterOptions('utm_medium', filters, {enabled: shouldFetchOptions('utm_medium')});
-    const {options: utmCampaignOptions, loading: utmCampaignLoading} = useTinybirdFilterOptions('utm_campaign', filters, {enabled: shouldFetchOptions('utm_campaign')});
-    const {options: utmContentOptions, loading: utmContentLoading} = useTinybirdFilterOptions('utm_content', filters, {enabled: shouldFetchOptions('utm_content')});
-    const {options: utmTermOptions, loading: utmTermLoading} = useTinybirdFilterOptions('utm_term', filters, {enabled: shouldFetchOptions('utm_term')});
-    const {options: sourceOptions, loading: sourceLoading} = useTinybirdFilterOptions('source', filters, {enabled: shouldFetchOptions('source')});
-    const {options: deviceOptions, loading: deviceLoading} = useTinybirdFilterOptions('device', filters, {enabled: shouldFetchOptions('device')});
-    const {options: locationOptions, loading: locationLoading} = useTinybirdFilterOptions('location', filters, {enabled: shouldFetchOptions('location')});
+    const {options: utmSourceOptions, loading: utmSourceLoading} = useTinybirdFilterOptions('utm_source', filters, {enabled: webAnalyticsEnabled && shouldFetchOptions('utm_source')});
+    const {options: utmMediumOptions, loading: utmMediumLoading} = useTinybirdFilterOptions('utm_medium', filters, {enabled: webAnalyticsEnabled && shouldFetchOptions('utm_medium')});
+    const {options: utmCampaignOptions, loading: utmCampaignLoading} = useTinybirdFilterOptions('utm_campaign', filters, {enabled: webAnalyticsEnabled && shouldFetchOptions('utm_campaign')});
+    const {options: utmContentOptions, loading: utmContentLoading} = useTinybirdFilterOptions('utm_content', filters, {enabled: webAnalyticsEnabled && shouldFetchOptions('utm_content')});
+    const {options: utmTermOptions, loading: utmTermLoading} = useTinybirdFilterOptions('utm_term', filters, {enabled: webAnalyticsEnabled && shouldFetchOptions('utm_term')});
+    const {options: sourceOptions, loading: sourceLoading} = useTinybirdFilterOptions('source', filters, {enabled: webAnalyticsEnabled && shouldFetchOptions('source')});
+    const {options: deviceOptions, loading: deviceLoading} = useTinybirdFilterOptions('device', filters, {enabled: webAnalyticsEnabled && shouldFetchOptions('device')});
+    const {options: locationOptions, loading: locationLoading} = useTinybirdFilterOptions('location', filters, {enabled: webAnalyticsEnabled && shouldFetchOptions('location')});
 
     // Fetch options for posts - data is contextual based on current filters
-    const {options: postOptions, loading: postLoading} = usePostOptions(filters, {enabled: shouldFetchOptions('post')});
+    const {options: postOptions, loading: postLoading} = usePostOptions(filters, {enabled: webAnalyticsEnabled && shouldFetchOptions('post')});
 
     // Note: Only 'is' operator supported - Tinybird pipes only support exact match
     const supportedOperators = useMemo(() => [

--- a/apps/stats/src/views/Stats/components/stats-filter.tsx
+++ b/apps/stats/src/views/Stats/components/stats-filter.tsx
@@ -10,7 +10,7 @@ import {getAudienceFromFilterValues, getAudienceQueryParam} from '@src/utils/aud
 import {useAppContext} from '@src/app';
 import {useGlobalData} from '@src/providers/global-data-provider';
 import {useLabsFlag} from '@hooks/use-labs-flag';
-import {useTinybirdQuery} from '@tryghost/admin-x-framework';
+import {useTinybirdQuery, useWebAnalyticsEnabled} from '@tryghost/admin-x-framework';
 import {useTopContent} from '@tryghost/admin-x-framework/api/stats';
 
 countries.registerLocale(enLocale);
@@ -219,6 +219,9 @@ interface UsePostOptionsConfig {
 // This uses a different API pattern so it can't use the generic hook
 const usePostOptions = (currentFilters: Filter[] = [], config: UsePostOptionsConfig = {}) => {
     const {enabled = true} = config;
+    // Post options come from a Ghost API (useTopContent), not useTinybirdQuery, so
+    // they don't inherit the central web-analytics gate — apply it here.
+    const webAnalyticsEnabled = useWebAnalyticsEnabled();
     const {range} = useGlobalData();
     const {startDate, endDate, timezone} = getRangeDates(range);
 
@@ -246,7 +249,7 @@ const usePostOptions = (currentFilters: Filter[] = [], config: UsePostOptionsCon
     // Fetch top content data from Ghost API (which queries Tinybird and enriches with titles)
     const {data: topContentData, isLoading} = useTopContent({
         searchParams: queryParams,
-        enabled
+        enabled: enabled && webAnalyticsEnabled
     });
 
     const options = useMemo(() => {
@@ -286,7 +289,6 @@ const usePostOptions = (currentFilters: Filter[] = [], config: UsePostOptionsCon
 function StatsFilter({filters, onChange, ...props}: StatsFilterProps) {
     const {appSettings} = useAppContext();
     const giftLinksEnabled = useLabsFlag('giftLinks');
-    const webAnalyticsEnabled = appSettings?.analytics?.webAnalytics === true;
 
     // Track which filter field is currently being selected (lazy loading)
     const [activeFilterField, setActiveFilterField] = useState<string | null>(null);
@@ -331,17 +333,17 @@ function StatsFilter({filters, onChange, ...props}: StatsFilterProps) {
     // Fetch options for all Tinybird-backed fields using the generic hook
     // Options are contextual - filtered based on currently applied filters
     // Lazy loading: only fetch when field is active or has applied filter
-    const {options: utmSourceOptions, loading: utmSourceLoading} = useTinybirdFilterOptions('utm_source', filters, {enabled: webAnalyticsEnabled && shouldFetchOptions('utm_source')});
-    const {options: utmMediumOptions, loading: utmMediumLoading} = useTinybirdFilterOptions('utm_medium', filters, {enabled: webAnalyticsEnabled && shouldFetchOptions('utm_medium')});
-    const {options: utmCampaignOptions, loading: utmCampaignLoading} = useTinybirdFilterOptions('utm_campaign', filters, {enabled: webAnalyticsEnabled && shouldFetchOptions('utm_campaign')});
-    const {options: utmContentOptions, loading: utmContentLoading} = useTinybirdFilterOptions('utm_content', filters, {enabled: webAnalyticsEnabled && shouldFetchOptions('utm_content')});
-    const {options: utmTermOptions, loading: utmTermLoading} = useTinybirdFilterOptions('utm_term', filters, {enabled: webAnalyticsEnabled && shouldFetchOptions('utm_term')});
-    const {options: sourceOptions, loading: sourceLoading} = useTinybirdFilterOptions('source', filters, {enabled: webAnalyticsEnabled && shouldFetchOptions('source')});
-    const {options: deviceOptions, loading: deviceLoading} = useTinybirdFilterOptions('device', filters, {enabled: webAnalyticsEnabled && shouldFetchOptions('device')});
-    const {options: locationOptions, loading: locationLoading} = useTinybirdFilterOptions('location', filters, {enabled: webAnalyticsEnabled && shouldFetchOptions('location')});
+    const {options: utmSourceOptions, loading: utmSourceLoading} = useTinybirdFilterOptions('utm_source', filters, {enabled: shouldFetchOptions('utm_source')});
+    const {options: utmMediumOptions, loading: utmMediumLoading} = useTinybirdFilterOptions('utm_medium', filters, {enabled: shouldFetchOptions('utm_medium')});
+    const {options: utmCampaignOptions, loading: utmCampaignLoading} = useTinybirdFilterOptions('utm_campaign', filters, {enabled: shouldFetchOptions('utm_campaign')});
+    const {options: utmContentOptions, loading: utmContentLoading} = useTinybirdFilterOptions('utm_content', filters, {enabled: shouldFetchOptions('utm_content')});
+    const {options: utmTermOptions, loading: utmTermLoading} = useTinybirdFilterOptions('utm_term', filters, {enabled: shouldFetchOptions('utm_term')});
+    const {options: sourceOptions, loading: sourceLoading} = useTinybirdFilterOptions('source', filters, {enabled: shouldFetchOptions('source')});
+    const {options: deviceOptions, loading: deviceLoading} = useTinybirdFilterOptions('device', filters, {enabled: shouldFetchOptions('device')});
+    const {options: locationOptions, loading: locationLoading} = useTinybirdFilterOptions('location', filters, {enabled: shouldFetchOptions('location')});
 
     // Fetch options for posts - data is contextual based on current filters
-    const {options: postOptions, loading: postLoading} = usePostOptions(filters, {enabled: webAnalyticsEnabled && shouldFetchOptions('post')});
+    const {options: postOptions, loading: postLoading} = usePostOptions(filters, {enabled: shouldFetchOptions('post')});
 
     // Note: Only 'is' operator supported - Tinybird pipes only support exact match
     const supportedOperators = useMemo(() => [


### PR DESCRIPTION
## Summary

- prevent Tinybird token/query setup when analytics is disabled or stats config is missing
- gate Stats and Post Analytics web queries, filter option loading, and token loading behind webAnalytics
- return an empty query state when Tinybird queries are disabled to avoid stale data

Fixes #28264

## Testing

- mise exec node@22.18.0 -- pnpm --filter @tryghost/admin-x-framework exec vitest run test/unit/hooks/use-tinybird-query.test.ts test/unit/hooks/use-active-visitors.test.ts
- mise exec node@22.18.0 -- pnpm nx run-many -t lint --projects=@tryghost/admin-x-framework,@tryghost/stats,@tryghost/posts
- mise exec node@22.18.0 -- pnpm nx run-many -t build --projects=@tryghost/admin-x-framework,@tryghost/stats,@tryghost/posts