### PR TITLE
Routed gift-link token validation through the content API

### DIFF
--- a/ghost/core/core/frontend/services/proxy.js
+++ b/ghost/core/core/frontend/services/proxy.js
@@ -70,9 +70,6 @@ module.exports = {
 
     // Labs utils for enabling/disabling helpers
     labs: require('../../shared/labs'),
-    // Gift links service — reached through this seam so the entry controller
-    // doesn't require a server module directly.
-    giftLinks: require('../../server/services/gift-links'),
     // Paid-member shim for gift-link reads (shared with previews). Lazy getter so
     // the members service resolves at call time, avoiding boot-time require-order
     // coupling.

--- a/ghost/core/core/frontend/services/routing/controllers/entry/gift-links.ts
+++ b/ghost/core/core/frontend/services/routing/controllers/entry/gift-links.ts
@@ -46,6 +46,20 @@ function giftToken(req: Request): string | null {
 }
 
 /**
+ * The id of the post a token unlocks, read through the content endpoint so the
+ * check flows through the API like every other content read. Null for an unknown
+ * token (the endpoint 404s).
+ */
+async function unlockedPostId(token: string): Promise<string | null> {
+    try {
+        const {gift_links: [link]} = await proxy.api.giftLinksPublic.read({token});
+        return link?.post_id ?? null;
+    } catch {
+        return null;
+    }
+}
+
+/**
  * Re-read the entry as a paid-member shim (the grant `/p/` previews use) to
  * reveal gated content, then render it. The shim is passed as the read context
  * only, so it never leaks into res.locals/@member.
@@ -74,7 +88,7 @@ async function renderUnlocked(req: Request, res: EntryResponse, token: string) {
 export async function serveGiftRequest(req: Request, res: EntryResponse, entry: Entry) {
     const token = giftToken(req);
 
-    if (token && await proxy.giftLinks.service.isValidTokenForPost(token, entry.id)) {
+    if (token && await unlockedPostId(token) === entry.id) {
         return renderUnlocked(req, res, token);
     }
 

--- a/ghost/core/core/server/api/endpoints/gift-links-public.ts
+++ b/ghost/core/core/server/api/endpoints/gift-links-public.ts
@@ -1,0 +1,31 @@
+import {service} from '../../services/gift-links';
+
+const errors = require('@tryghost/errors');
+
+interface Frame {
+    options: {
+        token: string;
+        [key: string]: unknown;
+    };
+}
+
+const controller = {
+    docName: 'gift_links',
+
+    read: {
+        headers: {cacheInvalidate: false},
+        options: ['token'],
+        validation: {options: {token: {required: true}}},
+        permissions: true,
+        async query(frame: Frame) {
+            const post = await service!.getPostByToken(frame.options.token);
+            if (!post) {
+                throw new errors.NotFoundError({message: 'Gift link not found.'});
+            }
+            return post;
+        }
+    }
+};
+
+// module.exports (not export): the API framework loads controllers via require().
+module.exports = controller;

--- a/ghost/core/core/server/api/endpoints/index.js
+++ b/ghost/core/core/server/api/endpoints/index.js
@@ -308,6 +308,10 @@ module.exports = {
         return apiFramework.pipeline(require('./gift-links'), localUtils);
     },
 
+    get giftLinksPublic() {
+        return apiFramework.pipeline(require('./gift-links-public'), localUtils, 'content');
+    },
+
     get giftReminders() {
         return apiFramework.pipeline(require('./gift-reminders'), localUtils);
     },

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/gift-links.ts
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/gift-links.ts
@@ -1,4 +1,4 @@
-import {toGiftLinksResponse, toRevokeAllResponse} from '../../../../../services/gift-links/serializers';
+import {toGiftLinksResponse, toGiftLinkPostResponse, toRevokeAllResponse} from '../../../../../services/gift-links/serializers';
 import type {Post} from '../../../../../services/gift-links/models';
 
 interface Frame {
@@ -9,12 +9,17 @@ const serializeGiftLinks = (post: Post, _apiConfig: unknown, frame: Frame): void
     frame.response = toGiftLinksResponse.parse(post.giftLinks);
 };
 
+const serializeGiftLinkPost = (post: Post, _apiConfig: unknown, frame: Frame): void => {
+    frame.response = toGiftLinkPostResponse.parse(post);
+};
+
 // module.exports (not export): the API framework loads serializers via require(). The endpoint ->
 // serializer mapping lives here; the response shaping lives with the gift-links service module.
 module.exports = {
     browse: serializeGiftLinks,
     ensure: serializeGiftLinks,
     create: serializeGiftLinks,
+    read: serializeGiftLinkPost,
     removeAll(data: {count: number}, _apiConfig: unknown, frame: Frame): void {
         frame.response = toRevokeAllResponse.parse(data);
     }

--- a/ghost/core/core/server/services/gift-links/serializers.ts
+++ b/ghost/core/core/server/services/gift-links/serializers.ts
@@ -8,6 +8,7 @@ const GiftLinkResource = z.object({
     created_at: z.date()
 });
 const GiftLinksResponse = z.object({gift_links: z.array(GiftLinkResource)});
+const GiftLinkPostResponse = z.object({gift_links: z.array(z.object({post_id: z.string()}))});
 const RevokeAllResponse = z.object({meta: z.object({count: z.number()})});
 
 export const toGiftLinksResponse = z.array(GiftLink)
@@ -15,6 +16,13 @@ export const toGiftLinksResponse = z.array(GiftLink)
         gift_links: links.map(link => snakeKeys(link))
     }))
     .pipe(GiftLinksResponse);
+
+// The content read resolves a token to its post; only the post id leaves the boundary.
+export const toGiftLinkPostResponse = z.object({id: z.string()})
+    .transform((post): z.input<typeof GiftLinkPostResponse> => ({
+        gift_links: [{post_id: post.id}]
+    }))
+    .pipe(GiftLinkPostResponse);
 
 export const toRevokeAllResponse = z.object({count: z.number()})
     .transform((data): z.input<typeof RevokeAllResponse> => ({meta: {count: data.count}}))

--- a/ghost/core/core/server/services/gift-links/service.ts
+++ b/ghost/core/core/server/services/gift-links/service.ts
@@ -52,10 +52,6 @@ export class GiftLinksService {
         return row ? {id: row.post_id, giftLinks: [z.decode(queries.giftLinkCodec, row)]} : null;
     }
 
-    async isValidTokenForPost(token: string, postId: string): Promise<boolean> {
-        return (await this.getPostByToken(token))?.id === postId;
-    }
-
     async ensure(context: RequestContext, postId: string): Promise<Post> {
         const post = await this.requirePost(postId);
         if (post.giftLinks.length) {

--- a/ghost/core/core/server/web/api/endpoints/content/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/content/routes.js
@@ -4,6 +4,7 @@ const api = require('../../../../api').endpoints;
 const {http} = require('@tryghost/api-framework');
 const mw = require('./middleware');
 const config = require('../../../../../shared/config');
+const labs = require('../../../../../shared/labs');
 
 /**
  * @returns {import('express').Router}
@@ -40,6 +41,9 @@ module.exports = function apiRoutes() {
     router.get('/newsletters', mw.authenticatePublic, http(api.newslettersPublic.browse));
     router.get('/tiers', mw.authenticatePublic, http(api.tiersPublic.browse));
     router.get('/offers/:id', mw.authenticatePublic, http(api.offersPublic.read));
+
+    // ## Gift links (behind the giftLinks flag)
+    router.get('/gift_links/:token', mw.authenticatePublic, labs.enabledMiddleware('giftLinks'), http(api.giftLinksPublic.read));
 
     // ## Recommendations
     router.get('/recommendations', mw.authenticatePublic, http(api.recommendationsPublic.browse));

--- a/ghost/core/test/e2e-api/content/gift-links.test.ts
+++ b/ghost/core/test/e2e-api/content/gift-links.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+
+const {agentProvider, fixtureManager, mockManager} = require('../../utils/e2e-framework');
+const models = require('../../../core/server/models');
+
+describe('Gift Links Content API', function () {
+    let agent: {
+        get: (_url: string) => any;
+        authenticate: () => Promise<void>;
+    };
+    let postId: string;
+
+    const mintToken = async (): Promise<string> => {
+        const giftLinksService = require('../../../core/server/services/gift-links');
+        const {giftLinks: [{token}]} = await giftLinksService.service.ensure({actor: null}, postId);
+        return token;
+    };
+
+    beforeAll(async function () {
+        agent = await agentProvider.getContentAPIAgent();
+        await fixtureManager.init('api_keys', 'posts');
+        await agent.authenticate();
+        postId = fixtureManager.get('posts', 0).id;
+    });
+
+    beforeEach(function () {
+        mockManager.mockLabsEnabled('giftLinks');
+    });
+
+    afterEach(async function () {
+        mockManager.restore();
+        await models.Base.knex('post_gift_links').del();
+        await models.Base.knex('gift_links').del();
+    });
+
+    it('resolves a live token to the post it unlocks', async function () {
+        const token = await mintToken();
+
+        const {body} = await agent.get(`/gift_links/${token}/`).expectStatus(200);
+        assert.deepEqual(body, {gift_links: [{post_id: postId}]});
+    });
+
+    it('404s for an unknown token', async function () {
+        await agent.get('/gift_links/not-a-real-token/').expectStatus(404);
+    });
+
+    it('404s when the giftLinks flag is disabled', async function () {
+        const token = await mintToken();
+        mockManager.mockLabsDisabled('giftLinks');
+
+        await agent.get(`/gift_links/${token}/`).expectStatus(404);
+    });
+});

--- a/ghost/core/test/integration/services/gift-links.test.ts
+++ b/ghost/core/test/integration/services/gift-links.test.ts
@@ -127,27 +127,6 @@ describe('GiftLinksService (integration)', function () {
         });
     });
 
-    describe('isValidTokenForPost', function () {
-        it('is true only for a live token bound to the given post', async function () {
-            const post = await service.ensure(CTX, postId);
-            const token = post.giftLinks[0]!.token;
-
-            assert.equal(await service.isValidTokenForPost(token, postId), true);
-
-            // Defence in depth: a token for one post must not validate another.
-            assert.equal(await service.isValidTokenForPost(token, otherPostId), false);
-
-            // Once replaced, the old token no longer validates.
-            await service.create(CTX, postId);
-            assert.equal(await service.isValidTokenForPost(token, postId), false);
-        });
-
-        it('is false for unknown and empty tokens', async function () {
-            assert.equal(await service.isValidTokenForPost('nope', postId), false);
-            assert.equal(await service.isValidTokenForPost('', postId), false);
-        });
-    });
-
     describe('removeAll', function () {
         it('drops every live link across posts and returns the count', async function () {
             await service.ensure(CTX, postId);


### PR DESCRIPTION
## Problem

Validating a gift-link token meant the frontend routing layer reached directly into the gift-links domain service through an in-process seam. That coupled the theme-facing entry controller to the internals of the service and left two parallel ways of resolving a token: one for the public web and one for anything running in-process.

## Solution

Gift-link token validation now goes through a public content API endpoint, `GET /content/gift_links/:token`, which resolves a token to the post it unlocks. The endpoint is labs-gated and behaves like the other public content endpoints.

The frontend entry controller now calls that endpoint the same way it already reads public posts, and compares the returned post against the entry being rendered rather than asking the service directly. With the endpoint in place the old frontend-to-service seam is removed, along with the service method that only existed to serve it.