### PR TITLE
Fixed global virtual store package resolution

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,7 +363,7 @@ overrides:
   '@xmldom/xmldom@<0.8.13': ^0.9.0
   perf-primitives: ^0.0.6
 
-packageExtensionsChecksum: sha256-gFsvptlcVXY90ntXWh9ANUP1/LYyeqXjWoDGw6BCfOY=
+packageExtensionsChecksum: sha256-joxbkdxF/Ld/13fnjoxE4XsHHFPqETTooUKCHz896IQ=
 
 importers:
 
@@ -761,7 +761,7 @@ importers:
         version: 2.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-select:
         specifier: 5.10.2
-        version: 5.10.2(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 5.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@codemirror/lang-html':
         specifier: 6.4.11
@@ -1093,7 +1093,7 @@ importers:
         version: 2.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-select:
         specifier: 5.10.2
-        version: 5.10.2(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 5.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       sonner:
         specifier: 'catalog:'
         version: 2.0.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -7293,6 +7293,14 @@ packages:
 
   '@secretlint/secretlint-rule-preset-recommend@13.0.2':
     resolution: {integrity: sha512-D03Kw51qOgffj9zNlJFZUarVmP8zGcCZNi7A14+vZtHskbbBPEsS/f09idb48rrlMSaRMBN29IkqfbmPyL9xtw==}
+    engines: {node: '>=22.0.0'}
+
+  '@secretlint/secretlint-rule-privatekey@13.0.2':
+    resolution: {integrity: sha512-u/dIkif3oflAzZDJmoXChyfMzgBqZzj3jqa4rRgrkv8baeMTocjyVnDGdCj/YzKUXN2zKXi81z+h0Lz3C/WLSw==}
+    engines: {node: '>=22.0.0'}
+
+  '@secretlint/secretlint-rule-stripe@13.0.2':
+    resolution: {integrity: sha512-/pThB12CiJix90JYxM5TTCsy3Re8JYnD/25KIiUHY35Gi0m+uOlbAYI9+o4+jq1SKatt9xtbR0OngO4tYjamRg==}
     engines: {node: '>=22.0.0'}
 
   '@secretlint/source-creator@13.0.2':
@@ -23880,6 +23888,8 @@ snapshots:
     dependencies:
       '@dnd-kit/accessibility': 3.1.1(react@18.3.1)
       '@dnd-kit/utilities': 3.2.2(react@18.3.1)
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.8.1
@@ -23904,6 +23914,8 @@ snapshots:
 
   '@ebay/nice-modal-react@1.2.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
@@ -26866,7 +26878,14 @@ snapshots:
 
   '@secretlint/profiler@13.0.2': {}
 
-  '@secretlint/resolver@13.0.2': {}
+  '@secretlint/resolver@13.0.2':
+    dependencies:
+      '@secretlint/secretlint-rule-pattern': 13.0.2(supports-color@5.5.0)
+      '@secretlint/secretlint-rule-preset-recommend': 13.0.2
+      '@secretlint/secretlint-rule-privatekey': 13.0.2
+      '@secretlint/secretlint-rule-stripe': 13.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   '@secretlint/secretlint-rule-pattern@13.0.2(supports-color@5.5.0)':
     dependencies:
@@ -26878,6 +26897,15 @@ snapshots:
       - supports-color
 
   '@secretlint/secretlint-rule-preset-recommend@13.0.2': {}
+
+  '@secretlint/secretlint-rule-privatekey@13.0.2':
+    dependencies:
+      '@textlint/regexp-string-matcher': 2.0.2
+
+  '@secretlint/secretlint-rule-stripe@13.0.2':
+    dependencies:
+      '@secretlint/types': 13.0.2
+      '@textlint/regexp-string-matcher': 2.0.2
 
   '@secretlint/source-creator@13.0.2':
     dependencies:
@@ -27080,6 +27108,7 @@ snapshots:
       '@sentry/core': 7.120.4
       '@sentry/types': 7.120.4
       '@sentry/utils': 7.120.4
+      '@types/react': 18.3.31
       hoist-non-react-statics: 3.3.2
       react: 17.0.2
 
@@ -27089,6 +27118,7 @@ snapshots:
       '@sentry/core': 7.120.4
       '@sentry/types': 7.120.4
       '@sentry/utils': 7.120.4
+      '@types/react': 18.3.31
       hoist-non-react-statics: 3.3.2
       react: 18.3.1
 
@@ -40741,6 +40771,7 @@ snapshots:
 
   lucide-react@1.18.0(react@18.3.1):
     dependencies:
+      '@types/react': 18.3.31
       react: 18.3.1
 
   luxon@3.7.2: {}
@@ -44018,6 +44049,7 @@ snapshots:
 
   react-dropzone@14.4.1(react@18.3.1):
     dependencies:
+      '@types/react': 18.3.31
       attr-accept: 2.2.5
       file-selector: 2.1.2
       prop-types: 15.8.1
@@ -44076,12 +44108,14 @@ snapshots:
     optionalDependencies:
       react-dom: 18.3.1(react@18.3.1)
 
-  react-select@5.10.2(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-select@5.10.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.29.7
       '@emotion/cache': 11.14.0
       '@emotion/react': 11.14.0(@types/react@18.3.31)(react@18.3.1)
       '@floating-ui/dom': 1.7.6
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
       '@types/react-transition-group': 4.4.12(@types/react@18.3.31)
       memoize-one: 6.0.0
       prop-types: 15.8.1
@@ -44090,7 +44124,6 @@ snapshots:
       react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       use-isomorphic-layout-effect: 1.2.1(@types/react@18.3.31)(react@18.3.1)
     transitivePeerDependencies:
-      - '@types/react'
       - supports-color
 
   react-smooth@4.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
@@ -44234,6 +44267,8 @@ snapshots:
 
   recharts@2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
       clsx: 2.1.1
       eventemitter3: 4.0.7
       lodash: 4.18.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -208,6 +208,39 @@ packageExtensions:
   '@doist/react-interpolate@2.2.1':
     dependencies:
       '@babel/runtime': ^7.26.10
+  # Keep packages that resolve peers from their own global virtual-store path
+  # able to find repo-level secretlint rules and React type packages.
+  '@secretlint/resolver@13.0.2':
+    dependencies:
+      '@secretlint/secretlint-rule-pattern': 13.0.2
+      '@secretlint/secretlint-rule-preset-recommend': 13.0.2
+      '@secretlint/secretlint-rule-privatekey': 13.0.2
+      '@secretlint/secretlint-rule-stripe': 13.0.2
+  '@dnd-kit/core@6.3.1':
+    dependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7
+  '@ebay/nice-modal-react@1.2.13':
+    dependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7
+  '@sentry/react@7.120.4':
+    dependencies:
+      '@types/react': 18.3.31
+  'lucide-react@1.18.0':
+    dependencies:
+      '@types/react': 18.3.31
+  'react-dropzone@14.4.1':
+    dependencies:
+      '@types/react': 18.3.31
+  'react-select@5.10.2':
+    dependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7
+  'recharts@2.15.4':
+    dependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7
 minimumReleaseAgeExclude:
   # Our own packages are published by us, so the release-age delay doesn't apply
   - "@tryghost/*"


### PR DESCRIPTION
## What changed

- Added pnpm package extensions for packages that resolve peers from their own global virtual-store package path.
- Ensured secretlint can resolve the repo's configured rule packages under `enableGlobalVirtualStore`.
- Ensured React packages used by declaration builds can resolve `@types/react` / `@types/react-dom` from their global-store location.
- Regenerated `pnpm-lock.yaml`.

## Why

With `enableGlobalVirtualStore`, package realpaths live outside the workspace. Tools and declaration files that resolve dependencies from their own package location can miss repo-level peers, which caused secretlint rule loading failures and TypeScript JSX/declaration build failures in packages like Shade and admin-x-design-system.

## Testing

- `pnpm exec secretlint README.md`
- `pnpm nx run @tryghost/shade:build --skip-nx-cache`
- `pnpm nx run @tryghost/admin-x-design-system:build --skip-nx-cache`
- `pnpm lint --skip-nx-cache`
