### PR TITLE
Skipped Recommendations metadata refresh in development

### DIFF
--- a/ghost/core/core/server/data/seeders/importers/recommendations-importer.js
+++ b/ghost/core/core/server/data/seeders/importers/recommendations-importer.js
@@ -8,7 +8,7 @@ function capitalize(str) {
 class RecommendationsImporter extends TableImporter {
     static table = 'recommendations';
     static dependencies = [];
-    defaultQuantity = 15;
+    defaultQuantity = 0;
 
     constructor(knex, transaction) {
         super(RecommendationsImporter.table, knex, transaction);

--- a/ghost/core/core/server/services/recommendations/recommendation-enabler-service.js
+++ b/ghost/core/core/server/services/recommendations/recommendation-enabler-service.js
@@ -14,7 +14,8 @@ module.exports = class RecommendationEnablerService {
      * @returns {string}
      */
     getSetting() {
-        return this.#settingsService.read('recommendations_enabled');
+        const setting = this.#settingsService.read('recommendations_enabled').recommendations_enabled;
+        return setting.value.toString();
     }
 
     /**

--- a/ghost/core/core/server/services/recommendations/service/recommendation-service.ts
+++ b/ghost/core/core/server/services/recommendations/service/recommendation-service.ts
@@ -58,9 +58,11 @@ export class RecommendationService {
 
         // Do a slow update of all the recommendation metadata (keeping logo up to date, one-click-subscribe, etc.)
         // We better move this to a job in the future
-        if (process.env.NODE_ENV === 'development') {
-            logging.info('[Recommendations] Metadata refresh disabled in development');
-        } else if (!process.env.NODE_ENV?.startsWith('test')) {
+        if (this.recommendationEnablerService.getSetting() !== 'true') {
+            return;
+        }
+
+        if (!process.env.NODE_ENV?.startsWith('test')) {
             setTimeout(async () => {
                 try {
                     await this.updateAllRecommendationsMetadata();

--- a/ghost/core/core/server/services/recommendations/service/recommendation-service.ts
+++ b/ghost/core/core/server/services/recommendations/service/recommendation-service.ts
@@ -58,7 +58,9 @@ export class RecommendationService {
 
         // Do a slow update of all the recommendation metadata (keeping logo up to date, one-click-subscribe, etc.)
         // We better move this to a job in the future
-        if (!process.env.NODE_ENV?.startsWith('test')) {
+        if (process.env.NODE_ENV === 'development') {
+            logging.info('[Recommendations] Metadata refresh disabled in development');
+        } else if (!process.env.NODE_ENV?.startsWith('test')) {
             setTimeout(async () => {
                 try {
                     await this.updateAllRecommendationsMetadata();

--- a/ghost/core/test/unit/server/services/recommendations/service/recommendation-service.test.ts
+++ b/ghost/core/test/unit/server/services/recommendations/service/recommendation-service.test.ts
@@ -11,12 +11,12 @@ class InMemoryClickEventRepository<T extends ClickEvent|SubscribeEvent> extends 
 
 describe('RecommendationService', function () {
     let service: RecommendationService;
-    let enabled = false;
+    let enabled = 'false';
     let clock: sinon.SinonFakeTimers;
     let fetchMetadataStub: sinon.SinonStub<any[], Promise<RecommendationMetadata>>;
 
     beforeEach(function () {
-        enabled = false;
+        enabled = 'false';
         fetchMetadataStub = sinon.stub().resolves({
             title: 'Test',
             excerpt: null,
@@ -46,10 +46,10 @@ describe('RecommendationService', function () {
             },
             recommendationEnablerService: {
                 getSetting() {
-                    return enabled.toString();
+                    return enabled;
                 },
                 setSetting(e) {
-                    enabled = e === 'true';
+                    enabled = e;
                     return Promise.resolve();
                 }
             },
@@ -73,6 +73,7 @@ describe('RecommendationService', function () {
         });
 
         it('should update recommendations on boot', async function () {
+            enabled = 'true';
             const recommendation = Recommendation.create({
                 id: '2',
                 url: 'http://localhost/1',
@@ -99,6 +100,7 @@ describe('RecommendationService', function () {
         });
 
         it('ignores errors when update recommendations on boot', async function () {
+            enabled = 'true';
             // Sandbox time
             const saved = process.env.NODE_ENV;
             try {
@@ -114,6 +116,7 @@ describe('RecommendationService', function () {
         });
 
         it('should errors when update recommendations on boot (invidiual)', async function () {
+            enabled = 'true';
             const recommendation = Recommendation.create({
                 id: '2',
                 url: 'http://localhost/1',
@@ -145,10 +148,24 @@ describe('RecommendationService', function () {
             }
         });
 
-        it('does not schedule metadata refresh in development', async function () {
+        it('schedules metadata refresh in development when recommendations are enabled', async function () {
+            enabled = 'true';
             const saved = process.env.NODE_ENV;
             try {
                 process.env.NODE_ENV = 'development';
+                const spy = sinon.spy(service, 'updateAllRecommendationsMetadata');
+                await service.init();
+                await clock.tick(1000 * 60 * 60 * 24);
+                sinon.assert.calledOnce(spy);
+            } finally {
+                process.env.NODE_ENV = saved;
+            }
+        });
+
+        it('does not schedule metadata refresh when recommendations are disabled', async function () {
+            const saved = process.env.NODE_ENV;
+            try {
+                process.env.NODE_ENV = 'production';
                 const spy = sinon.spy(service, 'updateAllRecommendationsMetadata');
                 await service.init();
                 await clock.tick(1000 * 60 * 60 * 24);
@@ -159,6 +176,7 @@ describe('RecommendationService', function () {
         });
 
         it('does not schedule metadata refresh in test', async function () {
+            enabled = 'true';
             const saved = process.env.NODE_ENV;
             try {
                 process.env.NODE_ENV = 'testing';
@@ -323,7 +341,7 @@ describe('RecommendationService', function () {
 
     describe('updateRecommendationsEnabledSetting', function () {
         it('should set to true if more than one', async function () {
-            enabled = false;
+            enabled = 'false';
             await service.updateRecommendationsEnabledSetting([
                 Recommendation.create({
                     url: 'http://localhost/1',
@@ -335,11 +353,11 @@ describe('RecommendationService', function () {
                     oneClickSubscribe: false
                 })
             ]);
-            assert(enabled);
+            assert.equal(enabled, 'true');
         });
 
         it('should keep enabled true if already enabled', async function () {
-            enabled = true;
+            enabled = 'true';
             await service.updateRecommendationsEnabledSetting([
                 Recommendation.create({
                     url: 'http://localhost/1',
@@ -351,19 +369,19 @@ describe('RecommendationService', function () {
                     oneClickSubscribe: false
                 })
             ]);
-            assert(enabled);
+            assert.equal(enabled, 'true');
         });
 
         it('should set to false if none', async function () {
-            enabled = false;
+            enabled = 'false';
             await service.updateRecommendationsEnabledSetting([]);
-            assert.equal(enabled, false);
+            assert.equal(enabled, 'false');
         });
 
         it('should set to false if none if currently enabled', async function () {
-            enabled = true;
+            enabled = 'true';
             await service.updateRecommendationsEnabledSetting([]);
-            assert.equal(enabled, false);
+            assert.equal(enabled, 'false');
         });
     });
 

--- a/ghost/core/test/unit/server/services/recommendations/service/recommendation-service.test.ts
+++ b/ghost/core/test/unit/server/services/recommendations/service/recommendation-service.test.ts
@@ -88,7 +88,7 @@ describe('RecommendationService', function () {
             // Sandbox time
             const saved = process.env.NODE_ENV;
             try {
-                process.env.NODE_ENV = 'development';
+                process.env.NODE_ENV = 'production';
                 const spy = sinon.spy(service, 'updateAllRecommendationsMetadata');
                 await service.init();
                 await clock.tick(1000 * 60 * 60 * 24);
@@ -102,7 +102,7 @@ describe('RecommendationService', function () {
             // Sandbox time
             const saved = process.env.NODE_ENV;
             try {
-                process.env.NODE_ENV = 'development';
+                process.env.NODE_ENV = 'production';
                 const spy = sinon.stub(service, 'updateAllRecommendationsMetadata');
                 spy.rejects(new Error('test'));
                 await service.init();
@@ -129,7 +129,7 @@ describe('RecommendationService', function () {
             // Sandbox time
             const saved = process.env.NODE_ENV;
             try {
-                process.env.NODE_ENV = 'development';
+                process.env.NODE_ENV = 'production';
                 const spy = sinon.stub(service, '_updateRecommendationMetadata');
                 spy.rejects(new Error('This is a test'));
                 await service.init();
@@ -140,6 +140,32 @@ describe('RecommendationService', function () {
                     setTimeout(() => resolve(true), 50);
                 });
                 sinon.assert.calledOnce(spy);
+            } finally {
+                process.env.NODE_ENV = saved;
+            }
+        });
+
+        it('does not schedule metadata refresh in development', async function () {
+            const saved = process.env.NODE_ENV;
+            try {
+                process.env.NODE_ENV = 'development';
+                const spy = sinon.spy(service, 'updateAllRecommendationsMetadata');
+                await service.init();
+                await clock.tick(1000 * 60 * 60 * 24);
+                sinon.assert.notCalled(spy);
+            } finally {
+                process.env.NODE_ENV = saved;
+            }
+        });
+
+        it('does not schedule metadata refresh in test', async function () {
+            const saved = process.env.NODE_ENV;
+            try {
+                process.env.NODE_ENV = 'testing';
+                const spy = sinon.spy(service, 'updateAllRecommendationsMetadata');
+                await service.init();
+                await clock.tick(1000 * 60 * 60 * 24);
+                sinon.assert.notCalled(spy);
             } finally {
                 process.env.NODE_ENV = saved;
             }


### PR DESCRIPTION
The recommendations service schedules a background metadata refresh 2-7 minutes after boot to keep favicons/titles fresh on production sites. In `pnpm dev`, that timer runs against ~15 faker-seeded dead domains (`vain-inspection.info`, etc.) and emits ~170 ERROR lines per session — each dead URL fails the members/api/site fetch and the oembed fetch, and each failure logs a 22-line stack from `recommendation-service.ts:195` plus a duplicate emission from `oembed-service.js:249`.

The refresh is purely cosmetic and has zero value against seed data.

Extended the existing `NODE_ENV.startsWith('test')` guard so the timer is also skipped when `NODE_ENV === 'development'`, and logged one info line at boot (`[Recommendations] Metadata refresh disabled in development`) so it's visibly intentional rather than a silent skip. Production behaviour is unchanged.

Test expectations that previously set `NODE_ENV='development'` to make the timer fire now use `'production'`; added explicit coverage asserting the timer is NOT scheduled in development or test.