### PR TITLE
Changed placeholder copy for welcome & automation emails

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
@@ -333,7 +333,7 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
                             <MemberEmailEditor
                                 key={automatedEmail?.id || 'new'}
                                 className='welcome-email-editor'
-                                placeholder='Write your welcome email content...'
+                                placeholder='Begin writing your email...'
                                 value={formState.lexical}
                                 onChange={handleEditorChange}
                             />

--- a/apps/posts/src/views/Automations/components/email-modal/email-content-modal.tsx
+++ b/apps/posts/src/views/Automations/components/email-modal/email-content-modal.tsx
@@ -345,7 +345,7 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({initialMode = 'edi
                                 >
                                     <EmailEditor
                                         className='automation-email-editor'
-                                        placeholder='Write your email content...'
+                                        placeholder='Begin writing your email...'
                                         value={formState.lexical}
                                         onChange={handleEditorChange}
                                     />


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1364

Before this change, the placeholder said "Write your email content...".

To be more consistent with the post editor, it now says "Begin writing your email...".
