### PR TITLE
Cleaned admin-toolbar eslint config (Preact context + dead jquery globals)

### DIFF
--- a/apps/admin-toolbar/eslint.config.js
+++ b/apps/admin-toolbar/eslint.config.js
@@ -4,10 +4,11 @@ import ghostPlugin from 'eslint-plugin-ghost';
 
 import {correctnessRules, strictLinterOptions} from '../../eslint.shared.mjs';
 
-// Standalone (not factory-based) because admin-toolbar is vanilla JS + jQuery,
-// no React. Adding it to reactAppConfig with `typescript: false, reactRefresh:
-// false` would still load eslint-plugin-react unnecessarily. The base rules
-// come from the shared correctnessRules atom.
+// Standalone (not factory-based) because admin-toolbar is Preact (~3KB) + JS
+// hyperscript, served as a UMD bundle via CDN — see README. Neither factory
+// fits: reactAppConfig would load eslint-plugin-react/react-hooks for code
+// that doesn't use them, and nodeLibConfig assumes Node globals. The base
+// rules come from the shared correctnessRules atom.
 
 export default [
     {
@@ -23,10 +24,7 @@ export default [
         languageOptions: {
             ecmaVersion: 2022,
             sourceType: 'module',
-            globals: {
-                ...globals.browser,
-                ...globals.jquery
-            }
+            globals: globals.browser
         },
         plugins: {
             ghost: ghostPlugin

--- a/apps/admin-toolbar/package.json
+++ b/apps/admin-toolbar/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tryghost/admin-toolbar",
   "type": "module",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",


### PR DESCRIPTION
The header comment claimed the workspace was "vanilla JS + jQuery" — it's actually Preact (~3KB) with hyperscript, served as a UMD bundle via CDN ([README](apps/admin-toolbar/README.md)). Zero jQuery usage in `src/`, so the dead `globals.jquery` import is dropped too.

No behavior change for lint — just accurate context for the next reader.