### PR TITLE
🐛 Fixed orphaned Stripe prices when importing members by tier

### DIFF
--- a/ghost/core/core/server/services/members/importer/members-csv-importer-stripe-utils.js
+++ b/ghost/core/core/server/services/members/importer/members-csv-importer-stripe-utils.js
@@ -1,4 +1,5 @@
 const {DataImportError} = require('@tryghost/errors');
+const logging = require('@tryghost/logging');
 const tpl = require('@tryghost/tpl');
 
 const messages = {
@@ -150,12 +151,25 @@ module.exports = class MembersCSVImporterStripeUtils {
                 interval: stripeSubscriptionItemPriceInterval
             });
 
-            await this._stripeAPIService.updateSubscriptionItemPrice(
-                stripeSubscription.id,
-                stripeSubscriptionItem.id,
-                newStripePrice.id,
-                {prorationBehavior: 'none'}
-            );
+            try {
+                await this._stripeAPIService.updateSubscriptionItemPrice(
+                    stripeSubscription.id,
+                    stripeSubscriptionItem.id,
+                    newStripePrice.id,
+                    {prorationBehavior: 'none'}
+                );
+            } catch (err) {
+                // The subscription update failed after we created a new price, which would
+                // otherwise leave the price orphaned on the Stripe product (these accumulate
+                // across imports). Archive it, then surface the original error regardless of
+                // whether archiving succeeds. Ref: https://github.com/TryGhost/Ghost/issues/22115
+                try {
+                    await this.archivePrice(newStripePrice.id);
+                } catch (archiveErr) {
+                    logging.warn(`Failed to archive orphaned Stripe price ${newStripePrice.id} after a failed subscription update: ${archiveErr.message}`);
+                }
+                throw err;
+            }
 
             stripePriceId = newStripePrice.id;
             isNewStripePrice = true;

--- a/ghost/core/test/unit/server/services/members/importer/members-csv-importer-stripe-utils.test.js
+++ b/ghost/core/test/unit/server/services/members/importer/members-csv-importer-stripe-utils.test.js
@@ -361,6 +361,9 @@ describe('MembersCSVImporterStripeUtils', function () {
                 NEW_STRIPE_PRICE_ID,
                 {prorationBehavior: 'none'}
             ), true);
+
+            // Assert the new price was not archived — that cleanup only runs when the update fails (#22115)
+            sinon.assert.notCalled(stripeAPIServiceStub.updatePrice);
         });
 
         it('archives the newly-created price if updating the subscription fails (#22115)', async function () {
@@ -377,18 +380,14 @@ describe('MembersCSVImporterStripeUtils', function () {
                 productRepository: productRepositoryStub
             });
 
-            let thrown;
-            try {
-                await membersCSVImporterStripeUtils.forceStripeSubscriptionToProduct({
+            // The original error surfaces...
+            await assert.rejects(
+                membersCSVImporterStripeUtils.forceStripeSubscriptionToProduct({
                     customer_id: CUSTOMER_ID,
                     product_id: PRODUCT_ID
-                }, OPTIONS);
-            } catch (err) {
-                thrown = err;
-            }
-
-            // The original error surfaces...
-            assert.equal(thrown, updateError);
+                }, OPTIONS),
+                err => err === updateError
+            );
 
             // ...and the price we just created is archived so it can't be orphaned/accumulate
             sinon.assert.calledOnce(stripeAPIServiceStub.updatePrice);
@@ -410,18 +409,14 @@ describe('MembersCSVImporterStripeUtils', function () {
                 productRepository: productRepositoryStub
             });
 
-            let thrown;
-            try {
-                await membersCSVImporterStripeUtils.forceStripeSubscriptionToProduct({
+            // The original update error must surface, not the archive failure
+            await assert.rejects(
+                membersCSVImporterStripeUtils.forceStripeSubscriptionToProduct({
                     customer_id: CUSTOMER_ID,
                     product_id: PRODUCT_ID
-                }, OPTIONS);
-            } catch (err) {
-                thrown = err;
-            }
-
-            // The original update error must surface, not the archive failure
-            assert.equal(thrown, updateError);
+                }, OPTIONS),
+                err => err === updateError
+            );
         });
 
         it('does not archive anything when updating to an existing matching price fails — nothing was created (#22115)', async function () {
@@ -441,17 +436,13 @@ describe('MembersCSVImporterStripeUtils', function () {
                 productRepository: productRepositoryStub
             });
 
-            let thrown;
-            try {
-                await membersCSVImporterStripeUtils.forceStripeSubscriptionToProduct({
+            await assert.rejects(
+                membersCSVImporterStripeUtils.forceStripeSubscriptionToProduct({
                     customer_id: CUSTOMER_ID,
                     product_id: PRODUCT_ID
-                }, OPTIONS);
-            } catch (err) {
-                thrown = err;
-            }
-
-            assert.equal(thrown, updateError);
+                }, OPTIONS),
+                err => err === updateError
+            );
             sinon.assert.notCalled(stripeAPIServiceStub.createPrice);
             sinon.assert.notCalled(stripeAPIServiceStub.updatePrice);
         });
@@ -467,41 +458,14 @@ describe('MembersCSVImporterStripeUtils', function () {
                 productRepository: productRepositoryStub
             });
 
-            let thrown;
-            try {
-                await membersCSVImporterStripeUtils.forceStripeSubscriptionToProduct({
+            await assert.rejects(
+                membersCSVImporterStripeUtils.forceStripeSubscriptionToProduct({
                     customer_id: CUSTOMER_ID,
                     product_id: PRODUCT_ID
-                }, OPTIONS);
-            } catch (err) {
-                thrown = err;
-            }
-
-            assert.equal(thrown, createError);
+                }, OPTIONS),
+                err => err === createError
+            );
             sinon.assert.notCalled(stripeAPIServiceStub.updateSubscriptionItemPrice);
-            sinon.assert.notCalled(stripeAPIServiceStub.updatePrice);
-        });
-
-        it('does not archive the new price when the subscription update succeeds (#22115)', async function () {
-            const stripeAPIServiceStub = getStripeApiServiceStub();
-            const NEW_STRIPE_PRICE_ID = 'new_stripe_price_id';
-            stripeAPIServiceStub.createPrice.resolves({id: NEW_STRIPE_PRICE_ID});
-            // updateSubscriptionItemPrice resolves by default (the happy path)
-
-            const productRepositoryStub = getProductRepositoryStub({resolveGhostProductPrice: false});
-            const membersCSVImporterStripeUtils = new MembersCSVImporterStripeUtils({
-                stripeAPIService: stripeAPIServiceStub,
-                productRepository: productRepositoryStub
-            });
-
-            const result = await membersCSVImporterStripeUtils.forceStripeSubscriptionToProduct({
-                customer_id: CUSTOMER_ID,
-                product_id: PRODUCT_ID
-            }, OPTIONS);
-
-            assert.equal(result.isNewStripePrice, true);
-            assert.equal(result.stripePriceId, NEW_STRIPE_PRICE_ID);
-            // The cleanup must only run on failure — a successful update keeps the price
             sinon.assert.notCalled(stripeAPIServiceStub.updatePrice);
         });
 

--- a/ghost/core/test/unit/server/services/members/importer/members-csv-importer-stripe-utils.test.js
+++ b/ghost/core/test/unit/server/services/members/importer/members-csv-importer-stripe-utils.test.js
@@ -363,6 +363,148 @@ describe('MembersCSVImporterStripeUtils', function () {
             ), true);
         });
 
+        it('archives the newly-created price if updating the subscription fails (#22115)', async function () {
+            const stripeAPIServiceStub = getStripeApiServiceStub();
+            const NEW_STRIPE_PRICE_ID = 'new_stripe_price_id';
+            const updateError = new Error('Stripe rejected the subscription update');
+
+            stripeAPIServiceStub.createPrice.resolves({id: NEW_STRIPE_PRICE_ID});
+            stripeAPIServiceStub.updateSubscriptionItemPrice.rejects(updateError);
+
+            const productRepositoryStub = getProductRepositoryStub({resolveGhostProductPrice: false});
+            const membersCSVImporterStripeUtils = new MembersCSVImporterStripeUtils({
+                stripeAPIService: stripeAPIServiceStub,
+                productRepository: productRepositoryStub
+            });
+
+            let thrown;
+            try {
+                await membersCSVImporterStripeUtils.forceStripeSubscriptionToProduct({
+                    customer_id: CUSTOMER_ID,
+                    product_id: PRODUCT_ID
+                }, OPTIONS);
+            } catch (err) {
+                thrown = err;
+            }
+
+            // The original error surfaces...
+            assert.equal(thrown, updateError);
+
+            // ...and the price we just created is archived so it can't be orphaned/accumulate
+            sinon.assert.calledOnce(stripeAPIServiceStub.updatePrice);
+            assert.equal(stripeAPIServiceStub.updatePrice.calledWithExactly(NEW_STRIPE_PRICE_ID, {active: false}), true);
+        });
+
+        it('surfaces the original update error even if archiving the orphaned price also fails (#22115)', async function () {
+            const stripeAPIServiceStub = getStripeApiServiceStub();
+            const NEW_STRIPE_PRICE_ID = 'new_stripe_price_id';
+            const updateError = new Error('Stripe rejected the subscription update');
+
+            stripeAPIServiceStub.createPrice.resolves({id: NEW_STRIPE_PRICE_ID});
+            stripeAPIServiceStub.updateSubscriptionItemPrice.rejects(updateError);
+            stripeAPIServiceStub.updatePrice.rejects(new Error('archiving failed too'));
+
+            const productRepositoryStub = getProductRepositoryStub({resolveGhostProductPrice: false});
+            const membersCSVImporterStripeUtils = new MembersCSVImporterStripeUtils({
+                stripeAPIService: stripeAPIServiceStub,
+                productRepository: productRepositoryStub
+            });
+
+            let thrown;
+            try {
+                await membersCSVImporterStripeUtils.forceStripeSubscriptionToProduct({
+                    customer_id: CUSTOMER_ID,
+                    product_id: PRODUCT_ID
+                }, OPTIONS);
+            } catch (err) {
+                thrown = err;
+            }
+
+            // The original update error must surface, not the archive failure
+            assert.equal(thrown, updateError);
+        });
+
+        it('does not archive anything when updating to an existing matching price fails — nothing was created (#22115)', async function () {
+            const stripeAPIServiceStub = getStripeApiServiceStub();
+            const updateError = new Error('Stripe rejected the subscription update');
+            stripeAPIServiceStub.updateSubscriptionItemPrice.rejects(updateError);
+
+            // A matching Ghost price already exists, but with a different Stripe price id, so the
+            // subscription genuinely needs updating (and can therefore fail) — yet no new price is
+            // created on this path, so there must be nothing to archive.
+            const productRepositoryStub = getProductRepositoryStub({
+                resolveGhostProductPrice: true,
+                ghostProductStripePriceId: 'existing_stripe_price_id'
+            });
+            const membersCSVImporterStripeUtils = new MembersCSVImporterStripeUtils({
+                stripeAPIService: stripeAPIServiceStub,
+                productRepository: productRepositoryStub
+            });
+
+            let thrown;
+            try {
+                await membersCSVImporterStripeUtils.forceStripeSubscriptionToProduct({
+                    customer_id: CUSTOMER_ID,
+                    product_id: PRODUCT_ID
+                }, OPTIONS);
+            } catch (err) {
+                thrown = err;
+            }
+
+            assert.equal(thrown, updateError);
+            sinon.assert.notCalled(stripeAPIServiceStub.createPrice);
+            sinon.assert.notCalled(stripeAPIServiceStub.updatePrice);
+        });
+
+        it('does not update the subscription or archive when creating the new price itself fails (#22115)', async function () {
+            const stripeAPIServiceStub = getStripeApiServiceStub();
+            const createError = new Error('Stripe rejected createPrice');
+            stripeAPIServiceStub.createPrice.rejects(createError);
+
+            const productRepositoryStub = getProductRepositoryStub({resolveGhostProductPrice: false});
+            const membersCSVImporterStripeUtils = new MembersCSVImporterStripeUtils({
+                stripeAPIService: stripeAPIServiceStub,
+                productRepository: productRepositoryStub
+            });
+
+            let thrown;
+            try {
+                await membersCSVImporterStripeUtils.forceStripeSubscriptionToProduct({
+                    customer_id: CUSTOMER_ID,
+                    product_id: PRODUCT_ID
+                }, OPTIONS);
+            } catch (err) {
+                thrown = err;
+            }
+
+            assert.equal(thrown, createError);
+            sinon.assert.notCalled(stripeAPIServiceStub.updateSubscriptionItemPrice);
+            sinon.assert.notCalled(stripeAPIServiceStub.updatePrice);
+        });
+
+        it('does not archive the new price when the subscription update succeeds (#22115)', async function () {
+            const stripeAPIServiceStub = getStripeApiServiceStub();
+            const NEW_STRIPE_PRICE_ID = 'new_stripe_price_id';
+            stripeAPIServiceStub.createPrice.resolves({id: NEW_STRIPE_PRICE_ID});
+            // updateSubscriptionItemPrice resolves by default (the happy path)
+
+            const productRepositoryStub = getProductRepositoryStub({resolveGhostProductPrice: false});
+            const membersCSVImporterStripeUtils = new MembersCSVImporterStripeUtils({
+                stripeAPIService: stripeAPIServiceStub,
+                productRepository: productRepositoryStub
+            });
+
+            const result = await membersCSVImporterStripeUtils.forceStripeSubscriptionToProduct({
+                customer_id: CUSTOMER_ID,
+                product_id: PRODUCT_ID
+            }, OPTIONS);
+
+            assert.equal(result.isNewStripePrice, true);
+            assert.equal(result.stripePriceId, NEW_STRIPE_PRICE_ID);
+            // The cleanup must only run on failure — a successful update keeps the price
+            sinon.assert.notCalled(stripeAPIServiceStub.updatePrice);
+        });
+
         it('creates a new product in Stripe if one does not already existing for the Ghost product', async function () {
             const stripeAPIServiceStub = getStripeApiServiceStub();
             const productRepositoryStub = getProductRepositoryStub({


### PR DESCRIPTION
fixes https://github.com/TryGhost/Ghost/issues/22115

### Why
@9larsons reproduced this on main and tagged it bug + help wanted. Importing members by tier could leave orphaned, unused prices piling up on a Stripe product.

### What it does
When you import a member with an `import_tier` and a Stripe customer, `forceStripeSubscriptionToProduct()` creates a new price on the tier's product, then updates the customer's subscription to use it. That new price is only recorded for archival (it gets cleaned up after the import) once the update succeeds. So if the update throws, for example because Stripe rejects it or the subscription is schedule-managed, the price is never archived and stays orphaned on the product, building up on every import.

The subscription update is now wrapped so that on failure the just-created price is archived before the error propagates. The original error always surfaces, even if archiving itself fails (that's logged as a warning). This is what @9larsons suggested on the issue: "archive the just-created price if the update throws."

### Why Ghost users/developers need it
Site owners and integrations that import paid members by tier end up with a growing list of unused prices on their Stripe products, which is confusing to manage. This keeps the price list clean.

### Tests
5 unit cases covering the full create → update → archive path: a successful update does not archive; a failed update archives the new price; the original error still surfaces if archiving also fails; an existing-price update failure does not archive (nothing was created); and a createPrice failure does not update or archive. All 17 tests in the file pass.

- [x] I've read and followed the Contributor Guide
- [x] I've written an automated test to prove my change works
