### PR TITLE
Added Nx self-healing CI steps to the test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,6 +421,9 @@ jobs:
         # (ghost core's test:unit job requires sqlite3)
         run: pnpm install --frozen-lockfile --force
 
+      - name: Start Nx Cloud CI run
+        run: npx nx start-ci-run
+
       - name: Set timezone (non-UTC)
         uses: szenius/set-timezone@1f9716b0f7120e344f0c62bb7b1ee98819aefd42 # v2.0
         with:
@@ -458,6 +461,10 @@ jobs:
             git diff
             exit 1
           fi
+
+      - name: Nx fix-ci
+        if: always()
+        run: npx nx fix-ci
 
       - uses: tryghost/actions/actions/slack-build@acee0acf6c537eca953cb54ee843eaa1c3d91f01 # main
         if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -534,6 +541,9 @@ jobs:
             pnpm install --frozen-lockfile
           fi
 
+      - name: Start Nx Cloud CI run
+        run: npx nx start-ci-run
+
       - name: Set timezone (non-UTC)
         uses: szenius/set-timezone@1f9716b0f7120e344f0c62bb7b1ee98819aefd42 # v2.0
         with:
@@ -604,6 +614,10 @@ jobs:
             ghost/*/coverage-e2e/cobertura-coverage.xml
             ghost/*/coverage-integration/cobertura-coverage.xml
 
+      - name: Nx fix-ci
+        if: always()
+        run: npx nx fix-ci
+
       - uses: tryghost/actions/actions/slack-build@acee0acf6c537eca953cb54ee843eaa1c3d91f01 # main
         if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
         with:
@@ -667,6 +681,9 @@ jobs:
             pnpm install --frozen-lockfile
           fi
 
+      - name: Start Nx Cloud CI run
+        run: npx nx start-ci-run
+
       - name: Set env vars (SQLite)
         if: contains(matrix.env.DB, 'sqlite')
         run: echo "database__connection__filename=/dev/shm/ghost-test.db" >> $GITHUB_ENV
@@ -689,6 +706,10 @@ jobs:
             git diff
             exit 1
           fi
+
+      - name: Nx fix-ci
+        if: always()
+        run: npx nx fix-ci
 
       - uses: tryghost/actions/actions/slack-build@acee0acf6c537eca953cb54ee843eaa1c3d91f01 # main
         if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
Wires the canonical Nx self-healing CI pattern into the three test jobs (`job_unit-tests`, `job_acceptance-tests`, `job_legacy-tests`). Each gets `npx nx start-ci-run` after dependency install and `npx nx fix-ci` with `if: always()` as the final step.

This is in response to a SIGSEGV in `nx run` that took down [Acceptance tests on PR #28872](https://github.com/TryGhost/Ghost/actions/runs/28115689749/job/83254780565) (and the same signature on two other unrelated PRs in the same hour). The crash is at process startup, before any test code runs — no stack, just `undefined` in stdout. `useDaemonProcess: false` and `DISABLE_V8_COMPILE_CACHE: 1` are already on, so the usual workarounds are already applied. Self-healing CI is the next lever — Nx Cloud can auto-retry failed tasks on a new agent.

There's already precedent for this kind of crash: the unit-test job has a hand-rolled 3-attempt retry loop ([ci.yml:432-440](https://github.com/TryGhost/Ghost/blob/main/.github/workflows/ci.yml#L432-L440)) with the comment "ghost/core's vitest run intermittently crashes a worker on loaded CI runners — an abnormal process exit, not a reported test failure. ... Interim stopgap until the vitest worker/teardown issue is fixed." `nx fix-ci` is intended to supersede that, but **the manual retry loop is left in place for one CI cycle** as belt-and-suspenders. Plan is a follow-up PR to drop the loop once fix-ci is proven to catch the same crashes.

## Prereq

Self-Healing CI must be toggled on in the Nx Cloud workspace settings (admin UI, not in repo). `nxCloudId` is already wired in [nx.json:72](https://github.com/TryGhost/Ghost/blob/main/nx.json#L72) so the connection exists.

If `NX_CLOUD_ACCESS_TOKEN` is needed (e.g. for write access to record runs), that needs to be added as a repo secret — the docs suggest the VCS integration handles this without an explicit token, but worth verifying on the first run.

## Test plan

- [ ] One CI cycle passes with the new steps in place — confirms `start-ci-run` and `fix-ci` execute without error
- [ ] Verify in Nx Cloud dashboard that runs are being recorded
- [ ] If a future flake occurs, confirm fix-ci attempts a retry
- [ ] Follow-up: drop the manual retry loop in `job_unit-tests` once the above is confirmed