### PR TITLE
Removed parse-email-address prepare hook that broke Docker dev build

### DIFF
--- a/ghost/parse-email-address/package.json
+++ b/ghost/parse-email-address/package.json
@@ -18,7 +18,6 @@
     "dev": "tsc --watch --preserveWatchOutput --sourceMap",
     "build": "pnpm build:tsc",
     "build:tsc": "tsc",
-    "prepare": "pnpm build",
     "test:unit": "NODE_ENV=testing vitest run --coverage",
     "test": "pnpm test:types && pnpm test:unit",
     "test:types": "tsc --noEmit",


### PR DESCRIPTION
## Problem

The `prepare: pnpm build` script added in #28969 runs during `pnpm install`, including inside the ghost-dev Docker image build. That build stage only copies workspace `package.json` files into the image (not `src/` directories), so `tsc` finds no input files, prints help output, and exits 1. Docker build fails, `pnpm dev` cannot start.

## Fix

Removed the prepare hook. One-line change.

## Type-resolution gap

The original motivation for adding prepare: ghost/core type-checks against parse-email-address types at `build/index.d.ts`. Without prepare, a fresh-clone dev session has no `build/` until a manual build runs. Today this is mitigated by ghost/core's `lint:types` script which explicitly builds parse-email-address first, and by anyone who has ever run `pnpm dev` in the old fan-out (which kept `tsc --watch` running). A cleaner fix to track separately: expose `src/index.ts` as the types path in the exports field so node10 resolution doesn't need a build artifact.

ref #28969