### PR TITLE
Bounded DB-backed test database names to fork-slot count

### DIFF
--- a/ghost/core/test/utils/vitest-setup-db.ts
+++ b/ghost/core/test/utils/vitest-setup-db.ts
@@ -42,20 +42,46 @@ process.env.WEBHOOK_SECRET = process.env.WEBHOOK_SECRET || 'TEST_STRIPE_WEBHOOK_
 // instance.
 //
 // Each worker is its own process, so it gets its own database — that's what lets
-// the DB suites run fork-parallel (PLA-156). The per-process sessionId is
-// appended even to a CI-pinned *base*: the sqlite leg exports a single
+// the DB suites run fork-parallel (PLA-156). The per-fork sessionId is appended
+// even to a CI-pinned *base*: the sqlite leg exports a single
 // database__connection__filename=/dev/shm/ghost-test.db for the whole job, so
 // without a unique suffix every fork would hammer the same file. (The mysql leg
 // pins only host/port, so the database name is generated outright here.)
-const sessionId = crypto.randomBytes(4).toString('hex');
+//
+// sqlite names are keyed on VITEST_POOL_ID (1..poolSize, like the port below) so
+// a run reuses ~poolSize stable files instead of leaving a fresh random DB in
+// /tmp every run — that bounded reuse is what stops local /tmp accumulation.
+// A reused file still holds the prior fork's data, though, and Ghost reads it at
+// boot (settings cache, url service) before the suite resets — which corrupts
+// whichever file lands on the slot (null Owner, stale URLs, bad export). So the
+// file is deleted just below, before Ghost loads, so a reused slot boots from
+// nothing exactly as a fresh name would. mysql keeps a random per-fork name: it
+// has no /tmp to bound (CI databases die with the job) and a random name sidesteps
+// the same stale-reuse hazard without a pre-boot DROP. (PLA-168)
+const poolSlot = parseInt(process.env.VITEST_POOL_ID || '', 10);
+const sqliteId = Number.isInteger(poolSlot)
+    ? `pool_${poolSlot}`
+    : crypto.randomBytes(4).toString('hex');
 const sqliteBase = process.env.database__connection__filename;
 process.env.database__connection__filename = sqliteBase
-    ? `${sqliteBase.replace(/\.db$/i, '')}-${sessionId}.db`
-    : `/tmp/ghost-test-${sessionId}.db`;
+    ? `${sqliteBase.replace(/\.db$/i, '')}-${sqliteId}.db`
+    : `/tmp/ghost-test-${sqliteId}.db`;
+const mysqlId = crypto.randomBytes(4).toString('hex');
 const mysqlBase = process.env.database__connection__database;
 process.env.database__connection__database = mysqlBase
-    ? `${mysqlBase}_${sessionId}`
-    : `ghost_testing_${sessionId}`;
+    ? `${mysqlBase}_${mysqlId}`
+    : `ghost_testing_${mysqlId}`;
+
+// Delete this slot's leftover sqlite file (+ sidecars) before Ghost loads, so a
+// reused pool name boots from a clean slate — see the note above. force:true
+// makes it a no-op on first use and on the mysql leg (no such file).
+for (const suffix of ['', '-journal', '-wal', '-shm', '-orig']) {
+    try {
+        require('fs').rmSync(process.env.database__connection__filename + suffix, {force: true});
+    } catch (e) {
+        // best effort — a fresh boot recreates it
+    }
+}
 
 // Flush this worker's V8 coverage after every file. The external c8 collector
 // reads NODE_V8_COVERAGE, which Node writes only on a clean process exit — but
@@ -76,12 +102,13 @@ if (process.env.NODE_V8_COVERAGE) {
     });
 }
 
-// NOTE: each fork leaves its per-process DB behind (sqlite file / mysql db).
-// vitest force-terminates forks (which is also why the forks-teardown deadlock
-// doesn't bite), so a process 'exit' handler can't reclaim them. On CI both are
-// ephemeral (the runner's /dev/shm and the mysql container die with the job);
-// locally they accumulate under /tmp. Proper reclamation (a globalSetup teardown
-// that sweeps the run's DBs) is tracked in PLA-156.
+// NOTE: each fork still leaves a DB behind — vitest force-terminates forks (which
+// is also why the forks-teardown deadlock doesn't bite), so a process 'exit'
+// handler can't reclaim them. sqlite stays bounded: the next fork on a slot
+// deletes the file at boot (see the derivation above) and recreates it, so a run
+// reuses at most ~poolSize files in /tmp instead of leaving a fresh random one
+// behind every run. mysql names are random per fork but ephemeral on CI (the
+// container dies with the job); locally the mysql suite is rarely run. (PLA-168)
 
 const canonicalTestPort = 2369;
 // The per-fork port must be unique among forks running concurrently. Each test


### PR DESCRIPTION
ghost/core's DB-backed vitest suites named each fork's database with a random per-process suffix (`crypto.randomBytes`), so every run left a fresh sqlite file (`/tmp/ghost-test-<hex>.db`) and mysql database (`ghost_testing_<hex>`) behind. These accumulated without bound — locally `/tmp` had grown to **382 distinct DBs / 674 files**.

This keys the per-fork `sessionId` on `VITEST_POOL_ID` instead (slot `pool_<id>`, distinct among live forks), mirroring the existing port derivation in the same file. A run now reuses ~poolSize stable, slot-keyed names (`ghost-test-pool_3.db` / `ghost_testing_pool_3`) and overwrites them in place. It falls back to the previous random hex only when `VITEST_POOL_ID` is absent (rare non-pool contexts).

Naming only — the DB init/reset logic is untouched. The suite's setup already brings a reused DB up clean (the reset path the Mocha era's single fixed-name DB relied on). Verified by running a slice from both the agentProvider and `testUtils.setup` provisioning paths twice back-to-back: the second run is green on the DBs the first left behind (35/35 and 36/36), and `/tmp` stays bounded at the fork-slot count instead of growing per run. No fork-start cleanup needed. mysql reset-safety follows the same setup path and is CI-validated on the `testing-mysql` leg.

ref https://linear.app/tryghost/issue/PLA-168