### PR TITLE
Disabled ssh2 build scripts to speed up e2e tests

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -36,7 +36,7 @@
     "@types/dockerode": "4.0.1",
     "@types/express": "catalog:",
     "busboy": "1.6.0",
-    "dockerode": "4.0.12",
+    "dockerode": "5.0.0",
     "dotenv": "catalog:",
     "eslint": "catalog:",
     "eslint-plugin-no-relative-import-paths": "1.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2097,8 +2097,8 @@ importers:
         specifier: 1.6.0
         version: 1.6.0
       dockerode:
-        specifier: 4.0.12
-        version: 4.0.12(supports-color@5.5.0)
+        specifier: 5.0.0
+        version: 5.0.0
       dotenv:
         specifier: 'catalog:'
         version: 17.4.2
@@ -13040,9 +13040,9 @@ packages:
     resolution: {integrity: sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==}
     engines: {node: '>= 8.0'}
 
-  dockerode@4.0.12:
-    resolution: {integrity: sha512-/bCZd6KlGcjZO8Buqmi/vXuqEGVEZ0PNjx/biBNqJD3MhK9DmdiAuKxqfNhflgDESDIiBz3qF+0e55+CpnrUcw==}
-    engines: {node: '>= 8.0'}
+  dockerode@5.0.0:
+    resolution: {integrity: sha512-C52mvJ+7lcyhWNfrzVfFsbTrBfy/ezE9FGEYLpu17FUeBcCkxERk9nN7uDl/478ynDiQ4U+5DbQC2vENHkVEtQ==}
+    engines: {node: '>= 14.17'}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -21779,11 +21779,6 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
-
-  uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
@@ -34427,7 +34422,7 @@ snapshots:
 
   dlv@1.1.3: {}
 
-  docker-modem@5.0.7(supports-color@5.5.0):
+  docker-modem@5.0.7:
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       readable-stream: 3.6.2
@@ -34436,15 +34431,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  dockerode@4.0.12(supports-color@5.5.0):
+  dockerode@5.0.0:
     dependencies:
       '@balena/dockerignore': 1.0.2
       '@grpc/grpc-js': 1.14.4
       '@grpc/proto-loader': 0.7.15
-      docker-modem: 5.0.7(supports-color@5.5.0)
+      docker-modem: 5.0.7
       protobufjs: 7.6.1
       tar-fs: 2.1.4
-      uuid: 10.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -46794,8 +46788,6 @@ snapshots:
       which-typed-array: 1.1.21
 
   utils-merge@1.0.1: {}
-
-  uuid@10.0.0: {}
 
   uuid@3.4.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,7 +12,7 @@ blockExoticSubdeps: true
 allowBuilds:
   '@swc/core': true
   core-js: true
-  cpu-features: true
+  cpu-features: false
   dtrace-provider: true
   esbuild: true
   fsevents: true
@@ -22,7 +22,7 @@ allowBuilds:
   re2: true
   sharp: true
   sqlite3: true
-  ssh2: true
+  ssh2: false
 
 catalog:
   '@ebay/nice-modal-react': 1.2.13


### PR DESCRIPTION
no issue
- ssh2 is only used by dockerode to connect to Docker hosts through ssh, which we don't use
- bump dockerode to v5