### PR TITLE
Pinned autoprefixer to config/targets browserslist in ghost/admin

### DIFF
--- a/ghost/admin/ember-cli-build.js
+++ b/ghost/admin/ember-cli-build.js
@@ -23,6 +23,7 @@ const postcssColorModFunction = require('postcss-color-mod-function');
 const postcssCustomMedia = require('postcss-custom-media');
 const autoprefixer = require('autoprefixer');
 const cssnano = require('cssnano');
+const targets = require('./config/targets');
 
 const codemirrorAssets = function () {
     let codemirrorFiles = [
@@ -105,7 +106,10 @@ const postcssCompilePlugins = [
         module: postcssCustomMedia
     },
     {
-        module: autoprefixer
+        module: autoprefixer,
+        options: {
+            overrideBrowserslist: targets.browsers
+        }
     }
 ];
 


### PR DESCRIPTION
## Changes

`ghost/admin/ember-cli-build.js`: autoprefixer plugin now passes `overrideBrowserslist: require('./config/targets').browsers`. Previously fell back to autoprefixer's default browserslist (~all browsers, including IE11).

## Note

Changes prod CSS output — narrower vendor-prefix table matching the project's declared JS targets (last 2 Chrome/Firefox/Edge, last 3 Safari). Functionally equivalent to current behavior on supported browsers; smaller CSS, slightly faster postcss compile.