### PR TITLE
🐛 Improved upload error messages in the editor

### DIFF
--- a/apps/admin-x-framework/src/hooks/use-koenig-file-upload.ts
+++ b/apps/admin-x-framework/src/hooks/use-koenig-file-upload.ts
@@ -180,10 +180,16 @@ export const useKoenigFileUpload = (type: KoenigFileUploadType = 'image'): FileU
         } catch (error) {
             console.error(error); // eslint-disable-line
 
-            // TODO: check for or expose known error types?
+            // The API wraps some errors (e.g. HostLimitError) with a generic
+            // message and puts the specific, user-actionable text in `context`.
+            // Prefer `context` so the user sees the useful message, falling back
+            // to `message` for errors that don't set a context.
+            const context = getStringAtPath(error, ['data', 'errors', 0, 'context']) || '';
+            const message = getStringAtPath(error, ['data', 'errors', 0, 'message']) || getStringAtPath(error, ['message']) || '';
+
             const errorResult = {
-                message: getStringAtPath(error, ['data', 'errors', 0, 'message']) || getStringAtPath(error, ['message']) || '',
-                context: getStringAtPath(error, ['data', 'errors', 0, 'context']) || '',
+                message: context || message,
+                context,
                 fileName: file.name
             };
 
@@ -194,6 +200,9 @@ export const useKoenigFileUpload = (type: KoenigFileUploadType = 'image'): FileU
     const upload = async (files: FileList | ReadonlyArray<File> = [], options: UploadOptions = {}) => {
         setFilesNumber(files.length);
         setLoading(true);
+        // Each upload attempt starts fresh so retries don't accumulate
+        // duplicate error messages from previous failed attempts.
+        setErrors([]);
 
         const validationResult = validate(files);
 
@@ -225,7 +234,7 @@ export const useKoenigFileUpload = (type: KoenigFileUploadType = 'image'): FileU
         } catch (error) {
             console.error(error); // eslint-disable-line no-console
 
-            setErrors(prev => [...prev, error as UploadError]);
+            setErrors([error as UploadError]);
             setLoading(false);
             setProgress(100);
             progressTracker.current.clear();

--- a/apps/admin-x-framework/test/unit/hooks/use-koenig-file-upload.test.ts
+++ b/apps/admin-x-framework/test/unit/hooks/use-koenig-file-upload.test.ts
@@ -29,6 +29,19 @@ const serverErrorUploadResponse: UploadResponse = {
     status: 413
 };
 
+// HostLimitError responses use a generic `message` and put the specific,
+// user-actionable text in `context` (see @tryghost/mw-error-handler).
+const hostLimitUploadResponse: UploadResponse = {
+    body: {
+        errors: [{
+            type: 'HostLimitError',
+            message: 'Host Limit error, cannot upload image.',
+            context: 'Your plan supports uploads up to 5.24288MB. Please upgrade to upload larger files.'
+        }]
+    },
+    status: 403
+};
+
 interface RequestLog {
     method?: string;
     url?: string;
@@ -229,6 +242,47 @@ describe('useKoenigFileUpload', () => {
         expect(result.current.errors[0].message).toBe(
             'Request is larger than the maximum file size the server allows'
         );
+    });
+
+    it('prefers the actionable context message over the generic message', async () => {
+        uploadResponse = hostLimitUploadResponse;
+
+        const {result} = renderHook(() => useKoenigFileUpload('image'));
+
+        const file = makeFile('photo.jpg');
+        await act(async () => {
+            await result.current.upload([file]);
+        });
+
+        expect(result.current.errors).toHaveLength(1);
+        expect(result.current.errors[0].fileName).toBe('photo.jpg');
+        // The user should see the specific limit text from `context`, not the
+        // generic "Host Limit error, cannot upload image." wrapper message.
+        expect(result.current.errors[0].message).toBe(
+            'Your plan supports uploads up to 5.24288MB. Please upgrade to upload larger files.'
+        );
+        expect(result.current.errors[0].context).toBe(
+            'Your plan supports uploads up to 5.24288MB. Please upgrade to upload larger files.'
+        );
+    });
+
+    it('does not accumulate errors across repeated failed uploads', async () => {
+        uploadResponse = hostLimitUploadResponse;
+
+        const {result} = renderHook(() => useKoenigFileUpload('image'));
+
+        const file = makeFile('photo.jpg');
+
+        await act(async () => {
+            await result.current.upload([file]);
+        });
+        expect(result.current.errors).toHaveLength(1);
+
+        // Retrying the same failing upload should replace, not append.
+        await act(async () => {
+            await result.current.upload([file]);
+        });
+        expect(result.current.errors).toHaveLength(1);
     });
 
     it('rejects files with no extension for image type', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,8 +97,8 @@ catalogs:
       specifier: 1.2.2
       version: 1.2.2
     '@tryghost/koenig-lexical':
-      specifier: 1.8.2
-      version: 1.8.2
+      specifier: 1.8.3
+      version: 1.8.3
     '@tryghost/limit-service':
       specifier: 1.5.6
       version: 1.5.6
@@ -532,7 +532,7 @@ importers:
         version: 0.4.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tryghost/koenig-lexical':
         specifier: 'catalog:'
-        version: 1.8.2
+        version: 1.8.3
       '@tryghost/posts':
         specifier: workspace:*
         version: link:../posts
@@ -872,7 +872,7 @@ importers:
         version: 14.3.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tryghost/koenig-lexical':
         specifier: 'catalog:'
-        version: 1.8.2
+        version: 1.8.3
       '@types/react':
         specifier: 'catalog:'
         version: 18.3.31
@@ -1329,7 +1329,7 @@ importers:
         version: 0.2.19
       '@tryghost/koenig-lexical':
         specifier: 'catalog:'
-        version: 1.8.2
+        version: 1.8.3
       '@tryghost/nql-lang':
         specifier: 'catalog:'
         version: 0.6.6
@@ -2016,7 +2016,7 @@ importers:
         version: 1.2.2
       '@tryghost/koenig-lexical':
         specifier: 'catalog:'
-        version: 1.8.2
+        version: 1.8.3
       '@tryghost/limit-service':
         specifier: 'catalog:'
         version: 1.5.6
@@ -8867,8 +8867,8 @@ packages:
   '@tryghost/kg-utils@1.1.2':
     resolution: {integrity: sha512-pATOtb4JhSm+Tx8+7FxHdEkBIi8h43ZffPQu1Mr8bdHVLzN4FalB4fHukRYy53JZc3UEtxSVBZHeg7Q2ZPFR1Q==}
 
-  '@tryghost/koenig-lexical@1.8.2':
-    resolution: {integrity: sha512-pnb3jcrksqimtE8wWo2Rd95Fmi6a1D5St9BqkeE/rpETMAg7e3cYVyssK9+fbT0zvlL6W3n396Yp4nuL+tbtbA==}
+  '@tryghost/koenig-lexical@1.8.3':
+    resolution: {integrity: sha512-LbiM6T95ZvXaQwGgEpbch0opcWMLYhG3kk/ZB3sONoR8q4Yfo32CXL7G+eJGqZXbEOH7CBERLSGPzF2qW+oduA==}
 
   '@tryghost/limit-service@1.5.6':
     resolution: {integrity: sha512-wR+Hm2v5k2FjOUhLhfPZ0p0acCfaTQoSEhuw96uw8c15CLZtm/HKsLnxA5d3AXwYmjRo5gkYskP8UYxrCKNcoQ==}
@@ -28987,7 +28987,7 @@ snapshots:
     dependencies:
       semver: 7.8.1
 
-  '@tryghost/koenig-lexical@1.8.2': {}
+  '@tryghost/koenig-lexical@1.8.3': {}
 
   '@tryghost/limit-service@1.5.6':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -55,7 +55,7 @@ catalog:
   '@tryghost/helpers': 1.1.106
   '@tryghost/kg-clean-basic-html': 4.3.2
   '@tryghost/kg-converters': 1.2.2
-  '@tryghost/koenig-lexical': 1.8.2
+  '@tryghost/koenig-lexical': 1.8.3
   '@tryghost/limit-service': 1.5.6
   '@tryghost/logging': 4.2.1
   '@tryghost/nql': 0.13.1


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1847/cant-upload-files

## Context

This contributes to ONC-1847 (file uploads in the editor failing with no useful feedback). It does **not** close the issue on its own — see "Scope" below.

## Problem

When an upload in the editor failed (e.g. a file exceeding the plan's upload-size limit), the error surfaced to the user was unhelpful:

- The card showed a generic **"Host Limit error, cannot upload image."** instead of the actionable message (e.g. "Your plan supports uploads up to X. Please upgrade to upload larger files.").
- Repeated failed uploads **stacked duplicate** error messages.

## Fix

`apps/admin-x-framework/src/hooks/use-koenig-file-upload.ts`:

1. **Wrong message shown.** The API (`@tryghost/mw-error-handler`) wraps some errors with a generic `message` and puts the specific, user-facing text in `context`. The hook surfaced `message`. It now prefers `context`, falling back to `message` — matching the existing `getErrorMessage` convention used elsewhere in the admin.

2. **Duplicate errors.** The hook appended each failure to the existing `errors` array, so retrying a failing upload accumulated duplicates. It now clears errors at the start of each attempt and **replaces** rather than appends on failure.

## Tests

Added unit tests covering both behaviours (prefer `context`; no accumulation across retries). All 15 hook tests pass.

## Scope

The actual ONC-1847 symptom — the **file card showing no error at all** when an upload fails — is caused by the file card's error rendering in `@tryghost/koenig-lexical` and is fixed there in **TryGhost/Koenig#1994**.

This PR is a prerequisite: it fixes the error *text* (visible today on the image card) and the duplicate-message behaviour. Once Koenig#1994 is published and bumped in Ghost, the file card will show the correct, non-duplicated message and ONC-1847 is fully resolved.

## Before

https://github.com/user-attachments/assets/90e8471e-e6c6-47c7-8314-fc94769004dc

## After

https://github.com/user-attachments/assets/7aa55164-14ee-4c85-abe1-38d9593e388c

