### PR TITLE
Enforced the core/server to core/frontend boundary and removed a dead rule

### DIFF
--- a/ghost/core/.eslintrc.js
+++ b/ghost/core/.eslintrc.js
@@ -139,26 +139,6 @@ module.exports = {
                 'no-console': 'off'
             }
         },
-        /**
-         * @TODO: enable these soon
-         */
-        {
-            files: 'core/frontend/**',
-            rules: {
-                'ghost/node/no-restricted-require': ['off', [
-                    // If we make the frontend entirely independent, these have to be solved too
-                    // {
-                    //     name: path.resolve(__dirname, 'core/shared/**'),
-                    //     message: 'Invalid require of core/shared from core/frontend.'
-                    // },
-                    // These are critical refactoring issues that we need to tackle ASAP
-                    {
-                        name: [path.resolve(__dirname, 'core/server/**')],
-                        message: 'Invalid require of core/server from core/frontend.'
-                    }
-                ]]
-            }
-        },
         {
             // Frontend must not access the model layer directly; use the public Content API via services/proxy
             files: 'core/frontend/**',
@@ -204,13 +184,22 @@ module.exports = {
             }
         },
         {
+            // Prevent new direct requires of core/frontend from the server.
+            // Adding files to this list is an anti-pattern
+            // Work down until the list is empty
             files: 'core/server/**',
+            excludedFiles: [
+                // Composition root: mounts the frontend Express app onto the server (less wrong).
+                'core/server/web/parent/frontend.js',
+
+                // Leak: reaches into the frontend routing config for QUERY/TAXONOMIES (fix first — config should be injected, see the in-file TODO).
+                'core/server/services/route-settings/validate.js'
+            ],
             rules: {
-                'ghost/node/no-restricted-require': ['warn', [
+                'ghost/node/no-restricted-require': ['error', [
                     {
-                        // Throw an error for all requires of the frontend, _except_ the url service which will be moved soon
                         name: [path.resolve(__dirname, 'core/frontend/**')],
-                        message: 'Invalid require of core/frontend from core/server.'
+                        message: 'Invalid require of core/frontend from core/server. The server must not depend on the frontend rendering layer.'
                     }
                 ]]
             }


### PR DESCRIPTION
## Summary

- Removes a dead frontend lint rule and enforces the reverse `core/server` → `core/frontend` boundary, mirroring the frontend rule added in #28677.

## Context

Follow-up to #28677 (frontend → `core/server` boundary) and the leaf-cleanup PRs that followed. Two `.eslintrc.js` changes:

**Removed a dead frontend rule.** Once #28677 added the broad `core/server/**` error rule for the frontend, the old `'off'` block became a no-op: every `core/frontend` file already matches the `models` block and the broad block that follow it, and ESLint overrides are last-match-wins, so the `'off'` block never took effect. The `models`-specific block is deliberately kept — it's the only thing banning `core/server/models` in the *allowlisted* files (including the proxy seam itself), so it isn't superseded.

**Enforced the reverse boundary.** The `core/server` → `core/frontend` rule was sitting at `warn`, which nothing reads, so it held nothing. Switched it to `error` with the same `excludedFiles` ratchet pattern as the frontend rule — green today, only new crossings fail. The allowlist holds the only two current crossers and grades them inline:

- `web/parent/frontend.js` — composition root that mounts the frontend Express app (less wrong)
- `services/route-settings/validate.js` — reaches into the frontend routing config for `QUERY`/`TAXONOMIES` (fix first; config should be injected, per its own in-file TODO)

The stale "url service which will be moved soon" comment was dropped — no such crosser exists anymore.

## Testing

- [x] `cd ghost/core && npx eslint 'core/frontend/**/*.js'` — green
- [x] `cd ghost/core && npx eslint 'core/server/**/*.js'` — green
- [x] Verified the server ratchet bites: a new `require('…/frontend/…')` in a non-excluded server file errors; the two excluded crossers are green
- [x] Verified the `models` ban survives the dead-rule removal: a `require('…/server/models')` in the allowlisted `services/proxy.js` still errors, while a non-models server require there is allowed
