### PR TITLE
Raised the test service-probe timeout and refreshed test DX docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,15 +68,23 @@ cd ghost/core
 pnpm test:unit                 # Unit tests only (Vitest, run once)
 pnpm test:watch                # Watch mode — ghost/core unit tests only
 pnpm test:integration          # Integration tests
-pnpm test:e2e                  # E2E API tests (not browser)
+pnpm test:e2e                  # Server-side e2e suites (webhooks/server/frontend/api) — not browser
 pnpm test:all                  # All test types
+
+# These run on sqlite with no extra services. The Redis/MinIO/S3 adapter suites
+# probe for their service and auto-skip when it's down (run `pnpm dev:storage`
+# etc. to exercise them); they always run in CI, which starts the services.
 
 # E2E browser tests (from root)
 pnpm test:e2e                  # Run e2e/ Playwright tests
 
 # Running a single test
 cd ghost/core
-pnpm test:single test/unit/path/to/test.test.js
+pnpm test:single test/unit/path/to/test.test.js   # routes test/unit/* → unit config, test/* → DB config
+
+# Watch a single DB-backed file (integration/e2e) — the default test:watch only
+# covers unit tests, so point it at the DB config explicitly:
+pnpm exec vitest -c vitest.config.db.ts test/integration/path/to/test.test.js
 ```
 
 ### Linting

--- a/ghost/core/test/unit/shared/config/loader.test.js
+++ b/ghost/core/test/unit/shared/config/loader.test.js
@@ -82,10 +82,10 @@ describe('Config Loader', function () {
 
             assert(!customConfig.get('paths:corePath').includes('try-to-override'));
             assert.equal(customConfig.get('database:client'), 'sqlite3');
-            // Note: database:connection:filename is now set via process.env in overrides.js
+            // Note: database:connection:filename is now set via process.env in test/utils/vitest-setup-db.ts
             // for concurrent test isolation, so we skip asserting the config file value
             assert.equal(customConfig.get('database:debug'), true);
-            // Note: url is now set via process.env in overrides.js for dynamic port allocation
+            // Note: url is now set via process.env in test/utils/vitest-setup-db.ts for dynamic port allocation
             assert.equal(customConfig.get('logging:level'), 'error');
             assert.deepEqual(customConfig.get('logging:transports'), ['stdout']);
         });

--- a/ghost/core/test/utils/e2e-framework-mock-manager.js
+++ b/ghost/core/test/utils/e2e-framework-mock-manager.js
@@ -6,7 +6,8 @@ const nock = require('nock');
 // nock 14 can't intercept the Stripe SDK's default NodeHttpClient (it flushes
 // the request body on a socket 'connect' event the mocked socket never emits,
 // so every Stripe call hangs). Force the fetch-based client, which nock 14 can
-// intercept. Loaded via overrides.js before Ghost boots.
+// intercept. Runs when the vitest setup files (test/utils/vitest-setup*.ts)
+// require this module, before Ghost boots.
 const {Stripe} = require('stripe');
 Stripe.createNodeHttpClient = () => Stripe.createFetchHttpClient();
 

--- a/ghost/core/test/utils/vitest-globalsetup-services.ts
+++ b/ghost/core/test/utils/vitest-globalsetup-services.ts
@@ -10,7 +10,14 @@ import net from 'node:net';
 // cleanly when the service is down and RUN when it's up — CI starts both
 // services, so they always run there. (PLA-170)
 
-const PROBE_TIMEOUT_MS = 400;
+// 1s, not a few hundred ms: this probe runs in the vitest main process right
+// before the worker forks spawn, when the event loop is busiest (config load,
+// transforms). socket.setTimeout is an inactivity timeout, so a busy loop that
+// can't fire the 'connect' callback in time trips it and the probe reports a
+// running service as down — silently SKIPPING an adapter suite that should run.
+// A down service still resolves instantly (connection refused), so the wider
+// ceiling only adds latency in the rare case where it prevents a false skip.
+const PROBE_TIMEOUT_MS = 1000;
 
 // Resolve a service's host:port the same way the code under test does:
 //   - Redis: nconf maps `adapters:Redis:{host,port}` from these `__`-separated


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/PLA-147

Local-dev hardening from a test-DX audit (ghost/core is fully on Vitest now):

- **Service-probe timeout 400ms → 1s** (`vitest-globalsetup-services.ts`). The 400ms ceiling could falsely SKIP an adapter suite whose service is actually up: `socket.setTimeout` is an inactivity timeout, and the globalSetup probes while the event loop is briefly blocked (before forks spawn) — a ~500ms block made a live service read as "down". Reproduced the false-skip at 400ms / correct at 1s. When the service is down, connection-refused fires instantly regardless of the ceiling, so this adds zero latency to the skip path.
- Refreshed 3 stale code comments referencing the deleted `test/utils/overrides.js`, and the AGENTS.md Testing section (corrected `test:e2e`, noted the sqlite adapter auto-skip, documented single-file DB watch).

Verified: unit / integration / single-file / watch all green; `pnpm lint` (incl. tsc) clean.

Test/docs infrastructure only.