### PR TITLE
Fixed exports condition order in admin-x-framework and admin-x-settings

### DIFF
--- a/apps/admin-x-framework/package.json
+++ b/apps/admin-x-framework/package.json
@@ -7,59 +7,59 @@
     "private": true,
     "exports": {
         ".": {
+            "types": "./types/index.d.ts",
             "import": "./dist/index.js",
-            "require": "./dist/index.cjs",
-            "types": "./types/index.d.ts"
+            "require": "./dist/index.cjs"
         },
         "./errors": {
+            "types": "./types/errors.d.ts",
             "import": "./dist/errors.js",
-            "require": "./dist/errors.cjs",
-            "types": "./types/errors.d.ts"
+            "require": "./dist/errors.cjs"
         },
         "./helpers": {
+            "types": "./types/helpers.d.ts",
             "import": "./dist/helpers.js",
-            "require": "./dist/helpers.cjs",
-            "types": "./types/helpers.d.ts"
+            "require": "./dist/helpers.cjs"
         },
         "./hooks": {
+            "types": "./types/hooks.d.ts",
             "import": "./dist/hooks.js",
-            "require": "./dist/hooks.cjs",
-            "types": "./types/hooks.d.ts"
+            "require": "./dist/hooks.cjs"
         },
         "./routing": {
+            "types": "./types/routing.d.ts",
             "import": "./dist/routing.js",
-            "require": "./dist/routing.cjs",
-            "types": "./types/routing.d.ts"
+            "require": "./dist/routing.cjs"
         },
         "./api/*": {
+            "types": "./types/api/*.d.ts",
             "import": "./dist/api/*.js",
-            "require": "./dist/api/*.cjs",
-            "types": "./types/api/*.d.ts"
+            "require": "./dist/api/*.cjs"
         },
         "./utils/post-utils": {
+            "types": "./types/utils/post-utils.d.ts",
             "import": "./dist/utils/post-utils.js",
-            "require": "./dist/utils/post-utils.cjs",
-            "types": "./types/utils/post-utils.d.ts"
+            "require": "./dist/utils/post-utils.cjs"
         },
         "./utils/nql": {
+            "types": "./types/utils/nql.d.ts",
             "import": "./dist/utils/nql.js",
-            "require": "./dist/utils/nql.cjs",
-            "types": "./types/utils/nql.d.ts"
+            "require": "./dist/utils/nql.cjs"
         },
         "./vite": {
+            "types": "./types/vite.d.ts",
             "import": "./dist/vite.js",
-            "require": "./dist/vite.cjs",
-            "types": "./types/vite.d.ts"
+            "require": "./dist/vite.cjs"
         },
         "./playwright": {
+            "types": "./types/playwright.d.ts",
             "import": "./dist/playwright.js",
-            "require": "./dist/playwright.cjs",
-            "types": "./types/playwright.d.ts"
+            "require": "./dist/playwright.cjs"
         },
         "./test/*": {
+            "types": "./types/test/*.d.ts",
             "import": "./dist/test/*.js",
-            "require": "./dist/test/*.cjs",
-            "types": "./types/test/*.d.ts"
+            "require": "./dist/test/*.cjs"
         }
     },
     "sideEffects": false,

--- a/apps/admin-x-settings/package.json
+++ b/apps/admin-x-settings/package.json
@@ -16,9 +16,9 @@
   "module": "./dist/admin-x-settings.js",
   "exports": {
     ".": {
+      "types": "./src/index.tsx",
       "import": "./dist/admin-x-settings.js",
-      "require": "./dist/admin-x-settings.umd.cjs",
-      "types": "./src/index.tsx"
+      "require": "./dist/admin-x-settings.umd.cjs"
     },
     "./src/*": {
       "import": "./src/*.tsx",


### PR DESCRIPTION
Fixes the `exports` condition ordering in `@tryghost/admin-x-framework` and `@tryghost/admin-x-settings`.

### Problem
In a package.json `exports` map, conditions are matched **top-to-bottom, first match wins**. In both packages, `"types"` was listed *after* `"import"`/`"require"`, so it was never reached:

```json
".": {
  "import": "./dist/index.js",
  "require": "./dist/index.cjs",
  "types": "./types/index.d.ts"   // dead — never matched
}
```

esbuild warned on every Vitest / `pnpm test:watch` run (`The condition "types" here will never be used…`), and TypeScript was resolving these packages' declarations via fallback rather than through the `exports` map.

### Fix
Moved `"types"` to the front of all 12 export blocks (11 in admin-x-framework, 1 in admin-x-settings). No runtime impact — a JS runtime never requests the `types` condition, so `import`/`require` still match exactly as before; only the type resolver benefits from `types` now being reachable.

Verified: the esbuild `types`-condition warnings no longer appear on `pnpm test:watch`.
