### PR TITLE
Added nx.json to the shared CI path filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,7 @@ jobs:
                 - '!.github/renovate-bot.cjs'
                 - '!.github/workflows/renovate.yml'
               - '.npmrc'
+              - 'nx.json'
               - 'package.json'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'


### PR DESCRIPTION
The `shared` anchor in `job_setup`'s paths-filter feeds the `core`, `e2e`, and `any-code` filters. `nx.json` was missing — so PRs that only touch nx.json (cache config, target `dependsOn`, named-input edits) skipped acceptance + legacy + e2e jobs, masking any regression those config changes could introduce.

Surfaced by [#28845](https://github.com/TryGhost/Ghost/pull/28845): that PR enables cache for `test:ci:*` targets but its own CI never runs those targets to validate the change.

Adds `nx.json` alongside the other workspace-root config files (`.npmrc`, `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`).

## Test plan
- [ ] CI green on this PR
- [ ] This PR's own run shows Acceptance + Legacy tests executing (not "skipping")