### PR TITLE
Changed comments-ui `test` to run unit tests only

### DIFF
--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -21,7 +21,7 @@
     "build": "vite build",
     "build:watch": "vite build --watch",
     "preview": "vite preview",
-    "test": "pnpm test:unit && pnpm test:acceptance",
+    "test": "pnpm test:unit",
     "test:unit": "vitest run --coverage",
     "test:acceptance": "NODE_OPTIONS='--experimental-specifier-resolution=node --no-warnings' VITE_TEST=true playwright test",
     "test:acceptance:slowmo": "TIMEOUT=100000 PLAYWRIGHT_SLOWMO=1000 pnpm test:acceptance --headed",


### PR DESCRIPTION
Drops the chained `test:acceptance` from comments-ui's `test` script so root `pnpm test` (and `nx run-many -t test`) no longer launches Playwright. Matches activitypub and admin-x-settings.

CI is unaffected — the acceptance suite is discovered and run via `nx show projects --withTarget test:acceptance` independently of the `test` script ([ci.yml:213](.github/workflows/ci.yml#L213) and [ci.yml:717](.github/workflows/ci.yml#L717)), so no coverage is lost. The suite remains runnable locally via `pnpm --filter @tryghost/comments-ui test:acceptance`.