### PR TITLE
Added source export condition to @tryghost/parse-email-address

### DIFF
--- a/ghost/core/nodemon.json
+++ b/ghost/core/nodemon.json
@@ -9,5 +9,5 @@
     "core/built/**"
   ],
   "ext": "js,mjs,cjs,json,ts,tsx",
-  "exec": "node --import=tsx"
+  "exec": "node --conditions=source --import=tsx"
 }

--- a/ghost/parse-email-address/package.json
+++ b/ghost/parse-email-address/package.json
@@ -5,6 +5,13 @@
   "repository": "https://github.com/TryGhost/Ghost/tree/main/ghost/parse-email-address",
   "author": "Ghost Foundation",
   "license": "MIT",
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    }
+  },
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {


### PR DESCRIPTION
Adds a `source` export condition to `@tryghost/parse-email-address` and wires `ghost/core`'s nodemon to pass `--conditions=source`. The dev backend now resolves the package directly to `src/index.ts` via tsx (already loaded in dev by `--import=tsx`), rather than the compiled `build/index.js`.

**Verified locally:** with `ghost/parse-email-address/build/` removed, `require('@tryghost/parse-email-address')` resolves to `src/index.ts` and runs correctly under `node --conditions=source --import=tsx`.

The built artifact + `main`/`types` are retained as the default-condition fallback for consumers that don't pass `--conditions=source` (CI, production, anything not going through the dev nodemon).

**Why this matters:** `@tryghost/parse-email-address` is the *one* workspace dep `ghost/core` consumes that requires a build artifact at boot — its TS source compiles to `build/index.js`, and Node resolves workspace `main` paths regardless of the `--import=tsx` hook. Making it source-resolvable for dev unblocks shrinking `pnpm setup`'s eager full-workspace `pnpm build` step. Setup-script trim will follow.