### PR TITLE
Fixed a TS overload error in admin-x-framework tinybird tests

### DIFF
--- a/apps/admin-x-framework/test/unit/hooks/use-tinybird-query.test.ts
+++ b/apps/admin-x-framework/test/unit/hooks/use-tinybird-query.test.ts
@@ -269,7 +269,7 @@ describe('useTinybirdQuery', () => {
             ({children}) => React.createElement(
                 QueryClientProvider,
                 {client: queryClient},
-                React.createElement(AppProvider, {appSettings: buildAppSettings(webAnalytics)}, children)
+                React.createElement(AppProvider, {appSettings: buildAppSettings(webAnalytics), children})
             );
 
         it('noops without a per-call flag when web analytics is disabled', () => {

--- a/apps/admin-x-framework/test/unit/hooks/use-tinybird-token.test.tsx
+++ b/apps/admin-x-framework/test/unit/hooks/use-tinybird-token.test.tsx
@@ -294,7 +294,7 @@ describe('useTinybirdToken', () => {
             ({children}) => React.createElement(
                 QueryClientProvider,
                 {client: queryClient},
-                React.createElement(AppProvider, {appSettings: buildAppSettings(webAnalytics)}, children)
+                React.createElement(AppProvider, {appSettings: buildAppSettings(webAnalytics), children})
             );
 
         beforeEach(() => {
@@ -351,7 +351,7 @@ describe('useTinybirdToken', () => {
             const loadingWrapper: React.FC<{children: React.ReactNode}> = ({children}) => React.createElement(
                 QueryClientProvider,
                 {client: queryClient},
-                React.createElement(AppProvider, {appSettings: undefined}, children)
+                React.createElement(AppProvider, {appSettings: undefined, children})
             );
 
             renderHook(() => useTinybirdToken({enabled: true}), {wrapper: loadingWrapper});


### PR DESCRIPTION
## Summary
- `admin-x-framework`'s `test:types` was failing on `use-tinybird-query.test.ts` and `use-tinybird-token.test.tsx`: the test wrapper passed `children` positionally to `React.createElement(AppProvider, {...}, children)`, but `AppProviderProps.children` is a required (non-optional) prop. TS's `createElement<P>` overload resolution can't reconcile a positional child with a required `children` field in `P`, so it falls through to a stricter overload and errors.
- Fixed by moving `children` into the props object at all three call sites.
- This has been broken for a while but invisible in CI: `test:unit` is scoped to Nx-`--affected` projects, and nothing in `admin-x-framework`'s dependency graph was touched by the `@types/react` catalog bump that started tripping this overload, so the project's `test:types`/`test:unit` target never re-ran to surface it.

## Test plan
- [x] `pnpm --filter @tryghost/shade --filter @tryghost/admin-x-design-system build` (rebuild workspace deps)
- [x] `cd apps/admin-x-framework && pnpm test` — `tsc --noEmit` clean, 30 test files / 436 tests passing
- [x] `pnpm lint` in `apps/admin-x-framework` clean