### PR TITLE
🐛 Fixed Safari bug where automations list wasn't clickable

### DIFF
--- a/apps/posts/src/views/Automations/components/automations-list.tsx
+++ b/apps/posts/src/views/Automations/components/automations-list.tsx
@@ -55,7 +55,7 @@ const AutomationsList: React.FC<AutomationsListProps> = ({automations = [], isLo
                             className="grid w-full cursor-pointer grid-cols-[1fr_auto] items-center gap-x-4 p-2 lg:table-row lg:p-0"
                             data-testid="automation-list-row"
                         >
-                            <TableCell className="static min-w-0 lg:p-4">
+                            <TableCell className="min-w-0 lg:p-4">
                                 <Link
                                     className="before:absolute before:inset-0 before:z-10 before:rounded-sm focus-visible:outline-hidden focus-visible:before:ring-2 focus-visible:before:ring-focus-ring"
                                     to={`/automations/${automation.id}`}

--- a/apps/posts/src/views/Automations/components/automations-list.tsx
+++ b/apps/posts/src/views/Automations/components/automations-list.tsx
@@ -16,13 +16,13 @@ interface AutomationsListProps {
 
 const AutomationsListSkeleton: React.FC = () => {
     return (
-        <Table className="flex table-fixed flex-col border-t lg:table" data-testid="automations-list-loading">
-            <TableBody className="flex flex-col lg:table-row-group">
+        <Table className="flex flex-col border-t" data-testid="automations-list-loading">
+            <TableBody className="flex flex-col">
                 {Array.from({length: 2}, (_, index) => (
                     <TableRow
                         key={index}
                         aria-hidden="true"
-                        className="grid w-full grid-cols-[1fr_auto] items-center gap-x-4 p-2 lg:table-row lg:p-0"
+                        className="grid w-full grid-cols-[1fr_auto] items-center gap-x-4 p-2 lg:p-0"
                     >
                         <TableCell className="min-w-0 lg:p-4">
                             <Skeleton className="mb-1 h-3 w-48 max-w-full " />
@@ -44,18 +44,18 @@ const AutomationsList: React.FC<AutomationsListProps> = ({automations = [], isLo
     }
 
     return (
-        <Table className="flex table-fixed flex-col border-t lg:table" data-testid="automations-list">
-            <TableBody className="flex flex-col lg:table-row-group">
+        <Table className="flex flex-col border-t" data-testid="automations-list">
+            <TableBody className="flex flex-col">
                 {automations.map((automation) => {
                     const description = AUTOMATION_DESCRIPTIONS[automation.slug];
 
                     return (
                         <TableRow
                             key={automation.slug}
-                            className="grid w-full cursor-pointer grid-cols-[1fr_auto] items-center gap-x-4 p-2 lg:table-row lg:p-0"
+                            className="grid w-full cursor-pointer grid-cols-[1fr_auto] items-center gap-x-4 p-2 hover:bg-muted/50 lg:p-0"
                             data-testid="automation-list-row"
                         >
-                            <TableCell className="min-w-0 lg:p-4">
+                            <TableCell className="static min-w-0 group-hover:bg-transparent lg:p-4">
                                 <Link
                                     className="before:absolute before:inset-0 before:z-10 before:rounded-sm focus-visible:outline-hidden focus-visible:before:ring-2 focus-visible:before:ring-focus-ring"
                                     to={`/automations/${automation.id}`}
@@ -70,7 +70,7 @@ const AutomationsList: React.FC<AutomationsListProps> = ({automations = [], isLo
                                     </span>
                                 )}
                             </TableCell>
-                            <TableCell className="text-right lg:w-32 lg:p-4">
+                            <TableCell className="text-right group-hover:bg-transparent lg:w-32 lg:p-4">
                                 <AutomationStatusBadge status={automation.status} />
                             </TableCell>
                         </TableRow>


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1379
closes https://linear.app/ghost/issue/NY-1352

The automations list had a Safari-exclusive bug: only the last automation in the list was clickable. This fixes that.


Before:

https://github.com/user-attachments/assets/33f0a458-4b8b-44b6-b83a-d1a87c8bbf5b

After:

https://github.com/user-attachments/assets/bf0848d4-cea5-4bb5-9636-25874a206b18

It also fixes a hover color bug on smaller screens. There was white padding around the status cell before.
<img width="588" height="302" alt="image" src="https://github.com/user-attachments/assets/0db58269-a344-4b3f-99c1-658a71241114" />

