### PR TITLE
i18n: add Lithuanian (lt) search translations

### DIFF
--- a/ghost/i18n/locales/lt/search.json
+++ b/ghost/i18n/locales/lt/search.json
@@ -1,9 +1,9 @@
 {
-    "Authors": "",
-    "Cancel": "",
-    "No matches found": "",
-    "Posts": "",
-    "Search posts, tags and authors": "",
-    "Show more results": "",
-    "Tags": ""
+    "Authors": "Autoriai",
+    "Cancel": "Atšaukti",
+    "No matches found": "Atitikmenų nerasta",
+    "Posts": "Įrašai",
+    "Search posts, tags and authors": "Ieškoti įrašų, žymų ir autorių",
+    "Show more results": "Rodyti daugiau rezultatų",
+    "Tags": "Žymos"
 }


### PR DESCRIPTION
Fills the previously-empty lt/search.json so the Sodo Search app renders in Lithuanian. Values only — no keys added or removed.
