### PR TITLE
Add a flat case-key mapper for the gift-links codec and serializer

### DIFF
--- a/ghost/core/core/server/services/gift-links/case-keys.ts
+++ b/ghost/core/core/server/services/gift-links/case-keys.ts
@@ -1,0 +1,30 @@
+// Flat snake_case <-> camelCase key mappers. Top-level keys only: values are copied by reference
+// and their types pass through untouched (T[K]). Deep case-convert libraries recurse into value
+// types, which mangles branded primitives (a branded string is `string & {...}`, so it reads as an
+// object and gets walked); staying flat sidesteps that and keeps the keys' value types exact.
+
+type SnakeToCamel<S extends string> = S extends `${infer Head}_${infer Tail}`
+    ? `${Head}${Capitalize<SnakeToCamel<Tail>>}`
+    : S;
+
+type CamelToSnake<S extends string> = S extends `${infer Head}${infer Tail}`
+    ? Head extends Uppercase<Head>
+        ? Head extends Lowercase<Head>
+            ? `${Head}${CamelToSnake<Tail>}` // non-letter (digit, etc.): leave as-is
+            : `_${Lowercase<Head>}${CamelToSnake<Tail>}` // uppercase letter: split with an underscore
+        : `${Head}${CamelToSnake<Tail>}` // lowercase letter: keep
+    : S;
+
+export type CamelKeys<T> = {[K in keyof T as SnakeToCamel<K & string>]: T[K]};
+export type SnakeKeys<T> = {[K in keyof T as CamelToSnake<K & string>]: T[K]};
+
+const toCamel = (key: string): string => key.replace(/_([a-z])/g, (_full, letter: string) => letter.toUpperCase());
+const toSnake = (key: string): string => key.replace(/[A-Z]/g, letter => `_${letter.toLowerCase()}`);
+
+export function camelKeys<T extends object>(row: T): CamelKeys<T> {
+    return Object.fromEntries(Object.entries(row).map(([key, value]) => [toCamel(key), value])) as CamelKeys<T>;
+}
+
+export function snakeKeys<T extends object>(model: T): SnakeKeys<T> {
+    return Object.fromEntries(Object.entries(model).map(([key, value]) => [toSnake(key), value])) as SnakeKeys<T>;
+}

--- a/ghost/core/core/server/services/gift-links/queries.ts
+++ b/ghost/core/core/server/services/gift-links/queries.ts
@@ -1,5 +1,6 @@
 import {z} from 'zod';
 import type {Knex} from 'knex';
+import {camelKeys, snakeKeys} from './case-keys';
 import {DbGiftLink} from './database';
 import {GiftLink} from './models';
 
@@ -13,18 +14,8 @@ export const GiftLinkRow = DbGiftLink.pick({
 
 // Maps a selected row to/from the domain GiftLink (snake_case to camelCase, token branding).
 export const giftLinkCodec = z.codec(GiftLinkRow, GiftLink, {
-    decode: row => ({
-        token: row.token,
-        redeemedCount: row.redeemed_count,
-        lastRedeemedAt: row.last_redeemed_at,
-        createdAt: row.created_at
-    }),
-    encode: link => ({
-        token: link.token,
-        redeemed_count: link.redeemedCount,
-        last_redeemed_at: link.lastRedeemedAt,
-        created_at: link.createdAt
-    })
+    decode: row => camelKeys(row),
+    encode: link => snakeKeys(link)
 });
 
 const giftLinkColumns = Object.keys(GiftLinkRow.shape).map(column => `gift_links.${column}`);

--- a/ghost/core/core/server/services/gift-links/serializers.ts
+++ b/ghost/core/core/server/services/gift-links/serializers.ts
@@ -1,4 +1,5 @@
 import {z} from 'zod';
+import {snakeKeys} from './case-keys';
 import {GiftLink} from './models';
 
 // Response schemas — the shapes the admin endpoints emit.
@@ -13,12 +14,7 @@ const RevokeAllResponse = z.object({meta: z.object({count: z.number()})});
 
 export const toGiftLinksResponse = z.array(GiftLink)
     .transform((links): z.input<typeof GiftLinksResponse> => ({
-        gift_links: links.map(link => ({
-            token: link.token,
-            redeemed_count: link.redeemedCount,
-            last_redeemed_at: link.lastRedeemedAt,
-            created_at: link.createdAt
-        }))
+        gift_links: links.map(link => snakeKeys(link))
     }))
     .pipe(GiftLinksResponse);
 


### PR DESCRIPTION
## Problem

The gift-links codec (database row to domain) and the response serializer (domain to API) each mapped fields with hand-written snake_case to camelCase object literals. The field list was repeated across the row schema, the domain schema, and the literal bodies, and it was hard to tell the deliberate, type-checked projection from incidental boilerplate.

## Solution

Replace the literals in both places with a small in-house flat key mapper. It renames top-level keys only and copies values by reference, so the branded token, dates and nulls pass through untouched. The codec and the response schema still check the result, so adding, removing, or retyping any field - the token included - is a compile error, not a runtime surprise or a silent pass-through.

A deep third-party case-convert library was evaluated and rejected: it recurses into value types and mangles the branded token type, so it could not type-check the serializer at all.

Stacked on #28809. Retargets to main once that merges.