### PR TITLE
Fixed dev gateway forcing X-Forwarded-Proto https on ActivityPub routes

### DIFF
--- a/docker/dev-gateway/Caddyfile
+++ b/docker/dev-gateway/Caddyfile
@@ -1,5 +1,13 @@
 {
 	admin off
+
+	# Everything reaching this gateway comes from loopback or the docker
+	# bridge, so trust it as a proxy hop. This makes Caddy pass through
+	# X-Forwarded-Proto from https tunnel agents (tailscale funnel / ngrok)
+	# instead of overwriting it with the plain-http scheme it sees on :80.
+	servers {
+		trusted_proxies static private_ranges
+	}
 }
 
 :80 {
@@ -50,11 +58,16 @@
 
 	# ActivityPub API - proxy activityPub requests to activityPub service (running in separate project)
 	# Requires activitypub containers to be running via the ActivityPub project's docker-compose
+	#
+	# Unlike the Ghost blocks below, the ActivityPub blocks must NOT force
+	# X-Forwarded-Proto: the AP service derives its own URLs (and whether to
+	# fetch Ghost's JWKS over http or https) from the real scheme. Direct
+	# localhost access needs http; tunneled access gets https passed through
+	# from the tunnel agent via trusted_proxies (see global options).
 	handle /.ghost/activitypub/* {
 		reverse_proxy {env.ACTIVITYPUB_PROXY_TARGET} {
 			header_up Host {host}
 			header_up X-Real-IP {remote_host}
-			header_up X-Forwarded-Proto https
 		}
 	}
 
@@ -63,7 +76,6 @@
 		reverse_proxy {env.ACTIVITYPUB_PROXY_TARGET} {
 			header_up Host {host}
 			header_up X-Real-IP {remote_host}
-			header_up X-Forwarded-Proto https
 		}
 	}
 
@@ -72,7 +84,6 @@
 		reverse_proxy {env.ACTIVITYPUB_PROXY_TARGET} {
 			header_up Host {host}
 			header_up X-Real-IP {remote_host}
-			header_up X-Forwarded-Proto https
 		}
 	}
 


### PR DESCRIPTION
## Problem

Accessing the ActivityPub service through the docker dev gateway over plain `http://localhost:2368` fails: Ghost↔AP auth breaks and you can't get the two talking locally.

Root cause: the gateway hardcodes `header_up X-Forwarded-Proto https` on the three ActivityPub routes. The AP service reconstructs request URLs from that header (via `x-forwarded-fetch`'s `behindProxy`), and its role-guard only downgrades the Ghost JWKS fetch to http when the request URL isn't https ([role-guard.ts](https://github.com/TryGhost/ActivityPub/blob/main/src/http/middleware/role-guard.ts)). With the spoofed header it always tries `https://localhost:2368/ghost/.well-known/jwks.json`, nothing serves TLS there, JWT verification fails, and every AP request 401s.

## Why the hardcode existed

The dev gateway was built around the tunnel workflow (né `dev:forward`): the [documented AP dev setup](https://github.com/TryGhost/ActivityPub#readme) points a Tailscale funnel / ngrok https domain at port 80, TLS terminates at the agent, and everything reaches Caddy as plain http. Forcing `https` upstream kept Ghost from redirect-looping and made the AP service mint https federation URLs in that flow.

## Fix

Tell the AP service the truth, without breaking the tunnel flow:

- Added `trusted_proxies static private_ranges` to the global options. Everything reaching this gateway arrives from loopback or the docker bridge, so Caddy treats the sender as a proxy hop and **passes through** `X-Forwarded-Proto` when the client supplies it — which tailscale funnel, ngrok, and cloudflared all do.
- Removed the hardcoded `X-Forwarded-Proto: https` from the three AP routes. Direct localhost requests now get `http` (fixing local dev); tunneled requests still arrive upstream as `https`.
- The Ghost-backend routes are untouched and still force `https`: Ghost builds its URLs from config and only uses this header for redirect decisions, so the lie is harmless there and prevents redirect loops when `url` is an https tunnel domain.

This also matches the AP repo's own reference proxy — its [dev nginx config](https://github.com/TryGhost/ActivityPub/blob/main/dev/nginx/nginx.conf) maps `X-Forwarded-Proto` to https-if-claimed-else-http. The hardcode on these routes was a copy-paste artifact from the Ghost blocks.

## Verification

`caddy validate` + `caddy fmt` clean with the dev-gateway image. Ran the real gateway container against a header-echo upstream:

| Request | `X-Forwarded-Proto` seen upstream |
|---|---|
| `/.ghost/activitypub/*` direct localhost | `http` ✅ (was `https` — the bug) |
| `/.ghost/activitypub/*` with tunnel-agent header | `https` ✅ passed through |
| `/.well-known/webfinger`, `/.well-known/nodeinfo` | same as above ✅ |
| `/foo`, `/ghost/api/*` (Ghost backend) | `https` ✅ unchanged |

Known edge: a tunnel that terminates TLS but injects no `X-Forwarded-Proto` (e.g. a raw `ssh -R` TCP forward) would now stamp `http` where the hardcode papered over it — the documented agents all inject the header.

No automated test — this config only runs in the local dev environment; verification above exercises the real image + Caddyfile.