### PR TITLE
🐛 Fixed profile picture button styling inconsistency

### DIFF
--- a/apps/admin-x-settings/src/components/settings/general/user-detail-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/user-detail-modal.tsx
@@ -360,7 +360,7 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
                                     <ImageUpload
                                         deleteButtonClassName='md:invisible absolute -right-1 -top-2 flex size-8 cursor-pointer items-center justify-center rounded-full bg-[rgba(0,0,0,0.75)] text-white group-hover:visible!'
                                         deleteButtonContent={<Icon colorClass='text-white' name='trash' size='sm' />}
-                                        editButtonClassName='md:invisible absolute right-10 -top-2 flex size-8 cursor-pointer items-center justify-center rounded-full bg-[rgba(0,0,0,0.75)] text-white group-hover:visible!'
+                                        editButtonClassName='md:invisible absolute right-8 -top-2 flex size-8 cursor-pointer items-center justify-center rounded-full bg-[rgba(0,0,0,0.75)] text-white group-hover:visible!'
                                         fileUploadClassName='rounded-full bg-black flex items-center justify-center opacity-80 transition hover:opacity-100 -ml-2 cursor-pointer h-[80px] w-[80px]'
                                         fileUploadProps={{dragIndicatorClassName: 'rounded-full'}}
                                         id='avatar'

--- a/apps/admin-x-settings/src/components/settings/general/user-detail-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/user-detail-modal.tsx
@@ -365,7 +365,7 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
                                         fileUploadProps={{dragIndicatorClassName: 'rounded-full'}}
                                         id='avatar'
                                         imageClassName='w-full h-full object-cover rounded-full shrink-0'
-                                        imageContainerClassName='relative group bg-cover bg-center -ml-1 h-16 w-16 md:h-18 md:w-18 shrink-0'
+                                        imageContainerClassName='relative group bg-cover bg-center -ml-1 h-[80px] w-[80px] shrink-0'
                                         imageURL={formState.profile_image ?? undefined}
                                         pintura={
                                             {

--- a/apps/admin-x-settings/src/components/settings/general/user-detail-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/user-detail-modal.tsx
@@ -360,7 +360,7 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
                                     <ImageUpload
                                         deleteButtonClassName='md:invisible absolute -right-1 -top-2 flex size-8 cursor-pointer items-center justify-center rounded-full bg-[rgba(0,0,0,0.75)] text-white group-hover:visible!'
                                         deleteButtonContent={<Icon colorClass='text-white' name='trash' size='sm' />}
-                                        editButtonClassName='md:invisible absolute right-8 -top-2 flex size-8 cursor-pointer items-center justify-center rounded-full bg-[rgba(0,0,0,0.75)] text-white group-hover:visible!'
+                                        editButtonClassName='md:invisible absolute -left-1 -top-2 flex size-8 cursor-pointer items-center justify-center rounded-full bg-[rgba(0,0,0,0.75)] text-white group-hover:visible!'
                                         fileUploadClassName='rounded-full bg-black flex items-center justify-center opacity-80 transition hover:opacity-100 -ml-2 cursor-pointer h-[80px] w-[80px]'
                                         fileUploadProps={{dragIndicatorClassName: 'rounded-full'}}
                                         id='avatar'

--- a/apps/admin-x-settings/src/components/settings/general/user-detail-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/user-detail-modal.tsx
@@ -358,9 +358,9 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
                             <div className='flex flex-nowrap items-start justify-between gap-3'>
                                 <div>
                                     <ImageUpload
-                                        deleteButtonClassName='md:invisible absolute pr-3 -right-2 -top-2 flex h-8 w-10 cursor-pointer items-center justify-end rounded-full bg-[rgba(0,0,0,0.75)] text-white group-hover:visible!'
+                                        deleteButtonClassName='md:invisible absolute -right-1 -top-2 flex size-8 cursor-pointer items-center justify-center rounded-full bg-[rgba(0,0,0,0.75)] text-white group-hover:visible!'
                                         deleteButtonContent={<Icon colorClass='text-white' name='trash' size='sm' />}
-                                        editButtonClassName='md:invisible absolute right-[22px] -top-2 flex h-8 w-8 cursor-pointer items-center justify-center text-white group-hover:visible! z-20'
+                                        editButtonClassName='md:invisible absolute right-10 -top-2 flex size-8 cursor-pointer items-center justify-center rounded-full bg-[rgba(0,0,0,0.75)] text-white group-hover:visible!'
                                         fileUploadClassName='rounded-full bg-black flex items-center justify-center opacity-80 transition hover:opacity-100 -ml-2 cursor-pointer h-[80px] w-[80px]'
                                         fileUploadProps={{dragIndicatorClassName: 'rounded-full'}}
                                         id='avatar'


### PR DESCRIPTION
On the profile page, the two avatar buttons - edit (pencil icon) and delete (trash icon) have inconsistent styling. The edit button only has a pencil white icon with no background, which makes it really hard to spot when you have a white profile picture, for example. They also overlap slightly due to mismatched positioning and sizing classes.

Proposing this fix, gave the pencil icon the same circular background (rounded-full bg-[rgba(0,0,0,0.75)]), refined size and positioned buttons at opposite top corners of the avatar.

Before:
<img width="613" height="114" alt="before" src="https://github.com/user-attachments/assets/667bc366-daa6-4529-b865-6bfcde3a8b37" />

After:

<img width="608" height="117" alt="after" src="https://github.com/user-attachments/assets/c6a50492-483b-4fc7-b6f1-604bef248540" />


Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [ ] I've written an automated test to prove my change works
