### PR TITLE
Fixed lazy URL service handing out URLs for non-public resources

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/authors.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/authors.js
@@ -1,4 +1,5 @@
 const debug = require('@tryghost/debug')('api:endpoints:utils:serializers:input:authors');
+const url = require('./utils/url');
 const slugFilterOrder = require('./utils/slug-filter-order');
 const utils = require('../../index');
 
@@ -16,6 +17,8 @@ module.exports = {
     browse(apiConfig, frame) {
         debug('browse');
 
+        url.forceUrlColumnsWhenLazy(frame, 'authors');
+
         if (utils.isContentAPI(frame)) {
             setDefaultOrder(frame);
         }
@@ -23,6 +26,8 @@ module.exports = {
 
     read(apiConfig, frame) {
         debug('read');
+
+        url.forceUrlColumnsWhenLazy(frame, 'authors');
 
         if (utils.isContentAPI(frame)) {
             setDefaultOrder(frame);

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/pages.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/pages.js
@@ -58,6 +58,7 @@ function forceUrlRelationsWhenLazy(frame) {
         if (relations.length) {
             frame.options.withRelated = _.union(frame.options.withRelated || [], relations);
         }
+        url.forceUrlColumnsWhenLazy(frame, 'pages');
     }
 }
 

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/posts.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/posts.js
@@ -81,6 +81,7 @@ function forceUrlRelationsWhenLazy(frame) {
         if (relations.length) {
             frame.options.withRelated = _.union(frame.options.withRelated || [], relations);
         }
+        url.forceUrlColumnsWhenLazy(frame, 'posts');
     }
 }
 

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/tags.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/tags.js
@@ -19,6 +19,8 @@ module.exports = {
     browse(apiConfig, frame) {
         debug('browse');
 
+        url.forceUrlColumnsWhenLazy(frame, 'tags');
+
         if (utils.isContentAPI(frame)) {
             setDefaultOrder(frame);
         }

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/utils/url.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/utils/url.js
@@ -1,4 +1,5 @@
 const urlUtils = require('../../../../../../../shared/url-utils');
+const urlService = require('../../../../../../services/url');
 
 const handleImageUrl = (imageUrl) => {
     try {
@@ -65,7 +66,26 @@ const forSetting = (attrs) => {
     return attrs;
 };
 
+// When a Content API `?fields=url` query narrows the selected columns, the
+// columns the lazy URL service needs to build a URL (the type's base-filter
+// columns and permalink fields, e.g. status/visibility/slug) get stripped
+// before the URL is generated, so the service rejects the resource as thin.
+// Force those columns back into the fetch so they are available at mapping
+// time; the output serializer still strips them from the response. No-op under
+// the eager service (getRequiredFields → []) and when `url` was not requested.
+const forceUrlColumnsWhenLazy = (frame, routerType) => {
+    if (!Array.isArray(frame.options.columns) || !frame.options.columns.includes('url')) {
+        return;
+    }
+    for (const field of urlService.facade.getRequiredFields(routerType)) {
+        if (!frame.options.columns.includes(field)) {
+            frame.options.columns.push(field);
+        }
+    }
+};
+
 module.exports.forPost = forPost;
 module.exports.forUser = forUser;
 module.exports.forTag = forTag;
 module.exports.forSetting = forSetting;
+module.exports.forceUrlColumnsWhenLazy = forceUrlColumnsWhenLazy;

--- a/ghost/core/core/server/services/url/lazy-url-service.ts
+++ b/ghost/core/core/server/services/url/lazy-url-service.ts
@@ -57,6 +57,38 @@ function buildBaseFilters(): Map<string, BaseFilter> {
     return baseFilters;
 }
 
+// Relation roots are loaded via getRequiredRelations (as withRelated), not as
+// scalar columns; `page`/`type` are the router-type discriminator, always set
+// on the resource. Everything else a router filter references is a scalar
+// own-column the resource must carry to be routed like eager.
+const FILTER_NON_SCALAR_FIELDS = new Set([
+    'tag', 'tags', 'author', 'authors', 'primary_tag', 'primary_author', 'page', 'type'
+]);
+
+// Scalar (own-column) fields a router filter reads, e.g. 'featured' from
+// 'featured:true'. Dotted clauses (e.g. tags.visibility) are relation
+// sub-fields and skipped — getRequiredRelations loads those relations.
+//
+// Only field names at an NQL expression boundary (start of the filter, or after
+// a `+`/`,`/`(` combinator) are matched, so colon-bearing values — URLs,
+// timestamps like 2020-01-01T00:00:00 — aren't mistaken for fields.
+function filterScalarFields(filter: string | null): string[] {
+    if (!filter) {
+        return [];
+    }
+    const fields = new Set<string>();
+    const matcher = /(?:^|[+,(])\s*(\w+)(\.\w+)?:/g;
+    let match;
+    while ((match = matcher.exec(filter)) !== null) {
+        const [, root, sub] = match;
+        if (sub || FILTER_NON_SCALAR_FIELDS.has(root)) {
+            continue;
+        }
+        fields.add(root);
+    }
+    return [...fields];
+}
+
 interface LazyUrlServiceDeps {
     urlUtils?: typeof localUtils;
     findResource: FindResource;
@@ -143,8 +175,8 @@ export class LazyUrlService implements LazyUrlServiceBackend {
 
     // Columns a resource of this type must carry for the lazy service to build
     // its URL: its base-filter columns plus the scalar columns its routers'
-    // permalinks substitute. Permalink relations are covered separately by
-    // getRequiredRelations; eager needs none of this (it looks URLs up by id).
+    // permalinks substitute and filters read. Relations are covered separately
+    // by getRequiredRelations; eager needs none of this (it looks URLs up by id).
     getRequiredFields(routerType: string): string[] {
         const fields = new Set<string>();
         const base = this.baseFilters.get(routerType);
@@ -164,6 +196,7 @@ export class LazyUrlService implements LazyUrlServiceBackend {
             if (/\b(year|month|day)\b/.test(config.permalink)) {
                 fields.add('published_at');
             }
+            filterScalarFields(config.filter).forEach(field => fields.add(field));
         }
         return [...fields];
     }
@@ -373,6 +406,11 @@ export class LazyUrlService implements LazyUrlServiceBackend {
         }
         if (/\bprimary_author\b/.test(config.filter) && r.primary_author === undefined) {
             missing.push('primary_author');
+        }
+        for (const field of filterScalarFields(config.filter)) {
+            if (r[field] === undefined) {
+                missing.push(field);
+            }
         }
         if (missing.length === 0) {
             return;

--- a/ghost/core/core/server/services/url/lazy-url-service.ts
+++ b/ghost/core/core/server/services/url/lazy-url-service.ts
@@ -141,6 +141,14 @@ export class LazyUrlService implements LazyUrlServiceBackend {
         return [...this.requiredRelations];
     }
 
+    // The record columns the base filter for a type reads (e.g. ['status',
+    // 'type'] for posts, ['visibility'] for tags). Callers serializing a
+    // resource's URL must load these or the resource is rejected as thin.
+    getRequiredFields(routerType: string): string[] {
+        const base = this.baseFilters.get(routerType);
+        return base ? [...base.fields] : [];
+    }
+
     hasFinished(): boolean {
         return true;
     }

--- a/ghost/core/core/server/services/url/lazy-url-service.ts
+++ b/ghost/core/core/server/services/url/lazy-url-service.ts
@@ -141,12 +141,31 @@ export class LazyUrlService implements LazyUrlServiceBackend {
         return [...this.requiredRelations];
     }
 
-    // The record columns the base filter for a type reads (e.g. ['status',
-    // 'type'] for posts, ['visibility'] for tags). Callers serializing a
-    // resource's URL must load these or the resource is rejected as thin.
+    // Columns a resource of this type must carry for the lazy service to build
+    // its URL: its base-filter columns plus the scalar columns its routers'
+    // permalinks substitute. Permalink relations are covered separately by
+    // getRequiredRelations; eager needs none of this (it looks URLs up by id).
     getRequiredFields(routerType: string): string[] {
+        const fields = new Set<string>();
         const base = this.baseFilters.get(routerType);
-        return base ? [...base.fields] : [];
+        if (base) {
+            base.fields.forEach(field => fields.add(field));
+        }
+        for (const config of this.routerConfigs) {
+            if (config.resourceType !== routerType) {
+                continue;
+            }
+            if (/\bslug\b/.test(config.permalink)) {
+                fields.add('slug');
+            }
+            if (/\bid\b/.test(config.permalink)) {
+                fields.add('id');
+            }
+            if (/\b(year|month|day)\b/.test(config.permalink)) {
+                fields.add('published_at');
+            }
+        }
+        return [...fields];
     }
 
     hasFinished(): boolean {

--- a/ghost/core/core/server/services/url/lazy-url-service.ts
+++ b/ghost/core/core/server/services/url/lazy-url-service.ts
@@ -23,6 +23,40 @@ interface RouterConfig {
     compiledFilter: CompiledFilter | null;
 }
 
+// Per-resource-type base filters, mirroring eager's resource-fetch filters
+// (`modelOptions.filter` in services/url/config.js). Deliberately duplicated
+// rather than imported: lazy is meant to replace eager, at which point eager's
+// config goes away and this becomes the single source. `fields` lists the
+// record columns each filter reads; a resource that reaches URL generation
+// must carry them (a thin one is rejected — see _assertBaseFieldsPresent).
+//
+// Authors are intentionally absent: users.visibility is schema-pinned to
+// 'public' (isIn: [['public']]), so eager's visibility:public author filter
+// never excludes anyone — every author is routable, and serialized authors
+// drop visibility anyway (#10438).
+const BASE_FILTERS: Record<string, {filter: string; fields: string[]}> = {
+    posts: {filter: 'status:published+type:post', fields: ['status', 'type']},
+    pages: {filter: 'status:published+type:page', fields: ['status', 'type']},
+    tags: {filter: 'visibility:public', fields: ['visibility']}
+};
+
+interface BaseFilter {
+    filter: string;
+    compiledFilter: CompiledFilter;
+    fields: string[];
+}
+
+function buildBaseFilters(): Map<string, BaseFilter> {
+    const baseFilters = new Map<string, BaseFilter>();
+    for (const [type, {filter, fields}] of Object.entries(BASE_FILTERS)) {
+        const compiledFilter = buildFilter(filter);
+        if (compiledFilter) {
+            baseFilters.set(type, {filter, compiledFilter, fields});
+        }
+    }
+    return baseFilters;
+}
+
 interface LazyUrlServiceDeps {
     urlUtils?: typeof localUtils;
     findResource: FindResource;
@@ -42,6 +76,7 @@ export class LazyUrlService implements LazyUrlServiceBackend {
     // Router configs in registration order, which is also their priority.
     private routerConfigs: RouterConfig[];
     private requiredRelations: string[] | null;
+    private baseFilters: Map<string, BaseFilter>;
 
     constructor({urlUtils = localUtils, findResource}: LazyUrlServiceDeps) {
         if (typeof findResource !== 'function') {
@@ -53,6 +88,7 @@ export class LazyUrlService implements LazyUrlServiceBackend {
         this.findResource = findResource;
         this.routerConfigs = [];
         this.requiredRelations = null;
+        this.baseFilters = buildBaseFilters();
     }
 
     onRouterAddedType(identifier: string, filter: string | null, resourceType: string, permalink: string): void {
@@ -116,6 +152,19 @@ export class LazyUrlService implements LazyUrlServiceBackend {
         }
 
         const record = this._recordForFilter(resource);
+
+        // Eager only builds URLs for resources that pass the per-type base
+        // filter (e.g. visibility:public tags, status:published posts), so a
+        // resource failing it has no URL there and must 404 here too. Checked
+        // only when a router for the type exists, since otherwise the resource
+        // 404s regardless.
+        if (this._hasRouterForType(routerType)) {
+            this._assertBaseFieldsPresent(routerType, resource);
+            if (!this._baseFilterMatches(routerType, record)) {
+                return this._formatNotFound(options);
+            }
+        }
+
         for (const config of this.routerConfigs) {
             if (config.resourceType !== routerType) {
                 continue;
@@ -137,9 +186,14 @@ export class LazyUrlService implements LazyUrlServiceBackend {
         if (!routerType) {
             return false;
         }
+        // A resource failing its base filter is not in eager's map, so no
+        // router owns it. Mirrors the base-filter gate in getUrlForResource.
+        const record = this._recordForFilter(resource);
+        if (!this._baseFilterMatches(routerType, record)) {
+            return false;
+        }
         // Ownership is exclusive: only the first matching router of the type
         // owns the resource, matching eager's reservation.
-        const record = this._recordForFilter(resource);
         const owner = this.routerConfigs.find(
             c => c.resourceType === routerType && filterMatches(c.compiledFilter, record)
         );
@@ -171,6 +225,9 @@ export class LazyUrlService implements LazyUrlServiceBackend {
             }
             // Normalize the same way the forward paths do so page: filters are
             // evaluated against an identical shape regardless of findResource.
+            // The base filter is enforced upstream by findResource's query
+            // scoping (visibility:public / status:published), so only the
+            // router filter needs re-checking here.
             const record = this._recordForFilter(resource as Resource);
             if (!filterMatches(config.compiledFilter, record)) {
                 continue;
@@ -197,6 +254,45 @@ export class LazyUrlService implements LazyUrlServiceBackend {
         const captured = params as Record<string, string>;
         const canonical = canonicalParams as Record<string, string>;
         return Object.keys(captured).every(key => canonical[key] === captured[key]);
+    }
+
+    private _hasRouterForType(routerType: string): boolean {
+        return this.routerConfigs.some(config => config.resourceType === routerType);
+    }
+
+    private _baseFilterMatches(routerType: string, record: Record<string, unknown>): boolean {
+        const base = this.baseFilters.get(routerType);
+        if (!base) {
+            return true;
+        }
+        return filterMatches(base.compiledFilter, record);
+    }
+
+    // A resource that reaches URL generation must carry the columns its base
+    // filter reads (status for posts/pages, visibility for tags) — production
+    // callers always do (full models, or forced by the serializers). Without
+    // them the filter can't be evaluated and we'd silently 404 a URL eager would
+    // have produced, so refuse loudly instead of guessing.
+    private _assertBaseFieldsPresent(routerType: string, resource: Resource): void {
+        const base = this.baseFilters.get(routerType);
+        if (!base) {
+            return;
+        }
+        const r = resource as Record<string, unknown>;
+        const missing = base.fields.filter(field => r[field] === undefined);
+        if (missing.length === 0) {
+            return;
+        }
+        throw new errors.InternalServerError({
+            message: 'Thin resource passed to LazyUrlService.getUrlForResource',
+            code: 'LAZY_URL_THIN_RESOURCE',
+            errorDetails: {
+                resourceType: routerType,
+                resourceId: resource.id,
+                baseFilter: base.filter,
+                missing
+            }
+        });
     }
 
     // Normalizes the plural router type to the singular DB value for filter

--- a/ghost/core/core/server/services/url/url-service-facade.ts
+++ b/ghost/core/core/server/services/url/url-service-facade.ts
@@ -68,6 +68,7 @@ export interface LazyUrlServiceBackend {
     ownsResource(routerId: string, resource: Resource): boolean;
     resolveUrl(path: string): Promise<Resource | null>;
     getRequiredRelations(): string[];
+    getRequiredFields(routerType: string): string[];
     hasFinished(): boolean;
     onRouterAddedType(...args: unknown[]): unknown;
     onRouterUpdated(...args: unknown[]): unknown;
@@ -159,6 +160,16 @@ export class UrlServiceFacade {
     getRequiredRelations(): string[] {
         if (this.lazyUrlService) {
             return this.lazyUrlService.getRequiredRelations();
+        }
+        return [];
+    }
+
+    // Columns a resource of this type must carry for the lazy backend to build
+    // its URL. [] with no lazy backend: eager looks URLs up by id and never
+    // reads these fields.
+    getRequiredFields(routerType: string): string[] {
+        if (this.lazyUrlService) {
+            return this.lazyUrlService.getRequiredFields(routerType);
         }
         return [];
     }

--- a/ghost/core/test/integration/url-service-parity.test.js
+++ b/ghost/core/test/integration/url-service-parity.test.js
@@ -9,6 +9,23 @@ const {createFindResource} = require('../../core/server/services/url/lazy-find-r
 
 const RESOURCE_TYPES = ['posts', 'pages', 'tags', 'authors'];
 
+// Eager filters resources at fetch time, then drops the routing columns
+// (status/visibility) from its cache to keep it lean — so `resource.data` lacks
+// them. A real caller hands the lazy service a serialized resource that still
+// carries those columns, and the lazy service requires them to evaluate its base
+// filter. Re-add the values eager filtered on (everything in the cache is
+// published/public) so the comparison reflects what lazy actually receives.
+function toLazyResource(type, data) {
+    const resource = Object.assign({}, data, {type});
+    if (type === 'posts' || type === 'pages') {
+        resource.status = 'published';
+    }
+    if (type === 'tags') {
+        resource.visibility = 'public';
+    }
+    return resource;
+}
+
 // Routing sets registered identically on both services. Slug-backed permalinks
 // only, since that is Ghost's default shape and the one resolveUrl queries by.
 const SCENARIOS = [
@@ -128,7 +145,7 @@ describe('Integration: eager/lazy URL service parity', function () {
                 for (const {type, resources} of cachedResourcesByType()) {
                     for (const resource of resources) {
                         const id = resource.data.id;
-                        const lazyResource = Object.assign({}, resource.data, {type});
+                        const lazyResource = toLazyResource(type, resource.data);
 
                         assert.equal(
                             lazy.getUrlForResource(lazyResource),
@@ -143,7 +160,7 @@ describe('Integration: eager/lazy URL service parity', function () {
                 for (const {type, resources} of cachedResourcesByType()) {
                     for (const resource of resources) {
                         const id = resource.data.id;
-                        const lazyResource = Object.assign({}, resource.data, {type});
+                        const lazyResource = toLazyResource(type, resource.data);
 
                         assert.equal(
                             lazy.getUrlForResource(lazyResource, {absolute: true}),
@@ -158,7 +175,7 @@ describe('Integration: eager/lazy URL service parity', function () {
                 for (const {type, resources} of cachedResourcesByType()) {
                     for (const resource of resources) {
                         const id = resource.data.id;
-                        const lazyResource = Object.assign({}, resource.data, {type});
+                        const lazyResource = toLazyResource(type, resource.data);
 
                         for (const route of scenario.routes) {
                             assert.equal(

--- a/ghost/core/test/unit/api/canary/utils/serializers/input/utils/url.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/input/utils/url.test.js
@@ -1,0 +1,48 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const urlService = require('../../../../../../../../core/server/services/url');
+const urlUtil = require('../../../../../../../../core/server/api/endpoints/utils/serializers/input/utils/url');
+
+describe('Unit: endpoints/utils/serializers/input/utils/url', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('forceUrlColumnsWhenLazy', function () {
+        it('forces the lazy-required columns into the fetch when url is requested', function () {
+            sinon.stub(urlService.facade, 'getRequiredFields').withArgs('tags').returns(['visibility']);
+            const frame = {options: {columns: ['url', 'id']}};
+
+            urlUtil.forceUrlColumnsWhenLazy(frame, 'tags');
+
+            assert.deepEqual(frame.options.columns, ['url', 'id', 'visibility']);
+        });
+
+        it('does not duplicate a column already requested', function () {
+            sinon.stub(urlService.facade, 'getRequiredFields').withArgs('tags').returns(['visibility']);
+            const frame = {options: {columns: ['url', 'visibility']}};
+
+            urlUtil.forceUrlColumnsWhenLazy(frame, 'tags');
+
+            assert.deepEqual(frame.options.columns, ['url', 'visibility']);
+        });
+
+        it('is a no-op when url is not requested', function () {
+            const stub = sinon.stub(urlService.facade, 'getRequiredFields');
+            const frame = {options: {columns: ['id', 'slug']}};
+
+            urlUtil.forceUrlColumnsWhenLazy(frame, 'tags');
+
+            assert.deepEqual(frame.options.columns, ['id', 'slug']);
+            sinon.assert.notCalled(stub);
+        });
+
+        it('is a no-op when no columns are set (full fetch carries every field)', function () {
+            const frame = {options: {}};
+
+            urlUtil.forceUrlColumnsWhenLazy(frame, 'tags');
+
+            assert.deepEqual(frame.options, {});
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/url/lazy-url-service.test.js
+++ b/ghost/core/test/unit/server/services/url/lazy-url-service.test.js
@@ -650,4 +650,20 @@ describe('LazyUrlService', function () {
             assert.deepEqual(service.getRequiredRelations(), []);
         });
     });
+
+    describe('getRequiredFields', function () {
+        it('returns the base-filter columns per resource type', function () {
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
+
+            assert.deepEqual(service.getRequiredFields('tags'), ['visibility']);
+            assert.deepEqual(service.getRequiredFields('posts').sort(), ['status', 'type']);
+            assert.deepEqual(service.getRequiredFields('pages').sort(), ['status', 'type']);
+        });
+
+        it('returns [] for a type with no base filter (incl. authors — visibility is vestigial)', function () {
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
+            assert.deepEqual(service.getRequiredFields('authors'), []);
+            assert.deepEqual(service.getRequiredFields('unknown'), []);
+        });
+    });
 });

--- a/ghost/core/test/unit/server/services/url/lazy-url-service.test.js
+++ b/ghost/core/test/unit/server/services/url/lazy-url-service.test.js
@@ -132,6 +132,34 @@ describe('LazyUrlService', function () {
             );
         });
 
+        it('throws when a router filter references a scalar field the resource lacks (e.g. featured)', function () {
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
+            // featured:true needs the featured column; without it the filter would
+            // see undefined and silently route to the wrong permalink.
+            service.onRouterAddedType('featured', 'featured:true', 'posts', '/featured/:slug/');
+            service.onRouterAddedType('default', null, 'posts', '/:slug/');
+
+            assert.throws(
+                () => service.getUrlForResource({type: 'posts', id: 'p', slug: 'hot', status: 'published'}),
+                /Thin resource passed to LazyUrlService/
+            );
+        });
+
+        it('routes via the filtered router when its scalar field is present', function () {
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
+            service.onRouterAddedType('featured', 'featured:true', 'posts', '/featured/:slug/');
+            service.onRouterAddedType('default', null, 'posts', '/:slug/');
+
+            assert.equal(
+                service.getUrlForResource({type: 'posts', id: 'p', slug: 'hot', status: 'published', featured: true}),
+                '/featured/hot/'
+            );
+            assert.equal(
+                service.getUrlForResource({type: 'posts', id: 'p', slug: 'meh', status: 'published', featured: false}),
+                '/meh/'
+            );
+        });
+
         it('expands shorthand tag/author filters via the EXPANSIONS table', function () {
             const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
             service.onRouterAddedType('podcast', 'tag:podcast', 'posts', '/podcast/:slug/');
@@ -684,6 +712,32 @@ describe('LazyUrlService', function () {
 
             assert.deepEqual(service.getRequiredFields('posts').sort(), ['published_at', 'slug', 'status', 'type']);
             assert.deepEqual(service.getRequiredFields('pages').sort(), ['id', 'status', 'type']);
+        });
+
+        it('includes scalar columns referenced by a router filter, but not relation or discriminator fields', function () {
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
+            service.onRouterAddedType('featured', 'featured:true', 'posts', '/featured/:slug/');
+            service.onRouterAddedType('default', null, 'posts', '/:slug/');
+
+            // featured (scalar) is required; page/type (discriminator) and tag/
+            // author relations are not — those go through getRequiredRelations.
+            assert.deepEqual(service.getRequiredFields('posts').sort(), ['featured', 'slug', 'status', 'type']);
+        });
+
+        it('does not treat relation or page/type filter clauses as scalar columns', function () {
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
+            service.onRouterAddedType('news', 'tag:news+page:false', 'posts', '/:slug/');
+
+            assert.deepEqual(service.getRequiredFields('posts').sort(), ['slug', 'status', 'type']);
+        });
+
+        it('does not capture colon-bearing filter values (timestamps, URLs) as fields', function () {
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
+            // The timestamp value contains `00:00:00`; only `published_at` (at an
+            // expression boundary) is a field, not `00`.
+            service.onRouterAddedType('recent', "published_at:>'2020-01-01T00:00:00Z'", 'posts', '/:slug/');
+
+            assert.deepEqual(service.getRequiredFields('posts').sort(), ['published_at', 'slug', 'status', 'type']);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/url/lazy-url-service.test.js
+++ b/ghost/core/test/unit/server/services/url/lazy-url-service.test.js
@@ -59,7 +59,7 @@ describe('LazyUrlService', function () {
             const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
             service.onRouterAddedType('default', null, 'posts', '/:slug/');
 
-            const url = service.getUrlForResource({type: 'posts', id: 'p', slug: 'hello'});
+            const url = service.getUrlForResource({type: 'posts', id: 'p', slug: 'hello', status: 'published'});
             assert.equal(url, '/hello/');
         });
 
@@ -69,8 +69,8 @@ describe('LazyUrlService', function () {
             service.onRouterAddedType('featured', 'featured:true', 'posts', '/featured/:slug/');
             service.onRouterAddedType('default', null, 'posts', '/:slug/');
 
-            const featured = service.getUrlForResource({type: 'posts', id: 'f', slug: 'hot', featured: true});
-            const ordinary = service.getUrlForResource({type: 'posts', id: 'p', slug: 'meh', featured: false});
+            const featured = service.getUrlForResource({type: 'posts', id: 'f', slug: 'hot', status: 'published', featured: true});
+            const ordinary = service.getUrlForResource({type: 'posts', id: 'p', slug: 'meh', status: 'published', featured: false});
 
             assert.equal(featured, '/featured/hot/');
             assert.equal(ordinary, '/meh/');
@@ -81,8 +81,31 @@ describe('LazyUrlService', function () {
             // Only featured posts are routed.
             service.onRouterAddedType('featured', 'featured:true', 'posts', '/featured/:slug/');
 
-            const url = service.getUrlForResource({type: 'posts', id: 'p', slug: 'meh', featured: false});
+            const url = service.getUrlForResource({type: 'posts', id: 'p', slug: 'meh', status: 'published', featured: false});
             assert.equal(url, '/404/');
+        });
+
+        it('returns /404/ for a post that fails the base filter (e.g. a draft)', function () {
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
+            service.onRouterAddedType('default', null, 'posts', '/:slug/');
+
+            // Eager only maps status:published posts, so a draft has no URL.
+            const url = service.getUrlForResource({type: 'posts', id: 'p', slug: 'hello', status: 'draft'});
+            assert.equal(url, '/404/');
+        });
+
+        it('throws when a post is missing a base-filter field (status)', function () {
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
+            service.onRouterAddedType('default', null, 'posts', '/:slug/');
+
+            // A resource that reaches URL generation must carry the columns its
+            // base filter reads; production callers always provide status, so a
+            // status-less post is a thin-resource bug we refuse loudly rather
+            // than silently 404.
+            assert.throws(
+                () => service.getUrlForResource({type: 'posts', id: 'p', slug: 'hello'}),
+                /Thin resource passed to LazyUrlService/
+            );
         });
 
         it('throws when a relation-filtered router is given a thin resource', function () {
@@ -92,7 +115,7 @@ describe('LazyUrlService', function () {
             service.onRouterAddedType('news', 'tag:news', 'posts', '/:slug/');
 
             assert.throws(
-                () => service.getUrlForResource({type: 'posts', id: 'p', slug: 'hello'}),
+                () => service.getUrlForResource({type: 'posts', id: 'p', slug: 'hello', status: 'published'}),
                 /Thin resource passed to LazyUrlService/
             );
         });
@@ -104,7 +127,7 @@ describe('LazyUrlService', function () {
             // An empty tags array is still a loaded relation, so the resource is
             // evaluated normally and falls through to /404/ on no match.
             assert.equal(
-                service.getUrlForResource({type: 'posts', id: 'p', slug: 'hello', tags: []}),
+                service.getUrlForResource({type: 'posts', id: 'p', slug: 'hello', status: 'published', tags: []}),
                 '/404/'
             );
         });
@@ -118,6 +141,7 @@ describe('LazyUrlService', function () {
                 type: 'posts',
                 id: 'p',
                 slug: 'episode-1',
+                status: 'published',
                 tags: [{id: 't1', slug: 'podcast'}, {id: 't2', slug: 'misc'}]
             });
             assert.equal(podcastPost, '/podcast/episode-1/');
@@ -135,7 +159,7 @@ describe('LazyUrlService', function () {
             const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
             service.onRouterAddedType('posts-only', 'page:false', 'posts', '/:slug/');
 
-            const post = service.getUrlForResource({type: 'post', id: 'p', slug: 'hello'});
+            const post = service.getUrlForResource({type: 'post', id: 'p', slug: 'hello', status: 'published'});
             assert.equal(post, '/hello/');
         });
 
@@ -146,16 +170,52 @@ describe('LazyUrlService', function () {
             service.onRouterAddedType('staticPages', null, 'pages', '/:slug/');
 
             assert.equal(
-                service.getUrlForResource({type: 'tags', id: 't1', slug: 'food'}),
+                service.getUrlForResource({type: 'tags', id: 't1', slug: 'food', visibility: 'public'}),
                 '/tag/food/'
             );
             assert.equal(
-                service.getUrlForResource({type: 'authors', id: 'a1', slug: 'jane'}),
+                service.getUrlForResource({type: 'authors', id: 'a1', slug: 'jane', visibility: 'public'}),
                 '/author/jane/'
             );
             assert.equal(
-                service.getUrlForResource({type: 'pages', id: 'pg1', slug: 'about'}),
+                service.getUrlForResource({type: 'pages', id: 'pg1', slug: 'about', status: 'published'}),
                 '/about/'
+            );
+        });
+
+        it('returns /404/ for an internal/private tag (fails visibility:public)', function () {
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
+            service.onRouterAddedType('tagsRouter', null, 'tags', '/tag/:slug/');
+
+            // Eager filters its tag resources to visibility:public, so an
+            // internal tag (#hash) has no URL there and must 404 here too.
+            assert.equal(
+                service.getUrlForResource({type: 'tags', id: 't1', slug: 'hash-internal', visibility: 'internal'}),
+                '/404/'
+            );
+        });
+
+        it('throws when a tag is missing the visibility base-filter field', function () {
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
+            service.onRouterAddedType('tagsRouter', null, 'tags', '/tag/:slug/');
+
+            assert.throws(
+                () => service.getUrlForResource({type: 'tags', id: 't1', slug: 'food'}),
+                /Thin resource passed to LazyUrlService/
+            );
+        });
+
+        it('routes an author without a visibility field (authors have no base filter)', function () {
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
+            service.onRouterAddedType('authorsRouter', null, 'authors', '/author/:slug/');
+
+            // users.visibility is schema-pinned to 'public', so BASE_FILTERS has
+            // no entry for authors. Serialized authors drop visibility (#10438),
+            // so unlike tags they must not be treated as thin — every author is
+            // routable, matching eager.
+            assert.equal(
+                service.getUrlForResource({type: 'authors', id: 'a1', slug: 'jane'}),
+                '/author/jane/'
             );
         });
 
@@ -167,6 +227,7 @@ describe('LazyUrlService', function () {
                 type: 'posts',
                 id: 'p',
                 slug: 'hello',
+                status: 'published',
                 published_at: '2026-04-15T10:00:00Z'
             });
             assert.equal(url, '/2026/04/hello/');
@@ -176,7 +237,7 @@ describe('LazyUrlService', function () {
             const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
             service.onRouterAddedType('default', null, 'posts', '/:slug/');
 
-            const post = {type: 'posts', id: 'p', slug: 'hello'};
+            const post = {type: 'posts', id: 'p', slug: 'hello', status: 'published'};
             assert.equal(service.getUrlForResource(post, {absolute: true}), 'https://example.com/hello/');
             assert.equal(service.getUrlForResource(post, {withSubdirectory: true}), '/sub/hello/');
         });
@@ -191,21 +252,30 @@ describe('LazyUrlService', function () {
         it('returns true for an unfiltered router that matches the resource type', function () {
             const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
             service.onRouterAddedType('default', null, 'posts', '/:slug/');
-            assert.equal(service.ownsResource('default', {type: 'posts', id: 'p', slug: 'x'}), true);
+            assert.equal(service.ownsResource('default', {type: 'posts', id: 'p', slug: 'x', status: 'published'}), true);
         });
 
         it('returns false when the resource type does not match the router', function () {
             const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
             service.onRouterAddedType('default', null, 'posts', '/:slug/');
-            assert.equal(service.ownsResource('default', {type: 'pages', id: 'p', slug: 'x'}), false);
+            assert.equal(service.ownsResource('default', {type: 'pages', id: 'p', slug: 'x', status: 'published'}), false);
+        });
+
+        it('returns false for a resource that fails its base filter', function () {
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
+            service.onRouterAddedType('tagsRouter', null, 'tags', '/tag/:slug/');
+
+            // An internal tag is not in eager's map, so no router owns it.
+            assert.equal(service.ownsResource('tagsRouter', {type: 'tags', id: 't1', slug: 'x', visibility: 'internal'}), false);
+            assert.equal(service.ownsResource('tagsRouter', {type: 'tags', id: 't1', slug: 'x', visibility: 'public'}), true);
         });
 
         it('evaluates NQL filters against the resource', function () {
             const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
             service.onRouterAddedType('featured', 'featured:true', 'posts', '/featured/:slug/');
 
-            assert.equal(service.ownsResource('featured', {type: 'posts', id: 'a', featured: true}), true);
-            assert.equal(service.ownsResource('featured', {type: 'posts', id: 'b', featured: false}), false);
+            assert.equal(service.ownsResource('featured', {type: 'posts', id: 'a', status: 'published', featured: true}), true);
+            assert.equal(service.ownsResource('featured', {type: 'posts', id: 'b', status: 'published', featured: false}), false);
         });
 
         it('grants exclusive ownership to the first matching router', function () {
@@ -215,11 +285,11 @@ describe('LazyUrlService', function () {
             service.onRouterAddedType('featured', 'featured:true', 'posts', '/featured/:slug/');
             service.onRouterAddedType('default', null, 'posts', '/:slug/');
 
-            const featured = {type: 'posts', id: 'f', slug: 'hot', featured: true};
+            const featured = {type: 'posts', id: 'f', slug: 'hot', status: 'published', featured: true};
             assert.equal(service.ownsResource('featured', featured), true);
             assert.equal(service.ownsResource('default', featured), false);
 
-            const ordinary = {type: 'posts', id: 'p', slug: 'meh', featured: false};
+            const ordinary = {type: 'posts', id: 'p', slug: 'meh', status: 'published', featured: false};
             assert.equal(service.ownsResource('featured', ordinary), false);
             assert.equal(service.ownsResource('default', ordinary), true);
         });
@@ -235,10 +305,10 @@ describe('LazyUrlService', function () {
         it('drops all registered router configs', function () {
             const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
             service.onRouterAddedType('default', null, 'posts', '/:slug/');
-            assert.equal(service.getUrlForResource({type: 'posts', slug: 'hello', id: 'p'}), '/hello/');
+            assert.equal(service.getUrlForResource({type: 'posts', slug: 'hello', id: 'p', status: 'published'}), '/hello/');
 
             service.reset();
-            assert.equal(service.getUrlForResource({type: 'posts', slug: 'hello', id: 'p'}), '/404/');
+            assert.equal(service.getUrlForResource({type: 'posts', slug: 'hello', id: 'p', status: 'published'}), '/404/');
         });
     });
 
@@ -528,7 +598,7 @@ describe('LazyUrlService', function () {
             // Caller (e.g. the entry controller / RSS feed) hands the lazy
             // service a raw DB record with type:'post'. The service should
             // still match the posts collection.
-            const url = service.getUrlForResource({type: 'post', id: 'p1', slug: 'hello'});
+            const url = service.getUrlForResource({type: 'post', id: 'p1', slug: 'hello', status: 'published'});
             assert.equal(url, '/hello/');
         });
     });

--- a/ghost/core/test/unit/server/services/url/lazy-url-service.test.js
+++ b/ghost/core/test/unit/server/services/url/lazy-url-service.test.js
@@ -665,5 +665,25 @@ describe('LazyUrlService', function () {
             assert.deepEqual(service.getRequiredFields('authors'), []);
             assert.deepEqual(service.getRequiredFields('unknown'), []);
         });
+
+        it('adds the scalar columns a registered permalink substitutes', function () {
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
+            service.onRouterAddedType('tagsRouter', null, 'tags', '/tag/:slug/');
+            service.onRouterAddedType('authorsRouter', null, 'authors', '/author/:slug/');
+
+            // slug is needed to build the permalink even though eager (id-based)
+            // never reads it; authors have no base filter, only the permalink slug.
+            assert.deepEqual(service.getRequiredFields('tags').sort(), ['slug', 'visibility']);
+            assert.deepEqual(service.getRequiredFields('authors'), ['slug']);
+        });
+
+        it('requires published_at for date-based permalinks and id for :id permalinks', function () {
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
+            service.onRouterAddedType('dated', null, 'posts', '/:year/:month/:slug/');
+            service.onRouterAddedType('byId', null, 'pages', '/:id/');
+
+            assert.deepEqual(service.getRequiredFields('posts').sort(), ['published_at', 'slug', 'status', 'type']);
+            assert.deepEqual(service.getRequiredFields('pages').sort(), ['id', 'status', 'type']);
+        });
     });
 });

--- a/ghost/core/test/unit/server/services/url/url-service-facade.test.js
+++ b/ghost/core/test/unit/server/services/url/url-service-facade.test.js
@@ -50,6 +50,12 @@ describe('UrlServiceFacade', function () {
         });
     });
 
+    describe('getRequiredFields', function () {
+        it('returns [] with no lazy backend (eager looks up by id, reads no fields)', function () {
+            assert.deepEqual(facade.getRequiredFields('tags'), []);
+        });
+    });
+
     describe('resolveUrl', function () {
         it('returns null when the underlying lookup misses', async function () {
             urlService.getResource.returns(null);
@@ -111,6 +117,7 @@ describe('UrlServiceFacade', function () {
                 ownsResource: sinon.stub().returns(true),
                 resolveUrl: sinon.stub().resolves({type: 'posts', id: 'p1'}),
                 getRequiredRelations: sinon.stub().returns(['tags']),
+                getRequiredFields: sinon.stub().returns(['visibility']),
                 hasFinished: sinon.stub().returns(true),
                 onRouterAddedType: sinon.stub(),
                 onRouterUpdated: sinon.stub(),
@@ -126,6 +133,11 @@ describe('UrlServiceFacade', function () {
         it('delegates getRequiredRelations to the lazy backend', function () {
             assert.deepEqual(lazyFacade.getRequiredRelations(), ['tags']);
             sinon.assert.calledOnce(lazyUrlService.getRequiredRelations);
+        });
+
+        it('delegates getRequiredFields to the lazy backend', function () {
+            assert.deepEqual(lazyFacade.getRequiredFields('tags'), ['visibility']);
+            sinon.assert.calledWith(lazyUrlService.getRequiredFields, 'tags');
         });
 
         it('routes getUrlForResource through the lazy backend', function () {


### PR DESCRIPTION
## Summary

While the lazy URL service runs alongside eager in **compare mode**, the lazy forward path handed out URLs for resources eager returns `/404/` for — most visibly **internal/private tags** (the reported divergence), and also draft/scheduled/sent posts.

### Root cause
Eager only builds URLs for resources that pass each type's resource-fetch filter (`visibility:public` for tags, `status:published+type:*` for posts/pages), applied at fetch time. The lazy forward path (`getUrlForResource`/`ownsResource`) only consulted the **per-router** filter, which is `null` for taxonomy routers, so any tag/post matched.

## Changes (5 atomic commits)

1. **Fixed lazy URL service handing out URLs for non-public resources** — lazy applies the same per-type base filter (`BASE_FILTERS`, an explicit inline constant duplicated from `services/url/config.js` for now — lazy is meant to replace eager and consolidate) in `getUrlForResource`/`ownsResource`. A resource that reaches URL generation **must** carry the columns its base filter reads (`status`/`visibility`); production callers always do (full models, or forced by the serializers), so a thin resource throws `LAZY_URL_THIN_RESOURCE` rather than silently 404 a URL eager would produce. Authors have no base filter (`users.visibility` is schema-pinned to `'public'`). The `url-service-parity` integration test fed eager's *cached* resources (which drop those columns after fetch-time filtering) — updated it to re-add them so it exercises the shape lazy actually receives.
2. **Added getRequiredFields to the lazy URL service and facade** — exposes the per-type columns the lazy backend needs (mirrors `getRequiredRelations`); returns `[]` under eager.
3. **Forced lazy URL base-filter columns in the API input serializers** — under `?fields=url` the selected columns are narrowed, so posts/pages/tags serializers force the base-filter columns back into the fetch. No-op under eager.
4. **Forced permalink columns for lazy URL generation under `?fields=url`** — lazy builds URLs by substituting resource fields into the permalink template (`slug`, `id`, `published_at` for date tokens), which `?fields=url` also strips. `getRequiredFields` reports each type's permalink scalar columns; permalink relations stay covered by `getRequiredRelations`.
5. **Required router-filter scalar columns on the lazy forward path** — a router filter's own-columns (e.g. `featured:true`) were neither reported by `getRequiredFields` nor required by the thin-check, so a thin record under `?fields=url` could route a featured post to `/:slug/` instead of `/featured/:slug/`. Now the non-relation scalar fields a router filter references are reported (so the serializers force them) and required on the forward path (relations and the `page`/`type` discriminator stay excluded).

The eager `services/url/config.js` is **not** modified.

## Testing (run locally)
- Unit: `test/unit/api` + `test/unit/server` + `test/unit/frontend` — all green.
- Integration: full `test/integration` suite green (incl. `url-service-parity.test.js`).

## Known remaining divergence (follow-up, not in this PR)
- `shouldHavePosts`: eager omits tags/authors with zero published posts from its forward map → `/404/`; lazy's forward path still returns a URL (the reverse `resolveUrl` path already matches, via `TagPublic`). Needs post-count data on the resource. Low impact: nothing branches on a forward tag/author `/404/`, and the archive page itself still 404s via the reverse path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)