### PR TITLE
Added content import ledger tables

### DIFF
--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost-admin",
-  "version": "6.46.1-rc.0",
+  "version": "6.47.0-rc.0",
   "description": "Ember.js admin client for Ghost",
   "author": "Ghost Foundation",
   "homepage": "http://ghost.org",

--- a/ghost/core/core/server/data/exporter/table-lists.js
+++ b/ghost/core/core/server/data/exporter/table-lists.js
@@ -45,6 +45,8 @@ const BACKUP_TABLES = [
     'comments',
     'comment_likes',
     'comment_reports',
+    'content_imports',
+    'content_import_rows',
     'jobs',
     'redirects',
     'members_click_events',

--- a/ghost/core/core/server/data/migrations/versions/6.47/2026-06-21-19-30-38-add-content-import-ledger-tables.js
+++ b/ghost/core/core/server/data/migrations/versions/6.47/2026-06-21-19-30-38-add-content-import-ledger-tables.js
@@ -1,0 +1,42 @@
+const {addTable, combineNonTransactionalMigrations} = require('../../utils');
+
+const contentImports = {
+    id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+    created_at: {type: 'dateTime', nullable: false},
+    updated_at: {type: 'dateTime', nullable: false},
+    started_at: {type: 'dateTime', nullable: true},
+    finished_at: {type: 'dateTime', nullable: true},
+    status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'pending', validations: {isIn: [['pending', 'running', 'completed', 'failed']]}},
+    source_filename: {type: 'string', maxlength: 255, nullable: true},
+    source_path: {type: 'string', maxlength: 2000, nullable: false},
+    mapping: {type: 'text', maxlength: 65535, nullable: true},
+    user_id: {type: 'string', maxlength: 24, nullable: false, references: 'users.id'},
+    '@@INDEXES@@': [
+        ['status', 'updated_at']
+    ]
+};
+
+const contentImportRows = {
+    id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+    import_id: {type: 'string', maxlength: 24, nullable: false, references: 'content_imports.id', cascadeDelete: true},
+    source_index: {type: 'integer', nullable: false, unsigned: true},
+    original_data: {type: 'text', maxlength: 1000000000, fieldtype: 'long', nullable: false},
+    outcome: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'pending', validations: {isIn: [['pending', 'created', 'updated', 'skipped', 'failed']]}},
+    reason: {type: 'string', maxlength: 2000, nullable: true},
+    warnings: {type: 'text', maxlength: 65535, nullable: true},
+    post_id: {type: 'string', maxlength: 24, nullable: true, references: 'posts.id', setNullDelete: true},
+    resulting_url: {type: 'string', maxlength: 2000, nullable: true},
+    created_at: {type: 'dateTime', nullable: false},
+    updated_at: {type: 'dateTime', nullable: false},
+    '@@INDEXES@@': [
+        ['import_id', 'outcome']
+    ],
+    '@@UNIQUE_CONSTRAINTS@@': [
+        ['import_id', 'source_index']
+    ]
+};
+
+module.exports = combineNonTransactionalMigrations(
+    addTable('content_imports', contentImports),
+    addTable('content_import_rows', contentImportRows)
+);

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1038,6 +1038,40 @@ module.exports = {
         metadata: {type: 'string', maxlength: 2000, nullable: true},
         queue_entry: {type: 'integer', nullable: true, unsigned: true}
     },
+    content_imports: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        created_at: {type: 'dateTime', nullable: false},
+        updated_at: {type: 'dateTime', nullable: false},
+        started_at: {type: 'dateTime', nullable: true},
+        finished_at: {type: 'dateTime', nullable: true},
+        status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'pending', validations: {isIn: [['pending', 'running', 'completed', 'failed']]}},
+        source_filename: {type: 'string', maxlength: 255, nullable: true},
+        source_path: {type: 'string', maxlength: 2000, nullable: false},
+        mapping: {type: 'text', maxlength: 65535, nullable: true},
+        user_id: {type: 'string', maxlength: 24, nullable: false, references: 'users.id'},
+        '@@INDEXES@@': [
+            ['status', 'updated_at']
+        ]
+    },
+    content_import_rows: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        import_id: {type: 'string', maxlength: 24, nullable: false, references: 'content_imports.id', cascadeDelete: true},
+        source_index: {type: 'integer', nullable: false, unsigned: true},
+        original_data: {type: 'text', maxlength: 1000000000, fieldtype: 'long', nullable: false},
+        outcome: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'pending', validations: {isIn: [['pending', 'created', 'updated', 'skipped', 'failed']]}},
+        reason: {type: 'string', maxlength: 2000, nullable: true},
+        warnings: {type: 'text', maxlength: 65535, nullable: true},
+        post_id: {type: 'string', maxlength: 24, nullable: true, references: 'posts.id', setNullDelete: true},
+        resulting_url: {type: 'string', maxlength: 2000, nullable: true},
+        created_at: {type: 'dateTime', nullable: false},
+        updated_at: {type: 'dateTime', nullable: false},
+        '@@INDEXES@@': [
+            ['import_id', 'outcome']
+        ],
+        '@@UNIQUE_CONSTRAINTS@@': [
+            ['import_id', 'source_index']
+        ]
+    },
     redirects: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         from: {type: 'string', maxlength: 191, nullable: false, index: true},

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost",
-  "version": "6.46.1-rc.0",
+  "version": "6.47.0-rc.0",
   "description": "The professional publishing platform",
   "author": "Ghost Foundation",
   "homepage": "https://ghost.org",

--- a/ghost/core/test/integration/exporter/exporter.test.js
+++ b/ghost/core/test/integration/exporter/exporter.test.js
@@ -39,6 +39,8 @@ describe('Exporter', function () {
             'comments',
             'comment_likes',
             'comment_reports',
+            'content_import_rows',
+            'content_imports',
             'custom_theme_settings',
             'donation_payment_events',
             'email_batches',

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '0aa8f53f1df03b6fe6f8a8a1f44af8f0';
+    const currentSchemaHash = 'c80c5e75947e3048c8f4992e2e857c06';
     const currentFixturesHash = '353da9c0389256cfae495bbf05350911';
     const currentSettingsHash = '397be8628c753b1959b8954d5610f83f';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
ref https://linear.app/ghost/issue/MIG-1435/

Creates persisted working-state tables for CSV content import runs and row outcomes so later milestones can record results, resume work, and render reports.