### PR TITLE
✨ Added publisher gift links

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -71,10 +71,6 @@ const features: Feature[] = [{
     title: 'Get helper deduplication',
     description: 'Deduplicate identical {{#get}} helper queries within a single request to avoid redundant database calls',
     flag: 'getHelperDeduplication'
-}, {
-    title: 'Gift links',
-    description: 'Tokenized links that let anyone read a single gated post or page in full, no account required',
-    flag: 'giftLinks'
 }];
 
 const AlphaFeatures: React.FC = () => {

--- a/ghost/admin/mirage/fixtures/settings.js
+++ b/ghost/admin/mirage/fixtures/settings.js
@@ -107,6 +107,7 @@ export default [
     // LABS
     setting('labs', 'labs', JSON.stringify({
         // Keep the GA flags that are not yet cleaned up in frontend code here
+        giftLinks: true
     })),
 
     // SLACK

--- a/ghost/admin/tests/acceptance/content-test.js
+++ b/ghost/admin/tests/acceptance/content-test.js
@@ -380,16 +380,17 @@ describe('Acceptance: Posts / Pages', function () {
                         let buttons = contextMenu.querySelectorAll('button');
 
                         expect(contextMenu, 'context menu').to.exist;
-                        expect(buttons.length, 'context menu buttons').to.equal(6);
+                        expect(buttons.length, 'context menu buttons').to.equal(7);
                         expect(buttons[0].innerText.trim(), 'context menu button 1').to.contain('Copy link to post');
-                        expect(buttons[1].innerText.trim(), 'context menu button 1').to.contain('Unpublish');
-                        expect(buttons[2].innerText.trim(), 'context menu button 2').to.contain('Feature'); // or Unfeature
-                        expect(buttons[3].innerText.trim(), 'context menu button 3').to.contain('Add a tag');
-                        expect(buttons[4].innerText.trim(), 'context menu button 4').to.contain('Duplicate');
-                        expect(buttons[5].innerText.trim(), 'context menu button 5').to.contain('Delete');
+                        expect(buttons[1].innerText.trim(), 'context menu button 2').to.contain('Share as a gift');
+                        expect(buttons[2].innerText.trim(), 'context menu button 3').to.contain('Unpublish');
+                        expect(buttons[3].innerText.trim(), 'context menu button 4').to.contain('Feature'); // or Unfeature
+                        expect(buttons[4].innerText.trim(), 'context menu button 5').to.contain('Add a tag');
+                        expect(buttons[5].innerText.trim(), 'context menu button 6').to.contain('Duplicate');
+                        expect(buttons[6].innerText.trim(), 'context menu button 7').to.contain('Delete');
 
                         // duplicate the post
-                        await click(buttons[4]);
+                        await click(buttons[5]);
 
                         const posts = findAll('[data-test-post-id]');
                         expect(posts.length, 'all posts count').to.equal(5);
@@ -502,13 +503,14 @@ describe('Acceptance: Posts / Pages', function () {
                         let buttons = contextMenu.querySelectorAll('button');
 
                         expect(contextMenu, 'context menu').to.exist;
-                        expect(buttons.length, 'context menu buttons').to.equal(6);
+                        expect(buttons.length, 'context menu buttons').to.equal(7);
                         expect(buttons[0].innerText.trim(), 'context menu button 1').to.contain('Copy link to post');
-                        expect(buttons[1].innerText.trim(), 'context menu button 1').to.contain('Unpublish');
-                        expect(buttons[2].innerText.trim(), 'context menu button 2').to.contain('Feature'); // or Unfeature
-                        expect(buttons[3].innerText.trim(), 'context menu button 3').to.contain('Add a tag');
-                        expect(buttons[4].innerText.trim(), 'context menu button 4').to.contain('Duplicate');
-                        expect(buttons[5].innerText.trim(), 'context menu button 5').to.contain('Delete');
+                        expect(buttons[1].innerText.trim(), 'context menu button 2').to.contain('Share as a gift');
+                        expect(buttons[2].innerText.trim(), 'context menu button 3').to.contain('Unpublish');
+                        expect(buttons[3].innerText.trim(), 'context menu button 4').to.contain('Feature'); // or Unfeature
+                        expect(buttons[4].innerText.trim(), 'context menu button 5').to.contain('Add a tag');
+                        expect(buttons[5].innerText.trim(), 'context menu button 6').to.contain('Duplicate');
+                        expect(buttons[6].innerText.trim(), 'context menu button 7').to.contain('Delete');
 
                         // Copy the post link
                         await click(buttons[0]);

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -29,7 +29,8 @@ const GA_FEATURES = [
     'featurebaseFeedback',
     'dangerZoneResetAuth',
     'indexnow',
-    'llmsTxt'
+    'llmsTxt',
+    'giftLinks'
 ];
 
 // These features are considered publicly available and can be enabled/disabled by users
@@ -56,8 +57,7 @@ const PRIVATE_FEATURES = [
     'themeTranslation',
     'pictureImageFormats',
     'smarterCounts',
-    'getHelperDeduplication',
-    'giftLinks'
+    'getHelperDeduplication'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -2253,7 +2253,7 @@ exports[`Settings API Edit can edit Stripe settings when Stripe Connect limit is
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "5466",
+  "content-length": "5485",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/unit/frontend/helpers/ghost-foot.test.js
+++ b/ghost/core/test/unit/frontend/helpers/ghost-foot.test.js
@@ -18,7 +18,7 @@ describe('{{ghost_foot}} helper', function () {
     it('outputs global injected code', function () {
         settingsCacheStub.withArgs('codeinjection_foot').returns('<script>var test = \'I am a variable!\'</script>');
 
-        const rendered = ghost_foot({data: {}});
+        const rendered = ghost_foot({data: {root: {}}});
         assertExists(rendered);
         assert.match(rendered.string, /<script>var test = 'I am a variable!'<\/script>/);
     });
@@ -77,7 +77,7 @@ describe('{{ghost_foot}} helper', function () {
     it('handles global empty code injection', function () {
         settingsCacheStub.withArgs('codeinjection_foot').returns('');
 
-        const rendered = ghost_foot({data: {}});
+        const rendered = ghost_foot({data: {root: {}}});
         assertExists(rendered);
         assert.equal(rendered.string, '');
     });
@@ -85,7 +85,7 @@ describe('{{ghost_foot}} helper', function () {
     it('handles global undefined code injection', function () {
         settingsCacheStub.withArgs('codeinjection_foot').returns(undefined);
 
-        const rendered = ghost_foot({data: {}});
+        const rendered = ghost_foot({data: {root: {}}});
         assertExists(rendered);
         assert.equal(rendered.string, '');
     });

--- a/ghost/core/test/unit/frontend/services/routing/controllers/entry.test.ts
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/entry.test.ts
@@ -15,6 +15,7 @@ const EDITOR_URL = `/#/editor/post/`;
 interface MockRequest {
     path: string;
     originalUrl: string;
+    query: Record<string, unknown>;
     params: object;
     route: object;
     app: {get: sinon.SinonStub};
@@ -66,6 +67,7 @@ describe('Unit - services/routing/controllers/entry', function () {
         req = {
             path: '/',
             originalUrl: '/',
+            query: {},
             params: {},
             route: {},
             app: {get: sinon.stub()},


### PR DESCRIPTION
no issue

Publishers can now share paywalled posts and pages with anyone via gift links, without comping a subscription or making the content public.
