### PR TITLE
Fixed browser back handling in automation email editor

### DIFF
--- a/apps/posts/src/views/Automations/components/canvas/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/canvas/automation-canvas.tsx
@@ -289,6 +289,13 @@ const insertActionByType = {
     send_email: insertSendEmailAction
 };
 
+const hasAutomationEmailModalState = (state: unknown): state is {automationEmailModal: boolean} => (
+    !!state
+    && typeof state === 'object'
+    && 'automationEmailModal' in state
+    && typeof state.automationEmailModal === 'boolean'
+);
+
 const AutomationCanvas: React.FC<AutomationCanvasProps> = ({
     actionErrors = {},
     automation,
@@ -309,7 +316,7 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({
     const [deleteConfirmationActionId, setDeleteConfirmationActionId] = useState<string | null>(null);
     const selectedStepId = selectedStep?.id ?? null;
     const emailModalStepId = searchParams.get(EMAIL_STEP_QUERY_PARAM);
-    const isRouterOpenedEmailModal = Boolean((location.state as {automationEmailModal?: boolean} | null)?.automationEmailModal);
+    const isRouterOpenedEmailModal = hasAutomationEmailModalState(location.state) && location.state.automationEmailModal;
 
     const removeEmailStepParam = useCallback((options?: {replace?: boolean}) => {
         const nextSearchParams = new URLSearchParams(searchParams);

--- a/apps/posts/src/views/Automations/components/canvas/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/canvas/automation-canvas.tsx
@@ -23,7 +23,7 @@ const INITIAL_VIEWPORT_Y = 40;
 const NODE_ENTER_ANIMATION_DURATION = 250;
 const DISABLED_REASON = 'Maximum steps added';
 const DEFAULT_EDGE_STROKE = 'var(--xy-edge-stroke)';
-const EMAIL_STEP_QUERY_PARAM = 'emailStep';
+export const EMAIL_STEP_QUERY_PARAM = 'emailStep';
 
 const edgeTypes = {
     'add-step-edge': AddStepEdge

--- a/apps/posts/src/views/Automations/components/canvas/automation-canvas.tsx
+++ b/apps/posts/src/views/Automations/components/canvas/automation-canvas.tsx
@@ -12,6 +12,7 @@ import {type StepPickerType} from './step-picker';
 import {StepSidebar} from './step-sidebar';
 import {formatWait} from './format-wait';
 import {isEmptyEmailLexical} from '../../utils';
+import {useLocation, useNavigate, useSearchParams} from '@tryghost/admin-x-framework';
 import type {EmailModalMode} from '../types';
 
 const NODE_X = 0;
@@ -22,6 +23,7 @@ const INITIAL_VIEWPORT_Y = 40;
 const NODE_ENTER_ANIMATION_DURATION = 250;
 const DISABLED_REASON = 'Maximum steps added';
 const DEFAULT_EDGE_STROKE = 'var(--xy-edge-stroke)';
+const EMAIL_STEP_QUERY_PARAM = 'emailStep';
 
 const edgeTypes = {
     'add-step-edge': AddStepEdge
@@ -269,9 +271,13 @@ const getInitialViewport = (canvasWidth: number): { x: number; y: number; zoom: 
 type AutomationCanvasProps = {
     actionErrors?: Record<string, string>;
     automation?: AutomationDetail;
+    isEmailNavigationBlocked?: boolean;
     isLoading: boolean;
     isError: boolean;
     onChange: (next: AutomationDetail) => void;
+    onDiscardBlockedEmailNavigation?: (closeEmailModal: () => void) => void;
+    onEmailDirtyChange?: (isDirty: boolean) => void;
+    onKeepEditingAfterBlockedEmailNavigation?: () => void;
 };
 
 type SelectedStep = {
@@ -283,13 +289,33 @@ const insertActionByType = {
     send_email: insertSendEmailAction
 };
 
-const AutomationCanvas: React.FC<AutomationCanvasProps> = ({actionErrors = {}, automation, isLoading, isError, onChange}) => {
+const AutomationCanvas: React.FC<AutomationCanvasProps> = ({
+    actionErrors = {},
+    automation,
+    isEmailNavigationBlocked = false,
+    isLoading,
+    isError,
+    onChange,
+    onDiscardBlockedEmailNavigation,
+    onEmailDirtyChange,
+    onKeepEditingAfterBlockedEmailNavigation
+}) => {
+    const location = useLocation();
+    const navigate = useNavigate();
+    const [searchParams, setSearchParams] = useSearchParams();
     const [newStepId, setNewStepId] = useState<string | null>(null);
     const [emailModalMode, setEmailModalMode] = useState<EmailModalMode>('edit');
-    const [emailModalStepId, setEmailModalStepId] = useState<string | null>(null);
     const [selectedStep, setSelectedStep] = useState<SelectedStep | null>(null);
     const [deleteConfirmationActionId, setDeleteConfirmationActionId] = useState<string | null>(null);
     const selectedStepId = selectedStep?.id ?? null;
+    const emailModalStepId = searchParams.get(EMAIL_STEP_QUERY_PARAM);
+    const isRouterOpenedEmailModal = Boolean((location.state as {automationEmailModal?: boolean} | null)?.automationEmailModal);
+
+    const removeEmailStepParam = useCallback((options?: {replace?: boolean}) => {
+        const nextSearchParams = new URLSearchParams(searchParams);
+        nextSearchParams.delete(EMAIL_STEP_QUERY_PARAM);
+        setSearchParams(nextSearchParams, {replace: options?.replace ?? true});
+    }, [searchParams, setSearchParams]);
 
     const handlePick = useCallback((type: StepPickerType, anchor: CanvasAnchor) => {
         if (!automation) {
@@ -324,11 +350,13 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({actionErrors = {}, a
             return;
         }
         const next = removeAction({detail: automation, actionId});
-        setEmailModalStepId(currentId => (currentId === actionId ? null : currentId));
+        if (emailModalStepId === actionId) {
+            removeEmailStepParam();
+        }
         setSelectedStep(null);
         setDeleteConfirmationActionId(null);
         onChange(next);
-    }, [automation, onChange]);
+    }, [automation, emailModalStepId, onChange, removeEmailStepParam]);
 
     const handleRequestDelete = useCallback((actionId: string) => {
         if (!automation) {
@@ -364,14 +392,20 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({actionErrors = {}, a
 
     const handleEditEmail = useCallback((actionId: string, mode: EmailModalMode = 'edit') => {
         setEmailModalMode(mode);
-        setEmailModalStepId(actionId);
-    }, []);
+        const nextSearchParams = new URLSearchParams(searchParams);
+        nextSearchParams.set(EMAIL_STEP_QUERY_PARAM, actionId);
+        setSearchParams(nextSearchParams, {
+            state: {
+                ...(location.state && typeof location.state === 'object' ? location.state : {}),
+                automationEmailModal: true
+            }
+        });
+    }, [location.state, searchParams, setSearchParams]);
 
     const handleContextMenuEditEmail = useCallback((actionId: string, mode: EmailModalMode = 'edit') => {
         setSelectedStep(null);
-        setEmailModalMode(mode);
-        setEmailModalStepId(actionId);
-    }, []);
+        handleEditEmail(actionId, mode);
+    }, [handleEditEmail]);
 
     const handleContextMenuPreviewEmail = useCallback((actionId: string) => {
         handleContextMenuEditEmail(actionId, 'preview');
@@ -410,9 +444,30 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({actionErrors = {}, a
     }, []);
 
     const closeEmailModal = () => {
-        setEmailModalStepId(null);
         setEmailModalMode('edit');
+        if (isRouterOpenedEmailModal) {
+            navigate(-1);
+            return;
+        }
+
+        removeEmailStepParam();
     };
+
+    const closeEmailModalWithoutHistoryNavigation = useCallback(() => {
+        setEmailModalMode('edit');
+        removeEmailStepParam();
+    }, [removeEmailStepParam]);
+
+    useEffect(() => {
+        if (!automation || !emailModalStepId) {
+            return;
+        }
+
+        const hasEmailAction = automation.actions.some(action => action.id === emailModalStepId && action.type === 'send_email');
+        if (!hasEmailAction) {
+            removeEmailStepParam();
+        }
+    }, [automation, emailModalStepId, removeEmailStepParam]);
 
     const handleNodeDoubleClick = useCallback((event: React.MouseEvent, node: AutomationFlowNode) => {
         event.stopPropagation();
@@ -495,7 +550,11 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({actionErrors = {}, a
                     initialLexical={emailModalAction.data.email_lexical}
                     initialMode={emailModalMode}
                     initialSubject={emailModalAction.data.email_subject}
+                    isDiscardNavigationBlocked={isEmailNavigationBlocked}
                     onClose={closeEmailModal}
+                    onDirtyChange={onEmailDirtyChange}
+                    onDiscardBlockedNavigation={() => onDiscardBlockedEmailNavigation?.(closeEmailModalWithoutHistoryNavigation)}
+                    onKeepEditingAfterBlockedNavigation={onKeepEditingAfterBlockedEmailNavigation}
                     onSave={({subject, lexical}) => {
                         onChange(updateSendEmailAction({detail: automation, actionId: emailModalAction.id, emailSubject: subject, emailLexical: lexical}));
                     }}

--- a/apps/posts/src/views/Automations/components/email-modal/email-content-modal.tsx
+++ b/apps/posts/src/views/Automations/components/email-modal/email-content-modal.tsx
@@ -84,11 +84,25 @@ export interface EmailContentModalProps {
     initialLexical: string;
     initialMode?: EmailModalMode;
     initialSubject: string;
+    isDiscardNavigationBlocked?: boolean;
     onClose: () => void;
+    onDirtyChange?: (isDirty: boolean) => void;
+    onDiscardBlockedNavigation?: () => void;
+    onKeepEditingAfterBlockedNavigation?: () => void;
     onSave: (data: {subject: string; lexical: string}) => void;
 }
 
-const EmailContentModal: React.FC<EmailContentModalProps> = ({initialMode = 'edit', initialSubject, initialLexical, onClose, onSave}) => {
+const EmailContentModal: React.FC<EmailContentModalProps> = ({
+    initialMode = 'edit',
+    initialSubject,
+    initialLexical,
+    isDiscardNavigationBlocked = false,
+    onClose,
+    onDirtyChange,
+    onDiscardBlockedNavigation,
+    onKeepEditingAfterBlockedNavigation,
+    onSave
+}) => {
     const {mutateAsync: previewWelcomeEmail} = usePreviewWelcomeEmail();
     const {data: automatedEmailsData} = useBrowseAutomatedEmails();
     const [showTestDropdown, setShowTestDropdown] = useState(false);
@@ -99,6 +113,7 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({initialMode = 'edi
     const dropdownRef = useRef<HTMLDivElement>(null);
     const normalizedLexical = useRef<string>(initialLexical || '');
     const hasEditorBeenFocused = useRef(false);
+    const allowDirtyCloseRef = useRef(false);
     const handleError = useHandleError();
     const automatedEmails = automatedEmailsData?.automated_emails || [];
     const {resolvedSenderName, resolvedSenderEmail, resolvedReplyToEmail, hasDistinctReplyTo} = useEmailSenderDetails(automatedEmails);
@@ -147,6 +162,13 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({initialMode = 'edi
     }, [enterPreview, formState, initialMode]);
 
     const isDirty = saveState === 'unsaved';
+
+    useEffect(() => {
+        onDirtyChange?.(isDirty && !allowDirtyCloseRef.current);
+        return () => {
+            onDirtyChange?.(false);
+        };
+    }, [isDirty, onDirtyChange]);
 
     // Single close funnel: Esc, overlay click, and the Close button all route here.
     const attemptClose = useCallback(() => {
@@ -359,7 +381,20 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({initialMode = 'edi
                     </EmailPreviewModalContent>
                 </DialogContent>
             </Dialog>
-            <AlertDialog open={confirmDiscardOpen} onOpenChange={setConfirmDiscardOpen}>
+            <AlertDialog
+                open={confirmDiscardOpen || isDiscardNavigationBlocked}
+                onOpenChange={(open) => {
+                    if (open) {
+                        setConfirmDiscardOpen(true);
+                        return;
+                    }
+
+                    setConfirmDiscardOpen(false);
+                    if (isDiscardNavigationBlocked) {
+                        onKeepEditingAfterBlockedNavigation?.();
+                    }
+                }}
+            >
                 <AlertDialogContent>
                     <AlertDialogHeader>
                         <AlertDialogTitle>Discard changes?</AlertDialogTitle>
@@ -371,6 +406,13 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({initialMode = 'edi
                             variant='destructive'
                             onClick={() => {
                                 setConfirmDiscardOpen(false);
+                                if (isDiscardNavigationBlocked) {
+                                    onDiscardBlockedNavigation?.();
+                                    return;
+                                }
+
+                                allowDirtyCloseRef.current = true;
+                                onDirtyChange?.(false);
                                 onClose();
                             }}
                         >

--- a/apps/posts/src/views/Automations/editor.tsx
+++ b/apps/posts/src/views/Automations/editor.tsx
@@ -1,4 +1,4 @@
-import AutomationCanvas from './components/canvas/automation-canvas';
+import AutomationCanvas, {EMAIL_STEP_QUERY_PARAM} from './components/canvas/automation-canvas';
 import AutomationHeader from './components/automation-header';
 import React from 'react';
 import {AlertDialog, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, Button, type ButtonProps, LoadingIndicator} from '@tryghost/shade/components';
@@ -13,7 +13,6 @@ import type {AutomationEditState} from './types';
 const SUBJECT_REQUIRED_MESSAGE = 'Add a subject line.';
 const BODY_REQUIRED_MESSAGE = 'Add an email body.';
 const SUBJECT_AND_BODY_REQUIRED_MESSAGE = 'Add a subject line and email body.';
-const EMAIL_STEP_QUERY_PARAM = 'emailStep';
 
 const editableSlice = (automation: AutomationDetail) => ({
     status: automation.status,

--- a/apps/posts/src/views/Automations/editor.tsx
+++ b/apps/posts/src/views/Automations/editor.tsx
@@ -13,6 +13,7 @@ import type {AutomationEditState} from './types';
 const SUBJECT_REQUIRED_MESSAGE = 'Add a subject line.';
 const BODY_REQUIRED_MESSAGE = 'Add an email body.';
 const SUBJECT_AND_BODY_REQUIRED_MESSAGE = 'Add a subject line and email body.';
+const EMAIL_STEP_QUERY_PARAM = 'emailStep';
 
 const editableSlice = (automation: AutomationDetail) => ({
     status: automation.status,
@@ -58,6 +59,10 @@ const AutomationEditor: React.FC = () => {
     const editMutation = useEditAutomation();
     const [editState, setEditState] = React.useState<AutomationEditState>({phase: 'idle'});
     const [actionErrors, setActionErrors] = React.useState<Record<string, string>>({});
+    const [isEmailModalDirty, setIsEmailModalDirty] = React.useState(false);
+    const isEmailModalDirtyRef = React.useRef(false);
+    const navigationBlockerReasonRef = React.useRef<'automation' | 'email' | null>(null);
+    const isBlockedEmailNavigationLeavingEditorRef = React.useRef(false);
 
     // Draft is the user-facing, locally mutable copy. The React Query cache stays as server truth;
     // staged edits (adding steps, etc.) live here until the user publishes. Seeded once when the
@@ -361,16 +366,38 @@ const AutomationEditor: React.FC = () => {
         }
     };
 
-    useConfirmUnload(isEditRequestActive || hasUnsavedChanges);
-    const navigationBlocker = useBlocker(({currentLocation, nextLocation}) => (
-        hasUnsavedChanges && currentLocation.pathname !== nextLocation.pathname
-    ));
+    useConfirmUnload(isEditRequestActive || hasUnsavedChanges || isEmailModalDirty);
+    const navigationBlocker = useBlocker(({currentLocation, nextLocation}) => {
+        const currentEmailStep = new URLSearchParams(currentLocation.search).get(EMAIL_STEP_QUERY_PARAM);
+        const nextEmailStep = new URLSearchParams(nextLocation.search).get(EMAIL_STEP_QUERY_PARAM);
+        if (isEmailModalDirtyRef.current && currentEmailStep && currentEmailStep !== nextEmailStep) {
+            navigationBlockerReasonRef.current = 'email';
+            isBlockedEmailNavigationLeavingEditorRef.current = currentLocation.pathname !== nextLocation.pathname;
+            return true;
+        }
+
+        if (hasUnsavedChanges && currentLocation.pathname !== nextLocation.pathname) {
+            navigationBlockerReasonRef.current = 'automation';
+            return true;
+        }
+
+        navigationBlockerReasonRef.current = null;
+        isBlockedEmailNavigationLeavingEditorRef.current = false;
+        return false;
+    });
+    const isEmailNavigationBlocked = navigationBlocker.state === 'blocked' && navigationBlockerReasonRef.current === 'email';
+    const isAutomationNavigationBlocked = navigationBlocker.state === 'blocked' && navigationBlockerReasonRef.current === 'automation';
 
     const onConfirmDiscardOpenChange = (open: boolean): void => {
-        if (!open && navigationBlocker.state === 'blocked') {
+        if (!open && isAutomationNavigationBlocked) {
             navigationBlocker.reset();
         }
     };
+
+    const onEmailDirtyChange = React.useCallback((dirty: boolean) => {
+        isEmailModalDirtyRef.current = dirty;
+        setIsEmailModalDirty(dirty);
+    }, []);
 
     return (
         <div className='fixed inset-0 z-50 flex flex-col bg-background' data-testid='automation-editor'>
@@ -392,13 +419,31 @@ const AutomationEditor: React.FC = () => {
             <AutomationCanvas
                 actionErrors={actionErrors}
                 automation={draft}
+                isEmailNavigationBlocked={isEmailNavigationBlocked}
                 isError={isError}
                 isLoading={isLoadingAutomation}
                 onChange={onDraftChange}
+                onDiscardBlockedEmailNavigation={(closeEmailModal) => {
+                    onEmailDirtyChange(false);
+                    if (isBlockedEmailNavigationLeavingEditorRef.current) {
+                        isBlockedEmailNavigationLeavingEditorRef.current = false;
+                        navigationBlocker.reset?.();
+                        closeEmailModal();
+                        return;
+                    }
+
+                    isBlockedEmailNavigationLeavingEditorRef.current = false;
+                    navigationBlocker.proceed?.();
+                }}
+                onEmailDirtyChange={onEmailDirtyChange}
+                onKeepEditingAfterBlockedEmailNavigation={() => {
+                    isBlockedEmailNavigationLeavingEditorRef.current = false;
+                    navigationBlocker.reset?.();
+                }}
             />
 
             <AlertDialog
-                open={navigationBlocker.state === 'blocked'}
+                open={isAutomationNavigationBlocked}
                 onOpenChange={onConfirmDiscardOpenChange}
             >
                 <AlertDialogContent>

--- a/apps/posts/src/views/Automations/editor.tsx
+++ b/apps/posts/src/views/Automations/editor.tsx
@@ -377,6 +377,7 @@ const AutomationEditor: React.FC = () => {
 
         if (hasUnsavedChanges && currentLocation.pathname !== nextLocation.pathname) {
             navigationBlockerReasonRef.current = 'automation';
+            isBlockedEmailNavigationLeavingEditorRef.current = false;
             return true;
         }
 

--- a/apps/posts/test/unit/views/automations/automation-editor.test.tsx
+++ b/apps/posts/test/unit/views/automations/automation-editor.test.tsx
@@ -2,8 +2,8 @@ import AutomationEditor from '@src/views/Automations/editor';
 import React from 'react';
 import {AutomationDetail, MAX_AUTOMATION_ACTIONS} from '@tryghost/admin-x-framework/api/automations';
 import {RouterProvider, createMemoryRouter} from 'react-router';
+import {act, fireEvent, render, screen, waitFor, within} from '@testing-library/react';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import {fireEvent, render, screen, waitFor, within} from '@testing-library/react';
 
 const {mockToastError} = vi.hoisted(() => ({
     mockToastError: vi.fn()
@@ -20,23 +20,75 @@ vi.mock('sonner', () => ({
 // Stub the email content editor modal — its real internals (Koenig + email API
 // hooks) are out of scope here. The stub exposes the seed props and a save button
 // so we can assert the canvas wiring (open → seed → onSave → draft → publish).
-vi.mock('@src/views/Automations/components/email-modal/email-content-modal', () => ({
-    default: ({initialMode, initialSubject, initialLexical, onClose, onSave}: {
+vi.mock('@src/views/Automations/components/email-modal/email-content-modal', () => {
+    const EmailContentModalStub = ({initialMode, initialSubject, initialLexical, isDiscardNavigationBlocked, onClose, onDirtyChange, onDiscardBlockedNavigation, onKeepEditingAfterBlockedNavigation, onSave}: {
         initialMode?: 'edit' | 'preview';
         initialSubject: string;
         initialLexical: string;
+        isDiscardNavigationBlocked?: boolean;
         onClose: () => void;
+        onDirtyChange?: (isDirty: boolean) => void;
+        onDiscardBlockedNavigation?: () => void;
+        onKeepEditingAfterBlockedNavigation?: () => void;
         onSave: (data: {subject: string; lexical: string}) => void;
-    }) => (
-        <div data-testid='email-content-modal'>
-            <span data-testid='modal-initial-mode'>{initialMode ?? 'edit'}</span>
-            <span data-testid='modal-initial-subject'>{initialSubject}</span>
-            <span data-testid='modal-initial-lexical'>{initialLexical}</span>
-            <button data-testid='modal-save' type='button' onClick={() => onSave({subject: 'Edited via modal', lexical: NON_EMPTY_EMAIL_LEXICAL})}>save</button>
-            <button data-testid='modal-close' type='button' onClick={onClose}>close</button>
-        </div>
-    )
-}));
+    }) => {
+        const [isDirty, setIsDirty] = React.useState(false);
+        const [confirmDiscardOpen, setConfirmDiscardOpen] = React.useState(false);
+        const allowDirtyCloseRef = React.useRef(false);
+
+        React.useEffect(() => {
+            onDirtyChange?.(isDirty && !allowDirtyCloseRef.current);
+            return () => onDirtyChange?.(false);
+        }, [isDirty, onDirtyChange]);
+
+        const attemptClose = () => {
+            if (isDirty) {
+                setConfirmDiscardOpen(true);
+                return;
+            }
+
+            onClose();
+        };
+
+        return (
+            <div data-testid='email-content-modal'>
+                <span data-testid='modal-initial-mode'>{initialMode ?? 'edit'}</span>
+                <span data-testid='modal-initial-subject'>{initialSubject}</span>
+                <span data-testid='modal-initial-lexical'>{initialLexical}</span>
+                <button data-testid='modal-dirty' type='button' onClick={() => setIsDirty(true)}>dirty</button>
+                <button data-testid='modal-save' type='button' onClick={() => {
+                    onSave({subject: 'Edited via modal', lexical: NON_EMPTY_EMAIL_LEXICAL});
+                    setIsDirty(false);
+                }}>save</button>
+                <button data-testid='modal-close' type='button' onClick={attemptClose}>close</button>
+                {(confirmDiscardOpen || isDiscardNavigationBlocked) && (
+                    <div aria-label='Discard changes?' role='alertdialog'>
+                        <p>Your changes to this email haven&apos;t been saved.</p>
+                        <button type='button' onClick={() => {
+                            setConfirmDiscardOpen(false);
+                            onKeepEditingAfterBlockedNavigation?.();
+                        }}>Keep editing</button>
+                        <button type='button' onClick={() => {
+                            setConfirmDiscardOpen(false);
+                            if (isDiscardNavigationBlocked) {
+                                onDiscardBlockedNavigation?.();
+                                return;
+                            }
+
+                            allowDirtyCloseRef.current = true;
+                            onDirtyChange?.(false);
+                            onClose();
+                        }}>Discard</button>
+                    </div>
+                )}
+            </div>
+        );
+    };
+
+    return {
+        default: EmailContentModalStub
+    };
+});
 
 const mockUseReadAutomation = vi.fn();
 const mockEditMutation = {
@@ -176,7 +228,7 @@ const automationDetail: AutomationDetail = {
     edges: [{source_action_id: 'action-wait', target_action_id: 'action-email'}]
 };
 
-const renderEditor = () => {
+const renderEditor = (initialEntries = ['/automations/automation-id-1']) => {
     const router = createMemoryRouter([
         {
             path: '/automations/:id',
@@ -187,7 +239,7 @@ const renderEditor = () => {
             element: <div data-testid='automations-list-route'>Automations list route</div>
         }
     ], {
-        initialEntries: ['/automations/automation-id-1']
+        initialEntries
     });
 
     return {
@@ -453,13 +505,14 @@ describe('AutomationEditor', () => {
             isError: false
         });
 
-        renderEditor();
+        const {router} = renderEditor();
 
         const emailStep = screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'});
         fireEvent.contextMenu(emailStep);
         fireEvent.click(await screen.findByRole('menuitem', {name: 'Edit email body'}));
 
         expect(await screen.findByTestId('email-content-modal')).toBeInTheDocument();
+        expect(router.state.location.search).toBe('?emailStep=action-email');
         expect(screen.queryByRole('complementary', {name: 'Step details'})).not.toBeInTheDocument();
         expect(emailStep).toHaveAttribute('aria-pressed', 'false');
         expect(screen.getByTestId('modal-initial-mode')).toHaveTextContent('edit');
@@ -474,16 +527,56 @@ describe('AutomationEditor', () => {
             isError: false
         });
 
-        renderEditor();
+        const {router} = renderEditor();
 
         const emailStep = screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'});
         fireEvent.contextMenu(emailStep);
         fireEvent.click(await screen.findByRole('menuitem', {name: 'Preview'}));
 
         expect(await screen.findByTestId('email-content-modal')).toBeInTheDocument();
+        expect(router.state.location.search).toBe('?emailStep=action-email');
         expect(screen.queryByRole('complementary', {name: 'Step details'})).not.toBeInTheDocument();
         expect(emailStep).toHaveAttribute('aria-pressed', 'false');
         expect(screen.getByTestId('modal-initial-mode')).toHaveTextContent('preview');
+    });
+
+    it('closes an app-opened email editor by removing the emailStep entry from router history', async () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [automationDetail]},
+            isLoading: false,
+            isError: false
+        });
+
+        const {router} = renderEditor();
+
+        const emailStep = screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'});
+        fireEvent.doubleClick(emailStep);
+        expect(await screen.findByTestId('email-content-modal')).toBeInTheDocument();
+        expect(router.state.location.search).toBe('?emailStep=action-email');
+
+        fireEvent.click(screen.getByTestId('modal-close'));
+
+        await waitFor(() => {
+            expect(screen.queryByTestId('email-content-modal')).not.toBeInTheDocument();
+        });
+        expect(router.state.location.pathname).toBe('/automations/automation-id-1');
+        expect(router.state.location.search).toBe('');
+    });
+
+    it('ignores an invalid emailStep query param safely', async () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [automationDetail]},
+            isLoading: false,
+            isError: false
+        });
+
+        const {router} = renderEditor(['/automations/automation-id-1?emailStep=missing-action']);
+
+        await waitFor(() => {
+            expect(router.state.location.search).toBe('');
+        });
+        expect(screen.queryByTestId('email-content-modal')).not.toBeInTheDocument();
+        expect(screen.getByTestId('automation-editor')).toBeInTheDocument();
     });
 
     it('asks for confirmation before deleting a send email step with a body from the node right-click menu', async () => {
@@ -1281,6 +1374,139 @@ describe('AutomationEditor', () => {
             expect(screen.getByTestId('automations-list-route')).toBeInTheDocument();
         });
         expect(screen.queryByTestId('automation-editor')).not.toBeInTheDocument();
+    });
+
+    it('uses the email discard dialog, not the automation discard dialog, when Back closes a dirty email editor', async () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [automationDetail]},
+            isLoading: false,
+            isError: false
+        });
+
+        const {router} = renderEditor(['/automations', '/automations/automation-id-1']);
+
+        await stageLocalEdit();
+        fireEvent.doubleClick(screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'}));
+        fireEvent.click(await screen.findByTestId('modal-dirty'));
+
+        await act(async () => {
+            await router.navigate(-1);
+        });
+
+        let emailDialog = screen.getByRole('alertdialog', {name: 'Discard changes?'});
+        expect(within(emailDialog).getByText('Your changes to this email haven\'t been saved.')).toBeInTheDocument();
+        expect(screen.queryByRole('alertdialog', {name: 'Discard unsaved changes?'})).not.toBeInTheDocument();
+        expect(router.state.location.search).toBe('?emailStep=action-email');
+
+        fireEvent.click(within(emailDialog).getByRole('button', {name: 'Keep editing'}));
+
+        await waitFor(() => {
+            expect(screen.queryByRole('alertdialog', {name: 'Discard changes?'})).not.toBeInTheDocument();
+        });
+        expect(screen.getByTestId('email-content-modal')).toBeInTheDocument();
+        expect(router.state.location.search).toBe('?emailStep=action-email');
+
+        await act(async () => {
+            await router.navigate(-1);
+        });
+        emailDialog = screen.getByRole('alertdialog', {name: 'Discard changes?'});
+        fireEvent.click(within(emailDialog).getByRole('button', {name: 'Discard'}));
+
+        await waitFor(() => {
+            expect(screen.queryByTestId('email-content-modal')).not.toBeInTheDocument();
+        });
+        expect(router.state.location.pathname).toBe('/automations/automation-id-1');
+        expect(router.state.location.search).toBe('');
+        expect(screen.getAllByRole('button', {name: 'Wait: 1 day'})).toHaveLength(2);
+        expect(screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'})).toBeInTheDocument();
+        expect(screen.queryByTestId('automations-list-route')).not.toBeInTheDocument();
+    });
+
+    it('removes emailStep query param after confirming discard from the dirty email editor close button', async () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [automationDetail]},
+            isLoading: false,
+            isError: false
+        });
+
+        const {router} = renderEditor(['/automations', '/automations/automation-id-1']);
+
+        fireEvent.doubleClick(screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'}));
+        fireEvent.click(await screen.findByTestId('modal-dirty'));
+        fireEvent.click(screen.getByTestId('modal-close'));
+
+        const emailDialog = screen.getByRole('alertdialog', {name: 'Discard changes?'});
+        fireEvent.click(within(emailDialog).getByRole('button', {name: 'Discard'}));
+
+        await waitFor(() => {
+            expect(screen.queryByTestId('email-content-modal')).not.toBeInTheDocument();
+        });
+        expect(router.state.location.pathname).toBe('/automations/automation-id-1');
+        expect(router.state.location.search).toBe('');
+        expect(screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'})).toBeInTheDocument();
+        expect(screen.queryByRole('alertdialog', {name: 'Discard unsaved changes?'})).not.toBeInTheDocument();
+    });
+
+    it('closes only the dirty email editor when discarding from a blocked route navigation', async () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [automationDetail]},
+            isLoading: false,
+            isError: false
+        });
+
+        const {router} = renderEditor(['/automations', '/automations/automation-id-1']);
+
+        await stageLocalEdit();
+        fireEvent.doubleClick(screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'}));
+        fireEvent.click(await screen.findByTestId('modal-dirty'));
+        fireEvent.click(screen.getByRole('link', {name: 'Back to automations'}));
+
+        const emailDialog = screen.getByRole('alertdialog', {name: 'Discard changes?'});
+        expect(screen.queryByRole('alertdialog', {name: 'Discard unsaved changes?'})).not.toBeInTheDocument();
+        fireEvent.click(within(emailDialog).getByRole('button', {name: 'Discard'}));
+
+        await waitFor(() => {
+            expect(screen.queryByTestId('email-content-modal')).not.toBeInTheDocument();
+        });
+        expect(router.state.location.pathname).toBe('/automations/automation-id-1');
+        expect(router.state.location.search).toBe('');
+        expect(screen.getAllByRole('button', {name: 'Wait: 1 day'})).toHaveLength(2);
+        expect(screen.queryByTestId('automations-list-route')).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('link', {name: 'Back to automations'}));
+
+        expect(screen.getByRole('alertdialog', {name: 'Discard unsaved changes?'})).toBeInTheDocument();
+        expect(screen.queryByTestId('automations-list-route')).not.toBeInTheDocument();
+    });
+
+    it('shows the automation discard dialog with one Back press after saving and closing the email editor', async () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [automationDetail]},
+            isLoading: false,
+            isError: false
+        });
+
+        const {router} = renderEditor(['/automations', '/automations/automation-id-1']);
+
+        await stageLocalEdit();
+        fireEvent.doubleClick(screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'}));
+        expect(router.state.location.search).toBe('?emailStep=action-email');
+        fireEvent.click(await screen.findByTestId('modal-save'));
+        fireEvent.click(screen.getByTestId('modal-close'));
+
+        await waitFor(() => {
+            expect(screen.queryByTestId('email-content-modal')).not.toBeInTheDocument();
+        });
+        expect(router.state.location.pathname).toBe('/automations/automation-id-1');
+        expect(router.state.location.search).toBe('');
+
+        await act(async () => {
+            await router.navigate(-1);
+        });
+
+        const dialog = screen.getByRole('alertdialog', {name: 'Discard unsaved changes?'});
+        expect(within(dialog).getByText('Your changes will be lost if you leave this automation.')).toBeInTheDocument();
+        expect(screen.queryByTestId('automations-list-route')).not.toBeInTheDocument();
     });
 
     it('navigates away without confirmation when the automation has no unsaved changes', async () => {


### PR DESCRIPTION
closes [NY-1353](https://linear.app/ghost/issue/NY-1353/back-button-from-email-editor-closes-and-discards-changes-from-entire)

## The bugs

This change fixes two related bugs in the automation email editor.

### Bug 1 steps to reproduce:

1. Open an automation from the list view
2. Add a wait step (so the automation editor is now "dirty")
3. Add an email step, fill in the subject, open the email editor
4. Type some text in the email editor (so the email editor is now "dirty")
5. Hit "Back" button in your browser

**Expected**: this should take you back to the automation editor screen, with your unsaved changes still present locally<br>**Actual**: this discards the unsaved changes in the automation itself and takes you back to the automations list view

### Bug 2 steps to reproduce:

1. Open automation from the list view
2. Add a wait step (so the automation editor is now "dirty")
3. Add an email step, fill in the subject, open the email editor
4. Type some text in the email editor, and click "Save"
5. Hit "Back" button in your browser

**Expected**: this should take you back to the automation editor screen, with your unsaved changes (including the email content) saved locally. Clicking "Back" again should present the "Are you sure?" modal.<br>**Actual**: this discards the unsaved changes in the automation itself and takes you back to the automations list view

## The fix

* Move automation email modal state into the router query string so the open email step is deep-linkable and history-aware.
* Separate email editor discard handling from automation-level unsaved-change blocking.
* Add safeguards for invalid or deleted `emailStep` params and keep navigation behavior consistent when closing from a blocked route change.
* Expand tests to cover router-driven open/close flows, invalid query params, and dirty discard behavior.

## Manual testing

https://github.com/user-attachments/assets/c1a8aec8-2bba-49c5-9f74-73ecfdd1f9ec