### PR TITLE
Moved the frontend storage-util crosser onto the proxy seam

### DIFF
--- a/ghost/core/.eslintrc.js
+++ b/ghost/core/.eslintrc.js
@@ -191,8 +191,7 @@ module.exports = {
                 // Leaks that bypass the proxy (fix first).
                 'core/frontend/services/routing/controllers/unsubscribe.js', // services/members + settings-helpers
                 'core/frontend/services/routing/router-manager.js', // server/lib/common/events bus
-                'core/frontend/services/sitemap/site-map-manager.js', // server/lib/common/events bus
-                'core/frontend/utils/images.js' // server/adapters/storage/utils
+                'core/frontend/services/sitemap/site-map-manager.js' // server/lib/common/events bus
             ],
             rules: {
                 'ghost/node/no-restricted-require': ['error', [

--- a/ghost/core/core/frontend/services/proxy.js
+++ b/ghost/core/core/frontend/services/proxy.js
@@ -29,6 +29,7 @@ module.exports = {
     socialUrls: require('@tryghost/social-urls'),
     blogIcon: require('../../server/lib/image').blogIcon,
     cachedImageSizeFromUrl: require('../../server/lib/image').cachedImageSizeFromUrl,
+    isInternalImage: require('../../server/adapters/storage/utils').isInternalImage,
     // Used by router service and {{get}} helper to prepare data for optimal usage in themes
     prepareContextResource(data) {
         (Array.isArray(data) ? data : [data]).forEach((resource) => {

--- a/ghost/core/core/frontend/services/proxy.js
+++ b/ghost/core/core/frontend/services/proxy.js
@@ -2,6 +2,7 @@
 const settingsCache = require('../../shared/settings-cache');
 const config = require('../../shared/config');
 const settingsHelpers = require('../../server/services/settings-helpers');
+const storageUtils = require('../../server/adapters/storage/utils');
 const internalKeys = require('../../server/services/internal-keys').default;
 const logging = require('@tryghost/logging');
 
@@ -29,7 +30,8 @@ module.exports = {
     socialUrls: require('@tryghost/social-urls'),
     blogIcon: require('../../server/lib/image').blogIcon,
     cachedImageSizeFromUrl: require('../../server/lib/image').cachedImageSizeFromUrl,
-    isInternalImage: require('../../server/adapters/storage/utils').isInternalImage,
+    // bound because isInternalImage relies on `this` to reach sibling helpers in storage utils
+    isInternalImage: storageUtils.isInternalImage.bind(storageUtils),
     // Used by router service and {{get}} helper to prepare data for optimal usage in themes
     prepareContextResource(data) {
         (Array.isArray(data) ? data : [data]).forEach((resource) => {

--- a/ghost/core/core/frontend/utils/images.js
+++ b/ghost/core/core/frontend/utils/images.js
@@ -1,11 +1,11 @@
 const imageTransform = require('@tryghost/image-transform');
 const urlUtils = require('../../shared/url-utils');
-const storageUtils = require('../../server/adapters/storage/utils');
+const {isInternalImage} = require('../services/proxy');
 
 module.exports.detectInternalImage = function detectInternalImage(requestedImageUrl) {
     const siteUrl = urlUtils.getSiteUrl();
     const isAbsoluteImage = /https?:\/\//.test(requestedImageUrl);
-    const isAbsoluteInternalImage = isAbsoluteImage && (requestedImageUrl.startsWith(siteUrl) || storageUtils.isInternalImage(requestedImageUrl));
+    const isAbsoluteInternalImage = isAbsoluteImage && (requestedImageUrl.startsWith(siteUrl) || isInternalImage(requestedImageUrl));
 
     // CASE: imagePath is a "protocol relative" url e.g. "//www.gravatar.com/ava..."
     //       by resolving the the imagePath relative to the blog url, we can then


### PR DESCRIPTION
## Summary

- Routes `core/frontend/utils/images.js` through the sanctioned proxy seam instead of reaching directly into `core/server/adapters/storage/utils` for its one needed function, `isInternalImage`.
- Drops that file from the `no-restricted-require` allowlist, so the frontend → `core/server` boundary rule now enforces it like the rest of the frontend.

## Context

Follow-up to #28677, which added the boundary-regression lint rule with an `excludedFiles` allowlist that doubles as a cleanup ledger. This works the simplest leaf-level entry off that list: `utils/images.js` only needed `storageUtils.isInternalImage`, used in a single expression. Exposing it on `services/proxy.js` (which already carries the other image helpers like `blogIcon` and `cachedImageSizeFromUrl`) and requiring it from there removes a real crosser rather than shuffling wiring — the same move that #28677 made for the `meta/*` layer.

The remaining allowlist entries (`unsubscribe.js` → members/settings-helpers, and the two `lib/common/events` bus files) are deliberately left for later: those are genuine untangles, not a one-line re-export.

## Testing

- [x] `cd ghost/core && npx eslint 'core/frontend/**/*.js'` — green
- [x] Verified the ratchet now bites on this file: injecting a new `require('../../server/services/members')` into `utils/images.js` errors with the boundary message; removing it returns to green
- [x] `npx vitest run test/unit/frontend/meta/image-dimensions.test.js test/unit/frontend/web/middleware/handle-image-sizes.test.js` — pass (these import `utils/images.js`, confirming the new proxy require loads with no cycle)
