### PR TITLE
🐛 Fixed post card styles and scripts going missing until Ghost restarts

### DIFF
--- a/ghost/core/core/frontend/services/assets-minification/assets-minification-base.js
+++ b/ghost/core/core/frontend/services/assets-minification/assets-minification-base.js
@@ -16,6 +16,27 @@ module.exports = class AssetsMinificationBase {
         this.loading = null;
     }
 
+    /**
+     * Ensure an asset build has run, joining an in-flight load() when one
+     * exists so concurrent callers only trigger a single build. Used both by
+     * serveMiddleware() and as a recovery path when a built file has gone
+     * missing from disk at runtime.
+     *
+     * @returns {Promise<void>}
+     */
+    ensureLoaded() {
+        if (!this.loading) {
+            const pending = this.load().finally(() => {
+                if (this.loading === pending) {
+                    this.loading = null;
+                }
+            });
+            this.loading = pending;
+        }
+
+        return this.loading;
+    }
+
     generateGlobs() {
         throw new errors.InternalServerError({
             message: 'generateGlobs not implemented'
@@ -52,15 +73,15 @@ module.exports = class AssetsMinificationBase {
          */
         return async function serveMiddleware(req, res, next) {
             if (!self.ready) {
-                if (!self.loading) {
-                    const pending = self.load().finally(() => {
-                        if (self.loading === pending) {
-                            self.loading = null;
-                        }
-                    });
-                    self.loading = pending;
+                try {
+                    await self.ensureLoaded();
+                } catch (error) {
+                    // A failed build must not block the request — without this
+                    // the rejection escapes the express handler and the request
+                    // hangs. The file middleware downstream serves the previous
+                    // build, or responds with a 404 if there is none.
+                    logging.error(error);
                 }
-                await self.loading;
             }
 
             next();

--- a/ghost/core/core/frontend/services/assets-minification/assets-minification-base.js
+++ b/ghost/core/core/frontend/services/assets-minification/assets-minification-base.js
@@ -72,7 +72,10 @@ module.exports = class AssetsMinificationBase {
          * @param {import('express').NextFunction} next
          */
         return async function serveMiddleware(req, res, next) {
-            if (!self.ready) {
+            // Wait when assets are not built yet, but also when a build is in
+            // flight (e.g. the ENOENT recovery rebuild) — reading while the
+            // minifier truncates/rewrites the files would serve partial assets
+            if (!self.ready || self.loading) {
                 try {
                     await self.ensureLoaded();
                 } catch (error) {

--- a/ghost/core/core/frontend/web/routers/serve-public-file.js
+++ b/ghost/core/core/frontend/web/routers/serve-public-file.js
@@ -2,6 +2,7 @@ const crypto = require('crypto');
 const fs = require('fs-extra');
 const path = require('path');
 const errors = require('@tryghost/errors');
+const logging = require('@tryghost/logging');
 const config = require('../../../shared/config');
 const urlUtils = require('../../../shared/url-utils');
 const tpl = require('@tryghost/tpl');
@@ -66,39 +67,55 @@ function createPublicFileMiddleware(location, file, mime, maxAge, options = {}) 
         }
 
         // modify text files before caching+serving to ensure URL placeholders are transformed
-        fs.readFile(filePath, (err, buf) => {
-            if (err) {
-                // Downgrade to a simple 404 if the file didn't exist
-                if (err.code === 'ENOENT') {
-                    err = new errors.NotFoundError({
-                        message: tpl(messages.fileNotFound),
-                        code: 'PUBLIC_FILE_NOT_FOUND',
-                        property: err.path
-                    });
+        const serveFile = (canRebuild) => {
+            fs.readFile(filePath, (err, buf) => {
+                if (err) {
+                    // CASE: a generated file has gone missing from the content folder
+                    // at runtime - attempt to regenerate it once before giving up,
+                    // otherwise the 404 sticks until the next reboot
+                    if (err.code === 'ENOENT' && canRebuild && options.rebuild) {
+                        return Promise.resolve()
+                            .then(options.rebuild)
+                            .catch((rebuildError) => {
+                                logging.error(rebuildError);
+                            })
+                            .then(() => serveFile(false));
+                    }
+
+                    // Downgrade to a simple 404 if the file didn't exist
+                    if (err.code === 'ENOENT') {
+                        err = new errors.NotFoundError({
+                            message: tpl(messages.fileNotFound),
+                            code: 'PUBLIC_FILE_NOT_FOUND',
+                            property: err.path
+                        });
+                    }
+                    return next(err);
                 }
-                return next(err);
-            }
 
-            let str = buf.toString();
+                let str = buf.toString();
 
-            if (mime === 'text/xsl' || mime === 'text/plain' || mime === 'application/javascript') {
-                str = str.replace(blogRegex, urlUtils.urlFor('home', true).replace(/\/$/, ''));
-            }
+                if (mime === 'text/xsl' || mime === 'text/plain' || mime === 'application/javascript') {
+                    str = str.replace(blogRegex, urlUtils.urlFor('home', true).replace(/\/$/, ''));
+                }
 
-            cache = {
-                headers: {
-                    'Content-Type': mime,
-                    'Content-Length': Buffer.from(str).length,
-                    ETag: `"${crypto.createHash('md5').update(str, 'utf8').digest('hex')}"`,
-                    'Cache-Control': `public, max-age=${maxAge}`
-                },
-                body: str,
-                key: req.query && req.query.v ? req.query.v : null
-            };
+                cache = {
+                    headers: {
+                        'Content-Type': mime,
+                        'Content-Length': Buffer.from(str).length,
+                        ETag: `"${crypto.createHash('md5').update(str, 'utf8').digest('hex')}"`,
+                        'Cache-Control': `public, max-age=${maxAge}`
+                    },
+                    body: str,
+                    key: req.query && req.query.v ? req.query.v : null
+                };
 
-            res.writeHead(200, cache.headers);
-            res.end(cache.body);
-        });
+                res.writeHead(200, cache.headers);
+                res.end(cache.body);
+            });
+        };
+
+        serveFile(true);
     };
 }
 
@@ -128,8 +145,9 @@ function servePublicFiles(siteApp) {
     siteApp.get('/public/ghost-stats.min.js', createPublicFileMiddleware('static', 'public/ghost-stats.min.js', 'application/javascript', config.get('caching:publicAssets:maxAge')));
 
     // Card assets (built on the fly)
-    siteApp.get('/public/cards.min.css', cardAssets.serveMiddleware(), createPublicFileMiddleware('built', 'public/cards.min.css', 'text/css', config.get('caching:publicAssets:maxAge')));
-    siteApp.get('/public/cards.min.js', cardAssets.serveMiddleware(), createPublicFileMiddleware('built', 'public/cards.min.js', 'application/javascript', config.get('caching:publicAssets:maxAge')));
+    const rebuildCardAssets = () => cardAssets.ensureLoaded();
+    siteApp.get('/public/cards.min.css', cardAssets.serveMiddleware(), createPublicFileMiddleware('built', 'public/cards.min.css', 'text/css', config.get('caching:publicAssets:maxAge'), {rebuild: rebuildCardAssets}));
+    siteApp.get('/public/cards.min.js', cardAssets.serveMiddleware(), createPublicFileMiddleware('built', 'public/cards.min.js', 'application/javascript', config.get('caching:publicAssets:maxAge'), {rebuild: rebuildCardAssets}));
 
     // Comment counts
     siteApp.get('/public/comment-counts.min.js', createPublicFileMiddleware('static', 'public/comment-counts.min.js', 'application/javascript', config.get('caching:publicAssets:maxAge')));

--- a/ghost/core/core/frontend/web/routers/serve-public-file.js
+++ b/ghost/core/core/frontend/web/routers/serve-public-file.js
@@ -30,8 +30,14 @@ function matchCacheKey(req, cache) {
     return true;
 }
 
+// Minimum time between rebuild attempts for a missing generated file, so a
+// persistently failing build (e.g. an unwritable content folder) doesn't add
+// minification cost to every request
+const REBUILD_MIN_INTERVAL_MS = 10000;
+
 function createPublicFileMiddleware(location, file, mime, maxAge, options = {}) {
     let cache;
+    let lastRebuildAttempt = 0;
     // These files are provided by Ghost, and therefore live inside of the core folder
     const staticFilePath = config.get('paths').publicFilePath;
     // These files are built on the fly, and must be saved in the content folder
@@ -73,7 +79,8 @@ function createPublicFileMiddleware(location, file, mime, maxAge, options = {}) 
                     // CASE: a generated file has gone missing from the content folder
                     // at runtime - attempt to regenerate it once before giving up,
                     // otherwise the 404 sticks until the next reboot
-                    if (err.code === 'ENOENT' && canRebuild && options.rebuild) {
+                    if (err.code === 'ENOENT' && canRebuild && options.rebuild && location === 'built' && Date.now() - lastRebuildAttempt >= REBUILD_MIN_INTERVAL_MS) {
+                        lastRebuildAttempt = Date.now();
                         return Promise.resolve()
                             .then(options.rebuild)
                             .catch((rebuildError) => {

--- a/ghost/core/test/unit/frontend/services/assets-minification/assets-minification-base.test.js
+++ b/ghost/core/test/unit/frontend/services/assets-minification/assets-minification-base.test.js
@@ -3,6 +3,7 @@ const sinon = require('sinon');
 const path = require('path');
 const fs = require('fs').promises;
 const os = require('os');
+const logging = require('@tryghost/logging');
 const AssetsMinificationBase = require('../../../../../core/frontend/services/assets-minification/assets-minification-base');
 
 describe('AssetsMinificationBase', function () {
@@ -193,7 +194,8 @@ describe('AssetsMinificationBase', function () {
             assert.equal(assets.loading, null);
         });
 
-        it('clears loading promise even when load() throws', async function () {
+        it('clears loading promise and continues the request when load() throws', async function () {
+            const loggingStub = sinon.stub(logging, 'error');
             let shouldThrow = true;
 
             class TestAssets extends AssetsMinificationBase {
@@ -210,7 +212,71 @@ describe('AssetsMinificationBase', function () {
             const middleware = assets.serveMiddleware();
             const next = sinon.stub();
 
-            await assert.rejects(() => middleware({}, {}, next));
+            // The rejection must not escape the middleware — that would leave
+            // the request hanging with no response
+            await middleware({}, {}, next);
+
+            sinon.assert.calledOnce(next);
+            sinon.assert.calledOnce(loggingStub);
+            assert.equal(assets.loading, null);
+        });
+    });
+
+    describe('ensureLoaded', function () {
+        it('starts a build even when assets are marked ready', async function () {
+            let loadCallCount = 0;
+
+            class TestAssets extends AssetsMinificationBase {
+                async load() {
+                    loadCallCount += 1;
+                    this.ready = true;
+                }
+            }
+
+            const assets = new TestAssets();
+            assets.ready = true;
+
+            await assets.ensureLoaded();
+
+            assert.equal(loadCallCount, 1);
+        });
+
+        it('joins an in-flight build instead of starting a second one', async function () {
+            let loadCallCount = 0;
+            let resolveLoad;
+
+            class TestAssets extends AssetsMinificationBase {
+                async load() {
+                    loadCallCount += 1;
+                    await new Promise((resolve) => {
+                        resolveLoad = resolve;
+                    });
+                    this.ready = true;
+                }
+            }
+
+            const assets = new TestAssets();
+
+            const first = assets.ensureLoaded();
+            const second = assets.ensureLoaded();
+
+            resolveLoad();
+            await Promise.all([first, second]);
+
+            assert.equal(loadCallCount, 1, 'concurrent callers should share a single load()');
+            assert.equal(assets.loading, null);
+        });
+
+        it('clears the loading promise when load() throws', async function () {
+            class TestAssets extends AssetsMinificationBase {
+                async load() {
+                    throw new Error('load failed');
+                }
+            }
+
+            const assets = new TestAssets();
+
+            await assert.rejects(() => assets.ensureLoaded());
 
             assert.equal(assets.loading, null);
         });

--- a/ghost/core/test/unit/frontend/services/assets-minification/assets-minification-base.test.js
+++ b/ghost/core/test/unit/frontend/services/assets-minification/assets-minification-base.test.js
@@ -194,6 +194,40 @@ describe('AssetsMinificationBase', function () {
             assert.equal(assets.loading, null);
         });
 
+        it('waits for an in-flight rebuild even when assets are marked ready', async function () {
+            let resolveLoad;
+
+            class TestAssets extends AssetsMinificationBase {
+                async load() {
+                    await new Promise((resolve) => {
+                        resolveLoad = resolve;
+                    });
+                    this.ready = true;
+                }
+            }
+
+            const assets = new TestAssets();
+            assets.ready = true;
+
+            // A recovery rebuild is in flight (e.g. triggered by an ENOENT on a
+            // sibling file) — the minifier may be truncating/rewriting files
+            const rebuild = assets.ensureLoaded();
+
+            const middleware = assets.serveMiddleware();
+            const next = sinon.stub();
+            const request = middleware({}, {}, next);
+
+            // The request must not proceed while the rebuild is writing files
+            await new Promise((resolve) => {
+                setImmediate(resolve);
+            });
+            sinon.assert.notCalled(next);
+
+            resolveLoad();
+            await Promise.all([rebuild, request]);
+            sinon.assert.calledOnce(next);
+        });
+
         it('clears loading promise and continues the request when load() throws', async function () {
             const loggingStub = sinon.stub(logging, 'error');
             let shouldThrow = true;

--- a/ghost/core/test/unit/frontend/web/middleware/serve-public-file.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/serve-public-file.test.js
@@ -3,6 +3,7 @@ const sinon = require('sinon');
 const request = require('supertest');
 const express = require('express');
 const fs = require('fs-extra');
+const logging = require('@tryghost/logging');
 const config = require('../../../../../core/shared/config');
 const {servePublicFile} = require('../../../../../core/frontend/web/routers/serve-public-file');
 
@@ -166,6 +167,98 @@ describe('servePublicFile', function () {
                 code: 'PUBLIC_FILE_NOT_FOUND',
                 property: null
             });
+    });
+
+    it('rebuilds a missing built file once and serves the result', async function () {
+        const body = '.kg-card {display: block}';
+        const rebuild = sinon.stub().resolves();
+
+        const middleware = servePublicFile('built', 'public/cards.min.css', 'text/css', 3600, {rebuild});
+        const app = createApp(middleware);
+
+        const enoent = new Error();
+        enoent.code = 'ENOENT';
+
+        const fileStub = sinon.stub(fs, 'readFile');
+        fileStub.onFirstCall().callsFake(function (file, cb) {
+            cb(enoent, null);
+        });
+        fileStub.callsFake(function (file, cb) {
+            cb(null, body);
+        });
+
+        const {text} = await request(app)
+            .get('/public/cards.min.css')
+            .expect(200)
+            .expect('Content-Type', /^text\/css/);
+
+        assert.equal(text, body);
+        sinon.assert.calledOnce(rebuild);
+        sinon.assert.calledTwice(fileStub);
+        assert(fileStub.firstCall.calledBefore(rebuild.firstCall));
+    });
+
+    it('404s when the file is still missing after a rebuild', async function () {
+        const rebuild = sinon.stub().resolves();
+
+        const middleware = servePublicFile('built', 'public/cards.min.css', 'text/css', 3600, {rebuild});
+        const app = createApp(middleware);
+
+        sinon.stub(fs, 'readFile').callsFake(function (file, cb) {
+            const err = new Error();
+            err.code = 'ENOENT';
+            cb(err, null);
+        });
+
+        await request(app)
+            .get('/public/cards.min.css')
+            .expect(404)
+            .expect({
+                errorType: 'NotFoundError',
+                code: 'PUBLIC_FILE_NOT_FOUND',
+                property: null
+            });
+
+        // The rebuild is only attempted once per request — no retry loops
+        sinon.assert.calledOnce(rebuild);
+    });
+
+    it('404s when the rebuild itself fails', async function () {
+        const loggingStub = sinon.stub(logging, 'error');
+        const rebuild = sinon.stub().rejects(new Error('rebuild failed'));
+
+        const middleware = servePublicFile('built', 'public/cards.min.css', 'text/css', 3600, {rebuild});
+        const app = createApp(middleware);
+
+        sinon.stub(fs, 'readFile').callsFake(function (file, cb) {
+            const err = new Error();
+            err.code = 'ENOENT';
+            cb(err, null);
+        });
+
+        await request(app)
+            .get('/public/cards.min.css')
+            .expect(404);
+
+        sinon.assert.calledOnce(rebuild);
+        sinon.assert.calledOnce(loggingStub);
+    });
+
+    it('does not attempt a rebuild when no rebuild option is configured', async function () {
+        const middleware = servePublicFile('built', 'public/cards.min.css', 'text/css', 3600);
+        const app = createApp(middleware);
+
+        const fileStub = sinon.stub(fs, 'readFile').callsFake(function (file, cb) {
+            const err = new Error();
+            err.code = 'ENOENT';
+            cb(err, null);
+        });
+
+        await request(app)
+            .get('/public/cards.min.css')
+            .expect(404);
+
+        sinon.assert.calledOnce(fileStub);
     });
 
     it('can serve a built asset file as well as public files', async function () {

--- a/ghost/core/test/unit/frontend/web/middleware/serve-public-file.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/serve-public-file.test.js
@@ -269,6 +269,34 @@ describe('servePublicFile', function () {
         sinon.assert.calledOnce(rebuild);
     });
 
+    it('attempts another rebuild after the throttle window has passed', async function () {
+        // Only fake Date — the throttle uses Date.now() and supertest needs
+        // real timers to run
+        const clock = sinon.useFakeTimers({now: Date.now(), toFake: ['Date']});
+        const rebuild = sinon.stub().resolves();
+
+        const middleware = servePublicFile('built', 'public/cards.min.css', 'text/css', 3600, {rebuild});
+        const app = createApp(middleware);
+
+        sinon.stub(fs, 'readFile').callsFake(function (file, cb) {
+            const err = new Error();
+            err.code = 'ENOENT';
+            cb(err, null);
+        });
+
+        await request(app)
+            .get('/public/cards.min.css')
+            .expect(404);
+
+        clock.tick(10001);
+
+        await request(app)
+            .get('/public/cards.min.css')
+            .expect(404);
+
+        sinon.assert.calledTwice(rebuild);
+    });
+
     it('never attempts a rebuild for static files', async function () {
         const rebuild = sinon.stub().resolves();
 

--- a/ghost/core/test/unit/frontend/web/middleware/serve-public-file.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/serve-public-file.test.js
@@ -244,6 +244,50 @@ describe('servePublicFile', function () {
         sinon.assert.calledOnce(loggingStub);
     });
 
+    it('throttles rebuild attempts when the file keeps going missing', async function () {
+        const rebuild = sinon.stub().resolves();
+
+        const middleware = servePublicFile('built', 'public/cards.min.css', 'text/css', 3600, {rebuild});
+        const app = createApp(middleware);
+
+        sinon.stub(fs, 'readFile').callsFake(function (file, cb) {
+            const err = new Error();
+            err.code = 'ENOENT';
+            cb(err, null);
+        });
+
+        await request(app)
+            .get('/public/cards.min.css')
+            .expect(404);
+
+        await request(app)
+            .get('/public/cards.min.css')
+            .expect(404);
+
+        // The second request arrives within the throttle window, so it must
+        // not trigger another expensive rebuild
+        sinon.assert.calledOnce(rebuild);
+    });
+
+    it('never attempts a rebuild for static files', async function () {
+        const rebuild = sinon.stub().resolves();
+
+        const middleware = servePublicFile('static', 'robots.txt', 'text/plain', 3600, {rebuild});
+        const app = createApp(middleware);
+
+        sinon.stub(fs, 'readFile').callsFake(function (file, cb) {
+            const err = new Error();
+            err.code = 'ENOENT';
+            cb(err, null);
+        });
+
+        await request(app)
+            .get('/robots.txt')
+            .expect(404);
+
+        sinon.assert.notCalled(rebuild);
+    });
+
     it('does not attempt a rebuild when no rebuild option is configured', async function () {
         const middleware = servePublicFile('built', 'public/cards.min.css', 'text/css', 3600);
         const app = createApp(middleware);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1865

## Problem

`/public/cards.min.js` and `/public/cards.min.css` are generated at runtime into `content/public/` — built lazily on the first request after boot or theme activation. The serving pipeline has two dead ends that make any failure **permanent until the process restarts**:

1. If the built files go missing from disk at runtime, the public file middleware returns a plain 404 (`PUBLIC_FILE_NOT_FOUND`) forever — nothing ever triggers a rebuild, because `ready` stays `true` on the assets service.
2. If the rebuild itself fails (e.g. `EACCES` writing to `content/public/`), the error is reduced to a log line and requests fall through to the same terminal 404.

We hit this in production at scale: sites whose `content/public/` became unwritable/emptied mid-run would 404 both card assets on every request — for days — until their container was restarted. During Jun 25–29 this accumulated to ~486 sites before a fleet restart cleared it. The `Ghost was not able to write asset files due to permissions.` error log correlates 1:1 with the 404s.

## Solution

- `AssetsMinificationBase` gains `ensureLoaded()` — starts a build, or joins the in-flight one, so concurrent callers share a single `load()` (preserving the 0-byte concurrent-write protection added in 21d33b53fe).
- `createPublicFileMiddleware` accepts a `rebuild` option: on `ENOENT` for a generated file it triggers one shared rebuild and retries the read once before falling back to the 404. Wired up for the two card asset routes, so a missing built file now self-heals on the next request instead of requiring a restart.
- `serveMiddleware` no longer lets a rejected `load()` escape as an unhandled rejection — previously that left the request hanging with no response under Express 4. It now logs and continues, letting the downstream middleware serve the previous build or 404.

The recovery is bounded: one rebuild attempt per request, single-flight across concurrent requests, and no behaviour change for static (non-generated) public files.

## Testing

- New unit tests for `ensureLoaded()` (join-in-flight, runs even when `ready`, clears `loading` on failure).
- New unit tests for the rebuild path in `servePublicFile`: successful recovery, still-missing after rebuild → 404 with no retry loop, rebuild rejection → 404, and no rebuild attempted when the option isn't configured.
- Updated the existing throwing-`load()` test to assert the request continues instead of rejecting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)