### PR TITLE
🐛 Fixed admin sidebar hidden behind legacy screens on mobile

### DIFF
--- a/apps/admin/src/index.css
+++ b/apps/admin/src/index.css
@@ -137,6 +137,9 @@ body.react-admin .safe-area-inset-bottom {
 body.react-admin #ember-app {
     width: 100%;
     height: 100%;
+    /* Contain legacy Ember z-indexes (e.g. the billing overlay at 9999) so they can't
+       paint over React shell chrome like the mobile sidebar drawer (z-50). */
+    isolation: isolate;
 }
 
 /* Temporary overrides until Ember transition is finished */


### PR DESCRIPTION
On mobile, opening the sidebar from a legacy Ember screen (e.g. the billing/Ghost(Pro) screen) appeared to do nothing — the sidebar drawer opened in the DOM but was painted behind the screen content.

Legacy Ember screens use very high z-index values (the billing overlay is z-index: 9999) and none of the Ember host's ancestors establish a stacking context, so those z-indexes compete in the root stacking context and paint over the React shell's mobile sidebar drawer (z-50), which is portalled to <body>.

Isolating #ember-app into its own stacking context keeps those legacy z-indexes scoped to the Ember content region, so the shell's sidebar drawer renders above it as expected. Fullscreen Ember screens are unaffected — they hide the sidebar via sidebar visibility, not z-index.

Got some code for us? Awesome 🎊!

Please take a minute to explain the change you're making:
- Why are you making it?
- What does it do?
- Why is this something Ghost users or developers need?

Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works

We appreciate your contribution! 🙏
