### PR TITLE
Removed public-app vite preview servers in favor of Caddy file_server

### DIFF
--- a/apps/admin-toolbar/package.json
+++ b/apps/admin-toolbar/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "pnpm exec vite build",
     "build:watch": "pnpm exec vite build --watch --mode development",
-    "dev": "concurrently --kill-others --names preview,build \"pnpm exec vite preview -l silent\" \"pnpm build:watch\"",
+    "dev": "pnpm build:watch",
     "lint": "pnpm exec eslint src test --cache",
     "test": "pnpm test:unit",
     "test:unit": "pnpm run build && pnpm exec vitest run",

--- a/apps/announcement-bar/package.json
+++ b/apps/announcement-bar/package.json
@@ -19,7 +19,7 @@
     "react-dom": "catalog:react17"
   },
   "scripts": {
-    "dev": "pnpm build && concurrently --kill-others --names preview,build \"vite preview -l silent\" \"pnpm build:watch\"",
+    "dev": "pnpm build:watch",
     "build": "vite build",
     "build:watch": "vite build --watch --mode development",
     "test": "vitest run",

--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -16,7 +16,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "dev": "pnpm build && concurrently --kill-others --names preview,build \"pnpm preview --host -l silent\" \"pnpm build:watch\"",
+    "dev": "pnpm build:watch",
     "dev:test": "vite build && vite preview --port 7175",
     "build": "vite build",
     "build:watch": "vite build --watch --mode development",

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -15,7 +15,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "dev": "pnpm build && concurrently --kill-others --names preview,build \"pnpm preview -l silent\" \"pnpm build:watch\"",
+    "dev": "pnpm build:watch",
     "build": "vite build",
     "build:watch": "vite build --watch --mode development",
     "preview": "vite preview",

--- a/apps/sodo-search/package.json
+++ b/apps/sodo-search/package.json
@@ -22,7 +22,7 @@
     "react-dom": "catalog:react17"
   },
   "scripts": {
-    "dev": "pnpm build && concurrently --kill-others --names preview,build \"vite preview -l silent\" \"pnpm build:watch\"",
+    "dev": "pnpm build:watch",
     "build": "vite build",
     "build:watch": "vite build --watch --mode development",
     "test": "vitest run",

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -123,6 +123,11 @@ services:
     volumes:
       # Mount Caddyfile for live config changes without rebuilding
       - ./docker/dev-gateway/Caddyfile:/etc/caddy/Caddyfile:ro
+      # All workspace apps mounted read-only. Caddy file_server resolves
+      # /srv/apps/<name>/umd dynamically for the public-app routes (see
+      # the Caddyfile @public_app block). Replaces the per-app `vite preview`
+      # sirv layer + avoids per-app bind mounts.
+      - ./apps:/srv/apps:ro
     depends_on:
       ghost-dev:
         condition: service_healthy

--- a/docker/dev-gateway/Caddyfile
+++ b/docker/dev-gateway/Caddyfile
@@ -98,64 +98,20 @@
             }
         }
 
-        # Portal
-        @portal path /portal/*
-        handle @portal {
-            uri strip_prefix /portal
-            reverse_proxy {env.PORTAL_DEV_SERVER} {
-                header_up Host {http.reverse_proxy.upstream.hostport}
-                header_up X-Forwarded-Host {host}
-            }
-        }
-
-        # Comments UI
-        @comments path /comments-ui/*
-        handle @comments {
-            uri strip_prefix /comments-ui
-            reverse_proxy {env.COMMENTS_DEV_SERVER} {
-                header_up Host {http.reverse_proxy.upstream.hostport}
-                header_up X-Forwarded-Host {host}
-            }
-        }
-
-        # Signup Form
-        @signup path /signup-form/*
-        handle @signup {
-            uri strip_prefix /signup-form
-            reverse_proxy {env.SIGNUP_DEV_SERVER} {
-                header_up Host {http.reverse_proxy.upstream.hostport}
-                header_up X-Forwarded-Host {host}
-            }
-        }
-
-        # Sodo Search
-        @search path /sodo-search/*
-        handle @search {
-            uri strip_prefix /sodo-search
-            reverse_proxy {env.SEARCH_DEV_SERVER} {
-                header_up Host {http.reverse_proxy.upstream.hostport}
-                header_up X-Forwarded-Host {host}
-            }
-        }
-
-        # Announcement Bar
-        @announcement path /announcement-bar/*
-        handle @announcement {
-            uri strip_prefix /announcement-bar
-            reverse_proxy {env.ANNOUNCEMENT_DEV_SERVER} {
-                header_up Host {http.reverse_proxy.upstream.hostport}
-                header_up X-Forwarded-Host {host}
-            }
-        }
-
-        # Admin Toolbar
-        @admin-toolbar path /admin-toolbar/*
-        handle @admin-toolbar {
-            uri strip_prefix /admin-toolbar
-            reverse_proxy {env.ADMIN_TOOLBAR_DEV_SERVER} {
-                header_up Host {http.reverse_proxy.upstream.hostport}
-                header_up X-Forwarded-Host {host}
-            }
+        # Public app UMD bundles — served directly from each app's umd/
+        # build output. Vite's build:watch writes to disk on every source
+        # change, Caddy picks up the new file on next request. Replaces the
+        # per-app `vite preview` server (sirv) layer that used to sit in front.
+        #
+        # The named allowlist is load-bearing: a generic [a-z0-9-]+ pattern
+        # would swallow admin asset paths (e.g. /ghost/assets/built/foo.css)
+        # before they could fall through to the admin dev server below.
+        # Adding a new public app = add its name to the alternation.
+        @public_app path_regexp public_app ^/(portal|comments-ui|signup-form|sodo-search|announcement-bar|admin-toolbar)/(.*)$
+        handle @public_app {
+            rewrite * /{re.public_app.2}
+            root * /srv/apps/{re.public_app.1}/umd
+            file_server
         }
 
         # Everything else under /ghost/assets/* goes to admin dev server.


### PR DESCRIPTION
Each public app's `dev` script previously ran `concurrently` over `vite preview` (sirv static server, ~85 MB Node process per app) plus `vite build --watch`. The preview server existed only so the Caddy dev gateway could reverse-proxy to it; site themes load `/ghost/assets/portal/portal.min.js` etc. through the gateway.

## Changes

- **`docker/dev-gateway/Caddyfile`** — six per-app handles (`portal`, `comments-ui`, `signup-form`, `sodo-search`, `announcement-bar`, `admin-toolbar`) swap `reverse_proxy {env.*_DEV_SERVER}` for `root * /srv/public-apps/<app>` + `file_server`.
- **`compose.dev.yaml`** — adds six read-only bind mounts of each app's `umd/` into the gateway container at `/srv/public-apps/<app>/`.
- **`apps/{portal,comments-ui,sodo-search,announcement-bar,admin-toolbar}/package.json`** — `dev` collapses from a `concurrently` 2-process invocation (`vite preview -l silent` + `vite build --watch`) to just `pnpm build:watch`. Vite still writes to `umd/` on every source change; Caddy serves the new file on the next request.

`signup-form/package.json` is intentionally not in this PR — it's a 3-way concurrently (standalone dev server on :6173 + preview + build:watch) and is being handled in a separate sibling PR. The Caddyfile + compose mount for signup-form are switched here because they're consistent regardless: Caddy can serve from disk even while signup-form keeps its own preview running on the side.

## Why it's safe

Caddy's `file_server` is functionally equivalent to vite preview's `sirv` for this use case — both are read-only static-file servers with no app logic in front. The gateway is the only consumer of these URLs, so removing the intermediate preview hop is transparent to theme code and to anything calling `ghost/assets/*`.

## Impact

Removes 5 vite preview servers (~500 MB RSS, ~15 host processes including the pnpm wrapper + concurrently parent + esbuild service each preview spawned) and 5 host listening ports (4175/4176/4177/4178/7173). Behavior for theme consumers is unchanged.

## Test plan

- [ ] `pnpm dev` boots cleanly with no listeners on 4175-4178 or 7173
- [ ] Admin loads at `http://localhost:2368/ghost`
- [ ] A site theme renders Portal / Comments / Sodo Search / Announcement Bar / Admin Toolbar correctly (assets resolve through Caddy)
- [ ] Editing a source file in any of the 5 apps triggers a rebuild and the new bundle is served on next request