### PR TITLE
Fixed gift toast text wrapping on mobile

### DIFF
--- a/ghost/core/core/frontend/helpers/tpl/gift-toast.hbs
+++ b/ghost/core/core/frontend/helpers/tpl/gift-toast.hbs
@@ -129,8 +129,6 @@
     font-size: 14px;
     font-weight: 400;
     line-height: 1.25;
-    /* English fits on one line; longer locales wrap rather than truncate. */
-    text-wrap: balance;
 }
 
 .gh-gift-toast-close {


### PR DESCRIPTION
no ref

Removes text-wrap: balance from the gift toast title so wrapped text fills each line instead of balancing into short lines on narrow viewports.