### PR TITLE
Changed dev gateway to build Caddy locally

### DIFF
--- a/docker/dev-gateway/Dockerfile
+++ b/docker/dev-gateway/Dockerfile
@@ -1,6 +1,6 @@
 FROM caddy:2.11.4-builder-alpine@sha256:b6a94e74b72261bd536b35acdd22f3577d4e466a9550f2c8d6c8ed6413085d72 AS builder
 
-RUN xcaddy build --with github.com/caddyserver/transform-encoder
+RUN xcaddy build --with github.com/caddyserver/transform-encoder@ba4124974830222da7f12a091cf11ddf4d49363f
 
 FROM caddy:2-alpine@sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648
 

--- a/docker/dev-gateway/Dockerfile
+++ b/docker/dev-gateway/Dockerfile
@@ -1,6 +1,10 @@
+FROM caddy:2.11.4-builder-alpine@sha256:b6a94e74b72261bd536b35acdd22f3577d4e466a9550f2c8d6c8ed6413085d72 AS builder
+
+RUN xcaddy build --with github.com/caddyserver/transform-encoder
+
 FROM caddy:2-alpine@sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648
 
-RUN caddy add-package github.com/caddyserver/transform-encoder
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy
 
 # Default proxy targets (can be overridden via environment variables)
 ENV GHOST_BACKEND=ghost-dev:2368 \


### PR DESCRIPTION
no ref

## Summary

- Replaced `caddy add-package` in the dev gateway image with a local `xcaddy` build stage
- Avoided depending on Caddy's remote package build service during `pnpm dev`
- Kept the runtime image pinned while copying in the custom Caddy binary with `transform-encoder`

## Why?

The `caddy add-package` command is [indicated as experimental](https://caddyserver.com/docs/command-line#caddy-add-package) currently by Caddy's official docs, as it depends on infrastructure without strict uptime SLAs, and is prone to hanging without any recourse. This replaces `caddy add-package` with a local build instead to avoid this experimental dependency.