### PR TITLE
Unblocked CI lint chain: ghost/core TS rule + stale i18n ignores

### DIFF
--- a/ghost/core/.eslintrc.js
+++ b/ghost/core/.eslintrc.js
@@ -21,7 +21,17 @@ module.exports = {
             extends: [
                 'plugin:ghost/ts'
             ],
-            parser: '@typescript-eslint/parser'
+            parser: '@typescript-eslint/parser',
+            rules: {
+                // The @typescript-eslint v8.49 plugin's no-unused-expressions
+                // rule fails to apply its default options under ESLint 8 in
+                // this workspace's current pnpm peer-dep resolution, throwing
+                // "Cannot read properties of undefined (reading
+                // 'allowShortCircuit')" at lint time. Disabling here as an
+                // interim fix; the rule comes back when ghost/core migrates
+                // to ESLint 9 / flat config.
+                '@typescript-eslint/no-unused-expressions': 'off'
+            }
         },
         {
             files: 'core/server/api/endpoints/*',

--- a/ghost/i18n/test/i18n-ignores.json
+++ b/ghost/i18n/test/i18n-ignores.json
@@ -39,16 +39,6 @@
                 "comment": "translated text doesn't fit on the button"
             },
             {
-                "file": "eu/ghost.json",
-                "key": "{count} month_one",
-                "comment": "There is no need for the variable since in Basque there is this word that means one month, and it would be redundant to pair it with the number."
-            },
-            {
-                "file": "eu/ghost.json",
-                "key": "{count} year_one",
-                "comment": "There is no need for the variable since in Basque there is this word that means one year, and it would be redundant to pair it with the number."
-            },
-            {
                 "file": "is/portal.json",
                 "key": "{trialDays} days free",
                 "comment": "FIXME: This error was automatically ignored. Please update the translation, or explain why a variable is ignored"


### PR DESCRIPTION
## Summary

Two pre-existing lint failures on `main` that are blocking every open PR's `Lint` job. Both are unrelated to any feature work, surfaced after the recent foundation libs PR ([#28802](https://github.com/TryGhost/Ghost/pull/28802)) shifted pnpm's resolution and Nx cache invalidation.

### Fix 1 — `ghost/core` TS lint

The `@typescript-eslint` v8.49 plugin's `no-unused-expressions` rule throws:

```
TypeError: Cannot read properties of undefined (reading 'allowShortCircuit')
```

The rule has a `defaultOptions = [{ allowShortCircuit: false, ... }]` that the typescript-eslint `RuleCreator` wrapper applies at lint time via `applyDefault(defaultOptions, context.options)`. The plugin's transitive `@typescript-eslint/utils@8.49.0` now resolves to a variant peered to `eslint@9`, which mishandles the legacy ESLint 8 rule-loading path — so the rule body receives `context.options === []` and the destructure `[{ allowShortCircuit }]` blows up.

Disabled the rule in [ghost/core/.eslintrc.js](ghost/core/.eslintrc.js)'s `*.ts` override block. It comes back automatically when `ghost/core` migrates to ESLint 9 / flat config.

### Fix 2 — Stale i18n ignores

`ghost/i18n/test/i18n-ignores.json` had two pre-existing entries for `eu/ghost.json` (`{count} month_one` and `{count} year_one`) that the lint:translations validator reports as "unused ignore" — both keys have empty values in `eu/ghost.json`, so the underlying `no-unused-variables` rule doesn't fire, so suppressing it is a no-op the validator complains about.

Removed both entries. If/when the Basque translations are filled in, the variable-usage check will fire properly and the ignores can be re-added with the original rationale.

## Test plan

- [ ] CI `Lint` job passes (which gates every other open PR — slices 6, 7, 8, 9 of the ongoing ESLint 9 migration)
- [ ] \`pnpm --filter ghost lint:types\` is green locally (ESLint portion; `tsc --noEmit` still requires built deps via `pnpm setup`)
- [ ] \`pnpm --filter @tryghost/i18n lint:translations\` is green locally