### PR TITLE
Loaded only the URL relations live routes need under lazy routing

### DIFF
--- a/ghost/core/core/server/api/endpoints/email-post.js
+++ b/ghost/core/core/server/api/endpoints/email-post.js
@@ -1,6 +1,7 @@
 const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const models = require('../../models');
+const urlService = require('../../services/url');
 const ALLOWED_INCLUDES = ['authors', 'tags', 'tiers'];
 
 const messages = {
@@ -38,7 +39,7 @@ const controller = {
             const callerIncludes = Array.isArray(frame.options.withRelated) ? frame.options.withRelated : [];
             const options = {
                 ...frame.options,
-                withRelated: [...new Set([...callerIncludes, 'tags', 'authors'])]
+                withRelated: [...new Set([...callerIncludes, ...urlService.facade.getRequiredRelations()])]
             };
             const model = await models.Post.findOne(Object.assign(frame.data, {status: 'sent'}), options);
 

--- a/ghost/core/core/server/api/endpoints/search-index-public.js
+++ b/ghost/core/core/server/api/endpoints/search-index-public.js
@@ -1,16 +1,11 @@
 const models = require('../../models');
-const config = require('../../../shared/config');
+const urlService = require('../../services/url');
 const getPostServiceInstance = require('../../services/posts/posts-service-instance');
 const postsService = getPostServiceInstance();
 
 const urlRelationsWhenLazyRouting = () => {
-    if (config.get('lazyRouting')) {
-        return {
-            withRelated: ['tags', 'authors']
-        };
-    }
-
-    return {};
+    const withRelated = urlService.facade.getRequiredRelations();
+    return withRelated.length ? {withRelated} : {};
 };
 
 /** @type {import('@tryghost/api-framework').Controller} */

--- a/ghost/core/core/server/api/endpoints/search-index.js
+++ b/ghost/core/core/server/api/endpoints/search-index.js
@@ -1,16 +1,11 @@
 const models = require('../../models');
-const config = require('../../../shared/config');
+const urlService = require('../../services/url');
 const getPostServiceInstance = require('../../services/posts/posts-service-instance');
 const postsService = getPostServiceInstance();
 
 const urlRelationsWhenLazyRouting = () => {
-    if (config.get('lazyRouting')) {
-        return {
-            withRelated: ['tags', 'authors']
-        };
-    }
-
-    return {};
+    const withRelated = urlService.facade.getRequiredRelations();
+    return withRelated.length ? {withRelated} : {};
 };
 
 /** @type {import('@tryghost/api-framework').Controller} */

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/comments.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/comments.js
@@ -1,3 +1,5 @@
+const urlService = require('../../../../../services/url');
+
 module.exports = {
     all(_apiConfig, frame) {
         if (!frame.options.withRelated || frame.options.withRelated.length === 0) {
@@ -21,16 +23,12 @@ module.exports = {
             return relation;
         });
 
-        // If the caller asked for `post`, also load post.tags / post.authors
-        // — the comments output mapper calls url.forPost on the embedded
-        // post, which needs the relations to resolve tag/author-filtered
-        // routes under lazyRouting.
         if (frame.options.withRelated.includes('post')) {
-            if (!frame.options.withRelated.includes('post.tags')) {
-                frame.options.withRelated.push('post.tags');
-            }
-            if (!frame.options.withRelated.includes('post.authors')) {
-                frame.options.withRelated.push('post.authors');
+            for (const relation of urlService.facade.getRequiredRelations()) {
+                const prefixed = `post.${relation}`;
+                if (!frame.options.withRelated.includes(prefixed)) {
+                    frame.options.withRelated.push(prefixed);
+                }
             }
         }
     },

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/pages.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/pages.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const config = require('../../../../../../shared/config');
+const urlService = require('../../../../../services/url');
 const debug = require('@tryghost/debug')('api:endpoints:utils:serializers:input:pages');
 const {ValidationError} = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
@@ -52,12 +52,12 @@ function selectAllAllowedColumns(frame) {
     }
 }
 
-// Mirror of input/posts.js. See the comment there.
 function forceUrlRelationsWhenLazy(frame) {
-    if (config.get('lazyRouting')
-        && Array.isArray(frame.options.columns)
-        && frame.options.columns.includes('url')) {
-        frame.options.withRelated = _.union(frame.options.withRelated || [], ['tags', 'authors']);
+    if (Array.isArray(frame.options.columns) && frame.options.columns.includes('url')) {
+        const relations = urlService.facade.getRequiredRelations();
+        if (relations.length) {
+            frame.options.withRelated = _.union(frame.options.withRelated || [], relations);
+        }
     }
 }
 

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/posts.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/posts.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const config = require('../../../../../../shared/config');
+const urlService = require('../../../../../services/url');
 const debug = require('@tryghost/debug')('api:endpoints:utils:serializers:input:posts');
 const {ValidationError} = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
@@ -75,13 +75,12 @@ function mapWithRelated(frame) {
     }
 }
 
-// Under lazyRouting, urlService.facade.getUrlForResource evaluates
-// router filters against tags/authors, so ?fields=url needs them loaded.
 function forceUrlRelationsWhenLazy(frame) {
-    if (config.get('lazyRouting')
-        && Array.isArray(frame.options.columns)
-        && frame.options.columns.includes('url')) {
-        frame.options.withRelated = _.union(frame.options.withRelated || [], ['tags', 'authors']);
+    if (Array.isArray(frame.options.columns) && frame.options.columns.includes('url')) {
+        const relations = urlService.facade.getRequiredRelations();
+        if (relations.length) {
+            frame.options.withRelated = _.union(frame.options.withRelated || [], relations);
+        }
     }
 }
 

--- a/ghost/core/core/server/services/comments/comments-service.js
+++ b/ghost/core/core/server/services/comments/comments-service.js
@@ -107,6 +107,9 @@ class CommentsService {
         /** @private */
         this.contentGating = contentGating;
 
+        /** @private */
+        this.urlService = urlService;
+
         const Emails = require('./comments-service-emails');
         /** @private */
         this.emails = new Emails({
@@ -465,7 +468,8 @@ class CommentsService {
      * @param {AdminBrowseAllOptions} options
      */
     async getAdminAllComments({includeNested, filter, mongoTransformer, reportCount, order, page, limit}) {
-        const withRelated = ['member', 'post', 'post.tags', 'post.authors', 'count.replies', 'count.direct_replies', 'count.likes', 'count.dislikes', 'count.net_score', 'count.reports', 'in_reply_to', 'parent'];
+        const postUrlRelations = this.urlService.facade.getRequiredRelations().map(relation => `post.${relation}`);
+        const withRelated = ['member', 'post', ...postUrlRelations, 'count.replies', 'count.direct_replies', 'count.likes', 'count.dislikes', 'count.net_score', 'count.reports', 'in_reply_to', 'parent'];
 
         return await this.models.Comment.findPage({
             withRelated,

--- a/ghost/core/core/server/services/email-service/batch-sending-service.js
+++ b/ghost/core/core/server/services/email-service/batch-sending-service.js
@@ -32,6 +32,7 @@ class BatchSendingService {
     #db;
     #sentry;
     #debugStorageFilePath;
+    #getRequiredUrlRelations;
 
     // Retry database queries happening before sending the email
     #BEFORE_RETRY_CONFIG = {maxRetries: 10, maxTime: 10 * 60 * 1000, sleep: 2000};
@@ -51,6 +52,7 @@ class BatchSendingService {
      * @param {Email} dependencies.models.Email
      * @param {object} dependencies.models.Member
      * @param {object} dependencies.db
+     * @param {() => string[]} [dependencies.getRequiredUrlRelations] Post relations the live routes need loaded to generate URLs (lazy routing); defaults to none
      * @param {object} [dependencies.sentry]
      * @param {object} [dependencies.BEFORE_RETRY_CONFIG]
      * @param {object} [dependencies.AFTER_RETRY_CONFIG]
@@ -66,6 +68,7 @@ class BatchSendingService {
         models,
         db,
         sentry,
+        getRequiredUrlRelations = () => [],
         BEFORE_RETRY_CONFIG,
         AFTER_RETRY_CONFIG,
         MAILGUN_API_RETRY_CONFIG,
@@ -80,6 +83,7 @@ class BatchSendingService {
         this.#db = db;
         this.#sentry = sentry;
         this.#debugStorageFilePath = debugStorageFilePath;
+        this.#getRequiredUrlRelations = getRequiredUrlRelations;
 
         if (BEFORE_RETRY_CONFIG) {
             this.#BEFORE_RETRY_CONFIG = BEFORE_RETRY_CONFIG;
@@ -202,8 +206,9 @@ class BatchSendingService {
             return await email.getLazyRelation('newsletter', {require: true});
         }, {...this.#getBeforeRetryConfig(email), description: `getLazyRelation newsletter for email ${email.id}`});
 
+        const postRelations = [...new Set(['posts_meta', 'authors', ...this.#getRequiredUrlRelations()])];
         const post = await this.retryDb(async () => {
-            return await email.getLazyRelation('post', {require: true, withRelated: ['posts_meta', 'authors', 'tags']});
+            return await email.getLazyRelation('post', {require: true, withRelated: postRelations});
         }, {...this.#getBeforeRetryConfig(email), description: `getLazyRelation post for email ${email.id}`});
 
         let batches = await this.retryDb(async () => {

--- a/ghost/core/core/server/services/email-service/email-controller.js
+++ b/ghost/core/core/server/services/email-service/email-controller.js
@@ -11,25 +11,28 @@ const messages = {
 class EmailController {
     service;
     models;
+    getRequiredUrlRelations;
 
     /**
      *
      * @param {EmailService} service
-     * @param {{models: {Post: any, Newsletter: any, Email: any}}} dependencies
+     * @param {{models: {Post: any, Newsletter: any, Email: any}, getRequiredUrlRelations?: () => string[]}} dependencies
      */
-    constructor(service, {models}) {
+    constructor(service, {models, getRequiredUrlRelations = () => []}) {
         this.service = service;
         this.models = models;
+        this.getRequiredUrlRelations = getRequiredUrlRelations;
     }
 
     async _getFrameData(frame) {
         // Bit absurd situation in email-previews endpoints that one endpoint is using options and other one is using data.
         // So we need to handle both cases.
         let post;
+        const withRelated = [...new Set(['posts_meta', 'authors', ...this.getRequiredUrlRelations()])];
         if (frame.options.id) {
-            post = await this.models.Post.findOne({...frame.options, status: 'all'}, {withRelated: ['posts_meta', 'authors', 'tags']});
+            post = await this.models.Post.findOne({...frame.options, status: 'all'}, {withRelated});
         } else {
-            post = await this.models.Post.findOne({...frame.data, status: 'all'}, {...frame.options, withRelated: ['posts_meta', 'authors', 'tags']});
+            post = await this.models.Post.findOne({...frame.data, status: 'all'}, {...frame.options, withRelated});
         }
 
         if (!post) {

--- a/ghost/core/core/server/services/email-service/email-renderer.js
+++ b/ghost/core/core/server/services/email-service/email-renderer.js
@@ -162,6 +162,7 @@ class EmailRenderer {
     #imageSize;
     #urlUtils;
     #getPostUrl;
+    #getRequiredUrlRelations;
     #storageUtils;
 
     #linkReplacer;
@@ -189,6 +190,7 @@ class EmailRenderer {
      * @param {{urlFor(type: string, optionsOrAbsolute, absolute): string, isSiteUrl(url, context): boolean}} dependencies.urlUtils
      * @param {{isLocalImage(url: string): boolean, isInternalImage(url: string): boolean}} dependencies.storageUtils
      * @param {(post: Post) => string} dependencies.getPostUrl
+     * @param {() => string[]} [dependencies.getRequiredUrlRelations] Post relations the live routes need loaded to generate URLs (lazy routing); defaults to none
      * @param {object} dependencies.linkReplacer
      * @param {object} dependencies.linkTracking
      * @param {object} dependencies.memberAttributionService
@@ -208,6 +210,7 @@ class EmailRenderer {
         urlUtils,
         storageUtils,
         getPostUrl,
+        getRequiredUrlRelations = () => [],
         linkReplacer,
         linkTracking,
         memberAttributionService,
@@ -226,6 +229,7 @@ class EmailRenderer {
         this.#urlUtils = urlUtils;
         this.#storageUtils = storageUtils;
         this.#getPostUrl = getPostUrl;
+        this.#getRequiredUrlRelations = getRequiredUrlRelations;
         this.#linkReplacer = linkReplacer;
         this.#linkTracking = linkTracking;
         this.#memberAttributionService = memberAttributionService;
@@ -1077,11 +1081,12 @@ class EmailRenderer {
         let latestPostsHasImages = false;
         if (newsletter.get('show_latest_posts')) {
             // Fetch last 3 published posts
+            const urlRelations = this.#getRequiredUrlRelations();
             const {data} = await this.#models.Post.findPage({
                 filter: `status:published+id:-'${post.id}'`,
                 order: 'published_at DESC',
                 limit: 3,
-                withRelated: ['tags', 'authors']
+                ...(urlRelations.length ? {withRelated: urlRelations} : {})
             });
 
             for (const latestPost of data) {

--- a/ghost/core/core/server/services/email-service/email-service-wrapper.js
+++ b/ghost/core/core/server/services/email-service/email-service-wrapper.js
@@ -25,6 +25,8 @@ class EmailServiceWrapper {
         const {DomainWarmingService} = require('./domain-warming-service');
 
         const {Post, Newsletter, Email, EmailBatch, EmailRecipient, Member} = require('../../models');
+        const urlService = require('../url');
+        const getRequiredUrlRelations = () => urlService.facade.getRequiredRelations();
         const MailgunClient = require('../lib/mailgun-client');
         const configService = require('../../../shared/config');
         const settingsCache = require('../../../shared/settings-cache');
@@ -83,6 +85,7 @@ class EmailServiceWrapper {
             urlUtils,
             storageUtils,
             getPostUrl: this.getPostUrl,
+            getRequiredUrlRelations,
             linkReplacer,
             linkTracking,
             memberAttributionService: memberAttribution.service,
@@ -124,6 +127,7 @@ class EmailServiceWrapper {
             domainWarmingService,
             db,
             sentry,
+            getRequiredUrlRelations,
             debugStorageFilePath: configService.getContentPath('data')
         });
 
@@ -151,7 +155,8 @@ class EmailServiceWrapper {
                 Post,
                 Newsletter,
                 Email
-            }
+            },
+            getRequiredUrlRelations
         });
     }
 }

--- a/ghost/core/core/server/services/url/lazy-url-service.ts
+++ b/ghost/core/core/server/services/url/lazy-url-service.ts
@@ -84,14 +84,21 @@ export class LazyUrlService implements LazyUrlServiceBackend {
         }
         const required = new Set<string>();
         for (const config of this.routerConfigs) {
-            if (!config.filter) {
-                continue;
+            if (config.filter) {
+                if (/\btags?\b/.test(config.filter) || /\bprimary_tag\b/.test(config.filter)) {
+                    required.add('tags');
+                }
+                if (/\bauthors?\b/.test(config.filter) || /\bprimary_author\b/.test(config.filter)) {
+                    required.add('authors');
+                }
             }
-            if (/\btags?\b/.test(config.filter) || /\bprimary_tag\b/.test(config.filter)) {
-                required.add('tags');
-            }
-            if (/\bauthors?\b/.test(config.filter) || /\bprimary_author\b/.test(config.filter)) {
-                required.add('authors');
+            if (config.permalink) {
+                if (/\bprimary_tag\b/.test(config.permalink)) {
+                    required.add('tags');
+                }
+                if (/\bprimary_author\b/.test(config.permalink)) {
+                    required.add('authors');
+                }
             }
         }
         this.requiredRelations = [...required];

--- a/ghost/core/core/server/services/url/lazy-url-service.ts
+++ b/ghost/core/core/server/services/url/lazy-url-service.ts
@@ -80,7 +80,7 @@ export class LazyUrlService implements LazyUrlServiceBackend {
 
     getRequiredRelations(): string[] {
         if (this.requiredRelations !== null) {
-            return this.requiredRelations;
+            return [...this.requiredRelations];
         }
         const required = new Set<string>();
         for (const config of this.routerConfigs) {
@@ -95,7 +95,7 @@ export class LazyUrlService implements LazyUrlServiceBackend {
             }
         }
         this.requiredRelations = [...required];
-        return this.requiredRelations;
+        return [...this.requiredRelations];
     }
 
     hasFinished(): boolean {

--- a/ghost/core/core/server/services/url/lazy-url-service.ts
+++ b/ghost/core/core/server/services/url/lazy-url-service.ts
@@ -70,7 +70,9 @@ export class LazyUrlService implements LazyUrlServiceBackend {
     }
 
     onRouterUpdated(): void {
-        // No precomputed state to regenerate.
+        // Defensive: a router update could change a filter the cache derived
+        // from, so drop it and recompute lazily on next read.
+        this.requiredRelations = null;
     }
 
     reset(): void {

--- a/ghost/core/core/server/services/url/lazy-url-service.ts
+++ b/ghost/core/core/server/services/url/lazy-url-service.ts
@@ -43,6 +43,7 @@ export class LazyUrlService implements LazyUrlServiceBackend {
     private findResource: FindResource;
     // Router configs in registration order, which is also their priority.
     private routerConfigs: RouterConfig[];
+    private requiredRelations: string[] | null;
 
     constructor({urlUtils = localUtils, findResource}: LazyUrlServiceDeps) {
         if (typeof findResource !== 'function') {
@@ -53,6 +54,7 @@ export class LazyUrlService implements LazyUrlServiceBackend {
         this.urlUtils = urlUtils;
         this.findResource = findResource;
         this.routerConfigs = [];
+        this.requiredRelations = null;
     }
 
     onRouterAddedType(identifier: string, filter: string | null, resourceType: string, permalink: string): void {
@@ -64,6 +66,7 @@ export class LazyUrlService implements LazyUrlServiceBackend {
             permalink,
             compiledFilter: buildFilter(filter)
         });
+        this.requiredRelations = null;
     }
 
     onRouterUpdated(): void {
@@ -72,6 +75,27 @@ export class LazyUrlService implements LazyUrlServiceBackend {
 
     reset(): void {
         this.routerConfigs = [];
+        this.requiredRelations = null;
+    }
+
+    getRequiredRelations(): string[] {
+        if (this.requiredRelations !== null) {
+            return this.requiredRelations;
+        }
+        const required = new Set<string>();
+        for (const config of this.routerConfigs) {
+            if (!config.filter) {
+                continue;
+            }
+            if (/\btags?\b/.test(config.filter) || /\bprimary_tag\b/.test(config.filter)) {
+                required.add('tags');
+            }
+            if (/\bauthors?\b/.test(config.filter) || /\bprimary_author\b/.test(config.filter)) {
+                required.add('authors');
+            }
+        }
+        this.requiredRelations = [...required];
+        return this.requiredRelations;
     }
 
     hasFinished(): boolean {

--- a/ghost/core/core/server/services/url/url-service-facade.ts
+++ b/ghost/core/core/server/services/url/url-service-facade.ts
@@ -69,6 +69,7 @@ export interface LazyUrlServiceBackend {
     getUrlForResource(resource: Resource, options?: UrlOptions): string;
     ownsResource(routerId: string, resource: Resource): boolean;
     resolveUrl(path: string): Promise<Resource | null>;
+    getRequiredRelations(): string[];
     hasFinished(): boolean;
     onRouterAddedType(...args: unknown[]): unknown;
     onRouterUpdated(...args: unknown[]): unknown;
@@ -153,6 +154,15 @@ export class UrlServiceFacade {
                 (a, b) => _.isEqual(a, b));
         }
         return eagerResult;
+    }
+
+    // Returns [] when there is no lazy backend: eager looks URLs up by id and
+    // never touches a resource's relations.
+    getRequiredRelations(): string[] {
+        if (this.lazyUrlService) {
+            return this.lazyUrlService.getRequiredRelations();
+        }
+        return [];
     }
 
     hasFinished(): boolean {

--- a/ghost/core/test/unit/api/canary/utils/serializers/input/comments.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/input/comments.test.js
@@ -1,7 +1,13 @@
 const assert = require('node:assert/strict');
+const sinon = require('sinon');
 const serializers = require('../../../../../../../core/server/api/endpoints/utils/serializers');
+const urlService = require('../../../../../../../core/server/services/url');
 
 describe('Unit: endpoints/utils/serializers/input/comments', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
     describe('all', function () {
         it('converts member reaction includes to count relations', function () {
             const apiConfig = {};
@@ -23,7 +29,9 @@ describe('Unit: endpoints/utils/serializers/input/comments', function () {
             ]);
         });
 
-        it('loads post routing relations when post is included', function () {
+        it('loads the post routing relations the live routes reference when post is included', function () {
+            sinon.stub(urlService.facade, 'getRequiredRelations').returns(['tags', 'authors']);
+
             const apiConfig = {};
             const frame = {
                 options: {
@@ -35,6 +43,22 @@ describe('Unit: endpoints/utils/serializers/input/comments', function () {
             serializers.input.comments.all(apiConfig, frame);
 
             assert.deepEqual(frame.options.withRelated, ['post', 'post.tags', 'post.authors']);
+        });
+
+        it('loads no post relations when no route references tags or authors', function () {
+            sinon.stub(urlService.facade, 'getRequiredRelations').returns([]);
+
+            const apiConfig = {};
+            const frame = {
+                options: {
+                    context: {},
+                    withRelated: ['post']
+                }
+            };
+
+            serializers.input.comments.all(apiConfig, frame);
+
+            assert.deepEqual(frame.options.withRelated, ['post']);
         });
     });
 });

--- a/ghost/core/test/unit/api/canary/utils/serializers/input/posts.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/input/posts.test.js
@@ -1,7 +1,7 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
-const configUtils = require('../../../../../../utils/config-utils');
 const serializers = require('../../../../../../../core/server/api/endpoints/utils/serializers');
+const urlService = require('../../../../../../../core/server/services/url');
 const postsSchema = require('../../../../../../../core/server/data/schema').tables.posts;
 
 const mobiledocLib = require('../../../../../../../core/server/lib/mobiledoc');
@@ -133,51 +133,78 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
         // Regression for the bypass CodeRabbit caught in #27908: when the
         // caller passes both ?fields=url and ?include=relation, the
         // defaultRelations early-return on a non-empty withRelated must
-        // not skip the lazyRouting force-load — otherwise the URL still
-        // 404s for tag/author-filtered routes.
-        it('lazyRouting: merges tags+authors into withRelated when caller passes both ?fields=url and ?include=email', async function () {
-            configUtils.set('lazyRouting', true);
-            try {
-                const frame = {
-                    apiType: 'admin',
-                    options: {
-                        context: {user: 1},
-                        columns: ['id', 'url', 'title'],
-                        withRelated: ['email']
-                    }
-                };
+        // not skip the force-load — otherwise the URL still 404s for
+        // tag/author-filtered routes.
+        it('lazyRouting: merges the required relations into withRelated when caller passes both ?fields=url and ?include=email', function () {
+            sinon.stub(urlService.facade, 'getRequiredRelations').returns(['tags', 'authors']);
 
-                serializers.input.posts.browse({}, frame);
+            const frame = {
+                apiType: 'admin',
+                options: {
+                    context: {user: 1},
+                    columns: ['id', 'url', 'title'],
+                    withRelated: ['email']
+                }
+            };
 
-                assert.ok(frame.options.withRelated.includes('email'), 'caller-requested email must be preserved');
-                assert.ok(frame.options.withRelated.includes('tags'), 'tags must be force-loaded for URL');
-                assert.ok(frame.options.withRelated.includes('authors'), 'authors must be force-loaded for URL');
-            } finally {
-                await configUtils.restore();
-            }
+            serializers.input.posts.browse({}, frame);
+
+            assert.ok(frame.options.withRelated.includes('email'), 'caller-requested email must be preserved');
+            assert.ok(frame.options.withRelated.includes('tags'), 'tags must be force-loaded for URL');
+            assert.ok(frame.options.withRelated.includes('authors'), 'authors must be force-loaded for URL');
         });
 
-        it('lazyRouting: forces tags+authors on the Content API path', async function () {
+        it('lazyRouting: forces the required relations on the Content API path', function () {
             // Content API uses mapWithRelated rather than defaultRelations;
             // both branches must invoke the helper.
-            configUtils.set('lazyRouting', true);
-            try {
-                const frame = {
-                    apiType: 'content',
-                    options: {
-                        context: {api_key: {id: 1, type: 'content'}},
-                        columns: ['id', 'url']
-                    }
-                };
+            sinon.stub(urlService.facade, 'getRequiredRelations').returns(['tags', 'authors']);
 
-                serializers.input.posts.browse({}, frame);
+            const frame = {
+                apiType: 'content',
+                options: {
+                    context: {api_key: {id: 1, type: 'content'}},
+                    columns: ['id', 'url']
+                }
+            };
 
-                assert.ok(frame.options.withRelated);
-                assert.ok(frame.options.withRelated.includes('tags'));
-                assert.ok(frame.options.withRelated.includes('authors'));
-            } finally {
-                await configUtils.restore();
-            }
+            serializers.input.posts.browse({}, frame);
+
+            assert.ok(frame.options.withRelated);
+            assert.ok(frame.options.withRelated.includes('tags'));
+            assert.ok(frame.options.withRelated.includes('authors'));
+        });
+
+        it('lazyRouting: loads only the relations the live routes reference', function () {
+            sinon.stub(urlService.facade, 'getRequiredRelations').returns(['tags']);
+
+            const frame = {
+                apiType: 'admin',
+                options: {
+                    context: {user: 1},
+                    columns: ['id', 'url']
+                }
+            };
+
+            serializers.input.posts.browse({}, frame);
+
+            assert.ok(frame.options.withRelated.includes('tags'));
+            assert.ok(!frame.options.withRelated.includes('authors'), 'authors must not be loaded when no route references it');
+        });
+
+        it('does not force any relations when no route references tags or authors', function () {
+            sinon.stub(urlService.facade, 'getRequiredRelations').returns([]);
+
+            const frame = {
+                apiType: 'admin',
+                options: {
+                    context: {user: 1},
+                    columns: ['id', 'url']
+                }
+            };
+
+            serializers.input.posts.browse({}, frame);
+
+            assert.ok(!frame.options.withRelated, 'no relations should be force-loaded');
         });
 
         describe('Content API', function () {

--- a/ghost/core/test/unit/server/services/comments/comments-service.test.js
+++ b/ghost/core/test/unit/server/services/comments/comments-service.test.js
@@ -165,7 +165,7 @@ describe('Comments Service: CommentsService', function () {
                 get: sinon.stub().withArgs('comments_enabled').returns(commentsEnabled)
             },
             settingsHelpers: {},
-            urlService: {},
+            urlService: {facade: {getRequiredRelations: sinon.stub().returns([])}},
             urlUtils: {},
             contentGating: {
                 BLOCK_ACCESS: 'block',

--- a/ghost/core/test/unit/server/services/url/lazy-url-service.test.js
+++ b/ghost/core/test/unit/server/services/url/lazy-url-service.test.js
@@ -557,6 +557,20 @@ describe('LazyUrlService', function () {
             assert.deepEqual(service.getRequiredRelations().sort(), ['authors', 'tags']);
         });
 
+        it('requires the relation a permalink derives even when no filter references it', function () {
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
+            service.onRouterAddedType('default', null, 'posts', '/:primary_tag/:slug/');
+
+            assert.deepEqual(service.getRequiredRelations(), ['tags']);
+        });
+
+        it('requires authors when a permalink derives primary_author', function () {
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
+            service.onRouterAddedType('default', 'featured:true', 'posts', '/:primary_author/:slug/');
+
+            assert.deepEqual(service.getRequiredRelations(), ['authors']);
+        });
+
         it('recomputes after routers are reset', function () {
             const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
             service.onRouterAddedType('news', 'tag:news', 'posts', '/news/:slug/');

--- a/ghost/core/test/unit/server/services/url/lazy-url-service.test.js
+++ b/ghost/core/test/unit/server/services/url/lazy-url-service.test.js
@@ -532,4 +532,38 @@ describe('LazyUrlService', function () {
             assert.equal(url, '/hello/');
         });
     });
+
+    describe('getRequiredRelations', function () {
+        it('returns [] when no router references tags or authors', function () {
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
+            service.onRouterAddedType('default', null, 'posts', '/:slug/');
+            service.onRouterAddedType('featured', 'featured:true', 'posts', '/featured/:slug/');
+
+            assert.deepEqual(service.getRequiredRelations(), []);
+        });
+
+        it('returns only the relations the registered filters reference', function () {
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
+            service.onRouterAddedType('news', 'tag:news', 'posts', '/news/:slug/');
+
+            assert.deepEqual(service.getRequiredRelations(), ['tags']);
+        });
+
+        it('unions relations across all routers and maps primary_* tokens', function () {
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
+            service.onRouterAddedType('news', 'tag:news', 'posts', '/news/:slug/');
+            service.onRouterAddedType('staff', 'primary_author:jane', 'posts', '/staff/:slug/');
+
+            assert.deepEqual(service.getRequiredRelations().sort(), ['authors', 'tags']);
+        });
+
+        it('recomputes after routers are reset', function () {
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
+            service.onRouterAddedType('news', 'tag:news', 'posts', '/news/:slug/');
+            assert.deepEqual(service.getRequiredRelations(), ['tags']);
+
+            service.reset();
+            assert.deepEqual(service.getRequiredRelations(), []);
+        });
+    });
 });

--- a/ghost/core/test/unit/server/services/url/url-service-facade.test.js
+++ b/ghost/core/test/unit/server/services/url/url-service-facade.test.js
@@ -44,6 +44,12 @@ describe('UrlServiceFacade', function () {
         });
     });
 
+    describe('getRequiredRelations', function () {
+        it('returns [] with no lazy backend (eager touches no resource relations)', function () {
+            assert.deepEqual(facade.getRequiredRelations(), []);
+        });
+    });
+
     describe('resolveUrl', function () {
         it('returns null when the underlying lookup misses', async function () {
             urlService.getResource.returns(null);
@@ -104,6 +110,7 @@ describe('UrlServiceFacade', function () {
                 getUrlForResource: sinon.stub().returns('/lazy/'),
                 ownsResource: sinon.stub().returns(true),
                 resolveUrl: sinon.stub().resolves({type: 'posts', id: 'p1'}),
+                getRequiredRelations: sinon.stub().returns(['tags']),
                 hasFinished: sinon.stub().returns(true),
                 onRouterAddedType: sinon.stub(),
                 onRouterUpdated: sinon.stub(),
@@ -114,6 +121,11 @@ describe('UrlServiceFacade', function () {
 
         it('isLazy() reports true', function () {
             assert.equal(lazyFacade.isLazy(), true);
+        });
+
+        it('delegates getRequiredRelations to the lazy backend', function () {
+            assert.deepEqual(lazyFacade.getRequiredRelations(), ['tags']);
+            sinon.assert.calledOnce(lazyUrlService.getRequiredRelations);
         });
 
         it('routes getUrlForResource through the lazy backend', function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1870

Lazy URL routing resolves a resource's URL by evaluating each router's NQL
filter against the in-memory resource, so any resource passed to
`getUrlForResource` must already have the relations those filters reference
(e.g. `tags.slug`, `authors.slug`) loaded — otherwise it 404s as a "thin"
resource. The original lazy-404 fix (#27938) handled this by force-loading a
blanket `tags` + `authors` on a wide set of post/page reads. Some of those
loads ran unconditionally (email, comments), which added query noise and a
measurable performance cost even on sites that never use lazy routing.

This PR makes that loading precise and routes it all through one helper, ahead
of enabling compare-mode rollout (TryGhost/Zuul#1133).

## Changes

- **Added `getRequiredRelations()` to the lazy URL service + facade.** It scans
  the registered router filters and returns only the subset of `tags`/`authors`
  the live routes actually reference (`[]` when none do), cached and invalidated
  when routers change. The facade returns `[]` when there is no lazy backend, so
  eager and non-lazy sites compute nothing.
- **Switched the gated API call sites to the helper.** `search-index`,
  `search-index-public`, and the posts/pages input serializers now load only the
  referenced relations on the `?fields=url` path instead of a blanket
  `tags+authors`, and the early-return bypass when a caller passes both
  `?fields=url` and `?include=` is fixed.
- **Routed the unconditional email/comments callers through the helper via
  dependency injection.** `email-renderer`, `batch-sending-service`, and
  `email-controller` take an injected `getRequiredUrlRelations` wired by the
  email-service composition root; `comments-service` uses the `urlService` it was
  already handed. Each path keeps its own render relations (`posts_meta`,
  `authors`) intact.

## Safety / rollout

- **Eager (default, all self-hosters + 80% of Pro):** `getRequiredRelations()`
  returns `[]`, so no extra relations are loaded. Eager resolves URLs by id and
  never touches a resource's relations; anything needed for rendering is fetched
  via `getLazyRelation`. This removes the unconditional loads #27938 added and
  restores pre-#27938 query behavior.
- **Lazy compare mode (TryGhost/Zuul#1133, 20% of Pro):** eager remains the
  canonical, returned answer; lazy runs in the background. We load exactly the
  relations lazy needs to evaluate filters, so any edge case surfaces as a
  logged comparison mismatch rather than a user-facing 404.

## Test plan

- [x] `getRequiredRelations()` unit tests (lazy service + facade)
- [x] Updated posts/comments input-serializer tests to stub the helper
- [x] email-controller / batch-sending / comments-service unit tests pass
- [x] `tsc --noEmit` + eslint clean
- [ ] Watch compare-mode mismatch logs after Zuul#1133 ships at 20%
