### PR TITLE
Fix comments UI edit form nullable content

### DIFF
--- a/apps/comments-ui/src/components/content/forms/edit-form.tsx
+++ b/apps/comments-ui/src/components/content/forms/edit-form.tsx
@@ -18,7 +18,7 @@ const EditForm: React.FC<Props> = ({comment, openForm, parent}) => {
         // warning: we cannot use autofocus on the edit field, because that sets
         // the cursor position at the beginning of the text field instead of the end
         autofocus: false,
-        content: comment.html
+        content: comment.html ?? undefined
     }), [comment]);
 
     const {editor} = useEditor(editorConfig);


### PR DESCRIPTION
## Why I am making it

This is a focused follow-up to https://github.com/TryGhost/Ghost/pull/28938 / b0c8bda76eec3e48ec30b8c680789f03442acc02.

That PR handled nullable comment HTML in reply rendering/snippet paths. While continuing the comments-ui TypeScript cleanup file by file, I found the same nullable HTML boundary issue in `forms/edit-form.tsx`.

I didn't catch this in b0c8bda76eec3e48ec30b8c680789f03442acc02 because that commit was focused on `comment.tsx`, and this remaining error lives in the edit form path.

## What it does

Normalizes `Comment.html` before passing it to the editor config used by the edit form.

`Comment.html` can be `null`, while `CommentsEditorConfig.content` expects `string | undefined`. The edit form now passes `undefined` for null content, which lets the existing editor config default initialize empty content without widening the editor config type to accept `null`.

## Type error fixed

This removes the `apps/comments-ui/src/components/content/forms/edit-form.tsx` `TS2345` error from the comments-ui `tsc --noEmit` cleanup:

```text
src/components/content/forms/edit-form.tsx(24,32): error TS2345: Argument of type '{ placeholder: string; autofocus: boolean; content: string | null; }' is not assignable to parameter of type 'CommentsEditorConfig'.
  Types of property 'content' are incompatible.
    Type 'string | null' is not assignable to type 'string | undefined'.
      Type 'null' is not assignable to type 'string | undefined'.
```

## Why developers need it

This keeps reducing the comments-ui TypeScript error count while preserving the existing editor config contract. Developers working on comments-ui can continue seeing the real remaining type errors instead of another nullable comment HTML boundary issue.

## Testing

- `PATH=/Users/pedroalmeida/.nvm/versions/node/v22.13.1/bin:$PATH CI=true pnpm --filter @tryghost/comments-ui exec tsc --noEmit`

This still fails on the known remaining comments-ui TypeScript errors, but the `forms/edit-form.tsx` error is gone.

## Checklist

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [ ] I've written an automated test to prove my change works
