### PR TITLE
Sped up per-file sqlite DB init with the shared run template

### DIFF
--- a/ghost/core/test/utils/db-template-paths.js
+++ b/ghost/core/test/utils/db-template-paths.js
@@ -1,19 +1,34 @@
-// Pure derivation of the shared DB-template database name from a per-fork
-// database identifier. Kept dependency-free (NO Ghost config/db imports) so it
-// can be required by the vitest globalSetup BEFORE Ghost's config loads.
+// Pure derivation of the shared DB-template identifiers from a per-fork database
+// identifier. Kept dependency-free (NO Ghost config/db imports) so it can be
+// required by the vitest globalSetup BEFORE Ghost's config loads.
 //
-// `vitest-setup-db.ts` appends a per-fork session suffix to a base mysql database
-// name (`_<8 hex>`). Stripping that suffix yields a value shared across every fork
-// of the run, to which we add a stable `template` marker. globalSetup derives from
-// the raw (un-suffixed) base; the forks derive from their suffixed config value at
-// restore time — because both strip the suffix, they resolve to the identical
-// template. (Template restore is MySQL-only — see db-template.js.)
+// `vitest-setup-db.ts` appends a per-fork session suffix to a base database
+// identifier. Stripping that suffix yields a value shared across every fork of
+// the run, to which we add a stable `template` marker. globalSetup derives from
+// the raw (un-suffixed) base; the forks derive from their suffixed config value
+// at restore time — because both strip the suffix, they resolve to the identical
+// template.
 
+// MySQL: the per-fork suffix is `_<8 hex>` appended to a database name.
 const deriveMySQLTemplateDatabase = (database) => {
     const base = database.replace(/_[a-f0-9]{8}$/i, '');
     return `${base}_template`;
 };
 
+// SQLite: the per-fork suffix is `-pool_<N>` (or `-<8 hex>` when there is no
+// VITEST_POOL_ID) inserted before the `.db` extension — see vitest-setup-db.ts.
+// Strip whichever suffix is present, then append a `-template.db` marker. The
+// marker is distinct from every per-fork name (no fork is named `template`), so
+// the template file can never collide with a `pool_N.db` a fork would open.
+// globalSetup passes the un-suffixed base (e.g. `/tmp/ghost-test.db`); a fork
+// passes its own suffixed filename — both resolve to `<base>-template.db`.
+const deriveSQLiteTemplateFilename = (filename) => {
+    const withoutDb = filename.replace(/\.db$/i, '');
+    const base = withoutDb.replace(/-(?:pool_\d+|[a-f0-9]{8})$/i, '');
+    return `${base}-template.db`;
+};
+
 module.exports = {
-    deriveMySQLTemplateDatabase
+    deriveMySQLTemplateDatabase,
+    deriveSQLiteTemplateFilename
 };

--- a/ghost/core/test/utils/db-template.js
+++ b/ghost/core/test/utils/db-template.js
@@ -1,5 +1,6 @@
 const debug = require('@tryghost/debug')('test:dbTemplate');
 const path = require('path');
+const fs = require('fs-extra');
 const knex = require('knex');
 const KnexMigrator = require('knex-migrator');
 const {sequence} = require('@tryghost/promise');
@@ -9,25 +10,29 @@ const db = require('../../core/server/data/db');
 const schemaModule = require('../../core/server/data/schema');
 const schemaTables = Object.keys(schemaModule.tables);
 const schemaViews = schemaModule.views || {};
-const {deriveMySQLTemplateDatabase} = require('./db-template-paths');
+const {deriveMySQLTemplateDatabase, deriveSQLiteTemplateFilename} = require('./db-template-paths');
 
 // A migrated + seeded database is expensive to build (full knex-migrator init:
 // create every table, record all ~120 versioned migrations as applied, and
-// insert every default fixture). On MySQL each step is a network round-trip, and
-// the DB-suite runner's `isolate:true` projects run every test FILE in a fresh
-// fork, so without help each file pays that full init once — the bulk of the
-// MySQL acceptance-test runtime regression (PLA-165).
+// insert every default fixture). On MySQL each step is a network round-trip; on
+// sqlite each is a file write. The DB-suite runner's `isolate:true` projects run
+// every test FILE in a fresh fork, so without help each file pays that full init
+// once — the bulk of the acceptance-test runtime regression (PLA-165 mysql,
+// PLA-172 sqlite).
 //
 // Instead we build ONE migrated + seeded "template" database for the whole run
 // (in the vitest globalSetup, before any fork spawns) and have each fork RESTORE
 // from it when it first provisions its per-process DB, replacing the migrate+seed
-// with a cheap same-server bulk copy (`CREATE TABLE ... LIKE` + `INSERT ...
-// SELECT`).
+// with a cheap bulk copy.
 //
-// MySQL only. sqlite's per-file init is cheap (~0.65s, not the bottleneck), and a
-// sqlite restore would copy the template file over a fork's already-open
-// connection — which destabilizes read order for order-dependent tests — so
-// sqlite keeps a plain per-file init.
+// MySQL restores via a same-server `SHOW CREATE TABLE` + `INSERT ... SELECT`.
+// sqlite restores by ATTACHing the template file to the fork's connection,
+// replaying the template's schema from its sqlite_master, and bulk-copying every
+// table with `INSERT ... SELECT`. We deliberately do NOT copy the template .db
+// file over a fork's open connection — that approach destabilized sqlite read
+// order for order-dependent tests and was reverted (PLA-165); building the fork
+// DB from the template's CONTENTS via SQL keeps physical row order identical to a
+// fresh init (PLA-172).
 //
 // Readiness is published from globalSetup to the forks via an env var (forks
 // inherit the main process env at spawn time). When it is unset — e.g.
@@ -35,10 +40,10 @@ const {deriveMySQLTemplateDatabase} = require('./db-template-paths');
 // knex-migrator init, so behaviour is unchanged outside the orchestrated run.
 //
 // SCOPE: only the db.reset() provisioning path (agentProvider-based e2e / e2e-api
-// / e2e-* suites, the dominant MySQL cost) uses this. The getFixtureOps
-// `testUtils.setup()` path (integration/legacy) opens Ghost's bookshelf
-// connection BEFORE provisioning, so that path still does a full init. See the
-// PLA-165 notes for the deferred follow-up.
+// / e2e-* suites) uses this. The getFixtureOps `testUtils.setup()` path
+// (integration/legacy) opens Ghost's bookshelf connection BEFORE provisioning, so
+// that path still does a full init. See the PLA-165 / PLA-171 notes for the
+// deferred follow-up.
 
 const TEMPLATE_ENV_VAR = 'GHOST_TEST_DB_TEMPLATE_READY';
 
@@ -54,7 +59,6 @@ const configuredClientIsSQLite = () => config.get('database:client') === 'sqlite
 /**
  * Whether the shared template has been built for this run (published by
  * globalSetup). Callers use this to choose a cheap restore over a full init.
- * Always false on sqlite — no template is built there.
  * @returns {boolean}
  */
 const hasTemplate = () => {
@@ -70,6 +74,17 @@ const hasTemplate = () => {
  */
 const getForkTemplateDatabase = () => {
     return deriveMySQLTemplateDatabase(config.get('database:connection:database'));
+};
+
+/**
+ * Resolve the template sqlite filename from the CURRENT fork connection's config.
+ * config holds the suffixed per-fork filename (`<base>-pool_N.db`); the pure
+ * deriver strips that suffix so this resolves to the same `<base>-template.db`
+ * globalSetup built from the un-suffixed base.
+ * @returns {string}
+ */
+const getForkTemplateFilename = () => {
+    return deriveSQLiteTemplateFilename(config.get('database:connection:filename'));
 };
 
 /**
@@ -98,20 +113,47 @@ const ensureForkDatabaseExists = async () => {
 
 /**
  * Build the shared template database. Called ONCE from globalSetup (main process,
- * before any fork). MySQL only. Derives the template location from the run's BASE
+ * before any fork). Derives the template location from the run's BASE
  * (un-suffixed) DB identifier, points Ghost's config there, then runs a full
  * knex-migrator reset + init. A fresh KnexMigrator is constructed AFTER the config
  * override so it reads the template location via MigratorConfig.js.
  *
- * @param {{mysqlBase?: string}} base the run's base DB identifier, un-suffixed
+ * @param {{mysqlBase?: string, sqliteBase?: string}} base the run's base DB identifier, un-suffixed
  */
 const buildTemplate = async (base) => {
-    // The template is MySQL-only. sqlite's per-file init is cheap (~0.65s), and
-    // restoring it by copying the template file over a fork's already-open
-    // connection destabilizes read order for order-dependent tests (PLA-165) — so
-    // sqlite does a plain per-file init and hasTemplate() stays false here.
     if (configuredClientIsSQLite()) {
-        debug('sqlite: skipping shared template');
+        // Build the template .db file at a path that can't collide with any
+        // per-fork `pool_N.db` (deriveSQLiteTemplateFilename appends a `-template`
+        // marker no fork uses). Remove any stale file first — knex-migrator's
+        // reset drops tables but not the file, and a leftover from a previous run
+        // could carry the wrong schema (mirrors db-utils' sqlite reset, which
+        // fs.remove()s before init).
+        const templateFile = deriveSQLiteTemplateFilename(base.sqliteBase);
+        debug(`Building shared sqlite DB template at ${templateFile}`);
+        for (const suffix of ['', '-journal', '-wal', '-shm']) {
+            await fs.remove(`${templateFile}${suffix}`);
+        }
+
+        // Point Ghost's config at the template file so the KnexMigrator built
+        // below (which reads config.get('database') via MigratorConfig.js) targets
+        // it. We replace the whole `database:connection` node rather than the
+        // `:filename` leaf: CI exports `database__connection__filename` to the main
+        // process where globalSetup runs (see ci.yml), and nconf's env layer
+        // shadows a leaf set when an object-level get reads the node — so a leaf
+        // set would silently build the template into the base file. Setting the
+        // object node overrides the env layer. (The mysql path sets a leaf safely:
+        // its db NAME is not exported to the main process — vitest-setup-db.ts sets
+        // it per fork — so there is no env node to shadow it.)
+        config.set('database:connection', {
+            ...config.get('database:connection'),
+            filename: templateFile
+        });
+        const knexMigrator = new KnexMigrator({knexMigratorFilePath: path.join(__dirname, '../..')});
+        await knexMigrator.reset({force: true});
+        await knexMigrator.init();
+
+        process.env[TEMPLATE_ENV_VAR] = '1';
+        debug('Shared sqlite DB template ready');
         return;
     }
 
@@ -131,13 +173,107 @@ const buildTemplate = async (base) => {
 };
 
 /**
+ * Restore the current fork's per-process sqlite database from the shared
+ * template.
+ *
+ * ATTACH is per-connection, and the fork's db.knex pool may route successive
+ * statements to different connections — so the whole restore runs on ONE
+ * connection pinned from that pool (acquireConnection + `.connection(conn)`).
+ * Pinning the LIVE pool's connection (rather than opening a second knex to the
+ * same file) means the restore writes the fork's own inode, so db.knex reads the
+ * committed result back directly — copying into a separate connection's inode, or
+ * fs.remove()ing the file out from under the open pool, would leave db.knex on a
+ * stale empty handle. (Mirrors the short-lived connection the mysql path opens in
+ * ensureForkDatabaseExists, but here it must be a pool connection, not a new pool.)
+ *
+ * The fork .db file is fresh on first provision (deleted at boot, see
+ * vitest-setup-db.ts), so the restore builds the entire schema + data from the
+ * template: replay every sqlite_master object's DDL in creation (rowid) order —
+ * tables, then their indexes, triggers and views, which always follow their table
+ * in that order — then bulk-copy each table's rows, foreign keys off during the
+ * load. This keeps physical row order identical to a fresh init (PLA-172) — we do
+ * NOT copy the template file over the connection, the approach reverted in PLA-165.
+ */
+const restoreFromTemplateSQLite = async () => {
+    const templateFile = getForkTemplateFilename();
+    debug(`Restoring fork sqlite DB ${config.get('database:connection:filename')} from template ${templateFile}`);
+
+    // ATTACH on a missing file silently creates an empty DB, which would surface
+    // later as a baffling "no such table: template.<t>" mid-restore. Fail loudly
+    // up front instead if the template (built by globalSetup) is not where the
+    // fork derived it should be — a path-derivation drift between build and restore.
+    if (!fs.existsSync(templateFile)) {
+        throw new Error(`sqlite DB template not found at ${templateFile} (built by vitest globalSetup)`);
+    }
+
+    // Pin one connection: ATTACH/DETACH and the schema replay must all run on the
+    // same connection, and it must be the live pool's so db.knex sees the result.
+    const connection = await db.knex.client.acquireConnection();
+    const run = (sql, bindings) => db.knex.raw(sql, bindings || []).connection(connection);
+
+    try {
+        await run('ATTACH DATABASE ? AS template', [templateFile]);
+
+        // Every schema object with a CREATE statement, in creation order. Auto
+        // objects (sqlite_autoindex_*) have NULL sql and so are excluded — they
+        // are recreated implicitly when their table's DDL replays. sqlite_sequence
+        // carries non-null DDL but is reserved/auto-created, so skip it here; its
+        // counters are copied with the row data below.
+        const objects = (await run(
+            'SELECT type, name, sql FROM template.sqlite_master WHERE sql IS NOT NULL ORDER BY rowid'
+        )).filter(object => object.name !== 'sqlite_sequence');
+
+        // Disable FK enforcement so tables load in any order and a table's FK can
+        // reference one not yet populated. Replaying the template's exact CREATE
+        // TABLE DDL (rather than a column-only copy) preserves its foreign keys,
+        // making the restore byte-faithful to a fresh init — the same faithfulness
+        // the mysql path needs (PLA-165/PLA-172).
+        await run('PRAGMA foreign_keys = OFF');
+        try {
+            for (const object of objects) {
+                await run(object.sql);
+            }
+
+            // Copy EVERY table the template holds, derived from its sqlite_master
+            // rather than getResetTables(): that list omits knex-migrator's own
+            // `migrations_lock`, whose released-lock row (locked=0) Ghost's boot
+            // requires — an empty lock table reads as "migration in progress" and
+            // boot dies with MigrationsAreLockedError. This also picks up
+            // `sqlite_sequence` (the AUTOINCREMENT counters, auto-created with the
+            // first AUTOINCREMENT table above) so inserts continue exactly where the
+            // template left off. Using the template's own table set keeps the copy
+            // complete and faithful by construction.
+            const dataTables = (await run(
+                'SELECT name FROM template.sqlite_master WHERE type = ?', ['table']
+            )).map(row => row.name);
+
+            await sequence(dataTables.map(table => async () => {
+                await run('DELETE FROM ??', [table]);
+                await run('INSERT INTO ?? SELECT * FROM template.??', [table, table]);
+            }));
+        } finally {
+            await run('PRAGMA foreign_keys = ON');
+        }
+
+        await run('DETACH DATABASE template');
+    } finally {
+        await db.knex.client.releaseConnection(connection);
+    }
+};
+
+/**
  * Restore the current fork's per-process database from the shared template.
  * Assumes the caller has verified hasTemplate(). Copies every table from the
- * template DB into the fork DB on the same server (replay the template's exact
- * CREATE TABLE DDL + INSERT ... SELECT). The fork's connection is bound to its
- * own database, so the template is referenced by qualified name.
+ * template DB into the fork DB (replay the template's exact schema + INSERT ...
+ * SELECT). On mysql the template is referenced by qualified name on the fork's
+ * bound connection; on sqlite the template file is ATTACHed (see the sqlite
+ * helper above).
  */
 const restoreFromTemplate = async () => {
+    if (configuredClientIsSQLite()) {
+        return restoreFromTemplateSQLite();
+    }
+
     const templateDb = getForkTemplateDatabase();
     debug('Restoring fork DB from template');
 
@@ -180,7 +316,8 @@ const restoreFromTemplate = async () => {
     // getResetTables (the existing snapshot path relies on init() having created
     // them once). Recreate them here from the schema definitions, exactly as
     // migrations/init/1-create-tables.js does, so a template-provisioned fork DB
-    // has the same views as a fully-migrated one.
+    // has the same views as a fully-migrated one. (sqlite copies views as part of
+    // the sqlite_master replay above, so this is mysql-only.)
     for (const [name, sql] of Object.entries(schemaViews)) {
         await db.knex.schema.createViewOrReplace(name, function (view) {
             view.as(db.knex.raw(sql));
@@ -189,14 +326,24 @@ const restoreFromTemplate = async () => {
 };
 
 /**
- * Drop the shared template database. Called from globalSetup teardown. MySQL only
- * (no-op on sqlite). Best effort — on CI the whole server is ephemeral; this is
- * for local hygiene and to avoid a stale template surviving into the next run.
+ * Drop the shared template database. Called from globalSetup teardown. Best
+ * effort — on CI the whole server is ephemeral; this is for local hygiene and to
+ * avoid a stale template surviving into the next run.
  *
- * @param {{mysqlBase?: string}} base the run's base DB id
+ * @param {{mysqlBase?: string, sqliteBase?: string}} base the run's base DB id
  */
 const dropTemplate = async (base) => {
     if (configuredClientIsSQLite()) {
+        // knex-migrator's reset drops tables but not the file; delete the template
+        // file (+ sidecars) outright.
+        try {
+            const templateFile = deriveSQLiteTemplateFilename(base.sqliteBase);
+            for (const suffix of ['', '-journal', '-wal', '-shm']) {
+                await fs.remove(`${templateFile}${suffix}`);
+            }
+        } catch (err) {
+            debug(`Failed to drop sqlite template (ignored): ${err.message}`);
+        }
         return;
     }
     try {
@@ -214,6 +361,7 @@ const dropTemplate = async (base) => {
 module.exports = {
     TEMPLATE_ENV_VAR,
     deriveMySQLTemplateDatabase,
+    deriveSQLiteTemplateFilename,
     configuredClientIsSQLite,
     hasTemplate,
     buildTemplate,

--- a/ghost/core/test/utils/db-template.js
+++ b/ghost/core/test/utils/db-template.js
@@ -254,9 +254,14 @@ const restoreFromTemplateSQLite = async () => {
         } finally {
             await run('PRAGMA foreign_keys = ON');
         }
-
-        await run('DETACH DATABASE template');
     } finally {
+        // Always detach before releasing the connection — an error mid-restore must
+        // not return a connection still attached to the template back to the pool.
+        try {
+            await run('DETACH DATABASE template');
+        } catch (e) {
+            // nothing attached (ATTACH may have failed)
+        }
         await db.knex.client.releaseConnection(connection);
     }
 };

--- a/ghost/core/test/utils/db-utils.js
+++ b/ghost/core/test/utils/db-utils.js
@@ -57,6 +57,19 @@ module.exports.reset = async ({truncate} = {truncate: false}) => {
 
         if (dbInitialized) {
             await fs.copyFile(filenameOrig, filename);
+        } else if (dbTemplate.hasTemplate()) {
+            // First provision in this fork: build the schema + fixtures from the
+            // run's shared (migrated + seeded) template — ATTACH the template file
+            // and bulk-copy it onto db.knex's own connection — instead of a full
+            // per-file migrate+seed (PLA-172). Then snapshot to `-orig` so later
+            // in-fork resets take the fast file-copy path above. The fork file is
+            // already fresh (deleted at boot, see vitest-setup-db.ts), and the
+            // restore writes db.knex's inode, so we must NOT fs.remove() it here —
+            // that would strand db.knex on a stale empty handle.
+            await dbTemplate.restoreFromTemplate();
+
+            await fs.copyFile(filename, filenameOrig);
+            dbInitialized = true;
         } else {
             await fs.remove(filename);
             await fs.remove(`${filename}-journal`);

--- a/ghost/core/test/utils/vitest-global-db-setup.ts
+++ b/ghost/core/test/utils/vitest-global-db-setup.ts
@@ -3,11 +3,13 @@
 //
 // It builds the run's migrated + seeded "template" database once; each fork then
 // RESTORES from it when it first provisions its per-process DB (see
-// test/utils/db-utils.js) instead of running a full migrate+seed per file. On
-// MySQL that per-file init is the dominant cost of the acceptance-test runtime
-// regression (PLA-165); restoring from a same-server template replaces it with a
-// cheap bulk table copy. MySQL only — sqlite keeps a plain per-file init (cheap,
-// and copying the template over a fork's open connection is unsafe).
+// test/utils/db-utils.js) instead of running a full migrate+seed per file. That
+// per-file init is the dominant cost of the acceptance-test runtime regression
+// (PLA-165 mysql, PLA-172 sqlite). MySQL restores from a same-server template via
+// a bulk table copy; sqlite ATTACHes the template file and bulk-copies it onto
+// the fork's own connection (never copying the file over an open connection — the
+// approach reverted in PLA-165). Both keep the restore byte-faithful to a fresh
+// init.
 //
 // The fork learns the template is ready via an inherited env var — env set here,
 // before the forks spawn, is inherited by them. We point the DB config at the


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/PLA-172

Follow-up to PLA-165 (#28752), which built a once-per-run migrated+seeded DB template and had each fork restore from it instead of a full per-file migrate+seed — mysql-only, because the original sqlite attempt copied the template file over a fork's open connection and destabilized read order.

This extends the template to the sqlite leg with a **safe same-connection restore**: ATTACH the template `.db`, replay its schema from `sqlite_master` (tables → indexes/triggers/views, in creation order), and `INSERT … SELECT` per table on a connection pinned from `db.knex`'s own pool (FK checks off during the load) — the fork builds its DB from the template's *contents* via SQL, never a file copy.

Faithfulness verified (the restore must be byte-equivalent to a fresh `knex-migrator init` — the lesson from #28752's FK-drop bug): **0 data mismatches across 89 tables / 953 rows, schema byte-identical, physical row order identical, `sqlite_sequence` counters match**. Handles `migrations_lock` (its released-lock row is required at boot) and `sqlite_sequence`.

Result (e2e-api leg, sqlite, 3 runs each): **tests-phase 416s → 315s (−24.3%)**, 97/97 files green, stable (no order-dependent flakes).

Test infrastructure only.