### PR TITLE
Removed per-file isolation from the e2e-api test suite (isolate:false)

### DIFF
--- a/ghost/core/test/e2e-api/admin/images.test.js
+++ b/ghost/core/test/e2e-api/admin/images.test.js
@@ -153,9 +153,13 @@ describe('Images API', function () {
         await agent.loginAsOwner();
     });
 
-    afterAll(function () {
-        configUtils.restore();
-        ghostServer.stop();
+    afterAll(async function () {
+        // configUtils.restore() is async (config.reset + re-apply defaults). Left
+        // un-awaited it raced the next file under the shared boot (isolate:false),
+        // leaking this suite's imageOptimization:contentImageSizes (w1/w10) into
+        // e.g. posts-legacy's srcset rendering. (PLA-173)
+        await configUtils.restore();
+        await ghostServer.stop();
     });
 
     afterEach(async function () {

--- a/ghost/core/test/e2e-api/members-comments/max-limit-cap.test.js
+++ b/ghost/core/test/e2e-api/members-comments/max-limit-cap.test.js
@@ -35,6 +35,12 @@ describe('Comments API - Max Limit Cap', function () {
     afterAll(function () {
         // Restore the original middleware
         sharedMiddleware.maxLimitCap[0] = originalMiddleware;
+        // beforeAll stubs settingsCache.get directly (not via mockManager), and
+        // there is no global sinon.restore() in the shared boot (isolate:false).
+        // Without this the stub leaks into the next file: the first later file to
+        // (re)stub settingsCache.get — e.g. any mockManager.mockMailgun/mockSetting
+        // — throws "Attempted to wrap get which is already wrapped". (PLA-173)
+        sinon.restore();
     });
 
     it('should call maxLimitCap middleware when browsing posts', async function () {

--- a/ghost/core/test/e2e-api/members/send-magic-link.test.js
+++ b/ghost/core/test/e2e-api/members/send-magic-link.test.js
@@ -344,8 +344,10 @@ describe('sendMagicLink', function () {
             await settingsService.init();
         });
 
-        afterEach(function () {
-            configUtils.restore();
+        afterEach(async function () {
+            // await the async restore so spam:blocked_email_domains can't leak
+            // into a later file under the shared boot (isolate:false). (PLA-173)
+            await configUtils.restore();
         });
 
         it('blocks signups from email domains blocked in config', async function () {

--- a/ghost/core/test/utils/config-utils.js
+++ b/ghost/core/test/utils/config-utils.js
@@ -6,6 +6,19 @@ const configUtils = {};
 configUtils.config = config;
 configUtils.defaultConfig = _.cloneDeep(config.get());
 
+// The redirects FileStore basePath is lazily derived from the content path
+// (adapter-manager/config.js: `basePath ||= getContentPath('data')`) and then
+// cached on the shared nconf `adapters` object. In production the content path
+// is fixed for the process lifetime, so freezing it is fine; under the shared
+// e2e boot (isolate:false) each file points the content path at a fresh tmp
+// folder, but the frozen basePath keeps the redirects adapter reading the first
+// booter's folder — leaking another file's redirects.yaml/json into e.g. the
+// redirects download suite. Clear it whenever the content path moves so the next
+// boot re-derives it. (PLA-173)
+const clearDerivedContentPaths = function () {
+    config.set('adapters:redirects:FileStore:basePath', undefined);
+};
+
 /**
  * configUtils.set({});
  * configUtils.set('key', 'value');
@@ -18,8 +31,14 @@ configUtils.set = function () {
         _.each(key, function (settingValue, settingKey) {
             config.set(settingKey, settingValue);
         });
+        if (Object.prototype.hasOwnProperty.call(key, 'paths:contentPath')) {
+            clearDerivedContentPaths();
+        }
     } else {
         config.set(key, value);
+        if (key === 'paths:contentPath') {
+            clearDerivedContentPaths();
+        }
     }
 };
 

--- a/ghost/core/test/utils/e2e-framework.js
+++ b/ghost/core/test/utils/e2e-framework.js
@@ -178,6 +178,18 @@ const resetRateLimits = async () => {
 };
 
 /**
+ * Reset the image-size cache. core/server/lib/image captures its cache adapter
+ * at module load and never refreshes it, so under the shared boot (isolate:false)
+ * the first file to probe an image (e.g. the test content folder's test.jpg)
+ * caches a result that every later file reads — flaking email previews, whose
+ * committed snapshot expects the un-resized URL (a fresh probe of the 1x1 fixture
+ * yields no dimensions). Clear it between boots so each file probes fresh. (PLA-173)
+ */
+const resetImageSizeCache = () => {
+    require('../../core/server/lib/image').cachedImageSizeFromUrl.cache.reset();
+};
+
+/**
  * This function ensures that Ghost's data is reset back to "factory settings"
  *
  */
@@ -192,6 +204,9 @@ const resetData = async () => {
 
     // Reset rate limiting instances (resetting the table is not enough!)
     await resetRateLimits();
+
+    // Reset the image-size cache (a module-level singleton not cleared by boot)
+    resetImageSizeCache();
 };
 
 /**

--- a/ghost/core/test/utils/e2e-utils.js
+++ b/ghost/core/test/utils/e2e-utils.js
@@ -111,6 +111,12 @@ const _startGhost = async (options) => {
     // Adapter cache has to be cleared to avoid reusing cached adapter instances between restarts
     adapterManager.clearCache();
 
+    // Reset the image-size cache. core/server/lib/image captures its cache adapter
+    // at module load and never refreshes it, so under the shared boot (isolate:false)
+    // a prior file's probe result leaks into this one (e.g. resizing email-preview
+    // images that should stay un-resized). Clear it so each boot probes fresh. (PLA-173)
+    require('../../core/server/lib/image').cachedImageSizeFromUrl.cache.reset();
+
     // Reset the settings cache and disable listeners so they don't get triggered further
     settingsService.reset();
 

--- a/ghost/core/vitest.config.db.ts
+++ b/ghost/core/vitest.config.db.ts
@@ -145,10 +145,9 @@ export default defineConfig({
                 test: {
                     ...sharedDbConfig,
                     name: 'e2e-api',
-                    // isolate:true like integration/legacy: this large (~97-file)
-                    // snapshot-heavy suite is state-pollution-prone, so per-file
-                    // isolation removes the inter-file bleed by construction.
-                    isolate: true,
+                    // Shares the default isolate:false (one shared boot per fork):
+                    // the cross-file leakers that forced per-file isolation here are
+                    // fixed at the source (PLA-173), dropping the dominant boot cost.
                     include: ['test/e2e-api/**/*.test.{js,ts}'],
                     exclude: ['**/node_modules/**'],
                     // Matches the mocha `--timeout=15000` for the e2e suites.


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/PLA-173

Another round of dropping per-file isolation (continues the e2e work in #28762). The e2e-api suite ran `isolate: true` — a fresh Ghost boot per file — purely to brute-force away cross-file state leaks. This fixes the leaks at the source and flips it to the shared `isolate: false` boot, removing the per-file boot that dominates the acceptance leg.

Leakers fixed (each root-caused + revert-proven):
- redirects `basePath` frozen across content-path changes in the shared boot
- leaked `settingsCache.get` stub (members-comments max-limit-cap)
- image-size cache never reset across boots
- un-awaited async `configUtils.restore()` (images, send-magic-link)

Then removed e2e-api's `isolate: true` override so it inherits the shared `isolate: false` default.

**Verified on the flipped config** (not a CLI override), shuffled file order, `retry=0`: **8/8 mysql8 + 5/5 sqlite green**, 1355 tests, ~25s wall on mysql8 (vs the per-file-boot version that dominated the leg).