### PR TITLE
Added Nx cache for ghost/core CI test targets

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -358,6 +358,9 @@
       "test:ci:e2e": {
         "dependsOn": [
           "^build"
+        ],
+        "outputs": [
+          "{projectRoot}/coverage-e2e"
         ]
       },
       "test:ci:e2e:no-coverage": {
@@ -373,6 +376,9 @@
       "test:ci:integration": {
         "dependsOn": [
           "^build"
+        ],
+        "outputs": [
+          "{projectRoot}/coverage-integration"
         ]
       },
       "test:ci:integration:no-coverage": {

--- a/nx.json
+++ b/nx.json
@@ -47,6 +47,19 @@
         "build"
       ]
     },
+    "test:ci:*": {
+      "cache": true,
+      "inputs": [
+        "default",
+        "^default",
+        {
+          "env": "DB"
+        },
+        {
+          "env": "NODE_ENV"
+        }
+      ]
+    },
     "dev": {
       "dependsOn": [
         "^dev"


### PR DESCRIPTION
Adds `test:ci:*` to nx.json `targetDefaults` so `test:ci:legacy`, `test:ci:integration` (+`:no-coverage`), and `test:ci:e2e` (+`:no-coverage`) inherit `cache: true`.

Inputs declared only for env vars that **legitimately change what's being tested**, not what could expose flakiness:

- **`DB` + `NODE_ENV`** — matrix discriminators. The MySQL and SQLite cells exercise different SQL dialects, drivers, and connection semantics; a pass on one doesn't imply a pass on the other. `test:ci:legacy` runs the same nx target name on both cells, so without these a SQLite pass could satisfy the MySQL leg via cache hit. (`TZ` and `CI` deliberately excluded — tests should be timezone- and CI-mode-independent; baking them into the hash would protect flaky tests from being caught.)

Outputs declared on the coverage-emitting variants:

- **`test:ci:e2e`** → `{projectRoot}/coverage-e2e`
- **`test:ci:integration`** → `{projectRoot}/coverage-integration`

c8 writes those dirs and the workflow uploads `ghost/*/coverage-{e2e,integration}/cobertura-coverage.xml` as the `e2e-coverage` artifact ([ci.yml:591](https://github.com/TryGhost/Ghost/blob/main/.github/workflows/ci.yml#L591)). Without declared outputs a cache hit would replay the exit code but leave coverage dirs unrestored, silently uploading nothing.

Caches activate on retries against the same tree, rebases that preserve the parent, and local `pnpm test:integration` runs that inherit a CI-populated remote cache. The existing `changed_core` gate ([ci.yml:502](https://github.com/TryGhost/Ghost/blob/main/.github/workflows/ci.yml#L502)) still handles the coarse "ghost/core didn't change at all" case.

## Test plan
- [ ] CI green on this PR (requires [#28846](https://github.com/TryGhost/Ghost/pull/28846) for nx.json to land in the `core` path filter; otherwise acceptance + legacy still skip and the cache change isn't exercised)
- [ ] Subsequent identical-tree pushes / retries skip these targets and show `[cache hit]` in the Nx Cloud pipeline view (PR [#28843](https://github.com/TryGhost/Ghost/pull/28843) is the prerequisite for that pipeline view)