### PR TITLE
🐛 Fixed analytics Today view showing data points in the future

### DIFF
--- a/ghost/core/core/server/data/tinybird/endpoints/api_kpis.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_kpis.pipe
@@ -35,13 +35,29 @@ SQL >
                 ) as end
             {% else %} toStartOfDay(today()) as end
             {% end %}
+            {% if _single_day %}
+                ,
+                {% if defined(current_time) %}
+                    toDateTime({{ String(current_time, description="Current time override for tests", required=False) }}, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})
+                {% else %}
+                    toTimezone(now(), {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})
+                {% end %} as current_time,
+                if(
+                    toDate(end) = toDate(current_time),
+                    least(
+                        timestampAdd(end, interval 1 day),
+                        timestampAdd(start, toIntervalHour(toHour(current_time) + 1))
+                    ),
+                    timestampAdd(end, interval 1 day)
+                ) as end_exclusive
+            {% end %}
         {% if _single_day %}
             select
                 arrayJoin(
                     arrayMap(
                         x -> toDateTime(toString(toDateTime(x)), {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}),
                         range(
-                            toUInt32(toDateTime(start)), toUInt32(timestampAdd(end, interval 1 day)), 3600
+                            toUInt32(toDateTime(start)), toUInt32(end_exclusive), 3600
                         )
                     )
                 ) as date

--- a/ghost/core/core/server/data/tinybird/endpoints/api_kpis_v2.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_kpis_v2.pipe
@@ -35,13 +35,29 @@ SQL >
                 ) as end
             {% else %} toStartOfDay(today()) as end
             {% end %}
+            {% if _single_day %}
+                ,
+                {% if defined(current_time) %}
+                    toDateTime({{ String(current_time, description="Current time override for tests", required=False) }}, {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})
+                {% else %}
+                    toTimezone(now(), {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}})
+                {% end %} as current_time,
+                if(
+                    toDate(end) = toDate(current_time),
+                    least(
+                        timestampAdd(end, interval 1 day),
+                        timestampAdd(start, toIntervalHour(toHour(current_time) + 1))
+                    ),
+                    timestampAdd(end, interval 1 day)
+                ) as end_exclusive
+            {% end %}
         {% if _single_day %}
             select
                 arrayJoin(
                     arrayMap(
                         x -> toDateTime(toString(toDateTime(x)), {{String(timezone, 'Etc/UTC', description="Site timezone", required=True)}}),
                         range(
-                            toUInt32(toDateTime(start)), toUInt32(timestampAdd(end, interval 1 day)), 3600
+                            toUInt32(toDateTime(start)), toUInt32(end_exclusive), 3600
                         )
                     )
                 ) as date

--- a/ghost/core/core/server/data/tinybird/tests/api_kpis.yaml
+++ b/ghost/core/core/server/data/tinybird/tests/api_kpis.yaml
@@ -124,6 +124,46 @@
     {"date":"2100-01-01 22:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
     {"date":"2100-01-01 23:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
 
+- name: Single day - Current day excludes future hours
+  description: Single day date range only returns elapsed hourly buckets when the requested day is today
+  parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-01&timezone=Etc/UTC&current_time=2100-01-01%2011%3A30%3A00
+  expected_result: |
+    {"date":"2100-01-01 00:00:00","visits":1,"pageviews":1,"bounce_rate":1,"avg_session_sec":0}
+    {"date":"2100-01-01 01:00:00","visits":1,"pageviews":2,"bounce_rate":0,"avg_session_sec":1111}
+    {"date":"2100-01-01 02:00:00","visits":1,"pageviews":2,"bounce_rate":0,"avg_session_sec":630}
+    {"date":"2100-01-01 03:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 04:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 05:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 06:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 07:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 08:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 09:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 10:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 11:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+
+- name: Single day - Current day excludes future hours with timezone
+  description: Single day date range only returns elapsed hourly buckets when the requested day is today in a non-UTC timezone
+  parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-01&timezone=America/Los_Angeles&current_time=2100-01-01%2017%3A30%3A00
+  expected_result: |
+    {"date":"2100-01-01 00:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 01:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 02:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 03:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 04:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 05:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 06:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 07:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 08:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 09:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 10:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 11:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 12:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 13:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 14:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 15:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 16:00:00","visits":1,"pageviews":3,"bounce_rate":0,"avg_session_sec":1027}
+    {"date":"2100-01-01 17:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+
 - name: Single day - Filtered by pathname - /about/
   description: Filtered by pathname - /about/
   parameters: site_uuid=mock_site_uuid&date_from=2100-01-03&date_to=2100-01-03&pathname=%2Fabout%2F

--- a/ghost/core/core/server/data/tinybird/tests/api_kpis_v2.yaml
+++ b/ghost/core/core/server/data/tinybird/tests/api_kpis_v2.yaml
@@ -124,6 +124,46 @@
     {"date":"2100-01-01 22:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
     {"date":"2100-01-01 23:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
 
+- name: Single day - Current day excludes future hours
+  description: Single day date range only returns elapsed hourly buckets when the requested day is today
+  parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-01&timezone=Etc/UTC&current_time=2100-01-01%2011%3A30%3A00
+  expected_result: |
+    {"date":"2100-01-01 00:00:00","visits":1,"pageviews":1,"bounce_rate":1,"avg_session_sec":0}
+    {"date":"2100-01-01 01:00:00","visits":1,"pageviews":2,"bounce_rate":0,"avg_session_sec":1111}
+    {"date":"2100-01-01 02:00:00","visits":1,"pageviews":2,"bounce_rate":0,"avg_session_sec":630}
+    {"date":"2100-01-01 03:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 04:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 05:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 06:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 07:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 08:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 09:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 10:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 11:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+
+- name: Single day - Current day excludes future hours with timezone
+  description: Single day date range only returns elapsed hourly buckets when the requested day is today in a non-UTC timezone
+  parameters: site_uuid=mock_site_uuid&date_from=2100-01-01&date_to=2100-01-01&timezone=America/Los_Angeles&current_time=2100-01-01%2017%3A30%3A00
+  expected_result: |
+    {"date":"2100-01-01 00:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 01:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 02:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 03:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 04:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 05:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 06:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 07:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 08:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 09:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 10:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 11:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 12:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 13:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 14:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 15:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+    {"date":"2100-01-01 16:00:00","visits":1,"pageviews":3,"bounce_rate":0,"avg_session_sec":1027}
+    {"date":"2100-01-01 17:00:00","visits":0,"pageviews":0,"bounce_rate":0,"avg_session_sec":0}
+
 - name: Single day - Filtered by pathname - /about/
   description: Filtered by pathname - /about/
   parameters: site_uuid=mock_site_uuid&date_from=2100-01-03&date_to=2100-01-03&pathname=%2Fabout%2F


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1367/investigate-discrepancy-in-post-analytics-chart

## The bug

In Ghost Admin's Analytics views, if you select "Today", the visitors/views graph shows all 24 hours of the current day, including hours in the future. This is confusing, as the current hour's data point will display somewhere random in the middle of the chart, with all future data points showing zero.

**Example**: this screenshot was taken at 2pm EST. The spike in the middle of the graph is actually the current hour, and the flatline after that is all zeroed out future hours, which should not be displayed here at all. This is particularly confusing with the "1 online" in the top right corner, yet the final data point on the graph shows zero visitors.

<img width="2222" height="988" alt="Screenshot 2026-06-25 at 14 08 51@2x" src="https://github.com/user-attachments/assets/c448ff8b-78e2-423a-906e-c3407053efed" />

## The fix
- Cap `api_kpis` and `api_kpis_v2` single-day hourly buckets at the current hour when the requested day is today in the requested timezone
- Preserve full 24-hour hourly output for historical single-day requests
- Add deterministic Tinybird tests using a `current_time` override so the Today behavior is covered without relying on wall-clock time

**Example after the fix:** this screenshot was taken at 2pm eastern time. The single visitor is from 2pm, the current hour, which now appears as the final data point in the chart.
<img width="2244" height="990" alt="Screenshot 2026-06-25 at 14 13 45@2x" src="https://github.com/user-attachments/assets/5dbca8c6-9156-4d76-b5b4-fa221e5c2939" />

