### PR TITLE
🐛 Fixed staff profile URL not updating after changing a user's slug

### DIFF
--- a/apps/admin-x-framework/src/providers/routing-provider.tsx
+++ b/apps/admin-x-framework/src/providers/routing-provider.tsx
@@ -21,6 +21,7 @@ export type ExternalLink = {
 export type InternalLink = {
     isExternal?: false;
     route: string;
+    replace?: boolean;
 }
 
 export type RoutingModalProps = {
@@ -125,13 +126,17 @@ export const RoutingProvider: React.FC<RoutingProviderProps> = ({basePath, modal
         }
 
         const newPath = options.route.replace(/^\//, '');
+        const newHash = newPath ? `/${basePath}/${newPath}` : `/${basePath}`;
 
         if (newPath === route) {
             // No change
-        } else if (newPath) {
-            window.location.hash = `/${basePath}/${newPath}`;
+        } else if (options.replace) {
+            // Replace the current history entry so back/refresh use the new
+            // path, then fire hashchange manually since replaceState doesn't
+            window.history.replaceState(window.history.state, '', `#${newHash}`);
+            window.dispatchEvent(new HashChangeEvent('hashchange'));
         } else {
-            window.location.hash = `/${basePath}`;
+            window.location.hash = newHash;
         }
 
         eventTarget.dispatchEvent(new CustomEvent('routeChange', {detail: {newPath, oldPath: route}}));

--- a/apps/admin-x-settings/src/components/settings/general/user-detail-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/user-detail-modal.tsx
@@ -1,7 +1,7 @@
 import EmailNotificationsTab from './users/email-notifications-tab';
 import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import ProfileTab from './users/profile-tab';
-import React, {useCallback, useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 import SocialLinksTab from './users/social-links-tab';
 import clsx from 'clsx';
 import usePinturaEditor from '../../../hooks/use-pintura-editor';
@@ -95,7 +95,24 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
             }, {});
         },
         onSave: async (values) => {
-            await updateUser?.(values);
+            const response = await updateUser?.(values);
+            const savedUser = response?.users?.[0];
+
+            if (!savedUser) {
+                return;
+            }
+
+            // Sync the form with the saved user — the server may have
+            // modified submitted values, e.g. sanitizing the slug
+            setFormState(() => savedUser);
+
+            if (savedUser.slug !== user.slug) {
+                // Keep the URL in sync with the new slug, replacing the
+                // history entry so refresh and back button still work
+                const tab = getTabFromPath(route);
+                const urlSegment = tab === 'profile' ? '' : `/${tab}`;
+                updateRoute({route: `staff/${savedUser.slug}${urlSegment}`, replace: true});
+            }
         },
         onSaveError: handleError
     });
@@ -482,24 +499,67 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
 
 const UserDetailModal: React.FC<RoutingModalProps> = ({params}) => {
     const {currentUser} = useGlobalData();
+    const {updateRoute} = useRouting();
+    const handleError = useHandleError();
 
     // Skip API call if it's the current user (we already have their data)
     const isCurrentUser = currentUser.slug === params?.slug;
 
     // Fetch user by slug if it's not the current user
-    const {data: fetchedUserData} = useGetUserBySlug(
+    const {data: fetchedUserData, error} = useGetUserBySlug(
         params?.slug || '',
-        {enabled: !isCurrentUser && !!params?.slug}
+        {enabled: !isCurrentUser && !!params?.slug, defaultErrorHandler: false}
     );
 
     // Use current user data or fetched user data
     const user = isCurrentUser ? currentUser : fetchedUserData?.users?.[0];
 
+    // Only a 404 (or an empty response) means the user doesn't exist — other
+    // errors (server/network issues) get the default error handling below
+    const isNotFoundError = error instanceof APIError && error.response?.status === 404;
+
+    useEffect(() => {
+        if (error && !isNotFoundError) {
+            handleError(error);
+        }
+    }, [error, isNotFoundError, handleError]);
+
+    // The slug lookup has settled without finding a user
+    const hasResolvedMissingUser = !isCurrentUser && !!params?.slug && !user && (isNotFoundError || fetchedUserData !== undefined);
+
+    // Keep showing the last loaded user while a refetch is in flight, e.g.
+    // when a slug change updates the URL and triggers a fetch by the new
+    // slug — but not once the lookup has settled without finding a user
+    const lastUserRef = useRef<User | undefined>(undefined);
     if (user) {
-        return <UserDetailModalContent user={user} />;
-    } else {
-        return null;
+        lastUserRef.current = user;
     }
+    const displayUser = user || (hasResolvedMissingUser ? undefined : lastUserRef.current);
+
+    const notFoundSlug = hasResolvedMissingUser ? (params?.slug ?? null) : null;
+    const notFoundHandledRef = useRef<string | null>(null);
+
+    useEffect(() => {
+        if (!notFoundSlug || notFoundHandledRef.current === notFoundSlug) {
+            return;
+        }
+        notFoundHandledRef.current = notFoundSlug;
+
+        showToast({
+            type: 'error',
+            message: 'User not found'
+        });
+
+        if (canAccessSettings(currentUser)) {
+            // Replace the history entry so the back button doesn't return
+            // to the dead URL and redirect again
+            updateRoute({route: 'staff', replace: true});
+        } else {
+            updateRoute({isExternal: true, route: ''});
+        }
+    }, [notFoundSlug, currentUser, updateRoute]);
+
+    return displayUser ? <UserDetailModalContent user={displayUser} /> : null;
 };
 
 export default NiceModal.create(UserDetailModal);

--- a/apps/admin-x-settings/test/acceptance/general/users/profile.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/users/profile.test.ts
@@ -932,3 +932,71 @@ test.describe('User profile', async () => {
         });
     });
 });
+
+test.describe('Staff profile URLs', async () => {
+    test('Updates the URL and keeps the modal open when changing a user\'s slug', async ({page}) => {
+        const userToEdit = responseFixtures.users.users.find(user => user.email === 'administrator@test.com')!;
+
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            getUserBySlug: {method: 'GET', path: `/users/slug/${userToEdit.slug}/?include=roles`, response: {
+                users: [userToEdit]
+            }},
+            getUserByNewSlug: {method: 'GET', path: '/users/slug/new-admin/?include=roles', response: {
+                users: [{...userToEdit, slug: 'new-admin'}]
+            }},
+            browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users},
+            editUser: {method: 'PUT', path: `/users/${userToEdit.id}/?include=roles`, response: {
+                users: [{...userToEdit, slug: 'new-admin'}]
+            }}
+        }});
+
+        await page.goto('/');
+
+        const section = page.getByTestId('users');
+        const activeTab = section.locator('[role=tabpanel]:not(.hidden)');
+
+        await section.getByRole('tab', {name: 'Administrators'}).click();
+
+        const listItem = activeTab.getByTestId('user-list-item').last();
+        await listItem.hover();
+        await listItem.getByRole('button', {name: 'Edit'}).click();
+
+        const modal = page.getByTestId('user-detail-modal');
+
+        await expect(page).toHaveURL(new RegExp(`#/settings/staff/${userToEdit.slug}$`));
+
+        // The server sanitizes the submitted slug ('New Admin' -> 'new-admin')
+        await modal.getByLabel('Slug').fill('New Admin');
+        await modal.getByRole('button', {name: 'Save'}).click();
+
+        await expect(modal.getByRole('button', {name: 'Saved'})).toBeVisible();
+
+        // The URL and form follow the server-sanitized slug and the modal stays open
+        await expect(page).toHaveURL(/#\/settings\/staff\/new-admin$/);
+        await expect(modal).toBeVisible();
+        await expect(modal.getByLabel('Slug')).toHaveValue('new-admin');
+
+        // Refreshing the updated URL loads the same profile
+        await page.reload();
+        await expect(page.getByTestId('user-detail-modal')).toBeVisible();
+        await expect(page).toHaveURL(/#\/settings\/staff\/new-admin$/);
+    });
+
+    test('Shows an error and returns to the staff list when the user is not found', async ({page}) => {
+        await mockApi({page, requests: {
+            ...globalDataRequests,
+            browseUsers: {method: 'GET', path: '/users/?limit=100&include=roles', response: responseFixtures.users},
+            getUserBySlug: {method: 'GET', path: '/users/slug/unknown-user/?include=roles', responseStatus: 404, response: {
+                errors: [{type: 'NotFoundError', message: 'Resource not found error, cannot read user.'}]
+            }}
+        }});
+
+        await page.goto('/#/settings/staff/unknown-user');
+
+        await expect(page.getByTestId('toast-error').filter({hasText: 'User not found'})).toBeVisible();
+        await expect(page).toHaveURL(/#\/settings\/staff$/);
+        await expect(page.getByTestId('user-detail-modal')).not.toBeVisible();
+    });
+
+});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1873

## Problem

A customer reported that the admin URL for a staff user's profile used to follow slug changes automatically, but no longer does.

The old Ember staff screen rewrote the browser URL via `replaceState` whenever a user's slug was saved, so refresh, back button and bookmarks kept working after a rename. That behaviour was lost when staff management moved to the React settings app (#18740):

- After saving a slug change, the address bar stayed on `#/settings/staff/old-slug` — a dead URL on the next refresh, which rendered a silent blank (the modal component returns `null` when the slug lookup fails).
- Changing **your own** slug was worse: the modal decides how to load data by comparing `currentUser.slug` against the URL param. Saving updates the shared current-user cache immediately, the comparison flips, the fetch by the (now stale) URL slug finds nothing, and the profile modal silently unmounts right after hitting Save.

## Solution

- Added a `replace` option to the legacy routing provider's `updateRoute`, implemented with `history.replaceState` + a synthetic `hashchange`, mirroring the old Ember behaviour so a slug rename swaps the history entry instead of pushing a dead one.
- After a successful save, the user detail modal updates the route to the **server-returned** slug (the API may sanitize the submitted value), preserving the active tab.
- The modal keeps showing the last loaded user while the refetch by the new slug is in flight, so it no longer unmounts mid-save.
- Opening a stale/unknown staff slug URL now shows a "User not found" toast and navigates back to the staff list instead of rendering nothing.

## Testing

- Added three acceptance tests: slug change on another user updates the URL (incl. surviving a reload), slug change on your own profile keeps the modal open, and unknown slugs show an error and return to the staff list.
- All 42 users/routing acceptance tests, framework unit tests (432) and lint pass locally.