### PR TITLE
🐛 Fixed flaky target delivery window batch-sending test

### DIFF
--- a/ghost/core/test/integration/services/email-service/batch-sending.test.js
+++ b/ghost/core/test/integration/services/email-service/batch-sending.test.js
@@ -618,13 +618,17 @@ describe('Batch sending tests', function () {
             const calls = stubbedSend.getCalls();
             const deadline = new Date(t0.getTime() + targetDeliveryWindow);
 
-            // Check that the emails were sent with the deliverytime
-            for (const call of calls) {
-                const options = call.args[1];
-                const deliveryTimeString = options['o:deliverytime'];
-                const deliveryTimeDate = new Date(Date.parse(deliveryTimeString));
-                assert.equal(typeof deliveryTimeString, 'string');
-                assert.ok(deliveryTimeDate.getTime() <= deadline.getTime());
+            // The first/immediate batch's delivery time is "now" at calculation time,
+            // which the sender drops once the clock ticks past it (it never schedules a
+            // delivery in the past), so that batch legitimately sends with no
+            // deliverytime. Workers also run concurrently, so the batch order isn't
+            // guaranteed. Assert the windowed batches each carry a valid deliverytime
+            // within the deadline, rather than requiring one on every batch.
+            const deliveryTimes = calls.map(call => call.args[1]['o:deliverytime']);
+            const scheduled = deliveryTimes.filter(time => typeof time === 'string');
+            assert.ok(scheduled.length >= 3, `expected at least 3 scheduled delivery times, got ${scheduled.length}`);
+            for (const deliveryTimeString of scheduled) {
+                assert.ok(Date.parse(deliveryTimeString) <= deadline.getTime());
             }
             configUtils.restore();
         });


### PR DESCRIPTION
The `Target Delivery Window > can send an email with a target delivery window set` integration test asserts that *every* batch is sent with an `o:deliverytime` option. This fails intermittently (seen on the mysql8 acceptance leg) with `Expected: "string" / Received: "undefined"`.

The first/immediate batch's delivery time is computed as "now" (`delay 0`). The sender intentionally drops any delivery time that is no longer in the future (`deliveryTime >= Date.now()` in `batch-sending-service.js`) — it never schedules a delivery in the past — so once a millisecond elapses between calculation and dispatch, the first batch correctly sends with no delivery time. The test then fails. On a same-millisecond run all four batches keep their time and it passes, which is why it's flaky, and more so under the slower/jittery mysql8 leg.

This asserts the windowed batches each carry a valid `o:deliverytime` within the deadline (and tolerates the immediate batch having none, without assuming worker/batch ordering), rather than requiring a delivery time on every batch.

Verified locally on sqlite: passes across repeated runs.