### PR TITLE
Ordered automation list alphabetically by name

### DIFF
--- a/ghost/core/core/server/services/automations/database-automations-repository.ts
+++ b/ghost/core/core/server/services/automations/database-automations-repository.ts
@@ -699,10 +699,7 @@ async function loadAutomationBySlug(trx: Knex.Transaction, slug: string): Promis
 async function loadAutomations(trx: Knex.Transaction): Promise<AutomationRow[]> {
     return await trx('automations')
         .select('id', 'slug', 'name', 'status', 'created_at', 'updated_at')
-        .orderBy([
-            'created_at',
-            'id'
-        ]);
+        .orderBy('name');
 }
 
 async function updateAutomation(trx: Knex.Transaction, automation: AutomationRow): Promise<AutomationRow> {

--- a/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
+++ b/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
@@ -577,6 +577,27 @@ describe('automations repository', function () {
             }
         };
 
+        it('returns a list of automations, ordered by name', async function () {
+            await knex('automations').insert({
+                id: ObjectId().toHexString(),
+                created_at: toDatabaseDate(new Date()),
+                updated_at: toDatabaseDate(new Date()),
+                slug: 'alpha-flow',
+                name: 'Alpha flow',
+                status: 'inactive'
+            });
+
+            const result = await repo.browse();
+
+            const names = result.data.map(automation => automation.name);
+
+            assert.deepEqual(names, [
+                'Alpha flow',
+                'Free member welcome flow',
+                'Paid member welcome flow'
+            ]);
+        });
+
         it('creates missing default free and paid automations', async function () {
             const automationIds = await knex('automations')
                 .whereIn('slug', ['member-welcome-email-free', 'member-welcome-email-paid'])


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1375

For now, this will mean the order is Free, then Paid. Supports additional automations in the future.

Note that `name` is a unique field, so we don't need a tiebreaker.

![Screenshot](https://github.com/user-attachments/assets/75bd79bf-eac1-489b-86b6-284d3b1aa7a7)

