### PR TITLE
Skipped adapter integration tests when their service is unavailable

### DIFF
--- a/ghost/core/test/integration/adapters/redirects/s3-redirects-store.test.ts
+++ b/ghost/core/test/integration/adapters/redirects/s3-redirects-store.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable ghost/mocha/no-setup-in-describe -- runStoreContract is the parameterised-test seam; calling it inside describe is the intended use. */
+/* eslint-disable ghost/mocha/no-top-level-hooks -- false positive: the hooks are inside the describe, but the lint plugin can't see through the describe.skipIf()() gate below. (PLA-170) */
 import {describe, it, beforeAll, afterEach, afterAll} from 'vitest';
 import assert from 'node:assert/strict';
 import {ListObjectsV2Command, S3Client} from '@aws-sdk/client-s3';
@@ -33,7 +34,10 @@ const backupKeyPattern = (tenantPrefix = '') => new RegExp(
     `^${tenantPrefix ? `${tenantPrefix}/` : ''}${STATIC_PREFIX}/redirects-\\d{4}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{2}\\.json$`
 );
 
-describe('Integration: S3RedirectsStore', function () {
+// Skip when MinIO is unreachable. The flag is set by the integration
+// globalSetup (vitest-globalsetup-services.ts), which probes MinIO once before
+// the forks spawn. (PLA-170)
+describe.skipIf(process.env.GHOST_TEST_MINIO_AVAILABLE !== '1')('Integration: S3RedirectsStore', function () {
     let adminClient: S3Client;
     let bucket: string;
     const minioConfig = getMinioConfig();

--- a/ghost/core/test/integration/adapters/redis/adapter-cache-redis.test.js
+++ b/ghost/core/test/integration/adapters/redis/adapter-cache-redis.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable ghost/mocha/no-top-level-hooks -- false positive: the hooks are inside the describe, but the lint plugin can't see through the describe.skipIf()() gate below. (PLA-170) */
 const assert = require('node:assert/strict');
 const crypto = require('node:crypto');
 const _ = require('lodash');
@@ -30,8 +31,11 @@ const SCENARIOS = [
     {label: 'deep-cloned instance', wrap: c => _.cloneDeep(c)}
 ];
 
+// Skip the whole parameterised set when Redis is unreachable. The flag is set by
+// the integration globalSetup (vitest-globalsetup-services.ts), which probes
+// Redis once before the forks spawn. (PLA-170)
 SCENARIOS.forEach(({label, wrap}) => {
-    describe(`Integration: AdapterCacheRedis on a ${label}`, function () {
+    describe.skipIf(process.env.GHOST_TEST_REDIS_AVAILABLE !== '1')(`Integration: AdapterCacheRedis on a ${label}`, function () {
         const caches = [];
 
         afterEach(async function () {

--- a/ghost/core/test/integration/utils/minio.test.js
+++ b/ghost/core/test/integration/utils/minio.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable ghost/mocha/no-top-level-hooks -- false positive: the hooks are inside the describe, but the lint plugin can't see through the describe.skipIf()() gate below. (PLA-170) */
 const assert = require('node:assert/strict');
 const {
     createTestS3Client,
@@ -9,7 +10,10 @@ const {
     deleteObject
 } = require('../../utils/minio');
 
-describe('Integration: MinIO test helper', function () {
+// Skip when MinIO is unreachable. The flag is set by the integration
+// globalSetup (vitest-globalsetup-services.ts), which probes MinIO once before
+// the forks spawn. (PLA-170)
+describe.skipIf(process.env.GHOST_TEST_MINIO_AVAILABLE !== '1')('Integration: MinIO test helper', function () {
     let client;
     let bucket;
 

--- a/ghost/core/test/utils/vitest-globalsetup-services.ts
+++ b/ghost/core/test/utils/vitest-globalsetup-services.ts
@@ -26,7 +26,14 @@ function getRedisTarget(): {host: string; port: number} {
 }
 
 function getMinioTarget(): {host: string; port: number} {
-    const url = new URL(process.env.MINIO_TEST_ENDPOINT || 'http://127.0.0.1:9000');
+    let url: URL;
+    try {
+        url = new URL(process.env.MINIO_TEST_ENDPOINT || 'http://127.0.0.1:9000');
+    } catch (e) {
+        // A malformed endpoint can't be probed; fall back to the default target so
+        // a bad env var skips the suite rather than crashing globalSetup.
+        url = new URL('http://127.0.0.1:9000');
+    }
     return {
         host: url.hostname,
         port: parseInt(url.port || '9000')
@@ -65,10 +72,9 @@ export async function setup(): Promise<void> {
         isReachable(minio.host, minio.port)
     ]);
 
-    if (redisUp) {
-        process.env.GHOST_TEST_REDIS_AVAILABLE = '1';
-    }
-    if (minioUp) {
-        process.env.GHOST_TEST_MINIO_AVAILABLE = '1';
-    }
+    // Set both flags to reflect THIS run's probe unconditionally, so a stale value
+    // inherited from the parent environment can't leave a suite enabled against a
+    // service that is actually down.
+    process.env.GHOST_TEST_REDIS_AVAILABLE = redisUp ? '1' : '0';
+    process.env.GHOST_TEST_MINIO_AVAILABLE = minioUp ? '1' : '0';
 }

--- a/ghost/core/test/utils/vitest-globalsetup-services.ts
+++ b/ghost/core/test/utils/vitest-globalsetup-services.ts
@@ -1,0 +1,74 @@
+import net from 'node:net';
+
+// Vitest globalSetup for the integration suite — probes the optional Docker
+// services (Redis, MinIO) ONCE in the vitest main process before any fork is
+// spawned, and exports the result as process.env flags that the forks inherit.
+//
+// The adapter integration tests (Redis cache, MinIO helper, S3 redirects store)
+// connect to their backing service in beforeAll, so they hard-fail locally when
+// the service isn't running. Gating each suite on these flags lets them SKIP
+// cleanly when the service is down and RUN when it's up — CI starts both
+// services, so they always run there. (PLA-170)
+
+const PROBE_TIMEOUT_MS = 400;
+
+// Resolve a service's host:port the same way the code under test does:
+//   - Redis: nconf maps `adapters:Redis:{host,port}` from these `__`-separated
+//     env vars (core/shared/config/loader.js uses `separator: '__'`); defaults
+//     match AdapterCacheRedis' 127.0.0.1:6379.
+//   - MinIO: test/utils/minio.ts reads MINIO_TEST_ENDPOINT (default
+//     http://127.0.0.1:9000); parse it for the host + port to probe.
+function getRedisTarget(): {host: string; port: number} {
+    return {
+        host: process.env.adapters__Redis__host || '127.0.0.1',
+        port: parseInt(process.env.adapters__Redis__port || '6379')
+    };
+}
+
+function getMinioTarget(): {host: string; port: number} {
+    const url = new URL(process.env.MINIO_TEST_ENDPOINT || 'http://127.0.0.1:9000');
+    return {
+        host: url.hostname,
+        port: parseInt(url.port || '9000')
+    };
+}
+
+// Resolves true only when a TCP connection is established within the timeout;
+// any error (connection refused, host unreachable) or timeout resolves false.
+function isReachable(host: string, port: number): Promise<boolean> {
+    return new Promise((resolve) => {
+        const socket = new net.Socket();
+        let settled = false;
+        const done = (reachable: boolean) => {
+            if (settled) {
+                return;
+            }
+            settled = true;
+            socket.destroy();
+            resolve(reachable);
+        };
+
+        socket.setTimeout(PROBE_TIMEOUT_MS);
+        socket.once('connect', () => done(true));
+        socket.once('timeout', () => done(false));
+        socket.once('error', () => done(false));
+        socket.connect(port, host);
+    });
+}
+
+export async function setup(): Promise<void> {
+    const redis = getRedisTarget();
+    const minio = getMinioTarget();
+
+    const [redisUp, minioUp] = await Promise.all([
+        isReachable(redis.host, redis.port),
+        isReachable(minio.host, minio.port)
+    ]);
+
+    if (redisUp) {
+        process.env.GHOST_TEST_REDIS_AVAILABLE = '1';
+    }
+    if (minioUp) {
+        process.env.GHOST_TEST_MINIO_AVAILABLE = '1';
+    }
+}

--- a/ghost/core/vitest.config.db.ts
+++ b/ghost/core/vitest.config.db.ts
@@ -107,6 +107,12 @@ export default defineConfig({
                     isolate: true,
                     include: ['test/integration/**/*.test.{js,ts}'],
                     exclude: ['**/node_modules/**'],
+                    // Probes the optional Docker services (Redis, MinIO) once in
+                    // the main process and exports GHOST_TEST_{REDIS,MINIO}_AVAILABLE
+                    // so the adapter suites skip when their service is down and run
+                    // when it's up. Integration-only — no adapter tests live in the
+                    // other DB suites. (PLA-170)
+                    globalSetup: ['./test/utils/vitest-globalsetup-services.ts'],
                     // Matches the mocha `--timeout=10000` for the integration suite.
                     testTimeout: 10000
                 }


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/PLA-170

The Redis cache, MinIO helper, and S3 redirects-store integration tests connect to a backing Docker service in `beforeAll`, so they hard-failed on any machine running `pnpm test:integration` without Redis/MinIO up. Only CI starts those services, so locally these three always errored.

**What changed**
- New integration-only vitest `globalSetup` (`test/utils/vitest-globalsetup-services.ts`) probes Redis and MinIO once in the main process (short-timeout `net.connect`) before the forks spawn, exporting `GHOST_TEST_{REDIS,MINIO}_AVAILABLE`. Forks inherit that `process.env`.
- Each suite's top-level describe is gated with `describe.skipIf(process.env.GHOST_TEST_*_AVAILABLE !== '1')`, matching the existing `describe.skipIf(isMySQL)` idiom — skips cleanly when the service is down, runs when it's up.
- Wired into the `integration` project only (e2e/e2e-api/legacy have no adapter tests).
- The probe resolves Redis host/port from the same `adapters__Redis__*` env vars nconf maps to `config.get('adapters:Redis:*')`, and MinIO from `MINIO_TEST_ENDPOINT` — identical to the code under test.

**Verification**
- Services down: the 3 files report 51 tests skipped, no failures.
- Services up (CI-identical `redis:7.0` + `minio/minio` containers): the 3 files run and all 51 tests pass.
- A mixed run confirms unrelated integration tests are unaffected.

Test infrastructure only — no product code changes.