### PR TITLE
Fix bookmark favicon selection in oEmbed fallback

### DIFF
--- a/ghost/core/core/server/services/oembed/oembed-service.js
+++ b/ghost/core/core/server/services/oembed/oembed-service.js
@@ -306,12 +306,12 @@ class OEmbedService {
 
         const pickFn = (sizes, pickDefault) => {
             const appleTouchIcon = sizes.find(item => item.rel?.includes('apple') && item.sizes && item.size?.width >= 180);
-            // Bookmark cards render the icon inline in the post body, where the
-            // site's standard (often transparent) favicon matches surrounding
-            // chrome better than an Apple Touch icon's solid-background square.
-            // Other call sites (Recommendations Avatar via type='mention', plus
-            // the generic oembed fallback) scale the icon up into a larger
-            // tile, where Apple Touch is the better fit.
+            // Bookmark cards (including the oembed fallback, which resolves to a
+            // bookmark) render the icon inline in the post body, where the site's
+            // standard (often transparent) favicon matches surrounding chrome
+            // better than an Apple Touch icon's solid-background square. The
+            // Recommendations Avatar (type='mention') instead scales the icon up
+            // into a larger tile, where Apple Touch is the better fit.
             if (type === 'bookmark') {
                 // metascraper-logo-favicon gathers anything matching link[rel*="icon"], which
                 // includes apple-touch-icon, mask-icon (Safari pinned-tab silhouette), and

--- a/ghost/core/core/server/services/oembed/oembed-service.js
+++ b/ghost/core/core/server/services/oembed/oembed-service.js
@@ -588,7 +588,7 @@ class OEmbedService {
 
             // fallback to bookmark when we can't get oembed
             if (!data && !type) {
-                data = await this.fetchBookmarkData(url, body, type);
+                data = await this.fetchBookmarkData(url, body, 'bookmark');
             }
 
             // couldn't get anything, throw a validation error

--- a/ghost/core/test/unit/server/services/oembed/oembed-service.test.js
+++ b/ghost/core/test/unit/server/services/oembed/oembed-service.test.js
@@ -272,6 +272,30 @@ describe('oembed-service', function () {
             assert.equal(response.metadata.title, 'Example');
         });
 
+        it('prefers the standard favicon over an apple-touch-icon in the bookmark fallback', async function () {
+            // With no oembed endpoint and no explicit type, fetchOembedDataFromUrl
+            // falls through to the bookmark fallback (!data && !type). That path
+            // resolves to a bookmark card, so it must pick the standard favicon,
+            // not the apple-touch-icon reserved for scaled-up call sites.
+            sinon.stub(oembedService, 'processImageFromUrl').callsFake(async imageUrl => imageUrl);
+
+            nock('https://www.example.com')
+                .get('/')
+                .query(true)
+                .reply(200, `<html><head>
+                    <title>Example</title>
+                    <link rel="apple-touch-icon" sizes="180x180" href="https://www.example.com/apple.png">
+                    <link rel="icon" href="https://www.example.com/favicon.png">
+                </head></html>`);
+
+            const response = await oembedService.fetchOembedDataFromUrl('https://www.example.com');
+
+            assert.equal(response.type, 'bookmark');
+            assert.equal(response.metadata.icon, 'https://www.example.com/favicon.png');
+
+            sinon.restore();
+        });
+
         it('converts YT live URLs to watch URLs', async function () {
             nock('https://www.youtube.com')
                 .get('/oembed')


### PR DESCRIPTION
Hi @9larsons,

I tested the merged change and found that bookmark cards can still prefer Apple Touch Icons in the oEmbed fallback path.

The bookmark-specific favicon logic works when `fetchBookmarkData` is called with `type === 'bookmark'`, but the fallback path currently calls it with the original undefined type:

```
if (!data && !type) {
    data = await this.fetchBookmarkData(url, body, type);
}
```

That means pickFn does not enter the bookmark-specific branch and falls back to the previous Apple-first behavior.

This change passes `'bookmark'` explicitly in that fallback path:

`data = await this.fetchBookmarkData(url, body, 'bookmark');`