### PR TITLE
Cleaned up public-app dev scripts

### DIFF
--- a/apps/admin-toolbar/package.json
+++ b/apps/admin-toolbar/package.json
@@ -19,8 +19,7 @@
   },
   "scripts": {
     "build": "pnpm exec vite build",
-    "build:watch": "pnpm exec vite build --watch --mode development",
-    "dev": "pnpm build:watch",
+    "dev": "pnpm exec vite build --watch --mode development",
     "lint": "pnpm exec eslint src test --cache",
     "test": "pnpm test:unit",
     "test:unit": "pnpm run build && pnpm exec vitest run",

--- a/apps/admin-toolbar/package.json
+++ b/apps/admin-toolbar/package.json
@@ -18,11 +18,11 @@
     "preact": "catalog:"
   },
   "scripts": {
-    "build": "pnpm exec vite build",
-    "dev": "pnpm exec vite build --watch --mode development",
-    "lint": "pnpm exec eslint src test --cache",
+    "build": "vite build",
+    "dev": "vite build --watch --mode development",
+    "lint": "eslint src test --cache",
     "test": "pnpm test:unit",
-    "test:unit": "pnpm run build && pnpm exec vitest run",
+    "test:unit": "pnpm run build && vitest run",
     "preship": "pnpm lint",
     "ship": "node ../../.github/scripts/release-apps.js",
     "prepublishOnly": "pnpm build"

--- a/apps/admin-toolbar/package.json
+++ b/apps/admin-toolbar/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tryghost/admin-toolbar",
   "type": "module",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/announcement-bar/package.json
+++ b/apps/announcement-bar/package.json
@@ -19,9 +19,8 @@
     "react-dom": "catalog:react17"
   },
   "scripts": {
-    "dev": "pnpm build:watch",
+    "dev": "vite build --watch --mode development",
     "build": "vite build",
-    "build:watch": "vite build --watch --mode development",
     "test": "vitest run",
     "test:ci": "pnpm test --coverage",
     "test:unit": "pnpm test:ci",

--- a/apps/announcement-bar/package.json
+++ b/apps/announcement-bar/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tryghost/announcement-bar",
   "type": "module",
-  "version": "1.1.24",
+  "version": "1.1.25",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tryghost/comments-ui",
   "type": "module",
-  "version": "1.5.19",
+  "version": "1.5.20",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -16,11 +16,9 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "dev": "pnpm build:watch",
+    "dev": "vite build --watch --mode development",
     "dev:test": "vite build && vite preview --port 7175",
     "build": "vite build",
-    "build:watch": "vite build --watch --mode development",
-    "preview": "vite preview",
     "test": "pnpm test:unit",
     "test:unit": "vitest run --coverage",
     "test:acceptance": "NODE_OPTIONS='--experimental-specifier-resolution=node --no-warnings' VITE_TEST=true playwright test",

--- a/apps/portal/README.md
+++ b/apps/portal/README.md
@@ -49,10 +49,7 @@ Portal runs automatically when using Ghost's development command from the monore
 pnpm dev
 ```
 
-This starts all frontend apps (including Portal.)
----
-
-To run Portal in a standalone fashion, use `pnpm preview` and open [http://localhost:3000](http://localhost:3000).
+This starts all frontend apps (including Portal.) Portal is served via the dev gateway at `http://localhost:2368/ghost/assets/portal/portal.min.js` and is loaded into theme pages on the dev site.
 
 ## Build
 

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tryghost/portal",
   "type": "module",
-  "version": "2.69.12",
+  "version": "2.69.13",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -15,10 +15,8 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "dev": "pnpm build:watch",
+    "dev": "vite build --watch --mode development",
     "build": "vite build",
-    "build:watch": "vite build --watch --mode development",
-    "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:ci": "pnpm test --coverage",

--- a/apps/signup-form/README.md
+++ b/apps/signup-form/README.md
@@ -18,11 +18,12 @@ pnpm dev
 
 This starts all frontend apps (including Signup Form.)
 
-### Running the development version only
+### Running the standalone demo page
 
-Run `pnpm dev` (in package folder) to start the development server to test/develop the form standalone. 
-- This will generate a demo site on http://localhost:6173
-- This will build and watch the production build and host it on http://localhost:6174/signup-form.min.js (different port!)
+Run `pnpm dev:standalone` (in this package folder) to start the standalone development server with HMR for testing/developing the form in isolation.
+- This serves the demo page at http://localhost:6173
+
+`pnpm dev` on its own (in this package folder) only builds `umd/signup-form.min.js` and watches for changes — it does not bind a port. The UMD is served by Caddy at http://localhost:2368/ghost/assets/signup-form/signup-form.min.js when you run `pnpm dev` from the monorepo root.
 
 ### Using the UMD build during development
 

--- a/apps/signup-form/README.md
+++ b/apps/signup-form/README.md
@@ -29,7 +29,7 @@ Run `pnpm dev:standalone` (in this package folder) to start the standalone devel
 
 Vite by default only supports HRM with an ESM output. But when loading a script on a site as a ESM module (`<script type="module" src="...">`), you don't have access to `document.currentScript` inside the script, which is required to determine the location to inject the iframe. In development mode we use a workaround for this to make the ESM HMR work. But this workaround is not suitable for production.
 
-To test the real production behaviour without this hack, you can use http://localhost:6173/preview.html. This HTML page will use `http://localhost:6174/signup-form.min.js` directly. 
+To test the real production behaviour without this hack, you can use http://localhost:6173/preview.html (served by `pnpm dev:standalone`). The page loads the production UMD via `<script src="http://localhost:2368/ghost/assets/signup-form/signup-form.min.js">`, which is served by Caddy when `pnpm dev` is also running from the monorepo root. Both processes need to be up at the same time.
 
 ## Develop
 

--- a/apps/signup-form/package.json
+++ b/apps/signup-form/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tryghost/signup-form",
   "type": "module",
-  "version": "0.3.31",
+  "version": "0.3.32",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/signup-form/package.json
+++ b/apps/signup-form/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "dev": "vite build --watch --mode development",
-    "dev:standalone": "concurrently --kill-others --names standalone,build \"vite --port 6173\" \"vite build --watch --mode development\"",
+    "dev:standalone": "vite --port 6173",
     "preview": "concurrently --kill-others --names preview,build \"vite preview -l silent\" \"vite build --watch --mode development\"",
     "dev:test": "vite build && vite preview --port 6175",
     "build": "tsc && vite build",

--- a/apps/signup-form/package.json
+++ b/apps/signup-form/package.json
@@ -17,7 +17,6 @@
   "scripts": {
     "dev": "vite build --watch --mode development",
     "dev:standalone": "vite --port 6173",
-    "preview": "concurrently --kill-others --names preview,build \"vite preview -l silent\" \"vite build --watch --mode development\"",
     "dev:test": "vite build && vite preview --port 6175",
     "build": "tsc && vite build",
     "lint": "pnpm run lint:js",

--- a/apps/signup-form/package.json
+++ b/apps/signup-form/package.json
@@ -15,7 +15,8 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "dev": "pnpm build && concurrently --kill-others --names dev,preview,build \"vite --port 6173\" \"vite preview -l silent\" \"vite build --watch --mode development\"",
+    "dev": "vite build --watch --mode development",
+    "dev:standalone": "concurrently --kill-others --names standalone,build \"vite --port 6173\" \"vite build --watch --mode development\"",
     "preview": "concurrently --kill-others --names preview,build \"vite preview -l silent\" \"vite build --watch --mode development\"",
     "dev:test": "vite build && vite preview --port 6175",
     "build": "tsc && vite build",

--- a/apps/signup-form/preview.html
+++ b/apps/signup-form/preview.html
@@ -20,7 +20,7 @@
         <!-- Because we need to use ESM modules during develoment, the src should be different to force reexecution of each script -->
         <div style="height: 40vmin; min-height: 360px;">
             <script
-                src="http://localhost:6174/signup-form.min.js"
+                src="http://localhost:2368/ghost/assets/signup-form/signup-form.min.js"
                 data-title="My site name"
                 data-description="An independent publication about embeddable signup forms."
                 data-icon="https://static.ghost.org/v4.0.0/images/ghost-orb-1.png"
@@ -37,7 +37,7 @@
         <h1>Without icon</h1>
         <div style="height: 40vmin; min-height: 360px;">
             <script
-                src="http://localhost:6174/signup-form.min.js"
+                src="http://localhost:2368/ghost/assets/signup-form/signup-form.min.js"
                 data-title="Site without icon"
                 data-description="An independent publication about embeddable signup forms."
                 data-background-color="#F1F3F4"
@@ -54,7 +54,7 @@
 
         <div style="min-height: 58px">
             <script
-                src="http://localhost:6174/signup-form.min.js"
+                src="http://localhost:2368/ghost/assets/signup-form/signup-form.min.js"
                 data-button-color="#ff0095"
                 data-site="%VITE_SITE_URL%"
                 data-label-1="Signup form"
@@ -69,7 +69,7 @@
 
         <div style="min-height: 58px">
             <script
-                src="http://localhost:6174/signup-form.min.js"
+                src="http://localhost:2368/ghost/assets/signup-form/signup-form.min.js"
                 data-button-color="#ff0095"
                 data-site="https://invalid/"
                 async
@@ -81,7 +81,7 @@
 
         <div style="height: 40vmin; min-height: 360px;">
             <script
-                src="http://localhost:6174/signup-form.min.js"
+                src="http://localhost:2368/ghost/assets/signup-form/signup-form.min.js"
                 data-title="My site name"
                 data-description="An independent publication about embeddable signup forms."
                 data-icon="https://static.ghost.org/v4.0.0/images/ghost-orb-1.png"
@@ -99,7 +99,7 @@
 
         <div style="min-height: 58px; max-width: 440px;">
             <script
-                src="http://localhost:6174/signup-form.min.js"
+                src="http://localhost:2368/ghost/assets/signup-form/signup-form.min.js"
                 data-button-color="#ff0095"
                 data-site="%VITE_SITE_URL%"
                 data-label-1="Signup form"

--- a/apps/sodo-search/package.json
+++ b/apps/sodo-search/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tryghost/sodo-search",
   "type": "module",
-  "version": "1.8.27",
+  "version": "1.8.28",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/sodo-search/package.json
+++ b/apps/sodo-search/package.json
@@ -22,9 +22,8 @@
     "react-dom": "catalog:react17"
   },
   "scripts": {
-    "dev": "pnpm build:watch",
+    "dev": "vite build --watch --mode development",
     "build": "vite build",
-    "build:watch": "vite build --watch --mode development",
     "test": "vitest run",
     "lint": "eslint src test --cache",
     "preship": "pnpm lint",


### PR DESCRIPTION
## What changed

**signup-form `dev`** collapsed from a 3-process `concurrently` (standalone HMR + `vite preview` + `vite build --watch`) to just `vite build --watch --mode development`. Matches every other public app.

**signup-form `dev:standalone`** added (`vite --port 6173`) for solo work on the standalone demo page at `apps/signup-form/index.html`. Opt-in via `pnpm --filter @tryghost/signup-form dev:standalone`.

**`preview` script removed** from portal, comments-ui, signup-form. Nothing invokes `pnpm preview` from CI, scripts, or playwright configs. portal/comments-ui were bare `vite preview` aliases; signup-form's was a stale `concurrently` invocation. Now redundant with Caddy `file_server` serving the UMDs directly (#28970).

**`build:watch` indirection removed** (portal, comments-ui, sodo-search, announcement-bar, admin-toolbar). Was `dev: pnpm build:watch` → `build:watch: vite build --watch …`. Inlined into `dev` directly. signup-form was already inline.

**portal/README.md** dropped a stale `pnpm preview` / `localhost:3000` reference and now describes the gateway-served path.

## Verified

- `pnpm dev` boots cleanly with all 6 watchers running, Ghost backend healthy
- All 6 UMDs serve via Caddy at correct sizes (portal 4.0 MB, comments-ui 1.7 MB, signup-form 529 KB, sodo-search 1.3 MB, announcement-bar 940 KB, admin-toolbar 49 KB)
- `pnpm --filter @tryghost/signup-form dev:standalone` brings up :6173 on demand, demo page serves HTTP 200
