### PR TITLE
Canceled active automation runs when an automation is disabled

### DIFF
--- a/ghost/core/core/server/services/automations/database-automations-repository.ts
+++ b/ghost/core/core/server/services/automations/database-automations-repository.ts
@@ -17,7 +17,7 @@ import type {
     EditAutomationData,
     Page
 } from './automations-repository';
-import {LOCK_TIMEOUT_MS} from './constants';
+import {getStaleLockCutoff} from './stale-lock-cutoff';
 import type {ExclusifyUnion, ReadonlyDeep} from 'type-fest';
 
 const HOUR_MS = 60 * 60 * 1000;
@@ -165,13 +165,19 @@ export function createDatabaseAutomationsRepository({
                     return null;
                 }
 
+                const now = new Date();
+
                 const updatedAutomation = await updateAutomation(trx, {
                     ...automation,
                     status: data.status,
-                    updated_at: toDatabaseDate(new Date())
+                    updated_at: toDatabaseDate(now)
                 });
 
                 await replaceAutomationGraph(trx, updatedAutomation.id, data.actions, data.edges);
+
+                if (updatedAutomation.status === 'inactive') {
+                    await cancelCancelablePendingStepsForAutomation(trx, updatedAutomation.id, now);
+                }
 
                 return await buildAutomation(trx, updatedAutomation);
             });
@@ -375,7 +381,7 @@ async function fetchAndLockSteps(trx: Knex.Transaction, limit: number): Promise<
 
     const now = new Date();
     const nowString = toDatabaseDate(now);
-    const staleLockCutoff = new Date(now.getTime() - LOCK_TIMEOUT_MS);
+    const staleLockCutoff = getStaleLockCutoff(now);
     const staleLockCutoffString = toDatabaseDate(staleLockCutoff);
     const lockId = crypto.randomUUID();
 
@@ -561,6 +567,10 @@ async function finishStepAndEnqueueNext(
         return null;
     }
 
+    if (!await isRunAutomationActive(trx, step.automation_run_id)) {
+        return null;
+    }
+
     const next = await findNextActionRevision(trx, step.action_id);
 
     if (!next) {
@@ -620,6 +630,11 @@ async function retryStep(
     step: Pick<AutomationStepToRun, 'id' | 'locked_by'>,
     retryAt: Readonly<Date>
 ): Promise<boolean> {
+    if (!await isStepRunAutomationActive(trx, step.id)) {
+        await markStepTerminal(trx, step, 'automation disabled');
+        return false;
+    }
+
     const nowString = toDatabaseDate(new Date());
     return await updateStep(trx, step, {
         status: 'pending',
@@ -653,6 +668,58 @@ function getReadyAtForAction(
         });
     }
     }
+}
+
+async function cancelCancelablePendingStepsForAutomation(
+    trx: Knex.Transaction,
+    automationId: string,
+    now: Readonly<Date>
+): Promise<void> {
+    const nowString = toDatabaseDate(now);
+    const staleLockCutoff = toDatabaseDate(getStaleLockCutoff(now));
+    await trx('automation_run_steps')
+        .update({
+            status: 'automation disabled',
+            finished_at: nowString,
+            updated_at: nowString,
+            locked_by: null,
+            locked_at: null
+        })
+        .where('status', 'pending')
+        .whereIn('automation_run_id', trx('automation_runs')
+            .select('id')
+            .where('automation_id', automationId))
+        .where((builder) => {
+            builder
+                .whereNull('locked_by')
+                .orWhere('locked_at', '<', staleLockCutoff);
+        });
+}
+
+async function isStepRunAutomationActive(trx: Knex.Transaction, stepId: string): Promise<boolean> {
+    const query = trx('automation_run_steps as step')
+        .select(trx.raw('1'))
+        .innerJoin('automation_runs as run', 'run.id', 'step.automation_run_id')
+        .innerJoin('automations as automation', 'automation.id', 'run.automation_id')
+        .where('step.id', stepId)
+        .where('automation.status', 'active');
+    return await selectExists(trx, query);
+}
+
+async function isRunAutomationActive(trx: Knex.Transaction, automationRunId: string): Promise<boolean> {
+    const query = trx('automation_runs as run')
+        .select(trx.raw('1'))
+        .innerJoin('automations as automation', 'automation.id', 'run.automation_id')
+        .where('run.id', automationRunId)
+        .where('automation.status', 'active');
+    return await selectExists(trx, query);
+}
+
+async function selectExists(trx: Knex.Transaction, query: Knex.QueryBuilder): Promise<boolean> {
+    const row = await trx
+        .select<{exists: boolean | number | string}>(trx.raw('exists ? as `exists`', [query]))
+        .first();
+    return Boolean(Number(row?.exists));
 }
 
 /**

--- a/ghost/core/core/server/services/automations/stale-lock-cutoff.ts
+++ b/ghost/core/core/server/services/automations/stale-lock-cutoff.ts
@@ -1,0 +1,5 @@
+import {LOCK_TIMEOUT_MS} from './constants';
+
+export function getStaleLockCutoff(now: Readonly<Date>): Date {
+    return new Date(now.getTime() - LOCK_TIMEOUT_MS);
+}

--- a/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
+++ b/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
@@ -822,6 +822,98 @@ describe('automations repository', function () {
             });
         };
 
+        it('cancels pending unlocked steps when disabling an automation', async function () {
+            const automation = await getAutomationBySlug('member-welcome-email-free');
+            const action = await getActionByIndex(automation.id, 0);
+            const run = await insertRun(automation.id);
+            const step = await insertStep(run.id, action.revision_id);
+
+            const beforeEdit = Date.now();
+            await repo.edit(automation.id, {
+                ...automation,
+                status: 'inactive'
+            });
+            const afterEdit = Date.now();
+
+            const cancelled = await getStepById(step.id);
+            assert.equal(cancelled.status, 'automation disabled');
+            assert.equal(cancelled.locked_by, null);
+            assert.equal(cancelled.locked_at, null);
+            assert.equal(cancelled.started_at, null);
+            const cancelledFinishedAt = cancelled.finished_at;
+            assert(typeof cancelledFinishedAt === 'string');
+            assert(cancelledFinishedAt >= toDatabaseDate(new Date(beforeEdit - 1000)));
+            assert(cancelledFinishedAt <= toDatabaseDate(new Date(afterEdit)));
+        });
+
+        it('cancels pending steps with expired locks when disabling an automation', async function () {
+            const automation = await getAutomationBySlug('member-welcome-email-free');
+            const action = await getActionByIndex(automation.id, 0);
+            const run = await insertRun(automation.id);
+            const step = await insertStep(run.id, action.revision_id, {
+                locked_by: 'expired-lock',
+                locked_at: new Date(Date.now() - (31 * 60 * 1000)).toISOString(),
+                started_at: new Date(Date.now() - (31 * 60 * 1000)).toISOString()
+            });
+
+            await repo.edit(automation.id, {
+                ...automation,
+                status: 'inactive'
+            });
+
+            const cancelled = await getStepById(step.id);
+            assert.equal(cancelled.status, 'automation disabled');
+            assert.equal(cancelled.locked_by, null);
+            assert.equal(cancelled.locked_at, null);
+            assert.equal(typeof cancelled.finished_at, 'string');
+        });
+
+        it('does not cancel pending steps with fresh locks when disabling an automation', async function () {
+            const automation = await getAutomationBySlug('member-welcome-email-free');
+            const action = await getActionByIndex(automation.id, 0);
+            const run = await insertRun(automation.id);
+            const lockedAt = toDatabaseDate(new Date(Date.now() - (29 * 60 * 1000)));
+            const step = await insertStep(run.id, action.revision_id, {
+                locked_by: 'fresh-lock',
+                locked_at: lockedAt,
+                started_at: lockedAt
+            });
+
+            await repo.edit(automation.id, {
+                ...automation,
+                status: 'inactive'
+            });
+
+            const unchanged = await getStepById(step.id);
+            assert.equal(unchanged.status, 'pending');
+            assert.equal(unchanged.locked_by, 'fresh-lock');
+            assert.equal(unchanged.locked_at, lockedAt);
+            assert.equal(unchanged.finished_at, null);
+        });
+
+        it('does not cancel pending steps for other automations when disabling an automation', async function () {
+            const freeAutomation = await getAutomationBySlug('member-welcome-email-free');
+            const paidAutomation = await getAutomationBySlug('member-welcome-email-paid');
+            const freeAction = await getActionByIndex(freeAutomation.id, 0);
+            const paidAction = await getActionByIndex(paidAutomation.id, 0);
+            const freeRun = await insertRun(freeAutomation.id);
+            const paidRun = await insertRun(paidAutomation.id);
+            const freeStep = await insertStep(freeRun.id, freeAction.revision_id);
+            const paidStep = await insertStep(paidRun.id, paidAction.revision_id);
+
+            await repo.edit(freeAutomation.id, {
+                ...freeAutomation,
+                status: 'inactive'
+            });
+
+            const cancelledFreeStep = await getStepById(freeStep.id);
+            assert.equal(cancelledFreeStep.status, 'automation disabled');
+
+            const unchangedPaidStep = await getStepById(paidStep.id);
+            assert.equal(unchangedPaidStep.status, 'pending');
+            assert.equal(unchangedPaidStep.finished_at, null);
+        });
+
         it('only inserts action revisions when action data changes', async function () {
             const initialAutomation = await getAutomationBySlug('member-welcome-email-free');
             const initialRevisionCount = await getRevisionCount();
@@ -1366,6 +1458,35 @@ describe('automations repository', function () {
             assert.equal(finished.locked_at, null);
         });
 
+        it('does not enqueue the next step when the automation was disabled after the step was locked', async function () {
+            const automation = await getAutomationBySlug('member-welcome-email-free');
+            const action = await getActionByIndex(automation.id, 0);
+            const run = await insertRun(automation.id);
+            const stepRow = await insertStep(run.id, action.revision_id, {
+                ready_at: new Date(Date.now() - 1000).toISOString()
+            });
+            const step = await getLockedStep(stepRow.id);
+
+            await knex('automations')
+                .update({
+                    status: 'inactive',
+                    updated_at: toDatabaseDate(new Date())
+                })
+                .where('id', automation.id);
+
+            const nextReadyAt = await repo.finishStepAndEnqueueNext(step);
+
+            assert.equal(nextReadyAt, null);
+
+            const finished = await getStepById(stepRow.id);
+            assert.equal(finished.status, 'finished');
+            assert.equal(finished.locked_by, null);
+            assert.equal(finished.locked_at, null);
+
+            const allSteps = await getStepsByRunId(run.id);
+            assert.equal(allSteps.length, 1);
+        });
+
         it('does not finish or enqueue if the step lock has been taken by another runner', async function () {
             const automation = await getAutomationBySlug('member-welcome-email-free');
             const action = await getActionByIndex(automation.id, 0);
@@ -1610,6 +1731,36 @@ describe('automations repository', function () {
 
             const unchanged = await getStepById(step.id);
             assert.deepEqual(unchanged, beforeRetry);
+        });
+
+        it('marks the step disabled instead of retrying when the automation was disabled after the step was locked', async function () {
+            const automation = await getAutomationBySlug('member-welcome-email-free');
+            const action = await getActionByIndex(automation.id, 0);
+            const run = await insertRun(automation.id);
+            const stepRow = await insertStep(run.id, action.revision_id, {
+                ready_at: new Date(Date.now() - 1000).toISOString()
+            });
+            const step = await getLockedStep(stepRow.id);
+            const lockedStep = await getStepById(step.id);
+
+            await knex('automations')
+                .update({
+                    status: 'inactive',
+                    updated_at: toDatabaseDate(new Date())
+                })
+                .where('id', automation.id);
+
+            const didRetry = await repo.retryStep(step, new Date(Date.now() + 1000));
+
+            assert.equal(didRetry, false);
+
+            const disabled = await getStepById(step.id);
+            assert.equal(disabled.status, 'automation disabled');
+            assert.equal(disabled.locked_by, null);
+            assert.equal(disabled.locked_at, null);
+            assert.equal(disabled.started_at, lockedStep.started_at);
+            assert.equal(disabled.ready_at, stepRow.ready_at);
+            assert.equal(typeof disabled.finished_at, 'string');
         });
     });
 });

--- a/ghost/core/test/unit/server/services/automations/stale-lock-cutoff.test.ts
+++ b/ghost/core/test/unit/server/services/automations/stale-lock-cutoff.test.ts
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import {getStaleLockCutoff} from '../../../../../core/server/services/automations/stale-lock-cutoff';
+
+describe('getStaleLockCutoff', function () {
+    it('returns the lock timeout before now', function () {
+        const now = new Date('2026-06-22T12:00:00.000Z');
+
+        const cutoff = getStaleLockCutoff(now);
+
+        assert.equal(cutoff.toISOString(), '2026-06-22T11:30:00.000Z');
+    });
+});


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1358

When an automation is marked inactive, we now cancel any active runs.

## How it works

To do this, we:

- Mark all pending steps canceled.
- If an automation is deactivated while a step is running:
    - Don't enqueue subsequent steps.
    - Don't retry failed steps.

Note that, if a step is already locked and running, we may not be able to stop it.

## Manual test

In addition to automated tests, I manually tested this by:

1. Temporarily set `automations.fakeWaitHoursMultiplier` to 2500 (one day becomes one minute).
2. Created a "send email, wait 2 days, send email" automation.
3. Signed up a member and got the first email.
4. Deactivated then reactivated the automation.
5. Verified that I never received the second email.

I also ran through this *without* deactivating the automation and made sure I got both emails.
