### PR TITLE
Quieted Docker layer of pnpm dev boot output

### DIFF
--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -4,7 +4,7 @@ services:
   mysql:
     image: mysql:8.4.9@sha256:c36050afdca850f23cef85703f84c7531a5ae155a11b5ee1c60acb09937c4084
     container_name: ghost-dev-mysql
-    command: --innodb-buffer-pool-size=1G --innodb-log-buffer-size=500M --innodb-change-buffer-max-size=50 --innodb-flush-log-at-trx_commit=0 --innodb-flush-method=O_DIRECT
+    command: --innodb-buffer-pool-size=1G --innodb-log-buffer-size=500M --innodb-change-buffer-max-size=50 --innodb-flush-log-at-trx_commit=0 --innodb-flush-method=O_DIRECT --log-error-verbosity=1
     ports:
       - "3306:3306"
     environment:
@@ -24,6 +24,7 @@ services:
   redis:
     image: redis:7.0@sha256:352c1fdadc91926edda08f45aeb3f27f37194c2f14101229c0523a11195c96e3
     container_name: ghost-dev-redis
+    command: ["redis-server", "--loglevel", "warning"]
     ports:
       - "6379:6379"
     volumes:
@@ -41,6 +42,7 @@ services:
   mailpit:
     image: axllent/mailpit@sha256:37a38e48e9338cd7e89dfeb487f37b02ebfcd9cb23111bed2d345e79d37d6dd6
     container_name: ghost-dev-mailpit
+    command: ["--quiet"]
     ports:
       - "1025:1025"  # SMTP server
       - "8025:8025"  # Web interface

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "reset:data:empty": "docker exec ghost-dev bash -c 'cd /home/ghost/ghost/core && node index.js generate-data --clear-database --quantities members:0,posts:0 --seed 123'",
     "reset:data:xxl": "docker exec ghost-dev bash -c 'cd /home/ghost/ghost/core && node index.js generate-data --clear-database --quantities members:2000000,posts:0,emails:0,members_stripe_customers:0,members_login_events:0,members_status_events:0 --seed 123'",
     "seed:multi-sub-scenarios": "docker exec ghost-dev bash -c 'cd /home/ghost/ghost/core && node scripts/seed-multi-sub-scenarios.js'",
-    "docker:build": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} build --quiet",
+    "docker:build": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} build",
     "docker:clean": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} --profile all down -v --remove-orphans --rmi local",
     "docker:down": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} down",
     "docker:rebase": "git fetch ${GHOST_UPSTREAM:-origin} main && git rebase ${GHOST_UPSTREAM:-origin}/main && pnpm install && pnpm nx run-many -t build --projects=@tryghost/shade,@tryghost/admin-x-design-system,@tryghost/admin-x-framework && docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} up -d --build --force-recreate ghost-dev",
@@ -123,7 +123,7 @@
       "docker:build": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} build --quiet"
+          "command": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} build"
         }
       },
       "docker:dev": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "reset:data:empty": "docker exec ghost-dev bash -c 'cd /home/ghost/ghost/core && node index.js generate-data --clear-database --quantities members:0,posts:0 --seed 123'",
     "reset:data:xxl": "docker exec ghost-dev bash -c 'cd /home/ghost/ghost/core && node index.js generate-data --clear-database --quantities members:2000000,posts:0,emails:0,members_stripe_customers:0,members_login_events:0,members_status_events:0 --seed 123'",
     "seed:multi-sub-scenarios": "docker exec ghost-dev bash -c 'cd /home/ghost/ghost/core && node scripts/seed-multi-sub-scenarios.js'",
-    "docker:build": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} build",
+    "docker:build": "docker compose --progress=quiet -f compose.dev.yaml ${DEV_COMPOSE_FILES} build",
+    "docker:build:verbose": "docker compose --progress=plain -f compose.dev.yaml ${DEV_COMPOSE_FILES} build",
     "docker:clean": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} --profile all down -v --remove-orphans --rmi local",
     "docker:down": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} down",
     "docker:rebase": "git fetch ${GHOST_UPSTREAM:-origin} main && git rebase ${GHOST_UPSTREAM:-origin}/main && pnpm install && pnpm nx run-many -t build --projects=@tryghost/shade,@tryghost/admin-x-design-system,@tryghost/admin-x-framework && docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} up -d --build --force-recreate ghost-dev",
@@ -123,7 +124,7 @@
       "docker:build": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} build"
+          "command": "docker compose --progress=quiet -f compose.dev.yaml ${DEV_COMPOSE_FILES} build"
         }
       },
       "docker:dev": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "reset:data:empty": "docker exec ghost-dev bash -c 'cd /home/ghost/ghost/core && node index.js generate-data --clear-database --quantities members:0,posts:0 --seed 123'",
     "reset:data:xxl": "docker exec ghost-dev bash -c 'cd /home/ghost/ghost/core && node index.js generate-data --clear-database --quantities members:2000000,posts:0,emails:0,members_stripe_customers:0,members_login_events:0,members_status_events:0 --seed 123'",
     "seed:multi-sub-scenarios": "docker exec ghost-dev bash -c 'cd /home/ghost/ghost/core && node scripts/seed-multi-sub-scenarios.js'",
-    "docker:build": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} build",
+    "docker:build": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} build --quiet",
     "docker:clean": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} --profile all down -v --remove-orphans --rmi local",
     "docker:down": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} down",
     "docker:rebase": "git fetch ${GHOST_UPSTREAM:-origin} main && git rebase ${GHOST_UPSTREAM:-origin}/main && pnpm install && pnpm nx run-many -t build --projects=@tryghost/shade,@tryghost/admin-x-design-system,@tryghost/admin-x-framework && docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} up -d --build --force-recreate ghost-dev",
@@ -108,7 +108,7 @@
       "docker:up": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} up -d --force-recreate --wait"
+          "command": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} up -d --force-recreate --wait --quiet-pull"
         },
         "dependsOn": [
           "docker:build"
@@ -123,7 +123,7 @@
       "docker:build": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} build"
+          "command": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} build --quiet"
         }
       },
       "docker:dev": {


### PR DESCRIPTION
no ref

Quiets the Docker layers. ~125 lines/boot removed.

We're looking to move away from `nx tui` which buries a lot of logs/separate streams and go back to a unified view, which means it's much more important to keep it clean. And past that, noisy logs just pollute agentic context.

| Surface | How |
|---|---|
| `docker compose build` (success) | `--progress=quiet` — silent on success, Dockerfile location + line on failure |
| `docker compose up` pull progress | `--quiet-pull` |
| Redis | `--loglevel warning` |
| Mailpit | `--quiet` |
| MySQL | `--log-error-verbosity=1` (errors only — suppresses warnings too) |

`--progress=quiet` hides the actual RUN-step error text on failure ([moby/buildkit#5061](https://github.com/moby/buildkit/issues/5061)). Run `pnpm docker:build:verbose` (added) for full output when debugging.
