### PR TITLE
Fixed tag slug 'new' not editable due to admin route collision

### DIFF
--- a/ghost/core/core/server/models/tag.js
+++ b/ghost/core/core/server/models/tag.js
@@ -128,7 +128,20 @@ Tag = ghostBookshelf.Model.extend({
                 {transacting: options.transacting})
                 .then(function then(slug) {
                     self.set({slug: slug});
+
+                    if (slug === 'new') {
+                        throw new errors.ValidationError({
+                            message: 'Tag slug "new" is reserved and cannot be used.'
+                        });
+                    }
                 });
+        }
+
+        // Prevent direct assignment of the reserved slug "new"
+        if (self.get('slug') === 'new') {
+            throw new errors.ValidationError({
+                message: 'Tag slug "new" is reserved and cannot be used.'
+            });
         }
     },
 


### PR DESCRIPTION
Closes #26095

## Problem

Creating a tag named "new" makes it uneditable in Ghost Admin. The route `/ghost/#/tags/new` is reserved for creating new tags and takes precedence over the dynamic edit route `/ghost/#/tags/:tag_slug`. So a tag with slug "new" can never be reached via the edit screen.

## Fix

Added validation in the Tag model to reserve "new" as a slug. The check runs in two places:

1. After slug generation: if the generated slug is "new", throw ValidationError
2. Direct assignment guard: if slug is set to "new" directly (import, API), throw ValidationError

Prevents the collision at the data layer regardless of how the tag enters the system.

## Testing

- Create a tag with name "New" - should fail with validation error
- Set tag slug to "new" via API - should fail
- Import a tag with slug "new" - should fail
- All other tag creation/editing - works as before

## Why backend over frontend

The Ember router could be patched to check for an existing "new" tag before rendering the create screen, but that adds latency to every new-tag page load. Backend validation is the simpler fix and prevents the collision at the source.