### PR TITLE
Dropped the ghost/core unit-test hookTimeout override

### DIFF
--- a/ghost/core/vitest.config.ts
+++ b/ghost/core/vitest.config.ts
@@ -43,7 +43,7 @@ const unitConfig = {
     // 5000ms (vitest's default) — generous headroom over the slowest unit
     // test (~1s locally) for loaded CI runners.
     testTimeout: 5000,
-    hookTimeout: 60000,
+    hookTimeout: 10000,
     // Retry a failed test up to twice (3 attempts total) before reporting
     // it as failed — absorbs transient flakiness on loaded CI runners.
     retry: 2

--- a/ghost/core/vitest.config.ts
+++ b/ghost/core/vitest.config.ts
@@ -43,7 +43,6 @@ const unitConfig = {
     // 5000ms (vitest's default) — generous headroom over the slowest unit
     // test (~1s locally) for loaded CI runners.
     testTimeout: 5000,
-    hookTimeout: 10000,
     // Retry a failed test up to twice (3 attempts total) before reporting
     // it as failed — absorbs transient flakiness on loaded CI runners.
     retry: 2


### PR DESCRIPTION
The 60s `hookTimeout` on the ghost/core unit suite was a Mocha-era override carried through the Vitest migration. Vitest's default (10s) is well above the actual hook cost in the unit suite — no hook hits the new ceiling across a 15-run hammer locally (5 shuffled + 10 natural-order). Drop the explicit setting and accept the default.

## Out of scope

The companion `retry: 2` on the same `unitConfig` stays for now. Removing it surfaces a real intermittent in `test/unit/server/adapters/scheduling/scheduling-default.test.js` (5 tests timing out at the 5s `testTimeout` in ~1/10 natural-order runs — fake-clock × nock interaction). Separate PR after that's root-caused; tracked under Linear PLA-41 and PLA-46.

## Test plan
- [ ] CI green