### PR TITLE
Fixed gift links E2E test failing on main under Vitest

### DIFF
--- a/ghost/core/test/e2e-api/admin/gift-links.test.ts
+++ b/ghost/core/test/e2e-api/admin/gift-links.test.ts
@@ -13,7 +13,7 @@ describe('Gift Links Admin API', function () {
     };
     let postId: string;
 
-    before(async function () {
+    beforeAll(async function () {
         agent = await agentProvider.getAdminAPIAgent();
         await fixtureManager.init('users', 'posts');
         await agent.loginAsOwner();


### PR DESCRIPTION
## Problem

Main's build is red. The gift links E2E API test was added using Mocha's `before` setup hook, but the e2e-api suite has since moved to the Vitest runner, where `before` is undefined. The test passed when the PR was raised; main migrated the runner before the branch merged, so the merged result fails both Lint (type error) and the Acceptance run (runtime error, no tests collected).

## Solution

Swap the Mocha `before` hook for Vitest's `beforeAll`, matching the migrated e2e-api convention. The suite passes 7/7 under Vitest, with tsc and lint clean.