### PR TITLE
Added file-order shuffling to the DB test suites in CI

### DIFF
--- a/ghost/core/vitest.config.db.ts
+++ b/ghost/core/vitest.config.db.ts
@@ -45,6 +45,7 @@ const sharedDbConfig = {
     // threads share process.env, so the per-process DB derivation would collide.
     pool: 'forks' as const,
     isolate: false,
+    sequence: {shuffle: {files: !!process.env.CI}},
     setupFiles: ['./test/utils/vitest-setup-db.ts'],
     resolveSnapshotPath,
     // Keep the testing env (CI sets `testing-mysql` on the MySQL leg; default to


### PR DESCRIPTION
Follow-up to the e2e/e2e-api de-isolation (#28762) — this is the guard that keeps the shared-boot suites honest.

## What
Shuffle the file execution order of the DB-backed test suites (`vitest.config.db.ts`) when running in CI.

## Why
The `e2e` and `e2e-api` projects share one Ghost boot per fork (`isolate: false`) for speed. That only stays correct if every test is order-independent. A new cross-file leak would otherwise pass by lucky ordering in the fixed local order and only surface as a flake later under CI sharding.

Shuffling file order in CI turns that class of regression into an immediate, deterministic failure. Retry stays at vitest's default of `0`, so a flake fails the run rather than being silently retried.

Gated on `process.env.CI`, so no effect locally; and no effect on the `integration`/`legacy` projects, which run a fresh boot per file (`isolate: true`) and can't leak across files.

## Verified
- Shuffle is active: serial file order differs run-to-run.
- e2e 3/3 and e2e-api 2/2 green under the shuffle (sqlite); e2e-api also 13/13 across both engines while de-isolating it.