### PR TITLE
Fixed share modal close button position in Admin

### DIFF
--- a/apps/shade/src/components/patterns/share-modal.tsx
+++ b/apps/shade/src/components/patterns/share-modal.tsx
@@ -95,7 +95,7 @@ const CloseButton = React.forwardRef<HTMLButtonElement, CloseButtonProps>(({
     <Button
         ref={ref}
         className={cn(
-            '-mr-2 cursor-pointer p-2 text-muted-foreground hover:text-foreground [&_svg]:size-6!',
+            'aspect-square cursor-pointer p-2 text-muted-foreground hover:text-foreground [&_svg]:size-6!',
             className
         )}
         size={size}


### PR DESCRIPTION
closes https://linear.app/ghost/issue/DES-1412/x-icons-changed-position-on-modals

- Due to recent sizing changes in Shade, the X (close) button position shifted in the post Share modal in the Admin. The PR fixes this regression.