### PR TITLE
Flipped storybook/prefer-pascal-case to error (0 real violations)

### DIFF
--- a/eslint.shared.mjs
+++ b/eslint.shared.mjs
@@ -655,18 +655,16 @@ export async function reactAppConfig(options = {}) {
     if (storybook === 'plugin') {
         storybookBlocks.push(...storybookPlugin.configs['flat/recommended']);
         // The storybook preset ships 3 warn-level rules. Ghost's stance is
-        // error-or-off, never warn — normalize them. hierarchy-separator and
-        // no-redundant-story-name have zero violations across shade so they
-        // flip to error for free; prefer-pascal-case has 29 violations so
-        // it's off until cleanup.
+        // error-or-off, never warn — normalize them to error. (The earlier
+        // "29 legacy violations" count for prefer-pascal-case was a measurement
+        // artifact from forcing the rule globally via --rule; scoped to actual
+        // story files, all three rules are clean.)
         storybookBlocks.push({
             files: ['**/*.stories.{ts,tsx,js,jsx,mjs,cjs}', '**/*.story.{ts,tsx,js,jsx,mjs,cjs}'],
             rules: {
                 'storybook/hierarchy-separator': 'error',
                 'storybook/no-redundant-story-name': 'error',
-                // TODO: 29 legacy violations in shade. Flip to 'error' after the
-                // cleanup PR renames story exports to PascalCase.
-                'storybook/prefer-pascal-case': 'off'
+                'storybook/prefer-pascal-case': 'error'
             }
         });
     } else if (storybook === 'storiesBlock') {

--- a/eslint.shared.mjs
+++ b/eslint.shared.mjs
@@ -654,11 +654,6 @@ export async function reactAppConfig(options = {}) {
     const storybookBlocks = [];
     if (storybook === 'plugin') {
         storybookBlocks.push(...storybookPlugin.configs['flat/recommended']);
-        // The storybook preset ships 3 warn-level rules. Ghost's stance is
-        // error-or-off, never warn — normalize them to error. (The earlier
-        // "29 legacy violations" count for prefer-pascal-case was a measurement
-        // artifact from forcing the rule globally via --rule; scoped to actual
-        // story files, all three rules are clean.)
         storybookBlocks.push({
             files: ['**/*.stories.{ts,tsx,js,jsx,mjs,cjs}', '**/*.story.{ts,tsx,js,jsx,mjs,cjs}'],
             rules: {


### PR DESCRIPTION
The TODO had been measured by forcing the rule globally via `--rule`, which fires on every export across all 19 `.ts`/`.tsx` files in shade. Scoped to the actual matched glob (`**/*.stories.{ts,tsx,...}` + `**/*.story.{...}`), there are 0 violations — shade's story exports already use PascalCase.

Just flip `off` → `error` in [eslint.shared.mjs](eslint.shared.mjs). No source changes needed.