### PR TITLE
Bumped pnpm to 11.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0-private",
   "description": "The professional publishing platform",
   "private": true,
-  "packageManager": "pnpm@11.6.0+sha512.9a36518224080c6fe5165afdcfe79bfa118c29be703f3f462b1e32efe1e98e47e8750b148e08286250aad4113cc7993ca413c4e2cd447752708c2ee5751bc95f",
+  "packageManager": "pnpm@11.8.0+sha512.c1f5e7c4cb241c8f174b743851d82f42b802324afc8b0f116b96adb15aa06664948dde36960a3ba1079ba5b4b29dd0140135b94b5b5f5263592249d68e555f26",
   "engines": {
     "node": "^22.18.0"
   },


### PR DESCRIPTION
Bumps the repo's pinned package manager from `pnpm@11.6.0` to `pnpm@11.8.0`.

## Changes
- Updated the `packageManager` field in the root `package.json` (version + corepack integrity hash).

## Verification
- Integrity hash computed from the npm tarball (`sha512` of `pnpm-11.8.0.tgz`); method cross-checked against the existing 11.6.0 hash, which matched exactly.
- `pnpm install --frozen-lockfile` runs clean on 11.8.0 with no lockfile churn — only `package.json` changes in this PR.