### PR TITLE
🐛 Fixed automation email formatting toolbar buttons

### DIFF
--- a/apps/admin/src/index.css
+++ b/apps/admin/src/index.css
@@ -8,6 +8,12 @@
 
 @import "@tryghost/shade/styles.css";
 
+/* Koenig mounts floating toolbars to document.body. Radix modal dialogs disable
+   body pointer events, so body-level Koenig portals need to opt back in. */
+[data-kg-portal] {
+    pointer-events: auto;
+}
+
 /* Legacy utility compatibility (Spirit/Tachyons-style percentages). */
 .w-100 {
     width: 100%;


### PR DESCRIPTION
closes [NY-1380](https://linear.app/ghost/issue/NY-1380/formatting-toolbar-is-not-clickable-in-automations-editor)

Automations opens the email editor inside a Shade/Radix modal. Radix disables pointer events on document.body for modal content, but Koenig renders its floating formatting toolbar through a body-level portal. That made the toolbar visible while clicks fell through to the selected editor text underneath.

The Koenig portal now opts back into pointer events from the admin CSS entry, so the toolbar remains clickable inside the automation email modal without changing the editor behavior used by older welcome emails.

This doesn't have any negative impacts on the toolbar in the post editor.

Before:
<img width="620" height="223" alt="toolbar-bug-before" src="https://github.com/user-attachments/assets/67bc16bb-bf55-4a38-a2ae-c0f42fd367d8" />


After:
<img width="620" height="223" alt="toolbar-bug-after" src="https://github.com/user-attachments/assets/dbca2ee8-1f5c-4709-8460-2e7475475945" />

