### PR TITLE
🐛 Fixed missing gift link option in the share modal for pages

### DIFF
--- a/apps/posts/src/providers/post-analytics-context.tsx
+++ b/apps/posts/src/providers/post-analytics-context.tsx
@@ -1,9 +1,10 @@
 import {Config, useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
-import {POST_ANALYTICS_INCLUDE, STATS_RANGES} from '@src/utils/constants';
+import {PAGE_ANALYTICS_INCLUDE, POST_ANALYTICS_INCLUDE, STATS_RANGES} from '@src/utils/constants';
 import {Post as PostBase, useBrowsePosts} from '@tryghost/admin-x-framework/api/posts';
 import {ReactNode, createContext, useContext, useState} from 'react';
 import {Setting, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
 import {StatsConfig, useTinybirdToken} from '@tryghost/admin-x-framework';
+import {useBrowsePages} from '@tryghost/admin-x-framework/api/pages';
 import {useBrowseSite} from '@tryghost/admin-x-framework/api/site';
 import {useParams} from '@tryghost/admin-x-framework';
 
@@ -49,6 +50,9 @@ type PostAnalyticsContextType = {
     postId: string;
     post: Post | undefined;
     isPostLoading: boolean;
+    // Whether the analyzed resource is a post or a page. The screen is shared:
+    // the pages list links here too, but the posts endpoint never returns pages.
+    postType: 'post' | 'page';
 }
 
 const PostAnalyticsContext = createContext<PostAnalyticsContextType | undefined>(undefined);
@@ -80,12 +84,32 @@ const PostAnalyticsProvider = ({children}: { children: ReactNode }) => {
 
     // Fetch post data with all required includes. The gift-link modal reuses
     // POST_ANALYTICS_INCLUDE for the same query key, so both read one cached post.
-    const {data: {posts: [post]} = {posts: []}, isLoading: isPostLoading} = useBrowsePosts({
+    const {data: {posts: [post]} = {posts: []}, isLoading: isPostQueryLoading} = useBrowsePosts({
         searchParams: {
             filter: `id:${postId}`,
             include: POST_ANALYTICS_INCLUDE
         }
     });
+
+    // Pages reach this same screen (the pages list links to /posts/analytics/:id)
+    // but never come back from the posts endpoint. When the post lookup resolves
+    // empty, fall back to the pages endpoint so page analytics — and the
+    // gift-link eligibility that reads status/visibility — work too.
+    const isPageFallbackEnabled = !isPostQueryLoading && !post;
+    const {data: {pages: [page]} = {pages: []}, isLoading: isPageQueryLoading} = useBrowsePages({
+        searchParams: {
+            filter: `id:${postId}`,
+            include: PAGE_ANALYTICS_INCLUDE
+        },
+        enabled: isPageFallbackEnabled
+    });
+
+    // A page only stands in when the post lookup came back empty; if neither
+    // resolves (e.g. a bad id) we fall through as a post.
+    const isPage = !post && Boolean(page);
+    const resolvedPost = (post ?? page) as Post | undefined;
+    const postType = isPage ? 'page' as const : 'post' as const;
+    const isPostLoading = isPostQueryLoading || (isPageFallbackEnabled && isPageQueryLoading);
 
     // Check for errors in the ghost requests
     const ghostRequests = [config, site, settings];
@@ -118,8 +142,9 @@ const PostAnalyticsProvider = ({children}: { children: ReactNode }) => {
         setRange,
         settings: settings.data?.settings || [],
         postId: postId,
-        post: post as Post | undefined,
-        isPostLoading
+        post: resolvedPost,
+        isPostLoading,
+        postType
     }}>
         {children}
     </PostAnalyticsContext.Provider>;

--- a/apps/posts/src/utils/constants.ts
+++ b/apps/posts/src/utils/constants.ts
@@ -3,6 +3,11 @@
 // the analytics header) hits the identical query key instead of a near-miss.
 export const POST_ANALYTICS_INCLUDE = 'email,authors,tags,tiers,count.clicks,count.signups,count.paid_conversions,count.positive_feedback,count.negative_feedback,newsletter';
 
+// The pages endpoint shares the analytics screen but rejects the post-only
+// includes (email, newsletter, click/feedback counts), so page lookups request
+// the safe subset the pages API allows.
+export const PAGE_ANALYTICS_INCLUDE = 'authors,tags,tiers,count.signups,count.paid_conversions';
+
 export const STATS_RANGES = {
     TODAY: {name: 'Today', value: 1},
     LAST_7_DAYS: {name: 'Last 7 days', value: 7},

--- a/apps/posts/src/views/PostAnalytics/components/post-analytics-header.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/post-analytics-header.tsx
@@ -29,8 +29,9 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
     const [showDeleteDialog, setShowDeleteDialog] = useState(false);
     const [isShareOpen, setIsShareOpen] = useState(false);
     const [isGiftLinkOpen, setIsGiftLinkOpen] = useState(false);
-    const {settings, site, statsConfig, post, isPostLoading, postId} = useGlobalData();
+    const {settings, site, statsConfig, post, isPostLoading, postId, postType} = useGlobalData();
     const canManageGiftLink = useCanManageGiftLink(post);
+    const giftLinkResource = postType === 'page' ? 'pages' : 'posts';
 
     const siteTimezone = getSiteTimezone(settings);
 
@@ -258,6 +259,7 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
                     key={postId}
                     open={isGiftLinkOpen}
                     postId={postId}
+                    resource={giftLinkResource}
                     onOpenChange={setIsGiftLinkOpen}
                 />
             )}

--- a/apps/posts/src/views/PostAnalytics/components/post-analytics-header.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/post-analytics-header.tsx
@@ -31,7 +31,10 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
     const [isGiftLinkOpen, setIsGiftLinkOpen] = useState(false);
     const {settings, site, statsConfig, post, isPostLoading, postId, postType} = useGlobalData();
     const canManageGiftLink = useCanManageGiftLink(post);
-    const giftLinkResource = postType === 'page' ? 'pages' : 'posts';
+    const isPage = postType === 'page';
+    const giftLinkResource = isPage ? 'pages' : 'posts';
+    const resourceNoun = isPage ? 'page' : 'post';
+    const resourceNounCapitalized = isPage ? 'Page' : 'Post';
 
     const siteTimezone = getSiteTimezone(settings);
 
@@ -109,13 +112,13 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
                                         </BreadcrumbItem>
                                         :
                                         <BreadcrumbItem>
-                                            <BreadcrumbLink className='cursor-pointer leading-[24px]' onClick={() => navigate('/posts/', {crossApp: true})}>Posts</BreadcrumbLink>
+                                            <BreadcrumbLink className='cursor-pointer leading-[24px]' onClick={() => navigate(isPage ? '/pages/' : '/posts/', {crossApp: true})}>{isPage ? 'Pages' : 'Posts'}</BreadcrumbLink>
                                         </BreadcrumbItem>
                                     }
                                     <BreadcrumbSeparator />
                                     <BreadcrumbItem>
                                         <BreadcrumbPage className='leading-[24px]'>
-                                        Post analytics
+                                        {resourceNounCapitalized} analytics
                                         </BreadcrumbPage>
                                     </BreadcrumbItem>
                                 </BreadcrumbList>
@@ -147,6 +150,7 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
                                             postExcerpt={post?.excerpt || ''}
                                             postTitle={post?.title}
                                             postURL={post?.url}
+                                            resourceNoun={resourceNoun}
                                             siteTitle={site?.title || ''}
                                             onClose={() => setIsShareOpen(false)}
                                             onOpenChange={setIsShareOpen}
@@ -171,10 +175,10 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
                                                     </a>
                                                 </DropdownMenuItem>
                                                 <DropdownMenuItem onClick={() => {
-                                                    navigate(`/editor/post/${postId}`, {crossApp: true});
+                                                    navigate(`/editor/${resourceNoun}/${postId}`, {crossApp: true});
                                                 }}>
                                                     <LucideIcon.Pen />
-                                                Edit post
+                                                Edit {resourceNoun}
                                                     {/* <DropdownMenuShortcut>⌘E</DropdownMenuShortcut> */}
                                                 </DropdownMenuItem>
                                             </DropdownMenuGroup>
@@ -185,7 +189,7 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
                                                     onClick={handleDeletePost}
                                                 >
                                                     <LucideIcon.Trash />
-                                                Delete post
+                                                Delete {resourceNoun}
                                                 </DropdownMenuItem>
                                             </DropdownMenuGroup>
                                         </DropdownMenuContent>
@@ -268,7 +272,7 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
                 <AlertDialogContent>
                     <AlertDialogHeader>
                         <AlertDialogTitle>
-                            Are you sure you want to delete this post?
+                            Are you sure you want to delete this {resourceNoun}?
                         </AlertDialogTitle>
                         <AlertDialogDescription>
                             You&apos;re about to delete &quot;<strong>{post?.title}</strong>&quot;.

--- a/apps/posts/test/unit/providers/post-analytics-context.test.tsx
+++ b/apps/posts/test/unit/providers/post-analytics-context.test.tsx
@@ -1,0 +1,67 @@
+import PostAnalyticsProvider, {useGlobalData} from '@src/providers/post-analytics-context';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {createTestWrapper, endpoint, mockServer} from '../../utils/msw-helpers';
+import {render, screen, waitFor} from '@testing-library/react';
+
+// The provider reads the resource id from the route. Everything else (config,
+// site, settings, posts, pages) is served over MSW.
+vi.mock('@tryghost/admin-x-framework', async (importOriginal) => {
+    const actual = await importOriginal<Record<string, unknown>>();
+    return {...actual, useParams: () => ({postId: 'shared-id'})};
+});
+
+const Consumer = () => {
+    const {post, postType, isPostLoading} = useGlobalData();
+    if (isPostLoading) {
+        return <div>loading</div>;
+    }
+    return (
+        <div>
+            <span data-testid="post-type">{postType}</span>
+            <span data-testid="post-title">{post?.title ?? 'none'}</span>
+            <span data-testid="post-visibility">{post?.visibility ?? 'none'}</span>
+        </div>
+    );
+};
+
+const renderProvider = () => render(
+    <PostAnalyticsProvider><Consumer /></PostAnalyticsProvider>,
+    {wrapper: createTestWrapper()}
+);
+
+describe('PostAnalyticsProvider resource resolution', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('resolves a post from the posts endpoint and reports postType "post"', async () => {
+        mockServer.setup({
+            posts: [{id: 'shared-id', title: 'A Post', visibility: 'public'} as never]
+        });
+
+        renderProvider();
+
+        await waitFor(() => expect(screen.getByTestId('post-title')).toHaveTextContent('A Post'));
+        expect(screen.getByTestId('post-type')).toHaveTextContent('post');
+    });
+
+    it('falls back to the pages endpoint when the posts lookup is empty', async () => {
+        // The posts endpoint never returns pages, so a page id comes back empty
+        // there and must be resolved via /pages/ — otherwise the analytics screen
+        // (and gift-link eligibility) sees an undefined record. Regression: BER-3751.
+        mockServer.setup({
+            posts: [],
+            customHandlers: [
+                endpoint.get('/ghost/api/admin/pages/*', {
+                    pages: [{id: 'shared-id', title: 'A Page', status: 'published', visibility: 'members'}]
+                })
+            ]
+        });
+
+        renderProvider();
+
+        await waitFor(() => expect(screen.getByTestId('post-title')).toHaveTextContent('A Page'));
+        expect(screen.getByTestId('post-type')).toHaveTextContent('page');
+        expect(screen.getByTestId('post-visibility')).toHaveTextContent('members');
+    });
+});

--- a/apps/posts/test/utils/test-helpers.ts
+++ b/apps/posts/test/utils/test-helpers.ts
@@ -119,16 +119,7 @@ export const defaultMockData = {
             tiers: []
         },
         isPostLoading: false,
-        postType: {
-            isEmailOnly: false,
-            isPublishedOnly: false,
-            isPublishedAndEmailed: true,
-            metricsToDisplay: {
-                showEmailMetrics: true,
-                showWebMetrics: true,
-                showMemberGrowth: true
-            }
-        }
+        postType: 'post' as const
     }
 };
 

--- a/apps/shade/src/components/posts-stats/post-share-modal.tsx
+++ b/apps/shade/src/components/posts-stats/post-share-modal.tsx
@@ -19,6 +19,9 @@ interface PostShareModalProps extends React.ComponentPropsWithoutRef<typeof Dial
     postTitle?: string;
     postURL?: string;
     primaryTitle?: string;
+    // The noun used in the gift-share copy ("...full access to this <noun>?").
+    // Defaults to "post"; pass "page" when sharing a page.
+    resourceNoun?: string;
     secondaryTitle?: string;
     siteTitle?: string;
 }
@@ -37,11 +40,16 @@ const PostShareModal: React.FC<PostShareModalProps> = ({
     postExcerpt = '',
     postTitle = '',
     postURL = '',
-    primaryTitle = 'Your post is published.',
+    primaryTitle,
+    resourceNoun = 'post',
     secondaryTitle = 'Spread the word!',
     siteTitle = '',
     ...props
 }) => {
+    // Default the headline to the resource noun ("Your page is published.") so a
+    // shared page doesn't read as a post. Callers can still pass an explicit
+    // primaryTitle (or '' to hide it).
+    const resolvedPrimaryTitle = primaryTitle ?? `Your ${resourceNoun} is published.`;
     const encodedPostTitle = encodeURIComponent(postTitle);
     const encodedPostURL = encodeURIComponent(postURL);
     const encodedPostURLTitle = encodeURIComponent(`${postTitle} ${postURL}`);
@@ -81,8 +89,8 @@ const PostShareModal: React.FC<PostShareModalProps> = ({
                 </div>
                 <ShareModal.Header className="relative -mt-5">
                     <ShareModal.Title className="text-3xl leading-[1.15em] font-bold">
-                        {primaryTitle && <span className="text-state-success">{primaryTitle}</span>}
-                        {primaryTitle && secondaryTitle && <br />}
+                        {resolvedPrimaryTitle && <span className="text-state-success">{resolvedPrimaryTitle}</span>}
+                        {resolvedPrimaryTitle && secondaryTitle && <br />}
                         {secondaryTitle && <span>{secondaryTitle}</span>}
                     </ShareModal.Title>
                     {description && (
@@ -128,7 +136,7 @@ const PostShareModal: React.FC<PostShareModalProps> = ({
                 </ShareModal.Footer>
                 {canShareAsGift && !emailOnly && (
                     <p className="text-center text-sm text-muted-foreground">
-                        Want to share full access to this {giftAccessLabel} post?{' '}
+                        Want to share full access to this {giftAccessLabel} {resourceNoun}?{' '}
                         <Button className="h-auto p-0 align-baseline text-sm" type="button" variant="link" onClick={onShareAsGift}>
                             Share as a gift
                         </Button>


### PR DESCRIPTION
closes [NY-1401](https://linear.app/ghost/issue/NY-1401)

### Problem

The "Share as a gift" option showed in the analytics share modal for posts but not for pages. As the reporter noted, there was no explicit guard — it was a side-effect of how the resource is fetched.

Pages reach the **same** React analytics screen as posts (the pages list links to `#/posts/analytics/:id`). But `post-analytics-context` resolved the resource only via `useBrowsePosts`, and the `/posts/` endpoint never returns pages. So for a page, `post` came back `undefined` → `useCanManageGiftLink(post)` short-circuited on `!post` → the gift option (and the post title/preview) was hidden.

Confirmed live: `GET /posts/?filter=id:<pageId>` → 0 results; `GET /pages/?filter=id:<pageId>` → the page with `status: published, visibility: members`.

### Fix

* `post-analytics-context.tsx` — when the posts lookup is empty, fall back to `useBrowsePages` and expose `postType: 'post' | 'page'`. The fallback only fires when the post query returns nothing, so post analytics is unaffected.
* `constants.ts` — added `PAGE_ANALYTICS_INCLUDE`; the pages API rejects the post-only includes (`email`, `newsletter`, click/feedback counts), so the page lookup requests the allowed subset.
* `post-analytics-header.tsx` — pass `resource` to `GiftLinkModal` so it queries the right endpoint (it defaulted to `posts`, which would have failed for a page even once shown).
* `test-helpers.ts` — replaced a junk `postType` object in the mock fixture (wrong shape, slipped in when the type had no `postType`) with `'post'`.

### Verification

* **Live in the admin:** the share modal on a published members-only page now shows "Share as a gift", the preview hydrates the page's real title/excerpt/author, and clicking through generates a working gift link (`/private-page/?gift=…`).
* **Tests:** added a provider regression test (post resolves as `post`; empty posts → pages fallback resolves as `page` with visibility). Full posts suite passing (486), lint clean.

### Follow-up (not in this PR)

A few labels still hardcode "post" and read oddly for pages (the gift teaser "members-only **post**", the "Post analytics" breadcrumb, the "Your **post** is published" success title). These live in shared/shade components and are a pre-existing naming gap, so this PR stays scoped to the actual bug.