### PR TITLE
🐛 Fixed dark mode in the automations email editor

### DIFF
--- a/apps/posts/src/views/Automations/components/email-modal/email-content-modal.tsx
+++ b/apps/posts/src/views/Automations/components/email-modal/email-content-modal.tsx
@@ -30,7 +30,7 @@ const EmailPreviewModalContent = React.forwardRef<
         className={cn(
             'flex h-full w-full flex-col gap-0 overflow-hidden p-0',
             isEditMode ? 'bg-white' : 'bg-gray-100',
-            'dark:bg-gray-975',
+            'dark:bg-[#151719]',
             className
         )}
     >
@@ -59,7 +59,7 @@ interface EmailPreviewEmailHeaderProps {
 
 const EmailPreviewEmailHeader: React.FC<EmailPreviewEmailHeaderProps> = ({children, className}) => (
     <div className={cn(
-        'relative z-20 isolate mx-auto w-full max-w-[780px] rounded-t-lg border border-b-0 border-gray-200 bg-white px-6 py-4 transition-[max-width,padding] duration-300 ease-out motion-reduce:transition-none dark:border-grey-900 dark:bg-grey-975',
+        'relative z-20 isolate mx-auto w-full max-w-[780px] rounded-t-lg border border-b-0 border-gray-200 bg-white px-6 py-4 transition-[max-width,padding] duration-300 ease-out motion-reduce:transition-none dark:border-grey-900 dark:bg-[#2E3338]',
         className
     )}>
         {children}
@@ -273,8 +273,8 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({
                                 variant='segmented-sm'
                                 onValueChange={value => value && handleModeChange(value as EmailModalMode)}
                             >
-                                <TabsList className='grid w-[240px] grid-cols-2 bg-gray-100 shadow-[inset_0_0_0_1px_rgba(0,0,0,0.04)]'>
-                                    <TabsTrigger className='w-full justify-center data-[state=active]:bg-white dark:data-[state=active]:bg-white dark:data-[state=active]:text-black' data-testid='email-mode-edit' value='edit'>Email content</TabsTrigger>
+                                <TabsList className='grid w-[240px] grid-cols-2 shadow-[inset_0_0_0_1px_rgba(0,0,0,0.04)] dark:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.04)]'>
+                                    <TabsTrigger className='w-full justify-center' data-testid='email-mode-edit' value='edit'>Email content</TabsTrigger>
                                     <TabsTrigger className='w-full justify-center' data-testid='email-mode-preview' value='preview'>Preview</TabsTrigger>
                                 </TabsList>
                             </Tabs>
@@ -344,7 +344,7 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({
                                 </EmailPreviewEmailHeader>
                             )}
                             <EmailPreviewBody className={cn(
-                                mode === 'preview' && 'shadow-sm bg-white dark:bg-grey-975',
+                                mode === 'preview' && 'shadow-sm bg-white dark:bg-[#151719]',
                                 mode === 'edit' && 'px-6',
                                 mode === 'edit' && 'rounded-lg',
                                 mode === 'edit' && errors.lexical && 'border border-red-500'

--- a/apps/posts/src/views/Automations/components/email-modal/email-editor.tsx
+++ b/apps/posts/src/views/Automations/components/email-modal/email-editor.tsx
@@ -6,6 +6,7 @@ import {getSettingValues, useBrowseSettings} from '@tryghost/admin-x-framework/a
 import {koenigFileUploadTypes, useKoenigFetchEmbed, useKoenigFileUpload, usePinturaConfig} from '@tryghost/admin-x-framework/hooks';
 import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
 import {useEmailLinkSuggestions} from './use-link-suggestions';
+import {useFocusContext} from '@tryghost/shade/app';
 
 export interface EmailEditorProps {
     value?: string;
@@ -86,6 +87,7 @@ const EmailEditor: React.FC<EmailEditorProps> = ({
     const editorAPIRef = useRef<KoenigAPI | null>(null);
     // Capture the initial value once — the editor owns its own state after mount
     const initialEditorState = useRef(value);
+    const {darkMode} = useFocusContext();
     const {unsplashConfig} = useFramework();
     const pinturaConfig = usePinturaConfig();
     const {data: settingsData} = useBrowseSettings();
@@ -144,7 +146,7 @@ const EmailEditor: React.FC<EmailEditorProps> = ({
                         <EmailEditorComponent
                             cardConfig={cardConfig}
                             className="koenig-lexical koenig-lexical-editor-input"
-                            darkMode={false}
+                            darkMode={darkMode}
                             fileUploader={fileUploader}
                             initialEditorState={initialEditorState.current}
                             placeholderText={placeholder}


### PR DESCRIPTION
Fixes dark-mode rendering in the automations email editor (`apps/posts` → Automations → edit email).

## What was wrong
- The Koenig editor was hardcoded to light mode, so the editing surface stayed light when admin was in dark mode.
- Several dark backgrounds referenced a non-existent color shade (`gray-975`/`grey-975`). Those classes silently did nothing, so the light `bg-white`/`bg-gray-100` values leaked through in dark mode — including the editor body and the preview header.
- The content/preview toggle hardcoded light colors over the design system's theme-aware tokens, with a `dark:bg-white`/`text-black` band-aid that looked wrong in dark mode.

## Changes
- Wired the editor to the active theme (`darkMode` from the shade context) instead of forcing light.
- Replaced the invalid `*-975` backgrounds with valid values, using the modal's existing dark surface for the canvas/body.
- Switched the content/preview toggle to the `segmented-sm` variant's theme-aware tokens, so light mode is unchanged and dark mode renders correctly.
- Gave the preview header a distinct background in dark mode, matching the post preview.

Light mode is visually unchanged; the changes only affect dark mode.