### PR TITLE
🐛 Fixed complimentary subscription created when editing comped members

### DIFF
--- a/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
@@ -478,6 +478,19 @@ module.exports = class MemberBREADService {
     async edit(data, options) {
         delete data.last_seen_at;
 
+        // A member can be comped without a Stripe subscription (e.g. comped via the API or an
+        // import, where the subscription id is blank). In that case `comped: true` is still
+        // returned and re-sent on every subsequent edit, so we capture whether the member is
+        // *already* comped before updating. Otherwise an unrelated change (e.g. adding a label)
+        // that carries `comped: true` would wrongly create a new complimentary Stripe
+        // subscription. We only want to create/remove one on an actual transition.
+        // Ref: https://github.com/TryGhost/Ghost/issues/25735
+        let wasComped = false;
+        if (this.stripeService.configured && typeof data.comped === 'boolean' && options.id) {
+            const existingMember = await this.memberRepository.get({id: options.id}, {transacting: options.transacting});
+            wasComped = existingMember?.get('status') === 'comped';
+        }
+
         let model;
 
         try {
@@ -504,7 +517,7 @@ module.exports = class MemberBREADService {
             const hasCompedSubscription = !!model.related('stripeSubscriptions').find(sub => sub.get('plan_nickname') === 'Complimentary' && sub.get('status') === 'active');
 
             if (typeof data.comped === 'boolean') {
-                if (data.comped && !hasCompedSubscription) {
+                if (data.comped && !hasCompedSubscription && !wasComped) {
                     await this.memberRepository.setComplimentarySubscription(model, {
                         context: options.context,
                         transacting: options.transacting

--- a/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
@@ -478,19 +478,6 @@ module.exports = class MemberBREADService {
     async edit(data, options) {
         delete data.last_seen_at;
 
-        // A member can be comped without a Stripe subscription (e.g. comped via the API or an
-        // import, where the subscription id is blank). In that case `comped: true` is still
-        // returned and re-sent on every subsequent edit, so we capture whether the member is
-        // *already* comped before updating. Otherwise an unrelated change (e.g. adding a label)
-        // that carries `comped: true` would wrongly create a new complimentary Stripe
-        // subscription. We only want to create/remove one on an actual transition.
-        // Ref: https://github.com/TryGhost/Ghost/issues/25735
-        let wasComped = false;
-        if (this.stripeService.configured && typeof data.comped === 'boolean' && options.id) {
-            const existingMember = await this.memberRepository.get({id: options.id}, {transacting: options.transacting});
-            wasComped = existingMember?.get('status') === 'comped';
-        }
-
         let model;
 
         try {
@@ -515,6 +502,11 @@ module.exports = class MemberBREADService {
 
         if (this.stripeService.configured) {
             const hasCompedSubscription = !!model.related('stripeSubscriptions').find(sub => sub.get('plan_nickname') === 'Complimentary' && sub.get('status') === 'active');
+            // `comped` is derived from status and round-tripped on every edit, even for members
+            // comped without a Stripe subscription (e.g. via the API or an import), so only create
+            // a subscription on an actual transition. The model returned by update() still holds
+            // the pre-update status. Ref: https://github.com/TryGhost/Ghost/issues/25735
+            const wasComped = model.previous('status') === 'comped';
 
             if (typeof data.comped === 'boolean') {
                 if (data.comped && !hasCompedSubscription && !wasComped) {

--- a/ghost/core/test/unit/server/services/members/members-api/services/members-bread-service.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/members-bread-service.test.js
@@ -267,6 +267,109 @@ describe('MemberBreadService', function () {
 
             assert.equal(getSuppressionDataStub.called, false);
         });
+
+        // Stripe-connected comp handling. A member can be comped without a Stripe
+        // subscription, and `comped: true` is re-sent on every edit, so the edit path must
+        // only act on an actual transition. Ref: https://github.com/TryGhost/Ghost/issues/25735
+        function createStripeEditService({currentStatus = 'free', hasActiveCompSub = false, configured = true} = {}) {
+            const setComplimentarySubscription = sinon.stub().resolves();
+            const removeComplimentarySubscription = sinon.stub().resolves();
+            const get = sinon.stub().resolves({get: sinon.stub().returns(currentStatus)});
+
+            // model returned by update() — its stripeSubscriptions relation reflects whether
+            // the member currently has an active complimentary Stripe subscription.
+            const compSub = {get: key => ({plan_nickname: 'Complimentary', status: 'active'})[key]};
+            const subscriptions = hasActiveCompSub ? [compSub] : [];
+            const mockMemberModel = {
+                id: 'member_123',
+                get: sinon.stub().returns(false),
+                related: sinon.stub().returns({
+                    find: predicate => subscriptions.find(predicate),
+                    toJSON: () => [],
+                    models: subscriptions
+                }),
+                toJSON: sinon.stub().returns({id: 'member_123', email: 'test@example.com'})
+            };
+
+            const service = new MemberBreadService({
+                memberRepository: {
+                    update: sinon.stub().resolves(mockMemberModel),
+                    get,
+                    setComplimentarySubscription,
+                    removeComplimentarySubscription
+                },
+                stripeService: {configured},
+                memberAttributionService: {getAttributionFromContext: sinon.stub().resolves(null)},
+                emailService: {},
+                labsService: {isSet: sinon.stub().returns(false)},
+                newslettersService: {browse: sinon.stub().resolves([])},
+                settingsCache: {get: sinon.stub()},
+                emailSuppressionList: {getSuppressionData: sinon.stub().resolves({suppressed: false, info: null})},
+                settingsHelpers: {createUnsubscribeUrl: sinon.stub().returns('http://example.com/unsubscribe')}
+            });
+
+            sinon.stub(service, 'read').resolves({id: 'member_123'});
+
+            return {service, setComplimentarySubscription, removeComplimentarySubscription, get};
+        }
+
+        // Case 2 — the bug: an already-comped member (no Stripe sub) round-trips comped:true.
+        it('does not create a complimentary subscription when editing an already-comped member (#25735)', async function () {
+            const {service, setComplimentarySubscription} = createStripeEditService({currentStatus: 'comped'});
+
+            await service.edit({comped: true, labels: [{name: 'VIP'}]}, {id: 'member_123'});
+
+            assert.equal(setComplimentarySubscription.called, false);
+        });
+
+        // Case 1 — no regression: genuinely comping a previously-free member.
+        it('creates a complimentary subscription when comping a member that was not previously comped (#25735)', async function () {
+            const {service, setComplimentarySubscription} = createStripeEditService({currentStatus: 'free'});
+
+            await service.edit({comped: true}, {id: 'member_123'});
+
+            assert.equal(setComplimentarySubscription.calledOnce, true);
+        });
+
+        // Case 3 — idempotent: already comped via Stripe, comped:true round-tripped.
+        it('does not create a duplicate when an already-comped member has an active complimentary subscription (#25735)', async function () {
+            const {service, setComplimentarySubscription} = createStripeEditService({currentStatus: 'comped', hasActiveCompSub: true});
+
+            await service.edit({comped: true, labels: [{name: 'VIP'}]}, {id: 'member_123'});
+
+            assert.equal(setComplimentarySubscription.called, false);
+        });
+
+        // Case 5 — uncomp still works (remove branch unaffected by the fix).
+        it('removes the complimentary subscription when uncomping a member (#25735)', async function () {
+            const {service, removeComplimentarySubscription, setComplimentarySubscription} = createStripeEditService({currentStatus: 'comped', hasActiveCompSub: true});
+
+            await service.edit({comped: false}, {id: 'member_123'});
+
+            assert.equal(removeComplimentarySubscription.calledOnce, true);
+            assert.equal(setComplimentarySubscription.called, false);
+        });
+
+        // Case 6 — ordinary edit (no comped field): no comp work and no extra prior-status read.
+        it('does not touch subscriptions or read prior status on an edit without comped (#25735)', async function () {
+            const {service, setComplimentarySubscription, removeComplimentarySubscription, get} = createStripeEditService({currentStatus: 'comped'});
+
+            await service.edit({name: 'New Name'}, {id: 'member_123'});
+
+            assert.equal(setComplimentarySubscription.called, false);
+            assert.equal(removeComplimentarySubscription.called, false);
+            assert.equal(get.called, false);
+        });
+
+        // Case 7 — Stripe not connected: comp branch never runs.
+        it('does not create a complimentary subscription when Stripe is not connected (#25735)', async function () {
+            const {service, setComplimentarySubscription, get} = createStripeEditService({currentStatus: 'free', configured: false});
+
+            await service.edit({comped: true}, {id: 'member_123'});
+
+            assert.equal(setComplimentarySubscription.called, false);
+            assert.equal(get.called, false);
+        });
     });
 
     describe('read', function () {

--- a/ghost/core/test/unit/server/services/members/members-api/services/members-bread-service.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/members-bread-service.test.js
@@ -199,11 +199,16 @@ describe('MemberBreadService', function () {
     });
 
     describe('edit', function () {
-        function createMockMemberModel() {
+        function createMockMemberModel({previousStatus = 'free', subscriptions = []} = {}) {
             return {
                 id: 'member_123',
                 get: sinon.stub().returns(false),
-                related: sinon.stub().returns({find: () => null, toJSON: () => [], models: []}),
+                previous: sinon.stub().returns(previousStatus),
+                related: sinon.stub().returns({
+                    find: predicate => subscriptions.find(predicate) || null,
+                    toJSON: () => [],
+                    models: subscriptions
+                }),
                 toJSON: sinon.stub().returns({
                     id: 'member_123',
                     email: 'test@example.com'
@@ -211,16 +216,20 @@ describe('MemberBreadService', function () {
             };
         }
 
-        function createService() {
-            const mockMemberModel = createMockMemberModel();
+        function createService({stripeConfigured = false, previousStatus = 'free', subscriptions = []} = {}) {
+            const mockMemberModel = createMockMemberModel({previousStatus, subscriptions});
             const updateStub = sinon.stub().resolves(mockMemberModel);
             const getSuppressionDataStub = sinon.stub().resolves({suppressed: false, info: null});
+            const setComplimentarySubscription = sinon.stub().resolves();
+            const removeComplimentarySubscription = sinon.stub().resolves();
 
             const service = new MemberBreadService({
                 memberRepository: {
-                    update: updateStub
+                    update: updateStub,
+                    setComplimentarySubscription,
+                    removeComplimentarySubscription
                 },
-                stripeService: {configured: false},
+                stripeService: {configured: stripeConfigured},
                 memberAttributionService: {getAttributionFromContext: sinon.stub().resolves(null)},
                 emailService: {},
                 labsService: {isSet: sinon.stub().returns(false)},
@@ -232,7 +241,7 @@ describe('MemberBreadService', function () {
 
             sinon.stub(service, 'read').resolves({id: 'member_123'});
 
-            return {service, updateStub, getSuppressionDataStub};
+            return {service, updateStub, getSuppressionDataStub, setComplimentarySubscription, removeComplimentarySubscription};
         }
 
         it('sets email_disabled to true when the new email is on the suppression list', async function () {
@@ -268,81 +277,44 @@ describe('MemberBreadService', function () {
             assert.equal(getSuppressionDataStub.called, false);
         });
 
-        // Stripe-connected comp handling. A member can be comped without a Stripe
-        // subscription, and `comped: true` is re-sent on every edit, so the edit path must
-        // only act on an actual transition. Ref: https://github.com/TryGhost/Ghost/issues/25735
-        function createStripeEditService({currentStatus = 'free', hasActiveCompSub = false, configured = true} = {}) {
-            const setComplimentarySubscription = sinon.stub().resolves();
-            const removeComplimentarySubscription = sinon.stub().resolves();
-            const get = sinon.stub().resolves({get: sinon.stub().returns(currentStatus)});
+        // Comp handling on edit must only act on an actual status transition, because `comped`
+        // is derived from status and round-tripped on every edit.
+        // Ref: https://github.com/TryGhost/Ghost/issues/25735
+        const compSubData = {plan_nickname: 'Complimentary', status: 'active'};
+        const activeCompSubscription = {get: key => compSubData[key]};
 
-            // model returned by update() — its stripeSubscriptions relation reflects whether
-            // the member currently has an active complimentary Stripe subscription.
-            const compSub = {get: key => ({plan_nickname: 'Complimentary', status: 'active'})[key]};
-            const subscriptions = hasActiveCompSub ? [compSub] : [];
-            const mockMemberModel = {
-                id: 'member_123',
-                get: sinon.stub().returns(false),
-                related: sinon.stub().returns({
-                    find: predicate => subscriptions.find(predicate),
-                    toJSON: () => [],
-                    models: subscriptions
-                }),
-                toJSON: sinon.stub().returns({id: 'member_123', email: 'test@example.com'})
-            };
-
-            const service = new MemberBreadService({
-                memberRepository: {
-                    update: sinon.stub().resolves(mockMemberModel),
-                    get,
-                    setComplimentarySubscription,
-                    removeComplimentarySubscription
-                },
-                stripeService: {configured},
-                memberAttributionService: {getAttributionFromContext: sinon.stub().resolves(null)},
-                emailService: {},
-                labsService: {isSet: sinon.stub().returns(false)},
-                newslettersService: {browse: sinon.stub().resolves([])},
-                settingsCache: {get: sinon.stub()},
-                emailSuppressionList: {getSuppressionData: sinon.stub().resolves({suppressed: false, info: null})},
-                settingsHelpers: {createUnsubscribeUrl: sinon.stub().returns('http://example.com/unsubscribe')}
-            });
-
-            sinon.stub(service, 'read').resolves({id: 'member_123'});
-
-            return {service, setComplimentarySubscription, removeComplimentarySubscription, get};
-        }
-
-        // Case 2 — the bug: an already-comped member (no Stripe sub) round-trips comped:true.
+        // The bug: an already-comped member (no Stripe sub) round-trips comped:true.
         it('does not create a complimentary subscription when editing an already-comped member (#25735)', async function () {
-            const {service, setComplimentarySubscription} = createStripeEditService({currentStatus: 'comped'});
+            const {service, setComplimentarySubscription} = createService({stripeConfigured: true, previousStatus: 'comped'});
 
             await service.edit({comped: true, labels: [{name: 'VIP'}]}, {id: 'member_123'});
 
             assert.equal(setComplimentarySubscription.called, false);
         });
 
-        // Case 1 — no regression: genuinely comping a previously-free member.
+        // No regression: genuinely comping a previously-free member.
         it('creates a complimentary subscription when comping a member that was not previously comped (#25735)', async function () {
-            const {service, setComplimentarySubscription} = createStripeEditService({currentStatus: 'free'});
+            const {service, setComplimentarySubscription} = createService({stripeConfigured: true, previousStatus: 'free'});
 
             await service.edit({comped: true}, {id: 'member_123'});
 
             assert.equal(setComplimentarySubscription.calledOnce, true);
         });
 
-        // Case 3 — idempotent: already comped via Stripe, comped:true round-tripped.
+        // Idempotent: already comped via Stripe, comped:true round-tripped.
         it('does not create a duplicate when an already-comped member has an active complimentary subscription (#25735)', async function () {
-            const {service, setComplimentarySubscription} = createStripeEditService({currentStatus: 'comped', hasActiveCompSub: true});
+            const {service, setComplimentarySubscription} = createService({stripeConfigured: true, previousStatus: 'comped', subscriptions: [activeCompSubscription]});
 
             await service.edit({comped: true, labels: [{name: 'VIP'}]}, {id: 'member_123'});
 
             assert.equal(setComplimentarySubscription.called, false);
         });
 
-        // Case 5 — uncomp still works (remove branch unaffected by the fix).
-        it('removes the complimentary subscription when uncomping a member (#25735)', async function () {
-            const {service, removeComplimentarySubscription, setComplimentarySubscription} = createStripeEditService({currentStatus: 'comped', hasActiveCompSub: true});
+        // The remove branch keys on the model's loaded stripeSubscriptions relation, so this
+        // only covers the service-level contract when that relation is present on the model —
+        // the Admin API edit path does not load it.
+        it('removes the complimentary subscription when uncomping a member whose model has an active complimentary subscription loaded (#25735)', async function () {
+            const {service, removeComplimentarySubscription, setComplimentarySubscription} = createService({stripeConfigured: true, previousStatus: 'comped', subscriptions: [activeCompSubscription]});
 
             await service.edit({comped: false}, {id: 'member_123'});
 
@@ -350,25 +322,23 @@ describe('MemberBreadService', function () {
             assert.equal(setComplimentarySubscription.called, false);
         });
 
-        // Case 6 — ordinary edit (no comped field): no comp work and no extra prior-status read.
-        it('does not touch subscriptions or read prior status on an edit without comped (#25735)', async function () {
-            const {service, setComplimentarySubscription, removeComplimentarySubscription, get} = createStripeEditService({currentStatus: 'comped'});
+        // Ordinary edit (no comped field): no comp work at all.
+        it('does not touch subscriptions on an edit without comped (#25735)', async function () {
+            const {service, setComplimentarySubscription, removeComplimentarySubscription} = createService({stripeConfigured: true, previousStatus: 'comped'});
 
             await service.edit({name: 'New Name'}, {id: 'member_123'});
 
             assert.equal(setComplimentarySubscription.called, false);
             assert.equal(removeComplimentarySubscription.called, false);
-            assert.equal(get.called, false);
         });
 
-        // Case 7 — Stripe not connected: comp branch never runs.
+        // Stripe not connected: comp branch never runs.
         it('does not create a complimentary subscription when Stripe is not connected (#25735)', async function () {
-            const {service, setComplimentarySubscription, get} = createStripeEditService({currentStatus: 'free', configured: false});
+            const {service, setComplimentarySubscription} = createService({previousStatus: 'free'});
 
             await service.edit({comped: true}, {id: 'member_123'});
 
             assert.equal(setComplimentarySubscription.called, false);
-            assert.equal(get.called, false);
         });
     });
 


### PR DESCRIPTION
fixes #25735

@9larsons confirmed this on the issue and tagged it bug + help wanted.

**The problem**

A member can be comped without a Stripe subscription behind it (comped through the API
or an import, where the subscription id is blank). When you GET that member and PUT it
back with an unrelated change like a new label, the payload still carries `comped: true`.
The edit path sees that, finds no complimentary Stripe sub, and creates one. So a simple
label edit creates a zero-amount yearly Stripe subscription and bumps the period out a year.

Nothing ever bills, but it's confusing, and the only workaround was stripping
`comped`/`status` out of the payload by hand.

**The fix**

`MemberBREADService.edit()` now checks whether the member was already comped before the
update, and only creates a complimentary subscription when comp status actually changes.
The uncomp path is untouched. This matches what the Admin UI already does (it strips these
fields before saving), which is what @9larsons suggested.

**Tests**

6 unit cases in `members-bread-service.test.js`, one per path: free to comped (creates),
already-comped with no Stripe sub (the bug, now skipped), already-comped with a Stripe sub
(no duplicate), uncomp (removes), edit with no comped field (no work), and Stripe not connected.

- [x] I've read and followed the Contributor Guide
- [x] I've written an automated test to prove my change works
