### PR TITLE
🐛 Fixed link selection in automations email editor

### DIFF
--- a/apps/posts/src/views/Automations/components/email-modal/email-content-modal.tsx
+++ b/apps/posts/src/views/Automations/components/email-modal/email-content-modal.tsx
@@ -250,7 +250,7 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({
 
     return (
         <>
-            <Dialog open onOpenChange={(next) => {
+            <Dialog modal={false} open onOpenChange={(next) => {
                 if (!next) {
                     attemptClose();
                 }


### PR DESCRIPTION
closes [NY-1394](https://linear.app/ghost/issue/NY-1394/adding-links-in-automation-email-editor-fails)

### Problem
Selecting text and adding a link only showed a few recent posts — you couldn't type a URL or search, and typing overwrote the selected text. Koenig renders its link input in a portal on document.body, outside the shade <Dialog>; Radix's modal focus trap pulled focus back into the editor, so keystrokes hit the selected text instead of the input.

### Fix
Set modal={false} on the editor's <Dialog> to disable the focus trap, letting the portaled link input hold focus.

I verified things like cmd+S to save and clicking escape to close the editor (and show a warning if there's changes) still work properly