### PR TITLE
Automate patch releases for public UMD apps

### DIFF
--- a/.github/scripts/build-public-apps-matrix.js
+++ b/.github/scripts/build-public-apps-matrix.js
@@ -1,0 +1,60 @@
+// Builds the publish matrix for public UMD apps, filtered to the apps affected
+// in the current run. The output (stdout, compact JSON array) feeds the
+// publish_public_apps job's `strategy.matrix.include` via fromJSON.
+//
+// Matrix context isn't available in a job-level `if:`, so the affected gate
+// can't live on the publish job — instead we compute the set here in job_setup
+// (mirroring the affected_playwright_projects dynamic matrix) and the job skips
+// itself when the result is `[]`.
+//
+// The app list (and the CURRENT_MINOR placeholder the publish job substitutes
+// with the released major.minor before purging jsDelivr) comes from the shared
+// public-apps.json.
+
+const PUBLIC_APPS = require('./public-apps.json');
+
+/**
+ * @param {string[]} affectedProjects - nx project names affected in this run
+ * @returns {Array<{package_name: string, package_path: string, cdn_paths: string}>}
+ *   matrix entries with cdn_paths flattened to the newline-delimited string the
+ *   publish job's purge step expects.
+ */
+function buildMatrix(affectedProjects) {
+    const affected = new Set(affectedProjects);
+    return PUBLIC_APPS
+        .filter(app => affected.has(app.packageName))
+        .map(app => ({
+            package_name: app.packageName,
+            package_path: app.path,
+            cdn_paths: app.cdnPaths.join('\n')
+        }));
+}
+
+function main() {
+    const raw = process.argv[2] || '[]';
+
+    let affectedProjects;
+    try {
+        affectedProjects = JSON.parse(raw);
+    } catch (error) {
+        throw new Error(`Invalid affected-projects JSON: ${error.message}`);
+    }
+
+    if (!Array.isArray(affectedProjects)) {
+        throw new Error('affected-projects argument must be a JSON array');
+    }
+
+    // Stdout is the contract — the workflow captures this into a job output.
+    process.stdout.write(JSON.stringify(buildMatrix(affectedProjects)));
+}
+
+if (require.main === module) {
+    try {
+        main();
+    } catch (error) {
+        console.error(error.message);
+        process.exit(1);
+    }
+}
+
+module.exports = {buildMatrix, PUBLIC_APPS};

--- a/.github/scripts/check-app-version-bump.js
+++ b/.github/scripts/check-app-version-bump.js
@@ -2,32 +2,10 @@ const fs = require('fs');
 const path = require('path');
 const execFileSync = require('child_process').execFileSync;
 
-const MONITORED_APPS = {
-    portal: {
-        packageName: '@tryghost/portal',
-        path: 'apps/portal'
-    },
-    sodoSearch: {
-        packageName: '@tryghost/sodo-search',
-        path: 'apps/sodo-search'
-    },
-    comments: {
-        packageName: '@tryghost/comments-ui',
-        path: 'apps/comments-ui'
-    },
-    announcementBar: {
-        packageName: '@tryghost/announcement-bar',
-        path: 'apps/announcement-bar'
-    },
-    signupForm: {
-        packageName: '@tryghost/signup-form',
-        path: 'apps/signup-form'
-    },
-    adminToolbar: {
-        packageName: '@tryghost/admin-toolbar',
-        path: 'apps/admin-toolbar'
-    }
-};
+// Keyed by defaults.json config key, derived from the shared public-apps list.
+const MONITORED_APPS = Object.fromEntries(
+    require('./public-apps.json').map(app => [app.configKey, {packageName: app.packageName, path: app.path}])
+);
 
 const MONITORED_APP_ENTRIES = Object.entries(MONITORED_APPS);
 const MONITORED_APP_PATHS = MONITORED_APP_ENTRIES.map(([, app]) => app.path);
@@ -82,86 +60,6 @@ function parseSemver(version) {
     };
 }
 
-function comparePrereleaseIdentifier(a, b) {
-    const isANumber = typeof a === 'number';
-    const isBNumber = typeof b === 'number';
-
-    if (isANumber && isBNumber) {
-        if (a === b) {
-            return 0;
-        }
-
-        return a > b ? 1 : -1;
-    }
-
-    if (isANumber) {
-        return -1;
-    }
-
-    if (isBNumber) {
-        return 1;
-    }
-
-    if (a === b) {
-        return 0;
-    }
-
-    return a > b ? 1 : -1;
-}
-
-function compareSemver(a, b) {
-    const aVersion = parseSemver(a);
-    const bVersion = parseSemver(b);
-
-    if (aVersion.major !== bVersion.major) {
-        return aVersion.major > bVersion.major ? 1 : -1;
-    }
-
-    if (aVersion.minor !== bVersion.minor) {
-        return aVersion.minor > bVersion.minor ? 1 : -1;
-    }
-
-    if (aVersion.patch !== bVersion.patch) {
-        return aVersion.patch > bVersion.patch ? 1 : -1;
-    }
-
-    const aPrerelease = aVersion.prerelease;
-    const bPrerelease = bVersion.prerelease;
-
-    if (!aPrerelease.length && !bPrerelease.length) {
-        return 0;
-    }
-
-    if (!aPrerelease.length) {
-        return 1;
-    }
-
-    if (!bPrerelease.length) {
-        return -1;
-    }
-
-    const maxLength = Math.max(aPrerelease.length, bPrerelease.length);
-    for (let i = 0; i < maxLength; i += 1) {
-        const aIdentifier = aPrerelease[i];
-        const bIdentifier = bPrerelease[i];
-
-        if (aIdentifier === undefined) {
-            return -1;
-        }
-
-        if (bIdentifier === undefined) {
-            return 1;
-        }
-
-        const identifierComparison = comparePrereleaseIdentifier(aIdentifier, bIdentifier);
-        if (identifierComparison !== 0) {
-            return identifierComparison;
-        }
-    }
-
-    return 0;
-}
-
 function getMajorMinorVersion(version) {
     const parsedVersion = parseSemver(version);
     return `${parsedVersion.major}.${parsedVersion.minor}`;
@@ -192,11 +90,6 @@ function getChangedApps(changedFiles) {
     return MONITORED_APP_ENTRIES
         .filter(([, app]) => getChangedAppFiles(app, changedFiles).length > 0)
         .map(([key, app]) => ({key, ...app}));
-}
-
-function isDependencyOnlyChange(app, changedFiles) {
-    const filesInApp = getChangedAppFiles(app, changedFiles);
-    return filesInApp.length > 0 && filesInApp.every(file => file === `${app.path}/package.json`);
 }
 
 function getPrVersion(app) {
@@ -244,13 +137,6 @@ function getPrDefaultsVersion(app) {
     );
 }
 
-function getMainVersion(app) {
-    return readVersionFromPackageJson(
-        runGit(['show', `origin/main:${app.path}/package.json`]),
-        `${app.path}/package.json from main`
-    );
-}
-
 function main() {
     const baseSha = process.env.PR_BASE_SHA;
     const compareSha = process.env.PR_COMPARE_SHA || process.env.GITHUB_SHA;
@@ -267,59 +153,60 @@ function main() {
     const changedApps = getChangedApps(changedFiles);
 
     if (changedApps.length === 0) {
-        console.log(`No app changes detected. Skipping version bump check.`);
+        console.log(`No app changes detected. Skipping app version consistency check.`);
         return;
     }
 
-    console.log(`Checking version bump for apps: ${changedApps.map(app => app.key).join(', ')}`);
+    console.log(`Checking app version consistency for: ${changedApps.map(app => app.key).join(', ')}`);
 
     const failedApps = [];
 
     for (const app of changedApps) {
-        const prVersion = getPrVersion(app);
-        const mainVersion = getMainVersion(app);
+        const error = checkAppConsistency(app, getPrVersion(app), getPrDefaultsVersion(app));
 
-        if (isDependencyOnlyChange(app, changedFiles)) {
-            if (prVersion === mainVersion) {
-                console.log(`${app.key} only has dependency changes in package.json; skipping version bump check.`);
-                continue;
-            }
-
-            console.log(`${app.key} package.json changed the package version; continuing version bump checks.`);
-        }
-
-        if (compareSemver(prVersion, mainVersion) <= 0) {
-            failedApps.push(
-                `${app.key} (${app.packageName}) was changed but version was not bumped above main (${prVersion} <= ${mainVersion}). Please run "pnpm ship" in ${app.path} to bump the package version.`
-            );
+        if (error) {
+            failedApps.push(error);
             continue;
         }
 
-        console.log(`${app.key} package version bump check passed (${prVersion} > ${mainVersion})`);
-
-        const prMajorMinorVersion = getMajorMinorVersion(prVersion);
-        const prDefaultsVersion = getPrDefaultsVersion(app);
-
-        if (prDefaultsVersion !== prMajorMinorVersion) {
-            failedApps.push(
-                `${app.key} (${app.packageName}) was bumped from ${mainVersion} to ${prVersion}, but defaults.json still has ${app.key}.version set to ${prDefaultsVersion}. Please update ghost/core/core/shared/config/defaults.json to ${prMajorMinorVersion}.`
-            );
-            continue;
-        }
-
-        console.log(`${app.key} defaults.json version check passed (${app.key}.version = ${prDefaultsVersion})`);
+        console.log(`${app.key} version consistency check passed (package.json ${getMajorMinorVersion(getPrVersion(app))} = defaults.json ${getPrDefaultsVersion(app)})`);
     }
 
     if (failedApps.length) {
-        throw new Error(`Version bump checks failed:\n- ${failedApps.join('\n- ')}`);
+        throw new Error(`App version consistency checks failed:\n- ${failedApps.join('\n- ')}`);
     }
 
-    console.log('All monitored app version bump checks passed.');
+    console.log('All monitored app version consistency checks passed.');
 }
 
-try {
-    main();
-} catch (error) {
-    console.error(error.message);
-    process.exit(1);
+/**
+ * Patch releases are published automatically on merge to main, with npm as the
+ * source of truth for the patch number — so PRs no longer need to bump the
+ * version at all. The only invariant we still enforce is that package.json's
+ * major.minor matches defaults.json, because Ghost core serves each app from
+ * `<pkg>@~<major.minor>` on jsDelivr. A deliberate minor/major release (via
+ * "pnpm ship") must move both in lockstep, or live sites would point at a
+ * version line that never gets published.
+ *
+ * @returns {string|null} an error message when inconsistent, otherwise null
+ */
+function checkAppConsistency(app, prVersion, prDefaultsVersion) {
+    const prMajorMinorVersion = getMajorMinorVersion(prVersion);
+
+    if (prDefaultsVersion !== prMajorMinorVersion) {
+        return `${app.key} (${app.packageName}): package.json is on ${prMajorMinorVersion} but defaults.json has ${app.key}.version set to ${prDefaultsVersion}. These must match — for a minor/major release run "pnpm ship" in ${app.path} (it updates both), otherwise align ghost/core/core/shared/config/defaults.json to ${prMajorMinorVersion}.`;
+    }
+
+    return null;
 }
+
+if (require.main === module) {
+    try {
+        main();
+    } catch (error) {
+        console.error(error.message);
+        process.exit(1);
+    }
+}
+
+module.exports = {checkAppConsistency, getMajorMinorVersion};

--- a/.github/scripts/compute-next-app-version.js
+++ b/.github/scripts/compute-next-app-version.js
@@ -1,0 +1,109 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const execFileSync = require('node:child_process').execFileSync;
+
+const semver = require('semver');
+
+/**
+ * Computes the next version to publish for a public app, treating npm as the
+ * source of truth for the patch number.
+ *
+ * Releases are patch-only and automated: the app's package.json pins the
+ * major.minor "line" (a human-controlled floor that only moves for intentional
+ * minor/major releases), and the live patch number lives in npm. So:
+ *
+ *   - If npm already has versions in the package.json major.minor line, publish
+ *     the next patch above the highest one published there.
+ *   - If npm has nothing in that line yet (a fresh minor/major just landed in
+ *     package.json + defaults.json), publish package.json's exact version.
+ *
+ * The package.json patch digit is otherwise unused — Ghost core resolves apps
+ * via `<pkg>@~<major.minor>` on jsDelivr, so it always tracks the newest
+ * published patch regardless of what package.json says.
+ *
+ * @param {string} currentVersion - the version field from the app's package.json
+ * @param {string[]} publishedVersions - all versions published to npm for the app
+ * @returns {string} the version to publish next
+ */
+function computeNextVersion(currentVersion, publishedVersions) {
+    const current = semver.parse(currentVersion);
+    if (!current) {
+        throw new Error(`Invalid version "${currentVersion}" in package.json`);
+    }
+
+    const patchesInLine = publishedVersions
+        .map(version => semver.parse(version))
+        // Ignore prereleases (e.g. 2.69.5-beta.1) — only stable patches in this
+        // major.minor line should drive the next patch number.
+        .filter(version => version
+            && version.major === current.major
+            && version.minor === current.minor
+            && version.prerelease.length === 0)
+        .map(version => version.patch);
+
+    if (patchesInLine.length === 0) {
+        // Fresh major.minor line — publish exactly what package.json declares.
+        return current.version;
+    }
+
+    const highestPatch = Math.max(...patchesInLine);
+    return `${current.major}.${current.minor}.${highestPatch + 1}`;
+}
+
+/**
+ * Reads every version published to npm for a package. Returns an empty array
+ * when the package has never been published (npm exits with E404).
+ *
+ * @param {string} packageName
+ * @returns {string[]}
+ */
+function getPublishedVersions(packageName) {
+    let output;
+
+    try {
+        output = execFileSync('npm', ['view', packageName, 'versions', '--json'], {encoding: 'utf8'});
+    } catch (error) {
+        const combined = `${error.stdout || ''}${error.stderr || ''}`;
+        if (combined.includes('E404') || combined.includes('404 Not Found')) {
+            return [];
+        }
+        throw new Error(`Failed to read published versions for ${packageName}: ${combined || error.message}`);
+    }
+
+    const trimmed = output.trim();
+    if (!trimmed) {
+        return [];
+    }
+
+    const parsed = JSON.parse(trimmed);
+    // npm returns a bare string when only one version exists, an array otherwise.
+    return Array.isArray(parsed) ? parsed : [parsed];
+}
+
+function main() {
+    const packageDir = process.argv[2] || process.cwd();
+    const packageJsonPath = path.resolve(packageDir, 'package.json');
+
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+
+    if (!packageJson.name || !packageJson.version) {
+        throw new Error(`${packageJsonPath} is missing a name or version`);
+    }
+
+    const publishedVersions = getPublishedVersions(packageJson.name);
+    const nextVersion = computeNextVersion(packageJson.version, publishedVersions);
+
+    // Stdout is the contract — the workflow captures this to set the version.
+    process.stdout.write(nextVersion);
+}
+
+if (require.main === module) {
+    try {
+        main();
+    } catch (error) {
+        console.error(error.message);
+        process.exit(1);
+    }
+}
+
+module.exports = {computeNextVersion, getPublishedVersions};

--- a/.github/scripts/public-apps.json
+++ b/.github/scripts/public-apps.json
@@ -1,0 +1,51 @@
+[
+    {
+        "packageName": "@tryghost/portal",
+        "path": "apps/portal",
+        "configKey": "portal",
+        "cdnPaths": [
+            "https://cdn.jsdelivr.net/ghost/portal@~CURRENT_MINOR/umd/portal.min.js"
+        ]
+    },
+    {
+        "packageName": "@tryghost/sodo-search",
+        "path": "apps/sodo-search",
+        "configKey": "sodoSearch",
+        "cdnPaths": [
+            "https://cdn.jsdelivr.net/ghost/sodo-search@~CURRENT_MINOR/umd/sodo-search.min.js",
+            "https://cdn.jsdelivr.net/ghost/sodo-search@~CURRENT_MINOR/umd/main.css"
+        ]
+    },
+    {
+        "packageName": "@tryghost/comments-ui",
+        "path": "apps/comments-ui",
+        "configKey": "comments",
+        "cdnPaths": [
+            "https://cdn.jsdelivr.net/ghost/comments-ui@~CURRENT_MINOR/umd/comments-ui.min.js"
+        ]
+    },
+    {
+        "packageName": "@tryghost/signup-form",
+        "path": "apps/signup-form",
+        "configKey": "signupForm",
+        "cdnPaths": [
+            "https://cdn.jsdelivr.net/ghost/signup-form@~CURRENT_MINOR/umd/signup-form.min.js"
+        ]
+    },
+    {
+        "packageName": "@tryghost/announcement-bar",
+        "path": "apps/announcement-bar",
+        "configKey": "announcementBar",
+        "cdnPaths": [
+            "https://cdn.jsdelivr.net/ghost/announcement-bar@~CURRENT_MINOR/umd/announcement-bar.min.js"
+        ]
+    },
+    {
+        "packageName": "@tryghost/admin-toolbar",
+        "path": "apps/admin-toolbar",
+        "configKey": "adminToolbar",
+        "cdnPaths": [
+            "https://cdn.jsdelivr.net/ghost/admin-toolbar@~CURRENT_MINOR/umd/admin-toolbar.min.js"
+        ]
+    }
+]

--- a/.github/scripts/release-apps.js
+++ b/.github/scripts/release-apps.js
@@ -5,15 +5,11 @@ const readline = require('readline/promises');
 
 const semver = require('semver');
 
-// Maps a package name to the config key in defaults.json
-const CONFIG_KEYS = {
-    '@tryghost/portal': 'portal',
-    '@tryghost/sodo-search': 'sodoSearch',
-    '@tryghost/comments-ui': 'comments',
-    '@tryghost/announcement-bar': 'announcementBar',
-    '@tryghost/signup-form': 'signupForm',
-    '@tryghost/admin-toolbar': 'adminToolbar'
-};
+// Maps a package name to the config key in defaults.json, derived from the
+// shared public-apps list.
+const CONFIG_KEYS = Object.fromEntries(
+    require('./public-apps.json').map(app => [app.packageName, app.configKey])
+);
 
 const CURRENT_DIR = process.cwd();
 
@@ -73,11 +69,17 @@ async function ensureCleanGit() {
 
 async function getNewVersion() {
     const rl = readline.createInterface({input: process.stdin, output: process.stdout});
-    const bumpTypeInput = await rl.question('Is this a patch, minor or major (patch)? ');
+    // Patch releases are published automatically on every merge to main (CI
+    // computes the next patch from npm), so this script only drives intentional
+    // minor/major releases — the ones that also move the major.minor pinned in
+    // defaults.json.
+    console.log('Patch releases are published automatically on merge to main.');
+    console.log('Use this only for an intentional minor or major release.\n');
+    const bumpTypeInput = await rl.question('Is this a minor or major release (minor)? ');
     rl.close();
-    const bumpType = bumpTypeInput.trim().toLowerCase() || 'patch';
-    if (!['patch', 'minor', 'major'].includes(bumpType)) {
-        console.error(`Unknown bump type ${bumpTypeInput} - expected one of "patch", "minor, "major"`)
+    const bumpType = bumpTypeInput.trim().toLowerCase() || 'minor';
+    if (!['minor', 'major'].includes(bumpType)) {
+        console.error(`Unknown bump type ${bumpTypeInput} - expected "minor" or "major" (patch releases are automated)`)
         process.exit(1);
     }
     return semver.inc(APP_VERSION, bumpType);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,11 +219,20 @@ jobs:
             --json)
           echo "affected_playwright_projects=$PLAYWRIGHT_PROJECTS" >> "$GITHUB_OUTPUT"
 
+          # Build the publish matrix for affected public apps. Matrix context
+          # isn't available in a job-level `if:`, so the publish job can't filter
+          # itself per-app — instead we emit the matrix here and it skips when
+          # the result is `[]`. The publish job's own is_main / event gates keep
+          # tags and PRs from publishing regardless of what this lists.
+          PUBLISH_PUBLIC_APPS_MATRIX=$(node .github/scripts/build-public-apps-matrix.js "$AFFECTED_PROJECTS")
+          echo "publish_public_apps_matrix=$PUBLISH_PUBLIC_APPS_MATRIX" >> "$GITHUB_OUTPUT"
+
     outputs:
       affected_projects: ${{ steps.affected.outputs.affected_projects }}
       affected_projects_str: ${{ steps.affected.outputs.affected_projects_str }}
       unit_test_projects_str: ${{ steps.affected.outputs.unit_test_projects_str }}
       affected_playwright_projects: ${{ steps.affected.outputs.affected_playwright_projects }}
+      publish_public_apps_matrix: ${{ steps.affected.outputs.publish_public_apps_matrix }}
       changed_i18n_apps: ${{ steps.affected.outputs.affected_i18n_projects != '' }}
       changed_core: ${{ steps.changed.outputs.core }}
       changed_tinybird: ${{ steps.changed.outputs.tinybird }}
@@ -1696,6 +1705,12 @@ jobs:
     ]
     name: Publish ${{ matrix.package_name }}
     runs-on: ubuntu-latest
+    # Serialize per-app publishes so two quick main merges can't both compute the
+    # same next-patch number and collide on npm. Different apps still publish in
+    # parallel; cancel-in-progress stays false so a queued publish isn't dropped.
+    concurrency:
+      group: publish-public-app-${{ matrix.package_name }}
+      cancel-in-progress: false
     if: |
       github.event_name != 'pull_request'
       && github.repository == 'TryGhost/Ghost'
@@ -1704,31 +1719,13 @@ jobs:
       && needs.job_lint.result == 'success'
       && needs.job_unit-tests.result == 'success'
       && needs.build_public_apps.result == 'success'
+      && needs.job_setup.outputs.publish_public_apps_matrix != '[]'
     permissions:
+      contents: read
       id-token: write
     strategy:
       matrix:
-        include:
-          - package_name: '@tryghost/portal'
-            package_path: 'apps/portal'
-            cdn_paths: 'https://cdn.jsdelivr.net/ghost/portal@~CURRENT_MINOR/umd/portal.min.js'
-          - package_name: '@tryghost/sodo-search'
-            package_path: 'apps/sodo-search'
-            cdn_paths: |
-              https://cdn.jsdelivr.net/ghost/sodo-search@~CURRENT_MINOR/umd/sodo-search.min.js
-              https://cdn.jsdelivr.net/ghost/sodo-search@~CURRENT_MINOR/umd/main.css
-          - package_name: '@tryghost/comments-ui'
-            package_path: 'apps/comments-ui'
-            cdn_paths: 'https://cdn.jsdelivr.net/ghost/comments-ui@~CURRENT_MINOR/umd/comments-ui.min.js'
-          - package_name: '@tryghost/signup-form'
-            package_path: 'apps/signup-form'
-            cdn_paths: 'https://cdn.jsdelivr.net/ghost/signup-form@~CURRENT_MINOR/umd/signup-form.min.js'
-          - package_name: '@tryghost/announcement-bar'
-            package_path: 'apps/announcement-bar'
-            cdn_paths: 'https://cdn.jsdelivr.net/ghost/announcement-bar@~CURRENT_MINOR/umd/announcement-bar.min.js'
-          - package_name: '@tryghost/admin-toolbar'
-            package_path: 'apps/admin-toolbar'
-            cdn_paths: 'https://cdn.jsdelivr.net/ghost/admin-toolbar@~CURRENT_MINOR/umd/admin-toolbar.min.js'
+        include: ${{ fromJSON(needs.job_setup.outputs.publish_public_apps_matrix) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -1743,65 +1740,54 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Check if version changed
-        id: version_check
+      - name: Determine release version
+        id: release
         working-directory: ${{ matrix.package_path }}
         run: |
-          CURRENT_VERSION=$(cat package.json | jq -r .version)
-          echo "Current version: $CURRENT_VERSION"
+          # npm is the source of truth for the patch number: compute the next
+          # patch above what's already published in this app's major.minor line
+          # (or publish package.json's exact version when starting a fresh
+          # minor/major line). The patch digit in package.json is otherwise
+          # unused — Ghost core resolves apps via <pkg>@~<major.minor> on
+          # jsDelivr, so the newest published patch is what sites receive.
+          NEXT_VERSION=$(node "$GITHUB_WORKSPACE/.github/scripts/compute-next-app-version.js" .)
+          echo "Publishing ${{ matrix.package_name }}@${NEXT_VERSION}"
 
-          CURRENT_MINOR=$(cat package.json | jq -r .version | awk -F. '{print $1"."$2}')
-          echo "current_minor=$CURRENT_MINOR" >> $GITHUB_OUTPUT
+          # Write it before building so the version baked into the bundle
+          # (e.g. portal's REACT_APP_VERSION) matches what we publish.
+          npm pkg set version="$NEXT_VERSION"
 
-          CURRENT_MAJOR=$(cat package.json | jq -r .version | awk -F. '{print $1}')
-          echo "current_major=$CURRENT_MAJOR" >> $GITHUB_OUTPUT
-
-          PUBLISHED_VERSION=$(npm show ${{ matrix.package_name }} version || echo "0.0.0")
-          echo "Published version (latest): $PUBLISHED_VERSION"
-
-          if [ "$CURRENT_VERSION" = "$PUBLISHED_VERSION" ]; then
-            echo "Version is unchanged."
-            echo "version_changed=false" >> $GITHUB_OUTPUT
-          else
-            echo "Version has changed."
-            echo "version_changed=true" >> $GITHUB_OUTPUT
-          fi
+          echo "current_minor=$(echo "$NEXT_VERSION" | awk -F. '{print $1"."$2}')" >> $GITHUB_OUTPUT
+          echo "current_major=$(echo "$NEXT_VERSION" | awk -F. '{print $1}')" >> $GITHUB_OUTPUT
 
       - name: Build the package
-        if: steps.version_check.outputs.version_changed == 'true'
         run: pnpm nx build ${{ matrix.package_name }}
 
       - name: Configure .npmrc
-        if: steps.version_check.outputs.version_changed == 'true'
         run: |
           echo "@tryghost:registry=https://registry.npmjs.org/" >> ~/.npmrc
 
       # TODO: Check we can remove this once we update Node to v24
       - name: Install v11 of NPM # We need this to install packages via OIDC.
-        if: steps.version_check.outputs.version_changed == 'true'
         run: npm install -g npm@11
 
       - name: Publish to npm
-        if: steps.version_check.outputs.version_changed == 'true'
         working-directory: ${{ matrix.package_path }}
         run: |
           pnpm publish --access public --no-git-checks
 
       - name: Replace version placeholders in cdn-paths
         id: cdn_paths
-        if: steps.version_check.outputs.version_changed == 'true'
         run: |
           cdn_paths="${{ matrix.cdn_paths }}"
           echo "cdn_paths<<EOF" >> $GITHUB_OUTPUT
-          echo "$cdn_paths" | sed -e 's/CURRENT_MINOR/${{ steps.version_check.outputs.current_minor }}/g' -e 's/CURRENT_MAJOR/${{ steps.version_check.outputs.current_major }}/g' >> $GITHUB_OUTPUT
+          echo "$cdn_paths" | sed -e 's/CURRENT_MINOR/${{ steps.release.outputs.current_minor }}/g' -e 's/CURRENT_MAJOR/${{ steps.release.outputs.current_major }}/g' >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Print cdn_paths
-        if: steps.version_check.outputs.version_changed == 'true'
         run: echo "${{ steps.cdn_paths.outputs.cdn_paths }}"
 
       - name: Purge jsDelivr cache
-        if: steps.version_check.outputs.version_changed == 'true'
         uses: gacts/purge-jsdelivr-cache@8d92aea944f1a3e8ad70505379e1a8ac72d56b73 # v1
         with:
           url: ${{ steps.cdn_paths.outputs.cdn_paths }}

--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -84,10 +84,7 @@
           "test:acceptance"
         ]
       }
-    },
-    "tags": [
-      "public-app"
-    ]
+    }
   },
   "dependencies": {
     "@hookform/resolvers": "5.4.0",


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLA-185

## Problem

The PR-time version-bump gate for public apps in `apps/*` was constantly missed (AI agents ignored it) and caused merge conflicts whenever multiple PRs touched the same app. The bump was a manual chore that, by design, had to change the same line in two files.

## Approach

Stop tracking the patch number in git — make **npm the source of truth** and publish patches automatically on merge to `main`. No version is committed back, so there are no protected-branch pushes or races.

This works because Ghost core resolves each app via `<pkg>@~<major.minor>` on jsDelivr, so a newly published patch auto-propagates to every site with no core change. Minor/major releases stay manual (via `pnpm ship`) because they move the `major.minor` pinned in `defaults.json` — a deliberate rollout decision.

## What changed

- **`compute-next-app-version.js`** (new) — derives the next patch from npm for an app's `major.minor` line (or publishes `package.json`'s exact version when starting a fresh minor/major line). Pure function + unit-tested.
- **`ci.yml → publish_public_apps`** — each matrix leg is gated on whether the app is in `affected_projects`; it computes + writes the version with `npm pkg set` **before** building (so portal's embedded `REACT_APP_VERSION` matches what's published), then publishes. Added per-app `concurrency` so two quick merges can't collide on the same next patch.
- **`check-app-version-bump.js`** — dropped the "must bump above main" rule (and ~165 lines of now-dead semver helpers). It now only enforces `package.json` major.minor == `defaults.json` — the one human coordination point for minor/major. Job name kept stable so required-status-check config isn't affected.
- **`release-apps.js`** (`pnpm ship`) — now minor/major-only (default `minor`), with a note that patches are automated.
- **`apps/activitypub/package.json`** — removed the stale `public-app` tag (leftover from its removed UMD build) so `tag:public-app` cleanly selects the 6 CDN apps.

## Note for reviewers

The publish gate reuses the existing `affected_projects` output, whose `AFFECTED_ARG` becomes "everything" when CI-globals (`.github/**`, lockfile, etc.) change on a main push. So a CI-only merge would patch-bump all 6 apps — identical bundles, forward-only, harmless but noisy. If we'd prefer CI-only changes not to republish apps, the fix is a dedicated strict-`--affected` public-app output instead of reusing `affected_projects`. Left as reuse for now; trivial to switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)