### PR TITLE
Stopped logging Docker healthcheck pings in dev

### DIFF
--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -103,7 +103,7 @@ services:
         condition: service_healthy
         required: false
     healthcheck:
-      test: ["CMD", "node", "-e", "fetch('http://localhost:2368',{redirect:'manual'}).then(r=>process.exit(r.status<500?0:1)).catch(()=>process.exit(1))"]
+      test: ["CMD", "node", "-e", "fetch('http://localhost:2368',{redirect:'manual',headers:{'user-agent':'GhostDockerHealthcheck/1.0'}}).then(r=>process.exit(r.status<500?0:1)).catch(()=>process.exit(1))"]
       timeout: 5s
       retries: 10
       start_period: 5s

--- a/ghost/core/core/server/web/parent/middleware/log-request.js
+++ b/ghost/core/core/server/web/parent/middleware/log-request.js
@@ -1,5 +1,7 @@
 const logging = require('@tryghost/logging');
 
+const HEALTHCHECK_USER_AGENT = 'GhostDockerHealthcheck/1.0';
+
 /**
  * @TODO: move this middleware to Framework monorepo?
  *
@@ -8,6 +10,10 @@ const logging = require('@tryghost/logging');
  * @param {import('express').NextFunction} next
  */
 module.exports = function logRequest(req, res, next) {
+    if (req.headers['user-agent'] === HEALTHCHECK_USER_AGENT) {
+        return next();
+    }
+
     const startTime = Date.now();
 
     function logResponse() {

--- a/ghost/core/test/unit/server/web/parent/middleware/log-request.test.js
+++ b/ghost/core/test/unit/server/web/parent/middleware/log-request.test.js
@@ -1,0 +1,66 @@
+const express = require('express');
+const sinon = require('sinon');
+const request = require('supertest');
+const logging = require('@tryghost/logging');
+
+const logRequest = require('../../../../../../core/server/web/parent/middleware/log-request');
+
+describe('Log request middleware', function () {
+    let infoStub;
+    let errorStub;
+
+    beforeEach(function () {
+        infoStub = sinon.stub(logging, 'info');
+        errorStub = sinon.stub(logging, 'error');
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    function createApp() {
+        const app = express();
+        app.use(logRequest);
+        app.get('/', (req, res) => {
+            res.json({ok: true});
+        });
+        return app;
+    }
+
+    it('logs normal requests', async function () {
+        await request(createApp())
+            .get('/')
+            .expect(200);
+
+        sinon.assert.calledOnce(infoStub);
+        sinon.assert.notCalled(errorStub);
+    });
+
+    it('skips logging for the Docker healthcheck user-agent', async function () {
+        await request(createApp())
+            .get('/')
+            .set('User-Agent', 'GhostDockerHealthcheck/1.0')
+            .expect(200);
+
+        sinon.assert.notCalled(infoStub);
+        sinon.assert.notCalled(errorStub);
+    });
+
+    it('still logs requests with a similar but not exact user-agent', async function () {
+        await request(createApp())
+            .get('/')
+            .set('User-Agent', 'GhostDockerHealthcheck/2.0')
+            .expect(200);
+
+        sinon.assert.calledOnce(infoStub);
+    });
+
+    it('still logs requests with the generic node UA', async function () {
+        await request(createApp())
+            .get('/')
+            .set('User-Agent', 'node')
+            .expect(200);
+
+        sinon.assert.calledOnce(infoStub);
+    });
+});


### PR DESCRIPTION
## Summary
- Filtered Docker's healthcheck pings out of Ghost's request log so steady-state `pnpm dev` access logs only show real traffic.
- Two changes:
  - `compose.dev.yaml`: `ghost-dev` healthcheck now sends `User-Agent: GhostDockerHealthcheck/1.0` (Node's global `fetch` defaults to `User-Agent: node`, too generic to filter on safely).
  - `ghost/core/core/server/web/parent/middleware/log-request.js`: when the UA matches that exact string, skip both response listeners and `next()` immediately.

## Why
The `ghost-dev` container runs a healthcheck against `GET /` every 30s. In steady-state dev that's the dominant access-log line — ~120 `INFO "GET /" 200 ...` entries per hour that bury real HTTP traffic when you're trying to see what the admin / portal / a curl is actually doing.

## Verification
- New unit test (`test/unit/server/web/parent/middleware/log-request.test.js`) covers four paths via supertest: normal request logged, exact healthcheck UA skipped, near-miss UA (`GhostDockerHealthcheck/2.0`) still logged, generic `node` UA still logged. 4/4 passing.
- Lint clean on both touched files.
- Skipped end-to-end docker verification: another worktree owned the running `ghost-dev` stack and I didn't want to clobber an active session. To verify manually after merge:
  1. `pnpm dev:daemon` from a fresh shell, wait 90s.
  2. `docker logs ghost-dev --since 90s | grep "GET /"` — should have no healthcheck lines.
  3. `curl -A "GhostDockerHealthcheck/1.0" http://localhost:2368/` — should NOT appear in the log.
  4. `curl http://localhost:2368/` — should appear in the log.

## Test plan
- [ ] `pnpm dev:daemon`, wait 90s, confirm `docker logs ghost-dev | grep "GET /"` has no healthcheck lines.
- [ ] Manual probes with the two UAs above behave as expected.