### PR TITLE
Changed admin-toolbar dev to opt out of vite preview's outDir guard via plugin

### DIFF
--- a/apps/admin-toolbar/package.json
+++ b/apps/admin-toolbar/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tryghost/admin-toolbar",
   "type": "module",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "pnpm exec vite build",
     "build:watch": "pnpm exec vite build --watch --mode development",
-    "dev": "mkdir -p umd && concurrently --kill-others --names preview,build \"pnpm exec vite preview -l silent\" \"pnpm build:watch\"",
+    "dev": "concurrently --kill-others --names preview,build \"pnpm exec vite preview -l silent\" \"pnpm build:watch\"",
     "lint": "pnpm exec eslint src test --cache",
     "test": "pnpm test:unit",
     "test:unit": "pnpm run build && pnpm exec vitest run",

--- a/apps/admin-toolbar/vite.config.mjs
+++ b/apps/admin-toolbar/vite.config.mjs
@@ -3,9 +3,21 @@ import {resolve} from 'path';
 
 import {defineConfig} from 'vite';
 
+// `vite preview` aborts when its outDir is missing — a UX nudge for the
+// "did you forget to build?" case. Our dev script runs preview alongside
+// `build:watch`, so the dir is missing for the first ~1s after a fresh
+// clone or `build:clean`. Defining configurePreviewServer is Vite's
+// documented opt-out from that guard; the underlying sirv server already
+// 404s for missing files.
+const tolerateMissingOutDir = () => ({
+    name: 'tolerate-missing-outdir',
+    configurePreviewServer() {}
+});
+
 export default defineConfig(({mode}) => ({
     logLevel: process.env.CI ? 'info' : 'warn',
     clearScreen: false,
+    plugins: [tolerateMissingOutDir()],
     define: {
         'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || mode)
     },


### PR DESCRIPTION
`vite preview`'s CLI throws on a missing `build.outDir` as a "did you forget to build?" UX nudge. Our `dev` script runs `vite preview` alongside `vite build --watch`, so `umd/` doesn't exist on a fresh clone or after `build:clean` — preview exits, `concurrently --kill-others` kills the watcher, and the whole `pnpm dev` Nx fan-out goes down.

Before [#28936](https://github.com/TryGhost/Ghost/pull/28936) a tracked `umd/admin-toolbar.min.js` masked this on fresh clones. With that artifact gone, the crash is reproducible on any first `pnpm dev`.

[#28962](https://github.com/TryGhost/Ghost/pull/28962) unblocked it with `mkdir -p umd && ...`, which satisfies the guard at the shell level but pushes a build concern outside the tool that owns it.

### Fix

Define `configurePreviewServer` on a no-op Vite plugin. The check in vite at `packages/vite/src/node/preview.ts` only fires when *every* plugin lacks the hook — the bypass is intentional and source-documented ("error if no plugins implement `configurePreviewServer`"). The hook was added in [vitejs/vite#7658](https://github.com/vitejs/vite/pull/7658) and the canonical "preview for libraries" issue ([vitejs/vite#7009](https://github.com/vitejs/vite/issues/7009)) is still open — so this is the sanctioned escape hatch, not a workaround.

The underlying sirv-based static server already 404s for missing files, so requests arriving before `build:watch` emits get a 404 instead of crashing the chain.

### Verification

Fresh clone (HEAD off this branch), `umd/` absent pre-dev, full `pnpm setup` + `pnpm dev` through Caddy → vite preview on `:4176`:

| t (s, approx) | `http://localhost:2368/ghost/assets/admin-toolbar/admin-toolbar.min.js` |
|---|---|
| 11 | connection refused (gateway booting) |
| 17 | 404 (gateway up, vite preview listening despite empty `umd/`) |
| 183 | 200 (`vite build --watch` emitted; ~49 KB bundle) |
| steady | 200 |

The 17s → 183s window is the Nx waterfall + `docker compose up` ahead of `build:watch` — not Vite. The plugin's job is to keep preview alive *across* that window so the chain doesn't tear down. It does. No `outDir missing` crash, no SIGTERM cascade.

### What's not in this PR

Peer public apps (portal, comments-ui, announcement-bar, sodo-search, signup-form) all do `pnpm build && concurrently ...` to side-step the same guard. That works but pays a cold-build tax on every `pnpm dev`. A follow-up should apply the same plugin to them and drop the prefix — and eventually extract a shared `publicAppViteConfig` helper to mirror the existing `adminXViteConfig` at [apps/admin-x-framework/src/vite.ts](apps/admin-x-framework/src/vite.ts) used by the admin apps.