### PR TITLE
Pinned React type resolution + secretlint rule resolution under vstore

### DIFF
--- a/apps/admin-x-design-system/tsconfig.json
+++ b/apps/admin-x-design-system/tsconfig.json
@@ -17,7 +17,19 @@
       "noUnusedLocals": true,
       "noUnusedParameters": true,
       "erasableSyntaxOnly": true,
-      "noFallthroughCasesInSwitch": true
+      "noFallthroughCasesInSwitch": true,
+
+      // Pin React type resolution to this workspace's @types/react copy.
+      // See apps/shade/tsconfig.json for the full explanation — same
+      // vstore / third-party-.d.ts issue.
+      "baseUrl": ".",
+      "paths": {
+        "react": ["./node_modules/@types/react"],
+        "react/jsx-runtime": ["./node_modules/@types/react/jsx-runtime"],
+        "react/jsx-dev-runtime": ["./node_modules/@types/react/jsx-dev-runtime"],
+        "react-dom": ["./node_modules/@types/react-dom"],
+        "react-dom/client": ["./node_modules/@types/react-dom/client"]
+      }
     },
     "include": ["src"],
     "references": [{ "path": "./tsconfig.node.json" }]

--- a/apps/admin-x-framework/tsconfig.json
+++ b/apps/admin-x-framework/tsconfig.json
@@ -17,7 +17,19 @@
       "noUnusedLocals": true,
       "noUnusedParameters": true,
       "erasableSyntaxOnly": true,
-      "noFallthroughCasesInSwitch": true
+      "noFallthroughCasesInSwitch": true,
+
+      // Pin React type resolution to this workspace's @types/react copy.
+      // See apps/shade/tsconfig.json for the full explanation — same
+      // vstore / third-party-.d.ts issue.
+      "baseUrl": ".",
+      "paths": {
+        "react": ["./node_modules/@types/react"],
+        "react/jsx-runtime": ["./node_modules/@types/react/jsx-runtime"],
+        "react/jsx-dev-runtime": ["./node_modules/@types/react/jsx-dev-runtime"],
+        "react-dom": ["./node_modules/@types/react-dom"],
+        "react-dom/client": ["./node_modules/@types/react-dom/client"]
+      }
     },
     "include": ["src", "test"],
     "references": [{ "path": "./tsconfig.node.json" }]

--- a/apps/admin/tsconfig.app.json
+++ b/apps/admin/tsconfig.app.json
@@ -21,6 +21,14 @@
     "paths": {
       "@/*": ["./src/*"],
       "@test-utils/*": ["./test-utils/*"],
+      // Pin React type resolution to this workspace's @types/react copy.
+      // See apps/shade/tsconfig.json for the full explanation — same
+      // vstore / third-party-.d.ts issue.
+      "react": ["./node_modules/@types/react"],
+      "react/jsx-runtime": ["./node_modules/@types/react/jsx-runtime"],
+      "react/jsx-dev-runtime": ["./node_modules/@types/react/jsx-dev-runtime"],
+      "react-dom": ["./node_modules/@types/react-dom"],
+      "react-dom/client": ["./node_modules/@types/react-dom/client"]
     },
 
     /* Linting */

--- a/apps/shade/tsconfig.json
+++ b/apps/shade/tsconfig.json
@@ -20,7 +20,21 @@
 
         "baseUrl": ".",
         "paths": {
-            "@/*": ["./src/*"]
+            "@/*": ["./src/*"],
+            // Pin React type resolution to this workspace's @types/react copy.
+            // Third-party .d.ts in recharts/react-dropzone/etc. say
+            // `import * as React from 'react'` and only declare `react` as a
+            // peer dep — never `@types/react`. With `enableGlobalVirtualStore`
+            // their .d.ts is read from the global pnpm store, where the
+            // upward `node_modules` walk for `@types/react` never reaches
+            // this workspace, so JSX shapes degrade to the runtime `react`
+            // module and `<XAxis />` etc. stop being valid JSX components.
+            // CI disables vstore, so this is local-dev only.
+            "react": ["./node_modules/@types/react"],
+            "react/jsx-runtime": ["./node_modules/@types/react/jsx-runtime"],
+            "react/jsx-dev-runtime": ["./node_modules/@types/react/jsx-dev-runtime"],
+            "react-dom": ["./node_modules/@types/react-dom"],
+            "react-dom/client": ["./node_modules/@types/react-dom/client"]
         }
     },
     "include": ["src", "test", "scripts"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,7 +363,7 @@ overrides:
   '@xmldom/xmldom@<0.8.13': ^0.9.0
   perf-primitives: ^0.0.6
 
-packageExtensionsChecksum: sha256-gFsvptlcVXY90ntXWh9ANUP1/LYyeqXjWoDGw6BCfOY=
+packageExtensionsChecksum: sha256-IPoJpRxL0fBEspKEjXcEysDQIHnj+jbR6Pbd5k8BeSo=
 
 importers:
 
@@ -377,7 +377,7 @@ importers:
         version: 1.60.0
       '@secretlint/secretlint-rule-pattern':
         specifier: 13.0.2
-        version: 13.0.2(supports-color@5.5.0)
+        version: 13.0.2(@secretlint/secretlint-rule-preset-recommend@13.0.2)(supports-color@5.5.0)
       '@secretlint/secretlint-rule-preset-recommend':
         specifier: 13.0.2
         version: 13.0.2
@@ -431,7 +431,7 @@ importers:
         version: 6.1.3
       secretlint:
         specifier: 13.0.2
-        version: 13.0.2(supports-color@5.5.0)
+        version: 13.0.2(@secretlint/secretlint-rule-pattern@13.0.2(@secretlint/secretlint-rule-preset-recommend@13.0.2)(supports-color@5.5.0))(@secretlint/secretlint-rule-preset-recommend@13.0.2)(supports-color@5.5.0)
       semver:
         specifier: 7.8.4
         version: 7.8.4
@@ -7286,6 +7286,14 @@ packages:
 
   '@secretlint/resolver@13.0.2':
     resolution: {integrity: sha512-Ko50V0P3YAtEO20xBTczOzguBVk6+taSqkoAPHoOSdsTsSq1gzeYggY1UC8vVEHPGyRp/mb2QOuwIShdJZ8JFg==}
+    peerDependencies:
+      '@secretlint/secretlint-rule-pattern': '*'
+      '@secretlint/secretlint-rule-preset-recommend': '*'
+    peerDependenciesMeta:
+      '@secretlint/secretlint-rule-pattern':
+        optional: true
+      '@secretlint/secretlint-rule-preset-recommend':
+        optional: true
 
   '@secretlint/secretlint-rule-pattern@13.0.2':
     resolution: {integrity: sha512-ntXHndXRJLB4TEt9bGY+dKH4naOq3mHM8h4hwftg/HA1EyrmuRN8+6qPUbBzsJvZWmMd7CZBBBU7DsNERdMqCQ==}
@@ -26815,15 +26823,17 @@ snapshots:
     dependencies:
       '@secretlint/types': 13.0.2
 
-  '@secretlint/config-loader@13.0.2(supports-color@5.5.0)':
+  '@secretlint/config-loader@13.0.2(@secretlint/secretlint-rule-pattern@13.0.2(@secretlint/secretlint-rule-preset-recommend@13.0.2)(supports-color@5.5.0))(@secretlint/secretlint-rule-preset-recommend@13.0.2)(supports-color@5.5.0)':
     dependencies:
       '@secretlint/profiler': 13.0.2
-      '@secretlint/resolver': 13.0.2
+      '@secretlint/resolver': 13.0.2(@secretlint/secretlint-rule-pattern@13.0.2(@secretlint/secretlint-rule-preset-recommend@13.0.2)(supports-color@5.5.0))(@secretlint/secretlint-rule-preset-recommend@13.0.2)
       '@secretlint/types': 13.0.2
       ajv: 8.20.0
       debug: 4.4.3(supports-color@5.5.0)
       rc-config-loader: 4.1.4(supports-color@5.5.0)
     transitivePeerDependencies:
+      - '@secretlint/secretlint-rule-pattern'
+      - '@secretlint/secretlint-rule-preset-recommend'
       - supports-color
 
   '@secretlint/core@13.0.2(supports-color@5.5.0)':
@@ -26835,9 +26845,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@secretlint/formatter@13.0.2':
+  '@secretlint/formatter@13.0.2(@secretlint/secretlint-rule-pattern@13.0.2(@secretlint/secretlint-rule-preset-recommend@13.0.2)(supports-color@5.5.0))(@secretlint/secretlint-rule-preset-recommend@13.0.2)':
     dependencies:
-      '@secretlint/resolver': 13.0.2
+      '@secretlint/resolver': 13.0.2(@secretlint/secretlint-rule-pattern@13.0.2(@secretlint/secretlint-rule-preset-recommend@13.0.2)(supports-color@5.5.0))(@secretlint/secretlint-rule-preset-recommend@13.0.2)
       '@secretlint/types': 13.0.2
       '@textlint/linter-formatter': 15.7.1
       '@textlint/module-interop': 15.7.1
@@ -26849,32 +26859,40 @@ snapshots:
       table: 6.9.0
       terminal-link: 5.0.0
     transitivePeerDependencies:
+      - '@secretlint/secretlint-rule-pattern'
+      - '@secretlint/secretlint-rule-preset-recommend'
       - supports-color
 
-  '@secretlint/node@13.0.2(supports-color@5.5.0)':
+  '@secretlint/node@13.0.2(@secretlint/secretlint-rule-pattern@13.0.2(@secretlint/secretlint-rule-preset-recommend@13.0.2)(supports-color@5.5.0))(@secretlint/secretlint-rule-preset-recommend@13.0.2)(supports-color@5.5.0)':
     dependencies:
-      '@secretlint/config-loader': 13.0.2(supports-color@5.5.0)
+      '@secretlint/config-loader': 13.0.2(@secretlint/secretlint-rule-pattern@13.0.2(@secretlint/secretlint-rule-preset-recommend@13.0.2)(supports-color@5.5.0))(@secretlint/secretlint-rule-preset-recommend@13.0.2)(supports-color@5.5.0)
       '@secretlint/core': 13.0.2(supports-color@5.5.0)
-      '@secretlint/formatter': 13.0.2
+      '@secretlint/formatter': 13.0.2(@secretlint/secretlint-rule-pattern@13.0.2(@secretlint/secretlint-rule-preset-recommend@13.0.2)(supports-color@5.5.0))(@secretlint/secretlint-rule-preset-recommend@13.0.2)
       '@secretlint/profiler': 13.0.2
       '@secretlint/source-creator': 13.0.2
       '@secretlint/types': 13.0.2
       debug: 4.4.3(supports-color@5.5.0)
       p-map: 7.0.4
     transitivePeerDependencies:
+      - '@secretlint/secretlint-rule-pattern'
+      - '@secretlint/secretlint-rule-preset-recommend'
       - supports-color
 
   '@secretlint/profiler@13.0.2': {}
 
-  '@secretlint/resolver@13.0.2': {}
+  '@secretlint/resolver@13.0.2(@secretlint/secretlint-rule-pattern@13.0.2(@secretlint/secretlint-rule-preset-recommend@13.0.2)(supports-color@5.5.0))(@secretlint/secretlint-rule-preset-recommend@13.0.2)':
+    optionalDependencies:
+      '@secretlint/secretlint-rule-pattern': 13.0.2(@secretlint/secretlint-rule-preset-recommend@13.0.2)(supports-color@5.5.0)
+      '@secretlint/secretlint-rule-preset-recommend': 13.0.2
 
-  '@secretlint/secretlint-rule-pattern@13.0.2(supports-color@5.5.0)':
+  '@secretlint/secretlint-rule-pattern@13.0.2(@secretlint/secretlint-rule-preset-recommend@13.0.2)(supports-color@5.5.0)':
     dependencies:
-      '@secretlint/tester': 13.0.2(supports-color@5.5.0)
+      '@secretlint/tester': 13.0.2(@secretlint/secretlint-rule-pattern@13.0.2(@secretlint/secretlint-rule-preset-recommend@13.0.2)(supports-color@5.5.0))(@secretlint/secretlint-rule-preset-recommend@13.0.2)(supports-color@5.5.0)
       '@secretlint/types': 13.0.2
       '@textlint/regexp-string-matcher': 2.0.2
       micromatch: 4.0.8
     transitivePeerDependencies:
+      - '@secretlint/secretlint-rule-preset-recommend'
       - supports-color
 
   '@secretlint/secretlint-rule-preset-recommend@13.0.2': {}
@@ -26884,13 +26902,15 @@ snapshots:
       '@secretlint/types': 13.0.2
       istextorbinary: 9.5.0
 
-  '@secretlint/tester@13.0.2(supports-color@5.5.0)':
+  '@secretlint/tester@13.0.2(@secretlint/secretlint-rule-pattern@13.0.2(@secretlint/secretlint-rule-preset-recommend@13.0.2)(supports-color@5.5.0))(@secretlint/secretlint-rule-preset-recommend@13.0.2)(supports-color@5.5.0)':
     dependencies:
-      '@secretlint/config-loader': 13.0.2(supports-color@5.5.0)
+      '@secretlint/config-loader': 13.0.2(@secretlint/secretlint-rule-pattern@13.0.2(@secretlint/secretlint-rule-preset-recommend@13.0.2)(supports-color@5.5.0))(@secretlint/secretlint-rule-preset-recommend@13.0.2)(supports-color@5.5.0)
       '@secretlint/core': 13.0.2(supports-color@5.5.0)
       '@secretlint/source-creator': 13.0.2
       '@secretlint/types': 13.0.2
     transitivePeerDependencies:
+      - '@secretlint/secretlint-rule-pattern'
+      - '@secretlint/secretlint-rule-preset-recommend'
       - supports-color
 
   '@secretlint/types@13.0.2': {}
@@ -44817,17 +44837,19 @@ snapshots:
       ajv-formats: 2.1.1(ajv@8.20.0)
       ajv-keywords: 5.1.0(ajv@8.20.0)
 
-  secretlint@13.0.2(supports-color@5.5.0):
+  secretlint@13.0.2(@secretlint/secretlint-rule-pattern@13.0.2(@secretlint/secretlint-rule-preset-recommend@13.0.2)(supports-color@5.5.0))(@secretlint/secretlint-rule-preset-recommend@13.0.2)(supports-color@5.5.0):
     dependencies:
       '@secretlint/config-creator': 13.0.2
-      '@secretlint/formatter': 13.0.2
-      '@secretlint/node': 13.0.2(supports-color@5.5.0)
+      '@secretlint/formatter': 13.0.2(@secretlint/secretlint-rule-pattern@13.0.2(@secretlint/secretlint-rule-preset-recommend@13.0.2)(supports-color@5.5.0))(@secretlint/secretlint-rule-preset-recommend@13.0.2)
+      '@secretlint/node': 13.0.2(@secretlint/secretlint-rule-pattern@13.0.2(@secretlint/secretlint-rule-preset-recommend@13.0.2)(supports-color@5.5.0))(@secretlint/secretlint-rule-preset-recommend@13.0.2)(supports-color@5.5.0)
       '@secretlint/profiler': 13.0.2
-      '@secretlint/resolver': 13.0.2
+      '@secretlint/resolver': 13.0.2(@secretlint/secretlint-rule-pattern@13.0.2(@secretlint/secretlint-rule-preset-recommend@13.0.2)(supports-color@5.5.0))(@secretlint/secretlint-rule-preset-recommend@13.0.2)
       '@secretlint/walker': 13.0.2
       debug: 4.4.3(supports-color@5.5.0)
       read-pkg: 10.1.0
     transitivePeerDependencies:
+      - '@secretlint/secretlint-rule-pattern'
+      - '@secretlint/secretlint-rule-preset-recommend'
       - supports-color
 
   section-tests@1.3.1:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -208,6 +208,28 @@ packageExtensions:
   '@doist/react-interpolate@2.2.1':
     dependencies:
       '@babel/runtime': ^7.26.10
+  # secretlint's @secretlint/resolver does `createRequire(import.meta.url)` from
+  # its own install path, then `require.resolve('@secretlint/secretlint-rule-…')`
+  # to load rules referenced by name from `.secretlintrc.json`. Under
+  # `enableGlobalVirtualStore: true` the resolver's install path is in the
+  # global pnpm store, and the rule packages — installed only at the workspace
+  # root — aren't reachable via Node's upward `node_modules` walk from there,
+  # so the pre-commit hook (and any local `pnpm exec secretlint`) crashes with
+  # "Failed to load secretlint's rule module". Declaring the rules as optional
+  # peer deps of the resolver makes pnpm symlink them next to it in the store,
+  # so `require.resolve` succeeds. (The mirror issue for TypeScript — third-
+  # party .d.ts not finding @types/react via the vstore — is solved per-
+  # workspace via tsconfig `paths` rather than another packageExtensions block,
+  # because it only affects the consumer's typecheck.)
+  '@secretlint/resolver@13.0.2':
+    peerDependencies:
+      '@secretlint/secretlint-rule-pattern': '*'
+      '@secretlint/secretlint-rule-preset-recommend': '*'
+    peerDependenciesMeta:
+      '@secretlint/secretlint-rule-pattern':
+        optional: true
+      '@secretlint/secretlint-rule-preset-recommend':
+        optional: true
 minimumReleaseAgeExclude:
   # Our own packages are published by us, so the release-age delay doesn't apply
   - "@tryghost/*"


### PR DESCRIPTION
## Why

[#28849](https://github.com/TryGhost/Ghost/pull/28849) turned on `enableGlobalVirtualStore: true`. Each dep's `node_modules` now lives under `~/Library/pnpm/store/v11/links/...`, and Node's upward `node_modules` walk from there never reaches the workspace's hoisted tree. Two things that quietly relied on that walk broke:

1. **TypeScript's `@types/react` lookup from third-party `.d.ts`.** `recharts`, `react-dropzone`, `react-select`, `@dnd-kit/core`, `@ebay/nice-modal-react`, `@sentry/react`, and `lucide-react` all `import * as React from 'react'` in their declaration files and declare only `react` / `react-dom` as peers — never `@types/react`. From the global-store path the walk never finds the workspace's `@types/react`, so JSX shapes degrade to the runtime `react` module and `'XAxis' cannot be used as a JSX component` (and friends) fire across `shade` / `admin-x-design-system` / `admin-x-framework` / `admin`.

2. **secretlint's rule resolver.** `@secretlint/resolver` does `createRequire(import.meta.url)` from its own store path, then `require.resolve('@secretlint/secretlint-rule-…')` for the rules listed in `.secretlintrc.json`. The rule packages live only at the workspace root, the walk-up from the store never reaches them, and `pnpm exec secretlint` (including the pre-commit hook) crashes with `Failed to load secretlint's rule module`.

The Nx remote cache hid (1) for everyone — CI keeps vstore off via `pnpm_config_enable_global_virtual_store=false`, so the broken local build was always masked by cached good artifacts. A fresh worktree without a warm cache reproduces it immediately.

## What changes

**(1) TS resolution — `tsconfig paths` per workspace.** TypeScript applies the consumer project's `paths` to every module specifier it sees, including ones inside imported third-party `.d.ts`. Pinning `react` / `react-dom` to `./node_modules/@types/react*` in each affected workspace's `tsconfig.json` forces recharts's `import * as React from 'react'` (and friends) to resolve against the workspace's own copy regardless of where the `.d.ts` lives on disk. Scoped to the four workspaces that actually surface the failure today:

- [apps/shade/tsconfig.json](apps/shade/tsconfig.json)
- [apps/admin-x-design-system/tsconfig.json](apps/admin-x-design-system/tsconfig.json)
- [apps/admin-x-framework/tsconfig.json](apps/admin-x-framework/tsconfig.json)
- [apps/admin/tsconfig.app.json](apps/admin/tsconfig.app.json)

**(2) secretlint resolution — one `packageExtensions` block.** Declared the two secretlint rule packages as optional peer deps of `@secretlint/resolver`. pnpm then symlinks them next to the resolver in the store and the runtime `require.resolve` walk finds them.

## Verification

```bash
pnpm nx reset && pnpm lint --skipNxCache
# NX   Successfully ran target lint for 19 projects and 4 tasks they depend on

echo test | pnpm exec secretlint --stdinFileName=test.txt; echo $?
# 0
```

## Tradeoff vs the alternative

An earlier draft of this PR (commit `8278877b25` on this branch's history) declared `@types/react` as an optional peer of all seven leaky upstreams via `packageExtensions`. That works but moves the fix into pnpm's resolution layer and bloats the lockfile by ~150 lines + a new hash per package in the global store. The current approach keeps the fix in the consumer's tsconfig where TS already expects to read `paths` — smaller blast radius, no lockfile churn, but has to be re-stamped into any new React-using workspace going forward. Repetition is mechanical; the existing four files document the pattern.

CI is unaffected either way because vstore stays off there.