### PR TITLE
Return JSON body from automations poll endpoint

### DIFF
--- a/ghost/core/core/server/api/endpoints/automations.js
+++ b/ghost/core/core/server/api/endpoints/automations.js
@@ -41,7 +41,7 @@ const controller = {
     },
 
     poll: {
-        statusCode: 204,
+        statusCode: 200,
         headers: {
             cacheInvalidate: false
         },
@@ -51,6 +51,11 @@ const controller = {
         },
         query() {
             automationsApi.requestPoll();
+
+            // The Ghost(Pro) Scheduler invokes this endpoint as a timed callback and
+            // requires the response to be a valid JSON object. An empty body (e.g. a
+            // 204) is treated as a failed job and retried, so we return a small object.
+            return {polled: true};
         }
     }
 };

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/automations.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/automations.js
@@ -1,0 +1,9 @@
+module.exports = {
+    // The poll endpoint is called by the Ghost(Pro) Scheduler, which requires a
+    // valid JSON object response. Pass the controller's plain object through as-is
+    // (rather than letting the default serializer wrap it under an `automations` key)
+    // so the body is `{polled: true}`.
+    poll(data, apiConfig, frame) {
+        frame.response = data;
+    }
+};

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/index.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/index.js
@@ -12,6 +12,10 @@ module.exports = {
         return require('./default');
     },
 
+    get automations() {
+        return require('./automations');
+    },
+
     get comments() {
         return require('./comments');
     },

--- a/ghost/core/test/e2e-api/admin/__snapshots__/automations.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/automations.test.js.snap
@@ -121,13 +121,21 @@ Object {
 }
 `;
 
-exports[`Automations API poll triggers a poll with a valid scheduler integration token 1: [headers] 1`] = `
+exports[`Automations API poll triggers a poll with a valid scheduler integration token 1: [body] 1`] = `
+Object {
+  "polled": true,
+}
+`;
+
+exports[`Automations API poll triggers a poll with a valid scheduler integration token 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
+  "content-length": "15",
+  "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
-  "vary": "Accept-Version, Origin",
+  "vary": "Accept-Version, Origin, Accept-Encoding",
   "x-powered-by": "Express",
 }
 `;

--- a/ghost/core/test/e2e-api/admin/automations.test.js
+++ b/ghost/core/test/e2e-api/admin/automations.test.js
@@ -1259,15 +1259,21 @@ describe('Automations API', function () {
         });
 
         it('triggers a poll with a valid scheduler integration token', async function () {
-            await agent
+            // The Ghost(Pro) Scheduler treats an empty body as a failed job and retries it,
+            // so the poll callback must return HTTP 200 with a parseable JSON object body.
+            const {body} = await agent
                 .put(`automations/poll/?token=${schedulerToken}`)
-                .expectStatus(204)
-                .expectEmptyBody()
+                .expectStatus(200)
                 .expect(cacheInvalidateHeaderNotSet())
                 .matchHeaderSnapshot({
                     'content-version': anyContentVersion,
                     etag: anyEtag
-                });
+                })
+                .matchBodySnapshot();
+
+            assert.equal(typeof body, 'object');
+            assert.notEqual(body, null);
+            assert.ok(Object.keys(body).length > 0, 'poll response body should be a non-empty JSON object');
 
             sinon.assert.calledOnceWithExactly(dispatchStub, sinon.match.instanceOf(StartAutomationsPollEvent));
         });

--- a/ghost/core/test/unit/api/endpoints/automations.test.js
+++ b/ghost/core/test/unit/api/endpoints/automations.test.js
@@ -22,7 +22,12 @@ describe('Automations controller', function () {
             const result = automationsController.poll.query({});
 
             sinon.assert.calledOnceWithExactly(dispatchStub, sinon.match.instanceOf(StartAutomationsPollEvent));
-            assert.equal(result, undefined);
+
+            // The Ghost(Pro) Scheduler requires a 200 with a JSON object body; an empty
+            // response is treated as a failed job and retried.
+            assert.equal(automationsController.poll.statusCode, 200);
+            assert.equal(typeof result, 'object');
+            assert.notEqual(result, null);
         });
     });
 });


### PR DESCRIPTION
## Why

The `PUT /ghost/api/admin/automations/poll` endpoint is invoked by the Ghost(Pro) Scheduler as a timed HTTP callback. The Scheduler's job executor parses every callback response with `response.json()` and treats the job as failed if the body is not a valid, non-null JSON object.

This endpoint was declared with `statusCode: 204` and returned an empty body. A `204 No Content` has no body, so the Scheduler's `response.json()` throws and the poll job is marked failed, then retried (up to its retry limit) on every cycle. That retry churn saturates the Scheduler's single-threaded executor and is the root amplifier behind scheduled posts being delayed or not publishing.

The other scheduler callback endpoints that work correctly (`PUT /schedules/posts/:id`, the gift-link endpoints) all return `200` with a JSON object body — which is exactly the contract the Scheduler expects.

## What

- Changed `/automations/poll` to return `200` with a small JSON object (`{polled: true}`) instead of an empty `204`. `automationsApi.requestPoll()` is still called exactly as before; only the response shape changes.
- Added a dedicated output serializer for `automations.poll` so the controller's object is passed through as-is, rather than being wrapped under an `automations` key by the default serializer.
- Updated the e2e and unit tests to assert the poll response is HTTP `200` with a parseable, non-empty JSON object body.

## Verification

- `automations` e2e suite (CI mode): 35 passed. The recorded body snapshot for the poll endpoint is `{polled: true}` and the response is served as `application/json`.
- `automations` controller unit test: passes, asserting `statusCode === 200` and a non-null object return.