### PR TITLE
Batched Renovate Docker digest pin updates into a weekly PR

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -459,12 +459,20 @@
             "automerge": true
         },
 
-        // Allow internal Docker digest pins to automerge once the relevant
-        // CI checks have gone green. Scoped to base images we control or
+        // Batch internal Docker digest pins into a single weekly PR and
+        // automerge after CI passes. Scoped to base images we control or
         // pin purely for build reproducibility, so digest rotations don't
-        // change runtime behavior.
+        // change runtime behavior. Frequently-rotating upstream tags
+        // (notably `tinybird-local:latest`) were opening ~5 individual PRs
+        // per week, each running the full E2E lane (~70-150 job-min) for a
+        // tweak with no runtime impact. Saturday-only `schedule` batches the
+        // week's churn into one PR + one CI run; the global automergeSchedule
+        // (all weekend, weekday evenings) lands it without human review.
+        // Digests for images not in this list (e.g. the pinned `redis` in
+        // ci.yml services) still open individually — they're rare and
+        // intentionally human-reviewed.
         {
-            "description": "Automerge internal Docker digest updates after CI passes",
+            "description": "Group + weekly-schedule internal Docker digest updates; automerge after CI passes",
             "matchDatasources": [
                 "docker"
             ],
@@ -479,6 +487,10 @@
             ],
             "matchUpdateTypes": [
                 "digest"
+            ],
+            "groupName": "Docker image digests",
+            "schedule": [
+                "* * * * 6"
             ],
             "automerge": true,
             "automergeType": "pr"


### PR DESCRIPTION
Groups internal Docker digest pin updates onto a weekly Saturday schedule rather than letting each rotation open its own PR.

The affected images (`tinybirdco/tinybird-local`, `tryghost/actions`, `python`, `axllent/mailpit`, `caddy`, `stripe/stripe-cli`, `ghcr.io/astral-sh/uv`, `ghost/traffic-analytics`) are base images we pin for build reproducibility — digest rotations don't change runtime behavior. They previously opened ~5 individual PRs/week, each running the full CI/E2E lane (~70-150 job-min). Frequently-rotating upstream `:latest` tags (notably `tinybird-local`) were the main amplifier.

The Saturday-only `schedule` batches the week's churn into one PR + one CI run. The global `automergeSchedule` (all weekend, weekday evenings) still applies, so the grouped PR lands without human review on green CI.

Out-of-list digests (e.g. the pinned `redis` in `ci.yml` services) continue to open individually — they're rare and intentionally human-reviewed.

Validated with `renovate-config-validator`.