### PR TITLE
Swapped models barrel for single-model requires in ghost/core unit tests

### DIFF
--- a/ghost/core/test/unit/api/canary/utils/validators/input/pages.test.js
+++ b/ghost/core/test/unit/api/canary/utils/validators/input/pages.test.js
@@ -2,11 +2,11 @@ const _ = require('lodash');
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const validators = require('../../../../../../../core/server/api/endpoints/utils/validators');
-const models = require('../../../../../../../core/server/models');
+const {Member} = require('../../../../../../../core/server/models/member');
 
 describe('Unit: endpoints/utils/validators/input/pages', function () {
     beforeEach(function () {
-        const memberFindPageStub = sinon.stub(models.Member, 'findPage').rejects();
+        const memberFindPageStub = sinon.stub(Member, 'findPage').rejects();
         memberFindPageStub.withArgs({filter: 'label:vip', limit: 1}).resolves();
     });
 

--- a/ghost/core/test/unit/api/canary/utils/validators/input/posts.test.js
+++ b/ghost/core/test/unit/api/canary/utils/validators/input/posts.test.js
@@ -2,11 +2,11 @@ const _ = require('lodash');
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const validators = require('../../../../../../../core/server/api/endpoints/utils/validators');
-const models = require('../../../../../../../core/server/models');
+const {Member} = require('../../../../../../../core/server/models/member');
 
 describe('Unit: endpoints/utils/validators/input/posts', function () {
     beforeEach(function () {
-        const memberFindPageStub = sinon.stub(models.Member, 'findPage').rejects();
+        const memberFindPageStub = sinon.stub(Member, 'findPage').rejects();
         memberFindPageStub.withArgs({filter: 'label:vip', limit: 1}).resolves();
     });
 

--- a/ghost/core/test/unit/api/endpoints/previews.test.js
+++ b/ghost/core/test/unit/api/endpoints/previews.test.js
@@ -1,12 +1,13 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
-const models = require('../../../../core/server/models');
+const {Post} = require('../../../../core/server/models/post');
+const {Product} = require('../../../../core/server/models/product');
 const previewsController = require('../../../../core/server/api/endpoints/previews');
 
 describe('Previews controller', function () {
     beforeEach(function () {
-        sinon.stub(models.Post, 'findOne').resolves({});
-        sinon.stub(models.Product, 'findAll').resolves([{
+        sinon.stub(Post, 'findOne').resolves({});
+        sinon.stub(Product, 'findAll').resolves([{
             get: sinon.stub().returns('silver')
         }]);
     });

--- a/ghost/core/test/unit/server/data/exporter/index.test.js
+++ b/ghost/core/test/unit/server/data/exporter/index.test.js
@@ -5,7 +5,7 @@ const errors = require('@tryghost/errors');
 const db = require('../../../../../core/server/data/db');
 const exporter = require('../../../../../core/server/data/exporter');
 const schema = require('../../../../../core/server/data/schema');
-const models = require('../../../../../core/server/models');
+const {Settings} = require('../../../../../core/server/models/settings');
 const logging = require('@tryghost/logging');
 const schemaTables = Object.keys(schema.tables);
 
@@ -133,7 +133,7 @@ describe('Exporter', function () {
 
     describe('exportFileName', function () {
         it('should return a correctly structured filename', async function () {
-            const settingsStub = sinon.stub(models.Settings, 'findOne').returns(
+            const settingsStub = sinon.stub(Settings, 'findOne').returns(
                 Promise.resolve({
                     get: function () {
                         return 'testblog';
@@ -148,7 +148,7 @@ describe('Exporter', function () {
         });
 
         it('should return a correctly structured filename if settings is empty', async function () {
-            const settingsStub = sinon.stub(models.Settings, 'findOne').returns(
+            const settingsStub = sinon.stub(Settings, 'findOne').returns(
                 Promise.resolve()
             );
 
@@ -159,7 +159,7 @@ describe('Exporter', function () {
         });
 
         it('should return a correctly structured filename if settings errors', async function () {
-            const settingsStub = sinon.stub(models.Settings, 'findOne').returns(
+            const settingsStub = sinon.stub(Settings, 'findOne').returns(
                 Promise.reject()
             );
             const loggingStub = sinon.stub(logging, 'error');

--- a/ghost/core/test/unit/server/data/importer/index.test.js
+++ b/ghost/core/test/unit/server/data/importer/index.test.js
@@ -28,7 +28,7 @@ const StripePricesImporter = require('../../../../../core/server/data/importer/i
 const PostsImporter = require('../../../../../core/server/data/importer/importers/data/posts-importer');
 const CustomThemeSettingsImporter = require('../../../../../core/server/data/importer/importers/data/custom-theme-settings-importer');
 const RevueSubscriberImporter = require('../../../../../core/server/data/importer/importers/data/revue-subscriber-importer');
-const models = require('../../../../../core/server/models');
+const Base = require('../../../../../core/server/models/base');
 const configUtils = require('../../../../utils/config-utils');
 const logging = require('@tryghost/logging');
 
@@ -724,7 +724,7 @@ describe('Importer', function () {
                 this.errors.push(importError);
             });
 
-            sinon.stub(models.Base, 'transaction').callsFake(fn => fn({fake: 'transacting'}));
+            sinon.stub(Base, 'transaction').callsFake(fn => fn({fake: 'transacting'}));
 
             await assert.rejects(DataImporter.doImport({meta: {version: '4.0.0'}, data: {}}, {}), (err) => {
                 assert(err instanceof Error);

--- a/ghost/core/test/unit/server/models/api-key.test.js
+++ b/ghost/core/test/unit/server/models/api-key.test.js
@@ -1,11 +1,11 @@
 const assert = require('node:assert/strict');
-const models = require('../../../../core/server/models');
+const {ApiKey} = require('../../../../core/server/models/api-key');
 const sinon = require('sinon');
 
 describe('Unit: models/api_key', function () {
     describe('fn: refreshSecret', function () {
         it('returns a call to edit passing a new admin secret', function () {
-            const editStub = sinon.stub(models.ApiKey, 'edit').resolves();
+            const editStub = sinon.stub(ApiKey, 'edit').resolves();
 
             const fakeData = {
                 id: 'TREVOR',
@@ -13,7 +13,7 @@ describe('Unit: models/api_key', function () {
             };
             const fakeOptions = {};
 
-            const result = models.ApiKey.refreshSecret(fakeData, fakeOptions);
+            const result = ApiKey.refreshSecret(fakeData, fakeOptions);
 
             assert.equal(result, editStub.returnValues[0]);
             assert.equal(editStub.args[0][0].id, 'TREVOR');
@@ -24,7 +24,7 @@ describe('Unit: models/api_key', function () {
         });
 
         it('returns a call to edit passing a new content secret', function () {
-            const editStub = sinon.stub(models.ApiKey, 'edit').resolves();
+            const editStub = sinon.stub(ApiKey, 'edit').resolves();
 
             const fakeData = {
                 id: 'TREVOR',
@@ -32,7 +32,7 @@ describe('Unit: models/api_key', function () {
             };
             const fakeOptions = {};
 
-            const result = models.ApiKey.refreshSecret(fakeData, fakeOptions);
+            const result = ApiKey.refreshSecret(fakeData, fakeOptions);
 
             assert.equal(result, editStub.returnValues[0]);
             assert.equal(editStub.args[0][0].id, 'TREVOR');

--- a/ghost/core/test/unit/server/models/automation.test.js
+++ b/ghost/core/test/unit/server/models/automation.test.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
-const models = require('../../../../core/server/models');
+const {Automation} = require('../../../../core/server/models/automation');
 const logging = require('@tryghost/logging');
 
 describe('Unit: models/automation', function () {
@@ -10,14 +10,14 @@ describe('Unit: models/automation', function () {
 
     describe('defaults', function () {
         it('sets default status to inactive', function () {
-            const model = new models.Automation();
+            const model = new Automation();
             const defaults = model.defaults();
 
             assert.equal(defaults.status, 'inactive');
         });
 
         it('returns expected default values', function () {
-            const model = new models.Automation();
+            const model = new Automation();
             const defaults = model.defaults();
 
             assert.ok(defaults);
@@ -29,7 +29,7 @@ describe('Unit: models/automation', function () {
     describe('onSaved', function () {
         it('logs when a welcome email is enabled', function () {
             const infoStub = sinon.stub(logging, 'info');
-            const model = models.Automation.forge({
+            const model = Automation.forge({
                 id: 'test-id',
                 slug: 'member-welcome-email-free',
                 status: 'active'
@@ -46,7 +46,7 @@ describe('Unit: models/automation', function () {
 
         it('logs when a welcome email is disabled', function () {
             const infoStub = sinon.stub(logging, 'info');
-            const model = models.Automation.forge({
+            const model = Automation.forge({
                 id: 'test-id',
                 slug: 'member-welcome-email-paid',
                 status: 'inactive'
@@ -63,7 +63,7 @@ describe('Unit: models/automation', function () {
 
         it('does not log for non-welcome-email slugs', function () {
             const infoStub = sinon.stub(logging, 'info');
-            const model = models.Automation.forge({
+            const model = Automation.forge({
                 id: 'test-id',
                 slug: 'some-other-slug',
                 status: 'active'
@@ -77,7 +77,7 @@ describe('Unit: models/automation', function () {
 
         it('does not log when status has not changed', function () {
             const infoStub = sinon.stub(logging, 'info');
-            const model = models.Automation.forge({
+            const model = Automation.forge({
                 id: 'test-id',
                 slug: 'member-welcome-email-free',
                 status: 'active'

--- a/ghost/core/test/unit/server/models/base/actions.test.js
+++ b/ghost/core/test/unit/server/models/base/actions.test.js
@@ -1,13 +1,13 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
-const models = require('../../../../../core/server/models');
+const Base = require('../../../../../core/server/models/base');
 
 describe('Unit: models/base/plugins/actions', function () {
     let TestModel;
 
     beforeEach(function () {
         // Create a test model that has actions enabled
-        TestModel = models.Base.Model.extend({
+        TestModel = Base.Model.extend({
             tableName: 'test_models',
             actionsCollectCRUD: true,
             actionsResourceType: 'test_resource',
@@ -22,7 +22,7 @@ describe('Unit: models/base/plugins/actions', function () {
     describe('getAction', function () {
         describe('Missing configuration', function () {
             it('should return undefined when actionsCollectCRUD is false', function () {
-                const UnconfiguredModel = models.Base.Model.extend({
+                const UnconfiguredModel = Base.Model.extend({
                     tableName: 'test',
                     actionsCollectCRUD: false
                 });
@@ -36,7 +36,7 @@ describe('Unit: models/base/plugins/actions', function () {
                 assert.equal(action, undefined);
             });
             it('should return undefined when actionsResourceType is not set', function () {
-                const UnconfiguredModel = models.Base.Model.extend({
+                const UnconfiguredModel = Base.Model.extend({
                     tableName: 'test',
                     actionsCollectCRUD: true,
                     actionsResourceType: null
@@ -260,7 +260,7 @@ describe('Unit: models/base/plugins/actions', function () {
 
         describe('Primary name extraction', function () {
             it('should handle models with title field', function () {
-                const TitleModel = models.Base.Model.extend({
+                const TitleModel = Base.Model.extend({
                     tableName: 'title_models',
                     actionsCollectCRUD: true,
                     actionsResourceType: 'post'
@@ -279,7 +279,7 @@ describe('Unit: models/base/plugins/actions', function () {
             });
 
             it('should handle models with name field', function () {
-                const NameModel = models.Base.Model.extend({
+                const NameModel = Base.Model.extend({
                     tableName: 'name_models',
                     actionsCollectCRUD: true,
                     actionsResourceType: 'tag'
@@ -298,7 +298,7 @@ describe('Unit: models/base/plugins/actions', function () {
             });
 
             it('should fallback through title -> name -> email for primary name', function () {
-                const FallbackModel = models.Base.Model.extend({
+                const FallbackModel = Base.Model.extend({
                     tableName: 'fallback_models',
                     actionsCollectCRUD: true,
                     actionsResourceType: 'resource'

--- a/ghost/core/test/unit/server/models/base/crud.test.js
+++ b/ghost/core/test/unit/server/models/base/crud.test.js
@@ -1,7 +1,7 @@
 const assert = require('node:assert/strict');
 const errors = require('@tryghost/errors');
 const sinon = require('sinon');
-const models = require('../../../../../core/server/models');
+const Base = require('../../../../../core/server/models/base');
 
 describe('Models: crud', function () {
     afterEach(function () {
@@ -15,15 +15,15 @@ describe('Models: crud', function () {
                     prop: 'whatever'
                 }
             };
-            const model = models.Base.Model.forge({});
-            const filterOptionsSpy = sinon.spy(models.Base.Model, 'filterOptions');
-            const forgeStub = sinon.stub(models.Base.Model, 'forge')
+            const model = Base.Model.forge({});
+            const filterOptionsSpy = sinon.spy(Base.Model, 'filterOptions');
+            const forgeStub = sinon.stub(Base.Model, 'forge')
                 .returns(model);
             const fetchStub = sinon.stub(model, 'fetch')
                 .resolves(model);
             const destroyStub = sinon.stub(model, 'destroy');
 
-            return models.Base.Model.destroy(unfilteredOptions).then(() => {
+            return Base.Model.destroy(unfilteredOptions).then(() => {
                 assert.equal(filterOptionsSpy.args[0][0], unfilteredOptions);
                 assert.equal(filterOptionsSpy.args[0][1], 'destroy');
 
@@ -42,15 +42,15 @@ describe('Models: crud', function () {
             const unfilteredOptions = {
                 id: 23
             };
-            const model = models.Base.Model.forge({});
-            const filterOptionsSpy = sinon.spy(models.Base.Model, 'filterOptions');
-            const forgeStub = sinon.stub(models.Base.Model, 'forge')
+            const model = Base.Model.forge({});
+            const filterOptionsSpy = sinon.spy(Base.Model, 'filterOptions');
+            const forgeStub = sinon.stub(Base.Model, 'forge')
                 .returns(model);
             const fetchStub = sinon.stub(model, 'fetch')
                 .resolves(model);
             const destroyStub = sinon.stub(model, 'destroy');
 
-            return models.Base.Model.destroy(unfilteredOptions).then(() => {
+            return Base.Model.destroy(unfilteredOptions).then(() => {
                 assert.equal(filterOptionsSpy.args[0][0], unfilteredOptions);
                 assert.equal(filterOptionsSpy.args[0][1], 'destroy');
 
@@ -74,16 +74,16 @@ describe('Models: crud', function () {
             const unfilteredOptions = {
                 donny: 'donson'
             };
-            const model = models.Base.Model.forge({});
-            const fetchedModel = models.Base.Model.forge({});
-            const filterOptionsSpy = sinon.spy(models.Base.Model, 'filterOptions');
-            const filterDataSpy = sinon.spy(models.Base.Model, 'filterData');
-            const forgeStub = sinon.stub(models.Base.Model, 'forge')
+            const model = Base.Model.forge({});
+            const fetchedModel = Base.Model.forge({});
+            const filterOptionsSpy = sinon.spy(Base.Model, 'filterOptions');
+            const filterDataSpy = sinon.spy(Base.Model, 'filterData');
+            const forgeStub = sinon.stub(Base.Model, 'forge')
                 .returns(model);
             const fetchStub = sinon.stub(model, 'fetch')
                 .resolves(fetchedModel);
 
-            const findOneReturnValue = models.Base.Model.findOne(data, unfilteredOptions);
+            const findOneReturnValue = Base.Model.findOne(data, unfilteredOptions);
 
             return findOneReturnValue.then((result) => {
                 assert.equal(result, fetchedModel);
@@ -110,16 +110,16 @@ describe('Models: crud', function () {
                 forUpdate: true,
                 transacting: {}
             };
-            const model = models.Base.Model.forge({});
-            const fetchedModel = models.Base.Model.forge({});
-            sinon.spy(models.Base.Model, 'filterOptions');
-            sinon.spy(models.Base.Model, 'filterData');
-            sinon.stub(models.Base.Model, 'forge')
+            const model = Base.Model.forge({});
+            const fetchedModel = Base.Model.forge({});
+            sinon.spy(Base.Model, 'filterOptions');
+            sinon.spy(Base.Model, 'filterData');
+            sinon.stub(Base.Model, 'forge')
                 .returns(model);
             const fetchStub = sinon.stub(model, 'fetch')
                 .resolves(fetchedModel);
 
-            await models.Base.Model.findOne(data, unfilteredOptions);
+            await Base.Model.findOne(data, unfilteredOptions);
 
             assert.equal(fetchStub.args[0][0].lock, 'forUpdate');
         });
@@ -133,18 +133,18 @@ describe('Models: crud', function () {
             const unfilteredOptions = {
                 id: 'something real special'
             };
-            const model = models.Base.Model.forge({});
-            const savedModel = models.Base.Model.forge({});
-            const filterOptionsSpy = sinon.spy(models.Base.Model, 'filterOptions');
-            const filterDataSpy = sinon.spy(models.Base.Model, 'filterData');
-            const forgeStub = sinon.stub(models.Base.Model, 'forge')
+            const model = Base.Model.forge({});
+            const savedModel = Base.Model.forge({});
+            const filterOptionsSpy = sinon.spy(Base.Model, 'filterOptions');
+            const filterDataSpy = sinon.spy(Base.Model, 'filterData');
+            const forgeStub = sinon.stub(Base.Model, 'forge')
                 .returns(model);
             const fetchStub = sinon.stub(model, 'fetch')
                 .resolves(model);
             const saveStub = sinon.stub(model, 'save')
                 .resolves(savedModel);
 
-            return models.Base.Model.edit(data, unfilteredOptions).then((result) => {
+            return Base.Model.edit(data, unfilteredOptions).then((result) => {
                 assert.equal(result, savedModel);
 
                 assert.equal(filterOptionsSpy.args[0][0], unfilteredOptions);
@@ -173,13 +173,13 @@ describe('Models: crud', function () {
                 transacting: {}
             };
 
-            const model = models.Base.Model.forge({});
-            sinon.stub(models.Base.Model, 'forge')
+            const model = Base.Model.forge({});
+            sinon.stub(Base.Model, 'forge')
                 .returns(model);
             const fetchStub = sinon.stub(model, 'fetch')
                 .resolves();
 
-            return models.Base.Model.findOne(data, unfilteredOptions).then(() => {
+            return Base.Model.findOne(data, unfilteredOptions).then(() => {
                 assert.equal(fetchStub.args[0][0].lock, undefined);
             });
         });
@@ -191,11 +191,11 @@ describe('Models: crud', function () {
             const unfilteredOptions = {
                 importing: true
             };
-            const model = models.Base.Model.forge({});
-            sinon.stub(models.Base.Model, 'forge').returns(model);
+            const model = Base.Model.forge({});
+            sinon.stub(Base.Model, 'forge').returns(model);
             sinon.stub(model, 'fetch').resolves();
 
-            return models.Base.Model.findOne(data, unfilteredOptions).then(() => {
+            return Base.Model.findOne(data, unfilteredOptions).then(() => {
                 assert.equal(model.hasTimestamps, true);
             });
         });
@@ -207,14 +207,14 @@ describe('Models: crud', function () {
             const unfilteredOptions = {
                 id: 'something real special'
             };
-            const model = models.Base.Model.forge({});
-            sinon.spy(models.Base.Model, 'filterOptions');
-            sinon.spy(models.Base.Model, 'filterData');
-            sinon.stub(models.Base.Model, 'forge').returns(model);
+            const model = Base.Model.forge({});
+            sinon.spy(Base.Model, 'filterOptions');
+            sinon.spy(Base.Model, 'filterData');
+            sinon.stub(Base.Model, 'forge').returns(model);
             sinon.stub(model, 'fetch').resolves();
             sinon.stub(model, 'save');
 
-            return models.Base.Model.edit(data, unfilteredOptions).then(() => {
+            return Base.Model.edit(data, unfilteredOptions).then(() => {
                 throw new Error('That should not happen');
             }).catch((err) => {
                 assert.equal((err instanceof errors.NotFoundError), true);
@@ -228,16 +228,16 @@ describe('Models: crud', function () {
                 rum: 'ham'
             };
             const unfilteredOptions = {};
-            const model = models.Base.Model.forge({});
-            const savedModel = models.Base.Model.forge({});
-            const filterOptionsSpy = sinon.spy(models.Base.Model, 'filterOptions');
-            const filterDataSpy = sinon.spy(models.Base.Model, 'filterData');
-            const forgeStub = sinon.stub(models.Base.Model, 'forge')
+            const model = Base.Model.forge({});
+            const savedModel = Base.Model.forge({});
+            const filterOptionsSpy = sinon.spy(Base.Model, 'filterOptions');
+            const filterDataSpy = sinon.spy(Base.Model, 'filterData');
+            const forgeStub = sinon.stub(Base.Model, 'forge')
                 .returns(model);
             const saveStub = sinon.stub(model, 'save')
                 .resolves(savedModel);
 
-            return models.Base.Model.add(data, unfilteredOptions).then((result) => {
+            return Base.Model.add(data, unfilteredOptions).then((result) => {
                 assert.equal(result, savedModel);
 
                 assert.equal(filterOptionsSpy.args[0][0], unfilteredOptions);
@@ -262,11 +262,11 @@ describe('Models: crud', function () {
             const unfilteredOptions = {
                 importing: true
             };
-            const model = models.Base.Model.forge({});
-            sinon.stub(models.Base.Model, 'forge').returns(model);
+            const model = Base.Model.forge({});
+            sinon.stub(Base.Model, 'forge').returns(model);
             sinon.stub(model, 'save').resolves();
 
-            return models.Base.Model.add(data, unfilteredOptions).then(() => {
+            return Base.Model.add(data, unfilteredOptions).then(() => {
                 assert.equal(model.hasTimestamps, false);
             });
         });

--- a/ghost/core/test/unit/server/models/base/index.test.js
+++ b/ghost/core/test/unit/server/models/base/index.test.js
@@ -1,7 +1,7 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const security = require('@tryghost/security');
-const models = require('../../../../../core/server/models');
+const Base = require('../../../../../core/server/models/base');
 const urlUtils = require('../../../../../core/shared/url-utils');
 const testUtils = require('../../../../utils');
 
@@ -29,7 +29,7 @@ describe('Models: base', function () {
             Model.findOne.resolves(false);
             securityStringSafeStub.withArgs('My-Slug').returns('my-slug');
 
-            return models.Base.Model.generateSlug(Model, 'My-Slug', options)
+            return Base.Model.generateSlug(Model, 'My-Slug', options)
                 .then((slug) => {
                     assert.equal(slug, 'my-slug');
                 });
@@ -47,7 +47,7 @@ describe('Models: base', function () {
 
             securityStringSafeStub.withArgs('My-Slug').returns('my-slug');
 
-            return models.Base.Model.generateSlug(Model, 'My-Slug', {modelId: 'incorrect-model-id'})
+            return Base.Model.generateSlug(Model, 'My-Slug', {modelId: 'incorrect-model-id'})
                 .then((slug) => {
                     assert.equal(slug, 'my-slug-2');
                 });
@@ -65,7 +65,7 @@ describe('Models: base', function () {
 
             securityStringSafeStub.withArgs('My-Slug').returns('my-slug');
 
-            return models.Base.Model.generateSlug(Model, 'My-Slug', {modelId: 'correct-model-id'})
+            return Base.Model.generateSlug(Model, 'My-Slug', {modelId: 'correct-model-id'})
                 .then((slug) => {
                     assert.equal(slug, 'my-slug');
                 });
@@ -83,7 +83,7 @@ describe('Models: base', function () {
 
             securityStringSafeStub.withArgs('My-Slug').returns('my-slug');
 
-            return models.Base.Model.generateSlug(Model, 'My-Slug', options)
+            return Base.Model.generateSlug(Model, 'My-Slug', options)
                 .then((slug) => {
                     assert.equal(slug, 'my-slug-2');
                 });
@@ -95,7 +95,7 @@ describe('Models: base', function () {
 
             securityStringSafeStub.withArgs(slug).returns(slug);
 
-            return models.Base.Model.generateSlug(Model, slug, options)
+            return Base.Model.generateSlug(Model, slug, options)
                 .then((generatedSlug) => {
                     assert.equal(generatedSlug, 'a'.repeat(185));
                 });
@@ -107,7 +107,7 @@ describe('Models: base', function () {
 
             securityStringSafeStub.withArgs(slug).returns(slug);
 
-            return models.Base.Model.generateSlug(Model, slug, options)
+            return Base.Model.generateSlug(Model, slug, options)
                 .then((generatedSlug) => {
                     assert.equal(generatedSlug, 'upsi-tableName');
                 });
@@ -123,7 +123,7 @@ describe('Models: base', function () {
 
             securityStringSafeStub.withArgs(slug).returns(slug);
 
-            return models.Base.Model.generateSlug(Model, slug, options)
+            return Base.Model.generateSlug(Model, slug, options)
                 .then((generatedSlug) => {
                     assert.equal(generatedSlug, 'hash-#lul');
                 });
@@ -133,7 +133,7 @@ describe('Models: base', function () {
             Model.findOne.resolves(false);
             securityStringSafeStub.withArgs('abc\u0008').returns('abc');
 
-            return models.Base.Model.generateSlug(Model, 'abc\u0008', options)
+            return Base.Model.generateSlug(Model, 'abc\u0008', options)
                 .then((slug) => {
                     assert.equal(slug, 'abc');
                 });
@@ -145,7 +145,7 @@ describe('Models: base', function () {
             const data = testUtils.DataGenerator.forKnex.createPost({updated_at: '0000-00-00 00:00:00'});
 
             try {
-                models.Base.Model.sanitizeData
+                Base.Model.sanitizeData
                     .bind({prototype: {tableName: 'posts'}})(data);
             } catch (err) {
                 assert.equal(err.code, 'DATE_INVALID');
@@ -157,7 +157,7 @@ describe('Models: base', function () {
 
             assert.equal(typeof data.updated_at, 'string');
 
-            models.Base.Model.sanitizeData
+            Base.Model.sanitizeData
                 .bind({prototype: {tableName: 'posts'}})(data);
 
             assert(data.updated_at instanceof Date);
@@ -168,7 +168,7 @@ describe('Models: base', function () {
 
             assert(data.updated_at instanceof Date);
 
-            models.Base.Model.sanitizeData
+            Base.Model.sanitizeData
                 .bind({prototype: {tableName: 'posts'}})(data);
 
             assert(data.updated_at instanceof Date);
@@ -184,7 +184,7 @@ describe('Models: base', function () {
 
             assert.equal(typeof data.authors[0].updated_at, 'string');
 
-            models.Base.Model.sanitizeData
+            Base.Model.sanitizeData
                 .bind({
                     prototype: {
                         tableName: 'posts',
@@ -200,7 +200,7 @@ describe('Models: base', function () {
 
     describe('setEmptyValuesToNull', function () {
         it('resets given empty value to null', function () {
-            const base = models.Base.Model.forge({a: '', b: ''});
+            const base = Base.Model.forge({a: '', b: ''});
 
             base.getNullableStringProperties = sinon.stub();
             base.getNullableStringProperties.returns(['a']);

--- a/ghost/core/test/unit/server/models/base/relations.test.js
+++ b/ghost/core/test/unit/server/models/base/relations.test.js
@@ -1,5 +1,5 @@
 const sinon = require('sinon');
-const models = require('../../../../../core/server/models');
+const Base = require('../../../../../core/server/models/base');
 const assert = require('node:assert/strict');
 
 describe('Models: getLazyRelation', function () {
@@ -8,18 +8,18 @@ describe('Models: getLazyRelation', function () {
     });
 
     it('can fetch collections', async function () {
-        var OtherModel = models.Base.Model.extend({
+        var OtherModel = Base.Model.extend({
             tableName: 'other_models'
         });
 
-        const TestModel = models.Base.Model.extend({
+        const TestModel = Base.Model.extend({
             tableName: 'test_models',
             tiers() {
                 return this.belongsToMany(OtherModel, 'test_others', 'test_id', 'other_id');
             }
         });
         let rel = null;
-        const fetchStub = sinon.stub(models.Base.Collection.prototype, 'fetch').callsFake(function () {
+        const fetchStub = sinon.stub(Base.Collection.prototype, 'fetch').callsFake(function () {
             if (rel !== null) {
                 throw new Error('Called twice');
             }
@@ -42,11 +42,11 @@ describe('Models: getLazyRelation', function () {
     });
 
     it('can fetch models', async function () {
-        var OtherModel = models.Base.Model.extend({
+        var OtherModel = Base.Model.extend({
             tableName: 'other_models'
         });
 
-        const TestModel = models.Base.Model.extend({
+        const TestModel = Base.Model.extend({
             tableName: 'test_models',
             other() {
                 return this.belongsTo(OtherModel, 'other_id', 'id');
@@ -77,11 +77,11 @@ describe('Models: getLazyRelation', function () {
     });
 
     it('can handle fetch of model without id for optional relations', async function () {
-        var OtherModel = models.Base.Model.extend({
+        var OtherModel = Base.Model.extend({
             tableName: 'other_models'
         });
 
-        const TestModel = models.Base.Model.extend({
+        const TestModel = Base.Model.extend({
             tableName: 'test_models',
             other() {
                 return this.belongsTo(OtherModel, 'other_id', 'id');
@@ -101,11 +101,11 @@ describe('Models: getLazyRelation', function () {
     });
 
     it('throws for model without id for optional relations with require', async function () {
-        var OtherModel = models.Base.Model.extend({
+        var OtherModel = Base.Model.extend({
             tableName: 'other_models'
         });
 
-        const TestModel = models.Base.Model.extend({
+        const TestModel = Base.Model.extend({
             tableName: 'test_models',
             other() {
                 return this.belongsTo(OtherModel, 'other_id', 'id');
@@ -125,7 +125,7 @@ describe('Models: getLazyRelation', function () {
     });
 
     it('returns undefined for nonexistent relations', async function () {
-        const TestModel = models.Base.Model.extend({
+        const TestModel = Base.Model.extend({
             tableName: 'test_models'
         });
         const modelA = TestModel.forge({id: '1'});
@@ -133,7 +133,7 @@ describe('Models: getLazyRelation', function () {
     });
 
     it('throws for nonexistent relations with require', async function () {
-        const TestModel = models.Base.Model.extend({
+        const TestModel = Base.Model.extend({
             tableName: 'test_models'
         });
         const modelA = TestModel.forge({id: '1'});

--- a/ghost/core/test/unit/server/models/comment.test.js
+++ b/ghost/core/test/unit/server/models/comment.test.js
@@ -1,12 +1,12 @@
 const assert = require('node:assert/strict');
-const models = require('../../../../core/server/models');
+const {Comment} = require('../../../../core/server/models/comment');
 
 describe('Unit: models/comment', function () {
     describe('defaultRelations', function () {
         it('includes member dislike state but not public dislike counts by default', function () {
             const options = {};
 
-            models.Comment.defaultRelations('findPage', options);
+            Comment.defaultRelations('findPage', options);
 
             assert.ok(options.withRelated.includes('count.likes'));
             assert.ok(!options.withRelated.includes('count.dislikes'));
@@ -19,7 +19,7 @@ describe('Unit: models/comment', function () {
                 isAdmin: true
             };
 
-            models.Comment.defaultRelations('findPage', options);
+            Comment.defaultRelations('findPage', options);
 
             assert.ok(options.withRelated.includes('count.likes'));
             assert.ok(options.withRelated.includes('count.dislikes'));
@@ -32,7 +32,7 @@ describe('Unit: models/comment', function () {
                 id: 'root-comment-id'
             };
 
-            models.Comment.defaultRelations('findOne', options);
+            Comment.defaultRelations('findOne', options);
 
             const repliesRelation = options.withRelated.find((relation) => {
                 return typeof relation === 'object' && relation.replies;
@@ -53,7 +53,7 @@ describe('Unit: models/comment', function () {
 
     describe('orderAttributes', function () {
         it('does not expose dislike count ordering directly', function () {
-            const attributes = models.Comment.forge().orderAttributes();
+            const attributes = Comment.forge().orderAttributes();
 
             assert.ok(attributes.includes('count__likes'));
             assert.ok(attributes.includes('count__net_score'));

--- a/ghost/core/test/unit/server/models/custom-theme-setting.test.js
+++ b/ghost/core/test/unit/server/models/custom-theme-setting.test.js
@@ -1,11 +1,11 @@
 const assert = require('node:assert/strict');
-const models = require('../../../../core/server/models');
+const {CustomThemeSetting} = require('../../../../core/server/models/custom-theme-setting');
 const config = require('../../../../core/shared/config');
 
 describe('Unit: models/custom-theme-setting', function () {
     describe('parse', function () {
         it('ensure correct parsing when fetching from db', function () {
-            const setting = models.CustomThemeSetting.forge();
+            const setting = CustomThemeSetting.forge();
 
             let returns = setting.parse({theme: 'test', key: 'dark_mode', value: 'false', type: 'boolean'});
             assert.equal(returns.value, false);
@@ -35,7 +35,7 @@ describe('Unit: models/custom-theme-setting', function () {
 
     describe('format', function () {
         it('ensure correct formatting when setting', function () {
-            const setting = models.CustomThemeSetting.forge();
+            const setting = CustomThemeSetting.forge();
 
             let returns = setting.format({theme: 'test', key: 'dark_mode', value: '0', type: 'boolean'});
             assert.equal(returns.value, 'false');
@@ -51,7 +51,7 @@ describe('Unit: models/custom-theme-setting', function () {
         });
 
         it('transforms urls when persisting to db', function () {
-            const setting = models.CustomThemeSetting.forge();
+            const setting = CustomThemeSetting.forge();
 
             let returns = setting.formatOnWrite({theme: 'test', key: 'something', value: '/assets/image.jpg', type: 'image'});
             assert.equal(returns.value, '__GHOST_URL__/assets/image.jpg');

--- a/ghost/core/test/unit/server/models/integration.test.js
+++ b/ghost/core/test/unit/server/models/integration.test.js
@@ -1,6 +1,7 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
-const models = require('../../../../core/server/models');
+const {Integration} = require('../../../../core/server/models/integration');
+const Base = require('../../../../core/server/models/base');
 const {knex} = require('../../../../core/server/data/db');
 
 describe('Unit: models/integration', function () {
@@ -13,17 +14,17 @@ describe('Unit: models/integration', function () {
 
         beforeEach(function () {
             basePermittedOptionsReturnVal = ['super', 'doopa'];
-            sinon.stub(models.Base.Model, 'permittedOptions')
+            sinon.stub(Base.Model, 'permittedOptions')
                 .returns(basePermittedOptionsReturnVal);
         });
 
         it('returns the base permittedOptions result', function () {
-            const returnedOptions = models.Integration.permittedOptions();
+            const returnedOptions = Integration.permittedOptions();
             assert.deepEqual(returnedOptions, basePermittedOptionsReturnVal);
         });
 
         it('returns the base permittedOptions result plus "filter" when methodName is findOne', function () {
-            const returnedOptions = models.Integration.permittedOptions('findOne');
+            const returnedOptions = Integration.permittedOptions('findOne');
             assert.deepEqual(returnedOptions, basePermittedOptionsReturnVal.concat('filter'));
         });
     });
@@ -50,7 +51,7 @@ describe('Unit: models/integration', function () {
                 query.response([]);
             });
 
-            return models.Integration.findOne({
+            return Integration.findOne({
                 id: '123'
             }, {
                 filter: 'type:[custom,builtin,core]'
@@ -83,7 +84,7 @@ describe('Unit: models/integration', function () {
                 query.response([{id: 'key-admin', secret: 'admin-secret'}]);
             });
 
-            const apiKey = await models.Integration.getApiKeyBySlug('ghost-scheduler', 'admin');
+            const apiKey = await Integration.getApiKeyBySlug('ghost-scheduler', 'admin');
             assert.deepEqual(apiKey, {id: 'key-admin', secret: 'admin-secret'});
             assert.equal(queries.length, 1);
             assert.equal(queries[0].sql, 'select `api_keys`.`id`, `api_keys`.`secret` from `api_keys` inner join `integrations` on `api_keys`.`integration_id` = `integrations`.`id` where `integrations`.`slug` = ? and `api_keys`.`type` = ? limit ?');
@@ -98,7 +99,7 @@ describe('Unit: models/integration', function () {
 
             const errors = require('@tryghost/errors');
             await assert.rejects(
-                models.Integration.getApiKeyBySlug('ghost-scheduler', 'admin'),
+                Integration.getApiKeyBySlug('ghost-scheduler', 'admin'),
                 err => err instanceof errors.NotFoundError
             );
         });

--- a/ghost/core/test/unit/server/models/invite.test.js
+++ b/ghost/core/test/unit/server/models/invite.test.js
@@ -1,7 +1,8 @@
 const assert = require('node:assert/strict');
 const errors = require('@tryghost/errors');
 const sinon = require('sinon');
-const models = require('../../../../core/server/models');
+const {Invite} = require('../../../../core/server/models/invite');
+const {Role} = require('../../../../core/server/models/role');
 const settingsCache = require('../../../../core/shared/settings-cache');
 
 describe('Unit: models/invite', function () {
@@ -35,9 +36,9 @@ describe('Unit: models/invite', function () {
             });
 
             it('role does not exist', function () {
-                sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(null);
+                sinon.stub(Role, 'findOne').withArgs({id: 'role_id'}).resolves(null);
 
-                return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs)
+                return Invite.permissible(inviteModel, 'add', context, unsafeAttrs)
                     .then(Promise.reject)
                     .catch((err) => {
                         assert.equal(err instanceof errors.NotFoundError, true);
@@ -45,10 +46,10 @@ describe('Unit: models/invite', function () {
             });
 
             it('invite owner', function () {
-                sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                sinon.stub(Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                 roleModel.get.withArgs('name').returns('Owner');
 
-                return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs)
+                return Invite.permissible(inviteModel, 'add', context, unsafeAttrs)
                     .then(Promise.reject)
                     .catch((err) => {
                         assert.equal(err instanceof errors.NoPermissionError, true);
@@ -61,31 +62,31 @@ describe('Unit: models/invite', function () {
                 });
 
                 it('invite administrator', function () {
-                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Administrator');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
+                    return Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
                 });
 
                 it('invite editor', function () {
-                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Editor');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
+                    return Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
                 });
 
                 it('invite author', function () {
-                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Author');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
+                    return Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
                 });
 
                 it('invite contributor', function () {
-                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Contributor');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
+                    return Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
                 });
             });
 
@@ -95,31 +96,31 @@ describe('Unit: models/invite', function () {
                 });
 
                 it('invite administrator', function () {
-                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Administrator');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
+                    return Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
                 });
 
                 it('invite editor', function () {
-                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Editor');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
+                    return Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
                 });
 
                 it('invite author', function () {
-                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Author');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
+                    return Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
                 });
 
                 it('invite contributor', function () {
-                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Contributor');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
+                    return Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
                 });
             });
 
@@ -129,10 +130,10 @@ describe('Unit: models/invite', function () {
                 });
 
                 it('invite administrator', function () {
-                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Administrator');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true)
+                    return Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true)
                         .then(Promise.reject)
                         .catch((err) => {
                             assert.equal(err instanceof errors.NoPermissionError, true);
@@ -140,10 +141,10 @@ describe('Unit: models/invite', function () {
                 });
 
                 it('invite editor', function () {
-                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Editor');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true)
+                    return Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true)
                         .then(Promise.reject)
                         .catch((err) => {
                             assert.equal(err instanceof errors.NoPermissionError, true);
@@ -154,10 +155,10 @@ describe('Unit: models/invite', function () {
                     loadedPermissions.apiKey = {
                         roles: [{name: 'Admin Integration'}]
                     };
-                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Editor');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true)
+                    return Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true)
                         .then(Promise.reject)
                         .catch((err) => {
                             assert.equal(err instanceof errors.NoPermissionError, true);
@@ -166,17 +167,17 @@ describe('Unit: models/invite', function () {
                 });
 
                 it('invite author', function () {
-                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Author');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
+                    return Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
                 });
 
                 it('invite contributor', function () {
-                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Contributor');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
+                    return Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
                 });
             });
 
@@ -186,10 +187,10 @@ describe('Unit: models/invite', function () {
                 });
 
                 it('invite administrator', function () {
-                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Administrator');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
+                    return Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
                         .then(Promise.reject)
                         .catch((err) => {
                             assert.equal(err instanceof errors.NoPermissionError, true);
@@ -197,10 +198,10 @@ describe('Unit: models/invite', function () {
                 });
 
                 it('invite editor', function () {
-                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Editor');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
+                    return Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
                         .then(Promise.reject)
                         .catch((err) => {
                             assert.equal(err instanceof errors.NoPermissionError, true);
@@ -208,10 +209,10 @@ describe('Unit: models/invite', function () {
                 });
 
                 it('invite author', function () {
-                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Author');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
+                    return Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
                         .then(Promise.reject)
                         .catch((err) => {
                             assert.equal(err instanceof errors.NoPermissionError, true);
@@ -219,10 +220,10 @@ describe('Unit: models/invite', function () {
                 });
 
                 it('invite contributor', function () {
-                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Contributor');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
+                    return Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
                         .then(Promise.reject)
                         .catch((err) => {
                             assert.equal(err instanceof errors.NoPermissionError, true);
@@ -236,10 +237,10 @@ describe('Unit: models/invite', function () {
                 });
 
                 it('invite administrator', function () {
-                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Administrator');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
+                    return Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
                         .then(Promise.reject)
                         .catch((err) => {
                             assert.equal(err instanceof errors.NoPermissionError, true);
@@ -247,10 +248,10 @@ describe('Unit: models/invite', function () {
                 });
 
                 it('invite editor', function () {
-                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Editor');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
+                    return Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
                         .then(Promise.reject)
                         .catch((err) => {
                             assert.equal(err instanceof errors.NoPermissionError, true);
@@ -258,10 +259,10 @@ describe('Unit: models/invite', function () {
                 });
 
                 it('invite author', function () {
-                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Author');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
+                    return Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
                         .then(Promise.reject)
                         .catch((err) => {
                             assert.equal(err instanceof errors.NoPermissionError, true);
@@ -269,10 +270,10 @@ describe('Unit: models/invite', function () {
                 });
 
                 it('invite contributor', function () {
-                    sinon.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
+                    sinon.stub(Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Contributor');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
+                    return Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
                         .then(Promise.reject)
                         .catch((err) => {
                             assert.equal(err instanceof errors.NoPermissionError, true);

--- a/ghost/core/test/unit/server/models/member-click-event.test.js
+++ b/ghost/core/test/unit/server/models/member-click-event.test.js
@@ -1,5 +1,5 @@
 const sinon = require('sinon');
-const models = require('../../../../core/server/models');
+const {MemberClickEvent} = require('../../../../core/server/models/member-click-event');
 
 describe('Unit: models/MemberClickEvent', function () {
     afterEach(function () {
@@ -7,13 +7,13 @@ describe('Unit: models/MemberClickEvent', function () {
     });
 
     it('Has link and member relations', function () {
-        const model = models.MemberClickEvent.forge({id: 'any'});
+        const model = MemberClickEvent.forge({id: 'any'});
         model.link();
         model.member();
     });
 
     it('Has filter relations', function () {
-        const model = models.MemberClickEvent.forge({id: 'any'});
+        const model = MemberClickEvent.forge({id: 'any'});
         model.filterRelations();
     });
 });

--- a/ghost/core/test/unit/server/models/member-created-event.test.js
+++ b/ghost/core/test/unit/server/models/member-created-event.test.js
@@ -1,7 +1,7 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const errors = require('@tryghost/errors');
-const models = require('../../../../core/server/models');
+const {MemberCreatedEvent} = require('../../../../core/server/models/member-created-event');
 
 describe('Unit: models/MemberCreatedEvent', function () {
     afterEach(function () {
@@ -10,7 +10,7 @@ describe('Unit: models/MemberCreatedEvent', function () {
 
     describe('validation', function () {
         it('throws error for invalid attribution_type', function () {
-            return models.MemberCreatedEvent.add({attribution_type: 'invalid', source: 'member', member_id: '123'})
+            return MemberCreatedEvent.add({attribution_type: 'invalid', source: 'member', member_id: '123'})
                 .then(function () {
                     throw new Error('expected ValidationError');
                 })
@@ -22,7 +22,7 @@ describe('Unit: models/MemberCreatedEvent', function () {
         });
 
         it('throws if member_id is missing', function () {
-            return models.MemberCreatedEvent.add({attribution_type: 'post', source: 'member'})
+            return MemberCreatedEvent.add({attribution_type: 'post', source: 'member'})
                 .then(function () {
                     throw new Error('expected ValidationError');
                 })
@@ -34,7 +34,7 @@ describe('Unit: models/MemberCreatedEvent', function () {
         });
 
         it('throws if source is missing', function () {
-            return models.MemberCreatedEvent.add({attribution_type: 'post', member_id: '123'})
+            return MemberCreatedEvent.add({attribution_type: 'post', member_id: '123'})
                 .then(function () {
                     throw new Error('expected ValidationError');
                 })
@@ -46,7 +46,7 @@ describe('Unit: models/MemberCreatedEvent', function () {
         });
 
         it('throws if source is invalid', function () {
-            return models.MemberCreatedEvent.add({attribution_type: 'post', member_id: '123', source: 'invalid'})
+            return MemberCreatedEvent.add({attribution_type: 'post', member_id: '123', source: 'invalid'})
                 .then(function () {
                     throw new Error('expected ValidationError');
                 })

--- a/ghost/core/test/unit/server/models/member-feedback.test.js
+++ b/ghost/core/test/unit/server/models/member-feedback.test.js
@@ -1,7 +1,7 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const errors = require('@tryghost/errors');
-const models = require('../../../../core/server/models');
+const {MemberFeedback} = require('../../../../core/server/models/member-feedback');
 
 describe('Unit: models/MemberFeedback', function () {
     afterEach(function () {
@@ -10,7 +10,7 @@ describe('Unit: models/MemberFeedback', function () {
 
     describe('validation', function () {
         it('throws if member_id is missing', function () {
-            return models.MemberFeedback.add({score: 1, post_id: 'post'})
+            return MemberFeedback.add({score: 1, post_id: 'post'})
                 .then(function () {
                     throw new Error('expected ValidationError');
                 })
@@ -22,7 +22,7 @@ describe('Unit: models/MemberFeedback', function () {
         });
 
         it('throws if post_id is missing', function () {
-            return models.MemberFeedback.add({score: 1, member_id: '123'})
+            return MemberFeedback.add({score: 1, member_id: '123'})
                 .then(function () {
                     throw new Error('expected ValidationError');
                 })
@@ -35,7 +35,7 @@ describe('Unit: models/MemberFeedback', function () {
     });
 
     it('Delete is disabled', function () {
-        return models.MemberFeedback.destroy({id: 'any'})
+        return MemberFeedback.destroy({id: 'any'})
             .then(function () {
                 throw new Error('expected IncorrectUsageError');
             })
@@ -45,7 +45,7 @@ describe('Unit: models/MemberFeedback', function () {
     });
 
     it('Has post and member relations', function () {
-        const model = models.MemberFeedback.forge({id: 'any'});
+        const model = MemberFeedback.forge({id: 'any'});
         model.post();
         model.member();
     });

--- a/ghost/core/test/unit/server/models/member-paid-subscription-event.test.js
+++ b/ghost/core/test/unit/server/models/member-paid-subscription-event.test.js
@@ -1,5 +1,5 @@
 const sinon = require('sinon');
-const models = require('../../../../core/server/models');
+const {MemberPaidSubscriptionEvent} = require('../../../../core/server/models/member-paid-subscription-event');
 
 describe('Unit: models/MemberPaidSubscriptionEvent', function () {
     afterEach(function () {
@@ -7,13 +7,13 @@ describe('Unit: models/MemberPaidSubscriptionEvent', function () {
     });
 
     it('Has member and subscriptionCreatedEvent relations', function () {
-        const model = models.MemberPaidSubscriptionEvent.forge({id: 'any'});
+        const model = MemberPaidSubscriptionEvent.forge({id: 'any'});
         model.member();
         model.subscriptionCreatedEvent();
     });
 
     it('Has filter relations', function () {
-        const model = models.MemberPaidSubscriptionEvent.forge({id: 'any'});
+        const model = MemberPaidSubscriptionEvent.forge({id: 'any'});
         model.filterRelations();
     });
 });

--- a/ghost/core/test/unit/server/models/member-subscribe-event.test.js
+++ b/ghost/core/test/unit/server/models/member-subscribe-event.test.js
@@ -1,7 +1,7 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const errors = require('@tryghost/errors');
-const models = require('../../../../core/server/models');
+const {MemberSubscribeEvent} = require('../../../../core/server/models/member-subscribe-event');
 
 describe('Unit: models/MemberSubscribeEvent', function () {
     afterEach(function () {
@@ -10,7 +10,7 @@ describe('Unit: models/MemberSubscribeEvent', function () {
 
     describe('validation', function () {
         it('throws if source is invalid', function () {
-            return models.MemberSubscribeEvent.add({member_id: '123', source: 'invalid'})
+            return MemberSubscribeEvent.add({member_id: '123', source: 'invalid'})
                 .then(function () {
                     throw new Error('expected ValidationError');
                 })

--- a/ghost/core/test/unit/server/models/member.test.js
+++ b/ghost/core/test/unit/server/models/member.test.js
@@ -1,6 +1,7 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
-const models = require('../../../../core/server/models');
+const {Member} = require('../../../../core/server/models/member');
+const {Label} = require('../../../../core/server/models/label');
 const configUtils = require('../../../utils/config-utils');
 const labs = require('../../../../core/shared/labs');
 
@@ -21,7 +22,7 @@ describe('Unit: models/member', function () {
 
         beforeEach(function () {
             toJSON = function (model, options) {
-                return new models.Member(model).toJSON(options);
+                return new Member(model).toJSON(options);
             };
         });
 
@@ -50,7 +51,7 @@ describe('Unit: models/member', function () {
 
     describe('onSaving', function () {
         it('skips labels without a name instead of throwing', async function () {
-            const memberModel = new models.Member({email: 'test@example.com'});
+            const memberModel = new Member({email: 'test@example.com'});
             // Simulate input from API where one label is missing `name`
             memberModel.set('labels', [
                 {name: 'Newsletter'},
@@ -65,7 +66,7 @@ describe('Unit: models/member', function () {
                 id: 'existing-1',
                 get: key => (key === 'name' ? 'Existing' : 'existing-1')
             }];
-            const findAllStub = sinon.stub(models.Label, 'findAll').resolves({
+            const findAllStub = sinon.stub(Label, 'findAll').resolves({
                 models: existingLabels
             });
 
@@ -83,7 +84,7 @@ describe('Unit: models/member', function () {
         let updatePivot;
 
         beforeEach(function () {
-            memberModel = new models.Member({email: 'text@example.com'});
+            memberModel = new Member({email: 'text@example.com'});
             updatePivot = sinon.stub();
 
             sinon.stub(memberModel, 'products').callsFake(() => {

--- a/ghost/core/test/unit/server/models/milestone.test.js
+++ b/ghost/core/test/unit/server/models/milestone.test.js
@@ -1,4 +1,4 @@
-const models = require('../../../../core/server/models');
+const {Milestone} = require('../../../../core/server/models/milestone');
 const assert = require('node:assert/strict');
 const errors = require('@tryghost/errors');
 
@@ -6,7 +6,7 @@ describe('Unit: models/milestone', function () {
     describe('validation', function () {
         describe('blank', function () {
             it('throws validation error for mandatory fields', function () {
-                return models.Milestone.add({})
+                return Milestone.add({})
                     .then(function () {
                         throw new Error('expected ValidationError');
                     })

--- a/ghost/core/test/unit/server/models/newsletter.test.js
+++ b/ghost/core/test/unit/server/models/newsletter.test.js
@@ -2,7 +2,7 @@
 const assert = require('node:assert/strict');
 const errors = require('@tryghost/errors');
 const sinon = require('sinon');
-const models = require('../../../../core/server/models');
+const {Newsletter} = require('../../../../core/server/models/newsletter');
 
 describe('Unit: models/newsletter', function () {
     afterAll(function () {
@@ -12,7 +12,7 @@ describe('Unit: models/newsletter', function () {
     describe('validation', function () {
         describe('blank', function () {
             it('throws validation error for mandatory fields', function () {
-                return models.Newsletter.add({})
+                return Newsletter.add({})
                     .then(function () {
                         throw new Error('expected ValidationError');
                     })

--- a/ghost/core/test/unit/server/models/outbox.test.js
+++ b/ghost/core/test/unit/server/models/outbox.test.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert/strict');
 const errors = require('@tryghost/errors');
-const models = require('../../../../core/server/models');
+const {Outbox} = require('../../../../core/server/models/outbox');
 const {OUTBOX_STATUSES} = require('../../../../core/server/models/outbox');
 
 describe('Unit: models/outbox', function () {
@@ -15,21 +15,21 @@ describe('Unit: models/outbox', function () {
 
     describe('defaults', function () {
         it('sets default status to pending', function () {
-            const model = new models.Outbox();
+            const model = new Outbox();
             const defaults = model.defaults();
 
             assert.equal(defaults.status, OUTBOX_STATUSES.PENDING);
         });
 
         it('sets default retry_count to 0', function () {
-            const model = new models.Outbox();
+            const model = new Outbox();
             const defaults = model.defaults();
 
             assert.equal(defaults.retry_count, 0);
         });
 
         it('returns both default values', function () {
-            const model = new models.Outbox();
+            const model = new Outbox();
             const defaults = model.defaults();
 
             assert.ok(defaults);
@@ -41,7 +41,7 @@ describe('Unit: models/outbox', function () {
 
     describe('validation', function () {
         it('rejects invalid status values', function () {
-            return models.Outbox.add({
+            return Outbox.add({
                 event_type: 'MemberCreatedEvent',
                 payload: '{}',
                 status: 'not-a-real-status'

--- a/ghost/core/test/unit/server/models/permission.test.js
+++ b/ghost/core/test/unit/server/models/permission.test.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
-const models = require('../../../../core/server/models');
+const {Permission} = require('../../../../core/server/models/permission');
 const configUtils = require('../../../utils/config-utils');
 
 describe('Unit: models/permission', function () {
@@ -11,7 +11,7 @@ describe('Unit: models/permission', function () {
 
     describe('add', function () {
         it('[error] validation', function () {
-            return models.Permission.add({})
+            return Permission.add({})
                 .then(function () {
                     assert.equal('Should fail', true);
                 })

--- a/ghost/core/test/unit/server/models/post.test.js
+++ b/ghost/core/test/unit/server/models/post.test.js
@@ -6,7 +6,7 @@ const sinon = require('sinon');
 const testUtils = require('../../../utils');
 const knex = require('../../../../core/server/data/db').knex;
 const urlService = require('../../../../core/server/services/url');
-const models = require('../../../../core/server/models');
+const {Post} = require('../../../../core/server/models/post');
 const security = require('@tryghost/security');
 
 describe('Unit: models/post', function () {
@@ -36,7 +36,7 @@ describe('Unit: models/post', function () {
                 query.response([]);
             });
 
-            return models.Post.findPage({
+            return Post.findPage({
                 filter: 'tags:[photo, video]+id:-' + testUtils.filterData.data.posts[3].id,
                 limit: 3,
                 withRelated: ['tags']
@@ -72,7 +72,7 @@ describe('Unit: models/post', function () {
                 query.response([]);
             });
 
-            return models.Post.findPage({
+            return Post.findPage({
                 filter: 'authors:[leslie,pat]+(tag:hash-audio,feature_image:-null)',
                 withRelated: ['authors', 'tags']
             }).then(() => {
@@ -107,7 +107,7 @@ describe('Unit: models/post', function () {
                 query.response([]);
             });
 
-            return models.Post.findPage({
+            return Post.findPage({
                 filter: 'published_at:>\'2015-07-20\'',
                 limit: 5,
                 withRelated: ['tags']
@@ -139,7 +139,7 @@ describe('Unit: models/post', function () {
                 query.response([]);
             });
 
-            return models.Post.findPage({
+            return Post.findPage({
                 filter: 'published_at:>\'2015-07-20\'',
                 limit: 1,
                 skipPagination: true,
@@ -166,7 +166,7 @@ describe('Unit: models/post', function () {
                 query.response([]);
             });
 
-            return models.Post.findPage({
+            return Post.findPage({
                 filter: 'published_at:>\'2015-07-20\'',
                 limit: -5,
                 page: -2,
@@ -195,7 +195,7 @@ describe('Unit: models/post', function () {
                     query.response([]);
                 });
 
-                return models.Post.findPage({
+                return Post.findPage({
                     filter: 'primary_tag:photo',
                     withRelated: ['tags']
                 }).then(() => {
@@ -228,7 +228,7 @@ describe('Unit: models/post', function () {
                     query.response([]);
                 });
 
-                return models.Post.findPage({
+                return Post.findPage({
                     filter: 'primary_author:leslie',
                     withRelated: ['authors']
                 }).then(() => {
@@ -263,7 +263,7 @@ describe('Unit: models/post', function () {
                     query.response([]);
                 });
 
-                return models.Post.findPage({
+                return Post.findPage({
                     filter: 'status:[published,draft]',
                     limit: 'all',
                     status: 'published',
@@ -291,7 +291,7 @@ describe('Unit: models/post', function () {
 
     describe('toJSON', function () {
         const toJSON = function toJSON(model, options) {
-            return new models.Post(model).toJSON(options);
+            return new Post(model).toJSON(options);
         };
 
         it('ensure mobiledoc revisions are never exposed', function () {
@@ -327,14 +327,14 @@ describe('Unit: models/post', function () {
                 status: 'published'
             };
 
-            const filter = new models.Post().extraFilters(options);
+            const filter = new Post().extraFilters(options);
             assert.equal(filter, 'status:published');
         });
     });
 
     describe('enforcedFilters', function () {
         const enforcedFilters = function enforcedFilters(model, options) {
-            return new models.Post(model).enforcedFilters(options);
+            return new Post(model).enforcedFilters(options);
         };
 
         it('returns published status filter for public context', function () {
@@ -364,7 +364,7 @@ describe('Unit: models/post', function () {
 
     describe('defaultFilters', function () {
         const defaultFilters = function defaultFilters(model, options) {
-            return new models.Post(model).defaultFilters(options);
+            return new Post(model).defaultFilters(options);
         };
 
         it('returns no default filter for internal context', function () {
@@ -404,7 +404,7 @@ describe('Unit: models/post', function () {
 
     describe('countRelations', function () {
         it('can include all count relations', function () {
-            return models.Post.findAll({withRelated: ['count.signups', 'count.paid_conversions', 'count.clicks', 'count.sentiment', 'count.negative_feedback', 'count.positive_feedback']});
+            return Post.findAll({withRelated: ['count.signups', 'count.paid_conversions', 'count.clicks', 'count.sentiment', 'count.negative_feedback', 'count.positive_feedback']});
         });
     });
 });
@@ -439,7 +439,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
 
                     await assert.rejects(
                         async () => {
-                            await models.Post.permissible(
+                            await Post.permissible(
                                 mockPostObj,
                                 'edit',
                                 context,
@@ -466,7 +466,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
                     await assert.rejects(
-                        models.Post.permissible(
+                        Post.permissible(
                             mockPostObj,
                             'edit',
                             context,
@@ -491,7 +491,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
                     await assert.rejects(
-                        models.Post.permissible(
+                        Post.permissible(
                             mockPostObj,
                             'edit',
                             context,
@@ -518,7 +518,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
                     mockPostObj.get.withArgs('status').returns('draft');
 
-                    const result = await models.Post.permissible(
+                    const result = await Post.permissible(
                         mockPostObj,
                         'edit',
                         context,
@@ -546,7 +546,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
                     await assert.rejects(
-                        models.Post.permissible(
+                        Post.permissible(
                             mockPostObj,
                             'edit',
                             context,
@@ -573,7 +573,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
                     await assert.rejects(
-                        models.Post.permissible(
+                        Post.permissible(
                             mockPostObj,
                             'edit',
                             context,
@@ -599,7 +599,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     mockPostObj.get.withArgs('status').returns('draft');
                     mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
-                    return models.Post.permissible(
+                    return Post.permissible(
                         mockPostObj,
                         'edit',
                         context,
@@ -626,7 +626,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     const unsafeAttrs = {status: 'published', authors: [{id: 1}]};
 
                     await assert.rejects(
-                        models.Post.permissible(
+                        Post.permissible(
                             mockPostObj,
                             'add',
                             context,
@@ -649,7 +649,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     const unsafeAttrs = {status: 'draft', authors: [{id: 2}]};
 
                     await assert.rejects(
-                        models.Post.permissible(
+                        Post.permissible(
                             mockPostObj,
                             'add',
                             context,
@@ -672,7 +672,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     const unsafeAttrs = {status: 'draft', authors: [{id: 2}]};
 
                     await assert.rejects(
-                        models.Post.permissible(
+                        Post.permissible(
                             mockPostObj,
                             'add',
                             context,
@@ -694,7 +694,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     const context = {user: 1};
                     const unsafeAttrs = {status: 'draft', authors: [{id: 1}]};
 
-                    const result = await models.Post.permissible(
+                    const result = await Post.permissible(
                         mockPostObj,
                         'add',
                         context,
@@ -721,7 +721,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
                     await assert.rejects(
-                        models.Post.permissible(
+                        Post.permissible(
                             mockPostObj,
                             'destroy',
                             context,
@@ -748,7 +748,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     mockPostObj.get.withArgs('status').returns('published');
 
                     await assert.rejects(
-                        models.Post.permissible(
+                        Post.permissible(
                             mockPostObj,
                             'destroy',
                             context,
@@ -774,7 +774,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     mockPostObj.get.withArgs('status').returns('draft');
                     mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
-                    return models.Post.permissible(
+                    return Post.permissible(
                         mockPostObj,
                         'destroy',
                         context,
@@ -806,7 +806,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     mockPostObj.related.withArgs('authors').returns({models: [{id: 2}]});
 
                     await assert.rejects(
-                        models.Post.permissible(
+                        Post.permissible(
                             mockPostObj,
                             'edit',
                             context,
@@ -834,7 +834,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
                     await assert.rejects(
-                        models.Post.permissible(
+                        Post.permissible(
                             mockPostObj,
                             'edit',
                             context,
@@ -861,7 +861,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
                     await assert.rejects(
-                        models.Post.permissible(
+                        Post.permissible(
                             mockPostObj,
                             'edit',
                             context,
@@ -888,7 +888,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
                     await assert.rejects(
-                        models.Post.permissible(
+                        Post.permissible(
                             mockPostObj,
                             'edit',
                             context,
@@ -913,7 +913,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
 
                     mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
-                    return models.Post.permissible(
+                    return Post.permissible(
                         mockPostObj,
                         'edit',
                         context,
@@ -937,7 +937,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     const unsafeAttrs = {authors: [{id: 2}]};
 
                     await assert.rejects(
-                        models.Post.permissible(
+                        Post.permissible(
                             mockPostObj,
                             'add',
                             context,
@@ -963,7 +963,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
                     await assert.rejects(
-                        models.Post.permissible(
+                        Post.permissible(
                             mockPostObj,
                             'add',
                             context,
@@ -992,7 +992,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                 mockPostObj.related.withArgs('authors').returns({models: [{id: 2}]});
 
                 await assert.rejects(
-                    models.Post.permissible(
+                    Post.permissible(
                         mockPostObj,
                         'edit',
                         context,
@@ -1015,7 +1015,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                 const context = {user: 1};
                 const unsafeAttrs = {authors: [{id: 2}]};
 
-                return models.Post.permissible(
+                return Post.permissible(
                     mockPostObj,
                     'edit',
                     context,
@@ -1040,7 +1040,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                 mockPostObj.get.withArgs('visibility').returns('paid');
                 mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
-                await models.Post.permissible(
+                await Post.permissible(
                     mockPostObj,
                     'edit',
                     context,
@@ -1065,7 +1065,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                 mockPostObj.get.withArgs('visibility').returns('paid');
                 mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
-                await models.Post.permissible(
+                await Post.permissible(
                     mockPostObj,
                     'edit',
                     context,

--- a/ghost/core/test/unit/server/models/session.test.js
+++ b/ghost/core/test/unit/server/models/session.test.js
@@ -1,6 +1,7 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
-const models = require('../../../../core/server/models');
+const {Session} = require('../../../../core/server/models/session');
+const Base = require('../../../../core/server/models/base');
 
 describe('Unit: models/session', function () {
     afterEach(function () {
@@ -9,7 +10,7 @@ describe('Unit: models/session', function () {
 
     describe('parse', function () {
         const parse = function parse(attrs) {
-            return new models.Session().parse(attrs);
+            return new Session().parse(attrs);
         };
 
         it('converts session_data to an object', function () {
@@ -27,7 +28,7 @@ describe('Unit: models/session', function () {
 
     describe('format', function () {
         const format = function format(attrs) {
-            return new models.Session().format(attrs);
+            return new Session().format(attrs);
         };
 
         it('converts session_data to a string', function () {
@@ -55,7 +56,7 @@ describe('Unit: models/session', function () {
 
     describe('user', function () {
         it('sets up the relation to the "User" model', function () {
-            const model = models.Session.forge({});
+            const model = Session.forge({});
             const belongsToSpy = sinon.spy(model, 'belongsTo');
             model.user();
 
@@ -69,32 +70,32 @@ describe('Unit: models/session', function () {
 
         beforeEach(function () {
             basePermittedOptionsReturnVal = ['super', 'doopa'];
-            basePermittedOptionsStub = sinon.stub(models.Base.Model, 'permittedOptions')
+            basePermittedOptionsStub = sinon.stub(Base.Model, 'permittedOptions')
                 .returns(basePermittedOptionsReturnVal);
         });
 
         it('passes the methodName and the context to the base permittedOptions method', function () {
             const methodName = 'methodName';
-            models.Session.permittedOptions(methodName);
+            Session.permittedOptions(methodName);
 
             assert.equal(basePermittedOptionsStub.args[0][0], methodName);
-            assert.equal(basePermittedOptionsStub.thisValues[0], models.Session);
+            assert.equal(basePermittedOptionsStub.thisValues[0], Session);
         });
 
         it('returns the base permittedOptions result', function () {
-            const returnedOptions = models.Session.permittedOptions();
+            const returnedOptions = Session.permittedOptions();
 
             assert.deepEqual(returnedOptions, basePermittedOptionsReturnVal);
         });
 
         it('returns the base permittedOptions result plus "session_id" when methodName is upsert', function () {
-            const returnedOptions = models.Session.permittedOptions('upsert');
+            const returnedOptions = Session.permittedOptions('upsert');
 
             assert.deepEqual(returnedOptions, basePermittedOptionsReturnVal.concat('session_id'));
         });
 
         it('returns the base permittedOptions result plus "session_id" when methodName is destroy', function () {
-            const returnedOptions = models.Session.permittedOptions('destroy');
+            const returnedOptions = Session.permittedOptions('destroy');
 
             assert.deepEqual(returnedOptions, basePermittedOptionsReturnVal.concat('session_id'));
         });
@@ -103,32 +104,32 @@ describe('Unit: models/session', function () {
     describe('destroy', function () {
         it('calls and returns the Base Model destroy if an id is passed', function () {
             const baseDestroyReturnVal = {};
-            const baseDestroyStub = sinon.stub(models.Base.Model, 'destroy')
+            const baseDestroyStub = sinon.stub(Base.Model, 'destroy')
                 .returns(baseDestroyReturnVal);
 
             const options = {id: 1};
-            const returnVal = models.Session.destroy(options);
+            const returnVal = Session.destroy(options);
 
             assert.equal(baseDestroyStub.args[0][0], options);
             assert.equal(returnVal, baseDestroyReturnVal);
         });
 
         it('calls forge with the session_id, fetchs with the filtered options and then destroys with the options', async function () {
-            const model = models.Session.forge({});
+            const model = Session.forge({});
             const session_id = 23;
             const unfilteredOptions = {session_id};
             const filteredOptions = {session_id};
 
-            const filterOptionsStub = sinon.stub(models.Session, 'filterOptions')
+            const filterOptionsStub = sinon.stub(Session, 'filterOptions')
                 .returns(filteredOptions);
-            const forgeStub = sinon.stub(models.Session, 'forge')
+            const forgeStub = sinon.stub(Session, 'forge')
                 .returns(model);
             const fetchStub = sinon.stub(model, 'fetch')
                 .resolves(model);
             const destroyStub = sinon.stub(model, 'destroy')
                 .resolves();
 
-            await models.Session.destroy(unfilteredOptions);
+            await Session.destroy(unfilteredOptions);
 
             assert.equal(filterOptionsStub.args[0][0], unfilteredOptions);
             assert.equal(filterOptionsStub.args[0][1], 'destroy');
@@ -151,15 +152,15 @@ describe('Unit: models/session', function () {
                 }
             };
 
-            const filterOptionsStub = sinon.stub(models.Session, 'filterOptions')
+            const filterOptionsStub = sinon.stub(Session, 'filterOptions')
                 .returns(filteredOptions);
 
-            const findOneStub = sinon.stub(models.Session, 'findOne')
+            const findOneStub = sinon.stub(Session, 'findOne')
                 .resolves();
 
-            const addStub = sinon.stub(models.Session, 'add');
+            const addStub = sinon.stub(Session, 'add');
 
-            await models.Session.upsert(data, unfilteredOptions);
+            await Session.upsert(data, unfilteredOptions);
 
             assert.equal(filterOptionsStub.args[0][0], unfilteredOptions);
             assert.equal(filterOptionsStub.args[0][1], 'upsert');
@@ -179,7 +180,7 @@ describe('Unit: models/session', function () {
         });
 
         it('calls findOne and then edit if findOne results in nothing', async function () {
-            const model = models.Session.forge({id: 2});
+            const model = Session.forge({id: 2});
             const session_id = 314;
             const unfilteredOptions = {session_id};
             const filteredOptions = {session_id};
@@ -189,15 +190,15 @@ describe('Unit: models/session', function () {
                 }
             };
 
-            const filterOptionsStub = sinon.stub(models.Session, 'filterOptions')
+            const filterOptionsStub = sinon.stub(Session, 'filterOptions')
                 .returns(filteredOptions);
 
-            const findOneStub = sinon.stub(models.Session, 'findOne')
+            const findOneStub = sinon.stub(Session, 'findOne')
                 .resolves(model);
 
-            const editStub = sinon.stub(models.Session, 'edit');
+            const editStub = sinon.stub(Session, 'edit');
 
-            await models.Session.upsert(data, unfilteredOptions);
+            await Session.upsert(data, unfilteredOptions);
 
             assert.equal(filterOptionsStub.args[0][0], unfilteredOptions);
             assert.equal(filterOptionsStub.args[0][1], 'upsert');

--- a/ghost/core/test/unit/server/models/settings.test.js
+++ b/ghost/core/test/unit/server/models/settings.test.js
@@ -2,7 +2,7 @@ const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
 const sinon = require('sinon');
 const mockDb = require('../../../utils/mock-knex');
-const models = require('../../../../core/server/models');
+const {Settings} = require('../../../../core/server/models/settings');
 const config = require('../../../../core/shared/config');
 const {knex} = require('../../../../core/server/data/db');
 const events = require('../../../../core/server/lib/common/events');
@@ -41,7 +41,7 @@ describe('Unit: models/settings', function () {
                 ][step - 1]();
             });
 
-            return models.Settings.add({
+            return Settings.add({
                 key: 'description',
                 value: 'added value',
                 type: 'string'
@@ -66,7 +66,7 @@ describe('Unit: models/settings', function () {
                 return query.response([{}]);
             });
 
-            return models.Settings.edit({
+            return Settings.edit({
                 key: 'description',
                 value: 'edited value'
             })
@@ -80,7 +80,7 @@ describe('Unit: models/settings', function () {
 
     describe('format', function () {
         it('transforms urls when persisting to db', function () {
-            const setting = models.Settings.forge();
+            const setting = Settings.forge();
             const siteUrl = config.get('url');
 
             let returns = setting.formatOnWrite({key: 'cover_image', value: `${siteUrl}/cover_image.png`, type: 'string'});
@@ -105,7 +105,7 @@ describe('Unit: models/settings', function () {
 
     describe('parse', function () {
         it('ensure correct parsing when fetching from db', function () {
-            const setting = models.Settings.forge();
+            const setting = Settings.forge();
             const siteUrl = config.get('url');
 
             let returns = setting.parse({key: 'is_private', value: 'false', type: 'boolean'});
@@ -151,7 +151,7 @@ describe('Unit: models/settings', function () {
 
     describe('validation', function () {
         async function testInvalidSetting({key, value, type, group}) {
-            const setting = models.Settings.forge({key, value, type, group});
+            const setting = Settings.forge({key, value, type, group});
 
             let error;
             try {
@@ -174,7 +174,7 @@ describe('Unit: models/settings', function () {
                 query.response([{}]);
             });
 
-            const setting = models.Settings.forge({key, value, type, group});
+            const setting = Settings.forge({key, value, type, group});
 
             // This should not reject.
             await setting.save();

--- a/ghost/core/test/unit/server/models/single-use-token.test.js
+++ b/ghost/core/test/unit/server/models/single-use-token.test.js
@@ -1,4 +1,4 @@
-const models = require('../../../../core/server/models');
+const {SingleUseToken} = require('../../../../core/server/models/single-use-token');
 const sinon = require('sinon');
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../utils/assertions');
@@ -20,13 +20,13 @@ describe('Unit: models/single-use-token', function () {
 
     describe('fn: defaults', function () {
         it('Defaults to used_count of zero', async function () {
-            const model = new models.SingleUseToken();
+            const model = new SingleUseToken();
             const defaults = model.defaults();
             assert.equal(defaults.used_count, 0);
         });
 
         it('Generates a valid v4 UUID by default', async function () {
-            const model = new models.SingleUseToken();
+            const model = new SingleUseToken();
             const defaults = model.defaults();
 
             assertExists(defaults.uuid);
@@ -34,8 +34,8 @@ describe('Unit: models/single-use-token', function () {
         });
 
         it('Generates unique UUIDs for different instances', async function () {
-            const model1 = new models.SingleUseToken();
-            const model2 = new models.SingleUseToken();
+            const model1 = new SingleUseToken();
+            const model2 = new SingleUseToken();
 
             const defaults1 = model1.defaults();
             const defaults2 = model2.defaults();

--- a/ghost/core/test/unit/server/models/stripe-customer-subscription.test.js
+++ b/ghost/core/test/unit/server/models/stripe-customer-subscription.test.js
@@ -1,6 +1,6 @@
 const {assertExists} = require('../../../utils/assertions');
 const sinon = require('sinon');
-const models = require('../../../../core/server/models');
+const {StripeCustomerSubscription} = require('../../../../core/server/models/stripe-customer-subscription');
 
 describe('Unit: models/stripe-customer-subscription', function () {
     afterEach(function () {
@@ -12,7 +12,7 @@ describe('Unit: models/stripe-customer-subscription', function () {
 
         beforeEach(function () {
             serialize = function (model, options) {
-                return new models.StripeCustomerSubscription(model).serialize(options);
+                return new StripeCustomerSubscription(model).serialize(options);
             };
         });
 

--- a/ghost/core/test/unit/server/models/subscription-created-event.test.js
+++ b/ghost/core/test/unit/server/models/subscription-created-event.test.js
@@ -1,7 +1,7 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const errors = require('@tryghost/errors');
-const models = require('../../../../core/server/models');
+const {SubscriptionCreatedEvent} = require('../../../../core/server/models/subscription-created-event');
 
 describe('Unit: models/SubscriptionCreatedEvent', function () {
     afterEach(function () {
@@ -10,7 +10,7 @@ describe('Unit: models/SubscriptionCreatedEvent', function () {
 
     describe('validation', function () {
         it('throws error for invalid attribution_type', function () {
-            return models.SubscriptionCreatedEvent.add({attribution_type: 'invalid', member_id: '123', subscription_id: '123'})
+            return SubscriptionCreatedEvent.add({attribution_type: 'invalid', member_id: '123', subscription_id: '123'})
                 .then(function () {
                     throw new Error('expected ValidationError');
                 })
@@ -22,7 +22,7 @@ describe('Unit: models/SubscriptionCreatedEvent', function () {
         });
 
         it('throws if member_id is missing', function () {
-            return models.SubscriptionCreatedEvent.add({attribution_type: 'post', subscription_id: '123'})
+            return SubscriptionCreatedEvent.add({attribution_type: 'post', subscription_id: '123'})
                 .then(function () {
                     throw new Error('expected ValidationError');
                 })
@@ -34,7 +34,7 @@ describe('Unit: models/SubscriptionCreatedEvent', function () {
         });
 
         it('throws if subscription_id is missing', function () {
-            return models.SubscriptionCreatedEvent.add({attribution_type: 'post', member_id: '123'})
+            return SubscriptionCreatedEvent.add({attribution_type: 'post', member_id: '123'})
                 .then(function () {
                     throw new Error('expected ValidationError');
                 })

--- a/ghost/core/test/unit/server/models/tag.test.js
+++ b/ghost/core/test/unit/server/models/tag.test.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
-const models = require('../../../../core/server/models');
+const {Tag} = require('../../../../core/server/models/tag');
 const {knex} = require('../../../../core/server/data/db');
 
 describe('Unit: models/tag', function () {
@@ -34,7 +34,7 @@ describe('Unit: models/tag', function () {
                 query.response([]);
             });
 
-            return models.Tag.findPage({
+            return Tag.findPage({
                 filter: 'count.posts:>=1',
                 order: 'count.posts DESC',
                 limit: 'all',

--- a/ghost/core/test/unit/server/models/welcome-email-automated-email.test.js
+++ b/ghost/core/test/unit/server/models/welcome-email-automated-email.test.js
@@ -1,6 +1,7 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
-const models = require('../../../../core/server/models');
+const {WelcomeEmailAutomatedEmail} = require('../../../../core/server/models/welcome-email-automated-email');
+const {EmailDesignSetting} = require('../../../../core/server/models/email-design-setting');
 const config = require('../../../../core/shared/config');
 
 describe('Unit: models/welcome-email-automated-email', function () {
@@ -10,7 +11,7 @@ describe('Unit: models/welcome-email-automated-email', function () {
 
     describe('parse', function () {
         it('transforms __GHOST_URL__ to absolute URL in lexical field', function () {
-            const model = models.WelcomeEmailAutomatedEmail.forge();
+            const model = WelcomeEmailAutomatedEmail.forge();
 
             const result = model.parse({
                 id: '123',
@@ -22,7 +23,7 @@ describe('Unit: models/welcome-email-automated-email', function () {
         });
 
         it('handles null lexical field', function () {
-            const model = models.WelcomeEmailAutomatedEmail.forge();
+            const model = WelcomeEmailAutomatedEmail.forge();
 
             const result = model.parse({
                 id: '123',
@@ -33,7 +34,7 @@ describe('Unit: models/welcome-email-automated-email', function () {
         });
 
         it('handles undefined lexical field', function () {
-            const model = models.WelcomeEmailAutomatedEmail.forge();
+            const model = WelcomeEmailAutomatedEmail.forge();
 
             const result = model.parse({
                 id: '123'
@@ -43,7 +44,7 @@ describe('Unit: models/welcome-email-automated-email', function () {
         });
 
         it('preserves other fields', function () {
-            const model = models.WelcomeEmailAutomatedEmail.forge();
+            const model = WelcomeEmailAutomatedEmail.forge();
 
             const result = model.parse({
                 id: '123',
@@ -58,7 +59,7 @@ describe('Unit: models/welcome-email-automated-email', function () {
 
     describe('formatOnWrite', function () {
         it('transforms absolute URLs to __GHOST_URL__ in lexical field', function () {
-            const model = models.WelcomeEmailAutomatedEmail.forge();
+            const model = WelcomeEmailAutomatedEmail.forge();
 
             const siteUrl = config.get('url');
             const result = model.formatOnWrite({
@@ -70,7 +71,7 @@ describe('Unit: models/welcome-email-automated-email', function () {
         });
 
         it('handles null lexical field', function () {
-            const model = models.WelcomeEmailAutomatedEmail.forge();
+            const model = WelcomeEmailAutomatedEmail.forge();
 
             const result = model.formatOnWrite({
                 lexical: null
@@ -80,7 +81,7 @@ describe('Unit: models/welcome-email-automated-email', function () {
         });
 
         it('handles undefined lexical field', function () {
-            const model = models.WelcomeEmailAutomatedEmail.forge();
+            const model = WelcomeEmailAutomatedEmail.forge();
 
             const result = model.formatOnWrite({
                 subject: 'Welcome!'
@@ -91,7 +92,7 @@ describe('Unit: models/welcome-email-automated-email', function () {
         });
 
         it('preserves other fields', function () {
-            const model = models.WelcomeEmailAutomatedEmail.forge();
+            const model = WelcomeEmailAutomatedEmail.forge();
 
             const result = model.formatOnWrite({
                 id: '123',
@@ -106,9 +107,9 @@ describe('Unit: models/welcome-email-automated-email', function () {
 
     describe('onCreating', function () {
         it('assigns the default email design setting when not provided', async function () {
-            const model = models.WelcomeEmailAutomatedEmail.forge();
-            const baseOnCreating = sinon.stub(Object.getPrototypeOf(models.WelcomeEmailAutomatedEmail.prototype), 'onCreating').resolves();
-            const findOne = sinon.stub(models.EmailDesignSetting, 'findOne').resolves(models.EmailDesignSetting.forge({id: 'default-setting-id'}));
+            const model = WelcomeEmailAutomatedEmail.forge();
+            const baseOnCreating = sinon.stub(Object.getPrototypeOf(WelcomeEmailAutomatedEmail.prototype), 'onCreating').resolves();
+            const findOne = sinon.stub(EmailDesignSetting, 'findOne').resolves(EmailDesignSetting.forge({id: 'default-setting-id'}));
 
             await model.onCreating(model, {}, {});
 
@@ -118,9 +119,9 @@ describe('Unit: models/welcome-email-automated-email', function () {
         });
 
         it('assigns the default email design setting when null is provided', async function () {
-            const model = models.WelcomeEmailAutomatedEmail.forge({email_design_setting_id: null});
-            sinon.stub(Object.getPrototypeOf(models.WelcomeEmailAutomatedEmail.prototype), 'onCreating').resolves();
-            sinon.stub(models.EmailDesignSetting, 'findOne').resolves(models.EmailDesignSetting.forge({id: 'default-setting-id'}));
+            const model = WelcomeEmailAutomatedEmail.forge({email_design_setting_id: null});
+            sinon.stub(Object.getPrototypeOf(WelcomeEmailAutomatedEmail.prototype), 'onCreating').resolves();
+            sinon.stub(EmailDesignSetting, 'findOne').resolves(EmailDesignSetting.forge({id: 'default-setting-id'}));
 
             await model.onCreating(model, {}, {});
 
@@ -128,9 +129,9 @@ describe('Unit: models/welcome-email-automated-email', function () {
         });
 
         it('keeps the provided email design setting id', async function () {
-            const model = models.WelcomeEmailAutomatedEmail.forge({email_design_setting_id: 'custom-setting-id'});
-            const baseOnCreating = sinon.stub(Object.getPrototypeOf(models.WelcomeEmailAutomatedEmail.prototype), 'onCreating').resolves();
-            const findOne = sinon.stub(models.EmailDesignSetting, 'findOne');
+            const model = WelcomeEmailAutomatedEmail.forge({email_design_setting_id: 'custom-setting-id'});
+            const baseOnCreating = sinon.stub(Object.getPrototypeOf(WelcomeEmailAutomatedEmail.prototype), 'onCreating').resolves();
+            const findOne = sinon.stub(EmailDesignSetting, 'findOne');
 
             await model.onCreating(model, {}, {});
 
@@ -140,9 +141,9 @@ describe('Unit: models/welcome-email-automated-email', function () {
         });
 
         it('throws when the default email design setting is missing', async function () {
-            const model = models.WelcomeEmailAutomatedEmail.forge();
-            sinon.stub(Object.getPrototypeOf(models.WelcomeEmailAutomatedEmail.prototype), 'onCreating').resolves();
-            sinon.stub(models.EmailDesignSetting, 'findOne').resolves(null);
+            const model = WelcomeEmailAutomatedEmail.forge();
+            sinon.stub(Object.getPrototypeOf(WelcomeEmailAutomatedEmail.prototype), 'onCreating').resolves();
+            sinon.stub(EmailDesignSetting, 'findOne').resolves(null);
 
             await assert.rejects(
                 () => model.onCreating(model, {}, {}),

--- a/ghost/core/test/unit/server/models/welcome-email-automation-run.test.js
+++ b/ghost/core/test/unit/server/models/welcome-email-automation-run.test.js
@@ -1,23 +1,23 @@
 const assert = require('node:assert/strict');
-const models = require('../../../../core/server/models');
+const {WelcomeEmailAutomationRun} = require('../../../../core/server/models/welcome-email-automation-run');
 
 describe('Unit: models/welcome-email-automation-run', function () {
     describe('tableName', function () {
         it('uses the correct table name', function () {
-            const model = new models.WelcomeEmailAutomationRun();
+            const model = new WelcomeEmailAutomationRun();
             assert.equal(model.tableName, 'welcome_email_automation_runs');
         });
     });
 
     describe('defaults', function () {
         it('sets stepAttempts to 0', function () {
-            const model = new models.WelcomeEmailAutomationRun();
+            const model = new WelcomeEmailAutomationRun();
             const defaults = model.defaults();
             assert.equal(defaults.stepAttempts, 0);
         });
 
         it('returns only stepAttempts as a default', function () {
-            const model = new models.WelcomeEmailAutomationRun();
+            const model = new WelcomeEmailAutomationRun();
             const defaults = model.defaults();
             assert.deepEqual(Object.keys(defaults), ['stepAttempts']);
         });
@@ -25,17 +25,17 @@ describe('Unit: models/welcome-email-automation-run', function () {
 
     describe('relationships', function () {
         it('has an automation relationship', function () {
-            const model = new models.WelcomeEmailAutomationRun();
+            const model = new WelcomeEmailAutomationRun();
             assert.equal(typeof model.automation, 'function');
         });
 
         it('has a member relationship', function () {
-            const model = new models.WelcomeEmailAutomationRun();
+            const model = new WelcomeEmailAutomationRun();
             assert.equal(typeof model.member, 'function');
         });
 
         it('has a nextWelcomeEmailAutomatedEmail relationship', function () {
-            const model = new models.WelcomeEmailAutomationRun();
+            const model = new WelcomeEmailAutomationRun();
             assert.equal(typeof model.nextWelcomeEmailAutomatedEmail, 'function');
         });
     });

--- a/ghost/core/test/unit/server/services/auth/api-key/admin.test.js
+++ b/ghost/core/test/unit/server/services/auth/api-key/admin.test.js
@@ -5,7 +5,7 @@ const errors = require('@tryghost/errors');
 const jwt = require('jsonwebtoken');
 const sinon = require('sinon');
 const apiKeyAuth = require('../../../../../../core/server/services/auth/api-key');
-const models = require('../../../../../../core/server/models');
+const {ApiKey} = require('../../../../../../core/server/models/api-key');
 
 describe('Admin API Key Auth', function () {
     const ADMIN_API_URL_VERSIONED = '/ghost/api/v4/admin/';
@@ -26,7 +26,7 @@ describe('Admin API Key Auth', function () {
         };
         secret = Buffer.from(fakeApiKey.secret, 'hex');
 
-        apiKeyStub = sinon.stub(models.ApiKey, 'findOne');
+        apiKeyStub = sinon.stub(ApiKey, 'findOne');
         apiKeyStub.resolves();
         apiKeyStub.withArgs({id: fakeApiKey.id}).resolves(fakeApiKey);
     });

--- a/ghost/core/test/unit/server/services/auth/api-key/content.test.js
+++ b/ghost/core/test/unit/server/services/auth/api-key/content.test.js
@@ -3,7 +3,7 @@ const deferred = require('../../../../../utils/deferred');
 const {assertExists} = require('../../../../../utils/assertions');
 const errors = require('@tryghost/errors');
 const {authenticateContentApiKey} = require('../../../../../../core/server/services/auth/api-key/content');
-const models = require('../../../../../../core/server/models');
+const {ApiKey} = require('../../../../../../core/server/models/api-key');
 const sinon = require('sinon');
 
 describe('Content API Key Auth', function () {
@@ -20,7 +20,7 @@ describe('Content API Key Auth', function () {
             }
         };
 
-        apiKeyStub = sinon.stub(models.ApiKey, 'findOne');
+        apiKeyStub = sinon.stub(ApiKey, 'findOne');
         apiKeyStub.returns(Promise.resolve());
         apiKeyStub.withArgs({secret: fakeApiKey.secret}).returns(Promise.resolve(fakeApiKey));
     });

--- a/ghost/core/test/unit/server/services/auth/session/store.test.js
+++ b/ghost/core/test/unit/server/services/auth/session/store.test.js
@@ -1,7 +1,7 @@
 const assert = require('node:assert/strict');
 const deferred = require('../../../../../utils/deferred');
 const SessionStore = require('../../../../../../core/server/services/auth/session/session-store');
-const models = require('../../../../../../core/server/models');
+const {Session} = require('../../../../../../core/server/models/session');
 const EventEmitter = require('events');
 const {Store} = require('express-session');
 const sinon = require('sinon');
@@ -26,10 +26,10 @@ describe('Auth Service SessionStore', function () {
     describe('SessionStore#destroy', function () {
         it('calls destroy on the model with the session_id `sid`', function () {
             const {promise, done} = deferred();
-            const destroyStub = sinon.stub(models.Session, 'destroy')
+            const destroyStub = sinon.stub(Session, 'destroy')
                 .resolves();
 
-            const store = new SessionStore(models.Session);
+            const store = new SessionStore(Session);
             const sid = 1;
             store.destroy(sid, function () {
                 const destroyStubCall = destroyStub.getCall(0);
@@ -41,10 +41,10 @@ describe('Auth Service SessionStore', function () {
 
         it('calls back with null if destroy resolve', function () {
             const {promise, done} = deferred();
-            sinon.stub(models.Session, 'destroy')
+            sinon.stub(Session, 'destroy')
                 .resolves();
 
-            const store = new SessionStore(models.Session);
+            const store = new SessionStore(Session);
             const sid = 1;
             store.destroy(sid, function (err) {
                 assert.equal(err, null);
@@ -56,10 +56,10 @@ describe('Auth Service SessionStore', function () {
         it('calls back with the error if destroy errors', function () {
             const {promise, done} = deferred();
             const error = new Error('beam me up scotty');
-            sinon.stub(models.Session, 'destroy')
+            sinon.stub(Session, 'destroy')
                 .rejects(error);
 
-            const store = new SessionStore(models.Session);
+            const store = new SessionStore(Session);
             const sid = 1;
             store.destroy(sid, function (err) {
                 assert.equal(err, error);
@@ -72,10 +72,10 @@ describe('Auth Service SessionStore', function () {
     describe('SessionStore#get', function () {
         it('calls findOne on the model with the session_id `sid`', function () {
             const {promise, done} = deferred();
-            const findOneStub = sinon.stub(models.Session, 'findOne')
+            const findOneStub = sinon.stub(Session, 'findOne')
                 .resolves();
 
-            const store = new SessionStore(models.Session);
+            const store = new SessionStore(Session);
             const sid = 1;
             store.get(sid, function () {
                 const findOneStubCall = findOneStub.getCall(0);
@@ -87,10 +87,10 @@ describe('Auth Service SessionStore', function () {
 
         it('callsback with null, null if findOne does not return a model', function () {
             const {promise, done} = deferred();
-            sinon.stub(models.Session, 'findOne')
+            sinon.stub(Session, 'findOne')
                 .resolves(null);
 
-            const store = new SessionStore(models.Session);
+            const store = new SessionStore(Session);
             const sid = 1;
             store.get(sid, function (err, session) {
                 assert.equal(err, null);
@@ -102,15 +102,15 @@ describe('Auth Service SessionStore', function () {
 
         it('callsback with null, model.session_data if findOne does return a model', function () {
             const {promise, done} = deferred();
-            const model = models.Session.forge({
+            const model = Session.forge({
                 session_data: {
                     ice: 'cube'
                 }
             });
-            sinon.stub(models.Session, 'findOne')
+            sinon.stub(Session, 'findOne')
                 .resolves(model);
 
-            const store = new SessionStore(models.Session);
+            const store = new SessionStore(Session);
             const sid = 1;
             store.get(sid, function (err, session) {
                 assert.equal(err, null);
@@ -125,10 +125,10 @@ describe('Auth Service SessionStore', function () {
         it('callsback with an error if the findOne does error', function () {
             const {promise, done} = deferred();
             const error = new Error('hot damn');
-            sinon.stub(models.Session, 'findOne')
+            sinon.stub(Session, 'findOne')
                 .rejects(error);
 
-            const store = new SessionStore(models.Session);
+            const store = new SessionStore(Session);
             const sid = 1;
             store.get(sid, function (err) {
                 assert.equal(err, error);
@@ -141,10 +141,10 @@ describe('Auth Service SessionStore', function () {
     describe('SessionStore#set', function () {
         it('calls upsert on the model with the session_id and the session_data', function () {
             const {promise, done} = deferred();
-            const upsertStub = sinon.stub(models.Session, 'upsert')
+            const upsertStub = sinon.stub(Session, 'upsert')
                 .resolves();
 
-            const store = new SessionStore(models.Session);
+            const store = new SessionStore(Session);
             const sid = 1;
             const session_data = {user_id: 100};
             store.set(sid, session_data, function () {
@@ -159,10 +159,10 @@ describe('Auth Service SessionStore', function () {
         it('calls back with an error if upsert errors', function () {
             const {promise, done} = deferred();
             const error = new Error('huuuuuurrr');
-            sinon.stub(models.Session, 'upsert')
+            sinon.stub(Session, 'upsert')
                 .rejects(error);
 
-            const store = new SessionStore(models.Session);
+            const store = new SessionStore(Session);
             const sid = 1;
             const session_data = {user_id: 100};
             store.set(sid, session_data, function (err) {
@@ -174,10 +174,10 @@ describe('Auth Service SessionStore', function () {
 
         it('calls back with null, null if upsert succeed', function () {
             const {promise, done} = deferred();
-            sinon.stub(models.Session, 'upsert')
+            sinon.stub(Session, 'upsert')
                 .resolves('success');
 
-            const store = new SessionStore(models.Session);
+            const store = new SessionStore(Session);
             const sid = 1;
             const session_data = {user_id: 100};
             store.set(sid, session_data, function (err, data) {

--- a/ghost/core/test/unit/server/services/milestones/bookshelf-milestone-repository.test.js
+++ b/ghost/core/test/unit/server/services/milestones/bookshelf-milestone-repository.test.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert/strict');
 
-const models = require('../../../../../core/server/models');
+const {Milestone} = require('../../../../../core/server/models/milestone');
 const DomainEvents = require('@tryghost/domain-events');
 
 describe('BookshelfMilestoneRepository', function () {
@@ -10,7 +10,7 @@ describe('BookshelfMilestoneRepository', function () {
         const BookshelfMilestoneRepository = require('../../../../../core/server/services/milestones/bookshelf-milestone-repository');
         repository = new BookshelfMilestoneRepository({
             DomainEvents,
-            MilestoneModel: models.Milestone
+            MilestoneModel: Milestone
         });
 
         assert.ok(repository.save);

--- a/ghost/core/test/unit/server/services/newsletters/service.test.js
+++ b/ghost/core/test/unit/server/services/newsletters/service.test.js
@@ -2,7 +2,8 @@ const sinon = require('sinon');
 const assert = require('node:assert/strict');
 
 // DI requirements
-const models = require('../../../../../core/server/models');
+const {Newsletter} = require('../../../../../core/server/models/newsletter');
+const {Member} = require('../../../../../core/server/models/member');
 const mail = require('../../../../../core/server/services/mail');
 
 // Mocked utilities
@@ -35,8 +36,8 @@ describe('NewslettersService', function () {
         };
 
         newsletterService = new NewslettersService({
-            NewsletterModel: models.Newsletter,
-            MemberModel: models.Member,
+            NewsletterModel: Newsletter,
+            MemberModel: Member,
             mail,
             singleUseTokenProvider: tokenProvider,
             urlUtils: urlUtils.stubUrlUtilsFromConfig(),
@@ -87,7 +88,7 @@ describe('NewslettersService', function () {
         let findOneStub;
         beforeEach(function () {
             // Stub edit as a function that returns its first argument
-            findOneStub = sinon.stub(models.Newsletter, 'findOne').returns({get: getStub, id: 'test'});
+            findOneStub = sinon.stub(Newsletter, 'findOne').returns({get: getStub, id: 'test'});
         });
 
         it('returns the result of findOne', async function () {
@@ -106,7 +107,7 @@ describe('NewslettersService', function () {
     // @TODO replace this with a specific function for fetching all available newsletters
     describe('browse', function () {
         it('lists all newsletters by calling findPage', async function () {
-            const findAllStub = sinon.stub(models.Newsletter, 'findPage').returns({data: []});
+            const findAllStub = sinon.stub(Newsletter, 'findPage').returns({data: []});
 
             await newsletterService.browse({});
 
@@ -121,10 +122,10 @@ describe('NewslettersService', function () {
             subscribeStub = sinon.stub().returns(fakeMemberIds);
 
             // Stub add as a function that returns get & subscribeMembersById methods
-            addStub = sinon.stub(models.Newsletter, 'add').returns({get: getStub, id: 'test', subscribeMembersById: subscribeStub});
-            fetchMembersStub = sinon.stub(models.Member, 'fetchAllSubscribed').returns([]);
-            getNextAvailableSortOrderStub = sinon.stub(models.Newsletter, 'getNextAvailableSortOrder').returns(1);
-            findOneStub = sinon.stub(models.Newsletter, 'findOne').returns({get: getStub, id: 'test', subscribeMembersById: subscribeStub});
+            addStub = sinon.stub(Newsletter, 'add').returns({get: getStub, id: 'test', subscribeMembersById: subscribeStub});
+            fetchMembersStub = sinon.stub(Member, 'fetchAllSubscribed').returns([]);
+            getNextAvailableSortOrderStub = sinon.stub(Newsletter, 'getNextAvailableSortOrder').returns(1);
+            findOneStub = sinon.stub(Newsletter, 'findOne').returns({get: getStub, id: 'test', subscribeMembersById: subscribeStub});
         });
 
         it('rejects if the limit services determines it would be over the limit', async function () {
@@ -224,8 +225,8 @@ describe('NewslettersService', function () {
         let editStub, findOneStub;
         beforeEach(function () {
             // Stub edit as a function that returns its first argument
-            editStub = sinon.stub(models.Newsletter, 'edit').returns({get: getStub, id: 'test'});
-            findOneStub = sinon.stub(models.Newsletter, 'findOne').returns({get: getStub, id: 'test'});
+            editStub = sinon.stub(Newsletter, 'edit').returns({get: getStub, id: 'test'});
+            findOneStub = sinon.stub(Newsletter, 'findOne').returns({get: getStub, id: 'test'});
         });
 
         it('rejects if called with no data', async function () {
@@ -259,7 +260,7 @@ describe('NewslettersService', function () {
         let editStub;
 
         beforeEach(function () {
-            editStub = sinon.stub(models.Newsletter, 'edit').returns({get: getStub});
+            editStub = sinon.stub(Newsletter, 'edit').returns({get: getStub});
             sinon.assert.notCalled(editStub);
         });
 

--- a/ghost/core/test/unit/server/services/outbox/handlers/member-created.test.js
+++ b/ghost/core/test/unit/server/services/outbox/handlers/member-created.test.js
@@ -3,7 +3,8 @@ const sinon = require('sinon');
 const {captureLoggerOutput, findByEvent} = require('../../../../../utils/logging-utils');
 const handler = require('../../../../../../core/server/services/outbox/handlers/member-created.js');
 const memberWelcomeEmailService = require('../../../../../../core/server/services/member-welcome-emails/service');
-const {Automation, AutomatedEmailRecipient} = require('../../../../../../core/server/models');
+const {Automation} = require('../../../../../../core/server/models/automation');
+const {AutomatedEmailRecipient} = require('../../../../../../core/server/models/automated-email-recipient');
 
 describe('member-created handler', function () {
     let memberWelcomeEmailServiceSendStub;

--- a/ghost/core/test/unit/server/services/post-scheduling/post-scheduling.test.js
+++ b/ghost/core/test/unit/server/services/post-scheduling/post-scheduling.test.js
@@ -2,7 +2,7 @@ const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const moment = require('moment');
 const testUtils = require('../../../../utils');
-const models = require('../../../../../core/server/models');
+const {Post} = require('../../../../../core/server/models/post');
 const events = require('../../../../../core/server/lib/common/events');
 const schedulingUtils = require('../../../../../core/server/adapters/scheduling/utils');
 const SchedulingDefault = require('../../../../../core/server/adapters/scheduling/scheduling-default');
@@ -31,7 +31,7 @@ describe('PostScheduling', function () {
 
     describe('constructor', function () {
         it('wires event handlers and starts the adapter', async function () {
-            const post = models.Post.forge(testUtils.DataGenerator.forKnex.createPost({
+            const post = Post.forge(testUtils.DataGenerator.forKnex.createPost({
                 id: 1337,
                 mobiledoc: testUtils.DataGenerator.markdownToMobiledoc('something')
             }));
@@ -58,11 +58,11 @@ describe('PostScheduling', function () {
 
     describe('rescheduleAll', function () {
         function stubScheduledPost() {
-            const post = models.Post.forge(testUtils.DataGenerator.forKnex.createPost({
+            const post = Post.forge(testUtils.DataGenerator.forKnex.createPost({
                 id: 4004,
                 mobiledoc: testUtils.DataGenerator.markdownToMobiledoc('something')
             }));
-            sinon.stub(models.Post, 'findAll').callsFake(({filter}) => {
+            sinon.stub(Post, 'findAll').callsFake(({filter}) => {
                 return Promise.resolve(filter.includes('type:post') ? [post] : []);
             });
             return post;

--- a/ghost/core/test/unit/server/services/settings/settings-service.test.js
+++ b/ghost/core/test/unit/server/services/settings/settings-service.test.js
@@ -3,7 +3,7 @@ const assert = require('node:assert/strict');
 const configUtils = require('../../../../utils/config-utils');
 const settingsCache = require('../../../../../core/shared/settings-cache');
 const logging = require('@tryghost/logging');
-const models = require('../../../../../core/server/models');
+const {Settings} = require('../../../../../core/server/models/settings');
 const adapterManager = require('../../../../../core/server/services/adapter-manager');
 const limits = require('../../../../../core/server/services/limits');
 
@@ -103,8 +103,8 @@ describe('UNIT: Settings Service', function () {
             configUtils.set('hostSettings:limits:customIntegrations:disabled', true);
 
             sinon.stub(adapterManager, 'getAdapter').withArgs('cache:settings').returns(cacheStore);
-            sinon.stub(models.Settings, 'populateDefaults').resolves();
-            sinon.stub(models.Settings, 'findAll').resolves(settingsCollection);
+            sinon.stub(Settings, 'populateDefaults').resolves();
+            sinon.stub(Settings, 'findAll').resolves(settingsCollection);
             const initStub = sinon.stub(settingsCache, 'init');
 
             await settingsService.init();
@@ -126,8 +126,8 @@ describe('UNIT: Settings Service', function () {
             });
 
             sinon.stub(adapterManager, 'getAdapter').withArgs('cache:settings').returns(cacheStore);
-            sinon.stub(models.Settings, 'populateDefaults').resolves();
-            sinon.stub(models.Settings, 'findAll').resolves(settingsCollection);
+            sinon.stub(Settings, 'populateDefaults').resolves();
+            sinon.stub(Settings, 'findAll').resolves(settingsCollection);
             const initStub = sinon.stub(settingsCache, 'init');
 
             await settingsService.init();
@@ -148,13 +148,13 @@ describe('UNIT: Settings Service', function () {
         beforeEach(function () {
             sinon.stub(adapterManager, 'getAdapter').withArgs('cache:settings').returns({});
             sinon.stub(settingsCache, 'init');
-            sinon.stub(models.Settings, 'populateDefaults').resolves();
-            sinon.stub(models.Settings, 'findAll').resolves({});
+            sinon.stub(Settings, 'populateDefaults').resolves();
+            sinon.stub(Settings, 'findAll').resolves({});
         });
 
         it('is a no-op when the limit is not disabled', async function () {
             sinon.stub(limits, 'isDisabled').withArgs('publicSiteAccess').returns(false);
-            const editStub = sinon.stub(models.Settings, 'edit').resolves();
+            const editStub = sinon.stub(Settings, 'edit').resolves();
 
             await settingsService.init();
 
@@ -163,10 +163,10 @@ describe('UNIT: Settings Service', function () {
 
         it('persists is_private = true and a generated access code when both are missing', async function () {
             sinon.stub(limits, 'isDisabled').withArgs('publicSiteAccess').returns(true);
-            const findOneStub = sinon.stub(models.Settings, 'findOne');
+            const findOneStub = sinon.stub(Settings, 'findOne');
             findOneStub.withArgs({key: 'is_private'}).resolves(fakeSettingRow(false));
             findOneStub.withArgs({key: 'password'}).resolves(fakeSettingRow(''));
-            const editStub = sinon.stub(models.Settings, 'edit').resolves();
+            const editStub = sinon.stub(Settings, 'edit').resolves();
 
             await settingsService.init();
 
@@ -180,10 +180,10 @@ describe('UNIT: Settings Service', function () {
 
         it('only writes the missing values when one is already enforced', async function () {
             sinon.stub(limits, 'isDisabled').withArgs('publicSiteAccess').returns(true);
-            const findOneStub = sinon.stub(models.Settings, 'findOne');
+            const findOneStub = sinon.stub(Settings, 'findOne');
             findOneStub.withArgs({key: 'is_private'}).resolves(fakeSettingRow(true));
             findOneStub.withArgs({key: 'password'}).resolves(fakeSettingRow(''));
-            const editStub = sinon.stub(models.Settings, 'edit').resolves();
+            const editStub = sinon.stub(Settings, 'edit').resolves();
 
             await settingsService.init();
 
@@ -194,10 +194,10 @@ describe('UNIT: Settings Service', function () {
 
         it('does not write when both values are already enforced', async function () {
             sinon.stub(limits, 'isDisabled').withArgs('publicSiteAccess').returns(true);
-            const findOneStub = sinon.stub(models.Settings, 'findOne');
+            const findOneStub = sinon.stub(Settings, 'findOne');
             findOneStub.withArgs({key: 'is_private'}).resolves(fakeSettingRow(true));
             findOneStub.withArgs({key: 'password'}).resolves(fakeSettingRow('anchor042'));
-            const editStub = sinon.stub(models.Settings, 'edit').resolves();
+            const editStub = sinon.stub(Settings, 'edit').resolves();
 
             await settingsService.init();
 
@@ -206,10 +206,10 @@ describe('UNIT: Settings Service', function () {
 
         it('treats a whitespace-only access code as missing', async function () {
             sinon.stub(limits, 'isDisabled').withArgs('publicSiteAccess').returns(true);
-            const findOneStub = sinon.stub(models.Settings, 'findOne');
+            const findOneStub = sinon.stub(Settings, 'findOne');
             findOneStub.withArgs({key: 'is_private'}).resolves(fakeSettingRow(true));
             findOneStub.withArgs({key: 'password'}).resolves(fakeSettingRow('   '));
-            const editStub = sinon.stub(models.Settings, 'edit').resolves();
+            const editStub = sinon.stub(Settings, 'edit').resolves();
 
             await settingsService.init();
 

--- a/ghost/core/test/unit/server/services/webhooks/serialize.test.js
+++ b/ghost/core/test/unit/server/services/webhooks/serialize.test.js
@@ -1,7 +1,8 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
 
-const models = require('../../../../../core/server/models');
+const {Post} = require('../../../../../core/server/models/post');
+const {Member} = require('../../../../../core/server/models/member');
 
 const serialize = require('../../../../../core/server/services/webhooks/serialize');
 
@@ -60,7 +61,7 @@ describe('WebhookService - Serialize', function () {
 
     it('can serialize a new post', async function () {
         const post = fixtureManager.get('posts', 1);
-        const postModel = new models.Post(post);
+        const postModel = new Post(post);
 
         const result = await serialize('post.added', postModel);
 
@@ -72,7 +73,7 @@ describe('WebhookService - Serialize', function () {
 
     it('can serialize an edited post', async function () {
         const post = fixtureManager.get('posts', 1);
-        const postModel = new models.Post(post);
+        const postModel = new Post(post);
 
         // We use both _previousAttributes and _changed in the webhook serializer
         postModel._previousAttributes.title = post.title;
@@ -90,7 +91,7 @@ describe('WebhookService - Serialize', function () {
     it('can serialize reconstructed member.edited model event state', async function () {
         const previousUpdatedAt = new Date('2026-04-28T15:55:45.000Z');
         const currentUpdatedAt = new Date('2026-05-29T00:00:00.000Z');
-        const memberModel = new models.Member({
+        const memberModel = new Member({
             id: 'member-id',
             uuid: 'member-uuid',
             email: 'member@example.com',


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/PLA-45

57 files in `test/unit/**` required the full `core/server/models` barrel — which loads bookshelf, every model, and every plugin (~223ms cold per worker) — when each only exercises one or two models. This swaps **43** of them to require the specific model file(s) directly (e.g. `const {Tag} = require('.../models/tag')`), so test workers stop paying the cold barrel-load cost. Behaviour is unchanged: the single-model files export the same bindings the barrel re-exports, and `models.Base` maps to the base module (ghostBookshelf).

**Kept on the barrel by design (14 files):** tests that genuinely touch three-plus models; `members/middleware.test.js` (mutates `models.Product` on the shared barrel object the SUT reads) and `milestone-queries.test.js` (deliberate import-time full-layer require, documented in-file); and the six files needing `models.User` — `models/user` pulls in `services/permissions`, which re-requires the barrel, so requiring `models/user` as a worker's first model load re-enters the barrel mid-init and throws via `author.js`.

Tests-only change; no production code touched. Full unit suite green (7020 passing), lint clean.