### PR TITLE
Co-locate gift-links response serializers in the service module

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/gift-links.ts
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/gift-links.ts
@@ -1,42 +1,21 @@
-import {z} from 'zod';
-import {GiftLink} from '../../../../../services/gift-links/models';
+import {toGiftLinksResponse, toRevokeAllResponse} from '../../../../../services/gift-links/serializers';
 import type {Post} from '../../../../../services/gift-links/models';
 
 interface Frame {
     response?: unknown;
 }
 
-const GiftLinkApiResponse = z.object({
-    token: z.string(),
-    redeemed_count: z.number(),
-    last_redeemed_at: z.date().nullable(),
-    created_at: z.date()
-});
-const GiftLinksResponse = z.object({gift_links: z.array(GiftLinkApiResponse)});
+const serializeGiftLinks = (post: Post, _apiConfig: unknown, frame: Frame): void => {
+    frame.response = toGiftLinksResponse.parse(post.giftLinks);
+};
 
-const toGiftLinksResponse = z.array(GiftLink)
-    .transform((links): z.input<typeof GiftLinksResponse> => ({
-        gift_links: links.map(link => ({
-            token: link.token,
-            redeemed_count: link.redeemedCount,
-            last_redeemed_at: link.lastRedeemedAt,
-            created_at: link.createdAt
-        }))
-    }))
-    .pipe(GiftLinksResponse);
-
-// module.exports (not export): the API framework loads serializers via require().
+// module.exports (not export): the API framework loads serializers via require(). The endpoint ->
+// serializer mapping lives here; the response shaping lives with the gift-links service module.
 module.exports = {
-    read(post: Post, _apiConfig: unknown, frame: Frame) {
-        frame.response = toGiftLinksResponse.parse(post.giftLinks);
-    },
-    issue(post: Post, _apiConfig: unknown, frame: Frame) {
-        frame.response = toGiftLinksResponse.parse(post.giftLinks);
-    },
-    reissue(post: Post, _apiConfig: unknown, frame: Frame) {
-        frame.response = toGiftLinksResponse.parse(post.giftLinks);
-    },
-    revokeAll(data: {count: number}, _apiConfig: unknown, frame: Frame) {
-        frame.response = {meta: {count: data.count}};
+    read: serializeGiftLinks,
+    issue: serializeGiftLinks,
+    reissue: serializeGiftLinks,
+    revokeAll(data: {count: number}, _apiConfig: unknown, frame: Frame): void {
+        frame.response = toRevokeAllResponse.parse(data);
     }
 };

--- a/ghost/core/core/server/services/gift-links/serializers.ts
+++ b/ghost/core/core/server/services/gift-links/serializers.ts
@@ -1,0 +1,27 @@
+import {z} from 'zod';
+import {GiftLink} from './models';
+
+// Response schemas — the shapes the admin endpoints emit.
+const GiftLinkResource = z.object({
+    token: z.string(),
+    redeemed_count: z.number(),
+    last_redeemed_at: z.date().nullable(),
+    created_at: z.date()
+});
+const GiftLinksResponse = z.object({gift_links: z.array(GiftLinkResource)});
+const RevokeAllResponse = z.object({meta: z.object({count: z.number()})});
+
+export const toGiftLinksResponse = z.array(GiftLink)
+    .transform((links): z.input<typeof GiftLinksResponse> => ({
+        gift_links: links.map(link => ({
+            token: link.token,
+            redeemed_count: link.redeemedCount,
+            last_redeemed_at: link.lastRedeemedAt,
+            created_at: link.createdAt
+        }))
+    }))
+    .pipe(GiftLinksResponse);
+
+export const toRevokeAllResponse = z.object({count: z.number()})
+    .transform((data): z.input<typeof RevokeAllResponse> => ({meta: {count: data.count}}))
+    .pipe(RevokeAllResponse);


### PR DESCRIPTION
## Problem

The gift-links response serialization lived in the API serializer layer, away from the rest of the module's concerns — its database mapping, queries, models, and service. The logic for one feature was split across two parts of the codebase.

## Solution

Move the whole serialization — the response schemas, the transforms, and the endpoint-to-schema mapping — into the gift-links service module as a pure ES module, so it sits alongside the module's other concerns. The framework's output serializer registry points straight at it, so there is no separate adapter file. The module now owns all of its concerns in one place.

Stacked on #28783 — review this as the serializer move on top of that branch's data-layer split. Retargets to `main` once that merges.