### PR TITLE
Removed pnpmDedupe from Renovate postUpdateOptions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,14 +20,12 @@
     "toolSettings": {
         "nodeMaxMemory": 1024
     },
-    // Run `pnpm dedupe` after every lockfile update. The shared preset still
-    // passes `yarnDedupeHighest`, which is a no-op for pnpm — Renovate's array
-    // merge concats both, so this entry is what actually consolidates duplicate
-    // transitive versions in `pnpm-lock.yaml`. Local override pending an upstream
-    // swap in tryghost/renovate-config.
-    "postUpdateOptions": [
-        "pnpmDedupe"
-    ],
+    // `pnpmDedupe` intentionally NOT in postUpdateOptions — Renovate dedupes
+    // on its Linux runner, but `pnpm install` on macOS produces a different
+    // lockfile (platform-sensitive peer-suffix resolution), so every stale
+    // Renovate branch fails --frozen-lockfile. Upstream: pnpm/pnpm#10258,
+    // renovatebot/renovate#31867. Ad-hoc `pnpm dedupe` PR or scheduled
+    // lockFileMaintenance when bloat becomes a problem.
     // We have to disable platform based automerge (forcing renovate to do it manually)
     // as otherwise renovate wont follow our schedule
     "platformAutomerge": false,


### PR DESCRIPTION
Drops `pnpmDedupe` from `.github/renovate.json5` postUpdateOptions.

Renovate runs `pnpm install && pnpm dedupe` on its Linux hosted runner and produces a deduped lockfile that doesn't reproduce when contributors run `pnpm install` on macOS — peer-suffix resolution is platform-sensitive, so the two outputs diverge by thousands of lines. This caused every stale Renovate branch (≥30 commits behind main) to fail `--frozen-lockfile` and need a manual lockfile-only reset before merging.

Trade-off accepted: `pnpm-lock.yaml` may slowly accumulate transitive duplication between cleanup passes. Mitigation is an ad-hoc `pnpm dedupe` PR, or a scheduled `lockFileMaintenance` run later if bloat becomes a problem. Matches what Next.js and Turborepo do.

Upstream tracking: [pnpm/pnpm#10258](https://github.com/pnpm/pnpm/issues/10258), [renovatebot/renovate#31867](https://github.com/renovatebot/renovate/discussions/31867).