### PR TITLE
🎨 Improved theme validation modals

### DIFF
--- a/apps/admin-x-design-system/src/global/modal/confirmation-modal.tsx
+++ b/apps/admin-x-design-system/src/global/modal/confirmation-modal.tsx
@@ -4,7 +4,7 @@ import React, {useState} from 'react';
 import {ButtonColor} from '../button';
 
 export interface ConfirmationModalProps {
-    title?: string;
+    title?: React.ReactNode;
     prompt?: React.ReactNode;
     cancelLabel?: string;
     okLabel?: string;
@@ -16,6 +16,7 @@ export interface ConfirmationModalProps {
     }) => void | Promise<void>;
     customFooter?: boolean | React.ReactNode;
     formSheet?: boolean;
+    stickyFooter?: boolean;
 }
 
 export const ConfirmationModalContent: React.FC<ConfirmationModalProps> = ({
@@ -28,7 +29,8 @@ export const ConfirmationModalContent: React.FC<ConfirmationModalProps> = ({
     onCancel,
     onOk,
     customFooter,
-    formSheet = true
+    formSheet = true,
+    stickyFooter = false
 }) => {
     const modal = useModal();
     const [taskState, setTaskState] = useState<'running' | ''>('');
@@ -41,6 +43,7 @@ export const ConfirmationModalContent: React.FC<ConfirmationModalProps> = ({
             formSheet={formSheet}
             okColor={okColor}
             okLabel={taskState === 'running' ? okRunningLabel : okLabel}
+            stickyFooter={stickyFooter}
             testId='confirmation-modal'
             title={title}
             width={540}

--- a/apps/admin-x-design-system/src/global/modal/modal.tsx
+++ b/apps/admin-x-design-system/src/global/modal/modal.tsx
@@ -21,7 +21,7 @@ export interface ModalProps {
     align?: 'center' | 'left' | 'right';
 
     testId?: string;
-    title?: string;
+    title?: React.ReactNode;
     okLabel?: string;
     okColor?: ButtonColor;
     okLoading?: boolean;

--- a/apps/admin-x-framework/src/api/themes.ts
+++ b/apps/admin-x-framework/src/api/themes.ts
@@ -22,7 +22,7 @@ export type InstalledTheme = Theme & {
     warnings?: ThemeProblem<'warning'>[];
 }
 
-export type ThemeProblem<Level extends string = 'error' | 'warning'> = {
+export type ThemeProblem<Level extends string = 'error' | 'warning' | 'recommendation'> = {
     code: string
     details: string
     failures: Array<{

--- a/apps/admin-x-settings/src/components/settings/site/theme-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme-modal.tsx
@@ -158,8 +158,8 @@ const ThemeToolbar: React.FC<ThemeToolbarProps> = ({
         }
 
         if (fatalErrors && !data) {
-            let title = 'Invalid Theme';
-            let prompt = <>This theme is invalid and cannot be activated. Fix the following errors and re-upload the theme</>;
+            let title = 'Theme not uploaded';
+            let prompt = <>This theme couldn&apos;t be uploaded because Ghost found a blocking validation error. Fix the issue below and upload the theme again.</>;
             NiceModal.show(InvalidThemeModal, {
                 title,
                 prompt,
@@ -190,17 +190,15 @@ const ThemeToolbar: React.FC<ThemeToolbarProps> = ({
         }
 
         if (uploadedTheme?.errors?.length || uploadedTheme.warnings?.length) {
-            const hasErrors = uploadedTheme?.errors?.length;
-
-            title = `Upload successful with ${hasErrors ? 'errors' : 'warnings'}`;
+            title = 'Upload successful';
             prompt = <>
-                The theme <strong>&quot;{uploadedTheme.name}&quot;</strong> was installed but we detected some {hasErrors ? 'errors' : 'warnings'}.
+                The theme <strong>&quot;{uploadedTheme.name}&quot;</strong> was installed successfully.
             </>;
 
             if (!uploadedTheme.active) {
                 prompt = <>
                     {prompt}
-                    You are still able to activate and use the theme but it is recommended to fix these {hasErrors ? 'errors' : 'warnings'} before you do so.
+                    You can activate it when you&apos;re ready.
                 </>;
             }
         }
@@ -484,17 +482,15 @@ const ChangeThemeModal: React.FC<ChangeThemeModalProps> = ({source, themeRef}) =
                 }
 
                 if (newlyInstalledTheme.errors?.length || newlyInstalledTheme.warnings?.length) {
-                    const hasErrors = newlyInstalledTheme.errors?.length;
-
-                    title = `Installed with ${hasErrors ? 'errors' : 'warnings'}`;
+                    title = 'Installed successfully';
                     prompt = <>
-        The theme <strong>&quot;{newlyInstalledTheme.name}&quot;</strong> was installed successfully but we detected some {hasErrors ? 'errors' : 'warnings'}.
+        The theme <strong>&quot;{newlyInstalledTheme.name}&quot;</strong> was installed successfully.
                     </>;
 
                     if (!newlyInstalledTheme.active) {
                         prompt = <>
                             {prompt}
-            You are still able to activate and use the theme but it is recommended to contact the theme developer fix these {hasErrors ? 'errors' : 'warnings'} before you do so.
+            You can activate it when you&apos;re ready.
                         </>;
                     }
                 }

--- a/apps/admin-x-settings/src/components/settings/site/theme/advanced-theme-settings.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/advanced-theme-settings.tsx
@@ -72,8 +72,8 @@ const ThemeActions: React.FC<ThemeActionProps> = ({
             } else {
                 handleError(e);
             }
-            let title = 'Invalid Theme';
-            let prompt = <>This theme is invalid and cannot be activated. Fix the following errors and re-upload the theme</>;
+            let title = 'Theme not activated';
+            let prompt = <>This theme couldn&apos;t be activated because Ghost found a blocking validation error. Fix the issue below and try again.</>;
 
             if (fatalErrors) {
                 NiceModal.show(InvalidThemeModal, {

--- a/apps/admin-x-settings/src/components/settings/site/theme/invalid-theme-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/invalid-theme-modal.tsx
@@ -1,89 +1,50 @@
 import NiceModal from '@ebay/nice-modal-react';
-import React, {type ReactNode, useState} from 'react';
-import {Button, ConfirmationModalContent, Heading, List, ListItem} from '@tryghost/admin-x-design-system';
-import {type ThemeProblem} from '@tryghost/admin-x-framework/api/themes';
+import React, {type ReactNode} from 'react';
+import {ConfirmationModalContent} from '@tryghost/admin-x-design-system';
+import {ErrorTextCard, type FatalErrors, ThemeValidationDetailsDisclosure, ValidationProblemCard, getIssuesFromFatalErrors} from './theme-validation-details';
+import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
 
-type FatalError = {
-    details: {
-      errors: ThemeProblem[];
-    }|string;
-  };
-
-export type FatalErrors = FatalError[];
-
-export const ThemeProblemView = ({problem}:{problem: ThemeProblem}) => {
-    const [isExpanded, setExpanded] = useState(false);
-
-    const handleClick = () => {
-        setExpanded(!isExpanded);
-    };
-
-    return <ListItem
-        title={
-            <>
-                <div className={`${problem.level === 'error' ? 'before:bg-red' : 'before:bg-yellow'} relative px-4 before:absolute before:top-1.5 before:left-0 before:block before:size-2 before:rounded-full before:content-['']`}>
-                    {
-                        problem?.fatal ?
-                            <strong>Fatal: </strong>
-                            :
-                            <strong>{problem.level === 'error' ? 'Error: ' : 'Warning: '}</strong>
-                    }
-                    <span dangerouslySetInnerHTML={{__html: problem.rule}} />
-                    <div className='absolute top-1 -right-4'>
-                        <Button color="green" icon={isExpanded ? 'chevron-down' : 'chevron-right'} iconColorClass='text-grey-700' size='sm' link onClick={() => handleClick()} />
-                    </div>
-                </div>
-                {
-                    isExpanded ?
-                        <div className='mt-2 px-4 text-[13px]'>
-                            <div dangerouslySetInnerHTML={{__html: problem.details}} className='mb-4' />
-                            <Heading level={6}>Affected files:</Heading>
-                            <ul className='mt-1'>
-                                {problem.failures.map(failure => <li><code>{failure.ref}</code>{failure.message ? `: ${failure.message}` : ''}</li>)}
-                            </ul>
-                        </div> :
-                        null
-                }
-            </>
-        }
-        hideActions
-        separator
-    />;
-};
+export type {FatalErrors} from './theme-validation-details';
 
 const InvalidThemeModal: React.FC<{
     title: string
     prompt: ReactNode
     fatalErrors?: FatalErrors;
+    validationDetailsDefaultOpen?: boolean;
     onRetry?: (modal?: {
         remove: () => void;
     }) => void | Promise<void>;
-}> = ({title, prompt, fatalErrors, onRetry}) => {
-    let warningPrompt = null;
-    if (fatalErrors) {
-        warningPrompt = <div className="mt-10">
-            <List title="Errors">
-                {fatalErrors.map((error) => {
-                    if (typeof error.details === 'object' && error.details.errors && error.details.errors.length > 0) {
-                        return error.details.errors.map(err => <ThemeProblemView problem={err} />);
-                    } else if (typeof error.details === 'string') {
-                        return <ListItem title={error.details} />;
-                    } else {
-                        return null;
-                    }
-                })}
-            </List>
-        </div>;
-    }
+}> = ({title, prompt, fatalErrors, validationDetailsDefaultOpen, onRetry}) => {
+    const {data: configData} = useBrowseConfig();
+    const defaultOpen = validationDetailsDefaultOpen ?? configData?.config?.environment === 'development';
+    const {blockingProblems, secondaryProblems, stringErrors} = getIssuesFromFatalErrors(fatalErrors);
+    const blockingIssueCount = blockingProblems.length + stringErrors.length;
+    const promptText = prompt ?? <>Ghost found {blockingIssueCount === 1 ? 'a blocking validation error' : `${blockingIssueCount} blocking validation errors`} and did not save your theme. Fix {blockingIssueCount === 1 ? 'the issue' : 'the issues'} below and try again.</>;
 
     return <ConfirmationModalContent
         cancelLabel='Close'
         okColor='black'
         okLabel={'Retry'}
         prompt={<>
-            {prompt}
-            {warningPrompt}
+            <div className='space-y-5'>
+                <div className='text-sm text-foreground'>{promptText}</div>
+
+                {(blockingProblems.length > 0 || stringErrors.length > 0) && (
+                    <div className='space-y-3'>
+                        {blockingProblems.map(problem => (
+                            <ValidationProblemCard key={problem.code} problem={problem} prominent />
+                        ))}
+                        {stringErrors.map(error => <ErrorTextCard key={error} message={error} />)}
+                    </div>
+                )}
+
+                <ThemeValidationDetailsDisclosure
+                    defaultOpen={defaultOpen}
+                    problems={secondaryProblems}
+                />
+            </div>
         </>}
+        stickyFooter={true}
         title={title}
         onOk={onRetry}
     />;

--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-code-editor-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-code-editor-modal.tsx
@@ -812,8 +812,7 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
             if (!response.ok) {
                 if (response.status === 422 && data?.errors) {
                     NiceModal.show(InvalidThemeModal, {
-                        title: 'Invalid Theme',
-                        prompt: <>Fix the validation errors below and try saving again.</>,
+                        title: 'Theme not saved',
                         fatalErrors: data.errors as FatalErrors
                     });
                     return;

--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-installed-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-installed-modal.tsx
@@ -1,76 +1,49 @@
 import NiceModal from '@ebay/nice-modal-react';
-import React, {type ReactNode, useState} from 'react';
+import React, {type ReactNode} from 'react';
 import useCustomFonts from '../../../../hooks/use-custom-fonts';
-import {Button, ConfirmationModalContent, Heading, List, ListItem, showToast} from '@tryghost/admin-x-design-system';
-import {type InstalledTheme, type ThemeProblem, useActivateTheme} from '@tryghost/admin-x-framework/api/themes';
+import {ConfirmationModalContent, showToast} from '@tryghost/admin-x-design-system';
+import {type InstalledTheme, useActivateTheme} from '@tryghost/admin-x-framework/api/themes';
+import {OutcomeBanner, ThemeValidationDetailsDisclosure, getIssuesFromInstalledTheme} from './theme-validation-details';
+import {getHomepageUrl, useBrowseSite} from '@tryghost/admin-x-framework/api/site';
+import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
-
-export const ThemeProblemView = ({problem}:{problem: ThemeProblem}) => {
-    const [isExpanded, setExpanded] = useState(false);
-
-    return <ListItem
-        title={
-            <>
-                <div className={`${problem.level === 'error' ? 'before:bg-red' : 'before:bg-yellow'} relative px-4 before:absolute before:top-1.5 before:left-0 before:block before:size-2 before:rounded-full before:content-['']`}>
-                    <strong>{problem.level === 'error' ? 'Error: ' : 'Warning: '}</strong>
-                    <span dangerouslySetInnerHTML={{__html: problem.rule}} />
-                    <div className='absolute top-1 -right-4'>
-                        <Button color="green" icon={isExpanded ? 'chevron-down' : 'chevron-right'} iconColorClass='text-grey-700' size='sm' link onClick={() => setExpanded(!isExpanded)} />
-                    </div>
-                </div>
-                {
-                    isExpanded ?
-                        <div className='mt-2 px-4 text-[13px]'>
-                            <div dangerouslySetInnerHTML={{__html: problem.details}} className='mb-4' />
-                            <Heading level={6}>Affected files:</Heading>
-                            <ul className='mt-1'>
-                                {problem.failures.map(failure => <li key={failure.ref}><code>{failure.ref}</code>{failure.message ? `: ${failure.message}` : ''}</li>)}
-                            </ul>
-                        </div> :
-                        null
-                }
-            </>
-        }
-        hideActions
-        separator
-    />;
-};
 
 const ThemeInstalledModal: React.FC<{
     title: string
     prompt: ReactNode
     installedTheme: InstalledTheme;
+    validationDetailsDefaultOpen?: boolean;
     onActivate?: () => void;
-}> = ({title, prompt, installedTheme, onActivate}) => {
+}> = ({title, installedTheme, validationDetailsDefaultOpen, onActivate}) => {
     const {mutateAsync: activateTheme} = useActivateTheme();
     const {refreshActiveThemeData} = useCustomFonts();
     const handleError = useHandleError();
+    const {data: configData} = useBrowseConfig();
+    const {data: siteData} = useBrowseSite();
+    const defaultOpen = validationDetailsDefaultOpen ?? configData?.config?.environment === 'development';
+    const secondaryProblems = getIssuesFromInstalledTheme(installedTheme);
+    const homepageUrl = siteData?.site ? getHomepageUrl(siteData.site) : undefined;
 
-    /* eslint-disable react/no-array-index-key */
-    let errorPrompt = null;
-    if (installedTheme && installedTheme.errors) {
-        errorPrompt = <div className="mt-6">
-            <List hint={<>Highly recommended to fix, functionality <strong>could</strong> be restricted</>} title="Errors">
-                {installedTheme.errors?.map((error, index) => <ThemeProblemView key={index} problem={error} />)}
-            </List>
-        </div>;
-    }
-
-    let warningPrompt = null;
-    if (installedTheme && installedTheme.warnings) {
-        warningPrompt = <div className="mt-10">
-            <List title="Warnings">
-                {installedTheme.warnings?.map((warning, index) => <ThemeProblemView key={index} problem={warning} />)}
-            </List>
-        </div>;
-    }
-    /* eslint-enable react/no-array-index-key */
-
-    let okLabel = `Activate${installedTheme.errors?.length ? ' with errors' : ''}`;
+    let okLabel = 'Activate theme';
 
     if (installedTheme.active) {
         okLabel = 'OK';
     }
+
+    const modalTitle = installedTheme.active ? <span className='text-green'>It&apos;s live!</span> : title;
+    const outcomeTitle = 'Uploaded successfully';
+    const outcomeCopy = installedTheme.active ? (
+        <>
+            Your theme <strong>{installedTheme.name}</strong> was saved successfully and is now visible to your readers.
+            {homepageUrl ? <>
+                {' '}<a className='font-semibold text-black hover:underline dark:text-white' href={homepageUrl} rel='noreferrer' target='_blank'>Take a look →</a>
+            </> : null}
+        </>
+    ) : (
+        <>
+            <strong>{installedTheme.name}</strong> has been uploaded. Activate it to make it live.
+        </>
+    );
 
     return <ConfirmationModalContent
         cancelLabel='Close'
@@ -78,12 +51,27 @@ const ThemeInstalledModal: React.FC<{
         okLabel={okLabel}
         okRunningLabel='Activating...'
         prompt={<>
-            {prompt}
+            <div className='space-y-5'>
+                {installedTheme.active ? (
+                    <div className='space-y-2 text-sm text-foreground'>
+                        <p>{outcomeCopy}</p>
+                    </div>
+                ) : (
+                    <OutcomeBanner title={outcomeTitle} variant='success'>
+                        <div className='space-y-2'>
+                            <p>{outcomeCopy}</p>
+                        </div>
+                    </OutcomeBanner>
+                )}
 
-            {errorPrompt}
-            {warningPrompt}
+                <ThemeValidationDetailsDisclosure
+                    defaultOpen={defaultOpen}
+                    problems={secondaryProblems}
+                />
+            </div>
         </>}
-        title={title}
+        stickyFooter={true}
+        title={modalTitle}
         onOk={async (activateModal) => {
             if (!installedTheme.active) {
                 try {

--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-validation-details.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-validation-details.tsx
@@ -1,0 +1,226 @@
+import React, {useEffect, useMemo, useState} from 'react';
+import {Badge, Banner} from '@tryghost/shade/components';
+import {type InstalledTheme, type ThemeProblem} from '@tryghost/admin-x-framework/api/themes';
+import {LucideIcon} from '@tryghost/shade/utils';
+
+type ThemeValidationErrorDetails = {
+    errors?: ThemeProblem[];
+    warnings?: ThemeProblem[];
+};
+
+type ThemeValidationError = {
+    details: ThemeValidationErrorDetails | string;
+};
+
+export type FatalErrors = ThemeValidationError[];
+
+type IssueSummary = {
+    blockingProblems: ThemeProblem[];
+    secondaryProblems: ThemeProblem[];
+    stringErrors: string[];
+};
+
+type DisplaySeverity = 'Error' | 'Warning' | 'Recommendation';
+
+function isDetailsObject(details: ThemeValidationError['details']): details is ThemeValidationErrorDetails {
+    return typeof details === 'object' && details !== null;
+}
+
+function allProblemsFromDetails(details: ThemeValidationErrorDetails) {
+    return [...(details.errors || []), ...(details.warnings || [])];
+}
+
+export function getIssuesFromFatalErrors(fatalErrors: FatalErrors = []): IssueSummary {
+    const blockingProblems: ThemeProblem[] = [];
+    const secondaryProblems: ThemeProblem[] = [];
+    const stringErrors: string[] = [];
+
+    fatalErrors.forEach((error) => {
+        if (isDetailsObject(error.details)) {
+            allProblemsFromDetails(error.details).forEach((problem) => {
+                if (problem.fatal) {
+                    blockingProblems.push(problem);
+                } else {
+                    secondaryProblems.push(problem);
+                }
+            });
+        } else {
+            stringErrors.push(error.details);
+        }
+    });
+
+    return {blockingProblems, secondaryProblems, stringErrors};
+}
+
+export function getIssuesFromInstalledTheme(installedTheme: InstalledTheme): ThemeProblem[] {
+    return [...(installedTheme.errors || []), ...(installedTheme.warnings || [])];
+}
+
+function getDisplaySeverity(problem: ThemeProblem): DisplaySeverity {
+    if (problem.level === 'warning') {
+        return 'Warning';
+    }
+
+    if (problem.level === 'recommendation') {
+        return 'Recommendation';
+    }
+
+    return 'Error';
+}
+
+function getDisplayVariant(problem: ThemeProblem): 'destructive' | 'warning' | 'secondary' {
+    if (problem.level === 'warning') {
+        return 'warning';
+    }
+
+    if (problem.level === 'recommendation') {
+        return 'secondary';
+    }
+
+    return 'destructive';
+}
+
+function formatNonBlockingIssueCount(count: number) {
+    return `${count} non-blocking ${count === 1 ? 'issue' : 'issues'}`;
+}
+
+function ProblemDetails({problem}: {problem: ThemeProblem}) {
+    return (
+        <div className='space-y-3'>
+            <div dangerouslySetInnerHTML={{__html: problem.details}} className='text-sm text-muted-foreground' />
+            {problem.failures?.length > 0 && (
+                <div>
+                    <h6 className='mb-1 text-xs font-semibold text-muted-foreground uppercase'>Affected files</h6>
+                    <ul className='space-y-1 text-sm text-muted-foreground'>
+                        {problem.failures.map(failure => (
+                            <li key={`${failure.ref}-${failure.message || ''}`}>
+                                <code className='rounded bg-muted px-1 py-0.5 text-xs text-foreground'>{failure.ref}</code>
+                                {failure.message ? <span>: {failure.message}</span> : null}
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            )}
+        </div>
+    );
+}
+
+export function ValidationProblemCard({problem, prominent = false}: {problem: ThemeProblem; prominent?: boolean}) {
+    const [expanded, setExpanded] = useState(prominent);
+    const displaySeverity = getDisplaySeverity(problem);
+
+    return (
+        <div className={`rounded-lg border ${prominent ? 'border-destructive/30 bg-background' : 'border-border bg-background'} p-4`}>
+            <button
+                className='flex w-full items-start justify-between gap-3 text-left'
+                type='button'
+                onClick={() => setExpanded(!expanded)}
+            >
+                <div className='min-w-0 flex-1'>
+                    <div className='mb-2 flex items-center gap-2'>
+                        <Badge variant={getDisplayVariant(problem)}>{displaySeverity}</Badge>
+                        {problem.code && <span className='text-xs text-muted-foreground'>{problem.code}</span>}
+                    </div>
+                    <div dangerouslySetInnerHTML={{__html: problem.rule}} className='text-sm font-medium text-foreground' />
+                </div>
+                <LucideIcon.ChevronDown className={`mt-1 size-4 shrink-0 text-muted-foreground transition-transform ${expanded ? 'rotate-180' : ''}`} />
+            </button>
+            {expanded && (
+                <div className='mt-4 border-t border-border pt-4'>
+                    <ProblemDetails problem={problem} />
+                </div>
+            )}
+        </div>
+    );
+}
+
+export function ThemeValidationDetailsDisclosure({
+    defaultOpen,
+    problems
+}: {
+    defaultOpen: boolean;
+    problems: ThemeProblem[];
+}) {
+    const [open, setOpen] = useState(defaultOpen);
+    const count = problems.length;
+
+    useEffect(() => {
+        setOpen(defaultOpen);
+    }, [defaultOpen]);
+
+    const sortedProblems = useMemo(() => {
+        return [...problems].sort((a, b) => {
+            const severityOrder: Record<DisplaySeverity, number> = {Error: 0, Warning: 1, Recommendation: 2};
+            return severityOrder[getDisplaySeverity(a)] - severityOrder[getDisplaySeverity(b)];
+        });
+    }, [problems]);
+
+    if (!count) {
+        return null;
+    }
+
+    return (
+        <div className='mt-6 border-t border-border pt-5'>
+            <button
+                className='flex w-full items-center justify-between gap-3 rounded-lg border border-border bg-background p-4 text-left transition-colors hover:bg-muted/40'
+                type='button'
+                onClick={() => setOpen(!open)}
+            >
+                <div>
+                    <div className='text-sm font-semibold text-foreground'>
+                        Review {formatNonBlockingIssueCount(count)}
+                    </div>
+                    <div className='mt-1 text-sm text-muted-foreground'>
+                        {open ? 'Hide details' : 'Show details'}
+                    </div>
+                </div>
+                <LucideIcon.ChevronDown className={`size-4 shrink-0 text-muted-foreground transition-transform ${open ? 'rotate-180' : ''}`} />
+            </button>
+            {open && (
+                <div className='mt-4 space-y-3'>
+                    {sortedProblems.map(problem => (
+                        <ValidationProblemCard key={problem.code} problem={problem} />
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}
+
+export function ErrorTextCard({message}: {message: string}) {
+    return (
+        <div className='rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive'>
+            <div className='flex items-start gap-2'>
+                <LucideIcon.AlertTriangle className='mt-0.5 size-4 shrink-0' />
+                <p>{message}</p>
+            </div>
+        </div>
+    );
+}
+
+export function OutcomeBanner({
+    children,
+    title,
+    variant
+}: {
+    children: React.ReactNode;
+    title: string;
+    variant: 'success' | 'destructive';
+}) {
+    const Icon = variant === 'success' ? LucideIcon.CheckCircle2 : LucideIcon.AlertTriangle;
+    const iconClassName = variant === 'success' ? 'text-state-success' : 'text-destructive';
+
+    return (
+        <Banner role={variant === 'destructive' ? 'alert' : 'status'} size='lg' variant={variant === 'success' ? 'success' : 'destructive'}>
+            <div className='flex items-start gap-3'>
+                <div className={`mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-full ${variant === 'success' ? 'bg-state-success/10' : 'bg-destructive/10'}`}>
+                    <Icon className={`size-5 ${iconClassName}`} />
+                </div>
+                <div>
+                    <h3 className={`text-xl font-semibold tracking-tight ${variant === 'success' ? 'text-state-success' : 'text-destructive'}`}>{title}</h3>
+                    <div className='mt-1 text-sm text-foreground'>{children}</div>
+                </div>
+            </div>
+        </Banner>
+    );
+}

--- a/apps/admin-x-settings/test/acceptance/site/design.test.ts
+++ b/apps/admin-x-settings/test/acceptance/site/design.test.ts
@@ -479,7 +479,7 @@ test.describe('Design settings', async () => {
 
         await modal.getByRole('button', {name: 'Install Headline'}).click();
 
-        await expect(page.getByTestId('confirmation-modal')).toHaveText(/installed/);
+        await expect(page.getByTestId('confirmation-modal')).toHaveText(/uploaded/i);
 
         await page.getByRole('button', {name: 'Activate'}).click();
 

--- a/apps/admin-x-settings/test/acceptance/site/theme.test.ts
+++ b/apps/admin-x-settings/test/acceptance/site/theme.test.ts
@@ -120,7 +120,7 @@ test.describe('Theme settings', async () => {
         await expect(modal.getByRole('button', {name: 'Activate Casper'})).toBeVisible();
 
         await modal.getByRole('button', {name: 'Activate Casper'}).click();
-        await expect(page.getByTestId('confirmation-modal')).toHaveText(/activate/);
+        await expect(page.getByTestId('confirmation-modal')).toHaveText(/activate/i);
         await page.getByTestId('confirmation-modal').getByRole('button', {name: 'Activate'}).click();
         await expect(page.getByTestId('toast-success')).toHaveText(/casper is now your active theme/);
 


### PR DESCRIPTION
## Why

Theme validation outcomes weren't clear: blocking and non-blocking issues were mixed together, and titles like "Upload successful with errors" muddled whether an upload had actually worked. This makes the outcome obvious — what blocked the theme vs. what's optional to fix later.

This is the production version of the approved spike #28254 (visual design is unchanged from that PR's screenshots), with the spike scaffolding removed.

## What

- Failed upload/save/activation modals show the blocking issue(s) first, with a collapsible "non-blocking issues" disclosure beneath.
- Successful upload/install modals lead with the success outcome and keep optional compatibility issues secondary.
- A shared `theme-validation-details` view drives both, so the modals stay consistent.
- `ConfirmationModalContent` gains `stickyFooter` + `ReactNode` titles so long validation content can't hide the modal actions.

## Behaviour is unchanged

- `problem.fatal === true` is the only blocking discriminator. By default in production only fatal errors block; errors/warnings/recommendations are grouped as non-blocking (collapsed in production, expanded in development).
- GScan levels and the API data shape are unchanged. Severity badges map straight from `problem.level` (error/warning/recommendation) with **no** remapping — a problem's reported level is what's shown.
- `ThemeProblem.level` is widened to include `recommendation` to match GScan's actual three levels (it previously only typed `error`/`warning`).

## Difference vs. the spike

- The Storybook spike and the live in-Admin scenario toolbar are dropped — the validation modal is an Admin feature, not a Shade component.
- Severity is no longer bumped down a level; it reflects the real GScan level.

## Testing

- [x] Lint clean on changed files — `admin-x-settings`, `admin-x-framework`, `admin-x-design-system` (Node 22.18.0)
- [x] Typecheck clean for the theme validation files
- [x] `pnpm dev` boots and serves Admin
- [ ] No automated test added — the change is presentational (modal layout/copy); the blocking logic is unchanged.
