### PR TITLE
Fixed Featurebase widget and help-card visuals on Automations page

### DIFF
--- a/apps/admin-x-framework/src/hooks/use-featurebase.ts
+++ b/apps/admin-x-framework/src/hooks/use-featurebase.ts
@@ -59,6 +59,36 @@ const getTheme = (): 'light' | 'dark' => {
     return document.documentElement.classList.contains('dark') ? 'dark' : 'light';
 };
 
+// Featurebase's SDK silently drops a second `initialize_feedback_widget` call —
+// the callback never fires, leaving any deferred awaiting it stuck forever.
+// Multiple hook instances (sidebar + embedded apps) must therefore share a
+// single init promise.
+let sharedInitPromise: Promise<void> | null = null;
+
+function initFeaturebaseWidget(organization: string, theme: 'light' | 'dark', token: string): Promise<void> {
+    if (sharedInitPromise) {
+        return sharedInitPromise;
+    }
+    sharedInitPromise = loadFeaturebaseSDK().then(() => new Promise<void>((resolve, reject) => {
+        window.Featurebase?.('initialize_feedback_widget', {
+            organization,
+            theme,
+            featurebaseJwt: token
+        }, (err) => {
+            if (err) {
+                sharedInitPromise = null;
+                reject(err);
+            } else {
+                resolve();
+            }
+        });
+    }));
+    sharedInitPromise.catch(() => {
+        sharedInitPromise = null;
+    });
+    return sharedInitPromise;
+}
+
 /**
  * Lazy-loads the Featurebase SDK and opens the feedback widget.
  *
@@ -98,23 +128,16 @@ export function useFeaturebase(): Featurebase {
         if (!shouldLoad || !organization || !token) {
             return;
         }
-        void featurebaseSDKPromise?.then(() => {
-            window.Featurebase?.('initialize_feedback_widget', {
-                organization,
-                theme: getTheme(),
-                featurebaseJwt: token
-            }, (err) => {
-                if (err) {
-                    // eslint-disable-next-line no-console
-                    console.error('[Featurebase] Failed to initialize widget:', err);
-                    deferredInitRef.current.reject(err);
-                    deferredInitRef.current = deferred();
-                    setShouldLoad(false);
-                } else {
-                    deferredInitRef.current.resolve();
-                }
-            });
-        });
+        initFeaturebaseWidget(organization, getTheme(), token).then(
+            () => deferredInitRef.current.resolve(),
+            (err) => {
+                // eslint-disable-next-line no-console
+                console.error('[Featurebase] Failed to initialize widget:', err);
+                deferredInitRef.current.reject(err);
+                deferredInitRef.current = deferred();
+                setShouldLoad(false);
+            }
+        );
     }, [organization, token, shouldLoad]);
 
     const preloadFeedbackWidget = useCallback(() => {

--- a/apps/posts/src/views/Automations/components/automations-help-cards.tsx
+++ b/apps/posts/src/views/Automations/components/automations-help-cards.tsx
@@ -13,7 +13,7 @@ interface HelpCardLayoutProps {
     children?: React.ReactNode;
 }
 
-const cardClass = 'block rounded-xl border bg-card p-6 text-left transition-all hover:shadow-xs hover:bg-accent/50 group/card';
+const cardClass = 'block w-full rounded-xl border border-border bg-card p-6 text-left transition-all hover:shadow-xs hover:bg-accent/50 group/card';
 
 const HelpCardBody: React.FC<HelpCardLayoutProps> = ({title, description, children}) => (
     <div className='flex items-center gap-6'>
@@ -46,7 +46,7 @@ interface HelpButtonCardProps extends HelpCardLayoutProps {
 }
 
 const HelpButtonCard: React.FC<HelpButtonCardProps> = ({className, title, description, children, onClick, onMouseEnter, onFocus}) => (
-    <button className={cn(cardClass, 'w-full cursor-pointer', className)} type='button' onClick={onClick} onFocus={onFocus} onMouseEnter={onMouseEnter}>
+    <button className={cn(cardClass, 'cursor-pointer appearance-none', className)} type='button' onClick={onClick} onFocus={onFocus} onMouseEnter={onMouseEnter}>
         <HelpCardBody description={description} title={title}>
             {children}
         </HelpCardBody>


### PR DESCRIPTION
## Summary

Two follow-up fixes for the Automations public-beta polish ([NY-1372](https://linear.app/tryghost/issue/NY-1372/)):

1. **Featurebase widget didn't open from the Automations help card** if the user had already clicked the sidebar "Feedback" button in the same session (or vice versa) — the two click sites behaved mutually exclusive.
2. **The Featurebase help card had a darker border** than its anchor sibling because the `<button>` picked up the user-agent's `buttonborder` system color.

## 1. Featurebase widget mutual-exclusion

### Root cause

Featurebase's SDK silently drops a second `initialize_feedback_widget` call — no error, no callback. The sidebar and the Automations help card each mount `useFeaturebase()`, and each instance ran its own init effect. Whichever instance initialized first resolved its deferred; the other instance's deferred stayed pending forever, so its `openFeedbackWidget()` `.then()` that posts the open message never fired.

### Fix

Lifted the SDK init into a module-level `sharedInitPromise` inside `useFeaturebase`. Only one `initialize_feedback_widget` call is ever made; all hook instances chain their per-instance deferreds off the same shared resolution. Per-instance deferreds are kept so each click site still has its own ordering.

## 2. Card border mismatch

### Root cause

Tailwind's `border` utility only sets `border-width: 1px`. Shade's preflight doesn't set a global `border-color`, so the color falls back to whatever the user agent applies — `currentColor` for the `<a>`, but the darker `buttonborder` system color for the `<button>`.

### Fix

Pinned `border-border` (Shade's `--border` token) in the shared `cardClass` so both card variants use the same explicit color. Also moved `w-full` into `cardClass` and added `appearance-none` on the button as insurance against further UA drift.

## Test plan

### Featurebase widget
- [ ] Click "Feedback" in the sidebar → modal opens
- [ ] Without reloading, navigate to Automations → click "Share your feedback" → modal opens
- [ ] Reload, click "Share your feedback" first → modal opens
- [ ] Without reloading, click sidebar "Feedback" → modal opens
- [ ] Confirm widget still loads lazily — nothing fetches `/featurebase/token/` or `do.featurebase.app/js/sdk.js` until first preload/click

### Card visuals
- [ ] Automations page bottom cards: anchor card and Featurebase button card have visually identical borders
- [ ] Same on a contributor account or with Featurebase disabled (both cards render as anchors — should still look identical)