### PR TITLE
Removed the PLA issue tags from test comments

### DIFF
--- a/ghost/core/test/e2e-api/admin/pages-legacy.test.js
+++ b/ghost/core/test/e2e-api/admin/pages-legacy.test.js
@@ -36,7 +36,7 @@ describe('Pages API', function () {
 
         // Absolute urls by default. Match pages by url rather than by sort index:
         // fixture pages are seeded with near-identical timestamps, so the relative
-        // order of same-status pages is not stable across databases (PLA-165).
+        // order of same-status pages is not stable across databases.
         const draftPage = jsonResponse.pages.find(page => /\/p\/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\//.test(new URL(page.url).pathname));
         assertExists(draftPage);
         const contributePage = jsonResponse.pages.find(page => new URL(page.url).pathname === '/contribute/');

--- a/ghost/core/test/e2e-api/admin/sso.test.js
+++ b/ghost/core/test/e2e-api/admin/sso.test.js
@@ -14,7 +14,7 @@ describe('SSO API', function () {
         // during boot); the owner is looked up lazily per request, because under
         // per-file isolation the DB isn't seeded until getGhostAPIAgent() /
         // fixtureManager.init() run below — an eager lookup hits an unmigrated
-        // database (the old serial suite inherited a prior file's schema). (PLA-153)
+        // database (the old serial suite inherited a prior file's schema).
         class MockSSOAdapter {
             async getRequestCredentials() {
                 return {

--- a/ghost/core/test/e2e-api/content/posts.test.js
+++ b/ghost/core/test/e2e-api/content/posts.test.js
@@ -50,7 +50,7 @@ async function trackDb(fn, skip) {
 
 // trackDb introspects sqlite query traffic, so its tests are sqlite-only; the
 // invalid-filter test is mysql-only. Decided at registration from NODE_ENV
-// (vitest has no runtime this.skip). (PLA-153)
+// (vitest has no runtime this.skip).
 const isMySQL = (process.env.NODE_ENV || '').includes('mysql');
 
 describe('Posts Content API', function () {

--- a/ghost/core/test/integration/adapters/redirects/s3-redirects-store.test.ts
+++ b/ghost/core/test/integration/adapters/redirects/s3-redirects-store.test.ts
@@ -35,7 +35,7 @@ const backupKeyPattern = (tenantPrefix = '') => new RegExp(
 
 // Skip when MinIO is unreachable. The flag is set by the integration
 // globalSetup (vitest-globalsetup-services.ts), which probes MinIO once before
-// the forks spawn. (PLA-170)
+// the forks spawn.
 describe.skipIf(process.env.GHOST_TEST_MINIO_AVAILABLE !== '1')('Integration: S3RedirectsStore', function () {
     let adminClient: S3Client;
     let bucket: string;

--- a/ghost/core/test/integration/adapters/redis/adapter-cache-redis.test.js
+++ b/ghost/core/test/integration/adapters/redis/adapter-cache-redis.test.js
@@ -33,7 +33,7 @@ const SCENARIOS = [
 
 // Skip the whole parameterised set when Redis is unreachable. The flag is set by
 // the integration globalSetup (vitest-globalsetup-services.ts), which probes
-// Redis once before the forks spawn. (PLA-170)
+// Redis once before the forks spawn.
 SCENARIOS.forEach(({label, wrap}) => {
     describe.skipIf(process.env.GHOST_TEST_REDIS_AVAILABLE !== '1')(`Integration: AdapterCacheRedis on a ${label}`, function () {
         const caches = [];
@@ -235,7 +235,7 @@ SCENARIOS.forEach(({label, wrap}) => {
                     // This delayed fetch is deliberately orphaned (cache.get
                     // resolves null at the 1ms timeout first); swallow its
                     // rejection so it doesn't surface as an unhandled error when
-                    // it fires after the worker is torn down (PLA-156).
+                    // it fires after the worker is torn down.
                     setTimeout(() => original(k).then(resolve).catch(() => {}), 50);
                 });
 
@@ -251,7 +251,7 @@ SCENARIOS.forEach(({label, wrap}) => {
                 cache.redisClient.get = k => new Promise((resolve) => {
                     // Orphaned delayed fetch (see the prior test) — swallow its
                     // rejection so it doesn't become an unhandled error after the
-                    // worker is torn down under per-file isolation (PLA-156).
+                    // worker is torn down under per-file isolation.
                     setTimeout(() => original(k).then(resolve).catch(() => {}), 50);
                 });
 

--- a/ghost/core/test/integration/services/mailgun-email-suppression-list.test.js
+++ b/ghost/core/test/integration/services/mailgun-email-suppression-list.test.js
@@ -17,7 +17,7 @@ describe('MailgunEmailSuppressionList', function () {
         // starts at ~now and the events (being "too close to NOW") are never
         // fetched, so no suppression is created. The suite previously passed only
         // by free-riding on an earlier file's timestamp state, which breaks under
-        // per-file isolation (PLA-156). Mirrors email-event-storage.test.js.
+        // per-file isolation. Mirrors email-event-storage.test.js.
         const queries = require('../../../core/server/services/email-analytics/lib/queries');
         sinon.stub(queries, 'getLastEventTimestamp').callsFake(async function () {
             return new Date(2000, 0, 1);

--- a/ghost/core/test/integration/utils/minio.test.js
+++ b/ghost/core/test/integration/utils/minio.test.js
@@ -12,7 +12,7 @@ const {
 
 // Skip when MinIO is unreachable. The flag is set by the integration
 // globalSetup (vitest-globalsetup-services.ts), which probes MinIO once before
-// the forks spawn. (PLA-170)
+// the forks spawn.
 describe.skipIf(process.env.GHOST_TEST_MINIO_AVAILABLE !== '1')('Integration: MinIO test helper', function () {
     let client;
     let bucket;

--- a/ghost/core/test/legacy/models/model-collections.test.js
+++ b/ghost/core/test/legacy/models/model-collections.test.js
@@ -6,7 +6,7 @@ const db = require('../../../core/server/data/db');
 // These two tests inspect raw sqlite query traffic (db.knex.client as an sqlite3
 // Database), so they only apply on the sqlite leg. Decide at registration from
 // NODE_ENV (the mysql leg sets testing-mysql) — db.knex isn't connected yet when
-// the file loads, and Vitest has no Mocha-style runtime this.skip(). (PLA-152)
+// the file loads, and Vitest has no Mocha-style runtime this.skip().
 const isMySQL = (process.env.NODE_ENV || '').includes('mysql');
 
 describe('Collection Model', function () {

--- a/ghost/core/test/legacy/models/model-settings.test.js
+++ b/ghost/core/test/legacy/models/model-settings.test.js
@@ -12,7 +12,7 @@ describe('Settings Model', function () {
     // assert populateDefaults() starting from an empty settings table (setup()
     // itself populates the 112 defaults, hence the teardown). Under the old
     // serial model this free-rode on an earlier file's init + truncated state;
-    // per-file isolation (PLA-152) means each file does its own.
+    // per-file isolation means each file does its own.
     beforeAll(testUtils.setup());
     beforeEach(testUtils.teardownDb);
 

--- a/ghost/core/test/utils/db-template.js
+++ b/ghost/core/test/utils/db-template.js
@@ -17,8 +17,7 @@ const {deriveMySQLTemplateDatabase, deriveSQLiteTemplateFilename} = require('./d
 // insert every default fixture). On MySQL each step is a network round-trip; on
 // sqlite each is a file write. The DB-suite runner's `isolate:true` projects run
 // every test FILE in a fresh fork, so without help each file pays that full init
-// once — the bulk of the acceptance-test runtime regression (PLA-165 mysql,
-// PLA-172 sqlite).
+// once — the bulk of the acceptance-test runtime regression.
 //
 // Instead we build ONE migrated + seeded "template" database for the whole run
 // (in the vitest globalSetup, before any fork spawns) and have each fork RESTORE
@@ -30,9 +29,9 @@ const {deriveMySQLTemplateDatabase, deriveSQLiteTemplateFilename} = require('./d
 // replaying the template's schema from its sqlite_master, and bulk-copying every
 // table with `INSERT ... SELECT`. We deliberately do NOT copy the template .db
 // file over a fork's open connection — that approach destabilized sqlite read
-// order for order-dependent tests and was reverted (PLA-165); building the fork
+// order for order-dependent tests and was reverted; building the fork
 // DB from the template's CONTENTS via SQL keeps physical row order identical to a
-// fresh init (PLA-172).
+// fresh init.
 //
 // Readiness is published from globalSetup to the forks via an env var (forks
 // inherit the main process env at spawn time). When it is unset — e.g.
@@ -42,8 +41,8 @@ const {deriveMySQLTemplateDatabase, deriveSQLiteTemplateFilename} = require('./d
 // SCOPE: only the db.reset() provisioning path (agentProvider-based e2e / e2e-api
 // / e2e-* suites) uses this. The getFixtureOps `testUtils.setup()` path
 // (integration/legacy) opens Ghost's bookshelf connection BEFORE provisioning, so
-// that path still does a full init. See the PLA-165 / PLA-171 notes for the
-// deferred follow-up.
+// that path still does a full init — those suites run isolate:true (a fresh
+// process per file), so the per-file boot, not provisioning, is their cost.
 
 const TEMPLATE_ENV_VAR = 'GHOST_TEST_DB_TEMPLATE_READY';
 
@@ -191,8 +190,8 @@ const buildTemplate = async (base) => {
  * template: replay every sqlite_master object's DDL in creation (rowid) order —
  * tables, then their indexes, triggers and views, which always follow their table
  * in that order — then bulk-copy each table's rows, foreign keys off during the
- * load. This keeps physical row order identical to a fresh init (PLA-172) — we do
- * NOT copy the template file over the connection, the approach reverted in PLA-165.
+ * load. This keeps physical row order identical to a fresh init — we do
+ * NOT copy the template file over the connection (the previously-reverted approach).
  */
 const restoreFromTemplateSQLite = async () => {
     const templateFile = getForkTemplateFilename();
@@ -227,7 +226,7 @@ const restoreFromTemplateSQLite = async () => {
         // reference one not yet populated. Replaying the template's exact CREATE
         // TABLE DDL (rather than a column-only copy) preserves its foreign keys,
         // making the restore byte-faithful to a fresh init — the same faithfulness
-        // the mysql path needs (PLA-165/PLA-172).
+        // the mysql path needs.
         await run('PRAGMA foreign_keys = OFF');
         try {
             for (const object of objects) {
@@ -304,7 +303,7 @@ const restoreFromTemplate = async () => {
     // surfacing as extra rows in attribution / activity-feed snapshots. The DDL
     // string is unqualified, so replaying it on the fork's connection creates the
     // table in the fork DB; its FK REFERENCES resolve to the fork's own copies.
-    // This makes the restore byte-faithful to a fresh init (PLA-165).
+    // This makes the restore byte-faithful to a fresh init.
     await db.knex.raw('SET FOREIGN_KEY_CHECKS=0;');
     try {
         await sequence(tables.map(table => async () => {

--- a/ghost/core/test/utils/db-utils.js
+++ b/ghost/core/test/utils/db-utils.js
@@ -61,7 +61,7 @@ module.exports.reset = async ({truncate} = {truncate: false}) => {
             // First provision in this fork: build the schema + fixtures from the
             // run's shared (migrated + seeded) template — ATTACH the template file
             // and bulk-copy it onto db.knex's own connection — instead of a full
-            // per-file migrate+seed (PLA-172). Then snapshot to `-orig` so later
+            // per-file migrate+seed. Then snapshot to `-orig` so later
             // in-fork resets take the fast file-copy path above. The fork file is
             // already fresh (deleted at boot, see vitest-setup-db.ts), and the
             // restore writes db.knex's inode, so we must NOT fs.remove() it here —

--- a/ghost/core/test/utils/vitest-global-db-setup.ts
+++ b/ghost/core/test/utils/vitest-global-db-setup.ts
@@ -4,11 +4,11 @@
 // It builds the run's migrated + seeded "template" database once; each fork then
 // RESTORES from it when it first provisions its per-process DB (see
 // test/utils/db-utils.js) instead of running a full migrate+seed per file. That
-// per-file init is the dominant cost of the acceptance-test runtime regression
-// (PLA-165 mysql, PLA-172 sqlite). MySQL restores from a same-server template via
+// per-file init is the dominant cost of the acceptance-test runtime regression.
+// MySQL restores from a same-server template via
 // a bulk table copy; sqlite ATTACHes the template file and bulk-copies it onto
-// the fork's own connection (never copying the file over an open connection — the
-// approach reverted in PLA-165). Both keep the restore byte-faithful to a fresh
+// the fork's own connection (never copying the file over an open connection — a
+// previously-reverted approach). Both keep the restore byte-faithful to a fresh
 // init.
 //
 // The fork learns the template is ready via an inherited env var — env set here,

--- a/ghost/core/test/utils/vitest-globalsetup-services.ts
+++ b/ghost/core/test/utils/vitest-globalsetup-services.ts
@@ -8,7 +8,7 @@ import net from 'node:net';
 // connect to their backing service in beforeAll, so they hard-fail locally when
 // the service isn't running. Gating each suite on these flags lets them SKIP
 // cleanly when the service is down and RUN when it's up — CI starts both
-// services, so they always run there. (PLA-170)
+// services, so they always run there.
 
 // 1s, not a few hundred ms: this probe runs in the vitest main process right
 // before the worker forks spawn, when the event loop is busiest (config load,

--- a/ghost/core/test/utils/vitest-setup-db.ts
+++ b/ghost/core/test/utils/vitest-setup-db.ts
@@ -42,7 +42,7 @@ process.env.WEBHOOK_SECRET = process.env.WEBHOOK_SECRET || 'TEST_STRIPE_WEBHOOK_
 // instance.
 //
 // Each worker is its own process, so it gets its own database — that's what lets
-// the DB suites run fork-parallel (PLA-156). The per-fork sessionId is appended
+// the DB suites run fork-parallel. The per-fork sessionId is appended
 // even to a CI-pinned *base*: the sqlite leg exports a single
 // database__connection__filename=/dev/shm/ghost-test.db for the whole job, so
 // without a unique suffix every fork would hammer the same file. (The mysql leg
@@ -57,7 +57,7 @@ process.env.WEBHOOK_SECRET = process.env.WEBHOOK_SECRET || 'TEST_STRIPE_WEBHOOK_
 // file is deleted just below, before Ghost loads, so a reused slot boots from
 // nothing exactly as a fresh name would. mysql keeps a random per-fork name: it
 // has no /tmp to bound (CI databases die with the job) and a random name sidesteps
-// the same stale-reuse hazard without a pre-boot DROP. (PLA-168)
+// the same stale-reuse hazard without a pre-boot DROP.
 const poolSlot = parseInt(process.env.VITEST_POOL_ID || '', 10);
 const sqliteId = Number.isInteger(poolSlot)
     ? `pool_${poolSlot}`
@@ -96,7 +96,7 @@ if (!process.env.NODE_ENV.includes('mysql')) {
 // lost (a SIGTERM handler is unreliable: recycled forks don't all get one).
 // Running v8.takeCoverage() in this per-file afterAll writes each file's coverage
 // to disk before its fork is torn down, so c8 captures every file. No-op off
-// coverage runs. (PLA-156)
+// coverage runs.
 if (process.env.NODE_V8_COVERAGE) {
     afterAll(() => {
         try {
@@ -113,7 +113,7 @@ if (process.env.NODE_V8_COVERAGE) {
 // deletes the file at boot (see the derivation above) and recreates it, so a run
 // reuses at most ~poolSize files in /tmp instead of leaving a fresh random one
 // behind every run. mysql names are random per fork but ephemeral on CI (the
-// container dies with the job); locally the mysql suite is rarely run. (PLA-168)
+// container dies with the job); locally the mysql suite is rarely run.
 
 const canonicalTestPort = 2369;
 // The per-fork port must be unique among forks running concurrently. Each test
@@ -126,7 +126,7 @@ const canonicalTestPort = 2369;
 // has exited and freed it, so base+poolId never collides among live forks. The
 // old `Math.random()` port in a 7630-wide range collided often enough across ~90
 // parallel boots to flake. (The DB name already uses a 2^32 sessionId, which is
-// collision-resistant; only the port was under-spread.) (PLA-153)
+// collision-resistant; only the port was under-spread.)
 const poolId = parseInt(process.env.VITEST_POOL_ID || '', 10);
 const derivedPort = Number.isInteger(poolId)
     ? 2370 + poolId

--- a/ghost/core/vitest.config.db.ts
+++ b/ghost/core/vitest.config.db.ts
@@ -62,7 +62,7 @@ const sharedDbConfig = {
         // import=tsx`; vitest only registers tsx in-process (not in the fork
         // execArgv worker_threads inherit) and ignores poolOptions.forks.execArgv
         // here, so route it through the env. Applied on test.env (after fork
-        // startup) so only the spawned workers pick it up, not the fork. (PLA-157/158)
+        // startup) so only the spawned workers pick it up, not the fork.
         NODE_OPTIONS: (process.env.NODE_OPTIONS ? process.env.NODE_OPTIONS + ' ' : '') + '--import tsx'
     },
     hookTimeout: 60000
@@ -75,7 +75,7 @@ export default defineConfig({
         // any worker fork spawns; each fork then restores its per-process DB from
         // that template (a cheap bulk copy) on first provision instead of running
         // a full migrate+seed per file. This is the lever for the MySQL
-        // acceptance-test runtime regression (PLA-165) — per-file migrate+seed is
+        // acceptance-test runtime regression — per-file migrate+seed is
         // its dominant cost. Defined at the root (not per-project) so a single
         // template is shared across every project in the invocation. See
         // test/utils/vitest-global-db-setup.ts and test/utils/db-template.js.
@@ -121,7 +121,7 @@ export default defineConfig({
                     // the main process and exports GHOST_TEST_{REDIS,MINIO}_AVAILABLE
                     // so the adapter suites skip when their service is down and run
                     // when it's up. Integration-only — no adapter tests live in the
-                    // other DB suites. (PLA-170)
+                    // other DB suites.
                     globalSetup: ['./test/utils/vitest-globalsetup-services.ts'],
                     // Matches the mocha `--timeout=10000` for the integration suite.
                     testTimeout: 10000


### PR DESCRIPTION
Strips the `(PLA-xxx)` issue-tracker tags from test comments — they describe the tracker, not the code, and the referenced issues (the merged migration work) add no value in-tree.

## What
- Stripped the `(PLA-xxx)` label tags across the test infrastructure (15 files); reworded two historical "reverted in PLA-165" prose mentions to drop the ref while keeping the context.
- Rewrote `db-template.js`'s SCOPE note: it cited **PLA-171** (the integration/legacy de-isolation) as a "deferred follow-up", but that work was decided against — so it now states the actual design (those suites run `isolate: true`, a fresh process per file, so the per-file boot is their cost, not provisioning).

## No further followups
Checked every PLA reference, not just the label tags. The only one implying pending work was that PLA-171 "deferred follow-up" — which is decided-against, not pending. Nothing actionable was erased.

Comment-only; no behaviour change; lint clean. Independent of #28791 (touches comment lines, not the eslint-disable directives that PR removes).