### PR TITLE
✨ Added system appearance mode to Ghost Admin

### DIFF
--- a/apps/admin/src/ember-bridge/ember-bridge.tsx
+++ b/apps/admin/src/ember-bridge/ember-bridge.tsx
@@ -18,6 +18,8 @@ export interface StateBridge {
     onUpdate: (dataType: string, response: unknown) => void;
     onInvalidate: (dataType: string) => void;
     onDelete: (dataType: string, id: string) => void;
+    preloadAdminThemeStylesheet?: () => Promise<void>;
+    applyAdminThemePreference?: (mode: 'light' | 'dark' | 'system') => Promise<void> | void;
     on<K extends keyof StateBridgeEventMap>(event: K, callback: (event: StateBridgeEventMap[K]) => void): void;
     off<K extends keyof StateBridgeEventMap>(event: K, callback: (event: StateBridgeEventMap[K]) => void): void;
     sidebarVisible: boolean;

--- a/apps/admin/src/hooks/use-theme.ts
+++ b/apps/admin/src/hooks/use-theme.ts
@@ -1,0 +1,129 @@
+import {useCallback, useEffect, useRef, useState} from 'react';
+import {useEditUserPreferences, useUserPreferences} from '@/hooks/user-preferences';
+
+export type ThemeMode = 'light' | 'dark' | 'system';
+export type ResolvedThemeMode = 'light' | 'dark';
+
+function getSystemTheme(): ResolvedThemeMode {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+        return 'light';
+    }
+
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function applyThemeClass(resolvedTheme: ResolvedThemeMode) {
+    document.documentElement.classList.toggle('dark', resolvedTheme === 'dark');
+}
+
+// In the embedded admin, Ember owns the DOM theme: it manages both the `dark`
+// class and the dark stylesheet, and installs its own prefers-color-scheme
+// listener. The class-toggling and media-query effects below are only a fallback
+// for running this hook standalone (no EmberBridge), so they must not fight Ember.
+function isEmberManaged(): boolean {
+    return typeof window !== 'undefined' && Boolean(window.EmberBridge);
+}
+
+async function preloadAdminThemeStylesheet() {
+    await window.EmberBridge?.state.preloadAdminThemeStylesheet?.();
+}
+
+function applyAdminTheme(mode: ThemeMode, resolvedTheme: ResolvedThemeMode) {
+    if (window.EmberBridge?.state.applyAdminThemePreference) {
+        void window.EmberBridge.state.applyAdminThemePreference(mode);
+    } else {
+        applyThemeClass(resolvedTheme);
+    }
+}
+
+export function useTheme() {
+    const {data: preferences} = useUserPreferences();
+    const {mutateAsync: editPreferences, isLoading: isEditingPreferences} = useEditUserPreferences();
+    const [systemTheme, setSystemTheme] = useState<ResolvedThemeMode>(getSystemTheme);
+    const [pendingTheme, setPendingTheme] = useState<ThemeMode | null>(null);
+    const [isPendingTheme, setIsPendingTheme] = useState(false);
+    const pendingRef = useRef(false);
+
+    const persistedTheme: ThemeMode = preferences?.nightShift ?? 'light';
+    const theme: ThemeMode = pendingTheme ?? persistedTheme;
+    const resolvedTheme: ResolvedThemeMode = theme === 'system' ? systemTheme : theme;
+
+    useEffect(() => {
+        if (isEmberManaged() || typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+            return;
+        }
+
+        const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+        const handleChange = (event: MediaQueryListEvent) => {
+            setSystemTheme(event.matches ? 'dark' : 'light');
+        };
+
+        setSystemTheme(mediaQuery.matches ? 'dark' : 'light');
+        if (typeof mediaQuery.addEventListener === 'function') {
+            mediaQuery.addEventListener('change', handleChange);
+        } else {
+            mediaQuery.addListener(handleChange);
+        }
+
+        return () => {
+            if (typeof mediaQuery.removeEventListener === 'function') {
+                mediaQuery.removeEventListener('change', handleChange);
+            } else {
+                mediaQuery.removeListener(handleChange);
+            }
+        };
+    }, []);
+
+    useEffect(() => {
+        if (isEmberManaged()) {
+            return;
+        }
+        applyThemeClass(resolvedTheme);
+    }, [resolvedTheme]);
+
+    // Clear the optimistic selection once the persisted preference catches up, so
+    // the menu indicator settles on the new value without flickering back via the
+    // brief window where the refetched preferences query has no data.
+    useEffect(() => {
+        if (pendingTheme !== null && persistedTheme === pendingTheme) {
+            setPendingTheme(null);
+        }
+    }, [pendingTheme, persistedTheme]);
+
+    const setTheme = useCallback(async (mode: ThemeMode) => {
+        if (pendingRef.current || mode === theme) {
+            return;
+        }
+
+        pendingRef.current = true;
+        setIsPendingTheme(true);
+        // Reflect the choice immediately; cleared on rollback (catch) or once the
+        // persisted preference matches (effect above).
+        setPendingTheme(mode);
+
+        try {
+            const nextResolvedTheme = mode === 'system' ? systemTheme : mode;
+            await preloadAdminThemeStylesheet().catch((error) => {
+                // eslint-disable-next-line no-console
+                console.error('[Theme] Failed to preload admin theme stylesheet:', error);
+            });
+            applyAdminTheme(mode, nextResolvedTheme);
+            await editPreferences({nightShift: mode});
+        } catch (error) {
+            setPendingTheme(null);
+            applyAdminTheme(theme, resolvedTheme);
+            // eslint-disable-next-line no-console
+            console.error('[Theme] Failed to update appearance preference:', error);
+        } finally {
+            pendingRef.current = false;
+            setIsPendingTheme(false);
+        }
+    }, [editPreferences, resolvedTheme, systemTheme, theme]);
+
+    return {
+        theme,
+        resolvedTheme,
+        setTheme,
+        isSettingTheme: isEditingPreferences || isPendingTheme
+    } as const;
+}

--- a/apps/admin/src/hooks/user-preferences.test.tsx
+++ b/apps/admin/src/hooks/user-preferences.test.tsx
@@ -249,6 +249,43 @@ describe("useUserPreferences", () => {
             });
         });
 
+        describe("nightShift migration", () => {
+            [
+                {scenario: "legacy boolean true", value: true, expected: "dark"},
+                {scenario: "legacy boolean false", value: false, expected: "light"},
+                {scenario: "dark string", value: "dark", expected: "dark"},
+                {scenario: "light string", value: "light", expected: "light"},
+                {scenario: "system string", value: "system", expected: "system"},
+                {scenario: "invalid value", value: "invalid", expected: "light"},
+            ].forEach(({scenario, value, expected}) => {
+                queryTest(`parses ${scenario}`, async ({ setup }) => {
+                    const result = await setup({
+                        accessibility: JSON.stringify({nightShift: value}),
+                    });
+
+                    expect(result.current.data?.nightShift).toBe(expected);
+                });
+            });
+
+            queryTest("omits nightShift when the preference is absent", async ({ setup }) => {
+                const result = await setup({
+                    accessibility: JSON.stringify({}),
+                });
+
+                // Absent stays absent so it isn't written back on unrelated saves;
+                // the display fallback to "light" lives in useTheme.
+                expect(result.current.data?.nightShift).toBeUndefined();
+            });
+
+            queryTest("preserves explicit system preference", async ({ setup }) => {
+                const result = await setup({
+                    accessibility: JSON.stringify({nightShift: "system"}),
+                });
+
+                expect(result.current.data?.nightShift).toBe("system");
+            });
+        });
+
         queryTest("returns undefined when user is not loaded", async ({ server, wrapper }) => {
             server.use(
                 http.get(USERS_API_URL, () => {
@@ -280,7 +317,7 @@ describe("useUserPreferences", () => {
                                     expanded: { posts: false },
                                     menu: { visible: true },
                                 },
-                                nightShift: true,
+                                nightShift: "dark",
                             }),
                         }],
                     });
@@ -455,7 +492,7 @@ describe("useEditUserPreferences", () => {
                         completedSteps: ["customize-design"],
                         checklistState: "started",
                     },
-                    nightShift: true,
+                    nightShift: "dark",
                 }),
             });
 
@@ -476,7 +513,7 @@ describe("useEditUserPreferences", () => {
                         completedSteps: ["customize-design", "first-post"],
                         checklistState: "started",
                     },
-                    nightShift: true, // Preserved
+                    nightShift: "dark", // Preserved
                 });
             });
         });

--- a/apps/admin/src/hooks/user-preferences.ts
+++ b/apps/admin/src/hooks/user-preferences.ts
@@ -39,7 +39,11 @@ export const NavigationPreferencesSchema = z.looseObject({
 
 const PreferencesSchema = z.looseObject({
     whatsNew: WhatsNewPreferencesSchema.optional().catch(undefined),
-    nightShift: z.boolean().optional(),
+    // Optional (not defaulted) so an absent preference stays absent and isn't
+    // eagerly written back on unrelated preference saves. The display fallback to
+    // "light" lives at the read site (see useTheme). New users get "system" from
+    // the server default; legacy booleans are migrated to strings in the queryFn.
+    nightShift: z.enum(["light", "dark", "system"]).optional().catch("light"),
     onboarding: OnboardingPreferencesSchema.default(DEFAULT_ONBOARDING_PREFERENCES).catch(DEFAULT_ONBOARDING_PREFERENCES),
     navigation: NavigationPreferencesSchema.default(DEFAULT_NAVIGATION_PREFERENCES).catch(DEFAULT_NAVIGATION_PREFERENCES),
 });
@@ -65,7 +69,17 @@ export function useUserPreferences<TData = Preferences>(
             }
 
             const raw = user.accessibility || "{}";
-            const parsed = JSON.parse(raw) as unknown;
+            const parsedRaw: unknown = JSON.parse(raw);
+            const parsed: Record<string, unknown> =
+                parsedRaw && typeof parsedRaw === "object" && !Array.isArray(parsedRaw)
+                    ? parsedRaw as Record<string, unknown>
+                    : {};
+
+            if (parsed.nightShift === true) {
+                parsed.nightShift = "dark";
+            } else if (parsed.nightShift === false) {
+                parsed.nightShift = "light";
+            }
 
             return PreferencesSchema.parse(parsed);
         },

--- a/apps/admin/src/layout/app-sidebar/user-menu.tsx
+++ b/apps/admin/src/layout/app-sidebar/user-menu.tsx
@@ -1,10 +1,10 @@
 import React from "react"
 
-import {DropdownMenu, DropdownMenuContent, DropdownMenuSeparator, DropdownMenuTrigger, Indicator, SidebarMenuButton, Switch} from "@tryghost/shade/components"
+import {DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuSub, DropdownMenuSubContent, DropdownMenuSubTrigger, DropdownMenuTrigger, Indicator, SidebarMenuButton} from "@tryghost/shade/components"
 import {LucideIcon} from "@tryghost/shade/utils"
 import { useCurrentUser } from "@tryghost/admin-x-framework/api/current-user";
 import { getGhostPaths } from "@tryghost/admin-x-framework/helpers";
-import { useUserPreferences, useEditUserPreferences } from "@/hooks/user-preferences";
+import { useTheme, type ThemeMode } from "@/hooks/use-theme";
 import { useWhatsNew } from "@/whats-new/hooks/use-whats-new";
 import { useUpgradeStatus } from "./hooks/use-upgrade-status";
 import { useBrowseSite } from "@tryghost/admin-x-framework/api/site";
@@ -27,32 +27,52 @@ function UserMenuProfile() {
     );
 }
 
-function UserMenuDarkMode() {
-    const {data: preferences} = useUserPreferences();
-    const {mutateAsync: editPreferences, isLoading: isEditingPreferences} = useEditUserPreferences();
+const THEME_OPTIONS: Array<{value: ThemeMode; label: string; Icon: typeof LucideIcon.Moon}> = [
+    {value: 'dark', label: 'Dark', Icon: LucideIcon.Moon},
+    {value: 'light', label: 'Light', Icon: LucideIcon.Sun},
+    {value: 'system', label: 'System', Icon: LucideIcon.Monitor},
+];
 
-    const setNightShift = (nightShift: boolean) => {
-        void editPreferences({nightShift});
-    };
+const THEME_LABELS = Object.fromEntries(
+    THEME_OPTIONS.map(({value, label}) => [value, label])
+) as Record<ThemeMode, string>;
+
+function UserMenuAppearance() {
+    const {theme, setTheme, isSettingTheme} = useTheme();
 
     return (
-        <UserMenuItem
-            asChild={false}
-            onSelect={(e: Event) => {
-                e.preventDefault();
-                setNightShift(!preferences?.nightShift);
-            }}
-        >
-            <LucideIcon.Moon />
-            <UserMenuItem.Label className="flex-1">Dark mode</UserMenuItem.Label>
-            <Switch
-                checked={preferences?.nightShift ?? false}
-                disabled={isEditingPreferences}
-                onCheckedChange={setNightShift}
-                onClick={(e: React.MouseEvent<HTMLElement>) => e.stopPropagation()}
-                tabIndex={-1}
-            />
-        </UserMenuItem>
+        <DropdownMenuSub>
+            <DropdownMenuSubTrigger
+                className="cursor-pointer gap-2 text-base [&>svg:last-child]:-ml-1.5 [&>svg:last-child]:size-3.5 [&>svg:last-child]:text-muted-foreground"
+                data-test-nav="appearance"
+            >
+                <LucideIcon.Palette />
+                <UserMenuItem.Label>Appearance</UserMenuItem.Label>
+                <span className="text-sm text-muted-foreground">{THEME_LABELS[theme]}</span>
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent alignOffset={-4} className="min-w-36">
+                {THEME_OPTIONS.map(({value, label, Icon}) => (
+                    <DropdownMenuItem
+                        key={value}
+                        disabled={isSettingTheme}
+                        aria-label={`${label} appearance`}
+                        data-test-theme-option={value}
+                        onSelect={() => {
+                            void setTheme(value);
+                        }}
+                    >
+                        <Icon />
+                        <span className="flex-1">{label}</span>
+                        {theme === value && (
+                            <LucideIcon.Check
+                                aria-hidden="true"
+                                className="text-muted-foreground"
+                            />
+                        )}
+                    </DropdownMenuItem>
+                ))}
+            </DropdownMenuSubContent>
+        </DropdownMenuSub>
     );
 }
 
@@ -162,7 +182,7 @@ function UserMenu(props: UserMenuProps) {
                         <UserMenuItem.Label>Resources & guides</UserMenuItem.Label>
                     </a>
                 </UserMenuItem>
-                <UserMenuDarkMode />
+                <UserMenuAppearance />
                 <DropdownMenuSeparator />
                 <UserMenuSignOut />
             </DropdownMenuContent>
@@ -178,7 +198,7 @@ function UserMenu(props: UserMenuProps) {
  * - Posts (navigate to posts list)
  * - View site (open site in new tab)
  * - Your profile (navigate to profile settings)
- * - Dark mode toggle
+ * - Appearance selector
  * - Sign out
  *
  * Contributors do not have access to:
@@ -228,7 +248,7 @@ function ContributorUserMenu() {
                 </UserMenuItem>
                 <DropdownMenuSeparator />
                 <UserMenuProfile />
-                <UserMenuDarkMode />
+                <UserMenuAppearance />
                 <DropdownMenuSeparator />
                 <UserMenuSignOut />
             </DropdownMenuContent>

--- a/e2e/helpers/pages/admin/sidebar/sidebar-page.ts
+++ b/e2e/helpers/pages/admin/sidebar/sidebar-page.ts
@@ -36,7 +36,10 @@ export class SidebarPage extends AdminPage {
     public readonly sidebar: Locator;
     public readonly postsToggle: Locator;
     public readonly userDropdownTrigger: Locator;
-    public readonly nightShiftToggle: Locator;
+    public readonly appearanceMenuItem: Locator;
+    public readonly themeLightOption: Locator;
+    public readonly themeSystemOption: Locator;
+    public readonly themeDarkOption: Locator;
     public readonly whatsNewButton: Locator;
     public readonly userProfileLink: Locator;
     public readonly signOutLink: Locator;
@@ -51,7 +54,10 @@ export class SidebarPage extends AdminPage {
         this.sidebar = page.getByRole('navigation');
         this.postsToggle = this.sidebar.getByRole('button', {name: /toggle post views/i});
         this.userDropdownTrigger = page.locator('[data-test-nav="arrow-down"]');
-        this.nightShiftToggle = page.getByRole('menuitem', {name: /dark mode/i}).getByRole('switch');
+        this.appearanceMenuItem = page.getByRole('menuitem', {name: /appearance/i});
+        this.themeLightOption = page.getByRole('menuitem', {name: /light appearance/i});
+        this.themeSystemOption = page.getByRole('menuitem', {name: /system appearance/i});
+        this.themeDarkOption = page.getByRole('menuitem', {name: /dark appearance/i});
         this.whatsNewButton = page.getByRole('menuitem', {name: /what's new/i});
         this.userProfileLink = page.getByRole('menuitem', {name: /your profile/i});
         this.signOutLink = page.getByRole('menuitem', {name: /sign out/i});
@@ -89,15 +95,10 @@ export class SidebarPage extends AdminPage {
         }
     }
 
-    async isNightShiftEnabled(): Promise<boolean> {
-        const isChecked = await this.nightShiftToggle.getAttribute('aria-checked');
-        return isChecked === 'true';
-    }
-
-    async waitForNightShiftEnabled(enabled: boolean): Promise<void> {
+    async waitForDarkMode(enabled: boolean): Promise<void> {
         const locator = enabled
-            ? this.page.locator('[aria-checked="true"]')
-            : this.page.locator('[aria-checked="false"]');
+            ? this.page.locator('html.dark')
+            : this.page.locator('html:not(.dark)');
         await locator.waitFor();
     }
 }

--- a/e2e/playwright.config.mjs
+++ b/e2e/playwright.config.mjs
@@ -30,7 +30,11 @@ const config = {
         // Base URL will be set dynamically per test via fixture
         baseURL: process.env.GHOST_BASE_URL || 'http://localhost:2368',
         trace: 'retain-on-failure',
-        browserName: 'chromium'
+        browserName: 'chromium',
+        // New users default to the "system" appearance preference, which follows the
+        // OS colour scheme. Pin it to light so admin theme state stays deterministic
+        // across the suite; theme-specific tests opt into other schemes explicitly.
+        colorScheme: 'light'
     },
     testDir: './',
     testMatch: ['tests/**/*.test.{js,ts}'],

--- a/e2e/tests/admin/sidebar/navigation.test.ts
+++ b/e2e/tests/admin/sidebar/navigation.test.ts
@@ -117,21 +117,54 @@ test.describe('Ghost Admin - Sidebar Navigation', () => {
             await expect(page).toHaveURL(/\/ghost\/#\/settings\/staff\//);
         });
 
-        test('night shift toggle - changes state on click', async ({page}) => {
+        test('appearance menu - switches to dark mode', async ({page}) => {
             const sidebar = new SidebarPage(page);
 
             await sidebar.goto('/ghost');
             await sidebar.userDropdownTrigger.click();
+            await sidebar.appearanceMenuItem.click();
 
-            const initialState = await sidebar.isNightShiftEnabled();
+            await sidebar.themeDarkOption.click();
+            await sidebar.waitForDarkMode(true);
 
-            await sidebar.nightShiftToggle.click();
+            await sidebar.userDropdownTrigger.click();
+            await expect(sidebar.appearanceMenuItem).toContainText('Dark');
+        });
 
-            const expectedState = !initialState;
-            await sidebar.waitForNightShiftEnabled(expectedState);
+        test('appearance menu - switches to light mode and displays current choice', async ({page}) => {
+            const sidebar = new SidebarPage(page);
 
-            const newState = await sidebar.isNightShiftEnabled();
-            expect(newState).toBe(expectedState);
+            await sidebar.goto('/ghost');
+            await sidebar.userDropdownTrigger.click();
+            await sidebar.appearanceMenuItem.click();
+            await sidebar.themeDarkOption.click();
+            await sidebar.waitForDarkMode(true);
+
+            await sidebar.userDropdownTrigger.click();
+            await sidebar.appearanceMenuItem.click();
+            await sidebar.themeLightOption.click();
+            await sidebar.waitForDarkMode(false);
+
+            await sidebar.userDropdownTrigger.click();
+            await expect(sidebar.appearanceMenuItem).toContainText('Light');
+        });
+
+        test('appearance menu - switches to system mode from dark', async ({page}) => {
+            const sidebar = new SidebarPage(page);
+
+            await sidebar.goto('/ghost');
+            await sidebar.userDropdownTrigger.click();
+            await sidebar.appearanceMenuItem.click();
+            await sidebar.themeDarkOption.click();
+            await sidebar.waitForDarkMode(true);
+
+            await sidebar.userDropdownTrigger.click();
+            await sidebar.appearanceMenuItem.click();
+            await sidebar.themeSystemOption.click();
+            await sidebar.waitForDarkMode(false);
+
+            await sidebar.userDropdownTrigger.click();
+            await expect(sidebar.appearanceMenuItem).toContainText('System');
         });
 
         test('sign out link - is visible in dropdown', async ({page}) => {

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -25,7 +25,7 @@ export function feature(name, options = {}) {
             return enabled;
         },
         set(key, value) {
-            this.update(key, value, options);
+            this.update(name, value, options);
 
             if (onChange) {
                 // value must be passed here because the value isn't set until
@@ -54,7 +54,23 @@ export default class FeatureService extends Service {
 
     // user-specific flags
     @feature('nightShift', {user: true, onChange: '_setAdminTheme'})
-        nightShift;
+        _nightShiftPref;
+
+    _osPrefersDark = false;
+
+    _systemThemeMediaQuery = null;
+    _systemThemeListener = null;
+
+    @computed('_nightShiftPref', '_osPrefersDark')
+    get nightShift() {
+        let preference = this._nightShiftPref;
+
+        if (preference === 'system') {
+            return this._osPrefersDark;
+        }
+
+        return preference === 'dark' || preference === true;
+    }
 
     // user-specific referral invitation
     @feature('referralInviteDismissed', {user: true}) referralInviteDismissed;
@@ -136,21 +152,88 @@ export default class FeatureService extends Service {
         });
     }
 
-    _setAdminTheme(enabled) {
-        let nightShift = enabled;
+    _loadAdminThemeStylesheet() {
+        return this.lazyLoader.loadStyle('dark', 'assets/ghost-dark.css', true);
+    }
 
-        if (typeof nightShift === 'undefined') {
-            nightShift = enabled || this.nightShift;
+    _setAdminTheme(value) {
+        let mode = value;
+
+        if (typeof mode === 'undefined') {
+            mode = this._nightShiftPref;
         }
 
-        document.documentElement.classList.toggle('dark', nightShift ?? false);
+        this._removeSystemThemeListener();
 
-        return this.lazyLoader.loadStyle('dark', 'assets/ghost-dark.css', true).then(() => {
-            $('link[title=dark]').prop('disabled', !nightShift);
+        if (mode === true) {
+            mode = 'dark';
+        } else if (mode === false) {
+            mode = 'light';
+        } else if (mode !== 'dark' && mode !== 'light' && mode !== 'system') {
+            mode = 'light';
+        }
+
+        let isDark = mode === 'dark';
+
+        if (mode === 'system') {
+            let mediaQuery = this._getSystemThemeMediaQuery();
+            isDark = mediaQuery?.matches ?? false;
+            set(this, '_osPrefersDark', isDark);
+
+            if (mediaQuery) {
+                this._systemThemeMediaQuery = mediaQuery;
+                this._systemThemeListener = (event) => {
+                    document.documentElement.classList.toggle('dark', event.matches);
+                    $('link[title=dark]').prop('disabled', !event.matches);
+                    set(this, '_osPrefersDark', event.matches);
+                };
+                this._addSystemThemeListener();
+            }
+        } else {
+            set(this, '_osPrefersDark', false);
+        }
+
+        document.documentElement.classList.toggle('dark', isDark);
+        $('link[title=dark]').prop('disabled', !isDark);
+
+        return this._loadAdminThemeStylesheet().then(() => {
+            $('link[title=dark]').prop('disabled', !isDark);
         }).catch(() => {
-            //TODO: Also disable toggle from settings and Labs hover
             $('link[title=dark]').prop('disabled', true);
             document.documentElement.classList.remove('dark');
         });
+    }
+
+    _getSystemThemeMediaQuery() {
+        if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+            return null;
+        }
+
+        return window.matchMedia('(prefers-color-scheme: dark)');
+    }
+
+    _addSystemThemeListener() {
+        if (typeof this._systemThemeMediaQuery?.addEventListener === 'function') {
+            this._systemThemeMediaQuery.addEventListener('change', this._systemThemeListener);
+        } else if (typeof this._systemThemeMediaQuery?.addListener === 'function') {
+            this._systemThemeMediaQuery.addListener(this._systemThemeListener);
+        }
+    }
+
+    _removeSystemThemeListener() {
+        if (this._systemThemeListener) {
+            if (typeof this._systemThemeMediaQuery?.removeEventListener === 'function') {
+                this._systemThemeMediaQuery.removeEventListener('change', this._systemThemeListener);
+            } else if (typeof this._systemThemeMediaQuery?.removeListener === 'function') {
+                this._systemThemeMediaQuery.removeListener(this._systemThemeListener);
+            }
+            this._systemThemeMediaQuery = null;
+            this._systemThemeListener = null;
+        }
+    }
+
+    willDestroy() {
+        super.willDestroy(...arguments);
+        this._removeSystemThemeListener();
     }
 }

--- a/ghost/admin/app/services/state-bridge.js
+++ b/ghost/admin/app/services/state-bridge.js
@@ -186,6 +186,16 @@ export default class StateBridgeService extends Service.extend(Evented) {
         }
     }
 
+    @action
+    preloadAdminThemeStylesheet() {
+        return this.feature._loadAdminThemeStylesheet();
+    }
+
+    @action
+    applyAdminThemePreference(mode) {
+        return this.feature._setAdminTheme(mode);
+    }
+
     /* Ember -> React -------------------------------------------------------
 
     When Ember Data store records are updated, created, or deleted via the

--- a/ghost/admin/tests/integration/services/feature-test.js
+++ b/ghost/admin/tests/integration/services/feature-test.js
@@ -2,6 +2,7 @@ import EmberError from '@ember/error';
 import FeatureService, {feature} from 'ghost-admin/services/feature';
 import Pretender from 'pretender';
 import ghostPaths from 'ghost-admin/utils/ghost-paths';
+import sinon from 'sinon';
 import {describe, it} from 'mocha';
 import {expect} from 'chai';
 import {run} from '@ember/runloop';
@@ -81,14 +82,29 @@ describe('Integration: Service: feature', function () {
     setupTest();
 
     let server;
+    let originalMatchMedia;
 
     beforeEach(function () {
         server = new Pretender();
+        originalMatchMedia = window.matchMedia;
     });
 
     afterEach(function () {
+        sinon.restore();
+        document.documentElement.classList.remove('dark');
+        Object.defineProperty(window, 'matchMedia', {
+            configurable: true,
+            value: originalMatchMedia
+        });
         server.shutdown();
     });
+
+    function stubMatchMedia(mediaQuery) {
+        Object.defineProperty(window, 'matchMedia', {
+            configurable: true,
+            value: sinon.stub().returns(mediaQuery)
+        });
+    }
 
     it('loads labs and user settings correctly', async function () {
         stubSettings(server, {testFlag: true});
@@ -204,6 +220,94 @@ describe('Integration: Service: feature', function () {
         await service.fetch();
         expect(service.get('accessibility.testUserFlag')).to.be.true;
         expect(service.get('testUserFlag')).to.be.true;
+    });
+
+    it('resolves system night shift from OS preference', async function () {
+        stubSettings(server, {});
+        stubUser(server, {nightShift: 'system'});
+
+        let session = this.owner.lookup('service:session');
+        await session.populateUser();
+
+        let service = this.owner.lookup('service:feature');
+        sinon.stub(service.lazyLoader, 'loadStyle').resolves();
+        stubMatchMedia({
+            matches: true,
+            addEventListener: sinon.stub(),
+            removeEventListener: sinon.stub()
+        });
+
+        await service.fetch();
+
+        expect(service.get('_nightShiftPref')).to.equal('system');
+        expect(service.get('nightShift')).to.be.true;
+        expect(document.documentElement.classList.contains('dark')).to.be.true;
+    });
+
+    it('updates resolved night shift when OS preference changes in system mode', async function () {
+        stubSettings(server, {});
+        stubUser(server, {nightShift: 'system'});
+
+        let session = this.owner.lookup('service:session');
+        await session.populateUser();
+
+        let service = this.owner.lookup('service:feature');
+        let changeHandler;
+        sinon.stub(service.lazyLoader, 'loadStyle').resolves();
+        stubMatchMedia({
+            matches: true,
+            addEventListener: (event, handler) => {
+                changeHandler = handler;
+            },
+            removeEventListener: sinon.stub()
+        });
+
+        await service.fetch();
+        expect(service.get('nightShift')).to.be.true;
+
+        changeHandler({matches: false});
+
+        expect(service.get('nightShift')).to.be.false;
+        expect(document.documentElement.classList.contains('dark')).to.be.false;
+    });
+
+    it('resolves missing night shift preference to light mode', async function () {
+        stubSettings(server, {});
+        stubUser(server, {});
+
+        let session = this.owner.lookup('service:session');
+        await session.populateUser();
+
+        let service = this.owner.lookup('service:feature');
+        sinon.stub(service.lazyLoader, 'loadStyle').resolves();
+        stubMatchMedia({
+            matches: true,
+            addEventListener: sinon.stub(),
+            removeEventListener: sinon.stub()
+        });
+
+        await service.fetch();
+
+        expect(service.get('_nightShiftPref')).to.be.undefined;
+        expect(service.get('nightShift')).to.be.false;
+        expect(document.documentElement.classList.contains('dark')).to.be.false;
+    });
+
+    it('migrates legacy boolean night shift values when resolving theme', async function () {
+        stubSettings(server, {});
+        stubUser(server, {nightShift: true});
+
+        let session = this.owner.lookup('service:session');
+        await session.populateUser();
+
+        let service = this.owner.lookup('service:feature');
+        sinon.stub(service.lazyLoader, 'loadStyle').resolves();
+
+        await service.fetch();
+
+        expect(service.get('_nightShiftPref')).to.be.true;
+        expect(service.get('nightShift')).to.be.true;
+        expect(document.documentElement.classList.contains('dark')).to.be.true;
     });
 
     it('saves labs setting correctly', async function () {

--- a/ghost/core/core/server/models/user.js
+++ b/ghost/core/core/server/models/user.js
@@ -13,6 +13,7 @@ const urlUtils = require('../../shared/url-utils');
 const {setIsRoles} = require('./role-utils');
 const activeStates = ['active', 'warn-1', 'warn-2', 'warn-3', 'warn-4'];
 const ASSIGNABLE_ROLES = ['Administrator', 'Super Editor', 'Editor', 'Author', 'Contributor'];
+const DEFAULT_ACCESSIBILITY_PREFERENCES = JSON.stringify({nightShift: 'system'});
 
 const messages = {
     valueCannotBeBlank: 'Value in [{tableName}.{columnKey}] cannot be blank.',
@@ -701,6 +702,10 @@ User = ghostBookshelf.Model.extend({
         roles = data.roles;
         delete data.roles;
 
+        if (!options.importing && typeof userData.accessibility === 'undefined') {
+            userData.accessibility = DEFAULT_ACCESSIBILITY_PREFERENCES;
+        }
+
         return ghostBookshelf.Model.add.call(self, userData, options)
             .then(function then(addedUser) {
                 // Assign the userData to our created user so we can pass it back
@@ -779,6 +784,10 @@ User = ghostBookshelf.Model.extend({
         }
 
         userData.slug = null;
+        if (typeof userData.accessibility === 'undefined') {
+            userData.accessibility = DEFAULT_ACCESSIBILITY_PREFERENCES;
+        }
+
         return self.edit(userData, options);
     },
 

--- a/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/members.test.js.snap
@@ -431,7 +431,7 @@ exports[`Members API - member attribution Returns sign up attributions of all ty
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "8869",
+  "content-length": "8894",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/pages.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/pages.test.js.snap
@@ -647,7 +647,7 @@ exports[`Pages API Convert can convert a mobiledoc page to lexical 2: [headers] 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4403",
+  "content-length": "4453",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -753,7 +753,7 @@ exports[`Pages API Convert can convert a mobiledoc page to lexical 4: [headers] 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4403",
+  "content-length": "4453",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -947,7 +947,7 @@ exports[`Pages API Copy Can copy a page 3: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4197",
+  "content-length": "4247",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1053,7 +1053,7 @@ exports[`Pages API Create Can create a page with html 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4427",
+  "content-length": "4477",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1333,7 +1333,7 @@ exports[`Pages API Update Access Visibility is set to tiers Saves only paid tier
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3832",
+  "content-length": "3882",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1438,7 +1438,7 @@ exports[`Pages API Update Can modify show_title_and_feature_image property 2: [h
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4198",
+  "content-length": "4248",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/posts.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/posts.test.js.snap
@@ -197,7 +197,7 @@ exports[`Posts API Can browse 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "11412",
+  "content-length": "11512",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -766,7 +766,7 @@ exports[`Posts API Can browse with formats 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "14210",
+  "content-length": "14310",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -874,7 +874,7 @@ exports[`Posts API Convert can convert a mobiledoc post to lexical 2: [headers] 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4440",
+  "content-length": "4490",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -983,7 +983,7 @@ exports[`Posts API Convert can convert a mobiledoc post to lexical 4: [headers] 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4440",
+  "content-length": "4490",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1089,7 +1089,7 @@ exports[`Posts API Copy Can copy a post 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4232",
+  "content-length": "4282",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1198,7 +1198,7 @@ exports[`Posts API Create Can create a post with html 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4462",
+  "content-length": "4512",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1307,7 +1307,7 @@ exports[`Posts API Create Can create a post with lexical 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4474",
+  "content-length": "4524",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1416,7 +1416,7 @@ exports[`Posts API Create Can create a post with mobiledoc 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4290",
+  "content-length": "4340",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1524,7 +1524,7 @@ exports[`Posts API Create invalidates preview cache when updating a draft post 1
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4260",
+  "content-length": "4310",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -2096,7 +2096,7 @@ exports[`Posts API Update Access Visibility is set to tiers Saves only paid tier
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "3865",
+  "content-length": "3915",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -2205,7 +2205,7 @@ exports[`Posts API Update Can update a post with lexical 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4425",
+  "content-length": "4475",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -2314,7 +2314,7 @@ exports[`Posts API Update Can update a post with lexical 4: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4422",
+  "content-length": "4472",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -2423,7 +2423,7 @@ exports[`Posts API Update Can update a post with mobiledoc 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4235",
+  "content-length": "4285",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -2532,7 +2532,7 @@ exports[`Posts API Update Can update a post with mobiledoc 4: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "4232",
+  "content-length": "4282",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/users.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/users.test.js.snap
@@ -30,7 +30,7 @@ exports[`User API Can edit user roles by name 1: [body] 1`] = `
 Object {
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -78,7 +78,7 @@ exports[`User API Can edit user roles by name 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1091",
+  "content-length": "1116",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -91,7 +91,7 @@ exports[`User API Can edit user with empty roles data and does not change the ro
 Object {
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -139,7 +139,7 @@ exports[`User API Can edit user with empty roles data and does not change the ro
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1154",
+  "content-length": "1179",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -162,7 +162,7 @@ Object {
   },
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -201,7 +201,7 @@ Object {
       "youtube": null,
     },
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -240,7 +240,7 @@ Object {
       "youtube": null,
     },
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -279,7 +279,7 @@ Object {
       "youtube": null,
     },
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -318,7 +318,7 @@ Object {
       "youtube": null,
     },
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -357,7 +357,7 @@ Object {
       "youtube": null,
     },
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -396,7 +396,7 @@ Object {
       "youtube": null,
     },
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": "You can delete this user to remove all the welcome posts",
       "bluesky": null,
       "comment_notifications": true,
@@ -435,7 +435,7 @@ Object {
       "youtube": null,
     },
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -481,7 +481,7 @@ exports[`User API Can include user roles 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "8795",
+  "content-length": "8995",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -504,7 +504,7 @@ Object {
   },
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -542,7 +542,7 @@ Object {
       "youtube": null,
     },
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": "You can delete this user to remove all the welcome posts",
       "bluesky": null,
       "comment_notifications": true,
@@ -580,7 +580,7 @@ Object {
       "youtube": null,
     },
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -625,7 +625,7 @@ exports[`User API Can paginate users 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "2973",
+  "content-length": "3048",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -708,7 +708,7 @@ Object {
   },
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -746,7 +746,7 @@ Object {
       "youtube": null,
     },
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -784,7 +784,7 @@ Object {
       "youtube": null,
     },
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -822,7 +822,7 @@ Object {
       "youtube": null,
     },
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -860,7 +860,7 @@ Object {
       "youtube": null,
     },
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -898,7 +898,7 @@ Object {
       "youtube": null,
     },
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -936,7 +936,7 @@ Object {
       "youtube": null,
     },
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": "You can delete this user to remove all the welcome posts",
       "bluesky": null,
       "comment_notifications": true,
@@ -974,7 +974,7 @@ Object {
       "youtube": null,
     },
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -1019,7 +1019,7 @@ exports[`User API Can request all users ordered by id 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "7436",
+  "content-length": "7636",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1032,7 +1032,7 @@ exports[`User API Can retrieve a user by email 1: [body] 1`] = `
 Object {
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -1077,7 +1077,7 @@ exports[`User API Can retrieve a user by email 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "920",
+  "content-length": "945",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1090,7 +1090,7 @@ exports[`User API Can retrieve a user by id 1: [body] 1`] = `
 Object {
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -1139,7 +1139,7 @@ exports[`User API Can retrieve a user by id 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1167",
+  "content-length": "1192",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1152,7 +1152,7 @@ exports[`User API Can retrieve a user by slug 1: [body] 1`] = `
 Object {
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -1197,7 +1197,7 @@ exports[`User API Can retrieve a user by slug 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "920",
+  "content-length": "945",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1210,7 +1210,7 @@ exports[`User API Can transfer ownership to admin user 1: [body] 1`] = `
 Object {
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": false,
@@ -1258,7 +1258,7 @@ Object {
       "youtube": null,
     },
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -1344,7 +1344,7 @@ exports[`User API Does not trigger cache invalidation when a private attribute o
 Object {
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": false,
@@ -1389,7 +1389,7 @@ exports[`User API Does not trigger cache invalidation when a private attribute o
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "989",
+  "content-length": "1014",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1402,7 +1402,7 @@ exports[`User API Does not trigger cache invalidation when no attribute on a use
 Object {
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": false,
@@ -1447,7 +1447,7 @@ exports[`User API Does not trigger cache invalidation when no attribute on a use
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1021",
+  "content-length": "1046",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1460,7 +1460,7 @@ exports[`User API Does trigger cache invalidation when a social link on a user h
 Object {
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": false,
@@ -1505,7 +1505,7 @@ exports[`User API Does trigger cache invalidation when a social link on a user h
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1021",
+  "content-length": "1046",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1519,7 +1519,7 @@ exports[`User API can edit a user 1: [body] 1`] = `
 Object {
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -1564,7 +1564,7 @@ exports[`User API can edit a user 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "988",
+  "content-length": "1013",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1578,7 +1578,7 @@ exports[`User API can edit a user fetched from the API 1: [body] 1`] = `
 Object {
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -1624,7 +1624,7 @@ exports[`User API can edit a user fetched from the API 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1098",
+  "content-length": "1123",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1637,7 +1637,7 @@ exports[`User API can edit a user fetched from the API 3: [body] 1`] = `
 Object {
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -1683,7 +1683,7 @@ exports[`User API can edit a user fetched from the API 4: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "1091",
+  "content-length": "1116",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-webhooks/__snapshots__/pages.test.js.snap
+++ b/ghost/core/test/e2e-webhooks/__snapshots__/pages.test.js.snap
@@ -18,7 +18,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"nightShift\\":\\"system\\"}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -78,7 +78,7 @@ Object {
       "og_title": null,
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"nightShift\\":\\"system\\"}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -192,7 +192,7 @@ Object {
     "previous": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"nightShift\\":\\"system\\"}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -281,7 +281,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"nightShift\\":\\"system\\"}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -356,7 +356,7 @@ Object {
       "og_title": null,
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"nightShift\\":\\"system\\"}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -520,7 +520,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"nightShift\\":\\"system\\"}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -595,7 +595,7 @@ Object {
       "og_title": null,
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"nightShift\\":\\"system\\"}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -759,7 +759,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"nightShift\\":\\"system\\"}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -834,7 +834,7 @@ Object {
       "og_title": null,
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"nightShift\\":\\"system\\"}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -997,7 +997,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"nightShift\\":\\"system\\"}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -1072,7 +1072,7 @@ Object {
       "og_title": null,
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"nightShift\\":\\"system\\"}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -1235,7 +1235,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"nightShift\\":\\"system\\"}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -1310,7 +1310,7 @@ Object {
       "og_title": null,
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"nightShift\\":\\"system\\"}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -1474,7 +1474,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"nightShift\\":\\"system\\"}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -1549,7 +1549,7 @@ Object {
       "og_title": null,
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"nightShift\\":\\"system\\"}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -1757,7 +1757,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"nightShift\\":\\"system\\"}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -1832,7 +1832,7 @@ Object {
       "og_title": null,
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"nightShift\\":\\"system\\"}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -1980,7 +1980,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"nightShift\\":\\"system\\"}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -2055,7 +2055,7 @@ Object {
       "og_title": null,
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"nightShift\\":\\"system\\"}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -2218,7 +2218,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"nightShift\\":\\"system\\"}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -2293,7 +2293,7 @@ Object {
       "og_title": null,
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"nightShift\\":\\"system\\"}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,

--- a/ghost/core/test/e2e-webhooks/__snapshots__/posts.test.js.snap
+++ b/ghost/core/test/e2e-webhooks/__snapshots__/posts.test.js.snap
@@ -18,7 +18,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"nightShift\\":\\"system\\"}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -81,7 +81,7 @@ Object {
       "og_title": null,
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"nightShift\\":\\"system\\"}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -194,7 +194,7 @@ Object {
     "previous": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"nightShift\\":\\"system\\"}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -282,7 +282,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"nightShift\\":\\"system\\"}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -359,7 +359,7 @@ Object {
       "og_title": null,
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"nightShift\\":\\"system\\"}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -521,7 +521,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"nightShift\\":\\"system\\"}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -619,7 +619,7 @@ Header Level 3
 #header h1 a{display: block;width: 300px;height: 80px;}",
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"nightShift\\":\\"system\\"}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -783,7 +783,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"nightShift\\":\\"system\\"}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -860,7 +860,7 @@ Object {
       "og_title": null,
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"nightShift\\":\\"system\\"}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -1022,7 +1022,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"nightShift\\":\\"system\\"}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -1099,7 +1099,7 @@ Object {
       "og_title": null,
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"nightShift\\":\\"system\\"}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -1261,7 +1261,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"nightShift\\":\\"system\\"}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -1338,7 +1338,7 @@ Object {
       "og_title": null,
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"nightShift\\":\\"system\\"}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -1501,7 +1501,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"nightShift\\":\\"system\\"}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -1599,7 +1599,7 @@ Header Level 3
 #header h1 a{display: block;width: 300px;height: 80px;}",
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"nightShift\\":\\"system\\"}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -1807,7 +1807,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"nightShift\\":\\"system\\"}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -1905,7 +1905,7 @@ Header Level 3
 #header h1 a{display: block;width: 300px;height: 80px;}",
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"nightShift\\":\\"system\\"}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -2053,7 +2053,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"nightShift\\":\\"system\\"}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -2151,7 +2151,7 @@ Header Level 3
 #header h1 a{display: block;width: 300px;height: 80px;}",
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"nightShift\\":\\"system\\"}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,
@@ -2314,7 +2314,7 @@ Object {
     "current": Object {
       "authors": Array [
         Object {
-          "accessibility": null,
+          "accessibility": "{\\"nightShift\\":\\"system\\"}",
           "bio": "bio",
           "bluesky": null,
           "comment_notifications": true,
@@ -2391,7 +2391,7 @@ Object {
       "og_title": null,
       "post_revisions": Any<Array>,
       "primary_author": Object {
-        "accessibility": null,
+        "accessibility": "{\\"nightShift\\":\\"system\\"}",
         "bio": "bio",
         "bluesky": null,
         "comment_notifications": true,

--- a/ghost/core/test/legacy/api/admin/__snapshots__/authentication.test.js.snap
+++ b/ghost/core/test/legacy/api/admin/__snapshots__/authentication.test.js.snap
@@ -4,7 +4,7 @@ exports[`Authentication API Blog setup complete setup 1: [body] 1`] = `
 Object {
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": null,
       "bluesky": null,
       "comment_notifications": true,
@@ -49,7 +49,7 @@ exports[`Authentication API Blog setup complete setup 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "892",
+  "content-length": "917",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -294,7 +294,7 @@ exports[`Authentication API Blog setup complete setup with default theme 1: [bod
 Object {
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": null,
       "bluesky": null,
       "comment_notifications": true,
@@ -339,7 +339,7 @@ exports[`Authentication API Blog setup complete setup with default theme 2: [hea
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "892",
+  "content-length": "917",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -599,7 +599,7 @@ exports[`Authentication API Blog setup update setup 1: [body] 1`] = `
 Object {
   "users": Array [
     Object {
-      "accessibility": null,
+      "accessibility": "{\\"nightShift\\":\\"system\\"}",
       "bio": "bio",
       "bluesky": null,
       "comment_notifications": true,
@@ -644,7 +644,7 @@ exports[`Authentication API Blog setup update setup 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "963",
+  "content-length": "988",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/unit/server/models/user.test.js
+++ b/ghost/core/test/unit/server/models/user.test.js
@@ -2,6 +2,7 @@ const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const errors = require('@tryghost/errors');
 const models = require('../../../../core/server/models');
+const ghostBookshelf = require('../../../../core/server/models/base');
 const permissions = require('../../../../core/server/services/permissions');
 const schema = require('../../../../core/server/data/schema');
 const security = require('@tryghost/security');
@@ -111,6 +112,94 @@ describe('Unit: models/user', function () {
                         assert.equal((err[0] instanceof errors.ValidationError), true);
                         assert.match(err[0].message, /users\.email/);
                     });
+            });
+        });
+    });
+
+    describe('add', function () {
+        // Stub the parent Bookshelf add so we can inspect the filtered data
+        // without hitting the database; the rest of the add chain is skipped.
+        function stubParentAdd() {
+            return sinon.stub(ghostBookshelf.Model, 'add').rejects(new Error('stop'));
+        }
+
+        it('sets system colour mode as the default accessibility preference for new users', async function () {
+            const add = stubParentAdd();
+
+            await assert.rejects(models.User.add({
+                name: 'Invited User',
+                email: 'invited@example.com'
+            }, {context: {internal: true}}));
+
+            assert.equal(add.calledOnce, true);
+            assert.deepEqual(JSON.parse(add.firstCall.args[0].accessibility), {
+                nightShift: 'system'
+            });
+        });
+
+        it('does not inject a default accessibility preference when importing', async function () {
+            const add = stubParentAdd();
+
+            await assert.rejects(models.User.add({
+                name: 'Imported User',
+                email: 'imported@example.com'
+            }, {context: {internal: true}, importing: true}));
+
+            assert.equal(add.calledOnce, true);
+            assert.equal(add.firstCall.args[0].accessibility, undefined);
+        });
+
+        it('preserves an explicit accessibility preference for new users', async function () {
+            const add = stubParentAdd();
+
+            await assert.rejects(models.User.add({
+                name: 'Invited User',
+                email: 'invited@example.com',
+                accessibility: JSON.stringify({nightShift: 'dark'})
+            }, {context: {internal: true}}));
+
+            assert.equal(add.calledOnce, true);
+            assert.deepEqual(JSON.parse(add.firstCall.args[0].accessibility), {
+                nightShift: 'dark'
+            });
+        });
+    });
+
+    describe('setup', function () {
+        it('sets system colour mode as the default accessibility preference for the initial owner', async function () {
+            const edit = sinon.stub(models.User, 'edit').resolves();
+
+            await models.User.setup({
+                name: 'Test User',
+                email: 'test@example.com',
+                password: 'Xt9!pL4#vQ8$mN2@rZ6%'
+            }, {
+                id: 'owner-id',
+                context: {internal: true}
+            });
+
+            assert.equal(edit.calledOnce, true);
+            assert.deepEqual(JSON.parse(edit.firstCall.args[0].accessibility), {
+                nightShift: 'system'
+            });
+        });
+
+        it('preserves explicit accessibility preference during initial owner setup', async function () {
+            const edit = sinon.stub(models.User, 'edit').resolves();
+
+            await models.User.setup({
+                name: 'Test User',
+                email: 'test@example.com',
+                password: 'Xt9!pL4#vQ8$mN2@rZ6%',
+                accessibility: JSON.stringify({nightShift: 'dark'})
+            }, {
+                id: 'owner-id',
+                context: {internal: true}
+            });
+
+            assert.equal(edit.calledOnce, true);
+            assert.deepEqual(JSON.parse(edit.firstCall.args[0].accessibility), {
+                nightShift: 'dark'
             });
         });
     });


### PR DESCRIPTION
Closes https://linear.app/ghost/issue/DES-1288/add-automatic-to-admin-darklight-mode

## Why

Ghost Admin only had a light/dark toggle stored as a boolean, so users had no way to follow their operating system's appearance preference. This adds a "system" mode that mirrors the OS and updates live when it changes.

## What

- Adds a third **System** appearance mode alongside Light and Dark. System resolves to light/dark from the OS and tracks changes live via `prefers-color-scheme`.
- Replaces the user menu's dark-mode switch with a **Light / Dark / System** submenu showing the current choice.
- `nightShift` moves from a boolean to a string enum (`light` / `dark` / `system`). Legacy booleans are migrated to strings on read in both the React and Ember layers, so there's **no database backfill**.
- **New users** (owner setup + invited staff) now default to `system`. **Existing users** keep their current preference; users with no stored preference continue to resolve to light.
- Imported users are intentionally left untouched — they reconstruct accounts that already existed elsewhere, so their source preference (or absence of one) is preserved.

## Implementation notes for reviewers

- **Ember remains the source of truth** for the admin theme (the `dark` class, the dark stylesheet, and the OS listener). The React menu applies changes through the state bridge (`applyAdminThemePreference` / `preloadAdminThemeStylesheet`) for instant feedback, and the existing user-update bridge re-applies the theme after the save round-trips, so editor and UI consumers stay in sync.
- React's own class-toggle and media-query effects are gated to only run standalone (no Ember bridge present), so they don't fight Ember in embedded admin.
- `nightShift` is optional (not eagerly defaulted) so an absent preference isn't written back on unrelated preference saves; the display fallback to light lives at the read site.
- E2E `colorScheme` is pinned to `light` at the Playwright config level so theme state is deterministic across the suite under the new `system` default.

## Tests

- Backend unit tests for the `add` (invited staff, importing skip, explicit preference) and `setup` (owner) default-injection paths.
- React unit tests for the `nightShift` migration (legacy booleans, strings, absent, invalid) and non-eager persistence.
- Ember integration tests for system resolution, live OS change, missing preference, and legacy-boolean migration.
- Reworked E2E sidebar tests for the Light/Dark/System menu.

## Checklist

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works