### PR TITLE
Added gift links admin UI for analytics, posts list, and settings

### DIFF
--- a/apps/admin-x-framework/src/api/gift-links.ts
+++ b/apps/admin-x-framework/src/api/gift-links.ts
@@ -1,0 +1,71 @@
+import {createMutation, createQueryWithId} from '../utils/api/hooks';
+
+// A gift link as the admin API emits it. Usage counts (visits/views) are NOT
+// stored on the link — they come from the analytics pipeline (see the
+// gift-link usage hook in the posts app), so the resource is just the token.
+export type GiftLink = {
+    token: string;
+    created_at: string;
+};
+
+export type GiftLinksResponseType = {
+    gift_links: GiftLink[];
+};
+
+export type RemoveAllGiftLinksResponseType = {
+    meta: {
+        count: number;
+    };
+};
+
+// Gift links hang off a post or a page; both map to the same id-keyed,
+// type-agnostic controller server-side, but we address the canonical route so
+// the resource stays explicit.
+export type GiftLinkResource = 'posts' | 'pages';
+
+export type GiftLinkMutationPayload = {
+    id: string;
+    resource?: GiftLinkResource;
+};
+
+const dataType = 'GiftLinksResponseType';
+
+const giftLinkPath = ({id, resource = 'posts'}: GiftLinkMutationPayload) => `/${resource}/${id}/gift_links/`;
+
+// GET /posts/:id/gift_links/ — read the active link for a post without minting
+// one (empty when none exists yet). Read-only, so it's safe to fire on render
+// (e.g. the analytics gift-link card). Posts only; the analytics screen never
+// reads pages.
+export const useReadGiftLink = createQueryWithId<GiftLinksResponseType>({
+    dataType,
+    path: id => `/posts/${id}/gift_links/`
+});
+
+// PUT /:resource/:id/gift_links/ — idempotently ensure (create-or-get) the
+// active link, so opening the UI always has a URL to show.
+export const useEnsureGiftLink = createMutation<GiftLinksResponseType, GiftLinkMutationPayload>({
+    method: 'PUT',
+    path: giftLinkPath,
+    invalidateQueries: {
+        dataType
+    }
+});
+
+// POST /:resource/:id/gift_links/ — mint a fresh link, invalidating the old
+// token. Surfaced in the UI as "reset", but the backend controller is `create`.
+export const useCreateGiftLink = createMutation<GiftLinksResponseType, GiftLinkMutationPayload>({
+    method: 'POST',
+    path: giftLinkPath,
+    invalidateQueries: {
+        dataType
+    }
+});
+
+// PUT /gift_links/remove_all/ — site-wide kill switch (Owner/Admin), danger zone.
+export const useRemoveAllGiftLinks = createMutation<RemoveAllGiftLinksResponseType, null>({
+    method: 'PUT',
+    path: () => '/gift_links/remove_all/',
+    invalidateQueries: {
+        dataType
+    }
+});

--- a/apps/admin-x-framework/src/api/gift-links.ts
+++ b/apps/admin-x-framework/src/api/gift-links.ts
@@ -38,8 +38,17 @@ const giftLinkPath = ({id, resource = 'posts'}: GiftLinkMutationPayload) => `/${
 // reads pages.
 export const useReadGiftLink = createQueryWithId<GiftLinksResponseType>({
     dataType,
-    path: id => `/posts/${id}/gift_links/`
+    path: id => giftLinkPath({id})
 });
+
+// A post/page has at most one active gift link, so narrow the read above to that
+// single link and surface its token directly — callers shouldn't have to reach
+// into the response array.
+export const useActiveGiftLink = (id: string, options?: Parameters<typeof useReadGiftLink>[1]) => {
+    const result = useReadGiftLink(id, options);
+    const giftLink = result.data?.gift_links?.[0];
+    return {...result, giftLink, token: giftLink?.token};
+};
 
 // PUT /:resource/:id/gift_links/ — idempotently ensure (create-or-get) the
 // active link, so opening the UI always has a URL to show.

--- a/apps/admin-x-framework/src/api/pages.ts
+++ b/apps/admin-x-framework/src/api/pages.ts
@@ -8,6 +8,8 @@ export type Page = {
     url: string;
     status?: string;
     published_at?: string;
+    visibility?: string;
+    uuid?: string;
 };
 
 export interface PagesResponseType {

--- a/apps/admin-x-framework/src/api/users.ts
+++ b/apps/admin-x-framework/src/api/users.ts
@@ -206,6 +206,11 @@ export function canManageTags(user: HasRoles) {
     return isOwnerUser(user) || isAdminUser(user) || isEditorUser(user);
 }
 
+export function canManageGiftLinks(user: HasRoles) {
+    // Owner, Admin or Editor can manage gift links
+    return isOwnerUser(user) || isAdminUser(user) || isEditorUser(user);
+}
+
 export function hasAdminAccess(user: HasRoles) {
     return isOwnerUser(user) || isAdminUser(user);
 }

--- a/apps/admin-x-settings/src/components/settings/advanced/danger-zone.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/danger-zone.tsx
@@ -8,17 +8,20 @@ import {useDeleteAllContent} from '@tryghost/admin-x-framework/api/db';
 import {useGlobalData} from '../../providers/global-data-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useQueryClient} from '@tryghost/admin-x-framework';
+import {useRemoveAllGiftLinks} from '@tryghost/admin-x-framework/api/gift-links';
 import {useResetAuth} from '@tryghost/admin-x-framework/api/security';
 
 const DangerZone: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {mutateAsync: deleteAllContent} = useDeleteAllContent();
     const {mutateAsync: resetAuth} = useResetAuth();
+    const {mutateAsync: removeAllGiftLinks} = useRemoveAllGiftLinks();
     const client = useQueryClient();
     const handleError = useHandleError();
     const {config} = useGlobalData();
     const {totalUsers} = useStaffUsers();
 
     const resetAuthEnabled = Boolean(config?.labs?.dangerZoneResetAuth);
+    const giftLinksEnabled = Boolean(config?.labs?.giftLinks);
 
     const resetAuthStaffSentence = totalUsers === 1
         ? 'You will be signed out and must reset your password before signing back in.'
@@ -83,6 +86,29 @@ const DangerZone: React.FC<{ keywords: string[] }> = ({keywords}) => {
         });
     };
 
+    const handleRemoveAllGiftLinks = () => {
+        NiceModal.show(ConfirmationModal, {
+            title: 'Reset all gift links?',
+            prompt: 'This immediately invalidates every active gift link across your site. Anyone holding one will lose access. New gift links can still be created afterwards.',
+            okLabel: 'Reset all gift links',
+            okRunningLabel: 'Resetting...',
+            okColor: 'red',
+            onOk: async (modal) => {
+                try {
+                    const response = await removeAllGiftLinks(null);
+                    const count = response?.meta?.count ?? 0;
+                    showToast({
+                        title: `Reset ${count} gift ${count === 1 ? 'link' : 'links'}.`,
+                        type: 'success'
+                    });
+                    modal?.remove();
+                } catch (e) {
+                    handleError(e);
+                }
+            }
+        });
+    };
+
     return (
         <TopLevelGroup
             customHeader={
@@ -107,6 +133,15 @@ const DangerZone: React.FC<{ keywords: string[] }> = ({keywords}) => {
                         detail='Rotate every API key, sign out every staff user, and require a password reset. Use after a suspected credential compromise.'
                         testId='reset-all-authentication'
                         title='Reset all authentication'
+                    />
+                )}
+                {giftLinksEnabled && (
+                    <ListItem
+                        action={<Button aria-label='Reset all gift links' color='red' label='Reset' onClick={handleRemoveAllGiftLinks} />}
+                        bgOnHover={false}
+                        detail='Invalidate every active gift link across your site. Anyone holding one will lose access.'
+                        testId='reset-all-gift-links'
+                        title='Reset all gift links'
                     />
                 )}
             </div>

--- a/apps/admin-x-settings/test/acceptance/advanced/dangerzone.test.ts
+++ b/apps/admin-x-settings/test/acceptance/advanced/dangerzone.test.ts
@@ -45,4 +45,29 @@ test.describe('DangerZone', async () => {
 
         expect(lastApiRequests.resetAuth).toBeTruthy();
     });
+
+    test('Reset all gift links', async ({page}) => {
+        toggleLabsFlag('giftLinks', true);
+
+        const {lastApiRequests} = await mockApi({page, requests: {
+            ...globalDataRequests,
+            removeAllGiftLinks: {
+                method: 'PUT',
+                path: '/gift_links/remove_all/',
+                response: {meta: {count: 3}}
+            }
+        }});
+
+        await page.goto('/');
+
+        const dangerZone = page.getByTestId('dangerzone');
+        await dangerZone.getByTestId('reset-all-gift-links').getByRole('button', {name: 'Reset'}).click();
+
+        const modal = page.getByTestId('confirmation-modal');
+        await modal.getByRole('button', {name: 'Reset all gift links'}).click();
+
+        await expect(page.getByTestId('toast-success')).toContainText('Reset 3 gift links');
+
+        expect(lastApiRequests.removeAllGiftLinks).toBeTruthy();
+    });
 });

--- a/apps/admin/src/ember-bridge/ember-bridge.tsx
+++ b/apps/admin/src/ember-bridge/ember-bridge.tsx
@@ -12,6 +12,7 @@ export type StateBridgeEventMap = {
     subscriptionChange: SubscriptionState;
     sidebarVisibilityChange: SidebarVisibilityChangeEvent;
     routeChange: RouteChangeEvent;
+    openGiftLinkModal: OpenGiftLinkModalEvent;
 }
 
 export interface StateBridge {
@@ -59,6 +60,11 @@ export interface SidebarVisibilityChangeEvent {
 export interface RouteChangeEvent {
     routeName: string;
     queryParams: Record<string, unknown>;
+}
+
+export interface OpenGiftLinkModalEvent {
+    id: string;
+    resource: 'posts' | 'pages';
 }
 
 export type EmberRouting = Pick<StateBridge, 'getRouteUrl' | 'isRouteActive'>;
@@ -208,6 +214,18 @@ export function useSubscriptionStatus() {
     }, []);
 
     return subscriptionStatus;
+}
+
+/**
+ * Subscribes to Ember's request to open the (React-owned) gift-link modal.
+ *
+ * Ember surfaces — the posts/pages list context menu — fire `openGiftLinkModal`
+ * over the bridge instead of rendering their own modal. The consumer owns the
+ * modal's open/close state and just reacts to each request. Returns an
+ * unsubscribe function.
+ */
+export function subscribeOpenGiftLinkModal(handler: (event: OpenGiftLinkModalEvent) => void): () => void {
+    return onEmberStateBridgeEvent('openGiftLinkModal', handler);
 }
 
 // External store for sidebar visibility state

--- a/apps/admin/src/ember-bridge/index.ts
+++ b/apps/admin/src/ember-bridge/index.ts
@@ -3,6 +3,6 @@ export { EmberProvider } from "./ember-provider";
 export { useEmberContext } from "./ember-context";
 export { EmberFallback } from "./ember-fallback";
 export { ForceUpgradeGuard } from "./force-upgrade-guard";
-export { useEmberAuthSync, useEmberDataSync, useSidebarVisibility, useSubscriptionStatus, useEmberRouting, useForceUpgrade } from "./ember-bridge";
-export type { EmberDataChangeEvent, EmberRouting } from "./ember-bridge";
+export { useEmberAuthSync, useEmberDataSync, useSidebarVisibility, useSubscriptionStatus, useEmberRouting, useForceUpgrade, subscribeOpenGiftLinkModal } from "./ember-bridge";
+export type { EmberDataChangeEvent, EmberRouting, OpenGiftLinkModalEvent } from "./ember-bridge";
 export type { RouteHandle } from "./force-upgrade-guard";

--- a/apps/admin/src/gift-link-modal-host.tsx
+++ b/apps/admin/src/gift-link-modal-host.tsx
@@ -1,0 +1,56 @@
+import { Suspense, lazy, useEffect, useState } from "react";
+import { EmberFallback, subscribeOpenGiftLinkModal } from "./ember-bridge";
+import type { OpenGiftLinkModalEvent } from "./ember-bridge";
+
+// The gift-link modal is React-owned but triggered from the Ember posts/pages
+// list. It's only needed once someone opens it, so lazy-load it rather than
+// pulling the posts bundle into every list view.
+const GiftLinkModal = lazy(() => import("@tryghost/posts/gift-link-modal"));
+
+/**
+ * Bridges the Ember posts/pages context menu to the React gift-link modal.
+ *
+ * Subscribes to the bridge on mount and owns the modal's open/close state:
+ * each request opens the modal for the named post/page (reopening the same one
+ * just re-fires the event), and closing flips `open` while keeping the target
+ * so the modal can animate out.
+ */
+function GiftLinkModalHost() {
+    const [target, setTarget] = useState<OpenGiftLinkModalEvent | null>(null);
+    const [open, setOpen] = useState(false);
+
+    useEffect(() => subscribeOpenGiftLinkModal((event) => {
+        setTarget(event);
+        setOpen(true);
+    }), []);
+
+    if (!target) {
+        return null;
+    }
+
+    return (
+        <Suspense fallback={null}>
+            <GiftLinkModal
+                key={`${target.resource}:${target.id}`}
+                open={open}
+                postId={target.id}
+                resource={target.resource}
+                onOpenChange={setOpen}
+            />
+        </Suspense>
+    );
+}
+
+/**
+ * Route element for the Ember-backed posts and pages lists. Delegates the page
+ * itself to Ember (EmberFallback) while keeping the React gift-link modal host
+ * mounted so the list's context menu can open it.
+ */
+export function EmberListWithGiftLinks() {
+    return (
+        <>
+            <EmberFallback />
+            <GiftLinkModalHost />
+        </>
+    );
+}

--- a/apps/admin/src/gift-link-modal-host.tsx
+++ b/apps/admin/src/gift-link-modal-host.tsx
@@ -12,29 +12,29 @@ const GiftLinkModal = lazy(() => import("@tryghost/posts/gift-link-modal"));
  *
  * Subscribes to the bridge on mount and owns the modal's open/close state:
  * each request opens the modal for the named post/page (reopening the same one
- * just re-fires the event), and closing flips `open` while keeping the target
+ * just re-fires the event), and closing flips `open` while keeping the entry
  * so the modal can animate out.
  */
 function GiftLinkModalHost() {
-    const [target, setTarget] = useState<OpenGiftLinkModalEvent | null>(null);
+    const [entry, setEntry] = useState<OpenGiftLinkModalEvent | null>(null);
     const [open, setOpen] = useState(false);
 
     useEffect(() => subscribeOpenGiftLinkModal((event) => {
-        setTarget(event);
+        setEntry(event);
         setOpen(true);
     }), []);
 
-    if (!target) {
+    if (!entry) {
         return null;
     }
 
     return (
         <Suspense fallback={null}>
             <GiftLinkModal
-                key={`${target.resource}:${target.id}`}
+                key={`${entry.resource}:${entry.id}`}
                 open={open}
-                postId={target.id}
-                resource={target.resource}
+                postId={entry.id}
+                resource={entry.resource}
                 onOpenChange={setOpen}
             />
         </Suspense>

--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -13,6 +13,7 @@ import MyProfileRedirect from "./my-profile-redirect";
 // Ember
 import { EmberFallback, ForceUpgradeGuard } from "./ember-bridge";
 import type { RouteHandle } from "./ember-bridge";
+import { EmberListWithGiftLinks } from "./gift-link-modal-host";
 import { MembersRoute } from "./members-route";
 import { OnboardingRedirect } from "./onboarding/onboarding-redirect";
 
@@ -31,11 +32,11 @@ const EMBER_ROUTES: string[] = [
     "/signup/*",
     "/reset/*",
     "/pro/*",
-    "/posts",
+    // "/posts" and "/pages" are Ember-rendered but get the gift-link modal host
+    // layered on top — see giftLinkEmberRoutes below.
     "/posts/analytics/:postId/mentions",
     "/posts/analytics/:postId/debug",
     "/restore",
-    "/pages",
     "/editor/*",
     "/tags/new",
     "/explore/*",
@@ -134,6 +135,10 @@ export const routes: RouteObject[] = [
                 lazy: lazyComponent(() => import("./settings/settings")),
                 handle: { allowInForceUpgrade: true } satisfies RouteHandle,
             },
+            // The posts and pages lists stay in Ember, but mount the React
+            // gift-link modal host alongside so their context menu can open it.
+            {path: "/posts", Component: EmberListWithGiftLinks, handle: emberFallbackHandle},
+            {path: "/pages", Component: EmberListWithGiftLinks, handle: emberFallbackHandle},
             // Ember-handled routes
             ...emberFallbackRoutes,
             {

--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -32,8 +32,6 @@ const EMBER_ROUTES: string[] = [
     "/signup/*",
     "/reset/*",
     "/pro/*",
-    // "/posts" and "/pages" are Ember-rendered but get the gift-link modal host
-    // layered on top — see giftLinkEmberRoutes below.
     "/posts/analytics/:postId/mentions",
     "/posts/analytics/:postId/debug",
     "/restore",
@@ -135,8 +133,6 @@ export const routes: RouteObject[] = [
                 lazy: lazyComponent(() => import("./settings/settings")),
                 handle: { allowInForceUpgrade: true } satisfies RouteHandle,
             },
-            // The posts and pages lists stay in Ember, but mount the React
-            // gift-link modal host alongside so their context menu can open it.
             {path: "/posts", Component: EmberListWithGiftLinks, handle: emberFallbackHandle},
             {path: "/pages", Component: EmberListWithGiftLinks, handle: emberFallbackHandle},
             // Ember-handled routes

--- a/apps/posts/package.json
+++ b/apps/posts/package.json
@@ -21,7 +21,8 @@
             "require": "./dist/posts.umd.cjs"
         },
         "./api": "./src/api.ts",
-        "./members": "./src/views/members/members.tsx"
+        "./members": "./src/views/members/members.tsx",
+        "./gift-link-modal": "./src/views/PostAnalytics/modals/gift-link-modal.tsx"
     },
     "private": true,
     "scripts": {

--- a/apps/posts/src/hooks/use-can-manage-gift-link.ts
+++ b/apps/posts/src/hooks/use-can-manage-gift-link.ts
@@ -1,0 +1,21 @@
+import {isAdminUser, isAuthorUser, isEditorUser, isOwnerUser} from '@tryghost/admin-x-framework/api/users';
+import {useCurrentUser} from '@tryghost/admin-x-framework/api/current-user';
+import {useGlobalData} from '@src/providers/post-analytics-context';
+import {useMemo} from 'react';
+
+// Whether the current user can manage a gift link for this post. Mirrors
+// canCopyGiftLink in the Ember app/utils/gift-link.js: requires the labs flag,
+// a published gated (non-public) post, and a managing role.
+export const useCanManageGiftLink = (post?: {status?: string; visibility?: string}) => {
+    const {data: globalData} = useGlobalData();
+    const {data: currentUser} = useCurrentUser();
+
+    return useMemo(() => {
+        if (!globalData?.labs?.giftLinks || !post || !currentUser) {
+            return false;
+        }
+        const eligible = post.status === 'published' && Boolean(post.visibility) && post.visibility !== 'public';
+        const canManage = isOwnerUser(currentUser) || isAdminUser(currentUser) || isEditorUser(currentUser) || isAuthorUser(currentUser);
+        return eligible && canManage;
+    }, [globalData?.labs?.giftLinks, post, currentUser]);
+};

--- a/apps/posts/src/hooks/use-can-manage-gift-link.ts
+++ b/apps/posts/src/hooks/use-can-manage-gift-link.ts
@@ -1,11 +1,10 @@
-import {isAdminUser, isAuthorUser, isEditorUser, isOwnerUser} from '@tryghost/admin-x-framework/api/users';
+import {canManageGiftLinks} from '@tryghost/admin-x-framework/api/users';
 import {useCurrentUser} from '@tryghost/admin-x-framework/api/current-user';
 import {useGlobalData} from '@src/providers/post-analytics-context';
 import {useMemo} from 'react';
 
 // Whether the current user can manage a gift link for this post. Mirrors
-// canCopyGiftLink in the Ember app/utils/gift-link.js: requires the labs flag,
-// a published gated (non-public) post, and a managing role.
+// canCopyGiftLink in the Ember app/utils/gift-link.js.
 export const useCanManageGiftLink = (post?: {status?: string; visibility?: string}) => {
     const {data: globalData} = useGlobalData();
     const {data: currentUser} = useCurrentUser();
@@ -15,7 +14,6 @@ export const useCanManageGiftLink = (post?: {status?: string; visibility?: strin
             return false;
         }
         const eligible = post.status === 'published' && Boolean(post.visibility) && post.visibility !== 'public';
-        const canManage = isOwnerUser(currentUser) || isAdminUser(currentUser) || isEditorUser(currentUser) || isAuthorUser(currentUser);
-        return eligible && canManage;
+        return eligible && canManageGiftLinks(currentUser);
     }, [globalData?.labs?.giftLinks, post, currentUser]);
 };

--- a/apps/posts/src/hooks/use-gift-link-usage.ts
+++ b/apps/posts/src/hooks/use-gift-link-usage.ts
@@ -1,0 +1,57 @@
+import {StatsConfig, useTinybirdQuery} from '@tryghost/admin-x-framework';
+import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
+import {useMemo} from 'react';
+
+export interface GiftLinkUsage {
+    visits: number;
+    views: number;
+}
+
+interface GiftLinkVisitsRow {
+    gift: string;
+    visits: number | string;
+    views: number | string;
+}
+
+// Reads gift-link usage from the web-analytics pipeline (the same Tinybird
+// mechanism every other analytics surface uses), keyed on the link token.
+//
+// Usage tracking is best-effort and entirely optional: analytics may be turned
+// off (no statsConfig), the per-link pipe may not be deployed yet, or the query
+// may error. In every one of those cases `usage` is `undefined` and the caller
+// simply hides the count — the rest of the gift-link UI keeps working.
+export const useGiftLinkUsage = ({postUuid, token, enabled = true}: {
+    postUuid?: string;
+    token?: string;
+    enabled?: boolean;
+}) => {
+    const {data: configData} = useBrowseConfig();
+    const statsConfig = configData?.config?.stats as StatsConfig | undefined;
+
+    const params = useMemo(() => ({
+        site_uuid: statsConfig?.id || '',
+        post_uuid: postUuid || ''
+    }), [statsConfig?.id, postUuid]);
+
+    const {data, loading, error} = useTinybirdQuery({
+        endpoint: 'api_gift_link_visits',
+        statsConfig: statsConfig || {id: ''},
+        params,
+        enabled: enabled && Boolean(statsConfig?.id) && Boolean(postUuid)
+    });
+
+    const usage = useMemo<GiftLinkUsage | undefined>(() => {
+        // No token yet, the query is disabled/loading, or it errored → no data
+        // to show. Distinct from "ran and found zero", which yields {visits: 0}.
+        if (!token || error || !Array.isArray(data)) {
+            return undefined;
+        }
+        const row = (data as unknown as GiftLinkVisitsRow[]).find(r => r.gift === token);
+        return {
+            visits: Number(row?.visits) || 0,
+            views: Number(row?.views) || 0
+        };
+    }, [data, token, error]);
+
+    return {usage, loading};
+};

--- a/apps/posts/src/hooks/use-gift-link-usage.ts
+++ b/apps/posts/src/hooks/use-gift-link-usage.ts
@@ -17,9 +17,9 @@ interface GiftLinkVisitsRow {
 // mechanism every other analytics surface uses), keyed on the link token.
 //
 // Usage tracking is best-effort and entirely optional: analytics may be turned
-// off (no statsConfig), the per-link pipe may not be deployed yet, or the query
-// may error. In every one of those cases `usage` is `undefined` and the caller
-// simply hides the count — the rest of the gift-link UI keeps working.
+// off (no statsConfig) or the query may error. In either case `usage` is
+// `undefined` and the caller simply hides the count — the rest of the gift-link
+// UI keeps working.
 export const useGiftLinkUsage = ({postUuid, token, enabled = true}: {
     postUuid?: string;
     token?: string;

--- a/apps/posts/src/hooks/use-post-details.ts
+++ b/apps/posts/src/hooks/use-post-details.ts
@@ -1,0 +1,50 @@
+import {GiftLinkResource} from '@tryghost/admin-x-framework/api/gift-links';
+import {POST_ANALYTICS_INCLUDE} from '@src/utils/constants';
+import {useBrowsePages} from '@tryghost/admin-x-framework/api/pages';
+import {useBrowsePosts} from '@tryghost/admin-x-framework/api/posts';
+
+// The post/page fields the gift-link modal needs: the canonical URL to hang the
+// token off, the visibility for the copy, and the uuid for usage stats.
+export interface PostDetails {
+    url: string;
+    title: string;
+    visibility?: string;
+    uuid?: string;
+}
+
+// Fetches the details for a post or page by id. Posts reuse the post-analytics
+// query (same include → shared cache with the analytics screen); pages fetch on
+// their own route. Gated pages are eligible for gift links too, hence both.
+export const usePostDetails = ({postId, resource = 'posts', enabled = true}: {
+    postId: string;
+    resource?: GiftLinkResource;
+    enabled?: boolean;
+}): {post: PostDetails | undefined; isLoading: boolean} => {
+    const isPost = resource === 'posts';
+
+    const {data: postsData, isLoading: isPostLoading} = useBrowsePosts({
+        searchParams: {filter: `id:${postId}`, include: POST_ANALYTICS_INCLUDE},
+        enabled: enabled && isPost
+    });
+
+    const {data: pagesData, isLoading: isPageLoading} = useBrowsePages({
+        searchParams: {filter: `id:${postId}`},
+        enabled: enabled && !isPost
+    });
+
+    if (isPost) {
+        const post = postsData?.posts?.[0];
+        return {
+            post: post && {url: post.url, title: post.title, visibility: post.visibility, uuid: post.uuid},
+            isLoading: isPostLoading
+        };
+    }
+
+    // The Page type omits visibility/uuid, but the API returns them (shared
+    // posts table); read them through a widened view.
+    const page = pagesData?.pages?.[0] as undefined | {url: string; title: string; visibility?: string; uuid?: string};
+    return {
+        post: page && {url: page.url, title: page.title, visibility: page.visibility, uuid: page.uuid},
+        isLoading: isPageLoading
+    };
+};

--- a/apps/posts/src/hooks/use-post-details.ts
+++ b/apps/posts/src/hooks/use-post-details.ts
@@ -40,9 +40,7 @@ export const usePostDetails = ({postId, resource = 'posts', enabled = true}: {
         };
     }
 
-    // The Page type omits visibility/uuid, but the API returns them (shared
-    // posts table); read them through a widened view.
-    const page = pagesData?.pages?.[0] as undefined | {url: string; title: string; visibility?: string; uuid?: string};
+    const page = pagesData?.pages?.[0];
     return {
         post: page && {url: page.url, title: page.title, visibility: page.visibility, uuid: page.uuid},
         isLoading: isPageLoading

--- a/apps/posts/src/providers/post-analytics-context.tsx
+++ b/apps/posts/src/providers/post-analytics-context.tsx
@@ -1,7 +1,7 @@
 import {Config, useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
+import {POST_ANALYTICS_INCLUDE, STATS_RANGES} from '@src/utils/constants';
 import {Post as PostBase, useBrowsePosts} from '@tryghost/admin-x-framework/api/posts';
 import {ReactNode, createContext, useContext, useState} from 'react';
-import {STATS_RANGES} from '@src/utils/constants';
 import {Setting, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
 import {StatsConfig, useTinybirdToken} from '@tryghost/admin-x-framework';
 import {useBrowseSite} from '@tryghost/admin-x-framework/api/site';
@@ -78,11 +78,12 @@ const PostAnalyticsProvider = ({children}: { children: ReactNode }) => {
     const hasStatsConfig = Boolean(config.data?.config?.stats);
     const tinybirdTokenQuery = useTinybirdToken({enabled: hasStatsConfig});
 
-    // Fetch post data with all required includes
+    // Fetch post data with all required includes. The gift-link modal reuses
+    // POST_ANALYTICS_INCLUDE for the same query key, so both read one cached post.
     const {data: {posts: [post]} = {posts: []}, isLoading: isPostLoading} = useBrowsePosts({
         searchParams: {
             filter: `id:${postId}`,
-            include: 'email,authors,tags,tiers,count.clicks,count.signups,count.paid_conversions,count.positive_feedback,count.negative_feedback,newsletter'
+            include: POST_ANALYTICS_INCLUDE
         }
     });
 

--- a/apps/posts/src/utils/constants.ts
+++ b/apps/posts/src/utils/constants.ts
@@ -1,3 +1,8 @@
+// The includes the post-analytics screen fetches for a post. Shared so any
+// consumer wanting the *same* cached post (e.g. the gift-link modal opened from
+// the analytics header) hits the identical query key instead of a near-miss.
+export const POST_ANALYTICS_INCLUDE = 'email,authors,tags,tiers,count.clicks,count.signups,count.paid_conversions,count.positive_feedback,count.negative_feedback,newsletter';
+
 export const STATS_RANGES = {
     TODAY: {name: 'Today', value: 1},
     LAST_7_DAYS: {name: 'Last 7 days', value: 7},

--- a/apps/posts/src/utils/gift-link.ts
+++ b/apps/posts/src/utils/gift-link.ts
@@ -1,0 +1,12 @@
+// Build the public gift-link URL for a post.
+//
+// Gift links hang off the canonical post URL as a `?gift=<token>` query param
+// (Fastly bypasses the cache on the param), so we just append to post.url —
+// which already carries any subdirectory and the trailing slash. Returns '' when
+// either input is missing so callers can guard the UI.
+export function buildGiftLinkUrl(postUrl?: string, token?: string): string {
+    if (!postUrl || !token) {
+        return '';
+    }
+    return `${postUrl}?gift=${encodeURIComponent(token)}`;
+}

--- a/apps/posts/src/utils/gift-link.ts
+++ b/apps/posts/src/utils/gift-link.ts
@@ -1,12 +1,21 @@
-// Build the public gift-link URL for a post.
-//
-// Gift links hang off the canonical post URL as a `?gift=<token>` query param
-// (Fastly bypasses the cache on the param), so we just append to post.url —
-// which already carries any subdirectory and the trailing slash. Returns '' when
-// either input is missing so callers can guard the UI.
+// Build the public gift-link URL: a `?gift=<token>` query param appended to the
+// canonical post URL (which already carries any subdirectory and trailing
+// slash). Returns '' when either input is missing so callers can guard the UI.
 export function buildGiftLinkUrl(postUrl?: string, token?: string): string {
     if (!postUrl || !token) {
         return '';
     }
     return `${postUrl}?gift=${encodeURIComponent(token)}`;
+}
+
+// The access label shown in the share copy ("...full access to this <label>
+// post"), keyed off the post's visibility.
+const GIFT_ACCESS_LABELS: Record<string, string> = {
+    members: 'members-only',
+    paid: 'paid-members-only',
+    tiers: 'paid-members-only'
+};
+
+export function giftAccessLabel(visibility?: string): string {
+    return (visibility && GIFT_ACCESS_LABELS[visibility]) || '';
 }

--- a/apps/posts/src/views/PostAnalytics/Overview/overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/overview.tsx
@@ -229,7 +229,7 @@ const Overview: React.FC = () => {
                                             Visitors
                                         </span>
                                         <span className='text-[2.2rem] leading-none font-semibold'>
-                                            {giftLinkUsage ? formatNumber(giftLinkUsage.visits) : '—'}
+                                            {formatNumber(giftLinkUsage?.visits || 0)}
                                         </span>
                                     </CardContent>
                                 </Card>

--- a/apps/posts/src/views/PostAnalytics/Overview/overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/overview.tsx
@@ -1,4 +1,5 @@
 import DisabledSourcesIndicator from '../components/disabled-sources-indicator';
+import GiftLinkModal from '../modals/gift-link-modal';
 import KpiCard, {KpiCardContent, KpiCardLabel, KpiCardValue} from '../components/kpi-card';
 import NewsletterOverview from './components/newsletter-overview';
 import PostAnalyticsContent from '../components/post-analytics-content';
@@ -14,8 +15,11 @@ import {centsToDollars} from '../Growth/growth';
 import {formatQueryDate, getRangeDates, getRangeForStartDate, sanitizeChartData} from '@tryghost/shade/app';
 import {hasBeenEmailed, isPublishedOnly, useNavigate, useTinybirdQuery} from '@tryghost/admin-x-framework';
 import {useAppContext} from '@src/providers/posts-app-context';
-import {useEffect, useMemo} from 'react';
+import {useCanManageGiftLink} from '@src/hooks/use-can-manage-gift-link';
+import {useEffect, useMemo, useState} from 'react';
+import {useGiftLinkUsage} from '@src/hooks/use-gift-link-usage';
 import {usePostReferrers} from '@hooks/use-post-referrers';
+import {useReadGiftLink} from '@tryghost/admin-x-framework/api/gift-links';
 
 const Overview: React.FC = () => {
     const navigate = useNavigate();
@@ -23,6 +27,14 @@ const Overview: React.FC = () => {
     const {totals, isLoading: isTotalsLoading, currencySymbol} = usePostReferrers(postId);
     const {appSettings} = useAppContext();
     const {emailTrackClicks: emailTrackClicksEnabled, emailTrackOpens: emailTrackOpensEnabled} = appSettings?.analytics || {};
+
+    // Gift link card: only for eligible posts. Read the active link (without
+    // minting) to scope the usage count to the current token, matching the modal.
+    const canManageGiftLink = useCanManageGiftLink(post);
+    const {data: giftLinkData} = useReadGiftLink(postId, {enabled: canManageGiftLink});
+    const giftToken = giftLinkData?.gift_links?.[0]?.token;
+    const {usage: giftLinkUsage} = useGiftLinkUsage({postUuid: post?.uuid, token: giftToken, enabled: canManageGiftLink});
+    const [isGiftLinkOpen, setIsGiftLinkOpen] = useState(false);
 
     // Calculate chart range based on days between today and post publication date
     const chartRange = useMemo(() => {
@@ -136,12 +148,14 @@ const Overview: React.FC = () => {
                             post={post as Post}
                         />
                     )}
-                    {showGrowthSection && (
-                        <Card className='group col-span-2 overflow-hidden p-0' data-testid='growth'>
-                            <div className='relative flex items-center justify-between gap-6'>
-                                <CardHeader>
-                                    <CardTitle className='flex items-center gap-1.5 text-lg'>
-                                        <LucideIcon.Sprout size={16} strokeWidth={1.5} />
+                    {(showGrowthSection || (canManageGiftLink && post)) && (
+                        <div className='col-span-2 flex flex-col gap-6 lg:grid lg:grid-cols-3'>
+                            {showGrowthSection && (
+                                <Card className={`group overflow-hidden p-0 ${canManageGiftLink && post ? 'lg:col-span-2' : 'lg:col-span-3'}`} data-testid='growth'>
+                                    <div className='relative flex items-center justify-between gap-6'>
+                                        <CardHeader>
+                                            <CardTitle className='flex items-center gap-1.5 text-lg'>
+                                                <LucideIcon.Sprout size={16} strokeWidth={1.5} />
                                 Growth
                                     </CardTitle>
                                 </CardHeader>
@@ -190,13 +204,51 @@ const Overview: React.FC = () => {
                                     </>
                                 }
                             </CardContent>
-                        </Card>
+                                </Card>
+                            )}
+                            {canManageGiftLink && post && (
+                                <Card className={`group/datalist overflow-hidden ${showGrowthSection ? 'lg:col-span-1' : 'lg:col-span-3'}`} data-testid='gift-link-card'>
+                                    <div className='relative flex items-center justify-between gap-6'>
+                                        <CardHeader>
+                                            <CardTitle className='flex items-center gap-1.5 text-lg'>
+                                                <LucideIcon.Gift size={16} strokeWidth={1.5} />
+                                                Gift link
+                                            </CardTitle>
+                                        </CardHeader>
+                                        <Button
+                                            className='absolute right-6 translate-x-10 opacity-0 transition-all duration-300 group-hover/datalist:translate-x-0 group-hover/datalist:opacity-100'
+                                            size='sm'
+                                            variant='outline'
+                                            onClick={() => setIsGiftLinkOpen(true)}
+                                        >
+                                            Share
+                                        </Button>
+                                    </div>
+                                    <CardContent className='flex flex-col gap-1'>
+                                        <span className='text-sm text-muted-foreground'>
+                                            Visitors
+                                        </span>
+                                        <span className='text-[2.2rem] leading-none font-semibold'>
+                                            {giftLinkUsage ? formatNumber(giftLinkUsage.visits) : '—'}
+                                        </span>
+                                    </CardContent>
+                                </Card>
+                            )}
+                        </div>
                     )}
-                    {!showWebSection && !showNewsletterSection && !showGrowthSection && (
+                    {!showWebSection && !showNewsletterSection && !showGrowthSection && !canManageGiftLink && (
                         <DisabledSourcesIndicator className='col-span-2 py-20' />
                     )}
                 </div>
             </PostAnalyticsContent>
+            {canManageGiftLink && post && (
+                <GiftLinkModal
+                    key={postId}
+                    open={isGiftLinkOpen}
+                    postId={postId}
+                    onOpenChange={setIsGiftLinkOpen}
+                />
+            )}
         </>
     );
 };

--- a/apps/posts/src/views/PostAnalytics/Overview/overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/overview.tsx
@@ -223,14 +223,16 @@ const Overview: React.FC = () => {
                                             Share
                                         </Button>
                                     </div>
-                                    <CardContent className='flex flex-col gap-1'>
-                                        <span className='text-sm text-muted-foreground'>
-                                            Visitors
-                                        </span>
-                                        <span className='text-[2.2rem] leading-none font-semibold'>
-                                            {formatNumber(giftLinkUsage?.visits || 0)}
-                                        </span>
-                                    </CardContent>
+                                    {giftLinkUsage && (
+                                        <CardContent className='flex flex-col gap-1'>
+                                            <span className='text-sm text-muted-foreground'>
+                                                Visitors
+                                            </span>
+                                            <span className='text-[2.2rem] leading-none font-semibold'>
+                                                {formatNumber(giftLinkUsage.visits)}
+                                            </span>
+                                        </CardContent>
+                                    )}
                                 </Card>
                             )}
                         </div>

--- a/apps/posts/src/views/PostAnalytics/Overview/overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/overview.tsx
@@ -158,7 +158,7 @@ const Overview: React.FC = () => {
                                 Growth
                                     </CardTitle>
                                 </CardHeader>
-                                <Button className='absolute right-6 translate-x-10 opacity-0 transition-all duration-200 group-hover:translate-x-0 group-hover:opacity-100' size='sm' variant='outline' onClick={() => {
+                                <Button className='absolute right-6 translate-x-10 opacity-0 transition-all duration-200 group-hover:translate-x-0 group-hover:opacity-100 focus-visible:translate-x-0 focus-visible:opacity-100' size='sm' variant='outline' onClick={() => {
                                     navigate(`/posts/analytics/${postId}/growth`);
                                 }}>View more</Button>
                             </div>
@@ -215,7 +215,7 @@ const Overview: React.FC = () => {
                                             </CardTitle>
                                         </CardHeader>
                                         <Button
-                                            className='absolute right-6 translate-x-10 opacity-0 transition-all duration-300 group-hover/datalist:translate-x-0 group-hover/datalist:opacity-100'
+                                            className='absolute right-6 translate-x-10 opacity-0 transition-all duration-300 group-hover/datalist:translate-x-0 group-hover/datalist:opacity-100 focus-visible:translate-x-0 focus-visible:opacity-100'
                                             size='sm'
                                             variant='outline'
                                             onClick={() => setIsGiftLinkOpen(true)}

--- a/apps/posts/src/views/PostAnalytics/Overview/overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/overview.tsx
@@ -14,12 +14,12 @@ import {STATS_RANGES} from '@src/utils/constants';
 import {centsToDollars} from '../Growth/growth';
 import {formatQueryDate, getRangeDates, getRangeForStartDate, sanitizeChartData} from '@tryghost/shade/app';
 import {hasBeenEmailed, isPublishedOnly, useNavigate, useTinybirdQuery} from '@tryghost/admin-x-framework';
+import {useActiveGiftLink} from '@tryghost/admin-x-framework/api/gift-links';
 import {useAppContext} from '@src/providers/posts-app-context';
 import {useCanManageGiftLink} from '@src/hooks/use-can-manage-gift-link';
 import {useEffect, useMemo, useState} from 'react';
 import {useGiftLinkUsage} from '@src/hooks/use-gift-link-usage';
 import {usePostReferrers} from '@hooks/use-post-referrers';
-import {useReadGiftLink} from '@tryghost/admin-x-framework/api/gift-links';
 
 const Overview: React.FC = () => {
     const navigate = useNavigate();
@@ -31,8 +31,7 @@ const Overview: React.FC = () => {
     // Gift link card: only for eligible posts. Read the active link (without
     // minting) to scope the usage count to the current token, matching the modal.
     const canManageGiftLink = useCanManageGiftLink(post);
-    const {data: giftLinkData} = useReadGiftLink(postId, {enabled: canManageGiftLink});
-    const giftToken = giftLinkData?.gift_links?.[0]?.token;
+    const {token: giftToken} = useActiveGiftLink(postId, {enabled: canManageGiftLink});
     const {usage: giftLinkUsage} = useGiftLinkUsage({postUuid: post?.uuid, token: giftToken, enabled: canManageGiftLink});
     const [isGiftLinkOpen, setIsGiftLinkOpen] = useState(false);
 

--- a/apps/posts/src/views/PostAnalytics/components/post-analytics-header.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/post-analytics-header.tsx
@@ -1,3 +1,4 @@
+import GiftLinkModal from '../modals/gift-link-modal';
 import React, {useMemo, useState} from 'react';
 import {AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator, Button, DropdownMenu, DropdownMenuContent, DropdownMenuGroup, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger, Navbar, PageMenu, PageMenuItem} from '@tryghost/shade/components';
 import {H1} from '@tryghost/shade/primitives';
@@ -7,6 +8,7 @@ import {PostShareModal} from '@tryghost/shade/posts-stats';
 import {getSiteTimezone} from '@src/utils/get-site-timezone';
 import {hasBeenEmailed, isEmailOnly, isPublishedAndEmailed, isPublishedOnly, useActiveVisitors, useNavigate} from '@tryghost/admin-x-framework';
 import {useAppContext} from '@src/providers/posts-app-context';
+import {useCanManageGiftLink} from '@src/hooks/use-can-manage-gift-link';
 import {useDeletePost} from '@tryghost/admin-x-framework/api/posts';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 
@@ -25,7 +27,9 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
     const handleError = useHandleError();
     const [showDeleteDialog, setShowDeleteDialog] = useState(false);
     const [isShareOpen, setIsShareOpen] = useState(false);
+    const [isGiftLinkOpen, setIsGiftLinkOpen] = useState(false);
     const {settings, site, statsConfig, post, isPostLoading, postId} = useGlobalData();
+    const canManageGiftLink = useCanManageGiftLink(post);
 
     const siteTimezone = getSiteTimezone(settings);
 
@@ -132,9 +136,11 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
                                     {!post?.email_only && (
                                         <PostShareModal
                                             author={post?.authors?.[0]?.name || ''}
+                                            canShareAsGift={canManageGiftLink}
                                             description=''
                                             faviconURL={site?.icon || ''}
                                             featureImageURL={post?.feature_image}
+                                            giftAccessLabel={post?.visibility === 'members' ? 'members-only' : 'paid-members-only'}
                                             open={isShareOpen}
                                             postExcerpt={post?.excerpt || ''}
                                             postTitle={post?.title}
@@ -142,6 +148,10 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
                                             siteTitle={site?.title || ''}
                                             onClose={() => setIsShareOpen(false)}
                                             onOpenChange={setIsShareOpen}
+                                            onShareAsGift={() => {
+                                                setIsShareOpen(false);
+                                                setIsGiftLinkOpen(true);
+                                            }}
                                         >
                                             <Button variant='outline' onClick={() => setIsShareOpen(true)}><LucideIcon.Share /> Share</Button>
                                         </PostShareModal>
@@ -241,6 +251,15 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
                 )}
                 {children}
             </Navbar>
+
+            {canManageGiftLink && postId && (
+                <GiftLinkModal
+                    key={postId}
+                    open={isGiftLinkOpen}
+                    postId={postId}
+                    onOpenChange={setIsGiftLinkOpen}
+                />
+            )}
 
             <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
                 <AlertDialogContent>

--- a/apps/posts/src/views/PostAnalytics/components/post-analytics-header.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/post-analytics-header.tsx
@@ -6,6 +6,7 @@ import {LucideIcon, formatDisplayDate, formatDisplayTime, formatNumber} from '@t
 import {Post, useGlobalData} from '@src/providers/post-analytics-context';
 import {PostShareModal} from '@tryghost/shade/posts-stats';
 import {getSiteTimezone} from '@src/utils/get-site-timezone';
+import {giftAccessLabel} from '@src/utils/gift-link';
 import {hasBeenEmailed, isEmailOnly, isPublishedAndEmailed, isPublishedOnly, useActiveVisitors, useNavigate} from '@tryghost/admin-x-framework';
 import {useAppContext} from '@src/providers/posts-app-context';
 import {useCanManageGiftLink} from '@src/hooks/use-can-manage-gift-link';
@@ -140,7 +141,7 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
                                             description=''
                                             faviconURL={site?.icon || ''}
                                             featureImageURL={post?.feature_image}
-                                            giftAccessLabel={post?.visibility === 'members' ? 'members-only' : 'paid-members-only'}
+                                            giftAccessLabel={giftAccessLabel(post?.visibility)}
                                             open={isShareOpen}
                                             postExcerpt={post?.excerpt || ''}
                                             postTitle={post?.title}

--- a/apps/posts/src/views/PostAnalytics/modals/gift-link-modal.tsx
+++ b/apps/posts/src/views/PostAnalytics/modals/gift-link-modal.tsx
@@ -85,7 +85,8 @@ const GiftLinkModal: React.FC<GiftLinkModalProps> = ({open, onOpenChange, postId
 
     const giftLinkUrl = buildGiftLinkUrl(post?.url, token);
     const memberType = post?.visibility === 'members' ? 'member' : 'paid member';
-    const description = `Anyone you share this link with will be able to access this post without becoming a ${memberType}.`;
+    const resourceLabel = resource === 'pages' ? 'page' : 'post';
+    const description = `Anyone you share this link with will be able to access this ${resourceLabel} without becoming a ${memberType}.`;
 
     const handleConfirmReset = async () => {
         if (resetting) {
@@ -145,7 +146,7 @@ const GiftLinkModal: React.FC<GiftLinkModalProps> = ({open, onOpenChange, postId
 
                         <DialogFooter className='sm:items-center sm:justify-between'>
                             <Button
-                                className='border-destructive/20 text-destructive hover:border-destructive hover:bg-transparent hover:text-destructive'
+                                className='border-destructive/20 text-destructive hover:border-destructive hover:bg-transparent hover:text-destructive dark:border-state-danger/50 dark:text-state-danger dark:hover:border-state-danger dark:hover:bg-transparent dark:hover:text-state-danger'
                                 data-testid='reset-gift-link'
                                 disabled={!giftLinkUrl}
                                 variant='outline'
@@ -165,7 +166,7 @@ const GiftLinkModal: React.FC<GiftLinkModalProps> = ({open, onOpenChange, postId
                         <DialogHeader>
                             <DialogTitle>Reset gift link</DialogTitle>
                             <DialogDescription>
-                                Are you sure you want to reset this link? Anyone with the current link will lose access to this post.
+                                Are you sure you want to reset this link? Anyone with the current link will lose access to this {resourceLabel}.
                             </DialogDescription>
                         </DialogHeader>
                         <DialogFooter>

--- a/apps/posts/src/views/PostAnalytics/modals/gift-link-modal.tsx
+++ b/apps/posts/src/views/PostAnalytics/modals/gift-link-modal.tsx
@@ -1,0 +1,193 @@
+import React, {useEffect, useRef, useState} from 'react';
+import {Badge, Button, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle} from '@tryghost/shade/components';
+import {GiftLinkResource, useCreateGiftLink, useEnsureGiftLink} from '@tryghost/admin-x-framework/api/gift-links';
+import {ShareModal} from '@tryghost/shade/patterns';
+import {buildGiftLinkUrl} from '@src/utils/gift-link';
+import {formatNumber} from '@tryghost/shade/utils';
+import {useGiftLinkUsage} from '@src/hooks/use-gift-link-usage';
+import {useHandleError} from '@tryghost/admin-x-framework/hooks';
+import {usePostDetails} from '@src/hooks/use-post-details';
+
+function visitorsLabel(count: number) {
+    if (count === 0) {
+        return 'No visitors yet';
+    }
+    return `${formatNumber(count)} ${count === 1 ? 'visitor' : 'visitors'}`;
+}
+
+type ResetState = 'idle' | 'confirm';
+
+interface GiftLinkModalProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    postId: string;
+    resource?: GiftLinkResource;
+}
+
+const GiftLinkModal: React.FC<GiftLinkModalProps> = ({open, onOpenChange, postId, resource = 'posts'}) => {
+    const handleError = useHandleError();
+    const {mutateAsync: ensureGiftLink} = useEnsureGiftLink();
+    const {mutateAsync: createGiftLink} = useCreateGiftLink();
+    const {post} = usePostDetails({postId, resource, enabled: open});
+
+    const [token, setToken] = useState<string | undefined>(undefined);
+    const [resetState, setResetState] = useState<ResetState>('idle');
+    const [resetting, setResetting] = useState(false);
+    const [ensuring, setEnsuring] = useState(false);
+    const cancelResetRef = useRef<HTMLButtonElement>(null);
+
+    // Usage is best-effort: undefined when analytics is off / unavailable, in
+    // which case we simply omit the visitor count.
+    const {usage} = useGiftLinkUsage({postUuid: post?.uuid, token, enabled: open});
+
+    // Ensure (create-or-get) the link as soon as the modal opens so there's a
+    // URL to show. Idempotent on the server.
+    useEffect(() => {
+        if (!open) {
+            return;
+        }
+        let cancelled = false;
+        setEnsuring(true);
+        ensureGiftLink({id: postId, resource})
+            .then((response) => {
+                if (cancelled) {
+                    return;
+                }
+                setToken(response.gift_links[0]?.token);
+            })
+            .catch((e) => {
+                if (!cancelled) {
+                    handleError(e);
+                }
+            })
+            .finally(() => {
+                if (!cancelled) {
+                    setEnsuring(false);
+                }
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [open, postId, resource, ensureGiftLink, handleError]);
+
+    // Reset transient UI on close so the next open starts clean.
+    useEffect(() => {
+        if (!open) {
+            setResetState('idle');
+        }
+    }, [open]);
+
+    useEffect(() => {
+        if (resetState === 'confirm') {
+            cancelResetRef.current?.focus();
+        }
+    }, [resetState]);
+
+    const giftLinkUrl = buildGiftLinkUrl(post?.url, token);
+    const memberType = post?.visibility === 'members' ? 'member' : 'paid member';
+    const description = `Anyone you share this link with will be able to access this post without becoming a ${memberType}.`;
+
+    const handleConfirmReset = async () => {
+        if (resetting) {
+            return;
+        }
+        setResetting(true);
+        try {
+            const response = await createGiftLink({id: postId, resource});
+            setToken(response.gift_links[0]?.token);
+            setResetState('idle');
+        } catch (e) {
+            handleError(e);
+        } finally {
+            setResetting(false);
+        }
+    };
+
+    const handleOpenChange = (isOpen: boolean) => {
+        if (!isOpen) {
+            setResetState('idle');
+        }
+        onOpenChange(isOpen);
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={handleOpenChange}>
+            <DialogContent className='max-w-lg gap-5'>
+                {resetState === 'idle' && (
+                    <>
+                        <DialogHeader className='gap-3'>
+                            <div className='flex items-center gap-2'>
+                                <DialogTitle className='text-xl leading-none'>Gift link</DialogTitle>
+                                {usage && (
+                                    <Badge
+                                        data-testid='gift-link-views'
+                                        variant='secondary'
+                                    >
+                                        {visitorsLabel(usage.visits)}
+                                    </Badge>
+                                )}
+                            </div>
+                            <DialogDescription className='text-sm leading-5'>
+                                {description}
+                            </DialogDescription>
+                        </DialogHeader>
+
+                        <ShareModal.CopyURLBox className='w-full min-w-0' copyURL={ensuring ? 'Generating link…' : giftLinkUrl}>
+                            <ShareModal.CopyButton
+                                className='shrink-0'
+                                copyURL={giftLinkUrl}
+                                data-testid='copy-gift-link'
+                                disabled={ensuring || !giftLinkUrl}
+                                icon='link'
+                                size='sm'
+                            />
+                        </ShareModal.CopyURLBox>
+
+                        <DialogFooter className='sm:items-center sm:justify-between'>
+                            <Button
+                                className='border-destructive/20 text-destructive hover:border-destructive hover:bg-transparent hover:text-destructive'
+                                data-testid='reset-gift-link'
+                                disabled={!giftLinkUrl}
+                                variant='outline'
+                                onClick={() => setResetState('confirm')}
+                            >
+                                Reset
+                            </Button>
+                            <Button variant='outline' onClick={() => handleOpenChange(false)}>
+                                Close
+                            </Button>
+                        </DialogFooter>
+                    </>
+                )}
+
+                {resetState === 'confirm' && (
+                    <>
+                        <DialogHeader>
+                            <DialogTitle>Reset gift link</DialogTitle>
+                            <DialogDescription>
+                                Are you sure you want to reset this link? Anyone with the current link will lose access to this post.
+                            </DialogDescription>
+                        </DialogHeader>
+                        <DialogFooter>
+                            <Button ref={cancelResetRef} disabled={resetting} variant='outline' onClick={() => setResetState('idle')}>
+                                Cancel
+                            </Button>
+                            <Button
+                                data-testid='confirm-reset-gift-link'
+                                disabled={resetting}
+                                variant='destructive'
+                                onClick={() => {
+                                    void handleConfirmReset();
+                                }}
+                            >
+                                {resetting ? 'Resetting' : 'Reset link'}
+                            </Button>
+                        </DialogFooter>
+                    </>
+                )}
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+export default GiftLinkModal;

--- a/apps/posts/src/views/PostAnalytics/modals/gift-link-modal.tsx
+++ b/apps/posts/src/views/PostAnalytics/modals/gift-link-modal.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {Badge, Button, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle} from '@tryghost/shade/components';
 import {GiftLinkResource, useCreateGiftLink, useEnsureGiftLink} from '@tryghost/admin-x-framework/api/gift-links';
 import {ShareModal} from '@tryghost/shade/patterns';
@@ -70,13 +70,6 @@ const GiftLinkModal: React.FC<GiftLinkModalProps> = ({open, onOpenChange, postId
         };
     }, [open, postId, resource, ensureGiftLink, handleError]);
 
-    // Reset transient UI on close so the next open starts clean.
-    useEffect(() => {
-        if (!open) {
-            setResetState('idle');
-        }
-    }, [open]);
-
     useEffect(() => {
         if (resetState === 'confirm') {
             cancelResetRef.current?.focus();
@@ -88,7 +81,7 @@ const GiftLinkModal: React.FC<GiftLinkModalProps> = ({open, onOpenChange, postId
     const resourceLabel = resource === 'pages' ? 'page' : 'post';
     const description = `Anyone you share this link with will be able to access this ${resourceLabel} without becoming a ${memberType}.`;
 
-    const handleConfirmReset = async () => {
+    const handleConfirmReset = useCallback(async () => {
         if (resetting) {
             return;
         }
@@ -102,14 +95,14 @@ const GiftLinkModal: React.FC<GiftLinkModalProps> = ({open, onOpenChange, postId
         } finally {
             setResetting(false);
         }
-    };
+    }, [resetting, createGiftLink, postId, resource, handleError]);
 
-    const handleOpenChange = (isOpen: boolean) => {
+    const handleOpenChange = useCallback((isOpen: boolean) => {
         if (!isOpen) {
             setResetState('idle');
         }
         onOpenChange(isOpen);
-    };
+    }, [onOpenChange]);
 
     return (
         <Dialog open={open} onOpenChange={handleOpenChange}>

--- a/apps/posts/test/unit/utils/gift-link.test.ts
+++ b/apps/posts/test/unit/utils/gift-link.test.ts
@@ -1,0 +1,25 @@
+import {buildGiftLinkUrl} from '@src/utils/gift-link';
+import {describe, expect, it} from 'vitest';
+
+describe('buildGiftLinkUrl', () => {
+    it('appends ?gift=<token> to the canonical post url', () => {
+        expect(buildGiftLinkUrl('https://example.com/my-post/', 'tok123'))
+            .toBe('https://example.com/my-post/?gift=tok123');
+    });
+
+    it('preserves a subdirectory in the post url', () => {
+        expect(buildGiftLinkUrl('https://example.com/blog/my-post/', 'tok123'))
+            .toBe('https://example.com/blog/my-post/?gift=tok123');
+    });
+
+    it('url-encodes the token', () => {
+        expect(buildGiftLinkUrl('https://example.com/p/', 'a/b+c='))
+            .toBe('https://example.com/p/?gift=a%2Fb%2Bc%3D');
+    });
+
+    it('returns an empty string when either input is missing', () => {
+        expect(buildGiftLinkUrl('', 'tok')).toBe('');
+        expect(buildGiftLinkUrl('https://example.com/p/', '')).toBe('');
+        expect(buildGiftLinkUrl(undefined, undefined)).toBe('');
+    });
+});

--- a/apps/posts/test/unit/utils/gift-link.test.ts
+++ b/apps/posts/test/unit/utils/gift-link.test.ts
@@ -1,4 +1,4 @@
-import {buildGiftLinkUrl} from '@src/utils/gift-link';
+import {buildGiftLinkUrl, giftAccessLabel} from '@src/utils/gift-link';
 import {describe, expect, it} from 'vitest';
 
 describe('buildGiftLinkUrl', () => {
@@ -21,5 +21,18 @@ describe('buildGiftLinkUrl', () => {
         expect(buildGiftLinkUrl('', 'tok')).toBe('');
         expect(buildGiftLinkUrl('https://example.com/p/', '')).toBe('');
         expect(buildGiftLinkUrl(undefined, undefined)).toBe('');
+    });
+});
+
+describe('giftAccessLabel', () => {
+    it('maps each gated visibility to its access label', () => {
+        expect(giftAccessLabel('members')).toBe('members-only');
+        expect(giftAccessLabel('paid')).toBe('paid-members-only');
+        expect(giftAccessLabel('tiers')).toBe('paid-members-only');
+    });
+
+    it('returns an empty string for unknown or missing visibility', () => {
+        expect(giftAccessLabel('public')).toBe('');
+        expect(giftAccessLabel(undefined)).toBe('');
     });
 });

--- a/apps/shade/src/components/posts-stats/post-share-modal.tsx
+++ b/apps/shade/src/components/posts-stats/post-share-modal.tsx
@@ -6,12 +6,15 @@ import React from 'react';
 
 interface PostShareModalProps extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Root> {
     author?: string;
+    canShareAsGift?: boolean;
     children?: React.ReactNode;
     description?: React.ReactNode;
     emailOnly?: boolean;
     faviconURL?: string;
     featureImageURL?: string;
+    giftAccessLabel?: string;
     onClose?: () => void;
+    onShareAsGift?: () => void;
     postExcerpt?: string;
     postTitle?: string;
     postURL?: string;
@@ -22,12 +25,15 @@ interface PostShareModalProps extends React.ComponentPropsWithoutRef<typeof Dial
 
 const PostShareModal: React.FC<PostShareModalProps> = ({
     author = '',
+    canShareAsGift = false,
     children,
     description = '',
     emailOnly = false,
     faviconURL = '',
     featureImageURL = '',
+    giftAccessLabel = '',
     onClose = () => {},
+    onShareAsGift = () => {},
     postExcerpt = '',
     postTitle = '',
     postURL = '',
@@ -104,6 +110,19 @@ const PostShareModal: React.FC<PostShareModalProps> = ({
                         </div>
                     </div>
                 </ShareModal.Preview>
+                {canShareAsGift && !emailOnly && (
+                    <div className="flex items-center justify-between gap-4 rounded-md border border-border p-4">
+                        <div className="flex flex-col">
+                            <strong>Share as a gift</strong>
+                            <span className="text-sm text-muted-foreground">
+                                Let anyone read this {giftAccessLabel} post without an account.
+                            </span>
+                        </div>
+                        <Button className="shrink-0 cursor-pointer" type="button" variant="outline" onClick={onShareAsGift}>
+                            Gift link
+                        </Button>
+                    </div>
+                )}
                 <ShareModal.Footer>
                     {emailOnly ? (
                         <Button className="cursor-pointer" type="button" onClick={onClose}>

--- a/apps/shade/src/components/posts-stats/post-share-modal.tsx
+++ b/apps/shade/src/components/posts-stats/post-share-modal.tsx
@@ -110,35 +110,33 @@ const PostShareModal: React.FC<PostShareModalProps> = ({
                         </div>
                     </div>
                 </ShareModal.Preview>
-                {canShareAsGift && !emailOnly && (
-                    <div className="flex items-center justify-between gap-4 rounded-md border border-border p-4">
-                        <div className="flex flex-col">
-                            <strong>Share as a gift</strong>
-                            <span className="text-sm text-muted-foreground">
-                                Let anyone read this {giftAccessLabel} post without an account.
-                            </span>
-                        </div>
-                        <Button className="shrink-0 cursor-pointer" type="button" variant="outline" onClick={onShareAsGift}>
-                            Gift link
-                        </Button>
-                    </div>
-                )}
-                <ShareModal.Footer>
-                    {emailOnly ? (
-                        <Button className="cursor-pointer" type="button" onClick={onClose}>
-                            Close
-                        </Button>
-                    ) : (
-                        <>
-                            <ShareModal.SocialLinks links={socialLinks} />
-                            <ShareModal.CopyButton
-                                className="ml-0! grow cursor-pointer"
-                                copyURL={postURL}
-                                icon="link"
-                            />
-                        </>
+                <div className="flex flex-col gap-5">
+                    <ShareModal.Footer>
+                        {emailOnly ? (
+                            <Button className="cursor-pointer" type="button" onClick={onClose}>
+                                Close
+                            </Button>
+                        ) : (
+                            <>
+                                <ShareModal.SocialLinks links={socialLinks} />
+                                <ShareModal.CopyButton
+                                    className="ml-0! grow cursor-pointer"
+                                    copyURL={postURL}
+                                    icon="link"
+                                />
+                            </>
+                        )}
+                    </ShareModal.Footer>
+                    {canShareAsGift && !emailOnly && (
+                        <p className="text-center text-sm text-muted-foreground">
+                            Want to share full access to this {giftAccessLabel} post?{' '}
+                            <Button className="h-auto p-0 align-baseline text-sm" type="button" variant="link" onClick={onShareAsGift}>
+                                Share as a gift
+                            </Button>
+                            .
+                        </p>
                     )}
-                </ShareModal.Footer>
+                </div>
             </ShareModal.Content>
         </ShareModal.Root>
     );

--- a/apps/shade/src/components/posts-stats/post-share-modal.tsx
+++ b/apps/shade/src/components/posts-stats/post-share-modal.tsx
@@ -110,33 +110,31 @@ const PostShareModal: React.FC<PostShareModalProps> = ({
                         </div>
                     </div>
                 </ShareModal.Preview>
-                <div className="flex flex-col gap-5">
-                    <ShareModal.Footer>
-                        {emailOnly ? (
-                            <Button className="cursor-pointer" type="button" onClick={onClose}>
-                                Close
-                            </Button>
-                        ) : (
-                            <>
-                                <ShareModal.SocialLinks links={socialLinks} />
-                                <ShareModal.CopyButton
-                                    className="ml-0! grow cursor-pointer"
-                                    copyURL={postURL}
-                                    icon="link"
-                                />
-                            </>
-                        )}
-                    </ShareModal.Footer>
-                    {canShareAsGift && !emailOnly && (
-                        <p className="text-center text-sm text-muted-foreground">
-                            Want to share full access to this {giftAccessLabel} post?{' '}
-                            <Button className="h-auto p-0 align-baseline text-sm" type="button" variant="link" onClick={onShareAsGift}>
-                                Share as a gift
-                            </Button>
-                            .
-                        </p>
+                <ShareModal.Footer>
+                    {emailOnly ? (
+                        <Button className="cursor-pointer" type="button" onClick={onClose}>
+                            Close
+                        </Button>
+                    ) : (
+                        <>
+                            <ShareModal.SocialLinks links={socialLinks} />
+                            <ShareModal.CopyButton
+                                className="ml-0! grow cursor-pointer"
+                                copyURL={postURL}
+                                icon="link"
+                            />
+                        </>
                     )}
-                </div>
+                </ShareModal.Footer>
+                {canShareAsGift && !emailOnly && (
+                    <p className="text-center text-sm text-muted-foreground">
+                        Want to share full access to this {giftAccessLabel} post?{' '}
+                        <Button className="h-auto p-0 align-baseline text-sm" type="button" variant="link" onClick={onShareAsGift}>
+                            Share as a gift
+                        </Button>
+                        .
+                    </p>
+                )}
             </ShareModal.Content>
         </ShareModal.Root>
     );

--- a/ghost/admin/app/components/posts-list/context-menu.hbs
+++ b/ghost/admin/app/components/posts-list/context-menu.hbs
@@ -29,6 +29,13 @@
             </li>
         {{/if}}
     {{/if}}
+    {{#if this.canCopyGiftLink}}
+        <li>
+            <button class="mr2" type="button" {{on "click" this.openGiftLink}} data-test-button="gift-link">
+                <span>{{svg-jar "link"}}Gift link</span>
+            </button>
+        </li>
+    {{/if}}
     {{#if this.canFeatureSelection}}
         {{#if this.shouldFeatureSelection}}
             <li>

--- a/ghost/admin/app/components/posts-list/context-menu.hbs
+++ b/ghost/admin/app/components/posts-list/context-menu.hbs
@@ -8,7 +8,14 @@
                 </button>
             </li>
         {{/if}}
-        <li>
+        {{#if this.canCopyGiftLink}}
+            <li>
+                <button class="mr2" type="button" {{on "click" this.openGiftLink}} data-test-button="gift-link">
+                    <span>{{svg-jar "gift-link" class="gift"}}Share as a gift</span>
+                </button>
+            </li>
+        {{/if}}
+        <li class="{{if this.canCopyGiftLink "gh-posts-context-menu-separated"}}">
             <button class="mr2" type="button" {{on "click" this.unpublishPosts}} data-test-button="unpublish">
                 <span>{{svg-jar "undo"}}Unpublish</span>
             </button>
@@ -28,13 +35,6 @@
                 </button>
             </li>
         {{/if}}
-    {{/if}}
-    {{#if this.canCopyGiftLink}}
-        <li>
-            <button class="mr2" type="button" {{on "click" this.openGiftLink}} data-test-button="gift-link">
-                <span>{{svg-jar "link"}}Gift link</span>
-            </button>
-        </li>
     {{/if}}
     {{#if this.canFeatureSelection}}
         {{#if this.shouldFeatureSelection}}

--- a/ghost/admin/app/components/posts-list/context-menu.js
+++ b/ghost/admin/app/components/posts-list/context-menu.js
@@ -7,6 +7,7 @@ import UnschedulePostsModal from './modals/unschedule-posts';
 import copyTextToClipboard from 'ghost-admin/utils/copy-text-to-clipboard';
 import nql from '@tryghost/nql';
 import {action} from '@ember/object';
+import {canCopyGiftLink} from 'ghost-admin/utils/gift-link';
 import {capitalizeFirstLetter} from 'ghost-admin/helpers/capitalize-first-letter';
 import {inject as service} from '@ember/service';
 import {task, timeout} from 'ember-concurrency';
@@ -66,9 +67,25 @@ export default class PostsContextMenu extends Component {
     @service store;
     @service notifications;
     @service membersUtils;
+    @service feature;
+    @service stateBridge;
 
     get menu() {
         return this.args.menu;
+    }
+
+    // Gift links apply to a single published, gated (non-public) post/page, and
+    // only for users who can manage them. Eligibility and URL shape live in
+    // app/utils/gift-link.js (shared with the React modal's expectations).
+    get canCopyGiftLink() {
+        if (!this.selectionList.isSingle) {
+            return false;
+        }
+        return canCopyGiftLink({
+            feature: this.feature,
+            user: this.session.user,
+            post: this.selectionList.first
+        });
     }
 
     get selectionList() {
@@ -94,6 +111,17 @@ export default class PostsContextMenu extends Component {
     @action
     async copyPreviewLink() {
         this.menu.performTask(this.copyPreviewLinkTask);
+    }
+
+    // The gift-link modal lives in React; hand off to it over the state bridge
+    // rather than duplicating the modal in Ember.
+    @action
+    openGiftLink() {
+        this.stateBridge.triggerOpenGiftLinkModal({
+            id: this.selectionList.first.id,
+            resource: this.type === 'page' ? 'pages' : 'posts'
+        });
+        this.menu.close();
     }
 
     @action

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -84,6 +84,7 @@ export default class FeatureService extends Service {
     @feature('editorExcerpt') editorExcerpt;
     @feature('tagsX') tagsX;
     @feature('commentModeration') commentModeration;
+    @feature('giftLinks') giftLinks;
     _user = null;
 
     @computed('settings.labs')

--- a/ghost/admin/app/services/state-bridge.js
+++ b/ghost/admin/app/services/state-bridge.js
@@ -10,6 +10,7 @@ const emberDataTypeMapping = {
     AutomatedEmailsResponseType: null, // automated emails only exist in React admin
     AutomationsResponseType: null, // automations only exist in React admin
     CommentsResponseType: null, // comments only exist in React admin
+    GiftLinksResponseType: null, // gift links only exist in React admin
     IntegrationsResponseType: {type: 'integration'},
     InvitesResponseType: {type: 'invite'},
     LabelsResponseType: null, // labels only exist in React admin
@@ -231,6 +232,14 @@ export default class StateBridgeService extends Service.extend(Evented) {
         this.trigger('sidebarVisibilityChange', {
             isVisible
         });
+    }
+
+    // The gift-link modal lives in React. Ember surfaces (the posts/pages
+    // context menu) ask React to open it for a given post/page rather than
+    // duplicating the modal — see useOpenGiftLinkModal on the React side.
+    @action
+    triggerOpenGiftLinkModal({id, resource}) {
+        this.trigger('openGiftLinkModal', {id, resource});
     }
 
     get sidebarVisible() {

--- a/ghost/admin/app/styles/components/dropdowns.css
+++ b/ghost/admin/app/styles/components/dropdowns.css
@@ -390,6 +390,7 @@ Post context menu
     stroke-width: 1.8px;
 }
 
+.gh-posts-context-menu li.gh-posts-context-menu-separated::before,
 .gh-posts-context-menu li:last-child::before,
 .gh-analytics-actions-menu li:last-child::before {
     display: block;

--- a/ghost/admin/app/utils/gift-link.js
+++ b/ghost/admin/app/utils/gift-link.js
@@ -1,0 +1,18 @@
+// Whether the current user can copy a gift link for the given post/page.
+//
+// Requires the giftLinks flag, a user who can manage links
+// (Owner/Administrator/Editor/Super Editor/Author), and a published, gated
+// (non-public) post/page. Authors are limited to their own posts server-side;
+// in the lists they only see posts they can edit, so the role check is
+// sufficient for surfacing the control here.
+//
+// The gift-link URL itself is built on the React side (the modal owns it), so
+// this util only decides whether to show the entry point.
+export function canCopyGiftLink({feature, user, post} = {}) {
+    if (!feature || !feature.giftLinks || !post) {
+        return false;
+    }
+    const canManage = Boolean(user && (user.isAdmin || user.isEitherEditor || user.isAuthor));
+    const eligible = Boolean(post.isPublished && post.visibility && post.visibility !== 'public');
+    return canManage && eligible;
+}

--- a/ghost/admin/app/utils/gift-link.js
+++ b/ghost/admin/app/utils/gift-link.js
@@ -1,10 +1,8 @@
 // Whether the current user can copy a gift link for the given post/page.
 //
 // Requires the giftLinks flag, a user who can manage links
-// (Owner/Administrator/Editor/Super Editor/Author), and a published, gated
-// (non-public) post/page. Authors are limited to their own posts server-side;
-// in the lists they only see posts they can edit, so the role check is
-// sufficient for surfacing the control here.
+// (Owner/Administrator/Editor/Super Editor), and a published, gated (non-public)
+// post/page.
 //
 // The gift-link URL itself is built on the React side (the modal owns it), so
 // this util only decides whether to show the entry point.
@@ -12,7 +10,7 @@ export function canCopyGiftLink({feature, user, post} = {}) {
     if (!feature || !feature.giftLinks || !post) {
         return false;
     }
-    const canManage = Boolean(user && (user.isAdmin || user.isEitherEditor || user.isAuthor));
+    const canManage = Boolean(user && (user.isAdmin || user.isEitherEditor));
     const eligible = Boolean(post.isPublished && post.visibility && post.visibility !== 'public');
     return canManage && eligible;
 }

--- a/ghost/admin/public/assets/icons/gift-link.svg
+++ b/ghost/admin/public/assets/icons/gift-link.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <title>gift-link</title>
+  <path d="M12 7v14"/>
+  <path d="M20 11v8a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-8"/>
+  <path d="M7.5 7a1 1 0 0 1 0-5A4.8 8 0 0 1 12 7a4.8 8 0 0 1 4.5-5 1 1 0 0 1 0 5"/>
+  <rect x="3" y="7" width="18" height="4" rx="1"/>
+</svg>

--- a/ghost/admin/tests/unit/utils/gift-link-test.js
+++ b/ghost/admin/tests/unit/utils/gift-link-test.js
@@ -1,0 +1,38 @@
+import {canCopyGiftLink} from 'ghost-admin/utils/gift-link';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+
+describe('Unit | Utility | gift-link', function () {
+    const flagOn = {giftLinks: true};
+    const admin = {isAdmin: true, isEitherEditor: false, isAuthor: false};
+    const author = {isAdmin: false, isEitherEditor: false, isAuthor: true};
+    const contributor = {isAdmin: false, isEitherEditor: false, isAuthor: false};
+    const gatedPublished = {isPublished: true, visibility: 'paid'};
+
+    it('allows a managing user on a published, gated post', function () {
+        expect(canCopyGiftLink({feature: flagOn, user: admin, post: gatedPublished})).to.be.true;
+        expect(canCopyGiftLink({feature: flagOn, user: author, post: gatedPublished})).to.be.true;
+        expect(canCopyGiftLink({feature: flagOn, user: admin, post: {isPublished: true, visibility: 'members'}})).to.be.true;
+    });
+
+    it('is false when the labs flag is off', function () {
+        expect(canCopyGiftLink({feature: {giftLinks: false}, user: admin, post: gatedPublished})).to.be.false;
+    });
+
+    it('is false for users who cannot manage links', function () {
+        expect(canCopyGiftLink({feature: flagOn, user: contributor, post: gatedPublished})).to.be.false;
+    });
+
+    it('is false for public, draft, or non-gated posts', function () {
+        expect(canCopyGiftLink({feature: flagOn, user: admin, post: {isPublished: true, visibility: 'public'}})).to.be.false;
+        expect(canCopyGiftLink({feature: flagOn, user: admin, post: {isPublished: false, visibility: 'paid'}})).to.be.false;
+        expect(canCopyGiftLink({feature: flagOn, user: admin, post: {isPublished: true, visibility: null}})).to.be.false;
+    });
+
+    it('is false when feature, user, or post is missing', function () {
+        expect(canCopyGiftLink({user: admin, post: gatedPublished})).to.be.false;
+        expect(canCopyGiftLink({feature: flagOn, post: gatedPublished})).to.be.false;
+        expect(canCopyGiftLink({feature: flagOn, user: admin})).to.be.false;
+        expect(canCopyGiftLink()).to.be.false;
+    });
+});

--- a/ghost/admin/tests/unit/utils/gift-link-test.js
+++ b/ghost/admin/tests/unit/utils/gift-link-test.js
@@ -5,13 +5,14 @@ import {expect} from 'chai';
 describe('Unit | Utility | gift-link', function () {
     const flagOn = {giftLinks: true};
     const admin = {isAdmin: true, isEitherEditor: false, isAuthor: false};
+    const editor = {isAdmin: false, isEitherEditor: true, isAuthor: false};
     const author = {isAdmin: false, isEitherEditor: false, isAuthor: true};
     const contributor = {isAdmin: false, isEitherEditor: false, isAuthor: false};
     const gatedPublished = {isPublished: true, visibility: 'paid'};
 
     it('allows a managing user on a published, gated post', function () {
         expect(canCopyGiftLink({feature: flagOn, user: admin, post: gatedPublished})).to.be.true;
-        expect(canCopyGiftLink({feature: flagOn, user: author, post: gatedPublished})).to.be.true;
+        expect(canCopyGiftLink({feature: flagOn, user: editor, post: gatedPublished})).to.be.true;
         expect(canCopyGiftLink({feature: flagOn, user: admin, post: {isPublished: true, visibility: 'members'}})).to.be.true;
     });
 
@@ -21,6 +22,7 @@ describe('Unit | Utility | gift-link', function () {
 
     it('is false for users who cannot manage links', function () {
         expect(canCopyGiftLink({feature: flagOn, user: contributor, post: gatedPublished})).to.be.false;
+        expect(canCopyGiftLink({feature: flagOn, user: author, post: gatedPublished})).to.be.false;
     });
 
     it('is false for public, draft, or non-gated posts', function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3729

## Summary

Adds the publisher-facing gift-links admin UI on top of the service + admin API already on `main`. A **single React gift-link modal** is reused across surfaces instead of maintaining a separate Ember modal:

- **Post analytics screen** — a "Share as a gift" entry in the post share modal opens the modal.
- **Ember posts/pages list** — the right-click context menu fires an `openGiftLinkModal` event over the state bridge; a host mounted alongside the Ember fallback (at the `/posts` and `/pages` routes) opens the React modal in place.
- **Settings → Advanced → Danger zone** — a "Reset all gift links" action.

All gated behind the existing private `giftLinks` flag.

## Notes

- The modal makes two separate reads: **link details** (admin API `gift_links`) and **usage** (visits/views via the same Tinybird analytics path as every other analytics surface). Usage **degrades gracefully** — when analytics is off, or the per-link usage pipe (BER-3746/BER-3728) isn't deployed yet, the visitor count is simply hidden and everything else still works.
- Share URL is the canonical post URL + `?gift=<token>` (no `utm`).
- Posts reuse the post-analytics screen's cached query (shared `POST_ANALYTICS_INCLUDE`); pages fetch on their own route. API wrapper names follow the backend controllers (`ensure` / `create` / `removeAll`).

## Testing

- `apps/posts` unit suite (482) green; new URL-builder unit test; Ember eligibility-util unit test.
- `admin-x-settings` danger-zone acceptance test for reset-all (passing locally).
- Typecheck + lint clean across `posts`, `admin`, `shade`, `admin-x-framework`, `admin-x-settings`, and `ghost/admin`.