### PR TITLE
Used exhaustiveness check when building automation action revision

### DIFF
--- a/ghost/core/core/server/services/automations/database-automations-repository.ts
+++ b/ghost/core/core/server/services/automations/database-automations-repository.ts
@@ -904,7 +904,8 @@ function getNextRevisionCreatedAt(latestCreatedAt: string | null, requestedCreat
 }
 
 function buildActionRevision(actionId: string, action: AutomationAction, createdAt: string) {
-    if (action.type === 'wait') {
+    switch (action.type) {
+    case 'wait':
         return {
             id: ObjectId().toString(),
             created_at: createdAt,
@@ -914,17 +915,23 @@ function buildActionRevision(actionId: string, action: AutomationAction, created
             email_lexical: null,
             email_design_setting_id: null
         };
+    case 'send_email':
+        return {
+            id: ObjectId().toString(),
+            created_at: createdAt,
+            action_id: actionId,
+            wait_hours: null,
+            email_subject: action.data.email_subject,
+            email_lexical: action.data.email_lexical,
+            email_design_setting_id: action.data.email_design_setting_id
+        };
+    default: {
+        const _exhaustive: never = action;
+        throw new errors.InternalServerError({
+            message: `Unexpected action type ${_exhaustive}`
+        });
     }
-
-    return {
-        id: ObjectId().toString(),
-        created_at: createdAt,
-        action_id: actionId,
-        wait_hours: null,
-        email_subject: action.data.email_subject,
-        email_lexical: action.data.email_lexical,
-        email_design_setting_id: action.data.email_design_setting_id
-    };
+    }
 }
 
 async function deleteAutomationEdges(trx: Knex.Transaction, automationId: string): Promise<void> {


### PR DESCRIPTION
no ref

*I recommend [reviewing this with whitespace changes disabled](https://github.com/TryGhost/Ghost/pull/28729/changes?w=1).*

This types-only change should have no user impact. It will make it harder to forget a spot when we add new automation action types.
