### PR TITLE
Cleaned 45 admin-x-settings lint TODOs (prefer-const + no-explicit-any)

### DIFF
--- a/apps/admin-x-settings/eslint.config.js
+++ b/apps/admin-x-settings/eslint.config.js
@@ -4,14 +4,6 @@ export default await reactAppConfig({
     tailwindCssPath: `${import.meta.dirname}/../admin/src/index.css`,
     shadeRestricted: true,
     sortImports: true,
-    extraSrcRules: {
-        // TODO: 43 legacy violations. Remove this override after the cleanup PR
-        // converts all `let` → `const` where reassignment never happens.
-        'prefer-const': 'off',
-        // TODO: 2 legacy violations. Easy to fix — drop this override and type
-        // the two remaining `any` usages (in design-and-branding + utils).
-        '@typescript-eslint/no-explicit-any': 'off'
-    },
     extraTestRules: {
         // TODO: 7 legacy violations in test/ — mock-fixture typing shortcuts.
         '@typescript-eslint/no-explicit-any': 'off'

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/newsletter-detail-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/newsletter-detail-modal.tsx
@@ -30,7 +30,7 @@ const ReplyToEmailField: React.FC<{
     // Because 'newsletter' 'support' or an empty value can be mapped to a default value, we don't want those changes to happen when entering text
     const [senderReplyTo, setSenderReplyTo] = useState(renderReplyToEmail(newsletter, config, supportEmailAddress, defaultEmailAddress) || '');
 
-    let newsletterAddress = renderSenderEmail(newsletter, config, defaultEmailAddress);
+    const newsletterAddress = renderSenderEmail(newsletter, config, defaultEmailAddress);
 
     const onChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
         setSenderReplyTo(e.target.value);
@@ -80,7 +80,7 @@ const Sidebar: React.FC<{
     const {data: {newsletters: apiNewsletters} = {}} = useBrowseNewsletters();
     const commentsEnabled = ['all', 'paid'].includes(getSettingValue(settings, 'comments_enabled') || '');
 
-    let newsletterAddress = renderSenderEmail(newsletter, config, defaultEmailAddress);
+    const newsletterAddress = renderSenderEmail(newsletter, config, defaultEmailAddress);
     const [newsletters, setNewsletters] = useState<Newsletter[]>(apiNewsletters || []);
     const activeNewsletters = newsletters.filter(n => n.status === 'active');
 

--- a/apps/admin-x-settings/src/components/settings/general/about.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/about.tsx
@@ -22,7 +22,7 @@ function VersionLink({label, version}: {label: string; version: string}) {
 const AboutModal = NiceModal.create<RoutingModalProps>(() => {
     const {updateRoute} = useRouting();
     const globalData = useGlobalData();
-    let config = globalData.config;
+    const config = globalData.config;
     const upgradeStatus = useUpgradeStatus();
 
     function copyrightYear():number {

--- a/apps/admin-x-settings/src/components/settings/general/invite-user-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/invite-user-modal.tsx
@@ -147,11 +147,11 @@ const InviteUserModal = NiceModal.create(() => {
             }
 
             setSaveState('error');
-            let title = 'Failed to send invitation';
+            const title = 'Failed to send invitation';
             let message = (<span>If the problem persists, <a href="https://ghost.org/contact"><u>contact support</u>.</a>.</span>);
             if (e instanceof APIError) {
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                let data = e.data as any; // we have unknown data types in the APIError/error classes
+                const data = e.data as any; // we have unknown data types in the APIError/error classes
                 if (data?.errors?.[0]?.type === 'EmailError') {
                     message = (<span>Check your Mailgun configuration.</span>);
                 }

--- a/apps/admin-x-settings/src/components/settings/general/user-detail-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/user-detail-modal.tsx
@@ -272,7 +272,7 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
     };
 
     const showMenu = hasAdminAccess(currentUser) || (isEditorUser(currentUser) && isAuthorOrContributor(user));
-    let menuItems: MenuItem[] = [];
+    const menuItems: MenuItem[] = [];
 
     if (isOwnerUser(currentUser) && isAdminUser(formState) && formState.status !== 'inactive') {
         menuItems.push({
@@ -295,7 +295,7 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
         (hasAdminAccess(currentUser) && !isOwnerUser(user)) ||
         (isEditorUser(currentUser) && isAuthorOrContributor(user))
     )) {
-        let suspendUserLabel = formState.status === 'inactive' ? 'Un-suspend user' : 'Suspend user';
+        const suspendUserLabel = formState.status === 'inactive' ? 'Un-suspend user' : 'Suspend user';
 
         menuItems.push({
             id: 'suspend-user',

--- a/apps/admin-x-settings/src/components/settings/general/users/change-password-form.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/users/change-password-form.tsx
@@ -22,11 +22,10 @@ const DISALLOWED_PASSWORDS = ['ghost', 'password', 'passw0rd'];
  * we return false and therefore invalidate the string.
  */
 const validateCharacterOccurrance = (stringToTest: string) => {
-    let chars: Record<string, number> = {};
-    let allowedOccurancy;
+    const chars: Record<string, number> = {};
     let valid = true;
 
-    allowedOccurancy = stringToTest.length / 2;
+    const allowedOccurancy = stringToTest.length / 2;
 
     // Loop through string and accumulate character counts
     for (let i = 0; i < stringToTest.length; i += 1) {
@@ -39,7 +38,7 @@ const validateCharacterOccurrance = (stringToTest: string) => {
 
     // check if any of the accumulated chars exceed the allowed occurancy
     // of 50% of the words' length.
-    for (let charCount in chars) {
+    for (const charCount in chars) {
         if (chars[charCount] >= allowedOccurancy) {
             valid = false;
             return valid;
@@ -84,10 +83,9 @@ const ChangePasswordForm: React.FC<{user: User}> = ({user}) => {
 
         let blogUrl = config.blogUrl || window.location.host;
         let blogTitle = siteData.title;
-        let blogUrlWithSlash;
 
         blogUrl = blogUrl.replace(/^http(s?):\/\//, '');
-        blogUrlWithSlash = blogUrl.match(/\/$/) ? blogUrl : `${blogUrl}/`;
+        const blogUrlWithSlash = blogUrl.match(/\/$/) ? blogUrl : `${blogUrl}/`;
 
         blogTitle = blogTitle ? blogTitle.trim().toLowerCase() : blogTitle;
 

--- a/apps/admin-x-settings/src/components/settings/growth/offers/add-offer-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/add-offer-modal.tsx
@@ -524,7 +524,7 @@ const AddOfferModal = () => {
     const handleNameInput = (e: React.ChangeEvent<HTMLInputElement>) => {
         const newValue = e.target.value;
         updateForm((prevOverrides) => {
-            let newOverrides = {...prevOverrides};
+            const newOverrides = {...prevOverrides};
             newOverrides.name = newValue;
             if (!prevOverrides.code.isDirty) {
                 clearError('code');

--- a/apps/admin-x-settings/src/components/settings/growth/recommendations/add-recommendation-modal-confirm.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/recommendations/add-recommendation-modal-confirm.tsx
@@ -51,7 +51,7 @@ const AddRecommendationModalConfirm: React.FC<AddRecommendationModalProps> = ({r
         okLabel = 'Added';
     }
 
-    let leftButtonProps = {
+    const leftButtonProps = {
         label: 'Back',
         icon: 'arrow-left',
         iconColorClass: 'text-black dark:text-white',

--- a/apps/admin-x-settings/src/components/settings/growth/recommendations/add-recommendation-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/recommendations/add-recommendation-modal.tsx
@@ -57,8 +57,7 @@ const AddRecommendationModal: React.FC<RoutingModalProps & AddRecommendationModa
             one_click_subscribe: false
         },
         onSave: async () => {
-            let validatedUrl: URL;
-            validatedUrl = new URL(formState.url);
+            const validatedUrl: URL = new URL(formState.url);
 
             // Use the hostname as fallback title
             const defaultTitle = validatedUrl.hostname.replace('www.', '');

--- a/apps/admin-x-settings/src/components/settings/growth/recommendations/edit-recommendation-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/recommendations/edit-recommendation-modal.tsx
@@ -34,7 +34,7 @@ const EditRecommendationModal: React.FC<RoutingModalProps & EditRecommendationMo
         }
     });
 
-    let leftButtonProps = {
+    const leftButtonProps = {
         label: 'Delete',
         link: true,
         color: 'red' as const,

--- a/apps/admin-x-settings/src/components/settings/membership/portal/account-page.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/portal/account-page.tsx
@@ -19,7 +19,7 @@ const AccountPage: React.FC<{
     const [value, setValue] = useState(calculatedSupportAddress);
 
     const updateSupportAddress: FocusEventHandler<HTMLInputElement> = (e) => {
-        let supportAddress = e.target.value;
+        const supportAddress = e.target.value;
 
         if (!supportAddress) {
             setError('members_support_address', 'Enter an email address');
@@ -29,7 +29,7 @@ const AccountPage: React.FC<{
             setError('members_support_address', '');
         }
 
-        let settingValue = emailDomain && supportAddress === `noreply@${emailDomain}` ? 'noreply' : supportAddress;
+        const settingValue = emailDomain && supportAddress === `noreply@${emailDomain}` ? 'noreply' : supportAddress;
 
         updateSetting('members_support_address', settingValue);
         setValue(fullEmailAddress(settingValue, siteData!, config));

--- a/apps/admin-x-settings/src/components/settings/membership/portal/portal-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/portal/portal-modal.tsx
@@ -78,7 +78,7 @@ const PortalModal: React.FC = () => {
     useEffect(() => {
         const checkToken = async ({token}: {token: string}) => {
             try {
-                let {settings: verifiedSettings} = await verifyToken({token});
+                const {settings: verifiedSettings} = await verifyToken({token});
                 const [supportEmail] = getSettingValues<string>(verifiedSettings, ['members_support_address']);
                 NiceModal.show(ConfirmationModal, {
                     title: 'Support address verified',
@@ -220,7 +220,7 @@ const PortalModal: React.FC = () => {
         selectedTab={selectedPreviewTab}
     />;
 
-    let previewTabs: Tab[] = [
+    const previewTabs: Tab[] = [
         {id: 'signup', title: 'Signup'},
         {id: 'account', title: 'Account page'},
         {id: 'links', title: 'Links'}

--- a/apps/admin-x-settings/src/components/settings/membership/portal/signup-options.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/portal/signup-options.tsx
@@ -66,7 +66,7 @@ const SignupOptions: React.FC<{
     const isFreeSignupAllowed = membersSignupAccess === 'all';
     const isStripeEnabled = checkStripeEnabled(localSettings, config!);
 
-    let tiersCheckboxes: CheckboxProps[] = [];
+    const tiersCheckboxes: CheckboxProps[] = [];
 
     if (localTiers) {
         localTiers.forEach((tier) => {

--- a/apps/admin-x-settings/src/components/settings/site/announcement-bar/announcement-bar-preview.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/announcement-bar/announcement-bar-preview.tsx
@@ -58,7 +58,7 @@ const AnnouncementBarPreview: React.FC<AnnouncementBarSettings> = ({announcement
 
                 // replace the iframe contents with the doctored preview html
                 const doctype = htmlDoc.doctype ? new XMLSerializer().serializeToString(htmlDoc.doctype) : '';
-                let finalDoc = doctype + htmlDoc.documentElement.outerHTML;
+                const finalDoc = doctype + htmlDoc.documentElement.outerHTML;
 
                 // Send the data to the iframe's window using postMessage
                 // Inject the received content into the iframe

--- a/apps/admin-x-settings/src/components/settings/site/design-and-branding/global-settings.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/design-and-branding/global-settings.tsx
@@ -160,13 +160,13 @@ const GlobalSettings: React.FC<{ values: GlobalSettingValues, updateSetting: (ke
 
     // Populate the heading and body font options
     const customHeadingFonts: HeadingFontOption[] = CUSTOM_FONTS.heading.map((x) => {
-        let className = fontClassName(x.name, true);
+        const className = fontClassName(x.name, true);
         return {label: x.name, value: x.name, creator: x.creator, className};
     });
     customHeadingFonts.unshift({label: DEFAULT_FONT, value: DEFAULT_FONT, creator: themeNameVersion, className: 'font-sans font-normal'});
 
     const customBodyFonts: BodyFontOption[] = CUSTOM_FONTS.body.map((x) => {
-        let className = fontClassName(x.name, false);
+        const className = fontClassName(x.name, false);
         return {label: x.name, value: x.name, creator: x.creator, className};
     });
     customBodyFonts.unshift({label: DEFAULT_FONT, value: DEFAULT_FONT, creator: themeNameVersion, className: 'font-sans font-normal'});
@@ -286,7 +286,7 @@ const GlobalSettings: React.FC<{ values: GlobalSettingValues, updateSetting: (ke
                         unsplashEnabled={unsplashEnabled}
                         width='160px'
                         onDelete={() => updateSetting('cover_image', null)}
-                        onUpload={async (file: any) => {
+                        onUpload={async (file: File) => {
                             try {
                                 updateSetting('cover_image', getImageUrl(await uploadImage({file})));
                             } catch (e) {

--- a/apps/admin-x-settings/src/components/settings/site/design-and-branding/theme-preview.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/design-and-branding/theme-preview.tsx
@@ -103,7 +103,7 @@ const ThemePreview: React.FC<ThemePreviewProps> = ({settings,url}) => {
 
                 // replace the iframe contents with the doctored preview html
                 const doctype = htmlDoc.doctype ? new XMLSerializer().serializeToString(htmlDoc.doctype) : '';
-                let finalDoc = doctype + htmlDoc.documentElement.outerHTML;
+                const finalDoc = doctype + htmlDoc.documentElement.outerHTML;
 
                 // Send the data to the iframe's window using postMessage
                 // Inject the received content into the iframe

--- a/apps/admin-x-settings/src/components/settings/site/theme-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme-modal.tsx
@@ -158,8 +158,8 @@ const ThemeToolbar: React.FC<ThemeToolbarProps> = ({
         }
 
         if (fatalErrors && !data) {
-            let title = 'Theme not uploaded';
-            let prompt = <>This theme couldn&apos;t be uploaded because Ghost found a blocking validation error. Fix the issue below and upload the theme again.</>;
+            const title = 'Theme not uploaded';
+            const prompt = <>This theme couldn&apos;t be uploaded because Ghost found a blocking validation error. Fix the issue below and upload the theme again.</>;
             NiceModal.show(InvalidThemeModal, {
                 title,
                 prompt,
@@ -343,13 +343,13 @@ const ChangeThemeModal: React.FC<ChangeThemeModalProps> = ({source, themeRef}) =
                     return;
                 }
 
-                let titleText = 'Install Theme';
+                const titleText = 'Install Theme';
                 const existingThemeNames = themes?.map(t => t.name) || [];
-                let willOverwrite = existingThemeNames.includes(themeName.toLowerCase());
+                const willOverwrite = existingThemeNames.includes(themeName.toLowerCase());
                 const index = existingThemeNames.indexOf(themeName.toLowerCase());
                 // get the theme that will be overwritten
                 const themeToOverwrite = themes?.[index];
-                let prompt = <>By clicking below, <strong>{themeName}</strong> will automatically be activated as the theme for your site.
+                const prompt = <>By clicking below, <strong>{themeName}</strong> will automatically be activated as the theme for your site.
                     {willOverwrite &&
                     <>
                         <br/>

--- a/apps/admin-x-settings/src/components/settings/site/theme/advanced-theme-settings.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/advanced-theme-settings.tsx
@@ -72,8 +72,8 @@ const ThemeActions: React.FC<ThemeActionProps> = ({
             } else {
                 handleError(e);
             }
-            let title = 'Theme not activated';
-            let prompt = <>This theme couldn&apos;t be activated because Ghost found a blocking validation error. Fix the issue below and try again.</>;
+            const title = 'Theme not activated';
+            const prompt = <>This theme couldn&apos;t be activated because Ghost found a blocking validation error. Fix the issue below and try again.</>;
 
             if (fatalErrors) {
                 NiceModal.show(InvalidThemeModal, {
@@ -140,7 +140,7 @@ const ThemeActions: React.FC<ThemeActionProps> = ({
         updateRoute(`theme/edit/${encodeURIComponent(theme.name)}?from=${encodeURIComponent(route ?? '')}`);
     };
 
-    let actions = [];
+    const actions = [];
 
     if (!isActiveTheme(theme)) {
         actions.push(
@@ -155,7 +155,7 @@ const ThemeActions: React.FC<ThemeActionProps> = ({
         );
     }
 
-    let menuItems = [
+    const menuItems = [
         {
             id: 'edit-code',
             label: 'Edit code',

--- a/apps/admin-x-settings/src/hooks/site/use-navigation-editor.tsx
+++ b/apps/admin-x-settings/src/hooks/site/use-navigation-editor.tsx
@@ -100,7 +100,7 @@ const useNavigationEditor = ({items, setItems}: {
             let isValid = true;
 
             list.items.forEach(({item, id}) => {
-                let errors = validateItem(item);
+                const errors = validateItem(item);
 
                 if (Object.values(errors).some(message => message)) {
                     isValid = false;

--- a/apps/admin-x-settings/src/hooks/use-pintura-editor.ts
+++ b/apps/admin-x-settings/src/hooks/use-pintura-editor.ts
@@ -54,7 +54,7 @@ export default function usePinturaEditor() {
     const [pinturaJsUrl] = getSettingValues<string>(settings, ['pintura_js_url']);
     const [pinturaCssUrl] = getSettingValues<string>(settings, ['pintura_css_url']);
 
-    let isEnabled = pintura && scriptLoaded && cssLoaded || false;
+    const isEnabled = pintura && scriptLoaded && cssLoaded || false;
     const pinturaConfig = globalConfig?.pintura as { js?: string; css?: string };
 
     useEffect(() => {
@@ -118,11 +118,11 @@ export default function usePinturaEditor() {
 
         try {
             // Check if the CSS file is already present in the document's head
-            let cssLink = document.querySelector(`link[href="${cssUrl}"]`);
+            const cssLink = document.querySelector(`link[href="${cssUrl}"]`);
             if (cssLink) {
                 setCssLoaded(true);
             } else {
-                let link = document.createElement('link');
+                const link = document.createElement('link');
                 link.rel = 'stylesheet';
                 link.type = 'text/css';
                 link.href = cssUrl;

--- a/apps/admin-x-settings/src/hooks/use-staff-users.tsx
+++ b/apps/admin-x-settings/src/hooks/use-staff-users.tsx
@@ -58,7 +58,7 @@ const useStaffUsers = (): UsersHook => {
     const authorUsers = useMemo(() => getUsersByRole(users, 'Author'), [users]);
     const contributorUsers = useMemo(() => getUsersByRole(users, 'Contributor'), [users]);
     const mappedInvites = useMemo(() => invites.map((invite) => {
-        let role = roles?.find((r) => {
+        const role = roles?.find((r) => {
             return invite.role_id === r.id;
         });
         return {

--- a/apps/admin-x-settings/src/utils/generate-embed-code.ts
+++ b/apps/admin-x-settings/src/utils/generate-embed-code.ts
@@ -40,7 +40,7 @@ export const generateCode = ({
     const siteUrl = config.blogUrl;
     const scriptUrl = config.signupForm.url.replace('{version}', config.signupForm.version);
 
-    let options: OptionsType = {
+    const options: OptionsType = {
         site: siteUrl,
         locale: settings.locale,
         'button-color': settings.accentColor,

--- a/apps/admin-x-settings/src/utils/get-portal-preview-url.ts
+++ b/apps/admin-x-settings/src/utils/get-portal-preview-url.ts
@@ -15,7 +15,7 @@ export const getPortalPreviewUrl = ({settings, config, tiers, siteData, selected
     if (!siteData?.url) {
         return null;
     }
-    let portalTiers = tiers.filter((t) => {
+    const portalTiers = tiers.filter((t) => {
         return t.visibility === 'public' && t.type === 'paid';
     }).map(t => t.id);
 

--- a/apps/admin-x-settings/src/utils/helpers.ts
+++ b/apps/admin-x-settings/src/utils/helpers.ts
@@ -21,8 +21,8 @@ export function getOptionLabel(
 }
 
 export function getInitials(name: string = '') {
-    let rgx = new RegExp(/([A-Za-z\u00C0-\u017F]{1})[A-Za-z\u00C0-\u017F]+/, 'g');
-    let rgxInitials = [...name.matchAll(rgx)];
+    const rgx = new RegExp(/([A-Za-z\u00C0-\u017F]{1})[A-Za-z\u00C0-\u017F]+/, 'g');
+    const rgxInitials = [...name.matchAll(rgx)];
 
     const initials = (
         (rgxInitials.shift()?.[1] || '') + (rgxInitials.pop()?.[1] || '')

--- a/apps/admin-x-settings/src/utils/link-to-github-releases.ts
+++ b/apps/admin-x-settings/src/utils/link-to-github-releases.ts
@@ -31,7 +31,7 @@ export function linkToGitHubReleases(version: string): string {
 
     // Check pre-release segment for a commit SHA (legacy format: -0-gabcdef or -pre-gabcdef)
     try {
-        const semverVersion = semverParse(versionWithoutBuild, {includePrerelease: true} as any);
+        const semverVersion = semverParse(versionWithoutBuild, {includePrerelease: true});
         const prerelease = semverVersion?.prerelease;
 
         if (prerelease && prerelease.length > 0) {

--- a/apps/admin-x-settings/src/utils/social-urls/bluesky.ts
+++ b/apps/admin-x-settings/src/utils/social-urls/bluesky.ts
@@ -77,7 +77,7 @@ export const blueskyHandleToUrl = (handle: string) => {
         throw new Error(ERRORS.INVALID_USERNAME);
     }
 
-    let username = formatUsername(handle);
+    const username = formatUsername(handle);
 
     // Validate username
     if (!isValidBlueskyUsername(username)) {


### PR DESCRIPTION
Drops the two src-only overrides on admin-x-settings.

**`prefer-const` (43 violations):** 40 autofixed by `eslint --fix` (let → const where TS confirmed no reassignment). 3 manual fixes for split-declaration patterns (`let foo; foo = expr`) in `change-password-form` + `add-recommendation-modal`.

**`@typescript-eslint/no-explicit-any` (2 violations):**
- `global-settings.tsx` — `onUpload(file: any)` → `File` (matches `useUploadImage`'s signature in admin-x-framework)
- `link-to-github-releases.ts` — redundant `as any` on the options object dropped (`semverParse` is already any-typed via the `@ts-expect-error` on its subpath import)

The `test/` override for `no-explicit-any` stays — 7 mock-fixture violations there need a separate typing pass.