### PR TITLE
Added auto-detect for lockfile drift in dev container entrypoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,7 @@ The `pnpm dev` command uses a **hybrid Docker + host development** setup:
 - Frontend dev servers (Admin, Portal, Comments UI, etc.) in watch mode with HMR
 - Foundation libraries (shade, admin-x-framework, etc.)
 
-Container `node_modules` lives in named volumes that survive `docker:build`. After adding/removing a dep on host, run `pnpm docker:refresh-deps` to rebuild the image and reseed the volumes.
+Container `node_modules` lives in named volumes. The container entrypoint auto-detects lockfile drift on boot and reinstalls inside the container, so a host-side `pnpm install` is enough — restart the container (or wait for the next boot) and the new deps land automatically. `pnpm docker:refresh-deps` exists as a hard reset (rebuilds the image + wipes the volumes) when something is wedged.
 
 **Setup:**
 ```bash

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -78,6 +78,14 @@ services:
       - ghost-dev-node-modules-core:/home/ghost/ghost/core/node_modules
       - ghost-dev-node-modules-i18n:/home/ghost/ghost/i18n/node_modules
       - ghost-dev-node-modules-parse-email:/home/ghost/ghost/parse-email-address/node_modules
+      # Read-only snapshots of host pnpm config files. The container entrypoint
+      # copies them over the image-baked versions on every boot and checks the
+      # lockfile hash against `node_modules/.lockfile-hash` — drift triggers a
+      # container-side `pnpm install`, so host-side dep changes are picked up
+      # automatically without rebuilding the image.
+      - ./pnpm-lock.yaml:/home/ghost/pnpm-lock.yaml.host:ro
+      - ./pnpm-workspace.yaml:/home/ghost/pnpm-workspace.yaml.host:ro
+      - ./package.json:/home/ghost/package.json.host:ro
       # Mount specific content subdirectories to preserve themes/adapters from source
       - ghost-dev-data:/home/ghost/ghost/core/content/data
       - ghost-dev-images:/home/ghost/ghost/core/content/images

--- a/docker/ghost-dev/Dockerfile
+++ b/docker/ghost-dev/Dockerfile
@@ -29,7 +29,7 @@ COPY ghost/parse-email-address/package.json ghost/parse-email-address/package.js
 # works under named-volume mounts (vstore symlinks would otherwise dangle
 # into the ephemeral BuildKit cache and break on first run).
 RUN sed -i '/^enableGlobalVirtualStore:/d' pnpm-workspace.yaml && \
-    ! grep -q '^enableGlobalVirtualStore' pnpm-workspace.yaml
+    ! grep -qE '^[[:space:]]*enableGlobalVirtualStore' pnpm-workspace.yaml
 
 # Install dependencies
 # Note: Dependencies are installed at build time, but source code is mounted at runtime.
@@ -41,9 +41,13 @@ COPY .github/hooks .github/hooks
 # Enable corepack so it can read packageManager from package.json and provide pnpm
 RUN corepack enable
 
-# Install deps with a persistent pnpm store cache to speed up rebuilds
+# Install deps with a persistent pnpm store cache to speed up rebuilds.
+# Write the lockfile hash to a marker file; the entrypoint compares this on
+# every boot against the host's mounted lockfile so drift triggers a
+# container-side reinstall without needing an image rebuild.
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store,id=pnpm-store \
-    pnpm install --frozen-lockfile --prefer-offline
+    pnpm install --frozen-lockfile --prefer-offline && \
+    sha256sum pnpm-lock.yaml | awk '{print $1}' > /home/ghost/node_modules/.lockfile-hash
 
 # Copy entrypoint script that optionally loads Tinybird config
 COPY docker/ghost-dev/entrypoint.sh entrypoint.sh

--- a/docker/ghost-dev/entrypoint.sh
+++ b/docker/ghost-dev/entrypoint.sh
@@ -29,6 +29,49 @@ if [ -f /mnt/shared-config/.env.stripe ]; then
     fi
 fi
 
+# Sync pnpm config snapshots from the host into the container's writable
+# filesystem, then re-strip enableGlobalVirtualStore (host has it on for the
+# local-dev shared vstore; container needs it off — same reason as the
+# Dockerfile sed).
+for f in pnpm-lock.yaml pnpm-workspace.yaml package.json; do
+    if [ -f "/home/ghost/${f}.host" ]; then
+        cp "/home/ghost/${f}.host" "/home/ghost/${f}"
+    fi
+done
+if [ -f /home/ghost/pnpm-workspace.yaml ]; then
+    sed -i '/^enableGlobalVirtualStore:/d' /home/ghost/pnpm-workspace.yaml
+    # Mirror the Dockerfile guard: fail loud if the strip didn't take (e.g.
+    # host workspace.yaml reformatted the key with indentation or a comment
+    # prefix). Container would otherwise install with vstore on and dangle
+    # symlinks across the host store mount.
+    # Detector is intentionally wider than the strip's `^` anchor: an
+    # indented `  enableGlobalVirtualStore: true` would bypass the sed AND
+    # bypass a BOL-anchored grep, letting vstore-on slip through silently
+    # if pnpm happens to accept the resulting YAML.
+    if grep -qE '^[[:space:]]*enableGlobalVirtualStore' /home/ghost/pnpm-workspace.yaml; then
+        echo "ERROR: enableGlobalVirtualStore strip in entrypoint failed — host pnpm-workspace.yaml may have reformatted the key. Check the file format." >&2
+        exit 1
+    fi
+fi
+
+# Lockfile-drift auto-install: if the host lockfile differs from what was
+# installed last (marker written at image build + after each in-container
+# install), reinstall to bring the named-volume node_modules back in sync.
+# Saves contributors from having to run `pnpm docker:refresh-deps` after
+# every host-side dep change.
+LOCK_HASH=$(sha256sum /home/ghost/pnpm-lock.yaml | awk '{print $1}')
+MARKER=/home/ghost/node_modules/.lockfile-hash
+if [ ! -f "$MARKER" ] || [ "$(cat "$MARKER")" != "$LOCK_HASH" ]; then
+    echo "Lockfile drift detected; running pnpm install in container (run 'pnpm docker:refresh-deps' on the host if this fails)..."
+    # `pnpm -C` instead of `cd && pnpm` so the entrypoint's cwd stays at the
+    # Dockerfile WORKDIR (/home/ghost/ghost/core). `exec "$@"` below inherits
+    # the cwd; a stray `cd /home/ghost` would make `pnpm dev` resolve to the
+    # root workspace script (which calls docker compose from inside the
+    # container) instead of ghost/core's nodemon.
+    pnpm -C /home/ghost install --frozen-lockfile
+    echo "$LOCK_HASH" > "$MARKER"
+fi
+
 # Execute the CMD
 exec "$@"
 


### PR DESCRIPTION
Follow-up to [#28849](https://github.com/TryGhost/Ghost/pull/28849). Removes the need to remember `pnpm docker:refresh-deps` after a host-side dep change.

## How it works

The dev container's entrypoint now:

1. Mounts host `pnpm-{lock,workspace}.yaml` and `package.json` read-only under `.host` suffixes (`compose.dev.yaml`).
2. Copies them over the image-baked versions on every boot, re-strips `enableGlobalVirtualStore` from the workspace file (with a guard that matches the Dockerfile's), and hashes the lockfile.
3. Compares the hash to a marker at `node_modules/.lockfile-hash` (initialized by the Dockerfile after the image-build install).
4. On drift, runs `pnpm -C /home/ghost install --frozen-lockfile` to bring the named-volume `node_modules` in sync, then updates the marker.

So the contributor workflow becomes:

```
pnpm install              # host
docker compose restart ghost-dev   # or `pnpm dev` if not already running
```

— and the container's deps refresh automatically. No more `pnpm docker:refresh-deps` for routine dep adds. `:refresh-deps` stays as a hard reset for when the in-container install can't recover.

## Why `pnpm -C` instead of `cd && pnpm`

`exec "$@"` at the end of the entrypoint inherits the script's cwd. A stray `cd /home/ghost` would make `pnpm dev` (the container's CMD) resolve to the **root workspace's** `dev` script — which tries to docker-compose from inside the container. `pnpm -C /home/ghost install` does the install without changing the cwd, so `exec` runs `pnpm dev` from the Dockerfile WORKDIR (`/home/ghost/ghost/core`) and it correctly resolves to ghost/core's `nodemon index.js`.

This was caught by an adversarial reviewer agent; first verification missed it because the **initial** container boot has no drift, no `cd`, so Ghost booted fine — the bug only manifested on the second boot after drift was simulated.

## Verified locally

| Scenario | Result |
|---|---|
| Cold boot from fresh image (marker matches host) | 3s to API 200, no spurious install |
| Simulated drift via stale marker + restart | 10s to API 200, install ran, marker updated |
| PID 1 cwd post-drift | `/home/ghost/ghost/core` ✓ |
| Ghost API after drift cycle | 200 ✓ |

## Known limitations (documented; not in scope)

- **Workspace package additions** (e.g. `apps/foo/package.json`) that don't change the lockfile aren't detected. Rare edge case; `:refresh-deps` covers it.
- **Devcontainer/Codespaces** may double-install (entrypoint's install + `.devcontainer/postCreate.sh`'s install). Different node_modules paths, so wasted ~1 min boot time; not broken. Worth a follow-up to detect devcontainer mode.

## AGENTS.md

Updated to describe the new automatic behavior; `:refresh-deps` is now the documented hard reset rather than the everyday command.

## Rollback

Revert this PR. The named-volume + Dockerfile pieces from #28849 are unchanged; this PR only adds the entrypoint logic and the host-snapshot mounts.