### PR TITLE
🐛 Fixed slow posts and pages lists when analytics data was unavailable

### DIFF
--- a/ghost/admin/app/routes/posts.js
+++ b/ghost/admin/app/routes/posts.js
@@ -13,29 +13,24 @@ class PostsWithAnalytics extends InfinityModel {
     @service feature;
     @service settings;
 
-    async afterInfinityModel(posts) {
+    afterInfinityModel(posts) {
         const publishedPosts = posts.filter(post => ['published', 'sent'].includes(post.status));
         if (publishedPosts.length === 0) {
             return posts;
         }
 
-        const promises = [];
-        
-        // Fetch visitor counts if web analytics is enabled
+        // Analytics loads are deliberately not awaited so a slow or
+        // unavailable analytics service can't block rendering the list -
+        // counts fill in reactively when the requests complete
         if (this.settings.webAnalyticsEnabled) {
             const postUuids = publishedPosts.map(post => post.uuid);
-            promises.push(this.postAnalytics.loadVisitorCounts(postUuids));
-        }
-        
-        // Fetch member counts if member tracking is enabled
-        if (this.settings.membersTrackSources) {
-            promises.push(this.postAnalytics.loadMemberCounts(publishedPosts));
+            this.postAnalytics.loadVisitorCounts(postUuids);
         }
 
-        if (promises.length > 0) {
-            await Promise.all(promises);
+        if (this.settings.membersTrackSources) {
+            this.postAnalytics.loadMemberCounts(publishedPosts);
         }
-        
+
         return posts;
     }
 }

--- a/ghost/admin/app/services/post-analytics.js
+++ b/ghost/admin/app/services/post-analytics.js
@@ -32,6 +32,12 @@ export default class PostAnalyticsService extends Service {
     _fetchedMemberIds = new Set();
 
     /**
+     * @type {number} Bumped by reset() so requests in flight from a previous
+     * filter/view can tell they're stale and skip writing back once they resolve
+     */
+    _generation = 0;
+
+    /**
      * Load visitor counts for the given post UUIDs
      * @param {string[]} postUuids - Array of post UUIDs
      * @returns {Promise}
@@ -55,8 +61,8 @@ export default class PostAnalyticsService extends Service {
         
         // Mark these UUIDs as being fetched
         newUuids.forEach(uuid => this._fetchedUuids.add(uuid));
-        
-        return this._loadVisitorCounts.perform(newUuids);
+
+        return this._loadVisitorCounts.perform(newUuids, this._generation);
     }
 
     /**
@@ -92,8 +98,8 @@ export default class PostAnalyticsService extends Service {
         
         // Mark these post IDs as being fetched
         newPosts.forEach(post => this._fetchedMemberIds.add(post.id));
-        
-        return this._loadMemberCounts.perform(newPosts);
+
+        return this._loadMemberCounts.perform(newPosts, this._generation);
     }
 
     /**
@@ -109,6 +115,7 @@ export default class PostAnalyticsService extends Service {
      * Reset the analytics cache - call this when filters change or on route transitions
      */
     reset() {
+        this._generation += 1;
         this.visitorCounts = {};
         this.memberCounts = {};
         this._fetchedUuids.clear();
@@ -116,7 +123,7 @@ export default class PostAnalyticsService extends Service {
     }
 
     @task
-    *_loadVisitorCounts(postUuids) {
+    *_loadVisitorCounts(postUuids, generation) {
         try {
             const statsUrl = this.ghostPaths.url.api('stats/posts-visitor-counts');
             const result = yield this.ajax.request(statsUrl, {
@@ -124,24 +131,33 @@ export default class PostAnalyticsService extends Service {
                 data: JSON.stringify({postUuids}),
                 contentType: 'application/json'
             });
+
+            // A reset() (e.g. filters changed) happened while this request was
+            // in flight - the cache has moved on, so don't write this back
+            if (generation !== this._generation) {
+                return;
+            }
+
             // Parse the nested response structure
             const statsData = result.stats?.[0]?.data?.visitor_counts || {};
-            
+
             // Merge with existing visitor counts instead of replacing
             this.visitorCounts = {
                 ...this.visitorCounts,
                 ...statsData
             };
         } catch (error) {
-            // Rollback: remove failed UUIDs from fetched set to allow retry
-            postUuids.forEach(uuid => this._fetchedUuids.delete(uuid));
-            // Silent failure - visitor counts are not critical
-            this.visitorCounts = this.visitorCounts || {};
+            if (generation === this._generation) {
+                // Rollback: remove failed UUIDs from fetched set to allow retry
+                postUuids.forEach(uuid => this._fetchedUuids.delete(uuid));
+                // Silent failure - visitor counts are not critical
+                this.visitorCounts = this.visitorCounts || {};
+            }
         }
     }
 
     @task
-    *_loadMemberCounts(posts) {
+    *_loadMemberCounts(posts, generation) {
         try {
             const postIds = posts.map(post => post.id);
             const statsUrl = this.ghostPaths.url.api('stats/posts-member-counts');
@@ -150,10 +166,16 @@ export default class PostAnalyticsService extends Service {
                 data: JSON.stringify({postIds}),
                 contentType: 'application/json'
             });
-            
+
+            // A reset() (e.g. filters changed) happened while this request was
+            // in flight - the cache has moved on, so don't write this back
+            if (generation !== this._generation) {
+                return;
+            }
+
             // Parse the nested response structure - similar to visitor counts
             const memberData = result.stats?.[0] || {};
-            
+
             // Convert from post ID -> counts to post UUID -> counts for consistency
             const memberCountsByUuid = {};
             posts.forEach((post) => {
@@ -165,17 +187,19 @@ export default class PostAnalyticsService extends Service {
                     };
                 }
             });
-            
+
             // Merge with existing member counts instead of replacing
             this.memberCounts = {
                 ...this.memberCounts,
                 ...memberCountsByUuid
             };
         } catch (error) {
-            // Rollback: remove failed post IDs from fetched set to allow retry
-            posts.forEach(post => this._fetchedMemberIds.delete(post.id));
-            // Silent failure - member counts are not critical
-            this.memberCounts = this.memberCounts || {};
+            if (generation === this._generation) {
+                // Rollback: remove failed post IDs from fetched set to allow retry
+                posts.forEach(post => this._fetchedMemberIds.delete(post.id));
+                // Silent failure - member counts are not critical
+                this.memberCounts = this.memberCounts || {};
+            }
         }
     }
 } 

--- a/ghost/admin/tests/unit/services/post-analytics-test.js
+++ b/ghost/admin/tests/unit/services/post-analytics-test.js
@@ -243,5 +243,58 @@ describe('Unit: Service: post-analytics', function () {
             expect(service._fetchedUuids.size).to.equal(0);
             expect(service._fetchedMemberIds.size).to.equal(0);
         });
+
+        it('ignores a visitor counts response that resolves after reset', async function () {
+            ghostPathsStub.url.api.returns('/stats/posts-visitor-counts');
+
+            let resolveFirstRequest;
+            ajaxStub.onCall(0).returns(new Promise((resolve) => {
+                resolveFirstRequest = resolve;
+            }));
+            ajaxStub.onCall(1).resolves({
+                stats: [{data: {visitor_counts: {uuid2: 200}}}]
+            });
+
+            // Start a fetch for the old filter view, then change filters
+            // (reset) before it resolves
+            const firstLoad = service.loadVisitorCounts(['uuid1']);
+            service.reset();
+            await service.loadVisitorCounts(['uuid2']);
+            await settled();
+
+            expect(service.visitorCounts).to.deep.equal({uuid2: 200});
+
+            // The stale request now resolves - it must not repopulate the cache
+            resolveFirstRequest({stats: [{data: {visitor_counts: {uuid1: 100}}}]});
+            await firstLoad;
+            await settled();
+
+            expect(service.visitorCounts).to.deep.equal({uuid2: 200});
+        });
+
+        it('ignores a member counts response that resolves after reset', async function () {
+            ghostPathsStub.url.api.returns('/stats/posts-member-counts');
+
+            let resolveFirstRequest;
+            ajaxStub.onCall(0).returns(new Promise((resolve) => {
+                resolveFirstRequest = resolve;
+            }));
+            ajaxStub.onCall(1).resolves({
+                stats: [{2: {free_members: 20, paid_members: 15}}]
+            });
+
+            const firstLoad = service.loadMemberCounts([{id: '1', uuid: 'uuid1'}]);
+            service.reset();
+            await service.loadMemberCounts([{id: '2', uuid: 'uuid2'}]);
+            await settled();
+
+            expect(service.memberCounts).to.deep.equal({uuid2: {free: 20, paid: 15}});
+
+            resolveFirstRequest({stats: [{1: {free_members: 10, paid_members: 5}}]});
+            await firstLoad;
+            await settled();
+
+            expect(service.memberCounts).to.deep.equal({uuid2: {free: 20, paid: 15}});
+        });
     });
 }); 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1871/possible-performance-issues-early-on-1st-july

## Problem

During the Tinybird slowdown early on July 1, customers reported the admin posts/pages lists taking up to 60s to render (and the Analytics page not loading).

The lists were slow because `PostsWithAnalytics.afterInfinityModel` **awaited** the visitor-count fetch before returning posts, and the route's model hook waits on that — so the whole screen sat on the loading spinner until the stats request finished. Server-side, each `stats/posts-visitor-counts` request proxies to Tinybird with a 10s timeout and got's default 2 retries (timeouts/5xx are retried), so a hanging Tinybird held each request for ~30s before returning an empty 200. Filter changes reset the analytics cache and refetch, blocking again each time.

## Fix

Fire the visitor-count and member-count loads without awaiting them. The `post-analytics` service exposes the counts as tracked state that the list-item components already read reactively (and they already handle null counts), so the list renders immediately and the count columns populate whenever the data arrives. An analytics outage now costs nothing but temporarily missing count badges.

## Testing

- `ember test --filter="Posts / Pages"` — 39 passing (includes the analytics column visibility tests)
- `ember test --filter="post-analytics"` — 19 passing
- lint clean

Possible follow-up (separate PR): cap retries / shorten the timeout on the interactive stats endpoints so they fail fast server-side too.