### PR TITLE
Raised Renovate nodeMaxMemory to 8192MB to stop lockfile-gen OOM

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,12 +13,21 @@
     // Keep manually-closed immortal/grouped PRs closed unless explicitly
     // reopened from the Dependency Dashboard.
     "recreateWhen": "never",
-    // pnpm lockfile generation has been hitting Mend's 3GB memory ceiling.
-    // Renovate maintainers suggested starting with toolSettings.nodeMaxMemory
-    // set to 1024MB to reduce pnpm's Node heap usage and keep the overall job
-    // under the hosted runner limit.
+    // pnpm lockfile generation (`pnpm install --lockfile-only` across all 20
+    // workspace projects — a ~47k-line, ~4300-entry lockfile) needs well over
+    // 1GB of Node heap. The old 1024MB cap was a workaround for Mend's hosted
+    // 3GB container ceiling: shrink Node's heap enough to keep the whole job
+    // under Mend's limit. Now that Renovate runs self-hosted on ubuntu-latest
+    // (~16GB) that ceiling is gone — but the cap stayed and became the binding
+    // limit. Lockfile regeneration was OOMing at ~1GB ("FATAL ERROR: ...
+    // JavaScript heap out of memory"), which fails renovate/artifacts on every
+    // PR; the PR then opens with a stale lockfile, `Setup`
+    // (pnpm install --frozen-lockfile) fails, every required check cascades red,
+    // nothing automerges, and open PRs jam against the concurrency cap. Raised
+    // to 8192MB: ample headroom for pnpm's resolution graph, still well under
+    // the runner's memory.
     "toolSettings": {
-        "nodeMaxMemory": 1024
+        "nodeMaxMemory": 8192
     },
     // `pnpmDedupe` intentionally NOT in postUpdateOptions — Renovate dedupes
     // on its Linux runner, but `pnpm install` on macOS produces a different


### PR DESCRIPTION
## What

Raise the Renovate `toolSettings.nodeMaxMemory` cap from **1024 MB → 8192 MB**, and rewrite the now-inverted comment explaining why.

## Why

Every Renovate dependency PR has been failing on the **same three checks** (`renovate/artifacts`, `Setup`, `All required tests passed or skipped`) regardless of the package being bumped. It's not the bumps — it's the lockfile step.

Renovate regenerates `pnpm-lock.yaml` via `pnpm install --lockfile-only` across all 20 workspace projects (~47k-line, ~4300-entry lockfile). That process **OOMs at ~1 GB**, right at the `nodeMaxMemory: 1024` cap. From the self-hosted runner log:

```
Command failed: pnpm install --lockfile-only --recursive --ignore-scripts --ignore-pnpmfile
  Mark-Compact (reduce) 1016.6 (1037.0) -> 1016.6 (1033.3) MB ... last resort
  FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - JavaScript heap out of memory
  419 Aborted (core dumped)
WARN: artifactErrors (branch=renovate/css-preprocessors)
```

The failure cascade:

1. `pnpm install --lockfile-only` OOMs → `renovate/artifacts` fails ("Artifact file update failure")
2. The PR opens with a stale/broken lockfile
3. `Setup` (`pnpm install --frozen-lockfile`) fails
4. Every required test cascades red
5. The PR can never go green → never automerges → **squats on a slot against the 10-PR concurrency cap**
6. ~6–7 of the 10 open slots are permanently occupied by these OOM zombies, collapsing effective throughput and stalling the backlog

### Why the cap was there, and why it's now wrong

The `1024` cap was a deliberate workaround for **Mend's hosted 3 GB container ceiling** — shrink Node's heap enough to keep the whole job under Mend's limit. Since Renovate moved to a **self-hosted `ubuntu-latest` runner (~16 GB)**, that ceiling no longer exists — but the cap stayed, and became the binding constraint that's OOMing lockfile generation.

## Impact

Unblocks lockfile regeneration → Renovate PRs reach green CI → automerge fires within the existing windows → the OOM-stuck PRs clear and the backlog drains on existing throughput. 8192 MB is ample headroom for pnpm's resolution graph while staying well under the runner's memory.

## Note

This does **not** fix the broader `pnpm-lock.yaml` churn (single-package bumps rewriting large unrelated subtrees, recurring "fixed broken lockfile" commits from hand-merged conflicts). That's a separate, tracked follow-up.
