### PR TITLE
🐛 Fixed free tier looking like a selectable card when it's the only tier

### DIFF
--- a/apps/portal/src/components/common/products-section.jsx
+++ b/apps/portal/src/components/common/products-section.jsx
@@ -414,6 +414,9 @@ export const ProductsSectionStyles = () => {
         .gh-portal-product-card.only-free {
             margin: 0 0 16px;
             min-height: unset;
+            padding: 0;
+            border: none;
+            background: transparent;
         }
 
         .gh-portal-product-card.only-free .gh-portal-product-card-header {
@@ -691,7 +694,7 @@ function FreeProductCard({products, handleChooseSignup, error}) {
 
     return (
         <>
-            <div className={cardClass} onClick={(e) => {
+            <div className={cardClass} onClick={hasOnlyFree ? undefined : (e) => {
                 e.stopPropagation();
                 setSelectedProduct('free');
             }} data-test-tier="free">

--- a/apps/portal/test/signup-flow.test.jsx
+++ b/apps/portal/test/signup-flow.test.jsx
@@ -380,6 +380,11 @@ describe('Signup', () => {
             await within(popupIframeDocument).findByText(freeProduct.description);
             await within(popupIframeDocument).findByText(benefitText);
 
+            // When free is the only tier the card drops its selectable framing
+            // (the .only-free modifier removes the border/background/padding).
+            const freeTierCard = popupIframeDocument.querySelector('[data-test-tier="free"]');
+            expect(freeTierCard).toHaveClass('only-free');
+
             submitButton = within(popupIframeDocument).queryByRole('button', {name: 'Sign up'});
 
             fireEvent.change(emailInput, {target: {value: 'jamie@example.com'}});


### PR DESCRIPTION
fixes #25517

- When a site has Stripe connected but no paid tiers, the signup modal shows the free tier inside a bordered, hoverable card (no price, no Choose button). That makes it look selectable when there's nothing to choose, which is the confusion reported in the issue.

- This removes the card framing (border, padding, background) for the only-free case and drops the now-pointless selection click, so the free tier reads as plain info above the Sign up button. The title, description, and benefits stay.

- This follows the "possibly better" option in the issue. I kept the "Free" title because signup-flow.test.js already asserts it renders for only-free signups, and the issue flagged title removal with a "?", so it didn't seem worth changing. Happy to drop it if you'd prefer.

- Multi-tier and single-paid signups are unaffected; the change only triggers when free is the only tier. The full Portal test suite passes.

- No new test added: this is a presentational/CSS change that jsdom can't meaningfully assert, and the existing signup-flow tests already cover only-free rendering (title, description, benefits).

- I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)

<img width="520" height="800" alt="shot pic" src="https://github.com/user-attachments/assets/65264d18-2e21-4688-9c13-47166c47157d" />

