### PR TITLE
Drop gift-link redemption tracking

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.48/2026-06-24-00-00-00-drop-gift-links-redemption-columns.js
+++ b/ghost/core/core/server/data/migrations/versions/6.48/2026-06-24-00-00-00-drop-gift-links-redemption-columns.js
@@ -1,0 +1,10 @@
+const {combineNonTransactionalMigrations, createDropColumnMigration} = require('../../utils');
+
+module.exports = combineNonTransactionalMigrations(
+    createDropColumnMigration('gift_links', 'redeemed_count', {
+        type: 'integer', nullable: false, unsigned: true, defaultTo: 0
+    }),
+    createDropColumnMigration('gift_links', 'last_redeemed_at', {
+        type: 'dateTime', nullable: true
+    })
+);

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -125,8 +125,6 @@ module.exports = {
     gift_links: {
         token: {type: 'string', maxlength: 32, nullable: false, primary: true},
         post_id: {type: 'string', maxlength: 24, nullable: false, references: 'posts.id', cascadeDelete: true},
-        redeemed_count: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0},
-        last_redeemed_at: {type: 'dateTime', nullable: true},
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: true}
     },

--- a/ghost/core/core/server/services/gift-links/database.ts
+++ b/ghost/core/core/server/services/gift-links/database.ts
@@ -13,8 +13,6 @@ const DbDate = z.codec(z.union([z.date(), z.string(), z.number()]), z.date(), {
 export const DbGiftLink = z.object({
     token: z.string(),
     post_id: z.string(),
-    redeemed_count: z.number().int().nonnegative(),
-    last_redeemed_at: DbDate.nullable(),
     created_at: DbDate,
     updated_at: DbDate.nullable()
 });

--- a/ghost/core/core/server/services/gift-links/models.ts
+++ b/ghost/core/core/server/services/gift-links/models.ts
@@ -5,8 +5,6 @@ export type GiftLinkToken = z.infer<typeof GiftLinkToken>;
 
 export const GiftLink = z.object({
     token: GiftLinkToken,
-    redeemedCount: z.number().int().nonnegative(),
-    lastRedeemedAt: z.date().nullable(),
     createdAt: z.date()
 });
 export type GiftLink = z.infer<typeof GiftLink>;

--- a/ghost/core/core/server/services/gift-links/queries.ts
+++ b/ghost/core/core/server/services/gift-links/queries.ts
@@ -7,8 +7,6 @@ import {GiftLink} from './models';
 // The columns the read path selects and the codec decodes into a GiftLink.
 export const GiftLinkRow = DbGiftLink.pick({
     token: true,
-    redeemed_count: true,
-    last_redeemed_at: true,
     created_at: true
 });
 

--- a/ghost/core/core/server/services/gift-links/serializers.ts
+++ b/ghost/core/core/server/services/gift-links/serializers.ts
@@ -5,8 +5,6 @@ import {GiftLink} from './models';
 // Response schemas — the shapes the admin endpoints emit.
 const GiftLinkResource = z.object({
     token: z.string(),
-    redeemed_count: z.number(),
-    last_redeemed_at: z.date().nullable(),
     created_at: z.date()
 });
 const GiftLinksResponse = z.object({gift_links: z.array(GiftLinkResource)});

--- a/ghost/core/core/server/services/gift-links/service.ts
+++ b/ghost/core/core/server/services/gift-links/service.ts
@@ -40,15 +40,6 @@ export class GiftLinksService {
         return this.knex('post_gift_links').del();
     }
 
-    // Keyed by token, not liveness: a read against a since-replaced token still counts for it.
-    async recordRedemption(token: string): Promise<number> {
-        const now = new Date();
-        return this.knex('gift_links')
-            .where({token})
-            .update({last_redeemed_at: now, updated_at: now})
-            .increment('redeemed_count', 1);
-    }
-
     // A missing post is a 404, not a post with no live links: no rows means no post, and the
     // remaining rows carrying a token are the live links.
     private async requirePost(postId: string): Promise<Post> {
@@ -66,7 +57,7 @@ export class GiftLinksService {
     // history. Concurrent adds are last-writer-wins, not an error.
     private async mint(postId: string): Promise<Post> {
         const now = new Date();
-        const link: GiftLink = {token: generateGiftLinkToken(), redeemedCount: 0, lastRedeemedAt: null, createdAt: now};
+        const link: GiftLink = {token: generateGiftLinkToken(), createdAt: now};
         await this.knex.transaction(async (trx) => {
             await trx('gift_links').insert({...z.encode(queries.giftLinkCodec, link), post_id: postId});
             await trx('post_gift_links')

--- a/ghost/core/test/e2e-api/admin/gift-links.test.ts
+++ b/ghost/core/test/e2e-api/admin/gift-links.test.ts
@@ -51,7 +51,7 @@ describe('Gift Links Admin API', function () {
             // Allow-list — the response exposes only these fields.
             assert.deepEqual(
                 Object.keys(body.gift_links[0]).sort(),
-                ['created_at', 'last_redeemed_at', 'redeemed_count', 'token']
+                ['created_at', 'token']
             );
         });
 
@@ -78,7 +78,6 @@ describe('Gift Links Admin API', function () {
             body = (await agent.put(`${name}/${id()}/gift_links/`).expectStatus(200)).body;
             const first = body.gift_links[0].token;
             assert.ok(first);
-            assert.equal(body.gift_links[0].redeemed_count, 0);
 
             // create
             body = (await agent.post(`${name}/${id()}/gift_links/`).expectStatus(200)).body;

--- a/ghost/core/test/integration/services/gift-links.test.ts
+++ b/ghost/core/test/integration/services/gift-links.test.ts
@@ -50,8 +50,6 @@ describe('GiftLinksService (integration)', function () {
 
             assert.equal(post.giftLinks.length, 1, 'a link should be created');
             assert.ok(post.giftLinks[0].token, 'token should be set');
-            assert.equal(post.giftLinks[0].redeemedCount, 0);
-            assert.equal(post.giftLinks[0].lastRedeemedAt, null);
             assert.equal((await liveLinks(postId)).length, 1);
         });
 
@@ -90,16 +88,6 @@ describe('GiftLinksService (integration)', function () {
             const live = await liveLinks(postId);
             assert.equal(live.length, 1);
             assert.equal(live[0]?.token, created.giftLinks[0]?.token);
-        });
-
-        it('starts the new link with zeroed counters', async function () {
-            const original = await service.ensure(postId);
-            await service.recordRedemption(original.giftLinks[0]!.token);
-            await service.recordRedemption(original.giftLinks[0]!.token);
-
-            const created = await service.create(postId);
-            assert.equal(created.giftLinks[0]?.redeemedCount, 0);
-            assert.equal(created.giftLinks[0]?.lastRedeemedAt, null);
         });
 
         it('mints a link even when none existed', async function () {
@@ -147,38 +135,12 @@ describe('GiftLinksService (integration)', function () {
         });
     });
 
-    describe('recordRedemption', function () {
-        it('atomically increments the counter and stamps last_redeemed_at, keyed by token', async function () {
-            const post = await service.ensure(postId);
-            const token = post.giftLinks[0]!.token;
-
-            assert.equal(await service.recordRedemption(token), 1);
-            assert.equal(await service.recordRedemption(token), 1);
-
-            const reloaded = await service.getPostByToken(token);
-            assert.equal(reloaded?.giftLinks[0]?.redeemedCount, 2);
-            assert.notEqual(reloaded?.giftLinks[0]?.lastRedeemedAt, null);
-        });
-
-        it('counts a read against a since-replaced token (history is retained)', async function () {
-            const original = await service.ensure(postId);
-            const token = original.giftLinks[0]!.token;
-            await service.create(postId);
-
-            assert.equal(await service.recordRedemption(token), 1);
-        });
-
-        it('affects no rows for an unknown token', async function () {
-            assert.equal(await service.recordRedemption('unknown-token'), 0);
-        });
-    });
-
     describe('the <=1-live-link-per-post invariant (database-enforced)', function () {
         it('rejects a second live association for the same post', async function () {
             await service.ensure(postId);
 
             await models.Base.knex('gift_links').insert({
-                token: 'second-live-token', post_id: postId, redeemed_count: 0, created_at: new Date()
+                token: 'second-live-token', post_id: postId, created_at: new Date()
             });
             await assert.rejects(
                 models.Base.knex('post_gift_links').insert({

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '1f97c498b7d1fc08413af9c6ab89e4e1';
+    const currentSchemaHash = '843875f56844de5c63752e18ceaeb095';
     const currentFixturesHash = 'f4941d9d92b59075e0c2a1cc3fc4c44a';
     const currentSettingsHash = '397be8628c753b1959b8954d5610f83f';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3745

## Problem

Gift links track redemptions with a per-link count and a last-redeemed timestamp, plus a service method to record a redemption. We are moving to an alternative method of counting redemptions, so this tracking is dead weight.

## Solution

Remove gift-link redemption counting across the data, service and API layers: the two columns (with a migration to drop them), the record-redemption service method, and the two redemption fields on the gift-link API response. Counting redemptions becomes the responsibility of the alternative method.

The token-resolution path is kept, since the reader-access feature (#28824) resolves a gift link by its token.