### PR TITLE
Added in-memory timer for automations poll

### DIFF
--- a/ghost/core/core/server/lib/earliest-scheduler.ts
+++ b/ghost/core/core/server/lib/earliest-scheduler.ts
@@ -1,0 +1,40 @@
+const MAX_TIMEOUT_MS = 2 ** 31 - 1;
+
+export class EarliestScheduler {
+    #scheduled: undefined | {
+        timeout: ReturnType<typeof setTimeout>;
+        at: Date;
+    };
+    #fn: () => unknown;
+
+    constructor(fn: () => unknown) {
+        this.#fn = fn;
+    }
+
+    scheduleAt(date: Readonly<Date>): void {
+        if (this.#scheduled && this.#scheduled.at <= date) {
+            return;
+        }
+
+        if (this.#scheduled) {
+            clearTimeout(this.#scheduled.timeout);
+        }
+
+        this.#scheduleAt(new Date(date));
+    }
+
+    #scheduleAt(at: Date): void {
+        const msUntilDate = at.getTime() - Date.now();
+        if (msUntilDate <= 0) {
+            this.#scheduled = undefined;
+            this.#fn();
+            return;
+        }
+
+        const timeout = setTimeout(() => {
+            this.#scheduleAt(at);
+        }, Math.min(msUntilDate, MAX_TIMEOUT_MS));
+
+        this.#scheduled = {timeout, at};
+    }
+}

--- a/ghost/core/core/server/lib/soonest-timer.ts
+++ b/ghost/core/core/server/lib/soonest-timer.ts
@@ -24,6 +24,9 @@ export class SoonestTimer {
     }
 
     #scheduleAt(at: Date): void {
+        // [`setTimeout` caps out at ~25 days][0], so we need a chain of timers
+        // if the delay is long.
+        // [0]: https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value
         const msUntilDate = at.getTime() - Date.now();
         if (msUntilDate <= 0) {
             this.#scheduled = undefined;

--- a/ghost/core/core/server/lib/soonest-timer.ts
+++ b/ghost/core/core/server/lib/soonest-timer.ts
@@ -1,6 +1,6 @@
 const MAX_TIMEOUT_MS = 2 ** 31 - 1;
 
-export class EarliestScheduler {
+export class SoonestTimer {
     #scheduled: undefined | {
         timeout: ReturnType<typeof setTimeout>;
         at: Date;

--- a/ghost/core/core/server/lib/soonest-timer.ts
+++ b/ghost/core/core/server/lib/soonest-timer.ts
@@ -1,5 +1,19 @@
 const MAX_TIMEOUT_MS = 2 ** 31 - 1;
 
+/**
+ * Schedule a function for the soonest date it's been called with.
+ *
+ * @example
+ * // Runs the function at `soon`, not `later`:
+ *
+ * const soonestTimer = new SoonestTimer(fn);
+ *
+ * const later = new Date(Date.now() + 10_000);
+ * soonestTimer.scheduleAt(later);
+ *
+ * const soon = new Date(Date.now() + 1000);
+ * soonestTimer.scheduleAt(soon);
+ */
 export class SoonestTimer {
     #scheduled: undefined | {
         timeout: ReturnType<typeof setTimeout>;

--- a/ghost/core/core/server/services/automations/service.ts
+++ b/ghost/core/core/server/services/automations/service.ts
@@ -32,6 +32,25 @@ type AutomationsServiceOptions = {
     schedulerAdapter: SchedulerAdapter;
 };
 
+class LatestScheduler {
+    #scheduled: undefined | {
+        timeout: ReturnType<typeof setTimeout>;
+        at: Date;
+    };
+    #fn: () => unknown;
+
+    constructor(fn: () => unknown) {
+        this.#fn = fn;
+    }
+
+    scheduleAt(date: Readonly<Date>): void {
+        if (this.#scheduled && this.#scheduled?.at < date) {
+            return;
+        }
+        // TODO: Schedule the function, possibly for far in the future.
+    }
+}
+
 export class AutomationsService {
     #enqueuePollAt: undefined | ((date: Readonly<Date>) => Promise<void>);
 
@@ -43,6 +62,8 @@ export class AutomationsService {
 
         const enqueuePollNow = () => domainEvents.dispatch(StartAutomationsPollEvent.create());
 
+        const latestScheduler = new LatestScheduler(enqueuePollNow);
+
         const enqueuePollAt = async (date: Readonly<Date>): Promise<void> => {
             const isRequestedDateInTheFuture = new Date() < date;
             if (!isRequestedDateInTheFuture) {
@@ -52,6 +73,8 @@ export class AutomationsService {
                 enqueuePollNow();
                 return;
             }
+
+            latestScheduler.scheduleAt(date);
 
             try {
                 const key = await internalKeys.get('ghost-scheduler');

--- a/ghost/core/core/server/services/automations/service.ts
+++ b/ghost/core/core/server/services/automations/service.ts
@@ -14,6 +14,8 @@ const StartAutomationsPollEvent = require('./events/start-automations-poll-event
 const {welcomeEmailAutomationPoll} = require('./welcome-email-automation-poll');
 const memberWelcomeEmailService = require('../member-welcome-emails/service');
 
+const MAX_TIMEOUT_MS = 2 ** 31 - 1;
+
 type SchedulerAdapter = {
     schedule(job: {
         extra: {
@@ -32,7 +34,7 @@ type AutomationsServiceOptions = {
     schedulerAdapter: SchedulerAdapter;
 };
 
-class LatestScheduler {
+class EarliestScheduler {
     #scheduled: undefined | {
         timeout: ReturnType<typeof setTimeout>;
         at: Date;
@@ -44,10 +46,30 @@ class LatestScheduler {
     }
 
     scheduleAt(date: Readonly<Date>): void {
-        if (this.#scheduled && this.#scheduled?.at < date) {
+        if (this.#scheduled && this.#scheduled.at <= date) {
             return;
         }
-        // TODO: Schedule the function, possibly for far in the future.
+
+        if (this.#scheduled) {
+            clearTimeout(this.#scheduled.timeout);
+        }
+
+        this.#scheduleAt(new Date(date));
+    }
+
+    #scheduleAt(at: Date): void {
+        const msUntilDate = at.getTime() - Date.now();
+        if (msUntilDate <= 0) {
+            this.#scheduled = undefined;
+            this.#fn();
+            return;
+        }
+
+        const timeout = setTimeout(() => {
+            this.#scheduleAt(at);
+        }, Math.min(msUntilDate, MAX_TIMEOUT_MS));
+
+        this.#scheduled = {timeout, at};
     }
 }
 
@@ -62,7 +84,7 @@ export class AutomationsService {
 
         const enqueuePollNow = () => domainEvents.dispatch(StartAutomationsPollEvent.create());
 
-        const latestScheduler = new LatestScheduler(enqueuePollNow);
+        const earliestScheduler = new EarliestScheduler(enqueuePollNow);
 
         const enqueuePollAt = async (date: Readonly<Date>): Promise<void> => {
             const isRequestedDateInTheFuture = new Date() < date;
@@ -74,7 +96,7 @@ export class AutomationsService {
                 return;
             }
 
-            latestScheduler.scheduleAt(date);
+            earliestScheduler.scheduleAt(date);
 
             try {
                 const key = await internalKeys.get('ghost-scheduler');

--- a/ghost/core/core/server/services/automations/service.ts
+++ b/ghost/core/core/server/services/automations/service.ts
@@ -6,6 +6,7 @@ import {oneAtATime} from '../../../shared/one-at-a-time';
 import {poll} from './poll';
 import * as automationsApi from './automations-api';
 import {setImmediate as flushEventLoop} from 'node:timers/promises';
+import {EarliestScheduler} from '../../lib/earliest-scheduler';
 
 const urlUtils = require('../../../shared/url-utils');
 const logging = require('@tryghost/logging');
@@ -13,8 +14,6 @@ const {getSignedAdminToken} = require('../../adapters/scheduling/utils');
 const StartAutomationsPollEvent = require('./events/start-automations-poll-event');
 const {welcomeEmailAutomationPoll} = require('./welcome-email-automation-poll');
 const memberWelcomeEmailService = require('../member-welcome-emails/service');
-
-const MAX_TIMEOUT_MS = 2 ** 31 - 1;
 
 type SchedulerAdapter = {
     schedule(job: {
@@ -33,45 +32,6 @@ type AutomationsServiceOptions = {
     internalKeys: InternalKeys;
     schedulerAdapter: SchedulerAdapter;
 };
-
-class EarliestScheduler {
-    #scheduled: undefined | {
-        timeout: ReturnType<typeof setTimeout>;
-        at: Date;
-    };
-    #fn: () => unknown;
-
-    constructor(fn: () => unknown) {
-        this.#fn = fn;
-    }
-
-    scheduleAt(date: Readonly<Date>): void {
-        if (this.#scheduled && this.#scheduled.at <= date) {
-            return;
-        }
-
-        if (this.#scheduled) {
-            clearTimeout(this.#scheduled.timeout);
-        }
-
-        this.#scheduleAt(new Date(date));
-    }
-
-    #scheduleAt(at: Date): void {
-        const msUntilDate = at.getTime() - Date.now();
-        if (msUntilDate <= 0) {
-            this.#scheduled = undefined;
-            this.#fn();
-            return;
-        }
-
-        const timeout = setTimeout(() => {
-            this.#scheduleAt(at);
-        }, Math.min(msUntilDate, MAX_TIMEOUT_MS));
-
-        this.#scheduled = {timeout, at};
-    }
-}
 
 export class AutomationsService {
     #enqueuePollAt: undefined | ((date: Readonly<Date>) => Promise<void>);

--- a/ghost/core/core/server/services/automations/service.ts
+++ b/ghost/core/core/server/services/automations/service.ts
@@ -6,7 +6,7 @@ import {oneAtATime} from '../../../shared/one-at-a-time';
 import {poll} from './poll';
 import * as automationsApi from './automations-api';
 import {setImmediate as flushEventLoop} from 'node:timers/promises';
-import {EarliestScheduler} from '../../lib/earliest-scheduler';
+import {SoonestTimer} from '../../lib/soonest-timer';
 
 const urlUtils = require('../../../shared/url-utils');
 const logging = require('@tryghost/logging');
@@ -44,7 +44,7 @@ export class AutomationsService {
 
         const enqueuePollNow = () => domainEvents.dispatch(StartAutomationsPollEvent.create());
 
-        const earliestScheduler = new EarliestScheduler(enqueuePollNow);
+        const soonestTimer = new SoonestTimer(enqueuePollNow);
 
         const enqueuePollAt = async (date: Readonly<Date>): Promise<void> => {
             const isRequestedDateInTheFuture = new Date() < date;
@@ -56,7 +56,7 @@ export class AutomationsService {
                 return;
             }
 
-            earliestScheduler.scheduleAt(date);
+            soonestTimer.scheduleAt(date);
 
             try {
                 const key = await internalKeys.get('ghost-scheduler');

--- a/ghost/core/core/server/services/automations/service.ts
+++ b/ghost/core/core/server/services/automations/service.ts
@@ -46,6 +46,20 @@ export class AutomationsService {
 
         const soonestTimer = new SoonestTimer(enqueuePollNow);
 
+        /**
+         * Enqueue an automations poll at a given time.
+         *
+         * If the poll is in the future, we schedule an in-memory timer *and*
+         * tell the scheduler.
+         *
+         * The in-memory timer can be more precise than the scheduler, and
+         * avoids reliance on an external service. The scheduler will wake up
+         * the server if it's stopped.
+         *
+         * (In an upcoming change (NY-1396), we plan to make the scheduler less
+         * precise to reduce load--that will make the in-memory timer more
+         * useful, but it's still useful now.)
+         */
         const enqueuePollAt = async (date: Readonly<Date>): Promise<void> => {
             const isRequestedDateInTheFuture = new Date() < date;
             if (!isRequestedDateInTheFuture) {

--- a/ghost/core/test/unit/server/lib/soonest-timer.test.ts
+++ b/ghost/core/test/unit/server/lib/soonest-timer.test.ts
@@ -1,0 +1,79 @@
+import sinon from 'sinon';
+import {SoonestTimer} from '../../../../core/server/lib/soonest-timer';
+
+describe('SoonestTimer', function () {
+    let clock: sinon.SinonFakeTimers;
+    let callback: sinon.SinonStub;
+
+    beforeEach(function () {
+        clock = sinon.useFakeTimers(new Date('2026-01-01T00:00:00.000Z').getTime());
+        callback = sinon.stub();
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it('runs the callback when the scheduled date arrives', async function () {
+        const timer = new SoonestTimer(callback);
+
+        timer.scheduleAt(new Date(Date.now() + 1000));
+        await clock.tickAsync(999);
+
+        sinon.assert.notCalled(callback);
+
+        await clock.tickAsync(1);
+
+        sinon.assert.calledOnceWithExactly(callback);
+    });
+
+    it('can run a callback scheduled far in the future', async function () {
+        const timer = new SoonestTimer(callback);
+        const thirtyDays = 30 * 24 * 60 * 60 * 1000;
+
+        timer.scheduleAt(new Date(Date.now() + thirtyDays));
+        await clock.tickAsync(thirtyDays - 1);
+
+        sinon.assert.notCalled(callback);
+
+        await clock.tickAsync(1);
+
+        sinon.assert.calledOnceWithExactly(callback);
+    });
+
+    it('replaces a scheduled callback when the new date is sooner', async function () {
+        const timer = new SoonestTimer(callback);
+
+        timer.scheduleAt(new Date(Date.now() + 10_000));
+        timer.scheduleAt(new Date(Date.now() + 5000));
+        await clock.tickAsync(4999);
+
+        sinon.assert.notCalled(callback);
+
+        await clock.tickAsync(1);
+
+        sinon.assert.calledOnceWithExactly(callback);
+
+        await clock.tickAsync(5000);
+
+        sinon.assert.calledOnce(callback);
+    });
+
+    it('keeps the scheduled callback when the new date is later', async function () {
+        const timer = new SoonestTimer(callback);
+
+        timer.scheduleAt(new Date(Date.now() + 5000));
+        timer.scheduleAt(new Date(Date.now() + 10_000));
+        await clock.tickAsync(4999);
+
+        sinon.assert.notCalled(callback);
+
+        await clock.tickAsync(1);
+
+        sinon.assert.calledOnceWithExactly(callback);
+
+        await clock.tickAsync(5000);
+
+        sinon.assert.calledOnce(callback);
+    });
+});

--- a/ghost/core/test/unit/server/services/automations/service.test.js
+++ b/ghost/core/test/unit/server/services/automations/service.test.js
@@ -90,19 +90,85 @@ describe('automations service', function () {
         });
 
         it('schedules an in-memory timer if date is in the future', async function () {
-            // TODO: Use Sinon's fake clock.
+            const clock = sinon.useFakeTimers(new Date('2026-01-01T00:00:00.000Z').getTime());
+            const future = new Date(Date.now() + 1000);
+
+            await automations.__testOnlyEnqueuePollAt(future);
+            await clock.tickAsync(999);
+
+            sinon.assert.notCalled(domainEvents.dispatch);
+
+            await clock.tickAsync(1);
+
+            sinon.assert.calledOnceWithExactly(
+                domainEvents.dispatch,
+                sinon.match.instanceOf(StartAutomationsPollEvent)
+            );
         });
 
         it('can schedule a timer for far in the future, avoiding setTimeout limits', async function () {
-            // TODO: Use Sinon's fake clock. Test a 30-day timeout, which is longer than what setTimeout supports.
+            const clock = sinon.useFakeTimers(new Date('2026-01-01T00:00:00.000Z').getTime());
+            const thirtyDays = 30 * 24 * 60 * 60 * 1000;
+            const future = new Date(Date.now() + thirtyDays);
+
+            await automations.__testOnlyEnqueuePollAt(future);
+
+            await clock.tickAsync(thirtyDays - 1);
+
+            sinon.assert.notCalled(domainEvents.dispatch);
+
+            await clock.tickAsync(1);
+
+            sinon.assert.calledOnceWithExactly(
+                domainEvents.dispatch,
+                sinon.match.instanceOf(StartAutomationsPollEvent)
+            );
         });
 
         it('cancels future in-memory timers if the date is sooner than the previous date', async function () {
-            // TODO: Similar to the test above.
+            const clock = sinon.useFakeTimers(new Date('2026-01-01T00:00:00.000Z').getTime());
+            const later = new Date(Date.now() + 10_000);
+            const sooner = new Date(Date.now() + 5000);
+
+            await automations.__testOnlyEnqueuePollAt(later);
+            await automations.__testOnlyEnqueuePollAt(sooner);
+            await clock.tickAsync(4999);
+
+            sinon.assert.notCalled(domainEvents.dispatch);
+
+            await clock.tickAsync(1);
+
+            sinon.assert.calledOnceWithExactly(
+                domainEvents.dispatch,
+                sinon.match.instanceOf(StartAutomationsPollEvent)
+            );
+
+            await clock.tickAsync(5000);
+
+            sinon.assert.calledOnce(domainEvents.dispatch);
         });
 
-        it('doesn\'t cancel future in-memory timers if the data is later than a previous date', async function () {
-            // TODO: Similar to the test above.
+        it('doesn\'t cancel future in-memory timers if the date is later than a previous date', async function () {
+            const clock = sinon.useFakeTimers(new Date('2026-01-01T00:00:00.000Z').getTime());
+            const sooner = new Date(Date.now() + 5000);
+            const later = new Date(Date.now() + 10_000);
+
+            await automations.__testOnlyEnqueuePollAt(sooner);
+            await automations.__testOnlyEnqueuePollAt(later);
+            await clock.tickAsync(4999);
+
+            sinon.assert.notCalled(domainEvents.dispatch);
+
+            await clock.tickAsync(1);
+
+            sinon.assert.calledOnceWithExactly(
+                domainEvents.dispatch,
+                sinon.match.instanceOf(StartAutomationsPollEvent)
+            );
+
+            await clock.tickAsync(5000);
+
+            sinon.assert.calledOnce(domainEvents.dispatch);
         });
 
         it('reaches out to the scheduler for dates in the future', async function () {

--- a/ghost/core/test/unit/server/services/automations/service.test.js
+++ b/ghost/core/test/unit/server/services/automations/service.test.js
@@ -89,6 +89,22 @@ describe('automations service', function () {
             sinon.assert.notCalled(schedulerAdapter.schedule);
         });
 
+        it('schedules an in-memory timer if date is in the future', async function () {
+            // TODO: Use Sinon's fake clock.
+        });
+
+        it('can schedule a timer for far in the future, avoiding setTimeout limits', async function () {
+            // TODO: Use Sinon's fake clock. Test a 30-day timeout, which is longer than what setTimeout supports.
+        });
+
+        it('cancels future in-memory timers if the date is sooner than the previous date', async function () {
+            // TODO: Similar to the test above.
+        });
+
+        it('doesn\'t cancel future in-memory timers if the data is later than a previous date', async function () {
+            // TODO: Similar to the test above.
+        });
+
         it('reaches out to the scheduler for dates in the future', async function () {
             const future = new Date(Date.now() + 10_000);
             await automations.__testOnlyEnqueuePollAt(future);


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1405

**Depends on #29026.**

## What

In addition to telling the scheduler when to do an automation poll, also use an in-memory timer.

This change should have no user impact.

## Why

1. [Soon][NY-1396], we plan to reduce the precision of requests to the scheduler. Instead of telling the scheduler *exactly* when to poll, we'll round to the nearest 30 minutes (with some per-site jitter).  This will reduce load on the scheduler and will boot Pro servers less.
1. If the scheduler service is down, polls will still happen at the right time if the server is up.

[NY-1396]: https://linear.app/ghost/issue/NY-1396/make-automations-poll-arming-idempotent-in-scheduler
