### PR TITLE
Dropped retry: 2 from the ghost/core unit suite

### DIFF
--- a/ghost/core/vitest.config.ts
+++ b/ghost/core/vitest.config.ts
@@ -42,10 +42,7 @@ const unitConfig = {
     resolveSnapshotPath,
     // 5000ms (vitest's default) — generous headroom over the slowest unit
     // test (~1s locally) for loaded CI runners.
-    testTimeout: 5000,
-    // Retry a failed test up to twice (3 attempts total) before reporting
-    // it as failed — absorbs transient flakiness on loaded CI runners.
-    retry: 2
+    testTimeout: 5000
 };
 
 export default defineConfig({


### PR DESCRIPTION
The 2-retry safety net was Mocha-era flakiness compensation we've been carrying through the Vitest migration. It silently absorbed up to 2 failures per test, masking real signal — including an actual `scheduling-default.test.js` flake that only surfaced once a hammer ran retry-free.

Pairs with the upcoming `scheduling-default.test.js` fix PR (separate, narrowly scoped). With both in, CI runs honest: no silent retries, no known flake.

## Test plan
- [ ] CI green
- [ ] Re-hammer 20× clean (running in parallel; will note if anything surfaces)