### PR TITLE
🐛 Fixed database update failing on automated_emails foreign key constraint

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.25/2026-03-31-20-31-19-drop-nullable-on-automated-emails-email-design-setting-id.js
+++ b/ghost/core/core/server/data/migrations/versions/6.25/2026-03-31-20-31-19-drop-nullable-on-automated-emails-email-design-setting-id.js
@@ -1,3 +1,3 @@
 const {createDropNullableMigration} = require('../../utils');
 
-module.exports = createDropNullableMigration('automated_emails', 'email_design_setting_id');
+module.exports = createDropNullableMigration('automated_emails', 'email_design_setting_id', {disableForeignKeyChecks: true});


### PR DESCRIPTION
fixes https://github.com/TryGhost/Ghost/issues/28986

## Problem

A self-hoster upgrading a long-lived database (5.82 → 6.49) gets wedged on this migration:

```
ERROR alter table `automated_emails` modify `email_design_setting_id` varchar(24) not null
  - Cannot change column 'email_design_setting_id': used in a foreign key constraint
    'automated_emails_email_design_setting_id_foreign'
```

The 6.25 migration makes `automated_emails.email_design_setting_id` non-nullable via a bare `ALTER … MODIFY`. The column carries a foreign key, and on databases that have been upgraded across many versions the FK columns often have a **legacy collation** (e.g. `utf8mb4_general_ci`) that differs from the MySQL 8 table default (`utf8mb4_0900_ai_ci`). knex's `MODIFY` re-emits the column at the table default, and MySQL refuses to rewrite a foreign-key column's charset/collation while the constraint exists — so the upgrade fails mid-migration.

Because the table is dropped at 6.28 but migrations run in order, affected installs can never reach the drop — they're stuck at 6.25.

## Why it wasn't caught

Fresh installs and CI build the database from the schema snapshot, which records this migration as applied **without running it** (and fresh tables have uniform modern collation anyway). So it never surfaced in CI or on Pro — only on old, long-lived self-hosted databases.

## Fix

Pass `{disableForeignKeyChecks: true}` so the `ALTER` can complete, matching how every other nullable migration on an FK column already behaves (e.g. the sibling 6.45 `automated_email_recipients` migration).

## Verification

Reproduced against MySQL **8.0.46** (the reporter's exact version) and 9.6 using Ghost's own knex migration path:

- Pristine table → migration succeeds (explains why most installs are fine).
- FK columns on a legacy collation → migration fails with the foreign-key constraint error (errno 3780), reproducing the report.
- With this fix → migration succeeds on both the pristine and legacy-collation tables.