### PR TITLE
Added nx-cloud start-ci-run to Nx-orchestrated CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
 
+      - name: Start Nx Cloud CI run
+        run: pnpm nx start-ci-run
+
       - name: Determine Affected Projects
         id: affected
         run: |


### PR DESCRIPTION
Calls `nx-cloud start-ci-run` once in `job_setup`, before any other nx command (the affected-project queries). Downstream lint/admin/unit/acceptance/legacy/playwright jobs run nx tasks that attribute to this Pipeline Execution via the shared `GITHUB_RUN_ID`. Surfaces per-task analytics (cache hit rates, durations, flake counts) in the Nx Cloud dashboard grouped per workflow run.

Tasks invoked outside Nx (i18n filter, Tinybird, version/migration scripts) remain uncorrelated.

## Test plan
- [ ] CI green on this PR
- [ ] Pipeline Execution shows up in Nx Cloud dashboard for this PR's workflow with tasks from all six nx-running jobs grouped under one entry