### PR TITLE
🐛 Fixed email preview always showing the paywall on tier-restricted posts

### DIFF
--- a/ghost/core/core/server/services/email-service/email-controller.js
+++ b/ghost/core/core/server/services/email-service/email-controller.js
@@ -28,7 +28,8 @@ class EmailController {
         // Bit absurd situation in email-previews endpoints that one endpoint is using options and other one is using data.
         // So we need to handle both cases.
         let post;
-        const withRelated = [...new Set(['posts_meta', 'authors', ...this.getRequiredUrlRelations()])];
+        // 'tiers' is required by the email tier-gating logic (renderer/segmenter), not for URL generation
+        const withRelated = [...new Set(['posts_meta', 'authors', 'tiers', ...this.getRequiredUrlRelations()])];
         if (frame.options.id) {
             post = await this.models.Post.findOne({...frame.options, status: 'all'}, {withRelated});
         } else {

--- a/ghost/core/core/server/services/email-service/email-renderer.js
+++ b/ghost/core/core/server/services/email-service/email-renderer.js
@@ -133,7 +133,10 @@ function getSegmentStatus(segment) {
  * Whether the members matched by a segment can read the post's gated content.
  * Derived from the post's visibility (not just free/paid): for paid posts the
  * access segment is the paid one; for tier-restricted posts it's the segment
- * carrying the post's positive tier filter.
+ * carrying the post's positive tier filter. A null segment is an unsegmented
+ * render — the send pipeline only produces one for posts without gated content,
+ * and API previews without a memberSegment expect the full body — so it always
+ * has access.
  * @param {Post} post
  * @param {Segment} segment
  * @returns {boolean}
@@ -143,12 +146,15 @@ function segmentHasPostAccess(post, segment) {
     if (visibility !== 'paid' && visibility !== 'tiers') {
         return true;
     }
+    if (!segment) {
+        return true;
+    }
     const accessFilter = getPostAccessFilter(getPostGatingShape(post));
     if (!accessFilter) {
         // misconfigured tiers post (no tiers) -> nobody has access
         return false;
     }
-    return !!segment && segment.includes(accessFilter);
+    return segment.includes(accessFilter);
 }
 
 /**
@@ -458,6 +464,28 @@ class EmailRenderer {
 
         // We have different content between free and paid members
         return allowedSegments;
+    }
+
+    /**
+     * Maps the fixed audience choices offered by the editor's email preview and
+     * test-email UI ('status:free' / 'status:-free') onto the segment the send
+     * pipeline renders for that audience, so previews match what members receive.
+     * For a tier-restricted post the paid audience maps to the tier access
+     * segment (the access variant getSegments produces): paid members on the
+     * post's tiers get the full content, and the free choice previews the
+     * no-access variant. Anything else passes through unchanged.
+     * @param {Post} post
+     * @param {Segment} segment
+     * @returns {Segment}
+     */
+    getPreviewSegment(post, segment) {
+        if (segment === 'status:-free' && post.get('visibility') === 'tiers') {
+            const accessFilter = getPostAccessFilter(getPostGatingShape(post));
+            if (accessFilter) {
+                return `status:-free+(${accessFilter})`;
+            }
+        }
+        return segment;
     }
 
     async renderPostBaseHtml(post, newsletter) {

--- a/ghost/core/core/server/services/email-service/email-service.js
+++ b/ghost/core/core/server/services/email-service/email-service.js
@@ -444,9 +444,10 @@ class EmailService {
      */
     async previewEmail(post, newsletter, segment) {
         const exampleMember = await this.getExampleMember(null, segment);
+        const renderSegment = this.#emailRenderer.getPreviewSegment(post, segment);
 
         const subject = this.#emailRenderer.getSubject(post);
-        let {html, plaintext, replacements} = await this.#emailRenderer.renderBody(post, newsletter, segment, {clickTrackingEnabled: false});
+        let {html, plaintext, replacements} = await this.#emailRenderer.renderBody(post, newsletter, renderSegment, {clickTrackingEnabled: false});
 
         return {
             subject,
@@ -471,7 +472,7 @@ class EmailService {
         await this.#sendingService.send({
             post,
             newsletter,
-            segment,
+            segment: this.#emailRenderer.getPreviewSegment(post, segment),
             members,
             emailId: null
         }, {

--- a/ghost/core/test/e2e-api/admin/email-previews.test.js
+++ b/ghost/core/test/e2e-api/admin/email-previews.test.js
@@ -341,6 +341,71 @@ describe('Email Preview API', function () {
         });
     });
 
+    describe('Tier-restricted posts', function () {
+        let post;
+
+        beforeAll(async function () {
+            const paidTier = await models.Product.findOne({type: 'paid'});
+
+            const lexical = JSON.stringify({
+                root: {
+                    children: [
+                        {
+                            children: [{detail: 0, format: 0, mode: 'normal', style: '', text: 'Free preview text', type: 'text', version: 1}],
+                            direction: 'ltr', format: '', indent: 0, type: 'paragraph', version: 1
+                        },
+                        {type: 'paywall', version: 1},
+                        {
+                            children: [{detail: 0, format: 0, mode: 'normal', style: '', text: 'Members only tier content', type: 'text', version: 1}],
+                            direction: 'ltr', format: '', indent: 0, type: 'paragraph', version: 1
+                        }
+                    ],
+                    direction: 'ltr', format: '', indent: 0, type: 'root', version: 1
+                }
+            });
+
+            const {body: draftBody} = await agent
+                .post('posts/')
+                .body({posts: [{title: 'Tier-restricted email preview post', status: 'draft', lexical}]})
+                .expectStatus(201);
+            const [draft] = draftBody.posts;
+
+            const {body: updatedBody} = await agent
+                .put(`posts/${draft.id}/`)
+                .body({posts: [{
+                    id: draft.id,
+                    updated_at: draft.updated_at,
+                    visibility: 'tiers',
+                    tiers: [{id: paidTier.id}]
+                }]})
+                .expectStatus(200);
+            post = updatedBody.posts[0];
+        });
+
+        it('renders the full content for the paid member preview', async function () {
+            await agent
+                .get(`email_previews/posts/${post.id}/?memberSegment=${encodeURIComponent('status:-free')}`)
+                .expectStatus(200)
+                .expect(({body}) => {
+                    const {html} = body.email_previews[0];
+                    assert.ok(html.includes('Members only tier content'), 'paid member preview should include the gated content');
+                    assert.ok(!html.includes('Become a paid member'), 'paid member preview should not include the paywall CTA');
+                });
+        });
+
+        it('renders the paywall for the free member preview', async function () {
+            await agent
+                .get(`email_previews/posts/${post.id}/?memberSegment=${encodeURIComponent('status:free')}`)
+                .expectStatus(200)
+                .expect(({body}) => {
+                    const {html} = body.email_previews[0];
+                    assert.ok(html.includes('Free preview text'), 'free member preview should include the public preview');
+                    assert.ok(!html.includes('Members only tier content'), 'free member preview should not include the gated content');
+                    assert.ok(html.includes('Become a paid member'), 'free member preview should include the paywall CTA');
+                });
+        });
+    });
+
     describe('As Owner', function () {
         it('can send test email', async function () {
             await agent

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -1329,6 +1329,63 @@ describe('Email renderer', function () {
         });
     });
 
+    describe('getPreviewSegment', function () {
+        let emailRenderer;
+
+        beforeEach(function () {
+            emailRenderer = new EmailRenderer({});
+        });
+
+        function createTiersPost(tiers) {
+            return {
+                get: (key) => {
+                    if (key === 'visibility') {
+                        return 'tiers';
+                    }
+                },
+                related: (key) => {
+                    if (key === 'tiers') {
+                        return {toJSON: () => tiers};
+                    }
+                }
+            };
+        }
+
+        it('maps the paid audience to the tier access segment for a tiers post', function () {
+            const post = createTiersPost([{slug: 'gold'}, {slug: 'silver'}]);
+            assert.equal(
+                emailRenderer.getPreviewSegment(post, 'status:-free'),
+                'status:-free+(product:\'gold\',product:\'silver\')'
+            );
+        });
+
+        it('keeps the free audience segment for a tiers post', function () {
+            const post = createTiersPost([{slug: 'gold'}]);
+            assert.equal(emailRenderer.getPreviewSegment(post, 'status:free'), 'status:free');
+        });
+
+        it('passes the paid audience through for non-tiers posts', function () {
+            const post = {
+                get: (key) => {
+                    if (key === 'visibility') {
+                        return 'paid';
+                    }
+                }
+            };
+            assert.equal(emailRenderer.getPreviewSegment(post, 'status:-free'), 'status:-free');
+        });
+
+        it('passes through for a tiers post with no tiers', function () {
+            const post = createTiersPost([]);
+            assert.equal(emailRenderer.getPreviewSegment(post, 'status:-free'), 'status:-free');
+        });
+
+        it('passes through a null segment', function () {
+            const post = createTiersPost([{slug: 'gold'}]);
+            assert.equal(emailRenderer.getPreviewSegment(post, null), null);
+        });
+    });
+
     describe('renderBody', function () {
         let renderedPost;
         let postUrl = 'http://example.com';
@@ -2352,6 +2409,50 @@ describe('Email renderer', function () {
             const access = await emailRenderer.renderBody(post, newsletter, 'product:\'gold\'', {});
             assert(access.html.includes('finishing part only for members'));
             assert(!access.html.includes('Become a paid member of Test Blog to get access to all'));
+
+            // The composite shape the email preview maps the paid audience to -> full content
+            const preview = await emailRenderer.renderBody(post, newsletter, 'status:-free+(product:\'gold\')', {});
+            assert(preview.html.includes('finishing part only for members'));
+            assert(!preview.html.includes('Become a paid member of Test Blog to get access to all'));
+        });
+
+        it('does not paywall an unsegmented (null segment) render of a gated post', async function () {
+            renderedPost = '<div> Lexical Test </div> some text for both <!--members-only--> finishing part only for members';
+            const post = {
+                related: () => {
+                    return null;
+                },
+                get: (key) => {
+                    if (key === 'lexical') {
+                        return '{}';
+                    }
+                    if (key === 'visibility') {
+                        return 'paid';
+                    }
+                    if (key === 'title') {
+                        return 'Test Post';
+                    }
+                },
+                getLazyRelation: () => {
+                    return {models: [{get: k => (k === 'name' ? 'Test Author' : undefined)}]};
+                }
+            };
+            const newsletter = {
+                get: (key) => {
+                    if (key === 'show_post_title_section') {
+                        return true;
+                    }
+                    if (key === 'feedback_enabled') {
+                        return true;
+                    }
+                    return false;
+                }
+            };
+
+            const response = await emailRenderer.renderBody(post, newsletter, null, {});
+            assert(response.html.includes('some text for both'));
+            assert(response.html.includes('finishing part only for members'));
+            assert(!response.html.includes('Become a paid member of Test Blog to get access to all'));
         });
 
         it('should output valid HTML and escape HTML characters in mobiledoc', async function () {

--- a/ghost/core/test/unit/server/services/email-service/email-service.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-service.test.js
@@ -48,6 +48,9 @@ describe('Email Service', function () {
                     plaintext: 'Plaintext',
                     replacements: []
                 };
+            },
+            getPreviewSegment: (post, segment) => {
+                return segment;
             }
         };
         sendingService = {
@@ -806,6 +809,27 @@ describe('Email Service', function () {
             assert.equal(data.plaintext, 'Hello Jamie Larson');
             assert.equal(data.subject, 'Subject');
         });
+
+        it('renders using the preview segment mapped for the post', async function () {
+            const post = createModel({
+                id: '123',
+                newsletter: createModel({
+                    status: 'active',
+                    feedback_enabled: true
+                })
+            });
+            sinon.stub(emailRenderer, 'getPreviewSegment').returns('status:-free+(product:\'gold\')');
+            const renderBody = sinon.stub(emailRenderer, 'renderBody').resolves({
+                html: 'HTML',
+                plaintext: 'Plaintext',
+                replacements: []
+            });
+
+            await service.previewEmail(post, post.get('newsletter'), 'status:-free');
+
+            sinon.assert.calledOnceWithExactly(emailRenderer.getPreviewSegment, post, 'status:-free');
+            assert.equal(renderBody.firstCall.args[2], 'status:-free+(product:\'gold\')');
+        });
     });
 
     describe('sendTestEmail', function () {
@@ -824,6 +848,25 @@ describe('Email Service', function () {
             assert.equal(members.length, 1);
             assert.equal(members[0].email, 'example@example.com');
             assert.equal(options.isTestEmail, true);
+        });
+
+        it('sends with the mapped preview segment while personalizing for the chosen audience', async function () {
+            const post = createModel({
+                id: '123',
+                newsletter: createModel({
+                    status: 'active',
+                    feedback_enabled: true
+                })
+            });
+            sinon.stub(emailRenderer, 'getPreviewSegment').returns('status:-free+(product:\'gold\')');
+
+            await service.sendTestEmail(post, post.get('newsletter'), 'status:-free', ['example@example.com']);
+
+            sinon.assert.calledOnce(sendingService.send);
+            const {segment, members} = sendingService.send.firstCall.args[0];
+            assert.equal(segment, 'status:-free+(product:\'gold\')');
+            // The example member is still built from the audience choice, not the mapped filter
+            assert.equal(members[0].status, 'paid');
         });
     });
 });


### PR DESCRIPTION
fixes https://linear.app/ghost/issue/ONC-1875/preview-showing-incorrect-cta-in-editor
ref https://github.com/TryGhost/Ghost/pull/28315

### Problem

Since #28315, newsletter sends correctly gate tier-restricted posts per tier — but the editor's email preview and test emails were never taught about it. For any post with visibility restricted to specific tiers, **every email preview selection rendered the paywalled version, including "Paid member"** — there was no selection that showed the full post. Actual sends were unaffected; only the preview lied. The Browser preview tab was also unaffected (its "Paid member" simulates a member holding all active paid tiers), so the two preview tabs contradicted each other.

### Cause

Two independent defects in the preview/test-email path, plus one adjacent behavior change:

1. The preview controller loaded the post without the `tiers` relation, so `getPostAccessFilter` saw an empty tier list and returned "nobody has access" — every segment of a tiers post got the paywall regardless of its value.
2. The editor only sends the fixed audiences `status:free` / `status:-free`, and the new `segmentHasPostAccess` check requires the segment to contain the post's tier filter — which those strings never do.
3. `segmentHasPostAccess` also returned false for a `null` segment, silently flipping the behavior of `GET /email_previews/posts/:id` without `memberSegment` for paywalled posts (used to return the full body).

### Change

- Load `tiers` in the email preview controller's `withRelated`, mirroring batch sending.
- New `EmailRenderer.getPreviewSegment(post, segment)` maps the editor's paid audience choice onto the tier access segment the send pipeline actually renders (`status:-free+(product:'…')`), so the email preview matches both delivery and the browser preview's existing "paid member with access" semantics. `previewEmail` and `sendTestEmail` render with the mapped segment while still personalizing the example member from the original choice. "Free member" is untouched — it already shows the no-access variant (public preview + paywall).
- Restored the pre-#28315 rule that an unsegmented (null-segment) render returns full content. Safe for sends: the pipeline only produces a null segment for posts with no gated content.

### Tests

- Unit: `getPreviewSegment` mapping across visibilities; `renderBody` renders full content for the composite access segment and for null-segment renders of gated posts.
- E2E: new regression test creates a tier-restricted post with a paywall card through the real API and asserts the paid preview contains the gated content with no paywall CTA, and the free preview shows the paywall. Verified it fails against the pre-fix code with the exact reported symptom.

### Known follow-up (not in this PR)

The preview dropdown has no option for "paid member on a tier this post doesn't include" — a real audience that receives the paywalled version when sending to all members. That option's naming should align with the planned rename of the "Public preview" card divider ("Only visible to members" is inaccurate for tiers posts), so it's tracked as a separate product+engineering issue in Linear.