### PR TITLE
🐛 Fixed disabling structured data for LLMs and AI search engines

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/settings.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/settings.js
@@ -27,6 +27,7 @@ const EDITABLE_SETTINGS = [
     'secondary_navigation',
     'meta_title',
     'meta_description',
+    'llms_enabled',
     'og_image',
     'og_title',
     'og_description',

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -1349,6 +1349,456 @@ Object {
 }
 `;
 
+exports[`Settings API Edit can disable llms_enabled 1: [body] 1`] = `
+Object {
+  "meta": Object {},
+  "settings": Array [
+    Object {
+      "key": "members_track_sources",
+      "value": true,
+    },
+    Object {
+      "key": "title",
+      "value": null,
+    },
+    Object {
+      "key": "description",
+      "value": "Thoughts, stories and ideas",
+    },
+    Object {
+      "key": "logo",
+      "value": "",
+    },
+    Object {
+      "key": "cover_image",
+      "value": "https://static.ghost.org/v5.0.0/images/publication-cover.jpg",
+    },
+    Object {
+      "key": "icon",
+      "value": "http://127.0.0.1:2369/content/images/size/w256h256/2019/07/icon.png",
+    },
+    Object {
+      "key": "accent_color",
+      "value": "#FF1A75",
+    },
+    Object {
+      "key": "locale",
+      "value": "ua",
+    },
+    Object {
+      "key": "timezone",
+      "value": "Pacific/Auckland",
+    },
+    Object {
+      "key": "codeinjection_head",
+      "value": null,
+    },
+    Object {
+      "key": "codeinjection_foot",
+      "value": "",
+    },
+    Object {
+      "key": "facebook",
+      "value": "ghost",
+    },
+    Object {
+      "key": "twitter",
+      "value": "@ghost",
+    },
+    Object {
+      "key": "threads",
+      "value": null,
+    },
+    Object {
+      "key": "bluesky",
+      "value": null,
+    },
+    Object {
+      "key": "mastodon",
+      "value": null,
+    },
+    Object {
+      "key": "tiktok",
+      "value": null,
+    },
+    Object {
+      "key": "youtube",
+      "value": null,
+    },
+    Object {
+      "key": "instagram",
+      "value": null,
+    },
+    Object {
+      "key": "linkedin",
+      "value": null,
+    },
+    Object {
+      "key": "navigation",
+      "value": "[{\\"label\\":\\"label1\\"}]",
+    },
+    Object {
+      "key": "secondary_navigation",
+      "value": "[{\\"label\\":\\"Data & privacy\\",\\"url\\":\\"/privacy/\\"},{\\"label\\":\\"Contact\\",\\"url\\":\\"/contact/\\"},{\\"label\\":\\"Contribute →\\",\\"url\\":\\"/contribute/\\"}]",
+    },
+    Object {
+      "key": "llms_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "meta_title",
+      "value": "SEO title",
+    },
+    Object {
+      "key": "meta_description",
+      "value": "SEO description",
+    },
+    Object {
+      "key": "og_image",
+      "value": "http://127.0.0.1:2369/content/images/2019/07/facebook.png",
+    },
+    Object {
+      "key": "og_title",
+      "value": "facebook title",
+    },
+    Object {
+      "key": "og_description",
+      "value": "facebook description",
+    },
+    Object {
+      "key": "twitter_image",
+      "value": "http://127.0.0.1:2369/content/images/2019/07/twitter.png",
+    },
+    Object {
+      "key": "twitter_title",
+      "value": "twitter title",
+    },
+    Object {
+      "key": "twitter_description",
+      "value": "twitter description",
+    },
+    Object {
+      "key": "active_theme",
+      "value": "source",
+    },
+    Object {
+      "key": "is_private",
+      "value": false,
+    },
+    Object {
+      "key": "password",
+      "value": "",
+    },
+    Object {
+      "key": "public_hash",
+      "value": StringMatching /\\[a-z0-9\\]\\{30\\}/,
+    },
+    Object {
+      "key": "default_content_visibility",
+      "value": "public",
+    },
+    Object {
+      "key": "default_content_visibility_tiers",
+      "value": "[]",
+    },
+    Object {
+      "key": "members_signup_access",
+      "value": "all",
+    },
+    Object {
+      "key": "members_support_address",
+      "value": "noreply",
+    },
+    Object {
+      "key": "stripe_billing_portal_configuration_id",
+      "value": null,
+    },
+    Object {
+      "key": "stripe_secret_key",
+      "value": null,
+    },
+    Object {
+      "key": "stripe_publishable_key",
+      "value": null,
+    },
+    Object {
+      "key": "stripe_plans",
+      "value": "[]",
+    },
+    Object {
+      "key": "stripe_connect_publishable_key",
+      "value": "pk_test_for_stripe",
+    },
+    Object {
+      "key": "stripe_connect_secret_key",
+      "value": "••••••••",
+    },
+    Object {
+      "key": "stripe_connect_livemode",
+      "value": null,
+    },
+    Object {
+      "key": "stripe_connect_display_name",
+      "value": null,
+    },
+    Object {
+      "key": "stripe_connect_account_id",
+      "value": null,
+    },
+    Object {
+      "key": "members_monthly_price_id",
+      "value": null,
+    },
+    Object {
+      "key": "members_yearly_price_id",
+      "value": null,
+    },
+    Object {
+      "key": "portal_name",
+      "value": true,
+    },
+    Object {
+      "key": "portal_button",
+      "value": true,
+    },
+    Object {
+      "key": "portal_plans",
+      "value": "[\\"free\\"]",
+    },
+    Object {
+      "key": "portal_default_plan",
+      "value": "yearly",
+    },
+    Object {
+      "key": "portal_products",
+      "value": "[]",
+    },
+    Object {
+      "key": "portal_button_style",
+      "value": "icon-and-text",
+    },
+    Object {
+      "key": "portal_button_icon",
+      "value": null,
+    },
+    Object {
+      "key": "portal_button_signup_text",
+      "value": "Subscribe",
+    },
+    Object {
+      "key": "portal_signup_terms_html",
+      "value": null,
+    },
+    Object {
+      "key": "portal_signup_checkbox_required",
+      "value": false,
+    },
+    Object {
+      "key": "mailgun_domain",
+      "value": null,
+    },
+    Object {
+      "key": "mailgun_api_key",
+      "value": null,
+    },
+    Object {
+      "key": "mailgun_base_url",
+      "value": null,
+    },
+    Object {
+      "key": "email_track_opens",
+      "value": true,
+    },
+    Object {
+      "key": "email_track_clicks",
+      "value": true,
+    },
+    Object {
+      "key": "email_verification_required",
+      "value": false,
+    },
+    Object {
+      "key": "firstpromoter",
+      "value": false,
+    },
+    Object {
+      "key": "firstpromoter_id",
+      "value": null,
+    },
+    Object {
+      "key": "labs",
+      "value": StringMatching /\\\\\\{\\[\\^\\\\s\\]\\+\\\\\\}/,
+    },
+    Object {
+      "key": "slack_url",
+      "value": "",
+    },
+    Object {
+      "key": "slack_username",
+      "value": "New Slack Username",
+    },
+    Object {
+      "key": "unsplash",
+      "value": false,
+    },
+    Object {
+      "key": "shared_views",
+      "value": "[]",
+    },
+    Object {
+      "key": "editor_default_email_recipients",
+      "value": "visibility",
+    },
+    Object {
+      "key": "editor_default_email_recipients_filter",
+      "value": "all",
+    },
+    Object {
+      "key": "announcement_content",
+      "value": "<p>Great news coming soon!</p>",
+    },
+    Object {
+      "key": "announcement_visibility",
+      "value": "[\\"visitors\\",\\"free_members\\"]",
+    },
+    Object {
+      "key": "announcement_background",
+      "value": "dark",
+    },
+    Object {
+      "key": "comments_enabled",
+      "value": "all",
+    },
+    Object {
+      "key": "outbound_link_tagging",
+      "value": true,
+    },
+    Object {
+      "key": "web_analytics",
+      "value": true,
+    },
+    Object {
+      "key": "pintura",
+      "value": true,
+    },
+    Object {
+      "key": "pintura_js_url",
+      "value": null,
+    },
+    Object {
+      "key": "pintura_css_url",
+      "value": null,
+    },
+    Object {
+      "key": "donations_currency",
+      "value": "USD",
+    },
+    Object {
+      "key": "donations_suggested_amount",
+      "value": "500",
+    },
+    Object {
+      "key": "recommendations_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "explore_ping",
+      "value": true,
+    },
+    Object {
+      "key": "explore_ping_growth",
+      "value": false,
+    },
+    Object {
+      "key": "transistor",
+      "value": false,
+    },
+    Object {
+      "key": "transistor_portal_enabled",
+      "value": true,
+    },
+    Object {
+      "key": "transistor_portal_heading",
+      "value": "Podcasts",
+    },
+    Object {
+      "key": "transistor_portal_description",
+      "value": "Access your private podcast feed",
+    },
+    Object {
+      "key": "transistor_portal_button_text",
+      "value": "View",
+    },
+    Object {
+      "key": "transistor_portal_url_template",
+      "value": "https://partner.transistor.fm/ghost/{memberUuid}",
+    },
+    Object {
+      "key": "members_enabled",
+      "value": true,
+    },
+    Object {
+      "key": "members_invite_only",
+      "value": false,
+    },
+    Object {
+      "key": "allow_self_signup",
+      "value": true,
+    },
+    Object {
+      "key": "paid_members_enabled",
+      "value": true,
+    },
+    Object {
+      "key": "firstpromoter_account",
+      "value": null,
+    },
+    Object {
+      "key": "donations_enabled",
+      "value": true,
+    },
+    Object {
+      "key": "default_email_address",
+      "value": "noreply@127.0.0.1",
+    },
+    Object {
+      "key": "support_email_address",
+      "value": "noreply@127.0.0.1",
+    },
+    Object {
+      "key": "all_blocked_email_domains",
+      "value": Array [],
+    },
+    Object {
+      "key": "social_web_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "web_analytics_enabled",
+      "value": false,
+    },
+    Object {
+      "key": "web_analytics_configured",
+      "value": false,
+    },
+  ],
+}
+`;
+
+exports[`Settings API Edit can disable llms_enabled 2: [headers] 1`] = `
+Object {
+  "access-control-allow-origin": "http://127.0.0.1:2369",
+  "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": StringMatching /\\\\d\\+/,
+  "content-type": "application/json; charset=utf-8",
+  "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
+  "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "vary": "Accept-Version, Origin, Accept-Encoding",
+  "x-cache-invalidate": "/*",
+  "x-powered-by": "Express",
+}
+`;
+
 exports[`Settings API Edit can edit Stripe settings when Stripe Connect limit is not enabled 1: [body] 1`] = `
 Object {
   "meta": Object {},

--- a/ghost/core/test/e2e-api/admin/settings.test.js
+++ b/ghost/core/test/e2e-api/admin/settings.test.js
@@ -260,6 +260,35 @@ describe('Settings API', function () {
             emailMockReceiver.assertSentEmailCount(0);
         });
 
+        it('can disable llms_enabled', async function () {
+            try {
+                await agent.put('settings/')
+                    .body({
+                        settings: [{key: 'llms_enabled', value: false}]
+                    })
+                    .expectStatus(200)
+                    .matchBodySnapshot({
+                        settings: matchSettingsArray(CURRENT_SETTINGS_COUNT)
+                    })
+                    .matchHeaderSnapshot({
+                        etag: anyEtag,
+                        // Special rule for this test, as the labs setting changes a lot
+                        'content-length': anyContentLength,
+                        'content-version': anyContentVersion
+                    })
+                    .expect(({body}) => {
+                        const llmsEnabled = body.settings.find(setting => setting.key === 'llms_enabled');
+                        assert.equal(llmsEnabled.value, false);
+                    });
+
+                assert.equal(settingsCache.get('llms_enabled'), false);
+                emailMockReceiver.assertSentEmailCount(0);
+            } finally {
+                // Restore so later tests see the default value
+                await models.Settings.edit({key: 'llms_enabled', value: true});
+            }
+        });
+
         it('does not trigger email verification flow if members_support_address remains the same', async function () {
             await models.Settings.edit({
                 key: 'members_support_address',


### PR DESCRIPTION
The "Enable structured data for LLMs and AI search engines" toggle in Meta data settings could not be turned off — flipping it appeared to save, but reopening settings showed it still enabled.

`llms_enabled` was shipped as a full setting (migration, default value, and the admin toggle) but was never added to the `EDITABLE_SETTINGS` allowlist in the settings API input serializer. That allowlist silently drops any key it doesn't recognise from external edits, so every save of the toggle stripped `llms_enabled` before it reached the database. The API then returned the unchanged value and the UI re-synced back to "on" — hence the "saved, but not really" behaviour and the unsaved-changes warning on exit.

The fix adds `llms_enabled` to the allowlist so the value persists and round-trips as a proper boolean. Added an e2e test covering the save path to prevent regression.

fixes https://linear.app/ghost/issue/ONC-1833/disabling-structured-data-for-llms-and-ai-search-engines-not-working
