### PR TITLE
Removed @tryghost/i18n placeholder dev script from pnpm dev fan-out

### DIFF
--- a/ghost/i18n/package.json
+++ b/ghost/i18n/package.json
@@ -11,7 +11,6 @@
   },
   "types": "./build/i18n.d.ts",
   "scripts": {
-    "dev": "echo \"Implement me!\"",
     "test:base": "NODE_ENV=testing vitest run --coverage",
     "test": "pnpm test:base && pnpm translate",
     "lint:code": "eslint *.js lib/ --cache",
@@ -48,11 +47,6 @@
   "nx": {
     "tags": [
       "i18n"
-    ],
-    "targets": {
-      "dev": {
-        "continuous": false
-      }
-    }
+    ]
   }
 }


### PR DESCRIPTION
Removed the `dev` script and its inline Nx target from `ghost/i18n/package.json`. The script was `echo "Implement me!"` — a never-filled scaffolding slot — but it was pulled into `pnpm dev` via the `^dev` chain because the public apps depend on `@tryghost/i18n`.

## Why it's safe

- i18n locales are static JSON in `ghost/i18n/locales/*` — loaded by the Ghost backend at runtime, no build step.
- The public-app UMDs (`portal`, `comments-ui`, `signup-form`, `sodo-search`, `announcement-bar`) bundle their own locales at build time via their own Vite configs — they import `ghost/i18n/lib/i18n.js` directly (visible in dev-server output) and don't depend on an i18n watcher.
- Translation extraction is the `translate` script, not `dev`.

## Verified

- `pnpm nx show project @tryghost/i18n` no longer lists a `dev` target.
- `pnpm dev:daemon` boots cleanly: 17 tasks fan out (was 18), no `nx run @tryghost/i18n:dev` line, no `Implement me!` line. Ghost backend up on `:2368`, admin Vite ready, all six public-app UMDs return 200 via Caddy at `/ghost/assets/<app>/<app>.min.js`.
- `pnpm --filter @tryghost/i18n test:base` still green (100% coverage).