### PR TITLE
Fixed displayed gift link being incorrect on first modal open

### DIFF
--- a/apps/posts/src/views/PostAnalytics/modals/gift-link-modal.tsx
+++ b/apps/posts/src/views/PostAnalytics/modals/gift-link-modal.tsx
@@ -35,20 +35,37 @@ const GiftLinkModal: React.FC<GiftLinkModalProps> = ({open, onOpenChange, postId
     const [resetting, setResetting] = useState(false);
     const [ensuring, setEnsuring] = useState(false);
     const cancelResetRef = useRef<HTMLButtonElement>(null);
+    const ensureGiftLinkRequestRef = useRef<{
+        postId: string;
+        request: ReturnType<typeof ensureGiftLink>;
+    } | null>(null);
 
     // Usage is best-effort: undefined when analytics is off / unavailable, in
     // which case we simply omit the visitor count.
     const {usage} = useGiftLinkUsage({postUuid: post?.uuid, token, enabled: open});
 
     // Ensure (create-or-get) the link as soon as the modal opens so there's a
-    // URL to show. Idempotent on the server.
+    // URL to show. Share one request per open target so StrictMode effect replay
+    // and local re-renders don't mint competing same-moment links.
     useEffect(() => {
         if (!open) {
+            ensureGiftLinkRequestRef.current = null;
+            setEnsuring(false);
             return;
         }
+
+        let ensureRequest = ensureGiftLinkRequestRef.current;
+        if (ensureRequest?.postId !== postId) {
+            ensureRequest = {
+                postId,
+                request: ensureGiftLink({id: postId, resource})
+            };
+            ensureGiftLinkRequestRef.current = ensureRequest;
+        }
+
         let cancelled = false;
         setEnsuring(true);
-        ensureGiftLink({id: postId, resource})
+        ensureRequest.request
             .then((response) => {
                 if (cancelled) {
                     return;

--- a/apps/posts/src/views/PostAnalytics/modals/gift-link-modal.tsx
+++ b/apps/posts/src/views/PostAnalytics/modals/gift-link-modal.tsx
@@ -37,6 +37,7 @@ const GiftLinkModal: React.FC<GiftLinkModalProps> = ({open, onOpenChange, postId
     const cancelResetRef = useRef<HTMLButtonElement>(null);
     const ensureGiftLinkRequestRef = useRef<{
         postId: string;
+        resource: GiftLinkResource;
         request: ReturnType<typeof ensureGiftLink>;
     } | null>(null);
 
@@ -55,9 +56,10 @@ const GiftLinkModal: React.FC<GiftLinkModalProps> = ({open, onOpenChange, postId
         }
 
         let ensureRequest = ensureGiftLinkRequestRef.current;
-        if (ensureRequest?.postId !== postId) {
+        if (ensureRequest?.postId !== postId || ensureRequest.resource !== resource) {
             ensureRequest = {
                 postId,
+                resource,
                 request: ensureGiftLink({id: postId, resource})
             };
             ensureGiftLinkRequestRef.current = ensureRequest;

--- a/apps/posts/test/unit/views/post-analytics/gift-link-modal.test.tsx
+++ b/apps/posts/test/unit/views/post-analytics/gift-link-modal.test.tsx
@@ -1,0 +1,128 @@
+import {StrictMode} from 'react';
+import GiftLinkModal from '@src/views/PostAnalytics/modals/gift-link-modal';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {render, screen, waitFor} from '@testing-library/react';
+
+const {
+    mockCreateGiftLink,
+    mockEnsureGiftLink,
+    mockHandleError,
+    mockUseGiftLinkUsage,
+    mockUsePostDetails
+} = vi.hoisted(() => ({
+    mockCreateGiftLink: vi.fn(),
+    mockEnsureGiftLink: vi.fn(),
+    mockHandleError: vi.fn(),
+    mockUseGiftLinkUsage: vi.fn(),
+    mockUsePostDetails: vi.fn()
+}));
+
+vi.mock('@tryghost/admin-x-framework/api/gift-links', async () => {
+    const actual = await vi.importActual<typeof import('@tryghost/admin-x-framework/api/gift-links')>(
+        '@tryghost/admin-x-framework/api/gift-links'
+    );
+    return {
+        ...actual,
+        useCreateGiftLink: () => ({
+            mutateAsync: mockCreateGiftLink
+        }),
+        useEnsureGiftLink: () => ({
+            mutateAsync: mockEnsureGiftLink
+        })
+    };
+});
+
+vi.mock('@tryghost/admin-x-framework/hooks', async () => {
+    const actual = await vi.importActual<typeof import('@tryghost/admin-x-framework/hooks')>(
+        '@tryghost/admin-x-framework/hooks'
+    );
+    return {
+        ...actual,
+        useHandleError: () => mockHandleError
+    };
+});
+
+vi.mock('@src/hooks/use-gift-link-usage', () => ({
+    useGiftLinkUsage: (...args: unknown[]) => mockUseGiftLinkUsage(...args)
+}));
+
+vi.mock('@src/hooks/use-post-details', () => ({
+    usePostDetails: (...args: unknown[]) => mockUsePostDetails(...args)
+}));
+
+describe('GiftLinkModal', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        mockEnsureGiftLink.mockResolvedValue({
+            gift_links: [{
+                token: 'gift-token',
+                created_at: '2026-07-01T00:00:00.000Z'
+            }]
+        });
+        mockCreateGiftLink.mockResolvedValue({
+            gift_links: [{
+                token: 'reset-token',
+                created_at: '2026-07-01T00:00:00.000Z'
+            }]
+        });
+        mockUseGiftLinkUsage.mockReturnValue({usage: undefined, loading: false, error: null});
+        mockUsePostDetails.mockReturnValue({
+            post: {
+                title: 'Test post',
+                url: 'https://example.com/test-post/',
+                uuid: 'post-uuid',
+                visibility: 'members'
+            },
+            isLoading: false
+        });
+    });
+
+    it('ensures the gift link once when opened under StrictMode', async () => {
+        render(
+            <StrictMode>
+                <GiftLinkModal postId='post-id' open onOpenChange={vi.fn()} />
+            </StrictMode>
+        );
+
+        await waitFor(() => {
+            expect(mockEnsureGiftLink).toHaveBeenCalledTimes(1);
+        });
+        expect(mockEnsureGiftLink).toHaveBeenCalledWith({id: 'post-id', resource: 'posts'});
+        expect(await screen.findByText('https://example.com/test-post/?gift=gift-token')).toBeInTheDocument();
+    });
+
+    it('ensures again after the modal is closed and reopened', async () => {
+        const {rerender} = render(
+            <GiftLinkModal postId='post-id' open onOpenChange={vi.fn()} />
+        );
+
+        await waitFor(() => {
+            expect(mockEnsureGiftLink).toHaveBeenCalledTimes(1);
+        });
+
+        rerender(<GiftLinkModal open={false} postId='post-id' onOpenChange={vi.fn()} />);
+        rerender(<GiftLinkModal postId='post-id' open onOpenChange={vi.fn()} />);
+
+        await waitFor(() => {
+            expect(mockEnsureGiftLink).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    it('ensures again when the open modal receives a different post id', async () => {
+        const {rerender} = render(
+            <GiftLinkModal postId='post-id' open onOpenChange={vi.fn()} />
+        );
+
+        await waitFor(() => {
+            expect(mockEnsureGiftLink).toHaveBeenCalledTimes(1);
+        });
+
+        rerender(<GiftLinkModal postId='other-post-id' open onOpenChange={vi.fn()} />);
+
+        await waitFor(() => {
+            expect(mockEnsureGiftLink).toHaveBeenCalledTimes(2);
+        });
+        expect(mockEnsureGiftLink).toHaveBeenLastCalledWith({id: 'other-post-id', resource: 'posts'});
+    });
+});

--- a/apps/posts/test/unit/views/post-analytics/gift-link-modal.test.tsx
+++ b/apps/posts/test/unit/views/post-analytics/gift-link-modal.test.tsx
@@ -125,4 +125,21 @@ describe('GiftLinkModal', () => {
         });
         expect(mockEnsureGiftLink).toHaveBeenLastCalledWith({id: 'other-post-id', resource: 'posts'});
     });
+
+    it('ensures again when the open modal receives a different resource', async () => {
+        const {rerender} = render(
+            <GiftLinkModal postId='post-id' resource='posts' open onOpenChange={vi.fn()} />
+        );
+
+        await waitFor(() => {
+            expect(mockEnsureGiftLink).toHaveBeenCalledTimes(1);
+        });
+
+        rerender(<GiftLinkModal postId='post-id' resource='pages' open onOpenChange={vi.fn()} />);
+
+        await waitFor(() => {
+            expect(mockEnsureGiftLink).toHaveBeenCalledTimes(2);
+        });
+        expect(mockEnsureGiftLink).toHaveBeenLastCalledWith({id: 'post-id', resource: 'pages'});
+    });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3762/

## Summary
- Guarded the gift-link modal ensure effect by resource/post target so StrictMode effect replay and local re-renders do not issue duplicate PUT requests.
- Kept the existing cancelled callback guard so closed/stale requests do not update modal UI or show stale errors.
- Added focused regression coverage for StrictMode replay, close/reopen, and changing post ids while open.

## Why
Opening the modal could fire two same-moment ensure requests. The API's last-write-wins tradeoff could then leave the modal displaying a token that was no longer the active gift link.