### PR TITLE
Tweaked automation save error title

### DIFF
--- a/apps/posts/src/views/Automations/editor.tsx
+++ b/apps/posts/src/views/Automations/editor.tsx
@@ -99,7 +99,7 @@ const AutomationEditor: React.FC = () => {
         if (Object.keys(nextActionErrors).length > 0) {
             setActionErrors(nextActionErrors);
             setEditState(errorState);
-            toast.error('Automation couldn’t be saved', {
+            toast.error('Automation needs a few details', {
                 description: 'Fix the highlighted steps and try again.'
             });
             return false;
@@ -171,7 +171,7 @@ const AutomationEditor: React.FC = () => {
 
                     setEditState(errorState);
                     if (hasActionErrors) {
-                        toast.error('Automation couldn’t be saved', {
+                        toast.error('Automation needs a few details', {
                             description: 'Fix the highlighted steps and try again.'
                         });
                     } else {

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -947,7 +947,7 @@ describe('AutomationEditor', () => {
 
         expect(screen.queryByRole('alertdialog', {name: 'Publish automation with empty emails?'})).not.toBeInTheDocument();
         expect(mockEditMutation.mutate).not.toHaveBeenCalled();
-        expect(mockToastError).toHaveBeenCalledWith('Automation couldn’t be saved', {
+        expect(mockToastError).toHaveBeenCalledWith('Automation needs a few details', {
             description: 'Fix the highlighted steps and try again.'
         });
 
@@ -1082,7 +1082,7 @@ describe('AutomationEditor', () => {
         expect(button).not.toBeDisabled();
         expect(button).toHaveClass('bg-destructive');
         expect(mockToastError).toHaveBeenCalledWith('Automation couldn’t be saved');
-        expect(mockToastError).not.toHaveBeenCalledWith('Automation couldn’t be saved', {
+        expect(mockToastError).not.toHaveBeenCalledWith('Automation needs a few details', {
             description: 'Fix the highlighted steps and try again.'
         });
         expect(screen.queryByText(/Couldn.t publish automation/)).not.toBeInTheDocument();
@@ -1338,7 +1338,7 @@ describe('AutomationEditor', () => {
         fireEvent.click(screen.getByRole('button', {name: 'Publish'}));
 
         expect(mockEditMutation.mutate).not.toHaveBeenCalled();
-        expect(mockToastError).toHaveBeenCalledWith('Automation couldn’t be saved', {
+        expect(mockToastError).toHaveBeenCalledWith('Automation needs a few details', {
             description: 'Fix the highlighted steps and try again.'
         });
 
@@ -1846,7 +1846,7 @@ describe('AutomationEditor', () => {
 
         expect(screen.queryByRole('alertdialog', {name: 'Update automation?'})).not.toBeInTheDocument();
         expect(mockEditMutation.mutate).not.toHaveBeenCalled();
-        expect(mockToastError).toHaveBeenCalledWith('Automation couldn’t be saved', {
+        expect(mockToastError).toHaveBeenCalledWith('Automation needs a few details', {
             description: 'Fix the highlighted steps and try again.'
         });
         expect(screen.getByRole('button', {name: 'Publish changes'})).toBeEnabled();


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1363

If an automation can't be saved because it's invalid (for example, an email is missing a body) we show an error. This tweaks the title of that error.

Notably, we didn't change the error that shows when the automation fails to send for another reason, such as a network error.
