### PR TITLE
🌵 Page analytics spike

### DIFF
--- a/apps/admin-x-framework/src/api/pages.ts
+++ b/apps/admin-x-framework/src/api/pages.ts
@@ -1,11 +1,13 @@
 import {InfiniteData} from '@tanstack/react-query';
-import {Meta, createInfiniteQuery, createQuery, createQueryWithId} from '../utils/api/hooks';
+import {Meta, createInfiniteQuery, createMutation, createQuery, createQueryWithId} from '../utils/api/hooks';
 
 export type Page = {
     id: string;
     title: string;
     slug: string;
     url: string;
+    uuid: string;
+    feature_image?: string;
     status?: string;
     published_at?: string;
 };
@@ -24,6 +26,11 @@ export const useBrowsePages = createQuery<PagesResponseType>({
 
 export const getPage = createQueryWithId<PagesResponseType>({
     dataType,
+    path: id => `/pages/${id}/`
+});
+
+export const useDeletePage = createMutation<unknown, string>({
+    method: 'DELETE',
     path: id => `/pages/${id}/`
 });
 

--- a/apps/posts/src/providers/post-analytics-context.tsx
+++ b/apps/posts/src/providers/post-analytics-context.tsx
@@ -1,4 +1,5 @@
 import {Config, useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
+import {Page as PageBase, useBrowsePages} from '@tryghost/admin-x-framework/api/pages';
 import {Post as PostBase, useBrowsePosts} from '@tryghost/admin-x-framework/api/posts';
 import {ReactNode, createContext, useContext, useState} from 'react';
 import {STATS_RANGES} from '@src/utils/constants';
@@ -7,8 +8,10 @@ import {StatsConfig, useTinybirdToken} from '@tryghost/admin-x-framework';
 import {useBrowseSite} from '@tryghost/admin-x-framework/api/site';
 import {useParams} from '@tryghost/admin-x-framework';
 
-// Comprehensive Post type with all the includes we fetch in PostAnalytics
-export interface Post extends PostBase {
+export type ContentType = 'post' | 'page';
+
+// Comprehensive analytics content type with all the includes we fetch in PostAnalytics
+export interface Post extends Omit<PageBase, keyof PostBase>, PostBase {
     published_at?: string;
     excerpt?: string;
     authors?: {
@@ -49,6 +52,10 @@ type PostAnalyticsContextType = {
     postId: string;
     post: Post | undefined;
     isPostLoading: boolean;
+    contentType: ContentType;
+    analyticsBasePath: string;
+    editorPath: string;
+    listPath: string;
 }
 
 const PostAnalyticsContext = createContext<PostAnalyticsContextType | undefined>(undefined);
@@ -61,7 +68,7 @@ export const useGlobalData = () => {
     return context;
 };
 
-const PostAnalyticsProvider = ({children}: { children: ReactNode }) => {
+const PostAnalyticsProvider = ({children, contentType = 'post'}: { children: ReactNode; contentType?: ContentType }) => {
     const {postId} = useParams();
     
     // Validate that postId exists - the app cannot function without it
@@ -78,13 +85,26 @@ const PostAnalyticsProvider = ({children}: { children: ReactNode }) => {
     const hasStatsConfig = Boolean(config.data?.config?.stats);
     const tinybirdTokenQuery = useTinybirdToken({enabled: hasStatsConfig});
 
-    // Fetch post data with all required includes
+    const isPage = contentType === 'page';
+
+    // Fetch content data with all required includes. Both hooks are called to keep hook ordering stable;
+    // the inactive query is disabled.
     const {data: {posts: [post]} = {posts: []}, isLoading: isPostLoading} = useBrowsePosts({
         searchParams: {
             filter: `id:${postId}`,
             include: 'email,authors,tags,tiers,count.clicks,count.signups,count.paid_conversions,count.positive_feedback,count.negative_feedback,newsletter'
-        }
+        },
+        enabled: !isPage
     });
+    const {data: {pages: [page]} = {pages: []}, isLoading: isPageLoading} = useBrowsePages({
+        searchParams: {
+            filter: `id:${postId}`,
+            include: 'authors,tags,tiers,count.signups,count.paid_conversions'
+        },
+        enabled: isPage
+    });
+
+    const content = isPage ? page : post;
 
     // Check for errors in the ghost requests
     const ghostRequests = [config, site, settings];
@@ -117,8 +137,12 @@ const PostAnalyticsProvider = ({children}: { children: ReactNode }) => {
         setRange,
         settings: settings.data?.settings || [],
         postId: postId,
-        post: post as Post | undefined,
-        isPostLoading
+        post: content as Post | undefined,
+        isPostLoading: isPage ? isPageLoading : isPostLoading,
+        contentType,
+        analyticsBasePath: `/${isPage ? 'pages' : 'posts'}/analytics/${postId}`,
+        editorPath: `/editor/${isPage ? 'page' : 'post'}/${postId}`,
+        listPath: `/${isPage ? 'pages' : 'posts'}/`
     }}>
         {children}
     </PostAnalyticsContext.Provider>;

--- a/apps/posts/src/routes.tsx
+++ b/apps/posts/src/routes.tsx
@@ -14,9 +14,9 @@ export const routes: RouteObject[] = [
         path: '',
         errorElement: <ErrorPage onBackToDashboard={() => {}} />, // @TODO: add back to dashboard click handle
         children: [
-            {
-                // Post Analytics
-                path: 'posts/analytics/:postId',
+            ...(['posts', 'pages'] as const).map(contentGroup => ({
+                // Post/Page Analytics
+                path: `${contentGroup}/analytics/:postId`,
                 lazy: async () => {
                     const [
                         {default: PostAnalyticsProvider},
@@ -27,7 +27,7 @@ export const routes: RouteObject[] = [
                     ]);
                     return {
                         element: (
-                            <PostAnalyticsProvider>
+                            <PostAnalyticsProvider contentType={contentGroup === 'pages' ? 'page' : 'post'}>
                                 <PostAnalytics />
                             </PostAnalyticsProvider>
                         )
@@ -42,16 +42,16 @@ export const routes: RouteObject[] = [
                         path: 'web',
                         lazy: lazyComponent(() => import('@views/PostAnalytics/Web/web'))
                     },
-                    {
+                    ...(contentGroup === 'posts' ? [{
                         path: 'growth',
                         lazy: lazyComponent(() => import('@views/PostAnalytics/Growth/growth'))
                     },
                     {
                         path: 'newsletter',
                         lazy: lazyComponent(() => import('@views/PostAnalytics/Newsletter/newsletter'))
-                    }
+                    }] : [])
                 ]
-            },
+            })),
             {
                 path: 'tags',
                 children: [

--- a/apps/posts/src/utils/kpi-helpers.ts
+++ b/apps/posts/src/utils/kpi-helpers.ts
@@ -45,3 +45,8 @@ export const getWebKpiValues = (data: KpiDataItem[] | null | undefined) => {
         duration: formatDuration(avgDuration)
     };
 };
+
+export const hasWebKpiData = (data: KpiDataItem[] | null | undefined) => {
+    const kpiValues = getWebKpiValues(data);
+    return kpiValues.visits !== '0' || kpiValues.views !== '0';
+};

--- a/apps/posts/src/views/PostAnalytics/Overview/components/web-overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/components/web-overview.tsx
@@ -1,7 +1,7 @@
 import React, {useMemo} from 'react';
 import Sources from '../../Web/components/sources';
 import {BarChartLoadingIndicator, Button, Card, CardContent, CardHeader, CardTitle, EmptyIndicator, Separator} from '@tryghost/shade/components';
-import {BaseSourceData, useNavigate, useParams} from '@tryghost/admin-x-framework';
+import {BaseSourceData, useNavigate} from '@tryghost/admin-x-framework';
 import {GhAreaChart, GhAreaChartDataItem, KpiCardHeader, KpiCardHeaderLabel, KpiCardHeaderValue} from '@tryghost/shade/patterns';
 import {HTable} from '@tryghost/shade/primitives';
 import {LucideIcon, formatNumber} from '@tryghost/shade/utils';
@@ -17,11 +17,10 @@ interface WebOverviewProps {
 }
 
 const WebOverview: React.FC<WebOverviewProps> = ({chartData, range, isLoading, visitors, sourcesData, isNewsletterShown = true}) => {
-    const {postId} = useParams();
     const navigate = useNavigate();
 
     // Get global data for site info
-    const {data: globalData} = useGlobalData();
+    const {data: globalData, analyticsBasePath} = useGlobalData();
     const siteUrl = globalData?.url as string | undefined;
     const siteIcon = globalData?.icon as string | undefined;
 
@@ -44,7 +43,7 @@ const WebOverview: React.FC<WebOverviewProps> = ({chartData, range, isLoading, v
                         </CardTitle>
                     </CardHeader>
                     <Button className='absolute right-6 translate-x-10 opacity-0 transition-all duration-300 group-hover/datalist:translate-x-0 group-hover/datalist:opacity-100' size='sm' variant='outline' onClick={() => {
-                        navigate(`/posts/analytics/${postId}/web`);
+                        navigate(`${analyticsBasePath}/web`);
                     }}>View more</Button>
                 </div>
                 <CardContent>

--- a/apps/posts/src/views/PostAnalytics/Overview/overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/overview.tsx
@@ -19,9 +19,10 @@ import {usePostReferrers} from '@hooks/use-post-referrers';
 
 const Overview: React.FC = () => {
     const navigate = useNavigate();
-    const {statsConfig, isLoading: isConfigLoading, post, isPostLoading, postId} = useGlobalData();
+    const {statsConfig, isLoading: isConfigLoading, post, isPostLoading, postId, contentType, analyticsBasePath} = useGlobalData();
     const {totals, isLoading: isTotalsLoading, currencySymbol} = usePostReferrers(postId);
     const {appSettings} = useAppContext();
+    const isPage = contentType === 'page';
     const {emailTrackClicks: emailTrackClicksEnabled, emailTrackOpens: emailTrackOpensEnabled} = appSettings?.analytics || {};
 
     // Calculate chart range based on days between today and post publication date
@@ -95,17 +96,17 @@ const Overview: React.FC = () => {
     const chartIsLoading = isPostLoading || isConfigLoading || chartLoading;
 
     // Use the utility function from admin-x-framework
-    const showNewsletterSection = hasBeenEmailed(post as Post) && emailTrackOpensEnabled && emailTrackClicksEnabled;
-    const showWebSection = !post?.email_only && appSettings?.analytics.webAnalytics;
-    const showGrowthSection = appSettings?.analytics.membersTrackSources;
+    const showNewsletterSection = !isPage && hasBeenEmailed(post as Post) && emailTrackOpensEnabled && emailTrackClicksEnabled;
+    const showWebSection = (isPage || !post?.email_only) && appSettings?.analytics.webAnalytics;
+    const showGrowthSection = !isPage && appSettings?.analytics.membersTrackSources;
 
     // Redirect to Growth tab if this is a published-only post with web analytics disabled
     // Only redirect if Growth section is available
     useEffect(() => {
-        if (!isPostLoading && post && isPublishedOnly(post as Post) && !appSettings?.analytics.webAnalytics && showGrowthSection) {
+        if (!isPage && !isPostLoading && post && isPublishedOnly(post as Post) && !appSettings?.analytics.webAnalytics && showGrowthSection) {
             navigate(`/posts/analytics/${postId}/growth`, {replace: true});
         }
-    }, [isPostLoading, post, appSettings?.analytics.webAnalytics, navigate, postId, showGrowthSection]);
+    }, [isPage, isPostLoading, post, appSettings?.analytics.webAnalytics, navigate, postId, showGrowthSection]);
 
     // First we have to wait for the post to be loaded to determine what sections (web, newsletter etc.) should be displayed
     if (isPostLoading) {
@@ -146,7 +147,7 @@ const Overview: React.FC = () => {
                                     </CardTitle>
                                 </CardHeader>
                                 <Button className='absolute right-6 translate-x-10 opacity-0 transition-all duration-200 group-hover:translate-x-0 group-hover:opacity-100' size='sm' variant='outline' onClick={() => {
-                                    navigate(`/posts/analytics/${postId}/growth`);
+                                    navigate(`${analyticsBasePath}/growth`);
                                 }}>View more</Button>
                             </div>
                             <CardContent className='flex flex-col gap-6 px-0 md:grid md:grid-cols-3 md:items-stretch md:gap-0'>

--- a/apps/posts/src/views/PostAnalytics/Web/components/kpis.tsx
+++ b/apps/posts/src/views/PostAnalytics/Web/components/kpis.tsx
@@ -72,12 +72,12 @@ const Kpis:React.FC<KpisProps> = ({data, range}) => {
                         <KpiTabTrigger value="visits" onClick={() => {
                             setCurrentTab('visits');
                         }}>
-                            <KpiTabValue color={KPI_METRICS.visits.color} label="Unique visitors" value={kpiValues.visits} />
+                            <KpiTabValue color={KPI_METRICS.visits.color} data-testid='unique-visitors-kpi' label="Unique visitors" value={kpiValues.visits} />
                         </KpiTabTrigger>
                         <KpiTabTrigger value="views" onClick={() => {
                             setCurrentTab('views');
                         }}>
-                            <KpiTabValue color={KPI_METRICS.views.color} label="Total views" value={kpiValues.views} />
+                            <KpiTabValue color={KPI_METRICS.views.color} data-testid='total-views-kpi' label="Total views" value={kpiValues.views} />
                         </KpiTabTrigger>
                     </TabsList>
                     <DropdownMenu>
@@ -96,7 +96,7 @@ const Kpis:React.FC<KpisProps> = ({data, range}) => {
                             <DropdownMenuItem onClick={() => setCurrentTab('views')}>Total views</DropdownMenuItem>
                         </DropdownMenuContent>
                     </DropdownMenu>
-                    <div className='my-4 [&_.recharts-cartesian-axis-tick-value]:fill-gray-500'>
+                    <div className='my-4 [&_.recharts-cartesian-axis-tick-value]:fill-gray-500' data-testid='web-traffic-chart'>
                         <GhAreaChart
                             className={'-mb-3 aspect-auto h-[16vw] max-h-[320px] min-h-[180px] w-full'}
                             color={currentMetric.color}

--- a/apps/posts/src/views/PostAnalytics/Web/web.tsx
+++ b/apps/posts/src/views/PostAnalytics/Web/web.tsx
@@ -7,7 +7,7 @@ import Sources from './components/sources';
 import StatsFilter from '../components/stats-filter';
 import {BarChartLoadingIndicator, Card, CardContent, EmptyIndicator, NavbarActions} from '@tryghost/shade/components';
 import {BaseSourceData, useNavigate, useParams, useTinybirdQuery} from '@tryghost/admin-x-framework';
-import {KpiDataItem, getWebKpiValues} from '@src/utils/kpi-helpers';
+import {KpiDataItem, hasWebKpiData} from '@src/utils/kpi-helpers';
 import {LucideIcon, getScrollParent} from '@tryghost/shade/utils';
 import {STATS_RANGES, UNKNOWN_LOCATION_VALUES} from '@src/utils/constants';
 import {createFilter} from '@tryghost/shade/patterns';
@@ -30,7 +30,8 @@ interface postAnalyticsProps {}
 const Web: React.FC<postAnalyticsProps> = () => {
     const navigate = useNavigate();
     const {postId} = useParams();
-    const {statsConfig, isLoading: isConfigLoading, range, data: globalData, post, isPostLoading} = useGlobalData();
+    const {statsConfig, isLoading: isConfigLoading, range, data: globalData, post, isPostLoading, contentType, analyticsBasePath} = useGlobalData();
+    const isPage = contentType === 'page';
     const containerRef = useRef<HTMLElement>(null);
 
     // Use URL-synced filter state for bookmarking and sharing
@@ -44,10 +45,10 @@ const Web: React.FC<postAnalyticsProps> = () => {
 
     // Redirect to Overview if this is an email-only post
     useEffect(() => {
-        if (!isPostLoading && post?.email_only) {
-            navigate(`/posts/analytics/${postId}`);
+        if (!isPage && !isPostLoading && post?.email_only) {
+            navigate(analyticsBasePath);
         }
-    }, [isPostLoading, post?.email_only, navigate, postId]);
+    }, [isPage, isPostLoading, post?.email_only, navigate, postId, analyticsBasePath]);
 
     // Calculate chart range based on days between today and post publication date
     const chartRange = useMemo(() => {
@@ -204,7 +205,7 @@ const Web: React.FC<postAnalyticsProps> = () => {
 
     const isPageLoading = isConfigLoading || isPostLoading || isKpisLoading || isLocationsLoading || isSourcesLoading;
 
-    const kpiValues = getWebKpiValues(kpiData as unknown as KpiDataItem[] | null);
+    const hasKpiData = hasWebKpiData(kpiData as unknown as KpiDataItem[] | null);
 
     // Check if filters are applied
     const hasFilters = analyticsFilters.length > 0;
@@ -233,7 +234,7 @@ const Web: React.FC<postAnalyticsProps> = () => {
                         </CardContent>
                     </Card>
                     :
-                    kpiData && kpiData.length !== 0 && kpiValues.visits !== '0' ?
+                    kpiData && kpiData.length !== 0 && hasKpiData ?
                         <>
                             <Kpis
                                 data={kpiData as KpiDataItem[] | null}

--- a/apps/posts/src/views/PostAnalytics/components/post-analytics-header.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/post-analytics-header.tsx
@@ -7,6 +7,7 @@ import {PostShareModal} from '@tryghost/shade/posts-stats';
 import {getSiteTimezone} from '@src/utils/get-site-timezone';
 import {hasBeenEmailed, isEmailOnly, isPublishedAndEmailed, isPublishedOnly, useActiveVisitors, useNavigate} from '@tryghost/admin-x-framework';
 import {useAppContext} from '@src/providers/posts-app-context';
+import {useDeletePage} from '@tryghost/admin-x-framework/api/pages';
 import {useDeletePost} from '@tryghost/admin-x-framework/api/posts';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 
@@ -22,10 +23,12 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
     const navigate = useNavigate();
     const {fromAnalytics, appSettings} = useAppContext();
     const {mutateAsync: deletePost} = useDeletePost();
+    const {mutateAsync: deletePage} = useDeletePage();
     const handleError = useHandleError();
     const [showDeleteDialog, setShowDeleteDialog] = useState(false);
     const [isShareOpen, setIsShareOpen] = useState(false);
-    const {settings, site, statsConfig, post, isPostLoading, postId} = useGlobalData();
+    const {settings, site, statsConfig, post, isPostLoading, postId, contentType, analyticsBasePath, editorPath, listPath} = useGlobalData();
+    const isPage = contentType === 'page';
 
     const siteTimezone = getSiteTimezone(settings);
 
@@ -44,23 +47,23 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
         const tabs = [];
 
         // Only show Overview and Web tabs if it's NOT a published-only post with web analytics disabled
-        const isPublishedOnlyWithoutWebAnalytics = isPublishedOnly(post as Post) && !appSettings?.analytics.webAnalytics;
+        const isPublishedOnlyWithoutWebAnalytics = !isPage && isPublishedOnly(post as Post) && !appSettings?.analytics.webAnalytics;
         if (!isPublishedOnlyWithoutWebAnalytics) {
             tabs.push('Overview');
-            if (!post.email_only && appSettings?.analytics.webAnalytics) {
+            if ((isPage || !post.email_only) && appSettings?.analytics.webAnalytics) {
                 tabs.push('Web');
             }
         }
-        if (hasBeenEmailed(post as Post)) {
+        if (!isPage && hasBeenEmailed(post as Post)) {
             tabs.push('Newsletter');
         }
         // Only show Growth tab if member source tracking is enabled
-        if (appSettings?.analytics.membersTrackSources) {
+        if (!isPage && appSettings?.analytics.membersTrackSources) {
             tabs.push('Growth');
         }
 
         return tabs;
-    }, [post, appSettings?.analytics.webAnalytics, appSettings?.analytics.membersTrackSources]);
+    }, [post, isPage, appSettings?.analytics.webAnalytics, appSettings?.analytics.membersTrackSources]);
 
     const handleDeletePost = () => {
         if (!post) {
@@ -76,10 +79,13 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
             return;
         }
         try {
-            await deletePost(postId);
+            if (isPage) {
+                await deletePage(postId);
+            } else {
+                await deletePost(postId);
+            }
             setShowDeleteDialog(false);
-            // Navigate back to posts list
-            navigate('/posts/', {crossApp: true});
+            navigate(listPath, {crossApp: true});
         } catch (e) {
             handleError(e);
         }
@@ -103,19 +109,19 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
                                         </BreadcrumbItem>
                                         :
                                         <BreadcrumbItem>
-                                            <BreadcrumbLink className='cursor-pointer leading-[24px]' onClick={() => navigate('/posts/', {crossApp: true})}>Posts</BreadcrumbLink>
+                                            <BreadcrumbLink className='cursor-pointer leading-[24px]' onClick={() => navigate(listPath, {crossApp: true})}>{isPage ? 'Pages' : 'Posts'}</BreadcrumbLink>
                                         </BreadcrumbItem>
                                     }
                                     <BreadcrumbSeparator />
                                     <BreadcrumbItem>
                                         <BreadcrumbPage className='leading-[24px]'>
-                                        Post analytics
+                                            {isPage ? 'Page analytics' : 'Post analytics'}
                                         </BreadcrumbPage>
                                     </BreadcrumbItem>
                                 </BreadcrumbList>
                             </Breadcrumb>
                             <div className='flex w-full items-center gap-2 md:w-auto'>
-                                {appSettings?.analytics.webAnalytics && !post?.email_only && (
+                                {appSettings?.analytics.webAnalytics && (isPage || !post?.email_only) && (
                                     <div className='mr-3 flex grow items-center gap-2 md:grow-0'>
                                         <div className='flex items-center gap-2 text-muted-foreground' title='Active readers in the last 5 minutes · Updates every 60 seconds'>
                                             <span>
@@ -129,7 +135,7 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
                                 {/* <Button variant='outline'><LucideIcon.Share /></Button> */}
                                 {!isPostLoading &&
                                 <>
-                                    {!post?.email_only && (
+                                    {(isPage || !post?.email_only) && (
                                         <PostShareModal
                                             author={post?.authors?.[0]?.name || ''}
                                             description=''
@@ -159,10 +165,10 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
                                                     </a>
                                                 </DropdownMenuItem>
                                                 <DropdownMenuItem onClick={() => {
-                                                    navigate(`/editor/post/${postId}`, {crossApp: true});
+                                                    navigate(editorPath, {crossApp: true});
                                                 }}>
                                                     <LucideIcon.Pen />
-                                                Edit post
+                                                    {isPage ? 'Edit page' : 'Edit post'}
                                                     {/* <DropdownMenuShortcut>⌘E</DropdownMenuShortcut> */}
                                                 </DropdownMenuItem>
                                             </DropdownMenuGroup>
@@ -173,7 +179,7 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
                                                     onClick={handleDeletePost}
                                                 >
                                                     <LucideIcon.Trash />
-                                                Delete post
+                                                    {isPage ? 'Delete page' : 'Delete post'}
                                                 </DropdownMenuItem>
                                             </DropdownMenuGroup>
                                         </DropdownMenuContent>
@@ -195,9 +201,9 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
                                 </H1>
                                 {post?.published_at && (
                                     <div className='mt-0.5 flex items-center justify-start leading-[1.65em] text-muted-foreground'>
-                                        {isEmailOnly(post) && `Sent on ${formatDisplayDate(post.published_at, siteTimezone)} at ${formatDisplayTime(post.published_at, siteTimezone)}`}
-                                        {isPublishedOnly(post) && `Published on your site on ${formatDisplayDate(post.published_at, siteTimezone)} at ${formatDisplayTime(post.published_at, siteTimezone)}`}
-                                        {isPublishedAndEmailed(post) && `Published and sent on ${formatDisplayDate(post.published_at, siteTimezone)} at ${formatDisplayTime(post.published_at, siteTimezone)}`}
+                                        {!isPage && isEmailOnly(post) && `Sent on ${formatDisplayDate(post.published_at, siteTimezone)} at ${formatDisplayTime(post.published_at, siteTimezone)}`}
+                                        {(isPage || isPublishedOnly(post)) && `Published on your site on ${formatDisplayDate(post.published_at, siteTimezone)} at ${formatDisplayTime(post.published_at, siteTimezone)}`}
+                                        {!isPage && isPublishedAndEmailed(post) && `Published and sent on ${formatDisplayDate(post.published_at, siteTimezone)} at ${formatDisplayTime(post.published_at, siteTimezone)}`}
                                     </div>
                                 )}
                             </div>
@@ -211,28 +217,28 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
                     <PageMenu className='min-h-[34px]' defaultValue={currentTab} responsive>
                         {availableTabs.includes('Overview') && (
                             <PageMenuItem value="Overview" onClick={() => {
-                                navigate(`/posts/analytics/${postId}`);
+                                navigate(analyticsBasePath);
                             }}>
                                 Overview
                             </PageMenuItem>
                         )}
                         {availableTabs.includes('Web') && (
                             <PageMenuItem value="Web" onClick={() => {
-                                navigate(`/posts/analytics/${postId}/web`);
+                                navigate(`${analyticsBasePath}/web`);
                             }}>
                                 Web traffic
                             </PageMenuItem>
                         )}
                         {availableTabs.includes('Newsletter') && (
                             <PageMenuItem value="Newsletter" onClick={() => {
-                                navigate(`/posts/analytics/${postId}/newsletter`);
+                                navigate(`${analyticsBasePath}/newsletter`);
                             }}>
                                 Newsletter
                             </PageMenuItem>
                         )}
                         {availableTabs.includes('Growth') && (
                             <PageMenuItem value="Growth" onClick={() => {
-                                navigate(`/posts/analytics/${postId}/growth`);
+                                navigate(`${analyticsBasePath}/growth`);
                             }}>
                                 Growth
                             </PageMenuItem>
@@ -246,7 +252,7 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
                 <AlertDialogContent>
                     <AlertDialogHeader>
                         <AlertDialogTitle>
-                            Are you sure you want to delete this post?
+                            Are you sure you want to delete this {isPage ? 'page' : 'post'}?
                         </AlertDialogTitle>
                         <AlertDialogDescription>
                             You&apos;re about to delete &quot;<strong>{post?.title}</strong>&quot;.

--- a/apps/posts/test/unit/utils/kpi-helpers.test.tsx
+++ b/apps/posts/test/unit/utils/kpi-helpers.test.tsx
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest';
-import {getWebKpiValues} from '@src/utils/kpi-helpers';
+import {getWebKpiValues, hasWebKpiData} from '@src/utils/kpi-helpers';
 
 describe('kpi-helpers', () => {
     describe('getWebKpiValues', () => {
@@ -109,6 +109,20 @@ describe('kpi-helpers', () => {
             expect(result.views).toBe('84');
             expect(result.bounceRate).toBe('33%');
             expect(result.duration).toBe('2m 7s');
+        });
+    });
+
+    describe('hasWebKpiData', () => {
+        it('returns true when pageviews exist without session-derived visits', () => {
+            expect(hasWebKpiData([
+                {visits: 0, pageviews: 1, bounce_rate: 0, avg_session_sec: 0, date: '2023-01-01'}
+            ])).toBe(true);
+        });
+
+        it('returns false when there are no visits or pageviews', () => {
+            expect(hasWebKpiData([
+                {visits: 0, pageviews: 0, bounce_rate: 0, avg_session_sec: 0, date: '2023-01-01'}
+            ])).toBe(false);
         });
     });
 });

--- a/apps/posts/test/utils/test-helpers.ts
+++ b/apps/posts/test/utils/test-helpers.ts
@@ -119,6 +119,10 @@ export const defaultMockData = {
             tiers: []
         },
         isPostLoading: false,
+        contentType: 'post' as const,
+        analyticsBasePath: '/posts/analytics/test-post-id',
+        editorPath: '/editor/post/test-post-id',
+        listPath: '/posts/',
         postType: {
             isEmailOnly: false,
             isPublishedOnly: false,

--- a/apps/stats/src/utils/url-helpers.ts
+++ b/apps/stats/src/utils/url-helpers.ts
@@ -100,9 +100,9 @@ export function getClickHandler(
     attributionType?: string
 ) {
     return () => {
-        // For posts with analytics, go to analytics page
-        if (postId && attributionUrl && attributionType === 'post') {
-            navigate(`/posts/analytics/${postId}`, {crossApp: true});
+        // For posts/pages with analytics, go to the content analytics page
+        if (postId && attributionUrl && (attributionType === 'post' || attributionType === 'page')) {
+            navigate(`/${attributionType}s/analytics/${postId}`, {crossApp: true});
             return;
         }
 

--- a/apps/stats/src/views/Stats/Web/components/top-content.tsx
+++ b/apps/stats/src/views/Stats/Web/components/top-content.tsx
@@ -54,8 +54,7 @@ const TopContentTable: React.FC<TopContentTableProps> = ({tableHeader = false, d
             }
             <DataListBody>
                 {data?.map((row: UnifiedContentData) => {
-                    // Only make posts clickable (not pages), since there's no analytics route for pages
-                    const isClickable = row.post_id && row.post_type === 'post';
+                    const isClickable = row.post_id && (row.post_type === 'post' || row.post_type === 'page');
                     const clickHandler = isClickable ? getClickHandler(row.pathname, row.post_id, site.url || '', navigate, row.post_type) : () => {};
 
                     return (

--- a/apps/stats/test/unit/utils/url-helpers.test.ts
+++ b/apps/stats/test/unit/utils/url-helpers.test.ts
@@ -262,8 +262,16 @@ describe('url-helpers', () => {
             expect(mockWindowOpen).toHaveBeenCalledWith('https://example.com/my-post/', '_blank', 'noopener,noreferrer');
         });
 
-        it('opens frontend URL for pages', () => {
+        it('navigates to analytics page for pages with postId and page attribution type', () => {
             const handler = getClickHandler('/about/', 'page-456', 'https://example.com', mockNavigate, 'page');
+            handler();
+
+            expect(mockNavigate).toHaveBeenCalledWith('/pages/analytics/page-456', {crossApp: true});
+            expect(mockWindowOpen).not.toHaveBeenCalled();
+        });
+
+        it('opens frontend URL for pages without postId', () => {
+            const handler = getClickHandler('/about/', null, 'https://example.com', mockNavigate, 'page');
             handler();
 
             expect(mockNavigate).not.toHaveBeenCalled();

--- a/e2e/helpers/pages/admin/analytics/post-analytics/post-analytics-web-traffic-page.ts
+++ b/e2e/helpers/pages/admin/analytics/post-analytics/post-analytics-web-traffic-page.ts
@@ -4,6 +4,7 @@ import {Locator, Page} from '@playwright/test';
 export class PostAnalyticsWebTrafficPage extends AdminPage {
     readonly uniqueVisitorsKpi: Locator;
     readonly totalViewsKpi: Locator;
+    readonly webTrafficChart: Locator;
 
     readonly topSourcesCard: Locator;
     readonly locationsCard: Locator;
@@ -21,6 +22,7 @@ export class PostAnalyticsWebTrafficPage extends AdminPage {
 
         this.uniqueVisitorsKpi = page.getByTestId('unique-visitors-kpi');
         this.totalViewsKpi = page.getByTestId('total-views-kpi');
+        this.webTrafficChart = page.getByTestId('web-traffic-chart');
 
         this.topSourcesCard = page.getByTestId('top-sources-card');
         this.locationsCard = page.getByTestId('locations-card');
@@ -38,6 +40,12 @@ export class PostAnalyticsWebTrafficPage extends AdminPage {
 
     async gotoForPost(postId: string) {
         this.setPostId(postId);
+        await this.goto();
+    }
+
+    async gotoForPage(pageId: string) {
+        this.postId = pageId;
+        this.pageUrl = `/ghost/#/pages/analytics/${pageId}/web`;
         await this.goto();
     }
 

--- a/e2e/helpers/pages/admin/posts/posts-page.ts
+++ b/e2e/helpers/pages/admin/posts/posts-page.ts
@@ -91,4 +91,12 @@ export class PostsPage extends AdminPage {
     async getActiveViewName(): Promise<string | null> {
         return await this.pageTitle.textContent();
     }
+
+    getWebTrafficMetricForPost(title: string): Locator {
+        return this.getPostByTitle(title).getByTestId('posts-list-web-traffic');
+    }
+
+    getWebTrafficLinkForPost(title: string): Locator {
+        return this.getPostByTitle(title).getByTestId('posts-list-web-traffic-link');
+    }
 }

--- a/e2e/tests/admin/analytics/page-analytics.test.ts
+++ b/e2e/tests/admin/analytics/page-analytics.test.ts
@@ -1,0 +1,23 @@
+import {PostAnalyticsWebTrafficPage, PostsPage} from '@/admin-pages';
+import {PublicPage} from '@/public-pages';
+import {expect, test, withIsolatedPage} from '@/helpers/playwright';
+
+test.describe('Ghost Admin - Page Analytics', () => {
+    test('page view from pages list - appears in page analytics trend', async ({page, browser, baseURL}) => {
+        await withIsolatedPage(browser, {baseURL}, async ({page: publicPage}) => {
+            const aboutPage = new PublicPage(publicPage);
+            await aboutPage.goto('/about/');
+        });
+
+        const pagesList = new PostsPage(page);
+        await pagesList.goto('/ghost/#/pages');
+        await expect(pagesList.getWebTrafficMetricForPost('About this site')).toContainText('1');
+
+        await pagesList.getWebTrafficLinkForPost('About this site').click();
+
+        const pageAnalytics = new PostAnalyticsWebTrafficPage(page);
+        await expect(page).toHaveURL(/\/ghost\/#\/pages\/analytics\/[^/]+\/web/);
+        await pageAnalytics.totalViewsKpi.click();
+        await expect(pageAnalytics.webTrafficChart).toContainText('1');
+    });
+});

--- a/ghost/admin/app/components/posts-list/list-item-analytics.hbs
+++ b/ghost/admin/app/components/posts-list/list-item-analytics.hbs
@@ -172,7 +172,7 @@
             {{!-- Visitor count column (only when web analytics is enabled) --}}
             {{#if this.settings.webAnalyticsEnabled}}
                 {{#if @post.isPublished}}
-                    <a href="#/posts/analytics/{{@post.id}}/web" class="permalink gh-list-data gh-post-list-metrics gh-post-list-analytics-tt-container">
+                    <a href="#/{{if @post.isPage "pages" "posts"}}/analytics/{{@post.id}}/web" class="permalink gh-list-data gh-post-list-metrics gh-post-list-analytics-tt-container" data-testid="posts-list-web-traffic-link">
                         <div class="gh-post-list-analytics-tooltip {{this.tooltipPosition}}">
                             <h3>Web traffic</h3>
                             <div class="metrics">
@@ -191,7 +191,7 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="gh-post-list-analytics-metric" data-test-analytics-visitors>
+                        <div class="gh-post-list-analytics-metric" data-test-analytics-visitors data-testid="posts-list-web-traffic">
                             {{svg-jar "analytics-visitors" class="gh-list-analytics-icon"}}
                             <span class="gh-content-email-stats-value">
                                 {{#if this.hasVisitorData}}
@@ -332,7 +332,7 @@
 
         {{!-- Button column --}}
         {{#if @post.hasAnalyticsPage }}
-            <a href="#/posts/analytics/{{@post.id}}" class="permalink gh-list-data gh-post-list-button" title="">
+            <a href="#/{{if @post.isPage "pages" "posts"}}/analytics/{{@post.id}}" class="permalink gh-list-data gh-post-list-button" title="">
                 <span class="gh-post-list-cta stats {{if this.isHovered "is-hovered"}}" title="Go to Analytics" data-ignore-select>
                     {{svg-jar "stats" title="Go to Analytics"}}
                 </span>

--- a/ghost/core/core/frontend/helpers/ghost_head.js
+++ b/ghost/core/core/frontend/helpers/ghost_head.js
@@ -203,9 +203,11 @@ function getTinybirdTrackerScript(dataRoot) {
     const token = localEnabled ? localConfig.token : statsConfig.token;
     const datasource = localEnabled ? localConfig.datasource : statsConfig.datasource;
 
+    const entry = dataRoot.post || dataRoot.page;
+
     const tbParams = _.map({
         site_uuid: settingsCache.get('site_uuid'),
-        post_uuid: dataRoot.post?.uuid,
+        post_uuid: entry?.uuid,
         post_type: dataRoot.context?.includes('post') ? 'post' : dataRoot.context?.includes('page') ? 'page' : null,
         member_uuid: dataRoot.member?.uuid,
         member_status: dataRoot.member?.status

--- a/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost-head.test.js.snap
+++ b/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost-head.test.js.snap
@@ -1657,6 +1657,148 @@ Object {
 }
 `;
 
+exports[`{{ghost_head}} helper includes tinybird tracker script when config is set sets tb_post_uuid on page page 1 1`] = `
+Object {
+  "rendered": "<meta name=\\"description\\" content=\\"all about our site\\">
+    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/about/\\">
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
+    
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"About\\">
+    <meta property=\\"og:description\\" content=\\"all about our site\\">
+    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/about/\\">
+    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/test-image-about.png\\">
+    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"About\\">
+    <meta name=\\"twitter:description\\" content=\\"all about our site\\">
+    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/about/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/test-image-about.png\\">
+    <meta name=\\"twitter:creator\\" content=\\"@testuser\\">
+    
+    <script type=\\"application/ld+json\\">
+{
+    \\"@context\\": \\"https://schema.org\\",
+    \\"@type\\": \\"Article\\",
+    \\"publisher\\": {
+        \\"@type\\": \\"Organization\\",
+        \\"name\\": \\"Ghost\\",
+        \\"url\\": \\"http://127.0.0.1:2369/\\",
+        \\"logo\\": {
+            \\"@type\\": \\"ImageObject\\",
+            \\"url\\": \\"http://127.0.0.1:2369/favicon.ico\\"
+        }
+    },
+    \\"author\\": {
+        \\"@type\\": \\"Person\\",
+        \\"name\\": \\"name\\",
+        \\"image\\": {
+            \\"@type\\": \\"ImageObject\\",
+            \\"url\\": \\"http://127.0.0.1:2369/content/images/test-author-image.png\\"
+        },
+        \\"url\\": \\"https://mysite.com/fakeauthor/\\",
+        \\"sameAs\\": [
+            \\"http://authorwebsite.com\\",
+            \\"https://www.facebook.com/testuser\\",
+            \\"https://x.com/testuser\\"
+        ]
+    },
+    \\"headline\\": \\"About\\",
+    \\"url\\": \\"http://127.0.0.1:2369/about/\\",
+    \\"datePublished\\": \\"1970-01-01T00:00:00.000Z\\",
+    \\"dateModified\\": \\"1970-01-01T00:00:00.000Z\\",
+    \\"image\\": {
+        \\"@type\\": \\"ImageObject\\",
+        \\"url\\": \\"http://127.0.0.1:2369/content/images/test-image-about.png\\"
+    },
+    \\"mainEntityOfPage\\": \\"http://127.0.0.1:2369/about/\\"
+}
+    </script>
+
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
+    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
+    
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
+    <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"77f09c60-5a34-4b4c-a3f6-e1b1d78f7412\\" tb_post_uuid=\\"11f01ac0-fb9c-4c0f-b8d0-ce2d01430ea3\\" tb_post_type=\\"page\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\"></script>",
+}
+`;
+
+exports[`{{ghost_head}} helper includes tinybird tracker script when config is set sets tb_post_uuid on page route 1 1`] = `
+Object {
+  "rendered": "<meta name=\\"description\\" content=\\"all about our site\\">
+    <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/about/\\">
+    <meta name=\\"referrer\\" content=\\"no-referrer-when-downgrade\\">
+    
+    <meta property=\\"og:site_name\\" content=\\"Ghost\\">
+    <meta property=\\"og:type\\" content=\\"website\\">
+    <meta property=\\"og:title\\" content=\\"About\\">
+    <meta property=\\"og:description\\" content=\\"all about our site\\">
+    <meta property=\\"og:url\\" content=\\"http://127.0.0.1:2369/about/\\">
+    <meta property=\\"og:image\\" content=\\"http://127.0.0.1:2369/content/images/test-image-about.png\\">
+    <meta property=\\"article:published_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:modified_time\\" content=\\"1970-01-01T00:00:00.000Z\\">
+    <meta property=\\"article:author\\" content=\\"https://www.facebook.com/testuser\\">
+    <meta name=\\"twitter:card\\" content=\\"summary_large_image\\">
+    <meta name=\\"twitter:title\\" content=\\"About\\">
+    <meta name=\\"twitter:description\\" content=\\"all about our site\\">
+    <meta name=\\"twitter:url\\" content=\\"http://127.0.0.1:2369/about/\\">
+    <meta name=\\"twitter:image\\" content=\\"http://127.0.0.1:2369/content/images/test-image-about.png\\">
+    <meta name=\\"twitter:creator\\" content=\\"@testuser\\">
+    
+    <script type=\\"application/ld+json\\">
+{
+    \\"@context\\": \\"https://schema.org\\",
+    \\"@type\\": \\"Article\\",
+    \\"publisher\\": {
+        \\"@type\\": \\"Organization\\",
+        \\"name\\": \\"Ghost\\",
+        \\"url\\": \\"http://127.0.0.1:2369/\\",
+        \\"logo\\": {
+            \\"@type\\": \\"ImageObject\\",
+            \\"url\\": \\"http://127.0.0.1:2369/favicon.ico\\"
+        }
+    },
+    \\"author\\": {
+        \\"@type\\": \\"Person\\",
+        \\"name\\": \\"name\\",
+        \\"image\\": {
+            \\"@type\\": \\"ImageObject\\",
+            \\"url\\": \\"http://127.0.0.1:2369/content/images/test-author-image.png\\"
+        },
+        \\"url\\": \\"https://mysite.com/fakeauthor/\\",
+        \\"sameAs\\": [
+            \\"http://authorwebsite.com\\",
+            \\"https://www.facebook.com/testuser\\",
+            \\"https://x.com/testuser\\"
+        ]
+    },
+    \\"headline\\": \\"About\\",
+    \\"url\\": \\"http://127.0.0.1:2369/about/\\",
+    \\"datePublished\\": \\"1970-01-01T00:00:00.000Z\\",
+    \\"dateModified\\": \\"1970-01-01T00:00:00.000Z\\",
+    \\"image\\": {
+        \\"@type\\": \\"ImageObject\\",
+        \\"url\\": \\"http://127.0.0.1:2369/content/images/test-image-about.png\\"
+    },
+    \\"mainEntityOfPage\\": \\"http://127.0.0.1:2369/about/\\"
+}
+    </script>
+
+    <meta name=\\"generator\\" content=\\"Ghost 0.3\\">
+    <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
+    
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
+    
+    <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">
+    <script defer src=\\"/public/ghost-stats.min.js?v=asset-hash\\" data-stringify-payload=\\"false\\" data-datasource=\\"analytics_events\\" data-storage=\\"localStorage\\" data-host=\\"https://e.ghost.org/tb/web_analytics\\" data-token=\\"tinybird_token\\" tb_site_uuid=\\"77f09c60-5a34-4b4c-a3f6-e1b1d78f7412\\" tb_post_uuid=\\"848325d4-e124-424b-a6b4-abe791ccb0ec\\" tb_post_type=\\"page\\" tb_member_uuid=\\"undefined\\" tb_member_status=\\"undefined\\"></script>",
+}
+`;
+
 exports[`{{ghost_head}} helper includes tinybird tracker script when config is set uses the provided host/endpoint from config 1 1`] = `
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"site description\\">

--- a/ghost/core/test/unit/frontend/helpers/ghost-head.test.js
+++ b/ghost/core/test/unit/frontend/helpers/ghost-head.test.js
@@ -1489,7 +1489,7 @@ describe('{{ghost_head}} helper', function () {
                 post: posts[10]
             };
 
-            await testGhostHead(testUtils.createHbsResponse({
+            const rendered = await testGhostHead(testUtils.createHbsResponse({
                 renderObject: renderObject,
                 locals: {
                     relativeUrl: '/post/',
@@ -1497,6 +1497,27 @@ describe('{{ghost_head}} helper', function () {
                     safeVersion: '0.3'
                 }
             }));
+
+            assert.match(rendered, new RegExp(`tb_post_uuid="${posts[10].uuid}"`));
+            assert.match(rendered, /tb_post_type="post"/);
+        });
+
+        it('sets tb_post_uuid on page route', async function () {
+            const renderObject = {
+                page: posts[0]
+            };
+
+            const rendered = await testGhostHead(testUtils.createHbsResponse({
+                renderObject: renderObject,
+                locals: {
+                    relativeUrl: '/about/',
+                    context: ['page'],
+                    safeVersion: '0.3'
+                }
+            }));
+
+            assert.match(rendered, new RegExp(`tb_post_uuid="${posts[0].uuid}"`));
+            assert.match(rendered, /tb_post_type="page"/);
         });
 
         it('sets tb_member_x variables on logged in home page', async function () {


### PR DESCRIPTION
# Page Analytics Implementation Breakdown

## 1. Track Page UUIDs In Pageview Events

### Scope

- Update `ghost_head` so rendered pages pass their UUID into the analytics payload as `post_uuid`.
- Add or adjust unit coverage for `ghost_head` output on pages.

### Acceptance Criteria

- Visiting a rendered page emits `page_hit` with the page UUID.
- Existing post UUID behavior is unchanged.
- Unit tests cover both post and page contexts.

---

## 2. Add Page Analytics Route And Content Loading

### Scope

- Add `/pages/analytics/:postId` and child routes alongside the existing post analytics routes.
- Extend the analytics provider to support `contentType: 'page'`.
- Fetch page data from the Pages Admin API when on a page analytics route.
- Keep existing Posts API behavior unchanged for post analytics.
- Set shared paths like `analyticsBasePath`, `editorPath`, and `listPath` based on content type.

### Acceptance Criteria

- Directly visiting `#/pages/analytics/:pageId` loads the page record.
- Directly visiting `#/pages/analytics/:pageId/web` queries Tinybird with the page UUID.
- Existing post analytics routes continue working.

---

## 3. Adapt Analytics UI For Pages

### Scope

- Update header copy/actions for pages.
- Link “Edit” to `/editor/page/:id`.
- Link “Back” to `/pages/`.
- Hide or disable post-only surfaces like newsletter/growth where pages do not support them.
- Ensure overview and web tabs work for pages.

### Acceptance Criteria

- Page Analytics reads as page-specific, not post-specific.
- No newsletter/growth-only post affordances appear for pages.
- Post Analytics UI remains unchanged.

---

## 4. Wire Pages List Analytics Links And E2E Coverage

### Scope

- Update Pages list metric/button links to route to `#/pages/analytics/:id/...` when `@post.isPage`.
- Add stable e2e selectors as needed.
- Add an e2e test that:
  - Visits the default About page.
  - Opens the Pages list.
  - Asserts `1` pageview is shown.
  - Clicks the web traffic metric.
  - Asserts the Page Analytics chart shows `1`.

### Acceptance Criteria

- The focused e2e test passes in the analytics project.
- Clicking the Pages list traffic metric lands on `#/pages/analytics/:id/web`.
- The link does not incorrectly route to `#/posts/analytics/:id/web`.