### PR TITLE
Removed the dead ghost/mocha mechanics lint directives

### DIFF
--- a/ghost/core/test/.eslintrc.js
+++ b/ghost/core/test/.eslintrc.js
@@ -21,10 +21,7 @@ module.exports = {
     overrides: [
         {
             files: ['**/*.ts'],
-            parser: '@typescript-eslint/parser',
-            extends: [
-                'plugin:ghost/test'
-            ]
+            parser: '@typescript-eslint/parser'
         }
     ],
     rules: {
@@ -45,11 +42,16 @@ module.exports = {
         ],
         'no-useless-escape': 'off',
 
+        // Kept: catches committed .skip/.only (applies to Vitest too).
         'ghost/mocha/no-skipped-tests': 'error',
         'ghost/filenames/match-regex': ['error', '^[a-z0-9-.]+$', null, true],
 
-        // TODO: remove these custom rules and fix problems in test files
+        // Mocha-mechanics checks that misfire on Vitest patterns (setup-file
+        // top-level hooks, describe.each, async tests with no done callback).
+        // Off post-migration; revisited when we move to oxlint.
         'ghost/mocha/no-setup-in-describe': 'off',
-        'ghost/mocha/no-sibling-hooks': 'off'
+        'ghost/mocha/no-sibling-hooks': 'off',
+        'ghost/mocha/no-top-level-hooks': 'off',
+        'ghost/mocha/handle-done-callback': 'off'
     }
 };

--- a/ghost/core/test/e2e-api/admin/gift-links.test.ts
+++ b/ghost/core/test/e2e-api/admin/gift-links.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable ghost/mocha/no-setup-in-describe -- describe.each is the parameterised-test seam; the mocha-era rule doesn't recognise Vitest's native .each and flags it like a manual loop. */
 import assert from 'node:assert/strict';
 
 const {agentProvider, fixtureManager, mockManager} = require('../../utils/e2e-framework');

--- a/ghost/core/test/integration/adapters/redirects/s3-redirects-store.test.ts
+++ b/ghost/core/test/integration/adapters/redirects/s3-redirects-store.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable ghost/mocha/no-top-level-hooks -- false positive: the hooks are inside the describe, but the lint plugin can't see through the describe.skipIf()() gate below. (PLA-170) */
 import {describe, it, beforeAll, afterEach, afterAll} from 'vitest';
 import assert from 'node:assert/strict';
 import {ListObjectsV2Command, S3Client} from '@aws-sdk/client-s3';

--- a/ghost/core/test/integration/adapters/redis/adapter-cache-redis.test.js
+++ b/ghost/core/test/integration/adapters/redis/adapter-cache-redis.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable ghost/mocha/no-top-level-hooks -- false positive: the hooks are inside the describe, but the lint plugin can't see through the describe.skipIf()() gate below. (PLA-170) */
 const assert = require('node:assert/strict');
 const crypto = require('node:crypto');
 const _ = require('lodash');

--- a/ghost/core/test/integration/utils/minio.test.js
+++ b/ghost/core/test/integration/utils/minio.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable ghost/mocha/no-top-level-hooks -- false positive: the hooks are inside the describe, but the lint plugin can't see through the describe.skipIf()() gate below. (PLA-170) */
 const assert = require('node:assert/strict');
 const {
     createTestS3Client,

--- a/ghost/core/test/unit/server/adapters/redirects/file-store.test.ts
+++ b/ghost/core/test/unit/server/adapters/redirects/file-store.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable ghost/mocha/no-setup-in-describe -- runStoreContract is the parameterised-test seam; calling it inside describe is the intended use. */
 import assert from 'node:assert/strict';
 import fs from 'fs-extra';
 import path from 'path';

--- a/ghost/core/test/unit/server/services/custom-redirects/in-memory-store.test.ts
+++ b/ghost/core/test/unit/server/services/custom-redirects/in-memory-store.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable ghost/mocha/no-setup-in-describe -- runStoreContract is the parameterised-test seam; calling it inside describe is the intended use. */
 import {InMemoryStore} from './helpers/in-memory-store';
 import {runStoreContract} from './helpers/store-contract';
 

--- a/ghost/core/test/utils/vitest-setup-db.ts
+++ b/ghost/core/test/utils/vitest-setup-db.ts
@@ -16,10 +16,6 @@
 // forks-based parallel model, where each fork is its own process with its own
 // DB) never collide.
 
-// vitest setup files are *meant* to register top-level hooks; the ghost/mocha
-// lint plugin (aimed at mocha test files) flags them. Disable for this file.
-/* eslint-disable ghost/mocha/no-top-level-hooks, ghost/mocha/no-sibling-hooks, ghost/mocha/handle-done-callback */
-
 import {beforeAll, beforeEach, afterEach, afterAll} from 'vitest';
 
 const crypto = require('crypto');

--- a/ghost/core/test/utils/vitest-setup.ts
+++ b/ghost/core/test/utils/vitest-setup.ts
@@ -2,12 +2,6 @@
 // bridges the snapshot hook contract from @tryghost/express-test onto
 // vitest's globals so it's exercised end-to-end.
 
-// The ghost/mocha lint plugin flags top-level beforeAll/afterEach/afterAll
-// calls — those rules guard against accidental top-level hooks in mocha
-// test files, but vitest setup files are *meant* to register global hooks
-// at the top level. Disable for this file only.
-/* eslint-disable ghost/mocha/no-top-level-hooks, ghost/mocha/handle-done-callback */
-
 import chalk from 'chalk';
 import {beforeAll, beforeEach, afterEach, afterAll} from 'vitest';
 


### PR DESCRIPTION
Cleanup follow-up to the mocha→vitest migration.

## What
The `ghost/mocha/*` rules (from eslint-plugin-ghost → eslint-plugin-mocha) are mostly mocha-mechanics checks that, post-migration, only misfire on Vitest patterns:
- `no-top-level-hooks` — flags top-level hooks in Vitest setup files + hooks inside `describe.skipIf()` gates
- `no-setup-in-describe` — flags `describe.each` / parameterised-test seams
- `no-sibling-hooks`, `handle-done-callback` — irrelevant under Vitest's async model

Turned those four off in `test/.eslintrc.js`, dropped their now-dead `eslint-disable` directives (8 files) + the comments explaining them, and removed a redundant `plugin:ghost/test` re-extend in the `.ts` override that was re-enabling them on top of the base config.

## Kept on purpose
`ghost/mocha/no-skipped-tests` (`error`) stays — it still catches committed `.skip`/`.only` on Vitest. I checked what its directives mask, and they're **intentional, in-code-documented skips**, not lint noise:
- `describe.skip('Batch sending tests')` — the whole suite ("ordering issue, fails intermittently; decide if worth keeping or rewrite")
- staff `sends email for…` ×5 ("pass in the full suite, fail in isolation; make isolation-safe as a follow-up")
- cache TTL ×3 ("TODO: fix this test so we can unskip")

Real disabled-test debt, worth their own follow-ups, but out of scope here.

## Verified
`eslint --print-config` resolves `no-skipped-tests: error` + the four `: off` for both `.js` and `.ts`; `--report-unused-disable-directives` clean on all touched files.