### PR TITLE
Added gift dimension to the web analytics tracker on gift reads

### DIFF
--- a/ghost/core/core/frontend/helpers/ghost_foot.js
+++ b/ghost/core/core/frontend/helpers/ghost_foot.js
@@ -28,10 +28,11 @@ module.exports = function ghost_foot(options) { // eslint-disable-line camelcase
         foot.push(tagCodeinjection);
     }
 
-    // Reader-side gift toast. `_gift` is set by the entry controller only on a
-    // verified gift render, so it shows on gift reads and never on canonical
-    // URLs. Overridable: a theme can supply its own `partials/gift-toast.hbs`.
-    if (labs.isSet('giftLinks') && options.data._gift) {
+    // Reader-side gift toast. `_giftLink` is set on res.locals by the entry
+    // controller only on a verified gift render, so it shows on gift reads and
+    // never on canonical URLs. Overridable: a theme can supply its own
+    // `partials/gift-toast.hbs`.
+    if (labs.isSet('giftLinks') && options.data.root._giftLink) {
         const data = createFrame(options.data);
         foot.push(templates.execute('gift-toast', this, {data}));
     }

--- a/ghost/core/core/frontend/helpers/ghost_head.js
+++ b/ghost/core/core/frontend/helpers/ghost_head.js
@@ -208,7 +208,8 @@ function getTinybirdTrackerScript(dataRoot) {
         post_uuid: dataRoot.post?.uuid,
         post_type: dataRoot.context?.includes('post') ? 'post' : dataRoot.context?.includes('page') ? 'page' : null,
         member_uuid: dataRoot.member?.uuid,
-        member_status: dataRoot.member?.status
+        member_status: dataRoot.member?.status,
+        gift_link: dataRoot._giftLink || ''
     }, (value, key) => `tb_${key}="${value}"`).join(' ');
 
     return `<script defer src="${src}" data-stringify-payload="false" ${datasource ? `data-datasource="${datasource}"` : ''} data-storage="localStorage" data-host="${endpoint}" ${token && env !== 'production' ? `data-token="${token}"` : ''} ${tbParams}></script>`;

--- a/ghost/core/core/frontend/services/routing/controllers/entry/gift-links.ts
+++ b/ghost/core/core/frontend/services/routing/controllers/entry/gift-links.ts
@@ -6,7 +6,6 @@ import type {Entry, EntryResponse} from '../entry';
 const dataService = require('../../../data');
 const renderer = require('../../../rendering');
 const proxy = require('../../../proxy');
-const hbs = require('../../../theme-engine/engine');
 
 /**
  * Build this request's URL with `?gift` removed, preserving path, subdirectory
@@ -21,18 +20,13 @@ function strippedGiftUrl(req: Request): string {
 
 /**
  * Flag the render as a gift view so `ghost_foot` injects the toast. Stores the
- * token (not just a boolean) for a later analytics pass-through. Internal flag,
+ * token (not just a boolean) for a later analytics pass-through. Set on
+ * res.locals so it merges onto the render context root (`@root._giftLink`),
+ * where both `ghost_foot` and `ghost_head`'s tracker read it. Internal flag,
  * not a public theme API.
  */
 function setGiftTemplateFlag(res: EntryResponse, token: string): void {
-    const localTemplateOptions = hbs.getLocalTemplateOptions(res.locals);
-    hbs.updateLocalTemplateOptions(res.locals, {
-        ...localTemplateOptions,
-        data: {
-            ...localTemplateOptions.data,
-            _gift: token
-        }
-    });
+    res.locals._giftLink = token;
 }
 
 /**

--- a/ghost/core/test/e2e-frontend/gift-links.test.ts
+++ b/ghost/core/test/e2e-frontend/gift-links.test.ts
@@ -40,7 +40,23 @@ describe('Front-end gift links', function () {
             if (key === 'active_theme') {
                 return 'members-test-theme';
             }
+            if (key === 'web_analytics') {
+                return true;
+            }
             return originalSettingsCacheGetFn(key, options);
+        });
+
+        // Enable the web-analytics tracker so the suite can assert the gift_link
+        // dimension it emits. isWebAnalyticsEnabled() needs the setting above plus
+        // a valid tinybird config (a tracker endpoint + a local/JWT credential).
+        configUtils.set('tinybird', {
+            tracker: {
+                endpoint: 'https://e.ghost.org/tb/web_analytics',
+                token: 'tinybird_token'
+            },
+            stats: {
+                local: {enabled: true}
+            }
         });
 
         await testUtils.startGhost({copyThemes: true});
@@ -79,8 +95,9 @@ describe('Front-end gift links', function () {
         request = supertest.agent(configUtils.config.get('url'));
     });
 
-    afterAll(function () {
+    afterAll(async function () {
         sinon.restore();
+        await configUtils.restore();
     });
 
     it('paywalls the paid post for an anonymous visitor on the canonical URL', async function () {
@@ -187,5 +204,53 @@ describe('Front-end gift links', function () {
             .expect(assertUnlocked);
 
         assert.match(res.text, /gh-test-member-state">anonymous</, '@member must stay anonymous on a gift view');
+    });
+
+    describe('the gift_link analytics dimension', function () {
+        // The web-analytics tracker only carries the gift token once the entry
+        // controller has verified it and flagged the render. An unverified or
+        // forged token is 301'd to the canonical URL before any render, so it can
+        // never reach analytics — these tests prove that end to end.
+        it('emits the verified token as tb_gift_link on a valid gift read', async function () {
+            const res = await request
+                .get(`/${slug}/?gift=${token}`)
+                .expect(200);
+
+            assert.ok(
+                res.text.includes(`tb_gift_link="${token}"`),
+                'the verified token is sent as the gift_link dimension'
+            );
+        });
+
+        it('emits an empty tb_gift_link on the canonical (non-gift) URL', async function () {
+            const res = await request
+                .get(`/${slug}/`)
+                .expect(200);
+
+            assert.match(res.text, /tb_gift_link=""/, 'a normal read carries no gift dimension');
+        });
+
+        it('keeps an invalid token out of analytics — the 301 strips it and the canonical render carries none', async function () {
+            // Follow the 301 to the canonical URL it strips to.
+            const res = await request
+                .get(`/${slug}/?gift=not-a-real-token`)
+                .redirects(1)
+                .expect(200);
+
+            assert.match(res.text, /tb_gift_link=""/, 'the canonical render carries no gift dimension');
+            assert.ok(!res.text.includes('not-a-real-token'), 'the forged token never appears in the response');
+        });
+
+        it('keeps a token for another post out of that post’s analytics', async function () {
+            // Post A's token on post B 301s to B's canonical URL, which must not
+            // carry A's token as B's gift dimension.
+            const res = await request
+                .get(`/${otherSlug}/?gift=${token}`)
+                .redirects(1)
+                .expect(200);
+
+            assert.match(res.text, /tb_gift_link=""/, 'B’s render carries no gift dimension');
+            assert.ok(!res.text.includes(token), 'A’s token never appears in B’s response');
+        });
     });
 });

--- a/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost-head.test.js.snap
+++ b/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost-head.test.js.snap
@@ -1092,7 +1092,7 @@ Object {
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
-    <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"77f09c60-5a34-4b4c-a3f6-e1b1d78f7412\\" tb_post_uuid=\\"post_uuid\\" tb_post_type=\\"post\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\"></script>",
+    <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"77f09c60-5a34-4b4c-a3f6-e1b1d78f7412\\" tb_post_uuid=\\"post_uuid\\" tb_post_type=\\"post\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\" tb_gift_link=\\"\\"></script>",
 }
 `;
 
@@ -1272,7 +1272,7 @@ Object {
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
-    <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\"  tb_site_uuid=\\"77f09c60-5a34-4b4c-a3f6-e1b1d78f7412\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\"></script>",
+    <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\"  tb_site_uuid=\\"77f09c60-5a34-4b4c-a3f6-e1b1d78f7412\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\" tb_gift_link=\\"\\"></script>",
 }
 `;
 
@@ -1324,7 +1324,7 @@ Object {
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
-    <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\"  tb_site_uuid=\\"77f09c60-5a34-4b4c-a3f6-e1b1d78f7412\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\"></script>",
+    <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\"  tb_site_uuid=\\"77f09c60-5a34-4b4c-a3f6-e1b1d78f7412\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\" tb_gift_link=\\"\\"></script>",
 }
 `;
 
@@ -1376,7 +1376,7 @@ Object {
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
-    <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"77f09c60-5a34-4b4c-a3f6-e1b1d78f7412\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\"></script>",
+    <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"77f09c60-5a34-4b4c-a3f6-e1b1d78f7412\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\" tb_gift_link=\\"\\"></script>",
 }
 `;
 
@@ -1428,7 +1428,7 @@ Object {
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
-    <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"http://localhost:7181/v0/events\\" data-token=\\"tinybird_local_token\\" tb_site_uuid=\\"77f09c60-5a34-4b4c-a3f6-e1b1d78f7412\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\"></script>",
+    <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"http://localhost:7181/v0/events\\" data-token=\\"tinybird_local_token\\" tb_site_uuid=\\"77f09c60-5a34-4b4c-a3f6-e1b1d78f7412\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\" tb_gift_link=\\"\\"></script>",
 }
 `;
 
@@ -1480,7 +1480,7 @@ Object {
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
-    <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"77f09c60-5a34-4b4c-a3f6-e1b1d78f7412\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\"></script>",
+    <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"77f09c60-5a34-4b4c-a3f6-e1b1d78f7412\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\" tb_gift_link=\\"\\"></script>",
 }
 `;
 
@@ -1532,7 +1532,7 @@ Object {
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://localhost:2388/blog/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://localhost:2388/blog/webmentions/receive/\\" rel=\\"webmention\\">
-    <script defer src=\\"/blog/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"77f09c60-5a34-4b4c-a3f6-e1b1d78f7412\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\"></script>",
+    <script defer src=\\"/blog/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"77f09c60-5a34-4b4c-a3f6-e1b1d78f7412\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\" tb_gift_link=\\"\\"></script>",
 }
 `;
 
@@ -1601,7 +1601,7 @@ Object {
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
-    <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"77f09c60-5a34-4b4c-a3f6-e1b1d78f7412\\" tb_post_uuid=\\"post_uuid\\" tb_post_type=\\"post\\" tb_member_uuid=\\"member_uuid\\" tb_member_status=\\"free\\"></script>",
+    <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"77f09c60-5a34-4b4c-a3f6-e1b1d78f7412\\" tb_post_uuid=\\"post_uuid\\" tb_post_type=\\"post\\" tb_member_uuid=\\"member_uuid\\" tb_member_status=\\"free\\" tb_gift_link=\\"\\"></script>",
 }
 `;
 
@@ -1653,7 +1653,7 @@ Object {
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
-    <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"77f09c60-5a34-4b4c-a3f6-e1b1d78f7412\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"member_uuid\\" tb_member_status=\\"paid\\"></script>",
+    <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"77f09c60-5a34-4b4c-a3f6-e1b1d78f7412\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"member_uuid\\" tb_member_status=\\"paid\\" tb_gift_link=\\"\\"></script>",
 }
 `;
 
@@ -1705,7 +1705,7 @@ Object {
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
-    <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"77f09c60-5a34-4b4c-a3f6-e1b1d78f7412\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\"></script>",
+    <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"77f09c60-5a34-4b4c-a3f6-e1b1d78f7412\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\" tb_gift_link=\\"\\"></script>",
 }
 `;
 
@@ -1757,7 +1757,7 @@ Object {
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
-    <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"77f09c60-5a34-4b4c-a3f6-e1b1d78f7412\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\"></script>",
+    <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"77f09c60-5a34-4b4c-a3f6-e1b1d78f7412\\" tb_post_uuid=\\"undefined\\" tb_post_type=\\"null\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\" tb_gift_link=\\"\\"></script>",
 }
 `;
 

--- a/ghost/core/test/unit/frontend/helpers/ghost-head.test.js
+++ b/ghost/core/test/unit/frontend/helpers/ghost-head.test.js
@@ -1548,6 +1548,43 @@ describe('{{ghost_head}} helper', function () {
             assert.match(rendered, /data-datasource="analytics_events"/);
         });
 
+        // These call ghost_head directly rather than via testGhostHead so they
+        // assert the tb_gift_link value without taking a snapshot — keeping them
+        // out of the shared tracker snapshots.
+        it('sets tb_gift_link to the token on a verified gift read', async function () {
+            // The gift reader path sets the verified token as `_giftLink` on
+            // res.locals, which merges onto the render context root — the same
+            // place ghost_foot reads it for the toast. The tracker reads
+            // `dataRoot._giftLink` and forwards it so analytics can segment gift
+            // traffic and count per-link usage. Inject it via locals here (which
+            // createHbsResponse merges into data.root) so this guards the real
+            // production data path.
+            const rendered = (await ghost_head(testUtils.createHbsResponse({
+                renderObject: {post: posts[10]},
+                locals: {
+                    relativeUrl: '/post/',
+                    context: ['post'],
+                    safeVersion: '4.3',
+                    _giftLink: 'gift_token_abc'
+                }
+            }))).toString();
+
+            assert.match(rendered, /tb_gift_link="gift_token_abc"/);
+        });
+
+        it('sets an empty tb_gift_link on a normal read', async function () {
+            const rendered = (await ghost_head(testUtils.createHbsResponse({
+                renderObject: {post: posts[10]},
+                locals: {
+                    relativeUrl: '/post/',
+                    context: ['post'],
+                    safeVersion: '4.3'
+                }
+            }))).toString();
+
+            assert.match(rendered, /tb_gift_link=""/);
+        });
+
         it('does not include tracker script when preview is set', async function () {
             const rendered = await testGhostHead(testUtils.createHbsResponse({
                 locals: {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3746/integrate-gift-link-usage-tracking-with-analytics

Stacked on #28824 (the `?gift=` reader path). **Producer** slice of moving gift-link usage tracking off the DB counter and onto the existing web-analytics pipeline (Tinybird), so gift numbers are measured the same way as every other page view.

### What this does

Attaches a single new dimension — `gift_link` (the gift-link token) — to the `page_hit` payload on a verified gift read, so downstream analytics can:
- segment "gift traffic" in the normal reports, and
- count usage per individual link.

### How

- The reader path (`entry/gift-links.ts`, `setGiftTemplateFlag`) flags a verified gift render with a single internal `_giftLink` token — the token itself, not a boolean — set on `res.locals` so it merges onto the render context root. One flag, not two: it also drives the reader toast.
- This renames the internal flag (`_gift` → `_giftLink`, to match the `gift_link` dimension) and moves it off the `@data` frame onto `res.locals`, so both consumers read it from the render root like `post_uuid`/`member`. Touches `ghost_foot` and the reader’s `gift-links` controller as well as `ghost_head`.
- `ghost_head`'s tracker reads it as `dataRoot._giftLink` and emits `tb_gift_link`, via the existing `ghost_head` → `ghost-stats` courier path that already carries `post_uuid`, `member_status`, etc. `ghost_foot` reads the same root flag for the toast.
- Always emitted, but **empty** (`tb_gift_link=""`) on a normal read; only a verified gift render carries the token. The empty-vs-token distinction (not an `"undefined"` sentinel) is what lets the downstream `gift_link != ''` filter decide what counts as gift traffic.

Gated on `labs.giftLinks`.

### This PR is producer-only

The two consumers are separate PRs so each can be reviewed independently:
- **Proxy** (TryGhost/TrafficAnalytics) — thread `gift_link` through the page-hit transforms, else it's dropped before Tinybird.
- **Data files** (Tinybird datafiles in this repo) — `_mv_hits` column, `gift_link` segment param, and a per-link endpoint.

Until the proxy lands, `gift_link` is sent but dropped — no behaviour change.

### Out of scope

The pre-existing `?gift=` token leak into `ghost-stats`' `location.href` (noted in #28824) is unchanged here. The token is sent deliberately as `gift_link` regardless; the `href` field is inert in reports.

### Test

- `ghost-head.test.js` (unit): `tb_gift_link` carries the token when `_giftLink` is set, empty otherwise.
- `e2e-frontend/gift-links.test.ts` (integration): drives the real reader path with web analytics enabled and asserts the rendered tracker — a verified token reaches `tb_gift_link`, while a forged token, a token for another post, and a normal read all render an empty `tb_gift_link`. Proves an unverified token never enters analytics.




