### PR TITLE
Removed pnpm build from pnpm setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ pnpm run setup                 # First-time setup (installs deps + submodules + 
 pnpm dev                       # Start development (Docker backend + host frontend dev servers)
 ```
 
-> **Fresh worktree / first run — run `pnpm setup` before anything else.** It installs deps, syncs submodules, and builds workspace packages (Nx-cached, fast). `pnpm fix` does a clean reinstall if anything misbehaves after a branch switch.
+> **Fresh worktree / first run — run `pnpm setup` before anything else.** It installs deps and syncs submodules. `pnpm fix` does a clean reinstall if anything misbehaves after a branch switch.
 
 ### Building
 ```bash

--- a/ghost/core/vitest.config.db.ts
+++ b/ghost/core/vitest.config.db.ts
@@ -33,6 +33,15 @@ const resolveSnapshotPath = (testPath: string, snapExtension: string) => path.jo
     path.basename(testPath) + snapExtension
 );
 
+// Vitest projects re-create their own Vite config — settings on the parent
+// `defineConfig` aren't inherited. The DB-backed runners use Vite's SSR
+// pipeline, so workspace TS deps with a `source` exports condition (e.g.
+// @tryghost/parse-email-address) need this on every project. Matches the
+// runtime backend's `--conditions=source` (ghost/core/nodemon.json).
+const sharedSsrConfig = {
+    resolve: {conditions: ['source', 'node']}
+};
+
 // Shared by every DB-backed project — the execution model is identical for all
 // of them; only the include globs and per-suite timeouts differ.
 const sharedDbConfig = {
@@ -63,7 +72,7 @@ const sharedDbConfig = {
         // execArgv worker_threads inherit) and ignores poolOptions.forks.execArgv
         // here, so route it through the env. Applied on test.env (after fork
         // startup) so only the spawned workers pick it up, not the fork.
-        NODE_OPTIONS: (process.env.NODE_OPTIONS ? process.env.NODE_OPTIONS + ' ' : '') + '--import tsx'
+        NODE_OPTIONS: (process.env.NODE_OPTIONS ? process.env.NODE_OPTIONS + ' ' : '') + '--import tsx --conditions=source'
     },
     hookTimeout: 60000
 };
@@ -87,6 +96,7 @@ export default defineConfig({
             : ['dot'],
         projects: [
             {
+                ssr: sharedSsrConfig,
                 test: {
                     ...sharedDbConfig,
                     name: 'e2e',
@@ -102,6 +112,7 @@ export default defineConfig({
                 }
             },
             {
+                ssr: sharedSsrConfig,
                 test: {
                     ...sharedDbConfig,
                     name: 'integration',
@@ -128,6 +139,7 @@ export default defineConfig({
                 }
             },
             {
+                ssr: sharedSsrConfig,
                 test: {
                     ...sharedDbConfig,
                     name: 'legacy',
@@ -143,6 +155,7 @@ export default defineConfig({
                 }
             },
             {
+                ssr: sharedSsrConfig,
                 test: {
                     ...sharedDbConfig,
                     name: 'e2e-api',

--- a/ghost/core/vitest.config.ts
+++ b/ghost/core/vitest.config.ts
@@ -69,6 +69,13 @@ export default defineConfig({
         },
         projects: [
             {
+                // Vitest projects re-create their own Vite config — settings on
+                // the parent `defineConfig` aren't inherited here. The unit
+                // runner uses Vite's SSR pipeline, so workspace TS deps with a
+                // `source` exports condition (e.g. @tryghost/parse-email-address)
+                // need `ssr.resolve.conditions` to resolve to src/*.ts. Matches
+                // the runtime backend's `--conditions=source` (nodemon.json).
+                ssr: {resolve: {conditions: ['source', 'node']}},
                 test: {
                     ...unitConfig,
                     name: 'unit',

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "dev:status": "node scripts/dev-supervisor.js status",
     "fix": "pnpm store prune && rimraf -g '**/node_modules' && pnpm install && pnpm nx reset",
     "knex-migrator": "pnpm --filter ghost run knex-migrator",
-    "setup": "pnpm install && git submodule update --init --recursive && pnpm build",
+    "setup": "pnpm install && git submodule update --init --recursive",
     "reset:db": "docker exec ghost-dev bash -c 'cd /home/ghost/ghost/core && pnpm knex-migrator reset && pnpm knex-migrator init'",
     "reset:db:volume": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} down && docker volume rm ghost-dev_mysql-data",
     "reset:data": "docker exec ghost-dev bash -c 'cd /home/ghost/ghost/core && node index.js generate-data --clear-database --quantities members:1000,posts:100 --seed 123'",


### PR DESCRIPTION
Follow-up to [#28842](https://github.com/TryGhost/Ghost/pull/28842). Drops `pnpm build` from root `pnpm setup` and wires Vitest to honor the `source` exports condition so workspace TS deps (`@tryghost/parse-email-address`) resolve to source under tests just as they do at runtime.

**Setup script trim:**

```diff
- "setup": "pnpm install && git submodule update --init --recursive && pnpm build"
+ "setup": "pnpm install && git submodule update --init --recursive"
```

Now that `@tryghost/parse-email-address` resolves to source at runtime, the eager full-workspace build during setup is no longer required for `pnpm dev` or `pnpm test`. Nx still builds dependencies on demand when a target actually needs build outputs (release/asset paths in CI).

**Vitest source-condition wiring:**

Vitest's `projects` re-create their own Vite config — `resolve`/`ssr` settings on the parent `defineConfig` aren't inherited. So each project block gets `ssr.resolve.conditions: ['source', 'node']`:

- `ghost/core/vitest.config.ts` — `unit` project
- `ghost/core/vitest.config.db.ts` — `e2e`, `integration`, `legacy`, `e2e-api` projects (via a shared `sharedSsrConfig` const)

`NODE_OPTIONS` in `vitest.config.db.ts` also gains `--conditions=source` so Bree worker_threads (which inherit it) match the resolver.

**Verified locally** with `ghost/parse-email-address/build/` deleted:
- `pnpm test:single test/unit/server/lib/get-inbox-links.test.ts` → 18/18 pass
- `pnpm exec vitest -c vitest.config.db.ts run --project integration test/integration/prometheus-client.test.js` → 3/3 pass

**AGENTS.md** fresh-worktree note updated to drop "builds workspace packages."