### PR TITLE
Tested automation poll enqueueing

### DIFF
--- a/ghost/core/core/server/services/automations/service.ts
+++ b/ghost/core/core/server/services/automations/service.ts
@@ -1,3 +1,4 @@
+import assert from 'node:assert/strict';
 import type {InternalKeys} from '../internal-keys';
 // @ts-expect-error @tryghost/domain-events currently lacks type declarations.
 import type DomainEvents from '@tryghost/domain-events';
@@ -88,5 +89,10 @@ export class AutomationsService {
      */
     async rescheduleAll(): Promise<void> {
         await this.#enqueuePollAt?.(new Date());
+    }
+
+    async __testOnlyEnqueuePollAt(date: Readonly<Date>): Promise<void> {
+        assert(this.#enqueuePollAt, 'Tests should not call this before initialization');
+        return await this.#enqueuePollAt(date);
     }
 }

--- a/ghost/core/core/server/services/automations/service.ts
+++ b/ghost/core/core/server/services/automations/service.ts
@@ -32,10 +32,10 @@ type AutomationsServiceOptions = {
 };
 
 export class AutomationsService {
-    #enqueuePollNow: undefined | (() => void);
+    #enqueuePollAt: undefined | ((date: Readonly<Date>) => Promise<void>);
 
     init({domainEvents, apiUrl, schedulerAdapter, internalKeys}: AutomationsServiceOptions): void {
-        const isInitialized = Boolean(this.#enqueuePollNow);
+        const isInitialized = Boolean(this.#enqueuePollAt);
         if (isInitialized) {
             return;
         }
@@ -78,7 +78,7 @@ export class AutomationsService {
 
         enqueuePollAt(new Date());
 
-        this.#enqueuePollNow = enqueuePollNow;
+        this.#enqueuePollAt = enqueuePollAt;
     }
 
     /**
@@ -86,7 +86,7 @@ export class AutomationsService {
      * key fails JWT verification when fired; this dispatches a fresh in-process
      * poll that re-schedules the next callback under the current key.
      */
-    rescheduleAll(): void {
-        this.#enqueuePollNow?.();
+    async rescheduleAll(): Promise<void> {
+        await this.#enqueuePollAt?.(new Date());
     }
 }

--- a/ghost/core/test/unit/server/services/automations/service.test.js
+++ b/ghost/core/test/unit/server/services/automations/service.test.js
@@ -56,6 +56,61 @@ describe('automations service', function () {
         });
     });
 
+    describe('enqueueing poll', function () {
+        beforeEach(async function () {
+            automations.init(initOptions);
+            await flushEventLoop();
+            domainEvents.dispatch.resetHistory();
+        });
+
+        it('dispatches a StartAutomationsPollEvent if date is in the past', async function () {
+            const past = new Date(Date.now() - 1000);
+            await automations.__testOnlyEnqueuePollAt(past);
+
+            sinon.assert.calledOnceWithExactly(
+                domainEvents.dispatch,
+                sinon.match.instanceOf(StartAutomationsPollEvent)
+            );
+
+            sinon.assert.notCalled(schedulerAdapter.schedule);
+        });
+
+        it('dispatches a StartAutomationsPollEvent if date is now', async function () {
+            await automations.__testOnlyEnqueuePollAt(new Date());
+
+            sinon.assert.calledOnceWithExactly(
+                domainEvents.dispatch,
+                sinon.match.instanceOf(StartAutomationsPollEvent)
+            );
+
+            sinon.assert.notCalled(schedulerAdapter.schedule);
+        });
+
+        it('reaches out to the scheduler for dates in the future', async function () {
+            const future = new Date(Date.now() + 10_000);
+            await automations.__testOnlyEnqueuePollAt(future);
+
+            sinon.assert.calledOnceWithExactly(
+                schedulerAdapter.schedule,
+                sinon.match({
+                    time: future.getTime(),
+                    url: sinon.match((value) => (
+                        typeof value === 'string' &&
+                        new URL(value).searchParams.has('token')
+                    )),
+                    extra: {
+                        httpMethod: 'PUT'
+                    }
+                })
+            );
+
+            sinon.assert.neverCalledWith(
+                domainEvents.dispatch,
+                sinon.match.instanceOf(StartAutomationsPollEvent)
+            );
+        });
+    });
+
     describe('rescheduleAll', function () {
         it('dispatches a fresh StartAutomationsPollEvent', async function () {
             automations.init(initOptions);

--- a/ghost/core/test/unit/server/services/automations/service.test.js
+++ b/ghost/core/test/unit/server/services/automations/service.test.js
@@ -1,4 +1,5 @@
 const sinon = require('sinon');
+const {setImmediate: flushEventLoop} = require('node:timers/promises');
 
 const StartAutomationsPollEvent = require('../../../../../core/server/services/automations/events/start-automations-poll-event');
 const {AutomationsService} = require('../../../../../core/server/services/automations/service');
@@ -36,9 +37,7 @@ describe('automations service', function () {
     describe('init', function () {
         it('dispatches a StartAutomationsPollEvent', async function () {
             automations.init(initOptions);
-            // The initial poll is enqueued for "now", which re-dispatches on the
-            // next macrotask (see enqueuePollAt's setImmediate), so wait a tick.
-            await new Promise(resolve => { setImmediate(resolve) });
+            await flushEventLoop();
             sinon.assert.calledWith(domainEvents.dispatch, sinon.match.instanceOf(StartAutomationsPollEvent));
         });
 
@@ -58,11 +57,12 @@ describe('automations service', function () {
     });
 
     describe('rescheduleAll', function () {
-        it('dispatches a fresh StartAutomationsPollEvent', function () {
+        it('dispatches a fresh StartAutomationsPollEvent', async function () {
             automations.init(initOptions);
+            await flushEventLoop();
             domainEvents.dispatch.resetHistory();
 
-            automations.rescheduleAll();
+            await automations.rescheduleAll();
 
             sinon.assert.calledOnceWithExactly(
                 domainEvents.dispatch,
@@ -70,8 +70,8 @@ describe('automations service', function () {
             );
         });
 
-        it('is a no-op before init', function () {
-            automations.rescheduleAll();
+        it('is a no-op before init', async function () {
+            await automations.rescheduleAll();
             sinon.assert.notCalled(domainEvents.dispatch);
         });
     });

--- a/ghost/core/test/unit/server/services/automations/service.test.js
+++ b/ghost/core/test/unit/server/services/automations/service.test.js
@@ -76,7 +76,10 @@ describe('automations service', function () {
         });
 
         it('dispatches a StartAutomationsPollEvent if date is now', async function () {
-            await automations.__testOnlyEnqueuePollAt(new Date());
+            const now = new Date('2026-01-01T00:00:00.000Z');
+            sinon.useFakeTimers({now, toFake: ['Date']});
+
+            await automations.__testOnlyEnqueuePollAt(now);
 
             sinon.assert.calledOnceWithExactly(
                 domainEvents.dispatch,


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1396

_I recommend [reviewing this commit-by-commit](https://github.com/TryGhost/Ghost/pull/29026/commits)._

This change should have no user impact.

As part of our work to [make automation polling idempotent][0], I'd like to test a previously-untested part of the code.

[0]: https://linear.app/ghost/issue/NY-1396
