### PR TITLE
Fixed thin post resources passed to Slack & IndexNow URLs under lazy routing

### DIFF
--- a/ghost/core/core/server/services/indexnow.js
+++ b/ghost/core/core/server/services/indexnow.js
@@ -222,7 +222,14 @@ function indexnowListener(model, options) {
         return;
     }
 
-    ping(model.toJSON()).catch(() => {
+    ping({
+        ...model.toJSON(),
+        // tags and authors are needed so the lazy URL service can evaluate
+        // collection filters (e.g. `tag:foo`) when resolving the post URL;
+        // without them a tag/author-filtered post resolves to /404/
+        authors: model.related('authors').toJSON(),
+        tags: model.related('tags').toJSON()
+    }).catch(() => {
         // Errors are already logged inside ping()
         // This catch is just to prevent unhandled rejection warnings
     });

--- a/ghost/core/core/server/services/slack.js
+++ b/ghost/core/core/server/services/slack.js
@@ -179,7 +179,11 @@ function slackListener(model, options) {
 
     ping({
         ...model.toJSON(),
-        authors: model.related('authors').toJSON()
+        authors: model.related('authors').toJSON(),
+        // tags are needed so the lazy URL service can evaluate collection
+        // filters (e.g. `tag:foo`) when resolving the post URL; without them
+        // a tag-filtered post resolves to /404/
+        tags: model.related('tags').toJSON()
     });
 }
 

--- a/ghost/core/test/unit/server/services/indexnow.test.js
+++ b/ghost/core/test/unit/server/services/indexnow.test.js
@@ -58,12 +58,29 @@ describe('IndexNow', function () {
             listener = eventStub.firstCall.args[1];
         });
 
-        it('calls ping() with toJSONified model when content changed', function () {
+        it('calls ping() with toJSONified model including tags and authors when content changed', function () {
             const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
+            const testAuthor = _.clone(testUtils.DataGenerator.Content.users[0]);
+            const testTag = _.clone(testUtils.DataGenerator.Content.tags[0]);
 
             const testModel = {
                 toJSON: function () {
                     return testPost;
+                },
+                related: function (relation) {
+                    return {
+                        toJSON: function () {
+                            if (relation === 'authors') {
+                                return [testAuthor];
+                            }
+
+                            if (relation === 'tags') {
+                                return [testTag];
+                            }
+
+                            return [];
+                        }
+                    };
                 },
                 get: function (key) {
                     if (key === 'status') {
@@ -86,7 +103,13 @@ describe('IndexNow', function () {
             listener(testModel);
 
             sinon.assert.calledOnce(urlStub);
-            sinon.assert.calledWith(urlStub, sinon.match({...testPost, type: 'posts'}), {absolute: true});
+            // tags and authors must reach the URL service so the lazy backend
+            // can evaluate collection filters (e.g. `tag:foo`) when building the URL
+            sinon.assert.calledWith(
+                urlStub,
+                sinon.match({...testPost, type: 'posts', authors: [testAuthor], tags: [testTag]}),
+                {absolute: true}
+            );
         });
 
         it('does not call ping() when importing', function () {
@@ -156,6 +179,9 @@ describe('IndexNow', function () {
                 toJSON: function () {
                     return testPost;
                 },
+                related: function () {
+                    return {toJSON: () => []};
+                },
                 get: function (key) {
                     if (key === 'title') {
                         return 'New Title';
@@ -182,6 +208,9 @@ describe('IndexNow', function () {
                 toJSON: function () {
                     return testPost;
                 },
+                related: function () {
+                    return {toJSON: () => []};
+                },
                 get: function (key) {
                     if (key === 'slug') {
                         return 'new-slug';
@@ -207,6 +236,9 @@ describe('IndexNow', function () {
             const testModel = {
                 toJSON: function () {
                     return testPost;
+                },
+                related: function () {
+                    return {toJSON: () => []};
                 },
                 get: function (key) {
                     if (key === 'meta_description') {

--- a/ghost/core/test/unit/server/services/slack.test.js
+++ b/ghost/core/test/unit/server/services/slack.test.js
@@ -53,7 +53,7 @@ describe('Slack', function () {
         };
     }
 
-    function createPostModel(post, authors = []) {
+    function createPostModel(post, authors = [], tags = []) {
         return {
             toJSON: function () {
                 return post;
@@ -63,6 +63,10 @@ describe('Slack', function () {
                     toJSON: function () {
                         if (relation === 'authors') {
                             return authors;
+                        }
+
+                        if (relation === 'tags') {
+                            return tags;
                         }
 
                         return [];
@@ -96,9 +100,10 @@ describe('Slack', function () {
         assert.equal(eventStub.secondCall.args[1].name, 'slackTestPing');
     });
 
-    it('listener() sends a ping with toJSONified model and related authors', async function () {
+    it('listener() sends a ping with toJSONified model and related authors and tags', async function () {
         const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
         const testAuthor = _.clone(testUtils.DataGenerator.Content.users[0]);
+        const testTag = _.clone(testUtils.DataGenerator.Content.tags[0]);
         const settingsCacheStub = sinon.stub(settingsCache, 'get');
         const urlServiceGetUrlForResourceStub = sinon.stub(urlService.facade, 'getUrlForResource');
         const {requests, scope} = mockSlackWebhook();
@@ -115,12 +120,19 @@ describe('Slack', function () {
 
         configUtils.set('url', 'http://myblog.com');
 
-        slackListener(createPostModel(testPost, [testAuthor]));
+        slackListener(createPostModel(testPost, [testAuthor], [testTag]));
 
         await waitFor(() => scope.isDone());
 
         assert.equal(scope.isDone(), true);
         assert.equal(requests[0].attachments[1].fields[0].value, `<http://myblog.com/author/${testAuthor.slug}/ | ${testAuthor.name}>`);
+        // tags must reach the URL service so the lazy backend can evaluate
+        // collection filters like `tag:foo` when resolving the post URL
+        sinon.assert.calledWith(
+            urlServiceGetUrlForResourceStub,
+            sinon.match({id: testPost.id, type: 'posts', tags: [testTag]}),
+            {absolute: true}
+        );
     });
 
     it('listener() does not call ping() when importing', function () {


### PR DESCRIPTION
## Summary

Under the lazy URL service (HKG-1876), `getUrlForResource` evaluates collection routing filters (e.g. `tag:foo`, `author:bar`) against the resource it is handed. Two `post.published` event listeners passed **thin** post objects — missing the `tags`/`authors` relations — so tag/author-filtered posts resolved to `/404/` and the service logged `LAZY_URL_THIN_RESOURCE`:

```json
{"resourceType":"posts","resourceId":"...","routerIdentifier":"5FJbDlAzLq","filter":"tag:rampart-talks","missing":["tags"]}
```

## Changes (2 commits)

- **Slack** — `slackListener` already re-attached `authors` from the saved model but not `tags`. Now attaches `tags` too.
- **IndexNow** — `indexnowListener` passed a bare `model.toJSON()` (no relations). Now attaches both `tags` and `authors`.

Both mirror the eager url config's `withRelated: ['tags', 'authors']`. Other URL callers (`comments-service-emails`, `member-attribution`, API output serializer, RSS, frontend meta) already load these relations.

## Testing

TDD — failing unit test added first for each case, then the fix. `slack.test.js` (10 passing) and `indexnow.test.js` (28 passing) green.

ref https://linear.app/ghost/issue/HKG-1876

🤖 Generated with [Claude Code](https://claude.com/claude-code)