### PR TITLE
Adopt browse/ensure/create nomenclature for the gift-links API and drop revoked_at

### DIFF
--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost-admin",
-  "version": "6.47.1-rc.0",
+  "version": "6.48.0-rc.0",
   "description": "Ember.js admin client for Ghost",
   "author": "Ghost Foundation",
   "homepage": "http://ghost.org",

--- a/ghost/core/core/server/api/endpoints/gift-links.ts
+++ b/ghost/core/core/server/api/endpoints/gift-links.ts
@@ -24,7 +24,7 @@ const noCacheInvalidation = {cacheInvalidate: false};
 const controller = {
     docName: 'gift_links',
 
-    read: {
+    browse: {
         headers: noCacheInvalidation,
         options: ['id'],
         validation: {options: {id: {required: true}}},
@@ -36,7 +36,7 @@ const controller = {
         }
     },
 
-    issue: {
+    ensure: {
         headers: noCacheInvalidation,
         statusCode: 200,
         options: ['id'],
@@ -45,11 +45,11 @@ const controller = {
             return assertCanManageGiftLink(frame);
         },
         query(frame: Frame) {
-            return service!.issue(frame.options.id);
+            return service!.ensure(frame.options.id);
         }
     },
 
-    reissue: {
+    create: {
         headers: noCacheInvalidation,
         statusCode: 200,
         options: ['id'],
@@ -58,18 +58,18 @@ const controller = {
             return assertCanManageGiftLink(frame);
         },
         query(frame: Frame) {
-            return service!.reissue(frame.options.id);
+            return service!.create(frame.options.id);
         }
     },
 
-    revokeAll: {
+    removeAll: {
         headers: noCacheInvalidation,
         statusCode: 200,
         permissions(frame: Frame) {
-            return permissionsService.canThis(frame.options.context).revokeAll.gift_link();
+            return permissionsService.canThis(frame.options.context).removeAll.gift_link();
         },
         async query() {
-            const count = await service!.revokeAll();
+            const count = await service!.removeAll();
             return {count};
         }
     }

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/gift-links.ts
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/gift-links.ts
@@ -12,10 +12,10 @@ const serializeGiftLinks = (post: Post, _apiConfig: unknown, frame: Frame): void
 // module.exports (not export): the API framework loads serializers via require(). The endpoint ->
 // serializer mapping lives here; the response shaping lives with the gift-links service module.
 module.exports = {
-    read: serializeGiftLinks,
-    issue: serializeGiftLinks,
-    reissue: serializeGiftLinks,
-    revokeAll(data: {count: number}, _apiConfig: unknown, frame: Frame): void {
+    browse: serializeGiftLinks,
+    ensure: serializeGiftLinks,
+    create: serializeGiftLinks,
+    removeAll(data: {count: number}, _apiConfig: unknown, frame: Frame): void {
         frame.response = toRevokeAllResponse.parse(data);
     }
 };

--- a/ghost/core/core/server/data/migrations/versions/6.48/2026-06-23-00-00-00-drop-gift-links-revoked-at.js
+++ b/ghost/core/core/server/data/migrations/versions/6.48/2026-06-23-00-00-00-drop-gift-links-revoked-at.js
@@ -1,0 +1,6 @@
+const {createDropColumnMigration} = require('../../utils');
+
+module.exports = createDropColumnMigration('gift_links', 'revoked_at', {
+    type: 'dateTime',
+    nullable: true
+});

--- a/ghost/core/core/server/data/migrations/versions/6.48/2026-06-23-00-00-01-rename-gift-links-revoke-all-permission-to-remove-all.js
+++ b/ghost/core/core/server/data/migrations/versions/6.48/2026-06-23-00-00-01-rename-gift-links-revoke-all-permission-to-remove-all.js
@@ -1,0 +1,37 @@
+const logging = require('@tryghost/logging');
+const {createTransactionalMigration} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        const revokeAll = await knex('permissions')
+            .where({object_type: 'gift_link', action_type: 'revokeAll'})
+            .first();
+        if (!revokeAll) {
+            return;
+        }
+
+        // A removeAll permission can already exist (fresh fixtures plus this migration both
+        // running): the unique name rules out a rename, so drop the legacy revokeAll and its
+        // grants. Otherwise rename in place, keeping the existing grants.
+        const removeAllExists = await knex('permissions')
+            .where({object_type: 'gift_link', action_type: 'removeAll'})
+            .first();
+        if (removeAllExists) {
+            await knex('permissions_roles').where({permission_id: revokeAll.id}).del();
+            await knex('permissions_users').where({permission_id: revokeAll.id}).del();
+            await knex('permissions').where({id: revokeAll.id}).del();
+            logging.info('Removed duplicate gift_link revokeAll permission (removeAll already present)');
+            return;
+        }
+
+        await knex('permissions')
+            .where({id: revokeAll.id})
+            .update({name: 'Remove all gift links', action_type: 'removeAll', updated_at: new Date()});
+        logging.info('Renamed gift_link revokeAll permission to removeAll');
+    },
+    async function down(knex) {
+        await knex('permissions')
+            .where({object_type: 'gift_link', action_type: 'removeAll'})
+            .update({name: 'Revoke all gift links', action_type: 'revokeAll', updated_at: new Date()});
+    }
+);

--- a/ghost/core/core/server/data/schema/fixtures/fixtures.json
+++ b/ghost/core/core/server/data/schema/fixtures/fixtures.json
@@ -805,8 +805,8 @@
                     "object_type": "gift_link"
                 },
                 {
-                    "name": "Revoke all gift links",
-                    "action_type": "revokeAll",
+                    "name": "Remove all gift links",
+                    "action_type": "removeAll",
                     "object_type": "gift_link"
                 }
             ]

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -121,13 +121,12 @@ module.exports = {
         feature_image_caption: {type: 'text', maxlength: 65535, nullable: true},
         email_only: {type: 'boolean', nullable: false, defaultTo: false}
     },
-    // Every gift link issued for a post; reissued tokens remain as history. Liveness lives in post_gift_links.
+    // Every gift link added to a post; replaced tokens remain as history. Liveness lives in post_gift_links.
     gift_links: {
         token: {type: 'string', maxlength: 32, nullable: false, primary: true},
         post_id: {type: 'string', maxlength: 24, nullable: false, references: 'posts.id', cascadeDelete: true},
         redeemed_count: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0},
         last_redeemed_at: {type: 'dateTime', nullable: true},
-        revoked_at: {type: 'dateTime', nullable: true},
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: true}
     },

--- a/ghost/core/core/server/services/gift-links/database.ts
+++ b/ghost/core/core/server/services/gift-links/database.ts
@@ -15,7 +15,6 @@ export const DbGiftLink = z.object({
     post_id: z.string(),
     redeemed_count: z.number().int().nonnegative(),
     last_redeemed_at: DbDate.nullable(),
-    revoked_at: DbDate.nullable(),
     created_at: DbDate,
     updated_at: DbDate.nullable()
 });
@@ -33,7 +32,7 @@ declare module 'knex/types/tables' {
     interface Tables {
         gift_links: Knex.CompositeTableType<
             z.infer<typeof DbGiftLink>,
-            Omit<z.input<typeof DbGiftLink>, 'revoked_at' | 'updated_at'>,
+            Omit<z.input<typeof DbGiftLink>, 'updated_at'>,
             Partial<z.infer<typeof DbGiftLink>>
         >;
         post_gift_links: Knex.CompositeTableType<

--- a/ghost/core/core/server/services/gift-links/service.ts
+++ b/ghost/core/core/server/services/gift-links/service.ts
@@ -25,31 +25,22 @@ export class GiftLinksService {
         return row ? {id: row.post_id, giftLinks: [z.decode(queries.giftLinkCodec, row)]} : null;
     }
 
-    async issue(postId: string): Promise<Post> {
+    async ensure(postId: string): Promise<Post> {
         const post = await this.requirePost(postId);
         return post.giftLinks.length ? post : this.mint(postId);
     }
 
-    async reissue(postId: string): Promise<Post> {
-        const post = await this.requirePost(postId);
-        return this.mint(postId, post.giftLinks[0]?.token);
+    async create(postId: string): Promise<Post> {
+        await this.requirePost(postId);
+        return this.mint(postId);
     }
 
-    // Stamp revoked_at on the live links, then drop their associations. The link records stay
-    // as history; liveness is the association, so revoked_at only marks deliberate revocation.
-    async revokeAll(): Promise<number> {
-        const now = new Date();
-        let revoked = 0;
-        await this.knex.transaction(async (trx) => {
-            await trx('gift_links')
-                .whereIn('token', trx('post_gift_links').select('gift_link_token'))
-                .update({revoked_at: now, updated_at: now});
-            revoked = await trx('post_gift_links').del();
-        });
-        return revoked;
+    // Remove every live association; the gift_links rows stay as history.
+    async removeAll(): Promise<number> {
+        return this.knex('post_gift_links').del();
     }
 
-    // Keyed by token, not liveness: a read against a since-reissued token still counts for it.
+    // Keyed by token, not liveness: a read against a since-replaced token still counts for it.
     async recordRedemption(token: string): Promise<number> {
         const now = new Date();
         return this.knex('gift_links')
@@ -71,16 +62,12 @@ export class GiftLinksService {
         return {id: postId, giftLinks};
     }
 
-    // Issue and reissue are one upsert: a new store row, with the live association repointed to
-    // it. On reissue the replaced link is stamped revoked_at as history. Concurrent issues are
-    // last-writer-wins, not an error.
-    private async mint(postId: string, replacing?: GiftLinkToken): Promise<Post> {
+    // A new store row with the live association repointed to it. The replaced link's row stays as
+    // history. Concurrent adds are last-writer-wins, not an error.
+    private async mint(postId: string): Promise<Post> {
         const now = new Date();
         const link: GiftLink = {token: generateGiftLinkToken(), redeemedCount: 0, lastRedeemedAt: null, createdAt: now};
         await this.knex.transaction(async (trx) => {
-            if (replacing) {
-                await trx('gift_links').where({token: replacing}).update({revoked_at: now, updated_at: now});
-            }
             await trx('gift_links').insert({...z.encode(queries.giftLinkCodec, link), post_id: postId});
             await trx('post_gift_links')
                 .insert({post_id: postId, gift_link_token: link.token, created_at: now})

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -64,13 +64,13 @@ module.exports = function apiRoutes() {
     router.post('/pages/:id/copy', mw.authAdminApi, http(api.pages.copy));
 
     // Gift links (behind the giftLinks flag)
-    router.get('/posts/:id/gift_link', mw.authAdminApi, labs.enabledMiddleware('giftLinks'), http(api.giftLinks.read));
-    router.put('/posts/:id/gift_link', mw.authAdminApi, labs.enabledMiddleware('giftLinks'), http(api.giftLinks.issue));
-    router.post('/posts/:id/gift_link', mw.authAdminApi, labs.enabledMiddleware('giftLinks'), http(api.giftLinks.reissue));
-    router.get('/pages/:id/gift_link', mw.authAdminApi, labs.enabledMiddleware('giftLinks'), http(api.giftLinks.read));
-    router.put('/pages/:id/gift_link', mw.authAdminApi, labs.enabledMiddleware('giftLinks'), http(api.giftLinks.issue));
-    router.post('/pages/:id/gift_link', mw.authAdminApi, labs.enabledMiddleware('giftLinks'), http(api.giftLinks.reissue));
-    router.put('/gift_links/revoke_all', mw.authAdminApi, labs.enabledMiddleware('giftLinks'), http(api.giftLinks.revokeAll));
+    router.get('/posts/:id/gift_links', mw.authAdminApi, labs.enabledMiddleware('giftLinks'), http(api.giftLinks.browse));
+    router.put('/posts/:id/gift_links', mw.authAdminApi, labs.enabledMiddleware('giftLinks'), http(api.giftLinks.ensure));
+    router.post('/posts/:id/gift_links', mw.authAdminApi, labs.enabledMiddleware('giftLinks'), http(api.giftLinks.create));
+    router.get('/pages/:id/gift_links', mw.authAdminApi, labs.enabledMiddleware('giftLinks'), http(api.giftLinks.browse));
+    router.put('/pages/:id/gift_links', mw.authAdminApi, labs.enabledMiddleware('giftLinks'), http(api.giftLinks.ensure));
+    router.post('/pages/:id/gift_links', mw.authAdminApi, labs.enabledMiddleware('giftLinks'), http(api.giftLinks.create));
+    router.put('/gift_links/remove_all', mw.authAdminApi, labs.enabledMiddleware('giftLinks'), http(api.giftLinks.removeAll));
 
     // # Integrations
 

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost",
-  "version": "6.47.1-rc.0",
+  "version": "6.48.0-rc.0",
   "description": "The professional publishing platform",
   "author": "Ghost Foundation",
   "homepage": "https://ghost.org",

--- a/ghost/core/test/e2e-api/admin/gift-links.test.ts
+++ b/ghost/core/test/e2e-api/admin/gift-links.test.ts
@@ -39,12 +39,12 @@ describe('Gift Links Admin API', function () {
         {name: 'pages', id: () => pageId}
     ])('on $name', function ({name, id}: {name: string, id: () => string}) {
         it('GET returns an empty list when no link exists', async function () {
-            const {body} = await agent.get(`${name}/${id()}/gift_link/`).expectStatus(200);
+            const {body} = await agent.get(`${name}/${id()}/gift_links/`).expectStatus(200);
             assert.deepEqual(body, {gift_links: []});
         });
 
-        it('PUT issues the gift link as a token-shaped resource in a list', async function () {
-            const {body} = await agent.put(`${name}/${id()}/gift_link/`).expectStatus(200);
+        it('PUT ensures the gift link as a token-shaped resource in a list', async function () {
+            const {body} = await agent.put(`${name}/${id()}/gift_links/`).expectStatus(200);
 
             assert.deepEqual(Object.keys(body), ['gift_links']);
             assert.equal(body.gift_links.length, 1);
@@ -55,9 +55,9 @@ describe('Gift Links Admin API', function () {
             );
         });
 
-        it('POST reissues to a fresh token', async function () {
-            const first = (await agent.put(`${name}/${id()}/gift_link/`).expectStatus(200)).body.gift_links[0].token;
-            const {body} = await agent.post(`${name}/${id()}/gift_link/`).expectStatus(200);
+        it('POST creates a fresh token', async function () {
+            const first = (await agent.put(`${name}/${id()}/gift_links/`).expectStatus(200)).body.gift_links[0].token;
+            const {body} = await agent.post(`${name}/${id()}/gift_links/`).expectStatus(200);
 
             assert.equal(body.gift_links.length, 1);
             assert.notEqual(body.gift_links[0].token, first);
@@ -65,46 +65,46 @@ describe('Gift Links Admin API', function () {
 
         it('403s for a role without gift-link permission', async function () {
             await agent.loginAsContributor();
-            await agent.get(`${name}/${id()}/gift_link/`).expectStatus(403);
+            await agent.get(`${name}/${id()}/gift_links/`).expectStatus(403);
             await agent.loginAsOwner();
         });
 
         it('supports the full lifecycle', async function () {
             // empty
-            let body = (await agent.get(`${name}/${id()}/gift_link/`).expectStatus(200)).body;
+            let body = (await agent.get(`${name}/${id()}/gift_links/`).expectStatus(200)).body;
             assert.deepEqual(body.gift_links, []);
 
-            // issue
-            body = (await agent.put(`${name}/${id()}/gift_link/`).expectStatus(200)).body;
+            // ensure
+            body = (await agent.put(`${name}/${id()}/gift_links/`).expectStatus(200)).body;
             const first = body.gift_links[0].token;
             assert.ok(first);
             assert.equal(body.gift_links[0].redeemed_count, 0);
 
-            // reissue
-            body = (await agent.post(`${name}/${id()}/gift_link/`).expectStatus(200)).body;
+            // create
+            body = (await agent.post(`${name}/${id()}/gift_links/`).expectStatus(200)).body;
             const second = body.gift_links[0].token;
             assert.notEqual(second, first);
-            body = (await agent.get(`${name}/${id()}/gift_link/`).expectStatus(200)).body;
+            body = (await agent.get(`${name}/${id()}/gift_links/`).expectStatus(200)).body;
             assert.equal(body.gift_links[0].token, second);
 
-            // revoke
-            body = (await agent.put('gift_links/revoke_all/').expectStatus(200)).body;
+            // remove
+            body = (await agent.put('gift_links/remove_all/').expectStatus(200)).body;
             assert.deepEqual(body, {meta: {count: 1}});
-            body = (await agent.get(`${name}/${id()}/gift_link/`).expectStatus(200)).body;
+            body = (await agent.get(`${name}/${id()}/gift_links/`).expectStatus(200)).body;
             assert.deepEqual(body.gift_links, []);
         });
     });
 
-    describe('revoke_all', function () {
+    describe('remove_all', function () {
         it('returns the count in a meta block, not as a resource', async function () {
-            await agent.put(`posts/${postId}/gift_link/`).expectStatus(200);
-            const {body} = await agent.put('gift_links/revoke_all/').expectStatus(200);
+            await agent.put(`posts/${postId}/gift_links/`).expectStatus(200);
+            const {body} = await agent.put('gift_links/remove_all/').expectStatus(200);
             assert.deepEqual(body, {meta: {count: 1}});
         });
     });
 
     it('404s when the giftLinks flag is disabled', async function () {
         mockManager.mockLabsDisabled('giftLinks');
-        await agent.get(`posts/${postId}/gift_link/`).expectStatus(404);
+        await agent.get(`posts/${postId}/gift_links/`).expectStatus(404);
     });
 });

--- a/ghost/core/test/integration/migrations/migration.test.js
+++ b/ghost/core/test/integration/migrations/migration.test.js
@@ -112,7 +112,7 @@ describe('Migrations', function () {
             assertHavePermission(permissions, 'Publish posts', ['Administrator', 'Editor', 'Admin Integration', 'Scheduler Integration', 'Super Editor']);
             assertHavePermission(permissions, 'Flush gift reminders', ['Scheduler Integration']);
             assertHavePermission(permissions, 'Manage gift links', ['Administrator', 'Editor', 'Author', 'Admin Integration', 'Super Editor']);
-            assertHavePermission(permissions, 'Revoke all gift links', ['Administrator']);
+            assertHavePermission(permissions, 'Remove all gift links', ['Administrator']);
 
             assertHavePermission(permissions, 'Browse settings', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration', 'Super Editor']);
             assertHavePermission(permissions, 'Read settings', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration', 'Super Editor']);

--- a/ghost/core/test/integration/services/gift-links.test.ts
+++ b/ghost/core/test/integration/services/gift-links.test.ts
@@ -32,7 +32,7 @@ describe('GiftLinksService (integration)', function () {
     });
 
     describe('getPost', function () {
-        it('returns the post with no links when none has been issued', async function () {
+        it('returns the post with no links when none exists', async function () {
             assert.deepEqual(await liveLinks(postId), []);
         });
 
@@ -44,20 +44,20 @@ describe('GiftLinksService (integration)', function () {
         });
     });
 
-    describe('issue', function () {
+    describe('ensure', function () {
         it('mints a live link with a token when none exists', async function () {
-            const post = await service.issue(postId);
+            const post = await service.ensure(postId);
 
-            assert.equal(post.giftLinks.length, 1, 'a link should be issued');
+            assert.equal(post.giftLinks.length, 1, 'a link should be created');
             assert.ok(post.giftLinks[0].token, 'token should be set');
             assert.equal(post.giftLinks[0].redeemedCount, 0);
             assert.equal(post.giftLinks[0].lastRedeemedAt, null);
             assert.equal((await liveLinks(postId)).length, 1);
         });
 
-        it('is idempotent: a repeat issue returns the same live link', async function () {
-            const first = await service.issue(postId);
-            const second = await service.issue(postId);
+        it('is idempotent: a repeat ensure returns the same live link', async function () {
+            const first = await service.ensure(postId);
+            const second = await service.ensure(postId);
 
             assert.equal(first.giftLinks[0]?.token, second.giftLinks[0]?.token);
             assert.equal((await liveLinks(postId)).length, 1);
@@ -65,15 +65,15 @@ describe('GiftLinksService (integration)', function () {
 
         it('throws NotFound for a post that does not exist', async function () {
             await assert.rejects(
-                () => service.issue(MISSING_POST_ID),
+                () => service.ensure(MISSING_POST_ID),
                 (err: unknown) => err instanceof errors.NotFoundError
             );
         });
 
         it('keeps exactly one live link under concurrent calls', async function () {
             const [a, b] = await Promise.all([
-                service.issue(postId),
-                service.issue(postId)
+                service.ensure(postId),
+                service.ensure(postId)
             ]);
 
             assert.ok(a.giftLinks[0] && b.giftLinks[0]);
@@ -81,50 +81,50 @@ describe('GiftLinksService (integration)', function () {
         });
     });
 
-    describe('reissue', function () {
-        it('rotates to a fresh token', async function () {
-            const original = await service.issue(postId);
-            const rotated = await service.reissue(postId);
+    describe('create', function () {
+        it('replaces the live link with a fresh token', async function () {
+            const original = await service.ensure(postId);
+            const created = await service.create(postId);
 
-            assert.notEqual(rotated.giftLinks[0]?.token, original.giftLinks[0]?.token);
+            assert.notEqual(created.giftLinks[0]?.token, original.giftLinks[0]?.token);
             const live = await liveLinks(postId);
             assert.equal(live.length, 1);
-            assert.equal(live[0]?.token, rotated.giftLinks[0]?.token);
+            assert.equal(live[0]?.token, created.giftLinks[0]?.token);
         });
 
         it('starts the new link with zeroed counters', async function () {
-            const original = await service.issue(postId);
+            const original = await service.ensure(postId);
             await service.recordRedemption(original.giftLinks[0]!.token);
             await service.recordRedemption(original.giftLinks[0]!.token);
 
-            const rotated = await service.reissue(postId);
-            assert.equal(rotated.giftLinks[0]?.redeemedCount, 0);
-            assert.equal(rotated.giftLinks[0]?.lastRedeemedAt, null);
+            const created = await service.create(postId);
+            assert.equal(created.giftLinks[0]?.redeemedCount, 0);
+            assert.equal(created.giftLinks[0]?.lastRedeemedAt, null);
         });
 
         it('mints a link even when none existed', async function () {
-            const rotated = await service.reissue(postId);
+            const created = await service.create(postId);
             assert.equal((await liveLinks(postId)).length, 1);
-            assert.ok(rotated.giftLinks[0]?.token);
+            assert.ok(created.giftLinks[0]?.token);
         });
 
         it('throws NotFound for a post that does not exist', async function () {
             await assert.rejects(
-                () => service.reissue(MISSING_POST_ID),
+                () => service.create(MISSING_POST_ID),
                 (err: unknown) => err instanceof errors.NotFoundError
             );
         });
     });
 
     describe('getPostByToken', function () {
-        it('resolves a live token, and stops resolving once reissued', async function () {
-            const original = await service.issue(postId);
+        it('resolves a live token, and stops resolving once replaced', async function () {
+            const original = await service.ensure(postId);
             const token = original.giftLinks[0]!.token;
 
             const found = await service.getPostByToken(token);
             assert.equal(found?.giftLinks[0]?.token, token);
 
-            await service.reissue(postId);
+            await service.create(postId);
             assert.equal(await service.getPostByToken(token), null);
         });
 
@@ -134,14 +134,14 @@ describe('GiftLinksService (integration)', function () {
         });
     });
 
-    describe('revokeAll', function () {
+    describe('removeAll', function () {
         it('drops every live link across posts and returns the count', async function () {
-            await service.issue(postId);
-            await service.issue(otherPostId);
+            await service.ensure(postId);
+            await service.ensure(otherPostId);
 
-            const revoked = await service.revokeAll();
+            const removed = await service.removeAll();
 
-            assert.equal(revoked, 2);
+            assert.equal(removed, 2);
             assert.deepEqual(await liveLinks(postId), []);
             assert.deepEqual(await liveLinks(otherPostId), []);
         });
@@ -149,7 +149,7 @@ describe('GiftLinksService (integration)', function () {
 
     describe('recordRedemption', function () {
         it('atomically increments the counter and stamps last_redeemed_at, keyed by token', async function () {
-            const post = await service.issue(postId);
+            const post = await service.ensure(postId);
             const token = post.giftLinks[0]!.token;
 
             assert.equal(await service.recordRedemption(token), 1);
@@ -160,10 +160,10 @@ describe('GiftLinksService (integration)', function () {
             assert.notEqual(reloaded?.giftLinks[0]?.lastRedeemedAt, null);
         });
 
-        it('counts a read against a since-reissued token (history is retained)', async function () {
-            const original = await service.issue(postId);
+        it('counts a read against a since-replaced token (history is retained)', async function () {
+            const original = await service.ensure(postId);
             const token = original.giftLinks[0]!.token;
-            await service.reissue(postId);
+            await service.create(postId);
 
             assert.equal(await service.recordRedemption(token), 1);
         });
@@ -173,30 +173,9 @@ describe('GiftLinksService (integration)', function () {
         });
     });
 
-    describe('revoked_at (deactivation history)', function () {
-        const revokedAt = async (token: string): Promise<Date | null> => (await models.Base.knex('gift_links').where({token}).first()).revoked_at;
-
-        it('stamps the replaced link on reissue and leaves the new one live', async function () {
-            const original = await service.issue(postId);
-            const rotated = await service.reissue(postId);
-
-            assert.notEqual(await revokedAt(original.giftLinks[0]!.token), null, 'replaced link is stamped');
-            assert.equal(await revokedAt(rotated.giftLinks[0]!.token), null, 'new link stays live');
-        });
-
-        it('stamps every link that revokeAll deactivates', async function () {
-            const a = await service.issue(postId);
-            const b = await service.issue(otherPostId);
-            await service.revokeAll();
-
-            assert.notEqual(await revokedAt(a.giftLinks[0]!.token), null);
-            assert.notEqual(await revokedAt(b.giftLinks[0]!.token), null);
-        });
-    });
-
     describe('the <=1-live-link-per-post invariant (database-enforced)', function () {
         it('rejects a second live association for the same post', async function () {
-            await service.issue(postId);
+            await service.ensure(postId);
 
             await models.Base.knex('gift_links').insert({
                 token: 'second-live-token', post_id: postId, redeemed_count: 0, created_at: new Date()

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,8 +35,8 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '5b821b03c5b210feed73f0bcdbaf8e9a';
-    const currentFixturesHash = '3e24fcdb43ebd1362014de1d664c3b53';
+    const currentSchemaHash = '1f97c498b7d1fc08413af9c6ab89e4e1';
+    const currentFixturesHash = 'f4941d9d92b59075e0c2a1cc3fc4c44a';
     const currentSettingsHash = '397be8628c753b1959b8954d5610f83f';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 

--- a/ghost/core/test/utils/fixtures/fixtures.json
+++ b/ghost/core/test/utils/fixtures/fixtures.json
@@ -806,8 +806,8 @@
                     "object_type": "gift_link"
                 },
                 {
-                    "name": "Revoke all gift links",
-                    "action_type": "revokeAll",
+                    "name": "Remove all gift links",
+                    "action_type": "removeAll",
                     "object_type": "gift_link"
                 }
             ]


### PR DESCRIPTION
## Problem

The gift-links admin API used issue / reissue / revokeAll verbs and a singular `/gift_link` route. "Reissue" implied a dyad that does not exist - the operation just creates a new gift link - and the singular route did not match the collection the response already returns. The table also carried a `revoked_at` validity timestamp.

## Solution

Adopt the agreed vocabulary across the controller, service, serializer and routes - **browse / ensure / create / removeAll** - and pluralise the per-post routes to the collection (`/posts/:id/gift_links`). The POST is named `create` rather than `add` because the framework reserves `add` for body-driven creates and this create is body-less; POST to the collection carries the "add" semantics at the REST layer.

Drop `revoked_at` and all its handling: a forthcoming action audit log will own the who/what/when of changes, so a redundant per-row validity timestamp is removed via a drop-column migration. The bulk-remove permission and route are renamed from `revoke_all` to `remove_all` to match.

Validated: integration + e2e suites green (the e2e boots Ghost, exercising both migrations, the routes, and the renamed permission).

Stacked on #28783. Retargets to `main` once that merges.