### PR TITLE
Pre-bundled @tryghost/koenig-lexical in apps/admin Vite dev

### DIFF
--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -50,6 +50,9 @@ export default defineConfig(({ command }) => ({
         port: 5174,
         allowedHosts: true
     },
+    optimizeDeps: {
+        include: ["@tryghost/koenig-lexical"],
+    },
     resolve: {
         alias: {
             "@ghost-cards": GHOST_CARDS_PATH,


### PR DESCRIPTION
## Changes

`apps/admin/vite.config.ts`: added `optimizeDeps.include: ['@tryghost/koenig-lexical']`. Other heavy deps (shade, admin-x-*) deliberately excluded — they're workspace:* packages and pre-bundling them would break their HMR watch.