### PR TITLE
Added package.json to e2e-runner-image trigger paths

### DIFF
--- a/.github/workflows/e2e-runner-image.yml
+++ b/.github/workflows/e2e-runner-image.yml
@@ -20,6 +20,9 @@ on:
       - '.github/workflows/e2e-runner-image.yml'
       # Playwright version pin — a bump here means a new runner tag to publish.
       - 'pnpm-workspace.yaml'
+      # pnpm's own version, pinned via `packageManager` — the Dockerfile COPYs this
+      # in and runs `corepack install` to bake it into the image.
+      - 'package.json'
 
 env:
   NODE_VERSION: 22.18.0


### PR DESCRIPTION
## Summary
- [#29050](https://github.com/TryGhost/Ghost/pull/29050) baked corepack + the pinned pnpm version into the E2E runner image by `COPY`ing root `package.json` into `e2e/Dockerfile.runner` and running `corepack install`, but the `e2e-runner-image.yml` publish workflow's `paths` filter never picked up `package.json`.
- Without this, a pnpm version bump (via the `packageManager` field in root `package.json`) would silently build a stale runner image until the next Playwright version bump or the weekly Monday schedule run.
- Adds `package.json` to the `push` trigger's `paths` list alongside the existing Dockerfile/workflow/`pnpm-workspace.yaml` entries.

## Test plan
- [x] Confirmed the change is scoped to the `paths` filter only, no functional workflow logic changed
- [ ] Verify a future `package.json` `packageManager` bump on `main` triggers this workflow