### PR TITLE
Changed apps/admin-toolbar to ESLint 9 / flat config

### DIFF
--- a/apps/admin-toolbar/eslint.config.js
+++ b/apps/admin-toolbar/eslint.config.js
@@ -1,0 +1,71 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import ghostPlugin from 'eslint-plugin-ghost';
+
+export default [
+    {
+        ignores: ['umd/**/*.js']
+    },
+    {
+        files: ['src/**/*.js'],
+        ...js.configs.recommended,
+        languageOptions: {
+            ecmaVersion: 2022,
+            sourceType: 'module',
+            globals: {
+                ...globals.browser,
+                ...globals.jquery
+            }
+        },
+        plugins: {
+            ghost: ghostPlugin
+        },
+        rules: {
+            curly: 'error',
+            camelcase: ['error', {properties: 'never'}],
+            'dot-notation': 'error',
+            eqeqeq: ['error', 'always'],
+            'no-plusplus': ['error', {allowForLoopAfterthoughts: true}],
+            'no-eval': 'error',
+            'no-useless-call': 'error',
+            'no-console': 'error',
+            'no-shadow': 'error',
+            'array-callback-return': 'error',
+            'no-constructor-return': 'error',
+            'no-promise-executor-return': 'error',
+            'ghost/filenames/match-regex': ['error', '^[a-z0-9.-]+$', false]
+        }
+    },
+    {
+        files: ['test/**/*.js'],
+        ...js.configs.recommended,
+        languageOptions: {
+            ecmaVersion: 2022,
+            sourceType: 'module',
+            globals: {
+                ...globals.node,
+                afterEach: 'readonly',
+                describe: 'readonly',
+                it: 'readonly'
+            }
+        },
+        plugins: {
+            ghost: ghostPlugin
+        },
+        rules: {
+            curly: 'error',
+            camelcase: ['error', {properties: 'never'}],
+            'dot-notation': 'error',
+            eqeqeq: ['error', 'always'],
+            'no-plusplus': ['error', {allowForLoopAfterthoughts: true}],
+            'no-eval': 'error',
+            'no-useless-call': 'error',
+            'no-console': 'error',
+            'no-shadow': 'error',
+            'array-callback-return': 'error',
+            'no-constructor-return': 'error',
+            'no-promise-executor-return': 'error',
+            'ghost/filenames/match-regex': ['error', '^[a-z0-9.-]+$', false]
+        }
+    }
+];

--- a/apps/admin-toolbar/package.json
+++ b/apps/admin-toolbar/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tryghost/admin-toolbar",
-  "version": "0.1.2",
+  "type": "module",
+  "version": "0.1.3",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",
@@ -20,7 +21,7 @@
     "build": "pnpm exec vite build",
     "build:watch": "pnpm exec vite build --watch",
     "dev": "concurrently --kill-others --names preview,build \"pnpm exec vite preview -l silent\" \"pnpm build:watch\"",
-    "lint": "pnpm exec eslint src --ext .js --cache",
+    "lint": "pnpm exec eslint src test --cache",
     "test": "pnpm test:unit",
     "test:unit": "pnpm run build && pnpm exec vitest run",
     "preship": "pnpm lint",
@@ -28,53 +29,13 @@
     "prepublishOnly": "pnpm build"
   },
   "devDependencies": {
+    "@eslint/js": "catalog:eslint9",
     "concurrently": "catalog:",
-    "eslint": "catalog:",
+    "eslint": "catalog:eslint9",
+    "eslint-plugin-ghost": "3.5.0",
+    "globals": "17.6.0",
     "jsdom": "catalog:",
     "vite": "catalog:",
     "vitest": "catalog:"
-  },
-  "eslintConfig": {
-    "ignorePatterns": [
-      "umd/**/*.js"
-    ],
-    "env": {
-      "browser": true
-    },
-    "parserOptions": {
-      "sourceType": "module",
-      "ecmaVersion": 2022
-    },
-    "extends": [
-      "plugin:ghost/browser"
-    ],
-    "plugins": [
-      "ghost"
-    ],
-    "overrides": [
-      {
-        "files": [
-          "test/**/*.js"
-        ],
-        "env": {
-          "node": true
-        },
-        "globals": {
-          "afterEach": "readonly",
-          "describe": "readonly",
-          "it": "readonly"
-        },
-        "parserOptions": {
-          "sourceType": "script"
-        }
-      }
-    ],
-    "rules": {
-      "ghost/filenames/match-regex": [
-        "error",
-        "^[a-z0-9.-]+$",
-        false
-      ]
-    }
   }
 }

--- a/apps/admin-toolbar/test/admin-toolbar.test.js
+++ b/apps/admin-toolbar/test/admin-toolbar.test.js
@@ -1,10 +1,10 @@
-const assert = require('node:assert/strict');
-const fs = require('node:fs');
-const path = require('path');
-const {JSDOM} = require('jsdom');
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import {JSDOM} from 'jsdom';
 
 const BUNDLE_PATH = path.join(
-    __dirname,
+    import.meta.dirname,
     '../umd/admin-toolbar.min.js'
 );
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -634,12 +634,21 @@ importers:
         specifier: 'catalog:'
         version: 10.29.2
     devDependencies:
+      '@eslint/js':
+        specifier: catalog:eslint9
+        version: 9.39.4
       concurrently:
         specifier: 'catalog:'
         version: 10.0.3
       eslint:
-        specifier: 'catalog:'
-        version: 8.57.1
+        specifier: catalog:eslint9
+        version: 9.39.4(jiti@2.7.0)
+      eslint-plugin-ghost:
+        specifier: 3.5.0
+        version: 3.5.0(@babel/core@7.29.7)(eslint@9.39.4(jiti@2.7.0))
+      globals:
+        specifier: 17.6.0
+        version: 17.6.0
       jsdom:
         specifier: 'catalog:'
         version: 29.1.1(@noble/hashes@1.8.0)
@@ -1919,7 +1928,7 @@ importers:
         version: 2.10.4(eslint@8.57.1)
       express:
         specifier: 4.22.2
-        version: 4.22.2(supports-color@1.2.0)
+        version: 4.22.2
       knex:
         specifier: 3.1.0
         version: 3.1.0(mysql2@3.22.5(@types/node@25.9.1))
@@ -2085,7 +2094,7 @@ importers:
         version: 3.0.1
       ember-cli:
         specifier: 3.24.0
-        version: 3.24.0(encoding@0.1.13)(handlebars@4.7.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@1.2.0)(underscore@1.13.8)
+        version: 3.24.0(encoding@0.1.13)(handlebars@4.7.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(underscore@1.13.8)
       ember-cli-app-version:
         specifier: 5.0.0
         version: 5.0.0
@@ -2100,7 +2109,7 @@ importers:
         version: 1.0.3
       ember-cli-dependency-checker:
         specifier: 3.3.2
-        version: 3.3.2(ember-cli@3.24.0(encoding@0.1.13)(handlebars@4.7.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@1.2.0)(underscore@1.13.8))
+        version: 3.3.2(ember-cli@3.24.0(encoding@0.1.13)(handlebars@4.7.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(underscore@1.13.8))
       ember-cli-deprecation-workflow:
         specifier: 2.2.0
         version: 2.2.0
@@ -2133,7 +2142,7 @@ importers:
         version: 3.1.0
       ember-composable-helpers:
         specifier: 5.0.0
-        version: 5.0.0(supports-color@1.2.0)
+        version: 5.0.0
       ember-concurrency:
         specifier: 2.3.7
         version: 2.3.7(@babel/core@7.29.7)
@@ -2454,7 +2463,7 @@ importers:
         version: 3.2.3
       '@tryghost/prometheus-metrics':
         specifier: 1.0.8
-        version: 1.0.8(supports-color@1.2.0)
+        version: 1.0.8
       '@tryghost/promise':
         specifier: 2.2.3
         version: 2.2.3
@@ -2568,7 +2577,7 @@ importers:
         version: 4.5.0
       express:
         specifier: 4.22.2
-        version: 4.22.2(supports-color@1.2.0)
+        version: 4.22.2
       express-brute:
         specifier: 1.0.1
         version: 1.0.1(express@4.22.2)
@@ -2586,10 +2595,10 @@ importers:
         version: 2.0.0
       express-queue:
         specifier: 0.0.13
-        version: 0.0.13(supports-color@1.2.0)
+        version: 0.0.13
       express-session:
         specifier: 1.19.0
-        version: 1.19.0(supports-color@1.2.0)
+        version: 1.19.0
       file-type:
         specifier: 21.3.4
         version: 21.3.4
@@ -2754,7 +2763,7 @@ importers:
         version: 0.9.1
       probe-image-size:
         specifier: 7.3.0
-        version: 7.3.0(supports-color@1.2.0)
+        version: 7.3.0
       rss:
         specifier: 1.2.2
         version: 1.2.2
@@ -14881,10 +14890,6 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  hasown@2.0.3:
-    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
-    engines: {node: '>= 0.4'}
-
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
@@ -22591,6 +22596,14 @@ snapshots:
       eslint-visitor-keys: 2.1.0
       semver: 6.3.1
 
+  '@babel/eslint-parser@7.28.6(@babel/core@7.29.7)(eslint@9.39.4(jiti@2.7.0))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
+      eslint: 9.39.4(jiti@2.7.0)
+      eslint-visitor-keys: 2.1.0
+      semver: 6.3.1
+
   '@babel/generator@7.29.7':
     dependencies:
       '@babel/parser': 7.29.7
@@ -28755,7 +28768,7 @@ snapshots:
     dependencies:
       '@tryghost/jest-snapshot': 2.1.0
       cookiejar: 2.1.4
-      express: 4.22.2(supports-color@1.2.0)
+      express: 4.22.2
       form-data: 4.0.5
       mime-types: 3.0.2
     transitivePeerDependencies:
@@ -29143,10 +29156,10 @@ snapshots:
       lodash: 4.18.1
       prettyjson: 1.2.5
 
-  '@tryghost/prometheus-metrics@1.0.8(supports-color@1.2.0)':
+  '@tryghost/prometheus-metrics@1.0.8':
     dependencies:
       '@tryghost/logging': 4.2.1
-      express: 4.22.1(supports-color@1.2.0)
+      express: 4.22.1
       prom-client: 15.1.3
       stoppable: 1.1.0
     transitivePeerDependencies:
@@ -29846,6 +29859,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@8.49.0(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.56.1(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.49.0
+      '@typescript-eslint/type-utils': 8.49.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.49.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.49.0
+      eslint: 9.39.4(jiti@2.7.0)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -29898,6 +29927,18 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.56.1
       debug: 4.4.3(supports-color@5.5.0)
       eslint: 8.57.1
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.56.1
+      '@typescript-eslint/types': 8.56.1
+      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.56.1
+      debug: 4.4.3(supports-color@5.5.0)
+      eslint: 9.39.4(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -30010,6 +30051,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/type-utils@8.49.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.49.0
+      '@typescript-eslint/typescript-estree': 8.49.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.49.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      debug: 4.4.3(supports-color@5.5.0)
+      eslint: 9.39.4(jiti@2.7.0)
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/type-utils@8.58.0(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.58.0
@@ -30109,6 +30162,17 @@ snapshots:
       '@typescript-eslint/types': 8.49.0
       '@typescript-eslint/typescript-estree': 8.49.0(typescript@5.9.3)
       eslint: 8.57.1
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.49.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
+      '@typescript-eslint/scope-manager': 8.49.0
+      '@typescript-eslint/types': 8.49.0
+      '@typescript-eslint/typescript-estree': 8.49.0(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -32025,7 +32089,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  broccoli-config-replace@1.1.3(supports-color@1.2.0):
+  broccoli-config-replace@1.1.3:
     dependencies:
       broccoli-plugin: 1.3.1
       debug: 2.6.9(supports-color@1.2.0)
@@ -32089,7 +32153,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  broccoli-funnel@2.0.1(supports-color@1.2.0):
+  broccoli-funnel@2.0.1:
     dependencies:
       array-equal: 1.0.2
       blank-object: 1.0.2
@@ -32419,7 +32483,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  broccoli@3.5.2(supports-color@1.2.0):
+  broccoli@3.5.2:
     dependencies:
       '@types/chai': 4.3.20
       '@types/chai-as-promised': 7.1.8
@@ -32429,7 +32493,7 @@ snapshots:
       broccoli-slow-trees: 3.1.0
       broccoli-source: 3.0.1
       commander: 4.1.1
-      connect: 3.7.0(supports-color@1.2.0)
+      connect: 3.7.0
       console-ui: 3.1.2
       esm: 3.2.25
       findup-sync: 4.0.0
@@ -33297,10 +33361,10 @@ snapshots:
 
   connect-slashes@1.4.0: {}
 
-  connect@3.7.0(supports-color@1.2.0):
+  connect@3.7.0:
     dependencies:
       debug: 2.6.9(supports-color@1.2.0)
-      finalhandler: 1.1.2(supports-color@1.2.0)
+      finalhandler: 1.1.2
       parseurl: 1.3.3
       utils-merge: 1.0.1
     transitivePeerDependencies:
@@ -34607,10 +34671,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-dependency-checker@3.3.2(ember-cli@3.24.0(encoding@0.1.13)(handlebars@4.7.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@1.2.0)(underscore@1.13.8)):
+  ember-cli-dependency-checker@3.3.2(ember-cli@3.24.0(encoding@0.1.13)(handlebars@4.7.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(underscore@1.13.8)):
     dependencies:
       chalk: 2.4.2
-      ember-cli: 3.24.0(encoding@0.1.13)(handlebars@4.7.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@1.2.0)(underscore@1.13.8)
+      ember-cli: 3.24.0(encoding@0.1.13)(handlebars@4.7.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(underscore@1.13.8)
       find-yarn-workspace-root: 1.2.1
       is-git-url: 1.0.0
       resolve: 1.22.12
@@ -34943,7 +35007,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli@3.24.0(encoding@0.1.13)(handlebars@4.7.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@1.2.0)(underscore@1.13.8):
+  ember-cli@3.24.0(encoding@0.1.13)(handlebars@4.7.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(underscore@1.13.8):
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-modules-amd': 7.29.7(@babel/core@7.29.7)
@@ -34951,13 +35015,13 @@ snapshots:
       babel-plugin-module-resolver: 4.1.0
       bower-config: 1.4.3
       bower-endpoint-parser: 0.2.2
-      broccoli: 3.5.2(supports-color@1.2.0)
+      broccoli: 3.5.2
       broccoli-amd-funnel: 2.0.1
       broccoli-babel-transpiler: 7.8.1
       broccoli-builder: 0.18.14
       broccoli-concat: 4.2.7
       broccoli-config-loader: 1.0.1
-      broccoli-config-replace: 1.1.3(supports-color@1.2.0)
+      broccoli-config-replace: 1.1.3
       broccoli-debug: 0.6.5
       broccoli-funnel: 2.0.2
       broccoli-funnel-reducer: 1.0.0
@@ -34986,7 +35050,7 @@ snapshots:
       ensure-posix-path: 1.1.1
       execa: 4.1.0
       exit: 0.1.2
-      express: 4.22.2(supports-color@1.2.0)
+      express: 4.22.2
       filesize: 6.4.0
       find-up: 5.0.0
       find-yarn-workspace-root: 2.0.0
@@ -35007,12 +35071,12 @@ snapshots:
       isbinaryfile: 4.0.10
       js-yaml: 3.14.2
       json-stable-stringify: 1.3.0
-      leek: 0.0.24(supports-color@1.2.0)
+      leek: 0.0.24
       lodash.template: 4.5.0
       markdown-it: 12.3.2
       markdown-it-terminal: 0.2.1
       minimatch: 3.1.5
-      morgan: 1.10.1(supports-color@1.2.0)
+      morgan: 1.10.1
       nopt: 3.0.6
       npm-package-arg: 8.1.5
       p-defer: 3.0.0
@@ -35099,10 +35163,10 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-composable-helpers@5.0.0(supports-color@1.2.0):
+  ember-composable-helpers@5.0.0:
     dependencies:
       '@babel/core': 7.29.7
-      broccoli-funnel: 2.0.1(supports-color@1.2.0)
+      broccoli-funnel: 2.0.1
       ember-cli-babel: 7.26.11
       resolve: 1.22.12
     transitivePeerDependencies:
@@ -35233,6 +35297,23 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7
       '@babel/eslint-parser': 7.28.6(@babel/core@7.29.7)(eslint@8.57.1)
+      '@glimmer/syntax': 0.95.0
+      '@typescript-eslint/tsconfig-utils': 8.60.0(typescript@5.9.3)
+      content-tag: 2.0.3
+      eslint-scope: 7.2.2
+      html-tags: 3.3.1
+      mathml-tag-names: 2.1.3
+      svg-tags: 1.0.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.56.1(eslint@8.57.1)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - eslint
+      - typescript
+
+  ember-eslint-parser@0.5.13(@babel/core@7.29.7)(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/eslint-parser': 7.28.6(@babel/core@7.29.7)(eslint@9.39.4(jiti@2.7.0))
       '@glimmer/syntax': 0.95.0
       '@typescript-eslint/tsconfig-utils': 8.60.0(typescript@5.9.3)
       content-tag: 2.0.3
@@ -35872,7 +35953,7 @@ snapshots:
       has-property-descriptors: 1.0.2
       has-proto: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       internal-slot: 1.1.0
       is-array-buffer: 3.0.5
       is-callable: 1.2.7
@@ -35957,11 +36038,11 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.3
+      hasown: 2.0.4
 
   es-shim-unscopables@1.1.0:
     dependencies:
-      hasown: 2.0.3
+      hasown: 2.0.4
 
   es-to-primitive@1.3.0:
     dependencies:
@@ -36087,6 +36168,11 @@ snapshots:
       eslint: 8.57.1
       semver: 7.8.4
 
+  eslint-compat-utils@0.5.1(eslint@9.39.4(jiti@2.7.0)):
+    dependencies:
+      eslint: 9.39.4(jiti@2.7.0)
+      semver: 7.8.4
+
   eslint-formatter-kakoune@1.0.0: {}
 
   eslint-plugin-babel@5.3.1(eslint@8.57.1):
@@ -36113,6 +36199,25 @@ snapshots:
       - '@babel/core'
       - typescript
 
+  eslint-plugin-ember@12.7.5(@babel/core@7.29.7)(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
+    dependencies:
+      '@ember-data/rfc395-data': 0.0.4
+      css-tree: 3.2.1
+      ember-eslint-parser: 0.5.13(@babel/core@7.29.7)(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      ember-rfc176-data: 0.3.18
+      eslint: 9.39.4(jiti@2.7.0)
+      eslint-utils: 3.0.0(eslint@9.39.4(jiti@2.7.0))
+      estraverse: 5.3.0
+      lodash.camelcase: 4.3.0
+      lodash.kebabcase: 4.1.1
+      requireindex: 1.2.0
+      snake-case: 3.0.4
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.56.1(eslint@8.57.1)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - typescript
+
   eslint-plugin-es-x@7.8.0(eslint@8.57.1):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
@@ -36120,9 +36225,24 @@ snapshots:
       eslint: 8.57.1
       eslint-compat-utils: 0.5.1(eslint@8.57.1)
 
+  eslint-plugin-es-x@7.8.0(eslint@9.39.4(jiti@2.7.0)):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
+      '@eslint-community/regexpp': 4.12.2
+      eslint: 9.39.4(jiti@2.7.0)
+      eslint-compat-utils: 0.5.1(eslint@9.39.4(jiti@2.7.0))
+
   eslint-plugin-filenames-ts@1.3.2(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
+      lodash.camelcase: 4.3.0
+      lodash.kebabcase: 4.1.1
+      lodash.snakecase: 4.1.1
+      lodash.upperfirst: 4.3.1
+
+  eslint-plugin-filenames-ts@1.3.2(eslint@9.39.4(jiti@2.7.0)):
+    dependencies:
+      eslint: 9.39.4(jiti@2.7.0)
       lodash.camelcase: 4.3.0
       lodash.kebabcase: 4.1.1
       lodash.snakecase: 4.1.1
@@ -36145,6 +36265,23 @@ snapshots:
       - '@babel/core'
       - supports-color
 
+  eslint-plugin-ghost@3.5.0(@babel/core@7.29.7)(eslint@9.39.4(jiti@2.7.0)):
+    dependencies:
+      '@kapouer/eslint-plugin-no-return-in-loop': 1.0.0
+      '@typescript-eslint/eslint-plugin': 8.49.0(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.56.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)
+      eslint-plugin-ember: 12.7.5(@babel/core@7.29.7)(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      eslint-plugin-filenames-ts: 1.3.2(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-mocha: 7.0.1(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-n: 17.24.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      eslint-plugin-sort-imports-es6-autofix: 0.6.0(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-unicorn: 42.0.0(eslint@9.39.4(jiti@2.7.0))
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
   eslint-plugin-i18next@6.1.4:
     dependencies:
       lodash: 4.18.1
@@ -36156,12 +36293,33 @@ snapshots:
       eslint-utils: 2.1.0
       ramda: 0.27.2
 
+  eslint-plugin-mocha@7.0.1(eslint@9.39.4(jiti@2.7.0)):
+    dependencies:
+      eslint: 9.39.4(jiti@2.7.0)
+      eslint-utils: 2.1.0
+      ramda: 0.27.2
+
   eslint-plugin-n@17.24.0(eslint@8.57.1)(typescript@5.9.3):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
       enhanced-resolve: 5.22.0
       eslint: 8.57.1
       eslint-plugin-es-x: 7.8.0(eslint@8.57.1)
+      get-tsconfig: 4.14.0
+      globals: 15.15.0
+      globrex: 0.1.2
+      ignore: 5.3.2
+      semver: 7.8.4
+      ts-declaration-location: 1.0.7(typescript@5.9.3)
+    transitivePeerDependencies:
+      - typescript
+
+  eslint-plugin-n@17.24.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
+      enhanced-resolve: 5.22.0
+      eslint: 9.39.4(jiti@2.7.0)
+      eslint-plugin-es-x: 7.8.0(eslint@9.39.4(jiti@2.7.0))
       get-tsconfig: 4.14.0
       globals: 15.15.0
       globrex: 0.1.2
@@ -36204,7 +36362,7 @@ snapshots:
       es-iterator-helpers: 1.3.2
       eslint: 8.57.1
       estraverse: 5.3.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       jsx-ast-utils: 3.3.5
       minimatch: 3.1.5
       object.entries: 1.1.9
@@ -36219,6 +36377,10 @@ snapshots:
   eslint-plugin-sort-imports-es6-autofix@0.6.0(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
+
+  eslint-plugin-sort-imports-es6-autofix@0.6.0(eslint@9.39.4(jiti@2.7.0)):
+    dependencies:
+      eslint: 9.39.4(jiti@2.7.0)
 
   eslint-plugin-storybook@10.4.4(eslint@8.57.1)(storybook@10.4.4(@testing-library/dom@9.3.4)(@types/react@18.3.31)(prettier@3.8.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3):
     dependencies:
@@ -36263,6 +36425,24 @@ snapshots:
       semver: 7.8.4
       strip-indent: 3.0.0
 
+  eslint-plugin-unicorn@42.0.0(eslint@9.39.4(jiti@2.7.0)):
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      ci-info: 3.9.0
+      clean-regexp: 1.0.0
+      eslint: 9.39.4(jiti@2.7.0)
+      eslint-utils: 3.0.0(eslint@9.39.4(jiti@2.7.0))
+      esquery: 1.7.0
+      indent-string: 4.0.0
+      is-builtin-module: 3.2.1
+      lodash: 4.18.1
+      pluralize: 8.0.0
+      read-pkg-up: 7.0.1
+      regexp-tree: 0.1.27
+      safe-regex: 2.1.1
+      semver: 7.8.4
+      strip-indent: 3.0.0
+
   eslint-rule-composer@0.3.0: {}
 
   eslint-scope@4.0.3:
@@ -36292,6 +36472,11 @@ snapshots:
   eslint-utils@3.0.0(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
+      eslint-visitor-keys: 2.1.0
+
+  eslint-utils@3.0.0(eslint@9.39.4(jiti@2.7.0)):
+    dependencies:
+      eslint: 9.39.4(jiti@2.7.0)
       eslint-visitor-keys: 2.1.0
 
   eslint-visitor-keys@1.3.0: {}
@@ -36563,11 +36748,11 @@ snapshots:
 
   express-brute@1.0.1(express@4.22.2):
     dependencies:
-      express: 4.22.2(supports-color@1.2.0)
+      express: 4.22.2
       long-timeout: 0.1.1
       underscore: 1.13.8
 
-  express-end@0.0.8(supports-color@1.2.0):
+  express-end@0.0.8:
     dependencies:
       debug: 2.6.9(supports-color@1.2.0)
     transitivePeerDependencies:
@@ -36595,19 +36780,19 @@ snapshots:
 
   express-lazy-router@1.0.6(express@4.22.2):
     dependencies:
-      express: 4.22.2(supports-color@1.2.0)
+      express: 4.22.2
 
   express-query-boolean@2.0.0: {}
 
-  express-queue@0.0.13(supports-color@1.2.0):
+  express-queue@0.0.13:
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
-      express-end: 0.0.8(supports-color@1.2.0)
+      express-end: 0.0.8
       mini-queue: 0.0.14
     transitivePeerDependencies:
       - supports-color
 
-  express-session@1.19.0(supports-color@1.2.0):
+  express-session@1.19.0:
     dependencies:
       cookie: 0.7.2
       cookie-signature: 1.0.7
@@ -36622,7 +36807,7 @@ snapshots:
 
   express-unless@2.1.3: {}
 
-  express@4.22.1(supports-color@1.2.0):
+  express@4.22.1:
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
@@ -36636,7 +36821,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 1.3.2(supports-color@1.2.0)
+      finalhandler: 1.3.2
       fresh: 0.5.2
       http-errors: 2.0.1
       merge-descriptors: 1.0.3
@@ -36648,7 +36833,7 @@ snapshots:
       qs: 6.15.2
       range-parser: 1.2.1
       safe-buffer: 5.2.1
-      send: 0.19.2(supports-color@1.2.0)
+      send: 0.19.2
       serve-static: 1.16.3
       setprototypeof: 1.2.0
       statuses: 2.0.2
@@ -36658,7 +36843,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  express@4.22.2(supports-color@1.2.0):
+  express@4.22.2:
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
@@ -36672,7 +36857,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 1.3.2(supports-color@1.2.0)
+      finalhandler: 1.3.2
       fresh: 0.5.2
       http-errors: 2.0.1
       merge-descriptors: 1.0.3
@@ -36684,7 +36869,7 @@ snapshots:
       qs: 6.15.2
       range-parser: 1.2.1
       safe-buffer: 5.2.1
-      send: 0.19.2(supports-color@1.2.0)
+      send: 0.19.2
       serve-static: 1.16.3
       setprototypeof: 1.2.0
       statuses: 2.0.2
@@ -36907,7 +37092,7 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@1.1.2(supports-color@1.2.0):
+  finalhandler@1.1.2:
     dependencies:
       debug: 2.6.9(supports-color@1.2.0)
       encodeurl: 1.0.2
@@ -36919,7 +37104,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  finalhandler@1.3.2(supports-color@1.2.0):
+  finalhandler@1.3.2:
     dependencies:
       debug: 2.6.9(supports-color@1.2.0)
       encodeurl: 2.0.0
@@ -37121,7 +37306,7 @@ snapshots:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       mime-types: 2.1.35
       safe-buffer: 5.2.1
 
@@ -37130,7 +37315,7 @@ snapshots:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   form-data@4.0.5:
@@ -37138,7 +37323,7 @@ snapshots:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   form-data@4.0.6:
@@ -37319,7 +37504,7 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       functions-have-names: 1.2.3
-      hasown: 2.0.3
+      hasown: 2.0.4
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
@@ -37379,7 +37564,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-nonce@1.0.1: {}
@@ -37768,10 +37953,6 @@ snapshots:
       minimalistic-assert: 1.0.1
 
   hasown@2.0.2:
-    dependencies:
-      function-bind: 1.1.2
-
-  hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
 
@@ -38246,7 +38427,7 @@ snapshots:
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       side-channel: 1.1.0
 
   internmap@2.0.3: {}
@@ -38371,7 +38552,7 @@ snapshots:
 
   is-core-module@2.16.2:
     dependencies:
-      hasown: 2.0.3
+      hasown: 2.0.4
 
   is-data-view@1.0.2:
     dependencies:
@@ -38500,7 +38681,7 @@ snapshots:
       call-bound: 1.0.4
       gopd: 1.2.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.3
+      hasown: 2.0.4
 
   is-relative-url@3.0.0:
     dependencies:
@@ -39676,7 +39857,7 @@ snapshots:
       ee-log: 3.0.9
       ee-types: 2.2.1
 
-  leek@0.0.24(supports-color@1.2.0):
+  leek@0.0.24:
     dependencies:
       debug: 2.6.9(supports-color@1.2.0)
       lodash.assign: 3.2.0
@@ -40989,7 +41170,7 @@ snapshots:
 
   moo@0.5.3: {}
 
-  morgan@1.10.1(supports-color@1.2.0):
+  morgan@1.10.1:
     dependencies:
       basic-auth: 2.0.1
       debug: 2.6.9(supports-color@1.2.0)
@@ -43014,11 +43195,11 @@ snapshots:
     dependencies:
       crypto: 0.0.3
 
-  probe-image-size@7.3.0(supports-color@1.2.0):
+  probe-image-size@7.3.0:
     dependencies:
       lodash.merge: 4.6.2
       needle: 2.9.1
-      stream-parser: 0.3.1(supports-color@1.2.0)
+      stream-parser: 0.3.1
     transitivePeerDependencies:
       - supports-color
 
@@ -44248,7 +44429,7 @@ snapshots:
 
   semver@7.8.4: {}
 
-  send@0.19.2(supports-color@1.2.0):
+  send@0.19.2:
     dependencies:
       debug: 2.6.9(supports-color@1.2.0)
       depd: 2.0.0
@@ -44285,7 +44466,7 @@ snapshots:
   sentry-testkit@6.4.1:
     dependencies:
       body-parser: 1.20.5
-      express: 4.22.2(supports-color@1.2.0)
+      express: 4.22.2
     transitivePeerDependencies:
       - supports-color
 
@@ -44300,7 +44481,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 0.19.2(supports-color@1.2.0)
+      send: 0.19.2
     transitivePeerDependencies:
       - supports-color
 
@@ -44827,7 +45008,7 @@ snapshots:
       to-arraybuffer: 1.0.1
       xtend: 4.0.2
 
-  stream-parser@0.3.1(supports-color@1.2.0):
+  stream-parser@0.3.1:
     dependencies:
       debug: 2.6.9(supports-color@1.2.0)
     transitivePeerDependencies:
@@ -45405,7 +45586,7 @@ snapshots:
       compression: 1.8.1
       consolidate: 1.0.4(@babel/core@7.29.7)(handlebars@4.7.9)(lodash@4.18.1)(mustache@4.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(underscore@1.13.8)
       execa: 9.6.1
-      express: 4.22.2(supports-color@1.2.0)
+      express: 4.22.2
       fireworm: 0.7.2
       glob: 13.0.6
       http-proxy: 1.18.1


### PR DESCRIPTION
## Summary

- Replaced the inline `eslintConfig` in `apps/admin-toolbar/package.json` with a flat `eslint.config.js`.
- Swapped `eslint: catalog:` to `catalog:eslint9` and added `@eslint/js`, `globals`, and `eslint-plugin-ghost` as direct deps.
- Dropped the `plugin:ghost/browser` extends. Its formatting rules (`indent`, `quotes`, `semi`, `space-*`, etc.) were removed from ESLint 9 core, so they could not survive the migration as-written. Non-formatting rules (`curly`, `eqeqeq`, `no-eval`, `no-console`, `no-shadow`, `array-callback-return`, etc.) preserved inline.
- ESLint 9 dropped the `--ext` CLI flag; the `lint` script now passes directory args (`src test`) and lets the config block's `files` glob do the matching.
- Modernized the package to ESM (\`"type": "module"\`): the test file's CommonJS \`require()\` calls and \`__dirname\` use are now \`import\` + \`import.meta.dirname\`. The src was already ESM under Vite; the test file was the only thing keeping the workspace stuck on CommonJS. Drops the need for an \`.mjs\` extension on the eslint config.

## Test plan

- [ ] CI lint passes
- [ ] \`pnpm --filter @tryghost/admin-toolbar lint\` is green locally
- [ ] \`pnpm --filter @tryghost/admin-toolbar test\` is green locally (20/20)