### PR TITLE
Added gift-link analytics journey E2E test

### DIFF
--- a/apps/posts/src/views/PostAnalytics/Overview/overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/overview.tsx
@@ -230,7 +230,7 @@ const Overview: React.FC = () => {
                                             <span className='text-sm text-muted-foreground'>
                                                 Visitors
                                             </span>
-                                            <span className='text-[2.2rem] leading-none font-semibold'>
+                                            <span className='text-[2.2rem] leading-none font-semibold' data-testid='gift-link-card-visitors'>
                                                 {formatNumber(giftLinkUsage?.visits ?? 0)}
                                             </span>
                                         </CardContent>

--- a/e2e/helpers/pages/admin/analytics/analytics-web-traffic-page.ts
+++ b/e2e/helpers/pages/admin/analytics/analytics-web-traffic-page.ts
@@ -55,8 +55,9 @@ export class AnalyticsWebTrafficPage extends AdminPage {
     }
 
     getFilterOptionValue(name: string): Locator {
-        // Filter option values show as "count name" (e.g., "1 Direct"), so use regex
-        return this.page.getByRole('option', {name: new RegExp(`^\\d+\\s+${name}$`)});
+        // Filter option values usually show as "count name" (e.g., "1 Direct");
+        // some dimensions (e.g. Gift link) show a plain label without a count
+        return this.page.getByRole('option', {name: new RegExp(`^(\\d+\\s+)?${name}$`)});
     }
 
     async selectFilterField(label: string) {

--- a/e2e/helpers/pages/admin/analytics/post-analytics/index.ts
+++ b/e2e/helpers/pages/admin/analytics/post-analytics/index.ts
@@ -1,3 +1,4 @@
 export * from './post-analytics-page';
 export * from './post-analytics-growth-page';
+export * from './post-analytics-overview-page';
 export * from './post-analytics-web-traffic-page';

--- a/e2e/helpers/pages/admin/analytics/post-analytics/post-analytics-overview-page.ts
+++ b/e2e/helpers/pages/admin/analytics/post-analytics/post-analytics-overview-page.ts
@@ -1,0 +1,31 @@
+import {AdminPage} from '@/admin-pages';
+import {Locator, Page} from '@playwright/test';
+
+export class PostAnalyticsOverviewPage extends AdminPage {
+    readonly giftLinkCard: Locator;
+    readonly shareGiftLinkButton: Locator;
+    readonly giftLinkVisitorsBadge: Locator;
+
+    constructor(page: Page) {
+        super(page);
+        this.pageUrl = '/ghost/#/posts/analytics';
+
+        this.giftLinkCard = page.getByTestId('gift-link-card');
+        this.shareGiftLinkButton = this.giftLinkCard.getByRole('button', {name: 'Share'});
+        // Badge inside the gift-link share modal showing the visitor count.
+        this.giftLinkVisitorsBadge = page.getByTestId('gift-link-views');
+    }
+
+    setPostId(postId: string) {
+        this.pageUrl = `/ghost/#/posts/analytics/${postId}`;
+    }
+
+    async gotoForPost(postId: string) {
+        this.setPostId(postId);
+        await this.goto();
+    }
+
+    async openShareModal() {
+        await this.shareGiftLinkButton.click();
+    }
+}

--- a/e2e/helpers/pages/admin/analytics/post-analytics/post-analytics-overview-page.ts
+++ b/e2e/helpers/pages/admin/analytics/post-analytics/post-analytics-overview-page.ts
@@ -5,6 +5,8 @@ export class PostAnalyticsOverviewPage extends AdminPage {
     readonly giftLinkCard: Locator;
     readonly shareGiftLinkButton: Locator;
     readonly giftLinkVisitorsBadge: Locator;
+    readonly giftLinkCardVisitors: Locator;
+    readonly copyGiftLinkButton: Locator;
 
     constructor(page: Page) {
         super(page);
@@ -13,6 +15,8 @@ export class PostAnalyticsOverviewPage extends AdminPage {
         this.giftLinkCard = page.getByTestId('gift-link-card');
         this.shareGiftLinkButton = this.giftLinkCard.getByRole('button', {name: 'Share'});
         this.giftLinkVisitorsBadge = page.getByTestId('gift-link-views');
+        this.giftLinkCardVisitors = page.getByTestId('gift-link-card-visitors');
+        this.copyGiftLinkButton = page.getByTestId('copy-gift-link');
     }
 
     setPostId(postId: string) {
@@ -26,5 +30,23 @@ export class PostAnalyticsOverviewPage extends AdminPage {
 
     async openShareModal() {
         await this.shareGiftLinkButton.click();
+    }
+
+    // Analytics is a hash route, so re-navigating to it is a same-document change
+    // that won't refetch; reload to pull freshly ingested data.
+    async refreshData() {
+        await this.page.reload();
+    }
+
+    /**
+     * Copy the gift link from the share modal the way a user would, then read it
+     * back off the clipboard. The button is disabled until the link is minted, so
+     * the click auto-waits for a real URL; the clipboard write is async, so poll
+     * until it lands before reading. Requires clipboard permissions on the context.
+     */
+    async copyGiftLinkUrl(): Promise<string> {
+        await this.copyGiftLinkButton.click();
+        await this.page.waitForFunction(async () => (await navigator.clipboard.readText()).includes('?gift='));
+        return this.page.evaluate(() => navigator.clipboard.readText());
     }
 }

--- a/e2e/helpers/pages/admin/analytics/post-analytics/post-analytics-overview-page.ts
+++ b/e2e/helpers/pages/admin/analytics/post-analytics/post-analytics-overview-page.ts
@@ -12,7 +12,6 @@ export class PostAnalyticsOverviewPage extends AdminPage {
 
         this.giftLinkCard = page.getByTestId('gift-link-card');
         this.shareGiftLinkButton = this.giftLinkCard.getByRole('button', {name: 'Share'});
-        // Badge inside the gift-link share modal showing the visitor count.
         this.giftLinkVisitorsBadge = page.getByTestId('gift-link-views');
     }
 

--- a/e2e/helpers/pages/admin/analytics/post-analytics/post-analytics-overview-page.ts
+++ b/e2e/helpers/pages/admin/analytics/post-analytics/post-analytics-overview-page.ts
@@ -2,11 +2,11 @@ import {AdminPage} from '@/admin-pages';
 import {Locator, Page} from '@playwright/test';
 
 export class PostAnalyticsOverviewPage extends AdminPage {
-    readonly giftLinkCard: Locator;
-    readonly shareGiftLinkButton: Locator;
-    readonly giftLinkVisitorsBadge: Locator;
-    readonly giftLinkCardVisitors: Locator;
-    readonly copyGiftLinkButton: Locator;
+    public readonly giftLinkVisitorsBadge: Locator;
+    public readonly giftLinkCardVisitors: Locator;
+    private readonly giftLinkCard: Locator;
+    private readonly shareGiftLinkButton: Locator;
+    private readonly giftLinkUrlText: Locator;
 
     constructor(page: Page) {
         super(page);
@@ -16,37 +16,21 @@ export class PostAnalyticsOverviewPage extends AdminPage {
         this.shareGiftLinkButton = this.giftLinkCard.getByRole('button', {name: 'Share'});
         this.giftLinkVisitorsBadge = page.getByTestId('gift-link-views');
         this.giftLinkCardVisitors = page.getByTestId('gift-link-card-visitors');
-        this.copyGiftLinkButton = page.getByTestId('copy-gift-link');
-    }
-
-    setPostId(postId: string) {
-        this.pageUrl = `/ghost/#/posts/analytics/${postId}`;
+        this.giftLinkUrlText = page.getByRole('dialog').getByText(/\?gift=/);
     }
 
     async gotoForPost(postId: string) {
-        this.setPostId(postId);
-        await this.goto();
+        await this.goto(`/ghost/#/posts/analytics/${postId}`);
     }
 
     async openShareModal() {
         await this.shareGiftLinkButton.click();
     }
 
-    // Analytics is a hash route, so re-navigating to it is a same-document change
-    // that won't refetch; reload to pull freshly ingested data.
-    async refreshData() {
-        await this.page.reload();
-    }
-
-    /**
-     * Copy the gift link from the share modal the way a user would, then read it
-     * back off the clipboard. The button is disabled until the link is minted, so
-     * the click auto-waits for a real URL; the clipboard write is async, so poll
-     * until it lands before reading. Requires clipboard permissions on the context.
-     */
-    async copyGiftLinkUrl(): Promise<string> {
-        await this.copyGiftLinkButton.click();
-        await this.page.waitForFunction(async () => (await navigator.clipboard.readText()).includes('?gift='));
-        return this.page.evaluate(() => navigator.clipboard.readText());
+    // The share modal mints the link on open and swaps the "Generating link…"
+    // placeholder for the real URL, so waiting for `?gift=` covers minting.
+    async giftLinkUrl(): Promise<string> {
+        await this.giftLinkUrlText.waitFor({state: 'visible'});
+        return await this.giftLinkUrlText.innerText();
     }
 }

--- a/e2e/tests/admin/analytics/gift-link-journey.test.ts
+++ b/e2e/tests/admin/analytics/gift-link-journey.test.ts
@@ -1,0 +1,68 @@
+import {AnalyticsWebTrafficPage, PostAnalyticsOverviewPage} from '@/admin-pages';
+import {Browser, Page} from '@playwright/test';
+import {PublicPage} from '@/public-pages';
+import {createPostFactory} from '@/data-factory';
+import {expect, test, withIsolatedPage} from '@/helpers/playwright';
+
+// The gift-link analytics journey exercises the full pipeline: a public gift read
+// fires the real ghost-stats beacon, which flows through the TrafficAnalytics proxy
+// into Tinybird, and the count surfaces back in admin. It can only pass once the
+// proxy carries the gift_link field (TryGhost/TrafficAnalytics#742) and the
+// analytics-lane proxy image is bumped to include it — until then the pinned proxy
+// rebuilds the page-hit payload and drops gift_link, so the beacon never carries it.
+// Flip GIFT_LINK_PROXY_READY on (and bump the proxy image) to enable.
+const GIFT_LINK_PROXY_READY = process.env.GIFT_LINK_PROXY_READY === 'true';
+
+async function recordGiftVisit({page, browser, baseURL}: {page: Page; browser: Browser; baseURL?: string}) {
+    const postFactory = createPostFactory(page.request);
+    const post = await postFactory.create({
+        title: 'Gifted paid post',
+        status: 'published',
+        visibility: 'paid'
+    });
+
+    const response = await page.request.put(`/ghost/api/admin/posts/${post.id}/gift_links`);
+    const {gift_links: giftLinks} = await response.json();
+    const token = giftLinks[0].token;
+
+    // Visiting in an isolated context fires the real beacon; in the analytics
+    // project PublicPage.goto waits for the page-hit request to complete, and the
+    // proxy runs with TINYBIRD_WAIT=true, so the hit is ingested before we assert.
+    await withIsolatedPage(browser, {baseURL}, async ({page: publicPage}) => {
+        const giftReadPage = new PublicPage(publicPage);
+        await giftReadPage.goto(`/${post.slug}/?gift=${encodeURIComponent(token)}`);
+    });
+
+    return {post, token};
+}
+
+test.describe('Ghost Admin - Gift link analytics journey', () => {
+    test.use({labs: {giftLinks: true}});
+
+    test.beforeEach(() => {
+        test.skip(!GIFT_LINK_PROXY_READY, 'Requires gift_link passthrough in the analytics proxy (TryGhost/TrafficAnalytics#742) + the compose image bump');
+    });
+
+    test('visiting a gift link - records one visitor on the per-link count', async ({page, browser, baseURL}) => {
+        const {post} = await recordGiftVisit({page, browser, baseURL});
+
+        const overview = new PostAnalyticsOverviewPage(page);
+        await overview.gotoForPost(post.id);
+        await overview.openShareModal();
+
+        await expect(overview.giftLinkVisitorsBadge).toHaveText('1 visitor');
+    });
+
+    test('filtering web traffic by gift link - scopes visitors to the gift read', async ({page, browser, baseURL}) => {
+        await recordGiftVisit({page, browser, baseURL});
+
+        const webTraffic = new AnalyticsWebTrafficPage(page);
+        await webTraffic.goto();
+        await webTraffic.openFilterPopover();
+        await webTraffic.selectFilterField('Gift link');
+        await webTraffic.selectFilterField('used');
+
+        await expect(webTraffic.getActiveFilter('Gift link')).toBeVisible();
+        await expect(webTraffic.totalUniqueVisitorsTab).toContainText('1');
+    });
+});

--- a/e2e/tests/admin/analytics/gift-link-journey.test.ts
+++ b/e2e/tests/admin/analytics/gift-link-journey.test.ts
@@ -4,7 +4,12 @@ import {PublicPage} from '@/public-pages';
 import {createPostFactory} from '@/data-factory';
 import {expect, test, withIsolatedPage} from '@/helpers/playwright';
 
-async function recordGiftVisit({page, browser, baseURL}: {page: Page; browser: Browser; baseURL?: string}) {
+// Drives the whole gift-link journey through the UI: mint the link from the share
+// modal's copy button, then read the gifted post in a fresh browser so the real
+// analytics beacon fires. In the analytics project PublicPage.goto waits for the
+// page-hit request and the proxy runs with TINYBIRD_WAIT=true, so the visit is
+// ingested by the time we return and assert on the admin side.
+async function createGiftLinkThenVisit({page, browser, baseURL}: {page: Page; browser: Browser; baseURL?: string}) {
     const postFactory = createPostFactory(page.request);
     const post = await postFactory.create({
         title: 'Gifted paid post',
@@ -12,36 +17,37 @@ async function recordGiftVisit({page, browser, baseURL}: {page: Page; browser: B
         visibility: 'paid'
     });
 
-    const response = await page.request.put(`/ghost/api/admin/posts/${post.id}/gift_links`);
-    const {gift_links: giftLinks} = await response.json();
-    const token = giftLinks[0].token;
+    await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
 
-    // Visiting in an isolated context fires the real beacon; in the analytics
-    // project PublicPage.goto waits for the page-hit request to complete, and the
-    // proxy runs with TINYBIRD_WAIT=true, so the hit is ingested before we assert.
+    const overview = new PostAnalyticsOverviewPage(page);
+    await overview.gotoForPost(post.id);
+    await overview.openShareModal();
+    const giftUrl = await overview.copyGiftLinkUrl();
+
     await withIsolatedPage(browser, {baseURL}, async ({page: publicPage}) => {
-        const giftReadPage = new PublicPage(publicPage);
-        await giftReadPage.goto(`/${post.slug}/?gift=${encodeURIComponent(token)}`);
+        const {pathname, search} = new URL(giftUrl);
+        await new PublicPage(publicPage).goto(`${pathname}${search}`);
     });
 
-    return {post, token};
+    return {post, overview};
 }
 
 test.describe('Ghost Admin - Gift link analytics journey', () => {
     test.use({labs: {giftLinks: true}});
 
-    test('visiting a gift link - records one visitor on the per-link count', async ({page, browser, baseURL}) => {
-        const {post} = await recordGiftVisit({page, browser, baseURL});
+    test('creating a gift link then visiting it - counts the visitor on the post gift-link card', async ({page, browser, baseURL}) => {
+        const {overview} = await createGiftLinkThenVisit({page, browser, baseURL});
 
-        const overview = new PostAnalyticsOverviewPage(page);
-        await overview.gotoForPost(post.id);
-        await overview.openShareModal();
+        // The card fetches its usage once on load, so reload to pull the visit we
+        // just recorded — the reload-then-assert guard the other analytics visit
+        // tests rely on.
+        await overview.refreshData();
 
-        await expect(overview.giftLinkVisitorsBadge).toHaveText('1 visitor');
+        await expect(overview.giftLinkCardVisitors).toHaveText('1');
     });
 
-    test('filtering web traffic by gift link - scopes visitors to the gift read', async ({page, browser, baseURL}) => {
-        await recordGiftVisit({page, browser, baseURL});
+    test('creating a gift link then visiting it - scopes the web traffic filter to the gift read', async ({page, browser, baseURL}) => {
+        await createGiftLinkThenVisit({page, browser, baseURL});
 
         const webTraffic = new AnalyticsWebTrafficPage(page);
         await webTraffic.goto();

--- a/e2e/tests/admin/analytics/gift-link-journey.test.ts
+++ b/e2e/tests/admin/analytics/gift-link-journey.test.ts
@@ -4,12 +4,6 @@ import {PublicPage} from '@/public-pages';
 import {createPostFactory} from '@/data-factory';
 import {expect, test, withIsolatedPage} from '@/helpers/playwright';
 
-// The full journey (public gift read → ghost-stats beacon → TrafficAnalytics proxy
-// → Tinybird → admin count) only works once the proxy carries gift_link
-// (TryGhost/TrafficAnalytics#742) and the analytics-lane image is bumped to include
-// it. Until then the pinned proxy drops gift_link; flip this on to enable.
-const GIFT_LINK_PROXY_READY = process.env.GIFT_LINK_PROXY_READY === 'true';
-
 async function recordGiftVisit({page, browser, baseURL}: {page: Page; browser: Browser; baseURL?: string}) {
     const postFactory = createPostFactory(page.request);
     const post = await postFactory.create({
@@ -35,10 +29,6 @@ async function recordGiftVisit({page, browser, baseURL}: {page: Page; browser: B
 
 test.describe('Ghost Admin - Gift link analytics journey', () => {
     test.use({labs: {giftLinks: true}});
-
-    test.beforeEach(() => {
-        test.skip(!GIFT_LINK_PROXY_READY, 'Requires gift_link passthrough in the analytics proxy (TryGhost/TrafficAnalytics#742) + the compose image bump');
-    });
 
     test('visiting a gift link - records one visitor on the per-link count', async ({page, browser, baseURL}) => {
         const {post} = await recordGiftVisit({page, browser, baseURL});

--- a/e2e/tests/admin/analytics/gift-link-journey.test.ts
+++ b/e2e/tests/admin/analytics/gift-link-journey.test.ts
@@ -4,13 +4,10 @@ import {PublicPage} from '@/public-pages';
 import {createPostFactory} from '@/data-factory';
 import {expect, test, withIsolatedPage} from '@/helpers/playwright';
 
-// The gift-link analytics journey exercises the full pipeline: a public gift read
-// fires the real ghost-stats beacon, which flows through the TrafficAnalytics proxy
-// into Tinybird, and the count surfaces back in admin. It can only pass once the
-// proxy carries the gift_link field (TryGhost/TrafficAnalytics#742) and the
-// analytics-lane proxy image is bumped to include it — until then the pinned proxy
-// rebuilds the page-hit payload and drops gift_link, so the beacon never carries it.
-// Flip GIFT_LINK_PROXY_READY on (and bump the proxy image) to enable.
+// The full journey (public gift read → ghost-stats beacon → TrafficAnalytics proxy
+// → Tinybird → admin count) only works once the proxy carries gift_link
+// (TryGhost/TrafficAnalytics#742) and the analytics-lane image is bumped to include
+// it. Until then the pinned proxy drops gift_link; flip this on to enable.
 const GIFT_LINK_PROXY_READY = process.env.GIFT_LINK_PROXY_READY === 'true';
 
 async function recordGiftVisit({page, browser, baseURL}: {page: Page; browser: Browser; baseURL?: string}) {

--- a/e2e/tests/admin/analytics/gift-link-journey.test.ts
+++ b/e2e/tests/admin/analytics/gift-link-journey.test.ts
@@ -1,61 +1,43 @@
 import {AnalyticsWebTrafficPage, PostAnalyticsOverviewPage} from '@/admin-pages';
-import {Browser, Page} from '@playwright/test';
 import {PublicPage} from '@/public-pages';
 import {createPostFactory} from '@/data-factory';
 import {expect, test, withIsolatedPage} from '@/helpers/playwright';
 
-// Drives the whole gift-link journey through the UI: mint the link from the share
-// modal's copy button, then read the gifted post in a fresh browser so the real
-// analytics beacon fires. In the analytics project PublicPage.goto waits for the
-// page-hit request and the proxy runs with TINYBIRD_WAIT=true, so the visit is
-// ingested by the time we return and assert on the admin side.
-async function createGiftLinkThenVisit({page, browser, baseURL}: {page: Page; browser: Browser; baseURL?: string}) {
-    const postFactory = createPostFactory(page.request);
-    const post = await postFactory.create({
-        title: 'Gifted paid post',
-        status: 'published',
-        visibility: 'paid'
-    });
-
-    await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
-
-    const overview = new PostAnalyticsOverviewPage(page);
-    await overview.gotoForPost(post.id);
-    await overview.openShareModal();
-    const giftUrl = await overview.copyGiftLinkUrl();
-
-    await withIsolatedPage(browser, {baseURL}, async ({page: publicPage}) => {
-        const {pathname, search} = new URL(giftUrl);
-        await new PublicPage(publicPage).goto(`${pathname}${search}`);
-    });
-
-    return {post, overview};
-}
-
+// One journey, asserted on every surface it feeds: mint the link in the share
+// modal, read the gifted post in a fresh browser so the real analytics beacon
+// fires (in the analytics project PublicPage.goto waits for the page-hit request
+// and the proxy ingests synchronously), then check the admin side.
 test.describe('Ghost Admin - Gift link analytics journey', () => {
-    test.use({labs: {giftLinks: true}});
+    test('creating a gift link then visiting it - counts the visitor across analytics surfaces', async ({page, browser, baseURL}) => {
+        const postFactory = createPostFactory(page.request);
+        const post = await postFactory.create({
+            title: 'Gifted paid post',
+            status: 'published',
+            visibility: 'paid'
+        });
+        const overview = new PostAnalyticsOverviewPage(page);
+        await overview.gotoForPost(post.id);
+        await overview.openShareModal();
+        const giftUrl = await overview.giftLinkUrl();
 
-    test('creating a gift link then visiting it - counts the visitor on the post gift-link card', async ({page, browser, baseURL}) => {
-        const {overview} = await createGiftLinkThenVisit({page, browser, baseURL});
-
-        // The card fetches its usage once on load, so reload to pull the visit we
-        // just recorded — the reload-then-assert guard the other analytics visit
-        // tests rely on.
-        await overview.refreshData();
+        await withIsolatedPage(browser, {baseURL}, async ({page: publicPage}) => {
+            const {pathname, search} = new URL(giftUrl);
+            await new PublicPage(publicPage).goto(`${pathname}${search}`);
+        });
+        // The overview fetches gift-link usage once on load; reload to pull the
+        // visit we just recorded.
+        await overview.refresh();
 
         await expect(overview.giftLinkCardVisitors).toHaveText('1');
-    });
 
-    test('creating a gift link then visiting it - scopes the web traffic filter to the gift read', async ({page, browser, baseURL}) => {
-        await createGiftLinkThenVisit({page, browser, baseURL});
+        await overview.openShareModal();
+        await expect(overview.giftLinkVisitorsBadge).toHaveText('1 visitor');
 
         const webTraffic = new AnalyticsWebTrafficPage(page);
         await webTraffic.goto();
-        await webTraffic.openFilterPopover();
-        await webTraffic.selectFilterField('Gift link');
-        await webTraffic.selectFilterField('used');
+        await webTraffic.addFilter('Gift link', 'used');
 
         await expect(webTraffic.getActiveFilter('Gift link')).toBeVisible();
-        await expect(webTraffic.totalUniqueVisitorsTab).toContainText('1');
+        await expect(webTraffic.totalUniqueVisitorsTab).toHaveText(/^Unique visitors\s*1$/);
     });
 });

--- a/e2e/tests/admin/analytics/gift-link-journey.test.ts
+++ b/e2e/tests/admin/analytics/gift-link-journey.test.ts
@@ -3,10 +3,11 @@ import {PublicPage} from '@/public-pages';
 import {createPostFactory} from '@/data-factory';
 import {expect, test, withIsolatedPage} from '@/helpers/playwright';
 
-// One journey, asserted on every surface it feeds: mint the link in the share
-// modal, read the gifted post in a fresh browser so the real analytics beacon
-// fires (in the analytics project PublicPage.goto waits for the page-hit request
-// and the proxy ingests synchronously), then check the admin side.
+// One journey, asserted on every surface it feeds: check the blank states, mint
+// the link in the share modal, read the gifted post in a fresh browser so the
+// real analytics beacon fires (in the analytics project PublicPage.goto waits
+// for the page-hit request and the proxy ingests synchronously), then verify
+// each count went from zero to one.
 test.describe('Ghost Admin - Gift link analytics journey', () => {
     test('creating a gift link then visiting it - counts the visitor across analytics surfaces', async ({page, browser, baseURL}) => {
         const postFactory = createPostFactory(page.request);
@@ -15,29 +16,36 @@ test.describe('Ghost Admin - Gift link analytics journey', () => {
             status: 'published',
             visibility: 'paid'
         });
+
         const overview = new PostAnalyticsOverviewPage(page);
         await overview.gotoForPost(post.id);
+        await expect(overview.giftLinkCardVisitors).toHaveText('0');
+
         await overview.openShareModal();
+        await expect(overview.giftLinkVisitorsBadge).toHaveText('No visitors yet');
         const giftUrl = await overview.giftLinkUrl();
+
+        const webTraffic = new AnalyticsWebTrafficPage(page);
+        await webTraffic.goto();
+        await webTraffic.addFilter('Gift link', 'used');
+        await expect(webTraffic.getActiveFilter('Gift link')).toBeVisible();
+        await expect(webTraffic.totalUniqueVisitorsTab).toHaveText(/^Unique visitors\s*0$/);
 
         await withIsolatedPage(browser, {baseURL}, async ({page: publicPage}) => {
             const {pathname, search} = new URL(giftUrl);
             await new PublicPage(publicPage).goto(`${pathname}${search}`);
         });
-        // The overview fetches gift-link usage once on load; reload to pull the
-        // visit we just recorded.
-        await overview.refresh();
+        // The filter persists in the URL, so reloading re-queries the same
+        // gift-scoped view against the freshly ingested visit.
+        await webTraffic.refresh();
 
+        await expect(webTraffic.getActiveFilter('Gift link')).toBeVisible();
+        await expect(webTraffic.totalUniqueVisitorsTab).toHaveText(/^Unique visitors\s*1$/);
+
+        await overview.gotoForPost(post.id);
         await expect(overview.giftLinkCardVisitors).toHaveText('1');
 
         await overview.openShareModal();
         await expect(overview.giftLinkVisitorsBadge).toHaveText('1 visitor');
-
-        const webTraffic = new AnalyticsWebTrafficPage(page);
-        await webTraffic.goto();
-        await webTraffic.addFilter('Gift link', 'used');
-
-        await expect(webTraffic.getActiveFilter('Gift link')).toBeVisible();
-        await expect(webTraffic.totalUniqueVisitorsTab).toHaveText(/^Unique visitors\s*1$/);
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3746/integrate-gift-link-usage-tracking-with-analytics

End-to-end coverage for the gift-link analytics journey — the one seam no single-layer test proves: that a real gift read flows producer → client beacon → TrafficAnalytics proxy → Tinybird and surfaces back in admin.

## What it covers

One journey, asserted on every surface it feeds:

1. Creates a published paid post and mints a gift link through the share modal, reading the URL from the modal's URL box.
2. Asserts the blank state on every surface first, so the later assertions prove the visit actually moved the counts.
3. Visits `/<slug>/?gift=<token>` in an isolated browser context, firing the **real** `ghost-stats` beacon.
4. Asserts each surface went from zero to one visitor:
   - the gift-link card visitor count on the post analytics overview (`0` → `1`),
   - the share modal's usage badge ("No visitors yet" → "1 visitor"), and
   - the web-traffic **Gift link = used** filter (unique visitors `0` → `1`, with the filter persisting across the reload via the URL).

Runs in the `analytics` Playwright project, where `PublicPage.goto` waits for the page-hit request and the proxy runs `TINYBIRD_WAIT=true` — ingestion is synchronous, so no polling.

## Notes

- No longer blocked: [TryGhost/TrafficAnalytics#742](https://github.com/TryGhost/TrafficAnalytics/pull/742) (the `gift_link` passthrough) is included in the proxy image `main` already pins, so the earlier `GIFT_LINK_PROXY_READY` escape hatch is gone and the test runs by default in CI.
- Adds a `PostAnalyticsOverviewPage` page object (gift-link card + share modal).
- Generalizes `getFilterOptionValue` to also match count-less filter option labels (gift-link options carry no visit-count prefix), so the test uses the standard `addFilter` path.
- `pnpm lint` and `pnpm test:types` pass; the test is green locally against the analytics stack, including repeat runs.
