### PR TITLE
Cleaned up redundant build steps in remaining frontend dev scripts

### DIFF
--- a/apps/admin-toolbar/package.json
+++ b/apps/admin-toolbar/package.json
@@ -37,5 +37,15 @@
     "jsdom": "catalog:",
     "vite": "catalog:",
     "vitest": "catalog:"
+  },
+  "nx": {
+    "targets": {
+      "dev": {
+        "dependsOn": [
+          "^dev",
+          "build"
+        ]
+      }
+    }
   }
 }

--- a/apps/announcement-bar/package.json
+++ b/apps/announcement-bar/package.json
@@ -19,7 +19,7 @@
     "react-dom": "catalog:react17"
   },
   "scripts": {
-    "dev": "pnpm build && concurrently --kill-others --names preview,build \"vite preview -l silent\" \"pnpm build:watch\"",
+    "dev": "concurrently --kill-others --names preview,build \"vite preview -l silent\" \"pnpm build:watch\"",
     "build": "vite build",
     "build:watch": "vite build --watch",
     "test": "vitest run",
@@ -63,5 +63,15 @@
     "vite": "catalog:",
     "vite-plugin-svgr": "catalog:",
     "vitest": "catalog:"
+  },
+  "nx": {
+    "targets": {
+      "dev": {
+        "dependsOn": [
+          "^dev",
+          "build"
+        ]
+      }
+    }
   }
 }

--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -16,7 +16,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "dev": "pnpm build && concurrently --kill-others --names preview,build \"pnpm preview --host -l silent\" \"pnpm build:watch\"",
+    "dev": "concurrently --kill-others --names preview,build \"pnpm preview --host -l silent\" \"pnpm build:watch\"",
     "dev:test": "vite build && vite preview --port 7175",
     "build": "vite build",
     "build:watch": "vite build --watch",
@@ -93,6 +93,14 @@
   "nx": {
     "tags": [
       "i18n"
-    ]
+    ],
+    "targets": {
+      "dev": {
+        "dependsOn": [
+          "^dev",
+          "build"
+        ]
+      }
+    }
   }
 }

--- a/apps/sodo-search/package.json
+++ b/apps/sodo-search/package.json
@@ -22,7 +22,7 @@
     "react-dom": "catalog:react17"
   },
   "scripts": {
-    "dev": "pnpm build && concurrently --kill-others --names preview,build,tailwind \"vite preview -l silent\" \"pnpm build:watch\" \"pnpm tailwind\"",
+    "dev": "concurrently --kill-others --names preview,build,tailwind \"vite preview -l silent\" \"pnpm build:watch\" \"pnpm tailwind\"",
     "build": "vite build && pnpm tailwind:base",
     "build:watch": "vite build --watch",
     "tailwind": "pnpm tailwind:base --watch ",
@@ -74,6 +74,14 @@
   "nx": {
     "tags": [
       "i18n"
-    ]
+    ],
+    "targets": {
+      "dev": {
+        "dependsOn": [
+          "^dev",
+          "build"
+        ]
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Same shape as #28827, applied to the rest of the public UMD apps.

- **comments-ui**, **sodo-search**, **announcement-bar**: dropped the leading `pnpm build &&` from the `dev` script and added `nx.targets.dev.dependsOn: ["^dev", "build"]` so the initial `vite build` is nx-cached on warm starts.
- **admin-toolbar**: only added the nx config. Its `dev` already didn't carry the build prefix, so the preview server was being spawned against an empty `umd/` on a fresh checkout — the nx wiring closes that hole.

## Test plan

- [ ] `pnpm dev` — comments thread, search modal, announcement bar, and admin toolbar all load via Caddy on a site that uses them
- [ ] Second `pnpm dev` skips each app's `vite build` (nx cache hit on `umd/`)