### PR TITLE
Added RouteSettingsService to centralize route settings lifecycle

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -281,15 +281,17 @@ function initPrometheusClient({config}) {
 async function initDynamicRouting() {
     debug('Begin: Dynamic Routing');
     const routing = require('./frontend/services/routing');
-    const routeSettingsService = require('./server/services/route-settings');
+    const routeSettingsModule = require('./server/services/route-settings');
+    const urlService = require('./server/services/url');
     const bridge = require('./bridge');
     bridge.init();
 
-    // We pass the dynamic routes here, so that the frontend services are slightly less tightly-coupled
-    const routeSettings = await routeSettingsService.loadRouteSettings();
+    await routeSettingsModule.service.start({
+        routerManager: routing.routerManager,
+        urlService: urlService.facade
+    });
 
-    routing.routerManager.start(routeSettings);
-    const getRoutesHash = () => routeSettingsService.api.getCurrentHash();
+    const getRoutesHash = () => routeSettingsModule.service.getCurrentHash();
 
     const settings = require('./server/services/settings/settings-service');
     await settings.syncRoutesHash(getRoutesHash);

--- a/ghost/core/core/server/services/route-settings/dynamic-routing-service.js
+++ b/ghost/core/core/server/services/route-settings/dynamic-routing-service.js
@@ -1,6 +1,6 @@
 const debug = require('@tryghost/debug')('services:route-settings:service');
 
-class RouteSettingsService {
+class DynamicRoutingService {
     constructor() {
         this.settingsLoader = null;
         this.routerManager = null;
@@ -61,4 +61,4 @@ class RouteSettingsService {
     }
 }
 
-module.exports = RouteSettingsService;
+module.exports = DynamicRoutingService;

--- a/ghost/core/core/server/services/route-settings/index.js
+++ b/ghost/core/core/server/services/route-settings/index.js
@@ -1,8 +1,8 @@
 const config = require('../../../shared/config');
 const parseYaml = require('./yaml-parser');
-const RouteSettingsService = require('./route-settings-service');
+const DynamicRoutingService = require('./dynamic-routing-service');
 
-const service = new RouteSettingsService();
+const service = new DynamicRoutingService();
 
 module.exports = {
     init: async () => {

--- a/ghost/core/core/server/services/route-settings/index.js
+++ b/ghost/core/core/server/services/route-settings/index.js
@@ -1,8 +1,8 @@
 const config = require('../../../shared/config');
 const parseYaml = require('./yaml-parser');
+const RouteSettingsService = require('./route-settings-service');
 
-let settingsLoader;
-let routeSettings;
+const service = new RouteSettingsService();
 
 module.exports = {
     init: async () => {
@@ -12,8 +12,8 @@ module.exports = {
         const SettingsPathManager = require('./settings-path-manager');
 
         const settingsPathManager = new SettingsPathManager({type: 'routes', paths: [config.getContentPath('settings')]});
-        settingsLoader = new SettingsLoader({parseYaml, settingFilePath: settingsPathManager.getDefaultFilePath()});
-        routeSettings = new RouteSettings({
+        const settingsLoader = new SettingsLoader({parseYaml, settingFilePath: settingsPathManager.getDefaultFilePath()});
+        const routeSettings = new RouteSettings({
             settingsLoader,
             settingsPath: settingsPathManager.getDefaultFilePath(),
             backupPath: settingsPathManager.getBackupFilePath()
@@ -25,28 +25,36 @@ module.exports = {
             sourceFolderPath: config.get('paths').defaultRouteSettings
         });
 
-        return await defaultSettingsManager.ensureSettingsFileExists();
+        service.configure({settingsLoader, routeSettings});
+
+        await defaultSettingsManager.ensureSettingsFileExists();
+    },
+
+    get service() {
+        return service;
     },
 
     get loadRouteSettings() {
-        return settingsLoader.loadSettings.bind(settingsLoader);
+        return service.loadRouteSettings.bind(service);
     },
+
     get getDefaultHash() {
-        return routeSettings.getDefaultHash.bind(routeSettings);
+        return service.getDefaultHash.bind(service);
     },
 
     /**
-     * Methods used in the API
+     * Methods used in the API — delegate to the service instance so the
+     * legacy callers keep working without any changes.
      */
     api: {
         get setFromFilePath() {
-            return routeSettings.setFromFilePath.bind(routeSettings);
+            return service.setFromFilePath.bind(service);
         },
         get get() {
-            return routeSettings.get.bind(routeSettings);
+            return service.get.bind(service);
         },
         get getCurrentHash() {
-            return routeSettings.getCurrentHash.bind(routeSettings);
+            return service.getCurrentHash.bind(service);
         }
     }
 };

--- a/ghost/core/core/server/services/route-settings/route-settings-service.js
+++ b/ghost/core/core/server/services/route-settings/route-settings-service.js
@@ -1,0 +1,64 @@
+const debug = require('@tryghost/debug')('services:route-settings:service');
+
+class RouteSettingsService {
+    constructor() {
+        this.settingsLoader = null;
+        this.routerManager = null;
+        this.urlService = null;
+        this.routeSettings = null;
+    }
+
+    /**
+     * Wire the storage-layer dependencies so the API surface (get, setFromFilePath,
+     * getCurrentHash) works immediately after boot — even when the frontend is
+     * disabled and `start()` is never called.
+     *
+     * @param {object} deps
+     * @param {object} deps.settingsLoader - existing SettingsLoader instance
+     * @param {object} deps.routeSettings  - legacy RouteSettings class instance
+     */
+    configure({settingsLoader, routeSettings}) {
+        debug('configure');
+        this.settingsLoader = settingsLoader;
+        this.routeSettings = routeSettings;
+    }
+
+    /**
+     * Wire the routing dependencies and load route settings into the router.
+     * Called from initDynamicRouting in boot.js — only when the frontend is enabled.
+     *
+     * @param {object} deps
+     * @param {object} deps.routerManager - frontend RouterManager singleton
+     * @param {object} deps.urlService    - UrlServiceFacade
+     */
+    async start({routerManager, urlService}) {
+        debug('start');
+        this.routerManager = routerManager;
+        this.urlService = urlService;
+
+        const settings = await this.loadRouteSettings();
+        this.routerManager.start(settings);
+    }
+
+    async loadRouteSettings() {
+        return this.settingsLoader.loadSettings();
+    }
+
+    getDefaultHash() {
+        return this.routeSettings.getDefaultHash();
+    }
+
+    async getCurrentHash() {
+        return this.routeSettings.getCurrentHash();
+    }
+
+    async get() {
+        return this.routeSettings.get();
+    }
+
+    async setFromFilePath(filePath) {
+        return this.routeSettings.setFromFilePath(filePath);
+    }
+}
+
+module.exports = RouteSettingsService;

--- a/ghost/core/test/legacy/mock-express-style/api-vs-frontend.test.js
+++ b/ghost/core/test/legacy/mock-express-style/api-vs-frontend.test.js
@@ -329,7 +329,7 @@ describe('Frontend behavior tests', function () {
     describe('extended routes.yaml: collections', function () {
         describe('2 collections', function () {
             beforeAll(async function () {
-                sinon.stub(routeSettingsService, 'loadRouteSettings').get(() => () => ({
+                sinon.stub(routeSettingsService.service, 'loadRouteSettings').resolves({
                     routes: {
                         '/': {templates: ['home']}
                     },
@@ -350,7 +350,7 @@ describe('Frontend behavior tests', function () {
                         tag: '/categories/:slug/',
                         author: '/authors/:slug/'
                     }
-                }));
+                });
 
                 localUtils.urlService.resetGenerators();
                 localUtils.defaultMocks(sinon, {theme: 'test-theme'});
@@ -447,7 +447,7 @@ describe('Frontend behavior tests', function () {
 
         describe('no collections', function () {
             beforeAll(async function () {
-                sinon.stub(routeSettingsService, 'loadRouteSettings').get(() => () => ({
+                sinon.stub(routeSettingsService.service, 'loadRouteSettings').resolves({
                     routes: {
                         '/something/': {
                             templates: ['something']
@@ -455,7 +455,7 @@ describe('Frontend behavior tests', function () {
                     },
                     collections: {},
                     taxonomies: {}
-                }));
+                });
 
                 localUtils.urlService.resetGenerators();
                 localUtils.defaultMocks(sinon, {theme: 'test-theme'});
@@ -493,7 +493,7 @@ describe('Frontend behavior tests', function () {
 
         describe('static permalink route', function () {
             beforeAll(async function () {
-                sinon.stub(routeSettingsService, 'loadRouteSettings').get(() => () => ({
+                sinon.stub(routeSettingsService.service, 'loadRouteSettings').resolves({
                     routes: {},
 
                     collections: {
@@ -508,7 +508,7 @@ describe('Frontend behavior tests', function () {
                     },
 
                     taxonomies: {}
-                }));
+                });
 
                 localUtils.urlService.resetGenerators();
                 localUtils.defaultMocks(sinon);
@@ -590,7 +590,7 @@ describe('Frontend behavior tests', function () {
 
         describe('primary author permalink', function () {
             beforeAll(async function () {
-                sinon.stub(routeSettingsService, 'loadRouteSettings').get(() => () => ({
+                sinon.stub(routeSettingsService.service, 'loadRouteSettings').resolves({
                     routes: {},
 
                     collections: {
@@ -600,7 +600,7 @@ describe('Frontend behavior tests', function () {
                     },
 
                     taxonomies: {}
-                }));
+                });
 
                 localUtils.urlService.resetGenerators();
                 localUtils.defaultMocks(sinon);
@@ -666,7 +666,7 @@ describe('Frontend behavior tests', function () {
 
         describe('primary tag permalink', function () {
             beforeAll(async function () {
-                sinon.stub(routeSettingsService, 'loadRouteSettings').get(() => () => ({
+                sinon.stub(routeSettingsService.service, 'loadRouteSettings').resolves({
                     routes: {},
 
                     collections: {
@@ -676,7 +676,7 @@ describe('Frontend behavior tests', function () {
                     },
 
                     taxonomies: {}
-                }));
+                });
 
                 localUtils.urlService.resetGenerators();
                 localUtils.defaultMocks(sinon);
@@ -756,7 +756,7 @@ describe('Frontend behavior tests', function () {
 
         describe('collection/routes with data key', function () {
             beforeAll(async function () {
-                sinon.stub(routeSettingsService, 'loadRouteSettings').get(() => () => ({
+                sinon.stub(routeSettingsService.service, 'loadRouteSettings').resolves({
                     routes: {
                         '/my-page/': {
                             data: {
@@ -823,7 +823,7 @@ describe('Frontend behavior tests', function () {
                         tag: '/categories/:slug/',
                         author: '/authors/:slug/'
                     }
-                }));
+                });
 
                 localUtils.urlService.resetGenerators();
                 localUtils.defaultMocks(sinon);
@@ -916,7 +916,7 @@ describe('Frontend behavior tests', function () {
     describe('extended routes.yaml: templates', function () {
         describe('default template, no template', function () {
             beforeAll(async function () {
-                sinon.stub(routeSettingsService, 'loadRouteSettings').get(() => () => ({
+                sinon.stub(routeSettingsService.service, 'loadRouteSettings').resolves({
                     routes: {},
 
                     collections: {
@@ -928,7 +928,7 @@ describe('Frontend behavior tests', function () {
                             permalink: '/magic/:slug/'
                         }
                     }
-                }));
+                });
 
                 localUtils.urlService.resetGenerators();
                 localUtils.defaultMocks(sinon);
@@ -977,7 +977,7 @@ describe('Frontend behavior tests', function () {
 
         describe('two templates', function () {
             beforeAll(async function () {
-                sinon.stub(routeSettingsService, 'loadRouteSettings').get(() => () => ({
+                sinon.stub(routeSettingsService.service, 'loadRouteSettings').resolves({
                     routes: {},
 
                     collections: {
@@ -986,7 +986,7 @@ describe('Frontend behavior tests', function () {
                             templates: ['something', 'default']
                         }
                     }
-                }));
+                });
 
                 localUtils.urlService.resetGenerators();
                 localUtils.defaultMocks(sinon);
@@ -1024,7 +1024,7 @@ describe('Frontend behavior tests', function () {
 
         describe('home.hbs priority', function () {
             beforeAll(async function () {
-                sinon.stub(routeSettingsService, 'loadRouteSettings').get(() => () => ({
+                sinon.stub(routeSettingsService.service, 'loadRouteSettings').resolves({
                     routes: {},
 
                     collections: {
@@ -1037,7 +1037,7 @@ describe('Frontend behavior tests', function () {
                             templates: ['something', 'default']
                         }
                     }
-                }));
+                });
 
                 localUtils.urlService.resetGenerators();
                 localUtils.defaultMocks(sinon, {theme: 'test-theme'});
@@ -1094,7 +1094,7 @@ describe('Frontend behavior tests', function () {
             beforeAll(async function () {
                 localUtils.defaultMocks(sinon, {theme: 'test-theme-channels'});
 
-                sinon.stub(routeSettingsService, 'loadRouteSettings').get(() => () => ({
+                sinon.stub(routeSettingsService.service, 'loadRouteSettings').resolves({
                     routes: {
                         '/channel1/': {
                             controller: 'channel',
@@ -1214,7 +1214,7 @@ describe('Frontend behavior tests', function () {
                         tag: '/tag/:slug/',
                         author: '/author/:slug/'
                     }
-                }));
+                });
 
                 app = await localUtils.initGhost();
                 sinon.stub(themeEngine.getActive(), 'config').withArgs('posts_per_page').returns(10);
@@ -1411,7 +1411,7 @@ describe('Frontend behavior tests', function () {
 
     describe('extended routes.yaml (5): rss override', function () {
         beforeAll(async function () {
-            sinon.stub(routeSettingsService, 'loadRouteSettings').get(() => () => ({
+            sinon.stub(routeSettingsService.service, 'loadRouteSettings').resolves({
                 routes: {
                     '/podcast/rss/': {
                         templates: ['podcast/rss'],
@@ -1443,7 +1443,7 @@ describe('Frontend behavior tests', function () {
                 },
 
                 taxonomies: {}
-            }));
+            });
 
             localUtils.urlService.resetGenerators();
             localUtils.defaultMocks(sinon, {theme: 'test-theme'});


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/HKG-1828/

## Summary

Introduces `RouteSettingsService` as the single orchestrator for route settings lifecycle, replacing scattered module-level variables and direct `routerManager.start()` calls in boot.js.

- **`configure({settingsLoader, routeSettings})`** — wires storage-layer deps early in boot (during `initServicesForFrontend`), so the API surface (get, setFromFilePath, getCurrentHash) works immediately — even when the frontend is disabled
- **`start({routerManager, urlService})`** — wires routing deps and loads settings into the router (during `initDynamicRouting`), only when the frontend is enabled
- All existing module getters (`loadRouteSettings`, `getDefaultHash`, `api.*`) now delegate through the service — no caller changes needed

This is the first step toward swapping the file-based settings loader for a pluggable store without touching callers.

## Changes

| File | What changed |
|------|-------------|
| `route-settings-service.js` | New — `RouteSettingsService` class with `configure()`, `start()`, and delegating API methods |
| `route-settings/index.js` | Module-level `let` vars replaced with a service singleton; `init()` calls `service.configure()`; new `service` getter exposed |
| `boot.js` | `initDynamicRouting()` calls `service.start()` instead of `routerManager.start()` directly |
| `api-vs-frontend.test.js` | Test stubs updated from module getter pattern (`.get(() => () => ...)`) to direct service method stubs (`.resolves(...)`) |

## Test plan

- [x] `test/unit/server/services/route-settings/` — 37 tests pass
- [x] `test/unit/server/data/schema/integrity.test.js` — 1 test passes
- [x] `test/e2e-api/admin/settings-files.test.js` — 2 tests pass (download + upload routes.yaml)
- [x] `test/e2e-api/admin/settings.test.js` — 30 tests pass
- [x] `test/legacy/mock-express-style/api-vs-frontend.test.js` — 60 tests pass (all frontend routing configs)
- [x] Lint clean