### PR TITLE
🐛 Fixed LinkedIn company/school URLs with international characters being rejected

### DIFF
--- a/apps/admin-x-settings/src/utils/social-urls/linkedin.ts
+++ b/apps/admin-x-settings/src/utils/social-urls/linkedin.ts
@@ -9,8 +9,11 @@ const PATH_TYPES = ['in', 'pub', 'company', 'school'] as const;
 type PathType = typeof PATH_TYPES[number];
 
 // validation info: https://www.linkedin.com/help/linkedin/answer/a542685/manage-your-public-profile-url?lang=en
-// Alphanumeric, hyphen, 3–100 characters
+// Personal profiles (/in/): alphanumeric and hyphen only, 3–100 characters
 const USERNAME_REGEX = /^[a-zA-Z0-9-]{3,100}$/;
+// Company and school pages support Unicode characters (e.g. accented chars in non-English names),
+// underscores, and hyphens. Input may arrive percent-encoded from browsers — decode first.
+const COMPANY_USERNAME_REGEX = /^[\p{L}\p{N}_-]{3,100}$/u;
 // For /pub/ profiles: username optionally followed by slash-separated segments (i.e. 12/34/567)
 const PUB_USERNAME_REGEX = /^[a-zA-Z0-9-]{3,100}(?:\/[a-zA-Z0-9-]*)*$/;
 
@@ -42,7 +45,15 @@ const extractInputParts = (input: string) => {
 
         // don't need protocol from match
         const [, regional, pathType, rawUsername] = match;
-        const username = formatUsername(rawUsername);
+        // Browsers percent-encode non-ASCII characters before sending; decode so validation
+        // works correctly for both raw Unicode and percent-encoded input forms
+        let decodedUsername = rawUsername;
+        try {
+            decodedUsername = decodeURIComponent(rawUsername);
+        } catch {
+            // malformed percent-encoding — leave as-is and let validation reject it
+        }
+        const username = formatUsername(decodedUsername);
 
         // validate regional code is two letters if present
         // validator.js has isISO31661Alpha2, but on a later version than is currently installed
@@ -67,8 +78,13 @@ const extractInputParts = (input: string) => {
 };
 
 const isValidUsername = (pathType: PathType, username: string) => {
-    const pattern = pathType === 'pub' ? PUB_USERNAME_REGEX : USERNAME_REGEX;
-    return pattern.test(username);
+    if (pathType === 'pub') {
+        return PUB_USERNAME_REGEX.test(username);
+    }
+    if (pathType === 'company' || pathType === 'school') {
+        return COMPANY_USERNAME_REGEX.test(username);
+    }
+    return USERNAME_REGEX.test(username);
 };
 
 const buildUrl = ({regional, pathType, username}: {regional?: string; pathType: PathType; username: string}) => {

--- a/apps/admin-x-settings/test/unit/utils/linkedin-urls.test.ts
+++ b/apps/admin-x-settings/test/unit/utils/linkedin-urls.test.ts
@@ -43,6 +43,21 @@ describe('LinkedIn URLs', () => {
             assert.equal(validateLinkedInUrl('linkedin.com/pub/john-smith-abc123'), 'https://www.linkedin.com/pub/john-smith-abc123');
             assert.equal(validateLinkedInUrl('linkedin.com/pub/johnsmith/12/34/567'), 'https://www.linkedin.com/pub/johnsmith/12/34/567');
         });
+
+        it('should accept company URLs with accented/international characters', () => {
+            assert.equal(
+                validateLinkedInUrl('https://www.linkedin.com/company/la-revue-européenne-des-médias-et-du-numérique/'),
+                'https://www.linkedin.com/company/la-revue-européenne-des-médias-et-du-numérique'
+            );
+            assert.equal(
+                validateLinkedInUrl('https://www.linkedin.com/company/la-revue-europ%C3%A9enne-des-m%C3%A9dias-et-du-num%C3%A9rique/'),
+                'https://www.linkedin.com/company/la-revue-européenne-des-médias-et-du-numérique'
+            );
+        });
+
+        it('should reject accented characters in personal /in/ URLs', () => {
+            assert.throws(() => validateLinkedInUrl('linkedin.com/in/jean-éric'), /Your Username is not a valid LinkedIn Username/);
+        });
     });
 
     describe('Handle to URL conversion', () => {


### PR DESCRIPTION
## Problem

LinkedIn company pages for non-English organisations can have URLs containing accented or other non-ASCII characters — for example:

```
https://www.linkedin.com/company/la-revue-européenne-des-médias-et-du-numérique/
```

Ghost's validator rejected these with "Your Username is not a valid LinkedIn Username" because the character classes were ASCII-only (`[a-zA-Z0-9-]`).

There's also a second form of the same URL that users may paste. Browsers automatically percent-encode non-ASCII characters before sending, so the URL above becomes:

```
https://www.linkedin.com/company/la-revue-europ%C3%A9enne-des-m%C3%A9dias-et-du-num%C3%A9rique/
```

Both forms were rejected.

## Solution

Two changes to `apps/admin-x-settings/src/utils/social-urls/linkedin.ts`:

1. **Added `COMPANY_USERNAME_REGEX`** using Unicode property escapes (`\p{L}\p{N}`) with the `/u` flag, so any Unicode letter or number is accepted for `company` and `school` path types. Personal `/in/` profiles remain ASCII-only, per LinkedIn's own documentation.

2. **Added `decodeURIComponent` step** before validation, so percent-encoded input is normalised to its Unicode form before being checked. Both forms now accept and store the same canonical value.

## Note on related PRs

Two earlier PRs from the same contributor touch the same file:
- [#28398](https://github.com/TryGhost/Ghost/pull/28398) — accepts LinkedIn URLs with a trailing slash
- [#28893](https://github.com/TryGhost/Ghost/pull/28893) — accepts underscores in company/school URLs

This PR is rebased from the current `main` and is independent of both. The `COMPANY_USERNAME_REGEX` introduced here (`[\p{L}\p{N}_-]`) is a superset of the underscore fix in #28893 — if that PR merges first, this one will show a trivial conflict on that one line.

## Testing

All 179 existing unit tests continue to pass. New tests cover:
- Raw Unicode company URL accepted and stored as-is
- Percent-encoded company URL accepted and normalised to Unicode
- Accented characters in personal `/in/` URLs continue to be rejected