### PR TITLE
Extracted shared ESLint rules + filename shim into root eslint.shared.mjs

### DIFF
--- a/apps/activitypub/eslint.config.js
+++ b/apps/activitypub/eslint.config.js
@@ -7,34 +7,18 @@ import reactRefreshPlugin from 'eslint-plugin-react-refresh';
 import tailwindcssPlugin from 'eslint-plugin-tailwindcss';
 import tseslint from 'typescript-eslint';
 
+import {
+    correctnessRules,
+    mochaRulesOff,
+    reactDefaultsOff,
+    reactStrictRules,
+    shadeLayeredImportsRule,
+    sortImportsRule,
+    tailwindRulesV4,
+    tsUnusedVarsRule
+} from '../../eslint.shared.mjs';
+
 const tailwindCssConfig = `${import.meta.dirname}/../admin/src/index.css`;
-
-const ghostRules = {
-    curly: 'error',
-    camelcase: ['error', {properties: 'never'}],
-    'dot-notation': 'error',
-    eqeqeq: ['error', 'always'],
-    'no-plusplus': ['error', {allowForLoopAfterthoughts: true}],
-    'no-eval': 'error',
-    'no-useless-call': 'error',
-    'no-console': 'error',
-    'array-callback-return': 'error',
-    'no-constructor-return': 'error',
-    'no-promise-executor-return': 'error',
-    'no-unused-vars': 'off',
-    '@typescript-eslint/no-unused-vars': ['error', {
-        args: 'after-used',
-        argsIgnorePattern: '^_',
-        caughtErrors: 'none'
-    }],
-    'ghost/filenames/match-regex': ['error', '^[a-z0-9.-]+$', false]
-};
-
-const mochaRulesOff = Object.fromEntries(
-    Object.keys(ghostPlugin.rules || {})
-        .filter(rule => rule.startsWith('mocha/'))
-        .map(rule => [`ghost/${rule}`, 'off'])
-);
 
 const reactFlat = reactPlugin.configs.flat.recommended;
 
@@ -69,43 +53,22 @@ export default tseslint.config(
             ...js.configs.recommended.rules,
             ...reactFlat.rules,
             ...reactHooksPlugin.configs.recommended.rules,
-            ...ghostRules,
+            ...correctnessRules,
+            ...tsUnusedVarsRule,
+            ...reactDefaultsOff,
+            ...reactStrictRules,
+            ...sortImportsRule,
+            ...shadeLayeredImportsRule,
+            ...tailwindRulesV4,
             'no-undef': 'off',
             'no-redeclare': 'off',
             'no-unexpected-multiline': 'off',
             'no-shadow': 'off',
             '@typescript-eslint/no-shadow': 'error',
-            'ghost/sort-imports-es6-autofix/sort-imports-es6': ['error', {
-                memberSyntaxSortOrder: ['none', 'all', 'single', 'multiple']
-            }],
-            'no-restricted-imports': ['error', {
-                paths: [{
-                    name: '@tryghost/shade',
-                    message: 'Import from layered subpaths instead (components/primitives/patterns/utils/app/tokens).'
-                }]
-            }],
             'react-refresh/only-export-components': 'off',
-            'react/react-in-jsx-scope': 'off',
-            'react/prop-types': 'off',
             '@typescript-eslint/no-inferrable-types': 'off',
             '@typescript-eslint/no-non-null-assertion': 'off',
-            '@typescript-eslint/no-empty-function': 'off',
-            'react/jsx-sort-props': ['error', {
-                reservedFirst: true,
-                callbacksLast: true,
-                shorthandLast: true,
-                locale: 'en'
-            }],
-            'react/button-has-type': 'error',
-            'react/no-array-index-key': 'error',
-            'react/jsx-key': 'off',
-            'tailwindcss/classnames-order': 'error',
-            'tailwindcss/enforces-negative-arbitrary-values': 'warn',
-            'tailwindcss/enforces-shorthand': 'warn',
-            'tailwindcss/migration-from-tailwind-2': 'warn',
-            'tailwindcss/no-arbitrary-value': 'off',
-            'tailwindcss/no-custom-classname': 'off',
-            'tailwindcss/no-contradicting-classname': 'error'
+            '@typescript-eslint/no-empty-function': 'off'
         }
     },
     {
@@ -125,8 +88,9 @@ export default tseslint.config(
             ghost: ghostPlugin
         },
         rules: {
-            ...ghostRules,
-            ...mochaRulesOff,
+            ...correctnessRules,
+            ...tsUnusedVarsRule,
+            ...mochaRulesOff(ghostPlugin),
             'no-undef': 'off',
             '@typescript-eslint/no-inferrable-types': 'off'
         }

--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tryghost/activitypub",
   "type": "module",
-  "version": "3.1.45",
+  "version": "3.1.46",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/admin-x-design-system/eslint.config.js
+++ b/apps/admin-x-design-system/eslint.config.js
@@ -7,35 +7,16 @@ import reactRefreshPlugin from 'eslint-plugin-react-refresh';
 import tailwindcssPlugin from 'eslint-plugin-tailwindcss';
 import tseslint from 'typescript-eslint';
 
+import {
+    correctnessRules,
+    mochaRulesOff,
+    reactDefaultsOff,
+    reactStrictRules,
+    tailwindRulesV4,
+    tsUnusedVarsRule
+} from '../../eslint.shared.mjs';
+
 const tailwindCssConfig = `${import.meta.dirname}/../admin/src/index.css`;
-
-const ghostRules = {
-    curly: 'error',
-    camelcase: ['error', {properties: 'never'}],
-    'dot-notation': 'error',
-    eqeqeq: ['error', 'always'],
-    'no-plusplus': ['error', {allowForLoopAfterthoughts: true}],
-    'no-eval': 'error',
-    'no-useless-call': 'error',
-    'no-console': 'error',
-    'no-shadow': 'error',
-    'array-callback-return': 'error',
-    'no-constructor-return': 'error',
-    'no-promise-executor-return': 'error',
-    'no-unused-vars': 'off',
-    '@typescript-eslint/no-unused-vars': ['error', {
-        args: 'after-used',
-        argsIgnorePattern: '^_',
-        caughtErrors: 'none'
-    }],
-    'ghost/filenames/match-regex': ['error', '^[a-z0-9.-]+$', false]
-};
-
-const mochaRulesOff = Object.fromEntries(
-    Object.keys(ghostPlugin.rules || {})
-        .filter(rule => rule.startsWith('mocha/'))
-        .map(rule => [`ghost/${rule}`, 'off'])
-);
 
 const reactFlat = reactPlugin.configs.flat.recommended;
 
@@ -70,30 +51,16 @@ export default tseslint.config(
             ...js.configs.recommended.rules,
             ...reactFlat.rules,
             ...reactHooksPlugin.configs.recommended.rules,
-            ...ghostRules,
+            ...correctnessRules,
+            ...tsUnusedVarsRule,
+            ...reactDefaultsOff,
+            ...reactStrictRules,
+            ...tailwindRulesV4,
             // TS handles these — disable the base ESLint variants
             'no-undef': 'off',
             'no-redeclare': 'off',
             'no-unexpected-multiline': 'off',
-            '@typescript-eslint/no-inferrable-types': 'off',
-            'react/react-in-jsx-scope': 'off',
-            'react/prop-types': 'off',
-            'react/jsx-sort-props': ['error', {
-                reservedFirst: true,
-                callbacksLast: true,
-                shorthandLast: true,
-                locale: 'en'
-            }],
-            'react/button-has-type': 'error',
-            'react/no-array-index-key': 'error',
-            'react/jsx-key': 'off',
-            'tailwindcss/classnames-order': 'error',
-            'tailwindcss/enforces-negative-arbitrary-values': 'warn',
-            'tailwindcss/enforces-shorthand': 'warn',
-            'tailwindcss/migration-from-tailwind-2': 'warn',
-            'tailwindcss/no-arbitrary-value': 'off',
-            'tailwindcss/no-custom-classname': 'off',
-            'tailwindcss/no-contradicting-classname': 'error'
+            '@typescript-eslint/no-inferrable-types': 'off'
         }
     },
     // Storybook story files — render() functions intentionally use hooks
@@ -120,8 +87,9 @@ export default tseslint.config(
             ghost: ghostPlugin
         },
         rules: {
-            ...ghostRules,
-            ...mochaRulesOff,
+            ...correctnessRules,
+            ...tsUnusedVarsRule,
+            ...mochaRulesOff(ghostPlugin),
             '@typescript-eslint/no-inferrable-types': 'off'
         }
     }

--- a/apps/admin-x-framework/eslint.config.js
+++ b/apps/admin-x-framework/eslint.config.js
@@ -6,33 +6,14 @@ import reactHooksPlugin from 'eslint-plugin-react-hooks';
 import reactRefreshPlugin from 'eslint-plugin-react-refresh';
 import tseslint from 'typescript-eslint';
 
-const ghostRules = {
-    curly: 'error',
-    camelcase: ['error', {properties: 'never'}],
-    'dot-notation': 'error',
-    eqeqeq: ['error', 'always'],
-    'no-plusplus': ['error', {allowForLoopAfterthoughts: true}],
-    'no-eval': 'error',
-    'no-useless-call': 'error',
-    'no-console': 'error',
-    'no-shadow': 'error',
-    'array-callback-return': 'error',
-    'no-constructor-return': 'error',
-    'no-promise-executor-return': 'error',
-    'no-unused-vars': 'off',
-    '@typescript-eslint/no-unused-vars': ['error', {
-        args: 'after-used',
-        argsIgnorePattern: '^_',
-        caughtErrors: 'none'
-    }],
-    'ghost/filenames/match-regex': ['error', '^[a-z0-9.-]+$', false]
-};
-
-const mochaRulesOff = Object.fromEntries(
-    Object.keys(ghostPlugin.rules || {})
-        .filter(rule => rule.startsWith('mocha/'))
-        .map(rule => [`ghost/${rule}`, 'off'])
-);
+import {
+    correctnessRules,
+    mochaRulesOff,
+    reactDefaultsOff,
+    reactStrictRules,
+    shadeLayeredImportsRule,
+    tsUnusedVarsRule
+} from '../../eslint.shared.mjs';
 
 const reactFlat = reactPlugin.configs.flat.recommended;
 
@@ -65,29 +46,16 @@ export default tseslint.config(
             ...js.configs.recommended.rules,
             ...reactFlat.rules,
             ...reactHooksPlugin.configs.recommended.rules,
-            ...ghostRules,
+            ...correctnessRules,
+            ...tsUnusedVarsRule,
+            ...reactDefaultsOff,
+            ...reactStrictRules,
+            ...shadeLayeredImportsRule,
             // TS handles these — disable the base ESLint variants
             'no-undef': 'off',
             'no-redeclare': 'off',
             'no-unexpected-multiline': 'off',
-            '@typescript-eslint/no-inferrable-types': 'off',
-            'react/react-in-jsx-scope': 'off',
-            'react/prop-types': 'off',
-            'no-restricted-imports': ['error', {
-                paths: [{
-                    name: '@tryghost/shade',
-                    message: 'Import from layered subpaths instead (components/primitives/patterns/utils/app/tokens).'
-                }]
-            }],
-            'react/jsx-sort-props': ['error', {
-                reservedFirst: true,
-                callbacksLast: true,
-                shorthandLast: true,
-                locale: 'en'
-            }],
-            'react/button-has-type': 'error',
-            'react/no-array-index-key': 'error',
-            'react/jsx-key': 'off'
+            '@typescript-eslint/no-inferrable-types': 'off'
         }
     },
     {
@@ -107,8 +75,9 @@ export default tseslint.config(
             ghost: ghostPlugin
         },
         rules: {
-            ...ghostRules,
-            ...mochaRulesOff,
+            ...correctnessRules,
+            ...tsUnusedVarsRule,
+            ...mochaRulesOff(ghostPlugin),
             '@typescript-eslint/no-inferrable-types': 'off',
             '@typescript-eslint/no-explicit-any': 'off'
         }

--- a/apps/admin-x-settings/eslint.config.js
+++ b/apps/admin-x-settings/eslint.config.js
@@ -7,35 +7,18 @@ import reactRefreshPlugin from 'eslint-plugin-react-refresh';
 import tailwindcssPlugin from 'eslint-plugin-tailwindcss';
 import tseslint from 'typescript-eslint';
 
+import {
+    correctnessRules,
+    mochaRulesOff,
+    reactDefaultsOff,
+    reactStrictRules,
+    shadeLayeredImportsRule,
+    sortImportsRule,
+    tailwindRulesV4,
+    tsUnusedVarsRule
+} from '../../eslint.shared.mjs';
+
 const tailwindCssConfig = `${import.meta.dirname}/../admin/src/index.css`;
-
-const ghostRules = {
-    curly: 'error',
-    camelcase: ['error', {properties: 'never'}],
-    'dot-notation': 'error',
-    eqeqeq: ['error', 'always'],
-    'no-plusplus': ['error', {allowForLoopAfterthoughts: true}],
-    'no-eval': 'error',
-    'no-useless-call': 'error',
-    'no-console': 'error',
-    'no-shadow': 'error',
-    'array-callback-return': 'error',
-    'no-constructor-return': 'error',
-    'no-promise-executor-return': 'error',
-    'no-unused-vars': 'off',
-    '@typescript-eslint/no-unused-vars': ['error', {
-        args: 'after-used',
-        argsIgnorePattern: '^_',
-        caughtErrors: 'none'
-    }],
-    'ghost/filenames/match-regex': ['error', '^[a-z0-9.-]+$', false]
-};
-
-const mochaRulesOff = Object.fromEntries(
-    Object.keys(ghostPlugin.rules || {})
-        .filter(rule => rule.startsWith('mocha/'))
-        .map(rule => [`ghost/${rule}`, 'off'])
-);
 
 const reactFlat = reactPlugin.configs.flat.recommended;
 
@@ -70,44 +53,22 @@ export default tseslint.config(
             ...js.configs.recommended.rules,
             ...reactFlat.rules,
             ...reactHooksPlugin.configs.recommended.rules,
-            ...ghostRules,
-            // TS handles these — disable the base ESLint variants
+            ...correctnessRules,
+            ...tsUnusedVarsRule,
+            ...reactDefaultsOff,
+            ...reactStrictRules,
+            ...sortImportsRule,
+            ...shadeLayeredImportsRule,
+            ...tailwindRulesV4,
             'no-undef': 'off',
             'no-redeclare': 'off',
             'no-unexpected-multiline': 'off',
-            'ghost/sort-imports-es6-autofix/sort-imports-es6': ['error', {
-                memberSyntaxSortOrder: ['none', 'all', 'single', 'multiple']
-            }],
-            'no-restricted-imports': ['error', {
-                paths: [{
-                    name: '@tryghost/shade',
-                    message: 'Import from layered subpaths instead (components/primitives/patterns/utils/app/tokens).'
-                }]
-            }],
             'prefer-const': 'off',
             'react-refresh/only-export-components': 'off',
-            'react/react-in-jsx-scope': 'off',
-            'react/prop-types': 'off',
             '@typescript-eslint/no-inferrable-types': 'off',
             '@typescript-eslint/no-explicit-any': 'warn',
             '@typescript-eslint/no-non-null-assertion': 'off',
-            '@typescript-eslint/no-empty-function': 'off',
-            'react/jsx-sort-props': ['error', {
-                reservedFirst: true,
-                callbacksLast: true,
-                shorthandLast: true,
-                locale: 'en'
-            }],
-            'react/button-has-type': 'error',
-            'react/no-array-index-key': 'error',
-            'react/jsx-key': 'off',
-            'tailwindcss/classnames-order': 'error',
-            'tailwindcss/enforces-negative-arbitrary-values': 'warn',
-            'tailwindcss/enforces-shorthand': 'warn',
-            'tailwindcss/migration-from-tailwind-2': 'warn',
-            'tailwindcss/no-arbitrary-value': 'off',
-            'tailwindcss/no-custom-classname': 'off',
-            'tailwindcss/no-contradicting-classname': 'error'
+            '@typescript-eslint/no-empty-function': 'off'
         }
     },
     // Final overrides for src files. Kept in a separate block to guarantee
@@ -135,8 +96,9 @@ export default tseslint.config(
             ghost: ghostPlugin
         },
         rules: {
-            ...ghostRules,
-            ...mochaRulesOff,
+            ...correctnessRules,
+            ...tsUnusedVarsRule,
+            ...mochaRulesOff(ghostPlugin),
             'no-undef': 'off',
             '@typescript-eslint/no-inferrable-types': 'off',
             '@typescript-eslint/no-explicit-any': 'off'

--- a/apps/announcement-bar/eslint.config.js
+++ b/apps/announcement-bar/eslint.config.js
@@ -3,21 +3,7 @@ import globals from 'globals';
 import ghostPlugin from 'eslint-plugin-ghost';
 import reactPlugin from 'eslint-plugin-react';
 
-const ghostRules = {
-    curly: 'error',
-    camelcase: ['error', {properties: 'never'}],
-    'dot-notation': 'error',
-    eqeqeq: ['error', 'always'],
-    'no-plusplus': ['error', {allowForLoopAfterthoughts: true}],
-    'no-eval': 'error',
-    'no-useless-call': 'error',
-    'no-console': 'error',
-    'no-shadow': 'error',
-    'array-callback-return': 'error',
-    'no-constructor-return': 'error',
-    'no-promise-executor-return': 'error',
-    'ghost/filenames/match-regex': ['error', '^[a-z0-9.-]+$', false]
-};
+import {correctnessRules} from '../../eslint.shared.mjs';
 
 const baseConfig = {
     ...js.configs.recommended,
@@ -32,7 +18,7 @@ const baseConfig = {
     rules: {
         ...js.configs.recommended.rules,
         ...reactPlugin.configs.flat.recommended.rules,
-        ...ghostRules,
+        ...correctnessRules,
         'react/prop-types': 'off'
     }
 };

--- a/apps/announcement-bar/package.json
+++ b/apps/announcement-bar/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tryghost/announcement-bar",
   "type": "module",
-  "version": "1.1.22",
+  "version": "1.1.23",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/comments-ui/eslint.config.js
+++ b/apps/comments-ui/eslint.config.js
@@ -6,32 +6,15 @@ import i18nextPlugin from 'eslint-plugin-i18next';
 import tailwindcssPlugin from 'eslint-plugin-tailwindcss';
 import tseslint from 'typescript-eslint';
 
-const tailwindConfig = `${import.meta.dirname}/tailwind.config.js`;
+import {
+    correctnessRules,
+    reactDefaultsOff,
+    sortImportsRule,
+    tailwindRulesWithConfig,
+    tsUnusedVarsRule
+} from '../../eslint.shared.mjs';
 
-const ghostRules = {
-    curly: 'error',
-    camelcase: ['error', {properties: 'never'}],
-    'dot-notation': 'error',
-    eqeqeq: ['error', 'always'],
-    'no-plusplus': ['error', {allowForLoopAfterthoughts: true}],
-    'no-eval': 'error',
-    'no-useless-call': 'error',
-    'no-console': 'error',
-    'no-shadow': 'error',
-    'array-callback-return': 'error',
-    'no-constructor-return': 'error',
-    'no-promise-executor-return': 'error',
-    'no-unused-vars': 'off',
-    '@typescript-eslint/no-unused-vars': ['error', {
-        args: 'after-used',
-        argsIgnorePattern: '^_',
-        caughtErrors: 'none'
-    }],
-    'ghost/filenames/match-regex': ['error', '^[a-z0-9.-]+$', false],
-    'ghost/sort-imports-es6-autofix/sort-imports-es6': ['error', {
-        memberSyntaxSortOrder: ['none', 'all', 'single', 'multiple']
-    }]
-};
+const tailwindConfig = `${import.meta.dirname}/tailwind.config.js`;
 
 const reactFlat = reactPlugin.configs.flat.recommended;
 const i18nextFlat = i18nextPlugin.configs['flat/recommended'];
@@ -65,11 +48,10 @@ export default tseslint.config(
             ...js.configs.recommended.rules,
             ...reactFlat.rules,
             ...i18nextFlat.rules,
-            ...ghostRules,
-            '@typescript-eslint/no-inferrable-types': 'off',
-            '@typescript-eslint/no-explicit-any': 'warn',
-            'react/react-in-jsx-scope': 'off',
-            'react/prop-types': 'off',
+            ...correctnessRules,
+            ...tsUnusedVarsRule,
+            ...sortImportsRule,
+            ...reactDefaultsOff,
             'react/jsx-sort-props': ['error', {
                 reservedFirst: true,
                 callbacksLast: true,
@@ -78,13 +60,9 @@ export default tseslint.config(
             }],
             'react/button-has-type': 'error',
             'react/no-array-index-key': 'error',
-            'tailwindcss/classnames-order': ['error', {config: tailwindConfig}],
-            'tailwindcss/enforces-negative-arbitrary-values': ['warn', {config: tailwindConfig}],
-            'tailwindcss/enforces-shorthand': ['warn', {config: tailwindConfig}],
-            'tailwindcss/migration-from-tailwind-2': ['warn', {config: tailwindConfig}],
-            'tailwindcss/no-arbitrary-value': 'off',
-            'tailwindcss/no-custom-classname': 'off',
-            'tailwindcss/no-contradicting-classname': ['error', {config: tailwindConfig}],
+            ...tailwindRulesWithConfig(tailwindConfig),
+            '@typescript-eslint/no-inferrable-types': 'off',
+            '@typescript-eslint/no-explicit-any': 'warn',
             'no-undef': 'off'
         }
     }

--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tryghost/comments-ui",
   "type": "module",
-  "version": "1.5.13",
+  "version": "1.5.14",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/eslint.config.js
+++ b/apps/portal/eslint.config.js
@@ -5,24 +5,10 @@ import reactPlugin from 'eslint-plugin-react';
 import i18nextPlugin from 'eslint-plugin-i18next';
 import tseslint from 'typescript-eslint';
 
-const ghostRules = {
-    curly: 'error',
-    camelcase: ['error', {properties: 'never'}],
-    'dot-notation': 'error',
-    eqeqeq: ['error', 'always'],
-    'no-plusplus': ['error', {allowForLoopAfterthoughts: true}],
-    'no-eval': 'error',
-    'no-useless-call': 'error',
-    'no-console': 'error',
-    'no-shadow': 'error',
-    'array-callback-return': 'error',
-    'no-constructor-return': 'error',
-    'no-promise-executor-return': 'error',
-    // ESLint 9 flipped no-unused-vars caughtErrors default from 'none' to 'all' —
-    // restore the previous behavior so unused catch bindings stay tolerated.
-    'no-unused-vars': ['error', {caughtErrors: 'none'}],
-    'ghost/filenames/match-regex': ['error', '^[a-z0-9.-]+$', false]
-};
+import {
+    correctnessRules,
+    jsUnusedVarsRule
+} from '../../eslint.shared.mjs';
 
 const i18nextFlat = i18nextPlugin.configs['flat/recommended'];
 const reactFlat = reactPlugin.configs.flat.recommended;
@@ -60,7 +46,8 @@ export default tseslint.config(
             ...reactFlat.rules,
             ...reactJsxRuntime.rules,
             ...i18nextFlat.rules,
-            ...ghostRules,
+            ...correctnessRules,
+            ...jsUnusedVarsRule,
             'react/prop-types': 'off'
         }
     },
@@ -94,7 +81,8 @@ export default tseslint.config(
             ...reactFlat.rules,
             ...reactJsxRuntime.rules,
             ...i18nextFlat.rules,
-            ...ghostRules,
+            ...correctnessRules,
+            ...jsUnusedVarsRule,
             'react/prop-types': 'off'
         }
     }

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tryghost/portal",
   "type": "module",
-  "version": "2.69.8",
+  "version": "2.69.9",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/posts/eslint.config.js
+++ b/apps/posts/eslint.config.js
@@ -7,35 +7,18 @@ import reactRefreshPlugin from 'eslint-plugin-react-refresh';
 import tailwindcssPlugin from 'eslint-plugin-tailwindcss';
 import tseslint from 'typescript-eslint';
 
+import {
+    correctnessRules,
+    mochaRulesOff,
+    reactDefaultsOff,
+    reactStrictRules,
+    shadeLayeredImportsRule,
+    sortImportsRule,
+    tailwindRulesV4,
+    tsUnusedVarsRule
+} from '../../eslint.shared.mjs';
+
 const tailwindCssConfig = `${import.meta.dirname}/../admin/src/index.css`;
-
-const ghostRules = {
-    curly: 'error',
-    camelcase: ['error', {properties: 'never'}],
-    'dot-notation': 'error',
-    eqeqeq: ['error', 'always'],
-    'no-plusplus': ['error', {allowForLoopAfterthoughts: true}],
-    'no-eval': 'error',
-    'no-useless-call': 'error',
-    'no-console': 'error',
-    'no-shadow': 'error',
-    'array-callback-return': 'error',
-    'no-constructor-return': 'error',
-    'no-promise-executor-return': 'error',
-    'no-unused-vars': 'off',
-    '@typescript-eslint/no-unused-vars': ['error', {
-        args: 'after-used',
-        argsIgnorePattern: '^_',
-        caughtErrors: 'none'
-    }],
-    'ghost/filenames/match-regex': ['error', '^[a-z0-9.-]+$', false]
-};
-
-const mochaRulesOff = Object.fromEntries(
-    Object.keys(ghostPlugin.rules || {})
-        .filter(rule => rule.startsWith('mocha/'))
-        .map(rule => [`ghost/${rule}`, 'off'])
-);
 
 const reactFlat = reactPlugin.configs.flat.recommended;
 
@@ -70,41 +53,20 @@ export default tseslint.config(
             ...js.configs.recommended.rules,
             ...reactFlat.rules,
             ...reactHooksPlugin.configs.recommended.rules,
-            ...ghostRules,
+            ...correctnessRules,
+            ...tsUnusedVarsRule,
+            ...reactDefaultsOff,
+            ...reactStrictRules,
+            ...sortImportsRule,
+            ...shadeLayeredImportsRule,
+            ...tailwindRulesV4,
             'no-undef': 'off',
             'no-redeclare': 'off',
             'no-unexpected-multiline': 'off',
-            'ghost/sort-imports-es6-autofix/sort-imports-es6': ['error', {
-                memberSyntaxSortOrder: ['none', 'all', 'single', 'multiple']
-            }],
-            'no-restricted-imports': ['error', {
-                paths: [{
-                    name: '@tryghost/shade',
-                    message: 'Import from layered subpaths instead (components/primitives/patterns/utils/app/tokens).'
-                }]
-            }],
             'react-refresh/only-export-components': 'off',
-            'react/react-in-jsx-scope': 'off',
-            'react/prop-types': 'off',
             '@typescript-eslint/no-inferrable-types': 'off',
             '@typescript-eslint/no-non-null-assertion': 'off',
-            '@typescript-eslint/no-empty-function': 'off',
-            'react/jsx-sort-props': ['error', {
-                reservedFirst: true,
-                callbacksLast: true,
-                shorthandLast: true,
-                locale: 'en'
-            }],
-            'react/button-has-type': 'error',
-            'react/no-array-index-key': 'error',
-            'react/jsx-key': 'off',
-            'tailwindcss/classnames-order': 'error',
-            'tailwindcss/enforces-negative-arbitrary-values': 'warn',
-            'tailwindcss/enforces-shorthand': 'warn',
-            'tailwindcss/migration-from-tailwind-2': 'warn',
-            'tailwindcss/no-arbitrary-value': 'off',
-            'tailwindcss/no-custom-classname': 'off',
-            'tailwindcss/no-contradicting-classname': 'error'
+            '@typescript-eslint/no-empty-function': 'off'
         }
     },
     {
@@ -124,8 +86,9 @@ export default tseslint.config(
             ghost: ghostPlugin
         },
         rules: {
-            ...ghostRules,
-            ...mochaRulesOff,
+            ...correctnessRules,
+            ...tsUnusedVarsRule,
+            ...mochaRulesOff(ghostPlugin),
             'no-undef': 'off',
             '@typescript-eslint/no-inferrable-types': 'off'
         }

--- a/apps/shade/eslint.config.js
+++ b/apps/shade/eslint.config.js
@@ -8,35 +8,16 @@ import storybookPlugin from 'eslint-plugin-storybook';
 import tailwindcssPlugin from 'eslint-plugin-tailwindcss';
 import tseslint from 'typescript-eslint';
 
+import {
+    correctnessRules,
+    mochaRulesOff,
+    reactDefaultsOff,
+    reactStrictRules,
+    tailwindRulesV4,
+    tsUnusedVarsRule
+} from '../../eslint.shared.mjs';
+
 const tailwindCssConfig = `${import.meta.dirname}/../admin/src/index.css`;
-
-const ghostRules = {
-    curly: 'error',
-    camelcase: ['error', {properties: 'never'}],
-    'dot-notation': 'error',
-    eqeqeq: ['error', 'always'],
-    'no-plusplus': ['error', {allowForLoopAfterthoughts: true}],
-    'no-eval': 'error',
-    'no-useless-call': 'error',
-    'no-console': 'error',
-    'no-shadow': 'error',
-    'array-callback-return': 'error',
-    'no-constructor-return': 'error',
-    'no-promise-executor-return': 'error',
-    'no-unused-vars': 'off',
-    '@typescript-eslint/no-unused-vars': ['error', {
-        args: 'after-used',
-        argsIgnorePattern: '^_',
-        caughtErrors: 'none'
-    }],
-    'ghost/filenames/match-regex': ['error', '^[a-z0-9.-]+$', false]
-};
-
-const mochaRulesOff = Object.fromEntries(
-    Object.keys(ghostPlugin.rules || {})
-        .filter(rule => rule.startsWith('mocha/'))
-        .map(rule => [`ghost/${rule}`, 'off'])
-);
 
 const reactFlat = reactPlugin.configs.flat.recommended;
 
@@ -71,30 +52,16 @@ export default tseslint.config(
             ...js.configs.recommended.rules,
             ...reactFlat.rules,
             ...reactHooksPlugin.configs.recommended.rules,
-            ...ghostRules,
+            ...correctnessRules,
+            ...tsUnusedVarsRule,
+            ...reactDefaultsOff,
+            ...reactStrictRules,
+            ...tailwindRulesV4,
             // TS handles these — disable the base ESLint variants
             'no-undef': 'off',
             'no-redeclare': 'off',
             'no-unexpected-multiline': 'off',
-            '@typescript-eslint/no-inferrable-types': 'off',
-            'react/react-in-jsx-scope': 'off',
-            'react/prop-types': 'off',
-            'react/jsx-sort-props': ['error', {
-                reservedFirst: true,
-                callbacksLast: true,
-                shorthandLast: true,
-                locale: 'en'
-            }],
-            'react/button-has-type': 'error',
-            'react/no-array-index-key': 'error',
-            'react/jsx-key': 'off',
-            'tailwindcss/classnames-order': 'error',
-            'tailwindcss/enforces-negative-arbitrary-values': 'warn',
-            'tailwindcss/enforces-shorthand': 'warn',
-            'tailwindcss/migration-from-tailwind-2': 'warn',
-            'tailwindcss/no-arbitrary-value': 'off',
-            'tailwindcss/no-custom-classname': 'off',
-            'tailwindcss/no-contradicting-classname': 'error'
+            '@typescript-eslint/no-inferrable-types': 'off'
         }
     },
     ...storybookPlugin.configs['flat/recommended'],
@@ -115,8 +82,9 @@ export default tseslint.config(
             ghost: ghostPlugin
         },
         rules: {
-            ...ghostRules,
-            ...mochaRulesOff,
+            ...correctnessRules,
+            ...tsUnusedVarsRule,
+            ...mochaRulesOff(ghostPlugin),
             '@typescript-eslint/no-inferrable-types': 'off'
         }
     }

--- a/apps/signup-form/eslint.config.js
+++ b/apps/signup-form/eslint.config.js
@@ -5,32 +5,15 @@ import reactPlugin from 'eslint-plugin-react';
 import tailwindcssPlugin from 'eslint-plugin-tailwindcss';
 import tseslint from 'typescript-eslint';
 
-const tailwindConfig = `${import.meta.dirname}/tailwind.config.cjs`;
+import {
+    correctnessRules,
+    reactDefaultsOff,
+    sortImportsRule,
+    tailwindRulesWithConfig,
+    tsUnusedVarsRule
+} from '../../eslint.shared.mjs';
 
-const ghostRules = {
-    curly: 'error',
-    camelcase: ['error', {properties: 'never'}],
-    'dot-notation': 'error',
-    eqeqeq: ['error', 'always'],
-    'no-plusplus': ['error', {allowForLoopAfterthoughts: true}],
-    'no-eval': 'error',
-    'no-useless-call': 'error',
-    'no-console': 'error',
-    'no-shadow': 'error',
-    'array-callback-return': 'error',
-    'no-constructor-return': 'error',
-    'no-promise-executor-return': 'error',
-    'no-unused-vars': 'off',
-    '@typescript-eslint/no-unused-vars': ['error', {
-        args: 'after-used',
-        argsIgnorePattern: '^_',
-        caughtErrors: 'none'
-    }],
-    'ghost/filenames/match-regex': ['error', '^[a-z0-9.-]+$', false],
-    'ghost/sort-imports-es6-autofix/sort-imports-es6': ['error', {
-        memberSyntaxSortOrder: ['none', 'all', 'single', 'multiple']
-    }]
-};
+const tailwindConfig = `${import.meta.dirname}/tailwind.config.cjs`;
 
 const reactFlat = reactPlugin.configs.flat.recommended;
 
@@ -61,10 +44,10 @@ export default tseslint.config(
         rules: {
             ...js.configs.recommended.rules,
             ...reactFlat.rules,
-            ...ghostRules,
-            '@typescript-eslint/no-inferrable-types': 'off',
-            'react/react-in-jsx-scope': 'off',
-            'react/prop-types': 'off',
+            ...correctnessRules,
+            ...tsUnusedVarsRule,
+            ...sortImportsRule,
+            ...reactDefaultsOff,
             'react/jsx-sort-props': ['error', {
                 reservedFirst: true,
                 callbacksLast: true,
@@ -73,13 +56,8 @@ export default tseslint.config(
             }],
             'react/button-has-type': 'error',
             'react/no-array-index-key': 'error',
-            'tailwindcss/classnames-order': ['error', {config: tailwindConfig}],
-            'tailwindcss/enforces-negative-arbitrary-values': ['warn', {config: tailwindConfig}],
-            'tailwindcss/enforces-shorthand': ['warn', {config: tailwindConfig}],
-            'tailwindcss/migration-from-tailwind-2': ['warn', {config: tailwindConfig}],
-            'tailwindcss/no-arbitrary-value': 'off',
-            'tailwindcss/no-custom-classname': 'off',
-            'tailwindcss/no-contradicting-classname': ['error', {config: tailwindConfig}]
+            ...tailwindRulesWithConfig(tailwindConfig),
+            '@typescript-eslint/no-inferrable-types': 'off'
         }
     }
 );

--- a/apps/signup-form/package.json
+++ b/apps/signup-form/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tryghost/signup-form",
   "type": "module",
-  "version": "0.3.28",
+  "version": "0.3.29",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/sodo-search/eslint.config.js
+++ b/apps/sodo-search/eslint.config.js
@@ -3,24 +3,10 @@ import globals from 'globals';
 import ghostPlugin from 'eslint-plugin-ghost';
 import reactPlugin from 'eslint-plugin-react';
 
-const ghostRules = {
-    curly: 'error',
-    camelcase: ['error', {properties: 'never'}],
-    'dot-notation': 'error',
-    eqeqeq: ['error', 'always'],
-    'no-plusplus': ['error', {allowForLoopAfterthoughts: true}],
-    'no-eval': 'error',
-    'no-useless-call': 'error',
-    'no-console': 'error',
-    'no-shadow': 'error',
-    'array-callback-return': 'error',
-    'no-constructor-return': 'error',
-    'no-promise-executor-return': 'error',
-    'ghost/filenames/match-regex': ['error', '^[a-z0-9.-]+$', false],
-    'ghost/sort-imports-es6-autofix/sort-imports-es6': ['error', {
-        memberSyntaxSortOrder: ['none', 'all', 'single', 'multiple']
-    }]
-};
+import {
+    correctnessRules,
+    sortImportsRule
+} from '../../eslint.shared.mjs';
 
 const baseConfig = {
     ...js.configs.recommended,
@@ -35,7 +21,8 @@ const baseConfig = {
     rules: {
         ...js.configs.recommended.rules,
         ...reactPlugin.configs.flat.recommended.rules,
-        ...ghostRules,
+        ...correctnessRules,
+        ...sortImportsRule,
         'react/prop-types': 'off'
     }
 };

--- a/apps/sodo-search/package.json
+++ b/apps/sodo-search/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tryghost/sodo-search",
   "type": "module",
-  "version": "1.8.24",
+  "version": "1.8.25",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/stats/eslint.config.js
+++ b/apps/stats/eslint.config.js
@@ -7,35 +7,18 @@ import reactRefreshPlugin from 'eslint-plugin-react-refresh';
 import tailwindcssPlugin from 'eslint-plugin-tailwindcss';
 import tseslint from 'typescript-eslint';
 
+import {
+    correctnessRules,
+    mochaRulesOff,
+    reactDefaultsOff,
+    reactStrictRules,
+    shadeLayeredImportsRule,
+    sortImportsRule,
+    tailwindRulesV4,
+    tsUnusedVarsRule
+} from '../../eslint.shared.mjs';
+
 const tailwindCssConfig = `${import.meta.dirname}/../admin/src/index.css`;
-
-const ghostRules = {
-    curly: 'error',
-    camelcase: ['error', {properties: 'never'}],
-    'dot-notation': 'error',
-    eqeqeq: ['error', 'always'],
-    'no-plusplus': ['error', {allowForLoopAfterthoughts: true}],
-    'no-eval': 'error',
-    'no-useless-call': 'error',
-    'no-console': 'error',
-    'no-shadow': 'error',
-    'array-callback-return': 'error',
-    'no-constructor-return': 'error',
-    'no-promise-executor-return': 'error',
-    'no-unused-vars': 'off',
-    '@typescript-eslint/no-unused-vars': ['error', {
-        args: 'after-used',
-        argsIgnorePattern: '^_',
-        caughtErrors: 'none'
-    }],
-    'ghost/filenames/match-regex': ['error', '^[a-z0-9.-]+$', false]
-};
-
-const mochaRulesOff = Object.fromEntries(
-    Object.keys(ghostPlugin.rules || {})
-        .filter(rule => rule.startsWith('mocha/'))
-        .map(rule => [`ghost/${rule}`, 'off'])
-);
 
 const reactFlat = reactPlugin.configs.flat.recommended;
 
@@ -70,41 +53,20 @@ export default tseslint.config(
             ...js.configs.recommended.rules,
             ...reactFlat.rules,
             ...reactHooksPlugin.configs.recommended.rules,
-            ...ghostRules,
+            ...correctnessRules,
+            ...tsUnusedVarsRule,
+            ...reactDefaultsOff,
+            ...reactStrictRules,
+            ...sortImportsRule,
+            ...shadeLayeredImportsRule,
+            ...tailwindRulesV4,
             'no-undef': 'off',
             'no-redeclare': 'off',
             'no-unexpected-multiline': 'off',
-            'ghost/sort-imports-es6-autofix/sort-imports-es6': ['error', {
-                memberSyntaxSortOrder: ['none', 'all', 'single', 'multiple']
-            }],
-            'no-restricted-imports': ['error', {
-                paths: [{
-                    name: '@tryghost/shade',
-                    message: 'Import from layered subpaths instead (components/primitives/patterns/utils/app/tokens).'
-                }]
-            }],
             'react-refresh/only-export-components': 'off',
-            'react/react-in-jsx-scope': 'off',
-            'react/prop-types': 'off',
             '@typescript-eslint/no-inferrable-types': 'off',
             '@typescript-eslint/no-non-null-assertion': 'off',
-            '@typescript-eslint/no-empty-function': 'off',
-            'react/jsx-sort-props': ['error', {
-                reservedFirst: true,
-                callbacksLast: true,
-                shorthandLast: true,
-                locale: 'en'
-            }],
-            'react/button-has-type': 'error',
-            'react/no-array-index-key': 'error',
-            'react/jsx-key': 'off',
-            'tailwindcss/classnames-order': 'error',
-            'tailwindcss/enforces-negative-arbitrary-values': 'warn',
-            'tailwindcss/enforces-shorthand': 'warn',
-            'tailwindcss/migration-from-tailwind-2': 'warn',
-            'tailwindcss/no-arbitrary-value': 'off',
-            'tailwindcss/no-custom-classname': 'off',
-            'tailwindcss/no-contradicting-classname': 'error'
+            '@typescript-eslint/no-empty-function': 'off'
         }
     },
     {
@@ -124,8 +86,9 @@ export default tseslint.config(
             ghost: ghostPlugin
         },
         rules: {
-            ...ghostRules,
-            ...mochaRulesOff,
+            ...correctnessRules,
+            ...tsUnusedVarsRule,
+            ...mochaRulesOff(ghostPlugin),
             'no-undef': 'off',
             '@typescript-eslint/no-inferrable-types': 'off'
         }

--- a/eslint.shared.mjs
+++ b/eslint.shared.mjs
@@ -1,0 +1,170 @@
+// Shared building blocks for workspace ESLint flat configs. Each export is a
+// rule object, a helper, or a plugin definition. Workspaces import only the
+// pieces they need; this file imports nothing from the eslint plugin ecosystem
+// so consumers don't take transitive peer deps via it.
+
+import path from 'node:path';
+
+// === Rule sets ===
+
+// Correctness baseline shared by every workspace flat config. Each rule is
+// individually overridable in the consumer's `rules` block.
+export const correctnessRules = {
+    curly: 'error',
+    camelcase: ['error', {properties: 'never'}],
+    'dot-notation': 'error',
+    eqeqeq: ['error', 'always'],
+    'no-plusplus': ['error', {allowForLoopAfterthoughts: true}],
+    'no-eval': 'error',
+    'no-useless-call': 'error',
+    'no-console': 'error',
+    'no-shadow': 'error',
+    'array-callback-return': 'error',
+    'no-constructor-return': 'error',
+    'no-promise-executor-return': 'error',
+    'ghost/filenames/match-regex': ['error', '^[a-z0-9.-]+$', false]
+};
+
+// TS-aware unused-vars: disables the base rule, enables the TS variant with
+// args ignore pattern. Most TS workspaces want this.
+export const tsUnusedVarsRule = {
+    'no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': ['error', {
+        args: 'after-used',
+        argsIgnorePattern: '^_',
+        caughtErrors: 'none'
+    }]
+};
+
+// Vanilla unused-vars with caughtErrors:'none' — ESLint 9 flipped the default
+// to 'all'. For non-TS workspaces where the previous behavior is wanted.
+export const jsUnusedVarsRule = {
+    'no-unused-vars': ['error', {caughtErrors: 'none'}]
+};
+
+// Import-sort autofix from eslint-plugin-ghost.
+export const sortImportsRule = {
+    'ghost/sort-imports-es6-autofix/sort-imports-es6': ['error', {
+        memberSyntaxSortOrder: ['none', 'all', 'single', 'multiple']
+    }]
+};
+
+// Block barrel imports of @tryghost/shade; consumers must import from layered
+// subpaths. Used by admin-x-* / posts / activitypub / admin host.
+export const shadeLayeredImportsRule = {
+    'no-restricted-imports': ['error', {
+        paths: [{
+            name: '@tryghost/shade',
+            message: 'Import from layered subpaths instead (components/primitives/patterns/utils/app/tokens).'
+        }]
+    }]
+};
+
+// React rule defaults turned off across React workspaces.
+export const reactDefaultsOff = {
+    'react/react-in-jsx-scope': 'off',
+    'react/prop-types': 'off'
+};
+
+// React stylistic + correctness preferences applied across the React workspaces.
+export const reactStrictRules = {
+    'react/jsx-sort-props': ['error', {
+        reservedFirst: true,
+        callbacksLast: true,
+        shorthandLast: true,
+        locale: 'en'
+    }],
+    'react/button-has-type': 'error',
+    'react/no-array-index-key': 'error',
+    'react/jsx-key': 'off'
+};
+
+// Tailwind v4 ruleset using settings-based config (consumer sets
+// `settings.tailwindcss.config`). For v3 workspaces use tailwindRulesWithConfig().
+export const tailwindRulesV4 = {
+    'tailwindcss/classnames-order': 'error',
+    'tailwindcss/enforces-negative-arbitrary-values': 'warn',
+    'tailwindcss/enforces-shorthand': 'warn',
+    'tailwindcss/migration-from-tailwind-2': 'warn',
+    'tailwindcss/no-arbitrary-value': 'off',
+    'tailwindcss/no-custom-classname': 'off',
+    'tailwindcss/no-contradicting-classname': 'error'
+};
+
+// Tailwind v3 ruleset with config passed per-rule (v3 didn't read `settings`
+// the same way). Use the consumer's tailwind config absolute path.
+export function tailwindRulesWithConfig(config) {
+    return {
+        'tailwindcss/classnames-order': ['error', {config}],
+        'tailwindcss/enforces-negative-arbitrary-values': ['warn', {config}],
+        'tailwindcss/enforces-shorthand': ['warn', {config}],
+        'tailwindcss/migration-from-tailwind-2': ['warn', {config}],
+        'tailwindcss/no-arbitrary-value': 'off',
+        'tailwindcss/no-custom-classname': 'off',
+        'tailwindcss/no-contradicting-classname': ['error', {config}]
+    };
+}
+
+// === Helpers ===
+
+// Build an object that disables every `ghost/mocha/*` rule shipped by
+// eslint-plugin-ghost. Used in test blocks so Vitest patterns don't trip
+// false-positive mocha warnings. Pass the consumer's ghostPlugin.
+export function mochaRulesOff(ghostPlugin) {
+    return Object.fromEntries(
+        Object.keys(ghostPlugin.rules || {})
+            .filter(rule => rule.startsWith('mocha/'))
+            .map(rule => [`ghost/${rule}`, 'off'])
+    );
+}
+
+// === Plugins ===
+
+// eslint-plugin-filenames-ts@1.3.2's match-regex rule calls context.getScope(),
+// which ESLint 9 removed. Minimal replacement: filename check + optional
+// ignoreExporting via AST scan (no scope traversal). Use under the
+// 'local-filenames' plugin name. Compatible with the three call sites that
+// previously defined their own shim (ghost/core, ghost/admin, ghost/i18n).
+const filenamesMatchRegex = {
+    meta: {
+        type: 'problem',
+        schema: [
+            {type: 'string'},
+            {type: ['boolean', 'null']},
+            {type: ['boolean', 'null']}
+        ]
+    },
+    create(context) {
+        const pattern = new RegExp(context.options[0]);
+        const ignoreExporting = Boolean(context.options[1]);
+        return {
+            Program(node) {
+                if (ignoreExporting) {
+                    const hasExport = node.body.some(stmt =>
+                        stmt.type === 'ExportDefaultDeclaration' ||
+                        stmt.type === 'ExportNamedDeclaration' ||
+                        (stmt.type === 'ExpressionStatement' &&
+                         stmt.expression.type === 'AssignmentExpression' &&
+                         stmt.expression.left.type === 'MemberExpression' &&
+                         stmt.expression.left.object.type === 'Identifier' &&
+                         stmt.expression.left.object.name === 'module' &&
+                         stmt.expression.left.property.type === 'Identifier' &&
+                         stmt.expression.left.property.name === 'exports')
+                    );
+                    if (hasExport) return;
+                }
+                const filename = path.parse(context.filename).name;
+                if (!pattern.test(filename)) {
+                    context.report({
+                        node,
+                        message: `Filename '${filename}' does not match the naming convention.`
+                    });
+                }
+            }
+        };
+    }
+};
+
+export const localFilenamesPlugin = {
+    rules: {'match-regex': filenamesMatchRegex}
+};

--- a/eslint.shared.mjs
+++ b/eslint.shared.mjs
@@ -81,24 +81,28 @@ export const reactStrictRules = {
 
 // Tailwind v4 ruleset using settings-based config (consumer sets
 // `settings.tailwindcss.config`). For v3 workspaces use tailwindRulesWithConfig().
+// All rules are 'error' or 'off' — Ghost's stance is no warnings (warnings
+// get ignored and pollute context). migration-from-tailwind-2 is off since
+// Ghost is already on v4; the rule is no longer providing value.
 export const tailwindRulesV4 = {
     'tailwindcss/classnames-order': 'error',
-    'tailwindcss/enforces-negative-arbitrary-values': 'warn',
-    'tailwindcss/enforces-shorthand': 'warn',
-    'tailwindcss/migration-from-tailwind-2': 'warn',
+    'tailwindcss/enforces-negative-arbitrary-values': 'error',
+    'tailwindcss/enforces-shorthand': 'error',
+    'tailwindcss/migration-from-tailwind-2': 'off',
     'tailwindcss/no-arbitrary-value': 'off',
     'tailwindcss/no-custom-classname': 'off',
     'tailwindcss/no-contradicting-classname': 'error'
 };
 
 // Tailwind v3 ruleset with config passed per-rule (v3 didn't read `settings`
-// the same way). Use the consumer's tailwind config absolute path.
+// the same way). Use the consumer's tailwind config absolute path. Same
+// error-or-off stance as tailwindRulesV4.
 export function tailwindRulesWithConfig(config) {
     return {
         'tailwindcss/classnames-order': ['error', {config}],
-        'tailwindcss/enforces-negative-arbitrary-values': ['warn', {config}],
-        'tailwindcss/enforces-shorthand': ['warn', {config}],
-        'tailwindcss/migration-from-tailwind-2': ['warn', {config}],
+        'tailwindcss/enforces-negative-arbitrary-values': ['error', {config}],
+        'tailwindcss/enforces-shorthand': ['error', {config}],
+        'tailwindcss/migration-from-tailwind-2': 'off',
         'tailwindcss/no-arbitrary-value': 'off',
         'tailwindcss/no-custom-classname': 'off',
         'tailwindcss/no-contradicting-classname': ['error', {config}]

--- a/ghost/admin/eslint.config.mjs
+++ b/ghost/admin/eslint.config.mjs
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import js from '@eslint/js';
 import globals from 'globals';
 import babelParser from '@babel/eslint-parser';
@@ -6,36 +5,7 @@ import ghostPlugin from 'eslint-plugin-ghost';
 import emberPlugin from 'eslint-plugin-ember';
 import reactPlugin from 'eslint-plugin-react';
 
-// eslint-plugin-filenames-ts@1.3.2's match-regex calls context.getScope(),
-// which ESLint 9 removed. Replace it with a minimal equivalent.
-const filenamesMatchRegex = {
-    meta: {
-        type: 'problem',
-        schema: [
-            {type: 'string'},
-            {type: ['boolean', 'null']},
-            {type: ['boolean', 'null']}
-        ]
-    },
-    create(context) {
-        const pattern = new RegExp(context.options[0]);
-        return {
-            Program(node) {
-                const filename = path.parse(context.filename).name;
-                if (!pattern.test(filename)) {
-                    context.report({
-                        node,
-                        message: `Filename '${filename}' does not match the naming convention.`
-                    });
-                }
-            }
-        };
-    }
-};
-
-const localFilenamesPlugin = {
-    rules: {'match-regex': filenamesMatchRegex}
-};
+import {localFilenamesPlugin} from '../../eslint.shared.mjs';
 
 const ghostBaseRules = {
     curly: 'error',

--- a/ghost/core/eslint.config.mjs
+++ b/ghost/core/eslint.config.mjs
@@ -4,54 +4,9 @@ import globals from 'globals';
 import ghostPlugin from 'eslint-plugin-ghost';
 import tseslint from 'typescript-eslint';
 
+import {localFilenamesPlugin} from '../../eslint.shared.mjs';
+
 const __dirname = import.meta.dirname;
-
-// eslint-plugin-filenames-ts@1.3.2's match-regex calls context.getScope(),
-// which ESLint 9 removed. Replace it with a minimal equivalent that does
-// the filename check (+ ignoreExporting via AST scan, no scope traversal).
-const filenamesMatchRegex = {
-    meta: {
-        type: 'problem',
-        schema: [
-            {type: 'string'},
-            {type: ['boolean', 'null']},
-            {type: ['boolean', 'null']}
-        ]
-    },
-    create(context) {
-        const pattern = new RegExp(context.options[0]);
-        const ignoreExporting = Boolean(context.options[1]);
-        return {
-            Program(node) {
-                if (ignoreExporting) {
-                    const hasExport = node.body.some(stmt =>
-                        stmt.type === 'ExportDefaultDeclaration' ||
-                        stmt.type === 'ExportNamedDeclaration' ||
-                        (stmt.type === 'ExpressionStatement' &&
-                         stmt.expression.type === 'AssignmentExpression' &&
-                         stmt.expression.left.type === 'MemberExpression' &&
-                         stmt.expression.left.object.type === 'Identifier' &&
-                         stmt.expression.left.object.name === 'module' &&
-                         stmt.expression.left.property.type === 'Identifier' &&
-                         stmt.expression.left.property.name === 'exports')
-                    );
-                    if (hasExport) return;
-                }
-                const filename = path.parse(context.filename).name;
-                if (!pattern.test(filename)) {
-                    context.report({
-                        node,
-                        message: `Filename '${filename}' does not match the naming convention.`
-                    });
-                }
-            }
-        };
-    }
-};
-
-const localFilenamesPlugin = {
-    rules: {'match-regex': filenamesMatchRegex}
-};
 
 const ghostBaseRules = {
     curly: 'error',

--- a/ghost/i18n/eslint.config.mjs
+++ b/ghost/i18n/eslint.config.mjs
@@ -1,50 +1,15 @@
-import path from 'node:path';
 import js from '@eslint/js';
 import globals from 'globals';
 import ghostPlugin from 'eslint-plugin-ghost';
 
-// eslint-plugin-filenames-ts@1.3.2's match-regex rule still calls
-// context.getScope(), which ESLint 9 removed. Replace it with a minimal
-// equivalent that only does the filename check (no isExporting / isExportingClass).
-const filenamesMatchRegex = {
-    meta: {
-        type: 'problem',
-        schema: [{type: 'string'}, {type: ['boolean', 'null']}, {type: ['boolean', 'null']}]
-    },
-    create(context) {
-        const pattern = new RegExp(context.options[0]);
-        return {
-            Program(node) {
-                const filename = path.parse(context.filename).name;
-                if (!pattern.test(filename)) {
-                    context.report({
-                        node,
-                        message: `Filename '${filename}' does not match the naming convention.`
-                    });
-                }
-            }
-        };
-    }
-};
+import {
+    correctnessRules,
+    jsUnusedVarsRule,
+    localFilenamesPlugin,
+    mochaRulesOff
+} from '../../eslint.shared.mjs';
 
-const localFilenamesPlugin = {
-    rules: {'match-regex': filenamesMatchRegex}
-};
-
-const ghostRules = {
-    curly: 'error',
-    camelcase: ['error', {properties: 'never'}],
-    'dot-notation': 'error',
-    eqeqeq: ['error', 'always'],
-    'no-plusplus': ['error', {allowForLoopAfterthoughts: true}],
-    'no-eval': 'error',
-    'no-useless-call': 'error',
-    'no-console': 'error',
-    'no-shadow': 'error',
-    'array-callback-return': 'error',
-    'no-constructor-return': 'error',
-    'no-promise-executor-return': 'error',
-    'no-unused-vars': ['error', {caughtErrors: 'none'}],
+const ghostI18nExtras = {
     'no-var': 'warn',
     'one-var': ['warn', 'never'],
     'ghost/node/no-restricted-require': ['warn', [
@@ -56,14 +21,11 @@ const ghostRules = {
     'ghost/ghost-custom/no-native-error': 'error',
     'ghost/ghost-custom/ghost-error-usage': 'error',
     'ghost/ghost-custom/ghost-tpl-usage': 'error',
+    // This workspace uses the local-filenames variant of the rule; turn off
+    // the eslint-plugin-ghost one that correctnessRules enables.
+    'ghost/filenames/match-regex': 'off',
     'local-filenames/match-regex': ['error', '^[a-z0-9.-]+$', false]
 };
-
-const mochaRulesOff = Object.fromEntries(
-    Object.keys(ghostPlugin.rules || {})
-        .filter(rule => rule.startsWith('mocha/'))
-        .map(rule => [`ghost/${rule}`, 'off'])
-);
 
 export default [
     {
@@ -83,7 +45,9 @@ export default [
         },
         rules: {
             ...js.configs.recommended.rules,
-            ...ghostRules
+            ...correctnessRules,
+            ...jsUnusedVarsRule,
+            ...ghostI18nExtras
         }
     },
     {
@@ -114,8 +78,10 @@ export default [
         },
         rules: {
             ...js.configs.recommended.rules,
-            ...ghostRules,
-            ...mochaRulesOff,
+            ...correctnessRules,
+            ...jsUnusedVarsRule,
+            ...ghostI18nExtras,
+            ...mochaRulesOff(ghostPlugin),
             'ghost/ghost-custom/node-assert-strict': 'error'
         }
     }

--- a/ghost/parse-email-address/eslint.config.mjs
+++ b/ghost/parse-email-address/eslint.config.mjs
@@ -3,38 +3,19 @@ import globals from 'globals';
 import ghostPlugin from 'eslint-plugin-ghost';
 import tseslint from 'typescript-eslint';
 
-const ghostRules = {
-    curly: 'error',
-    camelcase: ['error', {properties: 'never'}],
-    'dot-notation': 'error',
-    eqeqeq: ['error', 'always'],
-    'no-plusplus': ['error', {allowForLoopAfterthoughts: true}],
-    'no-eval': 'error',
-    'no-useless-call': 'error',
-    'no-console': 'error',
-    'no-shadow': 'error',
-    'array-callback-return': 'error',
-    'no-constructor-return': 'error',
-    'no-promise-executor-return': 'error',
-    'no-unused-vars': 'off',
-    '@typescript-eslint/no-unused-vars': ['error', {
-        args: 'after-used',
-        argsIgnorePattern: '^_',
-        caughtErrors: 'none'
-    }],
+import {
+    correctnessRules,
+    mochaRulesOff,
+    tsUnusedVarsRule
+} from '../../eslint.shared.mjs';
+
+const ghostParseEmailExtras = {
     'no-var': 'warn',
     'one-var': ['warn', 'never'],
     'ghost/ghost-custom/no-native-error': 'error',
     'ghost/ghost-custom/ghost-error-usage': 'error',
-    'ghost/ghost-custom/ghost-tpl-usage': 'error',
-    'ghost/filenames/match-regex': ['error', '^[a-z0-9.-]+$', false]
+    'ghost/ghost-custom/ghost-tpl-usage': 'error'
 };
-
-const mochaRulesOff = Object.fromEntries(
-    Object.keys(ghostPlugin.rules || {})
-        .filter(rule => rule.startsWith('mocha/'))
-        .map(rule => [`ghost/${rule}`, 'off'])
-);
 
 export default tseslint.config(
     {
@@ -53,7 +34,9 @@ export default tseslint.config(
         },
         rules: {
             ...js.configs.recommended.rules,
-            ...ghostRules,
+            ...correctnessRules,
+            ...tsUnusedVarsRule,
+            ...ghostParseEmailExtras,
             'no-undef': 'off'
         }
     },
@@ -77,8 +60,10 @@ export default tseslint.config(
         },
         rules: {
             ...js.configs.recommended.rules,
-            ...ghostRules,
-            ...mochaRulesOff,
+            ...correctnessRules,
+            ...tsUnusedVarsRule,
+            ...ghostParseEmailExtras,
+            ...mochaRulesOff(ghostPlugin),
             'no-undef': 'off'
         }
     }


### PR DESCRIPTION
## Summary

Adds `eslint.shared.mjs` at the repo root and refactors 16 workspace flat configs to import from it instead of redefining the same rule objects inline.

**Shared module exports:**
- `correctnessRules` — the 12 shared correctness rules (eqeqeq, no-eval, no-console, no-shadow, etc.)
- `tsUnusedVarsRule` / `jsUnusedVarsRule` — the two unused-vars shapes (TS-aware vs vanilla with `caughtErrors: 'none'`)
- `sortImportsRule` — `ghost/sort-imports-es6-autofix/sort-imports-es6` (used by ~6 workspaces)
- `shadeLayeredImportsRule` — restricts barrel imports of `@tryghost/shade`
- `reactDefaultsOff` / `reactStrictRules` — common React rule sets across the React workspaces
- `tailwindRulesV4` (settings-based) / `tailwindRulesWithConfig(cfg)` (v3, per-rule config)
- `mochaRulesOff(ghostPlugin)` — helper that disables every `ghost/mocha/*` rule
- `localFilenamesPlugin` — ESLint-9-compatible replacement for `eslint-plugin-filenames-ts`'s `match-regex` (the upstream still calls `context.getScope()`, removed in ESLint 9). Includes `ignoreExporting` support that previously only `ghost/core` had.

**Workspaces refactored** (each keeps its workspace-specific extras inline):
- React/TS: `apps/{activitypub, admin-x-design-system, admin-x-framework, admin-x-settings, announcement-bar, comments-ui, portal, posts, shade, signup-form, sodo-search, stats}`
- Node: `ghost/{i18n, parse-email-address}`
- Filename-shim only: `ghost/{core, admin}` (their rule sets stay inline; just the shim was extracted)

**Notes:**
- `ghost/i18n` explicitly disables `ghost/filenames/match-regex` (added by `correctnessRules`) because this workspace uses the `local-filenames/match-regex` variant instead.
- Comments-ui and signup-form opt out of `reactStrictRules` and inline 3 of its 4 rules — they don't want `react/jsx-key: 'off'`.

## Test plan

- [x] Verified lint output byte-identical to baseline for all 14 React/TS workspaces (full `pnpm exec eslint` output diffed before/after — zero changes)
- [x] `ghost/core` and `ghost/admin` lint counts match baseline (47 and 9 warnings respectively)
- [ ] CI lint passes across every workspace