### PR TITLE
Added gift links reader access via ?gift query param

### DIFF
--- a/ghost/core/core/frontend/helpers/ghost_foot.js
+++ b/ghost/core/core/frontend/helpers/ghost_foot.js
@@ -2,9 +2,11 @@
 // Usage: `{{ghost_foot}}`
 //
 // Outputs scripts and other assets at the bottom of a Ghost theme
-const {settingsCache} = require('../services/proxy');
-const {SafeString} = require('../services/handlebars');
+const {settingsCache, labs} = require('../services/proxy');
+const {SafeString, templates, hbs} = require('../services/handlebars');
 const _ = require('lodash');
+
+const createFrame = hbs.handlebars.createFrame;
 
 // We use the name ghost_foot to match the helper for consistency:
 module.exports = function ghost_foot(options) { // eslint-disable-line camelcase
@@ -24,6 +26,14 @@ module.exports = function ghost_foot(options) { // eslint-disable-line camelcase
 
     if (!_.isEmpty(tagCodeinjection)) {
         foot.push(tagCodeinjection);
+    }
+
+    // Reader-side gift toast. `_gift` is set by the entry controller only on a
+    // verified gift render, so it shows on gift reads and never on canonical
+    // URLs. Overridable: a theme can supply its own `partials/gift-toast.hbs`.
+    if (labs.isSet('giftLinks') && options.data._gift) {
+        const data = createFrame(options.data);
+        foot.push(templates.execute('gift-toast', this, {data}));
     }
 
     return new SafeString(foot.join(' ').trim());

--- a/ghost/core/core/frontend/helpers/tpl/gift-toast.hbs
+++ b/ghost/core/core/frontend/helpers/tpl/gift-toast.hbs
@@ -1,0 +1,130 @@
+<style>
+.gh-gift-toast {
+    --gh-gift-toast-bottom: 32px;
+    --gh-gift-toast-accent: {{@site.accent_color}};
+
+    position: fixed;
+    bottom: var(--gh-gift-toast-bottom);
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 99998;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    max-width: min(560px, calc(100vw - 32px));
+    padding: 16px;
+    background: #ffffff;
+    color: #15171a;
+    border-radius: 16px;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 8px 24px rgba(0, 0, 0, 0.08);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    font-size: 13px;
+    line-height: 1.4;
+    transition: opacity 200ms ease, transform 200ms ease;
+    box-sizing: border-box;
+}
+
+.gh-gift-toast-icon {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    /* Neutral tint fallback for browsers without color-mix() support */
+    background: rgba(0, 0, 0, 0.05);
+    background: color-mix(in srgb, var(--gh-gift-toast-accent) 15%, transparent);
+}
+
+.gh-gift-toast-icon svg {
+    width: 18px;
+    height: 18px;
+    color: var(--gh-gift-toast-accent);
+    fill: var(--gh-gift-toast-accent);
+}
+
+.gh-gift-toast-text {
+    flex: 1;
+    min-width: 0;
+    color: #15171a;
+    font-weight: 400;
+}
+
+.gh-gift-toast-close {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    border: none;
+    border-radius: 50%;
+    background: #f4f5f6;
+    color: #5b6573;
+    cursor: pointer;
+    transition: background 120ms ease, color 120ms ease;
+}
+
+.gh-gift-toast-close:hover {
+    background: #e8eaed;
+    color: #15171a;
+}
+
+.gh-gift-toast-close svg {
+    width: 12px;
+    height: 12px;
+}
+
+.gh-gift-toast.is-dismissed {
+    opacity: 0;
+    transform: translate(-50%, 16px);
+    pointer-events: none;
+}
+
+@media (max-width: 600px) {
+    .gh-gift-toast {
+        width: calc(100vw - 32px);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .gh-gift-toast {
+        transition: none;
+    }
+}
+</style>
+<aside id="gh-gift-toast" class="gh-gift-toast" role="status" aria-live="polite">
+    <div class="gh-gift-toast-icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path d="M12 21.488H4v-10.75a.75.75 0 0 0-1.5 0v10.75c0 .914.586 1.5 1.5 1.5h8a.75.75 0 0 0 0-1.5z"/>
+            <path d="M12.25 21.488h8v-10.75a.75.75 0 0 1 1.5 0v10.75c0 .914-.586 1.5-1.5 1.5h-8a.75.75 0 0 1 0-1.5z"/>
+            <path d="M2.682 6.238h18.636c1.004 0 1.682.546 1.682 1.5v2.25c0 .954-.678 1.5-1.682 1.5H2.682c-1.004 0-1.682-.546-1.682-1.5v-2.25c0-.954.678-1.5 1.682-1.5zm0 1.5c-.239 0-.182-.046-.182 0v2.25c0 .046-.057 0 .182 0h18.636c.239 0 .182.046.182 0v-2.25c0-.046.057 0-.182 0H2.682z"/>
+            <path d="M12.75 22.238V6.988a.75.75 0 0 0-1.5 0v15.25a.75.75 0 0 0 1.5 0z"/>
+            <path d="M3.5 17.25h17a.75.75 0 0 0 0-1.5h-17a.75.75 0 0 0 0 1.5zM7.271 5.457a12.506 12.506 0 0 0 4.51 2.255.75.75 0 0 0 .92-.918 12.473 12.473 0 0 0-2.256-4.511C8.947.777 7.705.657 6.671 1.683c-1.033 1.027-.908 2.273.533 3.714l.067.06zm.458-2.709c.397-.395.702-.366 1.596.528.587.755 1.079 1.6 1.456 2.516a11.002 11.002 0 0 1-2.549-1.487c-.865-.872-.89-1.173-.503-1.557z"/>
+            <path d="m16.796 5.397-.067.06a12.5 12.5 0 0 1-4.512 2.255.75.75 0 0 1-.918-.918 12.502 12.502 0 0 1 2.315-4.579c1.44-1.438 2.681-1.558 3.715-.531 1.033 1.026.908 2.272-.533 3.713zm-.525-2.649c-.397-.395-.702-.366-1.537.46a11.024 11.024 0 0 0-1.515 2.584 11.038 11.038 0 0 0 2.549-1.487c.865-.872.89-1.173.503-1.557z"/>
+        </svg>
+    </div>
+    <span class="gh-gift-toast-text">{{t "You've been gifted access to this post."}}</span>
+    <button type="button" class="gh-gift-toast-close" aria-label="{{t "Dismiss"}}">
+        <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+            <path d="M3 3 L13 13 M13 3 L3 13"/>
+        </svg>
+    </button>
+</aside>
+<script>
+(function(){
+    var toast = document.getElementById('gh-gift-toast');
+    if (!toast) return;
+
+    var closeBtn = toast.querySelector('.gh-gift-toast-close');
+    if (closeBtn) {
+        closeBtn.addEventListener('click', function(){
+            toast.classList.add('is-dismissed');
+            // Defer removal so the fade/slide-out transition runs to completion.
+            setTimeout(function(){ if (toast.parentNode) toast.parentNode.removeChild(toast); }, 260);
+        });
+    }
+})();
+</script>

--- a/ghost/core/core/frontend/services/proxy.js
+++ b/ghost/core/core/frontend/services/proxy.js
@@ -70,6 +70,15 @@ module.exports = {
 
     // Labs utils for enabling/disabling helpers
     labs: require('../../shared/labs'),
+    // Gift links service — reached through this seam so the entry controller
+    // doesn't require a server module directly.
+    giftLinks: require('../../server/services/gift-links'),
+    // Paid-member shim for gift-link reads (shared with previews). Lazy getter so
+    // the members service resolves at call time, avoiding boot-time require-order
+    // coupling.
+    get createPaidMemberShim() {
+        return require('../../server/services/members').createPaidMemberShim;
+    },
     // URGH... Yuk (unhelpful comment :D)
     urlService: require('../../server/services/url'),
     urlUtils: require('../../shared/url-utils')

--- a/ghost/core/core/frontend/services/routing/controllers/entry.js
+++ b/ghost/core/core/frontend/services/routing/controllers/entry.js
@@ -1,9 +1,12 @@
 const debug = require('@tryghost/debug')('services:routing:controllers:entry');
 const url = require('url');
+const _ = require('lodash');
 const config = require('../../../../shared/config');
 const urlUtils = require('../../../../shared/url-utils');
 const dataService = require('../../data');
 const renderer = require('../../rendering');
+const proxy = require('../../proxy');
+const hbs = require('../../theme-engine/engine');
 const {getAcceptedMarkdownContentType, getMarkdownPath, renderEntryMarkdown} = require('../../llms/markdown');
 
 function getLlmsService(req) {
@@ -19,96 +22,159 @@ function serveMarkdown(res, entry) {
 }
 
 /**
+ * Build this request's URL with `?gift` removed, preserving path, subdirectory
+ * and other query params. Rebuilt from req.query (qs-parsed) so bracket forms
+ * like `?gift[]=x` are dropped too — otherwise the stripped redirect would loop.
+ *
+ * @param {Object} req
+ * @returns {string}
+ */
+function strippedGiftUrl(req) {
+    const query = {...req.query};
+    delete query.gift;
+    return url.format({pathname: url.parse(req.originalUrl).pathname, query});
+}
+
+/**
+ * Flag the render as a gift view so `ghost_foot` injects the toast. Stores the
+ * token (not just a boolean) for a later analytics pass-through. Internal flag,
+ * not a public theme API.
+ *
+ * @param {Object} res
+ * @param {string} token
+ */
+function setGiftTemplateFlag(res, token) {
+    const localTemplateOptions = hbs.getLocalTemplateOptions(res.locals);
+    hbs.updateLocalTemplateOptions(res.locals, _.merge({}, localTemplateOptions, {
+        data: {_gift: token}
+    }));
+}
+
+/**
  * @description Entry controller.
  * @param {Object} req
  * @param {Object} res
  * @param {Function} next
  * @returns {Promise}
  */
-module.exports = function entryController(req, res, next) {
+module.exports = async function entryController(req, res, next) {
     debug('entryController', res.routerOptions);
 
-    return dataService.entryLookup(req.path, res.routerOptions, res.locals)
-        .then(function then(lookup) {
-            // Format data 1
-            const entry = lookup ? lookup.entry : false;
+    try {
+        const lookup = await dataService.entryLookup(req.path, res.routerOptions, res.locals);
 
-            if (!entry) {
-                debug('no entry');
+        // Format data 1
+        const entry = lookup ? lookup.entry : false;
+
+        if (!entry) {
+            debug('no entry');
+            return next();
+        }
+
+        // CASE: postlookup can detect options for example /edit, unknown options get ignored and end in 404
+        if (lookup.isUnknownOption) {
+            debug('isUnknownOption');
+            return next();
+        }
+
+        // CASE: last param is of url is /edit, redirect to admin
+        if (lookup.isEditURL) {
+            if (!config.get('admin:redirects')) {
+                debug('is edit url but admin redirects are disabled');
                 return next();
             }
 
-            // CASE: postlookup can detect options for example /edit, unknown options get ignored and end in 404
-            if (lookup.isUnknownOption) {
-                debug('isUnknownOption');
-                return next();
-            }
+            debug('redirect. is edit url');
+            const resourceType = res.routerOptions?.context?.includes('page') ? 'page' : 'post';
 
-            // CASE: last param is of url is /edit, redirect to admin
-            if (lookup.isEditURL) {
-                if (!config.get('admin:redirects')) {
-                    debug('is edit url but admin redirects are disabled');
-                    return next();
-                }
+            return urlUtils.redirectToAdmin(302, res, `/#/editor/${resourceType}/${entry.id}`);
+        }
 
-                debug('redirect. is edit url');
-                const resourceType = res.routerOptions?.context?.includes('page') ? 'page' : 'post';
-
-                return urlUtils.redirectToAdmin(302, res, `/#/editor/${resourceType}/${entry.id}`);
-            }
-
-            // CASE: .md URL — serve entry as markdown for LLM consumption
-            if (res.routerOptions.isMarkdownRequest) {
-                const llmsService = getLlmsService(req);
-                if (!llmsService || !llmsService.isEnabled()) {
-                    return res.redirect(302, url.format({
-                        pathname: url.parse(entry.url).pathname,
-                        search: url.parse(req.originalUrl).search
-                    }));
-                }
-
-                if (entry.visibility !== 'public') {
-                    return res.status(403).type('text/markdown').send(
-                        '# Members-only content\n\nThis post requires a subscription and is not available for public access.\n'
-                    );
-                }
-
-                return serveMarkdown(res, entry);
-            }
-
-            /**
-             * CASE: Permalink is not valid anymore, we redirect him permanently to the correct one
-             *       This should only happen if you have date permalinks enabled and you change
-             *       your publish date.
-             *
-             * @NOTE:
-             *
-             * Ensure we redirect to the correct post url including subdirectory.
-             */
-            if (urlUtils.absoluteToRelative(entry.url, {withoutSubdirectory: true}) !== req.path) {
-                debug('redirect');
-
-                return urlUtils.redirect301(res, url.format({
+        // CASE: .md URL — serve entry as markdown for LLM consumption
+        if (res.routerOptions.isMarkdownRequest) {
+            const llmsService = getLlmsService(req);
+            if (!llmsService || !llmsService.isEnabled()) {
+                return res.redirect(302, url.format({
                     pathname: url.parse(entry.url).pathname,
                     search: url.parse(req.originalUrl).search
                 }));
             }
 
-            // CASE: Accept: text/markdown content negotiation
-            if (entry.visibility === 'public') {
-                const markdownContentType = getAcceptedMarkdownContentType(req);
-
-                if (markdownContentType) {
-                    const llmsService = getLlmsService(req);
-
-                    if (llmsService && llmsService.isEnabled()) {
-                        res.vary('Accept');
-                        return serveMarkdown(res, entry);
-                    }
-                }
+            if (entry.visibility !== 'public') {
+                return res.status(403).type('text/markdown').send(
+                    '# Members-only content\n\nThis post requires a subscription and is not available for public access.\n'
+                );
             }
 
-            return renderer.renderEntry(req, res)(entry);
-        })
-        .catch(renderer.handleError(next));
+            return serveMarkdown(res, entry);
+        }
+
+        /**
+         * CASE: Permalink is not valid anymore, we redirect him permanently to the correct one
+         *       This should only happen if you have date permalinks enabled and you change
+         *       your publish date.
+         *
+         * @NOTE:
+         *
+         * Ensure we redirect to the correct post url including subdirectory.
+         */
+        if (urlUtils.absoluteToRelative(entry.url, {withoutSubdirectory: true}) !== req.path) {
+            debug('redirect');
+
+            return urlUtils.redirect301(res, url.format({
+                pathname: url.parse(entry.url).pathname,
+                search: url.parse(req.originalUrl).search
+            }));
+        }
+
+        // CASE: Accept: text/markdown content negotiation
+        if (entry.visibility === 'public') {
+            const markdownContentType = getAcceptedMarkdownContentType(req);
+
+            if (markdownContentType) {
+                const llmsService = getLlmsService(req);
+
+                if (llmsService && llmsService.isEnabled()) {
+                    res.vary('Accept');
+                    return serveMarkdown(res, entry);
+                }
+            }
+        }
+
+        // CASE: gift-link reader access. A gift link is the post's real URL plus
+        // `?gift=TOKEN`; the token is verified against the entry living at this
+        // URL, so a token for one post can never unlock another.
+        if (proxy.labs.isSet('giftLinks') && req.query?.gift !== undefined) {
+            // A non-string form (e.g. `?gift[]=x`) isn't a token — strip it.
+            const token = typeof req.query.gift === 'string' ? req.query.gift : null;
+
+            if (token && await proxy.giftLinks.service.isValidTokenForPost(token, entry.id)) {
+                // Re-read as a paid-member shim (the grant `/p/` previews use) to
+                // reveal gated content. Passed as the read context only, so it
+                // never leaks into res.locals/@member.
+                const giftLookup = await dataService.entryLookup(req.path, res.routerOptions, {
+                    ...res.locals,
+                    member: await proxy.createPaidMemberShim()
+                });
+
+                // Don't index the unlocked variant; keep the token out of the
+                // Referer on sub-resource requests.
+                res.set('X-Robots-Tag', 'noindex');
+                res.set('Referrer-Policy', 'no-referrer');
+                setGiftTemplateFlag(res, token);
+
+                return renderer.renderEntry(req, res)(giftLookup.entry);
+            }
+
+            // Invalid token, or one for a different post: strip it and 301 to the
+            // clean URL (the page still renders, paywalled). res.redirect, not
+            // urlUtils.redirect301, so the no-store set for ?gift requests survives
+            // and the token-bearing redirect isn't cached.
+            return res.redirect(301, strippedGiftUrl(req));
+        }
+
+        return renderer.renderEntry(req, res)(entry);
+    } catch (err) {
+        return renderer.handleError(next)(err);
+    }
 };

--- a/ghost/core/core/frontend/web/middleware/frontend-caching.js
+++ b/ghost/core/core/frontend/web/middleware/frontend-caching.js
@@ -2,6 +2,7 @@
  * @file Middleware to set the appropriate cache headers on the frontend
  */
 const config = require('../../../shared/config');
+const labs = require('../../../shared/labs');
 const shared = require('../../../server/web/shared');
 const {api} = require('../../services/proxy');
 const preview = require('../../services/theme-engine/preview');
@@ -66,6 +67,14 @@ const getMiddleware = async (getFreeTier = async () => {
 
         // CASE: Never cache preview routes
         if (req.path?.startsWith('/p/')) {
+            return shared.middleware.cacheControl('noCache')(req, res, next);
+        }
+
+        // CASE: never cache gift-link reads. A ?gift render holds unlocked gated
+        // content with no member cookie, so the edge would otherwise serve it to
+        // everyone. Keyed on the param's presence so an empty `?gift=` still
+        // bypasses.
+        if (req.query?.gift !== undefined && labs.isSet('giftLinks')) {
             return shared.middleware.cacheControl('noCache')(req, res, next);
         }
 

--- a/ghost/core/core/server/api/endpoints/previews.js
+++ b/ghost/core/core/server/api/endpoints/previews.js
@@ -1,7 +1,7 @@
 const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const models = require('../../models');
-const logging = require('@tryghost/logging');
+const membersService = require('../../services/members');
 const ALLOWED_INCLUDES = ['authors', 'tags', 'tiers'];
 const ALLOWED_MEMBER_STATUSES = ['anonymous', 'free', 'paid'];
 
@@ -31,29 +31,8 @@ const _addMemberContextToFrame = async (frame) => {
     }
 
     if (frame.options?.member_status === 'paid') {
-        // For member_status=paid, add all paid tiers to the member context
-        let memberProducts = [];
-        try {
-            const paidProducts = await models.Product.findAll({
-                status: 'active',
-                type: 'paid'
-            });
-            if (paidProducts.length > 0) {
-                memberProducts = paidProducts.map((product) => {
-                    return {
-                        slug: product.get('slug')
-                    };
-                });
-            }
-        } catch (error) {
-            // Log error but don't fail preview - fallback to empty products array
-            logging.error('Failed to fetch paid products for preview:', error);
-        }
-
-        frame.original.context.member = {
-            status: 'paid',
-            products: memberProducts
-        };
+        // For member_status=paid, render as a member with all active paid tiers
+        frame.original.context.member = await membersService.createPaidMemberShim();
     }
 };
 

--- a/ghost/core/core/server/services/gift-links/service.ts
+++ b/ghost/core/core/server/services/gift-links/service.ts
@@ -25,6 +25,12 @@ export class GiftLinksService {
         return row ? {id: row.post_id, giftLinks: [z.decode(queries.giftLinkCodec, row)]} : null;
     }
 
+    // True only when `token` is a live gift link bound to `postId`, so a token
+    // for one post can never validate against another.
+    async isValidTokenForPost(token: string, postId: string): Promise<boolean> {
+        return (await this.getPostByToken(token))?.id === postId;
+    }
+
     async ensure(postId: string): Promise<Post> {
         const post = await this.requirePost(postId);
         return post.giftLinks.length ? post : this.mint(postId);

--- a/ghost/core/core/server/services/members/create-paid-member-shim.ts
+++ b/ghost/core/core/server/services/members/create-paid-member-shim.ts
@@ -1,0 +1,31 @@
+import logging from '@tryghost/logging';
+const models = require('../../models');
+
+interface PaidMemberShim {
+    status: 'paid';
+    products: Array<{slug: string}>;
+}
+
+/**
+ * Build a stand-in "all active paid tiers" member for content gating — NOT a real
+ * member. It carries only the `status` and `products` that
+ * `contentGating.checkPostAccess` / `checkGatedBlockAccess` read, letting previews
+ * (`member_status=paid`) and gift-link reads reveal gated content without a
+ * logged-in member. Single source of truth for this security-sensitive grant.
+ */
+export async function createPaidMemberShim(): Promise<PaidMemberShim> {
+    let products: Array<{slug: string}> = [];
+    try {
+        const paidProducts = await models.Product.findAll({status: 'active', type: 'paid'});
+        products = paidProducts.map((product: {get(key: string): string}) => ({slug: product.get('slug')}));
+    } catch (error) {
+        // Fall back to no tiers rather than failing the render — still grants
+        // status:paid/members content, just not tier-specific blocks.
+        logging.error('Failed to build paid member shim tiers:', error);
+    }
+
+    return {
+        status: 'paid',
+        products
+    };
+}

--- a/ghost/core/core/server/services/members/service.js
+++ b/ghost/core/core/server/services/members/service.js
@@ -171,6 +171,10 @@ module.exports = {
     },
     contentGating: require('./content-gating'),
 
+    // Create an "all active paid tiers" member shim for rendering gated content
+    // without a logged-in member (post previews, gift-links reader path).
+    createPaidMemberShim: require('./create-paid-member-shim').createPaidMemberShim,
+
     config: membersConfig,
 
     get api() {

--- a/ghost/core/test/e2e-frontend/gift-links-toast-override.test.ts
+++ b/ghost/core/test/e2e-frontend/gift-links-toast-override.test.ts
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import sinon from 'sinon';
+import supertest from 'supertest';
+import moment from 'moment';
+import {afterAll, beforeAll} from 'vitest';
+
+const fs = require('fs-extra');
+const testUtils = require('../utils');
+const configUtils = require('../utils/config-utils');
+const settingsCache = require('../../core/shared/settings-cache');
+const themeActivator = require('../../core/server/services/themes/activate');
+
+const OVERRIDE_THEME = 'gift-toast-override-theme';
+
+// A theme's `partials/` dir is only registered (and thus able to override the
+// core `gift-toast` partial) when the theme references at least one partial:
+// gscan only reports referenced partials, and `active.partialsPath` is null
+// otherwise. So the theme references a `{{> marker}}` partial from its layout.
+const THEME_FILES: Record<string, string> = {
+    'package.json': JSON.stringify({
+        name: OVERRIDE_THEME,
+        description: 'Theme that overrides the default gift-toast partial',
+        version: '1.0.0',
+        license: 'MIT',
+        config: {posts_per_page: 25}
+    }),
+    'index.hbs': '',
+    'default.hbs': [
+        '<!DOCTYPE html>',
+        '<html lang="{{@site.locale}}">',
+        '<head>{{ghost_head}}</head>',
+        '<body class="{{body_class}}">',
+        '    {{> marker}}',
+        '    {{{body}}}',
+        '    {{ghost_foot}}',
+        '</body>',
+        '</html>'
+    ].join('\n'),
+    'post.hbs': '{{!< default}}\n{{#post}}<div class="post-content">{{content}}</div>{{/post}}',
+    'partials/marker.hbs': '<span id="theme-marker">override theme</span>',
+    'partials/gift-toast.hbs': '<div id="custom-gift-toast">Custom theme gift toast</div>'
+};
+
+// Generates the override theme on disk and activates it at runtime — kept out of
+// the shared test/utils/fixtures/themes dir so the admin themes-list fixtures
+// (and the tests that enumerate them) are unaffected.
+async function writeAndActivateOverrideTheme() {
+    const themesPath = configUtils.config.getContentPath('themes');
+    for (const [relPath, contents] of Object.entries(THEME_FILES)) {
+        const filePath = path.join(themesPath, OVERRIDE_THEME, relPath);
+        await fs.ensureDir(path.dirname(filePath));
+        await fs.writeFile(filePath, contents);
+    }
+    await themeActivator.loadAndActivate(OVERRIDE_THEME);
+}
+
+describe('Front-end gift links — theme toast override', function () {
+    let request: any;
+    let token: string;
+    const slug = 'gift-override-paid-post';
+
+    beforeAll(async function () {
+        const originalSettingsCacheGetFn = settingsCache.get;
+        sinon.stub(settingsCache, 'get').callsFake(function (key: any, options: any) {
+            if (key === 'labs') {
+                return {members: true, giftLinks: true};
+            }
+            if (key === 'active_theme') {
+                return OVERRIDE_THEME;
+            }
+            return originalSettingsCacheGetFn(key, options);
+        });
+
+        await testUtils.startGhost({copyThemes: true});
+        await writeAndActivateOverrideTheme();
+
+        const paidPost = testUtils.DataGenerator.forKnex.createPost({
+            slug,
+            visibility: 'paid',
+            status: 'published',
+            published_at: moment().toDate(),
+            mobiledoc: testUtils.DataGenerator.markdownToMobiledoc('Before paywall\n\n<!--members-only-->\n\nAfter paywall')
+        });
+        await testUtils.fixtures.insertPosts([paidPost]);
+
+        const giftLinksService = require('../../core/server/services/gift-links');
+        const post = await giftLinksService.service.ensure(paidPost.id);
+        token = post.giftLinks[0].token;
+
+        request = supertest.agent(configUtils.config.get('url'));
+    });
+
+    afterAll(function () {
+        sinon.restore();
+    });
+
+    it('renders the theme partials/gift-toast.hbs instead of the core default', async function () {
+        const res = await request
+            .get(`/${slug}/?gift=${token}`)
+            .expect(200);
+
+        assert.match(res.text, /id="custom-gift-toast"/, 'theme partial overrides the default toast');
+        assert.doesNotMatch(res.text, /id="gh-gift-toast"/, 'core default toast is not rendered when overridden');
+    });
+});

--- a/ghost/core/test/e2e-frontend/gift-links.test.ts
+++ b/ghost/core/test/e2e-frontend/gift-links.test.ts
@@ -89,6 +89,8 @@ describe('Front-end gift links', function () {
             .expect(200)
             .expect(assertLocked);
 
+        // No gift → no toast on the canonical URL.
+        assert.doesNotMatch(res.text, /gh-gift-toast/, 'gift toast must not appear on the canonical URL');
         // The bare URL has no ?gift, so it isn't no-store bypassed — it stays cacheable.
         assert.doesNotMatch(res.headers['cache-control'] || '', /no-store/, 'the bare URL is cacheable');
     });
@@ -103,6 +105,10 @@ describe('Front-end gift links', function () {
         assert.match(res.headers['cache-control'], /no-store/);
         assert.equal(res.headers['x-robots-tag'], 'noindex');
         assert.equal(res.headers['referrer-policy'], 'no-referrer');
+
+        // The default gift toast renders on the verified gift view.
+        assert.match(res.text, /id="gh-gift-toast"/, 'default gift toast renders on a gift view');
+        assert.match(res.text, /gifted access to this post/, 'toast announces the gift');
     });
 
     it('301s to the canonical URL, dropping ?gift, when the token is invalid', async function () {

--- a/ghost/core/test/e2e-frontend/gift-links.test.ts
+++ b/ghost/core/test/e2e-frontend/gift-links.test.ts
@@ -1,0 +1,185 @@
+import assert from 'node:assert/strict';
+import sinon from 'sinon';
+import supertest from 'supertest';
+import moment from 'moment';
+// This suite runs under vitest; beforeAll/afterAll aren't in the mocha globals
+// that tsc resolves project-wide, so import them explicitly for type-checking.
+import {afterAll, beforeAll} from 'vitest';
+
+const testUtils = require('../utils');
+const configUtils = require('../utils/config-utils');
+const settingsCache = require('../../core/shared/settings-cache');
+
+// Default member-test-theme renders `{{content}}`; a paid post with a
+// `<!--members-only-->` marker truncates at the paywall when the reader has no
+// access, so "After paywall" is the access tell.
+function assertUnlocked(res: any) {
+    assert.match(res.text, /Before paywall/, 'lead content should render');
+    assert.match(res.text, /After paywall/, 'gated content should render for a valid gift read');
+}
+
+function assertLocked(res: any) {
+    assert.match(res.text, /Before paywall/, 'lead content should render');
+    assert.doesNotMatch(res.text, /After paywall/, 'gated content must not render without access');
+}
+
+describe('Front-end gift links', function () {
+    let request: any;
+    let token: string;
+    let pageToken: string;
+    const slug = 'gift-me-this-paid-post';
+    const otherSlug = 'another-paid-post';
+    const pageSlug = 'gift-me-this-paid-page';
+
+    beforeAll(async function () {
+        const originalSettingsCacheGetFn = settingsCache.get;
+        sinon.stub(settingsCache, 'get').callsFake(function (key: any, options: any) {
+            if (key === 'labs') {
+                return {members: true, giftLinks: true};
+            }
+            if (key === 'active_theme') {
+                return 'members-test-theme';
+            }
+            return originalSettingsCacheGetFn(key, options);
+        });
+
+        await testUtils.startGhost({copyThemes: true});
+
+        const mobiledoc = testUtils.DataGenerator.markdownToMobiledoc('Before paywall\n\n<!--members-only-->\n\nAfter paywall');
+        const paidPost = testUtils.DataGenerator.forKnex.createPost({
+            slug,
+            visibility: 'paid',
+            status: 'published',
+            published_at: moment().toDate(),
+            mobiledoc
+        });
+        const otherPaidPost = testUtils.DataGenerator.forKnex.createPost({
+            slug: otherSlug,
+            visibility: 'paid',
+            status: 'published',
+            published_at: moment().toDate(),
+            mobiledoc
+        });
+        // A gift link works on a page's canonical URL too, not just a post's.
+        const paidPage = testUtils.DataGenerator.forKnex.createPost({
+            slug: pageSlug,
+            type: 'page',
+            visibility: 'paid',
+            status: 'published',
+            published_at: moment().toDate(),
+            mobiledoc
+        });
+        await testUtils.fixtures.insertPosts([paidPost, otherPaidPost, paidPage]);
+
+        // Mint a live gift link for the paid post and the paid page.
+        const giftLinksService = require('../../core/server/services/gift-links');
+        token = (await giftLinksService.service.ensure(paidPost.id)).giftLinks[0].token;
+        pageToken = (await giftLinksService.service.ensure(paidPage.id)).giftLinks[0].token;
+
+        request = supertest.agent(configUtils.config.get('url'));
+    });
+
+    afterAll(function () {
+        sinon.restore();
+    });
+
+    it('paywalls the paid post for an anonymous visitor on the canonical URL', async function () {
+        const res = await request
+            .get(`/${slug}/`)
+            .expect(200)
+            .expect(assertLocked);
+
+        // The bare URL has no ?gift, so it isn't no-store bypassed — it stays cacheable.
+        assert.doesNotMatch(res.headers['cache-control'] || '', /no-store/, 'the bare URL is cacheable');
+    });
+
+    it('unlocks the full post for an anonymous visitor with a valid ?gift token', async function () {
+        const res = await request
+            .get(`/${slug}/?gift=${token}`)
+            .expect(200)
+            .expect(assertUnlocked);
+
+        // Never cached (no member cookie, unlocked content) and never indexed.
+        assert.match(res.headers['cache-control'], /no-store/);
+        assert.equal(res.headers['x-robots-tag'], 'noindex');
+        assert.equal(res.headers['referrer-policy'], 'no-referrer');
+    });
+
+    it('301s to the canonical URL, dropping ?gift, when the token is invalid', async function () {
+        const res = await request
+            .get(`/${slug}/?gift=not-a-real-token`)
+            .redirects(0)
+            .expect(301);
+
+        assert.match(res.headers.location, new RegExp(`^/${slug}/?$`));
+        assert.doesNotMatch(res.headers.location, /gift=/);
+        // The 301 itself must not be cached, so a reset link can't poison
+        // subsequent requests via a stale browser-cached redirect.
+        assert.match(res.headers['cache-control'], /no-store/);
+    });
+
+    it('unlocks a paid page with a valid ?gift token on its canonical URL', async function () {
+        // The feature works on pages too, not just posts — same entry controller.
+        await request
+            .get(`/${pageSlug}/?gift=${pageToken}`)
+            .expect(200)
+            .expect(assertUnlocked);
+    });
+
+    it('301s a paid page, dropping ?gift, when the token is invalid', async function () {
+        const res = await request
+            .get(`/${pageSlug}/?gift=not-a-real-token`)
+            .redirects(0)
+            .expect(301);
+
+        assert.match(res.headers.location, new RegExp(`^/${pageSlug}/?$`));
+        assert.doesNotMatch(res.headers.location, /gift=/);
+    });
+
+    it('does not unlock a different post: a token for post A 301s away from post B', async function () {
+        // Defence in depth: appending a valid gift token to another post's URL
+        // must never reveal that post's gated content — the token is verified
+        // against the entry that lives at the request URL.
+        const res = await request
+            .get(`/${otherSlug}/?gift=${token}`)
+            .redirects(0)
+            .expect(301);
+
+        assert.match(res.headers.location, new RegExp(`^/${otherSlug}/?$`));
+        assert.doesNotMatch(res.headers.location, /gift=/);
+    });
+
+    it('preserves other query params when stripping an invalid ?gift', async function () {
+        const res = await request
+            .get(`/${slug}/?ref=newsletter&gift=not-a-real-token`)
+            .redirects(0)
+            .expect(301);
+
+        assert.match(res.headers.location, /ref=newsletter/);
+        assert.doesNotMatch(res.headers.location, /gift=/);
+    });
+
+    it('strips a malformed (non-string) ?gift param without looping', async function () {
+        // `?gift[]=x` parses to an array, not a token. It must canonicalise to
+        // the clean URL — not redirect to itself and loop.
+        const res = await request
+            .get(`/${slug}/?gift[]=x`)
+            .redirects(0)
+            .expect(301);
+
+        assert.match(res.headers.location, new RegExp(`^/${slug}/?$`));
+        assert.doesNotMatch(res.headers.location, /\?/, 'the malformed param is stripped, leaving no query string');
+    });
+
+    it('does not expose the synthesized member to template rendering (@member stays anonymous)', async function () {
+        // The shim unlocks gated content as the entry-lookup read context only —
+        // it must never surface as @member. The test theme renders member state,
+        // which stays anonymous even on an unlocked gift view.
+        const res = await request
+            .get(`/${slug}/?gift=${token}`)
+            .expect(200)
+            .expect(assertUnlocked);
+
+        assert.match(res.text, /gh-test-member-state">anonymous</, '@member must stay anonymous on a gift view');
+    });
+});

--- a/ghost/core/test/integration/services/gift-links.test.ts
+++ b/ghost/core/test/integration/services/gift-links.test.ts
@@ -134,6 +134,27 @@ describe('GiftLinksService (integration)', function () {
         });
     });
 
+    describe('isValidTokenForPost', function () {
+        it('is true only for a live token bound to the given post', async function () {
+            const post = await service.ensure(postId);
+            const token = post.giftLinks[0]!.token;
+
+            assert.equal(await service.isValidTokenForPost(token, postId), true);
+
+            // Defence in depth: a token for one post must not validate another.
+            assert.equal(await service.isValidTokenForPost(token, otherPostId), false);
+
+            // Once replaced, the old token no longer validates.
+            await service.create(postId);
+            assert.equal(await service.isValidTokenForPost(token, postId), false);
+        });
+
+        it('is false for unknown and empty tokens', async function () {
+            assert.equal(await service.isValidTokenForPost('nope', postId), false);
+            assert.equal(await service.isValidTokenForPost('', postId), false);
+        });
+    });
+
     describe('removeAll', function () {
         it('drops every live link across posts and returns the count', async function () {
             await service.ensure(postId);

--- a/ghost/core/test/unit/server/services/members/create-paid-member-shim.test.ts
+++ b/ghost/core/test/unit/server/services/members/create-paid-member-shim.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import sinon from 'sinon';
+import {createPaidMemberShim} from '../../../../../core/server/services/members/create-paid-member-shim';
+
+const models = require('../../../../../core/server/models');
+const logging = require('@tryghost/logging');
+
+describe('Unit - members/create-paid-member-shim', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it('returns a paid member with every active paid tier', async function () {
+        sinon.stub(models.Product, 'findAll').resolves([
+            {get: (key: string) => (key === 'slug' ? 'silver' : undefined)},
+            {get: (key: string) => (key === 'slug' ? 'gold' : undefined)}
+        ]);
+
+        const member = await createPaidMemberShim();
+
+        assert.deepEqual(member, {status: 'paid', products: [{slug: 'silver'}, {slug: 'gold'}]});
+    });
+
+    it('falls back to a paid member with no tiers (never throws) when the tier lookup fails', async function () {
+        const logError = sinon.stub(logging, 'error');
+        sinon.stub(models.Product, 'findAll').rejects(new Error('db down'));
+
+        const member = await createPaidMemberShim();
+
+        // Security-sensitive: must still resolve to a safe member shape rather
+        // than throwing — granting status:paid/members content but no
+        // tier-specific blocks.
+        assert.deepEqual(member, {status: 'paid', products: []});
+        sinon.assert.calledOnce(logError);
+    });
+});

--- a/ghost/core/test/utils/fixtures/themes/members-test-theme/post.hbs
+++ b/ghost/core/test/utils/fixtures/themes/members-test-theme/post.hbs
@@ -12,6 +12,10 @@
                 <h1 class="post-full-title">{{title}}</h1>
             </header>
 
+            {{!-- Reflects @member so tests can assert the visitor's real member
+            state (a gift read stays anonymous even when the content is unlocked). --}}
+            <p class="gh-test-member-state">{{#if @member}}member{{else}}anonymous{{/if}}</p>
+
             <section class="post-full-content">
                 <div class="post-content">
                     {{content}}


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3728

Builds the public reader path for gift links: a paid post or page's **own URL** plus `?gift=TOKEN` renders its full content to an anonymous visitor holding a valid token. The schema, `GiftLinksService` and admin API are already on `main`; this PR adds the reader path, reworked from the spike ([#28629](https://github.com/TryGhost/Ghost/pull/28629)).

### Why `?gift` on the real URL, not a dedicated `/g/` route

An earlier take mounted a dedicated `/g/<slug>/?key=TOKEN` route. That shape forced work the canonical routes already do:

- **Type isn't known up-front.** `/g/` is type-agnostic, so the controller had to resolve the token to a `{id, type}` just to pick the public read controller (post vs page), then read by id — a parallel resolution path that diverges from how every other entry renders.
- **A privileged router + its hazards.** `/g/` had to mount in preview's slot so a `routes.yaml` collection couldn't intercept it, carry its own slug-canonicalisation (token authoritative, slug cosmetic), and a redirect-loop guard against a collection permalinking under `/g/`.
- **A second cache-bypass key.** `frontend-caching` matched on the `/g/` path prefix, duplicating the route definition.

Hanging the feature off the post's real URL removes all of it: the existing collection/static-pages routers have already resolved the URL **and** the resource type, so the entry controller just needs to gate on the token.

### How it works now

- **One owner, in the entry controller.** A gift link is the post/page's canonical URL + `?gift=TOKEN`. The existing routers resolve it; the entry controller resolves the entry exactly as it does for any request, then a single `?gift` branch at the end of the function validates the token and, only on success, re-reads unlocked. No dedicated router, no slug-canonicalisation, no redirect-loop guard — and no separate gift module: the whole flow reads top-to-bottom in the controller.
- **Verify against the entry that's already resolved.** The controller hands the token and the resolved entry's id to the service: `giftLinks.service.isValidTokenForPost(token, entry.id)` is true only for a live token bound to *this* post. A token for post A can never unlock post B by appending it to B's URL — the mismatch path strips the param and 301s away. No second resolution path, no in-memory URL-map probe.
- **Access via a synthetic paid member, not gating edits.** A verified gift reads as a synthesized all-active-paid-tiers member — the same grant `/p/` previews use — so the existing `checkPostAccess` / `checkGatedBlockAccess` reveal member-only content unchanged. The member is layered over `res.locals` and passed to `entryLookup` as the **read context only**, so `res.locals.member` / `@member` stays the visitor's real member and the grant never leaks into theme data (`entryLookup`'s signature is untouched). The synthesis is extracted to `members/synthesize-member.js` and `previews.js` refactored onto it, so the security-sensitive grant has one source of truth. `content-gating.js`, `post-gating.js` and the posts-public cache key are **not touched**.
- **A second read only on a verified gift.** The normal path stays a single read through the real public serializer + `renderEntry`. Only when a token validates does the controller do one more `entryLookup` — as the synthetic member — to fetch the unlocked entry. The earlier version threaded a member-override through the lookup to avoid this; trading that for an extra read on the rare gift hit keeps the controller and the lookup API plain.
- **Invalid tokens canonicalise.** A missing/invalid/revoked token, or one for a different post, 301s to the clean URL with `?gift` dropped — the post then renders normally (paywalled). The strip uses `res.redirect` (never `urlUtils.redirect301`) so the `no-store` header set by `frontend-caching` survives: a token-bearing 301 is never edge-cached (which could serve one visitor's token to another) and a revocable token's state is never frozen into a permanently-cached browser redirect. `frontend-caching` marks any `?gift` request `no-store` so the edge never caches unlocked content, while the bare URL stays cacheable.

### Reader toast

A gift read shows the reader an overridable toast ("<publication> unlocked this post so you can read it for free.") so it's clear they're seeing gifted content. It ships as a `gift-toast` partial rendered by `ghost_foot` when an internal `_gift` flag is set on the verified render path — themes can supply their own `partials/gift-toast.hbs`, the same override mechanism as navigation/pagination. The flag holds the token value (not just a boolean) so a later change can pass it through to analytics. An underscore-prefixed internal flag is used instead of a public `@gift` theme-context contract, so there's no hard-to-walk-back API commitment.

Everything is gated on `labs.giftLinks`.

### Notes / follow-ups

- **The token is authoritative for access, but not for URL resolution.** Ghost keeps no slug history for posts, so a renamed post's old gift link 404s like any other stale URL — accepted, as gift links are short-lived shares and the canonical URL is the share target. The old `/g/` model preserved renamed-post links by canonicalising the slug; that property is traded for building on the real router and dropping a whole resolution path.
- **Read counting is handled separately** via the analytics service, so it's deliberately not in this PR (the schema's `redeemed_count` / `recordRedemption` remain for that path).
- Analytics token leak (`ghost-stats` sends `location.href` including `?gift=`) is tracked separately on BER-3728.

Delivered as two commits (reader access → reader toast).
