### PR TITLE
Changed staff device verification to default off in development

### DIFF
--- a/e2e/helpers/environment/constants.ts
+++ b/e2e/helpers/environment/constants.ts
@@ -85,6 +85,11 @@ export const BASE_GHOST_ENV = [
     'mail__options__host=ghost-dev-mailpit',
     'mail__options__port=1025',
 
+    // Staff device verification (new-device 2FA) defaults off in development but ships
+    // on in production. Force it on so the suite stays production-representative and the
+    // 2FA settings UI / sign-in flow render regardless of the dev default.
+    'security__staffDeviceVerification=true',
+
     // Disable IndexNow pings (tests run with real network access)
     'privacy__useIndexNow=false',
 

--- a/ghost/core/core/shared/config/env/config.development.json
+++ b/ghost/core/core/shared/config/env/config.development.json
@@ -30,5 +30,8 @@
         "admin": {
             "maxAge": 0
         }
+    },
+    "security": {
+        "staffDeviceVerification": false
     }
 }


### PR DESCRIPTION
## Summary

Staff device verification (the "Verify it's really you" new-device 2FA email challenge) is enabled by default via `staffDeviceVerification: true` in `defaults.json`. In local development that means every fresh clone / new machine forces an email verification step on first sign-in — real friction with no security benefit locally.

This flips the default to **off in development only**, by adding `security.staffDeviceVerification: false` to `env/config.development.json`.

## Behaviour

nconf resolves config leaves highest-priority-first, so:

| Layer | Value | Priority |
|---|---|---|
| your own `config.development.json` / `config.local.json` | _(unset)_ | highest |
| `env/config.development.json` (this PR) | `false` | ← new dev default |
| `defaults.json` | `true` | lowest |

- **Dev now defaults to off** — fresh clones skip the verification email.
- **Explicit `true` still wins** — set `"security": { "staffDeviceVerification": true }` in your own `config.local.json` / `config.development.json` to exercise the real flow; those layers sit above this default.
- **Production is unchanged** — `defaults.json` stays `true`; only the `development` env default flips.
- Mirrors existing precedent: `testing` already disables this the same way in `config.testing.json`.

No auth code changed — the read in `session/index.js` (`config.get('security:staffDeviceVerification') !== true`) already does the right thing, and `allowWebhookInternalIPs` still resolves from `defaults.json` since nconf merges per-leaf (same reason the file's existing partial `paths` override doesn't clobber `paths.fixtures`).

## Test plan
- [ ] `NODE_ENV=development`: new-device sign-in no longer prompts for a verification code
- [ ] Setting `security.staffDeviceVerification: true` in a local config re-enables the prompt in dev
- [ ] Production/staging behaviour unchanged (still `true` by default)