### PR TITLE
🐛 Fixed hover-reveal View more buttons staying hidden on keyboard focus

### DIFF
--- a/apps/posts/src/views/PostAnalytics/Overview/components/newsletter-overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/components/newsletter-overview.tsx
@@ -74,7 +74,7 @@ const NewsletterOverview: React.FC<NewsletterOverviewProps> = ({post, isNewslett
                         Newsletter performance
                     </CardTitle>
                 </CardHeader>
-                <Button className='absolute right-6 translate-x-10 opacity-0 transition-all duration-300 group-hover/datalist:translate-x-0 group-hover/datalist:opacity-100' size='sm' variant='outline' onClick={() => {
+                <Button className='absolute right-6 translate-x-10 opacity-0 transition-all duration-300 group-hover/datalist:translate-x-0 group-hover/datalist:opacity-100 focus-visible:translate-x-0 focus-visible:opacity-100' size='sm' variant='outline' onClick={() => {
                     navigate(`/posts/analytics/${postId}/newsletter`);
                 }}>View more</Button>
             </div>

--- a/apps/posts/src/views/PostAnalytics/Overview/components/web-overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/components/web-overview.tsx
@@ -43,7 +43,7 @@ const WebOverview: React.FC<WebOverviewProps> = ({chartData, range, isLoading, v
                             Web performance
                         </CardTitle>
                     </CardHeader>
-                    <Button className='absolute right-6 translate-x-10 opacity-0 transition-all duration-300 group-hover/datalist:translate-x-0 group-hover/datalist:opacity-100' size='sm' variant='outline' onClick={() => {
+                    <Button className='absolute right-6 translate-x-10 opacity-0 transition-all duration-300 group-hover/datalist:translate-x-0 group-hover/datalist:opacity-100 focus-visible:translate-x-0 focus-visible:opacity-100' size='sm' variant='outline' onClick={() => {
                         navigate(`/posts/analytics/${postId}/web`);
                     }}>View more</Button>
                 </div>

--- a/apps/posts/src/views/PostAnalytics/components/kpi-card.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/kpi-card.tsx
@@ -32,7 +32,7 @@ export const KpiCardValue: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({ch
 
 export const KpiCardMoreButton: React.FC<React.ComponentProps<typeof Button>> = ({children, className, ...props}) => {
     return (
-        <Button className={cn('absolute right-4 top-4 z-50 hidden translate-x-10 text-black dark:text-white/80 dark:hover:text-white opacity-0 transition-all duration-200 group-hover:translate-x-0 group-hover:opacity-100 md:visible! md:block!', className)} size='sm' variant='outline' {...props}>
+        <Button className={cn('absolute right-4 top-4 z-50 hidden translate-x-10 text-black dark:text-white/80 dark:hover:text-white opacity-0 transition-all duration-200 group-hover:translate-x-0 group-hover:opacity-100 focus-visible:translate-x-0 focus-visible:opacity-100 md:visible! md:block!', className)} size='sm' variant='outline' {...props}>
             {children}
         </Button>
     );

--- a/apps/shade/src/components/patterns/kpi-card.stories.tsx
+++ b/apps/shade/src/components/patterns/kpi-card.stories.tsx
@@ -144,7 +144,7 @@ export const WithHoverButton: Story = {
                     />
                 </div>
                 <Button
-                    className='absolute right-6 translate-x-full opacity-0 transition-all duration-300 group-hover:translate-x-0 group-hover:opacity-100'
+                    className='absolute right-6 translate-x-full opacity-0 transition-all duration-300 group-hover:translate-x-0 group-hover:opacity-100 focus-visible:translate-x-0 focus-visible:opacity-100'
                     size='sm'
                     variant='outline'
                 >

--- a/apps/stats/src/views/Stats/Overview/components/overview-kpis.tsx
+++ b/apps/stats/src/views/Stats/Overview/components/overview-kpis.tsx
@@ -91,7 +91,7 @@ const OverviewKPICard: React.FC<OverviewKPICardProps> = ({
                     />
                 </div>
                 {onClick &&
-                    <Button className='absolute right-6 translate-x-10 opacity-0 transition-all duration-200 group-hover:translate-x-0 group-hover:opacity-100' size='sm' variant='outline' onClick={onClick}>View more</Button>
+                    <Button className='absolute right-6 translate-x-10 opacity-0 transition-all duration-200 group-hover:translate-x-0 group-hover:opacity-100 focus-visible:translate-x-0 focus-visible:opacity-100' size='sm' variant='outline' onClick={onClick}>View more</Button>
                 }
             </KpiCardHeader>
             <CardContent>


### PR DESCRIPTION
### The bug
In Ghost Admin analytics, several View more buttons use a hover-reveal pattern: they are hidden by default (opacity-0 + horizontal offset) and only become visible when the parent card is hovered.

Keyboard users can still tab to these buttons, but they remained invisible while focused. That made it unclear which control was active and effectively blocked keyboard-only navigation to those actions.

Affected surfaces include Post Analytics overview cards (Web, Newsletter, Growth), KPI tile View more buttons on analytics detail pages, and site Stats overview KPI cards.

### The fix
Added focus-visible:translate-x-0 focus-visible:opacity-100 to each hover-reveal View more button so keyboard focus applies the same visible state as card hover.

Used focus-visible rather than focus so mouse clicks do not leave the button permanently visible after activation, matching existing Shade button focus behaviour.

https://github.com/user-attachments/assets/318938cc-0fa2-4c4a-8bd7-e3511a091fc2

Existing E2E coverage for Post Analytics overview View more clicks should continue to pass unchanged.