### PR TITLE
🐛 Fixed stored XSS in structured data via unescaped tag names

### DIFF
--- a/ghost/core/core/frontend/meta/schema.js
+++ b/ghost/core/core/frontend/meta/schema.js
@@ -126,7 +126,7 @@ function getPostSchema(metaData, data) {
         dateModified: metaData.modifiedDate,
         image: schemaImageObject(metaData.coverImage),
         keywords: metaData.keywords && metaData.keywords.length > 0 ?
-            metaData.keywords.join(', ') : null,
+            escapeExpression(metaData.keywords.join(', ')) : null,
         description: description,
         mainEntityOfPage: metaData.url
     };
@@ -140,7 +140,7 @@ function getHomeSchema(metaData) {
         '@type': 'WebSite',
         publisher: schemaPublisherObject(metaData),
         url: metaData.url,
-        name: metaData.site.title,
+        name: escapeExpression(metaData.site.title),
         image: schemaImageObject(metaData.coverImage),
         mainEntityOfPage: metaData.url,
         description: metaData.metaDescription ?
@@ -157,7 +157,7 @@ function getTagSchema(metaData, data) {
         publisher: schemaPublisherObject(metaData),
         url: metaData.url,
         image: schemaImageObject(metaData.coverImage),
-        name: data.tag.name,
+        name: escapeExpression(data.tag.name),
         mainEntityOfPage: metaData.url,
         description: metaData.metaDescription ?
             escapeExpression(metaData.metaDescription) :

--- a/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost-head.test.js.snap
+++ b/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost-head.test.js.snap
@@ -4951,7 +4951,7 @@ Object {
         \\"@type\\": \\"ImageObject\\",
         \\"url\\": \\"http://localhost:65530/content/images/test-image.png\\"
     },
-    \\"keywords\\": \\"Tom & Jerry\\",
+    \\"keywords\\": \\"Tom &amp; Jerry\\",
     \\"description\\": \\"site description\\",
     \\"mainEntityOfPage\\": \\"http://localhost:65530/post/\\"
 }

--- a/ghost/core/test/unit/frontend/meta/schema.test.js
+++ b/ghost/core/test/unit/frontend/meta/schema.test.js
@@ -426,6 +426,28 @@ describe('getSchema', function () {
         });
     });
 
+    it('should HTML-escape the site title in home schema (no script breakout)', function () {
+        const metadata = {
+            site: {
+                title: 'foo</script><script>alert(document.domain)</script>'
+            },
+            url: 'http://mysite.com/',
+            coverImage: null,
+            metaDescription: null
+        };
+
+        const data = {
+            context: ['home']
+        };
+
+        const schema = getSchema(metadata, data);
+
+        // site.title flows into the home WebSite JSON-LD `name` and must be escaped
+        // so it cannot close the inline <script type="application/ld+json"> element.
+        assert.equal(schema.name, 'foo&lt;/script&gt;&lt;script&gt;alert(document.domain)&lt;/script&gt;');
+        assert.ok(!schema.name.includes('</script>'), 'site title should not contain a literal </script>');
+    });
+
     it('should return tag schema if context starts with tag', function () {
         const metadata = {
             site: {
@@ -471,6 +493,56 @@ describe('getSchema', function () {
             },
             url: 'http://mysite.com/post/my-post-slug/'
         });
+    });
+
+    it('should HTML-escape the tag name in tag schema (no script breakout)', function () {
+        const metadata = {
+            site: {
+                title: 'Site Title'
+            },
+            url: 'http://mysite.com/tag/evil/',
+            coverImage: null,
+            metaDescription: null
+        };
+
+        const data = {
+            context: ['tag'],
+            tag: {
+                name: 'foo</script><script>alert(document.domain)</script>'
+            }
+        };
+
+        const schema = getSchema(metadata, data);
+
+        // The raw tag name must never appear unescaped — otherwise it can close
+        // the inline <script type="application/ld+json"> element and inject markup.
+        assert.equal(schema.name, 'foo&lt;/script&gt;&lt;script&gt;alert(document.domain)&lt;/script&gt;');
+        assert.ok(!schema.name.includes('</script>'), 'tag name should not contain a literal </script>');
+    });
+
+    it('should HTML-escape post keywords/tag names in post schema (no script breakout)', function () {
+        const metadata = {
+            site: {title: 'Site Title'},
+            authorUrl: 'http://mysite.com/author/me/',
+            metaTitle: 'Post Title',
+            url: 'http://mysite.com/post/my-post-slug/',
+            keywords: ['safe', 'foo</script><script>alert(document.domain)</script>'],
+            excerpt: null
+        };
+
+        const data = {
+            context: ['post'],
+            post: {
+                primary_author: {name: 'Post Author'}
+            }
+        };
+
+        const schema = getSchema(metadata, data);
+
+        // Tag names flow into the post JSON-LD `keywords` field via metaData.keywords
+        // (raw item.name) and must be escaped so they cannot close the inline script.
+        assert.ok(!schema.keywords.includes('</script>'), 'keywords should not contain a literal </script>');
+        assert.equal(schema.keywords, 'safe, foo&lt;/script&gt;&lt;script&gt;alert(document.domain)&lt;/script&gt;');
     });
 
     it('should return author schema if context starts with author', function () {


### PR DESCRIPTION
Tag names, post keywords, and the site title were written into the inline JSON-LD <script type="application/ld+json"> block via JSON.stringify, which doesn't escape </script>. An Editor-controlled tag name like foo</script><script>alert(document.domain)</script> broke out of the script element and executed arbitrary JS for any anonymous visitor on tag and post pages.

### Fix
Escape the three affected fields with escapeExpression in getTagSchema, getPostSchema, and getHomeSchema. This is consistent with every other text field in the file (headline, description, author/publisher name), which were already escaped.

### Testing
Added regression tests asserting a </script> payload is HTML-escaped in tag, post-keywords, and home schema output.
Updated the existing ghost_head snapshot that was silently capturing the previously-unescaped post keywords.

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works
