### PR TITLE
Fixed cross-file state leaks in the e2e vitest project

### DIFF
--- a/ghost/core/test/e2e-api/admin/images.test.js
+++ b/ghost/core/test/e2e-api/admin/images.test.js
@@ -153,9 +153,13 @@ describe('Images API', function () {
         await agent.loginAsOwner();
     });
 
-    afterAll(function () {
-        configUtils.restore();
-        ghostServer.stop();
+    afterAll(async function () {
+        // configUtils.restore() is async (config.reset + re-apply defaults). Left
+        // un-awaited it raced the next file under the shared boot (isolate:false),
+        // leaking this suite's imageOptimization:contentImageSizes (w1/w10) into
+        // e.g. posts-legacy's srcset rendering. (PLA-173)
+        await configUtils.restore();
+        await ghostServer.stop();
     });
 
     afterEach(async function () {

--- a/ghost/core/test/e2e-api/admin/images.test.js
+++ b/ghost/core/test/e2e-api/admin/images.test.js
@@ -157,7 +157,7 @@ describe('Images API', function () {
         // configUtils.restore() is async (config.reset + re-apply defaults). Left
         // un-awaited it raced the next file under the shared boot (isolate:false),
         // leaking this suite's imageOptimization:contentImageSizes (w1/w10) into
-        // e.g. posts-legacy's srcset rendering. (PLA-173)
+        // e.g. posts-legacy's srcset rendering.
         await configUtils.restore();
         await ghostServer.stop();
     });

--- a/ghost/core/test/e2e-api/admin/images.test.js
+++ b/ghost/core/test/e2e-api/admin/images.test.js
@@ -154,10 +154,6 @@ describe('Images API', function () {
     });
 
     afterAll(async function () {
-        // configUtils.restore() is async (config.reset + re-apply defaults). Left
-        // un-awaited it raced the next file under the shared boot (isolate:false),
-        // leaking this suite's imageOptimization:contentImageSizes (w1/w10) into
-        // e.g. posts-legacy's srcset rendering.
         await configUtils.restore();
         await ghostServer.stop();
     });

--- a/ghost/core/test/e2e-api/members-comments/max-limit-cap.test.js
+++ b/ghost/core/test/e2e-api/members-comments/max-limit-cap.test.js
@@ -35,6 +35,12 @@ describe('Comments API - Max Limit Cap', function () {
     afterAll(function () {
         // Restore the original middleware
         sharedMiddleware.maxLimitCap[0] = originalMiddleware;
+        // beforeAll stubs settingsCache.get directly (not via mockManager), and
+        // there is no global sinon.restore() in the shared boot (isolate:false).
+        // Without this the stub leaks into the next file: the first later file to
+        // (re)stub settingsCache.get — e.g. any mockManager.mockMailgun/mockSetting
+        // — throws "Attempted to wrap get which is already wrapped". (PLA-173)
+        sinon.restore();
     });
 
     it('should call maxLimitCap middleware when browsing posts', async function () {

--- a/ghost/core/test/e2e-api/members-comments/max-limit-cap.test.js
+++ b/ghost/core/test/e2e-api/members-comments/max-limit-cap.test.js
@@ -35,11 +35,6 @@ describe('Comments API - Max Limit Cap', function () {
     afterAll(function () {
         // Restore the original middleware
         sharedMiddleware.maxLimitCap[0] = originalMiddleware;
-        // beforeAll stubs settingsCache.get directly (not via mockManager), and
-        // there is no global sinon.restore() in the shared boot (isolate:false).
-        // Without this the stub leaks into the next file: the first later file to
-        // (re)stub settingsCache.get — e.g. any mockManager.mockMailgun/mockSetting
-        // — throws "Attempted to wrap get which is already wrapped".
         sinon.restore();
     });
 

--- a/ghost/core/test/e2e-api/members-comments/max-limit-cap.test.js
+++ b/ghost/core/test/e2e-api/members-comments/max-limit-cap.test.js
@@ -39,7 +39,7 @@ describe('Comments API - Max Limit Cap', function () {
         // there is no global sinon.restore() in the shared boot (isolate:false).
         // Without this the stub leaks into the next file: the first later file to
         // (re)stub settingsCache.get — e.g. any mockManager.mockMailgun/mockSetting
-        // — throws "Attempted to wrap get which is already wrapped". (PLA-173)
+        // — throws "Attempted to wrap get which is already wrapped".
         sinon.restore();
     });
 

--- a/ghost/core/test/e2e-api/members/send-magic-link.test.js
+++ b/ghost/core/test/e2e-api/members/send-magic-link.test.js
@@ -345,8 +345,6 @@ describe('sendMagicLink', function () {
         });
 
         afterEach(async function () {
-            // await the async restore so spam:blocked_email_domains can't leak
-            // into a later file under the shared boot (isolate:false).
             await configUtils.restore();
         });
 

--- a/ghost/core/test/e2e-api/members/send-magic-link.test.js
+++ b/ghost/core/test/e2e-api/members/send-magic-link.test.js
@@ -344,8 +344,10 @@ describe('sendMagicLink', function () {
             await settingsService.init();
         });
 
-        afterEach(function () {
-            configUtils.restore();
+        afterEach(async function () {
+            // await the async restore so spam:blocked_email_domains can't leak
+            // into a later file under the shared boot (isolate:false). (PLA-173)
+            await configUtils.restore();
         });
 
         it('blocks signups from email domains blocked in config', async function () {

--- a/ghost/core/test/e2e-api/members/send-magic-link.test.js
+++ b/ghost/core/test/e2e-api/members/send-magic-link.test.js
@@ -346,7 +346,7 @@ describe('sendMagicLink', function () {
 
         afterEach(async function () {
             // await the async restore so spam:blocked_email_domains can't leak
-            // into a later file under the shared boot (isolate:false). (PLA-173)
+            // into a later file under the shared boot (isolate:false).
             await configUtils.restore();
         });
 

--- a/ghost/core/test/e2e-frontend/member-stats.test.js
+++ b/ghost/core/test/e2e-frontend/member-stats.test.js
@@ -5,7 +5,7 @@ const {getMemberStats} = require('../../core/frontend/utils/member-count.js');
 describe('Front-end member stats ', function () {
     // getMemberStats reads statsService.api, which only exists once Ghost has
     // booted. Boot a backend here rather than depending on whichever file ran
-    // before in the shared fork having left the service initialised. (PLA-173)
+    // before in the shared fork having left the service initialised.
     beforeAll(async function () {
         await testUtils.startGhost({
             backend: true,

--- a/ghost/core/test/e2e-frontend/member-stats.test.js
+++ b/ghost/core/test/e2e-frontend/member-stats.test.js
@@ -3,9 +3,6 @@ const testUtils = require('../utils');
 const {getMemberStats} = require('../../core/frontend/utils/member-count.js');
 
 describe('Front-end member stats ', function () {
-    // getMemberStats reads statsService.api, which only exists once Ghost has
-    // booted. Boot a backend here rather than depending on whichever file ran
-    // before in the shared fork having left the service initialised.
     beforeAll(async function () {
         await testUtils.startGhost({
             backend: true,

--- a/ghost/core/test/e2e-frontend/member-stats.test.js
+++ b/ghost/core/test/e2e-frontend/member-stats.test.js
@@ -1,7 +1,22 @@
 const {assertExists} = require('../utils/assertions');
+const testUtils = require('../utils');
 const {getMemberStats} = require('../../core/frontend/utils/member-count.js');
 
 describe('Front-end member stats ', function () {
+    // getMemberStats reads statsService.api, which only exists once Ghost has
+    // booted. Boot a backend here rather than depending on whichever file ran
+    // before in the shared fork having left the service initialised. (PLA-173)
+    beforeAll(async function () {
+        await testUtils.startGhost({
+            backend: true,
+            frontend: false
+        });
+    });
+
+    afterAll(async function () {
+        await testUtils.stopGhost();
+    });
+
     it('should return free', async function () {
         const members = await getMemberStats();
         const {free} = members;

--- a/ghost/core/test/e2e-webhooks/__snapshots__/posts.test.js.snap
+++ b/ghost/core/test/e2e-webhooks/__snapshots__/posts.test.js.snap
@@ -2200,7 +2200,7 @@ Header Level 3
       "primary_tag": null,
       "published_at": StringMatching /\\\\d\\{4\\}-\\\\d\\{2\\}-\\\\d\\{2\\}T\\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\}\\\\\\.000Z/,
       "reading_time": 1,
-      "slug": "webhookz-2",
+      "slug": "webhookz-unpublished",
       "status": "draft",
       "tags": Array [],
       "tiers": Array [
@@ -2241,7 +2241,7 @@ Header Level 3
           "yearly_price_id": null,
         },
       ],
-      "title": "webhookz",
+      "title": "webhookz unpublished",
       "twitter_description": null,
       "twitter_image": null,
       "twitter_title": null,

--- a/ghost/core/test/e2e-webhooks/members.test.js
+++ b/ghost/core/test/e2e-webhooks/members.test.js
@@ -33,11 +33,8 @@ describe('member.* events', function () {
     });
 
     beforeEach(async function () {
-        // Each test registers another member.* webhook; without a reset they
-        // accumulate in the DB, so an event fired by a later test gets delivered
-        // to an earlier test's now-unmocked URL. Clearing just the webhooks table
-        // keeps the suite order-independent without the churn of a full DB
-        // reset. (PLA-173)
+        // Clear the webhooks each test registers, or a later test's event gets
+        // delivered to an earlier test's now-unmocked URL.
         await dbUtils.truncate('webhooks');
         webhookMockReceiver = mockManager.mockWebhookRequests();
     });

--- a/ghost/core/test/e2e-webhooks/members.test.js
+++ b/ghost/core/test/e2e-webhooks/members.test.js
@@ -1,5 +1,5 @@
 const assert = require('node:assert/strict');
-const {agentProvider, mockManager, fixtureManager, matchers} = require('../utils/e2e-framework');
+const {agentProvider, mockManager, fixtureManager, dbUtils, matchers} = require('../utils/e2e-framework');
 const {anyGhostAgent, anyObjectId, anyISODateTime, anyUuid, anyContentVersion, anyContentLength} = matchers;
 
 const buildNewsletterSnapshot = () => {
@@ -32,7 +32,13 @@ describe('member.* events', function () {
         await adminAPIAgent.loginAsOwner();
     });
 
-    beforeEach(function () {
+    beforeEach(async function () {
+        // Each test registers another member.* webhook; without a reset they
+        // accumulate in the DB, so an event fired by a later test gets delivered
+        // to an earlier test's now-unmocked URL. Clearing just the webhooks table
+        // keeps the suite order-independent without the churn of a full DB
+        // reset. (PLA-173)
+        await dbUtils.truncate('webhooks');
         webhookMockReceiver = mockManager.mockWebhookRequests();
     });
 

--- a/ghost/core/test/e2e-webhooks/members.test.js
+++ b/ghost/core/test/e2e-webhooks/members.test.js
@@ -33,8 +33,6 @@ describe('member.* events', function () {
     });
 
     beforeEach(async function () {
-        // Clear the webhooks each test registers, or a later test's event gets
-        // delivered to an earlier test's now-unmocked URL.
         await dbUtils.truncate('webhooks');
         webhookMockReceiver = mockManager.mockWebhookRequests();
     });

--- a/ghost/core/test/e2e-webhooks/pages.test.js
+++ b/ghost/core/test/e2e-webhooks/pages.test.js
@@ -113,8 +113,6 @@ describe('page.* events', function () {
     });
 
     beforeEach(async function () {
-        // Clear the webhooks each test registers, or a later test's event gets
-        // delivered to an earlier test's now-unmocked URL.
         await dbUtils.truncate('webhooks');
         webhookMockReceiver = mockManager.mockWebhookRequests();
     });

--- a/ghost/core/test/e2e-webhooks/pages.test.js
+++ b/ghost/core/test/e2e-webhooks/pages.test.js
@@ -3,6 +3,7 @@ const {
     agentProvider,
     mockManager,
     fixtureManager,
+    dbUtils,
     matchers
 } = require('../utils/e2e-framework');
 const {
@@ -111,7 +112,13 @@ describe('page.* events', function () {
         await adminAPIAgent.loginAsOwner();
     });
 
-    beforeEach(function () {
+    beforeEach(async function () {
+        // Each test registers another page.* webhook; without a reset they
+        // accumulate in the DB, so an action in a later test (e.g. editing a
+        // published page also fires page.edited) gets delivered to an earlier
+        // test's now-unmocked URL. Clearing just the webhooks table keeps the
+        // suite order-independent without the churn of a full DB reset. (PLA-173)
+        await dbUtils.truncate('webhooks');
         webhookMockReceiver = mockManager.mockWebhookRequests();
     });
 

--- a/ghost/core/test/e2e-webhooks/pages.test.js
+++ b/ghost/core/test/e2e-webhooks/pages.test.js
@@ -113,11 +113,8 @@ describe('page.* events', function () {
     });
 
     beforeEach(async function () {
-        // Each test registers another page.* webhook; without a reset they
-        // accumulate in the DB, so an action in a later test (e.g. editing a
-        // published page also fires page.edited) gets delivered to an earlier
-        // test's now-unmocked URL. Clearing just the webhooks table keeps the
-        // suite order-independent without the churn of a full DB reset. (PLA-173)
+        // Clear the webhooks each test registers, or a later test's event gets
+        // delivered to an earlier test's now-unmocked URL.
         await dbUtils.truncate('webhooks');
         webhookMockReceiver = mockManager.mockWebhookRequests();
     });

--- a/ghost/core/test/e2e-webhooks/posts.test.js
+++ b/ghost/core/test/e2e-webhooks/posts.test.js
@@ -1,5 +1,5 @@
 const moment = require('moment-timezone');
-const {agentProvider, mockManager, fixtureManager, matchers} = require('../utils/e2e-framework');
+const {agentProvider, mockManager, fixtureManager, dbUtils, matchers} = require('../utils/e2e-framework');
 const {anyGhostAgent, anyArray, anyObjectId, anyISODateTime, anyUuid, anyContentVersion, anyContentLength, anyLocalURL, anyString} = matchers;
 
 const tierSnapshot = {
@@ -119,7 +119,13 @@ describe('post.* events', function () {
         await adminAPIAgent.loginAsOwner();
     });
 
-    beforeEach(function () {
+    beforeEach(async function () {
+        // Each test registers another post.* webhook; without a reset they
+        // accumulate in the DB, so an action in a later test (e.g. editing a
+        // published post also fires post.edited) gets delivered to an earlier
+        // test's now-unmocked URL. Clearing just the webhooks table keeps the
+        // suite order-independent without the churn of a full DB reset. (PLA-173)
+        await dbUtils.truncate('webhooks');
         webhookMockReceiver = mockManager.mockWebhookRequests();
     });
 
@@ -191,7 +197,11 @@ describe('post.* events', function () {
             .body({
                 posts: [
                     {
-                        title: 'webhookz',
+                        // Distinct from the post.published test's 'webhookz' title:
+                        // both posts persist in the shared DB, so a shared title
+                        // would collide on slug (webhookz vs webhookz-2) depending
+                        // on which test ran first. (PLA-173)
+                        title: 'webhookz unpublished',
                         status: 'published',
                         mobiledoc: fixtureManager.get('posts', 1).mobiledoc
                     }

--- a/ghost/core/test/e2e-webhooks/posts.test.js
+++ b/ghost/core/test/e2e-webhooks/posts.test.js
@@ -120,11 +120,8 @@ describe('post.* events', function () {
     });
 
     beforeEach(async function () {
-        // Each test registers another post.* webhook; without a reset they
-        // accumulate in the DB, so an action in a later test (e.g. editing a
-        // published post also fires post.edited) gets delivered to an earlier
-        // test's now-unmocked URL. Clearing just the webhooks table keeps the
-        // suite order-independent without the churn of a full DB reset. (PLA-173)
+        // Clear the webhooks each test registers, or a later test's event gets
+        // delivered to an earlier test's now-unmocked URL.
         await dbUtils.truncate('webhooks');
         webhookMockReceiver = mockManager.mockWebhookRequests();
     });
@@ -200,7 +197,7 @@ describe('post.* events', function () {
                         // Distinct from the post.published test's 'webhookz' title:
                         // both posts persist in the shared DB, so a shared title
                         // would collide on slug (webhookz vs webhookz-2) depending
-                        // on which test ran first. (PLA-173)
+                        // on which test ran first.
                         title: 'webhookz unpublished',
                         status: 'published',
                         mobiledoc: fixtureManager.get('posts', 1).mobiledoc

--- a/ghost/core/test/e2e-webhooks/posts.test.js
+++ b/ghost/core/test/e2e-webhooks/posts.test.js
@@ -120,8 +120,6 @@ describe('post.* events', function () {
     });
 
     beforeEach(async function () {
-        // Clear the webhooks each test registers, or a later test's event gets
-        // delivered to an earlier test's now-unmocked URL.
         await dbUtils.truncate('webhooks');
         webhookMockReceiver = mockManager.mockWebhookRequests();
     });
@@ -194,10 +192,6 @@ describe('post.* events', function () {
             .body({
                 posts: [
                     {
-                        // Distinct from the post.published test's 'webhookz' title:
-                        // both posts persist in the shared DB, so a shared title
-                        // would collide on slug (webhookz vs webhookz-2) depending
-                        // on which test ran first.
                         title: 'webhookz unpublished',
                         status: 'published',
                         mobiledoc: fixtureManager.get('posts', 1).mobiledoc

--- a/ghost/core/test/e2e-webhooks/site.test.js
+++ b/ghost/core/test/e2e-webhooks/site.test.js
@@ -1,4 +1,4 @@
-const {agentProvider, mockManager, fixtureManager, matchers} = require('../utils/e2e-framework');
+const {agentProvider, mockManager, fixtureManager, dbUtils, matchers} = require('../utils/e2e-framework');
 const {anyGhostAgent, anyContentVersion, anyContentLength} = matchers;
 
 describe('site.* events', function () {
@@ -12,13 +12,10 @@ describe('site.* events', function () {
     });
 
     beforeEach(async function () {
-        // Each test registers another site.changed webhook; without a reset they
-        // accumulate in the DB and a single site.changed fired by one test gets
-        // delivered to every prior test's URL, contaminating the negative tests.
-        // Reset to a clean slate so each test only sees its own webhook. (PLA-173)
-        await fixtureManager.restore();
-        await fixtureManager.init('integrations');
-        await adminAPIAgent.loginAsOwner();
+        // Truncate the webhooks each test registers so they don't accumulate and
+        // cross-deliver into later tests. A full fixtureManager.restore() here would
+        // wipe the owner seeded in beforeAll, breaking loginAsOwner on mysql8. (PLA-173)
+        await dbUtils.truncate('webhooks');
         webhookMockReceiver = mockManager.mockWebhookRequests();
     });
 

--- a/ghost/core/test/e2e-webhooks/site.test.js
+++ b/ghost/core/test/e2e-webhooks/site.test.js
@@ -12,8 +12,6 @@ describe('site.* events', function () {
     });
 
     beforeEach(async function () {
-        // Clear the webhooks each test registers so they don't cross-deliver into
-        // later tests. A full reset would wipe the beforeAll owner (breaks mysql8).
         await dbUtils.truncate('webhooks');
         webhookMockReceiver = mockManager.mockWebhookRequests();
     });
@@ -175,8 +173,6 @@ describe('site.* events', function () {
             url: webhookURL
         });
 
-        // Set the customIntegrations limit explicitly — it used to rely on
-        // limit-service state leaking from the tests above.
         mockManager.mockLimitService('customIntegrations', {
             isLimited: true,
             wouldGoOverLimit: true
@@ -282,8 +278,6 @@ describe('site.* events', function () {
             url: webhookURL
         });
 
-        // Set the customIntegrations limit explicitly — it used to rely on
-        // limit-service state leaking from the tests above.
         mockManager.mockLimitService('customIntegrations', {
             isLimited: true,
             wouldGoOverLimit: true

--- a/ghost/core/test/e2e-webhooks/site.test.js
+++ b/ghost/core/test/e2e-webhooks/site.test.js
@@ -12,9 +12,8 @@ describe('site.* events', function () {
     });
 
     beforeEach(async function () {
-        // Truncate the webhooks each test registers so they don't accumulate and
-        // cross-deliver into later tests. A full fixtureManager.restore() here would
-        // wipe the owner seeded in beforeAll, breaking loginAsOwner on mysql8. (PLA-173)
+        // Clear the webhooks each test registers so they don't cross-deliver into
+        // later tests. A full reset would wipe the beforeAll owner (breaks mysql8).
         await dbUtils.truncate('webhooks');
         webhookMockReceiver = mockManager.mockWebhookRequests();
     });
@@ -176,10 +175,8 @@ describe('site.* events', function () {
             url: webhookURL
         });
 
-        // External webhooks are only held back here by the customIntegrations
-        // limit; the precondition used to come from limit-service state leaking
-        // out of the tests above. Set it explicitly so the test is
-        // order-independent. (PLA-173)
+        // Set the customIntegrations limit explicitly — it used to rely on
+        // limit-service state leaking from the tests above.
         mockManager.mockLimitService('customIntegrations', {
             isLimited: true,
             wouldGoOverLimit: true
@@ -285,10 +282,8 @@ describe('site.* events', function () {
             url: webhookURL
         });
 
-        // External webhooks are only held back here by the customIntegrations
-        // limit; the precondition used to come from limit-service state leaking
-        // out of the tests above. Set it explicitly so the test is
-        // order-independent. (PLA-173)
+        // Set the customIntegrations limit explicitly — it used to rely on
+        // limit-service state leaking from the tests above.
         mockManager.mockLimitService('customIntegrations', {
             isLimited: true,
             wouldGoOverLimit: true

--- a/ghost/core/test/e2e-webhooks/site.test.js
+++ b/ghost/core/test/e2e-webhooks/site.test.js
@@ -11,7 +11,14 @@ describe('site.* events', function () {
         await adminAPIAgent.loginAsOwner();
     });
 
-    beforeEach(function () {
+    beforeEach(async function () {
+        // Each test registers another site.changed webhook; without a reset they
+        // accumulate in the DB and a single site.changed fired by one test gets
+        // delivered to every prior test's URL, contaminating the negative tests.
+        // Reset to a clean slate so each test only sees its own webhook. (PLA-173)
+        await fixtureManager.restore();
+        await fixtureManager.init('integrations');
+        await adminAPIAgent.loginAsOwner();
         webhookMockReceiver = mockManager.mockWebhookRequests();
     });
 
@@ -172,6 +179,15 @@ describe('site.* events', function () {
             url: webhookURL
         });
 
+        // External webhooks are only held back here by the customIntegrations
+        // limit; the precondition used to come from limit-service state leaking
+        // out of the tests above. Set it explicitly so the test is
+        // order-independent. (PLA-173)
+        mockManager.mockLimitService('customIntegrations', {
+            isLimited: true,
+            wouldGoOverLimit: true
+        });
+
         await adminAPIAgent
             .post('posts/')
             .body({
@@ -270,6 +286,15 @@ describe('site.* events', function () {
         await fixtureManager.insertWebhook({
             event: 'site.changed',
             url: webhookURL
+        });
+
+        // External webhooks are only held back here by the customIntegrations
+        // limit; the precondition used to come from limit-service state leaking
+        // out of the tests above. Set it explicitly so the test is
+        // order-independent. (PLA-173)
+        mockManager.mockLimitService('customIntegrations', {
+            isLimited: true,
+            wouldGoOverLimit: true
         });
 
         await adminAPIAgent

--- a/ghost/core/test/e2e-webhooks/tags.test.js
+++ b/ghost/core/test/e2e-webhooks/tags.test.js
@@ -1,4 +1,4 @@
-const {agentProvider, mockManager, fixtureManager, matchers} = require('../utils/e2e-framework');
+const {agentProvider, mockManager, fixtureManager, dbUtils, matchers} = require('../utils/e2e-framework');
 const {anyGhostAgent, anyObjectId, anyISODateTime, anyString, anyContentVersion, anyContentLength, anyLocalURL} = matchers;
 
 const tagSnapshot = {
@@ -18,7 +18,13 @@ describe('tag.* events', function () {
         await adminAPIAgent.loginAsOwner();
     });
 
-    beforeEach(function () {
+    beforeEach(async function () {
+        // Each test registers another tag.* webhook; without a reset they
+        // accumulate in the DB, so an event fired by a later test gets delivered
+        // to an earlier test's now-unmocked URL. Clearing just the webhooks table
+        // keeps the suite order-independent without the churn of a full DB
+        // reset. (PLA-173)
+        await dbUtils.truncate('webhooks');
         webhookMockReceiver = mockManager.mockWebhookRequests();
     });
 

--- a/ghost/core/test/e2e-webhooks/tags.test.js
+++ b/ghost/core/test/e2e-webhooks/tags.test.js
@@ -19,8 +19,6 @@ describe('tag.* events', function () {
     });
 
     beforeEach(async function () {
-        // Clear the webhooks each test registers, or a later test's event gets
-        // delivered to an earlier test's now-unmocked URL.
         await dbUtils.truncate('webhooks');
         webhookMockReceiver = mockManager.mockWebhookRequests();
     });

--- a/ghost/core/test/e2e-webhooks/tags.test.js
+++ b/ghost/core/test/e2e-webhooks/tags.test.js
@@ -19,11 +19,8 @@ describe('tag.* events', function () {
     });
 
     beforeEach(async function () {
-        // Each test registers another tag.* webhook; without a reset they
-        // accumulate in the DB, so an event fired by a later test gets delivered
-        // to an earlier test's now-unmocked URL. Clearing just the webhooks table
-        // keeps the suite order-independent without the churn of a full DB
-        // reset. (PLA-173)
+        // Clear the webhooks each test registers, or a later test's event gets
+        // delivered to an earlier test's now-unmocked URL.
         await dbUtils.truncate('webhooks');
         webhookMockReceiver = mockManager.mockWebhookRequests();
     });

--- a/ghost/core/test/utils/config-utils.js
+++ b/ghost/core/test/utils/config-utils.js
@@ -6,6 +6,19 @@ const configUtils = {};
 configUtils.config = config;
 configUtils.defaultConfig = _.cloneDeep(config.get());
 
+// The redirects FileStore basePath is lazily derived from the content path
+// (adapter-manager/config.js: `basePath ||= getContentPath('data')`) and then
+// cached on the shared nconf `adapters` object. In production the content path
+// is fixed for the process lifetime, so freezing it is fine; under the shared
+// e2e boot (isolate:false) each file points the content path at a fresh tmp
+// folder, but the frozen basePath keeps the redirects adapter reading the first
+// booter's folder — leaking another file's redirects.yaml/json into e.g. the
+// redirects download suite. Clear it whenever the content path moves so the next
+// boot re-derives it. (PLA-173)
+const clearDerivedContentPaths = function () {
+    config.set('adapters:redirects:FileStore:basePath', undefined);
+};
+
 /**
  * configUtils.set({});
  * configUtils.set('key', 'value');
@@ -18,8 +31,14 @@ configUtils.set = function () {
         _.each(key, function (settingValue, settingKey) {
             config.set(settingKey, settingValue);
         });
+        if (Object.prototype.hasOwnProperty.call(key, 'paths:contentPath')) {
+            clearDerivedContentPaths();
+        }
     } else {
         config.set(key, value);
+        if (key === 'paths:contentPath') {
+            clearDerivedContentPaths();
+        }
     }
 };
 

--- a/ghost/core/test/utils/config-utils.js
+++ b/ghost/core/test/utils/config-utils.js
@@ -14,7 +14,7 @@ configUtils.defaultConfig = _.cloneDeep(config.get());
 // folder, but the frozen basePath keeps the redirects adapter reading the first
 // booter's folder — leaking another file's redirects.yaml/json into e.g. the
 // redirects download suite. Clear it whenever the content path moves so the next
-// boot re-derives it. (PLA-173)
+// boot re-derives it.
 const clearDerivedContentPaths = function () {
     config.set('adapters:redirects:FileStore:basePath', undefined);
 };

--- a/ghost/core/test/utils/config-utils.js
+++ b/ghost/core/test/utils/config-utils.js
@@ -6,15 +6,6 @@ const configUtils = {};
 configUtils.config = config;
 configUtils.defaultConfig = _.cloneDeep(config.get());
 
-// The redirects FileStore basePath is lazily derived from the content path
-// (adapter-manager/config.js: `basePath ||= getContentPath('data')`) and then
-// cached on the shared nconf `adapters` object. In production the content path
-// is fixed for the process lifetime, so freezing it is fine; under the shared
-// e2e boot (isolate:false) each file points the content path at a fresh tmp
-// folder, but the frozen basePath keeps the redirects adapter reading the first
-// booter's folder — leaking another file's redirects.yaml/json into e.g. the
-// redirects download suite. Clear it whenever the content path moves so the next
-// boot re-derives it.
 const clearDerivedContentPaths = function () {
     config.set('adapters:redirects:FileStore:basePath', undefined);
 };

--- a/ghost/core/test/utils/e2e-framework-mock-manager.js
+++ b/ghost/core/test/utils/e2e-framework-mock-manager.js
@@ -295,14 +295,7 @@ const mockLimitService = (limit, options) => {
             isDisabled: sinon.stub(limitService, 'isDisabled'),
             checkWouldGoOverLimit: sinon.stub(limitService, 'checkWouldGoOverLimit'),
             errorIfWouldGoOverLimit: sinon.stub(limitService, 'errorIfWouldGoOverLimit'),
-            // Whether limitService.limits existed at all before we touched it, so
-            // restore can put it back to undefined rather than an empty object.
             limitsExisted: !!limitService.limits,
-            // Per-key snapshot of any pre-existing entry we overwrite, so restore
-            // is precise. `limitService.limits` is the shared singleton's object,
-            // so it must NOT be captured by reference and reassigned — that leaves
-            // our mocked entry in place and breaks errorIfWouldGoOverLimit for the
-            // next file.
             originalEntries: new Map(),
             mockedLimits: new Set() // Track which limits we've mocked
         };
@@ -355,10 +348,6 @@ const restoreLimitService = () => {
             mocks.limitService.isDisabled.restore();
         }
 
-        // Put the shared limits object back exactly as we found it: restore any
-        // pre-existing entry we overwrote, delete the ones we added. Mutating in
-        // place (rather than reassigning a captured reference) is what keeps the
-        // singleton clean for the next file.
         if (limitService.limits && mocks.limitService.originalEntries) {
             for (const [limit, original] of mocks.limitService.originalEntries) {
                 if (original === undefined) {
@@ -369,8 +358,6 @@ const restoreLimitService = () => {
             }
         }
 
-        // If limits never existed before we mocked, and we emptied it again,
-        // drop it back to undefined so the fingerprint matches a fresh service.
         if (!mocks.limitService.limitsExisted &&
             limitService.limits && Object.keys(limitService.limits).length === 0) {
             limitService.limits = undefined;
@@ -384,10 +371,6 @@ const restore = () => {
     // eslint-disable-next-line no-console
     configUtils.restore().catch(console.error);
 
-    // Remove any mocked limit-service entries from the shared singleton before
-    // we drop our bookkeeping. Reassigning a captured reference here used to
-    // leave the mocked entry behind, breaking errorIfWouldGoOverLimit for every
-    // later file in the fork.
     restoreLimitService();
 
     sinon.restore();

--- a/ghost/core/test/utils/e2e-framework-mock-manager.js
+++ b/ghost/core/test/utils/e2e-framework-mock-manager.js
@@ -295,7 +295,15 @@ const mockLimitService = (limit, options) => {
             isDisabled: sinon.stub(limitService, 'isDisabled'),
             checkWouldGoOverLimit: sinon.stub(limitService, 'checkWouldGoOverLimit'),
             errorIfWouldGoOverLimit: sinon.stub(limitService, 'errorIfWouldGoOverLimit'),
-            originalLimits: limitService.limits || {},
+            // Whether limitService.limits existed at all before we touched it, so
+            // restore can put it back to undefined rather than an empty object.
+            limitsExisted: !!limitService.limits,
+            // Per-key snapshot of any pre-existing entry we overwrite, so restore
+            // is precise. `limitService.limits` is the shared singleton's object,
+            // so it must NOT be captured by reference and reassigned — that leaves
+            // our mocked entry in place and breaks errorIfWouldGoOverLimit for the
+            // next file. (PLA-173)
+            originalEntries: new Map(),
             mockedLimits: new Set() // Track which limits we've mocked
         };
     }
@@ -307,6 +315,12 @@ const mockLimitService = (limit, options) => {
     // Mock the limits property for checking allowlist
     if (!limitService.limits) {
         limitService.limits = {};
+    }
+    if (!mocks.limitService.originalEntries.has(limit)) {
+        mocks.limitService.originalEntries.set(
+            limit,
+            Object.prototype.hasOwnProperty.call(limitService.limits, limit) ? limitService.limits[limit] : undefined
+        );
     }
     limitService.limits[limit] = {
         allowlist: options.allowlist || []
@@ -328,32 +342,38 @@ const mockLimitService = (limit, options) => {
 
 const restoreLimitService = () => {
     if (mocks.limitService) {
-        if (mocks.limitService.isLimited) {
+        if (mocks.limitService.isLimited && mocks.limitService.isLimited.restore) {
             mocks.limitService.isLimited.restore();
         }
-        if (mocks.limitService.checkWouldGoOverLimit) {
+        if (mocks.limitService.checkWouldGoOverLimit && mocks.limitService.checkWouldGoOverLimit.restore) {
             mocks.limitService.checkWouldGoOverLimit.restore();
         }
-        if (mocks.limitService.errorIfWouldGoOverLimit) {
+        if (mocks.limitService.errorIfWouldGoOverLimit && mocks.limitService.errorIfWouldGoOverLimit.restore) {
             mocks.limitService.errorIfWouldGoOverLimit.restore();
         }
-        if (mocks.limitService.isDisabled) {
+        if (mocks.limitService.isDisabled && mocks.limitService.isDisabled.restore) {
             mocks.limitService.isDisabled.restore();
         }
 
-        // Remove any limits we mocked
-        if (mocks.limitService.mockedLimits && limitService.limits) {
-            for (const limit of mocks.limitService.mockedLimits) {
-                delete limitService.limits[limit];
+        // Put the shared limits object back exactly as we found it: restore any
+        // pre-existing entry we overwrote, delete the ones we added. Mutating in
+        // place (rather than reassigning a captured reference) is what keeps the
+        // singleton clean for the next file.
+        if (limitService.limits && mocks.limitService.originalEntries) {
+            for (const [limit, original] of mocks.limitService.originalEntries) {
+                if (original === undefined) {
+                    delete limitService.limits[limit];
+                } else {
+                    limitService.limits[limit] = original;
+                }
             }
         }
 
-        // If limits object is now empty and was originally empty, restore it
-        if (mocks.limitService.originalLimits !== undefined) {
-            if (Object.keys(mocks.limitService.originalLimits).length === 0 &&
-                limitService.limits && Object.keys(limitService.limits).length === 0) {
-                limitService.limits = mocks.limitService.originalLimits;
-            }
+        // If limits never existed before we mocked, and we emptied it again,
+        // drop it back to undefined so the fingerprint matches a fresh service.
+        if (!mocks.limitService.limitsExisted &&
+            limitService.limits && Object.keys(limitService.limits).length === 0) {
+            limitService.limits = undefined;
         }
 
         delete mocks.limitService;
@@ -364,10 +384,11 @@ const restore = () => {
     // eslint-disable-next-line no-console
     configUtils.restore().catch(console.error);
 
-    // Restore limit service limits if we mocked them
-    if (mocks.limitService && mocks.limitService.originalLimits) {
-        limitService.limits = mocks.limitService.originalLimits;
-    }
+    // Remove any mocked limit-service entries from the shared singleton before
+    // we drop our bookkeeping. Reassigning a captured reference here used to
+    // leave the mocked entry behind, breaking errorIfWouldGoOverLimit for every
+    // later file in the fork. (PLA-173)
+    restoreLimitService();
 
     sinon.restore();
     mocks = {};
@@ -378,10 +399,6 @@ const restore = () => {
     nock.cleanAll();
     nock.enableNetConnect();
     stripeMocker.reset();
-
-    if (mocks.webhookMockReceiver) {
-        mocks.webhookMockReceiver.reset();
-    }
 
     mailService.GhostMailer.prototype.sendMail = originalMailServiceSendMail;
 

--- a/ghost/core/test/utils/e2e-framework-mock-manager.js
+++ b/ghost/core/test/utils/e2e-framework-mock-manager.js
@@ -302,7 +302,7 @@ const mockLimitService = (limit, options) => {
             // is precise. `limitService.limits` is the shared singleton's object,
             // so it must NOT be captured by reference and reassigned — that leaves
             // our mocked entry in place and breaks errorIfWouldGoOverLimit for the
-            // next file. (PLA-173)
+            // next file.
             originalEntries: new Map(),
             mockedLimits: new Set() // Track which limits we've mocked
         };
@@ -387,7 +387,7 @@ const restore = () => {
     // Remove any mocked limit-service entries from the shared singleton before
     // we drop our bookkeeping. Reassigning a captured reference here used to
     // leave the mocked entry behind, breaking errorIfWouldGoOverLimit for every
-    // later file in the fork. (PLA-173)
+    // later file in the fork.
     restoreLimitService();
 
     sinon.restore();

--- a/ghost/core/test/utils/e2e-framework.js
+++ b/ghost/core/test/utils/e2e-framework.js
@@ -183,7 +183,7 @@ const resetRateLimits = async () => {
  * the first file to probe an image (e.g. the test content folder's test.jpg)
  * caches a result that every later file reads — flaking email previews, whose
  * committed snapshot expects the un-resized URL (a fresh probe of the 1x1 fixture
- * yields no dimensions). Clear it between boots so each file probes fresh. (PLA-173)
+ * yields no dimensions). Clear it between boots so each file probes fresh.
  */
 const resetImageSizeCache = () => {
     require('../../core/server/lib/image').cachedImageSizeFromUrl.cache.reset();

--- a/ghost/core/test/utils/e2e-framework.js
+++ b/ghost/core/test/utils/e2e-framework.js
@@ -205,7 +205,6 @@ const resetData = async () => {
     // Reset rate limiting instances (resetting the table is not enough!)
     await resetRateLimits();
 
-    // Reset the image-size cache (a module-level singleton not cleared by boot)
     resetImageSizeCache();
 };
 

--- a/ghost/core/test/utils/e2e-framework.js
+++ b/ghost/core/test/utils/e2e-framework.js
@@ -178,6 +178,18 @@ const resetRateLimits = async () => {
 };
 
 /**
+ * Reset the image-size cache. core/server/lib/image captures its cache adapter
+ * at module load and never refreshes it, so under the shared boot (isolate:false)
+ * the first file to probe an image (e.g. the test content folder's test.jpg)
+ * caches a result that every later file reads — flaking email previews, whose
+ * committed snapshot expects the un-resized URL (a fresh probe of the 1x1 fixture
+ * yields no dimensions). Clear it between boots so each file probes fresh. (PLA-173)
+ */
+const resetImageSizeCache = () => {
+    require('../../core/server/lib/image').cachedImageSizeFromUrl.cache.reset();
+};
+
+/**
  * This function ensures that Ghost's data is reset back to "factory settings"
  *
  */
@@ -192,6 +204,9 @@ const resetData = async () => {
 
     // Reset rate limiting instances (resetting the table is not enough!)
     await resetRateLimits();
+
+    // Reset the image-size cache (a module-level singleton not cleared by boot)
+    resetImageSizeCache();
 };
 
 /**

--- a/ghost/core/test/utils/e2e-utils.js
+++ b/ghost/core/test/utils/e2e-utils.js
@@ -105,7 +105,7 @@ const _startGhost = async (options) => {
     // generators. Without this reset, isFinished() below can observe that stale
     // `finished` before the new boot's queue starts, so requests run against the
     // old routing (e.g. custom-routes' /blog/ permalinks 301 instead of 200).
-    // Mirrors e2e-framework.startGhost. (PLA-173)
+    // Mirrors e2e-framework.startGhost.
     urlServiceUtils.resetGenerators();
 
     // Adapter cache has to be cleared to avoid reusing cached adapter instances between restarts
@@ -114,7 +114,7 @@ const _startGhost = async (options) => {
     // Reset the image-size cache. core/server/lib/image captures its cache adapter
     // at module load and never refreshes it, so under the shared boot (isolate:false)
     // a prior file's probe result leaks into this one (e.g. resizing email-preview
-    // images that should stay un-resized). Clear it so each boot probes fresh. (PLA-173)
+    // images that should stay un-resized). Clear it so each boot probes fresh.
     require('../../core/server/lib/image').cachedImageSizeFromUrl.cache.reset();
 
     // Reset the settings cache and disable listeners so they don't get triggered further

--- a/ghost/core/test/utils/e2e-utils.js
+++ b/ghost/core/test/utils/e2e-utils.js
@@ -99,6 +99,15 @@ const _startGhost = async (options) => {
     // Stop the server -- noops if it's not running
     await stopGhost();
 
+    // Reset the URL service unconditionally — stopGhost only resets it when THIS
+    // harness booted the previous server, but under the shared-boot e2e runner a
+    // file using e2e-framework can leave the url service `finished` with stale
+    // generators. Without this reset, isFinished() below can observe that stale
+    // `finished` before the new boot's queue starts, so requests run against the
+    // old routing (e.g. custom-routes' /blog/ permalinks 301 instead of 200).
+    // Mirrors e2e-framework.startGhost. (PLA-173)
+    urlServiceUtils.resetGenerators();
+
     // Adapter cache has to be cleared to avoid reusing cached adapter instances between restarts
     adapterManager.clearCache();
 

--- a/ghost/core/test/utils/e2e-utils.js
+++ b/ghost/core/test/utils/e2e-utils.js
@@ -111,6 +111,12 @@ const _startGhost = async (options) => {
     // Adapter cache has to be cleared to avoid reusing cached adapter instances between restarts
     adapterManager.clearCache();
 
+    // Reset the image-size cache. core/server/lib/image captures its cache adapter
+    // at module load and never refreshes it, so under the shared boot (isolate:false)
+    // a prior file's probe result leaks into this one (e.g. resizing email-preview
+    // images that should stay un-resized). Clear it so each boot probes fresh. (PLA-173)
+    require('../../core/server/lib/image').cachedImageSizeFromUrl.cache.reset();
+
     // Reset the settings cache and disable listeners so they don't get triggered further
     settingsService.reset();
 

--- a/ghost/core/test/utils/e2e-utils.js
+++ b/ghost/core/test/utils/e2e-utils.js
@@ -99,22 +99,11 @@ const _startGhost = async (options) => {
     // Stop the server -- noops if it's not running
     await stopGhost();
 
-    // Reset the URL service unconditionally — stopGhost only resets it when THIS
-    // harness booted the previous server, but under the shared-boot e2e runner a
-    // file using e2e-framework can leave the url service `finished` with stale
-    // generators. Without this reset, isFinished() below can observe that stale
-    // `finished` before the new boot's queue starts, so requests run against the
-    // old routing (e.g. custom-routes' /blog/ permalinks 301 instead of 200).
-    // Mirrors e2e-framework.startGhost.
     urlServiceUtils.resetGenerators();
 
     // Adapter cache has to be cleared to avoid reusing cached adapter instances between restarts
     adapterManager.clearCache();
 
-    // Reset the image-size cache. core/server/lib/image captures its cache adapter
-    // at module load and never refreshes it, so under the shared boot (isolate:false)
-    // a prior file's probe result leaks into this one (e.g. resizing email-preview
-    // images that should stay un-resized). Clear it so each boot probes fresh.
     require('../../core/server/lib/image').cachedImageSizeFromUrl.cache.reset();
 
     // Reset the settings cache and disable listeners so they don't get triggered further

--- a/ghost/core/vitest.config.db.ts
+++ b/ghost/core/vitest.config.db.ts
@@ -145,10 +145,9 @@ export default defineConfig({
                 test: {
                     ...sharedDbConfig,
                     name: 'e2e-api',
-                    // isolate:true like integration/legacy: this large (~97-file)
-                    // snapshot-heavy suite is state-pollution-prone, so per-file
-                    // isolation removes the inter-file bleed by construction.
-                    isolate: true,
+                    // Shares the default isolate:false (one shared boot per fork):
+                    // the cross-file leakers that forced per-file isolation here are
+                    // fixed at the source (PLA-173), dropping the dominant boot cost.
                     include: ['test/e2e-api/**/*.test.{js,ts}'],
                     exclude: ['**/node_modules/**'],
                     // Matches the mocha `--timeout=15000` for the e2e suites.

--- a/ghost/core/vitest.config.db.ts
+++ b/ghost/core/vitest.config.db.ts
@@ -147,7 +147,7 @@ export default defineConfig({
                     name: 'e2e-api',
                     // Shares the default isolate:false (one shared boot per fork):
                     // the cross-file leakers that forced per-file isolation here are
-                    // fixed at the source (PLA-173), dropping the dominant boot cost.
+                    // fixed at the source, dropping the dominant boot cost.
                     include: ['test/e2e-api/**/*.test.{js,ts}'],
                     exclude: ['**/node_modules/**'],
                     // Matches the mocha `--timeout=15000` for the e2e suites.


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/PLA-173

The `e2e` vitest project already runs `isolate: false` (shared boot across files), so it was flaky from cross-file state leaks. Fixing the leaks at the root — rather than paying for per-file isolation — is the model for the `isolate: true` suites next.

Four leaks, each a specific file mutating a shared **in-memory singleton** without restoring it (not the DB — the harness truncates per file):
- **limit-service**: mock restore reassigned the shared `limitService.limits` reference, so mocks never came out → later files threw "not a function" (poisoned mrr-stats / member-attribution / recommendation-emails / webhooks). Per-key snapshot/restore.
- **url-service**: generators left stale across harness boundaries → custom-routes `/blog/` permalinks 301'd instead of 200. Reset generators unconditionally before boot.
- **member-stats**: read a predecessor's `statsService.api` → give it its own boot.
- **site.test.js**: accumulated `site.changed` webhooks across tests → reset per test + explicit limit precondition.

Verified green across **20 shuffled file-order runs at retry=0** (`--sequence.shuffle.files`, `CI=true`) — zero flakes, zero new snapshots. The custom-routes 301 (which flaked on CI too) is fixed.

Known non-fatal: ~15% of runs log a redundant self-recovering `EADDRINUSE` re-boot (all 20 still passed); tracked as a boot-hygiene watch-item.

Test infrastructure only.