### PR TITLE
Fixed missing welcome email content as automation fallback

### DIFF
--- a/apps/admin-x-framework/src/api/automations.ts
+++ b/apps/admin-x-framework/src/api/automations.ts
@@ -60,6 +60,16 @@ export interface AutomationDetailResponseType {
     automations: AutomationDetail[];
 }
 
+export type AutomationEmailPreview = {
+    html: string;
+    plaintext: string;
+    subject: string;
+}
+
+export interface AutomationEmailPreviewResponseType {
+    automation_email_previews: AutomationEmailPreview[];
+}
+
 const dataType = 'AutomationsResponseType';
 
 export const useBrowseAutomations = createQuery<AutomationsResponseType>({
@@ -85,6 +95,18 @@ export const useEditAutomation = createMutation<AutomationDetailResponseType, Ed
     invalidateQueries: {
         dataType
     }
+});
+
+export const usePreviewAutomationEmail = createMutation<AutomationEmailPreviewResponseType, {id: string; subject: string; lexical: string}>({
+    method: 'POST',
+    path: ({id}) => `/automations/${id}/email_preview`,
+    body: ({subject, lexical}) => ({subject, lexical})
+});
+
+export const useSendTestAutomationEmail = createMutation<unknown, {id: string; email: string; subject: string; lexical: string}>({
+    method: 'POST',
+    path: ({id}) => `/automations/${id}/email_test`,
+    body: ({email, subject, lexical}) => ({email, subject, lexical})
 });
 
 const generateActionId = (): string => ObjectId().toHexString();

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-customize-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-customize-modal.tsx
@@ -4,6 +4,7 @@ import HeaderImageField from '../../email-design/header-image-field';
 import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import ShowBadgeField from '../../email-design/show-badge-field';
 import WelcomeEmailPreviewContent from '../../email-design/welcome-email-preview-content';
+import useFeatureFlag from '../../../../hooks/use-feature-flag';
 import validator from 'validator';
 import {type AutomatedEmailDesign, type EditAutomatedEmailDesign, useEditAutomatedEmailDesign, useReadAutomatedEmailDesign} from '@tryghost/admin-x-framework/api/automated-email-design';
 import {
@@ -346,6 +347,7 @@ const WelcomeEmailCustomizeModal = NiceModal.create(() => {
     const {mutateAsync: editDesign} = useEditAutomatedEmailDesign();
     const {mutateAsync: addAutomatedEmail} = useAddAutomatedEmail();
     const {mutateAsync: editAutomatedEmailSenders} = useEditAutomatedEmailSenders();
+    const hasAutomations = useFeatureFlag('automations');
     const [hasSaveError, setHasSaveError] = useState(false);
     const [senderInputsHydrated, setSenderInputsHydrated] = useState(false);
     const automatedEmails = automatedEmailsData?.automated_emails || [];
@@ -409,7 +411,9 @@ const WelcomeEmailCustomizeModal = NiceModal.create(() => {
                 throw new Error('Unable to load email design settings');
             }
 
-            await ensureWelcomeEmailRows();
+            if (!hasAutomations) {
+                await ensureWelcomeEmailRows();
+            }
             const senderPayload = {
                 sender_name: normalizeSenderValue(state.generalSettings.senderName),
                 sender_reply_to: normalizeSenderValue(state.generalSettings.replyToEmail),

--- a/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
@@ -52,6 +52,17 @@ const configWithTenorEnabled = {
     }
 };
 
+const configWithAutomationsEnabled = {
+    ...responseFixtures.config,
+    config: {
+        ...responseFixtures.config.config,
+        labs: {
+            ...responseFixtures.config.config.labs,
+            automations: true
+        }
+    }
+};
+
 const managedEmailConfigWithoutSendingDomain = {
     ...responseFixtures.config,
     config: {
@@ -1289,6 +1300,67 @@ test.describe('Member emails settings', async () => {
                 sender_email: 'shared@example.com',
                 sender_reply_to: 'shared-reply@example.com'
             });
+        });
+
+        test('saves shared sender settings without creating welcome-email rows when automations are enabled', async ({page}) => {
+            const emptyAutomatedEmailsFixture = {
+                automated_emails: []
+            };
+
+            const createdAutomatedEmailResponse = {
+                automated_emails: [{
+                    id: 'free-welcome-email-id',
+                    status: 'inactive',
+                    name: 'Welcome Email (Free)',
+                    slug: 'member-welcome-email-free',
+                    subject: 'Welcome to Test Site',
+                    lexical: '{"root":{"children":[]}}',
+                    sender_name: null,
+                    sender_email: null,
+                    sender_reply_to: null,
+                    created_at: '2024-01-01T00:00:00.000Z',
+                    updated_at: null
+                }]
+            };
+
+            const {lastApiRequests} = await mockApi({page, requests: {
+                ...globalDataRequests,
+                ...newslettersRequest,
+                browseConfig: {method: 'GET', path: '/config/', response: configWithAutomationsEnabled},
+                browseNewsletters: {method: 'GET', path: '/newsletters/?include=count.active_members%2Ccount.posts&limit=50', response: responseFixtures.newsletters},
+                browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: emptyAutomatedEmailsFixture},
+                readAutomatedEmailDesign: {method: 'GET', path: '/automated_emails/design/', response: automatedEmailDesignFixture},
+                editAutomatedEmailDesign: {method: 'PUT', path: '/automated_emails/design/', response: automatedEmailDesignFixture},
+                addAutomatedEmail: {method: 'POST', path: '/automated_emails/', response: createdAutomatedEmailResponse},
+                editAutomatedEmailSenders: {
+                    method: 'PUT',
+                    path: /^\/automated_emails\/senders\/?$/,
+                    response: emptyAutomatedEmailsFixture
+                }
+            }});
+
+            await page.goto('/');
+            await page.waitForLoadState('networkidle');
+
+            const section = page.getByTestId('emails');
+            await expect(section).toBeVisible({timeout: 10000});
+            await section.getByRole('tab', {name: 'Automation emails'}).click();
+            await section.getByTestId('automations-transactional-row').getByRole('button', {name: 'Edit'}).click();
+
+            const modal = page.getByTestId('welcome-email-customize-modal');
+            await expect(modal).toBeVisible();
+
+            await modal.getByLabel('Sender name').fill('Shared sender');
+            await modal.getByLabel('Sender email').fill('shared@example.com');
+            await modal.getByLabel('Reply-to email').fill('shared-reply@example.com');
+            await modal.getByRole('button', {name: 'Save'}).click();
+
+            await expect.poll(() => lastApiRequests.editAutomatedEmailSenders?.body).toEqual({
+                sender_name: 'Shared sender',
+                sender_email: 'shared@example.com',
+                sender_reply_to: 'shared-reply@example.com'
+            });
+            expect(lastApiRequests.addAutomatedEmail).toBeUndefined();
         });
     });
 

--- a/apps/posts/src/views/Automations/components/canvas/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/canvas/automation-canvas.tsx
@@ -554,6 +554,7 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({
             />
             {emailModalAction && automation && (
                 <EmailContentModal
+                    automationId={automation.id}
                     initialLexical={emailModalAction.data.email_lexical}
                     initialMode={emailModalMode}
                     initialSubject={emailModalAction.data.email_subject}

--- a/apps/posts/src/views/Automations/components/email-modal/email-content-modal.tsx
+++ b/apps/posts/src/views/Automations/components/email-modal/email-content-modal.tsx
@@ -4,12 +4,12 @@ import React, {useCallback, useEffect, useRef, useState} from 'react';
 import TestEmailDropdown from './test-email-dropdown';
 import {AlertDialog, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, Button, Dialog, DialogContent, DialogTitle, Input, Tabs, TabsList, TabsTrigger} from '@tryghost/shade/components';
 import {LucideIcon, cn} from '@tryghost/shade/utils';
-import {WELCOME_EMAIL_SLUGS} from './sender-details';
 import {getEmailValidationErrors} from './validation';
-import {useBrowseAutomatedEmails, usePreviewWelcomeEmail} from '@tryghost/admin-x-framework/api/automated-emails';
+import {useBrowseAutomatedEmails} from '@tryghost/admin-x-framework/api/automated-emails';
 import {useEmailPreview} from './use-email-preview';
 import {useEmailSenderDetails} from './use-sender-details';
 import {useForm, useHandleError} from '@tryghost/admin-x-framework/hooks';
+import {usePreviewAutomationEmail} from '@tryghost/admin-x-framework/api/automations';
 import type {EmailModalMode} from '../types';
 
 interface EmailPreviewModalContentProps {
@@ -81,6 +81,7 @@ const EmailPreviewBody: React.FC<EmailPreviewBodyProps> = ({children, className}
 );
 
 export interface EmailContentModalProps {
+    automationId: string;
     initialLexical: string;
     initialMode?: EmailModalMode;
     initialSubject: string;
@@ -93,6 +94,7 @@ export interface EmailContentModalProps {
 }
 
 const EmailContentModal: React.FC<EmailContentModalProps> = ({
+    automationId,
     initialMode = 'edit',
     initialSubject,
     initialLexical,
@@ -103,7 +105,7 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({
     onKeepEditingAfterBlockedNavigation,
     onSave
 }) => {
-    const {mutateAsync: previewWelcomeEmail} = usePreviewWelcomeEmail();
+    const {mutateAsync: previewAutomationEmail} = usePreviewAutomationEmail();
     const {data: automatedEmailsData} = useBrowseAutomatedEmails();
     const [showTestDropdown, setShowTestDropdown] = useState(false);
     const [mode, setMode] = useState<EmailModalMode>(initialMode);
@@ -117,14 +119,6 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({
     const handleError = useHandleError();
     const automatedEmails = automatedEmailsData?.automated_emails || [];
     const {resolvedSenderName, resolvedSenderEmail, resolvedReplyToEmail, hasDistinctReplyTo} = useEmailSenderDetails(automatedEmails);
-
-    // Preview & test reuse the legacy welcome-email endpoints, which are keyed by
-    // an automated-email id. Borrow the free welcome email's id (falling back to
-    // the first record) so unsaved automation content can be rendered/sent.
-    const previewAutomatedEmailId = (
-        automatedEmails.find(email => email.slug === WELCOME_EMAIL_SLUGS.free)
-        || automatedEmails[0]
-    )?.id || '';
 
     // Saving commits whatever the user has — including an empty subject or body — to the
     // automation draft. Completeness is only enforced when publishing the automation or
@@ -148,8 +142,8 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({
     }, [formState, setErrors]);
     const saveButtonLabel = okProps.label || 'Save';
     const {previewFrameState, enterPreview, exitPreview} = useEmailPreview({
-        automatedEmailId: previewAutomatedEmailId,
-        previewWelcomeEmail,
+        automationId,
+        previewAutomationEmail,
         setErrors
     });
 
@@ -317,7 +311,7 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({
                                                     Test
                                                 </Button>
                                                 {showTestDropdown && (
-                                                    <TestEmailDropdown automatedEmailId={previewAutomatedEmailId} lexical={formState.lexical} subject={formState.subject} validateForm={validateForTest} onClose={() => setShowTestDropdown(false)} />
+                                                    <TestEmailDropdown automationId={automationId} lexical={formState.lexical} subject={formState.subject} validateForm={validateForTest} onClose={() => setShowTestDropdown(false)} />
                                                 )}
                                             </div>
                                         </div>

--- a/apps/posts/src/views/Automations/components/email-modal/test-email-dropdown.tsx
+++ b/apps/posts/src/views/Automations/components/email-modal/test-email-dropdown.tsx
@@ -3,10 +3,10 @@ import {Button, Input} from '@tryghost/shade/components';
 import {JSONError} from '@tryghost/admin-x-framework/errors';
 import {useCurrentUser} from '@tryghost/admin-x-framework/api/current-user';
 import {useEffect, useRef, useState} from 'react';
-import {useSendTestWelcomeEmail} from '@tryghost/admin-x-framework/api/automated-emails';
+import {useSendTestAutomationEmail} from '@tryghost/admin-x-framework/api/automations';
 
 export interface TestEmailDropdownProps {
-  automatedEmailId: string
+  automationId: string
   subject: string
   lexical: string
   validateForm: () => boolean
@@ -14,14 +14,14 @@ export interface TestEmailDropdownProps {
 }
 
 const TestEmailDropdown: React.FC<TestEmailDropdownProps> = ({
-    automatedEmailId,
+    automationId,
     subject,
     lexical,
     validateForm,
     onClose
 }) => {
     const {data: currentUser} = useCurrentUser();
-    const {mutateAsync: sendTestEmail} = useSendTestWelcomeEmail();
+    const {mutateAsync: sendTestEmail} = useSendTestAutomationEmail();
 
     const [testEmail, setTestEmail] = useState(currentUser?.email || '');
     const [testEmailError, setTestEmailError] = useState('');
@@ -72,7 +72,7 @@ const TestEmailDropdown: React.FC<TestEmailDropdownProps> = ({
 
         try {
             await sendTestEmail({
-                id: automatedEmailId,
+                id: automationId,
                 email: testEmail,
                 subject,
                 lexical

--- a/apps/posts/src/views/Automations/components/email-modal/use-email-preview.ts
+++ b/apps/posts/src/views/Automations/components/email-modal/use-email-preview.ts
@@ -10,7 +10,7 @@ export type EmailPreview = {
 };
 
 export type EmailPreviewResponse = {
-    automated_emails?: EmailPreview[];
+    automation_email_previews?: EmailPreview[];
 };
 
 export type EmailPreviewState =
@@ -55,9 +55,9 @@ const getPreviewErrorMessage = (error: unknown) => {
     return fallbackMessage;
 };
 
-export const useEmailPreview = ({automatedEmailId, previewWelcomeEmail, setErrors}: {
-    automatedEmailId: string;
-    previewWelcomeEmail: (payload: EmailDraft & {id: string}) => Promise<EmailPreviewResponse>;
+export const useEmailPreview = ({automationId, previewAutomationEmail, setErrors}: {
+    automationId: string;
+    previewAutomationEmail: (payload: EmailDraft & {id: string}) => Promise<EmailPreviewResponse>;
     setErrors: (errors: Record<string, string>) => void;
 }) => {
     const [previewState, setPreviewState] = useState<EmailPreviewState>({status: 'idle'});
@@ -88,8 +88,8 @@ export const useEmailPreview = ({automatedEmailId, previewWelcomeEmail, setError
 
         try {
             // Only the latest preview request is allowed to update preview state.
-            const response = await previewWelcomeEmail({
-                id: automatedEmailId,
+            const response = await previewAutomationEmail({
+                id: automationId,
                 subject: draft.subject,
                 lexical: draft.lexical
             });
@@ -98,7 +98,7 @@ export const useEmailPreview = ({automatedEmailId, previewWelcomeEmail, setError
                 return;
             }
 
-            const preview = response.automated_emails?.[0];
+            const preview = response.automation_email_previews?.[0];
 
             if (!preview?.html || !preview?.plaintext || !preview?.subject) {
                 throw new Error('Preview response was incomplete');

--- a/ghost/core/core/server/api/endpoints/automated-emails.js
+++ b/ghost/core/core/server/api/endpoints/automated-emails.js
@@ -3,6 +3,7 @@ const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const models = require('../../models');
 const memberWelcomeEmailService = require('../../services/member-welcome-emails/service');
+const {DEFAULT_EMAIL_DESIGN_SETTING_SLUG} = require('../../services/member-welcome-emails/constants');
 
 const messages = {
     automatedEmailNotFound: 'Automated email not found.'
@@ -17,22 +18,43 @@ const AUTOMATION_FIELDS = ['status', 'name', 'slug'];
 const EMAIL_FIELDS = ['subject', 'lexical', 'email_design_setting_id'];
 const SENDER_FIELDS = ['sender_name', 'sender_email', 'sender_reply_to'];
 
-function flattenAutomation(automation, email = automation.related('welcomeEmailAutomatedEmail'), designSettings = email.related('emailDesignSetting')) {
+function flattenAutomation(automation, email = automation.related('welcomeEmailAutomatedEmail'), designSettings = email?.related('emailDesignSetting')) {
     const result = {
         id: automation.id,
         status: automation.get('status'),
         name: automation.get('name'),
         slug: automation.get('slug'),
-        subject: email.get('subject'),
-        lexical: email.get('lexical'),
+        subject: email?.get('subject') || null,
+        lexical: email?.get('lexical') || null,
         sender_name: designSettings?.get('sender_name') || null,
         sender_email: designSettings?.get('sender_email') || null,
         sender_reply_to: designSettings?.get('sender_reply_to') || null,
-        email_design_setting_id: email.get('email_design_setting_id'),
+        email_design_setting_id: email?.get('email_design_setting_id') || designSettings?.id || null,
         created_at: automation.get('created_at'),
         updated_at: automation.get('updated_at')
     };
     return result;
+}
+
+async function getDefaultEmailDesignSettings() {
+    const designSettings = await models.EmailDesignSetting.findOne({slug: DEFAULT_EMAIL_DESIGN_SETTING_SLUG});
+
+    if (!designSettings?.id) {
+        throw new errors.NotFoundError({
+            message: 'Default automated email design setting not found'
+        });
+    }
+
+    return designSettings;
+}
+
+function flattenAutomationWithDefaultSenderSettings(automation, defaultDesignSettings) {
+    const email = automation.related('welcomeEmailAutomatedEmail');
+    const designSettings = email?.related('emailDesignSetting')?.id ?
+        email.related('emailDesignSetting') :
+        defaultDesignSettings;
+
+    return flattenAutomation(automation, email, designSettings);
 }
 
 async function updateEmailDesignSenderFields(email, senderData, options) {
@@ -208,9 +230,10 @@ const controller = {
                 sender_email: data.sender_email,
                 sender_reply_to: data.sender_reply_to
             });
+            const defaultDesignSettings = await getDefaultEmailDesignSettings();
             return {
                 ...result,
-                data: result.data.map(automation => flattenAutomation(automation))
+                data: result.data.map(automation => flattenAutomationWithDefaultSenderSettings(automation, defaultDesignSettings))
             };
         }
     },
@@ -228,9 +251,10 @@ const controller = {
         async query(frame) {
             memberWelcomeEmailService.init();
             const result = await memberWelcomeEmailService.api.verifySenderPropertyUpdate(frame.data.token);
+            const defaultDesignSettings = await getDefaultEmailDesignSettings();
             return {
                 ...result,
-                data: result.data.map(automation => flattenAutomation(automation))
+                data: result.data.map(automation => flattenAutomationWithDefaultSenderSettings(automation, defaultDesignSettings))
             };
         }
     },

--- a/ghost/core/core/server/api/endpoints/automated-emails.js
+++ b/ghost/core/core/server/api/endpoints/automated-emails.js
@@ -91,9 +91,10 @@ const controller = {
                 ...frame.options,
                 withRelated: ['welcomeEmailAutomatedEmail', 'welcomeEmailAutomatedEmail.emailDesignSetting']
             });
+            const defaultDesignSettings = await getDefaultEmailDesignSettings();
             return {
                 ...result,
-                data: result.data.map(automation => flattenAutomation(automation))
+                data: result.data.map(automation => flattenAutomationWithDefaultSenderSettings(automation, defaultDesignSettings))
             };
         }
     },
@@ -121,7 +122,8 @@ const controller = {
                 });
             }
 
-            return flattenAutomation(model);
+            const defaultDesignSettings = await getDefaultEmailDesignSettings();
+            return flattenAutomationWithDefaultSenderSettings(model, defaultDesignSettings);
         }
     },
 

--- a/ghost/core/core/server/api/endpoints/automation-email-previews.js
+++ b/ghost/core/core/server/api/endpoints/automation-email-previews.js
@@ -1,0 +1,75 @@
+const memberWelcomeEmailService = require('../../services/member-welcome-emails/service');
+
+/** @type {import('@tryghost/api-framework').Controller} */
+const controller = {
+    docName: 'automation_email_previews',
+
+    preview: {
+        headers: {
+            cacheInvalidate: false
+        },
+        options: [
+            'id'
+        ],
+        data: [
+            'subject',
+            'lexical'
+        ],
+        validation: {
+            options: {
+                id: {
+                    required: true
+                }
+            }
+        },
+        permissions: {
+            docName: 'automations',
+            method: 'edit'
+        },
+        async query(frame) {
+            memberWelcomeEmailService.init();
+            return await memberWelcomeEmailService.api.previewAutomationEmail({
+                automationId: frame.options.id,
+                subject: frame.data.subject,
+                lexical: frame.data.lexical
+            });
+        }
+    },
+
+    sendTestEmail: {
+        statusCode: 204,
+        headers: {
+            cacheInvalidate: false
+        },
+        options: [
+            'id'
+        ],
+        data: [
+            'email',
+            'subject',
+            'lexical'
+        ],
+        validation: {
+            options: {
+                id: {
+                    required: true
+                }
+            }
+        },
+        permissions: {
+            docName: 'automations',
+            method: 'edit'
+        },
+        async query(frame) {
+            memberWelcomeEmailService.init();
+            await memberWelcomeEmailService.api.sendTestAutomationEmail({
+                automationId: frame.options.id,
+                email: frame.data.email,
+                subject: frame.data.subject,
+                lexical: frame.data.lexical
+            });
+        }
+    }
+};
+
+module.exports = controller;

--- a/ghost/core/core/server/api/endpoints/index.js
+++ b/ghost/core/core/server/api/endpoints/index.js
@@ -12,6 +12,10 @@ module.exports = {
         return apiFramework.pipeline(require('./automations'), localUtils);
     },
 
+    get automationEmailPreviews() {
+        return apiFramework.pipeline(require('./automation-email-previews'), localUtils);
+    },
+
     get authentication() {
         return apiFramework.pipeline(require('./authentication'), localUtils);
     },

--- a/ghost/core/core/server/api/endpoints/utils/validators/input/automation_email_previews.js
+++ b/ghost/core/core/server/api/endpoints/utils/validators/input/automation_email_previews.js
@@ -1,0 +1,60 @@
+// Filename must match the docName specified in ../../../automation-email-previews.js
+/* eslint-disable ghost/filenames/match-regex */
+
+const validator = require('@tryghost/validator');
+const {ValidationError} = require('@tryghost/errors');
+const tpl = require('@tryghost/tpl');
+
+const messages = {
+    invalidEmailReceived: 'The server did not receive a valid email',
+    invalidLexical: 'Lexical must be a valid JSON string',
+    subjectRequired: 'Subject is required',
+    lexicalRequired: 'Email content is required'
+};
+
+const validatePreviewData = (frame) => {
+    const subject = frame.data.subject;
+    const lexical = frame.data.lexical;
+
+    if (typeof subject !== 'string' || !subject.trim()) {
+        throw new ValidationError({
+            message: tpl(messages.subjectRequired),
+            property: 'subject'
+        });
+    }
+
+    if (typeof lexical !== 'string' || !lexical.trim()) {
+        throw new ValidationError({
+            message: tpl(messages.lexicalRequired),
+            property: 'lexical'
+        });
+    }
+
+    try {
+        JSON.parse(lexical);
+    } catch (e) {
+        throw new ValidationError({
+            message: tpl(messages.invalidLexical),
+            property: 'lexical'
+        });
+    }
+};
+
+module.exports = {
+    preview(apiConfig, frame) {
+        validatePreviewData(frame);
+    },
+
+    sendTestEmail(apiConfig, frame) {
+        const email = frame.data.email;
+
+        if (typeof email !== 'string' || !validator.isEmail(email)) {
+            throw new ValidationError({
+                message: tpl(messages.invalidEmailReceived),
+                property: 'email'
+            });
+        }
+
+        validatePreviewData(frame);
+    }
+};

--- a/ghost/core/core/server/api/endpoints/utils/validators/input/index.js
+++ b/ghost/core/core/server/api/endpoints/utils/validators/input/index.js
@@ -5,6 +5,10 @@
 /* eslint-disable max-lines */
 
 module.exports = {
+    get automation_email_previews() {
+        return require('./automation_email_previews');
+    },
+
     get automated_emails() {
         return require('./automated_emails');
     },

--- a/ghost/core/core/server/services/member-welcome-emails/service.js
+++ b/ghost/core/core/server/services/member-welcome-emails/service.js
@@ -12,7 +12,7 @@ const mail = require('../mail');
 const labs = require('../../../shared/labs');
 const {Automation, EmailDesignSetting, Newsletter} = require('../../models');
 const MemberWelcomeEmailRenderer = require('./member-welcome-email-renderer');
-const {MEMBER_WELCOME_EMAIL_LOG_KEY, MEMBER_WELCOME_EMAIL_TAG, MEMBER_WELCOME_EMAIL_SLUGS, MESSAGES} = require('./constants');
+const {DEFAULT_EMAIL_DESIGN_SETTING_SLUG, MEMBER_WELCOME_EMAIL_LOG_KEY, MEMBER_WELCOME_EMAIL_TAG, MEMBER_WELCOME_EMAIL_SLUGS, MESSAGES} = require('./constants');
 
 const VERIFIED_SENDER_PROPERTIES = ['sender_reply_to'];
 const WELCOME_EMAIL_FILTER = `slug:${MEMBER_WELCOME_EMAIL_SLUGS.free},slug:${MEMBER_WELCOME_EMAIL_SLUGS.paid}`;
@@ -206,32 +206,18 @@ class MemberWelcomeEmailService {
         });
     }
 
-    async #loadWelcomeEmailsMap({requireAll = false} = {}) {
-        const rows = await this.#loadWelcomeEmailsCollection();
-        const bySlug = new Map(rows.models.map(model => [model.get('slug'), model]));
+    async #getDefaultEmailDesignSettings() {
+        const designSettings = await EmailDesignSetting.findOne({
+            slug: DEFAULT_EMAIL_DESIGN_SETTING_SLUG
+        });
 
-        const free = bySlug.get(MEMBER_WELCOME_EMAIL_SLUGS.free);
-        const paid = bySlug.get(MEMBER_WELCOME_EMAIL_SLUGS.paid);
-
-        if (requireAll && (!free || !paid)) {
+        if (!designSettings?.id) {
             throw new errors.NotFoundError({
-                message: MESSAGES.NO_MEMBER_WELCOME_EMAIL
+                message: 'Default automated email design setting not found'
             });
         }
 
-        return {free, paid};
-    }
-
-    async #loadRequiredWelcomeEmailRows() {
-        const {free, paid} = await this.#loadWelcomeEmailsMap({requireAll: true});
-
-        if (!free.related('welcomeEmailAutomatedEmail')?.id || !paid.related('welcomeEmailAutomatedEmail')?.id) {
-            throw new errors.NotFoundError({
-                message: MESSAGES.NO_MEMBER_WELCOME_EMAIL
-            });
-        }
-
-        return [free, paid];
+        return designSettings;
     }
 
     #normalizeSharedSenderValue(value) {
@@ -257,14 +243,6 @@ class MemberWelcomeEmailService {
         return normalized;
     }
 
-    #hasSharedSenderFieldChanged(rows, field, value) {
-        return rows.some((row) => {
-            const email = row.related('welcomeEmailAutomatedEmail');
-            const currentValue = email?.related('emailDesignSetting')?.get(field);
-            return trimValue(currentValue) !== trimValue(value);
-        });
-    }
-
     #validateSharedSenderField(field, value) {
         const validationType = EMAIL_VALIDATION_TYPE_BY_FIELD[field];
 
@@ -286,13 +264,14 @@ class MemberWelcomeEmailService {
         };
     }
 
-    #prepareSharedSenderUpdate(rows, attrs = {}) {
+    async #prepareSharedSenderUpdate(attrs = {}) {
+        const designSettings = await this.#getDefaultEmailDesignSettings();
         const normalizedAttrs = this.#normalizeSharedSenderAttrs(attrs);
         const attrsToPersist = {};
         const emailsToVerify = [];
 
         for (const [field, value] of Object.entries(normalizedAttrs)) {
-            if (!this.#hasSharedSenderFieldChanged(rows, field, value)) {
+            if (trimValue(designSettings.get(field)) === trimValue(value)) {
                 continue;
             }
 
@@ -307,23 +286,9 @@ class MemberWelcomeEmailService {
 
         return {
             attrsToPersist,
-            emailsToVerify
+            emailsToVerify,
+            designSettings
         };
-    }
-
-    async #applySharedSenderAttrs(rows, attrs = {}) {
-        if (Object.keys(attrs).length === 0) {
-            return;
-        }
-
-        // De-dupe so we don't write to the same design row twice.
-        const designSettingIds = new Set(
-            rows.map(row => row.related('welcomeEmailAutomatedEmail')?.get('email_design_setting_id')).filter(Boolean)
-        );
-
-        await Promise.all([...designSettingIds].map(async (id) => {
-            await EmailDesignSetting.edit(attrs, {id});
-        }));
     }
 
     async #sendSharedSenderVerifications(emailsToVerify = []) {
@@ -536,14 +501,13 @@ class MemberWelcomeEmailService {
         return Boolean(email && email.get('lexical') && row.get('status') === 'active');
     }
 
-    async #renderWelcomeEmailPreview({automatedEmailId, subject, lexical, memberEmail = 'jamie@example.com'}) {
-        // Still validate the automated email exists (for permission purposes)
-        const automation = await Automation.findOne({id: automatedEmailId}, {
+    async #renderAutomationEmailPreview({automationId, subject, lexical, memberEmail = 'jamie@example.com', requireWelcomeEmail = false}) {
+        const automation = await Automation.findOne({id: automationId}, {
             withRelated: ['welcomeEmailAutomatedEmail', 'welcomeEmailAutomatedEmail.emailDesignSetting']
         });
         const automatedEmail = automation?.related('welcomeEmailAutomatedEmail');
 
-        if (!automation || !automatedEmail?.id) {
+        if (!automation || (requireWelcomeEmail && !automatedEmail?.id)) {
             throw new errors.NotFoundError({
                 message: MESSAGES.NO_MEMBER_WELCOME_EMAIL
             });
@@ -567,7 +531,9 @@ class MemberWelcomeEmailService {
             uuid: '00000000-0000-4000-8000-000000000000'
         };
 
-        const designSettings = automatedEmail.related('emailDesignSetting');
+        const designSettings = requireWelcomeEmail ?
+            automatedEmail.related('emailDesignSetting') :
+            await this.#getDefaultEmailDesignSettings();
         const designSettingsJson = designSettings?.id ? designSettings.toJSON() : null;
 
         const preview = await this.#renderer.render({
@@ -585,8 +551,23 @@ class MemberWelcomeEmailService {
     }
 
     async previewEmail({subject, lexical, automatedEmailId}) {
-        const {html, text, subject: renderedSubject} = await this.#renderWelcomeEmailPreview({
-            automatedEmailId,
+        const {html, text, subject: renderedSubject} = await this.#renderAutomationEmailPreview({
+            automationId: automatedEmailId,
+            requireWelcomeEmail: true,
+            subject,
+            lexical
+        });
+
+        return {
+            html,
+            plaintext: text,
+            subject: renderedSubject
+        };
+    }
+
+    async previewAutomationEmail({subject, lexical, automationId}) {
+        const {html, text, subject: renderedSubject} = await this.#renderAutomationEmailPreview({
+            automationId,
             subject,
             lexical
         });
@@ -599,13 +580,33 @@ class MemberWelcomeEmailService {
     }
 
     async sendTestEmail({email, subject, lexical, automatedEmailId}) {
+        await this.#sendTestAutomationEmail({
+            email,
+            subject,
+            lexical,
+            automationId: automatedEmailId,
+            requireWelcomeEmail: true
+        });
+    }
+
+    async sendTestAutomationEmail({email, subject, lexical, automationId}) {
+        await this.#sendTestAutomationEmail({
+            email,
+            subject,
+            lexical,
+            automationId
+        });
+    }
+
+    async #sendTestAutomationEmail({email, subject, lexical, automationId, requireWelcomeEmail = false}) {
         const {
             html,
             text,
             subject: renderedSubject,
             designSettings
-        } = await this.#renderWelcomeEmailPreview({
-            automatedEmailId,
+        } = await this.#renderAutomationEmailPreview({
+            automationId,
+            requireWelcomeEmail,
             subject,
             lexical,
             memberEmail: email
@@ -629,21 +630,26 @@ class MemberWelcomeEmailService {
     }
 
     async editSharedSenderOptions(attrs = {}) {
-        const rows = await this.#loadRequiredWelcomeEmailRows();
-        const {attrsToPersist, emailsToVerify} = this.#prepareSharedSenderUpdate(rows, attrs);
+        const {attrsToPersist, emailsToVerify, designSettings} = await this.#prepareSharedSenderUpdate(attrs);
 
-        await this.#applySharedSenderAttrs(rows, attrsToPersist);
+        if (Object.keys(attrsToPersist).length > 0) {
+            await EmailDesignSetting.edit(attrsToPersist, {id: designSettings.id});
+        }
+
         await this.#sendSharedSenderVerifications(emailsToVerify);
 
         const response = await this.#loadWelcomeEmailsCollection();
         if (emailsToVerify.length > 0) {
-            response.meta = response.meta || {};
-            response.meta.sent_email_verification = emailsToVerify.map(({property}) => property);
+            return {
+                data: response.models,
+                meta: {
+                    sent_email_verification: emailsToVerify.map(({property}) => property)
+                }
+            };
         }
 
         return {
-            data: response.models,
-            meta: response.meta
+            data: response.models
         };
     }
 
@@ -657,20 +663,20 @@ class MemberWelcomeEmailService {
             });
         }
 
-        const rows = await this.#loadRequiredWelcomeEmailRows();
         const normalizedValue = this.#normalizeSharedSenderValue(value);
         const attrs = {
             [property]: normalizedValue
         };
 
-        await this.#applySharedSenderAttrs(rows, attrs);
+        const designSettings = await this.#getDefaultEmailDesignSettings();
+        await EmailDesignSetting.edit(attrs, {id: designSettings.id});
 
         const response = await this.#loadWelcomeEmailsCollection();
-        response.meta = response.meta || {};
-        response.meta.email_verified = property;
         return {
             data: response.models,
-            meta: response.meta
+            meta: {
+                email_verified: property
+            }
         };
     }
 }

--- a/ghost/core/core/server/services/member-welcome-emails/service.js
+++ b/ghost/core/core/server/services/member-welcome-emails/service.js
@@ -643,13 +643,15 @@ class MemberWelcomeEmailService {
             return {
                 data: response.models,
                 meta: {
+                    ...response.meta,
                     sent_email_verification: emailsToVerify.map(({property}) => property)
                 }
             };
         }
 
         return {
-            data: response.models
+            data: response.models,
+            meta: response.meta
         };
     }
 
@@ -675,6 +677,7 @@ class MemberWelcomeEmailService {
         return {
             data: response.models,
             meta: {
+                ...response.meta,
                 email_verified: property
             }
         };

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -200,6 +200,8 @@ module.exports = function apiRoutes() {
     // ## Automations
     router.get('/automations', mw.authAdminApi, http(api.automations.browse));
     router.get('/automations/:id', mw.authAdminApi, http(api.automations.read));
+    router.post('/automations/:id/email_preview', mw.authAdminApi, http(api.automationEmailPreviews.preview));
+    router.post('/automations/:id/email_test', shared.middleware.brute.previewEmailLimiter, mw.authAdminApi, http(api.automationEmailPreviews.sendTestEmail));
     router.put('/automations/poll', mw.authAdminApiWithUrl, http(api.automations.poll));
     router.put('/automations/:id', mw.authAdminApi, http(api.automations.edit));
 

--- a/ghost/core/test/e2e-api/admin/__snapshots__/automations.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/automations.test.js.snap
@@ -46,6 +46,19 @@ Object {
 }
 `;
 
+exports[`Automations API email preview renders draft content without welcome email content rows 1: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "22649",
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Automations API poll does not poll when request lacks a token 1: [body] 1`] = `
 Object {
   "errors": Array [

--- a/ghost/core/test/e2e-api/admin/automated-emails.test.js
+++ b/ghost/core/test/e2e-api/admin/automated-emails.test.js
@@ -666,6 +666,66 @@ describe('Automated Emails API', function () {
             });
         });
 
+        it('Can edit shared sender settings without welcome email content rows', async function () {
+            await models.Base.knex('welcome_email_automated_emails').del();
+
+            await agent
+                .put('automated_emails/senders/')
+                .body({
+                    sender_name: 'Custom Sender',
+                    sender_email: 'sender@example.com',
+                    sender_reply_to: 'reply@example.com'
+                })
+                .expectStatus(200)
+                .expect(({body}) => {
+                    assert.equal(body.automated_emails.length, 2);
+                    for (const automatedEmail of body.automated_emails) {
+                        assert.equal(automatedEmail.sender_name, 'Custom Sender');
+                        assert.equal(automatedEmail.sender_email, 'sender@example.com');
+                        assert.equal(automatedEmail.sender_reply_to, 'reply@example.com');
+                    }
+                });
+
+            const welcomeEmailRows = await models.Base.knex('welcome_email_automated_emails')
+                .select('welcome_email_automation_id');
+            assert.equal(welcomeEmailRows.length, 0);
+
+            const designSettings = await models.Base.knex('email_design_settings')
+                .where('slug', 'default-automated-email')
+                .first('sender_name', 'sender_email', 'sender_reply_to');
+            assert.deepEqual(designSettings, {
+                sender_name: 'Custom Sender',
+                sender_email: 'sender@example.com',
+                sender_reply_to: 'reply@example.com'
+            });
+        });
+
+        it('Can edit shared sender settings without welcome email automation rows', async function () {
+            await models.Base.knex('welcome_email_automated_emails').del();
+            await models.Base.knex('automations').del();
+
+            await agent
+                .put('automated_emails/senders/')
+                .body({
+                    sender_name: 'Custom Sender',
+                    sender_email: 'sender@example.com',
+                    sender_reply_to: 'reply@example.com'
+                })
+                .expectStatus(200)
+                .expect(({body}) => {
+                    assert.equal(body.automated_emails.length, 0);
+                });
+
+            const designSettings = await models.Base.knex('email_design_settings')
+                .where('slug', 'default-automated-email')
+                .first('sender_name', 'sender_email', 'sender_reply_to');
+            assert.deepEqual(designSettings, {
+                sender_name: 'Custom Sender',
+                sender_email: 'sender@example.com',
+                sender_reply_to: 'reply@example.com'
+            });
+        });
+
         it('Returns sender details from email design settings after editing shared sender settings', async function () {
             await models.Base.knex('email_design_settings')
                 .where('slug', 'default-automated-email')
@@ -789,6 +849,29 @@ describe('Automated Emails API', function () {
                     'content-version': anyContentVersion,
                     etag: anyEtag
                 });
+        });
+
+        it('Cannot render legacy preview without a welcome email content row', async function () {
+            await models.Base.knex('welcome_email_automated_emails')
+                .where('welcome_email_automation_id', automatedEmailId)
+                .del();
+
+            await agent
+                .post(`automated_emails/${automatedEmailId}/preview/`)
+                .body({
+                    subject: 'Test Subject',
+                    lexical: validLexical
+                })
+                .expectStatus(404)
+                .expect(({body}) => {
+                    assert.equal(body.errors.length, 1);
+                    assert.equal(typeof body.errors[0].id, 'string');
+                });
+
+            const welcomeEmailRow = await models.Base.knex('welcome_email_automated_emails')
+                .where('welcome_email_automation_id', automatedEmailId)
+                .first('id');
+            assert.equal(welcomeEmailRow, undefined);
         });
 
         it('Can preview inactive automated email', async function () {

--- a/ghost/core/test/e2e-api/admin/automated-emails.test.js
+++ b/ghost/core/test/e2e-api/admin/automated-emails.test.js
@@ -700,7 +700,7 @@ describe('Automated Emails API', function () {
             });
         });
 
-        it('Can edit shared sender settings without welcome email automation rows', async function () {
+        it('Can edit shared sender settings without automation rows', async function () {
             await models.Base.knex('welcome_email_automated_emails').del();
             await models.Base.knex('automations').del();
 
@@ -856,6 +856,11 @@ describe('Automated Emails API', function () {
                 .where('welcome_email_automation_id', automatedEmailId)
                 .del();
 
+            const welcomeEmailRow = await models.Base.knex('welcome_email_automated_emails')
+                .where('welcome_email_automation_id', automatedEmailId)
+                .first('id');
+            assert.equal(welcomeEmailRow, undefined);
+
             await agent
                 .post(`automated_emails/${automatedEmailId}/preview/`)
                 .body({
@@ -867,11 +872,6 @@ describe('Automated Emails API', function () {
                     assert.equal(body.errors.length, 1);
                     assert.equal(typeof body.errors[0].id, 'string');
                 });
-
-            const welcomeEmailRow = await models.Base.knex('welcome_email_automated_emails')
-                .where('welcome_email_automation_id', automatedEmailId)
-                .first('id');
-            assert.equal(welcomeEmailRow, undefined);
         });
 
         it('Can preview inactive automated email', async function () {

--- a/ghost/core/test/e2e-api/admin/automations.test.js
+++ b/ghost/core/test/e2e-api/admin/automations.test.js
@@ -3,6 +3,7 @@ const sinon = require('sinon');
 const domainEvents = require('@tryghost/domain-events');
 const ObjectId = require('bson-objectid').default;
 const models = require('../../../core/server/models');
+const mailService = require('../../../core/server/services/mail');
 const {getSignedAdminToken} = require('../../../core/server/adapters/scheduling/utils');
 const {MEMBER_WELCOME_EMAIL_SLUGS} = require('../../../core/server/services/member-welcome-emails/constants');
 const {agentProvider, fixtureManager, matchers, assertions} = require('../../utils/e2e-framework');
@@ -255,6 +256,118 @@ describe('Automations API', function () {
                 .matchHeaderSnapshot({
                     'content-version': anyContentVersion,
                     etag: anyEtag
+                });
+        });
+    });
+
+    describe('email preview', function () {
+        it('renders draft content without welcome email content rows', async function () {
+            const {body: browseBody} = await agent
+                .get('automations')
+                .expectStatus(200);
+
+            const automationId = browseBody.automations[0].id;
+
+            await models.Base.knex('welcome_email_automated_emails').del();
+
+            await agent
+                .post(`automations/${automationId}/email_preview/`)
+                .body({
+                    subject: 'Automation Subject',
+                    lexical: NON_EMPTY_EMAIL_LEXICAL
+                })
+                .expectStatus(200)
+                .expect(cacheInvalidateHeaderNotSet())
+                .expect(({body}) => {
+                    assert.equal(body.automation_email_previews.length, 1);
+                    assert.equal(body.automation_email_previews[0].subject, 'Automation Subject');
+                    assert.match(body.automation_email_previews[0].html, /Lorem ipsum/);
+                    assert.match(body.automation_email_previews[0].plaintext, /Lorem ipsum/);
+                })
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag
+                });
+
+            const welcomeEmailRow = await models.Base.knex('welcome_email_automated_emails')
+                .where('welcome_email_automation_id', automationId)
+                .first('id');
+            assert.equal(welcomeEmailRow, undefined);
+        });
+
+        it('cannot render preview for a missing automation', async function () {
+            await agent
+                .post('automations/abcd1234abcd1234abcd1234/email_preview/')
+                .body({
+                    subject: 'Automation Subject',
+                    lexical: NON_EMPTY_EMAIL_LEXICAL
+                })
+                .expectStatus(404)
+                .expect(({body}) => {
+                    assert.equal(body.errors.length, 1);
+                    assert.equal(typeof body.errors[0].id, 'string');
+                });
+        });
+
+        it('cannot render preview without content', async function () {
+            const {body: browseBody} = await agent
+                .get('automations')
+                .expectStatus(200);
+
+            await agent
+                .post(`automations/${browseBody.automations[0].id}/email_preview/`)
+                .body({
+                    subject: 'Automation Subject'
+                })
+                .expectStatus(422)
+                .expect(({body}) => {
+                    assert.equal(body.errors.length, 1);
+                    assert.equal(body.errors[0].property, 'lexical');
+                });
+        });
+    });
+
+    describe('email test', function () {
+        it('sends a test email without welcome email content rows', async function () {
+            sinon.stub(mailService.GhostMailer.prototype, 'send').resolves('Mail sent');
+
+            const {body: browseBody} = await agent
+                .get('automations')
+                .expectStatus(200);
+
+            const automationId = browseBody.automations[0].id;
+
+            await models.Base.knex('welcome_email_automated_emails').del();
+
+            await agent
+                .post(`automations/${automationId}/email_test/`)
+                .body({
+                    email: 'test@ghost.org',
+                    subject: 'Automation Subject',
+                    lexical: NON_EMPTY_EMAIL_LEXICAL
+                })
+                .expectStatus(204)
+                .expectEmptyBody()
+                .expect(cacheInvalidateHeaderNotSet());
+
+            sinon.assert.calledOnce(mailService.GhostMailer.prototype.send);
+        });
+
+        it('cannot send a test email to an invalid email address', async function () {
+            const {body: browseBody} = await agent
+                .get('automations')
+                .expectStatus(200);
+
+            await agent
+                .post(`automations/${browseBody.automations[0].id}/email_test/`)
+                .body({
+                    email: 'not-an-email',
+                    subject: 'Automation Subject',
+                    lexical: NON_EMPTY_EMAIL_LEXICAL
+                })
+                .expectStatus(422)
+                .expect(({body}) => {
+                    assert.equal(body.errors.length, 1);
                 });
         });
     });


### PR DESCRIPTION
closes [NY-1368](https://linear.app/ghost/issue/NY-1368)

This fixes automations email preview/test flows on fresh sites where legacy welcome email rows do not exist.

Previously, the Automations email modal reused legacy automated_emails/:id/preview and test endpoints. Those endpoints require a welcome email row, so fresh sites with automations enabled could edit email content but failed to render previews or send tests with No member welcome email found.

This change adds automations-specific preview/test endpoints that render from the automation action payload and shared default-automated-email design settings, without depending on legacy welcome email rows. Legacy welcome email preview/test behavior remains strict and unchanged.

It also keeps shared sender/design settings independent of legacy row creation. Sender edits now write to the shared default email design settings row, and legacy response shaping reads from that row when welcome email content rows are absent, preserving the existing API response contract without creating legacy data.