### PR TITLE
Sped up ghost/admin dev builds with prod-only sourcemaps and CSS minification

### DIFF
--- a/ghost/admin/ember-cli-build.js
+++ b/ghost/admin/ember-cli-build.js
@@ -71,6 +71,9 @@ let denylist = [];
 if (process.env.CI) {
     denylist.push('ember-cli-eslint');
 }
+if (process.env.COVERAGE !== 'true') {
+    denylist.push('ember-cli-code-coverage');
+}
 
 let publicAssetURL;
 
@@ -80,6 +83,47 @@ if (isTesting) {
     publicAssetURL = process.env.GHOST_CDN_URL + 'assets/';
 } else {
     publicAssetURL = 'assets/';
+}
+
+const postcssCompilePlugins = [
+    {
+        module: postcssImport,
+        options: {
+            path: ['app/styles']
+        }
+    },
+    {
+        module: postcssCustomProperties,
+        options: {
+            preserve: false
+        }
+    },
+    {
+        module: postcssColorModFunction
+    },
+    {
+        module: postcssCustomMedia
+    },
+    {
+        module: autoprefixer
+    }
+];
+
+if (isProduction) {
+    postcssCompilePlugins.push({
+        module: cssnano,
+        options: {
+            zindex: false,
+            // cssnano sometimes minifies animations incorrectly causing them to break
+            // See: https://github.com/ben-eb/gulp-cssnano/issues/33#issuecomment-210518957
+            reduceIdents: {
+                keyframes: false
+            },
+            discardUnused: {
+                keyframes: false
+            }
+        }
+    });
 }
 
 module.exports = function (defaults) {
@@ -148,43 +192,7 @@ module.exports = function (defaults) {
         postcssOptions: {
             compile: {
                 enabled: true,
-                plugins: [
-                    {
-                        module: postcssImport,
-                        options: {
-                            path: ['app/styles']
-                        }
-                    },
-                    {
-                        module: postcssCustomProperties,
-                        options: {
-                            preserve: false
-                        }
-                    },
-                    {
-                        module: postcssColorModFunction
-                    },
-                    {
-                        module: postcssCustomMedia
-                    },
-                    {
-                        module: autoprefixer
-                    },
-                    {
-                        module: cssnano,
-                        options: {
-                            zindex: false,
-                            // cssnano sometimes minifies animations incorrectly causing them to break
-                            // See: https://github.com/ben-eb/gulp-cssnano/issues/33#issuecomment-210518957
-                            reduceIdents: {
-                                keyframes: false
-                            },
-                            discardUnused: {
-                                keyframes: false
-                            }
-                        }
-                    }
-                ]
+                plugins: postcssCompilePlugins
             }
         },
         sourcemaps: {enabled: true},
@@ -213,7 +221,7 @@ module.exports = function (defaults) {
         autoImport: {
             publicAssetURL,
             webpack: {
-                devtool: 'source-map',
+                devtool: isProduction ? 'source-map' : 'eval-cheap-module-source-map',
                 resolve: {
                     fallback: {
                         util: require.resolve('util'),

--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -16,9 +16,9 @@
     "test": "tests"
   },
   "scripts": {
-    "dev": "ember serve",
+    "dev": "SKIP_DEPENDENCY_CHECKER=true ember serve",
     "build": "ember build --environment=production --silent",
-    "build:dev": "pnpm build --environment=development",
+    "build:dev": "SKIP_DEPENDENCY_CHECKER=true pnpm build --environment=development",
     "test": "ember exam --split 2 --parallel",
     "lint:js": "eslint . --cache",
     "lint:hbs": "ember-template-lint .",


### PR DESCRIPTION
## Changes

`ghost/admin/ember-cli-build.js`:
- ember-auto-import webpack devtool: `'eval-cheap-module-source-map'` in dev, `'source-map'` in prod (was `'source-map'` always). Prod sourcemaps unchanged.
- postcss compile pipeline: cssnano only runs in production.
- ember-cli-code-coverage denylisted unless `COVERAGE=true`.

`ghost/admin/package.json`:
- `dev` + `build:dev` scripts default `SKIP_DEPENDENCY_CHECKER=true`. The prod `build` script is unchanged so CI keeps the integrity check.

## Measured

Cold `pnpm build:dev` mean: 17.75s → 14.43s (-19%) across a steady-state 3-trial benchmark.