### PR TITLE
Added browser-safe i18n entrypoint

### DIFF
--- a/ghost/i18n/index.browser.js
+++ b/ghost/i18n/index.browser.js
@@ -1,0 +1,8 @@
+const i18n = require('./lib/i18n.browser');
+
+// Explicit exports for better bundler compatibility
+module.exports = i18n;
+module.exports.default = i18n;
+module.exports.LOCALE_DATA = i18n.LOCALE_DATA;
+module.exports.SUPPORTED_LOCALES = i18n.SUPPORTED_LOCALES;
+module.exports.generateResources = i18n.generateResources;

--- a/ghost/i18n/lib/i18n-core.js
+++ b/ghost/i18n/lib/i18n-core.js
@@ -1,0 +1,80 @@
+const i18next = require('i18next');
+
+// Locale data loaded from JSON (single source of truth)
+const LOCALE_DATA = require('./locale-data.json');
+
+// Export just the locale codes for backward compatibility
+const SUPPORTED_LOCALES = LOCALE_DATA.map(locale => locale.code);
+
+function generateResources(locales, ns) {
+    return locales.reduce((acc, locale) => {
+        let res;
+        // add an extra fallback - this handles the case where we have a partial set of translations for some reason
+        // by falling back to the english translations
+        try {
+            res = require(`../locales/${locale}/${ns}.json`);
+        } catch (err) {
+            res = require(`../locales/en/${ns}.json`);
+        }
+
+        // Note: due some random thing in TypeScript, 'requiring' a JSON file with a space in a key name, only adds it to the default export
+        // If changing this behaviour, please also check the comments and signup-form apps in another language (mainly sentences with a space in them)
+        acc[locale] = {
+            [ns]: {...res, ...(res.default && typeof res.default === 'object' ? res.default : {})}
+        };
+        return acc;
+    }, {});
+}
+
+function createI18n({generateThemeResources}) {
+    return (lng = 'en', ns = 'portal', options = {}) => {
+        const i18nextInstance = i18next.createInstance();
+        const interpolation = {
+            prefix: '{',
+            suffix: '}'
+        };
+        if (ns === 'theme' || ns === 'portal') {
+            interpolation.escapeValue = false;
+        }
+        let resources;
+        if (ns !== 'theme') {
+            resources = generateResources(SUPPORTED_LOCALES, ns);
+        } else {
+            resources = generateThemeResources(lng, options);
+        }
+
+        i18nextInstance.init({
+            lng,
+
+            // allow keys to be phrases having `:`, `.`
+            nsSeparator: false,
+            keySeparator: false,
+
+            // if the value is an empty string, return the key
+            returnEmptyString: false,
+
+            // do not load a fallback
+            fallbackLng: {
+                no: ['nb', 'en'],
+                default: ['en']
+            },
+
+            ns: ns,
+            defaultNS: ns,
+
+            // separators
+            interpolation,
+
+            resources
+        });
+
+        return i18nextInstance;
+    };
+}
+
+module.exports = {
+    createI18n,
+    generateResources,
+    LOCALE_DATA,
+    SUPPORTED_LOCALES
+};

--- a/ghost/i18n/lib/i18n.browser.js
+++ b/ghost/i18n/lib/i18n.browser.js
@@ -1,0 +1,16 @@
+const {createI18n, generateResources, LOCALE_DATA, SUPPORTED_LOCALES} = require('./i18n-core');
+
+function generateThemeResources(lng) {
+    return {
+        [lng]: {
+            theme: {}
+        }
+    };
+}
+
+const i18n = createI18n({generateThemeResources});
+
+module.exports = i18n;
+module.exports.SUPPORTED_LOCALES = SUPPORTED_LOCALES;
+module.exports.LOCALE_DATA = LOCALE_DATA;
+module.exports.generateResources = generateResources;

--- a/ghost/i18n/lib/i18n.js
+++ b/ghost/i18n/lib/i18n.js
@@ -1,33 +1,7 @@
-const i18next = require('i18next');
 const path = require('path');
 const fs = require('fs');
 const debug = require('@tryghost/debug')('i18n');
-
-// Locale data loaded from JSON (single source of truth)
-const LOCALE_DATA = require('./locale-data.json');
-
-// Export just the locale codes for backward compatibility
-const SUPPORTED_LOCALES = LOCALE_DATA.map(locale => locale.code);
-
-function generateResources(locales, ns) {
-    return locales.reduce((acc, locale) => {
-        let res;
-        // add an extra fallback - this handles the case where we have a partial set of translations for some reason
-        // by falling back to the english translations
-        try {
-            res = require(`../locales/${locale}/${ns}.json`);
-        } catch (err) {
-            res = require(`../locales/en/${ns}.json`);
-        }
-
-        // Note: due some random thing in TypeScript, 'requiring' a JSON file with a space in a key name, only adds it to the default export
-        // If changing this behaviour, please also check the comments and signup-form apps in another language (mainly sentences with a space in them)
-        acc[locale] = {
-            [ns]: {...res, ...(res.default && typeof res.default === 'object' ? res.default : {})}
-        };
-        return acc;
-    }, {});
-}
+const {createI18n, generateResources, LOCALE_DATA, SUPPORTED_LOCALES} = require('./i18n-core');
 
 function generateThemeResources(lng, themeLocalesPath) {
     if (!themeLocalesPath) {
@@ -101,55 +75,14 @@ function generateThemeResources(lng, themeLocalesPath) {
     }, {});
 }
 
-/**
- * @param {string} [lng]
- * @param {'ghost'|'portal'|'test'|'signup-form'|'comments'|'search'|'theme'} ns
- */
-module.exports = (lng = 'en', ns = 'portal', options = {}) => {
-    const i18nextInstance = i18next.createInstance();
-    const interpolation = {
-        prefix: '{',
-        suffix: '}'
-    };
-    if (ns === 'theme' || ns === 'portal') {
-        interpolation.escapeValue = false;
-    }
-    let resources;
-    if (ns !== 'theme') {
-        resources = generateResources(SUPPORTED_LOCALES, ns);
-    } else {
+const i18n = createI18n({
+    generateThemeResources(lng, options) {
         debug(`generateThemeResources: ${lng}, ${options.themePath}`);
-        resources = generateThemeResources(lng, options.themePath);
+        return generateThemeResources(lng, options.themePath);
     }
-    
-    i18nextInstance.init({
-        lng,
+});
 
-        // allow keys to be phrases having `:`, `.`
-        nsSeparator: false,
-        keySeparator: false,
-
-        // if the value is an empty string, return the key
-        returnEmptyString: false,
-
-        // do not load a fallback
-        fallbackLng: {
-            no: ['nb', 'en'],
-            default: ['en']
-        },
-
-        ns: ns,
-        defaultNS: ns,
-
-        // separators
-        interpolation,
-
-        resources
-    });
-
-    return i18nextInstance;
-};
-
+module.exports = i18n;
 module.exports.SUPPORTED_LOCALES = SUPPORTED_LOCALES;
 module.exports.LOCALE_DATA = LOCALE_DATA;
 module.exports.generateResources = generateResources;

--- a/ghost/i18n/package.json
+++ b/ghost/i18n/package.json
@@ -6,8 +6,15 @@
   "private": true,
   "main": "index.js",
   "exports": {
-    ".": "./index.js",
+    ".": {
+      "browser": "./index.browser.js",
+      "default": "./index.js"
+    },
     "./lib/locale-data.json": "./lib/locale-data.json"
+  },
+  "browser": {
+    "./index.js": "./index.browser.js",
+    "./lib/i18n.js": "./lib/i18n.browser.js"
   },
   "types": "./build/i18n.d.ts",
   "scripts": {
@@ -27,6 +34,7 @@
   },
   "files": [
     "index.js",
+    "index.browser.js",
     "lib",
     "locales"
   ],

--- a/ghost/i18n/test/i18n.test.js
+++ b/ghost/i18n/test/i18n.test.js
@@ -5,6 +5,85 @@ const fsExtra = require('fs-extra');
 const i18n = require('../');
 
 describe('i18n', function () {
+    describe('browser entry', function () {
+        const browserI18n = require('../index.browser');
+
+        it('loads bundled public app translations without server-only helpers', function () {
+            const t = browserI18n('nl', 'portal').t;
+
+            assert.equal(t('Name'), 'Naam');
+        });
+
+        it('uses the default namespace and locale', function () {
+            const t = browserI18n().t;
+
+            assert.equal(t('Name'), 'Name');
+        });
+
+        it('uses single curly braces for browser interpolation', function () {
+            const portalT = browserI18n('en', 'portal').t;
+            const ghostT = browserI18n('en', 'ghost').t;
+
+            assert.equal(portalT('Welcome, {name}', {name: '<b>John O\'Nolan</b>'}), 'Welcome, <b>John O\'Nolan</b>');
+            assert.equal(ghostT('Welcome, {name}', {name: 'John'}), 'Welcome, John');
+        });
+
+        it('uses default export translations when available', function () {
+            const translationFile = require(path.join(`../locales/`, 'nl', 'portal.json'));
+            const originalName = translationFile.Name;
+            const originalDefault = translationFile.default;
+
+            translationFile.Name = undefined;
+            translationFile.default = {
+                Name: 'Naam'
+            };
+
+            try {
+                const t = browserI18n('nl', 'portal').t;
+                assert.equal(t('Name'), 'Naam');
+            } finally {
+                translationFile.Name = originalName;
+                if (originalDefault === undefined) {
+                    delete translationFile.default;
+                } else {
+                    translationFile.default = originalDefault;
+                }
+            }
+        });
+
+        it('ignores non-object default exports', function () {
+            const translationFile = require(path.join(`../locales/`, 'nl', 'portal.json'));
+            const originalDefault = translationFile.default;
+
+            translationFile.default = 'not an object';
+
+            try {
+                const t = browserI18n('nl', 'portal').t;
+                assert.equal(t('Name'), 'Naam');
+            } finally {
+                if (originalDefault === undefined) {
+                    delete translationFile.default;
+                } else {
+                    translationFile.default = originalDefault;
+                }
+            }
+        });
+
+        it('falls back to English for missing bundled locales', function () {
+            const resources = browserI18n.generateResources(['xx'], 'portal');
+            const englishResources = browserI18n.generateResources(['en'], 'portal');
+
+            assert.deepEqual(resources.xx, englishResources.en);
+        });
+
+        it('uses empty theme resources in browser builds', function () {
+            const instance = browserI18n('en', 'theme');
+
+            assert.deepEqual(instance.store.data.en.theme, {});
+            assert.equal(instance.t('Read more'), 'Read more');
+        });
+    });
+
     it('does not have too-long strings for the Stripe personal note label', async function () {
         for (const locale of i18n.SUPPORTED_LOCALES) {
             const translationFile = require(path.join(`../locales/`, locale, 'portal.json'));


### PR DESCRIPTION
## Summary

- Adds a browser conditional entrypoint for `@tryghost/i18n` so Vite public-app builds resolve `index.browser.js` instead of the Node/server entry.
- Extracts the shared i18next setup and bundled-locale resource loading into `lib/i18n-core.js`.
- Keeps the Node entry's filesystem-backed theme locale loading in `lib/i18n.js`, while the browser entry uses empty theme resources because browsers cannot read theme locale directories.
- Removes the `fs`/`path`/`@tryghost/debug`/`@tryghost/root-utils`/`find-root` chain from public browser bundles instead of filtering Vite's externalized-module warnings.

## Context

Vite was warning during public app builds because browser bundles imported `@tryghost/i18n`, whose current entrypoint includes Node-only filesystem theme helpers and imports `@tryghost/debug`. That debug helper imports `@tryghost/root-utils`, which imports `find-root`, `fs`, and `path`.

This PR keeps that behavior for Node consumers, but gives browser-aware bundlers a browser-safe entrypoint.

Follow-up to https://github.com/TryGhost/Ghost/pull/28984.

## Verification

- `pnpm --filter @tryghost/i18n test:base`
- `pnpm --filter @tryghost/i18n lint:code`
- `pnpm --filter @tryghost/i18n test`
- `pnpm --filter @tryghost/portal --filter @tryghost/comments-ui --filter @tryghost/sodo-search --filter @tryghost/announcement-bar --filter @tryghost/signup-form --filter @tryghost/admin-toolbar build`
- Confirmed the public-app build log contains no `externalized for browser compatibility` warnings.
- Confirmed emitted public app JS no longer contains `@tryghost/root-utils`, `find-root`, or the Node `ghost/i18n/lib/i18n.js` path.
- Confirmed default Node resolution still uses `index.js`, while `node --conditions=browser` resolves `index.browser.js`.

## Review note

I also ran a review subagent over the current diff. It found no blockers. Residual risk noted: the new browser entry is still CommonJS, so bare Vite/Rollup setups without Ghost's existing CommonJS handling may need equivalent handling. The actual Ghost public app builds passed.
