### PR TITLE
Changed dev target orchestration

### DIFF
--- a/apps/admin-toolbar/package.json
+++ b/apps/admin-toolbar/package.json
@@ -38,6 +38,16 @@
     "vitest": "catalog:"
   },
   "nx": {
+    "targets": {
+      "dev": {
+        "continuous": true,
+        "executor": "nx:run-commands",
+        "options": {
+          "cwd": "apps/admin-toolbar",
+          "command": "vite build --watch --mode development"
+        }
+      }
+    },
     "tags": [
       "public-app"
     ]

--- a/apps/admin-x-design-system/package.json
+++ b/apps/admin-x-design-system/package.json
@@ -96,6 +96,12 @@
     "nx": {
         "targets": {
             "dev": {
+                "continuous": true,
+                "executor": "nx:run-commands",
+                "options": {
+                    "cwd": "apps/admin-x-design-system",
+                    "command": "vite build --watch"
+                },
                 "dependsOn": [
                     "^build"
                 ]

--- a/apps/admin-x-framework/package.json
+++ b/apps/admin-x-framework/package.json
@@ -126,6 +126,12 @@
     "nx": {
         "targets": {
             "dev": {
+                "continuous": true,
+                "executor": "nx:run-commands",
+                "options": {
+                    "cwd": "apps/admin-x-framework",
+                    "command": "vite build --watch"
+                },
                 "dependsOn": [
                     "^build"
                 ]

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -56,7 +56,14 @@
   "nx": {
     "targets": {
       "dev": {
+        "continuous": true,
+        "executor": "nx:run-commands",
+        "options": {
+          "cwd": "apps/admin",
+          "command": "vite"
+        },
         "dependsOn": [
+          "ghost-monorepo:docker:up",
           "ghost-admin:dev",
           "@tryghost/admin-x-framework:dev",
           "@tryghost/admin-x-design-system:dev",

--- a/apps/announcement-bar/package.json
+++ b/apps/announcement-bar/package.json
@@ -64,6 +64,16 @@
     "vitest": "catalog:"
   },
   "nx": {
+    "targets": {
+      "dev": {
+        "continuous": true,
+        "executor": "nx:run-commands",
+        "options": {
+          "cwd": "apps/announcement-bar",
+          "command": "vite build --watch --mode development"
+        }
+      }
+    },
     "tags": [
       "public-app"
     ]

--- a/apps/comments-ui/package.json
+++ b/apps/comments-ui/package.json
@@ -91,6 +91,16 @@
     "vitest": "catalog:"
   },
   "nx": {
+    "targets": {
+      "dev": {
+        "continuous": true,
+        "executor": "nx:run-commands",
+        "options": {
+          "cwd": "apps/comments-ui",
+          "command": "vite build --watch --mode development"
+        }
+      }
+    },
     "tags": [
       "i18n",
       "public-app"

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -70,6 +70,16 @@
     "@tryghost/debug": "catalog:"
   },
   "nx": {
+    "targets": {
+      "dev": {
+        "continuous": true,
+        "executor": "nx:run-commands",
+        "options": {
+          "cwd": "apps/portal",
+          "command": "vite build --watch --mode development"
+        }
+      }
+    },
     "tags": [
       "i18n",
       "public-app"

--- a/apps/portal/vite.config.mjs
+++ b/apps/portal/vite.config.mjs
@@ -10,7 +10,7 @@ export default publicAppViteConfig({
     cssCodeSplit: false,
     overrides: {
         define: {
-            REACT_APP_VERSION: JSON.stringify(process.env.npm_package_version)
+            REACT_APP_VERSION: JSON.stringify(pkg.version)
         },
         resolve: {
             dedupe: ['@tryghost/debug']

--- a/apps/shade/package.json
+++ b/apps/shade/package.json
@@ -168,6 +168,12 @@
     "nx": {
         "targets": {
             "dev": {
+                "continuous": true,
+                "executor": "nx:run-commands",
+                "options": {
+                    "cwd": "apps/shade",
+                    "command": "vite build --watch"
+                },
                 "dependsOn": [
                     "^build"
                 ]

--- a/apps/signup-form/package.json
+++ b/apps/signup-form/package.json
@@ -64,6 +64,16 @@
     "vitest": "catalog:"
   },
   "nx": {
+    "targets": {
+      "dev": {
+        "continuous": true,
+        "executor": "nx:run-commands",
+        "options": {
+          "cwd": "apps/signup-form",
+          "command": "vite build --watch --mode development"
+        }
+      }
+    },
     "tags": [
       "i18n",
       "public-app"

--- a/apps/sodo-search/package.json
+++ b/apps/sodo-search/package.json
@@ -72,6 +72,16 @@
     "vitest": "catalog:"
   },
   "nx": {
+    "targets": {
+      "dev": {
+        "continuous": true,
+        "executor": "nx:run-commands",
+        "options": {
+          "cwd": "apps/sodo-search",
+          "command": "vite build --watch --mode development"
+        }
+      }
+    },
     "tags": [
       "i18n",
       "public-app"

--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -180,6 +180,12 @@
     ],
     "targets": {
       "dev": {
+        "continuous": true,
+        "executor": "nx:run-commands",
+        "options": {
+          "cwd": "ghost/admin",
+          "command": "JOBS=4 SKIP_DEPENDENCY_CHECKER=true ember serve"
+        },
         "dependsOn": [
           {
             "projects": [


### PR DESCRIPTION
## Summary

This is the base PR for reducing local dev overhead without changing which apps start by default.

### Changes

- Leveraged the Nx task graph directly for continuous dev targets
  - replaced inferred `nx:run-script` dev targets with explicit `nx:run-commands`
  - stops wrapping each continuous target in an extra `pnpm run dev` orchestration layer
  - removes redundant per-target `run-executor -> pnpm -> vite/ember` launcher chains while preserving the actual watcher commands

- Limited Ember workers
  - sets `JOBS=4` for legacy Ember Admin dev
  - cold checks showed higher worker counts were not meaningfully beneficial for current local dev startup
  - keeps peak legacy Ember parallelism bounded while the Ember app remains in the default graph

- Tightened dev target dependencies
  - makes Admin Vite explicitly depend on `ghost-monorepo:docker:up`, rather than relying on incidental startup delay from wrapper processes
  - replaces Portal's pnpm-injected `npm_package_version` usage with `pkg.version`

## Validation

- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"`
- `pnpm --silent nx show project ghost-monorepo --json`
- cold temp-worktree validation with submodules initialized and Nx cache disabled:
  - `NX_TUI=false NX_DEFAULT_OUTPUT_STYLE=stream pnpm nx run ghost-monorepo:docker:dev --skipRemoteCache --skipNxCache`
  - Ghost reached `GET /` 200
  - Admin API returned 200
  - Admin Vite reported ready
  - Ember reported `Build successful`

## Follow-up

The public-app default/script changes are split into stacked follow-up PR #29104 so this orchestration change can merge first.
