### PR TITLE
Automations: made scheduler requests idempotent

### DIFF
--- a/ghost/core/core/server/services/automations/get-scheduler-idempotency-key.ts
+++ b/ghost/core/core/server/services/automations/get-scheduler-idempotency-key.ts
@@ -1,0 +1,8 @@
+import crypto from 'node:crypto';
+
+export function getSchedulerIdempotencyKey(date: Readonly<Date>, url: Readonly<URL>): string {
+    const hash = crypto.createHash('sha256');
+    hash.update(date.toISOString());
+    hash.update(url.href);
+    return `ghost-automations-${hash.digest('hex')}`;
+}

--- a/ghost/core/core/server/services/automations/service.ts
+++ b/ghost/core/core/server/services/automations/service.ts
@@ -6,6 +6,7 @@ import type DomainEvents from '@tryghost/domain-events';
 import {oneAtATime} from '../../../shared/one-at-a-time';
 import {poll} from './poll';
 import * as automationsApi from './automations-api';
+import {getSchedulerIdempotencyKey} from './get-scheduler-idempotency-key';
 import {setImmediate as flushEventLoop} from 'node:timers/promises';
 import {SoonestTimer} from '../../lib/soonest-timer';
 import {getSchedulerPollTime} from './scheduler-poll-time';
@@ -85,7 +86,10 @@ export class AutomationsService {
                 schedulerAdapter.schedule({
                     time: schedulerPollTime.getTime(),
                     url: url.toString(),
-                    extra: {httpMethod: 'PUT'}
+                    extra: {
+                        httpMethod: 'PUT',
+                        idempotencyKey: getSchedulerIdempotencyKey(date, url)
+                    }
                 });
             } catch (err) {
                 logging.error({event: {name: 'automations.enqueue-poll.error'}, err, at: date.toISOString()}, 'Failed to enqueue automations poll');

--- a/ghost/core/test/unit/server/services/automations/get-scheduler-idempotency-key.test.ts
+++ b/ghost/core/test/unit/server/services/automations/get-scheduler-idempotency-key.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+
+import {getSchedulerIdempotencyKey} from '../../../../../core/server/services/automations/get-scheduler-idempotency-key';
+
+describe('getSchedulerIdempotencyKey', function () {
+    it('returns same result for same date and URL', function () {
+        const date = new Date();
+        const url = new URL('https://example.com/path?key=value');
+
+        const first = getSchedulerIdempotencyKey(date, url);
+        const second = getSchedulerIdempotencyKey(date, url);
+
+        assert.equal(first, second);
+    });
+
+    it('returns different results for different times', function () {
+        const url = new URL('https://example.com/path?key=value');
+
+        const first = getSchedulerIdempotencyKey(new Date(100), url);
+        const second = getSchedulerIdempotencyKey(new Date(200), url);
+
+        assert.notEqual(first, second);
+    });
+
+    it('returns different results for different URLs', function () {
+        const date = new Date();
+        const firstUrl = new URL('https://example.com/path?key=one');
+        const secondUrl = new URL('https://example.com/path?key=two');
+
+        const first = getSchedulerIdempotencyKey(date, firstUrl);
+        const second = getSchedulerIdempotencyKey(date, secondUrl);
+
+        assert.notEqual(first, second);
+    });
+
+    it('prefixes with an automations namespace', function () {
+        const date = new Date();
+        const url = new URL('https://example.com/path?key=value');
+
+        const key = getSchedulerIdempotencyKey(date, url);
+
+        assert(key.startsWith('ghost-automations-'));
+    });
+});

--- a/ghost/core/test/unit/server/services/automations/service.test.js
+++ b/ghost/core/test/unit/server/services/automations/service.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const {randomUUID} = require('node:crypto');
 const {setImmediate: flushEventLoop} = require('node:timers/promises');
@@ -189,7 +190,8 @@ describe('automations service', function () {
                         new URL(value).searchParams.has('token')
                     )),
                     extra: {
-                        httpMethod: 'PUT'
+                        httpMethod: 'PUT',
+                        idempotencyKey: sinon.match.string
                     }
                 })
             );
@@ -198,6 +200,19 @@ describe('automations service', function () {
                 domainEvents.dispatch,
                 sinon.match.instanceOf(StartAutomationsPollEvent)
             );
+        });
+
+        it('uses the same idempotency key when requesting the same time', async function () {
+            const future = new Date(Date.now() + 10_000);
+
+            await automations.__testOnlyEnqueuePollAt(future);
+            await automations.__testOnlyEnqueuePollAt(future);
+            await automations.__testOnlyEnqueuePollAt(future);
+
+            sinon.assert.calledThrice(schedulerAdapter.schedule);
+
+            const idempotencyKeys = schedulerAdapter.schedule.getCalls().map(call => call.args[0].extra.idempotencyKey);
+            assert.equal(new Set(idempotencyKeys).size, 1);
         });
     });
 


### PR DESCRIPTION
closes [NY-1396](https://linear.app/ghost/issue/NY-1396)<br>ref TryGhost/Ghost#29490

More accurately, this sends the new `idempotencyKey` option to the scheduler.

This will help reduce unnecessary pressure on the scheduler.