### PR TITLE
Improved gift toast partial structure and copy

### DIFF
--- a/ghost/core/core/frontend/helpers/ghost_foot.js
+++ b/ghost/core/core/frontend/helpers/ghost_foot.js
@@ -47,7 +47,9 @@ module.exports = function ghost_foot(options) { // eslint-disable-line camelcase
             noiseUrl: `${siteUrl}/gift/assets/gift-card-noise.png`
         };
 
-        foot.push(templates.execute('gift-toast', this, {data}));
+        // Execute with the post as context so the partial, and any theme
+        // override of it, gets the full post scope.
+        foot.push(templates.execute('gift-toast', options.data.root.post, {data}));
     }
 
     return new SafeString(foot.join(' ').trim());

--- a/ghost/core/core/frontend/helpers/tpl/gift-toast.hbs
+++ b/ghost/core/core/frontend/helpers/tpl/gift-toast.hbs
@@ -203,7 +203,21 @@
         <span class="gh-gift-toast-pattern"{{#if @giftToast.brandUrl}} hidden{{/if}}></span>
     </div>
     <span class="gh-gift-toast-content">
-        <span class="gh-gift-toast-title">{{t "You've been gifted access to this post."}}</span>
+        <span class="gh-gift-toast-title">
+            {{~#has visibility="members"~}}
+                {{~#is "page"~}}
+                    {{t "You've been gifted access to this members-only page."}}
+                {{~else~}}
+                    {{t "You've been gifted access to this members-only post."}}
+                {{~/is~}}
+            {{~else~}}
+                {{~#is "page"~}}
+                    {{t "You've been gifted access to this paid page."}}
+                {{~else~}}
+                    {{t "You've been gifted access to this paid post."}}
+                {{~/is~}}
+            {{~/has~}}
+        </span>
     </span>
     <button type="button" class="gh-gift-toast-close" aria-label="{{t "Dismiss"}}">
         <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">

--- a/ghost/core/test/e2e-frontend/gift-links.test.ts
+++ b/ghost/core/test/e2e-frontend/gift-links.test.ts
@@ -27,9 +27,11 @@ describe('Front-end gift links', function () {
     let request: any;
     let token: string;
     let pageToken: string;
+    let membersToken: string;
     const slug = 'gift-me-this-paid-post';
     const otherSlug = 'another-paid-post';
     const pageSlug = 'gift-me-this-paid-page';
+    const membersSlug = 'gift-me-this-members-post';
 
     beforeAll(async function () {
         const originalSettingsCacheGetFn = settingsCache.get;
@@ -85,12 +87,21 @@ describe('Front-end gift links', function () {
             published_at: moment().toDate(),
             mobiledoc
         });
-        await testUtils.fixtures.insertPosts([paidPost, otherPaidPost, paidPage]);
+        // A members-only post so the toast copy can be asserted for that access level.
+        const membersPost = testUtils.DataGenerator.forKnex.createPost({
+            slug: membersSlug,
+            visibility: 'members',
+            status: 'published',
+            published_at: moment().toDate(),
+            mobiledoc
+        });
+        await testUtils.fixtures.insertPosts([paidPost, otherPaidPost, paidPage, membersPost]);
 
-        // Mint a live gift link for the paid post and the paid page.
+        // Mint a live gift link for the paid post, the paid page and the members post.
         const giftLinksService = require('../../core/server/services/gift-links');
         token = (await giftLinksService.service.ensure({actor: null}, paidPost.id)).giftLinks[0].token;
         pageToken = (await giftLinksService.service.ensure({actor: null}, paidPage.id)).giftLinks[0].token;
+        membersToken = (await giftLinksService.service.ensure({actor: null}, membersPost.id)).giftLinks[0].token;
 
         request = supertest.agent(configUtils.config.get('url'));
     });
@@ -123,9 +134,19 @@ describe('Front-end gift links', function () {
         assert.equal(res.headers['x-robots-tag'], 'noindex');
         assert.equal(res.headers['referrer-policy'], 'no-referrer');
 
-        // The default gift toast renders on the verified gift view.
+        // The default gift toast renders on the verified gift view, and its copy
+        // reflects the post's access level (this fixture is a paid post).
         assert.match(res.text, /id="gh-gift-toast"/, 'default gift toast renders on a gift view');
-        assert.match(res.text, /gifted access to this post/, 'toast announces the gift');
+        assert.match(res.text, /gifted access to this paid post/, 'toast announces the gift and its paid access level');
+    });
+
+    it('varies the toast copy by access level: a members-only post reads "members-only"', async function () {
+        const res = await request
+            .get(`/${membersSlug}/?gift=${membersToken}`)
+            .expect(200);
+
+        assert.match(res.text, /id="gh-gift-toast"/, 'default gift toast renders on a gift view');
+        assert.match(res.text, /gifted access to this members-only post/, 'toast reflects the members-only access level');
     });
 
     it('301s to the canonical URL, dropping ?gift, when the token is invalid', async function () {
@@ -143,10 +164,13 @@ describe('Front-end gift links', function () {
 
     it('unlocks a paid page with a valid ?gift token on its canonical URL', async function () {
         // The feature works on pages too, not just posts — same entry controller.
-        await request
+        const res = await request
             .get(`/${pageSlug}/?gift=${pageToken}`)
             .expect(200)
             .expect(assertUnlocked);
+
+        // The toast copy says "page", not "post", for a gifted page.
+        assert.match(res.text, /gifted access to this paid page/, 'toast reflects that the gifted entry is a page');
     });
 
     it('301s a paid page, dropping ?gift, when the token is invalid', async function () {


### PR DESCRIPTION
No ref

Reworks the reader-side gift toast so its copy reflects the gifted entry's access level and type, following the same approach as the content-cta partial.

- Executes the partial with the post as context, so it (and any theme override of it) gets the full post scope, matching content-cta.
- Varies the toast copy by visibility and entry type using `{{#has visibility}}` and `{{#is "page"}}`: members-only vs paid, and post vs page.
- Adds coverage for the new copy variants in the gift-links e2e tests.