### PR TITLE
Cached in-flight gift preview image requests

### DIFF
--- a/ghost/core/core/server/web/gift-preview/image.js
+++ b/ghost/core/core/server/web/gift-preview/image.js
@@ -11,7 +11,7 @@ let giftCardNoiseTile;
 let giftCardOrbImageHref;
 
 function cacheResult(key, value) {
-    if (cache.size >= CACHE_MAX_SIZE) {
+    if (!cache.has(key) && cache.size >= CACHE_MAX_SIZE) {
         const firstKey = cache.keys().next().value;
 
         cache.delete(firstKey);
@@ -186,7 +186,7 @@ function buildNotchOverlay({accentColor}) {
     };
 }
 
-async function generateGiftPreviewImage({accentColor = '#15171A', siteTitle, tierLabel, cadenceLabel}) {
+function generateGiftPreviewImage({accentColor = '#15171A', siteTitle, tierLabel, cadenceLabel}) {
     const cacheKey = JSON.stringify({
         accentColor,
         siteTitle,
@@ -198,6 +198,19 @@ async function generateGiftPreviewImage({accentColor = '#15171A', siteTitle, tie
         return cache.get(cacheKey);
     }
 
+    const renderPromise = renderGiftPreviewImage({accentColor, siteTitle, tierLabel, cadenceLabel})
+        .catch((err) => {
+            if (cache.get(cacheKey) === renderPromise) {
+                cache.delete(cacheKey);
+            }
+            throw err;
+        });
+    cacheResult(cacheKey, renderPromise);
+
+    return renderPromise;
+}
+
+async function renderGiftPreviewImage({accentColor, siteTitle, tierLabel, cadenceLabel}) {
     const sharp = require('sharp');
 
     const svg = buildSvg({accentColor});
@@ -217,8 +230,6 @@ async function generateGiftPreviewImage({accentColor = '#15171A', siteTitle, tie
         .png()
         .timeout({seconds: 10})
         .toBuffer();
-
-    cacheResult(cacheKey, image);
 
     return image;
 }

--- a/ghost/core/test/unit/server/web/gift-preview/image.test.js
+++ b/ghost/core/test/unit/server/web/gift-preview/image.test.js
@@ -46,6 +46,21 @@ describe('Gift Preview Image', function () {
             assert.equal(first, second, 'Should return the exact same buffer reference from cache');
         });
 
+        it('returns the same cached result for concurrent calls with same params', async function () {
+            const params = {
+                accentColor: '#108775',
+                siteTitle: 'Test Blog',
+                tierLabel: 'Gold membership',
+                cadenceLabel: '1 year'
+            };
+
+            const results = await Promise.all(Array.from({length: 10}, () => (
+                imageModule.generateGiftPreviewImage(params)
+            )));
+
+            assert.equal(new Set(results).size, 1, 'Should return the same reference from the cache');
+        });
+
         it('returns different results for different gift details with the same accent color', async function () {
             const result1 = await imageModule.generateGiftPreviewImage({
                 tierLabel: 'Gold membership',


### PR DESCRIPTION
no ref

This caches gift preview image promises, not the results. That avoids unnecessary work and fixes a flaky test. (The latter is my motivation for this change.)

Old pseudocode:

```javascript
if (cache[options]) return cache[options];
const result = await generateImage(options);
cache[options] = result;
return result;
```

New pseudocode:

```javascript
if (cache[options]) return cache[options];
const resultPromise = generateImage(options);
cache[options] = resultPromise;
return resultPromise;
```
