### PR TITLE
Changed llms_enabled to default off for existing sites

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.46/2026-06-19-10-00-00-grandfather-llms.js
+++ b/ghost/core/core/server/data/migrations/versions/6.46/2026-06-19-10-00-00-grandfather-llms.js
@@ -1,0 +1,37 @@
+const logging = require('@tryghost/logging');
+
+const {createTransactionalMigration} = require('../../utils');
+
+// llms_enabled defaults to "true" in default-settings.json, so brand-new
+// sites get the feature switched on. This migration only runs when an
+// existing site upgrades (fresh installs stamp migrations as complete
+// without executing them), so it flips the setting off for sites that
+// predate the feature being on by default — leaving new sites untouched.
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        const setting = await knex('settings')
+            .where({key: 'llms_enabled'})
+            .first();
+
+        if (!setting) {
+            logging.warn('llms_enabled setting not found, skipping migration');
+            return;
+        }
+
+        // Previous default is "true". If a site has already chosen a value
+        // we don't want to overwrite it.
+        if (setting.value !== 'true') {
+            logging.info('llms_enabled setting is not the previous default of "true", skipping migration');
+            return;
+        }
+
+        logging.info('Disabling llms_enabled for existing site');
+        await knex('settings')
+            .where({key: 'llms_enabled'})
+            .update({value: 'false'});
+    },
+    async function down() {
+        // no-op: we can't tell a later explicit "false" apart from the value
+        // set here, so re-enabling could overwrite a deliberate choice
+    }
+);


### PR DESCRIPTION
`llms_enabled` was introduced switched on by default for everyone (6.40), but the feature should only default to on for **new** sites. Existing publications shouldn't silently gain a new public surface (llms.txt and per-entry markdown exports) at upgrade time without opting in.

`default-settings.json` keeps the default at `true`, so fresh installs get the feature on. Fresh installs stamp migrations as run without executing them, so a migration only ever runs when an **existing** site upgrades — which is exactly the grandfather hook. This migration flips `llms_enabled` to `false` for those existing sites, and guards on the previous default (`true`) so it never overwrites a value a site has already chosen. The down migration is intentionally a no-op: once flipped, an explicit later `false` is indistinguishable from the value this migration set, so re-enabling could clobber a deliberate choice.

The pattern mirrors 6.28's `disable-default-header-fields-for-existing-welcome-emails`: ship a feature on for new sites via the default, and grandfather existing sites off via a guarded migration.

The feature itself remains behind the private `llmsTxt` labs flag, so this only affects the default once that flag is enabled.
