### PR TITLE
Fix comments UI nullable reply HTML handling

### DIFF
--- a/apps/comments-ui/src/components/content/comment.tsx
+++ b/apps/comments-ui/src/components/content/comment.tsx
@@ -133,11 +133,8 @@ const PublishedComment: React.FC<PublishedCommentProps> = ({children, comment, p
             const inReplyToDetails: Partial<OpenCommentForm> = {};
 
             if (parent) {
-                if (comment.html === null) {
-                    return;
-                }
                 inReplyToDetails.in_reply_to_id = comment.id;
-                inReplyToDetails.in_reply_to_snippet = getCommentInReplyToSnippet({html: comment.html});
+                inReplyToDetails.in_reply_to_snippet = getCommentInReplyToSnippet(comment);
             }
 
             const newForm: OpenCommentForm = {
@@ -181,7 +178,7 @@ const PublishedComment: React.FC<PublishedCommentProps> = ({children, comment, p
                 ) : (
                     <>
                         <CommentHeader className={hiddenClass} comment={comment} useThreading={useThreading} />
-                        {comment.html && <CommentBody className={hiddenClass} html={comment.html} isHighlighted={isHighlighted} />}
+                        <CommentBody className={hiddenClass} html={comment.html} isHighlighted={isHighlighted} />
                         <CommentMenu
                             comment={comment}
                             highlightReplyButton={highlightReplyButton}
@@ -420,12 +417,16 @@ const CommentHeader: React.FC<CommentHeaderProps> = ({comment, className = '', u
 };
 
 type CommentBodyProps = {
-    html: string;
+    html?: string | null;
     className?: string;
     isHighlighted?: boolean;
 }
 
 const CommentBody: React.FC<CommentBodyProps> = ({html, className = '', isHighlighted}) => {
+    if (!html) {
+        return null;
+    }
+
     let commentHtml = html;
 
     if (isHighlighted) {

--- a/apps/comments-ui/src/components/content/comment.tsx
+++ b/apps/comments-ui/src/components/content/comment.tsx
@@ -133,8 +133,11 @@ const PublishedComment: React.FC<PublishedCommentProps> = ({children, comment, p
             const inReplyToDetails: Partial<OpenCommentForm> = {};
 
             if (parent) {
+                if (comment.html === null) {
+                    return;
+                }
                 inReplyToDetails.in_reply_to_id = comment.id;
-                inReplyToDetails.in_reply_to_snippet = getCommentInReplyToSnippet(comment);
+                inReplyToDetails.in_reply_to_snippet = getCommentInReplyToSnippet({html: comment.html});
             }
 
             const newForm: OpenCommentForm = {
@@ -166,7 +169,7 @@ const PublishedComment: React.FC<PublishedCommentProps> = ({children, comment, p
             layoutVariant={layoutVariant}
             memberUuid={comment.member?.uuid}
             replies={<RepliesContainer comment={comment} parent={parent} useThreading={useThreading}>{children}</RepliesContainer>}
-            replyForm={displayReplyForm ? <ReplyFormBox continueLine={hasChildReplies} openForm={openForm} parent={replyFormParent} useThreading={useThreading} /> : null}
+            replyForm={displayReplyForm && openForm ? <ReplyFormBox continueLine={hasChildReplies} openForm={openForm} parent={replyFormParent} useThreading={useThreading} /> : null}
             useThreading={useThreading}
         >
             <div id={comment.id}>
@@ -178,7 +181,7 @@ const PublishedComment: React.FC<PublishedCommentProps> = ({children, comment, p
                 ) : (
                     <>
                         <CommentHeader className={hiddenClass} comment={comment} useThreading={useThreading} />
-                        <CommentBody className={hiddenClass} html={comment.html} isHighlighted={isHighlighted} />
+                        {comment.html && <CommentBody className={hiddenClass} html={comment.html} isHighlighted={isHighlighted} />}
                         <CommentMenu
                             comment={comment}
                             highlightReplyButton={highlightReplyButton}
@@ -230,7 +233,7 @@ const UnpublishedComment: React.FC<React.PropsWithChildren<UnpublishedCommentPro
             isPinned={comment.pinned}
             layoutVariant={layoutVariant}
             replies={<RepliesContainer comment={comment} parent={parent} useThreading={useThreading}>{children}</RepliesContainer>}
-            replyForm={displayReplyForm ? <ReplyFormBox continueLine={hasChildReplies} openForm={openForm} parent={replyFormParent} useThreading={useThreading} /> : null}
+            replyForm={displayReplyForm && openForm ? <ReplyFormBox continueLine={hasChildReplies} openForm={openForm} parent={replyFormParent} useThreading={useThreading} /> : null}
             useThreading={useThreading}
         >
             <div className="mt-[-3px] flex items-start" id={comment.id}>

--- a/apps/comments-ui/src/components/content/comment.tsx
+++ b/apps/comments-ui/src/components/content/comment.tsx
@@ -74,20 +74,20 @@ export const CommentComponent: React.FC<CommentProps> = ({children, comment, par
 
 type CommentProps = React.PropsWithChildren<AnimatedCommentProps>;
 
-const getReplyFormDisplayState = (comment: Comment, openCommentForms: OpenCommentForm[], useThreading: boolean) => {
+const getReplyFormState = (comment: Comment, openCommentForms: OpenCommentForm[], useThreading: boolean) => {
     // Non-threaded replies to replies are displayed inside the top-level comment,
     // so match either the comment id or parent id. Threaded replies render their
     // own reply form inline, so only match the current comment.
-    const openForm = useThreading
+    const activeReplyForm = useThreading
         ? openCommentForms.find(f => f.id === comment.id && f.type === 'reply')
         : openCommentForms.find(f => (f.id === comment.id || f.parent_id === comment.id) && f.type === 'reply');
+    const visibleReplyForm = activeReplyForm && (useThreading || !activeReplyForm.parent_id || activeReplyForm.parent_id === comment.id)
+        ? activeReplyForm
+        : undefined;
 
     return {
-        openForm,
-        // Avoid showing nested reply forms in non-threaded RepliesContainer output.
-        displayReplyForm: useThreading
-            ? !!openForm
-            : !!openForm && (!openForm.parent_id || openForm.parent_id === comment.id)
+        activeReplyForm,
+        visibleReplyForm
     };
 };
 
@@ -122,13 +122,13 @@ const PublishedComment: React.FC<PublishedCommentProps> = ({children, comment, p
     const editForm = openCommentForms.find(openForm => openForm.id === comment.id && openForm.type === 'edit');
     const isInEditMode = !!editForm;
 
-    const {openForm, displayReplyForm} = getReplyFormDisplayState(comment, openCommentForms, useThreading);
+    const {activeReplyForm, visibleReplyForm} = getReplyFormState(comment, openCommentForms, useThreading);
     // only highlight the reply button for the comment that is being replied to
-    const highlightReplyButton = !!(openForm && openForm.id === comment.id);
+    const highlightReplyButton = !!(activeReplyForm && activeReplyForm.id === comment.id);
 
     const openReplyForm = useCallback(async () => {
-        if (openForm && openForm.id === comment.id) {
-            dispatchAction('closeCommentForm', openForm.id);
+        if (activeReplyForm && activeReplyForm.id === comment.id) {
+            dispatchAction('closeCommentForm', activeReplyForm.id);
         } else {
             const inReplyToDetails: Partial<OpenCommentForm> = {};
 
@@ -147,10 +147,10 @@ const PublishedComment: React.FC<PublishedCommentProps> = ({children, comment, p
 
             await dispatchAction('openCommentForm', newForm);
         }
-    }, [comment, parent, openForm, dispatchAction]);
+    }, [comment, parent, activeReplyForm, dispatchAction]);
 
     const hasChildReplies = hasNestedReplies || (comment.replies && comment.replies.length > 0);
-    const hasReplies = displayReplyForm || hasChildReplies;
+    const hasReplies = !!visibleReplyForm || hasChildReplies;
     const avatar = (<Avatar member={comment.member} />);
     const replyFormParent = parent || comment;
     const isHighlighted = commentIdFromHash
@@ -166,7 +166,7 @@ const PublishedComment: React.FC<PublishedCommentProps> = ({children, comment, p
             layoutVariant={layoutVariant}
             memberUuid={comment.member?.uuid}
             replies={<RepliesContainer comment={comment} parent={parent} useThreading={useThreading}>{children}</RepliesContainer>}
-            replyForm={displayReplyForm && openForm ? <ReplyFormBox continueLine={hasChildReplies} openForm={openForm} parent={replyFormParent} useThreading={useThreading} /> : null}
+            replyForm={visibleReplyForm ? <ReplyFormBox continueLine={hasChildReplies} openForm={visibleReplyForm} parent={replyFormParent} useThreading={useThreading} /> : null}
             useThreading={useThreading}
         >
             <div id={comment.id}>
@@ -213,9 +213,9 @@ const UnpublishedComment: React.FC<React.PropsWithChildren<UnpublishedCommentPro
             t('This comment has been removed.') :
             '';
 
-    const {openForm, displayReplyForm} = getReplyFormDisplayState(comment, openCommentForms, useThreading);
+    const {visibleReplyForm} = getReplyFormState(comment, openCommentForms, useThreading);
     const hasChildReplies = hasNestedReplies || (comment.replies && comment.replies.length > 0);
-    const hasReplies = displayReplyForm || hasChildReplies;
+    const hasReplies = !!visibleReplyForm || hasChildReplies;
 
     // Only show MoreButton for hidden (not deleted) comments when admin
     const showMoreButton = isAdmin && comment.status === 'hidden';
@@ -230,7 +230,7 @@ const UnpublishedComment: React.FC<React.PropsWithChildren<UnpublishedCommentPro
             isPinned={comment.pinned}
             layoutVariant={layoutVariant}
             replies={<RepliesContainer comment={comment} parent={parent} useThreading={useThreading}>{children}</RepliesContainer>}
-            replyForm={displayReplyForm && openForm ? <ReplyFormBox continueLine={hasChildReplies} openForm={openForm} parent={replyFormParent} useThreading={useThreading} /> : null}
+            replyForm={visibleReplyForm ? <ReplyFormBox continueLine={hasChildReplies} openForm={visibleReplyForm} parent={replyFormParent} useThreading={useThreading} /> : null}
             useThreading={useThreading}
         >
             <div className="mt-[-3px] flex items-start" id={comment.id}>
@@ -417,7 +417,7 @@ const CommentHeader: React.FC<CommentHeaderProps> = ({comment, className = '', u
 };
 
 type CommentBodyProps = {
-    html?: string | null;
+    html: string | null;
     className?: string;
     isHighlighted?: boolean;
 }

--- a/apps/comments-ui/src/utils/helpers.ts
+++ b/apps/comments-ui/src/utils/helpers.ts
@@ -233,8 +233,8 @@ export const scrollToElementInstantly = (element: HTMLElement) => {
     });
 };
 
-export function getCommentInReplyToSnippet(comment: {html?: string}): string {
-    const {html = ''} = comment;
+export function getCommentInReplyToSnippet(comment: {html?: string | null}): string {
+    const html = comment.html ?? '';
 
     // It would be nicer to use DOMParser here so we can use `innerText` instead
     // of `textContent` to have a more native "visible content" implementation.

--- a/apps/comments-ui/test/e2e/content.test.ts
+++ b/apps/comments-ui/test/e2e/content.test.ts
@@ -132,5 +132,44 @@ test.describe('Deleted and Hidden Content', async () => {
         // parent comment is hidden but shows text
         await expect (frame.getByText('This comment has been hidden')).toBeVisible();
     });
-});
 
+    test('deleted reply with null html renders as a tombstone without actions', async ({page}) => {
+        const mockedApi = new MockedApi({});
+        const childReply = mockedApi.buildReply({
+            id: 'child-reply',
+            html: '<p>Visible child reply</p>',
+            in_reply_to_id: 'deleted-reply',
+            in_reply_to_snippet: '[removed]'
+        });
+
+        mockedApi.addComment({
+            id: 'parent-comment',
+            html: '<p>Parent comment</p>',
+            replies: [
+                mockedApi.buildReply({
+                    id: 'deleted-reply',
+                    html: null,
+                    status: 'deleted',
+                    replies: [childReply]
+                }),
+                childReply
+            ]
+        });
+
+        const {frame} = await initialize({
+            mockedApi,
+            page,
+            publication: 'Publisher Weekly',
+            labs: {
+                commentsThreads: true
+            }
+        });
+
+        const deletedReply = frame.locator('[id="deleted-reply"]');
+        await expect(deletedReply).toContainText('This comment has been removed');
+        await expect(deletedReply.getByTestId('comment-content')).toHaveCount(0);
+        await expect(deletedReply.getByTestId('reply-button')).toHaveCount(0);
+        await expect(deletedReply.getByTestId('like-button')).toHaveCount(0);
+        await expect(frame.getByText('Visible child reply')).toBeVisible();
+    });
+});

--- a/apps/comments-ui/test/unit/utils/helpers.test.ts
+++ b/apps/comments-ui/test/unit/utils/helpers.test.ts
@@ -208,13 +208,17 @@ describe('getMemberInitialsFromComment', function () {
 });
 
 describe('getCommentInReplyToSnippet', function () {
-    function testGetSnippet(comment: {html?: string}, expected: string) {
+    function testGetSnippet(comment: {html?: string | null}, expected: string) {
         const snippet = helpers.getCommentInReplyToSnippet(comment);
         expect(snippet).to.equal(expected);
     }
 
     it('handles comment with missing html', function () {
         testGetSnippet({}, '');
+    });
+
+    it('handles comment with null html', function () {
+        testGetSnippet({html: null}, '');
     });
 
     it('handles comment with blank html', function () {


### PR DESCRIPTION
## Why I am making it

This started as a comments-ui typecheck cleanup. `Comment.html` is typed as `string | null`, because deleted comment replies can be returned with `html: null` when they need to stay visible as tombstones for visible descendant replies.

Some reply paths still treated `comment.html` as always being a string when rendering or building the “reply to” snippet. This makes those paths narrow nullable HTML explicitly and adds regression coverage for the deleted reply tombstone case.

## What it does

- Narrows nullable comment HTML before rendering comment content.
- Avoids generating a reply snippet from a reply when its HTML is `null`.
- Only renders `ReplyFormBox` when an `openForm` exists.
- Adds a comments-ui E2E regression test for a deleted reply with `html: null` and a visible child reply.
- Verifies the deleted reply renders as a tombstone without comment content, reply action, or like action.

## Type errors fixed

This removes the `apps/comments-ui/src/components/content/comment.tsx` errors caused by nullable comment HTML and optional reply form state:

- `Argument of type 'Comment' is not assignable to parameter of type '{ html?: string | undefined; }'`
- `Type 'string | null' is not assignable to type 'string | undefined'`
- `Type 'OpenCommentForm | undefined' is not assignable to type 'OpenCommentForm'`
- `Type 'string | null' is not assignable to type 'string'`

## Why developers need it

This cleans up the comments-ui typecheck path and protects the threaded comments UI from crashing or exposing actions for deleted reply tombstones when API data contains `html: null`.

## Testing

- `rtk pnpm --filter @tryghost/comments-ui test:acceptance test/e2e/content.test.ts`
- `rtk pnpm --dir apps/comments-ui exec eslint --cache -- test/e2e/content.test.ts`
  - Exits `0` with the existing warning that the test file is ignored because comments-ui lint config only targets `src`.

## Checklist

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works
