### PR TITLE
Silenced informational externalized-for-browser warnings in public app builds

### DIFF
--- a/apps/_shared/vite-public-app.mjs
+++ b/apps/_shared/vite-public-app.mjs
@@ -15,6 +15,7 @@
  */
 import {resolve} from 'path';
 import {defineConfig, mergeConfig} from 'vitest/config';
+import {createLogger} from 'vite';
 
 /**
  * @param {Object} opts
@@ -61,8 +62,29 @@ export function publicAppViteConfig(opts) {
             plugins.push(svgrPlugin());
         }
 
+        // Node built-ins (path, fs, fs/promises) are reachable in module graphs
+        // via @tryghost/i18n's server-side helpers, @tryghost/root-utils, and
+        // find-root. Vite externalizes them for the browser at bundle time —
+        // the runtime code paths that touch them are dead under SSR=false.
+        // The per-import "Module 'path'/'fs' has been externalized" warning is
+        // purely informational and re-emits on every boot/HMR rebuild, so we
+        // filter just those messages here. Adding `rollupOptions.external` was
+        // rejected because UMD output then asks for `path`/`fs` browser globals
+        // (`No name was provided for external module "path"` warnings) and
+        // injects a Node-polyfill notice.
+        const logLevel = process.env.CI ? 'info' : 'warn';
+        const customLogger = createLogger(logLevel);
+        const originalWarn = customLogger.warn;
+        customLogger.warn = (msg, warnOpts) => {
+            if (typeof msg === 'string' && /Module "(path|fs|fs\/promises)" has been externalized for browser compatibility/.test(msg)) {
+                return;
+            }
+            originalWarn(msg, warnOpts);
+        };
+
         const base = {
-            logLevel: process.env.CI ? 'info' : 'warn',
+            logLevel,
+            customLogger,
             clearScreen: false,
             plugins,
             define: {


### PR DESCRIPTION
## Summary

- Vite emits `[plugin vite:resolve] Module "path"/"fs" has been externalized for browser compatibility` for every transitive Node-builtin import in the public-app graph (`@tryghost/i18n`, `@tryghost/root-utils`, `find-root`). That's ~6 lines per app, repeated on every boot and HMR rebuild — ~48 lines on a typical `pnpm dev:daemon` boot across the 6 public apps.
- Filter just those messages via a `customLogger` in the shared public-app vite factory (`apps/_shared/vite-public-app.mjs`). Other warnings (vite, rollup, plugins) still flow through untouched.

## Why this is safe

- Vite was already externalizing these modules — the warning was purely informational. The browser-side runtime code paths that touch `path`/`fs` are dead under `SSR=false`, which is why nothing has ever broken from them being externalized.
- The shared config previously had no `rollupOptions.external` and still doesn't. Bundle output is byte-identical to baseline: portal (`b457f519…`), comments-ui (`3332dca1…`), sodo-search (`0899d626…`), announcement-bar (`6187be40…`), signup-form (`6ae7ed49…`), admin-toolbar (`1e480abe…`) — same sha256 before and after.
- Tried `rollupOptions.external: ['path', 'fs', 'fs/promises']` first; UMD output then requires browser globals for those names (`No name was provided for external module "path"`) and rollup adds a Node-polyfill suggestion. The customLogger filter avoids that and leaves the bundle untouched.

## Verification

- `pnpm --filter @tryghost/{portal,comments-ui,sodo-search,announcement-bar,signup-form,admin-toolbar} build` — 0 externalized warnings across all 6 (was 6 each for portal/comments-ui/sodo-search/announcement-bar/signup-form; 0 for admin-toolbar).
- Dev-mode reproduction (`NODE_ENV=production vite build --mode development`) — also 0 warnings after the change.
- `apps/portal` and `apps/comments-ui` unit tests pass (582/583 and 251/251).
- `check-app-version-bump.js`: "No app changes detected. Skipping version bump check." — `apps/_shared` is not a monitored app.

## Test plan

- [ ] CI build of public apps stays green
- [ ] `pnpm dev:daemon` boot log no longer shows `Module "path"/"fs" has been externalized` lines