### PR TITLE
Added admin-toolbar UMD build output to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,6 +144,9 @@ Caddyfile
 # Admin
 /ghost/admin/dist
 
+# Admin Toolbar
+/apps/admin-toolbar/umd
+
 # Comments-UI
 /apps/comments-ui/umd
 /apps/comments-ui/playwright-report


### PR DESCRIPTION
## Summary
- Add the Admin Toolbar UMD build directory to `.gitignore`
- Keep generated bundles out of version control