### PR TITLE
Updated reader-side gift link toast to the agreed design

### DIFF
--- a/ghost/core/core/frontend/helpers/ghost_foot.js
+++ b/ghost/core/core/frontend/helpers/ghost_foot.js
@@ -2,7 +2,7 @@
 // Usage: `{{ghost_foot}}`
 //
 // Outputs scripts and other assets at the bottom of a Ghost theme
-const {settingsCache, labs} = require('../services/proxy');
+const {blogIcon, labs, settingsCache, urlUtils} = require('../services/proxy');
 const {SafeString, templates, hbs} = require('../services/handlebars');
 const _ = require('lodash');
 
@@ -33,6 +33,19 @@ module.exports = function ghost_foot(options) { // eslint-disable-line camelcase
     // URLs. Overridable: a theme can supply its own `partials/gift-toast.hbs`.
     if (labs.isSet('giftLinks') && options.data._gift) {
         const data = createFrame(options.data);
+        const siteUrl = urlUtils.getSiteUrl().replace(/\/$/, '');
+
+        // Brand the toast's media panel with the publication icon — it's square,
+        // so it fills the 64px cover-fit cell cleanly (the logo isn't, and would
+        // crop badly). When no icon is set the partial paints the gift-card
+        // pattern from these long-cached texture assets instead.
+        data.giftToast = {
+            accentColor: settingsCache.get('accent_color') || '#15171a',
+            brandUrl: blogIcon.getIconUrl({absolute: true, fallbackToDefault: false}),
+            orbUrl: `${siteUrl}/gift/assets/gift-card-orb.png`,
+            noiseUrl: `${siteUrl}/gift/assets/gift-card-noise.png`
+        };
+
         foot.push(templates.execute('gift-toast', this, {data}));
     }
 

--- a/ghost/core/core/frontend/helpers/tpl/gift-toast.hbs
+++ b/ghost/core/core/frontend/helpers/tpl/gift-toast.hbs
@@ -1,75 +1,153 @@
 <style>
 .gh-gift-toast {
     --gh-gift-toast-bottom: 32px;
-    --gh-gift-toast-accent: {{@site.accent_color}};
+    --gh-gift-toast-accent: {{@giftToast.accentColor}};
+    --gh-gift-toast-ink: #15171a;
+    --gh-gift-toast-orb-url: url("{{@giftToast.orbUrl}}");
+    --gh-gift-toast-noise-url: url("{{@giftToast.noiseUrl}}");
+    --gh-gift-toast-ease: cubic-bezier(0.22, 1, 0.36, 1);
 
     position: fixed;
     bottom: var(--gh-gift-toast-bottom);
     left: 50%;
-    transform: translateX(-50%);
     z-index: 99998;
-    display: flex;
-    align-items: center;
-    gap: 12px;
+    display: grid;
+    grid-template-columns: 64px minmax(0, 1fr);
+    align-items: stretch;
+    width: max-content;
+    min-height: 64px;
     max-width: min(560px, calc(100vw - 32px));
-    padding: 16px;
-    background: #ffffff;
-    color: #15171a;
-    border-radius: 16px;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 8px 24px rgba(0, 0, 0, 0.08);
+    padding: 0;
+    overflow: hidden;
+    background: transparent;
+    color: var(--gh-gift-toast-ink);
+    border: none;
+    border-radius: 18px;
+    box-shadow: 0 0 0 1px rgba(21, 23, 26, 0.05), 0 0 28px rgba(21, 23, 26, 0.12), 0 6px 16px rgba(21, 23, 26, 0.14), 0 34px 88px rgba(21, 23, 26, 0.28);
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
     font-size: 13px;
-    line-height: 1.4;
-    transition: opacity 200ms ease, transform 200ms ease;
+    line-height: 1.35;
+    opacity: 0;
+    transform: translate3d(-50%, 18px, 0) scale(0.985);
+    animation: gh-gift-toast-enter 680ms var(--gh-gift-toast-ease) 100ms forwards;
+    transition: opacity 180ms ease, transform 180ms ease;
     box-sizing: border-box;
 }
 
-.gh-gift-toast-icon {
-    flex-shrink: 0;
+.gh-gift-toast * {
+    box-sizing: border-box;
+}
+
+.gh-gift-toast-media {
+    position: relative;
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 36px;
-    height: 36px;
-    border-radius: 50%;
-    /* Neutral tint fallback for browsers without color-mix() support */
-    background: rgba(0, 0, 0, 0.05);
-    background: color-mix(in srgb, var(--gh-gift-toast-accent) 15%, transparent);
+    width: 64px;
+    /* Stretches to the row height (set on the grid container) so the panel stays
+       flush when a longer locale wraps the title to a second line. */
+    min-height: 64px;
+    overflow: hidden;
+    background: var(--gh-gift-toast-accent);
 }
 
-.gh-gift-toast-icon svg {
-    width: 18px;
-    height: 18px;
-    color: var(--gh-gift-toast-accent);
-    fill: var(--gh-gift-toast-accent);
+.gh-gift-toast-icon {
+    display: block;
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    object-fit: cover;
 }
 
-.gh-gift-toast-text {
-    flex: 1;
+.gh-gift-toast-icon[hidden] {
+    display: none;
+}
+
+/* Mirrors the gift card aesthetic from apps/portal/src/components/pages/gift-page.js:
+   accent color base, Ghost orb at 0.2 opacity, noise grain at 0.1 opacity. */
+.gh-gift-toast-pattern {
+    display: none;
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    background-color: var(--gh-gift-toast-accent);
+}
+
+.gh-gift-toast-media.is-fallback .gh-gift-toast-pattern {
+    display: block;
+}
+
+.gh-gift-toast-pattern[hidden] {
+    display: none;
+}
+
+.gh-gift-toast-pattern::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-image: var(--gh-gift-toast-orb-url);
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+    opacity: 0.2;
+    pointer-events: none;
+}
+
+.gh-gift-toast-pattern::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-image: var(--gh-gift-toast-noise-url);
+    background-size: 192px 192px;
+    background-position: 50% 50%;
+    background-repeat: repeat;
+    opacity: 0.1;
+    pointer-events: none;
+}
+
+.gh-gift-toast-content {
+    display: flex;
+    align-items: center;
     min-width: 0;
-    color: #15171a;
+    min-height: 64px;
+    padding: 10px 44px 10px 14px;
+    background: #ffffff;
+}
+
+.gh-gift-toast-title {
+    display: block;
+    min-width: 0;
+    color: var(--gh-gift-toast-ink);
+    font-size: 14px;
     font-weight: 400;
+    line-height: 1.25;
+    /* English fits on one line; longer locales wrap rather than truncate. */
+    text-wrap: balance;
 }
 
 .gh-gift-toast-close {
-    flex-shrink: 0;
+    position: absolute;
+    top: 50%;
+    right: 9px;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 24px;
-    height: 24px;
+    width: 26px;
+    height: 26px;
     padding: 0;
     border: none;
     border-radius: 50%;
-    background: #f4f5f6;
-    color: #5b6573;
+    background: #f1f3f5;
+    color: #667085;
     cursor: pointer;
-    transition: background 120ms ease, color 120ms ease;
+    transform: translateY(-50%);
+    transition: background 140ms ease, color 140ms ease, transform 140ms ease;
 }
 
 .gh-gift-toast-close:hover {
-    background: #e8eaed;
+    background: #e7eaee;
     color: #15171a;
+    transform: translateY(-50%) scale(1.04);
 }
 
 .gh-gift-toast-close svg {
@@ -79,34 +157,46 @@
 
 .gh-gift-toast.is-dismissed {
     opacity: 0;
-    transform: translate(-50%, 16px);
+    transform: translate3d(-50%, 14px, 0) scale(0.985);
+    animation: none;
     pointer-events: none;
 }
 
-@media (max-width: 600px) {
-    .gh-gift-toast {
-        width: calc(100vw - 32px);
+@keyframes gh-gift-toast-enter {
+    to {
+        opacity: 1;
+        transform: translate3d(-50%, 0, 0) scale(1);
     }
 }
 
 @media (prefers-reduced-motion: reduce) {
-    .gh-gift-toast {
+    .gh-gift-toast,
+    .gh-gift-toast-close {
+        animation: none;
+        opacity: 1;
         transition: none;
+    }
+
+    .gh-gift-toast {
+        transform: translate3d(-50%, 0, 0);
+    }
+
+    .gh-gift-toast-close,
+    .gh-gift-toast-close:hover {
+        transform: translateY(-50%);
     }
 }
 </style>
 <aside id="gh-gift-toast" class="gh-gift-toast" role="status" aria-live="polite">
-    <div class="gh-gift-toast-icon" aria-hidden="true">
-        <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-            <path d="M12 21.488H4v-10.75a.75.75 0 0 0-1.5 0v10.75c0 .914.586 1.5 1.5 1.5h8a.75.75 0 0 0 0-1.5z"/>
-            <path d="M12.25 21.488h8v-10.75a.75.75 0 0 1 1.5 0v10.75c0 .914-.586 1.5-1.5 1.5h-8a.75.75 0 0 1 0-1.5z"/>
-            <path d="M2.682 6.238h18.636c1.004 0 1.682.546 1.682 1.5v2.25c0 .954-.678 1.5-1.682 1.5H2.682c-1.004 0-1.682-.546-1.682-1.5v-2.25c0-.954.678-1.5 1.682-1.5zm0 1.5c-.239 0-.182-.046-.182 0v2.25c0 .046-.057 0 .182 0h18.636c.239 0 .182.046.182 0v-2.25c0-.046.057 0-.182 0H2.682z"/>
-            <path d="M12.75 22.238V6.988a.75.75 0 0 0-1.5 0v15.25a.75.75 0 0 0 1.5 0z"/>
-            <path d="M3.5 17.25h17a.75.75 0 0 0 0-1.5h-17a.75.75 0 0 0 0 1.5zM7.271 5.457a12.506 12.506 0 0 0 4.51 2.255.75.75 0 0 0 .92-.918 12.473 12.473 0 0 0-2.256-4.511C8.947.777 7.705.657 6.671 1.683c-1.033 1.027-.908 2.273.533 3.714l.067.06zm.458-2.709c.397-.395.702-.366 1.596.528.587.755 1.079 1.6 1.456 2.516a11.002 11.002 0 0 1-2.549-1.487c-.865-.872-.89-1.173-.503-1.557z"/>
-            <path d="m16.796 5.397-.067.06a12.5 12.5 0 0 1-4.512 2.255.75.75 0 0 1-.918-.918 12.502 12.502 0 0 1 2.315-4.579c1.44-1.438 2.681-1.558 3.715-.531 1.033 1.026.908 2.272-.533 3.713zm-.525-2.649c-.397-.395-.702-.366-1.537.46a11.024 11.024 0 0 0-1.515 2.584 11.038 11.038 0 0 0 2.549-1.487c.865-.872.89-1.173.503-1.557z"/>
-        </svg>
+    <div class="gh-gift-toast-media {{#if @giftToast.brandUrl}}has-brand{{else}}is-fallback{{/if}}" aria-hidden="true">
+        {{#if @giftToast.brandUrl}}
+            <img class="gh-gift-toast-icon" src="{{@giftToast.brandUrl}}" alt="" loading="lazy">
+        {{/if}}
+        <span class="gh-gift-toast-pattern"{{#if @giftToast.brandUrl}} hidden{{/if}}></span>
     </div>
-    <span class="gh-gift-toast-text">{{t "You've been gifted access to this post."}}</span>
+    <span class="gh-gift-toast-content">
+        <span class="gh-gift-toast-title">{{t "You've been gifted access to this post."}}</span>
+    </span>
     <button type="button" class="gh-gift-toast-close" aria-label="{{t "Dismiss"}}">
         <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
             <path d="M3 3 L13 13 M13 3 L3 13"/>
@@ -118,12 +208,31 @@
     var toast = document.getElementById('gh-gift-toast');
     if (!toast) return;
 
+    var media = toast.querySelector('.gh-gift-toast-media');
+    var icon = toast.querySelector('.gh-gift-toast-icon');
+    var pattern = toast.querySelector('.gh-gift-toast-pattern');
+
+    if (icon && pattern) {
+        icon.addEventListener('error', function(){
+            icon.hidden = true;
+            pattern.hidden = false;
+            if (media) {
+                media.classList.remove('has-brand');
+                media.classList.add('is-fallback');
+            }
+        });
+    }
+
     var closeBtn = toast.querySelector('.gh-gift-toast-close');
     if (closeBtn) {
         closeBtn.addEventListener('click', function(){
             toast.classList.add('is-dismissed');
             // Defer removal so the fade/slide-out transition runs to completion.
-            setTimeout(function(){ if (toast.parentNode) toast.parentNode.removeChild(toast); }, 260);
+            setTimeout(function(){
+                if (toast.parentNode) {
+                    toast.parentNode.removeChild(toast);
+                }
+            }, 240);
         });
     }
 })();

--- a/ghost/core/core/frontend/helpers/tpl/gift-toast.hbs
+++ b/ghost/core/core/frontend/helpers/tpl/gift-toast.hbs
@@ -11,15 +11,15 @@
     bottom: var(--gh-gift-toast-bottom);
     left: 50%;
     z-index: 99998;
-    display: grid;
-    grid-template-columns: 64px minmax(0, 1fr);
-    align-items: stretch;
+    display: flex;
+    align-items: center;
+    gap: 12px;
     width: max-content;
     min-height: 64px;
     max-width: min(560px, calc(100vw - 32px));
-    padding: 0;
+    padding: 12px 48px 12px 12px;
     overflow: hidden;
-    background: transparent;
+    background: #ffffff;
     color: var(--gh-gift-toast-ink);
     border: none;
     border-radius: 18px;
@@ -43,12 +43,13 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 64px;
-    /* Stretches to the row height (set on the grid container) so the panel stays
-       flush when a longer locale wraps the title to a second line. */
-    min-height: 64px;
+    flex: none;
+    width: 40px;
+    min-width: 40px;
+    height: 40px;
+    min-height: 40px;
     overflow: hidden;
-    background: var(--gh-gift-toast-accent);
+    border-radius: 6px;
 }
 
 .gh-gift-toast-icon {
@@ -63,8 +64,11 @@
     display: none;
 }
 
-/* Mirrors the gift card aesthetic from apps/portal/src/components/pages/gift-page.js:
-   accent color base, Ghost orb at 0.2 opacity, noise grain at 0.1 opacity. */
+/* Fallback only — when no publication icon is set. Mirrors the gift card
+   aesthetic from apps/portal/src/components/pages/gift-page.js: accent color
+   base, Ghost orb at 0.2 opacity, noise grain at 0.1 opacity. When an icon
+   IS set the media has no background, so a transparent PNG simply shows the
+   toast's white surface rather than the accent colour. */
 .gh-gift-toast-pattern {
     display: none;
     position: absolute;
@@ -109,9 +113,6 @@
     display: flex;
     align-items: center;
     min-width: 0;
-    min-height: 64px;
-    padding: 10px 44px 10px 14px;
-    background: #ffffff;
 }
 
 .gh-gift-toast-title {

--- a/ghost/core/core/server/web/gift-preview/app.js
+++ b/ghost/core/core/server/web/gift-preview/app.js
@@ -1,8 +1,26 @@
+const path = require('path');
 const express = require('../../../shared/express');
 const controller = require('./controller');
 
+// Long-cache static texture assets shared by the gift card aesthetic
+// (gift preview OG image + reader-side gift toast). Filenames are fixed,
+// so the public URLs at /gift/assets/* can be safely cached forever.
+const ASSET_DIR = __dirname;
+const ASSETS = {
+    'gift-card-orb.png': 'image/png',
+    'gift-card-noise.png': 'image/png'
+};
+
 module.exports = function giftPreviewApp() {
     const app = express('gift-preview');
+
+    Object.keys(ASSETS).forEach((filename) => {
+        app.get(`/assets/${filename}`, (req, res) => {
+            res.set('Cache-Control', 'public, max-age=31536000, immutable');
+            res.type(ASSETS[filename]);
+            res.sendFile(path.join(ASSET_DIR, filename));
+        });
+    });
 
     app.get('/:token/image', controller.giftPreviewImage);
     app.get('/:token', controller.giftPreview);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3750

Updates the existing reader-side gift-link toast to align with the agreed design. This is purely cosmetic — the trigger, the `giftLinks` flag gating, theme override support, and i18n are all inherited unchanged from `main`.

## What changed

- Restyled the toast to a two-panel layout: the publication icon next to the announcement, with a gift-card pattern fallback when no icon is set.
- Uses the publication **icon** (square) rather than the logo, so it fills the media panel cleanly without cropping. Falls back to the accent gift-card texture, and to a flat accent panel if the textures are unavailable.
- The announcement wraps to a second line on longer locales rather than truncating; English stays on a single line.
- Serves the shared gift-card textures at `/gift/assets/*` so the fallback panel can render (reuses the existing assets already used by the gift preview image).

## Testing

- Existing `gift-links` and toast-override e2e suites pass unchanged.
