### PR TITLE
💡 Added a link to manage paid subscriptions on the newsletter unsubscribe

### DIFF
--- a/apps/portal/src/components/common/newsletter-management.js
+++ b/apps/portal/src/components/common/newsletter-management.js
@@ -130,13 +130,25 @@ function NewsletterPrefs({subscribedNewsletters, setSubscribedNewsletters, hasNe
     });
 }
 
-function ShowPaidMemberMessage({site, isPaid}) {
-    if (isPaid) {
-        return (
-            <p style={{textAlign: 'center', marginTop: '12px', marginBottom: '0', color: 'var(--grey6)'}}>{t('Unsubscribing from emails will not cancel your paid subscription to {title}', {title: site?.title})}</p>
-        );
+function ShowPaidMemberMessage({site, isPaid, onManageSubscription}) {
+    if (!isPaid) {
+        return null;
     }
-    return null;
+
+    return (
+        <>
+            <p style={{textAlign: 'center', marginTop: '12px', marginBottom: '0', color: 'var(--grey6)'}}>{t('Unsubscribing from emails will not cancel your paid subscription to {title}', {title: site?.title})}</p>
+            <p style={{textAlign: 'center', marginTop: '4px', marginBottom: '0'}}>
+                <button
+                    className="gh-portal-btn-link gh-portal-btn-branded gh-portal-btn-inline"
+                    onClick={onManageSubscription}
+                    data-testid="manage-subscription"
+                >
+                    {t('Manage your paid subscription')}
+                </button>
+            </p>
+        </>
+    );
 }
 
 export default function NewsletterManagement({
@@ -225,7 +237,12 @@ export default function NewsletterManagement({
                     <ShowPaidMemberMessage
                         isPaid={isPaidMember}
                         site={site}
-                        subscribedNewsletters={subscribedNewsletters}
+                        onManageSubscription={() => {
+                            // Logged-in members go straight to their account to manage their
+                            // subscription; logged-out members (e.g. arriving from an email link)
+                            // are routed to sign in first, as account pages require authentication.
+                            doAction('switchPage', {page: member ? 'accountHome' : 'signin'});
+                        }}
                     />
                 </div>
                 {hasMemberGotEmailSuppression({member}) && !isDisabled &&

--- a/apps/portal/test/email-subscriptions-flow.test.js
+++ b/apps/portal/test/email-subscriptions-flow.test.js
@@ -23,7 +23,8 @@ const setup = async ({site, member = null, newsletters}, loggedOut = false) => {
 
     ghostApi.member.newsletters = vi.fn(() => {
         return Promise.resolve({
-            newsletters
+            newsletters,
+            status: member?.status
         });
     });
 
@@ -279,6 +280,66 @@ describe('Newsletter Subscriptions', () => {
             expect(ghostApi.member.newsletters).not.toHaveBeenCalled();
             // expect sign in page
             expect(within(popupIframeDocument).queryByText('Sign in')).toBeInTheDocument();
+        });
+
+        test('does not show a cancel subscription link for free members', async () => {
+            // Mock window.location
+            Object.defineProperty(window, 'location', {
+                value: new URL(`https://portal.localhost/?action=unsubscribe&uuid=${FixtureMember.subbedToNewsletter.uuid}&newsletter=${Newsletters[0].uuid}&key=hashedMemberUuid`),
+                writable: true
+            });
+
+            const {popupIframeDocument} = await setup({
+                site: FixtureSite.singleTier.onlyFreePlanWithoutStripe,
+                member: FixtureMember.subbedToNewsletter,
+                newsletters: Newsletters
+            }, true);
+
+            expect(within(popupIframeDocument).queryByTestId('manage-subscription')).not.toBeInTheDocument();
+        });
+
+        test('routes paid members to sign in to manage their subscription when logged out', async () => {
+            // Mock window.location
+            Object.defineProperty(window, 'location', {
+                value: new URL(`https://portal.localhost/?action=unsubscribe&uuid=${FixtureMember.paid.uuid}&newsletter=${Newsletters[0].uuid}&key=hashedMemberUuid`),
+                writable: true
+            });
+
+            const {popupIframeDocument} = await setup({
+                site: FixtureSite.singleTier.onlyFreePlanWithoutStripe,
+                member: FixtureMember.paid,
+                newsletters: Newsletters
+            }, true);
+
+            const manageButton = within(popupIframeDocument).queryByTestId('manage-subscription');
+            expect(manageButton).toBeInTheDocument();
+            expect(manageButton).toHaveTextContent('Manage your paid subscription');
+
+            // Logged-out members must authenticate before they can manage billing
+            await userEvent.click(manageButton);
+            expect(within(popupIframeDocument).queryByText('Sign in')).toBeInTheDocument();
+        });
+
+        test('routes paid members to their account to manage their subscription when logged in', async () => {
+            // Mock window.location
+            Object.defineProperty(window, 'location', {
+                value: new URL(`https://portal.localhost/?action=unsubscribe&uuid=${FixtureMember.paid.uuid}&newsletter=${Newsletters[0].uuid}&key=hashedMemberUuid`),
+                writable: true
+            });
+
+            const {popupIframeDocument} = await setup({
+                site: FixtureSite.singleTier.onlyFreePlanWithoutStripe,
+                member: FixtureMember.paid,
+                newsletters: Newsletters
+            });
+
+            const manageButton = within(popupIframeDocument).queryByTestId('manage-subscription');
+            expect(manageButton).toBeInTheDocument();
+            expect(manageButton).toHaveTextContent('Manage your paid subscription');
+
+            // Logged-in members are taken straight to their account to manage their subscription
+            await userEvent.click(manageButton);
+            expect(within(popupIframeDocument).queryByText('Your account')).toBeInTheDocument();
         });
     });
 });

--- a/ghost/i18n/locales/en/portal.json
+++ b/ghost/i18n/locales/en/portal.json
@@ -144,6 +144,7 @@
     "LinkedIn": "",
     "Make sure emails aren't accidentally ending up in the Spam or Promotions folders of your inbox. If they are, click on \"Mark as not spam\" and/or \"Move to inbox\".": "",
     "Manage": "",
+    "Manage your paid subscription": "",
     "Maybe later": "",
     "Membership details": "",
     "Memberships from this email domain are currently restricted.": "",


### PR DESCRIPTION
Refs #23445

On the newsletter unsubscribe page, paid members just see the greyed-out note that unsubscribing won't cancel their paid subscription. There's no link to actually do anything about it, so if someone wants to manage or cancel their subscription they're stuck.

This adds a "Manage your paid subscription" link under that note for paid members. If they're logged in it takes them to their account; if they're not (e.g. coming from an email link) it sends them to sign in first, since the account pages need auth. Free members don't see the link.

I used the "Manage your paid subscription" wording from cathysarisky's suggestion in the issue, and kept the existing note rather than turning it into a one-click cancel (per 9larsons' comment that it shouldn't be framed as making cancellation easier).

Added tests for the three cases (free = no link, paid logged-out = sign in, paid logged-in = account) and checked it manually on a local build.

- I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- I've explained my change
-  I've written an automated test to prove my change works

<img width="500" height="720" alt="pic-after-click-signin" src="https://github.com/user-attachments/assets/e43b1c3d-b089-4fca-96ca-19bc694ece6c" />

<img width="500" height="720" alt="pic-fixed-paid-member" src="https://github.com/user-attachments/assets/227fccc0-52a5-419a-a0f1-cb4e6547def1" />
