### PR TITLE
✨ Added Social Web handle preferences

### DIFF
--- a/apps/activitypub/src/api/activitypub.test.ts
+++ b/apps/activitypub/src/api/activitypub.test.ts
@@ -35,6 +35,127 @@ function Fetch(specs: Record<string, Spec>) {
 }
 
 describe('ActivityPubAPI', function () {
+    describe('domain', function () {
+        test('It gets the Social Web domain state', async function () {
+            const fakeFetch = Fetch({
+                'https://activitypub.api/.ghost/activitypub/v1/domain': {
+                    async assert(_resource, init) {
+                        expect(init?.method).toEqual('GET');
+                    },
+                    response: JSONResponse({
+                        domain: null,
+                        handle: '@index@blog.site.com',
+                        actorUrl: 'https://blog.site.com/.ghost/activitypub/users/index'
+                    })
+                }
+            });
+            const api = new ActivityPubAPI(
+                new URL('https://activitypub.api'),
+                new URL('https://auth.api'),
+                'index',
+                fakeFetch
+            );
+
+            const result = await api.getDomain();
+
+            expect(result).toEqual({
+                domain: null,
+                handle: '@index@blog.site.com',
+                actorUrl: 'https://blog.site.com/.ghost/activitypub/users/index'
+            });
+        });
+
+        test('It updates the Social Web domain', async function () {
+            const fakeFetch = Fetch({
+                'https://activitypub.api/.ghost/activitypub/v1/domain': {
+                    async assert(_resource, init) {
+                        expect(init?.method).toEqual('PUT');
+                        expect(init?.body).toEqual('{"domain":"site.com"}');
+                    },
+                    response: JSONResponse({
+                        domain: 'site.com',
+                        handle: '@index@site.com',
+                        actorUrl: 'https://blog.site.com/.ghost/activitypub/users/index'
+                    })
+                }
+            });
+            const api = new ActivityPubAPI(
+                new URL('https://activitypub.api'),
+                new URL('https://auth.api'),
+                'index',
+                fakeFetch
+            );
+
+            const result = await api.updateDomain('site.com');
+
+            expect(result).toEqual({
+                domain: 'site.com',
+                handle: '@index@site.com',
+                actorUrl: 'https://blog.site.com/.ghost/activitypub/users/index'
+            });
+        });
+
+        test('It validates the Social Web domain without saving it', async function () {
+            const fakeFetch = Fetch({
+                'https://activitypub.api/.ghost/activitypub/v1/domain/validate': {
+                    async assert(_resource, init) {
+                        expect(init?.method).toEqual('POST');
+                        expect(init?.body).toEqual('{"domain":"site.com"}');
+                    },
+                    response: JSONResponse({
+                        domain: 'site.com',
+                        handle: '@index@site.com',
+                        actorUrl: 'https://blog.site.com/.ghost/activitypub/users/index'
+                    })
+                }
+            });
+            const api = new ActivityPubAPI(
+                new URL('https://activitypub.api'),
+                new URL('https://auth.api'),
+                'index',
+                fakeFetch
+            );
+
+            const result = await api.validateDomain('site.com');
+
+            expect(result).toEqual({
+                domain: 'site.com',
+                handle: '@index@site.com',
+                actorUrl: 'https://blog.site.com/.ghost/activitypub/users/index'
+            });
+        });
+
+        test('It clears the Social Web domain', async function () {
+            const fakeFetch = Fetch({
+                'https://activitypub.api/.ghost/activitypub/v1/domain': {
+                    async assert(_resource, init) {
+                        expect(init?.method).toEqual('PUT');
+                        expect(init?.body).toEqual('{"domain":null}');
+                    },
+                    response: JSONResponse({
+                        domain: null,
+                        handle: '@index@blog.site.com',
+                        actorUrl: 'https://blog.site.com/.ghost/activitypub/users/index'
+                    })
+                }
+            });
+            const api = new ActivityPubAPI(
+                new URL('https://activitypub.api'),
+                new URL('https://auth.api'),
+                'index',
+                fakeFetch
+            );
+
+            const result = await api.updateDomain(null);
+
+            expect(result).toEqual({
+                domain: null,
+                handle: '@index@blog.site.com',
+                actorUrl: 'https://blog.site.com/.ghost/activitypub/users/index'
+            });
+        });
+    });
+
     describe('follow', function () {
         test('It passes the token to the follow endpoint', async function () {
             const fakeFetch = Fetch({

--- a/apps/activitypub/src/api/activitypub.ts
+++ b/apps/activitypub/src/api/activitypub.ts
@@ -200,6 +200,12 @@ export interface GetBlockedDomainsResponse {
     next: string | null;
 }
 
+export interface SocialWebDomain {
+    domain: string | null;
+    handle: string;
+    actorUrl: string;
+}
+
 export const PostType = {
     Note: 0,
     Article: 1,
@@ -522,6 +528,27 @@ export class ActivityPubAPI {
         const json = await this.fetchJSON(url);
 
         return parseAccountAliasesResponse(json);
+    }
+
+    async getDomain(): Promise<SocialWebDomain> {
+        const url = new URL('.ghost/activitypub/v1/domain', this.apiUrl);
+        const json = await this.fetchJSON(url);
+
+        return json as SocialWebDomain;
+    }
+
+    async updateDomain(domain: string | null): Promise<SocialWebDomain> {
+        const url = new URL('.ghost/activitypub/v1/domain', this.apiUrl);
+        const json = await this.fetchJSON(url, 'PUT', {domain});
+
+        return json as SocialWebDomain;
+    }
+
+    async validateDomain(domain: string): Promise<SocialWebDomain> {
+        const url = new URL('.ghost/activitypub/v1/domain/validate', this.apiUrl);
+        const json = await this.fetchJSON(url, 'POST', {domain});
+
+        return json as SocialWebDomain;
     }
 
     async addAccountAlias(sourceHandle: string): Promise<AccountAliasesResponse> {

--- a/apps/activitypub/src/hooks/use-activity-pub-queries.ts
+++ b/apps/activitypub/src/hooks/use-activity-pub-queries.ts
@@ -11,6 +11,7 @@ import {
     type Post,
     type ReplyChainResponse,
     type SearchResults,
+    type SocialWebDomain,
     isApiError
 } from '../api/activitypub';
 import {Activity, ActorProperties} from '@tryghost/admin-x-framework/api/activitypub';
@@ -76,6 +77,7 @@ const QUERY_KEYS = {
     },
     account: (handle: string) => ['account', handle],
     accountAliases: (handle: string) => ['account_aliases', handle],
+    accountDomain: (handle: string) => ['account_domain', handle],
     accountFollows: (handle: string, type: AccountFollowsType) => ['account_follows', handle, type],
     searchResults: (query: string) => ['search_results', query],
     suggestedProfiles: (handle: string, limit: number) => ['suggested_profiles', handle, limit],
@@ -1668,6 +1670,48 @@ export function useAccountAliasesForUser(handle: string) {
     });
 }
 
+export function useAccountDomainForUser(handle: string) {
+    return useQuery({
+        queryKey: QUERY_KEYS.accountDomain(handle),
+        async queryFn() {
+            const siteUrl = await getSiteUrl();
+            const api = createActivityPubAPI(handle, siteUrl);
+
+            return api.getDomain();
+        }
+    });
+}
+
+export function useUpdateAccountDomainMutationForUser(handle: string) {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        async mutationFn(domain: string | null) {
+            const siteUrl = await getSiteUrl();
+            const api = createActivityPubAPI(handle, siteUrl);
+
+            return api.updateDomain(domain);
+        },
+        onSuccess(response: SocialWebDomain) {
+            queryClient.setQueryData(QUERY_KEYS.accountDomain(handle), response);
+            queryClient.invalidateQueries({
+                queryKey: QUERY_KEYS.account(handle)
+            });
+        }
+    });
+}
+
+export function useValidateAccountDomainMutationForUser(handle: string) {
+    return useMutation({
+        async mutationFn(domain: string) {
+            const siteUrl = await getSiteUrl();
+            const api = createActivityPubAPI(handle, siteUrl);
+
+            return api.validateDomain(domain);
+        }
+    });
+}
+
 export function useAddAccountAliasMutationForUser(handle: string) {
     const queryClient = useQueryClient();
 
@@ -2401,6 +2445,9 @@ export function useUpdateAccountMutationForUser(handle: string) {
         onSuccess() {
             queryClient.invalidateQueries({
                 queryKey: QUERY_KEYS.account('index')
+            });
+            queryClient.invalidateQueries({
+                queryKey: QUERY_KEYS.accountDomain('index')
             });
         }
     });

--- a/apps/activitypub/src/routes.tsx
+++ b/apps/activitypub/src/routes.tsx
@@ -114,6 +114,12 @@ export const routes: CustomRouteObject[] = [
                 showBackButton: true
             },
             {
+                path: 'preferences/handle',
+                lazy: lazyComponent(() => import('./views/preferences/components/domain')),
+                pageTitle: 'Handle',
+                showBackButton: true
+            },
+            {
                 path: 'welcome',
                 lazy: lazyComponent(() => import('./components/layout/onboarding')),
                 pageTitle: 'Welcome',

--- a/apps/activitypub/src/utils/social-web-handle.ts
+++ b/apps/activitypub/src/utils/social-web-handle.ts
@@ -1,0 +1,28 @@
+export const SOCIAL_WEB_USERNAME_MIN_LENGTH = 2;
+export const SOCIAL_WEB_USERNAME_MAX_LENGTH = 100;
+export const SOCIAL_WEB_USERNAME_PATTERN = /^[a-zA-Z0-9_]+$/;
+
+export function getHandleParts(handle?: string) {
+    const match = handle?.match(/^@?([^@]+)@(.+)$/);
+
+    return {
+        username: match?.[1] ?? '',
+        domain: match?.[2] ?? ''
+    };
+}
+
+export function validateSocialWebUsername(username: string) {
+    if (username.length < SOCIAL_WEB_USERNAME_MIN_LENGTH) {
+        return `Username must be at least ${SOCIAL_WEB_USERNAME_MIN_LENGTH} characters.`;
+    }
+
+    if (username.length > SOCIAL_WEB_USERNAME_MAX_LENGTH) {
+        return `Username must be less than ${SOCIAL_WEB_USERNAME_MAX_LENGTH} characters.`;
+    }
+
+    if (!SOCIAL_WEB_USERNAME_PATTERN.test(username)) {
+        return 'Username must contain only letters, numbers, and underscores.';
+    }
+
+    return null;
+}

--- a/apps/activitypub/src/utils/social-web-handle.ts
+++ b/apps/activitypub/src/utils/social-web-handle.ts
@@ -16,7 +16,7 @@ export function validateSocialWebUsername(username: string) {
         return `Username must be at least ${SOCIAL_WEB_USERNAME_MIN_LENGTH} characters.`;
     }
 
-    if (username.length > SOCIAL_WEB_USERNAME_MAX_LENGTH) {
+    if (username.length >= SOCIAL_WEB_USERNAME_MAX_LENGTH) {
         return `Username must be less than ${SOCIAL_WEB_USERNAME_MAX_LENGTH} characters.`;
     }
 

--- a/apps/activitypub/src/views/preferences/components/domain.tsx
+++ b/apps/activitypub/src/views/preferences/components/domain.tsx
@@ -263,7 +263,10 @@ const Domain: React.FC = () => {
             window.clearTimeout(copyTimeoutRef.current);
         }
 
-        copyTimeoutRef.current = window.setTimeout(() => setHasCopiedHandle(false), 2000);
+        copyTimeoutRef.current = window.setTimeout(() => {
+            setHasCopiedHandle(false);
+            setIsHandleTooltipOpen(false);
+        }, 2000);
     };
 
     return (

--- a/apps/activitypub/src/views/preferences/components/domain.tsx
+++ b/apps/activitypub/src/views/preferences/components/domain.tsx
@@ -7,8 +7,6 @@ import {getHandleParts, validateSocialWebUsername} from '@utils/social-web-handl
 import {useAccountDomainForUser, useAccountForUser, useUpdateAccountDomainMutationForUser, useUpdateAccountMutationForUser, useValidateAccountDomainMutationForUser} from '@hooks/use-activity-pub-queries';
 import {useBrowseSite} from '@tryghost/admin-x-framework/api/site';
 
-type DomainAction = 'validate' | 'save' | 'remove';
-
 function normalizeDomainInput(value: string) {
     const trimmed = value.trim();
 
@@ -92,7 +90,6 @@ const Domain: React.FC = () => {
     const [validatedDomain, setValidatedDomain] = useState<string | null>(null);
     const [fieldError, setFieldError] = useState<string | null>(null);
     const [validationError, setValidationError] = useState<string | null>(null);
-    const [action, setAction] = useState<DomainAction | null>(null);
     const [hasCopiedHandle, setHasCopiedHandle] = useState(false);
     const [isHandleTooltipOpen, setIsHandleTooltipOpen] = useState(false);
     const copyTimeoutRef = useRef<number | null>(null);
@@ -156,15 +153,12 @@ const Domain: React.FC = () => {
 
         setFieldError(null);
         setValidationError(null);
-        setAction('validate');
 
         try {
             await validateDomainMutation.mutateAsync(normalizedDomain);
             setValidatedDomain(normalizedDomain);
         } catch {
             setValidationError('Redirect could not be validated');
-        } finally {
-            setAction(null);
         }
     };
 
@@ -175,7 +169,6 @@ const Domain: React.FC = () => {
 
         setFieldError(null);
         setValidationError(null);
-        setAction('save');
 
         try {
             await updateDomainMutation.mutateAsync(validatedDomain);
@@ -185,8 +178,6 @@ const Domain: React.FC = () => {
             setValidatedDomain(null);
         } catch {
             setFieldError('Could not save the custom domain. Try again.');
-        } finally {
-            setAction(null);
         }
     };
 
@@ -234,7 +225,6 @@ const Domain: React.FC = () => {
 
     const handleRemove = async () => {
         setFieldError(null);
-        setAction('remove');
 
         try {
             await updateDomainMutation.mutateAsync(null);
@@ -244,8 +234,6 @@ const Domain: React.FC = () => {
             setValidatedDomain(null);
         } catch {
             setFieldError('Could not remove the custom domain. Try again.');
-        } finally {
-            setAction(null);
         }
     };
 
@@ -433,7 +421,7 @@ const Domain: React.FC = () => {
                                     disabled
                                 />
                                 <Button className='h-9 text-sm sm:w-auto' disabled={isDisabled} variant='outline' onClick={handleRemove}>
-                                    {action === 'remove' ? (
+                                    {updateDomainMutation.isLoading ? (
                                         <>
                                             <LoadingIndicator size='sm' />
                                             Removing...
@@ -532,7 +520,7 @@ const Domain: React.FC = () => {
                                         <Button disabled={isDisabled} variant='outline' onClick={handleCancel}>Cancel</Button>
                                         {canSave ? (
                                             <Button disabled={isDisabled} onClick={handleSave}>
-                                                {action === 'save' ? (
+                                                {updateDomainMutation.isLoading ? (
                                                     <>
                                                         <LoadingIndicator color='light' size='sm' />
                                                         Saving...
@@ -541,7 +529,7 @@ const Domain: React.FC = () => {
                                             </Button>
                                         ) : (
                                             <Button disabled={isDisabled || !canValidate || hasDomainLoadError} onClick={handleValidate}>
-                                                {action === 'validate' ? (
+                                                {validateDomainMutation.isLoading ? (
                                                     <>
                                                         <LoadingIndicator color='light' size='sm' />
                                                         Validating...

--- a/apps/activitypub/src/views/preferences/components/domain.tsx
+++ b/apps/activitypub/src/views/preferences/components/domain.tsx
@@ -1,0 +1,560 @@
+import Layout from '@src/components/layout';
+import React, {useEffect, useRef, useState} from 'react';
+import {Button, Field, FieldError, FieldLabel, Input, LoadingIndicator, Skeleton, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@tryghost/shade/components';
+import {H2, Inline} from '@tryghost/shade/primitives';
+import {LucideIcon} from '@tryghost/shade/utils';
+import {getHandleParts, validateSocialWebUsername} from '@utils/social-web-handle';
+import {useAccountDomainForUser, useAccountForUser, useUpdateAccountDomainMutationForUser, useUpdateAccountMutationForUser, useValidateAccountDomainMutationForUser} from '@hooks/use-activity-pub-queries';
+import {useBrowseSite} from '@tryghost/admin-x-framework/api/site';
+
+type DomainAction = 'validate' | 'save' | 'remove';
+
+function normalizeDomainInput(value: string) {
+    const trimmed = value.trim();
+
+    if (trimmed === '') {
+        return null;
+    }
+
+    try {
+        return new URL(trimmed.includes('://') ? trimmed : `https://${trimmed}`).host || null;
+    } catch {
+        return trimmed.replace(/^[a-z][a-z\d+\-.]*:\/\//i, '').split(/[/?#]/)[0] || null;
+    }
+}
+
+function getDefaultDomain(actorUrl?: string, handle?: string) {
+    if (actorUrl) {
+        try {
+            return new URL(actorUrl).host;
+        } catch {
+            // Fall through to handle parsing.
+        }
+    }
+
+    return handle?.split('@').at(-1) ?? '';
+}
+
+function getImageUrl(url?: string | null, baseUrl?: string) {
+    if (!url) {
+        return '';
+    }
+
+    try {
+        return new URL(url, baseUrl || window.location.origin).toString();
+    } catch {
+        return url;
+    }
+}
+
+async function copyTextToClipboard(text: string) {
+    if (navigator.clipboard?.writeText) {
+        try {
+            await navigator.clipboard.writeText(text);
+            return;
+        } catch {
+            // Fall back for browser contexts where the async clipboard API is blocked.
+        }
+    }
+
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.left = '-9999px';
+    textarea.style.top = '0';
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand('copy');
+    document.body.removeChild(textarea);
+}
+
+const Domain: React.FC = () => {
+    const {
+        data: account,
+        isLoading: isLoadingAccount
+    } = useAccountForUser('index', 'me');
+    const {data: siteData} = useBrowseSite();
+    const {
+        data: domainData,
+        isLoading: isLoadingDomain,
+        isError: hasDomainLoadError
+    } = useAccountDomainForUser('index');
+    const updateDomainMutation = useUpdateAccountDomainMutationForUser('index');
+    const validateDomainMutation = useValidateAccountDomainMutationForUser('index');
+    const updateAccountMutation = useUpdateAccountMutationForUser(account?.handle || 'index');
+    const [domainInput, setDomainInput] = useState('');
+    const [usernameInput, setUsernameInput] = useState('');
+    const [usernameError, setUsernameError] = useState<string | null>(null);
+    const [isEditingUsername, setIsEditingUsername] = useState(false);
+    const [isEditingDomain, setIsEditingDomain] = useState(false);
+    const [isAddingDomain, setIsAddingDomain] = useState(false);
+    const [validatedDomain, setValidatedDomain] = useState<string | null>(null);
+    const [fieldError, setFieldError] = useState<string | null>(null);
+    const [validationError, setValidationError] = useState<string | null>(null);
+    const [action, setAction] = useState<DomainAction | null>(null);
+    const [hasCopiedHandle, setHasCopiedHandle] = useState(false);
+    const [isHandleTooltipOpen, setIsHandleTooltipOpen] = useState(false);
+    const copyTimeoutRef = useRef<number | null>(null);
+
+    useEffect(() => {
+        if (account?.handle) {
+            setUsernameInput(getHandleParts(account.handle).username);
+            setUsernameError(null);
+        }
+    }, [account?.handle]);
+
+    useEffect(() => () => {
+        if (copyTimeoutRef.current) {
+            window.clearTimeout(copyTimeoutRef.current);
+        }
+    }, []);
+
+    const normalizedDomain = normalizeDomainInput(domainInput);
+    const activeDomain = domainData?.domain ?? null;
+    const defaultDomain = getDefaultDomain(domainData?.actorUrl, domainData?.handle);
+    const currentUsername = getHandleParts(account?.handle).username;
+    const isUpdatingAccount = updateAccountMutation.isLoading;
+    const isMutating = updateDomainMutation.isLoading || validateDomainMutation.isLoading;
+    const isDisabled = isLoadingDomain || isMutating;
+    const isUsernameDisabled = isLoadingAccount || isUpdatingAccount || !account;
+    const canSaveUsername = Boolean(isEditingUsername && usernameInput !== currentUsername);
+    const showInstructions = Boolean(isAddingDomain && normalizedDomain && (!activeDomain || validatedDomain === normalizedDomain));
+    const canAdd = Boolean(isEditingDomain && normalizedDomain && !isAddingDomain);
+    const canValidate = Boolean(showInstructions && normalizedDomain && normalizedDomain !== validatedDomain);
+    const canSave = Boolean(validatedDomain && normalizedDomain === validatedDomain);
+    const redirectSource = normalizedDomain ? `https://${normalizedDomain}/.well-known/webfinger` : '';
+    const redirectTarget = defaultDomain ? `https://${defaultDomain}/.well-known/webfinger` : '';
+    const handleParts = getHandleParts(domainData?.handle);
+    const previewHandleParts = {
+        username: isEditingUsername ? usernameInput : handleParts.username,
+        domain: (isEditingDomain || isAddingDomain) && domainInput ? normalizedDomain ?? domainInput.trim() : handleParts.domain
+    };
+    const previewHandle = `@${previewHandleParts.username}@${previewHandleParts.domain}`;
+    const profileImageUrl = getImageUrl(account?.avatarUrl || siteData?.site?.icon, siteData?.site?.url);
+
+    const handleAdd = (event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+
+        const formDomain = normalizeDomainInput(new FormData(event.currentTarget).get('domain')?.toString() ?? '');
+
+        if (!formDomain) {
+            return;
+        }
+
+        setDomainInput(formDomain);
+        setIsEditingDomain(true);
+        setIsAddingDomain(true);
+        setFieldError(null);
+        setValidationError(null);
+    };
+
+    const handleValidate = async () => {
+        if (!normalizedDomain || !canValidate) {
+            return;
+        }
+
+        setFieldError(null);
+        setValidationError(null);
+        setAction('validate');
+
+        try {
+            await validateDomainMutation.mutateAsync(normalizedDomain);
+            setValidatedDomain(normalizedDomain);
+        } catch {
+            setValidationError('Redirect could not be validated');
+        } finally {
+            setAction(null);
+        }
+    };
+
+    const handleSave = async () => {
+        if (!validatedDomain) {
+            return;
+        }
+
+        setFieldError(null);
+        setValidationError(null);
+        setAction('save');
+
+        try {
+            await updateDomainMutation.mutateAsync(validatedDomain);
+            setDomainInput('');
+            setIsEditingDomain(false);
+            setIsAddingDomain(false);
+            setValidatedDomain(null);
+        } catch {
+            setFieldError('Could not save the custom domain. Try again.');
+        } finally {
+            setAction(null);
+        }
+    };
+
+    const handleCancel = () => {
+        setDomainInput('');
+        setIsEditingDomain(false);
+        setIsAddingDomain(false);
+        setValidatedDomain(null);
+        setFieldError(null);
+        setValidationError(null);
+    };
+
+    const handleSaveUsername = async () => {
+        if (!account || !isEditingUsername || !canSaveUsername) {
+            return;
+        }
+
+        const validationMessage = validateSocialWebUsername(usernameInput);
+        if (validationMessage) {
+            setUsernameError(validationMessage);
+            return;
+        }
+
+        setUsernameError(null);
+
+        try {
+            await updateAccountMutation.mutateAsync({
+                name: account.name,
+                username: usernameInput,
+                bio: account.bio ?? '',
+                avatarUrl: account.avatarUrl || '',
+                bannerImageUrl: account.bannerImageUrl || ''
+            });
+            setIsEditingUsername(false);
+        } catch {
+            setUsernameError('Could not save the Social Web username. Try again.');
+        }
+    };
+
+    const handleCancelUsername = () => {
+        setUsernameInput(currentUsername);
+        setUsernameError(null);
+        setIsEditingUsername(false);
+    };
+
+    const handleRemove = async () => {
+        setFieldError(null);
+        setAction('remove');
+
+        try {
+            await updateDomainMutation.mutateAsync(null);
+            setDomainInput('');
+            setIsEditingDomain(false);
+            setIsAddingDomain(false);
+            setValidatedDomain(null);
+        } catch {
+            setFieldError('Could not remove the custom domain. Try again.');
+        } finally {
+            setAction(null);
+        }
+    };
+
+    const handleCopySocialWebHandle = async () => {
+        if (!previewHandleParts.username || !previewHandleParts.domain) {
+            return;
+        }
+
+        await copyTextToClipboard(previewHandle);
+
+        setHasCopiedHandle(true);
+        setIsHandleTooltipOpen(true);
+
+        if (copyTimeoutRef.current) {
+            window.clearTimeout(copyTimeoutRef.current);
+        }
+
+        copyTimeoutRef.current = window.setTimeout(() => setHasCopiedHandle(false), 2000);
+    };
+
+    return (
+        <Layout>
+            <div className='mx-auto max-w-[620px] py-[min(4vh,48px)]'>
+                <Inline gap='2xl' justify='between'>
+                    <H2>Your social web handle</H2>
+                </Inline>
+
+                <p className='mt-3 text-base text-muted-foreground'>
+                    Like an email address, your handle is how people can find and interact with you.
+                </p>
+
+                <div className='mt-10'>
+                    <div className='rounded-md border border-border-default bg-sidebar px-4 pt-3 pb-4'>
+                        <Field>
+                            {isLoadingDomain ? (
+                                <Skeleton className='mt-2 h-16 w-full' />
+                            ) : hasDomainLoadError ? (
+                                <p className='text-sm text-muted-foreground'>Could not load your Social Web handle.</p>
+                            ) : (
+                                <div className='mt-3 flex items-start gap-2'>
+                                    <div className='mt-[-5px] flex size-7 shrink-0 items-center justify-center overflow-hidden rounded-full bg-surface-elevated text-muted-foreground ring-1 ring-border-default'>
+                                        {isLoadingAccount ? (
+                                            <Skeleton className='size-7 rounded-full' />
+                                        ) : profileImageUrl ? (
+                                            <img
+                                                alt={account?.name || siteData?.site?.title || ''}
+                                                className='size-full rounded-full object-cover'
+                                                referrerPolicy='no-referrer'
+                                                src={profileImageUrl}
+                                            />
+                                        ) : (
+                                            <LucideIcon.UserRound className='size-4' strokeWidth={1.5} />
+                                        )}
+                                    </div>
+                                    <div className='-ml-14 min-w-0 overflow-x-auto px-14'>
+                                        <div aria-label='Social Web handle breakdown' className='inline-flex pb-9 font-mono text-xl leading-none font-medium text-foreground select-none' role='group'>
+                                            <span>@</span>
+                                            <div className='relative'>
+                                                <span>{previewHandleParts.username}</span>
+                                                <div className='absolute top-7 left-0 w-full border-t border-border-strong before:absolute before:top-[-5px] before:left-0 before:h-[5px] before:border-l before:border-border-strong after:absolute after:top-[-5px] after:right-0 after:h-[5px] after:border-l after:border-border-strong'>
+                                                    <span aria-hidden='true' className='absolute top-0 left-1/2 h-[5px] border-l border-border-strong' />
+                                                    <div className='absolute top-2 right-0 w-max min-w-full text-center font-sans text-[10px] leading-normal font-medium whitespace-nowrap text-muted-foreground uppercase'>
+                                                        Username
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <span className='ml-px'>@</span>
+                                            <div className='relative'>
+                                                <span>{previewHandleParts.domain}</span>
+                                                <div className='absolute top-7 left-0 w-full border-t border-state-success before:absolute before:top-[-5px] before:left-0 before:h-[5px] before:border-l before:border-state-success after:absolute after:top-[-5px] after:right-0 after:h-[5px] after:border-l after:border-state-success'>
+                                                    <span aria-hidden='true' className='absolute top-0 left-1/2 h-[5px] border-l border-state-success' />
+                                                    <div className='absolute top-2 left-0 w-max min-w-full text-center font-sans text-[10px] leading-normal font-medium whitespace-nowrap text-state-success uppercase'>
+                                                        Domain
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            {domainData?.handle && (
+                                                <TooltipProvider delayDuration={0}>
+                                                    <Tooltip open={isHandleTooltipOpen} onOpenChange={setIsHandleTooltipOpen}>
+                                                        <TooltipTrigger asChild>
+                                                            <Button
+                                                                aria-label='Copy Social Web handle'
+                                                                className='mt-[-2px] ml-1.5 size-5 shrink-0 self-start p-0 text-muted-foreground hover:text-foreground [&_svg]:size-3.5!'
+                                                                type='button'
+                                                                variant='ghost'
+                                                                onClick={() => {
+                                                                    void handleCopySocialWebHandle();
+                                                                }}
+                                                            >
+                                                                <LucideIcon.Copy size={12} />
+                                                            </Button>
+                                                        </TooltipTrigger>
+                                                        <TooltipContent>{hasCopiedHandle ? 'Copied!' : 'Copy'}</TooltipContent>
+                                                    </Tooltip>
+                                                </TooltipProvider>
+                                            )}
+                                        </div>
+                                    </div>
+                                </div>
+                            )}
+                        </Field>
+                    </div>
+                </div>
+
+                <form
+                    className='mt-10'
+                    onSubmit={(event) => {
+                        event.preventDefault();
+                        void handleSaveUsername();
+                    }}
+                >
+                    <Field>
+                        <FieldLabel htmlFor='social-web-username'>Social web username</FieldLabel>
+                        {isLoadingAccount ? (
+                            <Skeleton className='h-9 w-full' />
+                        ) : (
+                            <Inline className='flex-col items-stretch sm:flex-row sm:items-center' gap='md'>
+                                <Input
+                                    aria-describedby={usernameError ? 'social-web-username-error' : undefined}
+                                    aria-invalid={usernameError ? true : undefined}
+                                    autoComplete='off'
+                                    className='sm:flex-1'
+                                    disabled={isUsernameDisabled || !isEditingUsername}
+                                    id='social-web-username'
+                                    value={usernameInput}
+                                    data-1p-ignore
+                                    onChange={(event) => {
+                                        setUsernameInput(event.target.value);
+                                        setUsernameError(null);
+                                    }}
+                                />
+                                {isEditingUsername ? (
+                                    <Inline gap='md' justify='end'>
+                                        <Button className='h-9 text-sm sm:w-auto' disabled={isUpdatingAccount} type='button' variant='outline' onClick={handleCancelUsername}>
+                                            Cancel
+                                        </Button>
+                                        <Button className='h-9 text-sm sm:w-auto' disabled={isUsernameDisabled || !canSaveUsername} type='submit'>
+                                            {isUpdatingAccount ? (
+                                                <>
+                                                    <LoadingIndicator color='light' size='sm' />
+                                                    Saving...
+                                                </>
+                                            ) : 'Save'}
+                                        </Button>
+                                    </Inline>
+                                ) : (
+                                    <Button
+                                        aria-label='Edit Social web username'
+                                        className='h-9 text-sm sm:w-auto'
+                                        disabled={isUsernameDisabled}
+                                        type='button'
+                                        variant='outline'
+                                        onClick={() => {
+                                            setUsernameInput(currentUsername);
+                                            setUsernameError(null);
+                                            setIsEditingUsername(true);
+                                        }}
+                                    >
+                                        Edit
+                                    </Button>
+                                )}
+                            </Inline>
+                        )}
+                        {usernameError && (
+                            <FieldError id='social-web-username-error'>{usernameError}</FieldError>
+                        )}
+                    </Field>
+                </form>
+
+                <div className='mt-10'>
+                    {activeDomain && !validatedDomain ? (
+                        <Field data-invalid={fieldError ? true : undefined}>
+                            <FieldLabel htmlFor='social-web-active-domain'>Social web domain</FieldLabel>
+                            <Inline className='flex-col items-stretch sm:flex-row sm:items-center' gap='md'>
+                                <Input
+                                    aria-label='Active social web domain'
+                                    autoComplete='off'
+                                    className='sm:flex-1'
+                                    id='social-web-active-domain'
+                                    value={activeDomain}
+                                    data-1p-ignore
+                                    disabled
+                                />
+                                <Button className='h-9 text-sm sm:w-auto' disabled={isDisabled} variant='outline' onClick={handleRemove}>
+                                    {action === 'remove' ? (
+                                        <>
+                                            <LoadingIndicator size='sm' />
+                                            Removing...
+                                        </>
+                                    ) : 'Remove'}
+                                </Button>
+                            </Inline>
+                            {fieldError && (
+                                <FieldError id='social-web-domain-error'>{fieldError}</FieldError>
+                            )}
+                        </Field>
+                    ) : (
+                        <form onSubmit={handleAdd}>
+                            <Field data-invalid={fieldError ? true : undefined}>
+                                <FieldLabel htmlFor='social-web-domain'>Social web domain</FieldLabel>
+                                <Inline className='flex-col items-stretch sm:flex-row sm:items-center' gap='md'>
+                                    <Input
+                                        aria-describedby={fieldError ? 'social-web-domain-error' : undefined}
+                                        aria-invalid={fieldError ? true : undefined}
+                                        aria-label='Social web domain'
+                                        autoComplete='off'
+                                        className='sm:flex-1'
+                                        disabled={isDisabled || !isEditingDomain || isAddingDomain}
+                                        id='social-web-domain'
+                                        name='domain'
+                                        placeholder={defaultDomain}
+                                        value={isEditingDomain || isAddingDomain ? domainInput : defaultDomain}
+                                        data-1p-ignore
+                                        onChange={(event) => {
+                                            setDomainInput(event.target.value);
+                                            setIsAddingDomain(false);
+                                            setValidatedDomain(null);
+                                            setFieldError(null);
+                                            setValidationError(null);
+                                        }}
+                                    />
+                                    {!showInstructions && (
+                                        isEditingDomain ? (
+                                            <Inline gap='md' justify='end'>
+                                                <Button className='h-9 text-sm sm:w-auto' disabled={isDisabled} type='button' variant='outline' onClick={handleCancel}>
+                                                    Cancel
+                                                </Button>
+                                                <Button className='h-9 text-sm sm:w-auto' disabled={isDisabled || !canAdd || hasDomainLoadError} type='submit'>
+                                                    Activate
+                                                </Button>
+                                            </Inline>
+                                        ) : (
+                                            <Button
+                                                aria-label='Edit Social web domain'
+                                                className='h-9 text-sm sm:w-auto'
+                                                disabled={isDisabled || hasDomainLoadError}
+                                                type='button'
+                                                variant='outline'
+                                                onClick={() => {
+                                                    setDomainInput('');
+                                                    setFieldError(null);
+                                                    setValidationError(null);
+                                                    setIsEditingDomain(true);
+                                                }}
+                                            >
+                                                Edit
+                                            </Button>
+                                        )
+                                    )}
+                                </Inline>
+                                {fieldError && (
+                                    <FieldError id='social-web-domain-error'>{fieldError}</FieldError>
+                                )}
+                            </Field>
+
+                            {showInstructions && (
+                                <div className='mt-6 rounded-md border border-border-default bg-surface-elevated p-4'>
+                                    <div className='text-sm font-medium text-foreground'>Set up your redirect</div>
+                                    <p className='mt-2 text-sm text-muted-foreground'>
+                                        Add a redirect or proxy service to forward social web requests to Ghost.
+                                    </p>
+                                    <div className='mt-4 flex flex-col gap-3 text-sm'>
+                                        <div>
+                                            <div className='text-muted-foreground'>Redirect from</div>
+                                            <code className='mt-1 block overflow-x-auto rounded-sm bg-background px-3 py-2 text-foreground'>{redirectSource}</code>
+                                        </div>
+                                        <div>
+                                            <div className='text-muted-foreground'>Redirect to</div>
+                                            <code className='mt-1 block overflow-x-auto rounded-sm bg-background px-3 py-2 text-foreground'>{redirectTarget}</code>
+                                        </div>
+                                    </div>
+                                </div>
+                            )}
+
+                            {showInstructions && (
+                                <Inline className='mt-4 flex-col items-stretch sm:flex-row sm:items-center' gap='md' justify='between'>
+                                    <div className='text-sm text-destructive'>
+                                        {validationError}
+                                    </div>
+                                    <Inline gap='md' justify='end'>
+                                        <Button disabled={isDisabled} variant='outline' onClick={handleCancel}>Cancel</Button>
+                                        {canSave ? (
+                                            <Button disabled={isDisabled} onClick={handleSave}>
+                                                {action === 'save' ? (
+                                                    <>
+                                                        <LoadingIndicator color='light' size='sm' />
+                                                        Saving...
+                                                    </>
+                                                ) : 'Save'}
+                                            </Button>
+                                        ) : (
+                                            <Button disabled={isDisabled || !canValidate || hasDomainLoadError} onClick={handleValidate}>
+                                                {action === 'validate' ? (
+                                                    <>
+                                                        <LoadingIndicator color='light' size='sm' />
+                                                        Validating...
+                                                    </>
+                                                ) : validationError ? 'Retry' : 'Validate'}
+                                            </Button>
+                                        )}
+                                    </Inline>
+                                </Inline>
+                            )}
+                        </form>
+                    )}
+                </div>
+            </div>
+        </Layout>
+    );
+};
+
+export default Domain;

--- a/apps/activitypub/src/views/preferences/components/domain.tsx
+++ b/apps/activitypub/src/views/preferences/components/domain.tsx
@@ -301,7 +301,7 @@ const Domain: React.FC = () => {
                                         )}
                                     </div>
                                     <div className='-ml-14 min-w-0 overflow-x-auto px-14'>
-                                        <div aria-label='Social Web handle breakdown' className='inline-flex pb-9 font-mono text-xl leading-none font-medium text-foreground select-none' role='group'>
+                                        <div aria-label='Social Web handle breakdown' className='inline-flex pb-9 font-mono text-xl leading-none font-medium whitespace-nowrap text-foreground select-none' role='group'>
                                             <span>@</span>
                                             <div className='relative'>
                                                 <span>{previewHandleParts.username}</span>

--- a/apps/activitypub/src/views/preferences/components/edit-profile.tsx
+++ b/apps/activitypub/src/views/preferences/components/edit-profile.tsx
@@ -1,8 +1,9 @@
-import React, {ChangeEvent, useEffect, useRef, useState} from 'react';
+import React, {ChangeEvent, useRef, useState} from 'react';
 import {Account} from '@src/api/activitypub';
 import {Button, DialogClose, DialogFooter, Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage, Input, LoadingIndicator, Textarea} from '@tryghost/shade/components';
 import {FILE_SIZE_ERROR_MESSAGE, MAX_FILE_SIZE, SQUARE_IMAGE_ERROR_MESSAGE, isSquareImage} from '@utils/image';
 import {LucideIcon} from '@tryghost/shade/utils';
+import {getHandleParts} from '@utils/social-web-handle';
 import {toast} from 'sonner';
 import {uploadFile} from '@hooks/use-activity-pub-queries';
 import {useForm} from 'react-hook-form';
@@ -26,16 +27,6 @@ const FormSchema = z.object({
         .max(64, {
             message: 'Display name must be less than 64 characters.'
         }),
-    handle: z.string()
-        .min(2, {
-            message: 'Handle must be at least 2 characters.'
-        })
-        .max(100, {
-            message: 'Handle must be less than 100 characters.'
-        })
-        .regex(/^[a-zA-Z0-9_]+$/, {
-            message: 'Handle must contain only letters, numbers, and underscores.'
-        }),
     bio: z.string()
         .max(250, {
             message: 'Bio must be less than 250 characters.'
@@ -55,7 +46,6 @@ const EditProfile: React.FC<EditProfileProps> = ({account, setIsEditingProfile})
     const [coverImagePreview, setCoverImagePreview] = useState<string | null>(account.bannerImageUrl || null);
     const coverImageInputRef = useRef<HTMLInputElement>(null);
     const [isCoverImageUploading, setIsCoverImageUploading] = useState(false);
-    const [handleDomain, setHandleDomain] = useState<string>('');
     const [isSubmitting, setIsSubmitting] = useState(false);
     const {mutate: updateAccount} = useUpdateAccountMutationForUser(account?.handle || '');
 
@@ -65,23 +55,11 @@ const EditProfile: React.FC<EditProfileProps> = ({account, setIsEditingProfile})
             profileImage: account.avatarUrl,
             coverImage: account.bannerImageUrl || '',
             name: account.name,
-            handle: '',
             bio: account.bio ? decodeHTMLEntities(account.bio) : ''
         }
     });
 
     const hasNameError = !!form.formState.errors.name;
-    const hasHandleError = !!form.formState.errors.handle;
-
-    useEffect(() => {
-        if (account.handle) {
-            const match = account.handle.match(/@([^@]+)@(.+)/);
-            if (match) {
-                form.setValue('handle', match[1]);
-                setHandleDomain(match[2]);
-            }
-        }
-    }, [account.handle, form]);
 
     const triggerProfileImageInput = () => {
         profileImageInputRef.current?.click();
@@ -202,7 +180,6 @@ const EditProfile: React.FC<EditProfileProps> = ({account, setIsEditingProfile})
         const decodedBio = account.bio ? decodeHTMLEntities(account.bio) : '';
         if (
             data.name === account.name &&
-            data.handle === account.handle.split('@')[1] &&
             data.bio === decodedBio &&
             data.profileImage === account.avatarUrl &&
             data.coverImage === account.bannerImageUrl
@@ -215,7 +192,7 @@ const EditProfile: React.FC<EditProfileProps> = ({account, setIsEditingProfile})
 
         updateAccount({
             name: data.name || account.name,
-            username: data.handle || account.handle,
+            username: getHandleParts(account.handle).username || account.handle,
             bio: data.bio ?? '',
             avatarUrl: data.profileImage || '',
             bannerImageUrl: data.coverImage || ''
@@ -326,28 +303,6 @@ const EditProfile: React.FC<EditProfileProps> = ({account, setIsEditingProfile})
                             {!hasNameError && (
                                 <FormDescription>
                                     The name shown to your followers in the Inbox and Feed
-                                </FormDescription>
-                            )}
-                            <FormMessage />
-                        </FormItem>
-                    )}
-                />
-                <FormField
-                    control={form.control}
-                    name="handle"
-                    render={({field}) => (
-                        <FormItem>
-                            <FormLabel>Handle</FormLabel>
-                            <FormControl>
-                                <div className='relative flex items-center justify-stretch gap-1 rounded-md border border-transparent bg-gray-100 px-3 transition-colors focus-within:border-(--color-focus-ring) focus-within:bg-transparent focus-within:shadow-[(--color-focus-ring)] focus-within:outline-hidden dark:bg-gray-950'>
-                                    <LucideIcon.AtSign className='w-4 min-w-4 text-gray-700' size={16} />
-                                    <Input className='w-auto grow border-none! bg-transparent px-0 shadow-none! outline-hidden!' placeholder="index" {...field} />
-                                    <span className='max-w-[200px] truncate text-right whitespace-nowrap text-gray-700 max-sm:hidden' title={`@${handleDomain}`}>@{handleDomain}</span>
-                                </div>
-                            </FormControl>
-                            {!hasHandleError && (
-                                <FormDescription>
-                                    Your social web handle that others can follow. Works just like an email address. <a className='font-medium text-purple' href="https://ghost.org/help/social-web/" rel="noreferrer" target='_blank'>Learn more</a>
                                 </FormDescription>
                             )}
                             <FormMessage />

--- a/apps/activitypub/src/views/preferences/components/edit-profile.tsx
+++ b/apps/activitypub/src/views/preferences/components/edit-profile.tsx
@@ -192,7 +192,7 @@ const EditProfile: React.FC<EditProfileProps> = ({account, setIsEditingProfile})
 
         updateAccount({
             name: data.name || account.name,
-            username: getHandleParts(account.handle).username || account.handle,
+            username: getHandleParts(account.handle).username || account.handle.replace(/^@/, '').split('@')[0],
             bio: data.bio ?? '',
             avatarUrl: data.profileImage || '',
             bannerImageUrl: data.coverImage || ''

--- a/apps/activitypub/src/views/preferences/components/settings.tsx
+++ b/apps/activitypub/src/views/preferences/components/settings.tsx
@@ -39,6 +39,15 @@ const Settings: React.FC<SettingsProps> = ({account, className = ''}) => {
                     </DialogContent>
                 </Dialog>
             </SettingItem>
+            <SettingItem to='/preferences/handle' withHover>
+                <SettingHeader>
+                    <SettingTitle>Social web handle</SettingTitle>
+                    <SettingDescription>Set your account username and domain</SettingDescription>
+                </SettingHeader>
+                <SettingAction className='flex items-center gap-2'>
+                    <LucideIcon.ChevronRight size={20} />
+                </SettingAction>
+            </SettingItem>
             <SettingItem withHover onClick={() => navigate('/preferences/moderation')}>
                 <SettingHeader>
                     <SettingTitle>Moderation</SettingTitle>

--- a/apps/activitypub/test/acceptance/preferences.test.ts
+++ b/apps/activitypub/test/acceptance/preferences.test.ts
@@ -13,9 +13,388 @@ const account = {
     likedCount: 3
 };
 
+const getMyAccount = {
+    method: 'GET',
+    path: '/v1/account/me',
+    response: account
+} as const;
+
+const getMyIndexAccount = {
+    method: 'GET',
+    path: '/v1/account/me',
+    response: {
+        ...account,
+        handle: '@index@blog.site.com',
+        name: 'Test User'
+    }
+} as const;
+
+const getMyIndexAccountWithCustomDomain = {
+    method: 'GET',
+    path: '/v1/account/me',
+    response: {
+        ...account,
+        handle: '@index@site.com',
+        name: 'Test User'
+    }
+} as const;
+
 test.describe('Preferences', async () => {
     test.beforeEach(async ({page}) => {
         await mockInitialApiRequests(page);
+    });
+
+    test('I can open the Social Web domain screen from preferences', async ({page}) => {
+        await mockApi({page, requests: {
+            getMyAccount: getMyIndexAccount,
+            getDomain: {
+                method: 'GET',
+                path: '/v1/domain',
+                response: {
+                    domain: null,
+                    handle: '@index@blog.site.com',
+                    actorUrl: 'https://blog.site.com/.ghost/activitypub/users/index'
+                }
+            }
+        }, options: {useActivityPub: true}});
+
+        await page.goto('#/preferences');
+
+        await expect(page.getByRole('link', {name: /Social web handle/})).toBeVisible();
+        await expect(page.getByLabel('Handle domain')).toHaveCount(0);
+
+        await page.getByRole('link', {name: /Social web handle/}).click();
+
+        const handleBreakdown = page.getByRole('group', {name: 'Social Web handle breakdown'});
+
+        await expect(page.getByRole('heading', {exact: true, name: 'Your social web handle'})).toBeVisible();
+        await expect(handleBreakdown.locator(':scope > div > span').nth(0)).toHaveText('index');
+        await expect(handleBreakdown.locator(':scope > div > span').nth(1)).toHaveText('blog.site.com');
+        await expect(handleBreakdown.getByText('Username')).toBeVisible();
+        await expect(handleBreakdown.getByText('Domain', {exact: true})).toBeVisible();
+        await expect(page.getByLabel('Social web username', {exact: true})).toHaveValue('index');
+        await expect(page.getByText('Default Social Web domain')).toHaveCount(0);
+        await expect(page.getByLabel('Social web domain', {exact: true})).toHaveValue('blog.site.com');
+        await expect(page.getByLabel('Social web domain', {exact: true})).toBeDisabled();
+        await expect(page.getByRole('button', {name: 'Edit Social web domain'})).toBeVisible();
+        await expect(page.getByText('Use a bare domain without https:// or paths.')).toHaveCount(0);
+        await expect(page.getByText('Your new handle will be', {exact: true})).toHaveCount(0);
+        await expect(page.getByText('Actor URL:', {exact: false})).toHaveCount(0);
+    });
+
+    test('I can see a configured Social Web domain', async ({page}) => {
+        await mockApi({page, requests: {
+            getMyAccount: getMyIndexAccountWithCustomDomain,
+            getDomain: {
+                method: 'GET',
+                path: '/v1/domain',
+                response: {
+                    domain: 'site.com',
+                    handle: '@index@site.com',
+                    actorUrl: 'https://blog.site.com/.ghost/activitypub/users/index'
+                }
+            }
+        }, options: {useActivityPub: true}});
+
+        await page.goto('#/preferences/handle');
+        await page.evaluate(() => {
+            Object.defineProperty(navigator, 'clipboard', {
+                configurable: true,
+                value: {
+                    writeText: async (text: string) => window.localStorage.setItem('copiedHandle', text)
+                }
+            });
+        });
+
+        const handleBreakdown = page.getByRole('group', {name: 'Social Web handle breakdown'});
+        const copyHandleButton = page.getByRole('button', {name: 'Copy Social Web handle'});
+
+        await expect(page.getByText('Your social web handle', {exact: true})).toBeVisible();
+        await expect(handleBreakdown.locator(':scope > div > span').nth(0)).toHaveText('index');
+        await expect(handleBreakdown.locator(':scope > div > span').nth(1)).toHaveText('site.com');
+        await expect(handleBreakdown.getByText('Username')).toBeVisible();
+        await expect(handleBreakdown.getByText('Domain', {exact: true})).toBeVisible();
+        await expect(page.getByLabel('Social web username', {exact: true})).toHaveValue('index');
+        await expect(page.getByLabel('Active social web domain')).toHaveValue('site.com');
+        await expect(page.getByRole('button', {name: 'Remove'})).toBeVisible();
+        await expect(page.getByText('Your new handle will be', {exact: true})).toHaveCount(0);
+        await expect(page.getByText('Your handle: @index@site.com', {exact: true})).toHaveCount(0);
+
+        await copyHandleButton.hover();
+        await expect(page.getByText('Copy', {exact: true})).toBeVisible();
+        await copyHandleButton.click();
+        await expect(page.getByText('Copied!', {exact: true})).toBeVisible();
+        await expect.poll(() => page.evaluate(() => window.localStorage.getItem('copiedHandle'))).toBe('@index@site.com');
+    });
+
+    test('I can update my Social Web username from the domain screen', async ({page}) => {
+        const {lastApiRequests} = await mockApi({page, requests: {
+            getMyAccount: getMyIndexAccount,
+            getDomain: {
+                method: 'GET',
+                path: '/v1/domain',
+                response: {
+                    domain: null,
+                    handle: '@index@blog.site.com',
+                    actorUrl: 'https://blog.site.com/.ghost/activitypub/users/index'
+                }
+            },
+            updateAccount: {
+                method: 'PUT',
+                path: '/v1/account',
+                response: {}
+            }
+        }, options: {useActivityPub: true}});
+
+        await page.goto('#/preferences/handle');
+        const handleBreakdown = page.getByRole('group', {name: 'Social Web handle breakdown'});
+
+        await expect(page.getByLabel('Social web username', {exact: true})).toBeDisabled();
+        await page.getByRole('button', {name: 'Edit Social web username'}).click();
+        await expect(page.getByLabel('Social web username', {exact: true})).toBeEnabled();
+        await page.getByLabel('Social web username', {exact: true}).fill('john');
+        await expect(handleBreakdown.locator(':scope > div > span').nth(0)).toHaveText('john');
+        await expect(handleBreakdown.locator(':scope > div > span').nth(1)).toHaveText('blog.site.com');
+        await page.getByRole('button', {name: 'Save'}).click();
+
+        await expect.poll(() => lastApiRequests.updateAccount).toBeTruthy();
+        expect(lastApiRequests.updateAccount?.body).toEqual({
+            name: 'Test User',
+            username: 'john',
+            bio: '',
+            avatarUrl: 'https://fake.host/avatars/alice.jpg',
+            bannerImageUrl: ''
+        });
+    });
+
+    test('I can validate and save a Social Web domain', async ({page}) => {
+        const {lastApiRequests} = await mockApi({page, requests: {
+            getMyAccount: getMyIndexAccount,
+            getDomain: {
+                method: 'GET',
+                path: '/v1/domain',
+                response: {
+                    domain: null,
+                    handle: '@index@blog.site.com',
+                    actorUrl: 'https://blog.site.com/.ghost/activitypub/users/index'
+                }
+            },
+            updateDomain: {
+                method: 'PUT',
+                path: '/v1/domain',
+                response: {
+                    domain: 'site.com',
+                    handle: '@index@site.com',
+                    actorUrl: 'https://blog.site.com/.ghost/activitypub/users/index'
+                }
+            },
+            validateDomain: {
+                method: 'POST',
+                path: '/v1/domain/validate',
+                response: {
+                    domain: 'site.com',
+                    handle: '@index@site.com',
+                    actorUrl: 'https://blog.site.com/.ghost/activitypub/users/index'
+                }
+            }
+        }, options: {useActivityPub: true}});
+
+        await page.goto('#/preferences/handle');
+        const handleBreakdown = page.getByRole('group', {name: 'Social Web handle breakdown'});
+
+        await page.getByRole('button', {name: 'Edit Social web domain'}).click();
+        await expect(page.getByLabel('Social web domain')).toBeEnabled();
+        await page.getByLabel('Social web domain').fill(' https://site.com/some/path?query=true#hash ');
+        await expect(handleBreakdown.locator(':scope > div > span').nth(0)).toHaveText('index');
+        await expect(handleBreakdown.locator(':scope > div > span').nth(1)).toHaveText('site.com');
+
+        await expect(page.getByRole('button', {name: 'Activate'})).toBeVisible();
+        await expect(page.getByRole('button', {name: 'Validate'})).toHaveCount(0);
+        await expect(page.getByText('Set up your redirect')).toHaveCount(0);
+
+        await page.getByLabel('Social web domain').press('Enter');
+
+        await expect(page.getByText('Set up your redirect')).toBeVisible();
+        await expect(page.getByText('https://site.com/.well-known/webfinger')).toBeVisible();
+        await expect(page.getByText('https://blog.site.com/.well-known/webfinger')).toBeVisible();
+        await expect(page.getByText('Your new handle will be', {exact: true})).toHaveCount(0);
+
+        await page.getByRole('button', {name: 'Validate'}).click();
+
+        await expect.poll(() => lastApiRequests.validateDomain).toBeTruthy();
+        expect(lastApiRequests.validateDomain?.body).toEqual({domain: 'site.com'});
+        expect(lastApiRequests.updateDomain).toBeUndefined();
+        await expect(page.getByRole('button', {name: 'Save', exact: true})).toBeVisible();
+
+        await page.getByRole('button', {name: 'Save', exact: true}).click();
+
+        await expect.poll(() => lastApiRequests.updateDomain).toBeTruthy();
+        expect(lastApiRequests.updateDomain?.body).toEqual({domain: 'site.com'});
+        await expect(page.getByLabel('Active social web domain')).toHaveValue('site.com');
+        await expect(page.getByText('Your new handle will be', {exact: true})).toHaveCount(0);
+        await expect(page.getByText('Your handle: @index@site.com', {exact: true})).toHaveCount(0);
+    });
+
+    test('I can remove a Social Web domain', async ({page}) => {
+        const {lastApiRequests} = await mockApi({page, requests: {
+            getMyAccount,
+            getDomain: {
+                method: 'GET',
+                path: '/v1/domain',
+                response: {
+                    domain: 'site.com',
+                    handle: '@index@site.com',
+                    actorUrl: 'https://blog.site.com/.ghost/activitypub/users/index'
+                }
+            },
+            updateDomain: {
+                method: 'PUT',
+                path: '/v1/domain',
+                response: {
+                    domain: null,
+                    handle: '@index@blog.site.com',
+                    actorUrl: 'https://blog.site.com/.ghost/activitypub/users/index'
+                }
+            }
+        }, options: {useActivityPub: true}});
+
+        await page.goto('#/preferences/handle');
+        const handleBreakdown = page.getByRole('group', {name: 'Social Web handle breakdown'});
+        await page.getByRole('button', {name: 'Remove'}).click();
+
+        await expect.poll(() => lastApiRequests.updateDomain).toBeTruthy();
+        expect(lastApiRequests.updateDomain?.body).toEqual({domain: null});
+        await expect(page.getByLabel('Social web domain', {exact: true})).toHaveValue('blog.site.com');
+        await expect(page.getByLabel('Social web domain', {exact: true})).toBeDisabled();
+        await expect(page.getByText('Your new handle will be', {exact: true})).toHaveCount(0);
+        await expect(handleBreakdown.locator(':scope > div > span').nth(0)).toHaveText('index');
+        await expect(handleBreakdown.locator(':scope > div > span').nth(1)).toHaveText('blog.site.com');
+    });
+
+    test('I do not validate an empty Social Web domain', async ({page}) => {
+        const {lastApiRequests} = await mockApi({page, requests: {
+            getMyAccount,
+            getDomain: {
+                method: 'GET',
+                path: '/v1/domain',
+                response: {
+                    domain: null,
+                    handle: '@index@blog.site.com',
+                    actorUrl: 'https://blog.site.com/.ghost/activitypub/users/index'
+                }
+            },
+            validateDomain: {
+                method: 'POST',
+                path: '/v1/domain/validate',
+                response: {
+                    domain: 'site.com',
+                    handle: '@index@site.com',
+                    actorUrl: 'https://blog.site.com/.ghost/activitypub/users/index'
+                }
+            }
+        }, options: {useActivityPub: true}});
+
+        await page.goto('#/preferences/handle');
+
+        await page.getByRole('button', {name: 'Edit Social web domain'}).click();
+        await expect(page.getByRole('button', {name: 'Activate'})).toBeDisabled();
+        await expect(page.getByRole('button', {name: 'Validate'})).toHaveCount(0);
+        expect(lastApiRequests.validateDomain).toBeUndefined();
+    });
+
+    test('I see Social Web domain validation errors without losing the instructions', async ({page}) => {
+        const errorCases = [
+            {
+                code: 'invalid-domain',
+                status: 400
+            },
+            {
+                code: 'conflict',
+                status: 409
+            },
+            {
+                code: 'not-reachable',
+                status: 422
+            },
+            {
+                code: 'invalid-webfinger',
+                status: 400
+            },
+            {
+                code: 'wrong-actor',
+                status: 422
+            }
+        ];
+
+        for (const errorCase of errorCases) {
+            await mockApi({page, requests: {
+                getMyAccount,
+                getDomain: {
+                    method: 'GET',
+                    path: '/v1/domain',
+                    response: {
+                        domain: null,
+                        handle: '@index@blog.site.com',
+                        actorUrl: 'https://blog.site.com/.ghost/activitypub/users/index'
+                    }
+                },
+                validateDomain: {
+                    method: 'POST',
+                    path: '/v1/domain/validate',
+                    response: {
+                        code: errorCase.code
+                    },
+                    responseStatus: errorCase.status
+                }
+            }, options: {useActivityPub: true}});
+
+            await page.goto('#/preferences/handle');
+            await page.getByRole('button', {name: 'Edit Social web domain'}).click();
+            await page.getByLabel('Social web domain').fill('bad.example');
+            await page.getByRole('button', {name: 'Activate'}).click();
+            await page.getByRole('button', {name: 'Validate'}).click();
+
+            await expect(page.getByText('Set up your redirect')).toBeVisible();
+            await expect(page.getByText('https://bad.example/.well-known/webfinger')).toBeVisible();
+            await expect(page.getByText('https://blog.site.com/.well-known/webfinger')).toBeVisible();
+            await expect(page.getByText('Your new handle will be', {exact: true})).toHaveCount(0);
+            await expect(page.getByText('Redirect could not be validated')).toBeVisible();
+            await expect(page.getByRole('button', {name: 'Retry'})).toBeVisible();
+            await expect(page.getByRole('button', {name: 'Validate'})).toHaveCount(0);
+
+            await page.getByRole('button', {name: 'Cancel'}).click();
+        }
+    });
+
+    test('I see a Social Web unavailable error', async ({page}) => {
+        await mockApi({page, requests: {
+            getMyAccount,
+            getDomain: {
+                method: 'GET',
+                path: '/v1/domain',
+                response: {
+                    domain: null,
+                    handle: '@index@blog.site.com',
+                    actorUrl: 'https://blog.site.com/.ghost/activitypub/users/index'
+                }
+            },
+            validateDomain: {
+                method: 'POST',
+                path: '/v1/domain/validate',
+                response: {},
+                responseStatus: 404
+            }
+        }, options: {useActivityPub: true}});
+
+        await page.goto('#/preferences/handle');
+        await page.getByRole('button', {name: 'Edit Social web domain'}).click();
+        await page.getByLabel('Social web domain').fill('bad.example');
+        await page.getByRole('button', {name: 'Activate'}).click();
+        await page.getByRole('button', {name: 'Validate'}).click();
+
+        await expect(page.getByText('Set up your redirect')).toBeVisible();
+        await expect(page.getByText('Redirect could not be validated')).toBeVisible();
+        await expect(page.getByRole('button', {name: 'Retry'})).toBeVisible();
     });
 
     test('I can add an old Mastodon handle for follower migration', async ({page}) => {
@@ -34,6 +413,15 @@ test.describe('Preferences', async () => {
                         apId: 'https://fake.host/.ghost/activitypub/users/index'
                     },
                     aliases: []
+                }
+            },
+            getDomain: {
+                method: 'GET',
+                path: '/v1/domain',
+                response: {
+                    domain: null,
+                    handle: '@index@fake.host',
+                    actorUrl: 'https://fake.host/.ghost/activitypub/users/index'
                 }
             },
             addAlias: {

--- a/apps/activitypub/test/utils/initial-api-requests.ts
+++ b/apps/activitypub/test/utils/initial-api-requests.ts
@@ -28,6 +28,21 @@ const initialActivityPubRequests = {
         method: 'GET',
         path: '/users/index',
         response: activityPubUser
+    },
+    getActivityPubAccount: {
+        method: 'GET',
+        path: '/v1/account/me',
+        response: {
+            id: 'index',
+            handle: '@index@example.com',
+            name: 'Test User',
+            url: 'https://example.com/@index',
+            avatarUrl: null,
+            bannerImageUrl: null,
+            followingCount: 0,
+            followerCount: 0,
+            likedCount: 0
+        }
     }
 };
 


### PR DESCRIPTION
## Summary

This PR adds a dedicated Social Web handle preferences screen to the ActivityPub admin UI.

It moves Social Web username editing out of the profile dialog and adds a Social Web domain workflow that lets a publisher inspect their current handle, edit the username, enter a custom domain, review the required WebFinger redirect, validate the redirect, and only save once validation succeeds.

This depends on TryGhost/ActivityPub#1953, which adds the validate-only domain endpoint used by the Validate button.

## What changed

- Added `/preferences/handle` as a nested ActivityPub preferences screen.
- Added a new “Social web handle” row directly under Profile in preferences.
- Removed the username field from the profile edit dialog and moved username editing to the handle screen.
- Added a handle preview panel with:
  - the current Social Web handle
  - the Social Web account avatar, falling back to the publication icon when the account avatar is not set
  - username/domain diagram labels and guide lines
  - copy-to-clipboard behavior using the existing tooltip pattern
- Added disabled-by-default edit flows for:
  - Social Web username
  - Social Web domain
- Added a custom domain setup flow where the user:
  - clicks Edit
  - enters a domain
  - clicks Activate to show redirect instructions
  - clicks Validate to call the validate-only ActivityPub endpoint
  - clicks Save to persist only after successful validation
  - can Remove an active custom domain
- Normalized user-entered domains client-side by trimming schemes, paths, query strings, and fragments.
- Added API client and React Query hooks for:
  - fetching domain state
  - validating a domain
  - saving/removing a domain
- Updated ActivityPub preferences acceptance coverage and API client tests.

## Decisions

- Validation and persistence are intentionally separate. The Validate button calls `POST /.ghost/activitypub/v1/domain/validate`; Save calls `PUT /.ghost/activitypub/v1/domain`.
- The domain field is disabled by default and uses the default Social Web domain as its placeholder while editing.
- The active custom domain state is represented as a disabled input with an inline Remove button.
- The username field follows the same disabled-by-default edit pattern: Edit, then Cancel/Save.
- The handle preview live-updates while username/domain edits are in progress.
- The handle diagram keeps username and domain visually distinct, including short-value cases where centered labels would otherwise overlap.
- The preferences route was named `/preferences/handle` rather than `/preferences/domain` because the screen now controls both username and domain.
- The local dev Caddy/header and Ghost URL changes used during testing are intentionally not included in this PR.

## Validation

- `pnpm --filter @tryghost/activitypub lint`
- `pnpm --filter @tryghost/activitypub exec vitest run src/api/activitypub.test.ts`
- `pnpm --filter @tryghost/activitypub test:acceptance -- test/acceptance/preferences.test.ts`

Note: `pnpm --filter @tryghost/activitypub test -- apps/activitypub/src/api/activitypub.test.ts` currently fails in the package-wide `tsc --noEmit` preflight on latest `main` with JSX type errors in existing React Router/Lucide usage across untouched files. The targeted Vitest file passes when run directly.