### PR TITLE
Tweaked description for automations private feature flag

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -13,7 +13,7 @@ type Feature = {
 
 const features: Feature[] = [{
     title: 'Automations',
-    description: 'Enable automations management interface.',
+    description: 'Toggle the automations beta. Unexpected problems can occur if you turn this off after previously turning it on.',
     flag: 'automations'
 }, {
     title: 'Stripe Automatic Tax (private beta)',


### PR DESCRIPTION
no ref

*This only affects the private feature flag, so it should have no user impact.*

This text hasn't been quite right for awhile--let's update it.

![Screenshot](https://github.com/user-attachments/assets/c273ddcb-ed4a-48f2-9824-f9a3c0199384)
