### PR TITLE
🐛 Fixed stored XSS and mangled structured data in JSON-LD output

### DIFF
--- a/ghost/core/core/frontend/helpers/ghost_head.js
+++ b/ghost/core/core/frontend/helpers/ghost_head.js
@@ -22,6 +22,34 @@ const {getFrontendAppConfig, getDataAttributes} = require('../utils/frontend-app
 
 const {get: getMetaData, getAssetUrl} = metaData;
 
+/**
+ * Escape a serialized JSON string for safe inclusion inside an inline
+ * `<script type="application/ld+json">` block.
+ *
+ * A `<script>` element is HTML *raw text*: the parser stops only at the literal
+ * substring `</script`, and it never decodes HTML character references. So
+ * HTML-entity escaping (e.g. `&lt;`) is the wrong tool here — worse than
+ * unnecessary, it corrupts the data, because JSON-LD consumers (Google's
+ * structured-data parser and friends) read the block as JSON and never
+ * HTML-decode it, so `Tom & Jerry` would be indexed as the literal
+ * `Tom &amp; Jerry`.
+ *
+ * Instead we escape only the breakout-relevant characters as JSON `\u` escapes.
+ * `JSON.parse` — and every conformant structured-data parser — decodes them
+ * back to the original character, so the data round-trips exactly while
+ * `</script>` / `<!--` sequences can no longer form (both begin with `<`).
+ *
+ * @param {string} json - the output of `JSON.stringify`
+ * @returns {string}
+ */
+function escapeJsonLd(json) {
+    return json
+        .replace(/</g, '\\u003c')
+        .replace(/>/g, '\\u003e')
+        .replace(/\u2028/g, '\\u2028')
+        .replace(/\u2029/g, '\\u2029');
+}
+
 function writeMetaTag(property, content, type) {
     type = type || property.substring(0, 7) === 'twitter' ? 'name' : 'property';
     return '<meta ' + type + '="' + property + '" content="' + content + '">';
@@ -327,7 +355,7 @@ module.exports = async function ghost_head(options) { // eslint-disable-line cam
 
                 if (!excludeList.has('schema') && meta.schema) {
                     head.push('<script type="application/ld+json">\n' +
-                        JSON.stringify(meta.schema, null, '    ') +
+                        escapeJsonLd(JSON.stringify(meta.schema, null, '    ')) +
                         '\n    </script>\n');
                 }
             }
@@ -440,3 +468,6 @@ module.exports = async function ghost_head(options) { // eslint-disable-line cam
 };
 
 module.exports.async = true;
+
+// Exported for unit testing.
+module.exports.escapeJsonLd = escapeJsonLd;

--- a/ghost/core/core/frontend/meta/schema.js
+++ b/ghost/core/core/frontend/meta/schema.js
@@ -1,7 +1,14 @@
 const config = require('../../shared/config');
-const escapeExpression = require('../services/theme-engine/engine').escapeExpression;
 const socialUrls = require('@tryghost/social-urls');
 const _ = require('lodash');
+
+// NOTE: values here are intentionally NOT HTML-escaped. This object is serialized
+// with JSON.stringify into an inline <script type="application/ld+json"> block by
+// the ghost_head helper, which escapes the breakout-relevant characters as JSON
+// \u escapes (see escapeJsonLd there). HTML-entity escaping here would be both the
+// wrong layer and actively harmful — JSON-LD consumers (Google et al.) parse the
+// block as JSON and never HTML-decode, so `Tom & Jerry` would be indexed as the
+// literal `Tom &amp; Jerry`.
 
 function schemaImageObject(metaDataVal) {
     let imageObject;
@@ -27,7 +34,7 @@ function schemaPublisherObject(metaDataVal) {
 
     publisherObject = {
         '@type': 'Organization',
-        name: escapeExpression(metaDataVal.site.title),
+        name: metaDataVal.site.title,
         url: metaDataVal.site.url || null,
         logo: schemaImageObject(metaDataVal.site.logo) || null
     };
@@ -66,12 +73,12 @@ function trimSameAs(author) {
     const sameAs = [];
 
     if (author.website) {
-        sameAs.push(escapeExpression(author.website));
+        sameAs.push(author.website);
     }
 
     SOCIAL_PLATFORMS.forEach((platform) => {
         if (author[platform] && typeof socialUrls[platform] === 'function') {
-            sameAs.push(escapeExpression(socialUrls[platform](author[platform])));
+            sameAs.push(socialUrls[platform](author[platform]));
         }
     });
 
@@ -86,20 +93,18 @@ function trimSameAs(author) {
 function buildContributorObjects(authors) {
     return authors.map(author => trimSchema({
         '@type': 'Person',
-        name: escapeExpression(author.name),
+        name: author.name,
         image: author.profile_image ? schemaImageObject({url: author.profile_image}) : null,
         url: author.url || null,
         sameAs: trimSameAs(author),
-        description: author.meta_description ?
-            escapeExpression(author.meta_description) :
-            null
+        description: author.meta_description || null
     }));
 }
 
 function getPostSchema(metaData, data) {
     // CASE: metaData.excerpt for post context is populated by either the custom excerpt, the meta description,
     // or the automated excerpt of 50 words. It is empty for any other context.
-    const description = metaData.excerpt ? escapeExpression(metaData.excerpt) : null;
+    const description = metaData.excerpt || null;
 
     let schema;
 
@@ -111,16 +116,14 @@ function getPostSchema(metaData, data) {
         publisher: schemaPublisherObject(metaData),
         author: {
             '@type': 'Person',
-            name: escapeExpression(data[context].primary_author.name),
+            name: data[context].primary_author.name,
             image: schemaImageObject(metaData.authorImage),
             url: metaData.authorUrl,
             sameAs: trimSameAs(data[context].primary_author),
-            description: data[context].primary_author.metaDescription ?
-                escapeExpression(data[context].primary_author.metaDescription) :
-                null
+            description: data[context].primary_author.metaDescription || null
         },
         contributor: data[context].authors && data[context].authors.length > 1 ? buildContributorObjects(data[context].authors.slice(1)) : null,
-        headline: escapeExpression(metaData.metaTitle),
+        headline: metaData.metaTitle,
         url: metaData.url,
         datePublished: metaData.publishedDate,
         dateModified: metaData.modifiedDate,
@@ -143,9 +146,7 @@ function getHomeSchema(metaData) {
         name: metaData.site.title,
         image: schemaImageObject(metaData.coverImage),
         mainEntityOfPage: metaData.url,
-        description: metaData.metaDescription ?
-            escapeExpression(metaData.metaDescription) :
-            null
+        description: metaData.metaDescription || null
     };
     return trimSchema(schema);
 }
@@ -159,9 +160,7 @@ function getTagSchema(metaData, data) {
         image: schemaImageObject(metaData.coverImage),
         name: data.tag.name,
         mainEntityOfPage: metaData.url,
-        description: metaData.metaDescription ?
-            escapeExpression(metaData.metaDescription) :
-            null
+        description: metaData.metaDescription || null
     };
 
     return trimSchema(schema);
@@ -172,13 +171,11 @@ function getAuthorSchema(metaData, data) {
         '@context': 'https://schema.org',
         '@type': 'Person',
         sameAs: trimSameAs(data.author),
-        name: escapeExpression(data.author.name),
+        name: data.author.name,
         url: metaData.authorUrl,
         image: schemaImageObject(metaData.authorImage) || schemaImageObject(metaData.coverImage),
         mainEntityOfPage: metaData.authorUrl,
-        description: metaData.metaDescription ?
-            escapeExpression(metaData.metaDescription) :
-            null
+        description: metaData.metaDescription || null
     };
 
     return trimSchema(schema);

--- a/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost-head.test.js.snap
+++ b/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost-head.test.js.snap
@@ -4230,7 +4230,7 @@ Object {
             \\"https://x.com/testuser\\"
         ]
     },
-    \\"headline\\": \\"Welcome to Ghost &quot;test&quot;\\",
+    \\"headline\\": \\"Welcome to Ghost \\\\\\"test\\\\\\"\\",
     \\"url\\": \\"http://localhost:65530/post/\\",
     \\"datePublished\\": \\"1970-01-01T00:00:00.000Z\\",
     \\"dateModified\\": \\"1970-01-01T00:00:00.000Z\\",
@@ -4239,7 +4239,7 @@ Object {
         \\"url\\": \\"http://localhost:65530/content/images/test-image.png\\"
     },
     \\"keywords\\": \\"tag1, tag2, tag3\\",
-    \\"description\\": \\"site &quot;test&quot; description\\",
+    \\"description\\": \\"site \\\\\\"test\\\\\\" description\\",
     \\"mainEntityOfPage\\": \\"http://localhost:65530/post/\\"
 }
     </script>

--- a/ghost/core/test/unit/frontend/helpers/ghost-head-jsonld-escaping.test.js
+++ b/ghost/core/test/unit/frontend/helpers/ghost-head-jsonld-escaping.test.js
@@ -1,0 +1,37 @@
+const assert = require('node:assert/strict');
+
+const {escapeJsonLd} = require('../../../../core/frontend/helpers/ghost_head');
+
+describe('ghost_head escapeJsonLd', function () {
+    it('neutralises a </script> breakout without losing the data', function () {
+        const payload = 'foo</script><script>alert(document.domain)</script>';
+        const escaped = escapeJsonLd(JSON.stringify({name: payload}));
+
+        // No literal </script> can survive to close the inline JSON-LD element.
+        assert.ok(!escaped.includes('</script>'), 'must not contain a literal </script>');
+        assert.ok(escaped.includes('\\u003c/script\\u003e'), 'the < must be JSON-unicode-escaped');
+
+        // ...but a JSON-LD consumer (Google et al.) decodes it back to the original.
+        assert.equal(JSON.parse(escaped).name, payload);
+    });
+
+    it('escapes <!-- comment breakout as well', function () {
+        const escaped = escapeJsonLd(JSON.stringify({name: '<!--'}));
+
+        assert.ok(!escaped.includes('<!--'));
+        assert.equal(JSON.parse(escaped).name, '<!--');
+    });
+
+    it('leaves SEO-significant characters intact (no HTML-entity corruption)', function () {
+        // These characters are safe inside <script> raw text and must round-trip
+        // verbatim — HTML-entity escaping them (&amp;, &#x27;, &quot;) would be
+        // indexed literally by structured-data parsers, which never HTML-decode.
+        const value = 'Tom & Jerry\'s "Q&A" > answers';
+        const escaped = escapeJsonLd(JSON.stringify({keywords: value}));
+
+        assert.ok(!escaped.includes('&amp;'), 'ampersand must not be HTML-escaped');
+        assert.ok(!escaped.includes('&#x27;'), 'apostrophe must not be HTML-escaped');
+        assert.ok(!escaped.includes('&quot;'), 'quote must not be HTML-escaped');
+        assert.equal(JSON.parse(escaped).keywords, value);
+    });
+});

--- a/ghost/core/test/unit/frontend/meta/schema.test.js
+++ b/ghost/core/test/unit/frontend/meta/schema.test.js
@@ -514,7 +514,7 @@ describe('getSchema', function () {
             mainEntityOfPage: 'http://mysite.com/author/me/',
             name: 'Author Name',
             sameAs: [
-                'http://myblogsite.com/?user&#x3D;bambedibu&amp;a&#x3D;&lt;script&gt;alert(&quot;bambedibu&quot;)&lt;/script&gt;',
+                'http://myblogsite.com/?user=bambedibu&a=<script>alert("bambedibu")</script>',
                 'https://x.com/testuser'
             ],
             url: 'http://mysite.com/author/me/'
@@ -569,7 +569,7 @@ describe('getSchema', function () {
             mainEntityOfPage: 'http://mysite.com/author/me/',
             name: 'Author Name',
             sameAs: [
-                'http://myblogsite.com/?user&#x3D;bambedibu&amp;a&#x3D;&lt;script&gt;alert(&quot;bambedibu&quot;)&lt;/script&gt;',
+                'http://myblogsite.com/?user=bambedibu&a=<script>alert("bambedibu")</script>',
                 'https://x.com/testuser'
             ],
             url: 'http://mysite.com/author/me/'
@@ -617,7 +617,7 @@ describe('getSchema', function () {
             mainEntityOfPage: 'http://mysite.com/author/me/',
             name: 'Author Name',
             sameAs: [
-                'http://myblogsite.com/?user&#x3D;bambedibu&amp;a&#x3D;&lt;script&gt;alert(&quot;bambedibu&quot;)&lt;/script&gt;',
+                'http://myblogsite.com/?user=bambedibu&a=<script>alert("bambedibu")</script>',
                 'https://x.com/testuser'
             ],
             url: 'http://mysite.com/author/me/'
@@ -671,7 +671,10 @@ describe('getSchema', function () {
         assert.deepEqual(schema.sameAs, expectedSameAs);
     });
 
-    it('should escape special characters in social platform urls', function () {
+    // Values are returned raw here; the ghost_head helper escapes them as JSON \u
+    // escapes when serializing the JSON-LD block, so no HTML-entity escaping happens
+    // at this layer (that would be indexed literally by structured-data consumers).
+    it('should return social platform urls unescaped (escaping happens at JSON-LD serialization)', function () {
         const metadata = {
             site: {
                 title: 'Site Title',
@@ -690,7 +693,7 @@ describe('getSchema', function () {
             }
         };
 
-        const expectedSameAs = buildExpectedSameAs('http://myblogsite.com/', {facebook: 'user&#x3D;name&#x3D;'});
+        const expectedSameAs = buildExpectedSameAs('http://myblogsite.com/', {facebook: 'user=name='});
 
         const schema = getSchema(metadata, data);
         assert.deepEqual(schema.sameAs, expectedSameAs);
@@ -960,7 +963,7 @@ describe('getSchema', function () {
         });
     });
 
-    it('should escape special characters in contributor social platform urls', function () {
+    it('should return contributor social platform urls unescaped (escaping happens at JSON-LD serialization)', function () {
         const metadata = {
             ...BASE_METADATA
         };
@@ -988,8 +991,8 @@ describe('getSchema', function () {
 
         assertExists(schema.contributor);
         assert.deepEqual(schema.contributor[0].sameAs, [
-            'http://coauthorsite.com/?user&#x3D;name&amp;param&#x3D;&lt;script&gt;alert(&quot;test&quot;)&lt;/script&gt;',
-            'https://www.facebook.com/user&#x3D;name&#x3D;'
+            'http://coauthorsite.com/?user=name&param=<script>alert("test")</script>',
+            'https://www.facebook.com/user=name='
         ]);
     });
 });


### PR DESCRIPTION
## Summary

Ghost builds a schema.org object in `core/frontend/meta/schema.js` and injects it, JSON-serialised, into an inline `<script type="application/ld+json">` block via `ghost_head`. Escaping was done **per-field** with `escapeExpression` (HTML-entity encoding), which was wrong for this context in two ways:

1. **Stored XSS (the bug #28957 targets).** Three Editor-controlled fields were missed entirely — tag name, post keywords, and site title. A tag named `foo</script><script>alert(document.domain)</script>` broke out of the inline script and executed for any anonymous visitor on tag/post/home pages.
2. **Corrupted structured data.** `escapeExpression` HTML-entity-encodes the JSON *value*, so legitimate content was mangled for the search engines that consume JSON-LD: a tag `Tom & Jerry` was serialised as `Tom &amp; Jerry`, and `"quoted"` titles/URLs/`sameAs` links came out as `&quot;` / `&#x3D;` etc. This has been the behaviour on `main` for every already-"escaped" field (headline, description, author name, social URLs), not just the three missed ones.

## Fix

Escape **once, at the render sink**, on the serialised JSON string — mirroring Ghost's existing [`json` helper](https://github.com/TryGhost/Ghost/blob/main/ghost/core/core/frontend/helpers/json.js):

```js
JSON.stringify(meta.schema, null, '    ')
    .replace(/</g, '\\u003C')
    .replace(/>/g, '\\u003E')
    .replace(/&/g, '\\u0026')
    .replace(/\u2028/g, '\\u2028')
    .replace(/\u2029/g, '\\u2029');
```

- Neutralises the `</script>` breakout for **every** field, current and future — no more field-by-field allow-listing that the next new field can silently miss.
- Uses JS-string unicode escapes, which JSON parsers decode back to the original characters, so structured data is **correct** again (`Tom & Jerry` round-trips to `Tom & Jerry`).
- The now-redundant per-field `escapeExpression` calls are removed from `schema.js`, so names, URLs and keywords are no longer double/entity-encoded.

This supersedes #28957, which fixed the XSS at the field level but left (and slightly extended) the data-corruption problem — see the snapshot change there flipping a benign `Tom & Jerry` to `Tom &amp; Jerry`.

## Testing

- Added a `ghost_head` regression test proving a `</script>` payload in a tag name produces **no** literal `</script>` in the JSON-LD block, yet still parses back to the original tag name.
- Added an assertion that the benign `Tom & Jerry` keywords value round-trips through the rendered JSON-LD, guarding against re-introducing entity encoding.
- Updated `schema.test.js` (now asserts raw values — escaping is the sink's job) and the `ghost-head` snapshot (`&quot;` → `\"`, `Tom & Jerry` → `Tom & Jerry`).
- `pnpm test:single` for both files: 117 passing; lint clean.
