### PR TITLE
Changed apps/sodo-search + apps/announcement-bar to ESLint 9 / flat config

### DIFF
--- a/apps/announcement-bar/eslint.config.js
+++ b/apps/announcement-bar/eslint.config.js
@@ -1,0 +1,69 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import ghostPlugin from 'eslint-plugin-ghost';
+import reactPlugin from 'eslint-plugin-react';
+
+const ghostRules = {
+    curly: 'error',
+    camelcase: ['error', {properties: 'never'}],
+    'dot-notation': 'error',
+    eqeqeq: ['error', 'always'],
+    'no-plusplus': ['error', {allowForLoopAfterthoughts: true}],
+    'no-eval': 'error',
+    'no-useless-call': 'error',
+    'no-console': 'error',
+    'no-shadow': 'error',
+    'array-callback-return': 'error',
+    'no-constructor-return': 'error',
+    'no-promise-executor-return': 'error',
+    'ghost/filenames/match-regex': ['error', '^[a-z0-9.-]+$', false]
+};
+
+const baseConfig = {
+    ...js.configs.recommended,
+    ...reactPlugin.configs.flat.recommended,
+    plugins: {
+        ...reactPlugin.configs.flat.recommended.plugins,
+        ghost: ghostPlugin
+    },
+    settings: {
+        react: {version: 'detect'}
+    },
+    rules: {
+        ...js.configs.recommended.rules,
+        ...reactPlugin.configs.flat.recommended.rules,
+        ...ghostRules,
+        'react/prop-types': 'off'
+    }
+};
+
+export default [
+    {
+        ignores: ['umd/**/*', 'dist/**/*']
+    },
+    {
+        ...baseConfig,
+        files: ['src/**/*.{js,jsx}'],
+        languageOptions: {
+            ...reactPlugin.configs.flat.recommended.languageOptions,
+            ecmaVersion: 2022,
+            sourceType: 'module',
+            globals: globals.browser
+        }
+    },
+    {
+        ...baseConfig,
+        files: ['test/**/*.{js,jsx}'],
+        languageOptions: {
+            ...reactPlugin.configs.flat.recommended.languageOptions,
+            ecmaVersion: 2022,
+            sourceType: 'module',
+            globals: {
+                ...globals.browser,
+                ...globals.vitest,
+                ...globals.jest,
+                vi: 'readonly'
+            }
+        }
+    }
+];

--- a/apps/announcement-bar/package.json
+++ b/apps/announcement-bar/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tryghost/announcement-bar",
-  "version": "1.1.21",
+  "type": "module",
+  "version": "1.1.22",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",
@@ -24,40 +25,10 @@
     "test": "vitest run",
     "test:ci": "pnpm test --coverage",
     "test:unit": "pnpm test:ci",
-    "lint": "eslint src --ext .js --cache",
+    "lint": "eslint src test --cache",
     "preship": "pnpm lint",
     "ship": "node ../../.github/scripts/release-apps.js",
     "prepublishOnly": "pnpm build"
-  },
-  "eslintConfig": {
-    "env": {
-      "browser": true,
-      "jest": true
-    },
-    "parserOptions": {
-      "sourceType": "module",
-      "ecmaVersion": 2022
-    },
-    "extends": [
-      "plugin:ghost/browser",
-      "plugin:react/recommended"
-    ],
-    "plugins": [
-      "ghost"
-    ],
-    "rules": {
-      "react/prop-types": "off",
-      "ghost/filenames/match-regex": [
-        "error",
-        "^[a-z0-9.-]+$",
-        false
-      ]
-    },
-    "settings": {
-      "react": {
-        "version": "detect"
-      }
-    }
   },
   "browserslist": {
     "production": [
@@ -79,11 +50,15 @@
     ]
   },
   "devDependencies": {
+    "@eslint/js": "catalog:eslint9",
     "@vitejs/plugin-react": "catalog:",
     "@vitest/coverage-v8": "catalog:",
     "concurrently": "catalog:",
     "cross-fetch": "catalog:",
-    "eslint": "catalog:",
+    "eslint": "catalog:eslint9",
+    "eslint-plugin-ghost": "3.5.0",
+    "eslint-plugin-react": "7.37.5",
+    "globals": "17.6.0",
     "jsdom": "catalog:",
     "vite": "catalog:",
     "vite-plugin-svgr": "catalog:",

--- a/apps/announcement-bar/test/setup-tests.js
+++ b/apps/announcement-bar/test/setup-tests.js
@@ -1,8 +1,6 @@
 import {fetch} from 'cross-fetch';
 
 // TODO: remove this once we're switched `jest` to `vi` in code
-// eslint-disable-next-line no-undef
 globalThis.jest = vi;
 
-// eslint-disable-next-line no-undef
 globalThis.fetch = fetch;

--- a/apps/sodo-search/eslint.config.js
+++ b/apps/sodo-search/eslint.config.js
@@ -1,0 +1,72 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import ghostPlugin from 'eslint-plugin-ghost';
+import reactPlugin from 'eslint-plugin-react';
+
+const ghostRules = {
+    curly: 'error',
+    camelcase: ['error', {properties: 'never'}],
+    'dot-notation': 'error',
+    eqeqeq: ['error', 'always'],
+    'no-plusplus': ['error', {allowForLoopAfterthoughts: true}],
+    'no-eval': 'error',
+    'no-useless-call': 'error',
+    'no-console': 'error',
+    'no-shadow': 'error',
+    'array-callback-return': 'error',
+    'no-constructor-return': 'error',
+    'no-promise-executor-return': 'error',
+    'ghost/filenames/match-regex': ['error', '^[a-z0-9.-]+$', false],
+    'ghost/sort-imports-es6-autofix/sort-imports-es6': ['error', {
+        memberSyntaxSortOrder: ['none', 'all', 'single', 'multiple']
+    }]
+};
+
+const baseConfig = {
+    ...js.configs.recommended,
+    ...reactPlugin.configs.flat.recommended,
+    plugins: {
+        ...reactPlugin.configs.flat.recommended.plugins,
+        ghost: ghostPlugin
+    },
+    settings: {
+        react: {version: 'detect'}
+    },
+    rules: {
+        ...js.configs.recommended.rules,
+        ...reactPlugin.configs.flat.recommended.rules,
+        ...ghostRules,
+        'react/prop-types': 'off'
+    }
+};
+
+export default [
+    {
+        ignores: ['umd/**/*', 'dist/**/*']
+    },
+    {
+        ...baseConfig,
+        files: ['src/**/*.{js,jsx}'],
+        languageOptions: {
+            ...reactPlugin.configs.flat.recommended.languageOptions,
+            ecmaVersion: 2022,
+            sourceType: 'module',
+            globals: globals.browser
+        }
+    },
+    {
+        ...baseConfig,
+        files: ['test/**/*.{js,jsx}'],
+        languageOptions: {
+            ...reactPlugin.configs.flat.recommended.languageOptions,
+            ecmaVersion: 2022,
+            sourceType: 'module',
+            globals: {
+                ...globals.browser,
+                ...globals.vitest,
+                ...globals.jest,
+                vi: 'readonly'
+            }
+        }
+    }
+];

--- a/apps/sodo-search/package.json
+++ b/apps/sodo-search/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tryghost/sodo-search",
-  "version": "1.8.23",
+  "type": "module",
+  "version": "1.8.24",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",
@@ -27,51 +28,10 @@
     "tailwind": "pnpm tailwind:base --watch ",
     "tailwind:base": "tailwindcss -i ./src/index.css -o ./umd/main.css --minify",
     "test": "vitest run",
-    "lint": "eslint src --ext .js --cache",
+    "lint": "eslint src test --cache",
     "preship": "pnpm lint",
     "ship": "node ../../.github/scripts/release-apps.js",
     "prepublishOnly": "pnpm build"
-  },
-  "eslintConfig": {
-    "env": {
-      "browser": true,
-      "jest": true
-    },
-    "parserOptions": {
-      "sourceType": "module",
-      "ecmaVersion": 2022
-    },
-    "extends": [
-      "plugin:ghost/browser",
-      "plugin:react/recommended"
-    ],
-    "plugins": [
-      "ghost"
-    ],
-    "rules": {
-      "react/prop-types": "off",
-      "ghost/filenames/match-regex": [
-        "error",
-        "^[a-z0-9.-]+$",
-        false
-      ],
-      "ghost/sort-imports-es6-autofix/sort-imports-es6": [
-        "error",
-        {
-          "memberSyntaxSortOrder": [
-            "none",
-            "all",
-            "single",
-            "multiple"
-          ]
-        }
-      ]
-    },
-    "settings": {
-      "react": {
-        "version": "detect"
-      }
-    }
   },
   "browserslist": {
     "production": [
@@ -93,13 +53,17 @@
     ]
   },
   "devDependencies": {
+    "@eslint/js": "catalog:eslint9",
     "@testing-library/jest-dom": "catalog:",
     "@testing-library/react": "catalog:react17",
     "@vitejs/plugin-react": "catalog:",
     "@vitest/coverage-v8": "catalog:",
     "concurrently": "catalog:",
     "cross-fetch": "catalog:",
-    "eslint": "catalog:",
+    "eslint": "catalog:eslint9",
+    "eslint-plugin-ghost": "3.5.0",
+    "eslint-plugin-react": "7.37.5",
+    "globals": "17.6.0",
     "jsdom": "catalog:",
     "nock": "14.0.15",
     "tailwindcss": "catalog:tailwind3",

--- a/apps/sodo-search/src/app.js
+++ b/apps/sodo-search/src/app.js
@@ -60,7 +60,7 @@ export default class App extends React.Component {
                         window.document.body.style.marginRight = this.bodyMargin;
                     }
                 }
-            } catch (e) {
+            } catch {
                 /** Ignore any errors for scroll handling */
             }
         }

--- a/apps/sodo-search/test/setup-tests.js
+++ b/apps/sodo-search/test/setup-tests.js
@@ -4,10 +4,8 @@ import {cleanup} from '@testing-library/react';
 import {fetch} from 'cross-fetch';
 
 // TODO: remove this once we're switched `jest` to `vi` in code
-// eslint-disable-next-line no-undef
 globalThis.jest = vi;
 
-// eslint-disable-next-line no-undef
 globalThis.fetch = fetch;
 
 // Add the cleanup function for React testing library

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1103,6 +1103,9 @@ importers:
         specifier: catalog:react17
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@eslint/js':
+        specifier: catalog:eslint9
+        version: 9.39.4
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 4.7.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -1116,8 +1119,17 @@ importers:
         specifier: 'catalog:'
         version: 4.1.0(encoding@0.1.13)
       eslint:
-        specifier: 'catalog:'
-        version: 8.57.1
+        specifier: catalog:eslint9
+        version: 9.39.4(jiti@2.7.0)
+      eslint-plugin-ghost:
+        specifier: 3.5.0
+        version: 3.5.0(@babel/core@7.29.7)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-react:
+        specifier: 7.37.5
+        version: 7.37.5(eslint@9.39.4(jiti@2.7.0))
+      globals:
+        specifier: 17.6.0
+        version: 17.6.0
       jsdom:
         specifier: 'catalog:'
         version: 29.1.1(@noble/hashes@1.8.0)
@@ -1754,6 +1766,9 @@ importers:
         specifier: catalog:react17
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@eslint/js':
+        specifier: catalog:eslint9
+        version: 9.39.4
       '@testing-library/jest-dom':
         specifier: 'catalog:'
         version: 6.9.1
@@ -1773,8 +1788,17 @@ importers:
         specifier: 'catalog:'
         version: 4.1.0(encoding@0.1.13)
       eslint:
-        specifier: 'catalog:'
-        version: 8.57.1
+        specifier: catalog:eslint9
+        version: 9.39.4(jiti@2.7.0)
+      eslint-plugin-ghost:
+        specifier: 3.5.0
+        version: 3.5.0(@babel/core@7.29.7)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-react:
+        specifier: 7.37.5
+        version: 7.37.5(eslint@9.39.4(jiti@2.7.0))
+      globals:
+        specifier: 17.6.0
+        version: 17.6.0
       jsdom:
         specifier: 'catalog:'
         version: 29.1.1(@noble/hashes@1.8.0)
@@ -36361,6 +36385,28 @@ snapshots:
       doctrine: 2.1.0
       es-iterator-helpers: 1.3.2
       eslint: 8.57.1
+      estraverse: 5.3.0
+      hasown: 2.0.4
+      jsx-ast-utils: 3.3.5
+      minimatch: 3.1.5
+      object.entries: 1.1.9
+      object.fromentries: 2.0.8
+      object.values: 1.2.1
+      prop-types: 15.8.1
+      resolve: 2.0.0-next.7
+      semver: 6.3.1
+      string.prototype.matchall: 4.0.12
+      string.prototype.repeat: 1.0.0
+
+  eslint-plugin-react@7.37.5(eslint@9.39.4(jiti@2.7.0)):
+    dependencies:
+      array-includes: 3.1.9
+      array.prototype.findlast: 1.2.5
+      array.prototype.flatmap: 1.3.3
+      array.prototype.tosorted: 1.1.4
+      doctrine: 2.1.0
+      es-iterator-helpers: 1.3.2
+      eslint: 9.39.4(jiti@2.7.0)
       estraverse: 5.3.0
       hasown: 2.0.4
       jsx-ast-utils: 3.3.5


### PR DESCRIPTION
## Summary

- Replaced the inline `eslintConfig` in both `apps/sodo-search/package.json` and `apps/announcement-bar/package.json` with flat `eslint.config.js` files.
- Swapped `eslint: catalog:` to `catalog:eslint9` and added `@eslint/js`, `globals`, `eslint-plugin-ghost`, and `eslint-plugin-react` as direct deps.
- Dropped the `plugin:ghost/browser` + `plugin:react/recommended` legacy extends. Formatting rules (`indent`, `quotes`, `semi`, `space-*`, etc.) were removed from ESLint 9 core, so they could not survive the migration as-written. Non-formatting rules preserved inline.
- ESLint 9 dropped the `--ext` CLI flag; the `lint` script now passes directory args (`src test`).
- Dropped two stale \`// eslint-disable-next-line no-undef\` directives in the vitest setup files — \`vi\` is now declared in `globals` for test files, so the directives became unused.
- One ES2019 optional catch binding fix in `sodo-search/src/app.js` (\`catch (e) {}\` with unused `e` → \`catch {}\`). ESLint 9's `no-unused-vars` defaults to `caughtErrors: 'all'` now.
- Modernized both packages to ESM (\`"type": "module"\`). Both test files already used \`import\` syntax and src is Vite-built — declaring \`type: module\` just makes the package metadata match runtime behavior. Drops the need for an \`.mjs\` extension on the eslint config.
- Bumped \`sodo-search\` 1.8.23 → 1.8.24 and \`announcement-bar\` 1.1.21 → 1.1.22; both stay within the \`~1.8\` / \`~1.1\` ranges pinned in [defaults.json](ghost/core/core/shared/config/defaults.json).

## Test plan

- [ ] CI lint passes
- [ ] CI app version bump check passes
- [ ] \`pnpm --filter @tryghost/sodo-search lint\` is green locally
- [ ] \`pnpm --filter @tryghost/announcement-bar lint\` is green locally