### PR TITLE
Removed --force from mysql acceptance install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -510,9 +510,15 @@ jobs:
       - name: Install dependencies
         # sqlite3 is an optionalDependency. Without --force, pnpm may skip
         # installing/linking it when restoring from a cached store. --force
-        # ensures all optional deps are installed regardless.
+        # ensures all optional deps are installed regardless. The mysql leg
+        # doesn't need sqlite3, so it skips --force and gets a fast cache
+        # restore (matches the legacy-tests job below).
         run: |
-          pnpm install --frozen-lockfile --force
+          if [ "${{ matrix.env.DB }}" = "sqlite3" ]; then
+            pnpm install --frozen-lockfile --force
+          else
+            pnpm install --frozen-lockfile
+          fi
 
       - name: Set timezone (non-UTC)
         uses: szenius/set-timezone@1f9716b0f7120e344f0c62bb7b1ee98819aefd42 # v2.0


### PR DESCRIPTION
## Summary

- The acceptance-tests job was paying ~27s on every run for `pnpm install --frozen-lockfile --force`, regardless of DB
- `--force` is only needed on the sqlite leg because `sqlite3` is an `optionalDependency` that pnpm occasionally skips when restoring from cache; the mysql leg never installs it either way
- This mirrors the pattern already in use by `job_legacy-tests` immediately below, which conditions `--force` on the sqlite leg

Expected impact: the mysql acceptance-tests job drops from ~6:30 to ~6:00. The sqlite leg is unchanged.

## Test plan

- [ ] CI passes on this PR (both mysql and sqlite legs of `job_acceptance-tests`)
- [ ] Mysql leg install step duration drops from ~37s to ~10s (visible in the job log)