### PR TITLE
Fixed checkout failures when collecting tax IDs

### DIFF
--- a/ghost/core/core/server/services/stripe/stripe-api.js
+++ b/ghost/core/core/server/services/stripe/stripe-api.js
@@ -599,7 +599,7 @@ module.exports = class StripeAPI {
         }
 
         if (customerId && this._config.enableAutomaticTax) {
-            stripeSessionOptions.customer_update = {address: 'auto'};
+            stripeSessionOptions.customer_update = {address: 'auto', name: 'auto'};
         }
 
         // @ts-ignore
@@ -670,7 +670,7 @@ module.exports = class StripeAPI {
         };
 
         if (customer && this._config.enableAutomaticTax) {
-            stripeSessionOptions.customer_update = {address: 'auto'};
+            stripeSessionOptions.customer_update = {address: 'auto', name: 'auto'};
         }
 
         // @ts-ignore
@@ -729,7 +729,7 @@ module.exports = class StripeAPI {
         };
 
         if (customer && this._config.enableAutomaticTax) {
-            stripeSessionOptions.customer_update = {address: 'auto'};
+            stripeSessionOptions.customer_update = {address: 'auto', name: 'auto'};
         }
 
         // @ts-ignore

--- a/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
+++ b/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
@@ -458,7 +458,7 @@ describe('StripeAPI', function () {
             await api.createCheckoutSession('priceId', mockCustomer, {
                 trialDays: null
             });
-            assertExists(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_update);
+            assert.deepEqual(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_update, {address: 'auto', name: 'auto'});
         });
 
         it('createCheckoutSession does not add customer_update if automatic tax flag is enabled and customer is undefined', async function () {
@@ -647,6 +647,27 @@ describe('StripeAPI', function () {
             });
 
             assert(mockStripe.checkout.sessions.create.firstCall.firstArg.custom_fields.length <= 3);
+        });
+
+        it('sets customer_update when customer and automatic tax are enabled', async function () {
+            api.configure({
+                checkoutSessionSuccessUrl: '/success',
+                checkoutSessionCancelUrl: '/cancel',
+                checkoutSetupSessionSuccessUrl: '/setup-success',
+                checkoutSetupSessionCancelUrl: '/setup-cancel',
+                secretKey: '',
+                enableAutomaticTax: true
+            });
+
+            await api.createDonationCheckoutSession({
+                priceId: 'priceId',
+                successUrl: '/success',
+                cancelUrl: '/cancel',
+                metadata: {},
+                customer: {id: mockCustomerId}
+            });
+
+            assert.deepEqual(mockStripe.checkout.sessions.create.firstCall.firstArg.customer_update, {address: 'auto', name: 'auto'});
         });
     });
 
@@ -886,7 +907,7 @@ describe('StripeAPI', function () {
 
             const args = mockStripe.checkout.sessions.create.firstCall.firstArg;
 
-            assert.deepEqual(args.customer_update, {address: 'auto'});
+            assert.deepEqual(args.customer_update, {address: 'auto', name: 'auto'});
         });
 
         it('does not set customer_update without customer', async function () {


### PR DESCRIPTION
## Summary

- allowed Stripe Checkout to update existing customer names when automatic tax customer updates are enabled
- tightened Stripe API tests around customer_update for subscription, donation, and gift checkout sessions

## Testing

- pnpm test:single test/unit/server/services/stripe/stripe-api.test.js