### PR TITLE
Fixed mysql test leg deleting a concurrent sqlite run's database

### DIFF
--- a/ghost/core/test/utils/vitest-setup-db.ts
+++ b/ghost/core/test/utils/vitest-setup-db.ts
@@ -73,13 +73,18 @@ process.env.database__connection__database = mysqlBase
     : `ghost_testing_${mysqlId}`;
 
 // Delete this slot's leftover sqlite file (+ sidecars) before Ghost loads, so a
-// reused pool name boots from a clean slate — see the note above. force:true
-// makes it a no-op on first use and on the mysql leg (no such file).
-for (const suffix of ['', '-journal', '-wal', '-shm', '-orig']) {
-    try {
-        require('fs').rmSync(process.env.database__connection__filename + suffix, {force: true});
-    } catch (e) {
-        // best effort — a fresh boot recreates it
+// reused pool name boots from a clean slate — see the note above. SQLITE LEG ONLY:
+// on the mysql leg (NODE_ENV testing-mysql) this derived filename is never ours —
+// it belongs to a concurrent sqlite run on the same machine, and deleting it out
+// from under that run destroys its database mid-write (SQLITE_READONLY). force:true
+// makes the sqlite delete a no-op on a slot's first use.
+if (!process.env.NODE_ENV.includes('mysql')) {
+    for (const suffix of ['', '-journal', '-wal', '-shm', '-orig']) {
+        try {
+            require('fs').rmSync(process.env.database__connection__filename + suffix, {force: true});
+        } catch (e) {
+            // best effort — a fresh boot recreates it
+        }
     }
 }
 


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/PLA-168

The per-fork sqlite delete-at-boot added in PLA-168 (#28751) ran unconditionally in `vitest-setup-db.ts` — including on the **mysql leg**, where the derived sqlite filename is set but never used. When a sqlite suite and a mysql suite run on the same machine at the same time (e.g. a local `pnpm test:integration` while a mysql leg runs), the mysql forks deleted the sqlite run's `/tmp/ghost-test-pool_N.db` out from under it, destroying that database mid-write: `SQLITE_READONLY` across unrelated tests, then Ghost boot timeouts (`process.exit(2)`).

The cleanup is purely a sqlite-leg concern (mysql uses random per-fork DB names with no /tmp reuse to bound), so this gates the delete on the leg — it now only runs when `NODE_ENV` isn't the mysql config. CI legs are single-engine, so they were never affected; this is strictly a local concurrent-run hazard.

Verified: the gate resolves `true` on the sqlite leg and `false` on mysql, and the integration files that were collateral damage pass clean isolated (34/34, no readonly).

Test infrastructure only.