### PR TITLE
Cover the gift-link admin API for pages as well as posts

### DIFF
--- a/ghost/core/test/e2e-api/admin/gift-links.test.ts
+++ b/ghost/core/test/e2e-api/admin/gift-links.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable ghost/mocha/no-setup-in-describe -- describe.each is the parameterised-test seam; the mocha-era rule doesn't recognise Vitest's native .each and flags it like a manual loop. */
 import assert from 'node:assert/strict';
 
 const {agentProvider, fixtureManager, mockManager} = require('../../utils/e2e-framework');
@@ -12,12 +13,14 @@ describe('Gift Links Admin API', function () {
         loginAsContributor: () => Promise<void>;
     };
     let postId: string;
+    let pageId: string;
 
     beforeAll(async function () {
         agent = await agentProvider.getAdminAPIAgent();
         await fixtureManager.init('users', 'posts');
         await agent.loginAsOwner();
         postId = fixtureManager.get('posts', 0).id;
+        pageId = (await models.Base.knex('posts').where('type', 'page').first('id')).id;
     });
 
     beforeEach(function () {
@@ -30,76 +33,79 @@ describe('Gift Links Admin API', function () {
         await models.Base.knex('gift_links').del();
     });
 
-    it('GET returns an empty list when no link exists', async function () {
-        const {body} = await agent.get(`posts/${postId}/gift_link/`).expectStatus(200);
-        assert.deepEqual(body, {gift_links: []});
+    // The gift-link API is mounted for both posts and pages off the same controller; exercise
+    // both URL shapes so a missing route or a posts-only assumption can't pass unnoticed.
+    describe.each([
+        {name: 'posts', id: () => postId},
+        {name: 'pages', id: () => pageId}
+    ])('on $name', function ({name, id}: {name: string, id: () => string}) {
+        it('GET returns an empty list when no link exists', async function () {
+            const {body} = await agent.get(`${name}/${id()}/gift_link/`).expectStatus(200);
+            assert.deepEqual(body, {gift_links: []});
+        });
+
+        it('PUT issues the gift link as a token-shaped resource in a list', async function () {
+            const {body} = await agent.put(`${name}/${id()}/gift_link/`).expectStatus(200);
+
+            assert.deepEqual(Object.keys(body), ['gift_links']);
+            assert.equal(body.gift_links.length, 1);
+            // Allow-list — the response exposes only these fields.
+            assert.deepEqual(
+                Object.keys(body.gift_links[0]).sort(),
+                ['created_at', 'last_redeemed_at', 'redeemed_count', 'token']
+            );
+        });
+
+        it('POST reissues to a fresh token', async function () {
+            const first = (await agent.put(`${name}/${id()}/gift_link/`).expectStatus(200)).body.gift_links[0].token;
+            const {body} = await agent.post(`${name}/${id()}/gift_link/`).expectStatus(200);
+
+            assert.equal(body.gift_links.length, 1);
+            assert.notEqual(body.gift_links[0].token, first);
+        });
+
+        it('403s for a role without gift-link permission', async function () {
+            await agent.loginAsContributor();
+            await agent.get(`${name}/${id()}/gift_link/`).expectStatus(403);
+            await agent.loginAsOwner();
+        });
+
+        it('supports the full lifecycle', async function () {
+            // empty
+            let body = (await agent.get(`${name}/${id()}/gift_link/`).expectStatus(200)).body;
+            assert.deepEqual(body.gift_links, []);
+
+            // issue
+            body = (await agent.put(`${name}/${id()}/gift_link/`).expectStatus(200)).body;
+            const first = body.gift_links[0].token;
+            assert.ok(first);
+            assert.equal(body.gift_links[0].redeemed_count, 0);
+
+            // reissue
+            body = (await agent.post(`${name}/${id()}/gift_link/`).expectStatus(200)).body;
+            const second = body.gift_links[0].token;
+            assert.notEqual(second, first);
+            body = (await agent.get(`${name}/${id()}/gift_link/`).expectStatus(200)).body;
+            assert.equal(body.gift_links[0].token, second);
+
+            // revoke
+            body = (await agent.put('gift_links/revoke_all/').expectStatus(200)).body;
+            assert.deepEqual(body, {meta: {count: 1}});
+            body = (await agent.get(`${name}/${id()}/gift_link/`).expectStatus(200)).body;
+            assert.deepEqual(body.gift_links, []);
+        });
     });
 
-    it('PUT serialises the gift link as a token-shaped resource in a list', async function () {
-        const {body} = await agent.put(`posts/${postId}/gift_link/`).expectStatus(200);
-
-        assert.deepEqual(Object.keys(body), ['gift_links']);
-        assert.equal(body.gift_links.length, 1);
-        // Allow-list — the response exposes only these fields.
-        assert.deepEqual(
-            Object.keys(body.gift_links[0]).sort(),
-            ['created_at', 'last_redeemed_at', 'redeemed_count', 'token']
-        );
-    });
-
-    it('POST returns a single gift_link resource in the list', async function () {
-        const {body} = await agent.post(`posts/${postId}/gift_link/`).expectStatus(200);
-        assert.deepEqual(Object.keys(body), ['gift_links']);
-        assert.ok(body.gift_links[0].token);
-    });
-
-    it('revoke_all returns the count in a meta block, not as a resource', async function () {
-        await agent.put(`posts/${postId}/gift_link/`).expectStatus(200);
-        const {body} = await agent.put('gift_links/revoke_all/').expectStatus(200);
-        assert.deepEqual(body, {meta: {count: 1}});
-    });
-
-    it('403s for a role without gift-link permission', async function () {
-        await agent.loginAsContributor();
-        await agent.get(`posts/${postId}/gift_link/`).expectStatus(403);
-        await agent.loginAsOwner();
+    describe('revoke_all', function () {
+        it('returns the count in a meta block, not as a resource', async function () {
+            await agent.put(`posts/${postId}/gift_link/`).expectStatus(200);
+            const {body} = await agent.put('gift_links/revoke_all/').expectStatus(200);
+            assert.deepEqual(body, {meta: {count: 1}});
+        });
     });
 
     it('404s when the giftLinks flag is disabled', async function () {
         mockManager.mockLabsDisabled('giftLinks');
         await agent.get(`posts/${postId}/gift_link/`).expectStatus(404);
-    });
-
-    it('supports the full lifecycle through the API', async function () {
-        // empty
-        let body = (await agent.get(`posts/${postId}/gift_link/`).expectStatus(200)).body;
-        assert.deepEqual(body.gift_links, []);
-
-        // issue
-        body = (await agent.put(`posts/${postId}/gift_link/`).expectStatus(200)).body;
-        const first = body.gift_links[0].token;
-        assert.ok(first);
-        assert.equal(body.gift_links[0].redeemed_count, 0);
-        body = (await agent.get(`posts/${postId}/gift_link/`).expectStatus(200)).body;
-        assert.equal(body.gift_links[0].token, first);
-
-        // reissue
-        body = (await agent.post(`posts/${postId}/gift_link/`).expectStatus(200)).body;
-        const second = body.gift_links[0].token;
-        assert.notEqual(second, first);
-        body = (await agent.get(`posts/${postId}/gift_link/`).expectStatus(200)).body;
-        assert.equal(body.gift_links[0].token, second);
-
-        // revoke
-        body = (await agent.put('gift_links/revoke_all/').expectStatus(200)).body;
-        assert.deepEqual(body, {meta: {count: 1}});
-        body = (await agent.get(`posts/${postId}/gift_link/`).expectStatus(200)).body;
-        assert.deepEqual(body.gift_links, []);
-
-        // issue again
-        body = (await agent.put(`posts/${postId}/gift_link/`).expectStatus(200)).body;
-        const third = body.gift_links[0].token;
-        assert.ok(third && third !== first && third !== second);
-        assert.equal(body.gift_links[0].redeemed_count, 0);
     });
 });


### PR DESCRIPTION
## Problem

The gift-link admin API is mounted on both posts and pages off the same controller, but only the posts URL shape had test coverage. A broken or removed pages route, or a posts-only assumption creeping into the controller, could ship unnoticed.

## Solution

Parameterise the admin API tests over both resources, so the empty state, issuing, reissuing, the full lifecycle, and permission enforcement all run against both the posts and pages URL shapes. The page is resolved from the seeded fixtures by query rather than a brittle fixture index.

Verified: the full suite passes for both shapes, lint and typecheck clean.