### PR TITLE
Sped up per-file mysql DB init with a shared run template

### DIFF
--- a/ghost/core/test/e2e-api/admin/pages-legacy.test.js
+++ b/ghost/core/test/e2e-api/admin/pages-legacy.test.js
@@ -34,9 +34,13 @@ describe('Pages API', function () {
         localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
         assert.equal(_.isBoolean(jsonResponse.pages[0].featured), true);
 
-        // Absolute urls by default
-        assert.match(new URL(jsonResponse.pages[0].url).pathname, /\/p\/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/);
-        assert.equal(new URL(jsonResponse.pages[1].url).pathname, '/contribute/');
+        // Absolute urls by default. Match pages by url rather than by sort index:
+        // fixture pages are seeded with near-identical timestamps, so the relative
+        // order of same-status pages is not stable across databases (PLA-165).
+        const draftPage = jsonResponse.pages.find(page => /\/p\/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\//.test(new URL(page.url).pathname));
+        assertExists(draftPage);
+        const contributePage = jsonResponse.pages.find(page => new URL(page.url).pathname === '/contribute/');
+        assertExists(contributePage);
     });
 
     it('Can retrieve pages with just lexical format', async function () {

--- a/ghost/core/test/utils/db-template-paths.js
+++ b/ghost/core/test/utils/db-template-paths.js
@@ -1,0 +1,19 @@
+// Pure derivation of the shared DB-template database name from a per-fork
+// database identifier. Kept dependency-free (NO Ghost config/db imports) so it
+// can be required by the vitest globalSetup BEFORE Ghost's config loads.
+//
+// `vitest-setup-db.ts` appends a per-fork session suffix to a base mysql database
+// name (`_<8 hex>`). Stripping that suffix yields a value shared across every fork
+// of the run, to which we add a stable `template` marker. globalSetup derives from
+// the raw (un-suffixed) base; the forks derive from their suffixed config value at
+// restore time — because both strip the suffix, they resolve to the identical
+// template. (Template restore is MySQL-only — see db-template.js.)
+
+const deriveMySQLTemplateDatabase = (database) => {
+    const base = database.replace(/_[a-f0-9]{8}$/i, '');
+    return `${base}_template`;
+};
+
+module.exports = {
+    deriveMySQLTemplateDatabase
+};

--- a/ghost/core/test/utils/db-template.js
+++ b/ghost/core/test/utils/db-template.js
@@ -1,0 +1,209 @@
+const debug = require('@tryghost/debug')('test:dbTemplate');
+const path = require('path');
+const knex = require('knex');
+const KnexMigrator = require('knex-migrator');
+const {sequence} = require('@tryghost/promise');
+
+const config = require('../../core/shared/config');
+const db = require('../../core/server/data/db');
+const schemaModule = require('../../core/server/data/schema');
+const schemaTables = Object.keys(schemaModule.tables);
+const schemaViews = schemaModule.views || {};
+const {deriveMySQLTemplateDatabase} = require('./db-template-paths');
+
+// A migrated + seeded database is expensive to build (full knex-migrator init:
+// create every table, record all ~120 versioned migrations as applied, and
+// insert every default fixture). On MySQL each step is a network round-trip, and
+// the DB-suite runner's `isolate:true` projects run every test FILE in a fresh
+// fork, so without help each file pays that full init once — the bulk of the
+// MySQL acceptance-test runtime regression (PLA-165).
+//
+// Instead we build ONE migrated + seeded "template" database for the whole run
+// (in the vitest globalSetup, before any fork spawns) and have each fork RESTORE
+// from it when it first provisions its per-process DB, replacing the migrate+seed
+// with a cheap same-server bulk copy (`CREATE TABLE ... LIKE` + `INSERT ...
+// SELECT`).
+//
+// MySQL only. sqlite's per-file init is cheap (~0.65s, not the bottleneck), and a
+// sqlite restore would copy the template file over a fork's already-open
+// connection — which destabilizes read order for order-dependent tests — so
+// sqlite keeps a plain per-file init.
+//
+// Readiness is published from globalSetup to the forks via an env var (forks
+// inherit the main process env at spawn time). When it is unset — e.g.
+// `test:single` on one file with no globalSetup — the callers fall back to a full
+// knex-migrator init, so behaviour is unchanged outside the orchestrated run.
+//
+// SCOPE: only the db.reset() provisioning path (agentProvider-based e2e / e2e-api
+// / e2e-* suites, the dominant MySQL cost) uses this. The getFixtureOps
+// `testUtils.setup()` path (integration/legacy) opens Ghost's bookshelf
+// connection BEFORE provisioning, so that path still does a full init. See the
+// PLA-165 notes for the deferred follow-up.
+
+const TEMPLATE_ENV_VAR = 'GHOST_TEST_DB_TEMPLATE_READY';
+
+const getResetTables = () => {
+    return schemaTables.concat(['migrations']);
+};
+
+// Client detection from config (NOT db.knex) for the build/teardown paths, which
+// run in globalSetup where touching db.knex would bind Ghost's singleton
+// connection to a template location.
+const configuredClientIsSQLite = () => config.get('database:client') === 'sqlite3';
+
+/**
+ * Whether the shared template has been built for this run (published by
+ * globalSetup). Callers use this to choose a cheap restore over a full init.
+ * Always false on sqlite — no template is built there.
+ * @returns {boolean}
+ */
+const hasTemplate = () => {
+    return process.env[TEMPLATE_ENV_VAR] === '1';
+};
+
+/**
+ * Resolve the template database name from the CURRENT fork connection's config.
+ * config holds the suffixed per-fork value; the pure deriver strips that suffix
+ * so this resolves to the same template globalSetup built from the un-suffixed
+ * base.
+ * @returns {string}
+ */
+const getForkTemplateDatabase = () => {
+    return deriveMySQLTemplateDatabase(config.get('database:connection:database'));
+};
+
+/**
+ * Create the fork's per-process mysql database if it does not exist, via a
+ * short-lived connection with no default database (Ghost's db.knex is bound to
+ * the not-yet-existing fork DB, so it cannot do this itself). Mirrors
+ * knex-migrator's createDatabaseIfNotExist.
+ */
+const ensureForkDatabaseExists = async () => {
+    const connectionConfig = config.get('database:connection');
+    const {database, ...connectionWithoutDb} = connectionConfig;
+    const admin = knex({
+        client: config.get('database:client'),
+        connection: connectionWithoutDb
+    });
+    try {
+        // CHARACTER SET only (no explicit collation), matching knex-migrator's
+        // createDatabaseIfNotExist. Table collations come from the template via
+        // CREATE TABLE ... LIKE, so the DB default here is not load-bearing.
+        const charset = connectionConfig.charset || 'utf8mb4';
+        await admin.raw('CREATE DATABASE IF NOT EXISTS ?? CHARACTER SET ??', [database, charset]);
+    } finally {
+        await admin.destroy();
+    }
+};
+
+/**
+ * Build the shared template database. Called ONCE from globalSetup (main process,
+ * before any fork). MySQL only. Derives the template location from the run's BASE
+ * (un-suffixed) DB identifier, points Ghost's config there, then runs a full
+ * knex-migrator reset + init. A fresh KnexMigrator is constructed AFTER the config
+ * override so it reads the template location via MigratorConfig.js.
+ *
+ * @param {{mysqlBase?: string}} base the run's base DB identifier, un-suffixed
+ */
+const buildTemplate = async (base) => {
+    // The template is MySQL-only. sqlite's per-file init is cheap (~0.65s), and
+    // restoring it by copying the template file over a fork's already-open
+    // connection destabilizes read order for order-dependent tests (PLA-165) — so
+    // sqlite does a plain per-file init and hasTemplate() stays false here.
+    if (configuredClientIsSQLite()) {
+        debug('sqlite: skipping shared template');
+        return;
+    }
+
+    debug('Building shared DB template');
+    config.set('database:connection:database', deriveMySQLTemplateDatabase(base.mysqlBase));
+
+    // Construct after the override so MigratorConfig.js captures the template
+    // location. reset({force}) drops the template DB (DROP DATABASE, tolerating
+    // "does not exist"); init recreates, migrates, and seeds — exactly db-utils'
+    // forceReinit.
+    const knexMigrator = new KnexMigrator({knexMigratorFilePath: path.join(__dirname, '../..')});
+    await knexMigrator.reset({force: true});
+    await knexMigrator.init();
+
+    process.env[TEMPLATE_ENV_VAR] = '1';
+    debug('Shared DB template ready');
+};
+
+/**
+ * Restore the current fork's per-process database from the shared template.
+ * Assumes the caller has verified hasTemplate(). Copies every table from the
+ * template DB into the fork DB on the same server (CREATE TABLE ... LIKE +
+ * INSERT ... SELECT). The fork's connection is bound to its own database, so the
+ * template is referenced by qualified name.
+ */
+const restoreFromTemplate = async () => {
+    const templateDb = getForkTemplateDatabase();
+    debug('Restoring fork DB from template');
+
+    const tables = getResetTables();
+
+    // The fork's per-process database does not exist yet on first provision (the
+    // non-template path would have it created by knex-migrator init's
+    // createDatabaseIfNotExist). db.knex is bound to it, so a query would fail
+    // with ER_BAD_DB_ERROR — create it first via a short-lived db-less connection
+    // (mirrors knex-migrator's own approach), then run the copy.
+    await ensureForkDatabaseExists();
+
+    // Fresh fork DB: create each table from the template and bulk-copy its rows.
+    // Foreign key checks are disabled so tables can be loaded in any order.
+    await db.knex.raw('SET FOREIGN_KEY_CHECKS=0;');
+    try {
+        await sequence(tables.map(table => async () => {
+            await db.knex.schema.dropTableIfExists(table);
+            await db.knex.raw('CREATE TABLE ?? LIKE ??.??', [table, templateDb, table]);
+            await db.knex.raw('INSERT INTO ?? SELECT * FROM ??.??', [table, templateDb, table]);
+        }));
+    } finally {
+        await db.knex.raw('SET FOREIGN_KEY_CHECKS=1;');
+    }
+
+    // CREATE TABLE ... LIKE only copies base tables; views are not snapshotted by
+    // getResetTables (the existing snapshot path relies on init() having created
+    // them once). Recreate them here from the schema definitions, exactly as
+    // migrations/init/1-create-tables.js does, so a template-provisioned fork DB
+    // has the same views as a fully-migrated one.
+    for (const [name, sql] of Object.entries(schemaViews)) {
+        await db.knex.schema.createViewOrReplace(name, function (view) {
+            view.as(db.knex.raw(sql));
+        });
+    }
+};
+
+/**
+ * Drop the shared template database. Called from globalSetup teardown. MySQL only
+ * (no-op on sqlite). Best effort — on CI the whole server is ephemeral; this is
+ * for local hygiene and to avoid a stale template surviving into the next run.
+ *
+ * @param {{mysqlBase?: string}} base the run's base DB id
+ */
+const dropTemplate = async (base) => {
+    if (configuredClientIsSQLite()) {
+        return;
+    }
+    try {
+        // Point config at the template and let knex-migrator reset({force}) drop
+        // that database — reusing the same connection path build used, so we never
+        // bind Ghost's singleton db.knex to a template.
+        config.set('database:connection:database', deriveMySQLTemplateDatabase(base.mysqlBase));
+        const knexMigrator = new KnexMigrator({knexMigratorFilePath: path.join(__dirname, '../..')});
+        await knexMigrator.reset({force: true});
+    } catch (err) {
+        debug(`Failed to drop template (ignored): ${err.message}`);
+    }
+};
+
+module.exports = {
+    TEMPLATE_ENV_VAR,
+    deriveMySQLTemplateDatabase,
+    configuredClientIsSQLite,
+    hasTemplate,
+    buildTemplate,
+    restoreFromTemplate,
+    dropTemplate
+};

--- a/ghost/core/test/utils/db-template.js
+++ b/ghost/core/test/utils/db-template.js
@@ -88,7 +88,7 @@ const ensureForkDatabaseExists = async () => {
     try {
         // CHARACTER SET only (no explicit collation), matching knex-migrator's
         // createDatabaseIfNotExist. Table collations come from the template via
-        // CREATE TABLE ... LIKE, so the DB default here is not load-bearing.
+        // the replayed CREATE TABLE DDL, so the DB default here is not load-bearing.
         const charset = connectionConfig.charset || 'utf8mb4';
         await admin.raw('CREATE DATABASE IF NOT EXISTS ?? CHARACTER SET ??', [database, charset]);
     } finally {
@@ -133,9 +133,9 @@ const buildTemplate = async (base) => {
 /**
  * Restore the current fork's per-process database from the shared template.
  * Assumes the caller has verified hasTemplate(). Copies every table from the
- * template DB into the fork DB on the same server (CREATE TABLE ... LIKE +
- * INSERT ... SELECT). The fork's connection is bound to its own database, so the
- * template is referenced by qualified name.
+ * template DB into the fork DB on the same server (replay the template's exact
+ * CREATE TABLE DDL + INSERT ... SELECT). The fork's connection is bound to its
+ * own database, so the template is referenced by qualified name.
  */
 const restoreFromTemplate = async () => {
     const templateDb = getForkTemplateDatabase();
@@ -151,19 +151,32 @@ const restoreFromTemplate = async () => {
     await ensureForkDatabaseExists();
 
     // Fresh fork DB: create each table from the template and bulk-copy its rows.
-    // Foreign key checks are disabled so tables can be loaded in any order.
+    // Foreign key checks are disabled so tables can be loaded in any order (and so
+    // a table's FK can reference one created later in the sequence).
+    //
+    // We replay the template's `SHOW CREATE TABLE` DDL rather than `CREATE TABLE
+    // ... LIKE`: LIKE copies columns and indexes but DROPS foreign key constraints
+    // (a documented MySQL behaviour), so a LIKE-restored fork loses all ~96 FKs a
+    // fresh knex-migrator init creates. That breaks FK-dependent tests — orphaned
+    // inserts that should 422 succeed, and `ON DELETE CASCADE` no longer prunes
+    // child rows (e.g. deleting members leaves stale members_* events behind),
+    // surfacing as extra rows in attribution / activity-feed snapshots. The DDL
+    // string is unqualified, so replaying it on the fork's connection creates the
+    // table in the fork DB; its FK REFERENCES resolve to the fork's own copies.
+    // This makes the restore byte-faithful to a fresh init (PLA-165).
     await db.knex.raw('SET FOREIGN_KEY_CHECKS=0;');
     try {
         await sequence(tables.map(table => async () => {
+            const [[{'Create Table': createTableSql}]] = await db.knex.raw('SHOW CREATE TABLE ??.??', [templateDb, table]);
             await db.knex.schema.dropTableIfExists(table);
-            await db.knex.raw('CREATE TABLE ?? LIKE ??.??', [table, templateDb, table]);
+            await db.knex.raw(createTableSql);
             await db.knex.raw('INSERT INTO ?? SELECT * FROM ??.??', [table, templateDb, table]);
         }));
     } finally {
         await db.knex.raw('SET FOREIGN_KEY_CHECKS=1;');
     }
 
-    // CREATE TABLE ... LIKE only copies base tables; views are not snapshotted by
+    // The table copy above only covers base tables; views are not in
     // getResetTables (the existing snapshot path relies on init() having created
     // them once). Recreate them here from the schema definitions, exactly as
     // migrations/init/1-create-tables.js does, so a template-provisioned fork DB

--- a/ghost/core/test/utils/db-utils.js
+++ b/ghost/core/test/utils/db-utils.js
@@ -20,6 +20,7 @@ const {sequence} = require('@tryghost/promise');
 
 // Other Test Utilities
 const urlServiceUtils = require('./url-service-utils');
+const dbTemplate = require('./db-template');
 
 let dbInitialized = false;
 let mysqlSnapshotDatabase = null;
@@ -149,8 +150,17 @@ const isMySQLSnapshotCurrent = () => {
 
 const resetMySQLFromSnapshot = async () => {
     if (!isMySQLSnapshotCurrent()) {
-        await truncateAll();
-        await knexMigrator.init({only: 3});
+        if (dbTemplate.hasTemplate()) {
+            // First provision in this fork: load the schema + fixtures from the
+            // run's shared (migrated + seeded) template — a same-server bulk
+            // table copy rather than a full migrate+seed — then build the
+            // per-process snapshot tables so later in-fork resets take the fast
+            // restoreMySQLSnapshot path.
+            await dbTemplate.restoreFromTemplate();
+        } else {
+            await truncateAll();
+            await knexMigrator.init({only: 3});
+        }
         await createMySQLSnapshot();
         return;
     }

--- a/ghost/core/test/utils/vitest-global-db-setup.ts
+++ b/ghost/core/test/utils/vitest-global-db-setup.ts
@@ -1,0 +1,49 @@
+// Vitest globalSetup for the DB-backed suites — runs ONCE in the main process
+// before any worker fork is spawned (and a teardown once after they all exit).
+//
+// It builds the run's migrated + seeded "template" database once; each fork then
+// RESTORES from it when it first provisions its per-process DB (see
+// test/utils/db-utils.js) instead of running a full migrate+seed per file. On
+// MySQL that per-file init is the dominant cost of the acceptance-test runtime
+// regression (PLA-165); restoring from a same-server template replaces it with a
+// cheap bulk table copy. MySQL only — sqlite keeps a plain per-file init (cheap,
+// and copying the template over a fork's open connection is unsafe).
+//
+// The fork learns the template is ready via an inherited env var — env set here,
+// before the forks spawn, is inherited by them. We point the DB config at the
+// template location while building; the forks derive the same location from
+// their own (session-suffixed) config value via the shared pure helpers in
+// db-template-paths.js.
+
+// Register tsx's CommonJS hook so requiring Ghost's .ts sources works here too
+// (mirrors vitest-setup-db.ts). Must run before any Ghost source is required.
+require('tsx/cjs');
+
+// Reject vitest's own NODE_ENV='test' default (Ghost has no config.test.json);
+// keep any `testing*` value (CI uses `testing-mysql`), else default to `testing`.
+// Mirrors vitest-setup-db.ts so the templates are built under the same env the
+// forks will run under.
+process.env.NODE_ENV = process.env.NODE_ENV?.startsWith('testing') ? process.env.NODE_ENV : 'testing';
+process.env.WEBHOOK_SECRET = process.env.WEBHOOK_SECRET || 'TEST_STRIPE_WEBHOOK_SECRET';
+
+export default async function setup() {
+    // The run's BASE (un-suffixed) DB identifier. In this main process the base
+    // env vars carry no per-fork session suffix, so deriving template locations
+    // from them yields exactly the values the forks compute from their suffixed
+    // config. Captured before loading config so it reflects the true base.
+    const base = {
+        sqliteBase: process.env.database__connection__filename || '/tmp/ghost-test.db',
+        mysqlBase: process.env.database__connection__database || 'ghost_testing'
+    };
+
+    // Load Ghost's runtime overrides (nconf wiring) and the template builder.
+    require('../../core/server/overrides');
+    const {buildTemplate, dropTemplate} = require('./db-template');
+
+    await buildTemplate(base);
+
+    // Teardown: drop the template once all forks have exited. Best effort.
+    return async () => {
+        await dropTemplate(base);
+    };
+}

--- a/ghost/core/vitest.config.db.ts
+++ b/ghost/core/vitest.config.db.ts
@@ -70,6 +70,15 @@ const sharedDbConfig = {
 export default defineConfig({
     test: {
         resolveSnapshotPath,
+        // Build ONE migrated+seeded "template" database for the whole run, before
+        // any worker fork spawns; each fork then restores its per-process DB from
+        // that template (a cheap bulk copy) on first provision instead of running
+        // a full migrate+seed per file. This is the lever for the MySQL
+        // acceptance-test runtime regression (PLA-165) — per-file migrate+seed is
+        // its dominant cost. Defined at the root (not per-project) so a single
+        // template is shared across every project in the invocation. See
+        // test/utils/vitest-global-db-setup.ts and test/utils/db-template.js.
+        globalSetup: ['./test/utils/vitest-global-db-setup.ts'],
         // Local runs use the compact `dot` reporter. CI uses `default` plus
         // `github-actions` for inline annotations (mirrors vitest.config.ts).
         reporters: process.env.GITHUB_ACTIONS


### PR DESCRIPTION
The DB-backed suites run `isolate:true` — a fresh fork per test file — so each file re-ran a full knex-migrator migrate+seed to provision its DB. On mysql every migration/fixture/reset step is a network round-trip, so that per-file init is the bulk of the `Acceptance tests (mysql8)` runtime regression (~8 → ~14 min after the fork-parallel migration).

This builds the migrated+seeded DB **once per run** in a vitest `globalSetup`, and has each fork **restore from that shared template** on first provision — a same-server `CREATE TABLE … LIKE` + `INSERT … SELECT` bulk copy — instead of a full migrate+seed.

**mysql-only.** sqlite's per-file init is cheap (~0.65 s, not the bottleneck), and a sqlite restore would copy the template file over a fork's already-open connection, which destabilizes read order for order-dependent tests. So sqlite keeps a plain per-file init (identical to before); `hasTemplate()` stays false there.

**Scope:** the `db.reset()` path (agentProvider-based e2e / e2e-api / e2e-* suites — the dominant mysql cost; e2e-api is ~97 files). The `testUtils.setup()` path used by integration/legacy opens Ghost's bookshelf connection before provisioning, so it still does a full init — a documented follow-up.

**Validation:** local sqlite is the floor (init is cheap there); mysql gains more since each init step is a round-trip. Measured locally on e2e-api: tests-phase **392.9 s → 316.1 s (~20%)**, sqlite green and stable across repeated runs. **CI must confirm the mysql8 number** — the mysql restore path can't be run locally.

ref https://linear.app/tryghost/issue/PLA-165