### PR TITLE
Cleaned up redundant build steps in frontend dev scripts

### DIFF
--- a/apps/admin-toolbar/package.json
+++ b/apps/admin-toolbar/package.json
@@ -37,5 +37,15 @@
     "jsdom": "catalog:",
     "vite": "catalog:",
     "vitest": "catalog:"
+  },
+  "nx": {
+    "targets": {
+      "dev": {
+        "dependsOn": [
+          "^dev",
+          "build"
+        ]
+      }
+    }
   }
 }

--- a/apps/announcement-bar/package.json
+++ b/apps/announcement-bar/package.json
@@ -19,7 +19,7 @@
     "react-dom": "catalog:react17"
   },
   "scripts": {
-    "dev": "pnpm build && concurrently --kill-others --names preview,build \"vite preview -l silent\" \"pnpm build:watch\"",
+    "dev": "concurrently --kill-others --names preview,build \"vite preview -l silent\" \"pnpm build:watch\"",
     "build": "vite build",
     "build:watch": "vite build --watch",
     "test": "vitest run",
@@ -63,5 +63,15 @@
     "vite": "catalog:",
     "vite-plugin-svgr": "catalog:",
     "vitest": "catalog:"
+  },
+  "nx": {
+    "targets": {
+      "dev": {
+        "dependsOn": [
+          "^dev",
+          "build"
+        ]
+      }
+    }
   }
 }

--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -16,7 +16,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "dev": "pnpm build && concurrently --kill-others --names preview,build \"pnpm preview --host -l silent\" \"pnpm build:watch\"",
+    "dev": "concurrently --kill-others --names preview,build \"pnpm preview --host -l silent\" \"pnpm build:watch\"",
     "dev:test": "vite build && vite preview --port 7175",
     "build": "vite build",
     "build:watch": "vite build --watch",
@@ -93,6 +93,14 @@
   "nx": {
     "tags": [
       "i18n"
-    ]
+    ],
+    "targets": {
+      "dev": {
+        "dependsOn": [
+          "^dev",
+          "build"
+        ]
+      }
+    }
   }
 }

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -15,7 +15,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "dev": "pnpm build && concurrently --kill-others --names preview,build \"pnpm preview -l silent\" \"pnpm build:watch\"",
+    "dev": "concurrently --kill-others --names preview,build \"pnpm preview -l silent\" \"pnpm build:watch\"",
     "build": "vite build",
     "build:watch": "vite build --watch",
     "preview": "vite preview",
@@ -75,6 +75,14 @@
   "nx": {
     "tags": [
       "i18n"
-    ]
+    ],
+    "targets": {
+      "dev": {
+        "dependsOn": [
+          "^dev",
+          "build"
+        ]
+      }
+    }
   }
 }

--- a/apps/signup-form/package.json
+++ b/apps/signup-form/package.json
@@ -15,7 +15,8 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "dev": "pnpm build && concurrently --kill-others --names dev,preview,build \"vite --port 6173\" \"vite preview -l silent\" \"vite build --watch\"",
+    "dev": "pnpm build && concurrently --kill-others --names preview,build \"vite preview -l silent\" \"vite build --watch\"",
+    "dev:start": "vite --port 6173",
     "preview": "concurrently --kill-others --names preview,build \"vite preview -l silent\" \"vite build --watch\"",
     "dev:test": "vite build && vite preview --port 6175",
     "build": "tsc && vite build",

--- a/apps/signup-form/package.json
+++ b/apps/signup-form/package.json
@@ -15,7 +15,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "dev": "pnpm build && concurrently --kill-others --names preview,build \"vite preview -l silent\" \"vite build --watch\"",
+    "dev": "concurrently --kill-others --names preview,build \"vite preview -l silent\" \"vite build --watch\"",
     "dev:start": "vite --port 6173",
     "preview": "concurrently --kill-others --names preview,build \"vite preview -l silent\" \"vite build --watch\"",
     "dev:test": "vite build && vite preview --port 6175",
@@ -67,6 +67,14 @@
   "nx": {
     "tags": [
       "i18n"
-    ]
+    ],
+    "targets": {
+      "dev": {
+        "dependsOn": [
+          "^dev",
+          "build"
+        ]
+      }
+    }
   }
 }

--- a/apps/sodo-search/package.json
+++ b/apps/sodo-search/package.json
@@ -22,7 +22,7 @@
     "react-dom": "catalog:react17"
   },
   "scripts": {
-    "dev": "pnpm build && concurrently --kill-others --names preview,build,tailwind \"vite preview -l silent\" \"pnpm build:watch\" \"pnpm tailwind\"",
+    "dev": "concurrently --kill-others --names preview,build,tailwind \"vite preview -l silent\" \"pnpm build:watch\" \"pnpm tailwind\"",
     "build": "vite build && pnpm tailwind:base",
     "build:watch": "vite build --watch",
     "tailwind": "pnpm tailwind:base --watch ",
@@ -74,6 +74,14 @@
   "nx": {
     "tags": [
       "i18n"
-    ]
+    ],
+    "targets": {
+      "dev": {
+        "dependsOn": [
+          "^dev",
+          "build"
+        ]
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

`pnpm dev` was doing wasted work on every startup across the public UMD apps:

- **portal**, **comments-ui**, **sodo-search**, **announcement-bar**, **signup-form**: dropped the leading `pnpm build &&` from each `dev` script and added `nx.targets.dev.dependsOn: ["^dev", "build"]` so the initial `vite build` is nx-cached instead of re-run on every `pnpm dev`.
- **admin-toolbar**: only added the nx config — its `dev` already didn't carry the build prefix, so the preview server was being spawned against an empty `umd/` on a fresh checkout. The nx wiring closes that hole.
- **signup-form** (separate cleanup): dropped the always-on `vite --port 6173` standalone HMR server from `dev` (Caddy only routes to the preview server). Preserved as a new `dev:start` script matching the existing convention used by activitypub/posts/stats/admin-x-settings.

## Test plan

- [ ] `pnpm dev` — portal modal, comments, search, announcement bar, signup form, and admin toolbar all load via Caddy
- [ ] `pnpm dev:status` (or `ps`) shows signup-form running 2 host processes instead of 3
- [ ] Second `pnpm dev` invocation skips each app's `vite build` (nx cache hit)