### PR TITLE
Added Claude Code hook to auto-install deps in fresh worktrees

### DIFF
--- a/.claude/hooks/worktree-setup.sh
+++ b/.claude/hooks/worktree-setup.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Bootstraps a fresh Ghost checkout so `pnpm dev` works immediately: installs
+# workspace dependencies and theme submodules. Run it from a checkout root,
+# or let the SessionStart hook in .claude/settings.json run it for you.
+#
+# Fast path:
+# - `pnpm install` and submodule init are independent, so they run in parallel
+# - linked worktrees get their own submodule gitdirs, so a plain
+#   `git submodule update --init` re-clones the themes from GitHub every time;
+#   when a sibling checkout (usually the main one) already has the pinned
+#   commit we clone from it with --reference/--dissociate instead, which is
+#   local-disk fast and works offline
+set -u
+
+[ "$(jq -r '.name // empty' package.json 2>/dev/null)" = "ghost-monorepo" ] || exit 0
+[ -d node_modules ] && exit 0
+
+LOG="$HOME/.claude/ghost-worktree-setup.log"
+: > "$LOG"
+
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" >/dev/null 2>&1
+nvm use >/dev/null 2>&1
+command -v pnpm >/dev/null 2>&1 || corepack enable pnpm >/dev/null 2>&1
+if ! command -v pnpm >/dev/null 2>&1; then
+    echo "Fresh Ghost checkout: setup FAILED - pnpm not found (install nvm or enable corepack), then run 'pnpm run setup' manually."
+    exit 0
+fi
+
+init_submodules() {
+    local common main sm sha rc=0
+    common="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || return 1
+    main="$(dirname "$common")"
+    for sm in $(git config --file .gitmodules --get-regexp '\.path$' 2>/dev/null | awk '{print $2}'); do
+        sha="$(git ls-tree HEAD "$sm" --object-only 2>/dev/null)"
+        if [ -n "$sha" ] && git -C "$main/$sm" cat-file -e "$sha" 2>/dev/null; then
+            git submodule update --init --recursive --dissociate --reference "$main/$sm" "$sm" || rc=1
+        else
+            git submodule update --init --recursive "$sm" || rc=1
+        fi
+    done
+    return "$rc"
+}
+
+pnpm install --frozen-lockfile >>"$LOG" 2>&1 &
+install_pid=$!
+init_submodules >>"$LOG" 2>&1 &
+submodules_pid=$!
+
+install_rc=0
+submodules_rc=0
+wait "$install_pid" || install_rc=$?
+wait "$submodules_pid" || submodules_rc=$?
+echo "worktree-setup finished in ${SECONDS}s (pnpm install rc=$install_rc, submodules rc=$submodules_rc)" >>"$LOG"
+
+if [ "$install_rc" -eq 0 ] && [ "$submodules_rc" -eq 0 ]; then
+    echo "Fresh Ghost checkout: deps + theme submodules installed in ${SECONDS}s; pnpm dev is ready."
+else
+    echo "Fresh Ghost checkout: setup FAILED (pnpm install rc=$install_rc, submodules rc=$submodules_rc) - check ~/.claude/ghost-worktree-setup.log and run 'pnpm run setup' manually before pnpm dev."
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.cwd // empty' | { read -r d; cd \"$d\" 2>/dev/null || exit 0; [ \"$(jq -r '.name // empty' package.json 2>/dev/null)\" = \"ghost-monorepo\" ] || exit 0; [ -d node_modules ] && exit 0; export NVM_DIR=\"$HOME/.nvm\"; [ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\" >/dev/null 2>&1; nvm use >/dev/null 2>&1; command -v pnpm >/dev/null 2>&1 || corepack enable pnpm >/dev/null 2>&1; if pnpm run setup >\"$HOME/.claude/ghost-worktree-setup.log\" 2>&1; then echo \"Fresh Ghost checkout: pnpm run setup completed (deps + submodules installed).\"; else echo \"Fresh Ghost checkout: pnpm run setup FAILED - check ~/.claude/ghost-worktree-setup.log and run it manually before pnpm dev.\"; fi; }",
+            "command": "jq -r '.cwd // empty' | { read -r d; cd \"$d\" 2>/dev/null || exit 0; [ -f .claude/hooks/worktree-setup.sh ] || exit 0; bash .claude/hooks/worktree-setup.sh; }",
             "timeout": 1200,
             "statusMessage": "Checking Ghost worktree setup…"
           }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,19 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.cwd // empty' | { read -r d; cd \"$d\" 2>/dev/null || exit 0; [ \"$(jq -r '.name // empty' package.json 2>/dev/null)\" = \"ghost-monorepo\" ] || exit 0; [ -d node_modules ] && exit 0; export NVM_DIR=\"$HOME/.nvm\"; [ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\" >/dev/null 2>&1; nvm use >/dev/null 2>&1; command -v pnpm >/dev/null 2>&1 || corepack enable pnpm >/dev/null 2>&1; if pnpm run setup >\"$HOME/.claude/ghost-worktree-setup.log\" 2>&1; then echo \"Fresh Ghost checkout: pnpm run setup completed (deps + submodules installed).\"; else echo \"Fresh Ghost checkout: pnpm run setup FAILED - check ~/.claude/ghost-worktree-setup.log and run it manually before pnpm dev.\"; fi; }",
+            "timeout": 1200,
+            "statusMessage": "Checking Ghost worktree setup…"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
no ref

## Problem

A fresh git worktree checkout of the monorepo has no `node_modules` and no theme submodules, so `pnpm dev` (and most other commands) fail until `pnpm run setup` has been run manually. Anyone using Claude Code worktree sessions hits this on every new worktree.

## Solution

A `SessionStart` hook in the shared `.claude/settings.json` that no-ops unless the session cwd is a `ghost-monorepo` checkout **missing `node_modules`**, and otherwise runs `.claude/hooks/worktree-setup.sh`, which bootstraps the checkout as fast as possible:

- `pnpm install` and theme-submodule init run **in parallel** — they're independent, so wall time is bounded by the install alone
- linked worktrees get their own submodule gitdirs, so a plain `git submodule update --init` re-clones the themes from GitHub on every new worktree; the script instead clones with `--reference`/`--dissociate` from a sibling checkout that already has the pinned commit (local-disk fast, works offline), with a plain network clone as fallback
- bootstraps nvm, with a corepack fallback for non-nvm users
- logs to `~/.claude/ghost-worktree-setup.log` and injects a one-line success/failure status into the session context so the agent knows the state before doing any work

Measured on a warm pnpm store: serial `pnpm run setup` ≈ 25s (18s install + 6s network submodule clones); this script ≈ 17.5s.

## Notes

- Claude Code project hooks are **approve-on-first-use**, so each developer is prompted before this ever runs — it's opt-in per person.
- The script is also runnable by hand from any checkout root: `bash .claude/hooks/worktree-setup.sh`
- Tested end-to-end: standalone script run in a fresh worktree (17.5s, correct submodule SHAs, both rc=0) and a headless Claude session in a fresh worktree from this branch (hook fired through the launcher; deps + submodules present before the first turn).