### PR TITLE
Removed gift links permission from the Author role

### DIFF
--- a/ghost/core/core/server/data/migrations/utils/permissions.js
+++ b/ghost/core/core/server/data/migrations/utils/permissions.js
@@ -272,6 +272,7 @@ function createRemovePermissionMigration(config, roles) {
 module.exports = {
     addPermission,
     addPermissionToRole,
+    removePermissionFromRole,
     addPermissionWithRoles,
     createRemovePermissionMigration
 };

--- a/ghost/core/core/server/data/migrations/versions/6.50/2026-06-29-00-00-00-remove-gift-links-permission-from-author.js
+++ b/ghost/core/core/server/data/migrations/versions/6.50/2026-06-29-00-00-00-remove-gift-links-permission-from-author.js
@@ -1,0 +1,8 @@
+const {removePermissionFromRole} = require('../../utils');
+
+// Authors cannot change post visibility, so they should not be able to manage gift
+// links either. Drop the over-broad grant added in the original gift links rollout.
+module.exports = removePermissionFromRole({
+    permission: 'Manage gift links',
+    role: 'Author'
+});

--- a/ghost/core/core/server/data/schema/fixtures/fixtures.json
+++ b/ghost/core/core/server/data/schema/fixtures/fixtures.json
@@ -1090,8 +1090,7 @@
                     "product": ["browse", "read"],
                     "newsletter": ["browse", "read"],
                     "collection": ["browse", "read", "add"],
-                    "recommendation": ["browse", "read"],
-                    "gift_link": "manage"
+                    "recommendation": ["browse", "read"]
                 },
                 "Contributor": {
                     "post": ["browse", "read", "edit", "add", "destroy"],

--- a/ghost/core/test/e2e-api/admin/gift-links.test.ts
+++ b/ghost/core/test/e2e-api/admin/gift-links.test.ts
@@ -9,6 +9,7 @@ describe('Gift Links Admin API', function () {
         put: (_url: string) => any;
         post: (_url: string) => any;
         loginAsOwner: () => Promise<void>;
+        loginAsAuthor: () => Promise<void>;
         loginAsContributor: () => Promise<void>;
     };
     let postId: string;
@@ -64,12 +65,6 @@ describe('Gift Links Admin API', function () {
             assert.notEqual(body.gift_links[0].token, first);
         });
 
-        it('403s for a role without gift-link permission', async function () {
-            await agent.loginAsContributor();
-            await agent.get(`${name}/${id()}/gift_links/`).expectStatus(403);
-            await agent.loginAsOwner();
-        });
-
         it('supports the full lifecycle', async function () {
             // empty
             let body = (await agent.get(`${name}/${id()}/gift_links/`).expectStatus(200)).body;
@@ -92,6 +87,24 @@ describe('Gift Links Admin API', function () {
             assert.deepEqual(body, {meta: {count: 1}});
             body = (await agent.get(`${name}/${id()}/gift_links/`).expectStatus(200)).body;
             assert.deepEqual(body.gift_links, []);
+        });
+    });
+
+    // Permission is granted at the role level, independent of the post/page, so these
+    // run once rather than per-entity.
+    describe('without gift-link permission', function () {
+        afterEach(async function () {
+            await agent.loginAsOwner();
+        });
+
+        it('403s for an Author', async function () {
+            await agent.loginAsAuthor();
+            await agent.get(`posts/${postId}/gift_links/`).expectStatus(403);
+        });
+
+        it('403s for a Contributor', async function () {
+            await agent.loginAsContributor();
+            await agent.get(`posts/${postId}/gift_links/`).expectStatus(403);
         });
     });
 

--- a/ghost/core/test/integration/migrations/migration.test.js
+++ b/ghost/core/test/integration/migrations/migration.test.js
@@ -111,7 +111,7 @@ describe('Migrations', function () {
             assertHavePermission(permissions, 'Delete posts', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration', 'Super Editor']);
             assertHavePermission(permissions, 'Publish posts', ['Administrator', 'Editor', 'Admin Integration', 'Scheduler Integration', 'Super Editor']);
             assertHavePermission(permissions, 'Flush gift reminders', ['Scheduler Integration']);
-            assertHavePermission(permissions, 'Manage gift links', ['Administrator', 'Editor', 'Author', 'Admin Integration', 'Super Editor']);
+            assertHavePermission(permissions, 'Manage gift links', ['Administrator', 'Editor', 'Admin Integration', 'Super Editor']);
             assertHavePermission(permissions, 'Remove all gift links', ['Administrator']);
 
             assertHavePermission(permissions, 'Browse settings', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration', 'Super Editor']);

--- a/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
+++ b/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
@@ -398,7 +398,7 @@ describe('Migration Fixture Utils', function () {
             const rolesAllStub = sinon.stub(models.Role, 'findAll').returns(Promise.resolve(dataMethodStub));
 
             const result = await fixtureManager.addFixturesForRelation(fixtures.relations[0]);
-            const FIXTURE_COUNT = 148;
+            const FIXTURE_COUNT = 147;
             assertExists(result);
             assert(_.isPlainObject(result));
             assert.equal(result.expected, FIXTURE_COUNT);

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -36,7 +36,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '83bd80e87f81e4663242965e5048fc7a';
-    const currentFixturesHash = 'f4941d9d92b59075e0c2a1cc3fc4c44a';
+    const currentFixturesHash = '16c0d239e8d04682ccb1894124179289';
     const currentSettingsHash = '397be8628c753b1959b8954d5610f83f';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 

--- a/ghost/core/test/utils/fixtures/fixtures.json
+++ b/ghost/core/test/utils/fixtures/fixtures.json
@@ -1220,8 +1220,7 @@
                     "product": ["browse", "read"],
                     "newsletter": ["browse", "read"],
                     "collection": ["browse", "read", "add"],
-                    "recommendation": ["browse", "read"],
-                    "gift_link": "manage"
+                    "recommendation": ["browse", "read"]
                 },
                 "Super Editor": {
                     "notification": "all",


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3748/

The gift links permission fixtures were too broad: Authors were granted the "Manage gift links" permission, but Authors don't have permission to change post visibility — so they shouldn't be able to manage gift links either.

- Removed `gift_link: manage` from the Author role in the permission fixtures
- Added a migration to drop the existing "Manage gift links" grant from the Author role on sites that already ran the original gift links permission migration
- Exported the existing `removePermissionFromRole` migration helper (the natural inverse of `addPermissionToRole`) so the migration can use it
- Updated the migration integration assertion and the test-utils fixtures copy to match, and extended the gift-links API test to assert Authors (alongside Contributors) get a 403

Gift links are still behind the `giftLinks` labs flag, so this is not yet user-facing.