### PR TITLE
Fixed Top Posts stuck loading or hiding data when web analytics is off

### DIFF
--- a/apps/admin-x-framework/src/utils/api/hooks.ts
+++ b/apps/admin-x-framework/src/utils/api/hooks.ts
@@ -59,9 +59,12 @@ export const createQuery = <ResponseData>(options: QueryOptions<ResponseData>) =
         }
     }, [handleError, result.error, query.defaultErrorHandler]);
 
+    // React Query v4 keeps `isLoading` true forever for a disabled query that
+    // never fetched (fetchStatus stays 'idle'), so gate it on fetchStatus too.
     return {
         ...result,
-        data
+        data,
+        isLoading: result.isLoading && result.fetchStatus !== 'idle'
     };
 };
 
@@ -102,10 +105,13 @@ export const createPaginatedQuery = <ResponseData extends {meta?: Meta}>(options
         }
     }, [handleError, result.error, query.defaultErrorHandler]);
 
+    // React Query v4 keeps `isLoading` true forever for a disabled query that
+    // never fetched (fetchStatus stays 'idle'), so gate it on fetchStatus too.
     return {
         ...result,
         data,
-        pagination
+        pagination,
+        isLoading: result.isLoading && result.fetchStatus !== 'idle'
     };
 };
 
@@ -143,9 +149,12 @@ export const createInfiniteQuery = <ResponseData>(options: InfiniteQueryOptions<
         }
     }, [handleError, result.error, query.defaultErrorHandler]);
 
+    // React Query v4 keeps `isLoading` true forever for a disabled query that
+    // never fetched (fetchStatus stays 'idle'), so gate it on fetchStatus too.
     return {
         ...result,
-        data
+        data,
+        isLoading: result.isLoading && result.fetchStatus !== 'idle'
     };
 };
 

--- a/apps/admin-x-framework/src/utils/api/hooks.ts
+++ b/apps/admin-x-framework/src/utils/api/hooks.ts
@@ -59,8 +59,6 @@ export const createQuery = <ResponseData>(options: QueryOptions<ResponseData>) =
         }
     }, [handleError, result.error, query.defaultErrorHandler]);
 
-    // React Query v4 keeps `isLoading` true forever for a disabled query that
-    // never fetched (fetchStatus stays 'idle'), so gate it on fetchStatus too.
     return {
         ...result,
         data,
@@ -105,8 +103,6 @@ export const createPaginatedQuery = <ResponseData extends {meta?: Meta}>(options
         }
     }, [handleError, result.error, query.defaultErrorHandler]);
 
-    // React Query v4 keeps `isLoading` true forever for a disabled query that
-    // never fetched (fetchStatus stays 'idle'), so gate it on fetchStatus too.
     return {
         ...result,
         data,
@@ -149,8 +145,6 @@ export const createInfiniteQuery = <ResponseData>(options: InfiniteQueryOptions<
         }
     }, [handleError, result.error, query.defaultErrorHandler]);
 
-    // React Query v4 keeps `isLoading` true forever for a disabled query that
-    // never fetched (fetchStatus stays 'idle'), so gate it on fetchStatus too.
     return {
         ...result,
         data,

--- a/apps/stats/src/views/Stats/Overview/overview.tsx
+++ b/apps/stats/src/views/Stats/Overview/overview.tsx
@@ -75,7 +75,7 @@ const Overview: React.FC = () => {
     const {startDate, endDate, timezone} = getRangeDates(range);
     const {isLoading: isGrowthStatsLoading, chartData: growthChartData, totals: growthTotals, currencySymbol} = useGrowthStats(range);
     const {data: latestPostStats, isLoading: isLatestPostLoading} = useLatestPostStats();
-    const {data: topPostsData, isLoading: isTopPostsQueryLoading} = useTopPostsViews({
+    const {data: topPostsData, isLoading: isTopPostsLoading} = useTopPostsViews({
         searchParams: {
             date_from: formatQueryDate(startDate),
             date_to: formatQueryDate(endDate),
@@ -84,9 +84,6 @@ const Overview: React.FC = () => {
         },
         enabled: webAnalyticsEnabled
     });
-    // React Query's isLoading stays true forever for a disabled query that never
-    // fetched, so only report loading while the query is actually allowed to run.
-    const isTopPostsLoading = webAnalyticsEnabled && isTopPostsQueryLoading;
 
     /* Get visitors
     /* ---------------------------------------------------------------------- */

--- a/apps/stats/src/views/Stats/Overview/overview.tsx
+++ b/apps/stats/src/views/Stats/Overview/overview.tsx
@@ -71,18 +71,19 @@ type GrowthChartDataItem = {
 const Overview: React.FC = () => {
     const {appSettings} = useAppContext();
     const {statsConfig, isLoading: isConfigLoading, range} = useGlobalData();
-    const webAnalyticsEnabled = appSettings?.analytics?.webAnalytics === true;
     const {startDate, endDate, timezone} = getRangeDates(range);
     const {isLoading: isGrowthStatsLoading, chartData: growthChartData, totals: growthTotals, currencySymbol} = useGrowthStats(range);
     const {data: latestPostStats, isLoading: isLatestPostLoading} = useLatestPostStats();
+    // Not gated on webAnalyticsEnabled: this hits Ghost's own API, which already
+    // falls back to DB-only data (no view counts) when Tinybird isn't configured.
+    // The views metric itself is hidden by TopPosts via showWebAnalytics.
     const {data: topPostsData, isLoading: isTopPostsLoading} = useTopPostsViews({
         searchParams: {
             date_from: formatQueryDate(startDate),
             date_to: formatQueryDate(endDate),
             limit: '5',
             timezone
-        },
-        enabled: webAnalyticsEnabled
+        }
     });
 
     /* Get visitors

--- a/apps/stats/src/views/Stats/Overview/overview.tsx
+++ b/apps/stats/src/views/Stats/Overview/overview.tsx
@@ -74,9 +74,6 @@ const Overview: React.FC = () => {
     const {startDate, endDate, timezone} = getRangeDates(range);
     const {isLoading: isGrowthStatsLoading, chartData: growthChartData, totals: growthTotals, currencySymbol} = useGrowthStats(range);
     const {data: latestPostStats, isLoading: isLatestPostLoading} = useLatestPostStats();
-    // Not gated on webAnalyticsEnabled: this hits Ghost's own API, which already
-    // falls back to DB-only data (no view counts) when Tinybird isn't configured.
-    // The views metric itself is hidden by TopPosts via showWebAnalytics.
     const {data: topPostsData, isLoading: isTopPostsLoading} = useTopPostsViews({
         searchParams: {
             date_from: formatQueryDate(startDate),

--- a/apps/stats/src/views/Stats/Overview/overview.tsx
+++ b/apps/stats/src/views/Stats/Overview/overview.tsx
@@ -75,7 +75,7 @@ const Overview: React.FC = () => {
     const {startDate, endDate, timezone} = getRangeDates(range);
     const {isLoading: isGrowthStatsLoading, chartData: growthChartData, totals: growthTotals, currencySymbol} = useGrowthStats(range);
     const {data: latestPostStats, isLoading: isLatestPostLoading} = useLatestPostStats();
-    const {data: topPostsData, isLoading: isTopPostsLoading} = useTopPostsViews({
+    const {data: topPostsData, isLoading: isTopPostsQueryLoading} = useTopPostsViews({
         searchParams: {
             date_from: formatQueryDate(startDate),
             date_to: formatQueryDate(endDate),
@@ -84,6 +84,9 @@ const Overview: React.FC = () => {
         },
         enabled: webAnalyticsEnabled
     });
+    // React Query's isLoading stays true forever for a disabled query that never
+    // fetched, so only report loading while the query is actually allowed to run.
+    const isTopPostsLoading = webAnalyticsEnabled && isTopPostsQueryLoading;
 
     /* Get visitors
     /* ---------------------------------------------------------------------- */

--- a/ghost/core/core/server/services/stats/posts-stats-service.js
+++ b/ghost/core/core/server/services/stats/posts-stats-service.js
@@ -1209,86 +1209,93 @@ class PostsStatsService {
             // Filter out any rows without post_uuid and get unique UUIDs
             const postUuids = [...new Set(viewsData.filter(row => row.post_uuid).map(row => row.post_uuid))];
 
-            // Get posts data from Ghost DB - prioritize posts that were sent as newsletters
-            const posts = await this.knex('posts as p')
-                .select(
-                    'p.id as post_id',
-                    'p.uuid as post_uuid',
-                    'p.title',
-                    'p.published_at',
-                    'p.feature_image',
-                    'p.status',
-                    'emails.email_count',
-                    'emails.opened_count'
-                )
-                .leftJoin('emails', 'emails.post_id', 'p.id')
-                .where('p.status', 'published')
-                .where('p.type', 'post')
-                .whereNotNull('p.published_at')
-                .orderByRaw('CASE WHEN p.uuid IN (?) THEN 0 ELSE 1 END', [postUuids.length > 0 ? postUuids : ['none']])
-                .orderBy('p.published_at', 'desc')
-                .limit(limit);
+            let postsWithViews = [];
 
-            // Get authors for all posts
-            const postIds = posts.map(p => p.post_id);
-            const authorsData = postIds.length > 0 ? await this.knex('posts_authors as pa')
-                .select('pa.post_id', 'u.name', 'pa.sort_order')
-                .leftJoin('users as u', 'u.id', 'pa.author_id')
-                .whereIn('pa.post_id', postIds)
-                .whereNotNull('u.name')
-                .orderBy(['pa.post_id', 'pa.sort_order']) : [];
+            // Skip this lookup entirely when there's no Tinybird views data to enrich -
+            // postsWithViews would always end up empty anyway, since it's built by mapping
+            // over viewsData (nothing to match against DB posts).
+            if (viewsData.length > 0) {
+                // Get posts data from Ghost DB - prioritize posts that were sent as newsletters
+                const posts = await this.knex('posts as p')
+                    .select(
+                        'p.id as post_id',
+                        'p.uuid as post_uuid',
+                        'p.title',
+                        'p.published_at',
+                        'p.feature_image',
+                        'p.status',
+                        'emails.email_count',
+                        'emails.opened_count'
+                    )
+                    .leftJoin('emails', 'emails.post_id', 'p.id')
+                    .where('p.status', 'published')
+                    .where('p.type', 'post')
+                    .whereNotNull('p.published_at')
+                    .orderByRaw('CASE WHEN p.uuid IN (?) THEN 0 ELSE 1 END', [postUuids.length > 0 ? postUuids : ['none']])
+                    .orderBy('p.published_at', 'desc')
+                    .limit(limit);
 
-            // Group authors by post_id
-            const authorsByPost = {};
-            authorsData.forEach((author) => {
-                if (!authorsByPost[author.post_id]) {
-                    authorsByPost[author.post_id] = [];
-                }
-                authorsByPost[author.post_id].push(author.name);
-            });
+                // Get authors for all posts
+                const postIds = posts.map(p => p.post_id);
+                const authorsData = postIds.length > 0 ? await this.knex('posts_authors as pa')
+                    .select('pa.post_id', 'u.name', 'pa.sort_order')
+                    .leftJoin('users as u', 'u.id', 'pa.author_id')
+                    .whereIn('pa.post_id', postIds)
+                    .whereNotNull('u.name')
+                    .orderBy(['pa.post_id', 'pa.sort_order']) : [];
 
-            // Add authors to posts
-            posts.forEach((post) => {
-                post.authors = (authorsByPost[post.post_id] || []).join(', ');
-            });
+                // Group authors by post_id
+                const authorsByPost = {};
+                authorsData.forEach((author) => {
+                    if (!authorsByPost[author.post_id]) {
+                        authorsByPost[author.post_id] = [];
+                    }
+                    authorsByPost[author.post_id].push(author.name);
+                });
 
-            // Get member attribution counts and click counts for these posts
-            const [memberAttributionCounts, clickCounts] = await Promise.all([
-                this._getMemberAttributionCounts(posts.map(p => p.post_id), options),
-                this.getPostsClickCounts(posts.map(p => p.post_id))
-            ]);
+                // Add authors to posts
+                posts.forEach((post) => {
+                    post.authors = (authorsByPost[post.post_id] || []).join(', ');
+                });
 
-            // Process posts with views
-            const postsWithViews = viewsData.map((row) => {
-                const post = posts.find(p => p.post_uuid === row.post_uuid);
+                // Get member attribution counts and click counts for these posts
+                const [memberAttributionCounts, clickCounts] = await Promise.all([
+                    this._getMemberAttributionCounts(posts.map(p => p.post_id), options),
+                    this.getPostsClickCounts(posts.map(p => p.post_id))
+                ]);
 
-                if (!post) {
-                    return null;
-                }
+                // Process posts with views
+                postsWithViews = viewsData.map((row) => {
+                    const post = posts.find(p => p.post_uuid === row.post_uuid);
 
-                // Find the member attribution count for this post
-                const attributionCount = memberAttributionCounts.find(ac => ac.post_id === post.post_id);
-                const memberCount = attributionCount ? (attributionCount.free_members + attributionCount.paid_members) : 0;
-                const clickCount = clickCounts[post.post_id] || 0;
+                    if (!post) {
+                        return null;
+                    }
 
-                return {
-                    post_id: post.post_id,
-                    title: post.title,
-                    published_at: post.published_at,
-                    feature_image: post.feature_image ? urlUtils.transformReadyToAbsolute(post.feature_image) : post.feature_image,
-                    status: post.status,
-                    authors: post.authors,
-                    views: row.visits,
-                    sent_count: post.email_count || null,
-                    opened_count: post.opened_count || null,
-                    open_rate: post.email_count > 0 ? (post.opened_count / post.email_count) * 100 : null,
-                    clicked_count: clickCount,
-                    click_rate: post.email_count > 0 ? (clickCount / post.email_count) * 100 : null,
-                    members: memberCount,
-                    free_members: attributionCount ? attributionCount.free_members : 0,
-                    paid_members: attributionCount ? attributionCount.paid_members : 0
-                };
-            }).filter(Boolean);
+                    // Find the member attribution count for this post
+                    const attributionCount = memberAttributionCounts.find(ac => ac.post_id === post.post_id);
+                    const memberCount = attributionCount ? (attributionCount.free_members + attributionCount.paid_members) : 0;
+                    const clickCount = clickCounts[post.post_id] || 0;
+
+                    return {
+                        post_id: post.post_id,
+                        title: post.title,
+                        published_at: post.published_at,
+                        feature_image: post.feature_image ? urlUtils.transformReadyToAbsolute(post.feature_image) : post.feature_image,
+                        status: post.status,
+                        authors: post.authors,
+                        views: row.visits,
+                        sent_count: post.email_count || null,
+                        opened_count: post.opened_count || null,
+                        open_rate: post.email_count > 0 ? (post.opened_count / post.email_count) * 100 : null,
+                        clicked_count: clickCount,
+                        click_rate: post.email_count > 0 ? (clickCount / post.email_count) * 100 : null,
+                        members: memberCount,
+                        free_members: attributionCount ? attributionCount.free_members : 0,
+                        paid_members: attributionCount ? attributionCount.paid_members : 0
+                    };
+                }).filter(Boolean);
+            }
 
             // Calculate how many more posts we need - we want to always return 5 posts
             const remainingCount = limit - postsWithViews.length;

--- a/ghost/core/core/server/services/stats/posts-stats-service.js
+++ b/ghost/core/core/server/services/stats/posts-stats-service.js
@@ -1211,9 +1211,6 @@ class PostsStatsService {
 
             let postsWithViews = [];
 
-            // Skip this lookup entirely when there's no Tinybird views data to enrich -
-            // postsWithViews would always end up empty anyway, since it's built by mapping
-            // over viewsData (nothing to match against DB posts).
             if (viewsData.length > 0) {
                 // Get posts data from Ghost DB - prioritize posts that were sent as newsletters
                 const posts = await this.knex('posts as p')


### PR DESCRIPTION
## Summary
- `createQuery`/`createPaginatedQuery`/`createInfiniteQuery` in `admin-x-framework` now derive `isLoading` from `fetchStatus !== 'idle'` instead of passing React Query's raw `isLoading` through. A disabled query that never fetches otherwise reports `isLoading: true` forever, since `status` only leaves `'loading'` on an actual fetch dispatch.
- Removed `enabled: webAnalyticsEnabled` from `useTopPostsViews` in the Stats Overview page. `getTopPostsViews` already returns real DB-backed data (posts, authors, sent/opened counts, member attribution, clicks) when Tinybird isn't configured — gating the fetch discarded all of that, not just view counts. The views metric stays hidden via the existing `showWebAnalytics` check in `TopPosts`.
- Skipped a DB lookup in `getTopPostsViews` that ran unconditionally but was always discarded when there was no views data to enrich.

## Test plan
- [x] `apps/admin-x-framework` unit tests pass (161 tests)
- [x] `apps/stats` unit tests pass (234 tests)
- [x] `ghost/core` `test/unit/server/services/stats/posts.test.js` passes unmodified (46 tests)
- [x] `eslint` clean on all changed files