### PR TITLE
Defined the route-settings store contract and canonical RouteSettings type

### DIFF
--- a/ghost/core/core/server/adapters/route-settings/RouteSettingsStoreBase.d.ts
+++ b/ghost/core/core/server/adapters/route-settings/RouteSettingsStoreBase.d.ts
@@ -1,7 +1,5 @@
-/* eslint-disable ghost/filenames/match-regex, ghost/filenames/match-exported-class --
- * PascalCase mirrors the runtime `RouteSettingsStoreBase.js` so the TS adapter
- * can default-import via the matching declaration file.
- */
+// PascalCase mirrors the runtime `RouteSettingsStoreBase.js` so the TS adapter
+// can default-import via the matching declaration file.
 import type {RouteSettings} from '../../services/route-settings/route-settings-parser';
 
 /**

--- a/ghost/core/core/server/adapters/route-settings/RouteSettingsStoreBase.d.ts
+++ b/ghost/core/core/server/adapters/route-settings/RouteSettingsStoreBase.d.ts
@@ -1,0 +1,20 @@
+/* eslint-disable ghost/filenames/match-regex, ghost/filenames/match-exported-class --
+ * PascalCase mirrors the runtime `RouteSettingsStoreBase.js` so the TS adapter
+ * can default-import via the matching declaration file.
+ */
+import type {RouteSettings} from '../../services/route-settings/route-settings-parser';
+
+/**
+ * Concurrent `replace` calls have no ordering guarantee — serialize
+ * externally if that matters.
+ */
+export interface RouteSettingsStore {
+    get(): Promise<RouteSettings>;
+    replace(settings: RouteSettings): Promise<void>;
+}
+
+declare class RouteSettingsStoreBase {
+    readonly requiredFns: ReadonlyArray<string>;
+}
+
+export default RouteSettingsStoreBase;

--- a/ghost/core/core/server/adapters/route-settings/RouteSettingsStoreBase.js
+++ b/ghost/core/core/server/adapters/route-settings/RouteSettingsStoreBase.js
@@ -1,0 +1,8 @@
+module.exports = class RouteSettingsStoreBase {
+    constructor() {
+        Object.defineProperty(this, 'requiredFns', {
+            value: ['get', 'replace'],
+            writable: false
+        });
+    }
+};

--- a/ghost/core/core/server/services/route-settings/route-settings-parser.ts
+++ b/ghost/core/core/server/services/route-settings/route-settings-parser.ts
@@ -1,0 +1,74 @@
+export type DataShortFormResource = 'tag' | 'page' | 'post' | 'author';
+export type DataLongFormResource = 'tags' | 'posts' | 'pages' | 'authors';
+
+export type DataShortForm = string;
+
+export interface DataReadEntry {
+    type: 'read';
+    resource: DataLongFormResource;
+    slug: string;
+    redirect?: boolean;
+    include?: string;
+    visibility?: string;
+    status?: string;
+}
+
+export interface DataBrowseEntry {
+    type: 'browse';
+    resource: DataLongFormResource;
+    filter?: string;
+    limit?: number | 'all';
+    order?: string;
+    include?: string;
+    fields?: string;
+    visibility?: string;
+    status?: string;
+    page?: number;
+}
+
+export type DataLongFormEntry = DataReadEntry | DataBrowseEntry;
+export type DataEntry = DataShortForm | DataLongFormEntry;
+export type RouteData = DataShortForm | Record<string, DataEntry>;
+
+interface RouteBase {
+    path: string;
+    template?: string | string[];
+    data?: RouteData;
+}
+
+export interface ChannelRoute extends RouteBase {
+    type: 'channel';
+    filter?: string;
+    order?: string;
+    limit?: number | 'all';
+    rss: boolean;
+}
+
+export interface TemplateRoute extends RouteBase {
+    type: 'template';
+    contentType?: string;
+}
+
+export type Route = ChannelRoute | TemplateRoute;
+
+export interface CollectionConfig {
+    path: string;
+    permalink: string;
+    template?: string | string[];
+    filter?: string;
+    order?: string;
+    limit?: number | 'all';
+    rss?: boolean;
+    data?: RouteData;
+}
+
+export interface TaxonomyConfig {
+    tag?: string;
+    author?: string;
+}
+
+export interface RouteSettings {
+    routes: Route[];
+    collections: CollectionConfig[];
+    taxonomies: TaxonomyConfig;
+}

--- a/ghost/core/core/server/services/route-settings/route-settings-parser.ts
+++ b/ghost/core/core/server/services/route-settings/route-settings-parser.ts
@@ -1,7 +1,7 @@
 export type DataShortFormResource = 'tag' | 'page' | 'post' | 'author';
 export type DataLongFormResource = 'tags' | 'posts' | 'pages' | 'authors';
 
-export type DataShortForm = string;
+export type DataShortForm = `${DataShortFormResource}.${string}`;
 
 export interface DataReadEntry {
     type: 'read';
@@ -32,7 +32,7 @@ export type RouteData = DataShortForm | Record<string, DataEntry>;
 
 interface RouteBase {
     path: string;
-    template?: string | string[];
+    template?: string[];
     data?: RouteData;
 }
 
@@ -54,7 +54,7 @@ export type Route = ChannelRoute | TemplateRoute;
 export interface CollectionConfig {
     path: string;
     permalink: string;
-    template?: string | string[];
+    template?: string[];
     filter?: string;
     order?: string;
     limit?: number | 'all';

--- a/ghost/core/core/server/services/route-settings/route-settings-parser.ts
+++ b/ghost/core/core/server/services/route-settings/route-settings-parser.ts
@@ -32,7 +32,7 @@ export type RouteData = DataShortForm | Record<string, DataEntry>;
 
 interface RouteBase {
     path: string;
-    template?: string[];
+    templates?: string[];
     data?: RouteData;
 }
 
@@ -54,7 +54,7 @@ export type Route = ChannelRoute | TemplateRoute;
 export interface CollectionConfig {
     path: string;
     permalink: string;
-    template?: string[];
+    templates?: string[];
     filter?: string;
     order?: string;
     limit?: number | 'all';

--- a/ghost/core/test/unit/server/adapters/route-settings/helpers/in-memory-store.ts
+++ b/ghost/core/test/unit/server/adapters/route-settings/helpers/in-memory-store.ts
@@ -1,0 +1,14 @@
+import type {RouteSettings} from '../../../../../../core/server/services/route-settings/route-settings-parser';
+import type {RouteSettingsStore} from '../../../../../../core/server/adapters/route-settings/RouteSettingsStoreBase';
+
+export class InMemoryStore implements RouteSettingsStore {
+    private settings: RouteSettings = {routes: [], collections: [], taxonomies: {}};
+
+    async get(): Promise<RouteSettings> {
+        return structuredClone(this.settings);
+    }
+
+    async replace(settings: RouteSettings): Promise<void> {
+        this.settings = structuredClone(settings);
+    }
+}

--- a/ghost/core/test/unit/server/adapters/route-settings/helpers/store-contract.ts
+++ b/ghost/core/test/unit/server/adapters/route-settings/helpers/store-contract.ts
@@ -11,13 +11,13 @@ const emptySettings = (): RouteSettings => ({routes: [], collections: [], taxono
 
 const sampleSettings = (): RouteSettings => ({
     routes: [
-        {type: 'template', path: '/about/', template: 'about'}
+        {type: 'template', path: '/about/', template: ['about']}
     ],
     collections: [
         {
             path: '/',
             permalink: '/{slug}/',
-            template: 'index',
+            template: ['index'],
             data: {featured: {resource: 'posts', type: 'browse', filter: 'featured:true'}}
         }
     ],
@@ -39,7 +39,7 @@ export function runStoreContract({createStore}: ContractOptions): void {
                 await store.replace(sampleSettings());
 
                 const firstRead = await store.get();
-                firstRead.routes.push({type: 'template', path: '/x/', template: 'x'});
+                firstRead.routes.push({type: 'template', path: '/x/', template: ['x']});
                 firstRead.collections[0].permalink = '/mutated/';
 
                 assert.deepEqual(await store.get(), sampleSettings());
@@ -59,13 +59,13 @@ export function runStoreContract({createStore}: ContractOptions): void {
                 await store.replace(sampleSettings());
                 await store.replace({
                     routes: [],
-                    collections: [{path: '/blog/', permalink: '/blog/{slug}/', template: 'index'}],
+                    collections: [{path: '/blog/', permalink: '/blog/{slug}/', template: ['index']}],
                     taxonomies: {}
                 });
 
                 assert.deepEqual(await store.get(), {
                     routes: [],
-                    collections: [{path: '/blog/', permalink: '/blog/{slug}/', template: 'index'}],
+                    collections: [{path: '/blog/', permalink: '/blog/{slug}/', template: ['index']}],
                     taxonomies: {}
                 });
             });
@@ -81,7 +81,7 @@ export function runStoreContract({createStore}: ContractOptions): void {
                 const settings = sampleSettings();
 
                 await store.replace(settings);
-                settings.routes.push({type: 'template', path: '/x/', template: 'x'});
+                settings.routes.push({type: 'template', path: '/x/', template: ['x']});
                 settings.taxonomies.tag = '/mutated/';
 
                 assert.deepEqual(await store.get(), sampleSettings());

--- a/ghost/core/test/unit/server/adapters/route-settings/helpers/store-contract.ts
+++ b/ghost/core/test/unit/server/adapters/route-settings/helpers/store-contract.ts
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+
+import type {RouteSettings} from '../../../../../../core/server/services/route-settings/route-settings-parser';
+import type {RouteSettingsStore} from '../../../../../../core/server/adapters/route-settings/RouteSettingsStoreBase';
+
+interface ContractOptions {
+    createStore: () => RouteSettingsStore | Promise<RouteSettingsStore>;
+}
+
+const emptySettings = (): RouteSettings => ({routes: [], collections: [], taxonomies: {}});
+
+const sampleSettings = (): RouteSettings => ({
+    routes: [
+        {type: 'template', path: '/about/', template: 'about'}
+    ],
+    collections: [
+        {
+            path: '/',
+            permalink: '/{slug}/',
+            template: 'index',
+            data: {featured: {resource: 'posts', type: 'browse', filter: 'featured:true'}}
+        }
+    ],
+    taxonomies: {
+        tag: '/tag/{slug}/'
+    }
+});
+
+export function runStoreContract({createStore}: ContractOptions): void {
+    describe('RouteSettingsStore contract', function () {
+        let store: RouteSettingsStore;
+
+        beforeEach(async function () {
+            store = await createStore();
+        });
+
+        describe('get', function () {
+            it('returns settings that callers cannot mutate in place', async function () {
+                await store.replace(sampleSettings());
+
+                const firstRead = await store.get();
+                firstRead.routes.push({type: 'template', path: '/x/', template: 'x'});
+                firstRead.collections[0].permalink = '/mutated/';
+
+                assert.deepEqual(await store.get(), sampleSettings());
+            });
+        });
+
+        describe('replace', function () {
+            it('persists settings so get returns the same RouteSettings', async function () {
+                const settings = sampleSettings();
+
+                await store.replace(settings);
+
+                assert.deepEqual(await store.get(), settings);
+            });
+
+            it('overwrites previously stored settings rather than merging', async function () {
+                await store.replace(sampleSettings());
+                await store.replace({
+                    routes: [],
+                    collections: [{path: '/blog/', permalink: '/blog/{slug}/', template: 'index'}],
+                    taxonomies: {}
+                });
+
+                assert.deepEqual(await store.get(), {
+                    routes: [],
+                    collections: [{path: '/blog/', permalink: '/blog/{slug}/', template: 'index'}],
+                    taxonomies: {}
+                });
+            });
+
+            it('clears all settings when called with empty settings', async function () {
+                await store.replace(sampleSettings());
+                await store.replace(emptySettings());
+
+                assert.deepEqual(await store.get(), emptySettings());
+            });
+
+            it('does not retain a reference to the input (caller mutations do not leak)', async function () {
+                const settings = sampleSettings();
+
+                await store.replace(settings);
+                settings.routes.push({type: 'template', path: '/x/', template: 'x'});
+                settings.taxonomies.tag = '/mutated/';
+
+                assert.deepEqual(await store.get(), sampleSettings());
+            });
+        });
+    });
+}

--- a/ghost/core/test/unit/server/adapters/route-settings/helpers/store-contract.ts
+++ b/ghost/core/test/unit/server/adapters/route-settings/helpers/store-contract.ts
@@ -11,13 +11,13 @@ const emptySettings = (): RouteSettings => ({routes: [], collections: [], taxono
 
 const sampleSettings = (): RouteSettings => ({
     routes: [
-        {type: 'template', path: '/about/', template: ['about']}
+        {type: 'template', path: '/about/', templates: ['about']}
     ],
     collections: [
         {
             path: '/',
             permalink: '/{slug}/',
-            template: ['index'],
+            templates: ['index'],
             data: {featured: {resource: 'posts', type: 'browse', filter: 'featured:true'}}
         }
     ],
@@ -39,7 +39,7 @@ export function runStoreContract({createStore}: ContractOptions): void {
                 await store.replace(sampleSettings());
 
                 const firstRead = await store.get();
-                firstRead.routes.push({type: 'template', path: '/x/', template: ['x']});
+                firstRead.routes.push({type: 'template', path: '/x/', templates: ['x']});
                 firstRead.collections[0].permalink = '/mutated/';
 
                 assert.deepEqual(await store.get(), sampleSettings());
@@ -59,13 +59,13 @@ export function runStoreContract({createStore}: ContractOptions): void {
                 await store.replace(sampleSettings());
                 await store.replace({
                     routes: [],
-                    collections: [{path: '/blog/', permalink: '/blog/{slug}/', template: ['index']}],
+                    collections: [{path: '/blog/', permalink: '/blog/{slug}/', templates: ['index']}],
                     taxonomies: {}
                 });
 
                 assert.deepEqual(await store.get(), {
                     routes: [],
-                    collections: [{path: '/blog/', permalink: '/blog/{slug}/', template: ['index']}],
+                    collections: [{path: '/blog/', permalink: '/blog/{slug}/', templates: ['index']}],
                     taxonomies: {}
                 });
             });
@@ -81,7 +81,7 @@ export function runStoreContract({createStore}: ContractOptions): void {
                 const settings = sampleSettings();
 
                 await store.replace(settings);
-                settings.routes.push({type: 'template', path: '/x/', template: ['x']});
+                settings.routes.push({type: 'template', path: '/x/', templates: ['x']});
                 settings.taxonomies.tag = '/mutated/';
 
                 assert.deepEqual(await store.get(), sampleSettings());

--- a/ghost/core/test/unit/server/adapters/route-settings/in-memory-store.test.ts
+++ b/ghost/core/test/unit/server/adapters/route-settings/in-memory-store.test.ts
@@ -1,0 +1,8 @@
+import {InMemoryStore} from './helpers/in-memory-store';
+import {runStoreContract} from './helpers/store-contract';
+
+describe('UNIT: InMemoryStore (validates the contract)', function () {
+    runStoreContract({
+        createStore: () => new InMemoryStore()
+    });
+});


### PR DESCRIPTION
ref HKG-1825

### Why

The first step toward moving `routes.yaml` off local disk is establishing the
type contract the storage layer will be built on, before any behaviour changes.
This PR defines that contract and nothing else — it's purely additive, so it's
safe to land and review in isolation.

### What

* **`RouteSettings` type** (`route-settings-parser.ts`) — models what the user
  actually writes in `routes.yaml`. Routes and collections are arrays so their
  declared order is preserved, since router registration is positional.
  Taxonomies is a flat `{tag?, author?}` object since only two fixed keys are
  valid. Routes use a discriminated union (`TemplateRoute | ChannelRoute`) so
  channel-only and template-only fields are statically enforced. The types stay
  lossless for everything `routes.yaml` accepts today, so storing and reloading
  is functionally equivalent to reading from disk.
* **`RouteSettingsStore`** interface + **`RouteSettingsStoreBase`** class
  (`adapters/route-settings/`) — the storage contract (`get` / `replace`) and
  the runtime base. Each type is co-located with the module that owns it rather
  than in a central `types.ts`, keeping the dependency direction clear.
* **`runStoreContract`** test runner + an in-memory store — a reusable contract
  any store implementation can be run against, so the FileStore (HKG-1827) and
  the future remote store verify against a single shared spec.

### What this does NOT do

* Nothing is wired in yet — no service, adapter-manager, or boot path consumes
  these (follow-ups: HKG-1826 parser functions, HKG-1828/1829 cut-over).
* `"returns defaults on empty"` is intentionally left out of the shared contract
  since that behaviour is FileStore-specific, not part of the store contract.