### PR TITLE
[REVIEW ONLY — DO NOT MERGE] Combined view of 7 dev-noise PRs

### DIFF
--- a/apps/_shared/vite-public-app.mjs
+++ b/apps/_shared/vite-public-app.mjs
@@ -15,6 +15,7 @@
  */
 import {resolve} from 'path';
 import {defineConfig, mergeConfig} from 'vitest/config';
+import {createLogger} from 'vite';
 
 /**
  * @param {Object} opts
@@ -61,8 +62,29 @@ export function publicAppViteConfig(opts) {
             plugins.push(svgrPlugin());
         }
 
+        // Node built-ins (path, fs, fs/promises) are reachable in module graphs
+        // via @tryghost/i18n's server-side helpers, @tryghost/root-utils, and
+        // find-root. Vite externalizes them for the browser at bundle time —
+        // the runtime code paths that touch them are dead under SSR=false.
+        // The per-import "Module 'path'/'fs' has been externalized" warning is
+        // purely informational and re-emits on every boot/HMR rebuild, so we
+        // filter just those messages here. Adding `rollupOptions.external` was
+        // rejected because UMD output then asks for `path`/`fs` browser globals
+        // (`No name was provided for external module "path"` warnings) and
+        // injects a Node-polyfill notice.
+        const logLevel = process.env.CI ? 'info' : 'warn';
+        const customLogger = createLogger(logLevel);
+        const originalWarn = customLogger.warn;
+        customLogger.warn = (msg, warnOpts) => {
+            if (typeof msg === 'string' && /Module "(path|fs|fs\/promises)" has been externalized for browser compatibility/.test(msg)) {
+                return;
+            }
+            originalWarn(msg, warnOpts);
+        };
+
         const base = {
-            logLevel: process.env.CI ? 'info' : 'warn',
+            logLevel,
+            customLogger,
             clearScreen: false,
             plugins,
             define: {

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -103,7 +103,7 @@ services:
         condition: service_healthy
         required: false
     healthcheck:
-      test: ["CMD", "node", "-e", "fetch('http://localhost:2368',{redirect:'manual'}).then(r=>process.exit(r.status<500?0:1)).catch(()=>process.exit(1))"]
+      test: ["CMD", "node", "-e", "fetch('http://localhost:2368',{redirect:'manual',headers:{'user-agent':'GhostDockerHealthcheck/1.0'}}).then(r=>process.exit(r.status<500?0:1)).catch(()=>process.exit(1))"]
       timeout: 5s
       retries: 10
       start_period: 5s

--- a/docker/dev-gateway/Caddyfile
+++ b/docker/dev-gateway/Caddyfile
@@ -9,12 +9,17 @@
         format transform "{common_log}"
     }
 
+    # Vite dev server fans out hundreds of per-module fetches on every admin
+    # page load — skip those (and the internal auth-frame) so the access log
+    # stays useful during development.
+    log_skip /__admin-dev__*
+    log_skip /ghost/auth-frame/*
+
     # Ember live reload (runs on separate port 4201)
     # This handles both the script injection and WebSocket connections
     handle /ember-cli-live-reload.js {
         reverse_proxy {env.ADMIN_LIVE_RELOAD_SERVER} {
             header_up Host {http.reverse_proxy.upstream.hostport}
-            header_up X-Forwarded-Host {host}
             # Enable WebSocket support for live reload
             header_up Connection {>Connection}
             header_up Upgrade {>Upgrade}
@@ -26,7 +31,6 @@
         reverse_proxy {env.GHOST_BACKEND} {
             header_up Host {host}
             header_up X-Real-IP {remote_host}
-            header_up X-Forwarded-For {remote_host}
 
             # Always tell Ghost requests are HTTPS to prevent redirects
             header_up X-Forwarded-Proto https
@@ -40,9 +44,7 @@
         rewrite * {re.analytics_match.2}
         reverse_proxy {env.ANALYTICS_PROXY_TARGET} {
             header_up Host {host}
-            header_up X-Forwarded-Host {host}
             header_up X-Real-IP {remote_host}
-            header_up X-Forwarded-For {remote_host}
         }
     }
 
@@ -52,7 +54,6 @@
         reverse_proxy {env.ACTIVITYPUB_PROXY_TARGET} {
             header_up Host {host}
             header_up X-Real-IP {remote_host}
-            header_up X-Forwarded-For {remote_host}
             header_up X-Forwarded-Proto https
         }
     }
@@ -62,7 +63,6 @@
         reverse_proxy {env.ACTIVITYPUB_PROXY_TARGET} {
             header_up Host {host}
             header_up X-Real-IP {remote_host}
-            header_up X-Forwarded-For {remote_host}
             header_up X-Forwarded-Proto https
         }
     }
@@ -72,7 +72,6 @@
         reverse_proxy {env.ACTIVITYPUB_PROXY_TARGET} {
             header_up Host {host}
             header_up X-Real-IP {remote_host}
-            header_up X-Forwarded-For {remote_host}
             header_up X-Forwarded-Proto https
         }
     }
@@ -91,7 +90,6 @@
             uri strip_prefix /koenig-lexical
             reverse_proxy {env.LEXICAL_DEV_SERVER} {
                 header_up Host {http.reverse_proxy.upstream.hostport}
-                header_up X-Forwarded-Host {host}
                 # Fail quickly if dev server is down
                 fail_duration 1s
                 unhealthy_request_count 1
@@ -121,7 +119,6 @@
             rewrite * /__admin-dev__/assets{path}
             reverse_proxy {env.ADMIN_DEV_SERVER} {
                 header_up Host {http.reverse_proxy.upstream.hostport}
-                header_up X-Forwarded-Host {host}
             }
         }
     }
@@ -131,7 +128,6 @@
         reverse_proxy {env.GHOST_BACKEND} {
             header_up Host {host}
             header_up X-Real-IP {remote_host}
-            header_up X-Forwarded-For {remote_host}
             header_up X-Forwarded-Proto https
         }
     }
@@ -141,7 +137,6 @@
         reverse_proxy {env.GHOST_BACKEND} {
             header_up Host {host}
             header_up X-Real-IP {remote_host}
-            header_up X-Forwarded-For {remote_host}
             header_up X-Forwarded-Proto https
         }
     }
@@ -151,7 +146,6 @@
     # /ghost/* paths Ghost serves in production. Handles HMR WebSocket upgrade.
     handle /__admin-dev__* {
         reverse_proxy {env.ADMIN_DEV_SERVER} {
-            header_up X-Forwarded-Host {host}
             header_up Connection {>Connection}
             header_up Upgrade {>Upgrade}
         }
@@ -163,9 +157,7 @@
     @admin_html path /ghost /ghost/
     handle @admin_html {
         rewrite * /__admin-dev__/
-        reverse_proxy {env.ADMIN_DEV_SERVER} {
-            header_up X-Forwarded-Host {host}
-        }
+        reverse_proxy {env.ADMIN_DEV_SERVER}
     }
 
     # Everything else under /ghost/* (deep links, redirects, etc.) goes to
@@ -174,7 +166,6 @@
         reverse_proxy {env.GHOST_BACKEND} {
             header_up Host {host}
             header_up X-Real-IP {remote_host}
-            header_up X-Forwarded-For {remote_host}
             header_up X-Forwarded-Proto https
         }
     }
@@ -184,7 +175,6 @@
         reverse_proxy {env.GHOST_BACKEND} {
             header_up Host {host}
             header_up X-Real-IP {remote_host}
-            header_up X-Forwarded-For {remote_host}
 
             # Always tell Ghost requests are HTTPS to prevent redirects
             header_up X-Forwarded-Proto https

--- a/ghost/admin/.ember-cli
+++ b/ghost/admin/.ember-cli
@@ -7,5 +7,14 @@
 
         Setting `disableAnalytics` to true will prevent any data from being sent.
     */
-    "disableAnalytics": true
+    "disableAnalytics": true,
+
+    /**
+        Default to Node's native FS watcher instead of Watchman. Watchman
+        repeatedly trips its "MustScanSubDirs UserDropped" recrawl warning
+        in this monorepo (Docker bind mounts + Vite dev writes), spamming
+        ~6 lines per rebuild. The node watcher is quieter and good enough
+        for our tree size.
+    */
+    "watcher": "node"
 }

--- a/ghost/admin/lib/asset-delivery/index.js
+++ b/ghost/admin/lib/asset-delivery/index.js
@@ -101,7 +101,11 @@ module.exports = {
                 } else {
                     fs.ensureSymlinkSync(adminXPath, assetsAdminXPath);
                 }
-            } else  {
+            } else if (this.env === 'production') {
+                // In dev the admin-x apps may not have finished their first
+                // build yet and Nx will trigger another Ember rebuild once
+                // they do. Only flag a missing dist for production where it
+                // indicates a real pipeline failure.
                 console.log(`${app} folder not found`);
             }
         }

--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -16,7 +16,7 @@
     "test": "tests"
   },
   "scripts": {
-    "dev": "ember serve",
+    "dev": "NODE_OPTIONS=--disable-warning=DEP0179 ember serve",
     "build": "ember build --environment=production --silent",
     "build:dev": "pnpm build --environment=development",
     "test": "ember exam --split 2 --parallel",

--- a/ghost/core/core/server/services/activitypub/activity-pub-service-wrapper.js
+++ b/ghost/core/core/server/services/activitypub/activity-pub-service-wrapper.js
@@ -33,16 +33,20 @@ module.exports = class ActivityPubServiceWrapper {
         );
 
         async function configureActivityPub() {
-            if (settingsCache.get('social_web_enabled')) {
-                if (!ActivityPubServiceWrapper.initialised) {
-                    await ActivityPubServiceWrapper.instance.enable();
-                    ActivityPubServiceWrapper.initialised = true;
+            try {
+                if (settingsCache.get('social_web_enabled')) {
+                    if (!ActivityPubServiceWrapper.initialised) {
+                        await ActivityPubServiceWrapper.instance.enable();
+                        ActivityPubServiceWrapper.initialised = true;
+                    }
+                } else {
+                    if (ActivityPubServiceWrapper.initialised) {
+                        await ActivityPubServiceWrapper.instance.disable();
+                        ActivityPubServiceWrapper.initialised = false;
+                    }
                 }
-            } else {
-                if (ActivityPubServiceWrapper.initialised) {
-                    await ActivityPubServiceWrapper.instance.disable();
-                    ActivityPubServiceWrapper.initialised = false;
-                }
+            } catch (err) {
+                logging.error(err);
             }
         }
 

--- a/ghost/core/core/server/services/activitypub/activity-pub-service.ts
+++ b/ghost/core/core/server/services/activitypub/activity-pub-service.ts
@@ -1,7 +1,7 @@
 import ObjectID from 'bson-objectid';
 import {Knex} from 'knex';
 import {IdentityTokenService} from '../identity-tokens/identity-token-service';
-import fetch from 'node-fetch';
+import fetch, {FetchError} from 'node-fetch';
 
 type ExpectedWebhook = {
     event: string;
@@ -103,8 +103,14 @@ export class ActivityPubService {
 
             return body.webhook_secret;
         } catch (err: unknown) {
-            this.logging.error(`Could not get webhook secret for ActivityPub ${err}`);
-            return null;
+            // FetchError = network failure; SyntaxError = HTML response masquerading
+            // as JSON (gateway fallthrough). Both mean the sibling AP service is
+            // unreachable — degrade silently. Anything else is a real bug.
+            if (err instanceof FetchError || err instanceof SyntaxError) {
+                this.logging.info('[ActivityPub] Sibling service unreachable — federation disabled. Run the ActivityPub project to enable.');
+                return null;
+            }
+            throw err;
         }
     }
 
@@ -152,7 +158,7 @@ export class ActivityPubService {
         const secret = await this.getWebhookSecret();
 
         if (!secret) {
-            this.logging.error('No webhook secret found - cannot initialise');
+            // getWebhookSecret already logged or rethrew; nothing to add here.
             return;
         }
 

--- a/ghost/core/core/server/services/recommendations/service/recommendation-service.ts
+++ b/ghost/core/core/server/services/recommendations/service/recommendation-service.ts
@@ -58,7 +58,9 @@ export class RecommendationService {
 
         // Do a slow update of all the recommendation metadata (keeping logo up to date, one-click-subscribe, etc.)
         // We better move this to a job in the future
-        if (!process.env.NODE_ENV?.startsWith('test')) {
+        if (process.env.NODE_ENV === 'development') {
+            logging.info('[Recommendations] Metadata refresh disabled in development');
+        } else if (!process.env.NODE_ENV?.startsWith('test')) {
             setTimeout(async () => {
                 try {
                     await this.updateAllRecommendationsMetadata();

--- a/ghost/core/core/server/web/parent/middleware/log-request.js
+++ b/ghost/core/core/server/web/parent/middleware/log-request.js
@@ -1,5 +1,7 @@
 const logging = require('@tryghost/logging');
 
+const HEALTHCHECK_USER_AGENT = 'GhostDockerHealthcheck/1.0';
+
 /**
  * @TODO: move this middleware to Framework monorepo?
  *
@@ -8,6 +10,10 @@ const logging = require('@tryghost/logging');
  * @param {import('express').NextFunction} next
  */
 module.exports = function logRequest(req, res, next) {
+    if (req.headers['user-agent'] === HEALTHCHECK_USER_AGENT) {
+        return next();
+    }
+
     const startTime = Date.now();
 
     function logResponse() {

--- a/ghost/core/test/unit/server/services/activitypub/activity-pub-service.test.ts
+++ b/ghost/core/test/unit/server/services/activitypub/activity-pub-service.test.ts
@@ -99,6 +99,8 @@ describe('ActivityPubService', function () {
     afterEach(function () {
         // Restore any spies (isolate:false shares the module registry per worker).
         vi.restoreAllMocks();
+        // Clear any pending nock interceptors so they don't leak into the next test.
+        nock.cleanAll();
     });
 
     it('Can initialise the webhooks', async function () {
@@ -312,8 +314,119 @@ describe('ActivityPubService', function () {
         await knexInstance.destroy();
     });
 
-    it('Can handle errors getting the webhook secret without erroring', async function () {
+    it('Silently degrades when the sibling ActivityPub service is unreachable (FetchError)', async function () {
         const knexInstance = await getKnexInstance();
+        await addOwnerUser(knexInstance);
+        await addActivityPubIntegration(knexInstance);
+
+        const siteUrl = new URL('http://fake-site-url');
+
+        // Block any outbound network so the fetch fails with a FetchError,
+        // modelling the "sibling container not running" case.
+        nock.disableNetConnect();
+
+        try {
+            const identityTokenService = {
+                getTokenForUser(email: string, role: string) {
+                    return `token:${email}:${role}`;
+                }
+            };
+            const service = new ActivityPubService(
+                knexInstance,
+                siteUrl,
+                logging,
+                identityTokenService as unknown as IdentityTokenService
+            );
+
+            const secret = await service.getWebhookSecret();
+
+            assert.equal(secret, null, 'Expected getWebhookSecret to return null');
+            assert.equal(logging.error.mock.calls.length, 0, 'Expected no error to be logged');
+            assert(
+                logging.info.mock.calls.some(([message]) => typeof message === 'string' && message.includes('Sibling service unreachable')),
+                'Expected an info-level message about the sibling being unreachable'
+            );
+        } finally {
+            nock.enableNetConnect();
+        }
+
+        await knexInstance.destroy();
+    });
+
+    it('Silently degrades when the sibling response is HTML (SyntaxError)', async function () {
+        const knexInstance = await getKnexInstance();
+        await addOwnerUser(knexInstance);
+        await addActivityPubIntegration(knexInstance);
+
+        const siteUrl = new URL('http://fake-site-url');
+        // Models the Caddy fallthrough case: ACTIVITYPUB_PROXY_TARGET unset, so
+        // /.ghost/activitypub/* falls through to Ghost's frontend which serves
+        // an HTML 404 with status 200. res.json() then throws SyntaxError.
+        const scope = nock(siteUrl)
+            .get('/.ghost/activitypub/v1/site/')
+            .reply(200, '<!DOCTYPE html><html><body>Not Found</body></html>', {
+                'content-type': 'text/html'
+            });
+
+        const identityTokenService = {
+            getTokenForUser(email: string, role: string) {
+                return `token:${email}:${role}`;
+            }
+        };
+        const service = new ActivityPubService(
+            knexInstance,
+            siteUrl,
+            logging,
+            identityTokenService as unknown as IdentityTokenService
+        );
+
+        const secret = await service.getWebhookSecret();
+
+        assert(scope.isDone(), 'Expected the ActivityPub site endpoint to be called');
+        assert.equal(secret, null, 'Expected getWebhookSecret to return null');
+        assert.equal(logging.error.mock.calls.length, 0, 'Expected no error to be logged');
+        assert(
+            logging.info.mock.calls.some(([message]) => typeof message === 'string' && message.includes('Sibling service unreachable')),
+            'Expected an info-level message about the sibling being unreachable'
+        );
+
+        await knexInstance.destroy();
+    });
+
+    it('Re-throws unexpected errors so production failures still surface', async function () {
+        const knexInstance = await getKnexInstance();
+        await addOwnerUser(knexInstance);
+        await addActivityPubIntegration(knexInstance);
+
+        const siteUrl = new URL('http://fake-site-url');
+
+        // Stub the token lookup so it throws something that is neither FetchError
+        // nor SyntaxError — getWebhookSecret should not swallow this.
+        const unexpected = new Error('database is on fire');
+        const identityTokenService = {
+            getTokenForUser() {
+                throw unexpected;
+            }
+        };
+        const service = new ActivityPubService(
+            knexInstance,
+            siteUrl,
+            logging,
+            identityTokenService as unknown as IdentityTokenService
+        );
+
+        await assert.rejects(
+            () => service.getWebhookSecret(),
+            (err: unknown) => err === unexpected,
+            'Expected getWebhookSecret to re-throw unexpected errors'
+        );
+
+        await knexInstance.destroy();
+    });
+
+    it('initialiseWebhooks does not re-log when the secret is missing', async function () {
+        const knexInstance = await getKnexInstance();
+        await addOwnerUser(knexInstance);
         await addActivityPubIntegration(knexInstance);
 
         const siteUrl = new URL('http://fake-site-url');
@@ -335,11 +448,13 @@ describe('ActivityPubService', function () {
         const webhooks = await knexInstance.select('*').from('webhooks');
 
         assert.equal(webhooks.length, 0, 'There should be no webhooks');
-
-        assert(
-            logging.error.mock.calls.some(([message]) => typeof message === 'string' && message.startsWith('Could not get webhook secret for ActivityPub')),
-            'Expected an error to be logged when the webhook secret could not be retrieved'
+        assert.equal(logging.error.mock.calls.length, 0, 'Expected no error to be logged');
+        // getWebhookSecret logs once; the !secret branch in initialiseWebhooks
+        // must not log a second time.
+        const siblingMessages = logging.info.mock.calls.filter(
+            ([message]) => typeof message === 'string' && message.includes('Sibling service unreachable')
         );
+        assert.equal(siblingMessages.length, 1, 'Expected the sibling-unreachable message to be logged exactly once');
 
         await knexInstance.destroy();
     });

--- a/ghost/core/test/unit/server/services/recommendations/service/recommendation-service.test.ts
+++ b/ghost/core/test/unit/server/services/recommendations/service/recommendation-service.test.ts
@@ -88,7 +88,7 @@ describe('RecommendationService', function () {
             // Sandbox time
             const saved = process.env.NODE_ENV;
             try {
-                process.env.NODE_ENV = 'development';
+                process.env.NODE_ENV = 'production';
                 const spy = sinon.spy(service, 'updateAllRecommendationsMetadata');
                 await service.init();
                 await clock.tick(1000 * 60 * 60 * 24);
@@ -102,7 +102,7 @@ describe('RecommendationService', function () {
             // Sandbox time
             const saved = process.env.NODE_ENV;
             try {
-                process.env.NODE_ENV = 'development';
+                process.env.NODE_ENV = 'production';
                 const spy = sinon.stub(service, 'updateAllRecommendationsMetadata');
                 spy.rejects(new Error('test'));
                 await service.init();
@@ -129,7 +129,7 @@ describe('RecommendationService', function () {
             // Sandbox time
             const saved = process.env.NODE_ENV;
             try {
-                process.env.NODE_ENV = 'development';
+                process.env.NODE_ENV = 'production';
                 const spy = sinon.stub(service, '_updateRecommendationMetadata');
                 spy.rejects(new Error('This is a test'));
                 await service.init();
@@ -140,6 +140,32 @@ describe('RecommendationService', function () {
                     setTimeout(() => resolve(true), 50);
                 });
                 sinon.assert.calledOnce(spy);
+            } finally {
+                process.env.NODE_ENV = saved;
+            }
+        });
+
+        it('does not schedule metadata refresh in development', async function () {
+            const saved = process.env.NODE_ENV;
+            try {
+                process.env.NODE_ENV = 'development';
+                const spy = sinon.spy(service, 'updateAllRecommendationsMetadata');
+                await service.init();
+                await clock.tick(1000 * 60 * 60 * 24);
+                sinon.assert.notCalled(spy);
+            } finally {
+                process.env.NODE_ENV = saved;
+            }
+        });
+
+        it('does not schedule metadata refresh in test', async function () {
+            const saved = process.env.NODE_ENV;
+            try {
+                process.env.NODE_ENV = 'testing';
+                const spy = sinon.spy(service, 'updateAllRecommendationsMetadata');
+                await service.init();
+                await clock.tick(1000 * 60 * 60 * 24);
+                sinon.assert.notCalled(spy);
             } finally {
                 process.env.NODE_ENV = saved;
             }

--- a/ghost/core/test/unit/server/web/parent/middleware/log-request.test.js
+++ b/ghost/core/test/unit/server/web/parent/middleware/log-request.test.js
@@ -1,0 +1,66 @@
+const express = require('express');
+const sinon = require('sinon');
+const request = require('supertest');
+const logging = require('@tryghost/logging');
+
+const logRequest = require('../../../../../../core/server/web/parent/middleware/log-request');
+
+describe('Log request middleware', function () {
+    let infoStub;
+    let errorStub;
+
+    beforeEach(function () {
+        infoStub = sinon.stub(logging, 'info');
+        errorStub = sinon.stub(logging, 'error');
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    function createApp() {
+        const app = express();
+        app.use(logRequest);
+        app.get('/', (req, res) => {
+            res.json({ok: true});
+        });
+        return app;
+    }
+
+    it('logs normal requests', async function () {
+        await request(createApp())
+            .get('/')
+            .expect(200);
+
+        sinon.assert.calledOnce(infoStub);
+        sinon.assert.notCalled(errorStub);
+    });
+
+    it('skips logging for the Docker healthcheck user-agent', async function () {
+        await request(createApp())
+            .get('/')
+            .set('User-Agent', 'GhostDockerHealthcheck/1.0')
+            .expect(200);
+
+        sinon.assert.notCalled(infoStub);
+        sinon.assert.notCalled(errorStub);
+    });
+
+    it('still logs requests with a similar but not exact user-agent', async function () {
+        await request(createApp())
+            .get('/')
+            .set('User-Agent', 'GhostDockerHealthcheck/2.0')
+            .expect(200);
+
+        sinon.assert.calledOnce(infoStub);
+    });
+
+    it('still logs requests with the generic node UA', async function () {
+        await request(createApp())
+            .get('/')
+            .set('User-Agent', 'node')
+            .expect(200);
+
+        sinon.assert.calledOnce(infoStub);
+    });
+});

--- a/ghost/i18n/package.json
+++ b/ghost/i18n/package.json
@@ -11,7 +11,6 @@
   },
   "types": "./build/i18n.d.ts",
   "scripts": {
-    "dev": "echo \"Implement me!\"",
     "test:base": "NODE_ENV=testing vitest run --coverage",
     "test": "pnpm test:base && pnpm translate",
     "lint:code": "eslint *.js lib/ --cache",
@@ -48,11 +47,6 @@
   "nx": {
     "tags": [
       "i18n"
-    ],
-    "targets": {
-      "dev": {
-        "continuous": false
-      }
-    }
+    ]
   }
 }


### PR DESCRIPTION
## ⚠️ Do not merge this branch

This is a **combined view** of 7 in-flight dev-noise PRs cherry-picked onto one branch so the cumulative impact is visible in a single diff. The individual PRs are the ones to merge.

## Included PRs (in cherry-pick order)

| # | Title | Approx noise removed |
|---|---|---|
| [#28981](https://github.com/TryGhost/Ghost/pull/28981) | Stopped logging Docker healthcheck pings in dev | ~108 lines/hour |
| [#28982](https://github.com/TryGhost/Ghost/pull/28982) | Removed @tryghost/i18n placeholder dev script | 1 fan-out task |
| [#28983](https://github.com/TryGhost/Ghost/pull/28983) | Cleaned up Caddy dev-gateway noise | 21 warns/boot + 50–100 access-log lines/page-load |
| [#28984](https://github.com/TryGhost/Ghost/pull/28984) | Removed "externalized for browser" warnings in public-app builds | 30 lines/build |
| [#28994](https://github.com/TryGhost/Ghost/pull/28994) | Skipped Recommendations metadata refresh in development | ~170 ERROR lines/session |
| [#28996](https://github.com/TryGhost/Ghost/pull/28996) | Cleaned up ActivityPub boot noise when sibling offline | ~4 ERROR lines/boot |
| [#28997](https://github.com/TryGhost/Ghost/pull/28997) | Quieted ghost-admin dev-server noise (Watchman + DEP0179 + admin-x folder warns) | **~800 lines/session** |

## Combined estimate

A fresh `pnpm dev:daemon` boot log goes from **~1,635 lines → roughly 150–250 lines** of mostly signal (build progress + container lifecycle + the boot summary you actually care about).

The biggest single line-count win is the Watchman fix in #28997 (~800 lines/session). The biggest "scary red wall of errors" win is the Recommendations refresh skip in #28994 (~170 ERROR lines/session).

## How to inspect

```
git fetch origin all-noise-fixes-combined
git checkout all-noise-fixes-combined
pnpm install --frozen-lockfile && git submodule update --init --recursive
pnpm dev:daemon
```

Or just diff vs main:

```
gh pr diff <this PR>
```

## Cherry-pick conflicts

Zero. All 7 PRs apply cleanly to current main in this order. The individual PRs touch different files (or different parts of the same file for the apps/_shared and ghost/admin areas).
