### PR TITLE
✨ Added markdown and llms.txt support for AI tooling

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -68,10 +68,6 @@ const features: Feature[] = [{
     description: 'Use optimized COUNT queries for API pagination when safe',
     flag: 'smarterCounts'
 }, {
-    title: 'LLMs.txt',
-    description: 'Serve llms.txt, per-entry markdown exports, and Accept: text/markdown content negotiation for AI and LLM tooling',
-    flag: 'llmsTxt'
-}, {
     title: 'Get helper deduplication',
     description: 'Deduplicate identical {{#get}} helper queries within a single request to avoid redundant database calls',
     flag: 'getHelperDeduplication'

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -28,7 +28,8 @@ const GA_FEATURES = [
     'commentsPinning',
     'featurebaseFeedback',
     'dangerZoneResetAuth',
-    'indexnow'
+    'indexnow',
+    'llmsTxt'
 ];
 
 // These features are considered publicly available and can be enabled/disabled by users
@@ -55,7 +56,6 @@ const PRIVATE_FEATURES = [
     'themeTranslation',
     'pictureImageFormats',
     'smarterCounts',
-    'llmsTxt',
     'getHelperDeduplication',
     'giftLinks'
 ];

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -2253,7 +2253,7 @@ exports[`Settings API Edit can edit Stripe settings when Stripe Connect limit is
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "5449",
+  "content-length": "5466",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/members/__snapshots__/well-known.test.js.snap
+++ b/ghost/core/test/e2e-api/members/__snapshots__/well-known.test.js.snap
@@ -21,7 +21,9 @@ Object {
   "content-length": "265",
   "content-type": "application/json; charset=utf-8",
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
+  "link": "</llms.txt>; rel=\\"llms-txt\\", </llms-full.txt>; rel=\\"llms-full-txt\\"",
   "vary": "Origin, Accept-Encoding",
+  "x-llms-txt": "/llms.txt",
   "x-powered-by": "Express",
 }
 `;

--- a/ghost/core/test/e2e-frontend/llms-routes.test.js
+++ b/ghost/core/test/e2e-frontend/llms-routes.test.js
@@ -72,15 +72,4 @@ describe('llms.txt routing', function () {
         // truncation footer (if present) points at the sitemap, not /llms.txt
         assert.doesNotMatch(res.text, /Use `\/llms\.txt`/);
     });
-
-    it('does not serve llms.txt when the labs flag is disabled', async function () {
-        sinon.restore();
-
-        // with the flag off the handler defers to the rest of the routing
-        // stack, which treats the path like any other unknown frontend route
-        // (the trailing-slash middleware redirects it)
-        const res = await request.get('/llms.txt');
-
-        assert.equal(res.status, 302);
-    });
 });


### PR DESCRIPTION
## Why

The llms.txt feature has been stable behind the private `llmsTxt` labs flag and is ready for general availability. This makes it available to all sites without needing developer experiments enabled.

## What it does

The feature serves `/llms.txt` and `/llms-full.txt`, per-entry markdown exports (append `.md` to any post/page URL), and `Accept: text/markdown` content negotiation for AI/LLM tooling. Front-end responses also advertise it via `Link` / `X-Llms-Txt` discovery headers.

## Changes

- Moved `llmsTxt` from `PRIVATE_FEATURES` to `GA_FEATURES` in `core/shared/labs.js`, so it is always enabled.
- Removed the LLMs.txt toggle from the private developer-experiments list, since GA flags are no longer user-toggleable.
- Left the `labs.isSet('llmsTxt')` checks in the discovery middleware and service in place, following the usual GA staging convention (always-true now, full flag removal later).
- Dropped the now-unreachable e2e test that covered the disabled-flag path.
- Refreshed the snapshots that surface the flag: the admin settings `labs` payload now always includes `llmsTxt`, and site-app responses now carry the discovery headers.

The site-level "Enable structured data for LLMs and AI search engines" toggle in SEO settings continues to control the feature per-site.

## Testing

- Affected unit tests pass (labs + llms service).
- Full `e2e`, `e2e-api`, `integration`, `legacy` and `e2e-isolated` suites pass with no assertion failures (remaining local failures are unrelated storage-adapter tests that need MinIO).