### PR TITLE
Clean up number abbreviation utility edge cases

### DIFF
--- a/apps/shade/src/lib/ds-utils.ts
+++ b/apps/shade/src/lib/ds-utils.ts
@@ -190,8 +190,16 @@ export const formatNumber = (value: number, options?: Pick<Intl.NumberFormatOpti
 };
 
 // Abbreviate numbers
-export function abbreviateNumber(number: number) {
+export function abbreviateNumber(number: number): string {
     const num = Number(number);
+
+    if (Number.isNaN(num) || !Number.isFinite(number)) {
+        return formatNumber(num);
+    }
+
+    if (num < 0) {
+        return `-${abbreviateNumber(-num)}`;
+    }
 
     if (num < 1000) {
         return formatNumber(num);

--- a/apps/shade/test/unit/utils/utils.test.ts
+++ b/apps/shade/test/unit/utils/utils.test.ts
@@ -9,6 +9,7 @@ import {
     getRangeDates,
     getRangeForStartDate,
     formatNumber,
+    abbreviateNumber,
     formatDuration,
     formatPercentage,
     getMemberInitials
@@ -51,12 +52,12 @@ describe('utils', function () {
             const increment = () => {
                 counter += 1;
             };
-            
+
             const debouncedIncrement = debounce(increment, 100);
-            
+
             debouncedIncrement();
             assert.equal(counter, 0, 'Function should not be called immediately');
-            
+
             vi.advanceTimersByTime(150);
             assert.equal(counter, 1, 'Function should be called after the delay');
         });
@@ -66,15 +67,15 @@ describe('utils', function () {
             const increment = () => {
                 counter += 1;
             };
-            
+
             const debouncedIncrement = debounce(increment, 100);
-            
+
             debouncedIncrement();
             debouncedIncrement();
             debouncedIncrement();
-            
+
             assert.equal(counter, 0, 'Function should not be called immediately');
-            
+
             vi.advanceTimersByTime(150);
             assert.equal(counter, 1, 'Function should only be called once');
         });
@@ -84,9 +85,9 @@ describe('utils', function () {
             const increment = () => {
                 counter += 1;
             };
-            
+
             const debouncedIncrement = debounce(increment, 100, true);
-            
+
             debouncedIncrement();
             assert.equal(counter, 1, 'Function should be called immediately');
         });
@@ -238,10 +239,10 @@ describe('utils', function () {
         it('formats a number with thousand separators', function () {
             let formatted = formatNumber(1000);
             assert.equal(formatted, '1,000');
-            
+
             formatted = formatNumber(1234567);
             assert.equal(formatted, '1,234,567');
-            
+
             formatted = formatNumber(1234.56);
             assert.equal(formatted, '1,235'); // Should round
         });
@@ -255,26 +256,56 @@ describe('utils', function () {
         });
     });
 
+    describe('abbreviateNumber function', function () {
+        it.each([
+            [0, '0'],
+            [12.6, '13'],
+            [123, '123'],
+            [999, '999'],
+            [-1, '-1'],
+            [-1000, '-1k'],
+            [1000, '1k'],
+            [1004, '1k'],
+            [1099, '1.1k'],
+            [1500, '1.5k'],
+            [99999, '100k'],
+            [999500, '1M'],
+            [1_000_000, '1M'],
+            [-1_000_000, '-1M'],
+            [1_234_567, '1.2M'],
+            [2_500_000, '2.5M'],
+            [123_456_789, '123.5M'],
+            [999_999_999, '1000M'],
+            [123_456_789_000, '123456.8M'],
+            [150_000_000_000, '150000M'],
+            [Infinity, '0'],
+            [-Infinity, '0'],
+            [NaN, '0']
+        ])('formats %s as %s', (input, expected) => {
+            assert.equal(abbreviateNumber(input), expected);
+        });
+    });
+
     describe('formatDuration function', function () {
         it('formats duration in seconds properly', function () {
             // Only seconds
             let formatted = formatDuration(45);
             assert.equal(formatted, '45s');
-            
+
             // Minutes and seconds
             formatted = formatDuration(65);
             assert.equal(formatted, '1m 5s');
-            
+
             // Hours, minutes, and seconds
             formatted = formatDuration(3665);
             assert.equal(formatted, '1h 1m 5s');
         });
-        
+
         it('handles edge cases correctly', function () {
             // Zero values in various positions
             let formatted = formatDuration(3600);
             assert.equal(formatted, '1h 0m 0s');
-            
+
             formatted = formatDuration(60);
             assert.equal(formatted, '1m 0s');
         });
@@ -346,4 +377,4 @@ describe('utils', function () {
             assert.equal(initials, 'UM'); // "Unknown Member" -> "UM"
         });
     });
-}); 
+});


### PR DESCRIPTION
no ref

This makes a few changes to `abbreviateNumber`:

- Handles negative numbers.
- Handles `Infinity` and `NaN`.
- Adds tests.
