### PR TITLE
Removed two dead ghost/mocha eslint-disable directives in ghost/core tests

### DIFF
--- a/ghost/core/test/integration/adapters/redirects/s3-redirects-store.test.ts
+++ b/ghost/core/test/integration/adapters/redirects/s3-redirects-store.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable ghost/mocha/no-setup-in-describe -- runStoreContract is the parameterised-test seam; calling it inside describe is the intended use. */
 /* eslint-disable ghost/mocha/no-top-level-hooks -- false positive: the hooks are inside the describe, but the lint plugin can't see through the describe.skipIf()() gate below. (PLA-170) */
 import {describe, it, beforeAll, afterEach, afterAll} from 'vitest';
 import assert from 'node:assert/strict';

--- a/ghost/core/test/utils/vitest-setup.ts
+++ b/ghost/core/test/utils/vitest-setup.ts
@@ -6,7 +6,7 @@
 // calls — those rules guard against accidental top-level hooks in mocha
 // test files, but vitest setup files are *meant* to register global hooks
 // at the top level. Disable for this file only.
-/* eslint-disable ghost/mocha/no-top-level-hooks, ghost/mocha/no-sibling-hooks, ghost/mocha/handle-done-callback */
+/* eslint-disable ghost/mocha/no-top-level-hooks, ghost/mocha/handle-done-callback */
 
 import chalk from 'chalk';
 import {beforeAll, beforeEach, afterEach, afterAll} from 'vitest';


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/PLA-167

Post-migration hygiene: removed two genuinely-dead `ghost/mocha/*` eslint-disable directives in ghost/core tests (each proven dead via `--report-unused-disable-directives`, and proven not to mask anything via a directive-stripped lint run):
- `vitest-setup.ts` — dropped `ghost/mocha/no-sibling-hooks` (the file has no sibling hooks; only `no-top-level-hooks` + `handle-done-callback` actually fire, both kept).
- `s3-redirects-store.test.ts` — dropped `ghost/mocha/no-setup-in-describe` (its `describe.skipIf()()` gate changes the AST so the rule never fires; the live directive on its sibling contract files is untouched).

`pnpm lint` green.

**Scope note:** the substantive `ghost/mocha/*` ruleset retirement is deliberately NOT done here — it belongs with the upcoming oxlint migration. oxlint ships a native `vitest` plugin but no mocha plugin, so the entire `ghost/mocha/*` surface gets swapped for `vitest/*` wholesale there; rewriting the ~8 remaining (live) directives under eslint first would just be redone. The c8→vitest-native coverage move (PLA-166) likewise stays a separate, threshold-sensitive PR.

Test infrastructure only.