### PR TITLE
Removed site data collection from update check

### DIFF
--- a/ghost/core/core/server/services/update-check/index.js
+++ b/ghost/core/core/server/services/update-check/index.js
@@ -5,7 +5,6 @@ const api = require('../../api').endpoints;
 const config = require('../../../shared/config');
 const urlUtils = require('../../../shared/url-utils');
 const jobsService = require('../jobs');
-const databaseInfo = require('../../data/db/info');
 
 const request = require('@tryghost/request');
 const ghostVersion = require('@tryghost/version');
@@ -49,9 +48,6 @@ module.exports = async ({
                 read: api.settings.read,
                 edit: api.settings.edit
             },
-            posts: {
-                browse: api.posts.browse
-            },
             users: {
                 browse: api.users.browse
             },
@@ -60,11 +56,7 @@ module.exports = async ({
             }
         },
         config: {
-            mail: config.get('mail'),
-            env: config.get('env'),
-            databaseType: databaseInfo.getEngine(),
             checkEndpoint: updateCheckUrl,
-            isPrivacyDisabled: config.isPrivacyDisabled('useUpdateCheck'),
             notificationGroups: config.get('notificationGroups'),
             siteUrl: urlUtils.urlFor('home', true),
             forceUpdate,

--- a/ghost/core/core/server/services/update-check/run-update-check.js
+++ b/ghost/core/core/server/services/update-check/run-update-check.js
@@ -38,9 +38,6 @@ if (parentPort) {
     const settings = require('../settings/settings-service');
     await settings.init();
 
-    const tiers = require('../tiers');
-    await tiers.init();
-
     const emailAddress = require('../email-address');
     emailAddress.init();
     // Finished INIT

--- a/ghost/core/core/server/services/update-check/update-check-service.js
+++ b/ghost/core/core/server/services/update-check/update-check-service.js
@@ -1,9 +1,5 @@
 const _ = require('lodash');
-const url = require('url');
-const crypto = require('crypto');
 const moment = require('moment');
-const exec = require('child_process').exec;
-const util = require('util');
 const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
@@ -38,9 +34,8 @@ function normalizeNotifications(response) {
  * Update Checker Class
  *
  * Makes a request to Ghost.org to request release & custom notifications.
- * The service is provided in return for users opting in to anonymous usage data collection.
- *
- * Blog owners can opt-out of update checks by setting `privacy: { useUpdateCheck: false }` in their config file.
+ * The request only sends the Ghost version so the service can return the
+ * relevant release and security notifications - no site data is collected.
  */
 class UpdateCheckService {
     /**
@@ -50,18 +45,12 @@ class UpdateCheckService {
      * @param {Object} options.api.settings - Settings API methods
      * @param {Function} options.api.settings.read - method allowing to read Ghost's settings
      * @param {Function} options.api.settings.edit - method allowing to edit Ghost's settings
-     * @param {Object} options.api.posts - Posts API methods
-     * @param {Function} options.api.posts.browse - method allowing to read Ghost's posts
      * @param {Object} options.api.users - Users API methods
      * @param {Function} options.api.users.browse - method allowing to read Ghost's users
      * @param {Object} options.api.notifications - Notification API methods
      * @param {Function} options.api.notifications.add - method allowing to add Ghost notifications
      * @param {Object} options.config
-     * @param {Object} options.config.mail
-     * @param {string} options.config.env
-     * @param {string} options.config.databaseType
      * @param {string} options.config.checkEndpoint - update check service URL
-     * @param {boolean} [options.config.isPrivacyDisabled]
      * @param {string[]} [options.config.notificationGroups] - example values ["migration", "something"]
      * @param {boolean} [options.config.rethrowErrors] - allows to force throwing errors (useful in worker threads)
      * @param {string} options.config.siteUrl - Ghost instance URL
@@ -117,133 +106,32 @@ class UpdateCheckService {
     }
 
     /**
-     * @description Collect stats from your blog.
-     * @returns {Promise}
-     */
-    async updateCheckData() {
-        let data = {};
-        let mailConfig = this.config.mail;
-
-        data.ghost_version = this.config.ghostVersion;
-        data.node_version = process.versions.node;
-        data.env = this.config.env;
-        data.database_type = this.config.databaseType;
-        data.email_transport = mailConfig &&
-            (mailConfig.options && mailConfig.options.service ?
-                mailConfig.options.service :
-                mailConfig.transport);
-
-        // Telemetry sources are gathered in parallel; each is independently
-        // failure-tolerant so one bad source (e.g. a model-layer SQL error
-        // from posts.browse) doesn't prevent the rest of the data from being
-        // sent. Thunks (not pre-evaluated promises) so synchronous throws
-        // turn into rejections rather than escaping the resolution loop.
-        const sources = {
-            db_hash: () => this.api.settings.read(_.extend({key: 'db_hash'}, internal)),
-            active_theme: () => this.api.settings.read(_.extend({key: 'active_theme'}, internal)),
-            posts: () => this.api.posts.browse(),
-            users: () => this.api.users.browse({...internal, include: ['roles']}),
-            npm: () => util.promisify(exec)('npm -v')
-        };
-
-        const entries = Object.entries(sources);
-        const settled = await Promise.allSettled(entries.map(async ([, fn]) => fn()));
-
-        const values = {};
-        const failures = [];
-        settled.forEach((result, i) => {
-            const source = entries[i][0];
-            if (result.status === 'fulfilled') {
-                values[source] = result.value;
-            } else {
-                failures.push(source);
-                this.logging.error({
-                    event: {name: 'update-check.telemetry.error'},
-                    err: result.reason,
-                    source
-                }, 'Failed to gather telemetry source');
-            }
-        });
-
-        if (failures.length) {
-            this.logging.warn({
-                event: {name: 'update-check.telemetry.partial'},
-                failures,
-                attemptedCount: entries.length,
-                failedCount: failures.length
-            }, 'Update check telemetry collected partially');
-        }
-
-        const hash = values.db_hash && values.db_hash.settings && values.db_hash.settings[0];
-        const theme = values.active_theme && values.active_theme.settings && values.active_theme.settings[0];
-        const posts = values.posts;
-        const users = values.users;
-        const npm = values.npm;
-
-        const blogUrl = this.config.siteUrl;
-        const parsedBlogUrl = url.parse(blogUrl);
-
-        data.url = blogUrl;
-        data.blog_id = hash && hash.value
-            ? crypto.createHash('md5').update(parsedBlogUrl.hostname + parsedBlogUrl.pathname.replace(/\//, '') + hash.value).digest('hex')
-            : '';
-        data.theme = theme ? theme.value : '';
-        data.post_count = posts && posts.meta && posts.meta.pagination ? posts.meta.pagination.total : 0;
-        data.user_count = users && users.users && users.users.length ? users.users.length : 0;
-
-        let blogCreatedAt = null;
-        if (users && users.users && users.users.length > 0) {
-            const ownerUser = users.users.find(user => user.roles && user.roles.some(role => role.name === 'Owner'));
-            if (ownerUser) {
-                blogCreatedAt = ownerUser.created_at;
-            } else {
-                blogCreatedAt = users.users[0].created_at;
-            }
-        }
-
-        data.blog_created_at = blogCreatedAt ? moment(blogCreatedAt).unix() : '';
-        data.npm_version = npm && npm.stdout ? npm.stdout.trim() : '';
-
-        return data;
-    }
-
-    /**
      * @description Perform request to update check service.
      *
-     * With the privacy setting `useUpdateCheck` you can control if you want to expose data/stats from your blog to the
-     * service. Enabled or disabled, you will receive the latest notification available from the service.
+     * Only the Ghost version is sent so the service can return the relevant
+     * release and security notifications. No site data is collected.
      *
      * @see https://ghost.org/docs/concepts/config/#privacy
      * @returns {Promise}
      */
     async updateCheckRequest() {
-        const reqData = await this.updateCheckData();
+        const checkEndpoint = this.config.checkEndpoint;
 
-        let reqObj = {
+        const reqObj = {
+            method: 'GET',
             timeout: {
                 request: 1000
             },
-            headers: {}
+            headers: {},
+            searchParams: {
+                ghost_version: this.config.ghostVersion
+            }
         };
-
-        let checkEndpoint = this.config.checkEndpoint;
-        let checkMethod = this.config.isPrivacyDisabled ? 'GET' : 'POST';
-        reqObj.method = checkMethod;
-
-        // CASE: Expose stats and do a check-in
-        if (checkMethod === 'POST') {
-            reqObj.json = reqData;
-        } else {
-            reqObj.searchParams = {
-                ghost_version: reqData.ghost_version
-            };
-        }
 
         debug('Request Update Check Service', checkEndpoint);
         this.logging.info({
             event: {name: 'update-check.request.start'},
             endpoint: checkEndpoint,
-            method: checkMethod,
             ghostVersion: this.config.ghostVersion
         }, 'Sending update check request');
 

--- a/ghost/core/core/shared/config/env/config.development.json
+++ b/ghost/core/core/shared/config/env/config.development.json
@@ -22,9 +22,6 @@
     "paths": {
         "contentPath": "content/"
     },
-    "privacy": {
-        "useUpdateCheck": true
-    },
     "useMinFiles": false,
     "caching": {
         "theme": {

--- a/ghost/core/test/unit/server/services/update-check.test.js
+++ b/ghost/core/test/unit/server/services/update-check.test.js
@@ -3,13 +3,11 @@ const nock = require('nock');
 const moment = require('moment');
 const crypto = require('crypto');
 const assert = require('node:assert/strict');
-const util = require('util');
 const logging = require('@tryghost/logging');
 const request = require('@tryghost/request');
 const UpdateCheckService = require('../../../../core/server/services/update-check/update-check-service');
 
 describe('Update Check', function () {
-    const internal = {context: {internal: true}};
     let settingsStub;
     let requestStub;
 
@@ -17,20 +15,6 @@ describe('Update Check', function () {
         settingsStub = sinon.stub().resolves({
             settings: []
         });
-        settingsStub.withArgs(Object.assign({key: 'db_hash'}, internal)).resolves({
-            settings: [{
-                value: 'dummy_db_hash'
-            }]
-        });
-        settingsStub.withArgs(Object.assign({key: 'active_theme'}, internal)).resolves({
-            settings: [{
-                value: 'casperito'
-            }]
-        });
-
-        sinon.stub(util, 'promisify').returns(async () => ({
-            stdout: '10.8.2'
-        }));
 
         sinon.stub(logging, 'error');
         sinon.stub(logging, 'warn');
@@ -63,15 +47,11 @@ describe('Update Check', function () {
                     },
                     users: {
                         browse: sinon.stub().resolves()
-                    },
-                    posts: {
-                        browse: sinon.stub().resolves()
                     }
                 },
                 config: {
                     checkEndpoint: 'https://updates.ghost.org',
                     siteUrl: 'https://localhost:2368/test',
-                    isPrivacyDisabled: true,
                     ghostVersion: '0.8.0'
                 },
                 request: request
@@ -129,15 +109,11 @@ describe('Update Check', function () {
                     },
                     users: {
                         browse: sinon.stub().resolves()
-                    },
-                    posts: {
-                        browse: sinon.stub().resolves()
                     }
                 },
                 config: {
                     checkEndpoint: 'https://updates.ghost.org',
                     siteUrl: 'https://example.com',
-                    isPrivacyDisabled: true,
                     ghostVersion: '5.3.4'
                 },
                 request: request
@@ -149,12 +125,14 @@ describe('Update Check', function () {
         });
     });
 
-    describe('Data sent with the POST request', function () {
-        it('should report the correct data', async function () {
-            let capturedData;
+    describe('Data sent with the request', function () {
+        it('sends a GET with only the ghost_version and no site data', async function () {
+            let capturedQuery;
+            const postsBrowseStub = sinon.stub().resolves();
             const scope = nock('https://updates.ghost.org')
-                .post('/', (body) => {
-                    capturedData = body;
+                .get('/')
+                .query((query) => {
+                    capturedQuery = query;
                     return true;
                 })
                 .reply(200, JSON.stringify({
@@ -171,139 +149,36 @@ describe('Update Check', function () {
                         edit: settingsStub
                     },
                     users: {
-                        browse: sinon.stub().resolves({
-                            users: [{
-                                created_at: '1995-12-24T23:15:00Z',
-                                roles: [{
-                                    name: 'Owner'
-                                }]
-                            }, {}]
-                        })
+                        browse: sinon.stub().resolves()
                     },
                     posts: {
-                        browse: sinon.stub().resolves({
-                            meta: {
-                                pagination: {
-                                    total: 13
-                                }
-                            }
-                        })
+                        browse: postsBrowseStub
                     }
                 },
                 config: {
                     checkEndpoint: 'https://updates.ghost.org',
                     siteUrl: 'https://localhost:2368/test',
-                    isPrivacyDisabled: false,
-                    env: process.env.NODE_ENV,
-                    databaseType: 'mysql',
                     ghostVersion: '4.0.0'
                 },
-                request: request,
-                ghostMailer: {
-                    send: sinon.stub().resolves()
-                }
+                request: request
             });
 
             await updateCheckService.check();
 
+            // A GET request was made (the GET interceptor matched)
             assert.equal(scope.isDone(), true);
 
-            assert.equal(capturedData.ghost_version, '4.0.0');
-            assert.equal(capturedData.node_version, process.versions.node);
-            assert.equal(capturedData.env, process.env.NODE_ENV);
-            assert.match(capturedData.database_type, /sqlite3|mysql/);
-            assert.equal(typeof capturedData.blog_id, 'string');
-            assert(capturedData.blog_id);
-            assert.equal(capturedData.theme, 'casperito');
-            assert.equal(capturedData.blog_created_at, 819846900);
-            assert.equal(capturedData.user_count, 2);
-            assert.equal(capturedData.post_count, 13);
-            assert.equal(capturedData.npm_version, '10.8.2');
-        });
+            // Only the Ghost version is sent - no site data is collected
+            assert.deepEqual({...capturedQuery}, {ghost_version: '4.0.0'});
 
-        it('still sends the request when a telemetry query fails', async function () {
-            // This reproduces the staging condition where posts.browse fails
-            // with a model-layer SQL error (errno 1054). The update check
-            // should keep going: collect what it can, log what it couldn't,
-            // and send the request anyway so the notification flow still runs.
-            let capturedData;
-            const scope = nock('https://updates.ghost.org')
-                .post('/', (body) => {
-                    capturedData = body;
-                    return true;
-                })
-                .reply(200, JSON.stringify({notifications: []}), {
-                    'Content-Type': 'application/json'
-                });
-
-            const postsBrowseError = Object.assign(
-                new Error('Could not understand request.'),
-                {errno: 1054}
-            );
-
-            const updateCheckService = new UpdateCheckService({
-                api: {
-                    settings: {
-                        read: settingsStub,
-                        edit: settingsStub
-                    },
-                    users: {
-                        browse: sinon.stub().resolves({
-                            users: [{
-                                created_at: '1995-12-24T23:15:00Z',
-                                roles: [{name: 'Owner'}]
-                            }]
-                        })
-                    },
-                    posts: {
-                        browse: sinon.stub().rejects(postsBrowseError)
-                    }
-                },
-                config: {
-                    checkEndpoint: 'https://updates.ghost.org',
-                    siteUrl: 'https://localhost:2368/test',
-                    isPrivacyDisabled: false,
-                    env: process.env.NODE_ENV,
-                    databaseType: 'mysql',
-                    ghostVersion: '4.0.0'
-                },
-                request: request,
-                ghostMailer: {send: sinon.stub().resolves()}
-            });
-
-            await updateCheckService.check();
-
-            // The check sent its request despite posts.browse failing
-            assert.equal(scope.isDone(), true);
-
-            // Telemetry that didn't depend on posts.browse is intact
-            assert.equal(capturedData.ghost_version, '4.0.0');
-            assert.equal(capturedData.user_count, 1);
-            assert.equal(capturedData.blog_created_at, 819846900);
-
-            // post_count gracefully degrades to 0
-            assert.equal(capturedData.post_count, 0);
-
-            // The underlying error is still surfaced — with the source so we
-            // know which telemetry call failed
-            sinon.assert.calledWith(logging.error, sinon.match({
-                event: {name: 'update-check.telemetry.error'},
-                source: 'posts',
-                err: sinon.match({errno: 1054})
-            }));
-
-            // The partial-summary log surfaces which sources failed in one place
-            sinon.assert.calledWith(logging.warn, sinon.match({
-                event: {name: 'update-check.telemetry.partial'},
-                failures: ['posts'],
-                attemptedCount: 5,
-                failedCount: 1
-            }));
+            // No stats are gathered, so the posts API is never called
+            sinon.assert.notCalled(postsBrowseStub);
         });
 
         it('emits structured logs around the request lifecycle', async function () {
             nock('https://updates.ghost.org')
-                .post('/')
+                .get('/')
+                .query(true)
                 .reply(200, JSON.stringify({
                     notifications: [],
                     next_check: moment().add(1, 'day').unix()
@@ -316,20 +191,15 @@ describe('Update Check', function () {
             const updateCheckService = new UpdateCheckService({
                 api: {
                     settings: {read: settingsStub, edit: settingsStub},
-                    users: {browse: sinon.stub().resolves({users: []})},
-                    posts: {browse: sinon.stub().resolves({meta: {pagination: {total: 0}}})}
+                    users: {browse: sinon.stub().resolves({users: []})}
                 },
                 config: {
                     checkEndpoint: 'https://updates.ghost.org',
                     siteUrl: 'https://localhost:2368/test',
-                    isPrivacyDisabled: false,
-                    env: 'testing',
-                    databaseType: 'mysql',
                     ghostVersion: '4.0.0',
                     forceUpdate: true
                 },
-                request: request,
-                ghostMailer: {send: sinon.stub().resolves()}
+                request: request
             });
 
             await updateCheckService.check();
@@ -341,8 +211,7 @@ describe('Update Check', function () {
             }));
             sinon.assert.calledWith(logging.info, sinon.match({
                 event: {name: 'update-check.request.start'},
-                endpoint: 'https://updates.ghost.org',
-                method: 'POST'
+                endpoint: 'https://updates.ghost.org'
             }));
             sinon.assert.calledWith(logging.info, sinon.match({
                 event: {name: 'update-check.request.complete'},
@@ -399,9 +268,6 @@ describe('Update Check', function () {
                     users: {
                         browse: usersBrowseStub
                     },
-                    posts: {
-                        browse: sinon.stub().resolves()
-                    },
                     notifications: {
                         add: notificationsAPIAddStub
                     }
@@ -409,7 +275,6 @@ describe('Update Check', function () {
                 config: {
                     checkEndpoint: 'https://updates.ghost.org',
                     siteUrl: 'https://localhost:2368/test',
-                    isPrivacyDisabled: true,
                     ghostVersion: '0.8.0'
                 },
                 request: request
@@ -427,10 +292,9 @@ describe('Update Check', function () {
             assert.equal(targetNotification.type, 'info');
             assert.equal(targetNotification.message, notification.messages[0].content);
 
-            // users.browse is called once here, for stats reporting: this
-            // notification is non-alert, so the admin-lookup query in the
-            // alert branch never runs.
-            sinon.assert.calledOnce(usersBrowseStub);
+            // No site data is collected, so a non-alert notification never
+            // triggers a users.browse - that only happens in the alert branch.
+            sinon.assert.notCalled(usersBrowseStub);
         });
 
         it('preserves custom flag value from update check response', async function () {
@@ -513,9 +377,6 @@ describe('Update Check', function () {
                     users: {
                         browse: usersBrowseStub
                     },
-                    posts: {
-                        browse: sinon.stub().resolves()
-                    },
                     notifications: {
                         add: notificationsAPIAddStub
                     }
@@ -523,7 +384,6 @@ describe('Update Check', function () {
                 config: {
                     checkEndpoint: 'https://updates.ghost.org',
                     siteUrl: 'http://127.0.0.1:2369',
-                    isPrivacyDisabled: true,
                     ghostVersion: '0.8.0'
                 },
                 request: request,
@@ -531,6 +391,10 @@ describe('Update Check', function () {
             });
 
             await updateCheckService.check();
+
+            // users.browse is called once, in the alert branch, to look up
+            // the admin recipients for the critical alert email.
+            sinon.assert.calledOnce(usersBrowseStub);
 
             sinon.assert.calledOnce(emailSendStub);
             assert.deepEqual(emailSendStub.args[0][0].to, ['jbloggs@example.com']);
@@ -570,9 +434,6 @@ describe('Update Check', function () {
                             }]
                         })
                     },
-                    posts: {
-                        browse: sinon.stub().resolves()
-                    },
                     notifications: {
                         add: notificationsAPIAddStub
                     }
@@ -580,7 +441,6 @@ describe('Update Check', function () {
                 config: {
                     checkEndpoint: 'https://updates.ghost.org',
                     siteUrl: 'https://localhost:2368/test',
-                    isPrivacyDisabled: true,
                     ghostVersion: '0.8.0'
                 },
                 request: request
@@ -638,7 +498,6 @@ describe('Update Check', function () {
                 config: {
                     checkEndpoint: 'https://updates.ghost.org',
                     siteUrl: 'https://localhost:2368/test',
-                    isPrivacyDisabled: false,
                     ghostVersion: '6.44.0'
                 },
                 request: request,
@@ -648,7 +507,8 @@ describe('Update Check', function () {
 
         it('handles a bare-object response with messages at the top level', async function () {
             nock('https://updates.ghost.org')
-                .post('/')
+                .get('/')
+                .query(true)
                 .reply(200, JSON.stringify(releaseNotification), {'Content-Type': 'application/json'});
 
             const addStub = sinon.stub().resolves();
@@ -662,7 +522,8 @@ describe('Update Check', function () {
 
         it('handles a wrapped {notifications:[...]} response', async function () {
             nock('https://updates.ghost.org')
-                .post('/')
+                .get('/')
+                .query(true)
                 .reply(200, JSON.stringify({
                     notifications: [releaseNotification, customNotification],
                     next_check: 1781018713
@@ -676,7 +537,8 @@ describe('Update Check', function () {
 
         it('handles a bare-array response', async function () {
             nock('https://updates.ghost.org')
-                .post('/')
+                .get('/')
+                .query(true)
                 .reply(200, JSON.stringify([releaseNotification, customNotification]), {'Content-Type': 'application/json'});
 
             const addStub = sinon.stub().resolves();


### PR DESCRIPTION
## What

Stops the update check from sending site data to the update service. The check now always makes a `GET` carrying only the Ghost version, instead of `POST`ing a payload of site information.

## Why

To run, the update service only needs the Ghost version - it returns the relevant release and security notifications based on that. The rest of the previously-collected data (Node version, environment, database type, email transport, a hashed blog id, active theme, post/user counts, blog creation time, npm version) isn't required for that to work.

## How

- Removed the `updateCheckData()` collector and the `posts.browse` / `db_hash` / `active_theme` / npm telemetry sources it relied on.
- Dropped the posts API wiring and the `mail` / `env` / `databaseType` config the collector consumed.
- The request is now always a `GET` with a single `ghost_version` query param. The privacy `useUpdateCheck` branch that previously toggled `POST`/`GET` is gone; notifications are unaffected - enabled or disabled, sites still receive the latest notifications.
- Removed the now-redundant `tiers` service init from the update check worker. It was only needed because the check called `posts.browse()`, whose output serializer requires the tiers service; with that call gone the init is dead work. The `email-address` init is kept, as the alert-notification path still needs it.
- Removed the now-dead `privacy.useUpdateCheck` key from the development config, since nothing reads it anymore. Note: a `privacy.useUpdateCheck: false` in a self-hosted config is now a no-op (the check always runs as a minimal GET) - the privacy docs will need a follow-up.

Structured request/response logging is retained.

## Testing

- Unit tests rewritten for the GET-only behaviour (asserting only `ghost_version` is sent and the posts API is never called).
- Integration test exercising the real worker process end-to-end (including the alert-email path) still passes, confirming the tiers init removal is safe.

