### PR TITLE
Removed @tryghost/parse-email-address from pnpm dev fan-out

### DIFF
--- a/ghost/parse-email-address/package.json
+++ b/ghost/parse-email-address/package.json
@@ -18,6 +18,7 @@
     "dev": "tsc --watch --preserveWatchOutput --sourceMap",
     "build": "pnpm build:tsc",
     "build:tsc": "tsc",
+    "prepare": "pnpm build",
     "test:unit": "NODE_ENV=testing vitest run --coverage",
     "test": "pnpm test:types && pnpm test:unit",
     "test:types": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -150,8 +150,7 @@
               "@tryghost/signup-form",
               "@tryghost/sodo-search",
               "@tryghost/announcement-bar",
-              "@tryghost/admin-toolbar",
-              "@tryghost/parse-email-address"
+              "@tryghost/admin-toolbar"
             ]
           }
         ]


### PR DESCRIPTION
`@tryghost/parse-email-address` is a 20-line workspace package wrapping the npm `parse-email-address` module. Its `dev` script runs `tsc --watch` continuously, emitting `build/index.js` and `build/index.d.ts` (~145 MB RSS for the tsc process, plus ~145 MB of Nx run-executor + pnpm wrapper overhead).

None of that output is consumed in dev. The package's `package.json` exports declares:

```json
"exports": {
  ".": {
    "source": "./src/index.ts",
    "types": "./build/index.d.ts",
    "default": "./build/index.js"
  }
}
```

`ghost/core` runs with `node --conditions=source --import=tsx` (see `ghost/core/nodemon.json`), so the `source` condition wins and ghost/core imports the `.ts` source directly via tsx. The `build/` output is purely a production artifact, never read at dev time. `tsc --watch` was running for nothing.

### Change

Drop `@tryghost/parse-email-address` from `docker:dev`'s `dependsOn` list in the root `package.json`. Saves ~290 MB RSS and one process per `pnpm dev` session.

`pnpm --filter @tryghost/parse-email-address dev` still works for solo work on the package itself. CI builds (which need `build/`) are unaffected since they invoke `build` targets directly.