### PR TITLE
Added Ghost asset build to `pnpm dev` pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,12 @@
         "dependsOn": [
           "docker:up",
           {
+            "target": "build:assets",
+            "projects": [
+              "ghost"
+            ]
+          },
+          {
             "target": "dev",
             "projects": [
               "@tryghost/admin",


### PR DESCRIPTION
no refs

## Summary

### Problem

Ghost's frontend assets aren't built in the default `pnpm dev` pipeline. As a result, `pnpm dev:analytics` doesn't work right away, since the `ghost-stats.min.js` script is never generated, causing page_hits to not be recorded without the additional manual step of running `pnpm --filter=ghost build:assets`.

### Solution

- Runs the existing Ghost core build:assets target before the Docker dev stack starts as part of the default `pnpm dev` pipeline
- Does not run a continuous dev server, just a one-time build. We can add a dev server if needed, but it seems unnecessary for these files that are so rarely modified.