### PR TITLE
Fixed lazy URL service wrongly disowning posts in collection routes

### DIFF
--- a/ghost/core/core/frontend/services/routing/controllers/collection.js
+++ b/ghost/core/core/frontend/services/routing/controllers/collection.js
@@ -73,11 +73,13 @@ module.exports = function collectionController(req, res, next) {
              * People should always invert their filters to ensure that the database query loads unique posts per collection.
              */
             result.posts = _.filter(result.posts, (post) => {
-                // Tag the resource with the router-level type — the post
-                // objects from the API have their DB `type` column stripped
-                // by the serializer, but the collection router knows what
-                // type it serves.
-                const resource = {...post, type: res.routerOptions.resourceType};
+                // Restore the routing columns the Content API serializer strips:
+                // `type` (the collection router knows what it serves) and
+                // `status` (collections only ever load published posts). The
+                // lazy URL service evaluates the base filter
+                // `status:published+type:post` against these to decide ownership,
+                // so without them an owned post is wrongly disowned and dropped.
+                const resource = {...post, type: res.routerOptions.resourceType, status: 'published'};
                 if (routerManager.ownsResource(res.routerOptions.identifier, resource)) {
                     return post;
                 }

--- a/ghost/core/test/unit/frontend/services/routing/controllers/collection.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/collection.test.js
@@ -195,6 +195,40 @@ describe('Unit - services/routing/controllers/collection', function () {
         sinon.assert.notCalled(next);
     });
 
+    it('restores type and status stripped by the Content API before ownership check', async function () {
+        // The Content API strips `type` and `status` from public posts, but the
+        // lazy URL service evaluates the base filter `status:published+type:post`
+        // to decide ownership. The collection router knows it serves published
+        // posts of a given type, so the controller must restore both — otherwise
+        // an owned post is wrongly disowned and dropped from the collection.
+        const post = testUtils.DataGenerator.forKnex.createPost();
+        delete post.type;
+        delete post.status;
+
+        posts = [post];
+        res.routerOptions.resourceType = 'posts';
+
+        ownsResourceStub.reset();
+        ownsResourceStub.returns(true);
+
+        fetchDataStub.withArgs({page: 1, slug: undefined, limit: postsPerPage}, res.routerOptions)
+            .resolves({
+                posts: posts,
+                meta: {
+                    pagination: {
+                        pages: 5
+                    }
+                }
+            });
+
+        await controllers.collection(req, res, next);
+
+        const resource = ownsResourceStub.firstCall.args[1];
+        assert.equal(resource.type, 'posts');
+        assert.equal(resource.status, 'published');
+        sinon.assert.notCalled(next);
+    });
+
     it('should verify if post belongs to collection', async function () {
         posts = [
             testUtils.DataGenerator.forKnex.createPost({url: '/a/'}),


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1875

## Summary

In compare mode the lazy URL service reported `ownsResource` as `false` for posts that the eager service owned, surfacing as `LAZY_URL_PARITY_MISMATCH` divergences.

The collection controller hands each rendered post to `ownsResource` to drop posts that a higher-priority collection actually owns (so the same post never renders on two collection URLs). The lazy service decides ownership by evaluating the base filter `status:published+type:post` against the resource — but the Content API serializer strips both `status` and `type` from public posts, so the filter never matched and **every candidate post was disowned and removed from the collection**.

The eager service is unaffected: it owns by cache id membership (`hasId`), with the base filter applied once at fetch time against full models, so it never re-evaluates the filter per call.

## Fix

The controller already restored `type`; this restores `status: 'published'` as well, which is always correct because collections only ever load published posts (`postsPublic`). Restoring the stripped column keeps the base filter **fully enforced** rather than relaxing it, preserving parity with eager.

## Testing

TDD: added a controller unit test that simulates a Content-API-stripped post (no `type`/`status`) and asserts the resource handed to `ownsResource` carries both restored. Confirmed it fails before the fix and passes after. Full `collection.test.js` suite green; lint clean.