### PR TITLE
Changed public app dev defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,19 +117,24 @@ The `pnpm dev` command uses a **hybrid Docker + host development** setup:
 - MySQL, Redis, Mailpit
 - Caddy gateway/reverse proxy
 
-**What runs on host:**
-- Frontend dev servers (Admin, Portal, Comments UI, etc.) in watch mode with HMR
-- Foundation libraries (shade, admin-x-framework, etc.)
+**What runs on host by default:**
+- Admin, legacy Ember admin, Portal, and foundation library dev watchers
+- Optional public UMD app watchers can be added when needed
 
 **Setup:**
 ```bash
-# Start everything (Docker + frontend dev servers)
+# Start the default Docker backend + host frontend watchers
 pnpm dev
+
+# Add optional public app watchers
+pnpm dev:public
 
 # With optional services (uses Docker Compose file composition)
 pnpm dev:analytics             # Include Tinybird analytics
 pnpm dev:storage               # Include MinIO S3-compatible object storage
-pnpm dev:all                   # Include all optional services
+pnpm dev:stripe                # Include Stripe webhook forwarding
+pnpm dev:full                  # Include analytics, storage, Stripe, and public app watchers
+pnpm dev:all                   # Backwards-compatible alias for all optional services
 ```
 
 **Accessing Services:**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,10 +123,10 @@ The `pnpm dev` command uses a **hybrid Docker + host development** setup:
 
 **Setup:**
 ```bash
-# Start the default Docker backend + host frontend watchers
+# Start Ghost backend, Admin, Portal, and Docker services
 pnpm dev
 
-# Add optional public app watchers
+# Add optional public apps (comments-ui, sodo-search, signup-form, admin-toolbar)
 pnpm dev:public
 
 # With optional services (uses Docker Compose file composition)
@@ -134,7 +134,9 @@ pnpm dev:analytics             # Include Tinybird analytics
 pnpm dev:storage               # Include MinIO S3-compatible object storage
 pnpm dev:stripe                # Include Stripe webhook forwarding
 pnpm dev:full                  # Include analytics, storage, Stripe, and public app watchers
-pnpm dev:all                   # Backwards-compatible alias for all optional services
+
+# Everything available
+pnpm dev:all                   #
 ```
 
 **Accessing Services:**

--- a/docker/ghost-dev/README.md
+++ b/docker/ghost-dev/README.md
@@ -28,8 +28,11 @@ This lightweight image:
 This image is used automatically when running:
 
 ```bash
-pnpm dev              # Starts Docker backend + frontend dev servers on host
+pnpm dev              # Starts Docker backend + Admin/Ember/shared/Portal dev watchers
+pnpm dev:public       # Include all optional public UMD app watchers
 pnpm dev:analytics    # Include Tinybird analytics
 pnpm dev:storage      # Include MinIO S3-compatible object storage
-pnpm dev:all          # Include all optional services
+pnpm dev:stripe       # Include Stripe webhook forwarding
+pnpm dev:full         # Include analytics, storage, Stripe, and public app watchers
+pnpm dev:all          # Backwards-compatible alias for all optional services
 ```

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "dev:sqlite": "DEV_COMPOSE_FILES='-f compose.dev.sqlite.yaml' pnpm nx run ghost-monorepo:docker:dev",
     "dev:mailgun": "DEV_COMPOSE_FILES='-f compose.dev.mailgun.yaml' pnpm nx run ghost-monorepo:docker:dev",
     "dev:lexical": "EDITOR_URL=http://localhost:2368/ghost/assets/koenig-lexical/ pnpm dev",
+    "dev:public": "pnpm nx run ghost-monorepo:docker:dev:public",
+    "dev:full": "DEV_COMPOSE_FILES='-f compose.dev.analytics.yaml -f compose.dev.storage.yaml' ./docker/stripe/with-stripe.sh pnpm nx run ghost-monorepo:docker:dev:public",
     "dev:analytics": "DEV_COMPOSE_FILES='-f compose.dev.analytics.yaml' pnpm nx run ghost-monorepo:docker:dev",
     "dev:storage": "DEV_COMPOSE_FILES='-f compose.dev.storage.yaml' pnpm nx run ghost-monorepo:docker:dev",
     "dev:stripe": "./docker/stripe/with-stripe.sh pnpm nx run ghost-monorepo:docker:dev",
@@ -128,6 +130,29 @@
         }
       },
       "docker:dev": {
+        "continuous": true,
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "trap 'docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} down' EXIT; docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} logs -f"
+        },
+        "dependsOn": [
+          "docker:up",
+          {
+            "target": "build:assets",
+            "projects": [
+              "ghost"
+            ]
+          },
+          {
+            "target": "dev",
+            "projects": [
+              "@tryghost/admin",
+              "@tryghost/portal"
+            ]
+          }
+        ]
+      },
+      "docker:dev:public": {
         "continuous": true,
         "executor": "nx:run-commands",
         "options": {


### PR DESCRIPTION
no ref

`pnpm dev` was unnecessarily heavy - in most cases, developers _do not_ need to touch our public/frontend apps. It so happens that these apps are quite heavy by virtue of us serving UMD files, rather than a simple vite dev server. In light of that, I've stripped back `pnpm dev` to run **only Ghost + Portal**.

Other apps can be run using a convenient `pnpm dev:public` or by a more traditional `pnpm nx run @tryghost/comments-ui:dev` or `cd apps/comments-ui && pnpm dev` while running `pnpm dev` at the root.

## Summary

Updates local dev defaults so `pnpm dev` starts the common frontend set only:

- Admin
- Portal

The less common public UMD app watchers are now explicit opt-in via `pnpm dev:public`:

- Comments UI
- Signup Form
- Sodo Search
- Announcement Bar
- Admin Toolbar

## Changes

- Adds `pnpm dev:public`, backed by `ghost-monorepo:docker:dev:public`
- Adds `pnpm dev:full` for analytics, storage, Stripe, and public UMD app watchers
- Keeps optional services explicit with `dev:analytics`, `dev:storage`, and `dev:stripe`
- Keeps Stripe behind `docker/stripe/with-stripe.sh`, so `dev:stripe`, `dev:full`, and `dev:all` require `STRIPE_SECRET_KEY`
- Keeps existing service-specific scripts (`dev:analytics`, `dev:storage`, `dev:stripe`, etc.) working as before
- Updates `AGENTS.md` and `docker/ghost-dev/README.md` to describe the new default and opt-in commands

## Benchmark Notes

Steady-state host-process measurement:

- `pnpm dev`: 13 host processes, 2.88 GiB summed RSS
- `pnpm dev:public`: 23 host processes, 4.25 GiB summed RSS
- Default savings: -10 host processes, -1.37 GiB summed RSS

## Validation

- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"`
- `pnpm --silent nx show project ghost-monorepo --json`
- `git diff --check`
