### PR TITLE
Changed @tryghost/parse-email-address types to point at TS source

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -79,7 +79,7 @@
     "lint:frontend": "eslint 'core/frontend/**/*.js' --cache",
     "lint:test": "eslint 'test/**/*.js' --cache",
     "lint:code": "pnpm lint:server && pnpm lint:shared && pnpm lint:frontend",
-    "lint:types": "eslint '**/*.ts' --cache && tsc --noEmit",
+    "lint:types": "pnpm --filter @tryghost/parse-email-address build && eslint '**/*.ts' --cache && tsc --noEmit",
     "lint": "pnpm lint:server && pnpm lint:shared && pnpm lint:frontend && pnpm lint:test && pnpm lint:types"
   },
   "engines": {


### PR DESCRIPTION
Follow-up to [#28842](https://github.com/TryGhost/Ghost/pull/28842) + [#28844](https://github.com/TryGhost/Ghost/pull/28844). Points `@tryghost/parse-email-address`'s `types` at the TS source so `tsc` resolves types without a build artifact.

After #28844 removed `pnpm build` from `pnpm setup`, fresh worktrees no longer have `ghost/parse-email-address/build/`. Most paths handle this (runtime via tsx + `--conditions=source`, vitest via `ssr.resolve.conditions`), but ESLint+`tsc` resolves types via the `types` field / `exports.types` condition — both pointed at `build/index.d.ts`, so `pnpm --filter ghost lint` fails with:

> `core/server/lib/get-inbox-links.ts(32,33): error TS2307: Cannot find module '@tryghost/parse-email-address' or its corresponding type declarations.`

`pnpm lint` from root still works because it goes through Nx's `dependsOn: ['^build']` (already configured for the `lint` target), which builds the dep first. The bypass case via `pnpm --filter` did not — which agents and devs hit when scoping lint to one package.

Pointing `types` at `src/index.ts` lets `tsc` read TS sources directly. No runtime impact: `main` and `exports.default` still point at the built JS for Node's default resolver. The package is `private: true`, so there's no npm-publish concern.

**Verified locally** with `ghost/parse-email-address/build/` deleted: `pnpm --filter ghost lint` completes (169 warnings, 0 errors); `build/` stays absent (lint didn't trigger any rebuild).