### PR TITLE
Prefetch Tinybird image in background during E2E CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1415,6 +1415,20 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
+      # Tinybird is the largest image in the analytics infra and its pull (60-90s)
+      # otherwise wouldn't start until `docker compose up` in the Prepare step,
+      # serialized behind the Ghost image load + pnpm install. Kick it off in the
+      # background now so it overlaps those steps; `compose up --wait` later finds
+      # the image cached (or coalesces with the in-flight pull). Digests come from
+      # the compose file, so there's no new pin to keep in sync. Analytics legs only.
+      - name: Prefetch analytics infra images
+        if: matrix.analytics == 'true'
+        run: |
+          nohup docker compose -f compose.dev.yaml -f compose.dev.analytics.yaml \
+            pull tinybird-local analytics >/tmp/prefetch-analytics-images.log 2>&1 &
+          disown
+          echo "Started background prefetch of tinybird-local + analytics images"
+
       - name: Pull or build Tinybird CLI Image
         if: matrix.analytics == 'true'
         run: |


### PR DESCRIPTION
## Summary

On the **Analytics** legs of `job_e2e_tests`, the `tinybird-local` image pull (60–90s) doesn't start until `docker compose up --wait` in the *Prepare E2E CI job* step — which runs **after** the Ghost image load (~30s) and `pnpm install`. So the biggest pull in the analytics infra sits idle behind steps it could overlap with.

This adds a background prefetch right after Buildx setup that fires the Tinybird (+ analytics proxy) pull immediately, so it overlaps the Ghost load + install. When `compose up --wait` runs later, the image is already cached — or, if still in flight, dockerd coalesces the two pulls per-layer, so there's no double download.

```yaml
- name: Prefetch analytics infra images
  if: matrix.analytics == 'true'
  run: |
    nohup docker compose -f compose.dev.yaml -f compose.dev.analytics.yaml \
      pull tinybird-local analytics >/tmp/prefetch-analytics-images.log 2>&1 &
    disown
```

## Why this shape

- **No new pinned digest** — `compose pull` reads the digest straight from `compose.dev.analytics.yaml`, which Renovate already bumps. Nothing extra to keep in sync.
- **Analytics legs only** — gated behind `matrix.analytics == 'true'`; the 10 non-analytics shards never pull Tinybird and are untouched.
- `pull <services>` excludes the build-only `tb-cli`, so no accidental build.

## Alternatives rejected

- **GH Actions `services:`** — Tinybird is bound to the compose network (`analytics`, `tb-cli`, `ghost-dev` resolve `tinybird-local` by compose DNS) and a shared `shared-config` named volume for the token handshake. A `services:` container can't join either. Not viable without a larger rewrite.
- **Splitting into per-component images** — custom ClickHouse build + tight localhost coupling; ruled out earlier.

## ROI / validation

The win is bounded by how much Ghost-load + install time exists to hide behind (~50–70s of overlap against a 60–90s pull), so realistically ~30–60s off each Analytics leg's startup. **This is an estimate** — opening as draft to measure against a real CI run before merging. If we want more, the next lever is starting the Tinybird *container* early (not just the pull) to also hide its ~20–30s boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)