### PR TITLE
Fixed admin E2E isolation and Unsplash flake

### DIFF
--- a/e2e/helpers/environment/constants.ts
+++ b/e2e/helpers/environment/constants.ts
@@ -89,7 +89,10 @@ export const BASE_GHOST_ENV = [
     'privacy__useIndexNow=false',
 
     // Disable gravatar avatar lookups (real external call, no e2e coverage)
-    'privacy__useGravatar=false'
+    'privacy__useGravatar=false',
+
+    // Disable browser-side Sentry reporting during tests
+    'client_sentry__disabled=true'
 ] as const;
 
 export const TEST_ENVIRONMENT = {
@@ -128,6 +131,7 @@ export const EGRESS_MONITOR_ENABLED = process.env.E2E_EGRESS_MONITOR !== '0';
 // service that should be mocked) surface as a test failure. Set
 // E2E_EGRESS_ENFORCE=0 to record-only, e.g. while expanding the allowlist.
 export const EGRESS_ENFORCE = process.env.E2E_EGRESS_ENFORCE !== '0';
+export const EGRESS_MOCK_RESPONSE_HEADER = 'x-ghost-e2e-mocked-external';
 
 /**
  * Hosts the suite is allowed to reach. An entry matches itself and any subdomain
@@ -165,6 +169,5 @@ export const EGRESS_ALLOWLIST: readonly string[] = [
     // Other third-party services the product uses
     'bunny.net', // web fonts (fonts.bunny.net)
     'transistor.fm', // podcast embeds (partner.transistor.fm)
-    'unsplash.com', // editor image selector (api./images.unsplash.com)
     'geojs.io' // member signup + staff sign-in geolocation (get.geojs.io)
 ];

--- a/e2e/helpers/playwright/fixture.ts
+++ b/e2e/helpers/playwright/fixture.ts
@@ -1,7 +1,7 @@
 import baseDebug from '@tryghost/debug';
 import {AnalyticsOverviewPage} from '@/helpers/pages';
-import {Browser, BrowserContext, Page, Request, TestInfo, test as base} from '@playwright/test';
-import {EGRESS_ENFORCE, EGRESS_MONITOR_ENABLED} from '@/helpers/environment/constants';
+import {Browser, BrowserContext, Page, Request, Response, TestInfo, test as base} from '@playwright/test';
+import {EGRESS_ENFORCE, EGRESS_MOCK_RESPONSE_HEADER, EGRESS_MONITOR_ENABLED} from '@/helpers/environment/constants';
 import {EmailClient, MailPit} from '@/helpers/services/email/mail-pit';
 import {FakeMailgunServer, MailgunTestService} from '@/helpers/services/mailgun';
 import {FakeStripeServer, StripeTestService, WebhookClient} from '@/helpers/services/stripe';
@@ -556,7 +556,7 @@ export const test = base.extend<GhostInstanceFixture & InternalFixtures, WorkerF
         // the Ghost container's resolver can't see requests the browser makes itself
         // (changelog.json, embeds, avatar services, …), so we watch them here and
         // hand off-allowlist hosts to the worker-level sweep (_egressSummary).
-        const browserEgressHosts = new Set<string>();
+        const browserEgressRequests = new Map<Request, string>();
         const onRequest = (request: Request) => {
             let host: string;
             try {
@@ -569,11 +569,17 @@ export const test = base.extend<GhostInstanceFixture & InternalFixtures, WorkerF
                 return;
             }
             if (!isAllowedHost(host)) {
-                browserEgressHosts.add(host);
+                browserEgressRequests.set(request, host);
+            }
+        };
+        const onResponse = (response: Response) => {
+            if (response.headers()[EGRESS_MOCK_RESPONSE_HEADER] === '1') {
+                browserEgressRequests.delete(response.request());
             }
         };
         if (EGRESS_MONITOR_ENABLED) {
             page.on('request', onRequest);
+            page.on('response', onResponse);
         }
 
         const labsFlagsSpecified = labs && Object.keys(labs).length > 0;
@@ -593,7 +599,8 @@ export const test = base.extend<GhostInstanceFixture & InternalFixtures, WorkerF
 
         if (EGRESS_MONITOR_ENABLED) {
             page.off('request', onRequest);
-            for (const host of browserEgressHosts) {
+            page.off('response', onResponse);
+            for (const host of browserEgressRequests.values()) {
                 workerBrowserEgressHosts.add(host);
             }
         }

--- a/e2e/tests/admin/reset-password.test.ts
+++ b/e2e/tests/admin/reset-password.test.ts
@@ -1,8 +1,11 @@
 import {AnalyticsOverviewPage, LoginPage, PasswordResetPage, SettingsPage} from '@/admin-pages';
 import {EmailClient, MailPit} from '@/helpers/services/email/mail-pit';
-import {Page} from '@playwright/test';
 import {expect, test} from '@/helpers/playwright';
 import {extractPasswordResetLink} from '@/helpers/services/email/utils';
+import {usePerTestIsolation} from '@/helpers/playwright/isolation';
+import type {Page} from '@playwright/test';
+
+usePerTestIsolation();
 
 test.describe('Ghost Admin - Reset Password', () => {
     const emailClient: EmailClient = new MailPit();

--- a/e2e/tests/admin/settings/design.test.ts
+++ b/e2e/tests/admin/settings/design.test.ts
@@ -1,11 +1,112 @@
 import {DesignSection} from '@/admin-pages';
+import {EGRESS_MOCK_RESPONSE_HEADER} from '@/helpers/environment/constants';
 import {expect, test} from '@/helpers/playwright';
+import type {Page} from '@playwright/test';
+
+const testImage = 'data:image/gif;base64,R0lGODlhAQABAAAAACw=';
+const unsplashPhotos = [{
+    id: 'test-unsplash-photo',
+    slug: 'test-unsplash-photo',
+    created_at: '2026-06-22T00:00:00Z',
+    updated_at: '2026-06-22T00:00:00Z',
+    promoted_at: null,
+    width: 1200,
+    height: 800,
+    color: '#f0f0f0',
+    blur_hash: 'LKO2?U%2Tw=w]~RBVZRi};RPxuwH',
+    description: null,
+    alt_description: 'A mocked Unsplash test image',
+    breadcrumbs: [],
+    urls: {
+        raw: testImage,
+        full: testImage,
+        regular: testImage,
+        small: testImage,
+        thumb: testImage
+    },
+    links: {
+        self: 'https://api.unsplash.com/photos/test-unsplash-photo',
+        html: 'https://unsplash.com/photos/test-unsplash-photo',
+        download: 'https://unsplash.com/photos/test-unsplash-photo/download',
+        download_location: 'https://api.unsplash.com/photos/test-unsplash-photo/download'
+    },
+    likes: 1,
+    liked_by_user: false,
+    current_user_collections: [],
+    sponsorship: null,
+    topic_submissions: {},
+    user: {
+        id: 'test-user',
+        updated_at: '2026-06-22T00:00:00Z',
+        username: 'testuser',
+        name: 'Test User',
+        first_name: 'Test',
+        last_name: 'User',
+        twitter_username: null,
+        portfolio_url: null,
+        bio: null,
+        location: null,
+        links: {
+            self: 'https://api.unsplash.com/users/testuser',
+            html: 'https://unsplash.com/@testuser',
+            photos: 'https://api.unsplash.com/users/testuser/photos',
+            likes: 'https://api.unsplash.com/users/testuser/likes',
+            portfolio: 'https://api.unsplash.com/users/testuser/portfolio',
+            following: 'https://api.unsplash.com/users/testuser/following',
+            followers: 'https://api.unsplash.com/users/testuser/followers'
+        },
+        profile_image: {
+            small: testImage,
+            medium: testImage,
+            large: testImage
+        },
+        instagram_username: null,
+        total_collections: 0,
+        total_likes: 0,
+        total_photos: 1,
+        accepted_tos: true,
+        for_hire: false,
+        social: {
+            instagram_username: null,
+            portfolio_url: null,
+            twitter_username: null,
+            paypal_email: null
+        }
+    }
+}];
+
+async function mockUnsplashApi(page: Page) {
+    await page.route('https://api.unsplash.com/**', async (route) => {
+        const url = new URL(route.request().url());
+        let body: unknown;
+
+        if (url.pathname === '/photos') {
+            body = unsplashPhotos;
+        } else if (url.pathname === '/search/photos') {
+            body = {results: unsplashPhotos};
+        } else if (url.pathname.endsWith('/download')) {
+            body = {url: testImage};
+        } else {
+            await route.abort();
+            return;
+        }
+
+        await route.fulfill({
+            body: JSON.stringify(body),
+            contentType: 'application/json',
+            headers: {
+                [EGRESS_MOCK_RESPONSE_HEADER]: '1'
+            }
+        });
+    });
+}
 
 test.describe('Ghost Admin - Design & Branding', () => {
     test.describe('Unsplash Selector', () => {
         test('unsplash selector loads photos', async ({page}) => {
             const design = new DesignSection(page);
 
+            await mockUnsplashApi(page);
             await design.goto();
             await design.openDesignModal();
             await design.deleteCoverImage();


### PR DESCRIPTION
## Summary

- mocks the Unsplash API in the Design settings E2E so it does not depend on live Unsplash responses
- removes Unsplash from the E2E external egress allowlist and marks Playwright-fulfilled external mock responses so they do not count as real browser egress
- disables browser-side Sentry reporting in the E2E environment so local client_sentry config cannot trip the egress guard
- opts reset-password E2E into per-test isolation because the tests mutate the account owner password/session state

## Validation

- pnpm --dir e2e lint
- pnpm --dir e2e test:types
- pnpm --dir e2e test tests/admin/settings/design.test.ts
- pnpm --dir e2e test --workers=1 tests/admin/reset-password.test.ts tests/admin/settings/access.test.ts tests/admin/settings/announcement-bar.test.ts tests/admin/settings/danger-zone.test.ts tests/admin/settings/design.test.ts
