### PR TITLE
Improved webmention delete test reliability

### DIFF
--- a/ghost/core/test/e2e-api/webmentions/webmentions.test.js
+++ b/ghost/core/test/e2e-api/webmentions/webmentions.test.js
@@ -17,6 +17,17 @@ async function allSettled() {
     await DomainEvents.allSettled();
 }
 
+async function receiveWebmention(agent, body) {
+    const processWebmentionJob = jobsService.awaitCompletion('processWebmention');
+
+    await agent.post('/receive')
+        .body(body)
+        .expectStatus(202);
+
+    await processWebmentionJob;
+    await DomainEvents.allSettled();
+}
+
 describe('Webmentions (receiving)', function () {
     let agent;
 
@@ -162,14 +173,10 @@ describe('Webmentions (receiving)', function () {
             .reply(200, html, {'Content-Type': 'text/html'});
 
         testCreatingTheMention: {
-            await agent.post('/receive')
-                .body({
-                    source: sourceUrl.href,
-                    target: targetUrl.href
-                })
-                .expectStatus(202);
-
-            await allSettled();
+            await receiveWebmention(agent, {
+                source: sourceUrl.href,
+                target: targetUrl.href
+            });
 
             const mention = await models.Mention.findOne({source: 'http://testpage.com/update-mention-test-2/'});
             assert(mention);
@@ -190,14 +197,10 @@ describe('Webmentions (receiving)', function () {
             .reply(404);
 
         testUpdatingTheMention: {
-            await agent.post('/receive')
-                .body({
-                    source: sourceUrl.href,
-                    target: targetUrl.href
-                })
-                .expectStatus(202);
-
-            await allSettled();
+            await receiveWebmention(agent, {
+                source: sourceUrl.href,
+                target: targetUrl.href
+            });
 
             const mention = await models.Mention.findOne({source: 'http://testpage.com/update-mention-test-2/'});
             assert(mention);


### PR DESCRIPTION
## Summary
- added a helper that waits for the specific `processWebmention` job created by `/webmentions/receive`
- updated the flaky delete test to use that helper for both receive calls

## Why
The renovate CI failure in https://github.com/TryGhost/Ghost/actions/runs/28043128451/job/83014610404 was not caused by the renovate config change. The test can enqueue a `sendWebmentions` job when the post is unpublished, then enqueue `processWebmention` via `/receive`. The shared mentions job queue can make broad `allSettled()` timing too loose for the immediate DB assertion, so the test occasionally reads before the receive job persists `deleted: true`.

## Testing
- `pnpm exec vitest -c vitest.config.db.ts --project e2e-api test/e2e-api/webmentions/webmentions.test.js -t "will delete a mention" --maxWorkers=1`
- `pnpm exec vitest -c vitest.config.db.ts --project e2e-api test/e2e-api/webmentions/webmentions.test.js --maxWorkers=1`