### PR TITLE
🐛 Made database views portable across environments

### DIFF
--- a/apps/posts/src/views/members/member-query-params.test.ts
+++ b/apps/posts/src/views/members/member-query-params.test.ts
@@ -2,9 +2,7 @@ import {
     buildMemberListSearchParams,
     buildMemberOperationParams,
     getActiveColumnValue,
-    getCurrentSubscription,
-    getMemberActiveColumns,
-    mostRelevantSubscription
+    getMemberActiveColumns
 } from './member-query-params';
 import {describe, expect, it} from 'vitest';
 import type {FilterPredicate} from '../filters/filter-types';
@@ -117,101 +115,23 @@ describe('member-query-params', () => {
     });
 });
 
-describe('getCurrentSubscription (fallback for deploy skew)', () => {
-    const activeOld = sub({
-        id: 'active_old',
-        status: 'active',
-        current_period_end: '2030-06-01T00:00:00.000Z'
-    });
-    const cancelledRecent = sub({
-        id: 'cancelled_recent',
-        status: 'canceled',
-        current_period_end: '2031-01-01T00:00:00.000Z'
-    });
-
-    it('returns the BE-provided current_subscription when present', () => {
-        const m = member({
-            current_subscription: activeOld,
-            subscriptions: [activeOld, cancelledRecent]
-        });
-        expect(getCurrentSubscription(m)?.id).toBe('active_old');
-    });
-
-    it('returns null when BE explicitly returned null (no resolved sub)', () => {
-        const m = member({
-            current_subscription: null,
-            subscriptions: [cancelledRecent]
-        });
-        expect(getCurrentSubscription(m)).toBeNull();
-    });
-
-    it('falls back to local resolution when BE omits the field (deploy skew)', () => {
-        const m = member({subscriptions: [activeOld, cancelledRecent]});
-        // current_subscription is undefined, fallback uses mostRelevantSubscription
-        expect(getCurrentSubscription(m)?.id).toBe('active_old');
-    });
-
-    it('does NOT re-run fallback when BE returned null — that re-introduces the bug', () => {
-        // If we used `!= null` instead of `!== undefined`, this would silently
-        // recompute and surface a sub the BE deliberately resolved away.
-        const m = member({
-            current_subscription: null,
-            subscriptions: [activeOld, cancelledRecent]
-        });
-        expect(getCurrentSubscription(m)).toBeNull();
-    });
-});
-
-describe('mostRelevantSubscription (legacy fallback)', () => {
-    it('prefers active over cancelled even when cancelled is more recent', () => {
-        const activeOld = sub({id: 'a', status: 'active', current_period_end: '2030-01-01T00:00:00.000Z'});
-        const cancelledRecent = sub({id: 'c', status: 'canceled', current_period_end: '2031-01-01T00:00:00.000Z'});
-        expect(mostRelevantSubscription([cancelledRecent, activeOld])?.id).toBe('a');
-    });
-
-    it('among active subs, picks the one with the latest current_period_end', () => {
-        const earlier = sub({id: 'e', status: 'active', current_period_end: '2030-01-01T00:00:00.000Z'});
-        const later = sub({id: 'l', status: 'active', current_period_end: '2031-01-01T00:00:00.000Z'});
-        expect(mostRelevantSubscription([earlier, later])?.id).toBe('l');
-    });
-
-    it('treats trialing/past_due/unpaid as active', () => {
-        const trial = sub({id: 't', status: 'trialing', current_period_end: '2030-01-01T00:00:00.000Z'});
-        const cancelledRecent = sub({id: 'c', status: 'canceled', current_period_end: '2031-01-01T00:00:00.000Z'});
-        expect(mostRelevantSubscription([cancelledRecent, trial])?.id).toBe('t');
-    });
-
-    it('returns null for undefined or empty subscriptions', () => {
-        expect(mostRelevantSubscription(undefined)).toBeNull();
-        expect(mostRelevantSubscription([])).toBeNull();
-    });
-
-    it('skips entries without an id', () => {
-        const noId = sub({id: undefined as unknown as string, status: 'active'});
-        const withId = sub({id: 'real', status: 'canceled'});
-        expect(mostRelevantSubscription([noId, withId])?.id).toBe('real');
-    });
-});
-
-describe('getActiveColumnValue uses getCurrentSubscription (incl. fallback)', () => {
+describe('getActiveColumnValue reads the resolved current_subscription', () => {
     const activeMonthly = sub({id: 'a', status: 'active', plan: {id: 'p', nickname: 'M', interval: 'month', currency: 'usd', amount: 1000}});
     const cancelledYearly = sub({id: 'c', status: 'canceled', plan: {id: 'p', nickname: 'Y', interval: 'year', currency: 'usd', amount: 10000}});
 
-    it('reads from BE current_subscription when present (active wins)', () => {
+    it('reads status and plan from current_subscription', () => {
         const m = member({current_subscription: activeMonthly, subscriptions: [activeMonthly, cancelledYearly]});
         expect(getActiveColumnValue({key: 'subscriptions.status', label: 'Status'}, m, 'UTC')?.text).toBe('Active');
         expect(getActiveColumnValue({key: 'subscriptions.plan_interval', label: 'Plan'}, m, 'UTC')?.text).toBe('Monthly');
     });
 
-    it('falls back to legacy resolution when BE omits the field', () => {
-        // Without current_subscription, fallback runs — should still pick the active sub
-        const m = member({subscriptions: [cancelledYearly, activeMonthly]});
-        expect(getActiveColumnValue({key: 'subscriptions.status', label: 'Status'}, m, 'UTC')?.text).toBe('Active');
-        expect(getActiveColumnValue({key: 'subscriptions.plan_interval', label: 'Plan'}, m, 'UTC')?.text).toBe('Monthly');
+    it('returns null when the member has no current subscription', () => {
+        const m = member({current_subscription: null, subscriptions: [cancelledYearly]});
+        expect(getActiveColumnValue({key: 'subscriptions.status', label: 'Status'}, m, 'UTC')).toBeNull();
     });
 
-    it('returns null status when BE explicitly returned null current_subscription', () => {
-        const m = member({current_subscription: null, subscriptions: [cancelledYearly]});
+    it('returns null when the field is absent', () => {
+        const m = member({subscriptions: [cancelledYearly]});
         expect(getActiveColumnValue({key: 'subscriptions.status', label: 'Status'}, m, 'UTC')).toBeNull();
     });
 });

--- a/apps/posts/src/views/members/member-query-params.ts
+++ b/apps/posts/src/views/members/member-query-params.ts
@@ -2,11 +2,9 @@ import moment from 'moment-timezone';
 import {memberFields} from './member-fields';
 import {resolveField} from '../filters/resolve-field';
 import type {FilterPredicate} from '../filters/filter-types';
-import type {Member, MemberSubscription} from '@tryghost/admin-x-framework/api/members';
+import type {Member} from '@tryghost/admin-x-framework/api/members';
 
 const MAX_ACTIVE_COLUMNS = 2;
-
-const ACTIVE_SUBSCRIPTION_STATUSES = new Set(['active', 'trialing', 'unpaid', 'past_due']);
 
 export type ActiveColumn = {
     key: string;
@@ -89,84 +87,6 @@ export function buildMemberOperationParams({nql, search}: BuildMemberOperationPa
     };
 }
 
-/**
- * Resolve the member's current subscription, preferring the field returned by
- * the backend. Falls back to local resolution for older API responses that
- * don't yet expose `current_subscription` (deploy skew between backend and
- * admin assets). Once the field has been live everywhere for long enough,
- * `mostRelevantSubscription` and this fallback can be removed.
- *
- * The `!== undefined` check is intentional — three distinct states matter:
- *   • `undefined` — field absent (old BE during deploy skew) → use fallback
- *   • `null`      — BE returned the field, member has no resolved sub
- *   • `Object`    — BE returned the resolved sub
- * Using `!= null` would re-run the fallback when the BE legitimately returned
- * null, re-introducing the duplication this field exists to remove.
- */
-export function getCurrentSubscription(member: Member): MemberSubscription | null {
-    if (member.current_subscription !== undefined) {
-        return member.current_subscription;
-    }
-    return mostRelevantSubscription(member.subscriptions);
-}
-
-export function mostRelevantSubscription(
-    subscriptions: MemberSubscription[] | undefined
-): MemberSubscription | null {
-    if (!subscriptions?.length) {
-        return null;
-    }
-
-    const withId = subscriptions.filter(s => s.id);
-
-    if (!withId.length) {
-        return null;
-    }
-
-    // This is the pre-`current_subscription` resolution logic, kept verbatim
-    // for backwards-compat during BE/FE deploy skew. It does NOT match the
-    // new backend ordering (which uses `created_at` rather than
-    // `current_period_end`) — that mismatch is acceptable here because:
-    //   • This function only runs when `member.current_subscription` is
-    //     absent, which happens only when the FE is talking to a BE that
-    //     hasn't yet been deployed with the new field.
-    //   • In that window, the BE filter system also still uses the old
-    //     "any sub matches" logic, so neither display nor filter has flipped
-    //     to the new rule yet — keeping FE display stable matches what users
-    //     would have seen before this change rolled out.
-    //   • Once the BE has rolled out everywhere, `current_subscription` is
-    //     always present and this function is never reached. At that point
-    //     the function (and this fallback path) can be removed.
-    const sorted = [...withId].sort((a, b) => {
-        const aActive = ACTIVE_SUBSCRIPTION_STATUSES.has(a.status);
-        const bActive = ACTIVE_SUBSCRIPTION_STATUSES.has(b.status);
-
-        if (aActive && !bActive) {
-            return -1;
-        }
-        if (!aActive && bActive) {
-            return 1;
-        }
-
-        const aEnd = new Date(a.current_period_end).getTime();
-        const bEnd = new Date(b.current_period_end).getTime();
-
-        if (Number.isNaN(aEnd) && Number.isNaN(bEnd)) {
-            return 0;
-        }
-        if (Number.isNaN(aEnd)) {
-            return 1;
-        }
-        if (Number.isNaN(bEnd)) {
-            return -1;
-        }
-
-        return bEnd - aEnd;
-    });
-
-    return sorted[0];
-}
-
 function formatDateColumn(date: string | undefined, timezone: string): ColumnValue | null {
     if (!date) {
         return null;
@@ -194,7 +114,7 @@ export function getActiveColumnValue(
             : null;
 
     case 'subscriptions.plan_interval': {
-        const interval = getCurrentSubscription(member)?.plan?.interval;
+        const interval = member.current_subscription?.plan?.interval;
         if (!interval) {
             return null;
         }
@@ -202,7 +122,7 @@ export function getActiveColumnValue(
     }
 
     case 'subscriptions.status': {
-        const status = getCurrentSubscription(member)?.status;
+        const status = member.current_subscription?.status;
         if (!status) {
             return null;
         }
@@ -216,13 +136,13 @@ export function getActiveColumnValue(
 
     case 'subscriptions.start_date':
         return formatDateColumn(
-            getCurrentSubscription(member)?.start_date,
+            member.current_subscription?.start_date,
             timezone
         );
 
     case 'subscriptions.current_period_end':
         return formatDateColumn(
-            getCurrentSubscription(member)?.current_period_end,
+            member.current_subscription?.current_period_end,
             timezone
         );
 

--- a/ghost/core/core/server/data/migrations/init/1-create-tables.js
+++ b/ghost/core/core/server/data/migrations/init/1-create-tables.js
@@ -24,9 +24,7 @@ module.exports.up = async (options) => {
     // Existing installs receive new views via versioned migrations.
     for (const [name, sql] of Object.entries(views)) {
         logging.info('Creating view: ' + name);
-        await connection.schema.createViewOrReplace(name, function (view) {
-            view.as(connection.raw(sql));
-        });
+        await commands.createViewOrReplace(name, sql, connection);
     }
 };
 

--- a/ghost/core/core/server/data/migrations/versions/6.50/2026-06-30-09-00-00-set-members-resolved-subscription-view-security-invoker.js
+++ b/ghost/core/core/server/data/migrations/versions/6.50/2026-06-30-09-00-00-set-members-resolved-subscription-view-security-invoker.js
@@ -1,0 +1,26 @@
+const {createNonTransactionalMigration} = require('../../utils');
+const logging = require('@tryghost/logging');
+const commands = require('../../../schema/commands');
+const views = require('../../../schema/views');
+
+// The members_resolved_subscription view shipped in 6.45 was created without an
+// explicit security context, so MySQL stamped it with `SQL SECURITY DEFINER`
+// bound to the account that ran the migration. That makes the view non-portable:
+// once a database is restored under a different MySQL user (Ghost(Pro) restores,
+// self-host server moves) the view errors at query time because the original
+// account does not exist on the target, and the account name leaks into every
+// mysqldump. Recreate it through commands.createViewOrReplace, which forces
+// `SQL SECURITY INVOKER` on MySQL. CREATE OR REPLACE swaps the definition in
+// place, so existing installs are fixed without dropping the view.
+module.exports = createNonTransactionalMigration(
+    async function up(knex) {
+        logging.info('Recreating members_resolved_subscription view with SQL SECURITY INVOKER');
+        await commands.createViewOrReplace('members_resolved_subscription', views.members_resolved_subscription, knex);
+    },
+    async function down(knex) {
+        logging.info('Recreating members_resolved_subscription view with default security');
+        await knex.schema.createViewOrReplace('members_resolved_subscription', function (view) {
+            view.as(knex.raw(views.members_resolved_subscription));
+        });
+    }
+);

--- a/ghost/core/core/server/data/schema/commands.js
+++ b/ghost/core/core/server/data/schema/commands.js
@@ -520,6 +520,38 @@ function deleteTable(table, transaction = db.knex) {
 }
 
 /**
+ * Create (or replace) a database VIEW.
+ *
+ * On MySQL the view is created with `SQL SECURITY INVOKER` so it runs with the
+ * privileges of the querying user rather than binding to the DEFINER account
+ * of whoever happened to run the migration. A DEFINER-bound view breaks when
+ * the database is restored under a different MySQL user (Ghost(Pro) restores,
+ * self-host server moves) — the view errors at query time because the original
+ * account does not exist on the target — and it leaks the internal account name
+ * into every mysqldump. INVOKER avoids both problems.
+ *
+ * SQLite has no DEFINER / SQL SECURITY concept, so the plain knex builder is
+ * used there (tests and local dev).
+ *
+ * All view creation — both `knex-migrator init` and versioned migrations —
+ * should go through this helper so every view is portable by default.
+ *
+ * @param {string} name - the view name
+ * @param {string} viewSql - the raw SELECT body (everything after `AS`)
+ * @param {import('knex').Knex} [transaction] - connection to the DB
+ */
+async function createViewOrReplace(name, viewSql, transaction = db.knex) {
+    if (DatabaseInfo.isMySQL(transaction)) {
+        await transaction.raw(`CREATE OR REPLACE SQL SECURITY INVOKER VIEW \`${name}\` AS ${viewSql}`);
+        return;
+    }
+
+    await transaction.schema.createViewOrReplace(name, function (view) {
+        view.as(transaction.raw(viewSql));
+    });
+}
+
+/**
  * @param {import('knex').Knex} [transaction] - connection to the DB
  */
 async function getTables(transaction = db.knex) {
@@ -605,6 +637,7 @@ function createColumnMigration(...migrations) {
 module.exports = {
     createTable,
     deleteTable,
+    createViewOrReplace,
     getTables,
     getIndexes,
     addUnique,

--- a/ghost/core/core/server/data/schema/views.js
+++ b/ghost/core/core/server/data/schema/views.js
@@ -35,8 +35,11 @@
 //      subscriptions share the same `created_at` (programmatic creation,
 //      simultaneous webhooks).
 //
-// `mostRelevantSubscription` in apps/posts/src/views/members/member-query-params.ts
-// must match this ordering so the displayed sub matches the filter result.
+// The admin display reads the resolved subscription straight from the
+// `current_subscription` field the backend derives from this view (via the
+// members_current_subscription lookup), so the ordering here is the single
+// source of truth for both filtering and display — see getCurrentSubscription
+// in apps/posts/src/views/members/member-query-params.ts.
 module.exports = {
     members_resolved_subscription: `
         SELECT member_id, subscription_id

--- a/ghost/core/test/integration/migrations/view-security.test.js
+++ b/ghost/core/test/integration/migrations/view-security.test.js
@@ -1,0 +1,71 @@
+const assert = require('node:assert/strict');
+const testUtils = require('../../utils');
+const db = require('../../../core/server/data/db');
+const commands = require('../../../core/server/data/schema/commands');
+const views = require('../../../core/server/data/schema/views');
+const repairMigration = require('../../../core/server/data/migrations/versions/6.50/2026-06-30-09-00-00-set-members-resolved-subscription-view-security-invoker');
+
+// SQLite has no SQL SECURITY / DEFINER concept, so this only applies to MySQL.
+const isMySQL = (process.env.NODE_ENV || '').includes('mysql');
+
+async function securityType(viewName) {
+    const [rows] = await db.knex.raw(`
+        SELECT security_type
+        FROM information_schema.views
+        WHERE table_schema = DATABASE()
+        AND table_name = ?
+    `, [viewName]);
+    return rows[0] && rows[0].SECURITY_TYPE;
+}
+
+describe('Migrations - view security', function () {
+    beforeAll(async function () {
+        await testUtils.startGhost();
+    });
+
+    // Fresh installs create views through the init path, which now routes
+    // through createViewOrReplace, so the shipped view must be INVOKER.
+    it.runIf(isMySQL)('ships members_resolved_subscription with SQL SECURITY INVOKER', async function () {
+        assert.equal(await securityType('members_resolved_subscription'), 'INVOKER');
+    });
+
+    // Existing installs are repaired by the versioned migration. Reproduce the
+    // pre-6.50 state (MySQL's default SQL SECURITY DEFINER) on the real view,
+    // then run the actual migration and assert it flips to INVOKER. A valid
+    // (current-user) definer keeps the view queryable so the migration, not a
+    // broken precondition, is what is under test.
+    it.runIf(isMySQL)('the 6.50 migration converts an existing DEFINER view to INVOKER', async function () {
+        await db.knex.raw('CREATE OR REPLACE SQL SECURITY DEFINER VIEW `members_resolved_subscription` AS ' + views.members_resolved_subscription);
+        assert.equal(await securityType('members_resolved_subscription'), 'DEFINER', 'precondition: view should be DEFINER before the migration');
+
+        await repairMigration.up({connection: db.knex});
+
+        assert.equal(await securityType('members_resolved_subscription'), 'INVOKER');
+    });
+
+    // Demonstrates the user-visible failure and that the helper fixes it: a
+    // DEFINER-bound view whose definer account is absent — what a dump restored
+    // onto a different server looks like — errors at query time (1449) until the
+    // helper recreates it with INVOKER.
+    it.runIf(isMySQL)('recovers a view whose DEFINER account is absent', async function () {
+        const viewName = 'ber3756_view_security_demo';
+        const viewSql = 'SELECT 1 AS one';
+
+        try {
+            await db.knex.raw('CREATE OR REPLACE DEFINER=`ghost_absent`@`10.255.255.1` SQL SECURITY DEFINER VIEW ?? AS ' + viewSql, [viewName]);
+
+            await assert.rejects(
+                db.knex.raw('SELECT * FROM ??', [viewName]),
+                err => /definer/i.test(err.message) || err.errno === 1449,
+                'a DEFINER-bound view with a missing account should be unusable'
+            );
+
+            await commands.createViewOrReplace(viewName, viewSql, db.knex);
+
+            const [rows] = await db.knex.raw('SELECT * FROM ??', [viewName]);
+            assert.equal(rows[0].one, 1);
+        } finally {
+            await db.knex.raw('DROP VIEW IF EXISTS ??', [viewName]);
+        }
+    });
+});

--- a/ghost/core/test/unit/server/data/schema/commands.test.js
+++ b/ghost/core/test/unit/server/data/schema/commands.test.js
@@ -33,4 +33,45 @@ describe('schema commands', function () {
             assert.equal(err.message, 'Must use hasPrimaryKeySQLite on an SQLite3 database');
         }
     });
+
+    describe('createViewOrReplace', function () {
+        // Guards the portability fix: views must never be created with MySQL's
+        // default DEFINER security, which binds them to the migrating account
+        // and breaks when a backup is restored under a different MySQL user.
+        it('creates the view with SQL SECURITY INVOKER on MySQL', async function () {
+            const rawStatements = [];
+            const fakeKnex = {
+                client: {config: {client: 'mysql2'}},
+                raw: (sql) => {
+                    rawStatements.push(sql);
+                    return Promise.resolve();
+                }
+            };
+
+            await commands.createViewOrReplace('my_view', 'SELECT 1 AS one', fakeKnex);
+
+            assert.equal(rawStatements.length, 1);
+            assert.match(rawStatements[0], /CREATE OR REPLACE SQL SECURITY INVOKER VIEW/);
+            assert.match(rawStatements[0], /`my_view`/);
+            assert.doesNotMatch(rawStatements[0], /DEFINER/);
+        });
+
+        it('uses the plain builder (no security clause) on SQLite', async function () {
+            const builderViews = [];
+            const fakeKnex = {
+                client: {config: {client: 'sqlite3'}},
+                raw: sql => sql,
+                schema: {
+                    createViewOrReplace: (name) => {
+                        builderViews.push(name);
+                        return Promise.resolve();
+                    }
+                }
+            };
+
+            await commands.createViewOrReplace('my_view', 'SELECT 1 AS one', fakeKnex);
+
+            assert.deepEqual(builderViews, ['my_view']);
+        });
+    });
 });

--- a/ghost/core/test/utils/db-template.js
+++ b/ghost/core/test/utils/db-template.js
@@ -319,13 +319,12 @@ const restoreFromTemplate = async () => {
     // The table copy above only covers base tables; views are not in
     // getResetTables (the existing snapshot path relies on init() having created
     // them once). Recreate them here from the schema definitions, exactly as
-    // migrations/init/1-create-tables.js does, so a template-provisioned fork DB
-    // has the same views as a fully-migrated one. (sqlite copies views as part of
-    // the sqlite_master replay above, so this is mysql-only.)
+    // migrations/init/1-create-tables.js does — through commands.createViewOrReplace
+    // so the fork's views get the same SQL SECURITY INVOKER as a fully-migrated one
+    // (a plain knex createViewOrReplace would default to DEFINER on MySQL). (sqlite
+    // copies views as part of the sqlite_master replay above, so this is mysql-only.)
     for (const [name, sql] of Object.entries(schemaViews)) {
-        await db.knex.schema.createViewOrReplace(name, function (view) {
-            view.as(db.knex.raw(sql));
-        });
+        await schemaModule.commands.createViewOrReplace(name, sql, db.knex);
     }
 };
 


### PR DESCRIPTION
ref BER-3756

## Problem

`members_resolved_subscription` (the first VIEW Ghost ships, added in 6.45) is created with no explicit security context. MySQL therefore stamps it with `SQL SECURITY DEFINER` bound to the account that ran the migration. That makes the view non-portable:

- When the database is restored under a different MySQL user — Ghost(Pro) restores into a new site, or a self-hoster moving between servers — the view errors at query time (`The user specified as the definer ... does not exist`). Because the resolved-subscription lookup is touched on the Stripe subscription webhook path, this surfaces as repeated webhook failures on an otherwise healthy-looking site.
- The internal account name is also written into every `mysqldump`, including the archives handed to customers.

This is a brand-new failure mode: before this view, Ghost shipped no views/procedures/triggers, so dumps carried no `DEFINER` at all.

## Fix

- Add a single `commands.createViewOrReplace` helper that forces `SQL SECURITY INVOKER` on MySQL (the view runs with the querying user's privileges and binds to no specific account). SQLite has no such concept and keeps the plain builder.
- Route both creation paths — `knex-migrator init` and versioned migrations — through the helper, so every view is portable by default and future views inherit the behaviour.
- Add a versioned migration that recreates `members_resolved_subscription` in place (`CREATE OR REPLACE`) so existing installs are fixed without dropping the view.
- Unit-test the helper as a regression guard: MySQL emits `SQL SECURITY INVOKER` and no `DEFINER`; SQLite uses the plain builder.

## Also: removed a now-unneeded fallback

`getCurrentSubscription` in `apps/posts` kept a local `mostRelevantSubscription` resolver as a fallback for the deploy-skew window before the backend returned `current_subscription`. That field has shipped since 6.45 (now 6.50), well beyond the window, so the fallback is removed and the field is read directly. Separate commit; easy to split out if preferred.

## Notes

- INVOKER fixes the runtime breakage everywhere. Stripping the leftover `DEFINER` value from existing dumps/archives is handled separately in the Ghost(Pro) backup tooling (also tracked under BER-3756).
- The unrelated `mostRelevantSubscription` helper in the legacy Ember admin (`ghost/admin`) is untouched.

## Test plan

- [ ] `yarn workspace ghost test` — schema command unit tests (new `createViewOrReplace` cases)
- [ ] Migration up/down runs clean on MySQL and SQLite
- [ ] On MySQL, `information_schema.views.security_type` for `members_resolved_subscription` is `INVOKER` after migrate
- [ ] `apps/posts` unit tests for `member-query-params`