### PR TITLE
[REVIEW ONLY — DO NOT MERGE] Combined view of A+B+C dev-noise PRs

### DIFF
--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -4,7 +4,7 @@ services:
   mysql:
     image: mysql:8.4.9@sha256:c36050afdca850f23cef85703f84c7531a5ae155a11b5ee1c60acb09937c4084
     container_name: ghost-dev-mysql
-    command: --innodb-buffer-pool-size=1G --innodb-log-buffer-size=500M --innodb-change-buffer-max-size=50 --innodb-flush-log-at-trx_commit=0 --innodb-flush-method=O_DIRECT
+    command: --innodb-buffer-pool-size=1G --innodb-log-buffer-size=500M --innodb-change-buffer-max-size=50 --innodb-flush-log-at-trx_commit=0 --innodb-flush-method=O_DIRECT --log-error-verbosity=1
     ports:
       - "3306:3306"
     environment:
@@ -24,6 +24,7 @@ services:
   redis:
     image: redis:7.0@sha256:352c1fdadc91926edda08f45aeb3f27f37194c2f14101229c0523a11195c96e3
     container_name: ghost-dev-redis
+    command: ["redis-server", "--loglevel", "warning"]
     ports:
       - "6379:6379"
     volumes:
@@ -41,6 +42,7 @@ services:
   mailpit:
     image: axllent/mailpit@sha256:37a38e48e9338cd7e89dfeb487f37b02ebfcd9cb23111bed2d345e79d37d6dd6
     container_name: ghost-dev-mailpit
+    command: ["--quiet"]
     ports:
       - "1025:1025"  # SMTP server
       - "8025:8025"  # Web interface

--- a/docker/dev-gateway/Caddyfile
+++ b/docker/dev-gateway/Caddyfile
@@ -1,210 +1,210 @@
 {
-    admin off
+	admin off
 }
 
 :80 {
-    # Compact log format for development
-    log {
-        output stdout
-        format transform "{common_log}"
-    }
+	# Compact log format for development
+	log {
+		output stdout
+		format transform "{common_log}"
+	}
 
-    # Ember live reload (runs on separate port 4201)
-    # This handles both the script injection and WebSocket connections
-    handle /ember-cli-live-reload.js {
-        reverse_proxy {env.ADMIN_LIVE_RELOAD_SERVER} {
-            header_up Host {http.reverse_proxy.upstream.hostport}
-            header_up X-Forwarded-Host {host}
-            # Enable WebSocket support for live reload
-            header_up Connection {>Connection}
-            header_up Upgrade {>Upgrade}
-        }
-    }
+	# Ember live reload (runs on separate port 4201)
+	# This handles both the script injection and WebSocket connections
+	handle /ember-cli-live-reload.js {
+		reverse_proxy {env.ADMIN_LIVE_RELOAD_SERVER} {
+			header_up Host {http.reverse_proxy.upstream.hostport}
+			header_up X-Forwarded-Host {host}
+			# Enable WebSocket support for live reload
+			header_up Connection {>Connection}
+			header_up Upgrade {>Upgrade}
+		}
+	}
 
-    # Ghost API - must go to Ghost backend, not admin dev server
-    handle /ghost/api/* {
-        reverse_proxy {env.GHOST_BACKEND} {
-            header_up Host {host}
-            header_up X-Real-IP {remote_host}
-            header_up X-Forwarded-For {remote_host}
+	# Ghost API - must go to Ghost backend, not admin dev server
+	handle /ghost/api/* {
+		reverse_proxy {env.GHOST_BACKEND} {
+			header_up Host {host}
+			header_up X-Real-IP {remote_host}
+			header_up X-Forwarded-For {remote_host}
 
-            # Always tell Ghost requests are HTTPS to prevent redirects
-            header_up X-Forwarded-Proto https
-        }
-    }
+			# Always tell Ghost requests are HTTPS to prevent redirects
+			header_up X-Forwarded-Proto https
+		}
+	}
 
-    # Analytics API - proxy analytics requests to analytics service
-    # Handles paths like /.ghost/analytics/* or /blog/.ghost/analytics/*
-    @analytics_paths path_regexp analytics_match ^(.*)/\.ghost/analytics(.*)$
-    handle @analytics_paths {
-        rewrite * {re.analytics_match.2}
-        reverse_proxy {env.ANALYTICS_PROXY_TARGET} {
-            header_up Host {host}
-            header_up X-Forwarded-Host {host}
-            header_up X-Real-IP {remote_host}
-            header_up X-Forwarded-For {remote_host}
-        }
-    }
+	# Analytics API - proxy analytics requests to analytics service
+	# Handles paths like /.ghost/analytics/* or /blog/.ghost/analytics/*
+	@analytics_paths path_regexp analytics_match ^(.*)/\.ghost/analytics(.*)$
+	handle @analytics_paths {
+		rewrite * {re.analytics_match.2}
+		reverse_proxy {env.ANALYTICS_PROXY_TARGET} {
+			header_up Host {host}
+			header_up X-Forwarded-Host {host}
+			header_up X-Real-IP {remote_host}
+			header_up X-Forwarded-For {remote_host}
+		}
+	}
 
-    # ActivityPub API - proxy activityPub requests to activityPub service (running in separate project)
-    # Requires activitypub containers to be running via the ActivityPub project's docker-compose
-    handle /.ghost/activitypub/* {
-        reverse_proxy {env.ACTIVITYPUB_PROXY_TARGET} {
-            header_up Host {host}
-            header_up X-Real-IP {remote_host}
-            header_up X-Forwarded-For {remote_host}
-            header_up X-Forwarded-Proto https
-        }
-    }
+	# ActivityPub API - proxy activityPub requests to activityPub service (running in separate project)
+	# Requires activitypub containers to be running via the ActivityPub project's docker-compose
+	handle /.ghost/activitypub/* {
+		reverse_proxy {env.ACTIVITYPUB_PROXY_TARGET} {
+			header_up Host {host}
+			header_up X-Real-IP {remote_host}
+			header_up X-Forwarded-For {remote_host}
+			header_up X-Forwarded-Proto https
+		}
+	}
 
-    # WebFinger - required for ActivityPub federation
-    handle /.well-known/webfinger {
-        reverse_proxy {env.ACTIVITYPUB_PROXY_TARGET} {
-            header_up Host {host}
-            header_up X-Real-IP {remote_host}
-            header_up X-Forwarded-For {remote_host}
-            header_up X-Forwarded-Proto https
-        }
-    }
+	# WebFinger - required for ActivityPub federation
+	handle /.well-known/webfinger {
+		reverse_proxy {env.ACTIVITYPUB_PROXY_TARGET} {
+			header_up Host {host}
+			header_up X-Real-IP {remote_host}
+			header_up X-Forwarded-For {remote_host}
+			header_up X-Forwarded-Proto https
+		}
+	}
 
-    # NodeInfo - required for ActivityPub federation
-    handle /.well-known/nodeinfo {
-        reverse_proxy {env.ACTIVITYPUB_PROXY_TARGET} {
-            header_up Host {host}
-            header_up X-Real-IP {remote_host}
-            header_up X-Forwarded-For {remote_host}
-            header_up X-Forwarded-Proto https
-        }
-    }
+	# NodeInfo - required for ActivityPub federation
+	handle /.well-known/nodeinfo {
+		reverse_proxy {env.ACTIVITYPUB_PROXY_TARGET} {
+			header_up Host {host}
+			header_up X-Real-IP {remote_host}
+			header_up X-Forwarded-For {remote_host}
+			header_up X-Forwarded-Proto https
+		}
+	}
 
-    # Public app dev server assets - must come BEFORE general /ghost/* handler
-    # Ghost is configured to load these from /ghost/assets/* via compose.dev.yaml
-    handle /ghost/assets/* {
-        # Strip /ghost/assets/ prefix
-        uri strip_prefix /ghost/assets
+	# Public app dev server assets - must come BEFORE general /ghost/* handler
+	# Ghost is configured to load these from /ghost/assets/* via compose.dev.yaml
+	handle /ghost/assets/* {
+		# Strip /ghost/assets/ prefix
+		uri strip_prefix /ghost/assets
 
-        # Koenig Lexical Editor (optional - for developing Lexical in separate Koenig repo)
-        # Requires EDITOR_URL=/ghost/assets/koenig-lexical/ when starting admin dev server
-        # Falls back to Ghost backend (built package) via handle_errors if dev server isn't running
-        @lexical path /koenig-lexical/*
-        handle @lexical {
-            uri strip_prefix /koenig-lexical
-            reverse_proxy {env.LEXICAL_DEV_SERVER} {
-                header_up Host {http.reverse_proxy.upstream.hostport}
-                header_up X-Forwarded-Host {host}
-                # Fail quickly if dev server is down
-                fail_duration 1s
-                unhealthy_request_count 1
-            }
-        }
+		# Koenig Lexical Editor (optional - for developing Lexical in separate Koenig repo)
+		# Requires EDITOR_URL=/ghost/assets/koenig-lexical/ when starting admin dev server
+		# Falls back to Ghost backend (built package) via handle_errors if dev server isn't running
+		@lexical path /koenig-lexical/*
+		handle @lexical {
+			uri strip_prefix /koenig-lexical
+			reverse_proxy {env.LEXICAL_DEV_SERVER} {
+				header_up Host {http.reverse_proxy.upstream.hostport}
+				header_up X-Forwarded-Host {host}
+				# Fail quickly if dev server is down
+				fail_duration 1s
+				unhealthy_request_count 1
+			}
+		}
 
-        # Public app UMD bundles — served directly from each app's umd/
-        # build output. Vite's build:watch writes to disk on every source
-        # change, Caddy picks up the new file on next request. Replaces the
-        # per-app `vite preview` server (sirv) layer that used to sit in front.
-        #
-        # The named allowlist is load-bearing: a generic [a-z0-9-]+ pattern
-        # would swallow admin asset paths (e.g. /ghost/assets/built/foo.css)
-        # before they could fall through to the admin dev server below.
-        # Adding a new public app = add its name to the alternation.
-        @public_app path_regexp public_app ^/(portal|comments-ui|signup-form|sodo-search|announcement-bar|admin-toolbar)/(.*)$
-        handle @public_app {
-            rewrite * /{re.public_app.2}
-            root * /srv/apps/{re.public_app.1}/umd
-            file_server
-        }
+		# Public app UMD bundles — served directly from each app's umd/
+		# build output. Vite's build:watch writes to disk on every source
+		# change, Caddy picks up the new file on next request. Replaces the
+		# per-app `vite preview` server (sirv) layer that used to sit in front.
+		#
+		# The named allowlist is load-bearing: a generic [a-z0-9-]+ pattern
+		# would swallow admin asset paths (e.g. /ghost/assets/built/foo.css)
+		# before they could fall through to the admin dev server below.
+		# Adding a new public app = add its name to the alternation.
+		@public_app path_regexp public_app ^/(portal|comments-ui|signup-form|sodo-search|announcement-bar|admin-toolbar)/(.*)$
+		handle @public_app {
+			rewrite * /{re.public_app.2}
+			root * /srv/apps/{re.public_app.1}/umd
+			file_server
+		}
 
-        # Everything else under /ghost/assets/* goes to admin dev server.
-        # Vite serves admin/Ember assets under its dev base (/__admin-dev__/assets/),
-        # so we rewrite the request before proxying.
-        handle {
-            rewrite * /__admin-dev__/assets{path}
-            reverse_proxy {env.ADMIN_DEV_SERVER} {
-                header_up Host {http.reverse_proxy.upstream.hostport}
-                header_up X-Forwarded-Host {host}
-            }
-        }
-    }
+		# Everything else under /ghost/assets/* goes to admin dev server.
+		# Vite serves admin/Ember assets under its dev base (/__admin-dev__/assets/),
+		# so we rewrite the request before proxying.
+		handle {
+			rewrite * /__admin-dev__/assets{path}
+			reverse_proxy {env.ADMIN_DEV_SERVER} {
+				header_up Host {http.reverse_proxy.upstream.hostport}
+				header_up X-Forwarded-Host {host}
+			}
+		}
+	}
 
-    # Auth frame - must go to Ghost backend for comment admin authentication
-    handle /ghost/auth-frame/* {
-        reverse_proxy {env.GHOST_BACKEND} {
-            header_up Host {host}
-            header_up X-Real-IP {remote_host}
-            header_up X-Forwarded-For {remote_host}
-            header_up X-Forwarded-Proto https
-        }
-    }
+	# Auth frame - must go to Ghost backend for comment admin authentication
+	handle /ghost/auth-frame/* {
+		reverse_proxy {env.GHOST_BACKEND} {
+			header_up Host {host}
+			header_up X-Real-IP {remote_host}
+			header_up X-Forwarded-For {remote_host}
+			header_up X-Forwarded-Proto https
+		}
+	}
 
-    # JWKS endpoint - must go to Ghost backend for JWT verification
-    handle /ghost/.well-known/* {
-        reverse_proxy {env.GHOST_BACKEND} {
-            header_up Host {host}
-            header_up X-Real-IP {remote_host}
-            header_up X-Forwarded-For {remote_host}
-            header_up X-Forwarded-Proto https
-        }
-    }
+	# JWKS endpoint - must go to Ghost backend for JWT verification
+	handle /ghost/.well-known/* {
+		reverse_proxy {env.GHOST_BACKEND} {
+			header_up Host {host}
+			header_up X-Real-IP {remote_host}
+			header_up X-Forwarded-For {remote_host}
+			header_up X-Forwarded-Proto https
+		}
+	}
 
-    # Vite dev server lives under its own prefix so its internals
-    # (HMR client, module graph, refresh runtime) don't collide with the
-    # /ghost/* paths Ghost serves in production. Handles HMR WebSocket upgrade.
-    handle /__admin-dev__* {
-        reverse_proxy {env.ADMIN_DEV_SERVER} {
-            header_up X-Forwarded-Host {host}
-            header_up Connection {>Connection}
-            header_up Upgrade {>Upgrade}
-        }
-    }
+	# Vite dev server lives under its own prefix so its internals
+	# (HMR client, module graph, refresh runtime) don't collide with the
+	# /ghost/* paths Ghost serves in production. Handles HMR WebSocket upgrade.
+	handle /__admin-dev__* {
+		reverse_proxy {env.ADMIN_DEV_SERVER} {
+			header_up X-Forwarded-Host {host}
+			header_up Connection {>Connection}
+			header_up Upgrade {>Upgrade}
+		}
+	}
 
-    # Admin HTML entry — proxy to Vite, which serves the dev index.html.
-    # Matches `/ghost` and `/ghost/` exactly (deep links fall through to Ghost
-    # below so its redirect middleware turns them into hash URLs).
-    @admin_html path /ghost /ghost/
-    handle @admin_html {
-        rewrite * /__admin-dev__/
-        reverse_proxy {env.ADMIN_DEV_SERVER} {
-            header_up X-Forwarded-Host {host}
-        }
-    }
+	# Admin HTML entry — proxy to Vite, which serves the dev index.html.
+	# Matches `/ghost` and `/ghost/` exactly (deep links fall through to Ghost
+	# below so its redirect middleware turns them into hash URLs).
+	@admin_html path /ghost /ghost/
+	handle @admin_html {
+		rewrite * /__admin-dev__/
+		reverse_proxy {env.ADMIN_DEV_SERVER} {
+			header_up X-Forwarded-Host {host}
+		}
+	}
 
-    # Everything else under /ghost/* (deep links, redirects, etc.) goes to
-    # Ghost so the same Express middleware runs in dev as in production.
-    handle /ghost/* {
-        reverse_proxy {env.GHOST_BACKEND} {
-            header_up Host {host}
-            header_up X-Real-IP {remote_host}
-            header_up X-Forwarded-For {remote_host}
-            header_up X-Forwarded-Proto https
-        }
-    }
+	# Everything else under /ghost/* (deep links, redirects, etc.) goes to
+	# Ghost so the same Express middleware runs in dev as in production.
+	handle /ghost/* {
+		reverse_proxy {env.GHOST_BACKEND} {
+			header_up Host {host}
+			header_up X-Real-IP {remote_host}
+			header_up X-Forwarded-For {remote_host}
+			header_up X-Forwarded-Proto https
+		}
+	}
 
-    # Everything else goes to Ghost backend
-    handle {
-        reverse_proxy {env.GHOST_BACKEND} {
-            header_up Host {host}
-            header_up X-Real-IP {remote_host}
-            header_up X-Forwarded-For {remote_host}
+	# Everything else goes to Ghost backend
+	handle {
+		reverse_proxy {env.GHOST_BACKEND} {
+			header_up Host {host}
+			header_up X-Real-IP {remote_host}
+			header_up X-Forwarded-For {remote_host}
 
-            # Always tell Ghost requests are HTTPS to prevent redirects
-            header_up X-Forwarded-Proto https
-        }
-    }
+			# Always tell Ghost requests are HTTPS to prevent redirects
+			header_up X-Forwarded-Proto https
+		}
+	}
 
-    # Handle errors
-    handle_errors {
-        # Fallback for Lexical when dev server is unavailable (502/503/504)
-        # Forwards to Ghost backend which serves the built koenig-lexical package
-        @lexical_fallback `{http.request.orig_uri.path}.startsWith("/ghost/assets/koenig-lexical/")`
-        handle @lexical_fallback {
-            rewrite * {http.request.orig_uri.path}
-            reverse_proxy {env.GHOST_BACKEND} {
-                header_up Host {host}
-                header_up X-Forwarded-Proto https
-            }
-        }
+	# Handle errors
+	handle_errors {
+		# Fallback for Lexical when dev server is unavailable (502/503/504)
+		# Forwards to Ghost backend which serves the built koenig-lexical package
+		@lexical_fallback `{http.request.orig_uri.path}.startsWith("/ghost/assets/koenig-lexical/")`
+		handle @lexical_fallback {
+			rewrite * {http.request.orig_uri.path}
+			reverse_proxy {env.GHOST_BACKEND} {
+				header_up Host {host}
+				header_up X-Forwarded-Proto https
+			}
+		}
 
-        # Default error response
-        respond "{err.status_code} {err.status_text}"
-    }
+		# Default error response
+		respond "{err.status_code} {err.status_text}"
+	}
 }

--- a/ghost/core/core/server/quiet-tls-warning.js
+++ b/ghost/core/core/server/quiet-tls-warning.js
@@ -1,0 +1,35 @@
+// Replaces Node's two-line `NODE_TLS_REJECT_UNAUTHORIZED` warning + trace-warnings
+// follow-up with a single INFO line at boot.
+//
+// Ghost's dev container sets NODE_TLS_REJECT_UNAUTHORIZED=0 so self-signed local
+// certificates don't fail TLS verification. Node responds with a process-level
+// warning that prints twice on the first TLS request of each boot. The state is
+// expected in dev — we surface it with a single concise line and silence the
+// noisy default. Only this specific warning is filtered; any other warning
+// raised via process.emitWarning still surfaces.
+//
+// Must be required from index.js BEFORE any module that uses TLS — we wrap
+// process.emitWarning so the default emitter never gets called for the TLS
+// warning. (A plain 'warning' event listener does NOT suppress Node's default
+// stderr print.)
+
+const TLS_WARNING_NEEDLE = "NODE_TLS_REJECT_UNAUTHORIZED";
+
+if (process.env.NODE_TLS_REJECT_UNAUTHORIZED === '0') {
+    const originalEmitWarning = process.emitWarning.bind(process);
+    process.emitWarning = function (warning, ...rest) {
+        const message = typeof warning === 'string'
+            ? warning
+            : (warning && warning.message) || '';
+        if (message.includes(TLS_WARNING_NEEDLE)) {
+            return undefined;
+        }
+        return originalEmitWarning(warning, ...rest);
+    };
+
+    // Use stderr directly — @tryghost/logging may not be loaded yet at this
+    // point in boot, and a single deterministic line is what we want anyway.
+    process.stderr.write('[dev] TLS verification disabled for localhost development\n');
+}
+
+module.exports = {TLS_WARNING_NEEDLE};

--- a/ghost/core/core/server/services/explore-ping/explore-ping-service.js
+++ b/ghost/core/core/server/services/explore-ping/explore-ping-service.js
@@ -115,7 +115,9 @@ module.exports = class ExplorePingService {
 
         const exploreUrl = this.config.get('explore:update_url');
         if (!exploreUrl) {
-            this.logging.warn('Explore URL not set');
+            // Not set is the expected state in dev — drop to debug so it doesn't
+            // surface at default log level.
+            this.logging.debug('Explore URL not set');
             return;
         }
 

--- a/ghost/core/core/server/services/jobs/job-service.js
+++ b/ghost/core/core/server/services/jobs/job-service.js
@@ -54,5 +54,73 @@ const initTestMode = () => {
 
 const jobManager = new JobManager({errorHandler, workerMessageHandler, JobModel: models.Job, domainEvents, config, events});
 
+// Quiet the noisy per-job INFO chatter emitted from inside @tryghost/job-manager
+// (one "Adding offloaded job to the inline job queue" + one "Scheduling job X at Y..."
+// per registered job). Replace it with a single summary line at boot.
+//
+// We can't pass a custom logger to the external package (it imports the
+// @tryghost/logging singleton directly), so we briefly swap the singleton's
+// methods around each addJob() call and tally counts.
+const jobStats = {offloaded: 0, inline: 0, scheduled: 0};
+let summaryScheduled = false;
+
+const QUIETED_PREFIXES = [
+    'Adding offloaded job to the inline job queue',
+    'Scheduling job '
+];
+
+const scheduleSummary = () => {
+    if (summaryScheduled) {
+        return;
+    }
+    summaryScheduled = true;
+    setImmediate(() => {
+        summaryScheduled = false;
+        const total = jobStats.offloaded + jobStats.inline;
+        if (total === 0) {
+            return;
+        }
+        logging.info(
+            `[Jobs] Registered ${total} jobs (${jobStats.scheduled} scheduled, ${jobStats.inline} inline)`
+        );
+        jobStats.offloaded = 0;
+        jobStats.inline = 0;
+        jobStats.scheduled = 0;
+    });
+};
+
+const withQuietedJobLogging = (fn, jobOptions) => {
+    const originalInfo = logging.info;
+    logging.info = function (...args) {
+        const first = args[0];
+        if (typeof first === 'string' && QUIETED_PREFIXES.some(prefix => first.startsWith(prefix))) {
+            return undefined;
+        }
+        return originalInfo.apply(this, args);
+    };
+    try {
+        return fn();
+    } finally {
+        logging.info = originalInfo;
+        if (jobOptions.offloaded === false) {
+            jobStats.inline += 1;
+        } else {
+            jobStats.offloaded += 1;
+            if (jobOptions.at) {
+                jobStats.scheduled += 1;
+            }
+        }
+        scheduleSummary();
+    }
+};
+
+// We only wrap addJob — addOneOffJob() inside @tryghost/job-manager calls
+// this.addJob() internally, which now resolves to the wrapped version, so it's
+// covered transitively without double-counting.
+const originalAddJob = jobManager.addJob.bind(jobManager);
+jobManager.addJob = function (jobOptions = {}) {
+    return withQuietedJobLogging(() => originalAddJob(jobOptions), jobOptions);
+};
+
 module.exports = jobManager;
 module.exports.initTestMode = initTestMode;

--- a/ghost/core/index.js
+++ b/ghost/core/index.js
@@ -1,1 +1,2 @@
+require('./core/server/quiet-tls-warning');
 require('./ghost');

--- a/ghost/core/test/unit/server/fixtures/quiet-tls-warning-harness.js
+++ b/ghost/core/test/unit/server/fixtures/quiet-tls-warning-harness.js
@@ -1,0 +1,25 @@
+// Forked harness used by quiet-tls-warning.test.js. Loads the module under test
+// (which patches process.emitWarning), then synthesises both the real TLS
+// warning Node emits internally and any extra warning requested by env so the
+// test can assert non-TLS warnings still surface.
+
+require('../../../../core/server/quiet-tls-warning');
+
+// Synthesise the exact TLS warning Node emits internally on first HTTPS use.
+// We avoid making a real network request from the test suite by emitting the
+// same warning text through process.emitWarning — which is the API Node's
+// internals use to raise it (see lib/_tls_wrap.js).
+if (process.env.NODE_TLS_REJECT_UNAUTHORIZED === '0') {
+    process.emitWarning(
+        "Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure by disabling certificate verification."
+    );
+}
+
+if (process.env.EXTRA_WARNING_NAME && process.env.EXTRA_WARNING_MESSAGE) {
+    process.emitWarning(process.env.EXTRA_WARNING_MESSAGE, process.env.EXTRA_WARNING_NAME);
+}
+
+// Give Node a moment to flush any internal warning emission.
+setTimeout(() => {
+    process.exit(0);
+}, 50);

--- a/ghost/core/test/unit/server/quiet-tls-warning.test.js
+++ b/ghost/core/test/unit/server/quiet-tls-warning.test.js
@@ -1,0 +1,73 @@
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const {spawnSync} = require('node:child_process');
+
+// quiet-tls-warning.js mutates process state (adds a 'warning' listener), so we
+// exercise it in a forked Node process to keep the test isolated and to actually
+// observe what's printed to stderr at boot.
+function runHarness({rejectUnauthorized, extraEmitName, extraEmitMessage}) {
+    const harnessPath = path.join(__dirname, 'fixtures', 'quiet-tls-warning-harness.js');
+    const env = {
+        ...process.env,
+        EXTRA_WARNING_NAME: extraEmitName || '',
+        EXTRA_WARNING_MESSAGE: extraEmitMessage || ''
+    };
+    if (rejectUnauthorized !== undefined) {
+        env.NODE_TLS_REJECT_UNAUTHORIZED = rejectUnauthorized;
+    } else {
+        delete env.NODE_TLS_REJECT_UNAUTHORIZED;
+    }
+    const result = spawnSync(process.execPath, [harnessPath], {env, encoding: 'utf8'});
+    return {stdout: result.stdout, stderr: result.stderr, status: result.status};
+}
+
+describe('quiet-tls-warning', function () {
+    it('replaces the Node TLS warning with a single INFO line when the env var is "0"', function () {
+        const {stderr, status} = runHarness({rejectUnauthorized: '0'});
+
+        assert.equal(status, 0, `harness exited non-zero. stderr:\n${stderr}`);
+        // The replacement line is present...
+        assert.ok(
+            stderr.includes('[dev] TLS verification disabled for localhost development'),
+            `expected replacement INFO line, got:\n${stderr}`
+        );
+        // ...and Node's two-line warning + trace-warnings follow-up is gone.
+        assert.ok(
+            !stderr.includes('NODE_TLS_REJECT_UNAUTHORIZED'),
+            `expected Node TLS warning to be suppressed, got:\n${stderr}`
+        );
+        assert.ok(
+            !stderr.includes('Use `node --trace-warnings'),
+            `expected trace-warnings follow-up to be suppressed, got:\n${stderr}`
+        );
+    });
+
+    it('still surfaces other process warnings', function () {
+        const {stderr, status} = runHarness({
+            rejectUnauthorized: '0',
+            extraEmitName: 'DeprecationWarning',
+            extraEmitMessage: 'something-else-is-deprecated'
+        });
+
+        assert.equal(status, 0, `harness exited non-zero. stderr:\n${stderr}`);
+        assert.ok(
+            stderr.includes('DeprecationWarning: something-else-is-deprecated'),
+            `expected unrelated DeprecationWarning to be re-emitted, got:\n${stderr}`
+        );
+        // And the TLS warning is still filtered.
+        assert.ok(
+            !stderr.includes('NODE_TLS_REJECT_UNAUTHORIZED'),
+            `expected Node TLS warning to be suppressed, got:\n${stderr}`
+        );
+    });
+
+    it('does nothing when NODE_TLS_REJECT_UNAUTHORIZED is unset', function () {
+        const {stderr, status} = runHarness({rejectUnauthorized: undefined});
+
+        assert.equal(status, 0, `harness exited non-zero. stderr:\n${stderr}`);
+        assert.ok(
+            !stderr.includes('[dev] TLS verification disabled'),
+            `expected no INFO line when env var is unset, got:\n${stderr}`
+        );
+    });
+});

--- a/ghost/core/test/unit/server/services/explore-ping/explore-ping-service.test.js
+++ b/ghost/core/test/unit/server/services/explore-ping/explore-ping-service.test.js
@@ -41,7 +41,8 @@ describe('ExplorePingService', function () {
 
         loggingStub = {
             info: sinon.stub(),
-            warn: sinon.stub()
+            warn: sinon.stub(),
+            debug: sinon.stub()
         };
 
         ghostVersionStub = {
@@ -277,8 +278,9 @@ describe('ExplorePingService', function () {
             await explorePingService.ping();
 
             sinon.assert.notCalled(requestStub);
-            sinon.assert.calledOnce(loggingStub.warn);
-            assert.equal(loggingStub.warn.firstCall.args[0], 'Explore URL not set');
+            sinon.assert.notCalled(loggingStub.warn);
+            sinon.assert.calledOnce(loggingStub.debug);
+            assert.equal(loggingStub.debug.firstCall.args[0], 'Explore URL not set');
         });
 
         it('does not ping if explore ping is disabled', async function () {

--- a/ghost/core/test/unit/server/services/jobs/job-service-boot-logging.test.js
+++ b/ghost/core/test/unit/server/services/jobs/job-service-boot-logging.test.js
@@ -1,0 +1,132 @@
+const assert = require('node:assert/strict');
+const Module = require('module');
+const sinon = require('sinon');
+
+describe('JobService boot logging summary', function () {
+    const jobServicePath = '../../../../../core/server/services/jobs/job-service';
+    let originalLoad;
+    let loggingStub;
+    let jobService;
+
+    beforeEach(function () {
+        originalLoad = Module._load;
+        loggingStub = {
+            info: sinon.stub(),
+            warn: sinon.stub(),
+            error: sinon.stub()
+        };
+
+        // Fake JobManager that emits the same chatty INFO log lines as the real
+        // @tryghost/job-manager v1.0.9 so we can assert our wrapper filters them
+        // and replaces them with a single summary line.
+        Module._load = function (request, parent, isMain) {
+            if (request === '@tryghost/job-manager') {
+                const logging = loggingStub;
+                return class FakeJobManager {
+                    addJob(opts) {
+                        const {name, at, offloaded = true} = opts || {};
+                        if (offloaded) {
+                            logging.info('Adding offloaded job to the inline job queue');
+                            if (at) {
+                                logging.info(`Scheduling job ${name} at ${at}. Next run on: 2099-01-01T00:00:00.000Z`);
+                            } else {
+                                logging.info(`Scheduling job ${name} to run immediately`);
+                            }
+                        }
+                    }
+
+                    addOneOffJob(opts) {
+                        this.addJob(opts);
+                    }
+                };
+            }
+
+            if (request === '@tryghost/logging') {
+                return loggingStub;
+            }
+
+            if (request === './worker-model-event-bridge') {
+                return class WorkerModelEventBridge {
+                    isModelEventMessage() {
+                        return false;
+                    }
+                    handle() {}
+                };
+            }
+
+            if (request === '../../models') {
+                return {Job: {}};
+            }
+
+            if (request === '../../../shared/sentry') {
+                return {captureException: sinon.stub()};
+            }
+
+            if (request === '@tryghost/domain-events') {
+                return {};
+            }
+
+            if (request === '../../../shared/config') {
+                return {};
+            }
+
+            if (request === '../../lib/common/events') {
+                return {emit: sinon.stub()};
+            }
+
+            return originalLoad.call(this, request, parent, isMain);
+        };
+
+        delete require.cache[require.resolve(jobServicePath)];
+        jobService = require(jobServicePath);
+    });
+
+    afterEach(function () {
+        Module._load = originalLoad;
+        delete require.cache[require.resolve(jobServicePath)];
+        sinon.restore();
+    });
+
+    function flushSummary() {
+        return new Promise((resolve) => {
+            setImmediate(resolve);
+        });
+    }
+
+    it('suppresses the per-job "Scheduling job" and "Adding offloaded" INFO chatter', async function () {
+        jobService.addJob({name: 'one', at: '5 * * * *', job: () => {}});
+        jobService.addJob({name: 'two', at: '10 * * * *', job: () => {}});
+
+        await flushSummary();
+
+        const allMessages = loggingStub.info.getCalls().map(call => call.args[0]);
+        const chattyMessages = allMessages.filter(msg =>
+            typeof msg === 'string'
+            && (msg.startsWith('Adding offloaded job') || msg.startsWith('Scheduling job '))
+        );
+        assert.equal(
+            chattyMessages.length,
+            0,
+            `expected no chatty per-job INFO calls, got: ${JSON.stringify(chattyMessages)}`
+        );
+    });
+
+    it('emits a single summary INFO line covering all registered jobs', async function () {
+        jobService.addJob({name: 'one', at: '5 * * * *', job: () => {}});
+        jobService.addJob({name: 'two', at: '10 * * * *', job: () => {}});
+        jobService.addJob({name: 'three', at: '15 * * * *', job: () => {}});
+        jobService.addJob({name: 'inline-one', offloaded: false, job: () => {}});
+
+        await flushSummary();
+
+        const summaryCalls = loggingStub.info.getCalls()
+            .map(call => call.args[0])
+            .filter(msg => typeof msg === 'string' && msg.startsWith('[Jobs] Registered'));
+        assert.equal(
+            summaryCalls.length,
+            1,
+            `expected exactly one summary line, got: ${JSON.stringify(summaryCalls)}`
+        );
+        assert.equal(summaryCalls[0], '[Jobs] Registered 4 jobs (3 scheduled, 1 inline)');
+    });
+});

--- a/ghost/core/test/unit/server/services/jobs/job-service.test.js
+++ b/ghost/core/test/unit/server/services/jobs/job-service.test.js
@@ -18,6 +18,7 @@ describe('JobService', function () {
                     constructor(options) {
                         workerMessageHandler = options.workerMessageHandler;
                     }
+                    addJob() {}
                 };
             }
 
@@ -121,6 +122,7 @@ describe('JobService model-event bridge wiring', function () {
                     constructor(options) {
                         workerMessageHandler = options.workerMessageHandler;
                     }
+                    addJob() {}
                 };
             }
 
@@ -210,3 +212,4 @@ describe('JobService model-event bridge wiring', function () {
         assert.equal(options.context.internal, true);
     });
 });
+

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "reset:data:empty": "docker exec ghost-dev bash -c 'cd /home/ghost/ghost/core && node index.js generate-data --clear-database --quantities members:0,posts:0 --seed 123'",
     "reset:data:xxl": "docker exec ghost-dev bash -c 'cd /home/ghost/ghost/core && node index.js generate-data --clear-database --quantities members:2000000,posts:0,emails:0,members_stripe_customers:0,members_login_events:0,members_status_events:0 --seed 123'",
     "seed:multi-sub-scenarios": "docker exec ghost-dev bash -c 'cd /home/ghost/ghost/core && node scripts/seed-multi-sub-scenarios.js'",
-    "docker:build": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} build",
+    "docker:build": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} build --quiet",
     "docker:clean": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} --profile all down -v --remove-orphans --rmi local",
     "docker:down": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} down",
     "docker:rebase": "git fetch ${GHOST_UPSTREAM:-origin} main && git rebase ${GHOST_UPSTREAM:-origin}/main && pnpm install && pnpm nx run-many -t build --projects=@tryghost/shade,@tryghost/admin-x-design-system,@tryghost/admin-x-framework && docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} up -d --build --force-recreate ghost-dev",
@@ -108,7 +108,7 @@
       "docker:up": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} up -d --force-recreate --wait"
+          "command": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} up -d --force-recreate --wait --quiet-pull"
         },
         "dependsOn": [
           "docker:build"
@@ -123,7 +123,7 @@
       "docker:build": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} build"
+          "command": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} build --quiet"
         }
       },
       "docker:dev": {


### PR DESCRIPTION
## ⚠️ Do not merge this branch

Combined view of 3 dev-noise PRs (A + B + C) cherry-picked onto one branch so the cumulative impact is visible in a single diff. The individual PRs are the ones to merge.

This is the "second round" — after the 7 dev-noise PRs from earlier (#28981/82/83/84/94/96/97 — combined-view at #28998), this batch targets the remaining noise that those PRs didn't touch: Docker infrastructure, ghost-core boot logs, and Caddyfile whitespace.

## Included PRs (cherry-pick order)

| # | Title | Approx noise removed |
|---|---|---|
| [#29000](https://github.com/TryGhost/Ghost/pull/29000) | Quieted Docker layer of pnpm dev boot output | **~122 lines/boot** (compose build 115→4, Mailpit 3→0, Redis 7→4, MySQL warns gone) |
| [#29001](https://github.com/TryGhost/Ghost/pull/29001) | Cleaned up noisy boot-time logging in ghost/core | ~22 lines/boot (JobsService 20→1 summary, Explore URL warn gone, NODE_TLS warning replaced with one informative INFO) |
| [#28999](https://github.com/TryGhost/Ghost/pull/28999) | Reformatted dev-gateway Caddyfile via caddy fmt | 1 boot-time warning gone + canonical formatting going forward |

## Combined estimate

A fresh `pnpm dev:daemon` boot drops roughly **another 145 lines** on top of whatever the first 7 PRs deliver. With both rounds merged the visible boot log should be down to mostly real signal (build progress that actually changed, real HTTP requests, real ERROR/WARN).

## How to inspect

```
git fetch origin all-noise-abc-combined
git checkout all-noise-abc-combined
pnpm install --frozen-lockfile && git submodule update --init --recursive
pnpm dev:daemon
```

Diff vs main: 12 files, +556 / −213. Most of the line count is the Caddyfile whitespace reformat (`git diff -w` on Caddyfile is empty).

## Cherry-pick conflicts

Zero. All 3 PRs apply cleanly to current main in this order — they touch disjoint files.
