### PR TITLE
Collapsed the unit-isolated vitest project into unit

### DIFF
--- a/ghost/core/test/unit/frontend/services/routing/controllers/entry.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/entry.test.js
@@ -53,8 +53,13 @@ describe('Unit - services/routing/controllers/entry', function () {
         };
     });
 
-    afterEach(function () {
+    afterEach(async function () {
         sinon.restore();
+        // Some tests below toggle config (e.g. admin:redirects) and restore it
+        // inline from async callbacks. Restore unconditionally here too so a
+        // config change can never leak into a co-scheduled file under the
+        // shared module registry (isolate: false).
+        await configUtils.restore();
     });
 
     it('resource not found', function () {

--- a/ghost/core/test/unit/server/services/api-version-compatibility/mw-version-rewrites.test.js
+++ b/ghost/core/test/unit/server/services/api-version-compatibility/mw-version-rewrites.test.js
@@ -25,8 +25,12 @@ describe('MW Version Rewrites', function () {
         };
     });
 
-    afterEach(function () {
+    afterEach(async function () {
         sinon.restore();
+        // beforeEach overrides the site/admin URL config; restore it so the
+        // override can't leak into a co-scheduled file under the shared module
+        // registry (isolate: false).
+        await configUtils.restore();
     });
 
     function assertVersionRewrittenWithHeaders(version, path, done) {

--- a/ghost/core/test/unit/server/services/post-scheduling/post-scheduling.test.js
+++ b/ghost/core/test/unit/server/services/post-scheduling/post-scheduling.test.js
@@ -16,6 +16,17 @@ describe('PostScheduling', function () {
 
     beforeEach(function () {
         adapter = new SchedulingDefault();
+        // These tests only assert that schedule/unschedule are called with the
+        // right arguments — they don't need the adapter to actually run. Stub
+        // the internals that arm real setTimeout loops and fire real HTTP pings
+        // (run = recursive 5-min loop, _execute = per-job ping timers,
+        // _pingUrl = the got request). Otherwise the adapter leaves live timers
+        // and in-flight requests behind that, under the shared module registry
+        // (isolate: false), hang whichever file runs next in the worker — e.g.
+        // scheduling-default's own real-HTTP pingUrl tests then time out.
+        sinon.stub(adapter, 'run');
+        sinon.stub(adapter, '_execute');
+        sinon.stub(adapter, '_pingUrl').resolves();
         sinon.stub(schedulingUtils, 'createAdapter').returns(Promise.resolve(adapter));
         sinon.spy(adapter, 'schedule');
         sinon.spy(adapter, 'unschedule');

--- a/ghost/core/test/unit/server/services/settings-helpers/settings-helpers.test.js
+++ b/ghost/core/test/unit/server/services/settings-helpers/settings-helpers.test.js
@@ -364,8 +364,12 @@ describe('Settings Helpers', function () {
             });
         });
 
-        afterEach(function () {
+        afterEach(async function () {
             sinon.restore();
+            // beforeEach and some tests below set tinybird config (incl. a
+            // `stats` key); restore it so it can't leak into a co-scheduled
+            // file under the shared module registry (isolate: false).
+            await configUtils.restore();
         });
 
         it('returns false when the UI setting is set to false', function () {

--- a/ghost/core/test/unit/shared/sentry.test.js
+++ b/ghost/core/test/unit/shared/sentry.test.js
@@ -8,10 +8,25 @@ const Sentry = require('@sentry/node');
 const fakeDSN = 'https://aaabbbccc000111222333444555667@sentry.io/1234567';
 let sentry;
 
+// These tests deliberately bust core/shared/sentry out of the require cache and
+// re-require it under different configs. Under the unit suite's shared module
+// registry (isolate: false) that swaps the singleton other already-loaded
+// modules hold a reference to, so callers like the theme-upload reporter end up
+// invoking a different sentry instance than a co-scheduled test stubbed. Snapshot
+// the original cached module and put it back after each test so the registry is
+// left exactly as we found it.
+const sentryModulePath = require.resolve('../../../core/shared/sentry');
+const originalSentryModule = require.cache[sentryModulePath];
+
 describe('UNIT: sentry', function () {
     afterEach(async function () {
         await configUtils.restore();
         sinon.restore();
+        if (originalSentryModule) {
+            require.cache[sentryModulePath] = originalSentryModule;
+        } else {
+            delete require.cache[sentryModulePath];
+        }
     });
 
     describe('No sentry config', function () {
@@ -157,10 +172,18 @@ describe('UNIT: sentry', function () {
     });
 
     describe('beforeSendTransaction', function () {
-        it('filters transactions based on an allow list', function () {
-            sentry = require('../../../core/shared/sentry');
+        beforeEach(function () {
+            // beforeSendTransaction is only exported when sentry is enabled, so
+            // configure a DSN and re-require rather than relying on a previous
+            // test having left a configured instance in the require cache.
+            configUtils.set({sentry: {disabled: false, dsn: fakeDSN}});
+            delete require.cache[require.resolve('../../../core/shared/sentry')];
 
-            const beforeSendTransaction = sentry. beforeSendTransaction;
+            sentry = require('../../../core/shared/sentry');
+        });
+
+        it('filters transactions based on an allow list', function () {
+            const beforeSendTransaction = sentry.beforeSendTransaction;
 
             const allowedTransactions = [
                 {transaction: 'GET /ghost/api/settings'},

--- a/ghost/core/vitest.config.ts
+++ b/ghost/core/vitest.config.ts
@@ -5,27 +5,14 @@ import {defineConfig} from 'vitest/config';
 // e2e-api, and legacy suites run under vitest too, via the separate
 // vitest.config.db.ts — see ghost/core/package.json.
 //
-// The unit suite is split into two vitest projects:
-//
-//  - `unit` runs with `isolate: false` — one shared module registry per
-//    worker (the model mocha always used). Ghost's server modules are
-//    heavy; isolating each file cold-imports them ~550 times over, which
-//    is roughly an order of magnitude slower.
-//  - `unit-isolated` runs the handful of files that are not yet safe
-//    under a shared registry: they fail intermittently when run alongside
-//    other files (root causes still under investigation). They run with
-//    `isolate: true` until fixed, then move into `unit`.
-
-// Files quarantined to the isolated project. Keep this list short — each
-// entry is a known bug to fix, not a permanent home.
-const isolatedFiles = [
-    'test/unit/bin/create-migration.test.js',
-    'test/unit/frontend/helpers/asset.test.js',
-    'test/unit/frontend/services/routing/taxonomy-router.test.js',
-    'test/unit/server/adapters/scheduling/scheduling-default.test.js',
-    'test/unit/server/services/public-config/config.test.js',
-    'test/unit/server/services/themes/upload-size-limit-reporter.test.js'
-];
+// The whole unit suite runs in a single `unit` project with `isolate: false`
+// — one shared module registry per worker (the model mocha always used).
+// Ghost's server modules are heavy; isolating each file cold-imports them
+// ~550 times over, which is roughly an order of magnitude slower. Files that
+// share a worker therefore share module state, so a test that mutates a
+// singleton (config, a sinon stub on a shared module, the sentry require-cache
+// entry, a live timer/HTTP client) must restore it or it leaks into whichever
+// file runs next.
 
 // Ghost's snapshot tests use @tryghost/jest-snapshot, which manages its own
 // `__snapshots__/*.snap` files. Point vitest's *native* snapshot system at a
@@ -39,8 +26,7 @@ const resolveSnapshotPath = (testPath: string, snapExtension: string) => path.jo
     path.basename(testPath) + snapExtension
 );
 
-// Configuration shared by both projects.
-const sharedConfig = {
+const unitConfig = {
     globals: true,
     environment: 'node' as const,
     // The `forks` pool deadlocks at teardown once the run is large enough
@@ -84,19 +70,10 @@ export default defineConfig({
         projects: [
             {
                 test: {
-                    ...sharedConfig,
+                    ...unitConfig,
                     name: 'unit',
                     isolate: false,
                     include: ['test/unit/**/*.test.{js,ts}'],
-                    exclude: ['**/node_modules/**', ...isolatedFiles]
-                }
-            },
-            {
-                test: {
-                    ...sharedConfig,
-                    name: 'unit-isolated',
-                    isolate: true,
-                    include: isolatedFiles,
                     exclude: ['**/node_modules/**']
                 }
             }


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/PLA-46

The ghost/core unit suite split into two vitest projects: `unit` (`isolate: false`, shared module registry per worker) and `unit-isolated` (`isolate: true`) for six files that flaked when co-scheduled. Each flake was a real cross-file state leak under the shared registry — a *different* file mutating a singleton (config, a sinon stub on a shared module, the sentry require-cache entry, or a live timer/HTTP client) without restoring it. Fixed the five leakers and removed the project:

- `shared/sentry.test.js` — restore the `core/shared/sentry` require-cache entry it busts (was breaking the theme upload-size-limit reporter's sentry assertion).
- `mw-version-rewrites.test.js` — restore `url`/`admin:url` config (was leaking absolute asset URLs into `asset.test.js`).
- `settings-helpers.test.js` — restore `tinybird.stats` config (was adding a `stats` key to `public-config`).
- `controllers/entry.test.js` — unconditionally restore `admin:redirects` (was unmounting taxonomy-router's edit route).
- `post-scheduling.test.js` — stub the real `SchedulingDefault`'s timer/HTTP internals (live timers were hanging scheduling-default's `pingUrl` tests).

`create-migration` needed no change. Full unit suite passes (580 files / 7029 tests); the six are stable across 40 `retry=0` runs (scheduling-default's only flakes were real-HTTP timeouts under concurrent CPU load, absorbed by the existing `retry: 2`).

Test infrastructure only.