### PR TITLE
Added Claude Code Bash hook to align Node version with .nvmrc

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -c '{hookSpecificOutput:{hookEventName:\"PreToolUse\",updatedInput:{command:(\"[ -s ~/.nvm/nvm.sh ] && . ~/.nvm/nvm.sh >/dev/null 2>&1 && nvm use >/dev/null 2>&1; \" + .tool_input.command)}}}'"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds a `PreToolUse[Bash]` hook so commands inherit the Node version pinned in `.nvmrc`.

Works around [anthropics/claude-code#54135](https://github.com/anthropics/claude-code/issues/54135): the Claude Code Desktop launcher enumerates every `~/.nvm/versions/node/v*/bin` directory into PATH in lexical order, so the lowest-installed Node wins regardless of `nvm alias default` or `.nvmrc`. In practice this means agents land on Node 16 (or whatever's lexically first), which crashes corepack at the husky pre-commit hook.

The hook sources nvm and runs `nvm use` before each Bash command. Silent no-op on machines without nvm.

## Verify

In a new Claude Code session on this repo, run `node --version` via the Bash tool — should return `v22.18.0` regardless of how many older Node versions are installed.