### PR TITLE
🐛 Fixed complimentary members being unable to upgrade on non-USD sites

### DIFF
--- a/apps/portal/src/components/pages/account-plan-page.jsx
+++ b/apps/portal/src/components/pages/account-plan-page.jsx
@@ -597,7 +597,12 @@ export default class AccountPlanPage extends React.Component {
         this.prices = getAvailablePrices({site});
         let activePrice = getMemberActivePrice({member});
 
-        if (activePrice) {
+        // Only filter by currency for real Stripe subscriptions. Synthetic
+        // complimentary/gift subscriptions have an empty price_id and a
+        // hardcoded USD currency, which would wrongly filter out all plans
+        // on non-USD sites (matches the `activePrice?.id` guard in
+        // getUpgradeProducts).
+        if (activePrice?.id) {
             this.prices = getFilteredPrices({prices: this.prices, currency: activePrice.currency});
         }
 

--- a/apps/portal/test/unit/components/pages/account-plan-page.test.jsx
+++ b/apps/portal/test/unit/components/pages/account-plan-page.test.jsx
@@ -71,6 +71,47 @@ describe('Account Plan Page', () => {
         expect(queryByTestId('yearly-switch')).not.toBeInTheDocument();
     });
 
+    test('shows paid plans to complimentary members on non-USD sites', () => {
+        // Regression test for https://linear.app/ghost/issue/ONC-1877
+        // Ghost core builds a synthetic subscription for comped members with a
+        // hardcoded USD currency and an empty price_id (see
+        // attachSubscriptionsToMember in member-bread-service.js). Filtering
+        // the available prices by that synthetic currency wrongly emptied the
+        // plans list on non-USD sites, showing "Sorry, no paid plans are
+        // available." instead of the upgrade options.
+        const products = [
+            getProductData({
+                name: 'Bronze',
+                monthlyPrice: getPriceData({interval: 'month', amount: 700, currency: 'eur'}),
+                yearlyPrice: getPriceData({interval: 'year', amount: 7000, currency: 'eur'}),
+                numOfBenefits: 2
+            })
+        ];
+        const siteData = getSiteData({products});
+        const memberData = getMemberData({
+            status: 'comped',
+            paid: true,
+            subscriptions: [
+                getSubscriptionData({
+                    id: '',
+                    status: 'active',
+                    currency: 'USD',
+                    interval: 'year',
+                    amount: 0,
+                    nickname: 'Complimentary',
+                    priceId: '',
+                    offer: null,
+                    tier: products[0]
+                })
+            ]
+        });
+        const {getByTestId, queryByTestId} = customSetup({site: siteData, member: memberData});
+
+        expect(queryByTestId('no-plans-available-notification-text')).not.toBeInTheDocument();
+        expect(getByTestId('monthly-switch')).toBeInTheDocument();
+        expect(getByTestId('yearly-switch')).toBeInTheDocument();
+    });
+
     test('can choose plan and continue', async () => {
         const siteData = getSiteData({
             products: getProductsData({numOfProducts: 1})


### PR DESCRIPTION
fixes https://linear.app/ghost/issue/ONC-1877/complimentary-members-can-no-longer-upgrade-to-a-paid-plan

## Problem

Complimentary members on sites that don't sell in USD saw "Sorry, no paid plans are available." on the change-plan page instead of the available paid plans, blocking upgrades entirely.

## Root cause

Three pieces interact:

1. Ghost core builds a synthetic subscription for comped members with a **hardcoded USD currency** and an **empty `price_id`** (`attachSubscriptionsToMember` in `member-bread-service.js`).
2. Portal's `AccountPlanPage.getInitialState()` filtered the available prices by the active price's currency whenever an active price existed — including the synthetic one. On any non-USD site this left zero plans.
3. #22512 (June 10) added an empty state that renders "Sorry, no paid plans are available." when the plans list is empty. Before that commit the empty list was harmless, because the upgrade section renders products from `getUpgradeProducts()`, which already skips the currency filter when `price_id` is empty — so comped members still saw all plans and could upgrade.

This is why the bug only reproduces on non-USD sites: on USD sites the synthetic currency happens to match.

## Fix

Guard the currency filter with `activePrice?.id` instead of `activePrice`, matching the existing guard in `getUpgradeProducts()`. Real Stripe subscriptions always carry a `price_id`, so paid members' behaviour is unchanged; synthetic complimentary/gift subscriptions no longer wrongly empty the plans list.

A core-side follow-up (using the tier's real currency instead of hardcoded USD when building the synthetic subscription, which also affects gift members whose gift lookup fails) is tracked separately.

## Testing

- Added a regression test with the exact synthetic subscription shape core produces (USD, amount 0, empty `price_id`) on a EUR site — fails without the fix, passes with it
- Full Portal unit suite passes (583 tests), lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)