### PR TITLE
Cleaned up stats config payload

### DIFF
--- a/ghost/core/core/server/services/public-config/config.js
+++ b/ghost/core/core/server/services/public-config/config.js
@@ -5,6 +5,46 @@ const labs = require('../../../shared/labs');
 const databaseInfo = require('../../data/db/info');
 const ghostVersion = require('@tryghost/version');
 
+const tinybirdStatsPayloadProperties = [
+    'endpoint',
+    'endpointBrowser',
+    'version',
+    'datasource'
+];
+
+const tinybirdLocalStatsPayloadProperties = [
+    'enabled',
+    'endpoint',
+    'datasource'
+];
+
+const copyPayloadProperties = (target, source, properties) => {
+    for (const property of properties) {
+        if (Object.prototype.hasOwnProperty.call(source, property)) {
+            target[property] = source[property];
+        }
+    }
+};
+
+const getTinybirdStatsPayload = (statsConfig, siteUuid) => {
+    const statsPayload = {};
+
+    copyPayloadProperties(statsPayload, statsConfig, tinybirdStatsPayloadProperties);
+
+    statsPayload.id = siteUuid;
+
+    if (isPlainObject(statsConfig.local)) {
+        const localStatsPayload = {};
+        copyPayloadProperties(localStatsPayload, statsConfig.local, tinybirdLocalStatsPayloadProperties);
+
+        if (Object.keys(localStatsPayload).length > 0) {
+            statsPayload.local = localStatsPayload;
+        }
+    }
+
+    return statsPayload;
+};
+
 module.exports = function getConfigProperties() {
     const configProperties = {
         version: process.env.GHOST_BUILD_VERSION || ghostVersion.original,
@@ -33,10 +73,7 @@ module.exports = function getConfigProperties() {
     if (config.get('tinybird') && config.get('tinybird:stats')) {
         const statsConfig = config.get('tinybird:stats');
         const siteUuid = statsConfig.id || settingsCache.get('site_uuid');
-        configProperties.stats = {
-            ...statsConfig,
-            id: siteUuid
-        };
+        configProperties.stats = getTinybirdStatsPayload(statsConfig, siteUuid);
     }
 
     if (labs.isSet('featurebaseFeedback') && config.get('featurebase')) {

--- a/ghost/core/test/unit/server/services/public-config/config.test.js
+++ b/ghost/core/test/unit/server/services/public-config/config.test.js
@@ -120,13 +120,22 @@ describe('Public-config Service', function () {
         it('should return stats when tinybird config is set with the stats key', function () {
             configUtils.set('tinybird', {
                 stats: {
-                    endpoint: 'xxx'
+                    endpoint: 'xxx',
+                    endpointBrowser: 'https://browser.example.com',
+                    version: 'v2',
+                    datasource: 'analytics_events'
                 }
             });
 
             let configProperties = getConfigProperties();
 
-            assert.deepEqual(configProperties.stats, {endpoint: 'xxx', id: '931ade9e-a4f1-4217-8625-34bd34250c16'});
+            assert.deepEqual(configProperties.stats, {
+                endpoint: 'xxx',
+                endpointBrowser: 'https://browser.example.com',
+                version: 'v2',
+                datasource: 'analytics_events',
+                id: '931ade9e-a4f1-4217-8625-34bd34250c16'
+            });
         });
 
         it('should return stats id when tinybird config is set with the id key', function () {
@@ -139,6 +148,50 @@ describe('Public-config Service', function () {
             let configProperties = getConfigProperties();
 
             assert.deepEqual(configProperties.stats.id, '1234567890');
+        });
+
+        it('should not return stats token when tinybird config is set with a token', function () {
+            configUtils.set('tinybird', {
+                stats: {
+                    endpoint: 'xxx',
+                    token: 'secret-token'
+                }
+            });
+
+            let configProperties = getConfigProperties();
+
+            assert.deepEqual(configProperties.stats, {
+                endpoint: 'xxx',
+                id: '931ade9e-a4f1-4217-8625-34bd34250c16'
+            });
+            assert.equal(configProperties.stats.token, undefined);
+        });
+
+        it('should return public local stats config without the local stats token', function () {
+            configUtils.set('tinybird', {
+                stats: {
+                    endpoint: 'xxx',
+                    local: {
+                        enabled: true,
+                        endpoint: 'http://localhost:7181',
+                        datasource: 'analytics_events_local',
+                        token: 'local-secret-token'
+                    }
+                }
+            });
+
+            let configProperties = getConfigProperties();
+
+            assert.deepEqual(configProperties.stats, {
+                endpoint: 'xxx',
+                id: '931ade9e-a4f1-4217-8625-34bd34250c16',
+                local: {
+                    enabled: true,
+                    endpoint: 'http://localhost:7181',
+                    datasource: 'analytics_events_local'
+                }
+            });
+            assert.equal(configProperties.stats.local.token, undefined);
         });
 
         it('should NOT return stats when tinybird config is set without the stats key', function () {


### PR DESCRIPTION
closes [NY-879](https://linear.app/ghost/issue/NY-879)

Updated the Admin config response to build the stats payload from an allowlist instead of passing through the full config object.