### PR TITLE
Add gift-link commands to the audit log

### DIFF
--- a/apps/admin-x-framework/src/api/actions.ts
+++ b/apps/admin-x-framework/src/api/actions.ts
@@ -184,6 +184,8 @@ export const getActionTitle = (action: Action) => {
         resourceType = 'settings';
     } else if (resourceType === 'product') {
         resourceType = 'tier';
+    } else if (resourceType === 'gift_link') {
+        resourceType = 'gift link';
     }
 
     // Because a `page` and `post` both use the same model, we store the

--- a/ghost/admin/app/helpers/parse-history-event.js
+++ b/ghost/admin/app/helpers/parse-history-event.js
@@ -165,6 +165,8 @@ function getAction(ev) {
         resourceType = 'settings';
     } else if (resourceType === 'product') {
         resourceType = 'tier';
+    } else if (resourceType === 'gift_link') {
+        resourceType = 'gift link';
     }
 
     // Because a `page` and `post` both use the same model, we store the

--- a/ghost/core/core/server/api/endpoints/gift-links.ts
+++ b/ghost/core/core/server/api/endpoints/gift-links.ts
@@ -1,6 +1,5 @@
-import {service} from '../../services/gift-links';
+import {service, type RequestContext} from '../../services/gift-links';
 
-// permissions is untyped JS; require, don't import.
 const permissionsService = require('../../services/permissions');
 
 interface Frame {
@@ -11,11 +10,21 @@ interface Frame {
     };
 }
 
-// Also requires edit access to the post — you can gift a post only if you can edit it.
-async function assertCanManageGiftLink(frame: Frame): Promise<void> {
+async function assertCanEditAndGift(frame: Frame): Promise<void> {
     const {context, id} = frame.options;
     await permissionsService.canThis(context).manage.gift_link(id);
     await permissionsService.canThis(context).edit.post(id);
+}
+
+function requestContextFromFrame(frame: Frame): RequestContext {
+    const context = (frame.options.context ?? {}) as {user?: string; integration?: {id: string}};
+    if (context.integration) {
+        return {actor: {id: context.integration.id, type: 'integration'}};
+    }
+    if (context.user) {
+        return {actor: {id: context.user, type: 'user'}};
+    }
+    return {actor: null};
 }
 
 const noCacheInvalidation = {cacheInvalidate: false};
@@ -28,7 +37,7 @@ const controller = {
         options: ['id'],
         validation: {options: {id: {required: true}}},
         permissions(frame: Frame) {
-            return assertCanManageGiftLink(frame);
+            return assertCanEditAndGift(frame);
         },
         query(frame: Frame) {
             return service!.getPost(frame.options.id);
@@ -41,10 +50,10 @@ const controller = {
         options: ['id'],
         validation: {options: {id: {required: true}}},
         permissions(frame: Frame) {
-            return assertCanManageGiftLink(frame);
+            return assertCanEditAndGift(frame);
         },
         query(frame: Frame) {
-            return service!.ensure(frame.options.id);
+            return service!.ensure(requestContextFromFrame(frame), frame.options.id);
         }
     },
 
@@ -54,10 +63,10 @@ const controller = {
         options: ['id'],
         validation: {options: {id: {required: true}}},
         permissions(frame: Frame) {
-            return assertCanManageGiftLink(frame);
+            return assertCanEditAndGift(frame);
         },
         query(frame: Frame) {
-            return service!.create(frame.options.id);
+            return service!.create(requestContextFromFrame(frame), frame.options.id);
         }
     },
 
@@ -67,8 +76,8 @@ const controller = {
         permissions(frame: Frame) {
             return permissionsService.canThis(frame.options.context).removeAll.gift_link();
         },
-        async query() {
-            const count = await service!.removeAll();
+        async query(frame: Frame) {
+            const count = await service!.removeAll(requestContextFromFrame(frame));
             return {count};
         }
     }

--- a/ghost/core/core/server/services/gift-links/index.ts
+++ b/ghost/core/core/server/services/gift-links/index.ts
@@ -1,5 +1,7 @@
 import {GiftLinksService} from './service';
 
+export type {RequestContext} from './service';
+
 // Set by init() at boot, not at import: knex only exists once the DB has connected.
 export let service: GiftLinksService | undefined;
 
@@ -9,6 +11,7 @@ export function init(): void {
     }
 
     const {knex} = require('../../data/db');
+    const models = require('../../models');
 
-    service = new GiftLinksService({knex});
+    service = new GiftLinksService({knex, Action: models.Action});
 }

--- a/ghost/core/core/server/services/gift-links/queries.ts
+++ b/ghost/core/core/server/services/gift-links/queries.ts
@@ -26,6 +26,8 @@ const giftLinkColumns = Object.keys(GiftLinkRow.shape).map(column => `gift_links
 // post exists with no live link (hence the nullable columns).
 type LiveLinkRow = {[K in keyof z.input<typeof GiftLinkRow>]: z.input<typeof GiftLinkRow>[K] | null};
 
+// LEFT JOINs from posts: a missing post yields zero rows, while a post with no live link yields one
+// row with null link columns. So zero rows means "no such post".
 export function liveLinksForPost(postId: string) {
     return (knex: Knex) => knex('posts')
         .where('posts.id', postId)

--- a/ghost/core/core/server/services/gift-links/service.ts
+++ b/ghost/core/core/server/services/gift-links/service.ts
@@ -1,5 +1,6 @@
 import crypto from 'crypto';
 import errors from '@tryghost/errors';
+import logging from '@tryghost/logging';
 import {z} from 'zod';
 import type {Knex} from 'knex';
 import {GiftLinkToken, type GiftLink, type Post} from './models';
@@ -9,11 +10,37 @@ export function generateGiftLinkToken(): GiftLinkToken {
     return GiftLinkToken.parse(crypto.randomBytes(24).toString('base64url'));
 }
 
+export interface Actor {
+    id: string;
+    type: 'user' | 'integration';
+}
+
+interface ActionRecorder {
+    add(data: Record<string, unknown>, options: {autoRefresh: boolean}): Promise<unknown>;
+}
+
+export interface RequestContext {
+    actor: Actor | null;
+}
+
+// The history UI only surfaces a verb-specific label (action_name) for 'edited' events; 'added' and
+// 'deleted' render as the bare event. So 'reset' maps to 'edited' to read as "reset", while
+// 'add'/'remove' read as plain "added"/"deleted".
+const COMMANDS = {
+    add: 'added',
+    reset: 'edited',
+    remove: 'deleted'
+} as const satisfies Record<string, 'added' | 'edited' | 'deleted'>;
+
+type GiftLinkVerb = keyof typeof COMMANDS;
+
 export class GiftLinksService {
     private knex: Knex;
+    private Action: ActionRecorder;
 
-    constructor({knex}: {knex: Knex}) {
+    constructor({knex, Action}: {knex: Knex; Action: ActionRecorder}) {
         this.knex = knex;
+        this.Action = Action;
     }
 
     async getPost(postId: string): Promise<Post> {
@@ -25,29 +52,36 @@ export class GiftLinksService {
         return row ? {id: row.post_id, giftLinks: [z.decode(queries.giftLinkCodec, row)]} : null;
     }
 
-    // True only when `token` is a live gift link bound to `postId`, so a token
-    // for one post can never validate against another.
     async isValidTokenForPost(token: string, postId: string): Promise<boolean> {
         return (await this.getPostByToken(token))?.id === postId;
     }
 
-    async ensure(postId: string): Promise<Post> {
+    async ensure(context: RequestContext, postId: string): Promise<Post> {
         const post = await this.requirePost(postId);
-        return post.giftLinks.length ? post : this.mint(postId);
+        if (post.giftLinks.length) {
+            return post;
+        }
+        const minted = await this.mint(postId);
+        await this.recordAction(context, 'add', postId);
+        return minted;
     }
 
-    async create(postId: string): Promise<Post> {
+    async create(context: RequestContext, postId: string): Promise<Post> {
         await this.requirePost(postId);
-        return this.mint(postId);
+        const minted = await this.mint(postId);
+        await this.recordAction(context, 'reset', postId);
+        return minted;
     }
 
     // Remove every live association; the gift_links rows stay as history.
-    async removeAll(): Promise<number> {
-        return this.knex('post_gift_links').del();
+    async removeAll(context: RequestContext): Promise<number> {
+        const removed = await this.knex('post_gift_links').del();
+        if (removed > 0) {
+            await this.recordAction(context, 'remove', null);
+        }
+        return removed;
     }
 
-    // A missing post is a 404, not a post with no live links: no rows means no post, and the
-    // remaining rows carrying a token are the live links.
     private async requirePost(postId: string): Promise<Post> {
         const rows = await queries.liveLinksForPost(postId)(this.knex);
         if (rows.length === 0) {
@@ -59,8 +93,6 @@ export class GiftLinksService {
         return {id: postId, giftLinks};
     }
 
-    // A new store row with the live association repointed to it. The replaced link's row stays as
-    // history. Concurrent adds are last-writer-wins, not an error.
     private async mint(postId: string): Promise<Post> {
         const now = new Date();
         const link: GiftLink = {token: generateGiftLinkToken(), createdAt: now};
@@ -72,5 +104,24 @@ export class GiftLinksService {
                 .merge({gift_link_token: link.token, updated_at: now});
         });
         return {id: postId, giftLinks: [link]};
+    }
+
+    private async recordAction(context: RequestContext, verb: GiftLinkVerb, subject: string | null): Promise<void> {
+        if (!context.actor) {
+            return;
+        }
+        const event = COMMANDS[verb];
+        try {
+            await this.Action.add({
+                event,
+                resource_type: 'gift_link',
+                resource_id: subject,
+                actor_type: context.actor.type,
+                actor_id: context.actor.id,
+                ...(event === 'edited' ? {context: {action_name: verb}} : {})
+            }, {autoRefresh: false});
+        } catch (err) {
+            logging.error(err);
+        }
     }
 }

--- a/ghost/core/test/e2e-api/admin/gift-links.test.ts
+++ b/ghost/core/test/e2e-api/admin/gift-links.test.ts
@@ -30,6 +30,7 @@ describe('Gift Links Admin API', function () {
         mockManager.restore();
         await models.Base.knex('post_gift_links').del();
         await models.Base.knex('gift_links').del();
+        await models.Base.knex('actions').where('resource_type', 'gift_link').del();
     });
 
     // The gift-link API is mounted for both posts and pages off the same controller; exercise
@@ -99,6 +100,60 @@ describe('Gift Links Admin API', function () {
             await agent.put(`posts/${postId}/gift_links/`).expectStatus(200);
             const {body} = await agent.put('gift_links/remove_all/').expectStatus(200);
             assert.deepEqual(body, {meta: {count: 1}});
+        });
+    });
+
+    describe('records actions in the history (via the actions API)', function () {
+        let actorId: string;
+
+        const giftLinkActions = async () => {
+            const {body} = await agent.get('actions/?filter=resource_type:gift_link').expectStatus(200);
+            return body.actions;
+        };
+        const actionNameOf = (action: {context: unknown}): string | undefined => {
+            if (!action.context) {
+                return undefined;
+            }
+            const ctx = typeof action.context === 'string' ? JSON.parse(action.context) : action.context;
+            return ctx.action_name;
+        };
+
+        beforeAll(async function () {
+            actorId = (await agent.get('users/me/').expectStatus(200)).body.users[0].id;
+        });
+
+        it('records an "added" action when a gift link is ensured', async function () {
+            await agent.put(`posts/${postId}/gift_links/`).expectStatus(200);
+
+            const actions = await giftLinkActions();
+            assert.equal(actions.length, 1);
+            assert.equal(actions[0].event, 'added');
+            assert.equal(actions[0].resource_id, postId);
+            assert.equal(actions[0].actor_type, 'user');
+            assert.equal(actions[0].actor_id, actorId);
+            assert.equal(actionNameOf(actions[0]), undefined);
+        });
+
+        it('records an "edited" action labelled "reset" when the link is recreated', async function () {
+            await agent.put(`posts/${postId}/gift_links/`).expectStatus(200);
+            await agent.post(`posts/${postId}/gift_links/`).expectStatus(200);
+
+            const reset = (await giftLinkActions()).find((a: {event: string}) => a.event === 'edited');
+            assert.ok(reset, 'an edited action should be recorded');
+            assert.equal(reset.resource_id, postId);
+            assert.equal(reset.actor_id, actorId);
+            assert.equal(actionNameOf(reset), 'reset');
+        });
+
+        it('records a "deleted" action when gift links are revoked', async function () {
+            await agent.put(`posts/${postId}/gift_links/`).expectStatus(200);
+            await agent.put('gift_links/remove_all/').expectStatus(200);
+
+            const deleted = (await giftLinkActions()).find((a: {event: string}) => a.event === 'deleted');
+            assert.ok(deleted, 'a deleted action should be recorded');
+            assert.equal(deleted.resource_id, null);
+            assert.equal(deleted.actor_id, actorId);
+            assert.equal(actionNameOf(deleted), undefined);
         });
     });
 

--- a/ghost/core/test/e2e-frontend/gift-links-toast-override.test.ts
+++ b/ghost/core/test/e2e-frontend/gift-links-toast-override.test.ts
@@ -85,7 +85,7 @@ describe('Front-end gift links — theme toast override', function () {
         await testUtils.fixtures.insertPosts([paidPost]);
 
         const giftLinksService = require('../../core/server/services/gift-links');
-        const post = await giftLinksService.service.ensure(paidPost.id);
+        const post = await giftLinksService.service.ensure({actor: null}, paidPost.id);
         token = post.giftLinks[0].token;
 
         request = supertest.agent(configUtils.config.get('url'));

--- a/ghost/core/test/e2e-frontend/gift-links.test.ts
+++ b/ghost/core/test/e2e-frontend/gift-links.test.ts
@@ -73,8 +73,8 @@ describe('Front-end gift links', function () {
 
         // Mint a live gift link for the paid post and the paid page.
         const giftLinksService = require('../../core/server/services/gift-links');
-        token = (await giftLinksService.service.ensure(paidPost.id)).giftLinks[0].token;
-        pageToken = (await giftLinksService.service.ensure(paidPage.id)).giftLinks[0].token;
+        token = (await giftLinksService.service.ensure({actor: null}, paidPost.id)).giftLinks[0].token;
+        pageToken = (await giftLinksService.service.ensure({actor: null}, paidPage.id)).giftLinks[0].token;
 
         request = supertest.agent(configUtils.config.get('url'));
     });

--- a/ghost/core/test/integration/services/gift-links.test.ts
+++ b/ghost/core/test/integration/services/gift-links.test.ts
@@ -1,13 +1,14 @@
 import {afterAll, afterEach, beforeAll, describe, it} from 'vitest';
 import assert from 'node:assert/strict';
 import errors from '@tryghost/errors';
-import {GiftLinksService} from '../../../core/server/services/gift-links/service';
+import {GiftLinksService, type RequestContext} from '../../../core/server/services/gift-links/service';
 import type {GiftLink} from '../../../core/server/services/gift-links/models';
 
 const testUtils = require('../../utils');
 const models = require('../../../core/server/models');
 
 const MISSING_POST_ID = '0123456789abcdef01234567';
+const CTX: RequestContext = {actor: {id: 'test-actor-id', type: 'user'}};
 
 describe('GiftLinksService (integration)', function () {
     let postId: string;
@@ -23,12 +24,16 @@ describe('GiftLinksService (integration)', function () {
         await testUtils.setup('users:roles', 'posts')();
         postId = testUtils.DataGenerator.Content.posts[0].id;
         otherPostId = testUtils.DataGenerator.Content.posts[1].id;
-        service = new GiftLinksService({knex: models.Base.knex});
+        service = new GiftLinksService({
+            knex: models.Base.knex,
+            Action: models.Action
+        });
     });
 
     afterEach(async function () {
         await models.Base.knex('post_gift_links').del();
         await models.Base.knex('gift_links').del();
+        await models.Base.knex('actions').where('resource_type', 'gift_link').del();
     });
 
     describe('getPost', function () {
@@ -46,7 +51,7 @@ describe('GiftLinksService (integration)', function () {
 
     describe('ensure', function () {
         it('mints a live link with a token when none exists', async function () {
-            const post = await service.ensure(postId);
+            const post = await service.ensure(CTX, postId);
 
             assert.equal(post.giftLinks.length, 1, 'a link should be created');
             assert.ok(post.giftLinks[0].token, 'token should be set');
@@ -54,8 +59,8 @@ describe('GiftLinksService (integration)', function () {
         });
 
         it('is idempotent: a repeat ensure returns the same live link', async function () {
-            const first = await service.ensure(postId);
-            const second = await service.ensure(postId);
+            const first = await service.ensure(CTX, postId);
+            const second = await service.ensure(CTX, postId);
 
             assert.equal(first.giftLinks[0]?.token, second.giftLinks[0]?.token);
             assert.equal((await liveLinks(postId)).length, 1);
@@ -63,15 +68,15 @@ describe('GiftLinksService (integration)', function () {
 
         it('throws NotFound for a post that does not exist', async function () {
             await assert.rejects(
-                () => service.ensure(MISSING_POST_ID),
+                () => service.ensure(CTX, MISSING_POST_ID),
                 (err: unknown) => err instanceof errors.NotFoundError
             );
         });
 
         it('keeps exactly one live link under concurrent calls', async function () {
             const [a, b] = await Promise.all([
-                service.ensure(postId),
-                service.ensure(postId)
+                service.ensure(CTX, postId),
+                service.ensure(CTX, postId)
             ]);
 
             assert.ok(a.giftLinks[0] && b.giftLinks[0]);
@@ -81,8 +86,8 @@ describe('GiftLinksService (integration)', function () {
 
     describe('create', function () {
         it('replaces the live link with a fresh token', async function () {
-            const original = await service.ensure(postId);
-            const created = await service.create(postId);
+            const original = await service.ensure(CTX, postId);
+            const created = await service.create(CTX, postId);
 
             assert.notEqual(created.giftLinks[0]?.token, original.giftLinks[0]?.token);
             const live = await liveLinks(postId);
@@ -91,14 +96,14 @@ describe('GiftLinksService (integration)', function () {
         });
 
         it('mints a link even when none existed', async function () {
-            const created = await service.create(postId);
+            const created = await service.create(CTX, postId);
             assert.equal((await liveLinks(postId)).length, 1);
             assert.ok(created.giftLinks[0]?.token);
         });
 
         it('throws NotFound for a post that does not exist', async function () {
             await assert.rejects(
-                () => service.create(MISSING_POST_ID),
+                () => service.create(CTX, MISSING_POST_ID),
                 (err: unknown) => err instanceof errors.NotFoundError
             );
         });
@@ -106,13 +111,13 @@ describe('GiftLinksService (integration)', function () {
 
     describe('getPostByToken', function () {
         it('resolves a live token, and stops resolving once replaced', async function () {
-            const original = await service.ensure(postId);
+            const original = await service.ensure(CTX, postId);
             const token = original.giftLinks[0]!.token;
 
             const found = await service.getPostByToken(token);
             assert.equal(found?.giftLinks[0]?.token, token);
 
-            await service.create(postId);
+            await service.create(CTX, postId);
             assert.equal(await service.getPostByToken(token), null);
         });
 
@@ -124,7 +129,7 @@ describe('GiftLinksService (integration)', function () {
 
     describe('isValidTokenForPost', function () {
         it('is true only for a live token bound to the given post', async function () {
-            const post = await service.ensure(postId);
+            const post = await service.ensure(CTX, postId);
             const token = post.giftLinks[0]!.token;
 
             assert.equal(await service.isValidTokenForPost(token, postId), true);
@@ -133,7 +138,7 @@ describe('GiftLinksService (integration)', function () {
             assert.equal(await service.isValidTokenForPost(token, otherPostId), false);
 
             // Once replaced, the old token no longer validates.
-            await service.create(postId);
+            await service.create(CTX, postId);
             assert.equal(await service.isValidTokenForPost(token, postId), false);
         });
 
@@ -145,10 +150,10 @@ describe('GiftLinksService (integration)', function () {
 
     describe('removeAll', function () {
         it('drops every live link across posts and returns the count', async function () {
-            await service.ensure(postId);
-            await service.ensure(otherPostId);
+            await service.ensure(CTX, postId);
+            await service.ensure(CTX, otherPostId);
 
-            const removed = await service.removeAll();
+            const removed = await service.removeAll(CTX);
 
             assert.equal(removed, 2);
             assert.deepEqual(await liveLinks(postId), []);
@@ -158,7 +163,7 @@ describe('GiftLinksService (integration)', function () {
 
     describe('the <=1-live-link-per-post invariant (database-enforced)', function () {
         it('rejects a second live association for the same post', async function () {
-            await service.ensure(postId);
+            await service.ensure(CTX, postId);
 
             await models.Base.knex('gift_links').insert({
                 token: 'second-live-token', post_id: postId, created_at: new Date()
@@ -170,6 +175,20 @@ describe('GiftLinksService (integration)', function () {
                 // SQLite: "UNIQUE constraint failed"; MySQL: "Duplicate entry ... for key"
                 /unique|duplicate/i
             );
+        });
+    });
+
+    describe('action recording', function () {
+        it('does not fail the command when recording the action throws', async function () {
+            const failing = new GiftLinksService({
+                knex: models.Base.knex,
+                Action: {add: async () => {
+                    throw new Error('action write failed');
+                }}
+            });
+
+            await assert.doesNotReject(() => failing.create(CTX, postId));
+            assert.equal((await liveLinks(postId)).length, 1, 'the gift link is still created');
         });
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3742

## Problem

Adding, resetting, or revoking a gift link on a post left no trace in the audit log. The audit log is normally populated automatically for Bookshelf models, but gift links are stored through raw queries, so none of these actions were recorded and there was no way to see who changed a post's gift links, or when.

## Solution

Adding, resetting, or revoking a gift link now records an entry in the audit log, capturing what happened and the acting user or integration. The audit-writing lives in its own small module that the gift-links service calls through an injected function, so the service stays unaware of how the audit log is stored. Internal calls with no acting user are not recorded, and a failed audit write never fails the command it observed.