### PR TITLE
Added Shade conventions skills for AI agents

### DIFF
--- a/.agents/skills/shade-component-decision/SKILL.md
+++ b/.agents/skills/shade-component-decision/SKILL.md
@@ -17,7 +17,7 @@ Before adding anything to Shade, walk the decision flow and the promotion checkl
 | **Primitive** | `src/components/primitives/` | `Stack`, `Inline`, `Box`, `Grid`, `Container`, `Text` |
 | **Component** | `src/components/ui/` | `Button`, `Input`, `Dialog`, `Tabs`, `Card` |
 | **Recipe** | `src/components/ui/<name>.ts` (no JSX) | `inputSurface` |
-| **Pattern** | `src/components/patterns/` | `PageHeader`, `ListPage`, `KpiCard`, `Filters` |
+| **Pattern** | `src/components/patterns/` | `PageHeader`, `KpiCard`, `Filters`, `GhAreaChart` |
 
 Plus two additional barrels:
 

--- a/.agents/skills/shade-component-decision/SKILL.md
+++ b/.agents/skills/shade-component-decision/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: Shade component decision
+description: Decide which Shade layer (Token, Primitive, Component, Recipe, Pattern) a new piece of UI belongs in — and whether it should be added to Shade at all. Trigger when creating new files in apps/shade/src/components, or proposing to add a new Shade component.
+autoTrigger:
+  - fileEdit: "apps/shade/src/components/**/*.{ts,tsx}"
+---
+
+# Shade — pick the right layer (and decide whether to add to Shade at all)
+
+Before adding anything to Shade, walk the decision flow and the promotion checklist. The default is **keep code local first** — premature design system additions lock in the wrong API.
+
+## The five layers
+
+| Layer | Lives in | Examples |
+|---|---|---|
+| **Token** | `theme-variables.css`, `tailwind.theme.css` | `--background`, `--text-base`, `--radius-md` |
+| **Primitive** | `src/components/primitives/` | `Stack`, `Inline`, `Box`, `Grid`, `Container`, `Text` |
+| **Component** | `src/components/ui/` | `Button`, `Input`, `Dialog`, `Tabs`, `Card` |
+| **Recipe** | `src/components/ui/<name>.ts` (no JSX) | `inputSurface` |
+| **Pattern** | `src/components/patterns/` | `PageHeader`, `ListPage`, `KpiCard`, `Filters` |
+
+Plus two additional barrels:
+
+- **`page-templates/`** (`@tryghost/shade/page-templates`) — top-level page wrappers (`ListPage` today). Composes Patterns + Components + Primitives. If you're building a new shape that wraps a whole admin page, this is where it goes. See `shade-page-templates`.
+- **`posts-stats/`** (`@tryghost/shade/posts-stats`) — transitional layer for components shared between `apps/posts` and `apps/stats` until those merge. Don't add to it unless the file is genuinely posts-or-stats-only and shared between both apps.
+
+## Decision flow (top-to-bottom, stop at first match)
+
+1. **Just a colour, size, radius, duration?** → **Token**. Add to `theme-variables.css` (semantic) or `tailwind.theme.css` (raw `@theme`).
+2. **Layout-only (spacing, alignment, structure)?** → **Primitive**. Reuse an existing one; only add a new one if the structural shape is genuinely novel.
+3. **Generic, accessible UI control with no Ghost-specific knowledge?** → **Component**. Reuse first; only add if it doesn't exist and the promotion checklist below passes.
+4. **The same chrome / focus / density rule shared across ≥ 2 components?** → **Recipe**. A class-string function (no JSX, no React) next to the components in `src/components/ui/`.
+5. **Knows about Ghost (KPIs, members, posts, newsletters, analytics)?** → **Pattern**.
+
+**Quick gut check: generic name → Component; Ghost-shaped name → Pattern.** `Button` is web-y; `KpiCard` is Ghost-y.
+
+## Allowed dependencies (one-way)
+
+Each layer can use anything **below** it. The reverse is forbidden.
+
+- A Button can't reach into a Pattern.
+- A Primitive can't import a Component.
+- A Recipe is pure CSS classes — no React, no JSX.
+
+## Promotion checklist — add to Shade only if ALL are true
+
+1. **Reused at least twice in different surfaces.** Actual second use, not "we might reuse this."
+2. **It's generic.** A `<MembersTable>` that's just `<Table>` with three preset columns belongs in the app, not Shade.
+3. **The shape has settled.** Slots and composition have been stable across both local copies for at least one iteration.
+4. **It has a generic name.** `PageHeader`, `KpiCard`, `PostShareModal` — not `MembersFilterBar` or `PostAnalyticsHero`.
+5. **The API is slots, not props.** 3–6 named subcomponents (`.Title`, `.Actions`, `.Body`) — not `<ListPage title="..." onAdd={...} columns={...} />`.
+6. **State stays with the consumer.** No `useQuery`, no routing, no app-context reads inside Shade.
+
+**Fail any of these? Keep it local.** Build it again somewhere else first, then promote.
+
+## Common misclassifications
+
+| Tempting | Actually | Why |
+|---|---|---|
+| Add a `variant="kpi"` to `Card` | New Pattern `KpiCard` | Product-specific shape, generic Component shouldn't know about it |
+| Add `<MembersFilterBar>` to patterns | Keep local in `apps/admin-x-settings` | Single-surface name |
+| Add a one-off class string as a recipe | Inline it in the one component | Recipes are for shared rules across ≥ 2 components |
+| Add a `useQuery`-driven `<MembersList>` to patterns | Keep local — patterns are state-free | Bring-your-own state |
+| Wrap a `<div className="flex gap-3">` as a new primitive | Use `Inline gap="md"` | Already covered |
+
+## When you've decided
+
+- New **Component** or **Pattern** → also see the `shade-new-component` skill for the file/story/state checklist.
+- New **Recipe** → no JSX, follow the `recipeClasses` + `recipe()` shape (see `apps/shade/src/components/ui/input-surface.ts`).
+- New **Token** → add to `apps/shade/theme-variables.css` (semantic + dark-mode override) or `apps/shade/tailwind.theme.css` (raw `@theme`). Never an ad-hoc CSS variable in a component file.
+
+## Source of truth
+
+Full rules: `apps/shade/AGENTS.md`. Human-facing: Storybook → Overview / Layers.

--- a/.agents/skills/shade-dropdown-surface-contract/SKILL.md
+++ b/.agents/skills/shade-dropdown-surface-contract/SKILL.md
@@ -9,7 +9,7 @@ autoTrigger:
 
 `DropdownMenu`, `Select`, and `Popover` are the three Radix-backed floating menus that `Filters` and the rest of admin use. They share **one visual recipe**:
 
-```
+```text
 bg-surface-elevated-2
 border border-border/60 dark:border-border/30
 shadow-md

--- a/.agents/skills/shade-dropdown-surface-contract/SKILL.md
+++ b/.agents/skills/shade-dropdown-surface-contract/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: Shade dropdown surface contract
+description: DropdownMenu, Select, and Popover share one visual recipe (bg-surface-elevated-2 + border-border/60 dark:border-border/30 + shadow-md). Change them together. Trigger when editing any of those three Shade files.
+autoTrigger:
+  - fileEdit: "apps/shade/src/components/ui/{dropdown-menu,select,popover}.tsx"
+---
+
+# Shade — dropdown surface contract
+
+`DropdownMenu`, `Select`, and `Popover` are the three Radix-backed floating menus that `Filters` and the rest of admin use. They share **one visual recipe**:
+
+```
+bg-surface-elevated-2
+border border-border/60 dark:border-border/30
+shadow-md
+```
+
+Treat them as one component for any surface decision. **If you change the surface for one, change all three.**
+
+## Why this exists
+
+Floating menus open ON TOP of an already-elevated surface (sidebars, cards, top bars). They need to read as floating above their trigger. `--surface-elevated-2` is reserved for exactly this — popovers, dropdown content, and the sidebar user menu.
+
+In light mode the three surface tokens (`background` / `surface-elevated` / `surface-elevated-2`) flatten to near-white; the border + `shadow-md` carry elevation. In dark mode they're three distinct colours so layered surfaces stay legible without relying on borders alone.
+
+## The contract
+
+| Concern | Class |
+|---|---|
+| Background | `bg-surface-elevated-2` |
+| Border | `border border-border/60 dark:border-border/30` |
+| Shadow | `shadow-md` baseline. **`DropdownMenuContent` is the exception — it uses `shadow-lg`.** `DropdownMenuSubContent`, `SelectContent`, and `PopoverContent` all use `shadow-md`. |
+| Radius | `rounded-md` (component default) |
+| Animation | Standard Radix `data-[state=open]:` enter/exit set |
+
+The shadow split is intentional: the top-level `DropdownMenuContent` opens straight out of an unelevated trigger (a button on the page canvas) and needs the stronger drop. `DropdownMenuSubContent` already pops from inside a floating menu, so it uses the lighter `shadow-md` to avoid double-stacking elevation. `Select` and `Popover` also open from low-elevation triggers but their content sits closer to the trigger surface, so `shadow-md` is enough.
+
+The `dark:border-border/30` is a legitimate exception to the no-`dark:`-for-colour rule — it's an opacity modifier on an existing semantic token. See `shade-no-dark-variants`.
+
+## Changing the surface
+
+If a design change touches the floating-menu surface (background, border, shadow, elevation), edit **all three** files:
+
+- `apps/shade/src/components/ui/dropdown-menu.tsx` (`DropdownMenuContent` and `DropdownMenuSubContent`)
+- `apps/shade/src/components/ui/select.tsx` (`SelectContent`)
+- `apps/shade/src/components/ui/popover.tsx` (`PopoverContent`)
+
+If a fourth Radix-backed surface needs the same recipe, extract it as a `floatingSurface` recipe under `apps/shade/src/components/ui/`. Two consumers is too thin to justify a Recipe; three is the current count and just covered by mirroring.
+
+## Items inside the menu
+
+Hover state on menu items uses `--interactive-hover` (`bg-interactive-hover`) — the generic hover token. **Don't** use raw greys or apply ad-hoc opacity modifiers (`hover:bg-gray-900/30`). The interactive tokens already handle dark-mode translucency so they composite over the floating surface correctly.
+
+## Don't
+
+```tsx
+// BAD — changing dropdown surface but not Select / Popover
+// In dropdown-menu.tsx:
+'bg-surface-elevated border border-border/40 shadow-xl'  // <-- drifted from contract
+
+// BAD — raw greys for hover instead of the interactive token
+'hover:bg-gray-100 dark:hover:bg-gray-800'
+
+// BAD — surface-elevated (not -2) on a floating menu
+// loses the visual elevation above already-elevated triggers
+'bg-surface-elevated'
+```
+
+## Related skill
+
+Hover/active/selected state tokens (`--interactive-hover`, `--button-hover`, `--tab-hover`, `--table-row-hover`): see `shade-tokens-not-hex`.
+
+## Source of truth
+
+`apps/shade/AGENTS.md` (Tokens & dark mode → Dropdown surface contract). Storybook → Tokens / Tokens Guide.

--- a/.agents/skills/shade-imports/SKILL.md
+++ b/.agents/skills/shade-imports/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: Shade imports
+description: Import Shade from layer-specific subpaths (primitives, components, patterns, page-templates, utils), never the root barrel. Trigger when editing TSX/TS in Shade-consuming apps.
+autoTrigger:
+  - fileEdit: "apps/{shade,admin,admin-x-settings,admin-x-framework,posts,stats,activitypub}/**/*.{ts,tsx}"
+---
+
+# Shade imports
+
+Always import Shade from its **layer-specific subpath**. Never from the root barrel `@tryghost/shade`.
+
+## Correct
+
+```ts
+import {Stack, Inline, Box, Grid, Container, Text} from '@tryghost/shade/primitives';
+import {Button, Input, Dialog} from '@tryghost/shade/components';
+import {PageHeader, KpiCard, Filters} from '@tryghost/shade/patterns';
+import {ListPage} from '@tryghost/shade/page-templates';
+import {PostShareModal} from '@tryghost/shade/posts-stats';
+import {cn, formatNumber} from '@tryghost/shade/utils';
+import {ShadeApp} from '@tryghost/shade/app';
+```
+
+**Note:** `ListPage` is in `@tryghost/shade/page-templates`, not `/patterns`. Page templates are top-level page wrappers; patterns are the building blocks they compose.
+
+## Incorrect
+
+```ts
+// BAD — root barrel
+import {Button, Stack} from '@tryghost/shade';
+
+// BAD — deep path into source
+import {Button} from '@tryghost/shade/src/components/ui/button';
+```
+
+## Inside Shade itself
+
+When editing files under `apps/shade/src/**`, use the `@/` alias for cross-file imports:
+
+```ts
+import {cn} from '@/lib/utils';
+import {inputSurface} from '@/components/ui/input-surface';
+```
+
+## Why
+
+Subpath imports make the layer (primitive/component/pattern) visible at the call site, which is the first piece of information a reader needs. The root barrel hides that and encourages cross-layer drift.

--- a/.agents/skills/shade-input-surface-recipe/SKILL.md
+++ b/.agents/skills/shade-input-surface-recipe/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: Shade inputSurface recipe
+description: Use the inputSurface() recipe for form-control chrome (border, background, radius, focus ring, invalid state) — don't roll your own. Trigger when editing form-control-shaped files in Shade.
+autoTrigger:
+  - fileEdit: "apps/shade/src/components/ui/{input,textarea,input-group,select,combobox,multi-select-combobox,dropzone,calendar,command}.tsx"
+---
+
+# Shade — `inputSurface` recipe
+
+Form controls share one visual rule: border, background, radius, transition, focus ring, invalid state. That rule lives in **`inputSurface`** (`apps/shade/src/components/ui/input-surface.ts`) and is used by `Input`, `Textarea`, `InputGroup`, and the `Select` trigger. Don't duplicate the chrome — compose the recipe.
+
+```ts
+import {inputSurface, inputSurfaceClasses} from '@/components/ui/input-surface';
+import {cn} from '@/lib/utils';
+```
+
+## Two common modes
+
+### `inputSurface('self')` — directly on the focusable element
+
+Use on `<input>`, `<textarea>`, or any element that itself receives focus.
+
+```tsx
+<input
+    className={cn(
+        inputSurface('self'),
+        'flex h-9 w-full px-3 py-1 text-control placeholder:text-muted-foreground',
+        className
+    )}
+    {...props}
+/>
+```
+
+Covers: base chrome + `focus-visible:` ring + `aria-[invalid=true]` styling + `disabled:` opacity.
+
+### `inputSurface('within')` — on a wrapper containing a focusable child
+
+Use when the styled element is the wrapper (e.g. `InputGroup`) and focus state should react to **any** focusable descendant via `:has()`.
+
+```tsx
+<div className={cn(
+    inputSurface('within'),
+    'flex h-9 items-center gap-2 px-3',
+    className
+)}>
+    <Icon />
+    <input className="bg-transparent outline-hidden focus:outline-hidden" />
+</div>
+```
+
+Covers: base chrome + `has-[:focus-visible]:` ring + `has-[[aria-invalid=true]]:` styling. (No disabled atom — wrappers don't get a `disabled` HTML attribute.)
+
+## Edge case — only one specific child triggers focus state
+
+When `'within'` is too broad (e.g. a wrapper with multiple focusables but only one should drive chrome), compose atoms manually so Tailwind's JIT can statically detect the class string:
+
+```tsx
+import {inputSurfaceClasses} from '@/components/ui/input-surface';
+
+<div className={cn(
+    inputSurfaceClasses.base,
+    inputSurfaceClasses.invalidWithin,
+    // Literal class string — Tailwind needs to see it as text
+    'has-[[data-slot=control]:focus-visible]:border-focus-ring',
+    'has-[[data-slot=control]:focus-visible]:ring-2',
+    'has-[[data-slot=control]:focus-visible]:ring-focus-ring/25'
+)} />
+```
+
+Available atoms:
+
+- `inputSurfaceClasses.base` — border, background, radius, transition
+- `inputSurfaceClasses.focusSelf` — focus chrome for self mode
+- `inputSurfaceClasses.focusWithin` — focus chrome for within mode
+- `inputSurfaceClasses.invalidSelf` — `aria-[invalid=true]` styling on self
+- `inputSurfaceClasses.invalidWithin` — `aria-[invalid=true]` styling on a descendant
+- `inputSurfaceClasses.disabledSelf` — disabled styling for self mode
+
+## What the recipe owns vs. what you add
+
+| Recipe owns | You add |
+|---|---|
+| Border (`border-control-border`) | Height, padding |
+| Background (`bg-surface-elevated`, `dark:bg-transparent`) | Typography (`text-control`, `text-sm`) |
+| Radius (`rounded-md`) | Layout (`flex`, `items-center`) |
+| Transition (`transition-colors`) | Placeholder styling |
+| Focus ring (`focus-visible:ring-focus-ring/25`) | Component-specific tweaks |
+| Invalid state (`aria-[invalid=true]:border-destructive`) | Icons / slot positioning |
+| Disabled (`disabled:opacity-50`) — self only | — |
+
+## Don't
+
+```tsx
+// BAD — rolling your own focus chrome on a form control
+<input className="
+    rounded-md border border-input bg-background
+    focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring
+    aria-[invalid=true]:border-red-500
+    disabled:opacity-50
+" />
+
+// BAD — using inputSurface('within') on a self-focused element (over-broad)
+<input className={cn(inputSurface('within'), 'h-9')} />
+
+// BAD — non-literal class concatenation that Tailwind JIT can't see
+const dyn = `has-[[data-slot=control]:focus-visible]:${ringColor}`;
+```
+
+## Source of truth
+
+`apps/shade/src/components/ui/input-surface.ts` — the JSDoc on `inputSurface` is canonical. Human docs: Storybook → Recipes / inputSurface.

--- a/.agents/skills/shade-new-component/SKILL.md
+++ b/.agents/skills/shade-new-component/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: Shade new component
+description: Acceptance checklist for adding or editing a Shade component or pattern file — naming, sibling story, className forwarding, cva variants, required states, recipe usage. Trigger when editing files in apps/shade/src/components.
+autoTrigger:
+  - fileEdit: "apps/shade/src/components/**/*.{ts,tsx}"
+---
+
+# Shade — new component / pattern checklist
+
+Before marking a Shade component or pattern done, this checklist must pass.
+
+## Files and naming
+
+- File: **kebab-case** (`dropdown-menu.tsx`) — matches ShadCN CLI output. Don't rename for casing.
+- Exported identifier: **PascalCase** (`DropdownMenu`).
+- Hooks, functions, variables: camelCase.
+- Sibling **`<name>.stories.tsx`** is required (same folder).
+- Inside Shade itself, import via the `@/` alias (`@/lib/utils`, `@/components/ui/input-surface`).
+
+## Storybook title prefix
+
+| Layer | Title |
+|---|---|
+| Primitive | `Primitives / <Name>` |
+| Component | `Components / <Name>` |
+| Recipe | `Recipes / <Name>` |
+| Pattern | `Patterns / <Name>` |
+| Posts–Stats interim | `Posts–Stats / <Name>` |
+| Token gallery | `Tokens / <Topic>` |
+
+Required on every story file:
+
+- `tags: ['autodocs']`
+- `parameters.docs.description.component` — short one-line summary
+- Per-story `parameters.docs.description.story` — one-liner explaining when to use that variant
+- One story per important variant/state. Many small focused stories > one prose-heavy story.
+
+## Component shape
+
+```tsx
+import * as React from 'react';
+import {cva, type VariantProps} from 'class-variance-authority';
+import {cn} from '@/lib/utils';
+
+const thingVariants = cva('base-classes-here', {
+    variants: {
+        variant: {default: '...', destructive: '...'},
+        size: {default: '...', sm: '...'}
+    },
+    defaultVariants: {variant: 'default', size: 'default'}
+});
+
+export interface ThingProps
+    extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof thingVariants> {}
+
+const Thing = React.forwardRef<HTMLDivElement, ThingProps>(
+    ({className, variant, size, ...props}, ref) => (
+        <div
+            ref={ref}
+            className={cn(thingVariants({variant, size, className}))}
+            {...props}
+        />
+    )
+);
+Thing.displayName = 'Thing';
+
+export {Thing, thingVariants};
+```
+
+Hard requirements:
+
+- `className` forwarded and merged via `cn()` — never overwritten, never dropped. Applies to every component that renders DOM.
+- Visual/interactive props only (`variant`, `size`, `loading`). **No workflow props** (`isMembersPage`, `layoutMode`) — those mean you actually need a Pattern wrapper.
+- Multi-region components expose compound subcomponents (`.Title`, `.Actions`, `.Body`) — not a prop bag.
+
+When applicable:
+
+- **`forwardRef`** — use when the component renders a single DOM element consumers might need a ref to (most UI controls). Skip for: pure provider/context wrappers, Radix root re-exports that don't render DOM themselves, and components whose `ref` semantics are already handled by a child.
+- **`cva()`** — use when the component has variants or stateful class branches (`variant`, `size`, `tone`). Skip for simple single-style components where a `cn(...)` call is clearer.
+- **Recipes** (`<name>.ts`, no JSX): no `forwardRef`, no `cva()`, no React. They return class strings.
+
+## Required states (all four)
+
+Every interactive component must work in:
+
+- **default**
+- **hover**
+- **focus-visible** (use `focus-visible:`, never `focus:`)
+- **disabled**
+
+Each state visible in the story. Optional states (active, loading, error, empty) only when they apply.
+
+For form controls, drive chrome through the **`inputSurface` recipe** — don't roll your own border/focus ring. See the `shade-input-surface-recipe` skill.
+
+## Tokens
+
+- No hex values. No `bg-gray-200`-style raw palette utilities for UI chrome.
+- No `dark:` variants for colour — semantic tokens handle dark mode.
+
+See `shade-tokens-not-hex` and `shade-no-dark-variants`.
+
+## Before marking done
+
+- [ ] Lives in the right layer (`shade-component-decision`)
+- [ ] kebab-case filename, PascalCase export, sibling `<name>.stories.tsx`
+- [ ] `className` forwarded and merged with `cn()` (always)
+- [ ] `forwardRef` if the component renders DOM consumers might ref
+- [ ] `cva()` if the component has variants; `defaultVariants` set
+- [ ] All four required states work and are visible in the story
+- [ ] Semantic tokens only — no hex, no raw greys, no `dark:` colour variants
+- [ ] No product-specific props on a generic Component
+- [ ] Story has `tags: ['autodocs']`, component description, and one-line per-story descriptions
+- [ ] `pnpm lint`, `pnpm test`, and Storybook all clean
+
+## Source of truth
+
+`apps/shade/AGENTS.md`. Human docs: Storybook → Overview / Contributing.

--- a/.agents/skills/shade-no-dark-variants/SKILL.md
+++ b/.agents/skills/shade-no-dark-variants/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: Shade no dark variants
+description: Don't write dark: Tailwind variants for colour in Shade or admin apps — semantic tokens flip in dark mode automatically. Trigger when editing TSX in Shade-consuming apps.
+autoTrigger:
+  - fileEdit: "apps/{shade,admin,admin-x-settings,admin-x-framework,posts,stats,activitypub}/**/*.tsx"
+---
+
+# Shade — don't use `dark:` for colour
+
+Shade's semantic tokens (`bg-background`, `text-foreground`, `border-border-default`, `bg-surface-elevated`, …) already flip between light and dark mode. Writing `dark:bg-...` / `dark:text-...` / `dark:border-...` means the engineer reached for a raw, non-semantic token — fix the token, don't patch with a `dark:` variant.
+
+## Correct
+
+```tsx
+<div className="bg-surface-elevated border border-border-default text-foreground">
+    <p className="text-muted-foreground">Hint text</p>
+</div>
+```
+
+## Incorrect
+
+```tsx
+// BAD — using dark: to patch a raw palette utility
+<div className="bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+
+// BAD — duplicating a semantic token with a dark: override
+<div className="bg-surface-elevated dark:bg-surface-elevated">
+```
+
+## How to fix a `dark:` smell
+
+1. Identify what the class describes — surface? text? border? hover?
+2. Pick the matching **semantic token** (see the `shade-tokens-not-hex` skill for the inventory).
+3. Drop both the light and the `dark:` halves; the token handles both modes.
+
+## Exceptions
+
+Assets that are genuinely different in dark mode and can't be expressed as a token:
+
+- Logos and brand marks
+- Illustrations / SVG art
+- Screenshots or imagery
+
+For these, `dark:` is fine because there's nothing semantic to express.
+
+Some existing Shade components also use `dark:` for ring opacity (e.g. `dark:ring-destructive/40` inside `inputSurface`). When a token doesn't exist for the variant you need and the value is an opacity modifier on an existing token, a narrow `dark:` is acceptable — but first check whether a new token belongs in `theme-variables.css`.
+
+## When debugging dark mode
+
+If something looks wrong only in dark mode, the fix is almost always **wrong token**, not **missing `dark:` variant**. Re-pick from the semantic surface table; check `apps/shade/theme-variables.css` for what each token resolves to.

--- a/.agents/skills/shade-no-dark-variants/SKILL.md
+++ b/.agents/skills/shade-no-dark-variants/SKILL.md
@@ -23,7 +23,7 @@ Shade's semantic tokens (`bg-background`, `text-foreground`, `border-border-defa
 // BAD — using dark: to patch a raw palette utility
 <div className="bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
 
-// BAD — duplicating a semantic token with a dark: override
+// BAD — redundant: the semantic token already flips itself, so the dark: variant adds a duplicate rule that does nothing. Reading it suggests dark mode is special-cased here when it isn't.
 <div className="bg-surface-elevated dark:bg-surface-elevated">
 ```
 

--- a/.agents/skills/shade-page-templates/SKILL.md
+++ b/.agents/skills/shade-page-templates/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: Shade page templates
+description: Pick the right Shade page template (ListPage, PageHeader) for a new admin page instead of inventing chrome. Trigger when creating new admin pages or routes in apps/admin, apps/admin-x-settings, apps/posts, apps/stats, apps/activitypub.
+autoTrigger:
+  - fileEdit: "apps/{admin,admin-x-settings,activitypub,posts,stats}/src/**/*.tsx"
+---
+
+# Shade — page templates
+
+When building a new admin page, the first question is **what page type is this?** — then reach for the matching pattern instead of inventing chrome.
+
+## Page type taxonomy
+
+### List page
+
+Browsing or scanning a collection of items.
+
+- **Live examples**: Members, Tags, Comments, Automations, ActivityPub.
+- **Chrome shape**: `PageHeader` (title + count + search/filter/actions) → table or list → empty state → pagination.
+- **Pattern**: `ListPage` (composes `PageHeader`). Heavy filter UI uses `Filters`.
+
+### Detail page
+
+Working with a single item — viewing, editing, or both.
+
+- **Live examples**: Post editor.
+- **Chrome shape**: `PageHeader` with breadcrumb + title + meta, a primary action area, and a content area dedicated to the item.
+- **Pattern**: not built this milestone. Use `PageHeader` directly and lay out the body yourself.
+
+### Settings
+
+Out of scope for the current page-template milestone. Don't force a settings page into `ListPage` or `PageHeader`.
+
+### Workflow / multi-step flows
+
+No standard yet — too few examples. Don't standardise prematurely.
+
+## Canonical list page skeleton
+
+```tsx
+import {ListPage} from '@tryghost/shade/page-templates';
+import {PageHeader, ViewBar, FilterBar} from '@tryghost/shade/patterns';
+import {Button, EmptyIndicator, Table} from '@tryghost/shade/components';
+
+<ListPage>
+  <ListPage.Header>
+    {/* sticky={false} — ListPage.Header owns stickiness and blur */}
+    <PageHeader sticky={false} blurredBackground={false}>
+      <PageHeader.Left>
+        <PageHeader.Title>
+          Members<PageHeader.Count>{count}</PageHeader.Count>
+        </PageHeader.Title>
+      </PageHeader.Left>
+      <PageHeader.Actions>
+        <PageHeader.ActionGroup>
+          <Button>Add member</Button>
+        </PageHeader.ActionGroup>
+      </PageHeader.Actions>
+    </PageHeader>
+    <ViewBar>{/* optional */}</ViewBar>
+    <FilterBar>{/* optional — auto-collapses when empty */}</FilterBar>
+  </ListPage.Header>
+  <ListPage.Body>
+    {items.length === 0 ? <EmptyIndicator title='No members yet' /> : <Table>...</Table>}
+  </ListPage.Body>
+</ListPage>
+```
+
+## Gotchas
+
+- **`sticky={false}` on `PageHeader` inside `ListPage.Header`.** The wrapper handles stickiness and blur — leaving `PageHeader` sticky stacks two sticky containers and breaks scroll.
+- **Don't put `useQuery` inside a pattern.** State lives in the consumer. Patterns are layout/composition contracts.
+- **`PageHeader` is slot-based** (`.Left`, `.Title`, `.Count`, `.Description`, `.Meta`, `.Actions`, `.ActionGroup`, `.Breadcrumb`) — don't pass a prop bag.
+- **`FilterBar` auto-collapses when empty** — render it unconditionally; no need to conditionally mount.
+
+## Subcomponent inventory (PageHeader)
+
+- `PageHeader.Left` — title block container
+- `PageHeader.Breadcrumb` — small muted breadcrumb above the title
+- `PageHeader.Title` — H1, accepts inline `Count`
+- `PageHeader.Count` — inline secondary count next to the title
+- `PageHeader.Description` — paragraph below the title
+- `PageHeader.Meta` — small muted metadata line below
+- `PageHeader.Actions` — right-side action area
+- `PageHeader.ActionGroup` — grouping for buttons
+
+## When ListPage doesn't fit
+
+- The page is a **Detail page** → use `PageHeader` directly; build the body from primitives + components.
+- The page is **Settings** → out of scope; use whatever the surrounding settings shell uses.
+- The page is a **multi-step flow** → no pattern yet; assemble from primitives.
+
+If you're tempted to force a non-list shape into `ListPage`, stop and check whether you're actually building one of those three other shapes.
+
+## Source of truth
+
+`apps/shade/AGENTS.md`. Human docs: Storybook → Page Templates / Page Types.

--- a/.agents/skills/shade-shadcn-install/SKILL.md
+++ b/.agents/skills/shade-shadcn-install/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: Shade ShadCN install
+description: Guardrails for running `pnpm dlx shadcn@latest add` in Shade — never overwrite existing components, fresh branch first, swap raw colours for semantic tokens after integrating. Trigger when the user proposes a shadcn add, or when a fresh ShadCN-shaped file lands in apps/shade/src/components/ui.
+autoTrigger:
+  - fileEdit: "apps/shade/src/components/ui/**/*.tsx"
+---
+
+# Shade — ShadCN install guardrails
+
+Most new Shade components start from a ShadCN install. The CLI is destructive by default — follow these guardrails.
+
+## Command
+
+```bash
+pnpm dlx shadcn@latest add <component-name>
+```
+
+(Use `pnpm`, not `npx` / `yarn` / `bunx`. Ghost is pnpm.)
+
+## Before running
+
+1. **Be on a fresh branch.** The CLI's diff is mixed in with your branch's changes otherwise.
+2. **Check if the component already exists in `apps/shade/src/components/ui/`.** If it does, **do not run the CLI against the repo** — generate into a scratch repo and manually port the parts you want. The CLI will offer to overwrite, and you'd lose Shade customisations.
+
+## During the prompts
+
+- If asked to overwrite an existing file: **choose No.** Always.
+- If asked about path aliases: keep `@/`.
+
+## After the file lands — required cleanup
+
+Raw ShadCN output is not Shade-quality yet. Do all of these:
+
+1. **Swap raw colours for semantic tokens.** ShadCN ships things like `bg-white`, `border-gray-200`, `text-zinc-500`. Replace with `bg-surface-elevated`, `border-border-default`, `text-muted-foreground`, etc. See the `shade-tokens-not-hex` skill for the inventory.
+2. **Remove any `dark:` colour variants.** Semantic tokens flip automatically. See `shade-no-dark-variants`.
+3. **Use the `@/` alias** for internal imports (`@/lib/utils`, `@/components/ui/...`) — not relative paths.
+4. **Ensure all four required states** work: default, hover, focus-visible, disabled. (`focus-visible:` only — never `focus:`.)
+5. **Trim props that hint at a specific surface.** If a prop name reads like product workflow (`isMembersPage`, `layoutMode`), it doesn't belong on a generic Component — extract a Pattern instead.
+6. **For form controls**, drive border/background/focus through the `inputSurface` recipe instead of duplicating the chrome. See `shade-input-surface-recipe`.
+7. **Add a sibling `<name>.stories.tsx`** if one isn't already there. Copy useful examples from `https://ui.shadcn.com/docs/components/<name>` into stories. See `shade-new-component`.
+8. **forwardRef + className merge via `cn()`** — both are required.
+
+## What ShadCN gets wrong that Shade fixes
+
+| ShadCN default | Shade convention |
+|---|---|
+| `bg-background dark:bg-background` | `bg-background` (token already flips) |
+| `bg-white text-zinc-950 dark:bg-zinc-950 dark:text-zinc-50` | `bg-surface-elevated text-foreground` |
+| `border border-input` | `border border-control-border` (form controls) or `border-border-default` (other chrome) |
+| Direct `focus-visible:ring-2 focus-visible:ring-ring` chrome on every input | `inputSurface('self')` recipe |
+| Relative imports `import {cn} from "../../lib/utils"` | `@/` alias: `import {cn} from '@/lib/utils'` |
+
+## When NOT to use the CLI
+
+- The component already exists in Shade — port from a scratch repo instead.
+- You're building a Pattern (something Ghost-shaped like `KpiCard`, `PageHeader`). ShadCN doesn't ship Patterns — write it from primitives + components.
+- It's a Recipe (pure class-string function). ShadCN doesn't ship Recipes.
+
+## Source of truth
+
+`apps/shade/AGENTS.md`, Storybook → Overview / Contributing.

--- a/.agents/skills/shade-tokens-not-hex/SKILL.md
+++ b/.agents/skills/shade-tokens-not-hex/SKILL.md
@@ -18,8 +18,9 @@ Drive every UI colour/border/surface through **semantic tokens**. They flip in d
 | Floating menu on top of elevated | `bg-surface-elevated-2` | `--surface-elevated-2` |
 | Primary text | `text-foreground` / `text-primary` | `--text-primary` |
 | Secondary / muted text | `text-muted-foreground` | `--text-secondary` |
-| Standard border | `border-border` / `border-border-default` | `--border-default` |
-| Form-control border | `border-control-border` | `--control-border` |
+| Default border (cards, banners, dividers — opaque) | `border-border-default` | `--border-default` |
+| Compositing border for floating surfaces (popover, dropdown, select — translucent in dark mode, usually with an opacity modifier like `/60` or `/30`) | `border-border` | `--border` |
+| Form-control border (inputs, selects, outline buttons) | `border-control-border` | `--control-border` |
 | Hover (generic) | `bg-interactive-hover` | `--interactive-hover` |
 | Outline button hover | `bg-button-hover` | `--button-hover` |
 | Tabs / page menu hover/active | `bg-tab-hover`, `bg-tab-active` | `--tab-hover`, `--tab-active` |
@@ -27,7 +28,7 @@ Drive every UI colour/border/surface through **semantic tokens**. They flip in d
 | Destructive | `bg-destructive`, `text-destructive` | `--destructive` |
 | Focus ring | `ring-focus-ring`, `border-focus-ring` | `--focus-ring` |
 
-Full inventory: `apps/shade/theme-variables.css`.
+Full inventory: `apps/shade/theme-variables.css` — this is where the CSS custom property **values** live, including the `.dark { ... }` overrides. The companion file `apps/shade/tailwind.theme.css` is the Tailwind v4 `@theme` block that **maps** Tailwind utility names (`bg-foreground`, `text-muted-foreground`, etc.) to the variables defined in `theme-variables.css`, plus the raw `--color-*` scale. Edit `theme-variables.css` to change a token's value; edit `tailwind.theme.css` to wire a new utility name or add a raw colour.
 
 ## Surface elevation — pick by what's behind it
 

--- a/.agents/skills/shade-tokens-not-hex/SKILL.md
+++ b/.agents/skills/shade-tokens-not-hex/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: Shade tokens, not hex
+description: Use Shade semantic tokens (bg-background, text-foreground, border-border-default, bg-surface-elevated) — never hex, hsl(), or bg-gray-200-style raw palette utilities for UI chrome. Trigger when editing TSX/CSS in Shade-consuming apps.
+autoTrigger:
+  - fileEdit: "apps/{shade,admin,admin-x-settings,admin-x-framework,posts,stats,activitypub}/**/*.{tsx,css}"
+---
+
+# Shade tokens, not hex
+
+Drive every UI colour/border/surface through **semantic tokens**. They flip in dark mode automatically. Hardcoded hex, `hsl(...)`, or raw palette utilities (`bg-gray-200`, `text-zinc-500`) break dark mode and theming.
+
+## Use these instead
+
+| Concern | Semantic token (Tailwind) | CSS var |
+|---|---|---|
+| Page canvas | `bg-background` | `--background` |
+| One step above page | `bg-surface-elevated` | `--surface-elevated` |
+| Floating menu on top of elevated | `bg-surface-elevated-2` | `--surface-elevated-2` |
+| Primary text | `text-foreground` / `text-primary` | `--text-primary` |
+| Secondary / muted text | `text-muted-foreground` | `--text-secondary` |
+| Standard border | `border-border` / `border-border-default` | `--border-default` |
+| Form-control border | `border-control-border` | `--control-border` |
+| Hover (generic) | `bg-interactive-hover` | `--interactive-hover` |
+| Outline button hover | `bg-button-hover` | `--button-hover` |
+| Tabs / page menu hover/active | `bg-tab-hover`, `bg-tab-active` | `--tab-hover`, `--tab-active` |
+| Table row hover | `bg-table-row-hover` | `--table-row-hover` |
+| Destructive | `bg-destructive`, `text-destructive` | `--destructive` |
+| Focus ring | `ring-focus-ring`, `border-focus-ring` | `--focus-ring` |
+
+Full inventory: `apps/shade/theme-variables.css`.
+
+## Surface elevation — pick by what's behind it
+
+1. `--background` → body, app shell, editor.
+2. `--surface-elevated` → sidebars, cards, top bars, sticky headers.
+3. `--surface-elevated-2` → floating menus (DropdownMenu, Select, Popover) and the sidebar user menu.
+
+In light mode these all flatten to near-white; borders/shadows carry the elevation. In dark mode they're three distinct colours.
+
+## Interactive surfaces — use the dedicated tokens
+
+Hover, active, and selected states are their own tokens — don't reach for raw greys or apply `/30` opacity modifiers ad-hoc.
+
+| Token | Use for |
+|---|---|
+| `--interactive-hover` | Generic hover: dropdown items, menu items, list rows, filter options |
+| `--button-hover` | Outline / dropdown `Button` hover (aliased to `--interactive-hover`; separate so it can diverge) |
+| `--tab-hover` / `--tab-active` | Tabs (button, button-sm, pill, kpis), PageMenu, sidebar menu items, active Toggle (dark) |
+| `--table-row-hover` | Shade Table row hover. Also visually-table-like lists (analytics top posts, comments list, members sticky cell). Opaque, unlike the other hover tokens |
+
+## Form-control border
+
+Inputs, textareas, outline `Button`s, dropdown triggers, and the `inputSurface` recipe use `--control-border`, **not** `--border-default`. In dark mode it lifts a step above the page border so form controls keep contrast against the page surface. Borders inside cards or popovers can keep using `--border-default`.
+
+## Correct
+
+```tsx
+<div className="bg-surface-elevated border border-border-default rounded-md p-4">
+    <p className="text-foreground">Primary copy</p>
+    <p className="text-sm text-muted-foreground">Secondary copy</p>
+</div>
+```
+
+## Incorrect
+
+```tsx
+// BAD — raw palette utilities
+<div className="bg-gray-50 dark:bg-gray-900 border border-gray-200">
+
+// BAD — hex values
+<div style={{ backgroundColor: '#f9fafb', color: '#111' }}>
+
+// BAD — wrapping a token in hsl() (it already contains hsl())
+<div style={{ background: 'hsl(var(--background))' }}>
+
+// BAD — opacity-modifier-on-raw-grey instead of the hover token
+<div className="hover:bg-gray-900/30">
+```
+
+## Inside CSS
+
+```css
+/* Correct — variable already contains hsl(...) */
+.thing { background: var(--surface-elevated); }
+
+/* Incorrect — double-wraps */
+.thing { background: hsl(var(--surface-elevated)); }
+```
+
+## When no semantic token fits
+
+Use a **raw token** from `apps/shade/tailwind.theme.css` (chart series, brand assets, illustrations) — never a literal hex. If you need a new colour, add it to `theme-variables.css` (semantic) or `tailwind.theme.css` (raw `@theme`). Don't introduce ad-hoc CSS variables in component files.

--- a/.agents/skills/shade-use-primitives/SKILL.md
+++ b/.agents/skills/shade-use-primitives/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: Shade use primitives
+description: Replace bare divs that only carry flex/grid/gap utilities with Shade primitives (Stack, Inline, Box, Grid, Container, Text). Use semantic gap="md" instead of gap-4. Trigger when editing TSX in Shade-consuming apps.
+autoTrigger:
+  - fileEdit: "apps/{shade,admin,admin-x-settings,admin-x-framework,posts,stats,activitypub}/**/*.tsx"
+---
+
+# Shade — use primitives, not flex divs
+
+A `<div>` whose className is only `flex / grid / gap / items-* / justify-*` utilities is a primitive call site. Use a Shade primitive instead so layouts read by **intent**, not by class string.
+
+```ts
+import {Stack, Inline, Box, Grid, Container, Text} from '@tryghost/shade/primitives';
+```
+
+## Picking the primitive
+
+| You need | Use | Element |
+|---|---|---|
+| Column of children | `Stack` | flex-col |
+| Row of children | `Inline` | flex-row (with optional `wrap`, `as`) |
+| Padding / radius around content | `Box` | div with `padding`, `radius` props |
+| Two-dimensional layout | `Grid` | display: grid |
+| Width-constrained shell | `Container` | max-width wrapper |
+| Text with size/tone/weight | `Text` | `as`, `size`, `tone`, `weight` |
+
+## Use the semantic gap scale, not raw numbers
+
+`gap="md"` reads as intent and resolves to the shared spacing scale. Mapping:
+
+| Step | Tailwind | Use for |
+|---|---|---|
+| `none` | `gap-0` | flush |
+| `xs` | `gap-1` | inline icons-to-text |
+| `sm` | `gap-2` | dense lists, badges |
+| `md` | `gap-3` | default row/column spacing |
+| `lg` | `gap-5` | section spacing |
+| `xl` | `gap-6` | between major blocks |
+| `2xl` | `gap-8` | page-level rhythm |
+
+The same scale applies to `Box` padding (`padding="md"` → `p-3`).
+
+## Correct
+
+```tsx
+<Box padding="lg" radius="md" className="border border-border-default">
+    <Inline align="center" gap="md" justify="between">
+        <Stack gap="xs">
+            <Text weight="semibold">Email notifications</Text>
+            <Text size="sm" tone="secondary">Get notified about engagement.</Text>
+        </Stack>
+        <Switch />
+    </Inline>
+</Box>
+```
+
+## Incorrect
+
+```tsx
+// BAD — bare div doing flex layout
+<div className="flex flex-col gap-2">
+    <div className="font-semibold">Title</div>
+    <div className="text-sm text-gray-600">Hint</div>
+</div>
+
+// BAD — raw gap-4 instead of gap="md"
+<Stack className="gap-4">
+```
+
+## When NOT to reach for a primitive
+
+- A pattern already exists for the shape (page header → `PageHeader`, list page → `ListPage`).
+- The wrapper is starting to know about Ghost data — that's a Pattern, not a primitive composition.
+- You're inside a Shade primitive's own implementation.
+
+## className still works
+
+Primitives forward `className` and merge with `cn()`. Use it for one-offs the prop API doesn't cover (e.g. `className="border border-border-default"`). Don't reach for `className` to set `flex`, `gap`, `align`, or `justify` — that's what the props are for.

--- a/.claude/skills/shade-component-decision
+++ b/.claude/skills/shade-component-decision
@@ -1,0 +1,1 @@
+../../.agents/skills/shade-component-decision

--- a/.claude/skills/shade-dropdown-surface-contract
+++ b/.claude/skills/shade-dropdown-surface-contract
@@ -1,0 +1,1 @@
+../../.agents/skills/shade-dropdown-surface-contract

--- a/.claude/skills/shade-imports
+++ b/.claude/skills/shade-imports
@@ -1,0 +1,1 @@
+../../.agents/skills/shade-imports

--- a/.claude/skills/shade-input-surface-recipe
+++ b/.claude/skills/shade-input-surface-recipe
@@ -1,0 +1,1 @@
+../../.agents/skills/shade-input-surface-recipe

--- a/.claude/skills/shade-new-component
+++ b/.claude/skills/shade-new-component
@@ -1,0 +1,1 @@
+../../.agents/skills/shade-new-component

--- a/.claude/skills/shade-no-dark-variants
+++ b/.claude/skills/shade-no-dark-variants
@@ -1,0 +1,1 @@
+../../.agents/skills/shade-no-dark-variants

--- a/.claude/skills/shade-page-templates
+++ b/.claude/skills/shade-page-templates
@@ -1,0 +1,1 @@
+../../.agents/skills/shade-page-templates

--- a/.claude/skills/shade-shadcn-install
+++ b/.claude/skills/shade-shadcn-install
@@ -1,0 +1,1 @@
+../../.agents/skills/shade-shadcn-install

--- a/.claude/skills/shade-tokens-not-hex
+++ b/.claude/skills/shade-tokens-not-hex
@@ -1,0 +1,1 @@
+../../.agents/skills/shade-tokens-not-hex

--- a/.claude/skills/shade-use-primitives
+++ b/.claude/skills/shade-use-primitives
@@ -1,0 +1,1 @@
+../../.agents/skills/shade-use-primitives

--- a/apps/shade/AGENTS.md
+++ b/apps/shade/AGENTS.md
@@ -10,7 +10,8 @@ Canonical, rule-shaped reference for AI-assisted work on Shade and any admin app
   ```ts
   import {Stack, Inline, Box, Grid, Container, Text} from '@tryghost/shade/primitives';
   import {Button, Input, Dialog} from '@tryghost/shade/components';
-  import {PageHeader, ListPage, KpiCard} from '@tryghost/shade/patterns';
+  import {PageHeader, KpiCard, Filters} from '@tryghost/shade/patterns';
+  import {ListPage} from '@tryghost/shade/page-templates';
   import {PostShareModal} from '@tryghost/shade/posts-stats';
   import {cn} from '@tryghost/shade/utils';
   import {ShadeApp} from '@tryghost/shade/app';
@@ -25,9 +26,12 @@ Canonical, rule-shaped reference for AI-assisted work on Shade and any admin app
 | **Primitives** | `src/components/primitives/` | You need layout structure | `Stack`, `Inline`, `Box`, `Grid`, `Container`, `Text` |
 | **Components** | `src/components/ui/` | You need a generic, accessible UI control | `Button`, `Input`, `Dialog`, `Tabs`, `Card`, `DropdownMenu` |
 | **Recipes** | `src/components/ui/<name>.ts` | Several components share the same visual rule (chrome, focus, density) | `inputSurface` |
-| **Patterns** | `src/components/patterns/` | The shape is product-specific and recurs across Admin | `PageHeader`, `ListPage`, `Filters`, `KpiCard`, `GhAreaChart` |
+| **Patterns** | `src/components/patterns/` | The shape is product-specific and recurs across Admin | `PageHeader`, `Filters`, `KpiCard`, `GhAreaChart` |
 
-Plus one transitional layer: **`posts-stats/`** for components shared between `apps/posts` and `apps/stats` until those merge. Don't generalise it.
+Plus two additional barrels:
+
+- **`page-templates/`** (`src/components/page-templates/`) — top-level page wrappers (`ListPage` today). Composes Patterns + Components + Primitives. Imported via `@tryghost/shade/page-templates`.
+- **`posts-stats/`** (`src/components/posts-stats/`) — transitional layer for components shared between `apps/posts` and `apps/stats` until those merge. Don't generalise it. Imported via `@tryghost/shade/posts-stats`.
 
 ## Decision flow: where does new code go?
 

--- a/apps/shade/src/docs/contributing.mdx
+++ b/apps/shade/src/docs/contributing.mdx
@@ -15,7 +15,8 @@ apps/shade/src/
 ├── components/
 │   ├── ui/              Generic controls + recipes
 │   ├── primitives/      Layout primitives (Stack, Inline, …)
-│   ├── patterns/        Product compositions (PageHeader, ListPage, …)
+│   ├── patterns/        Product compositions (PageHeader, KpiCard, …)
+│   ├── page-templates/  Top-level page wrappers (ListPage)
 │   └── posts-stats/     Interim shared between Posts and Stats
 ├── docs/                MDX + showcase stories rendered in Storybook
 ├── hooks/               Generic React hooks
@@ -23,7 +24,7 @@ apps/shade/src/
 └── providers/           Context providers
 ```
 
-Each entrypoint barrel (`components.ts`, `primitives.ts`, `patterns.ts`) re-exports from its folder.
+Each entrypoint barrel (`components.ts`, `primitives.ts`, `patterns.ts`, `page-templates.ts`) re-exports from its folder.
 
 ## Naming
 

--- a/apps/shade/src/docs/introduction.mdx
+++ b/apps/shade/src/docs/introduction.mdx
@@ -13,7 +13,8 @@ import { Meta } from '@storybook/addon-docs/blocks';
 - **[Tokens](?path=/docs/tokens-tokens-guide--docs)** — colour, type, spacing, radius, motion. Visual galleries in the sidebar.
 - **[Primitives](?path=/docs/primitives-primitives-guide--docs)** — `Stack`, `Inline`, `Box`, `Grid`, `Container`, `Text`. Layout, not chrome.
 - **Components** — `Button`, `Input`, `Dialog`, `Tabs`… Generic and accessible. Built on Radix + ShadCN.
-- **Patterns** — `PageHeader`, `ListPage`, `KpiCard`, `Filters`. Product-shaped compositions.
+- **Patterns** — `PageHeader`, `KpiCard`, `Filters`. Product-shaped compositions.
+- **Page templates** — `ListPage`. Top-level page wrappers that compose patterns.
 
 The boundaries between those layers are the whole point. See **[Layers](?path=/docs/overview-layers--docs)** for the decision flow.
 

--- a/apps/shade/src/docs/layers.mdx
+++ b/apps/shade/src/docs/layers.mdx
@@ -16,7 +16,8 @@ import { Meta } from '@storybook/addon-docs/blocks';
 | **Primitives** | Layout vocabulary — rows, columns, padding, gaps. No domain meaning. | `src/components/primitives/` | `Stack`, `Inline`, `Box`, `Grid`, `Container`, `Text` |
 | **Components** | Generic, accessible UI controls. Same on every page. | `src/components/ui/` | `Button`, `Input`, `Dialog`, `Tabs`, `Card` |
 | **Recipes** | Shared visual rules (class-string functions). No JSX. | `src/components/ui/<name>.ts` | `inputSurface` — chrome shared by Input, Textarea, Select trigger |
-| **Patterns** | Product-shaped compositions. Know Ghost. | `src/components/patterns/` | `PageHeader`, `ListPage`, `Filters`, `KpiCard`, `GhAreaChart` |
+| **Patterns** | Product-shaped compositions. Know Ghost. | `src/components/patterns/` | `PageHeader`, `Filters`, `KpiCard`, `GhAreaChart` |
+| **Page templates** | Top-level page wrappers that compose patterns. | `src/components/page-templates/` | `ListPage` |
 
 Each layer is allowed to use anything below it. The reverse is forbidden: a Button can't reach into a Pattern, a Primitive can't import a Component.
 

--- a/apps/shade/src/docs/page-types.mdx
+++ b/apps/shade/src/docs/page-types.mdx
@@ -16,7 +16,7 @@ Browsing or scanning a collection of items.
 
 **Chrome shape**: `PageHeader` (title + count + search/filter/actions) → table or list → empty state → pagination.
 
-**Pattern**: [`ListPage`](?path=/docs/page-templates-list-page--docs) (composes [`PageHeader`](?path=/docs/patterns-pageheader--docs)). Heavy filter UI uses [`Filters`](?path=/docs/patterns-filters--docs).
+**Page template**: [`ListPage`](?path=/docs/page-templates-list-page--docs) (composes [`PageHeader`](?path=/docs/patterns-pageheader--docs)). Heavy filter UI uses [`Filters`](?path=/docs/patterns-filters--docs).
 
 ## Detail page
 

--- a/apps/shade/src/docs/patterns-guide.mdx
+++ b/apps/shade/src/docs/patterns-guide.mdx
@@ -6,7 +6,7 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 # Patterns
 
-<p className="excerpt">Product-shaped compositions. `PageHeader`, `ListPage`, `KpiCard`, `Filters`, `GhAreaChart`. Patterns compose primitives, components, and recipes with knowledge of how Ghost actually uses them.</p>
+<p className="excerpt">Product-shaped compositions. `PageHeader`, `KpiCard`, `Filters`, `GhAreaChart`. Patterns compose primitives, components, and recipes with knowledge of how Ghost actually uses them. Page-level wrappers like `ListPage` live in the separate [Page templates](?path=/docs/page-templates-page-types--docs) layer.</p>
 
 ## Use a pattern when
 
@@ -30,25 +30,22 @@ Promotion rules and the full decision flow: [Layers](?path=/docs/overview-layers
 ## Example
 
 ```tsx
-import {PageHeader, ListPage} from '@tryghost/shade/patterns';
-import {Button, Table} from '@tryghost/shade/components';
+import {PageHeader} from '@tryghost/shade/patterns';
+import {Button} from '@tryghost/shade/components';
 
-<ListPage>
-  <PageHeader>
-    <PageHeader.Left>
-      <PageHeader.Title>Members<PageHeader.Count>{count}</PageHeader.Count></PageHeader.Title>
-    </PageHeader.Left>
-    <PageHeader.Actions>
-      <PageHeader.ActionGroup>
-        <Button>Add member</Button>
-      </PageHeader.ActionGroup>
-    </PageHeader.Actions>
-  </PageHeader>
-  <ListPage.Body>
-    <Table>...</Table>
-  </ListPage.Body>
-</ListPage>
+<PageHeader>
+  <PageHeader.Left>
+    <PageHeader.Title>Members<PageHeader.Count>{count}</PageHeader.Count></PageHeader.Title>
+  </PageHeader.Left>
+  <PageHeader.Actions>
+    <PageHeader.ActionGroup>
+      <Button>Add member</Button>
+    </PageHeader.ActionGroup>
+  </PageHeader.Actions>
+</PageHeader>
 ```
+
+For the full list-page wrapper (`ListPage` composing `PageHeader` + body), see [Page templates / Page types](?path=/docs/page-templates-page-types--docs).
 
 Browse the sidebar for the live list of patterns.
 


### PR DESCRIPTION
closes https://linear.app/ghost/issue/DES-1394/add-shade-skills

Adds 10 auto-triggering Claude Code skills under `.agents/skills/shade-*` that encode Shade design system rules so AI agents follow them at the moment of edit, without needing to discover `apps/shade/AGENTS.md`.

**Tier 1 — broad triggers, fires often:**
- `shade-imports` — layer-specific subpaths, never root barrel
- `shade-tokens-not-hex` — semantic tokens only, with full inventory
- `shade-no-dark-variants` — don't write `dark:` for colour
- `shade-use-primitives` — `Stack`/`Inline`/`Box`/`Grid` over bare flex divs
- `shade-component-decision` — layer decision flow + promotion checklist

**Tier 2 — narrow, high-payoff triggers:**
- `shade-new-component` — acceptance checklist for new Shade files
- `shade-shadcn-install` — `pnpm dlx shadcn` guardrails + post-install cleanup
- `shade-page-templates` — `ListPage`/`PageHeader` skeleton + page-type taxonomy
- `shade-input-surface-recipe` — `inputSurface()` composition
- `shade-dropdown-surface-contract` — `DropdownMenu`/`Select`/`Popover` change together

Triggers are scoped to actual Shade-consuming apps (`shade`, `admin`, `admin-x-settings`, `admin-x-framework`, `posts`, `stats`, `activitypub`). Public apps (`portal`, `comments-ui`, `signup-form`, `sodo-search`, `announcement-bar`) and the legacy `admin-x-design-system` are excluded to avoid false positives.

`apps/shade/AGENTS.md` is also tightened:
- Fixed stale `ListPage` import (now `@tryghost/shade/page-templates`, not `/patterns`)
- Removed `ListPage` from the Patterns examples row
- Documented `page-templates/` and `posts-stats/` as additional barrels

## Dependency on PR #28895

Several skills (`shade-tokens-not-hex`, `shade-dropdown-surface-contract`, `shade-input-surface-recipe`) reference tokens introduced in [#28895](https://github.com/TryGhost/Ghost/pull/28895) — `--surface-elevated-2`, `--control-border`, `--interactive-hover`, `--button-hover`, `--tab-hover`, `--tab-active`, `--table-row-hover`. The skills don't break anything if merged first, but their examples reference tokens that don't yet exist on `main`. Ideally land #28895 first; otherwise the example references just become accurate as soon as #28895 merges.

## Test plan

- [ ] Skills load: open this branch in Claude Code and confirm `shade-*` skills appear in the available-skills list
- [ ] Auto-triggers fire: edit a TSX file under `apps/admin-x-settings/src/` containing `@tryghost/shade` and confirm relevant skills load
- [ ] Auto-triggers do NOT fire on excluded apps: edit a TSX in `apps/portal/src/` and confirm Shade skills don't load
- [ ] `apps/shade/AGENTS.md` renders correctly with the updated barrel list

🤖 Generated with [Claude Code](https://claude.com/claude-code)