### PR TITLE
Removed redundant plaintext fetching from llms markdown rendering

### DIFF
--- a/ghost/core/core/frontend/services/llms/markdown.js
+++ b/ghost/core/core/frontend/services/llms/markdown.js
@@ -124,10 +124,6 @@ function renderEntryMarkdownBody(entry) {
         return markdown;
     }
 
-    if (entry.plaintext) {
-        return collapseWhitespace(entry.plaintext);
-    }
-
     return collapseWhitespace(htmlToPlaintext.excerpt(entry.html || ''));
 }
 

--- a/ghost/core/core/frontend/services/llms/service.js
+++ b/ghost/core/core/frontend/services/llms/service.js
@@ -41,7 +41,7 @@ function createLlmsService({settingsCache, labs, config, urlUtils, routing, api,
         const responseKey = resourceType === 'pages' ? 'pages' : 'posts';
         const response = await controller.read({
             id,
-            formats: 'html,plaintext',
+            formats: 'html',
             include: 'authors,tags',
             context: {member}
         });
@@ -316,7 +316,7 @@ function createLlmsService({settingsCache, labs, config, urlUtils, routing, api,
             limit: BROWSE_PAGE_SIZE,
             page: pageNum,
             fields: LLMS_FULL_TXT_FIELDS,
-            formats: 'html,plaintext'
+            formats: 'html'
         });
 
         return {entries, hasMore: Boolean(pagination && pagination.next)};

--- a/ghost/core/test/unit/frontend/services/llms/markdown.test.js
+++ b/ghost/core/test/unit/frontend/services/llms/markdown.test.js
@@ -151,9 +151,9 @@ describe('Unit: frontend/services/llms/markdown', function () {
             assert.equal(body, 'Hello');
         });
 
-        it('falls back to plaintext', function () {
+        it('derives only from html, ignoring a separate plaintext field', function () {
             const body = renderEntryMarkdownBody({html: '', plaintext: 'Fallback text'});
-            assert.equal(body, 'Fallback text');
+            assert.equal(body, '');
         });
     });
 

--- a/ghost/core/test/unit/frontend/services/llms/service.test.js
+++ b/ghost/core/test/unit/frontend/services/llms/service.test.js
@@ -332,7 +332,7 @@ describe('Unit: frontend/services/llms/service', function () {
             assert.equal(page.title, 'Page');
             assert.equal(calls[0].controller, 'pages');
             assert.equal(calls[0].opts.id, 'p1');
-            assert.equal(calls[0].opts.formats, 'html,plaintext');
+            assert.equal(calls[0].opts.formats, 'html');
             assert.equal(calls[0].opts.include, 'authors,tags');
 
             const post = await service.fetchPublicEntry('posts', 'p2');
@@ -440,7 +440,7 @@ describe('Unit: frontend/services/llms/service', function () {
         const postCall = calls.find(call => call.key === 'posts');
 
         assert.ok(postCall, 'expected postsPublic.browse to be called');
-        assert.equal(postCall.options.formats, 'html,plaintext');
+        assert.equal(postCall.options.formats, 'html');
         assert.equal(postCall.options.fields, 'id,title,slug,featured,published_at,updated_at,created_at,url,visibility,custom_excerpt');
         assert.equal(postCall.options.limit, 100);
     });


### PR DESCRIPTION
Ghost derives a post's `plaintext` from its `html` (`htmlToPlaintext.excerpt(html)`), so it never exists independently of html. In the llms markdown renderer, the `entry.plaintext` fallback in `renderEntryMarkdownBody` could therefore never produce anything the final `excerpt(html)` fallback doesn't already compute from the same html — it only existed to consume a separately-fetched column.

This removes that unsound fallback and stops requesting `plaintext` in the two rendering fetches (the bounded `/llms-full.txt` browse and the per-entry `.md` read), which were pulling the full plaintext column for every post for nothing. The rendered output is unchanged.

The index (`/llms.txt`) still fetches plaintext for its short per-entry descriptions — a separate, legitimate use, left as-is.
