### PR TITLE
Removed the flaky cache TTL expiry tests

### DIFF
--- a/ghost/core/test/unit/server/adapters/cache/adapter-cache-memory-ttl.test.js
+++ b/ghost/core/test/unit/server/adapters/cache/adapter-cache-memory-ttl.test.js
@@ -23,59 +23,6 @@ describe('Cache Adapter In Memory with Time To Live', function () {
 
             assert.equal(cache.get('a'), 'b', 'should get the value from the cache after some time');
         });
-
-        // TODO: fix this test so we can unskip
-        // eslint-disable-next-line ghost/mocha/no-skipped-tests
-        it.skip('Can get a value from the cache before TTL kicks in', async function () {
-            const cache = new MemoryTTLCache({ttl: 50});
-            cache.set('a', 'b');
-            assert.equal(cache.get('a'), 'b', 'should get the value from the cache');
-
-            await sleep(20);
-
-            assert.equal(cache.get('a'), 'b', 'should get the value from the cache before TTL time');
-
-            // NOTE: 20 + 200 = 220, which is more than 50 TTL
-            await sleep(200);
-
-            assert.equal(cache.get('a'), undefined, 'should NOT get the value from the cache after TTL time');
-        });
-    });
-
-    describe('set', function () {
-        // TODO: fix this test so we can unskip
-        // eslint-disable-next-line ghost/mocha/no-skipped-tests
-        it.skip('Can set a value in the cache', async function () {
-            const cache = new MemoryTTLCache({ttl: 50});
-
-            cache.set('a', 'b');
-
-            assert.equal(cache.get('a'), 'b', 'should get the value from the cache');
-
-            await sleep(20);
-
-            assert.equal(cache.get('a'), 'b', 'should get the value from the cache after time < TTL');
-
-            await sleep(200);
-
-            assert.equal(cache.get('a'), undefined, 'should NOT get the value from the cache after TTL time');
-        });
-
-        // TODO: fix this test so we can unskip
-        // eslint-disable-next-line ghost/mocha/no-skipped-tests
-        it.skip('Can override TTL time', async function () {
-            const cache = new MemoryTTLCache({ttl: 20});
-
-            cache.set('a', 'b', {ttl: 50});
-
-            await sleep(21);
-
-            assert.equal(cache.get('a'), 'b', 'should get the value from the cache');
-
-            await sleep(200);
-
-            assert.equal(cache.get('a'), undefined, 'should NOT get the value from the cache after TTL time');
-        });
     });
 
     describe('reset', function () {


### PR DESCRIPTION
The three skipped tests in `adapter-cache-memory-ttl.test.js` asserted a value was still present a few ms after `set`, racing `@isaacs/ttlcache`'s `setTimeout`-driven eviction with ~30ms of slack — under CI load the eviction fires first and `get` returns `undefined`.

The adapter is a thin wrapper over the well-tested `@isaacs/ttlcache`; its `set`/`get`/`reset`/`keys` surface stays covered by the remaining tests, and `retry: 2` already absorbs this jitter. A deterministic fix would mean faking the library's internal `performance.now()` clock via a `require.cache` reload — not worth the complexity here. Removed the three tests and the now-empty `set` suite.