### PR TITLE
🐛 Fixed LinkedIn company and school URLs with underscores being rejected as invalid

### DIFF
--- a/apps/admin-x-settings/src/utils/social-urls/linkedin.ts
+++ b/apps/admin-x-settings/src/utils/social-urls/linkedin.ts
@@ -9,8 +9,10 @@ const PATH_TYPES = ['in', 'pub', 'company', 'school'] as const;
 type PathType = typeof PATH_TYPES[number];
 
 // validation info: https://www.linkedin.com/help/linkedin/answer/a542685/manage-your-public-profile-url?lang=en
-// Alphanumeric, hyphen, 3–100 characters
+// Personal profiles (/in/): alphanumeric and hyphen, 3–100 characters
 const USERNAME_REGEX = /^[a-zA-Z0-9-]{3,100}$/;
+// Company and school pages allow underscores in addition to alphanumeric and hyphen
+const COMPANY_USERNAME_REGEX = /^[a-zA-Z0-9_-]{3,100}$/;
 // For /pub/ profiles: username optionally followed by slash-separated segments (i.e. 12/34/567)
 const PUB_USERNAME_REGEX = /^[a-zA-Z0-9-]{3,100}(?:\/[a-zA-Z0-9-]*)*$/;
 
@@ -67,8 +69,13 @@ const extractInputParts = (input: string) => {
 };
 
 const isValidUsername = (pathType: PathType, username: string) => {
-    const pattern = pathType === 'pub' ? PUB_USERNAME_REGEX : USERNAME_REGEX;
-    return pattern.test(username);
+    if (pathType === 'pub') {
+        return PUB_USERNAME_REGEX.test(username);
+    }
+    if (pathType === 'company' || pathType === 'school') {
+        return COMPANY_USERNAME_REGEX.test(username);
+    }
+    return USERNAME_REGEX.test(username);
 };
 
 const buildUrl = ({regional, pathType, username}: {regional?: string; pathType: PathType; username: string}) => {

--- a/apps/admin-x-settings/test/unit/utils/linkedin-urls.test.ts
+++ b/apps/admin-x-settings/test/unit/utils/linkedin-urls.test.ts
@@ -43,6 +43,16 @@ describe('LinkedIn URLs', () => {
             assert.equal(validateLinkedInUrl('linkedin.com/pub/john-smith-abc123'), 'https://www.linkedin.com/pub/john-smith-abc123');
             assert.equal(validateLinkedInUrl('linkedin.com/pub/johnsmith/12/34/567'), 'https://www.linkedin.com/pub/johnsmith/12/34/567');
         });
+
+        it('should accept underscores in company and school URLs', () => {
+            assert.equal(validateLinkedInUrl('https://www.linkedin.com/company/eyeshot_2'), 'https://www.linkedin.com/company/eyeshot_2');
+            assert.equal(validateLinkedInUrl('linkedin.com/company/some_company'), 'https://www.linkedin.com/company/some_company');
+            assert.equal(validateLinkedInUrl('linkedin.com/school/some_school'), 'https://www.linkedin.com/school/some_school');
+        });
+
+        it('should reject underscores in personal /in/ URLs', () => {
+            assert.throws(() => validateLinkedInUrl('linkedin.com/in/john_smith'), /Your Username is not a valid LinkedIn Username/);
+        });
     });
 
     describe('Handle to URL conversion', () => {


### PR DESCRIPTION
## Problem

LinkedIn company and school page URLs can contain underscores — e.g. `https://www.linkedin.com/company/eyeshot_2` — but the front-end validator only permitted alphanumeric characters and hyphens, causing these valid URLs to be incorrectly rejected.

## Solution

Add a separate regex for `company` and `school` path types that permits underscores in addition to alphanumeric characters and hyphens. The stricter rule (no underscores) is preserved for personal `/in/` profiles, which follow LinkedIn's documented format of alphanumeric and hyphen only.

## Testing

New unit tests added covering:
- `company` and `school` URLs with underscores are accepted
- Personal `/in/` URLs with underscores continue to be rejected

All 179 unit tests pass.