### PR TITLE
Cleanups to automation poll enqueueing

### DIFF
--- a/ghost/core/core/server/services/automations/service.ts
+++ b/ghost/core/core/server/services/automations/service.ts
@@ -4,6 +4,7 @@ import type DomainEvents from '@tryghost/domain-events';
 import {oneAtATime} from '../../../shared/one-at-a-time';
 import {poll} from './poll';
 import * as automationsApi from './automations-api';
+import {setImmediate as flushEventLoop} from 'node:timers/promises';
 
 const urlUtils = require('../../../shared/url-utils');
 const logging = require('@tryghost/logging');
@@ -44,10 +45,10 @@ export class AutomationsService {
         const enqueuePollAt = async (date: Readonly<Date>): Promise<void> => {
             const isRequestedDateInTheFuture = new Date() < date;
             if (!isRequestedDateInTheFuture) {
-                // Dispatch a task instead of calling immediately to resolve issues with better-sqlite3
-                // being synchronous and blocking the schedulerAdapter.schedule call below, which can
-                // cause a deadlock in some cases.
-                setImmediate(() => enqueuePollNow());
+                // If you're using synchronous SQLite, we want to finish unwinding the call stack
+                // before dispatching another poll event.
+                await flushEventLoop();
+                enqueuePollNow();
                 return;
             }
 


### PR DESCRIPTION
ref 8c72afd949493c53ab564f87013982b4ba6937eb

This change should have no user impact.

1. Update the comment about deadlocking for accuracy.
2. `await` the flushing of the event loop instead of returning immediately, for consistency with the `await` elsewhere in the function.
