### PR TITLE
Dropped outbox table

### DIFF
--- a/ghost/core/core/server/data/exporter/table-lists.js
+++ b/ghost/core/core/server/data/exporter/table-lists.js
@@ -57,7 +57,6 @@ const BACKUP_TABLES = [
     'recommendations',
     'recommendation_click_events',
     'recommendation_subscribe_events',
-    'outbox',
     'gifts',
     'gift_links',
     'post_gift_links',

--- a/ghost/core/core/server/data/migrations/versions/6.48/2026-06-24-20-08-52-remove-outbox-table.js
+++ b/ghost/core/core/server/data/migrations/versions/6.48/2026-06-24-20-08-52-remove-outbox-table.js
@@ -1,0 +1,42 @@
+const logging = require('@tryghost/logging');
+const {commands} = require('../../../schema');
+const {createNonTransactionalMigration} = require('../../utils');
+
+const oldOutboxSpec = {
+    id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+    event_type: {type: 'string', maxlength: 50, nullable: false},
+    status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'pending'},
+    payload: {type: 'text', maxlength: 65535, nullable: false},
+    created_at: {type: 'dateTime', nullable: false},
+    updated_at: {type: 'dateTime', nullable: true},
+    retry_count: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0},
+    last_retry_at: {type: 'dateTime', nullable: true},
+    message: {type: 'string', maxlength: 2000, nullable: true},
+    '@@INDEXES@@': [
+        ['event_type', 'status', 'created_at']
+    ]
+};
+
+module.exports = createNonTransactionalMigration(
+    async function up(knex) {
+        const exists = await knex.schema.hasTable('outbox');
+        if (!exists) {
+            logging.warn('Skipping dropping table outbox - does not exist');
+            return;
+        }
+
+        logging.info('Dropping table: outbox');
+        await commands.deleteTable('outbox', knex);
+    },
+
+    async function down(knex) {
+        const exists = await knex.schema.hasTable('outbox');
+        if (exists) {
+            logging.warn('Skipping recreating table outbox - already exists');
+            return;
+        }
+
+        logging.info('Recreating table: outbox');
+        await commands.createTable('outbox', knex, oldOutboxSpec);
+    }
+);

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1151,26 +1151,6 @@ module.exports = {
         member_id: {type: 'string', maxlength: 24, nullable: true, references: 'members.id', unique: false, setNullDelete: true},
         created_at: {type: 'dateTime', nullable: false}
     },
-    outbox: {
-        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
-        event_type: {type: 'string', maxlength: 50, nullable: false},
-        status: {
-            type: 'string',
-            maxlength: 50,
-            nullable: false,
-            defaultTo: 'pending',
-            validations: {isIn: [['pending', 'processing', 'failed', 'completed']]}
-        },
-        payload: {type: 'text', maxlength: 65535, nullable: false},
-        created_at: {type: 'dateTime', nullable: false},
-        updated_at: {type: 'dateTime', nullable: true},
-        retry_count: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0},
-        last_retry_at: {type: 'dateTime', nullable: true},
-        message: {type: 'string', maxlength: 2000, nullable: true},
-        '@@INDEXES@@': [
-            ['event_type', 'status', 'created_at']
-        ]
-    },
     email_design_settings: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         slug: {type: 'string', maxlength: 191, nullable: false, unique: true},

--- a/ghost/core/test/integration/exporter/exporter.test.js
+++ b/ghost/core/test/integration/exporter/exporter.test.js
@@ -80,7 +80,6 @@ describe('Exporter', function () {
             'newsletters',
             'offers',
             'offer_redemptions',
-            'outbox',
             'permissions',
             'permissions_roles',
             'permissions_users',
@@ -144,7 +143,6 @@ describe('Exporter', function () {
             'members_status_events',
             'members_paid_subscription_events',
             'members_subscribe_events',
-            'outbox',
             'gifts',
             'gift_links',
             'post_gift_links'

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '843875f56844de5c63752e18ceaeb095';
+    const currentSchemaHash = 'b48048151823b7b0c3841dfd5f48d678';
     const currentFixturesHash = 'f4941d9d92b59075e0c2a1cc3fc4c44a';
     const currentSettingsHash = '397be8628c753b1959b8954d5610f83f';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1220
ref https://github.com/TryGhost/Ghost/pull/28884
ref abe3ccb78c5c5343a44556178cdcfa51aa756790

*This change should have no user impact.*

The welcome email outbox code was removed in #28884. We can now drop the tables, because they're unused.

Notably, I made this migration reversible just in case we roll back. It won't restore the rows, but that's better than "deployers cannot roll back to this version".
