### PR TITLE
Changed UMD build:watch to development mode for faster rebuilds

### DIFF
--- a/apps/admin-toolbar/package.json
+++ b/apps/admin-toolbar/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tryghost/admin-toolbar",
   "type": "module",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/admin-toolbar/package.json
+++ b/apps/admin-toolbar/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "build": "pnpm exec vite build",
-    "build:watch": "pnpm exec vite build --watch",
+    "build:watch": "pnpm exec vite build --watch --mode development",
     "dev": "concurrently --kill-others --names preview,build \"pnpm exec vite preview -l silent\" \"pnpm build:watch\"",
     "lint": "pnpm exec eslint src test --cache",
     "test": "pnpm test:unit",

--- a/apps/admin-toolbar/vite.config.mjs
+++ b/apps/admin-toolbar/vite.config.mjs
@@ -3,11 +3,11 @@ import {resolve} from 'path';
 
 import {defineConfig} from 'vite';
 
-export default defineConfig({
+export default defineConfig(({mode}) => ({
     logLevel: process.env.CI ? 'info' : 'warn',
     clearScreen: false,
     define: {
-        'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'production')
+        'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || mode)
     },
     preview: {
         host: '0.0.0.0',
@@ -18,7 +18,7 @@ export default defineConfig({
         outDir: resolve(import.meta.dirname, 'umd'),
         emptyOutDir: true,
         reportCompressedSize: false,
-        minify: true,
+        minify: mode === 'production',
         sourcemap: false,
         lib: {
             entry: resolve(import.meta.dirname, 'src/index.js'),
@@ -27,4 +27,4 @@ export default defineConfig({
             fileName: () => 'admin-toolbar.min.js'
         }
     }
-});
+}));

--- a/apps/announcement-bar/package.json
+++ b/apps/announcement-bar/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "dev": "pnpm build && concurrently --kill-others --names preview,build \"vite preview -l silent\" \"pnpm build:watch\"",
     "build": "vite build",
-    "build:watch": "vite build --watch",
+    "build:watch": "vite build --watch --mode development",
     "test": "vitest run",
     "test:ci": "pnpm test --coverage",
     "test:unit": "pnpm test:ci",

--- a/apps/announcement-bar/package.json
+++ b/apps/announcement-bar/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tryghost/announcement-bar",
   "type": "module",
-  "version": "1.1.22",
+  "version": "1.1.23",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/announcement-bar/vite.config.mjs
+++ b/apps/announcement-bar/vite.config.mjs
@@ -50,7 +50,7 @@ export default defineConfig((config) => {
             outDir: resolve(__dirname, 'umd'),
             emptyOutDir: true,
             reportCompressedSize: false,
-            minify: true,
+            minify: config.mode === 'production',
             sourcemap: true,
             cssCodeSplit: true,
             lib: {

--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -19,7 +19,7 @@
     "dev": "pnpm build && concurrently --kill-others --names preview,build \"pnpm preview --host -l silent\" \"pnpm build:watch\"",
     "dev:test": "vite build && vite preview --port 7175",
     "build": "vite build",
-    "build:watch": "vite build --watch",
+    "build:watch": "vite build --watch --mode development",
     "preview": "vite preview",
     "test": "pnpm test:unit && pnpm test:acceptance",
     "test:unit": "vitest run --coverage",

--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tryghost/comments-ui",
   "type": "module",
-  "version": "1.5.13",
+  "version": "1.5.14",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/comments-ui/vite.config.mts
+++ b/apps/comments-ui/vite.config.mts
@@ -8,8 +8,8 @@ import {stripFingerprintingPlugin} from './vite-plugin-strip-fingerprinting';
 const outputFileName = pkg.name[0] === '@' ? pkg.name.slice(pkg.name.indexOf('/') + 1) : pkg.name;
 
 // https://vitejs.dev/config/
-export default (function viteConfig() {
-    return defineConfig({
+export default defineConfig((config) => {
+    return {
         logLevel: process.env.CI ? 'info' : 'warn',
         plugins: [
             stripFingerprintingPlugin(),
@@ -33,7 +33,7 @@ export default (function viteConfig() {
             reportCompressedSize: false,
             outDir: resolve(__dirname, 'umd'),
             emptyOutDir: true,
-            minify: true,
+            minify: config.mode === 'production',
             sourcemap: true,
             cssCodeSplit: true,
             lib: {
@@ -90,5 +90,5 @@ export default (function viteConfig() {
                 maxThreads: 2
             })
         }
-    });
+    };
 });

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "dev": "pnpm build && concurrently --kill-others --names preview,build \"pnpm preview -l silent\" \"pnpm build:watch\"",
     "build": "vite build",
-    "build:watch": "vite build --watch",
+    "build:watch": "vite build --watch --mode development",
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tryghost/portal",
   "type": "module",
-  "version": "2.69.8",
+  "version": "2.69.9",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/vite.config.mjs
+++ b/apps/portal/vite.config.mjs
@@ -60,7 +60,7 @@ export default defineConfig((config) => {
             outDir: resolve(__dirname, 'umd'),
             emptyOutDir: true,
             reportCompressedSize: false,
-            minify: true,
+            minify: config.mode === 'production',
             sourcemap: true,
             cssCodeSplit: false,
             lib: {

--- a/apps/signup-form/package.json
+++ b/apps/signup-form/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tryghost/signup-form",
   "type": "module",
-  "version": "0.3.28",
+  "version": "0.3.29",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/signup-form/package.json
+++ b/apps/signup-form/package.json
@@ -15,8 +15,8 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "dev": "pnpm build && concurrently --kill-others --names dev,preview,build \"vite --port 6173\" \"vite preview -l silent\" \"vite build --watch\"",
-    "preview": "concurrently --kill-others --names preview,build \"vite preview -l silent\" \"vite build --watch\"",
+    "dev": "pnpm build && concurrently --kill-others --names dev,preview,build \"vite --port 6173\" \"vite preview -l silent\" \"vite build --watch --mode development\"",
+    "preview": "concurrently --kill-others --names preview,build \"vite preview -l silent\" \"vite build --watch --mode development\"",
     "dev:test": "vite build && vite preview --port 6175",
     "build": "tsc && vite build",
     "lint": "pnpm run lint:js",

--- a/apps/signup-form/vite.config.mts
+++ b/apps/signup-form/vite.config.mts
@@ -7,8 +7,8 @@ import {resolve} from 'path';
 const outputFileName = pkg.name[0] === '@' ? pkg.name.slice(pkg.name.indexOf('/') + 1) : pkg.name;
 
 // https://vitejs.dev/config/
-export default (function viteConfig() {
-    return defineConfig({
+export default defineConfig((config) => {
+    return {
         logLevel: process.env.CI ? 'info' : 'warn',
         plugins: [
             svgr(),
@@ -33,7 +33,7 @@ export default (function viteConfig() {
             outDir: resolve(__dirname, 'umd'),
             reportCompressedSize: false,
             emptyOutDir: true,
-            minify: true,
+            minify: config.mode === 'production',
             sourcemap: true,
             cssCodeSplit: true,
             lib: {
@@ -74,5 +74,5 @@ export default (function viteConfig() {
                 maxThreads: 2
             })
         }
-    });
+    };
 });

--- a/apps/sodo-search/package.json
+++ b/apps/sodo-search/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tryghost/sodo-search",
   "type": "module",
-  "version": "1.8.24",
+  "version": "1.8.25",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/sodo-search/package.json
+++ b/apps/sodo-search/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "dev": "pnpm build && concurrently --kill-others --names preview,build,tailwind \"vite preview -l silent\" \"pnpm build:watch\" \"pnpm tailwind\"",
     "build": "vite build && pnpm tailwind:base",
-    "build:watch": "vite build --watch",
+    "build:watch": "vite build --watch --mode development",
     "tailwind": "pnpm tailwind:base --watch ",
     "tailwind:base": "tailwindcss -i ./src/index.css -o ./umd/main.css --minify",
     "test": "vitest run",

--- a/apps/sodo-search/vite.config.mjs
+++ b/apps/sodo-search/vite.config.mjs
@@ -52,7 +52,7 @@ export default defineConfig((config) => {
             outDir: resolve(__dirname, 'umd'),
             reportCompressedSize: false,
             emptyOutDir: true,
-            minify: true,
+            minify: config.mode === 'production',
             sourcemap: true,
             cssCodeSplit: true,
             lib: {


### PR DESCRIPTION
## Summary

`pnpm dev` was running `vite build --watch` in production mode for all six public UMD apps. Every incremental rebuild paid for minification, terser passes, and production-grade sourcemap work that the dev environment never benefits from — the watcher only feeds Caddy's preview proxy, not anything that ships.

Two coupled changes per app:

- `build:watch` now passes `--mode development` (or its inline equivalent for signup-form, where the watcher lives inside the `dev` script rather than as a separate `build:watch`).
- The `vite.config.*` files no longer hardcode `minify: true`. Each now reads the `mode` flag and sets `minify: mode === 'production'`. Without this, the `--mode development` flag would have been a no-op because the hardcoded option overrode it.

Production builds (`pnpm build`) are unaffected — Vite defaults `mode` to `'production'` for `vite build`, and the conditional evaluates true. Verified by rebuilding all six apps post-change: minified byte counts unchanged, UMD wrapper intact.

### Structural notes
- `comments-ui` and `signup-form` were wrapped in `(function viteConfig() { return defineConfig({...}) })()`; refactored to `defineConfig((config) => ({...}))` so the config function can read `config.mode`.
- `admin-toolbar` was a static `defineConfig({...})`; refactored to the function form and threaded `mode` into its `NODE_ENV` define fallback.

## Test plan

- [x] `pnpm --filter @tryghost/<app> build` (all 6 apps) — production output still minified, byte counts match pre-change baseline
- [x] `pnpm --filter @tryghost/portal build:watch` — `umd/portal.min.js` ~1.6x larger, readable identifiers preserved, UMD wrapper intact
- [ ] `pnpm dev` — open a site that exercises each app (portal modal, comments, search, announcement bar, signup form, admin toolbar); confirm everything loads through Caddy unchanged
- [ ] Confirm subsequent edits during `pnpm dev` trigger noticeably faster watch rebuilds