### PR TITLE
Tightened service-container healthcheck interval

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,21 +467,24 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
         ports:
           - 3306
+        # Poll the healthcheck every 2s instead of 10s — same max wait window
+        # (120s = 60 × 2s), but ready-state is discovered ~8s earlier on a
+        # typical boot. Same change on the redis service below.
         options: >-
           --tmpfs /var/lib/mysql
           --health-cmd "mysqladmin ping -h 127.0.0.1 -uroot -proot"
-          --health-interval=10s
+          --health-interval=2s
           --health-timeout=5s
-          --health-retries=12
+          --health-retries=60
       redis:
         image: redis:7.0@sha256:352c1fdadc91926edda08f45aeb3f27f37194c2f14101229c0523a11195c96e3
         ports:
           - 6379:6379
         options: >-
           --health-cmd "redis-cli ping"
-          --health-interval=10s
+          --health-interval=2s
           --health-timeout=5s
-          --health-retries=12
+          --health-retries=60
     strategy:
       matrix:
         node: ${{ fromJSON(needs.job_setup.outputs.node_test_matrix) }}


### PR DESCRIPTION
## Summary

- The acceptance-tests job's `Waiting for all services to be ready` step takes ~12s on every run because the mysql and redis service containers have `health-interval=10s`
- With the first health check firing 10s after container start and the container typically being ready in <2s, most of that window is wasted poll-wait
- Drops the interval to 2s on both services and raises retries to 60 to keep the same 120s max wait window

Expected impact: ~6-8s saved per leg (both DBs). Same change benefits both legs since sqlite leg waits on redis and mysql leg waits on both.

## Test plan

- [ ] CI passes on this PR (both mysql and sqlite legs of `job_acceptance-tests`)
- [ ] `Waiting for all services to be ready` step duration drops from ~12s to ~4s (visible in the job log)