### PR TITLE
Gate automations sidebar link on Owner/Admin access

### DIFF
--- a/apps/admin-x-framework/src/api/users.ts
+++ b/apps/admin-x-framework/src/api/users.ts
@@ -204,3 +204,11 @@ export function canManageTags(user: User) {
 export function hasAdminAccess(user: User) {
     return isOwnerUser(user) || isAdminUser(user);
 }
+
+export function canManageAutomations(user: User) {
+    // Only Owner and Admin can edit automations. This matches the API permission rows,
+    // which grant automation browse/read/edit to Administrator + Admin Integration
+    // (the Owner role inherits all permissions). Super Editors can manage members but
+    // cannot edit automations, so we must not gate on canManageMembers here.
+    return isOwnerUser(user) || isAdminUser(user);
+}

--- a/apps/admin-x-framework/test/unit/api/users.test.ts
+++ b/apps/admin-x-framework/test/unit/api/users.test.ts
@@ -1,0 +1,28 @@
+import {User} from '../../../src/api/users';
+import {canManageAutomations} from '../../../src/api/users';
+
+const userWithRole = (roleName: string): User => ({
+    roles: [{name: roleName}]
+} as unknown as User);
+
+describe('users api helpers', () => {
+    describe('canManageAutomations', () => {
+        it('returns true for Owner', () => {
+            expect(canManageAutomations(userWithRole('Owner'))).toBe(true);
+        });
+
+        it('returns true for Administrator', () => {
+            expect(canManageAutomations(userWithRole('Administrator'))).toBe(true);
+        });
+
+        it('returns false for Super Editor', () => {
+            expect(canManageAutomations(userWithRole('Super Editor'))).toBe(false);
+        });
+
+        it('returns false for Editor, Author and Contributor', () => {
+            expect(canManageAutomations(userWithRole('Editor'))).toBe(false);
+            expect(canManageAutomations(userWithRole('Author'))).toBe(false);
+            expect(canManageAutomations(userWithRole('Contributor'))).toBe(false);
+        });
+    });
+});

--- a/apps/admin/src/layout/app-sidebar/nav-content.tsx
+++ b/apps/admin/src/layout/app-sidebar/nav-content.tsx
@@ -5,7 +5,7 @@ import {formatNumber, LucideIcon} from "@tryghost/shade/utils"
 import { useCurrentUser } from "@tryghost/admin-x-framework/api/current-user";
 import { useMemberCount } from "@tryghost/admin-x-framework/api/members";
 import {getSettingValue, useBrowseSettings} from "@tryghost/admin-x-framework/api/settings";
-import { canManageMembers, canManageTags } from "@tryghost/admin-x-framework/api/users";
+import { canManageAutomations, canManageMembers, canManageTags } from "@tryghost/admin-x-framework/api/users";
 import { NavMenuItem } from "./nav-menu-item";
 import { useNavigationExpanded } from "./hooks/use-navigation-preferences";
 import { NavCustomViews } from "./nav-custom-views";
@@ -83,6 +83,7 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
 
     const showTags = currentUser && canManageTags(currentUser);
     const showMembers = currentUser && canManageMembers(currentUser);
+    const showAutomations = currentUser && canManageAutomations(currentUser);
     const commentsEnabled = getSettingValue<string>(settingsData?.settings, 'comments_enabled');
     const showComments = !!showMembers && commentsEnabled !== 'off';
     const isDraftPostsRouteActive = routing.isRouteActive('posts', {type: 'draft'});
@@ -208,7 +209,7 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
                         </NavMenuItem>
                     )}
 
-                    {showMembers && automationsEnabled && (
+                    {showAutomations && automationsEnabled && (
                         <NavMenuItem>
                             <NavMenuItem.Link
                                 to="automations"


### PR DESCRIPTION
## Summary

The **Automations** sidebar nav link was gated on `canManageMembers`, which returns true for **Owner, Administrator, and Super Editor**. However, the automations API only grants `browse`/`read`/`edit` permission to **Administrator** and **Admin Integration** (the **Owner** role inherits all permissions). As a result, a **Super Editor** saw the Automations link in the sidebar but hit a permission error from the API when trying to view or edit an automation.

This tightens the frontend to match what the API actually allows, by gating on an automations-specific Owner/Admin check rather than `canManageMembers`.

## Changes

- Added a `canManageAutomations(user)` helper in `apps/admin-x-framework/src/api/users.ts` that returns true only for **Owner** and **Administrator** (mirrors the API permission rows; the Owner role inherits all permissions).
- Gated the Automations sidebar nav link in `apps/admin/src/layout/app-sidebar/nav-content.tsx` on `canManageAutomations` instead of `canManageMembers`.
- Added a unit test for `canManageAutomations` covering Owner/Admin (allowed) and Super Editor/Editor/Author/Contributor (denied).

## Testing

- `pnpm exec vitest run test/unit/api/users.test.ts` — passes (4/4)
- Lint + typecheck clean for `apps/admin-x-framework` and `apps/admin`

## Context

Slack thread: https://ghost.slack.com/archives/C07HTEJMR2R/p1782393171415609?thread_ts=1782392322.408749&cid=C07HTEJMR2R

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaR76hEiUXbTRJJueE1RKZ)_