### PR TITLE
Fixed 22 react/jsx-key violations + flipped rule to error

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tryghost/activitypub",
   "type": "module",
-  "version": "3.1.51",
+  "version": "3.1.52",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/activitypub/src/views/profile/components/profile-page.tsx
+++ b/apps/activitypub/src/views/profile/components/profile-page.tsx
@@ -279,7 +279,7 @@ const ProfilePage:React.FC<ProfilePageProps> = ({
                                     </>
                                 }
                                 {customFields?.map((attachment: {name: string, value: string}) => (
-                                    <span className='mt-3 line-clamp-1 flex flex-col text-[1.5rem]'>
+                                    <span key={attachment.name} className='mt-3 line-clamp-1 flex flex-col text-[1.5rem]'>
                                         <span className={`text-xs font-semibold`}>{attachment.name}</span>
                                         <span dangerouslySetInnerHTML={{__html: sanitizeHtml(attachment.value)}} className='ap-profile-content truncate'/>
                                     </span>

--- a/apps/admin-x-design-system/src/global/layout/page.tsx
+++ b/apps/admin-x-design-system/src/global/layout/page.tsx
@@ -123,9 +123,9 @@ const Page: React.FC<PageProps> = ({
     const globalActions = (
         (customGlobalActions?.length || showGlobalActions) &&
         <div className='sticky flex items-center gap-7'>
-            {(customGlobalActions?.map((action) => {
+            {(customGlobalActions?.map((action, idx) => {
                 return (
-                    <Button icon={action.iconName} iconColorClass='text-black dark:text-white' size='sm' link onClick={action.onClick} />
+                    <Button key={action.iconName ?? idx} icon={action.iconName} iconColorClass='text-black dark:text-white' size='sm' link onClick={action.onClick} />
                 );
             }))}
             {showGlobalActions && <GlobalActions />}

--- a/apps/admin-x-design-system/src/global/layout/view-container.stories.tsx
+++ b/apps/admin-x-design-system/src/global/layout/view-container.stories.tsx
@@ -36,16 +36,16 @@ export default meta;
 type Story = StoryObj<typeof ViewContainer>;
 
 export const exampleActions = [
-    <Button label='Filter' outlineOnMobile onClick={() => {
+    <Button key='filter' label='Filter' outlineOnMobile onClick={() => {
         alert('Clicked filter');
     }} />,
-    <Button label='Sort' outlineOnMobile onClick={() => {
+    <Button key='sort' label='Sort' outlineOnMobile onClick={() => {
         alert('Clicked sort');
     }} />,
-    <Button icon='magnifying-glass' iconSize='sm' outlineOnMobile onClick={() => {
+    <Button key='search' icon='magnifying-glass' iconSize='sm' outlineOnMobile onClick={() => {
         alert('Clicked search');
     }} />,
-    <ButtonGroup buttons={[
+    <ButtonGroup key='view-toggle' buttons={[
         {
             icon: 'listview',
             size: 'sm',
@@ -156,10 +156,10 @@ export const TabsWithPrimaryAction: Story = {
 };
 
 const sectionActions = [
-    <Button label='Filter' size='sm' onClick={() => {
+    <Button key='filter' label='Filter' size='sm' onClick={() => {
         alert('Clicked filter');
     }} />,
-    <ButtonGroup buttons={[
+    <ButtonGroup key='view-toggle' buttons={[
         {
             icon: 'listview',
             size: 'sm',

--- a/apps/admin-x-design-system/src/global/table/dynamic-table.stories.tsx
+++ b/apps/admin-x-design-system/src/global/table/dynamic-table.stories.tsx
@@ -64,7 +64,7 @@ export const testRows = (noOfRows: number) => {
                     alert('Clicked on row: ' + i);
                 },
                 cells: [
-                    (<div className='flex items-center gap-2'>
+                    (<div key='member' className='flex items-center gap-2'>
                         {i % 3 === 0 && <Avatar bgColor='green' label='JL' labelColor='white' />}
                         {i % 3 === 1 && <Avatar bgColor='orange' label='GS' labelColor='white' />}
                         {i % 3 === 2 && <Avatar bgColor='black' label='ZB' labelColor='white' />}
@@ -83,7 +83,7 @@ export const testRows = (noOfRows: number) => {
                     'Subscribed',
                     'Monthly',
                     '1,303',
-                    <Button color='green' label='Edit' link onClick={() => {
+                    <Button key='edit' color='green' label='Edit' link onClick={() => {
                         alert('Clicked Edit in row:' + i);
                     }} />
                 ]

--- a/apps/admin-x-settings/src/components/settings/advanced/history-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/history-modal.tsx
@@ -227,6 +227,7 @@ const HistoryModal = NiceModal.create<RoutingModalProps>(({params}) => {
                             <>
                                 <InfiniteScrollListener offset={250} onTrigger={fetchNext} />
                                 {data.actions.map(action => !action.skip && <ListItem
+                                    key={action.id}
                                     avatar={<HistoryAvatar action={action} />}
                                     detail={[
                                         new Date(action.created_at).toLocaleDateString('default', {year: 'numeric', month: 'short', day: '2-digit'}),

--- a/apps/admin-x-settings/src/components/settings/advanced/integrations.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/integrations.tsx
@@ -196,6 +196,7 @@ const CustomIntegrations: React.FC<{integrations: Integration[]}> = ({integratio
             <List borderTop={false}>
                 {integrations.map(integration => (
                     <IntegrationItem
+                        key={integration.id}
                         action={() => updateRoute({route: `integrations/${integration.id}`})}
                         detail={<div className="line-clamp-2 break-words">
                             <span title={`${integration.name}: ${integration.description || 'No description'}`}>{integration.description || 'No description'}</span>

--- a/apps/admin-x-settings/src/components/settings/advanced/integrations/webhooks-table.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/integrations/webhooks-table.tsx
@@ -38,7 +38,7 @@ const WebhooksTable: React.FC<{integration: Integration}> = ({integration}) => {
                 <TableHead>Last triggered</TableHead>
             </TableRow>
             {integration.webhooks?.map(webhook => (
-                <TableRow action={
+                <TableRow key={webhook.id} action={
                     <Button color='red' label='Delete' link onClick={(e) => {
                         e?.stopPropagation();
                         handleDelete(webhook.id);

--- a/apps/admin-x-settings/src/components/settings/advanced/integrations/zapier-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/integrations/zapier-modal.tsx
@@ -111,6 +111,7 @@ const ZapierModal = NiceModal.create(() => {
             <List>
                 {zapierTemplates.map(template => (
                     <ListItem
+                        key={template.url}
                         action={<Button className='font-semibold whitespace-nowrap text-[#FF4A00]' href={template.url} label='Use this Zap' tag='a' target='_blank' link unstyled />}
                         bgOnHover={false}
                         className='flex items-center gap-3 py-2 pl-3'

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/newsletters-list.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/newsletters-list.tsx
@@ -95,7 +95,7 @@ const NewslettersList: React.FC<NewslettersListProps> = ({newsletters, isLoading
     } else if (newsletters.length) {
         return <Table>
             {newsletters.map(newsletter => (
-                <NewsletterItemContainer id={newsletter.id}>
+                <NewsletterItemContainer key={newsletter.id} id={newsletter.id}>
                     <NewsletterItem newsletter={newsletter} />
                 </NewsletterItemContainer>
             ))}

--- a/apps/admin-x-settings/src/components/settings/site/theme/official-themes.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/official-themes.tsx
@@ -92,7 +92,7 @@ const OfficialThemes: React.FC<{
                                 <Heading level={4}>{theme.name}</Heading>
                                 {showVariants ?
                                     variants.map((variant, idx) => (
-                                        <span className={clsx('absolute left-0 translate-y-px text-grey-700 opacity-0', {
+                                        <span key={variant.category} className={clsx('absolute left-0 translate-y-px text-grey-700 opacity-0', {
                                             'opacity-100': idx === visibleVariantIdx && isVariantLooping || !isVariantLooping && idx === 0
                                         })}>{variant.category}</span>
                                     )) :

--- a/apps/admin-x-settings/src/utils/search.tsx
+++ b/apps/admin-x-settings/src/utils/search.tsx
@@ -79,7 +79,15 @@ const useSearchService = () => {
             const wordsPattern = words.map(word => word.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');
             const parts = text.split(new RegExp(`(${wordsPattern})`, 'gi'));
 
-            return parts.map(part => (words.includes(part.toLowerCase()) ? <span className='bg-yellow-500/40'>{part}</span> : part));
+            const seen = new Map<string, number>();
+            return parts.map((part) => {
+                if (!words.includes(part.toLowerCase())) {
+                    return part;
+                }
+                const occurrence = (seen.get(part) ?? 0) + 1;
+                seen.set(part, occurrence);
+                return <span key={`${part}-${occurrence}`} className='bg-yellow-500/40'>{part}</span>;
+            });
         } else if (Array.isArray(text)) {
             return text.map(part => highlightKeywords(part));
         } else if (text && typeof text === 'object' && text) {

--- a/apps/shade/src/components/ui/data-list.stories.tsx
+++ b/apps/shade/src/components/ui/data-list.stories.tsx
@@ -21,11 +21,11 @@ export const Default: Story = {
     args: {
         className: '',
         children: [
-            <DataListHeader>
+            <DataListHeader key='header'>
                 <DataListHead>Title</DataListHead>
                 <DataListHead>Visitors</DataListHead>
             </DataListHeader>,
-            <DataListBody className='group/datalist'>
+            <DataListBody key='body' className='group/datalist'>
                 <DataListRow>
                     <DataListBar />
                     <DataListItemContent>
@@ -96,7 +96,7 @@ export const Default: Story = {
 export const WithoutHeader: Story = {
     args: {
         children: [
-            <DataListBody className='group/datalist'>
+            <DataListBody key='body' className='group/datalist'>
                 <DataListRow>
                     <DataListBar style={{width: '100%'}} />
                     <DataListItemContent>

--- a/apps/shade/src/components/ui/popover.stories.tsx
+++ b/apps/shade/src/components/ui/popover.stories.tsx
@@ -29,7 +29,7 @@ export const Default: Story = {
     },
     args: {
         children: [
-            <div style={{height: 400}}>
+            <div key='popover-demo' style={{height: 400}}>
                 <Popover>
                     <PopoverTrigger asChild>
                         <Button variant="outline">Open popover</Button>
@@ -58,7 +58,7 @@ export const Placement: Story = {
     },
     args: {
         children: [
-            <div style={{display: 'flex', gap: 12, flexWrap: 'wrap', minHeight: 120}}>
+            <div key='placement-demo' style={{display: 'flex', gap: 12, flexWrap: 'wrap', minHeight: 120}}>
                 {(['top', 'right', 'bottom', 'left'] as const).map(side => (
                     <Popover key={side}>
                         <PopoverTrigger asChild>

--- a/eslint.shared.mjs
+++ b/eslint.shared.mjs
@@ -93,7 +93,7 @@ export const reactStrictRules = {
     }],
     'react/button-has-type': 'error',
     'react/no-array-index-key': 'error',
-    'react/jsx-key': 'off'  // TODO: 22 legacy violations across 4 workspaces; flip back to error after cleanup
+    'react/jsx-key': 'error'
 };
 
 // Tailwind v4 ruleset (settings-based config).


### PR DESCRIPTION
Added missing `key` props to JSX iterators in 13 files across 4 workspaces, then flipped `'react/jsx-key'` from `'off'` (legacy TODO) to `'error'` in [eslint.shared.mjs](eslint.shared.mjs) so the rule guards going forward.

**Breakdown:**
- `admin-x-design-system`: 9 (page.tsx + view-container.stories.tsx + dynamic-table.stories.tsx)
- `admin-x-settings`:      7 (history-modal, integrations, webhooks-table, zapier-modal, newsletters-list, official-themes, search)
- `activitypub`:           1 (profile-page.tsx)
- `shade`:                 5 (data-list.stories.tsx + popover.stories.tsx)

**Key choices:**
- Production code: stable IDs where available (`item.id`, `item.iconName`, `variant.category`); index fallback only when needed
- Stories files: literal semantic keys (`'header'`, `'body'`, `'popover-demo'`, etc.) since the JSX arrays are static demo content
- `search.tsx`: regex-split parts can contain duplicates, so an occurrence Map disambiguates (`'foo-1'`, `'foo-2'`) — straight index would trigger `react/no-array-index-key` (still at error)

Lint sweep across all 12 React workspaces: clean.