### PR TITLE
🐛 Fixed Safari bug where automations list wasn't clickable

### DIFF
--- a/apps/posts/src/views/Automations/components/automations-list.tsx
+++ b/apps/posts/src/views/Automations/components/automations-list.tsx
@@ -55,7 +55,7 @@ const AutomationsList: React.FC<AutomationsListProps> = ({automations = [], isLo
                             className="grid w-full cursor-pointer grid-cols-[1fr_auto] items-center gap-x-4 p-2 lg:table-row lg:p-0"
                             data-testid="automation-list-row"
                         >
-                            <TableCell className="static min-w-0 lg:p-4">
+                            <TableCell className="min-w-0 lg:p-4">
                                 <Link
                                     className="before:absolute before:inset-0 before:z-10 before:rounded-sm focus-visible:outline-hidden focus-visible:before:ring-2 focus-visible:before:ring-focus-ring"
                                     to={`/automations/${automation.id}`}


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1379

The automations list had a Safari-exclusive bug: only the last automation in the list was clickable. This fixes that.

I admit I don't perfectly understand this fix, but I *think* it's because [Shade's table cells are `position: relative` by default][0], and our override caused a problem. I think Safari was misplacing a `::before` pseudo-element, making everything but the last unclickable.

Before:

https://github.com/user-attachments/assets/33f0a458-4b8b-44b6-b83a-d1a87c8bbf5b

After:

https://github.com/user-attachments/assets/bf0848d4-cea5-4bb5-9636-25874a206b18

[0]: https://github.com/TryGhost/Ghost/blob/61861902d327436c9aad7b0431f823ad347ec1ae/apps/shade/src/components/ui/table.tsx#L123
