### PR TITLE
Fix misaligned checkmark in publish email recipient options

### DIFF
--- a/ghost/admin/app/styles/components/publishmenu.css
+++ b/ghost/admin/app/styles/components/publishmenu.css
@@ -139,7 +139,7 @@
 
 .gh-publish-send-to-option .for-checkbox .input-toggle-component {
     position: absolute;
-    top: calc(50%-9px);
+    top: calc(50% - 9px);
     left: 14px;
     margin: 0;
     border-color: transparent;


### PR DESCRIPTION
No ref

The checkmark icon in the publish flow's email recipient options was vertically misaligned with its label.

An invalid calc() value (missing spaces around the operator) was being dropped by the browser, and this only surfaced in dev builds after CSS minification was moved to production-only.