### PR TITLE
Cleaned up noisy boot-time logging in ghost/core

### DIFF
--- a/ghost/core/core/server/quiet-tls-warning.js
+++ b/ghost/core/core/server/quiet-tls-warning.js
@@ -1,0 +1,35 @@
+// Replaces Node's two-line `NODE_TLS_REJECT_UNAUTHORIZED` warning + trace-warnings
+// follow-up with a single INFO line at boot.
+//
+// Ghost's dev container sets NODE_TLS_REJECT_UNAUTHORIZED=0 so self-signed local
+// certificates don't fail TLS verification. Node responds with a process-level
+// warning that prints twice on the first TLS request of each boot. The state is
+// expected in dev — we surface it with a single concise line and silence the
+// noisy default. Only this specific warning is filtered; any other warning
+// raised via process.emitWarning still surfaces.
+//
+// Must be required from index.js BEFORE any module that uses TLS — we wrap
+// process.emitWarning so the default emitter never gets called for the TLS
+// warning. (A plain 'warning' event listener does NOT suppress Node's default
+// stderr print.)
+
+const TLS_WARNING_NEEDLE = "NODE_TLS_REJECT_UNAUTHORIZED";
+
+if (process.env.NODE_TLS_REJECT_UNAUTHORIZED === '0') {
+    const originalEmitWarning = process.emitWarning.bind(process);
+    process.emitWarning = function (warning, ...rest) {
+        const message = typeof warning === 'string'
+            ? warning
+            : (warning && warning.message) || '';
+        if (message.includes(TLS_WARNING_NEEDLE)) {
+            return undefined;
+        }
+        return originalEmitWarning(warning, ...rest);
+    };
+
+    // Use stderr directly — @tryghost/logging may not be loaded yet at this
+    // point in boot, and a single deterministic line is what we want anyway.
+    process.stderr.write('[dev] TLS verification disabled for localhost development\n');
+}
+
+module.exports = {TLS_WARNING_NEEDLE};

--- a/ghost/core/core/server/services/explore-ping/explore-ping-service.js
+++ b/ghost/core/core/server/services/explore-ping/explore-ping-service.js
@@ -115,7 +115,9 @@ module.exports = class ExplorePingService {
 
         const exploreUrl = this.config.get('explore:update_url');
         if (!exploreUrl) {
-            this.logging.warn('Explore URL not set');
+            // Not set is the expected state in dev — drop to debug so it doesn't
+            // surface at default log level.
+            this.logging.debug('Explore URL not set');
             return;
         }
 

--- a/ghost/core/core/server/services/jobs/job-service.js
+++ b/ghost/core/core/server/services/jobs/job-service.js
@@ -54,5 +54,73 @@ const initTestMode = () => {
 
 const jobManager = new JobManager({errorHandler, workerMessageHandler, JobModel: models.Job, domainEvents, config, events});
 
+// Quiet the noisy per-job INFO chatter emitted from inside @tryghost/job-manager
+// (one "Adding offloaded job to the inline job queue" + one "Scheduling job X at Y..."
+// per registered job). Replace it with a single summary line at boot.
+//
+// We can't pass a custom logger to the external package (it imports the
+// @tryghost/logging singleton directly), so we briefly swap the singleton's
+// methods around each addJob() call and tally counts.
+const jobStats = {offloaded: 0, inline: 0, scheduled: 0};
+let summaryScheduled = false;
+
+const QUIETED_PREFIXES = [
+    'Adding offloaded job to the inline job queue',
+    'Scheduling job '
+];
+
+const scheduleSummary = () => {
+    if (summaryScheduled) {
+        return;
+    }
+    summaryScheduled = true;
+    setImmediate(() => {
+        summaryScheduled = false;
+        const total = jobStats.offloaded + jobStats.inline;
+        if (total === 0) {
+            return;
+        }
+        logging.info(
+            `[Jobs] Registered ${total} jobs (${jobStats.scheduled} scheduled, ${jobStats.inline} inline)`
+        );
+        jobStats.offloaded = 0;
+        jobStats.inline = 0;
+        jobStats.scheduled = 0;
+    });
+};
+
+const withQuietedJobLogging = (fn, jobOptions) => {
+    const originalInfo = logging.info;
+    logging.info = function (...args) {
+        const first = args[0];
+        if (typeof first === 'string' && QUIETED_PREFIXES.some(prefix => first.startsWith(prefix))) {
+            return undefined;
+        }
+        return originalInfo.apply(this, args);
+    };
+    try {
+        return fn();
+    } finally {
+        logging.info = originalInfo;
+        if (jobOptions.offloaded === false) {
+            jobStats.inline += 1;
+        } else {
+            jobStats.offloaded += 1;
+            if (jobOptions.at) {
+                jobStats.scheduled += 1;
+            }
+        }
+        scheduleSummary();
+    }
+};
+
+// We only wrap addJob — addOneOffJob() inside @tryghost/job-manager calls
+// this.addJob() internally, which now resolves to the wrapped version, so it's
+// covered transitively without double-counting.
+const originalAddJob = jobManager.addJob.bind(jobManager);
+jobManager.addJob = function (jobOptions = {}) {
+    return withQuietedJobLogging(() => originalAddJob(jobOptions), jobOptions);
+};
+
 module.exports = jobManager;
 module.exports.initTestMode = initTestMode;

--- a/ghost/core/index.js
+++ b/ghost/core/index.js
@@ -1,1 +1,2 @@
+require('./core/server/quiet-tls-warning');
 require('./ghost');

--- a/ghost/core/test/unit/server/fixtures/quiet-tls-warning-harness.js
+++ b/ghost/core/test/unit/server/fixtures/quiet-tls-warning-harness.js
@@ -1,0 +1,25 @@
+// Forked harness used by quiet-tls-warning.test.js. Loads the module under test
+// (which patches process.emitWarning), then synthesises both the real TLS
+// warning Node emits internally and any extra warning requested by env so the
+// test can assert non-TLS warnings still surface.
+
+require('../../../../core/server/quiet-tls-warning');
+
+// Synthesise the exact TLS warning Node emits internally on first HTTPS use.
+// We avoid making a real network request from the test suite by emitting the
+// same warning text through process.emitWarning — which is the API Node's
+// internals use to raise it (see lib/_tls_wrap.js).
+if (process.env.NODE_TLS_REJECT_UNAUTHORIZED === '0') {
+    process.emitWarning(
+        "Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure by disabling certificate verification."
+    );
+}
+
+if (process.env.EXTRA_WARNING_NAME && process.env.EXTRA_WARNING_MESSAGE) {
+    process.emitWarning(process.env.EXTRA_WARNING_MESSAGE, process.env.EXTRA_WARNING_NAME);
+}
+
+// Give Node a moment to flush any internal warning emission.
+setTimeout(() => {
+    process.exit(0);
+}, 50);

--- a/ghost/core/test/unit/server/quiet-tls-warning.test.js
+++ b/ghost/core/test/unit/server/quiet-tls-warning.test.js
@@ -1,0 +1,73 @@
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const {spawnSync} = require('node:child_process');
+
+// quiet-tls-warning.js mutates process state (adds a 'warning' listener), so we
+// exercise it in a forked Node process to keep the test isolated and to actually
+// observe what's printed to stderr at boot.
+function runHarness({rejectUnauthorized, extraEmitName, extraEmitMessage}) {
+    const harnessPath = path.join(__dirname, 'fixtures', 'quiet-tls-warning-harness.js');
+    const env = {
+        ...process.env,
+        EXTRA_WARNING_NAME: extraEmitName || '',
+        EXTRA_WARNING_MESSAGE: extraEmitMessage || ''
+    };
+    if (rejectUnauthorized !== undefined) {
+        env.NODE_TLS_REJECT_UNAUTHORIZED = rejectUnauthorized;
+    } else {
+        delete env.NODE_TLS_REJECT_UNAUTHORIZED;
+    }
+    const result = spawnSync(process.execPath, [harnessPath], {env, encoding: 'utf8'});
+    return {stdout: result.stdout, stderr: result.stderr, status: result.status};
+}
+
+describe('quiet-tls-warning', function () {
+    it('replaces the Node TLS warning with a single INFO line when the env var is "0"', function () {
+        const {stderr, status} = runHarness({rejectUnauthorized: '0'});
+
+        assert.equal(status, 0, `harness exited non-zero. stderr:\n${stderr}`);
+        // The replacement line is present...
+        assert.ok(
+            stderr.includes('[dev] TLS verification disabled for localhost development'),
+            `expected replacement INFO line, got:\n${stderr}`
+        );
+        // ...and Node's two-line warning + trace-warnings follow-up is gone.
+        assert.ok(
+            !stderr.includes('NODE_TLS_REJECT_UNAUTHORIZED'),
+            `expected Node TLS warning to be suppressed, got:\n${stderr}`
+        );
+        assert.ok(
+            !stderr.includes('Use `node --trace-warnings'),
+            `expected trace-warnings follow-up to be suppressed, got:\n${stderr}`
+        );
+    });
+
+    it('still surfaces other process warnings', function () {
+        const {stderr, status} = runHarness({
+            rejectUnauthorized: '0',
+            extraEmitName: 'DeprecationWarning',
+            extraEmitMessage: 'something-else-is-deprecated'
+        });
+
+        assert.equal(status, 0, `harness exited non-zero. stderr:\n${stderr}`);
+        assert.ok(
+            stderr.includes('DeprecationWarning: something-else-is-deprecated'),
+            `expected unrelated DeprecationWarning to be re-emitted, got:\n${stderr}`
+        );
+        // And the TLS warning is still filtered.
+        assert.ok(
+            !stderr.includes('NODE_TLS_REJECT_UNAUTHORIZED'),
+            `expected Node TLS warning to be suppressed, got:\n${stderr}`
+        );
+    });
+
+    it('does nothing when NODE_TLS_REJECT_UNAUTHORIZED is unset', function () {
+        const {stderr, status} = runHarness({rejectUnauthorized: undefined});
+
+        assert.equal(status, 0, `harness exited non-zero. stderr:\n${stderr}`);
+        assert.ok(
+            !stderr.includes('[dev] TLS verification disabled'),
+            `expected no INFO line when env var is unset, got:\n${stderr}`
+        );
+    });
+});

--- a/ghost/core/test/unit/server/services/explore-ping/explore-ping-service.test.js
+++ b/ghost/core/test/unit/server/services/explore-ping/explore-ping-service.test.js
@@ -41,7 +41,8 @@ describe('ExplorePingService', function () {
 
         loggingStub = {
             info: sinon.stub(),
-            warn: sinon.stub()
+            warn: sinon.stub(),
+            debug: sinon.stub()
         };
 
         ghostVersionStub = {
@@ -277,8 +278,9 @@ describe('ExplorePingService', function () {
             await explorePingService.ping();
 
             sinon.assert.notCalled(requestStub);
-            sinon.assert.calledOnce(loggingStub.warn);
-            assert.equal(loggingStub.warn.firstCall.args[0], 'Explore URL not set');
+            sinon.assert.notCalled(loggingStub.warn);
+            sinon.assert.calledOnce(loggingStub.debug);
+            assert.equal(loggingStub.debug.firstCall.args[0], 'Explore URL not set');
         });
 
         it('does not ping if explore ping is disabled', async function () {

--- a/ghost/core/test/unit/server/services/jobs/job-service-boot-logging.test.js
+++ b/ghost/core/test/unit/server/services/jobs/job-service-boot-logging.test.js
@@ -1,0 +1,132 @@
+const assert = require('node:assert/strict');
+const Module = require('module');
+const sinon = require('sinon');
+
+describe('JobService boot logging summary', function () {
+    const jobServicePath = '../../../../../core/server/services/jobs/job-service';
+    let originalLoad;
+    let loggingStub;
+    let jobService;
+
+    beforeEach(function () {
+        originalLoad = Module._load;
+        loggingStub = {
+            info: sinon.stub(),
+            warn: sinon.stub(),
+            error: sinon.stub()
+        };
+
+        // Fake JobManager that emits the same chatty INFO log lines as the real
+        // @tryghost/job-manager v1.0.9 so we can assert our wrapper filters them
+        // and replaces them with a single summary line.
+        Module._load = function (request, parent, isMain) {
+            if (request === '@tryghost/job-manager') {
+                const logging = loggingStub;
+                return class FakeJobManager {
+                    addJob(opts) {
+                        const {name, at, offloaded = true} = opts || {};
+                        if (offloaded) {
+                            logging.info('Adding offloaded job to the inline job queue');
+                            if (at) {
+                                logging.info(`Scheduling job ${name} at ${at}. Next run on: 2099-01-01T00:00:00.000Z`);
+                            } else {
+                                logging.info(`Scheduling job ${name} to run immediately`);
+                            }
+                        }
+                    }
+
+                    addOneOffJob(opts) {
+                        this.addJob(opts);
+                    }
+                };
+            }
+
+            if (request === '@tryghost/logging') {
+                return loggingStub;
+            }
+
+            if (request === './worker-model-event-bridge') {
+                return class WorkerModelEventBridge {
+                    isModelEventMessage() {
+                        return false;
+                    }
+                    handle() {}
+                };
+            }
+
+            if (request === '../../models') {
+                return {Job: {}};
+            }
+
+            if (request === '../../../shared/sentry') {
+                return {captureException: sinon.stub()};
+            }
+
+            if (request === '@tryghost/domain-events') {
+                return {};
+            }
+
+            if (request === '../../../shared/config') {
+                return {};
+            }
+
+            if (request === '../../lib/common/events') {
+                return {emit: sinon.stub()};
+            }
+
+            return originalLoad.call(this, request, parent, isMain);
+        };
+
+        delete require.cache[require.resolve(jobServicePath)];
+        jobService = require(jobServicePath);
+    });
+
+    afterEach(function () {
+        Module._load = originalLoad;
+        delete require.cache[require.resolve(jobServicePath)];
+        sinon.restore();
+    });
+
+    function flushSummary() {
+        return new Promise((resolve) => {
+            setImmediate(resolve);
+        });
+    }
+
+    it('suppresses the per-job "Scheduling job" and "Adding offloaded" INFO chatter', async function () {
+        jobService.addJob({name: 'one', at: '5 * * * *', job: () => {}});
+        jobService.addJob({name: 'two', at: '10 * * * *', job: () => {}});
+
+        await flushSummary();
+
+        const allMessages = loggingStub.info.getCalls().map(call => call.args[0]);
+        const chattyMessages = allMessages.filter(msg =>
+            typeof msg === 'string'
+            && (msg.startsWith('Adding offloaded job') || msg.startsWith('Scheduling job '))
+        );
+        assert.equal(
+            chattyMessages.length,
+            0,
+            `expected no chatty per-job INFO calls, got: ${JSON.stringify(chattyMessages)}`
+        );
+    });
+
+    it('emits a single summary INFO line covering all registered jobs', async function () {
+        jobService.addJob({name: 'one', at: '5 * * * *', job: () => {}});
+        jobService.addJob({name: 'two', at: '10 * * * *', job: () => {}});
+        jobService.addJob({name: 'three', at: '15 * * * *', job: () => {}});
+        jobService.addJob({name: 'inline-one', offloaded: false, job: () => {}});
+
+        await flushSummary();
+
+        const summaryCalls = loggingStub.info.getCalls()
+            .map(call => call.args[0])
+            .filter(msg => typeof msg === 'string' && msg.startsWith('[Jobs] Registered'));
+        assert.equal(
+            summaryCalls.length,
+            1,
+            `expected exactly one summary line, got: ${JSON.stringify(summaryCalls)}`
+        );
+        assert.equal(summaryCalls[0], '[Jobs] Registered 4 jobs (3 scheduled, 1 inline)');
+    });
+});

--- a/ghost/core/test/unit/server/services/jobs/job-service.test.js
+++ b/ghost/core/test/unit/server/services/jobs/job-service.test.js
@@ -18,6 +18,7 @@ describe('JobService', function () {
                     constructor(options) {
                         workerMessageHandler = options.workerMessageHandler;
                     }
+                    addJob() {}
                 };
             }
 
@@ -121,6 +122,7 @@ describe('JobService model-event bridge wiring', function () {
                     constructor(options) {
                         workerMessageHandler = options.workerMessageHandler;
                     }
+                    addJob() {}
                 };
             }
 
@@ -210,3 +212,4 @@ describe('JobService model-event bridge wiring', function () {
         assert.equal(options.context.internal, true);
     });
 });
+


### PR DESCRIPTION
Demotes three sources of dev-time boot chatter to make `pnpm dev` output legible.

## What changed

**1. JobsService boot logs — ~20 lines → 1 summary line**
`@tryghost/job-manager` emits two INFO lines per registered job (`Adding offloaded job to the inline job queue` + `Scheduling job X at Y. Next run on: ...`). Wrapped `jobManager.addJob` in `ghost/core/core/server/services/jobs/job-service.js` to suppress those specific lines and emit a single summary on next tick:

```
[Jobs] Registered 10 jobs (8 scheduled, 2 inline)
```

We can't inject a logger into the external package (it imports the `@tryghost/logging` singleton directly), so the wrapper briefly swaps `logging.info` for a filter during each `addJob` call and tallies counts.

**2. `Explore URL not set` warn → debug**
`explore-ping-service` warned on every boot when the optional `explore:update_url` is absent — the default in dev. Demoted to `debug` since absence is the expected state, not a warning condition.

**3. Node `NODE_TLS_REJECT_UNAUTHORIZED` warning — 2 lines → 1 INFO line**
Ghost's dev container sets `NODE_TLS_REJECT_UNAUTHORIZED=0` for self-signed local certs. Node prints a two-line warning + `(Use node --trace-warnings ...)` follow-up on the first HTTPS request. Added `ghost/core/core/server/quiet-tls-warning.js`, loaded first in `index.js`, that patches `process.emitWarning` to filter that one warning and prints in its place:

```
[dev] TLS verification disabled for localhost development
```

Only that message is filtered — other process warnings (deprecations, real issues) still surface. A plain `'warning'` event listener does NOT suppress Node's default stderr print; patching `emitWarning` is the route that actually works (verified with a real HTTPS request).

## Verification

- 7144 unit tests pass (`pnpm test:unit`).
- Lint clean (`pnpm lint`).
- New unit tests:
  - `job-service-boot-logging.test.js`: per-job chatter is suppressed; one summary line is emitted.
  - `quiet-tls-warning.test.js`: forks a Node process and asserts the TLS warning is gone from stderr, the INFO line is present, and an unrelated DeprecationWarning still surfaces.
  - `explore-ping-service.test.js`: missing-URL path now logs at `debug`, not `warn`.

## Before / after line counts

| Fix | Before | After |
|-----|--------|-------|
| Jobs scheduling | ~20 INFO lines | 1 INFO line |
| Explore URL | 1 WARN line | 0 (debug) |
| Node TLS warning | 2 stderr lines | 1 INFO line |