### PR TITLE
Extracted shared vite config helper for public UMD apps

### DIFF
--- a/apps/_shared/vite-public-app.mjs
+++ b/apps/_shared/vite-public-app.mjs
@@ -1,0 +1,105 @@
+/* eslint-env node */
+/**
+ * Shared Vite config factory for Ghost's public UMD apps — portal,
+ * comments-ui, sodo-search, announcement-bar, signup-form, admin-toolbar.
+ *
+ * Each app loads as a <script src> from a Ghost theme and ships as a UMD
+ * (or IIFE) bundle in <app>/umd/<app>.min.js. This factory captures the
+ * shape they all share (outDir, lib, optional i18n locale glob, baseline
+ * plugins) and lets per-app divergence flow through `overrides`, which is
+ * deep-merged via Vite's `mergeConfig`. Plugin arrays in `overrides` are
+ * appended to the base plugins.
+ *
+ * Plugin imports are dynamic so an app can opt out (e.g. admin-toolbar
+ * uses Preact and never installs `@vitejs/plugin-react`).
+ */
+import {resolve} from 'path';
+import {defineConfig, mergeConfig} from 'vitest/config';
+
+/**
+ * @param {Object} opts
+ * @param {string} opts.packageRoot — absolute root of the calling app (typically `import.meta.dirname`)
+ * @param {string} opts.packageName — e.g. `'@tryghost/portal'`; sets the UMD/IIFE global name and output filename
+ * @param {string} opts.entry — entry path relative to `packageRoot` (e.g. `'src/index.jsx'`)
+ * @param {'react'|'preact'} [opts.framework='react'] — controls whether `@vitejs/plugin-react` is included
+ * @param {boolean} [opts.svgr=true] — include `vite-plugin-svgr`
+ * @param {'umd'|'iife'} [opts.libFormat='umd']
+ * @param {string} [opts.libName] — global var name override (default: `packageName`)
+ * @param {boolean} [opts.sourcemap=true]
+ * @param {boolean} [opts.cssCodeSplit=true]
+ * @param {string} [opts.i18nNamespace] — if set, wires `commonjsOptions` to glob `ghost/i18n/locales/*\/<ns>.json`
+ * @param {import('vitest/config').UserConfig} [opts.overrides] — deep-merged onto the base config
+ * @returns {import('vitest/config').UserConfig}
+ */
+export function publicAppViteConfig(opts) {
+    const {
+        packageRoot,
+        packageName,
+        entry,
+        framework = 'react',
+        svgr = true,
+        libFormat = 'umd',
+        libName,
+        sourcemap = true,
+        cssCodeSplit = true,
+        i18nNamespace,
+        overrides = {}
+    } = opts;
+
+    return defineConfig(async (config) => {
+        const outputFileName = packageName[0] === '@'
+            ? packageName.slice(packageName.indexOf('/') + 1)
+            : packageName;
+
+        const plugins = [];
+        if (framework === 'react') {
+            const {default: reactPlugin} = await import('@vitejs/plugin-react');
+            plugins.push(reactPlugin());
+        }
+        if (svgr) {
+            const {default: svgrPlugin} = await import('vite-plugin-svgr');
+            plugins.push(svgrPlugin());
+        }
+
+        const base = {
+            logLevel: process.env.CI ? 'info' : 'warn',
+            clearScreen: false,
+            plugins,
+            define: {
+                'process.env.NODE_ENV': JSON.stringify(config.mode)
+            },
+            build: {
+                outDir: resolve(packageRoot, 'umd'),
+                emptyOutDir: true,
+                reportCompressedSize: false,
+                minify: config.mode === 'production',
+                sourcemap,
+                cssCodeSplit,
+                lib: {
+                    entry: resolve(packageRoot, entry),
+                    formats: [libFormat],
+                    name: libName ?? packageName,
+                    fileName: () => `${outputFileName}.min.js`
+                },
+                ...(i18nNamespace && {
+                    commonjsOptions: {
+                        include: [/ghost/, /node_modules/],
+                        dynamicRequireRoot: '../../',
+                        // Single glob expands to all SUPPORTED_LOCALES; passing each
+                        // locale as an explicit path triggers a full repo-root
+                        // directory crawl per entry under vite 7's bundled
+                        // @rollup/plugin-commonjs, adding ~1s per locale to build time.
+                        dynamicRequireTargets: [`../../ghost/i18n/locales/*/${i18nNamespace}.json`]
+                    }
+                })
+            },
+            test: {
+                globals: true,
+                environment: 'jsdom',
+                testTimeout: 10000
+            }
+        };
+
+        return mergeConfig(base, overrides);
+    });
+}

--- a/apps/admin-toolbar/package.json
+++ b/apps/admin-toolbar/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tryghost/admin-toolbar",
   "type": "module",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/admin-toolbar/vite.config.mjs
+++ b/apps/admin-toolbar/vite.config.mjs
@@ -1,25 +1,13 @@
 /* eslint-env node */
-import {resolve} from 'path';
+import {publicAppViteConfig} from '../_shared/vite-public-app.mjs';
 
-import {defineConfig} from 'vite';
-
-export default defineConfig(({mode}) => ({
-    logLevel: process.env.CI ? 'info' : 'warn',
-    clearScreen: false,
-    define: {
-        'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || mode)
-    },
-    build: {
-        outDir: resolve(import.meta.dirname, 'umd'),
-        emptyOutDir: true,
-        reportCompressedSize: false,
-        minify: mode === 'production',
-        sourcemap: false,
-        lib: {
-            entry: resolve(import.meta.dirname, 'src/index.js'),
-            formats: ['iife'],
-            name: 'GhostAdminToolbar',
-            fileName: () => 'admin-toolbar.min.js'
-        }
-    }
-}));
+export default publicAppViteConfig({
+    packageRoot: import.meta.dirname,
+    packageName: '@tryghost/admin-toolbar',
+    entry: 'src/index.js',
+    framework: 'preact',
+    svgr: false,
+    libFormat: 'iife',
+    libName: 'GhostAdminToolbar',
+    sourcemap: false
+});

--- a/apps/announcement-bar/package.json
+++ b/apps/announcement-bar/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tryghost/announcement-bar",
   "type": "module",
-  "version": "1.1.27",
+  "version": "1.1.28",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/announcement-bar/vite.config.mjs
+++ b/apps/announcement-bar/vite.config.mjs
@@ -1,44 +1,15 @@
 /* eslint-env node */
-import {resolve} from 'path';
-
-import {defineConfig} from 'vitest/config';
-import reactPlugin from '@vitejs/plugin-react';
-import svgrPlugin from 'vite-plugin-svgr';
-
 import pkg from './package.json';
+import {publicAppViteConfig} from '../_shared/vite-public-app.mjs';
 
-export default defineConfig((config) => {
-    const outputFileName = pkg.name[0] === '@' ? pkg.name.slice(pkg.name.indexOf('/') + 1) : pkg.name;
-
-    return {
-        logLevel: process.env.CI ? 'info' : 'warn',
-        clearScreen: false,
-        define: {
-            'process.env.NODE_ENV': JSON.stringify(config.mode)
-        },
-        plugins: [
-            reactPlugin(),
-            svgrPlugin()
-        ],
-        build: {
-            outDir: resolve(__dirname, 'umd'),
-            emptyOutDir: true,
-            reportCompressedSize: false,
-            minify: config.mode === 'production',
-            sourcemap: false,
-            cssCodeSplit: true,
-            lib: {
-                entry: resolve(__dirname, 'src/index.jsx'),
-                formats: ['umd'],
-                name: pkg.name,
-                fileName: format => `${outputFileName}.min.js`
-            }
-        },
+export default publicAppViteConfig({
+    packageRoot: import.meta.dirname,
+    packageName: pkg.name,
+    entry: 'src/index.jsx',
+    sourcemap: false,
+    overrides: {
         test: {
-            globals: true,
-            environment: 'jsdom',
-            setupFiles: './test/setup-tests.js',
-            testTimeout: 10000
+            setupFiles: './test/setup-tests.js'
         }
-    };
+    }
 });

--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tryghost/comments-ui",
   "type": "module",
-  "version": "1.5.21",
+  "version": "1.5.22",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/comments-ui/vite.config.mts
+++ b/apps/comments-ui/vite.config.mts
@@ -1,23 +1,17 @@
-import pkg from './package.json';
-import react from '@vitejs/plugin-react';
-import svgr from 'vite-plugin-svgr';
-import {defineConfig} from 'vitest/config';
 import {resolve} from 'path';
+import pkg from './package.json';
+import {publicAppViteConfig} from '../_shared/vite-public-app.mjs';
 import {stripFingerprintingPlugin} from './vite-plugin-strip-fingerprinting';
 
-const outputFileName = pkg.name[0] === '@' ? pkg.name.slice(pkg.name.indexOf('/') + 1) : pkg.name;
-
-// https://vitejs.dev/config/
-export default defineConfig((config) => {
-    return {
-        logLevel: process.env.CI ? 'info' : 'warn',
-        plugins: [
-            stripFingerprintingPlugin(),
-            svgr(),
-            react()
-        ],
+export default publicAppViteConfig({
+    packageRoot: import.meta.dirname,
+    packageName: pkg.name,
+    entry: 'src/index.tsx',
+    i18nNamespace: 'comments',
+    sourcemap: false,
+    overrides: {
+        plugins: [stripFingerprintingPlugin()],
         define: {
-            'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
             'process.env.VITEST_SEGFAULT_RETRY': 3
         },
         preview: {
@@ -29,51 +23,22 @@ export default defineConfig((config) => {
         server: {
             port: 5368
         },
-        build: {
-            reportCompressedSize: false,
-            outDir: resolve(__dirname, 'umd'),
-            emptyOutDir: true,
-            minify: config.mode === 'production',
-            sourcemap: false,
-            cssCodeSplit: true,
-            lib: {
-                entry: resolve(__dirname, 'src/index.tsx'),
-                formats: ['umd'],
-                name: pkg.name,
-                fileName(format) {
-                    if (format === 'umd') {
-                        return `${outputFileName}.min.js`;
-                    }
-
-                    return `${outputFileName}.js`;
-                }
-            },
-            rollupOptions: {
-                output: {}
-            },
-            commonjsOptions: {
-                include: [/ghost/, /node_modules/],
-                dynamicRequireRoot: '../../',
-                // Single glob expands to all SUPPORTED_LOCALES; passing each
-                // locale as an explicit path triggers a full repo-root
-                // directory crawl per entry under vite 7's bundled
-                // @rollup/plugin-commonjs, adding ~1s per locale to build time.
-                dynamicRequireTargets: ['../../ghost/i18n/locales/*/comments.json']
-            }
-        },
         resolve: {
             // comments-ui uses React 17 while the monorepo hoists React 18;
             // dedupe + alias ensures all deps (including @tiptap/react) use
             // the same React 17 instance from comments-ui's node_modules
             dedupe: ['react', 'react-dom', '@tryghost/debug'],
             alias: {
-                'react': resolve(__dirname, 'node_modules/react'),
-                'react-dom': resolve(__dirname, 'node_modules/react-dom')
+                react: resolve(import.meta.dirname, 'node_modules/react'),
+                'react-dom': resolve(import.meta.dirname, 'node_modules/react-dom')
+            }
+        },
+        build: {
+            rollupOptions: {
+                output: {}
             }
         },
         test: {
-            globals: true, // required for @testing-library/jest-dom extensions
-            environment: 'jsdom',
             setupFiles: './src/setup-tests.ts',
             include: ['test/unit/**/*.test.{js,jsx,ts,tsx}'],
             testTimeout: process.env.TIMEOUT ? parseInt(process.env.TIMEOUT) : 10000,
@@ -90,5 +55,5 @@ export default defineConfig((config) => {
                 maxThreads: 2
             })
         }
-    };
+    }
 });

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tryghost/portal",
   "type": "module",
-  "version": "2.69.14",
+  "version": "2.69.15",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/portal/vite.config.mjs
+++ b/apps/portal/vite.config.mjs
@@ -1,67 +1,35 @@
 /* eslint-env node */
-import {resolve} from 'path';
-
-import {defineConfig} from 'vitest/config';
 import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js';
-import reactPlugin from '@vitejs/plugin-react';
-import svgrPlugin from 'vite-plugin-svgr';
 
 import pkg from './package.json';
+import {publicAppViteConfig} from '../_shared/vite-public-app.mjs';
 
-export default defineConfig((config) => {
-    const outputFileName = pkg.name[0] === '@' ? pkg.name.slice(pkg.name.indexOf('/') + 1) : pkg.name;
-
-    return {
-        logLevel: process.env.CI ? 'info' : 'warn',
-        clearScreen: false,
+export default publicAppViteConfig({
+    packageRoot: import.meta.dirname,
+    packageName: pkg.name,
+    entry: 'src/index.jsx',
+    i18nNamespace: 'portal',
+    cssCodeSplit: false,
+    overrides: {
+        plugins: [cssInjectedByJsPlugin()],
         define: {
-            'process.env.NODE_ENV': JSON.stringify(config.mode),
             REACT_APP_VERSION: JSON.stringify(process.env.npm_package_version)
         },
-        plugins: [
-            cssInjectedByJsPlugin(),
-            reactPlugin(),
-            svgrPlugin()
-        ],
         resolve: {
             dedupe: ['@tryghost/debug']
         },
         build: {
-            outDir: resolve(__dirname, 'umd'),
-            emptyOutDir: true,
-            reportCompressedSize: false,
-            minify: config.mode === 'production',
-            sourcemap: true,
-            cssCodeSplit: false,
-            lib: {
-                entry: resolve(__dirname, 'src/index.jsx'),
-                formats: ['umd'],
-                name: pkg.name,
-                fileName: format => `${outputFileName}.min.js`
-            },
             rollupOptions: {
                 output: {
                     manualChunks: false
                 }
-            },
-            commonjsOptions: {
-                include: [/ghost/, /node_modules/],
-                dynamicRequireRoot: '../../',
-                // Single glob expands to all SUPPORTED_LOCALES; passing each
-                // locale as an explicit path triggers a full repo-root
-                // directory crawl per entry under vite 7's bundled
-                // @rollup/plugin-commonjs, adding ~1s per locale to build time.
-                dynamicRequireTargets: ['../../ghost/i18n/locales/*/portal.json']
             }
         },
         test: {
-            globals: true,
-            environment: 'jsdom',
             setupFiles: './test/setup-tests.js',
-            testTimeout: 10000,
             coverage: {
                 reporter: ['cobertura', 'text-summary', 'html']
             }
         }
-    };
+    }
 });

--- a/apps/signup-form/package.json
+++ b/apps/signup-form/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tryghost/signup-form",
   "type": "module",
-  "version": "0.3.33",
+  "version": "0.3.34",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/signup-form/vite.config.mts
+++ b/apps/signup-form/vite.config.mts
@@ -1,21 +1,14 @@
 import pkg from './package.json';
-import react from '@vitejs/plugin-react';
-import svgr from 'vite-plugin-svgr';
-import {defineConfig} from 'vitest/config';
-import {resolve} from 'path';
+import {publicAppViteConfig} from '../_shared/vite-public-app.mjs';
 
-const outputFileName = pkg.name[0] === '@' ? pkg.name.slice(pkg.name.indexOf('/') + 1) : pkg.name;
-
-// https://vitejs.dev/config/
-export default defineConfig((config) => {
-    return {
-        logLevel: process.env.CI ? 'info' : 'warn',
-        plugins: [
-            svgr(),
-            react()
-        ],
+export default publicAppViteConfig({
+    packageRoot: import.meta.dirname,
+    packageName: pkg.name,
+    entry: 'src/index.tsx',
+    i18nNamespace: 'signup-form',
+    sourcemap: false,
+    overrides: {
         define: {
-            'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
             'process.env.VITEST_SEGFAULT_RETRY': 3
         },
         preview: {
@@ -30,43 +23,11 @@ export default defineConfig((config) => {
             dedupe: ['@tryghost/debug']
         },
         build: {
-            outDir: resolve(__dirname, 'umd'),
-            reportCompressedSize: false,
-            emptyOutDir: true,
-            minify: config.mode === 'production',
-            sourcemap: false,
-            cssCodeSplit: true,
-            lib: {
-                entry: resolve(__dirname, 'src/index.tsx'),
-                formats: ['umd'],
-                name: pkg.name,
-                fileName(format) {
-                    if (format === 'umd') {
-                        return `${outputFileName}.min.js`;
-                    }
-
-                    return `${outputFileName}.js`;
-                }
-            },
             rollupOptions: {
                 output: {}
-            },
-            commonjsOptions: {
-                include: [/ghost/, /node_modules/],
-                dynamicRequireRoot: '../../',
-                // Use a single glob instead of expanding SUPPORTED_LOCALES into
-                // ~60 explicit paths. Under vite 7's bundled
-                // @rollup/plugin-commonjs, each entry triggers a full directory
-                // crawl from dynamicRequireRoot (= repo root) at the start of
-                // the build, so the N-paths form adds ~1 second per locale.
-                // The glob is resolved by a single crawl and produces the same
-                // bundle output.
-                dynamicRequireTargets: ['../../ghost/i18n/locales/*/signup-form.json']
             }
         },
         test: {
-            globals: true, // required for @testing-library/jest-dom extensions
-            environment: 'jsdom',
             include: ['./test/unit/*'],
             testTimeout: process.env.TIMEOUT ? parseInt(process.env.TIMEOUT) : 10000,
             ...(process.env.CI && { // https://github.com/vitest-dev/vitest/issues/1674
@@ -74,5 +35,5 @@ export default defineConfig((config) => {
                 maxThreads: 2
             })
         }
-    };
+    }
 });

--- a/apps/sodo-search/package.json
+++ b/apps/sodo-search/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tryghost/sodo-search",
   "type": "module",
-  "version": "1.8.30",
+  "version": "1.8.31",
   "license": "MIT",
   "repository": "https://github.com/TryGhost/Ghost",
   "author": "Ghost Foundation",

--- a/apps/sodo-search/vite.config.mjs
+++ b/apps/sodo-search/vite.config.mjs
@@ -1,40 +1,19 @@
 /* eslint-env node */
-import {resolve} from 'path';
-
-import {defineConfig} from 'vitest/config';
-import reactPlugin from '@vitejs/plugin-react';
-import svgrPlugin from 'vite-plugin-svgr';
-
 import pkg from './package.json';
-export default defineConfig((config) => {
-    const outputFileName = pkg.name[0] === '@' ? pkg.name.slice(pkg.name.indexOf('/') + 1) : pkg.name;
+import {publicAppViteConfig} from '../_shared/vite-public-app.mjs';
 
-    return {
-        logLevel: process.env.CI ? 'info' : 'warn',
-        clearScreen: false,
-        define: {
-            'process.env.NODE_ENV': JSON.stringify(config.mode)
-        },
-        plugins: [
-            reactPlugin(),
-            svgrPlugin()
-        ],
+export default publicAppViteConfig({
+    packageRoot: import.meta.dirname,
+    packageName: pkg.name,
+    entry: 'src/index.jsx',
+    i18nNamespace: 'search',
+    sourcemap: false,
+    cssCodeSplit: false,
+    overrides: {
         resolve: {
             dedupe: ['@tryghost/debug']
         },
         build: {
-            outDir: resolve(__dirname, 'umd'),
-            reportCompressedSize: false,
-            emptyOutDir: true,
-            minify: config.mode === 'production',
-            sourcemap: false,
-            cssCodeSplit: false,
-            lib: {
-                entry: resolve(__dirname, 'src/index.jsx'),
-                formats: ['umd'],
-                name: pkg.name,
-                fileName: format => `${outputFileName}.min.js`
-            },
             rollupOptions: {
                 output: {
                     // Theme templates reference umd/main.css by name (see
@@ -47,22 +26,10 @@ export default defineConfig((config) => {
                         return 'assets/[name]-[hash][extname]';
                     }
                 }
-            },
-            commonjsOptions: {
-                include: [/ghost/, /node_modules/],
-                dynamicRequireRoot: '../../',
-                // Single glob expands to all SUPPORTED_LOCALES; passing each
-                // locale as an explicit path triggers a full repo-root
-                // directory crawl per entry under vite 7's bundled
-                // @rollup/plugin-commonjs, adding ~1s per locale to build time.
-                dynamicRequireTargets: ['../../ghost/i18n/locales/*/search.json']
             }
         },
         test: {
-            globals: true,
-            environment: 'jsdom',
-            setupFiles: './test/setup-tests.js',
-            testTimeout: 10000
+            setupFiles: './test/setup-tests.js'
         }
-    };
+    }
 });


### PR DESCRIPTION
## Summary

Extracts a shared `publicAppViteConfig` factory at `apps/_shared/vite-public-app.mjs`, then migrates all 6 public UMD apps onto it. Pure refactor: **bundle output byte-identical to current main** (verified post-rebase against #28974). Total vite-config code shrinks from ~360 → ~150 lines.

Now rebased onto `main` after [#28973](https://github.com/TryGhost/Ghost/pull/28973) and [#28974](https://github.com/TryGhost/Ghost/pull/28974) merged. The 4 apps #28974 set `sourcemap: false` for pass that through as a top-level helper arg (`sourcemap: false`).

### How the helper carves up "common" vs "per-app"

Helper covers what every app shares — `logLevel`, `clearScreen`, `outDir`, the `lib` block (entry, formats, name, fileName from `packageName`), `build.{emptyOutDir,reportCompressedSize,minify}`, optional i18n locale glob, baseline `test` block.

Per-app divergence flows through an `overrides` slot that's deep-merged via Vite's `mergeConfig` (appends plugin arrays, deep-merges objects, override-wins primitives). First-class knobs cover the dimensions that legitimately vary:
- `framework: 'react' | 'preact'`
- `svgr: boolean`
- `libFormat: 'umd' | 'iife'`
- `libName` (e.g. `'GhostAdminToolbar'` for admin-toolbar's IIFE global)
- `sourcemap` (false for 5 of 6 post-#28974), `cssCodeSplit`
- `i18nNamespace` (4 of 6 apps wire a locale glob)

Plugin imports are **dynamic** (`await import(...)` inside the factory) so apps can opt out of deps they don't use — admin-toolbar uses Preact and never installs `@vitejs/plugin-react`.

### Per-app config shrink

| App | Before | After | Real divergence in overrides |
|---|---|---|---|
| admin-toolbar | 30 | 10 | (just args — Preact, IIFE, no svgr) |
| announcement-bar | 38 | 13 | test.setupFiles |
| portal | 62 | 33 | cssInjectedByJsPlugin, REACT_APP_VERSION, manualChunks, coverage |
| sodo-search | 56 | 33 | dedupe, assetFileNames=main.css, setupFiles |
| signup-form | 78 | 35 | VITESEGFAULT, preview, optimizeDeps, CI threads |
| comments-ui | 96 | 48 | strip-fingerprint, React-17 dedupe/alias, tiptap inline test deps |
| **total** | **360** | **172** | |

### Verification

- **Byte-identical bundles** to current `main` (post-#28974) for all 6 apps — verified via `sha256sum` over emitted `umd/*` after rebuilding both states.
- **All unit test suites green** (pre-rebase, unchanged in scope): admin-toolbar 20/20, announcement-bar 1/1, portal 582/583, sodo-search 11/11, comments-ui 251/251. signup-form has no unit suite (only `test:acceptance`).
- **Lint clean** across all 6.
- **App version bumps** included in the final commit: all 6 apps patch-bumped (vite.config changes trigger the bump CI check).

### Notes

- Helper at `apps/_shared/` (underscore-prefix = not a published workspace package).
- Helper is `.mjs` + JSDoc (not `.ts`) to avoid an import-edge case with the 4 `.mjs` callers and 2 `.mts` callers.
- Plugin arrays in `overrides` get appended after base plugins (`reactPlugin()`, `svgrPlugin()`); confirmed no order-sensitive output drift via byte-diff (portal's `cssInjectedByJsPlugin` operates at the render hook, not transform — order doesn't matter).
- `comments-ui` dropped its unused multi-format `fileName` function (formats only contains `'umd'`; helper default produces the same `comments-ui.min.js`).

## Test plan

- [ ] CI: app-version-bump check passes
- [ ] CI: all unit + acceptance test suites green
- [ ] Smoke-test the dev gateway flows in `pnpm dev` (portal sign-in, comments-ui post, sodo-search query)