### PR TITLE
🐛 Fixed Portal offer link infinite-spinner for active paid members

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryghost/portal",
-  "version": "2.69.6",
+  "version": "2.69.7",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/src/app.js
+++ b/apps/portal/src/app.js
@@ -961,31 +961,49 @@ export default class App extends React.Component {
     async handleOfferQuery({site, offerId, member = this.state.member}) {
         removePortalLinkFromUrl();
 
-        if (!isPaidMember({member}) || isComplimentaryMember({member})) {
-            try {
-                const offerData = await this.GhostApi.site.offer({offerId});
-                const offer = offerData?.offers[0];
+        const isEligibleMember = !isPaidMember({member}) || isComplimentaryMember({member});
 
-                if (!offer || !offer.tier) {
-                    return;
-                }
+        if (!isEligibleMember) {
+            const notification = createNotification({
+                type: 'offer:failed',
+                status: 'error',
+                autoHide: false,
+                closeable: true,
+                state: this.state,
+                message: t('You already have an active subscription.')
+            });
 
-                // Retention offers are only triggered during a member cancellation flow - they cannot be accessed via an offer link
-                if (isRetentionOffer({offer})) {
-                    return;
-                }
+            await this.dispatchAction('closePopup');
+            this.setState({
+                notification,
+                notificationSequence: notification.count
+            });
+            return;
+        }
 
-                if (!isActiveOffer({site, offer})) {
-                    return;
-                }
+        try {
+            const offerData = await this.GhostApi.site.offer({offerId});
+            const offer = offerData?.offers[0];
 
-                this.dispatchAction('openPopup', {
-                    page: 'offer',
-                    pageData: offer
-                });
-            } catch (e) {
-                // ignore invalid portal url
+            if (!offer || !offer.tier) {
+                return;
             }
+
+            // Retention offers are only triggered during a member cancellation flow - they cannot be accessed via an offer link
+            if (isRetentionOffer({offer})) {
+                return;
+            }
+
+            if (!isActiveOffer({site, offer})) {
+                return;
+            }
+
+            this.dispatchAction('openPopup', {
+                page: 'offer',
+                pageData: offer
+            });
+        } catch (e) {
+            // ignore invalid portal url
         }
     }
 

--- a/apps/portal/test/data-attributes.test.js
+++ b/apps/portal/test/data-attributes.test.js
@@ -727,7 +727,7 @@ describe('Member Data attributes:', () => {
     });
 });
 
-const setup = async ({site, member = null, showPopup = true, waitForTrigger = true, offer = null}) => {
+const setup = async ({site, member = null, showPopup = true, waitForTrigger = true, offer = null, checkoutPlan = null}) => {
     const ghostApi = setupGhostApi({siteUrl: 'https://example.com'});
     ghostApi.init = vi.fn(() => {
         return Promise.resolve({
@@ -740,9 +740,9 @@ const setup = async ({site, member = null, showPopup = true, waitForTrigger = tr
         return Promise.resolve('success');
     });
 
-    ghostApi.member.checkoutPlan = vi.fn(() => {
+    ghostApi.member.checkoutPlan = vi.fn(checkoutPlan || (() => {
         return Promise.resolve();
-    });
+    }));
 
     ghostApi.site.offer = vi.fn(() => {
         return Promise.resolve({
@@ -940,6 +940,86 @@ describe('Portal Data attributes:', () => {
                 expect(within(popupFrame.contentDocument).queryByText(FixtureOffer.display_title)).toBeInTheDocument();
             });
             expect(ghostApi.member.checkoutPlan).not.toHaveBeenCalled();
+        });
+
+        test('does not open Portal when a paid member opens an offer link', async () => {
+            document.body.innerHTML = `
+                <button data-portal="offers/${FixtureOffer.id}">Offer</button>
+            `;
+
+            let {
+                ghostApi, popupFrame, ...utils
+            } = await setup({
+                site: FixturesSite.singleTier.basic,
+                member: FixtureMember.paid,
+                showPopup: false,
+                waitForTrigger: false,
+                offer: FixtureOffer
+            });
+            expect(popupFrame).not.toBeInTheDocument();
+
+            const offerElement = document.querySelector('[data-portal^="offers"]');
+            await waitFor(() => {
+                expect(offerElement).toHaveClass('gh-portal-close');
+            });
+
+            fireEvent.click(offerElement);
+
+            await waitFor(() => {
+                expect(utils.queryByTitle(/portal-popup/i)).not.toBeInTheDocument();
+            });
+            const notificationFrame = await utils.findByTitle(/portal-notification/i);
+            expect(within(notificationFrame.contentDocument).queryByText(/You already have an active subscription\./i)).toBeInTheDocument();
+            expect(ghostApi.site.offer).not.toHaveBeenCalled();
+            expect(ghostApi.member.checkoutPlan).not.toHaveBeenCalled();
+        });
+
+        test('closes a stale loading modal when a paid member opens an offer link', async () => {
+            const paidTier = FixturesSite.singleTier.basic.products.find(p => p.type === 'paid');
+            const pendingCheckout = new Promise((resolve) => {
+                void resolve;
+            });
+
+            document.body.innerHTML = `
+                <button data-portal="signup/${paidTier.id}/monthly">Checkout</button>
+                <button data-portal="offers/${FixtureOffer.id}">Offer</button>
+            `;
+
+            let {
+                ghostApi, popupFrame, ...utils
+            } = await setup({
+                site: FixturesSite.singleTier.basic,
+                member: FixtureMember.paid,
+                showPopup: false,
+                waitForTrigger: false,
+                offer: FixtureOffer,
+                checkoutPlan: () => pendingCheckout
+            });
+            expect(popupFrame).not.toBeInTheDocument();
+
+            const checkoutElement = document.querySelector('[data-portal^="signup"]');
+            const offerElement = document.querySelector('[data-portal^="offers"]');
+            await waitFor(() => {
+                expect(checkoutElement).toHaveClass('gh-portal-close');
+                expect(offerElement).toHaveClass('gh-portal-close');
+            });
+
+            fireEvent.click(checkoutElement);
+
+            popupFrame = await utils.findByTitle(/portal-popup/i);
+            await waitFor(() => {
+                expect(within(popupFrame.contentDocument).queryByTestId('loaderIcon')).toBeInTheDocument();
+            });
+
+            fireEvent.click(offerElement);
+
+            await waitFor(() => {
+                expect(utils.queryByTitle(/portal-popup/i)).not.toBeInTheDocument();
+            });
+            const notificationFrame = await utils.findByTitle(/portal-notification/i);
+            expect(within(notificationFrame.contentDocument).queryByText(/You already have an active subscription\./i)).toBeInTheDocument();
+            expect(ghostApi.member.checkoutPlan).toHaveBeenCalledTimes(1);
+            expect(ghostApi.site.offer).not.toHaveBeenCalled();
         });
     });
 

--- a/apps/portal/test/portal-links.test.js
+++ b/apps/portal/test/portal-links.test.js
@@ -1,5 +1,5 @@
 import App from '../src/app';
-import {site as FixtureSite, member as FixtureMember} from './utils/test-fixtures';
+import {offer as FixtureOffer, site as FixtureSite, member as FixtureMember} from './utils/test-fixtures';
 import {appRender, fireEvent, waitFor, within} from './utils/test-utils';
 import setupGhostApi from '../src/utils/api';
 
@@ -21,7 +21,7 @@ const defaultGiftResponse = {
     ]
 };
 
-const setup = async ({site, member = null, showPopup = true, giftResponse = defaultGiftResponse, giftError = null}) => {
+const setup = async ({site, member = null, showPopup = true, giftResponse = defaultGiftResponse, giftError = null, offer = null}) => {
     const ghostApi = setupGhostApi({siteUrl: 'https://example.com'});
 
     ghostApi.init = vi.fn(() => {
@@ -61,6 +61,12 @@ const setup = async ({site, member = null, showPopup = true, giftResponse = defa
                 token: giftResponse.gifts[0].token,
                 status: 'redeemed'
             }]
+        });
+    });
+
+    ghostApi.site.offer = vi.fn(() => {
+        return Promise.resolve({
+            offers: [offer]
         });
     });
 
@@ -244,6 +250,29 @@ describe('Portal Data links:', () => {
             expect(shareTitle).toBeInTheDocument();
             const poweredBy = within(popupFrame.contentDocument).queryByText(/Powered by Ghost/i);
             expect(poweredBy).not.toBeInTheDocument();
+        });
+    });
+
+    describe('#/portal/offers/:offerid', () => {
+        test('does not open Portal when a paid member opens an offer link directly', async () => {
+            window.location.hash = `#/portal/offers/${FixtureOffer.id}`;
+
+            let {
+                ghostApi, popupFrame, triggerButtonFrame, ...utils
+            } = await setup({
+                site: FixtureSite.singleTier.basic,
+                member: FixtureMember.paid,
+                showPopup: false,
+                offer: FixtureOffer
+            });
+
+            expect(triggerButtonFrame).toBeInTheDocument();
+            expect(popupFrame).not.toBeInTheDocument();
+            expect(utils.queryByTitle(/portal-popup/i)).not.toBeInTheDocument();
+            const notificationFrame = await utils.findByTitle(/portal-notification/i);
+            expect(within(notificationFrame.contentDocument).queryByText(/You already have an active subscription\./i)).toBeInTheDocument();
+            expect(ghostApi.site.offer).not.toHaveBeenCalled();
+            expect(ghostApi.member.checkoutPlan).not.toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3741/

## Summary
- keep Portal closed when active paid members open offer links directly or via data-portal
- close any stale loading modal when an ineligible paid member opens an offer link
- show the existing “You already have an active subscription.” error toast for logged-in paid members who try to open an offer link
- add regressions for direct hash links, data-portal links, and stale loading state

## Root cause
Offer links correctly skipped fetching offer data for active paid members, but the handler did not actively clear an already-open Portal loading state. That could leave the member looking at an infinite spinner even though they were not eligible to redeem the offer.
