### PR TITLE
Tweaked "edit email content" button copy in automations UI

### DIFF
--- a/apps/posts/src/views/Automations/components/canvas/step-sidebar.tsx
+++ b/apps/posts/src/views/Automations/components/canvas/step-sidebar.tsx
@@ -201,7 +201,7 @@ const SendEmailSidebarBody: React.FC<{
                 onClick={onEditEmail}
             >
                 <LucideIcon.Pencil className='size-4' />
-              Edit email content
+              Edit email
             </Button>
             <div className='mt-auto pt-6'>
                 <DeleteStepButton onClick={onDelete} />
@@ -313,7 +313,7 @@ const getStepSidebarDetail = ({automation, stepId, onDelete, onUpdateWait, onUpd
     }
 };
 
-type StepSidebarProps = { 
+type StepSidebarProps = {
     automation: AutomationDetail
     stepId: string | null
     onDelete: (actionId: string) => void;
@@ -333,7 +333,7 @@ export const StepSidebar: React.FC<StepSidebarProps> = ({automation, stepId, onD
         onUpdateSubject,
         onEditEmail
     });
-    
+
     useEffect(() => {
         if (!detail) {
             return;

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -625,7 +625,7 @@ describe('AutomationEditor', () => {
         expect(within(sidebar).getByDisplayValue('Welcome to The Blueprint')).toHaveFocus();
         expect(within(sidebar).queryByText('Sender')).not.toBeInTheDocument();
         expect(within(sidebar).queryByText('Reply-to')).not.toBeInTheDocument();
-        expect(within(sidebar).getByRole('button', {name: 'Edit email content'})).toBeEnabled();
+        expect(within(sidebar).getByRole('button', {name: 'Edit email'})).toBeEnabled();
         expect(within(sidebar).getByRole('button', {name: 'Delete step'})).toBeEnabled();
     });
 
@@ -679,7 +679,7 @@ describe('AutomationEditor', () => {
 
         fireEvent.click(screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'}));
         const sidebar = screen.getByRole('complementary', {name: 'Step details'});
-        fireEvent.click(within(sidebar).getByRole('button', {name: 'Edit email content'}));
+        fireEvent.click(within(sidebar).getByRole('button', {name: 'Edit email'}));
 
         // The modal opens, seeded from the step's current content.
         expect(screen.getByTestId('email-content-modal')).toBeInTheDocument();
@@ -727,7 +727,7 @@ describe('AutomationEditor', () => {
         const sidebar = screen.getByRole('complementary', {name: 'Step details'});
         expect(within(sidebar).getByDisplayValue('Welcome to The Blueprint')).toBeInTheDocument();
 
-        fireEvent.click(within(sidebar).getByRole('button', {name: 'Edit email content'}));
+        fireEvent.click(within(sidebar).getByRole('button', {name: 'Edit email'}));
         fireEvent.click(screen.getByTestId('modal-save'));
 
         expect(within(sidebar).getByDisplayValue('Edited via modal')).toBeInTheDocument();
@@ -1363,7 +1363,7 @@ describe('AutomationEditor', () => {
         expect(emailStep).toHaveClass('border-destructive');
 
         // Adding body content via the modal clears the error and lets the publish through.
-        fireEvent.click(within(sidebar).getByRole('button', {name: 'Edit email content'}));
+        fireEvent.click(within(sidebar).getByRole('button', {name: 'Edit email'}));
         fireEvent.click(await screen.findByTestId('modal-save'));
 
         emailStep = screen.getByRole('button', {name: 'Send email: Edited via modal'});


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1362

"Edit email content" became "Edit email".
