### PR TITLE
Added corepack to e2e runner image

### DIFF
--- a/e2e/Dockerfile.runner
+++ b/e2e/Dockerfile.runner
@@ -41,3 +41,8 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends ca-certificates; \
     npx --yes "playwright@${PLAYWRIGHT_VERSION}" install --with-deps chromium; \
     rm -rf /var/lib/apt/lists/* /root/.npm
+
+# Enable corepack and install the pnpm version pinned in the repo's package.json
+# `packageManager` field.
+COPY package.json ./
+RUN corepack enable && corepack install && rm package.json


### PR DESCRIPTION
no ref

Previously the runner image only shipped Node + Chromium, so every shard's container run did `corepack enable && pnpm exec ...` and downloaded pnpm from `registry.npmjs.org` fresh over the network. A transient socket reset during that download crashed the whole Node process (corepack/undici raise an unhandled `'error'` event instead of retrying/failing gracefully), taking the entire E2E shard down with it — unrelated to any actual test or code issue.