### PR TITLE
Improved app Playwright job setup time by scoping the install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -721,7 +721,11 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        # Each matrix leg only Playwright-tests one app, so scope the install to that
+        # app's dependency subgraph instead of the whole monorepo (which drags in
+        # ghost/core, ghost-admin and unrelated apps). nx and the app's workspace deps
+        # are still installed; the nx project name matches the package name.
+        run: pnpm install --frozen-lockfile --filter ${{ matrix.app }}...
 
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright


### PR DESCRIPTION
## Summary

`job_apps_acceptance-tests` runs a **per-app matrix** (one leg per affected app with a `test:acceptance` target), but every leg ran `pnpm install --frozen-lockfile` for the **whole monorepo** — pulling in ghost/core, ghost-admin, and every unrelated app just to Playwright-test one React app.

This scopes the install to the app's own dependency subgraph:

```diff
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --filter ${{ matrix.app }}...
```

Follows the same scoping already used by `job_i18n` and `job_e2e_tests`.

## Why it's safe (verified)

- **Root tooling survives the filter:** a filtered install still installs the workspace root's devDependencies — confirmed in a throwaway workspace that a root devDep (stand-in for `nx`) is present under `--filter pkg-a...`. So `pnpm nx run …` still works.
- **The identifier matches:** `matrix.app` comes from `nx show projects` and is the `@tryghost/*` **package name** (nx derives project names from `package.json`), so it's a valid `pnpm --filter` selector. Confirmed `--filter '@tryghost/comments-ui...'` resolves the app **plus** its workspace deps (e.g. `@tryghost/i18n`).
- **No cross-project build is triggered:** the `test:acceptance` target has `dependsOn: []`, so running it doesn't build other projects. The `...` selector installs the app's full dependency subtree, so it's behavior-equivalent to the full install for this app — just without ghost/core, ghost-admin, and unrelated apps.

## ROI note

Each matrix leg skips installing ghost/core (the heaviest tree) + admin + other apps. Exact per-leg savings will show on this PR's own `App Playwright Acceptance Tests` runs vs main.

## Context

Part of a small series scoping over-broad E2E installs; this is the highest-value one because it's a matrix that currently full-installs per leg. The `pnpm nx …` finding (root devDeps survive the filter) also opens up `job_acceptance-tests`/`job_legacy-tests` (`--filter ghost...`) and `publish_public_apps` as future candidates, each needing its own validating run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)