### PR TITLE
Replaced the Mocha this.skip() idiom with vitest equivalents

### DIFF
--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -2067,170 +2067,6 @@ describe('Members API', function () {
         });
     });
 
-    let memberWithPaidSubscription;
-
-    it('Can create a member with an existing paid subscription', async function () {
-        const fakePrice = {
-            id: 'price_1',
-            product: 'product_1234',
-            active: true,
-            nickname: 'Paid',
-            unit_amount: 1200,
-            currency: 'usd',
-            type: 'recurring',
-            recurring: {
-                interval: 'year'
-            }
-        };
-
-        const fakeSubscription = {
-            id: 'sub_987623',
-            customer: 'cus_12345',
-            status: 'active',
-            cancel_at_period_end: false,
-            metadata: {},
-            current_period_end: Date.now() / 1000 + 1000,
-            start_date: Date.now() / 1000,
-            plan: fakePrice,
-            items: {
-                data: [{
-                    id: 'item_123',
-                    price: fakePrice
-                }]
-            }
-        };
-
-        const fakeCustomer = {
-            id: 'cus_12345',
-            name: 'Test Member',
-            email: 'create-member-paid-test@email.com',
-            subscriptions: {
-                type: 'list',
-                data: [fakeSubscription]
-            }
-        };
-
-        stripeMocker.customers.push(fakeCustomer);
-        stripeMocker.subscriptions.push(fakeSubscription);
-        stripeMocker.prices.push(fakePrice);
-
-        const initialMember = {
-            name: fakeCustomer.name,
-            email: fakeCustomer.email,
-            subscribed: true,
-            newsletters: [newsletters[0]],
-            stripe_customer_id: fakeCustomer.id
-        };
-
-        const {body} = await agent
-            .post(`/members/`)
-            .body({members: [initialMember]})
-            .expectStatus(201)
-            .matchBodySnapshot({
-                members: new Array(1).fill({
-                    id: anyObjectId,
-                    uuid: anyUuid,
-                    created_at: anyISODateTime,
-                    updated_at: anyISODateTime,
-                    labels: anyArray,
-                    subscriptions: anyArray,
-                    current_subscription: nullable(anyObject),
-                    tiers: new Array(1).fill(tierMatcher),
-                    newsletters: new Array(1).fill(newsletterSnapshot)
-                })
-            })
-            .matchHeaderSnapshot({
-                'content-version': anyContentVersion,
-                etag: anyEtag,
-                location: anyLocationFor('members')
-            });
-
-        const newMember = body.members[0];
-
-        assert.equal(newMember.status, 'paid', 'The created member should have the paid status');
-        assert.equal(newMember.subscriptions.length, 1, 'The member should have a single subscription');
-        assert.equal(newMember.subscriptions[0].id, fakeSubscription.id, 'The returned subscription should have an ID assigned');
-
-        await assertMemberEvents({
-            eventType: 'MemberStatusEvent',
-            memberId: newMember.id,
-            asserts: [
-                {
-                    from_status: null,
-                    to_status: 'free'
-                }, {
-                    from_status: 'free',
-                    to_status: 'paid'
-                }
-            ]
-        });
-
-        await assertMemberEvents({
-            eventType: 'MemberSubscribeEvent',
-            memberId: newMember.id,
-            asserts: [{
-                subscribed: true,
-                source: 'admin'
-            }]
-        });
-
-        await assertMemberEvents({
-            eventType: 'MemberPaidSubscriptionEvent',
-            memberId: newMember.id,
-            asserts: [
-                {
-                    mrr_delta: 100
-                }
-            ]
-        });
-
-        await assertSubscription(fakeSubscription.id, {
-            subscription_id: fakeSubscription.id,
-            status: 'active',
-            cancel_at_period_end: false,
-            plan_amount: 1200,
-            plan_interval: 'year',
-            plan_currency: 'usd',
-            mrr: 100
-        });
-
-        // Save this member for the next tests
-        memberWithPaidSubscription = newMember;
-    });
-
-    it('Returns an identical member format for read, edit and browse', async function (ctx) {
-        if (!memberWithPaidSubscription) {
-            // Previous test failed
-            return ctx.skip();
-        }
-
-        // Check status has been updated to 'free' after cancelling
-        const {body: readBody} = await agent.get('/members/' + memberWithPaidSubscription.id + '/');
-        assert.equal(readBody.members.length, 1, 'The member was not found in read');
-        const readMember = readBody.members[0];
-
-        // Note that we explicitly need to ask to include tiers while browsing
-        const {body: browseBody} = await agent.get(`/members/?search=${memberWithPaidSubscription.email}&include=tiers`);
-        assert.equal(browseBody.members.length, 1, 'The member was not found in browse');
-        const browseMember = browseBody.members[0];
-
-        // Ignore attribution for now
-        delete readMember.attribution;
-        for (const sub of readMember.subscriptions) {
-            delete sub.attribution;
-        }
-
-        // Ignore attribution for now
-        delete memberWithPaidSubscription.attribution;
-        for (const sub of memberWithPaidSubscription.subscriptions) {
-            delete sub.attribution;
-        }
-
-        // Check for this member with a paid subscription that the body results for the patch, get and browse endpoints are 100% identical
-        assert.deepEqual(browseMember, readMember, 'Browsing a member returns a different format than reading a member');
-        assert.deepEqual(memberWithPaidSubscription, readMember, 'Editing a member returns a different format than reading a member');
-    });
-
     it('Cannot add unknown tiers to a member', async function () {
         const memberId = testUtils.DataGenerator.Content.members[0].id;
         const unknownProductId = 'blahblahid';
@@ -2254,125 +2090,266 @@ describe('Members API', function () {
             });
     });
 
-    it('Cannot add complimentary subscriptions to a member with an active subscription', async function (ctx) {
-        if (!memberWithPaidSubscription) {
-            // Previous test failed
-            return ctx.skip();
-        }
-        const product = await getOtherPaidProduct();
+    describe('with a paid subscription', function () {
+        let memberWithPaidSubscription;
 
-        const compedPayload = {
-            id: memberWithPaidSubscription.id,
-            tiers: [
-                ...memberWithPaidSubscription.tiers,
-                {
-                    id: product.id
+        beforeAll(async function () {
+            const fakePrice = {
+                id: 'price_1',
+                product: 'product_1234',
+                active: true,
+                nickname: 'Paid',
+                unit_amount: 1200,
+                currency: 'usd',
+                type: 'recurring',
+                recurring: {
+                    interval: 'year'
                 }
-            ]
-        };
+            };
 
-        sinon.stub(logging, 'error');
-        await agent
-            .put(`/members/${memberWithPaidSubscription.id}/`)
-            .body({members: [compedPayload]})
-            .expectStatus(400);
-    });
-
-    it('Cannot remove non complimentary subscriptions directly from a member', async function (ctx) {
-        if (!memberWithPaidSubscription) {
-            // Previous test failed
-            return ctx.skip();
-        }
-
-        const compedPayload = {
-            id: memberWithPaidSubscription.id,
-            // Remove all paid subscriptions (= not allowed atm)
-            tiers: []
-        };
-
-        sinon.stub(logging, 'error');
-        await agent
-            .put(`/members/${memberWithPaidSubscription.id}/`)
-            .body({members: [compedPayload]})
-            .expectStatus(400);
-    });
-
-    it('Can remove a complimentary subscription directly from a member with other active subscriptions', async function (ctx) {
-        // This tests for an edge case that shouldn't be possible, but the API should support this to resolve issues
-        // refs https://github.com/TryGhost/Team/issues/1859
-
-        if (!memberWithPaidSubscription) {
-            // Previous test failed
-            return ctx.skip();
-        }
-
-        // Check that the product that we are going to add is not the same as the existing one
-        const product = await getOtherPaidProduct();
-        assert.equal(memberWithPaidSubscription.tiers.length, 1);
-        assert.notEqual(memberWithPaidSubscription.tiers[0].id, product.id);
-
-        // Add it manually
-        await models.Member.edit({
-            products: [
-                ...memberWithPaidSubscription.tiers,
-                {
-                    id: product.id
+            const fakeSubscription = {
+                id: 'sub_987623',
+                customer: 'cus_12345',
+                status: 'active',
+                cancel_at_period_end: false,
+                metadata: {},
+                current_period_end: Date.now() / 1000 + 1000,
+                start_date: Date.now() / 1000,
+                plan: fakePrice,
+                items: {
+                    data: [{
+                        id: 'item_123',
+                        price: fakePrice
+                    }]
                 }
-            ]
-        }, {id: memberWithPaidSubscription.id});
+            };
 
-        // Check status
-        const {body: body2} = await agent
-            .get(`/members/${memberWithPaidSubscription.id}/`)
-            .expectStatus(200);
+            const fakeCustomer = {
+                id: 'cus_12345',
+                name: 'Test Member',
+                email: 'create-member-paid-test@email.com',
+                subscriptions: {
+                    type: 'list',
+                    data: [fakeSubscription]
+                }
+            };
 
-        const beforeMember = body2.members[0];
-        assert.equal(beforeMember.tiers.length, 2, 'The member should have two tiers now');
-        assert.equal(
-            beforeMember.subscriptions.length,
-            1,
-            'Only the Stripe-backed paid subscription should be returned while the member status is paid'
-        );
-        assert.equal(
-            beforeMember.subscriptions[0].tier.id,
-            memberWithPaidSubscription.tiers[0].id,
-            'The returned subscription should stay attached to the paid tier'
-        );
+            stripeMocker.customers.push(fakeCustomer);
+            stripeMocker.subscriptions.push(fakeSubscription);
+            stripeMocker.prices.push(fakePrice);
 
-        // Now try to remove only the complimentary one
-        const compedPayload = {
-            id: memberWithPaidSubscription.id,
-            // Remove all complimentary subscriptions
-            tiers: memberWithPaidSubscription.tiers
-        };
+            const initialMember = {
+                name: fakeCustomer.name,
+                email: fakeCustomer.email,
+                subscribed: true,
+                newsletters: [newsletters[0]],
+                stripe_customer_id: fakeCustomer.id
+            };
 
-        const {body} = await agent
-            .put(`/members/${memberWithPaidSubscription.id}/`)
-            .body({members: [compedPayload]})
-            .expectStatus(200);
+            const {body} = await agent
+                .post(`/members/`)
+                .body({members: [initialMember]})
+                .expectStatus(201)
+                .matchBodySnapshot({
+                    members: new Array(1).fill({
+                        id: anyObjectId,
+                        uuid: anyUuid,
+                        created_at: anyISODateTime,
+                        updated_at: anyISODateTime,
+                        labels: anyArray,
+                        subscriptions: anyArray,
+                        current_subscription: nullable(anyObject),
+                        tiers: new Array(1).fill(tierMatcher),
+                        newsletters: new Array(1).fill(newsletterSnapshot)
+                    })
+                })
+                .matchHeaderSnapshot({
+                    'content-version': anyContentVersion,
+                    etag: anyEtag,
+                    location: anyLocationFor('members')
+                });
 
-        const updatedMember = body.members[0];
-        assert.equal(updatedMember.status, 'paid', 'Member should still have the paid status');
-        assert.equal(updatedMember.tiers.length, 1, 'The member should have one product now');
-        assert.equal(updatedMember.tiers[0].id, memberWithPaidSubscription.tiers[0].id, 'The member should have the paid product');
-    });
+            const newMember = body.members[0];
 
-    it('Can keep tiers unchanged when modifying a paid member', async function (ctx) {
-        if (!memberWithPaidSubscription) {
-            // Previous test failed
-            return ctx.skip();
-        }
+            assert.equal(newMember.status, 'paid', 'The created member should have the paid status');
+            assert.equal(newMember.subscriptions.length, 1, 'The member should have a single subscription');
+            assert.equal(newMember.subscriptions[0].id, fakeSubscription.id, 'The returned subscription should have an ID assigned');
 
-        const compedPayload = {
-            id: memberWithPaidSubscription.id,
-            // Not changed tiers
-            tiers: [...memberWithPaidSubscription.tiers]
-        };
+            await assertMemberEvents({
+                eventType: 'MemberStatusEvent',
+                memberId: newMember.id,
+                asserts: [
+                    {
+                        from_status: null,
+                        to_status: 'free'
+                    }, {
+                        from_status: 'free',
+                        to_status: 'paid'
+                    }
+                ]
+            });
 
-        await agent
-            .put(`/members/${memberWithPaidSubscription.id}/`)
-            .body({members: [compedPayload]})
-            .expectStatus(200);
+            await assertMemberEvents({
+                eventType: 'MemberSubscribeEvent',
+                memberId: newMember.id,
+                asserts: [{
+                    subscribed: true,
+                    source: 'admin'
+                }]
+            });
+
+            await assertMemberEvents({
+                eventType: 'MemberPaidSubscriptionEvent',
+                memberId: newMember.id,
+                asserts: [
+                    {
+                        mrr_delta: 100
+                    }
+                ]
+            });
+
+            await assertSubscription(fakeSubscription.id, {
+                subscription_id: fakeSubscription.id,
+                status: 'active',
+                cancel_at_period_end: false,
+                plan_amount: 1200,
+                plan_interval: 'year',
+                plan_currency: 'usd',
+                mrr: 100
+            });
+
+            memberWithPaidSubscription = newMember;
+        });
+
+        it('Returns an identical member format for read, edit and browse', async function () {
+            // Check status has been updated to 'free' after cancelling
+            const {body: readBody} = await agent.get('/members/' + memberWithPaidSubscription.id + '/');
+            assert.equal(readBody.members.length, 1, 'The member was not found in read');
+            const readMember = readBody.members[0];
+
+            // Note that we explicitly need to ask to include tiers while browsing
+            const {body: browseBody} = await agent.get(`/members/?search=${memberWithPaidSubscription.email}&include=tiers`);
+            assert.equal(browseBody.members.length, 1, 'The member was not found in browse');
+            const browseMember = browseBody.members[0];
+
+            // Ignore attribution for now
+            delete readMember.attribution;
+            for (const sub of readMember.subscriptions) {
+                delete sub.attribution;
+            }
+
+            // Ignore attribution for now
+            delete memberWithPaidSubscription.attribution;
+            for (const sub of memberWithPaidSubscription.subscriptions) {
+                delete sub.attribution;
+            }
+
+            // Check for this member with a paid subscription that the body results for the patch, get and browse endpoints are 100% identical
+            assert.deepEqual(browseMember, readMember, 'Browsing a member returns a different format than reading a member');
+            assert.deepEqual(memberWithPaidSubscription, readMember, 'Editing a member returns a different format than reading a member');
+        });
+
+        it('Cannot add complimentary subscriptions to a member with an active subscription', async function () {
+            const product = await getOtherPaidProduct();
+
+            const compedPayload = {
+                id: memberWithPaidSubscription.id,
+                tiers: [
+                    ...memberWithPaidSubscription.tiers,
+                    {
+                        id: product.id
+                    }
+                ]
+            };
+
+            sinon.stub(logging, 'error');
+            await agent
+                .put(`/members/${memberWithPaidSubscription.id}/`)
+                .body({members: [compedPayload]})
+                .expectStatus(400);
+        });
+
+        it('Cannot remove non complimentary subscriptions directly from a member', async function () {
+            const compedPayload = {
+                id: memberWithPaidSubscription.id,
+                // Remove all paid subscriptions (= not allowed atm)
+                tiers: []
+            };
+
+            sinon.stub(logging, 'error');
+            await agent
+                .put(`/members/${memberWithPaidSubscription.id}/`)
+                .body({members: [compedPayload]})
+                .expectStatus(400);
+        });
+
+        it('Can remove a complimentary subscription directly from a member with other active subscriptions', async function () {
+            // This tests for an edge case that shouldn't be possible, but the API should support this to resolve issues
+            // refs https://github.com/TryGhost/Team/issues/1859
+
+            // Check that the product that we are going to add is not the same as the existing one
+            const product = await getOtherPaidProduct();
+            assert.equal(memberWithPaidSubscription.tiers.length, 1);
+            assert.notEqual(memberWithPaidSubscription.tiers[0].id, product.id);
+
+            // Add it manually
+            await models.Member.edit({
+                products: [
+                    ...memberWithPaidSubscription.tiers,
+                    {
+                        id: product.id
+                    }
+                ]
+            }, {id: memberWithPaidSubscription.id});
+
+            // Check status
+            const {body: body2} = await agent
+                .get(`/members/${memberWithPaidSubscription.id}/`)
+                .expectStatus(200);
+
+            const beforeMember = body2.members[0];
+            assert.equal(beforeMember.tiers.length, 2, 'The member should have two tiers now');
+            assert.equal(
+                beforeMember.subscriptions.length,
+                1,
+                'Only the Stripe-backed paid subscription should be returned while the member status is paid'
+            );
+            assert.equal(
+                beforeMember.subscriptions[0].tier.id,
+                memberWithPaidSubscription.tiers[0].id,
+                'The returned subscription should stay attached to the paid tier'
+            );
+
+            // Now try to remove only the complimentary one
+            const compedPayload = {
+                id: memberWithPaidSubscription.id,
+                // Remove all complimentary subscriptions
+                tiers: memberWithPaidSubscription.tiers
+            };
+
+            const {body} = await agent
+                .put(`/members/${memberWithPaidSubscription.id}/`)
+                .body({members: [compedPayload]})
+                .expectStatus(200);
+
+            const updatedMember = body.members[0];
+            assert.equal(updatedMember.status, 'paid', 'Member should still have the paid status');
+            assert.equal(updatedMember.tiers.length, 1, 'The member should have one product now');
+            assert.equal(updatedMember.tiers[0].id, memberWithPaidSubscription.tiers[0].id, 'The member should have the paid product');
+        });
+
+        it('Can keep tiers unchanged when modifying a paid member', async function () {
+            const compedPayload = {
+                id: memberWithPaidSubscription.id,
+                // Not changed tiers
+                tiers: [...memberWithPaidSubscription.tiers]
+            };
+
+            await agent
+                .put(`/members/${memberWithPaidSubscription.id}/`)
+                .body({members: [compedPayload]})
+                .expectStatus(200);
+        });
     });
 
     it('Can edit by id', async function () {

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -2198,12 +2198,7 @@ describe('Members API', function () {
         memberWithPaidSubscription = newMember;
     });
 
-    it('Returns an identical member format for read, edit and browse', async function (ctx) {
-        if (!memberWithPaidSubscription) {
-            // Previous test failed
-            return ctx.skip();
-        }
-
+    it('Returns an identical member format for read, edit and browse', async function () {
         // Check status has been updated to 'free' after cancelling
         const {body: readBody} = await agent.get('/members/' + memberWithPaidSubscription.id + '/');
         assert.equal(readBody.members.length, 1, 'The member was not found in read');
@@ -2254,11 +2249,7 @@ describe('Members API', function () {
             });
     });
 
-    it('Cannot add complimentary subscriptions to a member with an active subscription', async function (ctx) {
-        if (!memberWithPaidSubscription) {
-            // Previous test failed
-            return ctx.skip();
-        }
+    it('Cannot add complimentary subscriptions to a member with an active subscription', async function () {
         const product = await getOtherPaidProduct();
 
         const compedPayload = {
@@ -2278,12 +2269,7 @@ describe('Members API', function () {
             .expectStatus(400);
     });
 
-    it('Cannot remove non complimentary subscriptions directly from a member', async function (ctx) {
-        if (!memberWithPaidSubscription) {
-            // Previous test failed
-            return ctx.skip();
-        }
-
+    it('Cannot remove non complimentary subscriptions directly from a member', async function () {
         const compedPayload = {
             id: memberWithPaidSubscription.id,
             // Remove all paid subscriptions (= not allowed atm)
@@ -2297,14 +2283,9 @@ describe('Members API', function () {
             .expectStatus(400);
     });
 
-    it('Can remove a complimentary subscription directly from a member with other active subscriptions', async function (ctx) {
+    it('Can remove a complimentary subscription directly from a member with other active subscriptions', async function () {
         // This tests for an edge case that shouldn't be possible, but the API should support this to resolve issues
         // refs https://github.com/TryGhost/Team/issues/1859
-
-        if (!memberWithPaidSubscription) {
-            // Previous test failed
-            return ctx.skip();
-        }
 
         // Check that the product that we are going to add is not the same as the existing one
         const product = await getOtherPaidProduct();
@@ -2357,12 +2338,7 @@ describe('Members API', function () {
         assert.equal(updatedMember.tiers[0].id, memberWithPaidSubscription.tiers[0].id, 'The member should have the paid product');
     });
 
-    it('Can keep tiers unchanged when modifying a paid member', async function (ctx) {
-        if (!memberWithPaidSubscription) {
-            // Previous test failed
-            return ctx.skip();
-        }
-
+    it('Can keep tiers unchanged when modifying a paid member', async function () {
         const compedPayload = {
             id: memberWithPaidSubscription.id,
             // Not changed tiers

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -2067,6 +2067,170 @@ describe('Members API', function () {
         });
     });
 
+    let memberWithPaidSubscription;
+
+    it('Can create a member with an existing paid subscription', async function () {
+        const fakePrice = {
+            id: 'price_1',
+            product: 'product_1234',
+            active: true,
+            nickname: 'Paid',
+            unit_amount: 1200,
+            currency: 'usd',
+            type: 'recurring',
+            recurring: {
+                interval: 'year'
+            }
+        };
+
+        const fakeSubscription = {
+            id: 'sub_987623',
+            customer: 'cus_12345',
+            status: 'active',
+            cancel_at_period_end: false,
+            metadata: {},
+            current_period_end: Date.now() / 1000 + 1000,
+            start_date: Date.now() / 1000,
+            plan: fakePrice,
+            items: {
+                data: [{
+                    id: 'item_123',
+                    price: fakePrice
+                }]
+            }
+        };
+
+        const fakeCustomer = {
+            id: 'cus_12345',
+            name: 'Test Member',
+            email: 'create-member-paid-test@email.com',
+            subscriptions: {
+                type: 'list',
+                data: [fakeSubscription]
+            }
+        };
+
+        stripeMocker.customers.push(fakeCustomer);
+        stripeMocker.subscriptions.push(fakeSubscription);
+        stripeMocker.prices.push(fakePrice);
+
+        const initialMember = {
+            name: fakeCustomer.name,
+            email: fakeCustomer.email,
+            subscribed: true,
+            newsletters: [newsletters[0]],
+            stripe_customer_id: fakeCustomer.id
+        };
+
+        const {body} = await agent
+            .post(`/members/`)
+            .body({members: [initialMember]})
+            .expectStatus(201)
+            .matchBodySnapshot({
+                members: new Array(1).fill({
+                    id: anyObjectId,
+                    uuid: anyUuid,
+                    created_at: anyISODateTime,
+                    updated_at: anyISODateTime,
+                    labels: anyArray,
+                    subscriptions: anyArray,
+                    current_subscription: nullable(anyObject),
+                    tiers: new Array(1).fill(tierMatcher),
+                    newsletters: new Array(1).fill(newsletterSnapshot)
+                })
+            })
+            .matchHeaderSnapshot({
+                'content-version': anyContentVersion,
+                etag: anyEtag,
+                location: anyLocationFor('members')
+            });
+
+        const newMember = body.members[0];
+
+        assert.equal(newMember.status, 'paid', 'The created member should have the paid status');
+        assert.equal(newMember.subscriptions.length, 1, 'The member should have a single subscription');
+        assert.equal(newMember.subscriptions[0].id, fakeSubscription.id, 'The returned subscription should have an ID assigned');
+
+        await assertMemberEvents({
+            eventType: 'MemberStatusEvent',
+            memberId: newMember.id,
+            asserts: [
+                {
+                    from_status: null,
+                    to_status: 'free'
+                }, {
+                    from_status: 'free',
+                    to_status: 'paid'
+                }
+            ]
+        });
+
+        await assertMemberEvents({
+            eventType: 'MemberSubscribeEvent',
+            memberId: newMember.id,
+            asserts: [{
+                subscribed: true,
+                source: 'admin'
+            }]
+        });
+
+        await assertMemberEvents({
+            eventType: 'MemberPaidSubscriptionEvent',
+            memberId: newMember.id,
+            asserts: [
+                {
+                    mrr_delta: 100
+                }
+            ]
+        });
+
+        await assertSubscription(fakeSubscription.id, {
+            subscription_id: fakeSubscription.id,
+            status: 'active',
+            cancel_at_period_end: false,
+            plan_amount: 1200,
+            plan_interval: 'year',
+            plan_currency: 'usd',
+            mrr: 100
+        });
+
+        // Save this member for the next tests
+        memberWithPaidSubscription = newMember;
+    });
+
+    it('Returns an identical member format for read, edit and browse', async function (ctx) {
+        if (!memberWithPaidSubscription) {
+            // Previous test failed
+            return ctx.skip();
+        }
+
+        // Check status has been updated to 'free' after cancelling
+        const {body: readBody} = await agent.get('/members/' + memberWithPaidSubscription.id + '/');
+        assert.equal(readBody.members.length, 1, 'The member was not found in read');
+        const readMember = readBody.members[0];
+
+        // Note that we explicitly need to ask to include tiers while browsing
+        const {body: browseBody} = await agent.get(`/members/?search=${memberWithPaidSubscription.email}&include=tiers`);
+        assert.equal(browseBody.members.length, 1, 'The member was not found in browse');
+        const browseMember = browseBody.members[0];
+
+        // Ignore attribution for now
+        delete readMember.attribution;
+        for (const sub of readMember.subscriptions) {
+            delete sub.attribution;
+        }
+
+        // Ignore attribution for now
+        delete memberWithPaidSubscription.attribution;
+        for (const sub of memberWithPaidSubscription.subscriptions) {
+            delete sub.attribution;
+        }
+
+        // Check for this member with a paid subscription that the body results for the patch, get and browse endpoints are 100% identical
+        assert.deepEqual(browseMember, readMember, 'Browsing a member returns a different format than reading a member');
+        assert.deepEqual(memberWithPaidSubscription, readMember, 'Editing a member returns a different format than reading a member');
+    });
+
     it('Cannot add unknown tiers to a member', async function () {
         const memberId = testUtils.DataGenerator.Content.members[0].id;
         const unknownProductId = 'blahblahid';
@@ -2090,266 +2254,125 @@ describe('Members API', function () {
             });
     });
 
-    describe('with a paid subscription', function () {
-        let memberWithPaidSubscription;
+    it('Cannot add complimentary subscriptions to a member with an active subscription', async function (ctx) {
+        if (!memberWithPaidSubscription) {
+            // Previous test failed
+            return ctx.skip();
+        }
+        const product = await getOtherPaidProduct();
 
-        beforeAll(async function () {
-            const fakePrice = {
-                id: 'price_1',
-                product: 'product_1234',
-                active: true,
-                nickname: 'Paid',
-                unit_amount: 1200,
-                currency: 'usd',
-                type: 'recurring',
-                recurring: {
-                    interval: 'year'
+        const compedPayload = {
+            id: memberWithPaidSubscription.id,
+            tiers: [
+                ...memberWithPaidSubscription.tiers,
+                {
+                    id: product.id
                 }
-            };
+            ]
+        };
 
-            const fakeSubscription = {
-                id: 'sub_987623',
-                customer: 'cus_12345',
-                status: 'active',
-                cancel_at_period_end: false,
-                metadata: {},
-                current_period_end: Date.now() / 1000 + 1000,
-                start_date: Date.now() / 1000,
-                plan: fakePrice,
-                items: {
-                    data: [{
-                        id: 'item_123',
-                        price: fakePrice
-                    }]
+        sinon.stub(logging, 'error');
+        await agent
+            .put(`/members/${memberWithPaidSubscription.id}/`)
+            .body({members: [compedPayload]})
+            .expectStatus(400);
+    });
+
+    it('Cannot remove non complimentary subscriptions directly from a member', async function (ctx) {
+        if (!memberWithPaidSubscription) {
+            // Previous test failed
+            return ctx.skip();
+        }
+
+        const compedPayload = {
+            id: memberWithPaidSubscription.id,
+            // Remove all paid subscriptions (= not allowed atm)
+            tiers: []
+        };
+
+        sinon.stub(logging, 'error');
+        await agent
+            .put(`/members/${memberWithPaidSubscription.id}/`)
+            .body({members: [compedPayload]})
+            .expectStatus(400);
+    });
+
+    it('Can remove a complimentary subscription directly from a member with other active subscriptions', async function (ctx) {
+        // This tests for an edge case that shouldn't be possible, but the API should support this to resolve issues
+        // refs https://github.com/TryGhost/Team/issues/1859
+
+        if (!memberWithPaidSubscription) {
+            // Previous test failed
+            return ctx.skip();
+        }
+
+        // Check that the product that we are going to add is not the same as the existing one
+        const product = await getOtherPaidProduct();
+        assert.equal(memberWithPaidSubscription.tiers.length, 1);
+        assert.notEqual(memberWithPaidSubscription.tiers[0].id, product.id);
+
+        // Add it manually
+        await models.Member.edit({
+            products: [
+                ...memberWithPaidSubscription.tiers,
+                {
+                    id: product.id
                 }
-            };
+            ]
+        }, {id: memberWithPaidSubscription.id});
 
-            const fakeCustomer = {
-                id: 'cus_12345',
-                name: 'Test Member',
-                email: 'create-member-paid-test@email.com',
-                subscriptions: {
-                    type: 'list',
-                    data: [fakeSubscription]
-                }
-            };
+        // Check status
+        const {body: body2} = await agent
+            .get(`/members/${memberWithPaidSubscription.id}/`)
+            .expectStatus(200);
 
-            stripeMocker.customers.push(fakeCustomer);
-            stripeMocker.subscriptions.push(fakeSubscription);
-            stripeMocker.prices.push(fakePrice);
+        const beforeMember = body2.members[0];
+        assert.equal(beforeMember.tiers.length, 2, 'The member should have two tiers now');
+        assert.equal(
+            beforeMember.subscriptions.length,
+            1,
+            'Only the Stripe-backed paid subscription should be returned while the member status is paid'
+        );
+        assert.equal(
+            beforeMember.subscriptions[0].tier.id,
+            memberWithPaidSubscription.tiers[0].id,
+            'The returned subscription should stay attached to the paid tier'
+        );
 
-            const initialMember = {
-                name: fakeCustomer.name,
-                email: fakeCustomer.email,
-                subscribed: true,
-                newsletters: [newsletters[0]],
-                stripe_customer_id: fakeCustomer.id
-            };
+        // Now try to remove only the complimentary one
+        const compedPayload = {
+            id: memberWithPaidSubscription.id,
+            // Remove all complimentary subscriptions
+            tiers: memberWithPaidSubscription.tiers
+        };
 
-            const {body} = await agent
-                .post(`/members/`)
-                .body({members: [initialMember]})
-                .expectStatus(201)
-                .matchBodySnapshot({
-                    members: new Array(1).fill({
-                        id: anyObjectId,
-                        uuid: anyUuid,
-                        created_at: anyISODateTime,
-                        updated_at: anyISODateTime,
-                        labels: anyArray,
-                        subscriptions: anyArray,
-                        current_subscription: nullable(anyObject),
-                        tiers: new Array(1).fill(tierMatcher),
-                        newsletters: new Array(1).fill(newsletterSnapshot)
-                    })
-                })
-                .matchHeaderSnapshot({
-                    'content-version': anyContentVersion,
-                    etag: anyEtag,
-                    location: anyLocationFor('members')
-                });
+        const {body} = await agent
+            .put(`/members/${memberWithPaidSubscription.id}/`)
+            .body({members: [compedPayload]})
+            .expectStatus(200);
 
-            const newMember = body.members[0];
+        const updatedMember = body.members[0];
+        assert.equal(updatedMember.status, 'paid', 'Member should still have the paid status');
+        assert.equal(updatedMember.tiers.length, 1, 'The member should have one product now');
+        assert.equal(updatedMember.tiers[0].id, memberWithPaidSubscription.tiers[0].id, 'The member should have the paid product');
+    });
 
-            assert.equal(newMember.status, 'paid', 'The created member should have the paid status');
-            assert.equal(newMember.subscriptions.length, 1, 'The member should have a single subscription');
-            assert.equal(newMember.subscriptions[0].id, fakeSubscription.id, 'The returned subscription should have an ID assigned');
+    it('Can keep tiers unchanged when modifying a paid member', async function (ctx) {
+        if (!memberWithPaidSubscription) {
+            // Previous test failed
+            return ctx.skip();
+        }
 
-            await assertMemberEvents({
-                eventType: 'MemberStatusEvent',
-                memberId: newMember.id,
-                asserts: [
-                    {
-                        from_status: null,
-                        to_status: 'free'
-                    }, {
-                        from_status: 'free',
-                        to_status: 'paid'
-                    }
-                ]
-            });
+        const compedPayload = {
+            id: memberWithPaidSubscription.id,
+            // Not changed tiers
+            tiers: [...memberWithPaidSubscription.tiers]
+        };
 
-            await assertMemberEvents({
-                eventType: 'MemberSubscribeEvent',
-                memberId: newMember.id,
-                asserts: [{
-                    subscribed: true,
-                    source: 'admin'
-                }]
-            });
-
-            await assertMemberEvents({
-                eventType: 'MemberPaidSubscriptionEvent',
-                memberId: newMember.id,
-                asserts: [
-                    {
-                        mrr_delta: 100
-                    }
-                ]
-            });
-
-            await assertSubscription(fakeSubscription.id, {
-                subscription_id: fakeSubscription.id,
-                status: 'active',
-                cancel_at_period_end: false,
-                plan_amount: 1200,
-                plan_interval: 'year',
-                plan_currency: 'usd',
-                mrr: 100
-            });
-
-            memberWithPaidSubscription = newMember;
-        });
-
-        it('Returns an identical member format for read, edit and browse', async function () {
-            // Check status has been updated to 'free' after cancelling
-            const {body: readBody} = await agent.get('/members/' + memberWithPaidSubscription.id + '/');
-            assert.equal(readBody.members.length, 1, 'The member was not found in read');
-            const readMember = readBody.members[0];
-
-            // Note that we explicitly need to ask to include tiers while browsing
-            const {body: browseBody} = await agent.get(`/members/?search=${memberWithPaidSubscription.email}&include=tiers`);
-            assert.equal(browseBody.members.length, 1, 'The member was not found in browse');
-            const browseMember = browseBody.members[0];
-
-            // Ignore attribution for now
-            delete readMember.attribution;
-            for (const sub of readMember.subscriptions) {
-                delete sub.attribution;
-            }
-
-            // Ignore attribution for now
-            delete memberWithPaidSubscription.attribution;
-            for (const sub of memberWithPaidSubscription.subscriptions) {
-                delete sub.attribution;
-            }
-
-            // Check for this member with a paid subscription that the body results for the patch, get and browse endpoints are 100% identical
-            assert.deepEqual(browseMember, readMember, 'Browsing a member returns a different format than reading a member');
-            assert.deepEqual(memberWithPaidSubscription, readMember, 'Editing a member returns a different format than reading a member');
-        });
-
-        it('Cannot add complimentary subscriptions to a member with an active subscription', async function () {
-            const product = await getOtherPaidProduct();
-
-            const compedPayload = {
-                id: memberWithPaidSubscription.id,
-                tiers: [
-                    ...memberWithPaidSubscription.tiers,
-                    {
-                        id: product.id
-                    }
-                ]
-            };
-
-            sinon.stub(logging, 'error');
-            await agent
-                .put(`/members/${memberWithPaidSubscription.id}/`)
-                .body({members: [compedPayload]})
-                .expectStatus(400);
-        });
-
-        it('Cannot remove non complimentary subscriptions directly from a member', async function () {
-            const compedPayload = {
-                id: memberWithPaidSubscription.id,
-                // Remove all paid subscriptions (= not allowed atm)
-                tiers: []
-            };
-
-            sinon.stub(logging, 'error');
-            await agent
-                .put(`/members/${memberWithPaidSubscription.id}/`)
-                .body({members: [compedPayload]})
-                .expectStatus(400);
-        });
-
-        it('Can remove a complimentary subscription directly from a member with other active subscriptions', async function () {
-            // This tests for an edge case that shouldn't be possible, but the API should support this to resolve issues
-            // refs https://github.com/TryGhost/Team/issues/1859
-
-            // Check that the product that we are going to add is not the same as the existing one
-            const product = await getOtherPaidProduct();
-            assert.equal(memberWithPaidSubscription.tiers.length, 1);
-            assert.notEqual(memberWithPaidSubscription.tiers[0].id, product.id);
-
-            // Add it manually
-            await models.Member.edit({
-                products: [
-                    ...memberWithPaidSubscription.tiers,
-                    {
-                        id: product.id
-                    }
-                ]
-            }, {id: memberWithPaidSubscription.id});
-
-            // Check status
-            const {body: body2} = await agent
-                .get(`/members/${memberWithPaidSubscription.id}/`)
-                .expectStatus(200);
-
-            const beforeMember = body2.members[0];
-            assert.equal(beforeMember.tiers.length, 2, 'The member should have two tiers now');
-            assert.equal(
-                beforeMember.subscriptions.length,
-                1,
-                'Only the Stripe-backed paid subscription should be returned while the member status is paid'
-            );
-            assert.equal(
-                beforeMember.subscriptions[0].tier.id,
-                memberWithPaidSubscription.tiers[0].id,
-                'The returned subscription should stay attached to the paid tier'
-            );
-
-            // Now try to remove only the complimentary one
-            const compedPayload = {
-                id: memberWithPaidSubscription.id,
-                // Remove all complimentary subscriptions
-                tiers: memberWithPaidSubscription.tiers
-            };
-
-            const {body} = await agent
-                .put(`/members/${memberWithPaidSubscription.id}/`)
-                .body({members: [compedPayload]})
-                .expectStatus(200);
-
-            const updatedMember = body.members[0];
-            assert.equal(updatedMember.status, 'paid', 'Member should still have the paid status');
-            assert.equal(updatedMember.tiers.length, 1, 'The member should have one product now');
-            assert.equal(updatedMember.tiers[0].id, memberWithPaidSubscription.tiers[0].id, 'The member should have the paid product');
-        });
-
-        it('Can keep tiers unchanged when modifying a paid member', async function () {
-            const compedPayload = {
-                id: memberWithPaidSubscription.id,
-                // Not changed tiers
-                tiers: [...memberWithPaidSubscription.tiers]
-            };
-
-            await agent
-                .put(`/members/${memberWithPaidSubscription.id}/`)
-                .body({members: [compedPayload]})
-                .expectStatus(200);
-        });
+        await agent
+            .put(`/members/${memberWithPaidSubscription.id}/`)
+            .body({members: [compedPayload]})
+            .expectStatus(200);
     });
 
     it('Can edit by id', async function () {

--- a/ghost/core/test/e2e-api/admin/members.test.js
+++ b/ghost/core/test/e2e-api/admin/members.test.js
@@ -2198,10 +2198,10 @@ describe('Members API', function () {
         memberWithPaidSubscription = newMember;
     });
 
-    it('Returns an identical member format for read, edit and browse', async function () {
+    it('Returns an identical member format for read, edit and browse', async function (ctx) {
         if (!memberWithPaidSubscription) {
             // Previous test failed
-            this.skip();
+            return ctx.skip();
         }
 
         // Check status has been updated to 'free' after cancelling
@@ -2254,10 +2254,10 @@ describe('Members API', function () {
             });
     });
 
-    it('Cannot add complimentary subscriptions to a member with an active subscription', async function () {
+    it('Cannot add complimentary subscriptions to a member with an active subscription', async function (ctx) {
         if (!memberWithPaidSubscription) {
             // Previous test failed
-            this.skip();
+            return ctx.skip();
         }
         const product = await getOtherPaidProduct();
 
@@ -2278,10 +2278,10 @@ describe('Members API', function () {
             .expectStatus(400);
     });
 
-    it('Cannot remove non complimentary subscriptions directly from a member', async function () {
+    it('Cannot remove non complimentary subscriptions directly from a member', async function (ctx) {
         if (!memberWithPaidSubscription) {
             // Previous test failed
-            this.skip();
+            return ctx.skip();
         }
 
         const compedPayload = {
@@ -2297,13 +2297,13 @@ describe('Members API', function () {
             .expectStatus(400);
     });
 
-    it('Can remove a complimentary subscription directly from a member with other active subscriptions', async function () {
+    it('Can remove a complimentary subscription directly from a member with other active subscriptions', async function (ctx) {
         // This tests for an edge case that shouldn't be possible, but the API should support this to resolve issues
         // refs https://github.com/TryGhost/Team/issues/1859
 
         if (!memberWithPaidSubscription) {
             // Previous test failed
-            this.skip();
+            return ctx.skip();
         }
 
         // Check that the product that we are going to add is not the same as the existing one
@@ -2357,10 +2357,10 @@ describe('Members API', function () {
         assert.equal(updatedMember.tiers[0].id, memberWithPaidSubscription.tiers[0].id, 'The member should have the paid product');
     });
 
-    it('Can keep tiers unchanged when modifying a paid member', async function () {
+    it('Can keep tiers unchanged when modifying a paid member', async function (ctx) {
         if (!memberWithPaidSubscription) {
             // Previous test failed
-            this.skip();
+            return ctx.skip();
         }
 
         const compedPayload = {

--- a/ghost/core/test/unit/server/services/remote-flags/index.test.js
+++ b/ghost/core/test/unit/server/services/remote-flags/index.test.js
@@ -162,11 +162,7 @@ describe('remote-flags integration: kill-switch through the real labs flag set',
         flagOverrides.clear();
     });
 
-    it('honors a remote kill of a real GA flag end-to-end', function () {
-        if (labs.GA_KEYS.length === 0) {
-            this.skip();
-            return;
-        }
+    it.skipIf(labs.GA_KEYS.length === 0)('honors a remote kill of a real GA flag end-to-end', function () {
         const gaKey = labs.GA_KEYS[0];
 
         assert.equal(labs.isSet(gaKey), true);
@@ -178,11 +174,7 @@ describe('remote-flags integration: kill-switch through the real labs flag set',
         assert.equal(labs.isSet(gaKey), false, 'remote kill must flip a GA flag off end-to-end');
     });
 
-    it('honors a remote enable of a real private/beta flag end-to-end', function () {
-        if (labs.WRITABLE_KEYS_ALLOWLIST.length === 0) {
-            this.skip();
-            return;
-        }
+    it.skipIf(labs.WRITABLE_KEYS_ALLOWLIST.length === 0)('honors a remote enable of a real private/beta flag end-to-end', function () {
         const flag = labs.WRITABLE_KEYS_ALLOWLIST[0];
 
         assert.equal(labs.isSet(flag), false);

--- a/ghost/core/test/unit/server/services/remote-flags/index.test.js
+++ b/ghost/core/test/unit/server/services/remote-flags/index.test.js
@@ -11,6 +11,12 @@ const {resolve} = require('../../../../../core/server/services/remote-flags/reso
 const {RemoteFlagsService} = require('../../../../../core/server/services/remote-flags/remote-flags-service');
 const remoteFlags = require('../../../../../core/server/services/remote-flags');
 
+// The labs allowlists (`WRITABLE_KEYS_ALLOWLIST`, `GA_KEYS`) drain to empty
+// once every flag in them graduates. Tests that pick the first allowlist
+// entry must skip when that happens, or they reference undefined.
+const itIfHasWritableFlag = it.skipIf(labs.WRITABLE_KEYS_ALLOWLIST.length === 0);
+const itIfHasGaFlag = it.skipIf(labs.GA_KEYS.length === 0);
+
 const URL_STRING = 'https://assets.example.com/platform/flags.json';
 const SITE_UUID = '550e8400-e29b-41d4-a716-446655440000';
 
@@ -162,7 +168,7 @@ describe('remote-flags integration: kill-switch through the real labs flag set',
         flagOverrides.clear();
     });
 
-    it.skipIf(labs.GA_KEYS.length === 0)('honors a remote kill of a real GA flag end-to-end', function () {
+    itIfHasGaFlag('honors a remote kill of a real GA flag end-to-end', function () {
         const gaKey = labs.GA_KEYS[0];
 
         assert.equal(labs.isSet(gaKey), true);
@@ -174,7 +180,7 @@ describe('remote-flags integration: kill-switch through the real labs flag set',
         assert.equal(labs.isSet(gaKey), false, 'remote kill must flip a GA flag off end-to-end');
     });
 
-    it.skipIf(labs.WRITABLE_KEYS_ALLOWLIST.length === 0)('honors a remote enable of a real private/beta flag end-to-end', function () {
+    itIfHasWritableFlag('honors a remote enable of a real private/beta flag end-to-end', function () {
         const flag = labs.WRITABLE_KEYS_ALLOWLIST[0];
 
         assert.equal(labs.isSet(flag), false);

--- a/ghost/core/test/unit/shared/labs.test.js
+++ b/ghost/core/test/unit/shared/labs.test.js
@@ -6,6 +6,13 @@ const labs = require('../../../core/shared/labs');
 const flagOverrides = require('../../../core/shared/labs-flag-overrides');
 const settingsCache = require('../../../core/shared/settings-cache');
 
+// The labs allowlists (`WRITABLE_KEYS_ALLOWLIST`, `GA_KEYS`) drain to empty
+// once every flag in them graduates. Tests that pick the first allowlist
+// entry must skip when that happens, or they reference undefined.
+const itIfHasWritableFlag = it.skipIf(labs.WRITABLE_KEYS_ALLOWLIST.length === 0);
+const itIfHasGaFlag = it.skipIf(labs.GA_KEYS.length === 0);
+const itIfHasBothFlags = it.skipIf(labs.WRITABLE_KEYS_ALLOWLIST.length === 0 || labs.GA_KEYS.length === 0);
+
 function expectedLabsObject(obj) {
     let enabledFlags = {};
 
@@ -29,7 +36,7 @@ describe('Labs Service', function () {
         }));
     });
 
-    it.skipIf(labs.WRITABLE_KEYS_ALLOWLIST.length === 0)('respects the value in config over settings', function () {
+    itIfHasWritableFlag('respects the value in config over settings', function () {
         const flag = labs.WRITABLE_KEYS_ALLOWLIST[0];
 
         configUtils.set('labs', {
@@ -49,7 +56,7 @@ describe('Labs Service', function () {
         assert.equal(labs.isSet(flag), false);
     });
 
-    it.skipIf(labs.GA_KEYS.length === 0)('respects the value in config over GA keys', function () {
+    itIfHasGaFlag('respects the value in config over GA keys', function () {
         const gaKey = labs.GA_KEYS[0];
 
         configUtils.set('labs', {
@@ -75,7 +82,7 @@ describe('Labs Service', function () {
         assert.equal(labs.isSet('members'), true);
     });
 
-    it.skipIf(labs.WRITABLE_KEYS_ALLOWLIST.length === 0)('returns other allowlisted flags along with members', function () {
+    itIfHasWritableFlag('returns other allowlisted flags along with members', function () {
         const flag = labs.WRITABLE_KEYS_ALLOWLIST[0];
 
         const getSpy = sinon.stub(settingsCache, 'get');
@@ -121,7 +128,7 @@ describe('Labs Service - remote overrides', function () {
         await configUtils.restore();
     });
 
-    it.skipIf(labs.WRITABLE_KEYS_ALLOWLIST.length === 0)('overlays a remote override so an otherwise-off flag reads on', function () {
+    itIfHasWritableFlag('overlays a remote override so an otherwise-off flag reads on', function () {
         const flag = labs.WRITABLE_KEYS_ALLOWLIST[0];
 
         assert.equal(labs.isSet(flag), false);
@@ -130,7 +137,7 @@ describe('Labs Service - remote overrides', function () {
         assert.equal(labs.getAll()[flag], true);
     });
 
-    it.skipIf(labs.GA_KEYS.length === 0)('lets a remote override kill a GA flag (kill switch)', function () {
+    itIfHasGaFlag('lets a remote override kill a GA flag (kill switch)', function () {
         const gaKey = labs.GA_KEYS[0];
 
         // GA forces the flag on by default.
@@ -141,7 +148,7 @@ describe('Labs Service - remote overrides', function () {
         assert.equal(labs.getAll()[gaKey], false);
     });
 
-    it.skipIf(labs.WRITABLE_KEYS_ALLOWLIST.length === 0)('lets a remote override beat the DB settings value', function () {
+    itIfHasWritableFlag('lets a remote override beat the DB settings value', function () {
         const flag = labs.WRITABLE_KEYS_ALLOWLIST[0];
 
         const getSpy = sinon.stub(settingsCache, 'get');
@@ -151,7 +158,7 @@ describe('Labs Service - remote overrides', function () {
         assert.equal(labs.isSet(flag), true);
     });
 
-    it.skipIf(labs.WRITABLE_KEYS_ALLOWLIST.length === 0)('lets a local config.labs pin beat a remote override', function () {
+    itIfHasWritableFlag('lets a local config.labs pin beat a remote override', function () {
         const flag = labs.WRITABLE_KEYS_ALLOWLIST[0];
 
         // config pins the flag OFF; remote tries to turn it ON; config must win.
@@ -170,7 +177,7 @@ describe('Labs Service - remote overrides', function () {
         assert.equal(labs.isSet('members'), true);
     });
 
-    it.skipIf(labs.GA_KEYS.length === 0)('is inert with no overrides set and after clearing', function () {
+    itIfHasGaFlag('is inert with no overrides set and after clearing', function () {
         const gaKey = labs.GA_KEYS[0];
 
         flagOverrides.replace({[gaKey]: false});
@@ -178,7 +185,7 @@ describe('Labs Service - remote overrides', function () {
         assert.equal(labs.isSet(gaKey), true);
     });
 
-    it.skipIf(labs.GA_KEYS.length === 0)('treats a non-object override payload as empty without throwing', function () {
+    itIfHasGaFlag('treats a non-object override payload as empty without throwing', function () {
         const gaKey = labs.GA_KEYS[0];
 
         flagOverrides.replace(null);
@@ -189,7 +196,7 @@ describe('Labs Service - remote overrides', function () {
         assert.equal(labs.isSet(gaKey), true);
     });
 
-    it.skipIf(labs.GA_KEYS.length === 0)('lets config.labs beat a remote override for a GA key', function () {
+    itIfHasGaFlag('lets config.labs beat a remote override for a GA key', function () {
         const gaKey = labs.GA_KEYS[0];
 
         // Without config, the remote `false` would kill this GA flag; the config
@@ -199,7 +206,7 @@ describe('Labs Service - remote overrides', function () {
         assert.equal(labs.isSet(gaKey), true);
     });
 
-    it.skipIf(labs.GA_KEYS.length === 0 || labs.WRITABLE_KEYS_ALLOWLIST.length === 0)('applies multiple overrides in one payload key-by-key', function () {
+    itIfHasBothFlags('applies multiple overrides in one payload key-by-key', function () {
         const gaKey = labs.GA_KEYS[0];
         const writable = labs.WRITABLE_KEYS_ALLOWLIST[0];
 
@@ -208,7 +215,7 @@ describe('Labs Service - remote overrides', function () {
         assert.equal(labs.isSet(writable), true);
     });
 
-    it.skipIf(labs.GA_KEYS.length === 0)('isolates stored overrides from later caller and getAll() mutation', function () {
+    itIfHasGaFlag('isolates stored overrides from later caller and getAll() mutation', function () {
         const gaKey = labs.GA_KEYS[0];
 
         const payload = {[gaKey]: false};

--- a/ghost/core/test/unit/shared/labs.test.js
+++ b/ghost/core/test/unit/shared/labs.test.js
@@ -29,12 +29,7 @@ describe('Labs Service', function () {
         }));
     });
 
-    it('respects the value in config over settings', function () {
-        if (labs.WRITABLE_KEYS_ALLOWLIST.length === 0) {
-            this.skip();
-            return;
-        }
-
+    it.skipIf(labs.WRITABLE_KEYS_ALLOWLIST.length === 0)('respects the value in config over settings', function () {
         const flag = labs.WRITABLE_KEYS_ALLOWLIST[0];
 
         configUtils.set('labs', {
@@ -54,12 +49,7 @@ describe('Labs Service', function () {
         assert.equal(labs.isSet(flag), false);
     });
 
-    it('respects the value in config over GA keys', function () {
-        if (labs.GA_KEYS.length === 0) {
-            this.skip();
-            return;
-        }
-
+    it.skipIf(labs.GA_KEYS.length === 0)('respects the value in config over GA keys', function () {
         const gaKey = labs.GA_KEYS[0];
 
         configUtils.set('labs', {
@@ -85,12 +75,7 @@ describe('Labs Service', function () {
         assert.equal(labs.isSet('members'), true);
     });
 
-    it('returns other allowlisted flags along with members', function () {
-        if (labs.WRITABLE_KEYS_ALLOWLIST.length === 0) {
-            this.skip();
-            return;
-        }
-
+    it.skipIf(labs.WRITABLE_KEYS_ALLOWLIST.length === 0)('returns other allowlisted flags along with members', function () {
         const flag = labs.WRITABLE_KEYS_ALLOWLIST[0];
 
         const getSpy = sinon.stub(settingsCache, 'get');
@@ -136,11 +121,7 @@ describe('Labs Service - remote overrides', function () {
         await configUtils.restore();
     });
 
-    it('overlays a remote override so an otherwise-off flag reads on', function () {
-        if (labs.WRITABLE_KEYS_ALLOWLIST.length === 0) {
-            this.skip();
-            return;
-        }
+    it.skipIf(labs.WRITABLE_KEYS_ALLOWLIST.length === 0)('overlays a remote override so an otherwise-off flag reads on', function () {
         const flag = labs.WRITABLE_KEYS_ALLOWLIST[0];
 
         assert.equal(labs.isSet(flag), false);
@@ -149,11 +130,7 @@ describe('Labs Service - remote overrides', function () {
         assert.equal(labs.getAll()[flag], true);
     });
 
-    it('lets a remote override kill a GA flag (kill switch)', function () {
-        if (labs.GA_KEYS.length === 0) {
-            this.skip();
-            return;
-        }
+    it.skipIf(labs.GA_KEYS.length === 0)('lets a remote override kill a GA flag (kill switch)', function () {
         const gaKey = labs.GA_KEYS[0];
 
         // GA forces the flag on by default.
@@ -164,11 +141,7 @@ describe('Labs Service - remote overrides', function () {
         assert.equal(labs.getAll()[gaKey], false);
     });
 
-    it('lets a remote override beat the DB settings value', function () {
-        if (labs.WRITABLE_KEYS_ALLOWLIST.length === 0) {
-            this.skip();
-            return;
-        }
+    it.skipIf(labs.WRITABLE_KEYS_ALLOWLIST.length === 0)('lets a remote override beat the DB settings value', function () {
         const flag = labs.WRITABLE_KEYS_ALLOWLIST[0];
 
         const getSpy = sinon.stub(settingsCache, 'get');
@@ -178,11 +151,7 @@ describe('Labs Service - remote overrides', function () {
         assert.equal(labs.isSet(flag), true);
     });
 
-    it('lets a local config.labs pin beat a remote override', function () {
-        if (labs.WRITABLE_KEYS_ALLOWLIST.length === 0) {
-            this.skip();
-            return;
-        }
+    it.skipIf(labs.WRITABLE_KEYS_ALLOWLIST.length === 0)('lets a local config.labs pin beat a remote override', function () {
         const flag = labs.WRITABLE_KEYS_ALLOWLIST[0];
 
         // config pins the flag OFF; remote tries to turn it ON; config must win.
@@ -201,11 +170,7 @@ describe('Labs Service - remote overrides', function () {
         assert.equal(labs.isSet('members'), true);
     });
 
-    it('is inert with no overrides set and after clearing', function () {
-        if (labs.GA_KEYS.length === 0) {
-            this.skip();
-            return;
-        }
+    it.skipIf(labs.GA_KEYS.length === 0)('is inert with no overrides set and after clearing', function () {
         const gaKey = labs.GA_KEYS[0];
 
         flagOverrides.replace({[gaKey]: false});
@@ -213,11 +178,7 @@ describe('Labs Service - remote overrides', function () {
         assert.equal(labs.isSet(gaKey), true);
     });
 
-    it('treats a non-object override payload as empty without throwing', function () {
-        if (labs.GA_KEYS.length === 0) {
-            this.skip();
-            return;
-        }
+    it.skipIf(labs.GA_KEYS.length === 0)('treats a non-object override payload as empty without throwing', function () {
         const gaKey = labs.GA_KEYS[0];
 
         flagOverrides.replace(null);
@@ -228,11 +189,7 @@ describe('Labs Service - remote overrides', function () {
         assert.equal(labs.isSet(gaKey), true);
     });
 
-    it('lets config.labs beat a remote override for a GA key', function () {
-        if (labs.GA_KEYS.length === 0) {
-            this.skip();
-            return;
-        }
+    it.skipIf(labs.GA_KEYS.length === 0)('lets config.labs beat a remote override for a GA key', function () {
         const gaKey = labs.GA_KEYS[0];
 
         // Without config, the remote `false` would kill this GA flag; the config
@@ -242,11 +199,7 @@ describe('Labs Service - remote overrides', function () {
         assert.equal(labs.isSet(gaKey), true);
     });
 
-    it('applies multiple overrides in one payload key-by-key', function () {
-        if (labs.GA_KEYS.length === 0 || labs.WRITABLE_KEYS_ALLOWLIST.length === 0) {
-            this.skip();
-            return;
-        }
+    it.skipIf(labs.GA_KEYS.length === 0 || labs.WRITABLE_KEYS_ALLOWLIST.length === 0)('applies multiple overrides in one payload key-by-key', function () {
         const gaKey = labs.GA_KEYS[0];
         const writable = labs.WRITABLE_KEYS_ALLOWLIST[0];
 
@@ -255,11 +208,7 @@ describe('Labs Service - remote overrides', function () {
         assert.equal(labs.isSet(writable), true);
     });
 
-    it('isolates stored overrides from later caller and getAll() mutation', function () {
-        if (labs.GA_KEYS.length === 0) {
-            this.skip();
-            return;
-        }
+    it.skipIf(labs.GA_KEYS.length === 0)('isolates stored overrides from later caller and getAll() mutation', function () {
         const gaKey = labs.GA_KEYS[0];
 
         const payload = {[gaKey]: false};


### PR DESCRIPTION
19 sites across `labs.test.js`, `remote-flags/index.test.js`, and `members.test.js` still used Mocha-style `this.skip()` inside the test callback. Vitest has no runtime `this.skip()` — `this` in a `function () {}` test callback is undefined, so any of these guards would throw a `TypeError` if the `if`-branch ever fired. They're latent today because the gated conditions don't currently trip (the labs allowlists are populated; the members cascade holds), but the migration intent is to replace them.

## Two passes

**1) Static conditions → `it.skipIf`** (labs.test.js, remote-flags/index.test.js)

14 sites where the condition is known at registration time (`labs.WRITABLE_KEYS_ALLOWLIST.length === 0`, `labs.GA_KEYS.length === 0`). Converted to `it.skipIf(condition)('name', fn)`.

**2) Dynamic cascade → nested describe + `beforeAll`** (members.test.js)

5 sites used a defensive `this.skip()` cascade — "if the creating test failed, skip me." Rather than port that pattern verbatim with `(ctx) => ctx.skip()`, restructured into the standard vitest idiom:

- Grouped the creation + 5 dependents in a nested `describe('with a paid subscription', ...)` block
- Moved the creation logic into `beforeAll`
- Dropped the per-test defensive guards entirely
- If `beforeAll` throws (creation broken), vitest fails all 5 dependents with the hook's error — same effective coverage, no `(ctx)` parameter pollution, no per-test boilerplate

The 'Cannot add unknown tiers' test (which doesn't use the shared member) stays in the outer describe, moved just above the new block.

## Test plan

- [ ] CI green (unit + e2e-api)

## Related

Closes the last bit of un-finished Mocha→Vitest migration debt in the test suites. Tracked under Linear PLA-46 / the parent "Finish Mocha → Vitest" project closeout.