### PR TITLE
Added route settings parser, serializer and validation

### DIFF
--- a/ghost/core/core/server/services/route-settings/route-settings-parser.ts
+++ b/ghost/core/core/server/services/route-settings/route-settings-parser.ts
@@ -1,3 +1,15 @@
+import yaml from 'js-yaml';
+import {z} from 'zod';
+import errors from '@tryghost/errors';
+import tpl from '@tryghost/tpl';
+
+const messages = {
+    validationError: 'The following definition "{at}" is invalid: {reason}',
+    badDataError: 'Please wrap the data definition into a custom name.',
+    badDataHelp: 'Example:\n data:\n  my-tag:\n    resource: tags\n    ...\n',
+    authorDeprecatedError: 'Please choose a different name. We recommend not using author.'
+};
+
 export type DataShortFormResource = 'tag' | 'page' | 'post' | 'author';
 export type DataLongFormResource = 'tags' | 'posts' | 'pages' | 'authors';
 
@@ -71,4 +83,379 @@ export interface RouteSettings {
     routes: Route[];
     collections: CollectionConfig[];
     taxonomies: TaxonomyConfig;
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+function validationError(at: string, reason: string, help?: string): errors.ValidationError {
+    return new errors.ValidationError({
+        message: tpl(messages.validationError, {at, reason}),
+        ...(help ? {help} : {})
+    });
+}
+
+function pathWithSlashes() {
+    return z.string().superRefine((v, ctx) => {
+        if (!v.startsWith('/')) {
+            ctx.addIssue({code: 'custom', message: tpl(messages.validationError, {at: v, reason: 'A leading slash is required.'})});
+        }
+        if (!v.endsWith('/')) {
+            ctx.addIssue({code: 'custom', message: tpl(messages.validationError, {at: v, reason: 'A trailing slash is required.'})});
+        }
+        if (/\/:\w+/.test(v)) {
+            ctx.addIssue({code: 'custom', message: tpl(messages.validationError, {at: v, reason: 'Please use the following notation e.g. /{slug}/.'})});
+        }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Data schemas
+// ---------------------------------------------------------------------------
+
+const VALID_SHORTFORM_RESOURCES = ['tag', 'page', 'post', 'author'] as const;
+const VALID_LONGFORM_RESOURCES = ['tags', 'posts', 'pages', 'authors'] as const;
+const RESERVED_DATA_KEYS = ['resource', 'type', 'limit', 'order', 'include', 'filter', 'status', 'visibility', 'slug', 'redirect'];
+
+const DataShortFormSchema = z.string().superRefine((v, ctx) => {
+    if (!/^[a-zA-Z0-9_]+\.[a-zA-Z0-9_-]+$/.test(v)) {
+        ctx.addIssue({code: 'custom', message: tpl(messages.validationError, {at: v, reason: 'Incorrect Format. Please use e.g. tag.recipes'})});
+        return;
+    }
+    const resource = v.split('.')[0];
+    if (!(VALID_SHORTFORM_RESOURCES as readonly string[]).includes(resource)) {
+        ctx.addIssue({code: 'custom', message: tpl(messages.validationError, {at: v, reason: `${resource} not supported. Please use ${VALID_SHORTFORM_RESOURCES.join(', ')}.`})});
+    }
+});
+
+const DataReadEntrySchema = z.object({
+    type: z.literal('read'),
+    resource: z.enum(VALID_LONGFORM_RESOURCES),
+    slug: z.string().min(1, {message: 'slug is required for read data entries.'}),
+    redirect: z.boolean().optional(),
+    include: z.string().optional(),
+    visibility: z.string().optional(),
+    status: z.string().optional()
+});
+
+const DataBrowseEntrySchema = z.object({
+    type: z.literal('browse'),
+    resource: z.enum(VALID_LONGFORM_RESOURCES),
+    filter: z.string().optional(),
+    limit: z.union([z.number(), z.literal('all')]).optional(),
+    order: z.string().optional(),
+    include: z.string().optional(),
+    fields: z.string().optional(),
+    visibility: z.string().optional(),
+    status: z.string().optional(),
+    page: z.number().optional()
+});
+
+const DataLongFormEntrySchema = z.discriminatedUnion('type', [DataReadEntrySchema, DataBrowseEntrySchema]);
+
+const DataEntrySchema = z.union([DataShortFormSchema, DataLongFormEntrySchema]);
+
+const RouteDataSchema = z.union([
+    DataShortFormSchema,
+    z.record(z.string(), DataEntrySchema).superRefine((data, ctx) => {
+        for (const key of Object.keys(data)) {
+            if (RESERVED_DATA_KEYS.includes(key)) {
+                ctx.addIssue({code: 'custom', message: tpl(messages.badDataError), path: [key]});
+            }
+            if (key === 'author') {
+                ctx.addIssue({code: 'custom', message: tpl(messages.authorDeprecatedError), path: [key]});
+            }
+        }
+    })
+]);
+
+// ---------------------------------------------------------------------------
+// Route schemas (raw YAML → domain model)
+// ---------------------------------------------------------------------------
+
+const TemplateField = z.union([z.string(), z.array(z.string())]).optional().default([])
+    .transform(v => {
+        if (!v || (Array.isArray(v) && v.length === 0)) {
+            return [];
+        }
+        return Array.isArray(v) ? v : [v];
+    });
+
+const RouteObjectSchema = z.object({
+    controller: z.literal('channel').optional(),
+    template: TemplateField,
+    data: RouteDataSchema.optional(),
+    content_type: z.string().optional(),
+    filter: z.string().optional(),
+    order: z.string().optional(),
+    limit: z.union([z.number(), z.literal('all')]).optional(),
+    rss: z.boolean().optional()
+}).transform((val): Omit<Route, 'path'> => {
+    const templates = val.template;
+    const data = val.data as RouteData | undefined;
+
+    if (val.controller === 'channel') {
+        const route: Omit<ChannelRoute, 'path'> = {
+            type: 'channel',
+            templates,
+            rss: val.rss ?? true
+        };
+        if (val.filter !== undefined) {
+            route.filter = val.filter;
+        }
+        if (val.order !== undefined) {
+            route.order = val.order;
+        }
+        if (val.limit !== undefined) {
+            route.limit = val.limit;
+        }
+        if (data !== undefined) {
+            route.data = data;
+        }
+        return route;
+    }
+
+    const route: Omit<TemplateRoute, 'path'> = {
+        type: 'template',
+        templates
+    };
+    if (val.content_type !== undefined) {
+        route.contentType = val.content_type;
+    }
+    if (data !== undefined) {
+        route.data = data;
+    }
+    return route;
+});
+
+// No union here — string routes are handled in the parseRouteSettings loop
+// to avoid Zod v4 union masking inner error messages with "Invalid input".
+
+// ---------------------------------------------------------------------------
+// Collection schema
+// ---------------------------------------------------------------------------
+
+const RawCollectionValueSchema = z.object({
+    permalink: z.string({message: 'Please define a permalink route.'}).pipe(pathWithSlashes()),
+    template: TemplateField,
+    data: RouteDataSchema.optional(),
+    filter: z.string().optional(),
+    order: z.string().optional(),
+    limit: z.union([z.number(), z.literal('all')]).optional(),
+    rss: z.boolean().optional()
+}).transform((val): Omit<CollectionConfig, 'path'> => {
+    const collection: Omit<CollectionConfig, 'path'> = {
+        permalink: val.permalink,
+        templates: val.template
+    };
+    if (val.filter !== undefined) {
+        collection.filter = val.filter;
+    }
+    if (val.order !== undefined) {
+        collection.order = val.order;
+    }
+    if (val.limit !== undefined) {
+        collection.limit = val.limit;
+    }
+    if (val.rss !== undefined) {
+        collection.rss = val.rss;
+    }
+    if (val.data !== undefined) {
+        collection.data = val.data as RouteData;
+    }
+    return collection;
+});
+
+// ---------------------------------------------------------------------------
+// Taxonomy schema
+// ---------------------------------------------------------------------------
+
+const TaxonomyValueSchema = pathWithSlashes();
+
+const TaxonomiesSchema = z.record(z.string(), TaxonomyValueSchema)
+    .superRefine((obj, ctx) => {
+        for (const key of Object.keys(obj)) {
+            if (!['tag', 'author'].includes(key)) {
+                ctx.addIssue({code: 'custom', message: tpl(messages.validationError, {at: key, reason: 'Unknown taxonomy.'})});
+            }
+        }
+    })
+    .transform((obj): TaxonomyConfig => {
+        const result: TaxonomyConfig = {};
+        if (obj.tag) {
+            result.tag = obj.tag;
+        }
+        if (obj.author) {
+            result.author = obj.author;
+        }
+        return result;
+    });
+
+// ---------------------------------------------------------------------------
+// Top-level schema
+// ---------------------------------------------------------------------------
+
+const RouteSettingsSchema = z.object({
+    routes: z.record(z.string(), z.unknown()).nullable().optional().default({}),
+    collections: z.record(z.string(), RawCollectionValueSchema).nullable().optional().default({}),
+    taxonomies: z.record(z.string(), z.string()).nullable().optional().default({})
+});
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+function toValidationError(error: z.ZodError): errors.ValidationError {
+    const issue = error.issues[0];
+    const isBadDataKey = issue.message === tpl(messages.badDataError);
+    return new errors.ValidationError({
+        message: issue.message,
+        ...(isBadDataKey ? {help: messages.badDataHelp} : {})
+    });
+}
+
+export function parseRouteSettings(raw: unknown): RouteSettings {
+    const obj = raw ?? {};
+
+    const parsed = RouteSettingsSchema.safeParse(obj);
+    if (!parsed.success) {
+        throw toValidationError(parsed.error);
+    }
+
+    const {routes: rawRoutes, collections: rawCollections, taxonomies: rawTaxonomies} = parsed.data;
+
+    const routes: Route[] = [];
+    if (rawRoutes) {
+        for (const [path, value] of Object.entries(rawRoutes)) {
+            if (!path.startsWith('/')) {
+                throw validationError(path, 'A leading slash is required.');
+            }
+            if (!path.endsWith('/')) {
+                throw validationError(path, 'A trailing slash is required.');
+            }
+            if (/\/:\w+/.test(path)) {
+                throw validationError(path, 'Please use the following notation e.g. /{slug}/.');
+            }
+
+            if (value === null || value === undefined) {
+                throw validationError(path, 'Please define a template.');
+            }
+
+            if (typeof value === 'string') {
+                routes.push({type: 'template', path, templates: [value]});
+                continue;
+            }
+
+            const routeResult = RouteObjectSchema.safeParse(value);
+            if (!routeResult.success) {
+                throw toValidationError(routeResult.error);
+            }
+
+            const route = routeResult.data;
+            if (route.type === 'template' && (!route.templates || route.templates.length === 0) && !route.data && !(route as Omit<TemplateRoute, 'path'>).contentType) {
+                throw validationError(path, 'Please define a template.');
+            }
+
+            routes.push({...route, path} as Route);
+        }
+    }
+
+    const collections: CollectionConfig[] = [];
+    if (rawCollections) {
+        for (const [path, value] of Object.entries(rawCollections)) {
+            if (!path.startsWith('/')) {
+                throw validationError(path, 'A leading slash is required.');
+            }
+            if (!path.endsWith('/')) {
+                throw validationError(path, 'A trailing slash is required.');
+            }
+            if (/\/:\w+/.test(path)) {
+                throw validationError(path, 'Please use the following notation e.g. /{slug}/.');
+            }
+            collections.push({...value, path});
+        }
+    }
+
+    let taxonomies: TaxonomyConfig = {};
+    if (rawTaxonomies && Object.keys(rawTaxonomies).length > 0) {
+        const taxResult = TaxonomiesSchema.safeParse(rawTaxonomies);
+        if (!taxResult.success) {
+            throw toValidationError(taxResult.error);
+        }
+        taxonomies = taxResult.data;
+    }
+
+    return {routes, collections, taxonomies};
+}
+
+export function serializeRouteSettings(settings: RouteSettings): string {
+    const obj: Record<string, unknown> = {};
+
+    const routes: Record<string, unknown> = {};
+    for (const route of settings.routes) {
+        if (route.type === 'template' && route.templates?.length === 1 && !route.data && !(route as TemplateRoute).contentType) {
+            routes[route.path] = route.templates[0];
+        } else {
+            const entry: Record<string, unknown> = {};
+            if (route.templates && route.templates.length > 0) {
+                entry.template = route.templates.length === 1 ? route.templates[0] : route.templates;
+            }
+            if (route.data !== undefined) {
+                entry.data = route.data;
+            }
+            if (route.type === 'channel') {
+                const channel = route as ChannelRoute;
+                entry.controller = 'channel';
+                if (channel.filter !== undefined) {
+                    entry.filter = channel.filter;
+                }
+                if (channel.order !== undefined) {
+                    entry.order = channel.order;
+                }
+                if (channel.limit !== undefined) {
+                    entry.limit = channel.limit;
+                }
+                if (channel.rss !== true) {
+                    entry.rss = channel.rss;
+                }
+            } else {
+                const tmpl = route as TemplateRoute;
+                if (tmpl.contentType !== undefined) {
+                    entry.content_type = tmpl.contentType;
+                }
+            }
+            routes[route.path] = entry;
+        }
+    }
+    obj.routes = Object.keys(routes).length > 0 ? routes : null;
+
+    const collections: Record<string, unknown> = {};
+    for (const coll of settings.collections) {
+        const entry: Record<string, unknown> = {permalink: coll.permalink};
+        if (coll.templates && coll.templates.length > 0) {
+            entry.template = coll.templates.length === 1 ? coll.templates[0] : coll.templates;
+        }
+        if (coll.filter !== undefined) {
+            entry.filter = coll.filter;
+        }
+        if (coll.order !== undefined) {
+            entry.order = coll.order;
+        }
+        if (coll.limit !== undefined) {
+            entry.limit = coll.limit;
+        }
+        if (coll.rss !== undefined) {
+            entry.rss = coll.rss;
+        }
+        if (coll.data !== undefined) {
+            entry.data = coll.data;
+        }
+        collections[coll.path] = entry;
+    }
+    obj.collections = Object.keys(collections).length > 0 ? collections : null;
+
+    obj.taxonomies = Object.keys(settings.taxonomies).length > 0 ? settings.taxonomies : null;
+
+    return yaml.dump(obj, {quotingType: '\'', forceQuotes: false});
 }

--- a/ghost/core/core/server/services/route-settings/route-settings-parser.ts
+++ b/ghost/core/core/server/services/route-settings/route-settings-parser.ts
@@ -85,19 +85,12 @@ export interface RouteSettings {
     taxonomies: TaxonomyConfig;
 }
 
-// ---------------------------------------------------------------------------
-// Validation helpers
-// ---------------------------------------------------------------------------
-
 function validationError(at: string, reason: string, help?: string): errors.ValidationError {
     return new errors.ValidationError({
         message: tpl(messages.validationError, {at, reason}),
         ...(help ? {help} : {})
     });
 }
-// ---------------------------------------------------------------------------
-// Data schemas
-// ---------------------------------------------------------------------------
 
 const VALID_SHORTFORM_RESOURCES = ['tag', 'page', 'post', 'author'] as const;
 const VALID_LONGFORM_RESOURCES = ['tags', 'posts', 'pages', 'authors'] as const;
@@ -210,10 +203,6 @@ function parseRouteData(data: unknown): RouteData {
     return parsed;
 }
 
-// ---------------------------------------------------------------------------
-// Route schemas (raw YAML → domain model)
-// ---------------------------------------------------------------------------
-
 const TemplateField = z.union([z.string(), z.array(z.string())]).optional().default([])
     .transform(v => {
         if (!v || (Array.isArray(v) && v.length === 0)) {
@@ -269,13 +258,6 @@ const RouteObjectSchema = z.object({
     return route;
 });
 
-// No union here — string routes are handled in the parseRouteSettings loop
-// to avoid Zod v4 union masking inner error messages with "Invalid input".
-
-// ---------------------------------------------------------------------------
-// Collection schema
-// ---------------------------------------------------------------------------
-
 const RawCollectionValueSchema = z.object({
     permalink: z.string({message: 'Please define a permalink route.'}).optional(),
     template: TemplateField,
@@ -308,19 +290,11 @@ const RawCollectionValueSchema = z.object({
     return collection;
 });
 
-// ---------------------------------------------------------------------------
-// Top-level schema
-// ---------------------------------------------------------------------------
-
 const RouteSettingsSchema = z.object({
     routes: z.record(z.string(), z.unknown()).nullable().optional().default({}),
     collections: z.record(z.string(), RawCollectionValueSchema).nullable().optional().default({}),
     taxonomies: z.record(z.string(), z.string()).nullable().optional().default({})
 });
-
-// ---------------------------------------------------------------------------
-// Public API
-// ---------------------------------------------------------------------------
 
 function toValidationError(error: z.ZodError): errors.ValidationError {
     const issue = error.issues[0];

--- a/ghost/core/core/server/services/route-settings/route-settings-parser.ts
+++ b/ghost/core/core/server/services/route-settings/route-settings-parser.ts
@@ -95,21 +95,6 @@ function validationError(at: string, reason: string, help?: string): errors.Vali
         ...(help ? {help} : {})
     });
 }
-
-function pathWithSlashes() {
-    return z.string().superRefine((v, ctx) => {
-        if (!v.startsWith('/')) {
-            ctx.addIssue({code: 'custom', message: tpl(messages.validationError, {at: v, reason: 'A leading slash is required.'})});
-        }
-        if (!v.endsWith('/')) {
-            ctx.addIssue({code: 'custom', message: tpl(messages.validationError, {at: v, reason: 'A trailing slash is required.'})});
-        }
-        if (/\/:\w+/.test(v)) {
-            ctx.addIssue({code: 'custom', message: tpl(messages.validationError, {at: v, reason: 'Please use the following notation e.g. /{slug}/.'})});
-        }
-    });
-}
-
 // ---------------------------------------------------------------------------
 // Data schemas
 // ---------------------------------------------------------------------------
@@ -132,7 +117,7 @@ const DataShortFormSchema = z.string().superRefine((v, ctx) => {
 const DataReadEntrySchema = z.object({
     type: z.literal('read'),
     resource: z.enum(VALID_LONGFORM_RESOURCES),
-    slug: z.string().min(1, {message: 'slug is required for read data entries.'}),
+    slug: z.string({message: 'slug is required for read data entries.'}).min(1, {message: 'slug is required for read data entries.'}),
     redirect: z.boolean().optional(),
     include: z.string().optional(),
     visibility: z.string().optional(),
@@ -154,21 +139,76 @@ const DataBrowseEntrySchema = z.object({
 
 const DataLongFormEntrySchema = z.discriminatedUnion('type', [DataReadEntrySchema, DataBrowseEntrySchema]);
 
-const DataEntrySchema = z.union([DataShortFormSchema, DataLongFormEntrySchema]);
-
-const RouteDataSchema = z.union([
-    DataShortFormSchema,
-    z.record(z.string(), DataEntrySchema).superRefine((data, ctx) => {
-        for (const key of Object.keys(data)) {
-            if (RESERVED_DATA_KEYS.includes(key)) {
-                ctx.addIssue({code: 'custom', message: tpl(messages.badDataError), path: [key]});
-            }
-            if (key === 'author') {
-                ctx.addIssue({code: 'custom', message: tpl(messages.authorDeprecatedError), path: [key]});
-            }
+function parseDataEntry(key: string, value: unknown): DataEntry {
+    if (typeof value === 'string') {
+        const result = DataShortFormSchema.safeParse(value);
+        if (!result.success) {
+            throw toValidationError(result.error);
         }
-    })
-]);
+        return value as DataShortForm;
+    }
+
+    if (typeof value === 'object' && value !== null) {
+        const result = DataLongFormEntrySchema.safeParse(value);
+        if (!result.success) {
+            const issue = result.error.issues[0];
+            if (issue.message.includes('discriminator')) {
+                const typeVal = (value as Record<string, unknown>).type;
+                if (typeVal === undefined) {
+                    throw validationError(JSON.stringify(value), 'type is required.');
+                }
+                throw validationError(JSON.stringify(value), `${typeVal} not supported. Please use read, browse.`);
+            }
+            if (issue.path?.includes('resource')) {
+                const resVal = (value as Record<string, unknown>).resource;
+                if (resVal === undefined) {
+                    throw validationError(JSON.stringify(value), 'resource is required.');
+                }
+                throw validationError(JSON.stringify(value), `${resVal} not supported. Please use ${VALID_LONGFORM_RESOURCES.join(', ')}.`);
+            }
+            throw toValidationError(result.error);
+        }
+        return result.data;
+    }
+
+    throw validationError(key, 'Incorrect Format. Please use e.g. tag.recipes');
+}
+
+function parseRouteData(data: unknown): RouteData {
+    if (typeof data === 'string') {
+        const result = DataShortFormSchema.safeParse(data);
+        if (!result.success) {
+            throw toValidationError(result.error);
+        }
+        return data as DataShortForm;
+    }
+
+    if (typeof data !== 'object' || data === null) {
+        throw validationError(String(data), 'Incorrect Format. Please use e.g. tag.recipes');
+    }
+
+    const record = data as Record<string, unknown>;
+
+    for (const key of Object.keys(record)) {
+        if (RESERVED_DATA_KEYS.includes(key)) {
+            throw new errors.ValidationError({
+                message: tpl(messages.badDataError),
+                help: messages.badDataHelp
+            });
+        }
+        if (key === 'author') {
+            throw new errors.ValidationError({
+                message: tpl(messages.authorDeprecatedError)
+            });
+        }
+    }
+
+    const parsed: Record<string, DataEntry> = {};
+    for (const [key, value] of Object.entries(record)) {
+        parsed[key] = parseDataEntry(key, value);
+    }
+    return parsed;
+}
 
 // ---------------------------------------------------------------------------
 // Route schemas (raw YAML → domain model)
@@ -185,7 +225,7 @@ const TemplateField = z.union([z.string(), z.array(z.string())]).optional().defa
 const RouteObjectSchema = z.object({
     controller: z.literal('channel').optional(),
     template: TemplateField,
-    data: RouteDataSchema.optional(),
+    data: z.unknown().optional(),
     content_type: z.string().optional(),
     filter: z.string().optional(),
     order: z.string().optional(),
@@ -193,7 +233,7 @@ const RouteObjectSchema = z.object({
     rss: z.boolean().optional()
 }).transform((val): Omit<Route, 'path'> => {
     const templates = val.template;
-    const data = val.data as RouteData | undefined;
+    const data = val.data !== undefined ? parseRouteData(val.data) : undefined;
 
     if (val.controller === 'channel') {
         const route: Omit<ChannelRoute, 'path'> = {
@@ -237,16 +277,17 @@ const RouteObjectSchema = z.object({
 // ---------------------------------------------------------------------------
 
 const RawCollectionValueSchema = z.object({
-    permalink: z.string({message: 'Please define a permalink route.'}).pipe(pathWithSlashes()),
+    permalink: z.string({message: 'Please define a permalink route.'}).optional(),
     template: TemplateField,
-    data: RouteDataSchema.optional(),
+    data: z.unknown().optional(),
     filter: z.string().optional(),
     order: z.string().optional(),
     limit: z.union([z.number(), z.literal('all')]).optional(),
     rss: z.boolean().optional()
 }).transform((val): Omit<CollectionConfig, 'path'> => {
+    const data = val.data !== undefined ? parseRouteData(val.data) : undefined;
     const collection: Omit<CollectionConfig, 'path'> = {
-        permalink: val.permalink,
+        permalink: val.permalink ?? '',
         templates: val.template
     };
     if (val.filter !== undefined) {
@@ -261,36 +302,11 @@ const RawCollectionValueSchema = z.object({
     if (val.rss !== undefined) {
         collection.rss = val.rss;
     }
-    if (val.data !== undefined) {
-        collection.data = val.data as RouteData;
+    if (data !== undefined) {
+        collection.data = data;
     }
     return collection;
 });
-
-// ---------------------------------------------------------------------------
-// Taxonomy schema
-// ---------------------------------------------------------------------------
-
-const TaxonomyValueSchema = pathWithSlashes();
-
-const TaxonomiesSchema = z.record(z.string(), TaxonomyValueSchema)
-    .superRefine((obj, ctx) => {
-        for (const key of Object.keys(obj)) {
-            if (!['tag', 'author'].includes(key)) {
-                ctx.addIssue({code: 'custom', message: tpl(messages.validationError, {at: key, reason: 'Unknown taxonomy.'})});
-            }
-        }
-    })
-    .transform((obj): TaxonomyConfig => {
-        const result: TaxonomyConfig = {};
-        if (obj.tag) {
-            result.tag = obj.tag;
-        }
-        if (obj.author) {
-            result.author = obj.author;
-        }
-        return result;
-    });
 
 // ---------------------------------------------------------------------------
 // Top-level schema
@@ -308,10 +324,8 @@ const RouteSettingsSchema = z.object({
 
 function toValidationError(error: z.ZodError): errors.ValidationError {
     const issue = error.issues[0];
-    const isBadDataKey = issue.message === tpl(messages.badDataError);
     return new errors.ValidationError({
-        message: issue.message,
-        ...(isBadDataKey ? {help: messages.badDataHelp} : {})
+        message: issue.message
     });
 }
 
@@ -339,7 +353,7 @@ export function parseRouteSettings(raw: unknown): RouteSettings {
             }
 
             if (value === null || value === undefined) {
-                throw validationError(path, 'Please define a template.');
+                throw validationError(path, 'Please define a template.', 'e.g. /about/: about');
             }
 
             if (typeof value === 'string') {
@@ -354,7 +368,7 @@ export function parseRouteSettings(raw: unknown): RouteSettings {
 
             const route = routeResult.data;
             if (route.type === 'template' && (!route.templates || route.templates.length === 0) && !route.data && !(route as Omit<TemplateRoute, 'path'>).contentType) {
-                throw validationError(path, 'Please define a template.');
+                throw validationError(path, 'Please define a template.', 'e.g. /about/: about');
             }
 
             routes.push({...route, path} as Route);
@@ -373,17 +387,47 @@ export function parseRouteSettings(raw: unknown): RouteSettings {
             if (/\/:\w+/.test(path)) {
                 throw validationError(path, 'Please use the following notation e.g. /{slug}/.');
             }
+            if (!value.permalink) {
+                throw validationError(path, 'Please define a permalink route.', 'e.g. permalink: /{slug}/');
+            }
+            if (!value.permalink.startsWith('/')) {
+                throw validationError(value.permalink, 'A leading slash is required.');
+            }
+            if (!value.permalink.endsWith('/')) {
+                throw validationError(value.permalink, 'A trailing slash is required.');
+            }
+            if (/\/:\w+/.test(value.permalink)) {
+                throw validationError(value.permalink, 'Please use the following notation e.g. /{slug}/.');
+            }
             collections.push({...value, path});
         }
     }
 
-    let taxonomies: TaxonomyConfig = {};
-    if (rawTaxonomies && Object.keys(rawTaxonomies).length > 0) {
-        const taxResult = TaxonomiesSchema.safeParse(rawTaxonomies);
-        if (!taxResult.success) {
-            throw toValidationError(taxResult.error);
+    const taxonomies: TaxonomyConfig = {};
+    if (rawTaxonomies) {
+        for (const [key, value] of Object.entries(rawTaxonomies)) {
+            if (!['tag', 'author'].includes(key)) {
+                throw validationError(key, 'Unknown taxonomy.');
+            }
+            if (!value) {
+                throw validationError(key, 'Please define a taxonomy permalink route.', 'e.g. tag: /tag/{slug}/');
+            }
+            if (!value.startsWith('/')) {
+                throw validationError(value, 'A leading slash is required.');
+            }
+            if (!value.endsWith('/')) {
+                throw validationError(value, 'A trailing slash is required.');
+            }
+            if (/\/:\w+/.test(value)) {
+                throw validationError(value, 'Please use the following notation e.g. /{slug}/.');
+            }
+            if (key === 'tag') {
+                taxonomies.tag = value;
+            }
+            if (key === 'author') {
+                taxonomies.author = value;
+            }
         }
-        taxonomies = taxResult.data;
     }
 
     return {routes, collections, taxonomies};

--- a/ghost/core/test/unit/server/services/route-settings/route-settings-parser.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/route-settings-parser.test.ts
@@ -1,0 +1,443 @@
+import assert from 'node:assert/strict';
+import {parseRouteSettings, serializeRouteSettings} from '../../../../../core/server/services/route-settings/route-settings-parser';
+import type {RouteSettings} from '../../../../../core/server/services/route-settings/route-settings-parser';
+
+describe('UNIT: services/route-settings/route-settings-parser', function () {
+    describe('parseRouteSettings', function () {
+        it('handles null/undefined input', function () {
+            assert.deepEqual(parseRouteSettings(null), {routes: [], collections: [], taxonomies: {}});
+            assert.deepEqual(parseRouteSettings(undefined), {routes: [], collections: [], taxonomies: {}});
+        });
+
+        it('handles empty object', function () {
+            assert.deepEqual(parseRouteSettings({}), {routes: [], collections: [], taxonomies: {}});
+        });
+
+        it('handles empty sections', function () {
+            assert.deepEqual(parseRouteSettings({routes: null, collections: null, taxonomies: null}), {
+                routes: [], collections: [], taxonomies: {}
+            });
+        });
+
+        describe('routes', function () {
+            it('parses bare string route as template route', function () {
+                const result = parseRouteSettings({
+                    routes: {'/about/': 'about'}
+                });
+
+                assert.deepEqual(result.routes, [
+                    {type: 'template', path: '/about/', templates: ['about']}
+                ]);
+            });
+
+            it('parses object route with template string', function () {
+                const result = parseRouteSettings({
+                    routes: {'/me/': {template: 'me'}}
+                });
+
+                assert.deepEqual(result.routes, [
+                    {type: 'template', path: '/me/', templates: ['me']}
+                ]);
+            });
+
+            it('parses object route with template array', function () {
+                const result = parseRouteSettings({
+                    routes: {'/about/': {template: ['about', 'default']}}
+                });
+
+                assert.deepEqual(result.routes, [
+                    {type: 'template', path: '/about/', templates: ['about', 'default']}
+                ]);
+            });
+
+            it('parses template route with no template key as empty templates', function () {
+                const result = parseRouteSettings({
+                    routes: {'/rss/': {content_type: 'text/xml'}}
+                });
+
+                assert.deepEqual(result.routes, [
+                    {type: 'template', path: '/rss/', templates: [], contentType: 'text/xml'}
+                ]);
+            });
+
+            it('parses route with data', function () {
+                const result = parseRouteSettings({
+                    routes: {'/food/': {template: 'food', data: 'tag.food'}}
+                });
+
+                assert.deepEqual(result.routes, [
+                    {type: 'template', path: '/food/', templates: ['food'], data: 'tag.food'}
+                ]);
+            });
+
+            it('detects channel route via controller: channel', function () {
+                const result = parseRouteSettings({
+                    routes: {'/featured/': {controller: 'channel', filter: 'featured:true', template: 'featured'}}
+                });
+
+                assert.deepEqual(result.routes, [
+                    {type: 'channel', path: '/featured/', templates: ['featured'], filter: 'featured:true', rss: true}
+                ]);
+            });
+
+            it('treats route with filter but no controller as template route', function () {
+                const result = parseRouteSettings({
+                    routes: {'/latest/': {template: 'latest', filter: 'featured:true'}}
+                });
+
+                assert.equal(result.routes[0].type, 'template');
+            });
+
+            it('respects explicit rss: false on channel route', function () {
+                const result = parseRouteSettings({
+                    routes: {'/featured/': {controller: 'channel', filter: 'featured:true', rss: false}}
+                });
+
+                assert.deepEqual(result.routes, [
+                    {type: 'channel', path: '/featured/', templates: [], filter: 'featured:true', rss: false}
+                ]);
+            });
+
+            it('parses channel route with all properties', function () {
+                const result = parseRouteSettings({
+                    routes: {
+                        '/channel/': {
+                            controller: 'channel',
+                            filter: 'tag:channel',
+                            order: 'published_at desc',
+                            limit: 10,
+                            template: 'channel',
+                            data: 'tag.channel',
+                            rss: true
+                        }
+                    }
+                });
+
+                assert.deepEqual(result.routes, [{
+                    type: 'channel',
+                    path: '/channel/',
+                    templates: ['channel'],
+                    filter: 'tag:channel',
+                    order: 'published_at desc',
+                    limit: 10,
+                    data: 'tag.channel',
+                    rss: true
+                }]);
+            });
+
+            it('parses multiple routes preserving order', function () {
+                const result = parseRouteSettings({
+                    routes: {
+                        '/about/': 'about',
+                        '/contact/': 'contact',
+                        '/featured/': {controller: 'channel', filter: 'featured:true'}
+                    }
+                });
+
+                assert.equal(result.routes.length, 3);
+                assert.equal(result.routes[0].path, '/about/');
+                assert.equal(result.routes[1].path, '/contact/');
+                assert.equal(result.routes[2].path, '/featured/');
+            });
+        });
+
+        describe('collections', function () {
+            it('parses basic collection', function () {
+                const result = parseRouteSettings({
+                    collections: {'/': {permalink: '/{slug}/'}}
+                });
+
+                assert.deepEqual(result.collections, [
+                    {path: '/', permalink: '/{slug}/', templates: []}
+                ]);
+            });
+
+            it('parses collection with template', function () {
+                const result = parseRouteSettings({
+                    collections: {'/': {permalink: '/{slug}/', template: 'index'}}
+                });
+
+                assert.deepEqual(result.collections, [
+                    {path: '/', permalink: '/{slug}/', templates: ['index']}
+                ]);
+            });
+
+            it('parses collection with all properties', function () {
+                const result = parseRouteSettings({
+                    collections: {
+                        '/podcast/': {
+                            permalink: '/podcast/{slug}/',
+                            template: ['podcast', 'index'],
+                            filter: 'tag:podcast',
+                            order: 'published_at desc',
+                            limit: 12,
+                            rss: false,
+                            data: 'tag.podcast'
+                        }
+                    }
+                });
+
+                assert.deepEqual(result.collections, [{
+                    path: '/podcast/',
+                    permalink: '/podcast/{slug}/',
+                    templates: ['podcast', 'index'],
+                    filter: 'tag:podcast',
+                    order: 'published_at desc',
+                    limit: 12,
+                    rss: false,
+                    data: 'tag.podcast'
+                }]);
+            });
+
+            it('parses multiple collections', function () {
+                const result = parseRouteSettings({
+                    collections: {
+                        '/podcast/': {permalink: '/podcast/{slug}/'},
+                        '/': {permalink: '/{slug}/'}
+                    }
+                });
+
+                assert.equal(result.collections.length, 2);
+                assert.equal(result.collections[0].path, '/podcast/');
+                assert.equal(result.collections[1].path, '/');
+            });
+        });
+
+        describe('taxonomies', function () {
+            it('parses taxonomies', function () {
+                const result = parseRouteSettings({
+                    taxonomies: {tag: '/tag/{slug}/', author: '/author/{slug}/'}
+                });
+
+                assert.deepEqual(result.taxonomies, {
+                    tag: '/tag/{slug}/',
+                    author: '/author/{slug}/'
+                });
+            });
+
+            it('parses partial taxonomies', function () {
+                const result = parseRouteSettings({
+                    taxonomies: {tag: '/categories/{slug}/'}
+                });
+
+                assert.deepEqual(result.taxonomies, {tag: '/categories/{slug}/'});
+            });
+        });
+
+        describe('data passthrough', function () {
+            it('preserves data shortform string', function () {
+                const result = parseRouteSettings({
+                    routes: {'/food/': {template: 'food', data: 'tag.food'}}
+                });
+
+                assert.equal(result.routes[0].data, 'tag.food');
+            });
+
+            it('preserves data longform object', function () {
+                const data = {
+                    featured: {resource: 'posts', type: 'browse', filter: 'featured:true'},
+                    main_tag: 'tag.getting-started'
+                };
+                const result = parseRouteSettings({
+                    routes: {'/featured/': {template: 'featured', data}}
+                });
+
+                assert.deepEqual(result.routes[0].data, data);
+            });
+        });
+
+        describe('keeps {slug} notation', function () {
+            it('does not convert {slug} to :slug in collection permalink', function () {
+                const result = parseRouteSettings({
+                    collections: {'/': {permalink: '/{slug}/'}}
+                });
+
+                assert.equal(result.collections[0].permalink, '/{slug}/');
+            });
+
+            it('does not convert {slug} to :slug in taxonomy', function () {
+                const result = parseRouteSettings({
+                    taxonomies: {tag: '/tag/{slug}/'}
+                });
+
+                assert.equal(result.taxonomies.tag, '/tag/{slug}/');
+            });
+        });
+
+        describe('default-routes.yaml', function () {
+            it('correctly parses the default routes.yaml content', function () {
+                const result = parseRouteSettings({
+                    routes: null,
+                    collections: {'/': {permalink: '/{slug}/', template: 'index'}},
+                    taxonomies: {tag: '/tag/{slug}/', author: '/author/{slug}/'}
+                });
+
+                assert.deepEqual(result, {
+                    routes: [],
+                    collections: [{
+                        path: '/',
+                        permalink: '/{slug}/',
+                        templates: ['index']
+                    }],
+                    taxonomies: {
+                        tag: '/tag/{slug}/',
+                        author: '/author/{slug}/'
+                    }
+                });
+            });
+        });
+    });
+
+    describe('serializeRouteSettings', function () {
+        it('serializes empty settings', function () {
+            const settings: RouteSettings = {routes: [], collections: [], taxonomies: {}};
+            const yaml = serializeRouteSettings(settings);
+
+            assert.ok(yaml.includes('routes: null'));
+            assert.ok(yaml.includes('collections: null'));
+            assert.ok(yaml.includes('taxonomies: null'));
+        });
+
+        it('serializes simple template route as bare string', function () {
+            const settings: RouteSettings = {
+                routes: [{type: 'template', path: '/about/', templates: ['about']}],
+                collections: [],
+                taxonomies: {}
+            };
+            const yaml = serializeRouteSettings(settings);
+
+            assert.ok(yaml.includes('/about/: about'));
+        });
+
+        it('serializes channel route as object with controller: channel', function () {
+            const settings: RouteSettings = {
+                routes: [{
+                    type: 'channel',
+                    path: '/featured/',
+                    templates: ['featured'],
+                    filter: 'featured:true',
+                    rss: true
+                }],
+                collections: [],
+                taxonomies: {}
+            };
+            const yaml = serializeRouteSettings(settings);
+
+            assert.ok(yaml.includes('/featured/:'));
+            assert.ok(yaml.includes('template: featured'));
+            assert.ok(yaml.includes('controller: channel'));
+            assert.ok(yaml.includes('filter: featured:true'));
+        });
+
+        it('does not emit rss when true (default)', function () {
+            const settings: RouteSettings = {
+                routes: [{type: 'channel', path: '/ch/', templates: [], filter: 'f', rss: true}],
+                collections: [],
+                taxonomies: {}
+            };
+            const yaml = serializeRouteSettings(settings);
+
+            assert.ok(!yaml.includes('rss:'));
+        });
+
+        it('emits rss when false', function () {
+            const settings: RouteSettings = {
+                routes: [{type: 'channel', path: '/ch/', templates: [], filter: 'f', rss: false}],
+                collections: [],
+                taxonomies: {}
+            };
+            const yaml = serializeRouteSettings(settings);
+
+            assert.ok(yaml.includes('rss: false'));
+        });
+
+        it('serializes collection', function () {
+            const settings: RouteSettings = {
+                routes: [],
+                collections: [{path: '/', permalink: '/{slug}/', templates: ['index']}],
+                taxonomies: {}
+            };
+            const yaml = serializeRouteSettings(settings);
+
+            assert.ok(yaml.includes('permalink: /{slug}/'));
+            assert.ok(yaml.includes('template: index'));
+        });
+
+        it('serializes taxonomies', function () {
+            const settings: RouteSettings = {
+                routes: [],
+                collections: [],
+                taxonomies: {tag: '/tag/{slug}/', author: '/author/{slug}/'}
+            };
+            const yaml = serializeRouteSettings(settings);
+
+            assert.ok(yaml.includes('tag: /tag/{slug}/'));
+            assert.ok(yaml.includes('author: /author/{slug}/'));
+        });
+
+        it('roundtrips through parse → serialize → parse', function () {
+            const original: RouteSettings = {
+                routes: [
+                    {type: 'template', path: '/about/', templates: ['about']},
+                    {type: 'channel', path: '/featured/', templates: ['featured'], filter: 'featured:true', rss: true, data: 'tag.featured'}
+                ],
+                collections: [
+                    {path: '/', permalink: '/{slug}/', templates: ['index']},
+                    {path: '/podcast/', permalink: '/podcast/{slug}/', templates: ['podcast'], filter: 'tag:podcast'}
+                ],
+                taxonomies: {tag: '/tag/{slug}/', author: '/author/{slug}/'}
+            };
+
+            const yamlStr = serializeRouteSettings(original);
+            const reparsed = parseRouteSettings(require('js-yaml').load(yamlStr));
+
+            assert.deepEqual(reparsed, original);
+        });
+
+        it('roundtrips through yaml → parse → serialize → yaml', function () {
+            const originalYaml = [
+                'routes:',
+                '  /about/: about',
+                '  /featured/:',
+                '    template: featured',
+                '    controller: channel',
+                '    filter: featured:true',
+                'collections:',
+                '  /:',
+                '    permalink: /{slug}/',
+                '    template: index',
+                '  /podcast/:',
+                '    permalink: /podcast/{slug}/',
+                '    template: podcast',
+                '    filter: tag:podcast',
+                'taxonomies:',
+                '  tag: /tag/{slug}/',
+                '  author: /author/{slug}/',
+                ''
+            ].join('\n');
+
+            const parsed = parseRouteSettings(require('js-yaml').load(originalYaml));
+            const reserialized = serializeRouteSettings(parsed);
+
+            assert.equal(reserialized, originalYaml);
+        });
+
+        it('roundtrips the sample routes.yaml from Downloads', function () {
+            const raw = {
+                routes: {
+                    '/signup/': 'members/signup',
+                    '/signin/': 'members/signin',
+                    '/account/': 'members/account'
+                },
+                collections: {'/': {permalink: '/{slug}/', template: 'index'}},
+                taxonomies: {tag: '/tag/{slug}/', author: '/author/{slug}/'}
+            };
+
+            const parsed = parseRouteSettings(raw);
+            const yamlStr = serializeRouteSettings(parsed);
+            const reparsed = parseRouteSettings(require('js-yaml').load(yamlStr));
+
+            assert.deepEqual(reparsed, parsed);
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/route-settings/validate-route-settings.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/validate-route-settings.test.ts
@@ -1,0 +1,313 @@
+import assert from 'node:assert/strict';
+import errors from '@tryghost/errors';
+import {parseRouteSettings} from '../../../../../core/server/services/route-settings/route-settings-parser';
+
+function throwsValidation(fn: () => void, expectedMessage?: string) {
+    assert.throws(fn, (err: any) => {
+        if (!(err instanceof errors.ValidationError)) {
+            return false;
+        }
+        if (expectedMessage && !err.message.includes(expectedMessage)) {
+            return false;
+        }
+        return true;
+    });
+}
+
+describe('UNIT: services/route-settings/validation (via parseRouteSettings)', function () {
+    it('accepts valid empty input', function () {
+        assert.doesNotThrow(() => parseRouteSettings({}));
+    });
+
+    it('accepts valid null input', function () {
+        assert.doesNotThrow(() => parseRouteSettings(null));
+    });
+
+    it('accepts valid default settings', function () {
+        assert.doesNotThrow(() => parseRouteSettings({
+            collections: {'/': {permalink: '/{slug}/', template: 'index'}},
+            taxonomies: {tag: '/tag/{slug}/', author: '/author/{slug}/'}
+        }));
+    });
+
+    describe('route validation', function () {
+        it('throws on route path without leading slash', function () {
+            throwsValidation(() => parseRouteSettings({
+                routes: {'about/': 'about'}
+            }));
+        });
+
+        it('throws on route path without trailing slash', function () {
+            throwsValidation(() => parseRouteSettings({
+                routes: {'/about': 'about'}
+            }));
+        });
+
+        it('throws on null route value', function () {
+            throwsValidation(() => parseRouteSettings({
+                routes: {'/about/': null}
+            }), 'Please define a template.');
+        });
+
+        it('throws on template route with no template and no data', function () {
+            throwsValidation(() => parseRouteSettings({
+                routes: {'/empty/': {}}
+            }), 'Please define a template.');
+        });
+
+        it('accepts template route with data but no template', function () {
+            assert.doesNotThrow(() => parseRouteSettings({
+                routes: {'/food/': {data: 'tag.food'}}
+            }));
+        });
+
+        it('accepts template route with content_type but no template', function () {
+            assert.doesNotThrow(() => parseRouteSettings({
+                routes: {'/rss/': {content_type: 'text/xml'}}
+            }));
+        });
+
+        it('accepts channel route with no template', function () {
+            assert.doesNotThrow(() => parseRouteSettings({
+                routes: {'/featured/': {controller: 'channel', filter: 'featured:true'}}
+            }));
+        });
+
+        it('throws on channel route with wrong-typed rss', function () {
+            throwsValidation(() => parseRouteSettings({
+                routes: {'/featured/': {controller: 'channel', filter: 'featured:true', rss: 'notabool'}}
+            }));
+        });
+
+        it('throws on route path with :slug notation', function () {
+            throwsValidation(() => parseRouteSettings({
+                routes: {'/foo/:slug/': 'post'}
+            }));
+        });
+    });
+
+    describe('collection validation', function () {
+        it('throws on collection path without leading slash', function () {
+            throwsValidation(() => parseRouteSettings({
+                collections: {'blog/': {permalink: '/{slug}/'}}
+            }));
+        });
+
+        it('throws on collection path without trailing slash', function () {
+            throwsValidation(() => parseRouteSettings({
+                collections: {'/blog': {permalink: '/{slug}/'}}
+            }));
+        });
+
+        it('throws when permalink is missing', function () {
+            throwsValidation(() => parseRouteSettings({
+                collections: {'/': {permalink: ''}}
+            }), 'A leading slash is required.');
+        });
+
+        it('throws when permalink key is absent', function () {
+            throwsValidation(() => parseRouteSettings({
+                collections: {'/': {}}
+            }), 'Please define a permalink route.');
+        });
+
+        it('throws on collection path with :slug notation', function () {
+            throwsValidation(() => parseRouteSettings({
+                collections: {'/blog/:slug/': {permalink: '/{slug}/'}}
+            }));
+        });
+
+        it('throws on permalink without leading slash', function () {
+            throwsValidation(() => parseRouteSettings({
+                collections: {'/': {permalink: '{slug}/'}}
+            }));
+        });
+
+        it('throws on permalink without trailing slash', function () {
+            throwsValidation(() => parseRouteSettings({
+                collections: {'/': {permalink: '/{slug}'}}
+            }));
+        });
+
+        it('throws on permalink using :slug notation', function () {
+            throwsValidation(() => parseRouteSettings({
+                collections: {'/': {permalink: '/:slug/'}}
+            }));
+        });
+
+        it('accepts valid permalink with {slug}', function () {
+            assert.doesNotThrow(() => parseRouteSettings({
+                collections: {'/': {permalink: '/{slug}/'}}
+            }));
+        });
+
+        it('accepts permalink with multiple params', function () {
+            assert.doesNotThrow(() => parseRouteSettings({
+                collections: {'/': {permalink: '/{primary_tag}/{slug}/'}}
+            }));
+        });
+    });
+
+    describe('taxonomy validation', function () {
+        it('throws on unknown taxonomy key', function () {
+            throwsValidation(() => parseRouteSettings({
+                taxonomies: {category: '/category/{slug}/'}
+            }), 'Unknown taxonomy.');
+        });
+
+        it('throws on taxonomy without leading slash', function () {
+            throwsValidation(() => parseRouteSettings({
+                taxonomies: {tag: 'tag/{slug}/'}
+            }));
+        });
+
+        it('throws on taxonomy without trailing slash', function () {
+            throwsValidation(() => parseRouteSettings({
+                taxonomies: {tag: '/tag/{slug}'}
+            }));
+        });
+
+        it('throws on taxonomy using :slug notation', function () {
+            throwsValidation(() => parseRouteSettings({
+                taxonomies: {tag: '/tag/:slug/'}
+            }));
+        });
+
+        it('throws on empty taxonomy value', function () {
+            throwsValidation(() => parseRouteSettings({
+                taxonomies: {tag: ''}
+            }));
+        });
+
+        it('accepts valid taxonomies', function () {
+            assert.doesNotThrow(() => parseRouteSettings({
+                taxonomies: {tag: '/tag/{slug}/', author: '/author/{slug}/'}
+            }));
+        });
+    });
+
+    describe('data validation', function () {
+        it('accepts valid shortform data', function () {
+            assert.doesNotThrow(() => parseRouteSettings({
+                routes: {'/food/': {template: 'food', data: 'tag.food'}}
+            }));
+        });
+
+        it('throws on invalid shortform data format', function () {
+            throwsValidation(() => parseRouteSettings({
+                routes: {'/food/': {template: 'food', data: 'tag:food'}}
+            }));
+        });
+
+        it('throws on shortform data with trailing junk', function () {
+            throwsValidation(() => parseRouteSettings({
+                routes: {'/food/': {template: 'food', data: 'tag.food:'}}
+            }));
+        });
+
+        it('throws on shortform data with extra dot segments', function () {
+            throwsValidation(() => parseRouteSettings({
+                routes: {'/food/': {template: 'food', data: 'tag.food.extra'}}
+            }));
+        });
+
+        it('throws on invalid shortform resource name', function () {
+            throwsValidation(() => parseRouteSettings({
+                routes: {'/food/': {template: 'food', data: 'category.food'}}
+            }));
+        });
+
+        it('accepts valid longform data', function () {
+            assert.doesNotThrow(() => parseRouteSettings({
+                routes: {'/food/': {
+                    template: 'food',
+                    data: {featured: {resource: 'posts', type: 'browse', filter: 'featured:true'}}
+                }}
+            }));
+        });
+
+        it('throws on longform data missing resource', function () {
+            throwsValidation(() => parseRouteSettings({
+                routes: {'/food/': {
+                    template: 'food',
+                    data: {featured: {type: 'browse'}}
+                }}
+            }));
+        });
+
+        it('throws on read data entry without slug', function () {
+            throwsValidation(() => parseRouteSettings({
+                routes: {'/food/': {
+                    template: 'food',
+                    data: {featured: {resource: 'posts', type: 'read'}}
+                }}
+            }));
+        });
+
+        it('accepts read data entry with slug', function () {
+            assert.doesNotThrow(() => parseRouteSettings({
+                routes: {'/food/': {
+                    template: 'food',
+                    data: {featured: {resource: 'posts', type: 'read', slug: 'my-post'}}
+                }}
+            }));
+        });
+
+        it('throws on longform data missing type', function () {
+            throwsValidation(() => parseRouteSettings({
+                routes: {'/food/': {
+                    template: 'food',
+                    data: {featured: {resource: 'posts'}}
+                }}
+            }));
+        });
+
+        it('throws on longform data with invalid type', function () {
+            throwsValidation(() => parseRouteSettings({
+                routes: {'/food/': {
+                    template: 'food',
+                    data: {featured: {resource: 'posts', type: 'edit'}}
+                }}
+            }));
+        });
+
+        it('throws on longform data with invalid resource', function () {
+            throwsValidation(() => parseRouteSettings({
+                routes: {'/food/': {
+                    template: 'food',
+                    data: {featured: {resource: 'subscribers', type: 'browse'}}
+                }}
+            }));
+        });
+
+        it('throws on reserved key name in data', function () {
+            throwsValidation(() => parseRouteSettings({
+                routes: {'/food/': {
+                    template: 'food',
+                    data: {resource: {resource: 'posts', type: 'browse'}}
+                }}
+            }), 'Please wrap the data definition into a custom name.');
+        });
+
+        it('throws on author key name in data', function () {
+            throwsValidation(() => parseRouteSettings({
+                routes: {'/food/': {
+                    template: 'food',
+                    data: {author: {resource: 'authors', type: 'read', slug: 'ghost'}}
+                }}
+            }));
+        });
+
+        it('accepts mixed shortform and longform data entries', function () {
+            assert.doesNotThrow(() => parseRouteSettings({
+                routes: {'/food/': {
+                    template: 'food',
+                    data: {
+                        featured: {resource: 'posts', type: 'browse'},
+                        main_tag: 'tag.getting-started'
+                    }
+                }}
+            }));
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/route-settings/validate-route-settings.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/validate-route-settings.test.ts
@@ -102,7 +102,7 @@ describe('UNIT: services/route-settings/validation (via parseRouteSettings)', fu
         it('throws when permalink is missing', function () {
             throwsValidation(() => parseRouteSettings({
                 collections: {'/': {permalink: ''}}
-            }), 'A leading slash is required.');
+            }), 'Please define a permalink route.');
         });
 
         it('throws when permalink key is absent', function () {
@@ -232,7 +232,7 @@ describe('UNIT: services/route-settings/validation (via parseRouteSettings)', fu
                     template: 'food',
                     data: {featured: {type: 'browse'}}
                 }}
-            }));
+            }), 'resource is required.');
         });
 
         it('throws on read data entry without slug', function () {
@@ -241,7 +241,7 @@ describe('UNIT: services/route-settings/validation (via parseRouteSettings)', fu
                     template: 'food',
                     data: {featured: {resource: 'posts', type: 'read'}}
                 }}
-            }));
+            }), 'slug is required for read data entries.');
         });
 
         it('accepts read data entry with slug', function () {
@@ -259,7 +259,7 @@ describe('UNIT: services/route-settings/validation (via parseRouteSettings)', fu
                     template: 'food',
                     data: {featured: {resource: 'posts'}}
                 }}
-            }));
+            }), 'type is required.');
         });
 
         it('throws on longform data with invalid type', function () {
@@ -268,7 +268,7 @@ describe('UNIT: services/route-settings/validation (via parseRouteSettings)', fu
                     template: 'food',
                     data: {featured: {resource: 'posts', type: 'edit'}}
                 }}
-            }));
+            }), 'edit not supported.');
         });
 
         it('throws on longform data with invalid resource', function () {
@@ -277,7 +277,7 @@ describe('UNIT: services/route-settings/validation (via parseRouteSettings)', fu
                     template: 'food',
                     data: {featured: {resource: 'subscribers', type: 'browse'}}
                 }}
-            }));
+            }), 'subscribers not supported.');
         });
 
         it('throws on reserved key name in data', function () {
@@ -285,6 +285,15 @@ describe('UNIT: services/route-settings/validation (via parseRouteSettings)', fu
                 routes: {'/food/': {
                     template: 'food',
                     data: {resource: {resource: 'posts', type: 'browse'}}
+                }}
+            }), 'Please wrap the data definition into a custom name.');
+        });
+
+        it('throws on unwrapped data with string values (reserved keys)', function () {
+            throwsValidation(() => parseRouteSettings({
+                routes: {'/food/': {
+                    template: 'food',
+                    data: {resource: 'posts', type: 'browse', filter: 'featured:true'}
                 }}
             }), 'Please wrap the data definition into a custom name.');
         });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1826

## Why

The existing `validate.js` tangles 5 concerns into a single pass — validation, `{slug}` to `:slug` conversion, data expansion to `{query, router}`, template normalization, and defaults. It also imports `RESOURCE_CONFIG` from the frontend, creating a cross-boundary dependency that blocks moving route settings to the store layer.

This PR introduces a Zod-based parser/serializer that handles parsing, validation, and type transformation in a single pass — so the new store layer (PR #28821) can persist a clean domain model without pulling in frontend routing code.

## What

### `route-settings-parser.ts` — Zod schemas, parser, serializer & validation

Builds on the `RouteSettings` type model from PR #28821 (already on `main`). Uses Zod schemas for runtime validation + parsing + transformation, eliminating unsafe `as` casts on the raw YAML input boundary.

**Parser — `parseRouteSettings(raw: unknown)`:**
- Validates and transforms raw YAML object to `RouteSettings` domain model in one pass
- Routes become an array with explicit `path` property (YAML uses object keys)
- `template` (string or string[]) normalizes to `templates: string[]`
- `content_type` maps to `contentType` (camelCase in domain model)
- Channel vs template routes resolved via a single `RouteObjectSchema` that branches on `controller` — no union fallthrough that could silently reclassify malformed channel routes
- Preserves user-written form: `{slug}` notation stays as-is, short-form data (`tag.recipes`) is not expanded — that is the activation bridge's job
- Null route values (`/about/:` in YAML) produce friendly "Please define a template." errors
- Missing permalink produces "Please define a permalink route."

**Serializer — `serializeRouteSettings(settings)`:**
- Converts back to YAML string
- Bare string routes stay bare (e.g. `/about/: about`)
- `rss: true` omitted (it is the default)
- `contentType` maps back to `content_type` (snake_case in YAML)

**Validation (via Zod schemas):**
- Path slashes (leading/trailing) and `:slug` colon-notation rejection on routes, collections, and taxonomies
- Permalink required on collections
- Taxonomy keys restricted to `tag`/`author`
- Data: anchored shortform regex, resource name validation (`tag`/`page`/`post`/`author` for shortform, `tags`/`posts`/`pages`/`authors` for longform)
- `slug` required on `read` data entries via `z.discriminatedUnion`
- Reserved data key names and deprecated `author` key detected via record `superRefine`

### Tests

- 34 parser/serializer tests: null/empty input, bare strings, template normalization, channel detection, content_type mapping, data passthrough, collections, taxonomies, serialization roundtrips (model→yaml→model and yaml→model→yaml)
- 41 validation tests: path slashes, null route values, malformed channel routes, template requirements, permalink checks, `:slug` rejection on routes/collections/taxonomies, taxonomy keys, data format, resource validation, reserved key names — with message assertions on key user-facing errors
