### PR TITLE
Changed devcontainer dev stack to match Admin + Portal default

### DIFF
--- a/.devcontainer/compose.devcontainer.yaml
+++ b/.devcontainer/compose.devcontainer.yaml
@@ -2,8 +2,8 @@ services:
   mysql:
     # Smaller InnoDB buffer pool than the baseline compose.dev.yaml (1G).
     # Lets the dev stack stay within a 2-core / 8 GB Codespace's budget
-    # after Ghost + 6 Vite dev servers are running. 256 MB is plenty for
-    # dev data volumes.
+    # after Ghost + the default Admin/Portal dev watchers are running.
+    # 256 MB is plenty for dev data volumes.
     command: --innodb-buffer-pool-size=256M --innodb-log-buffer-size=64M --innodb-flush-log-at-trx_commit=0 --innodb-flush-method=O_DIRECT
     mem_limit: 512m
     restart: unless-stopped
@@ -38,15 +38,12 @@ services:
   ghost-dev-gateway:
     # Point Caddy at the dev servers running inside the ghost-dev container
     # instead of host.docker.internal (which is the default for the hybrid
-    # host/container dev setup).
+    # host/container dev setup). Public apps (Portal, Comments UI, Signup
+    # Form, Sodo Search, Announcement Bar, Admin Toolbar) have no entry here
+    # — Caddy serves their umd/ build output directly via file_server, so
+    # there's no dev-server host:port to point at.
     environment:
       GHOST_BACKEND: ghost-dev:2368
       ADMIN_DEV_SERVER: ghost-dev:5174
       ADMIN_LIVE_RELOAD_SERVER: ghost-dev:4200
-      PORTAL_DEV_SERVER: ghost-dev:4175
-      COMMENTS_DEV_SERVER: ghost-dev:7173
-      SIGNUP_DEV_SERVER: ghost-dev:6174
-      SEARCH_DEV_SERVER: ghost-dev:4178
-      ANNOUNCEMENT_DEV_SERVER: ghost-dev:4177
-      ADMIN_TOOLBAR_DEV_SERVER: ghost-dev:4176
       LEXICAL_DEV_SERVER: ghost-dev:4173

--- a/.devcontainer/compose.devcontainer.yaml
+++ b/.devcontainer/compose.devcontainer.yaml
@@ -19,8 +19,28 @@ services:
     # The original ./ghost:/home/ghost/ghost mount from compose.dev.yaml is
     # preserved via merge semantics so nodemon hot-reload still works for anyone
     # running the backend the original way.
+    #
+    # pnpm-store is a separate named volume, NOT under /workspaces/Ghost, so
+    # it survives the bind mount above (which fully shadows anything baked
+    # into the image at that path with the host's — node_modules-less — repo
+    # checkout). onCreateCommand/postCreateCommand still have to run a real
+    # `pnpm install` every time since the source is live-mounted, but with
+    # the store already warm it's linking already-fetched content instead of
+    # re-downloading and recompiling native deps (better-sqlite3, sharp, etc.)
+    # from scratch.
     volumes:
       - ./:/workspaces/Ghost:cached
+      - pnpm-store:/pnpm-store
+    environment:
+      npm_config_store_dir: /pnpm-store
+    # Prefer the prebuilt image (docker/ghost-dev/Dockerfile, published by
+    # .github/workflows/devcontainer-build.yml) over a local build. cache_from
+    # makes a local `docker compose build` (e.g. after a Dockerfile edit)
+    # reuse those layers too, rather than starting from zero.
+    image: ghcr.io/tryghost/ghost-devcontainer:latest
+    build:
+      cache_from:
+        - ghcr.io/tryghost/ghost-devcontainer:latest
     # Override the default `pnpm dev` command. VS Code controls startup and the
     # user runs backend/frontend dev servers as tasks (see .vscode/tasks.json).
     command: ["sleep", "infinity"]
@@ -47,3 +67,6 @@ services:
       ADMIN_DEV_SERVER: ghost-dev:5174
       ADMIN_LIVE_RELOAD_SERVER: ghost-dev:4200
       LEXICAL_DEV_SERVER: ghost-dev:4173
+
+volumes:
+  pnpm-store:

--- a/.devcontainer/compose.devcontainer.yaml
+++ b/.devcontainer/compose.devcontainer.yaml
@@ -5,7 +5,15 @@ services:
     # after Ghost + the default Admin/Portal dev watchers are running.
     # 256 MB is plenty for dev data volumes.
     command: --innodb-buffer-pool-size=256M --innodb-log-buffer-size=64M --innodb-flush-log-at-trx_commit=0 --innodb-flush-method=O_DIRECT
-    mem_limit: 512m
+    # mem_limit is a hard cgroup ceiling, separate from the buffer pool size
+    # above. Measured via `docker stats` under real usage: actual RSS sits
+    # around 440-460MiB, so the previous 512m cap left MySQL pinned at
+    # 85-90% of its ceiling continuously (real, not just at boot) -- more
+    # memory-management overhead on every query than the buffer pool size
+    # alone would suggest. 1g (matching host-hybrid's unconstrained default)
+    # gives real headroom above the actual working set, still a small slice
+    # even on the 2-core/8GB minimum tier.
+    mem_limit: 1g
     restart: unless-stopped
 
   redis:

--- a/.devcontainer/compose.devcontainer.yaml
+++ b/.devcontainer/compose.devcontainer.yaml
@@ -31,16 +31,16 @@ services:
     # pnpm-store is a separate named volume, NOT under /workspaces/Ghost, so
     # it survives the bind mount above (which fully shadows anything baked
     # into the image at that path with the host's — node_modules-less — repo
-    # checkout). onCreateCommand/postCreateCommand still have to run a real
-    # `pnpm install` every time since the source is live-mounted, but with
-    # the store already warm it's linking already-fetched content instead of
+    # checkout). Because the source is live-mounted, onCreateCommand still has
+    # to run a real `pnpm install` every time, but with the store already warm
+    # it's linking already-fetched content instead of
     # re-downloading and recompiling native deps (better-sqlite3, sharp, etc.)
     # from scratch.
     volumes:
       - ./:/workspaces/Ghost:cached
       - pnpm-store:/pnpm-store
     environment:
-      npm_config_store_dir: /pnpm-store
+      pnpm_config_store_dir: /pnpm-store
     # Prefer the prebuilt image (docker/ghost-dev/Dockerfile, published by
     # .github/workflows/devcontainer-build.yml) over a local build. cache_from
     # makes a local `docker compose build` (e.g. after a Dockerfile edit)

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -40,6 +40,10 @@
     // The script guards against double-starting if the stack is already up.
     "postAttachCommand": "bash .devcontainer/start-dev-stack.sh",
 
+    // Portal, Comments UI, Signup Form, Sodo Search, Announcement Bar, and
+    // Admin Toolbar are NOT listed here — since the Caddy file_server switch
+    // (#28970) they build to disk (`vite build --watch`) instead of running
+    // a dev server, so there's no port to forward for them.
     "forwardPorts": [
         2368,
         3306,
@@ -48,11 +52,6 @@
         8025,
         5174,
         4200,
-        4175,
-        7173,
-        6174,
-        4178,
-        4177,
         4173
     ],
     "portsAttributes": {
@@ -63,12 +62,7 @@
         "8025": {"label": "Mailpit Web"},
         "5174": {"label": "Admin (Vite)"},
         "4200": {"label": "Ember live-reload"},
-        "4175": {"label": "Portal"},
-        "7173": {"label": "Comments UI"},
-        "6174": {"label": "Signup Form"},
-        "4178": {"label": "Sodo Search"},
-        "4177": {"label": "Announcement Bar"},
-        "4173": {"label": "Koenig Lexical"}
+        "4173": {"label": "Koenig Lexical (optional)"}
     },
 
     "customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,8 +23,13 @@
     // dev containers where the host is the developer's own machine, but do
     // NOT replicate this pattern in shared build agents, CI runners, or
     // environments where untrusted code runs in the container.
+    // sshd enables `gh codespace ssh`/`logs` for direct diagnosis (top,
+    // free, docker stats) instead of only being able to probe over HTTP.
+    // Same trust boundary as docker-outside-of-docker below — standard for
+    // a Codespace/local dev container where the host is your own machine.
     "features": {
-        "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
+        "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+        "ghcr.io/devcontainers/features/sshd:1": {}
     },
 
     // Runs on the host/Codespaces VM before the container is built or pulled.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,8 +27,18 @@
         "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
     },
 
-    // Codespaces prebuild step — runs once when the image is built.
-    // Primes the pnpm store so first-open is fast.
+    // Runs on the host/Codespaces VM before the container is built or pulled.
+    // Warms the local image cache with the prebuilt ghost-dev image
+    // (.github/workflows/devcontainer-build.yml) so ghost-dev's cache_from
+    // (see compose.devcontainer.yaml) has something to reuse layers from,
+    // whether this container gets pulled directly or rebuilt locally.
+    // Best-effort: don't fail creation if the registry is unreachable.
+    "initializeCommand": "docker pull ghcr.io/tryghost/ghost-devcontainer:latest || true",
+
+    // Runs once the workspace mount is ready, after the container is created.
+    // Note: no Codespaces prebuild is configured for this repo, so this runs
+    // live on every creation rather than being baked into a snapshot ahead of
+    // time — same as postCreateCommand below.
     "onCreateCommand": "corepack enable && corepack prepare --activate && cd /workspaces/Ghost && pnpm install --prefer-offline || true",
 
     // Runs after the workspace mount is ready on every container create.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,19 +32,12 @@
         "ghcr.io/devcontainers/features/sshd:1": {}
     },
 
-    // Runs on the host/Codespaces VM before the container is built or pulled.
-    // Warms the local image cache with the prebuilt ghost-dev image
-    // (.github/workflows/devcontainer-build.yml) so ghost-dev's cache_from
-    // (see compose.devcontainer.yaml) has something to reuse layers from,
-    // whether this container gets pulled directly or rebuilt locally.
-    // Best-effort: don't fail creation if the registry is unreachable.
-    "initializeCommand": "docker pull ghcr.io/tryghost/ghost-devcontainer:latest || true",
-
     // Runs once the workspace mount is ready, after the container is created.
     // Note: no Codespaces prebuild is configured for this repo, so this runs
     // live on every creation rather than being baked into a snapshot ahead of
-    // time — same as postCreateCommand below.
-    "onCreateCommand": "corepack enable && corepack prepare --activate && cd /workspaces/Ghost && pnpm install --prefer-offline || true",
+    // time. A failed install must stop setup because postCreateCommand assumes
+    // workspace dependencies are available.
+    "onCreateCommand": "corepack enable && corepack prepare --activate && cd /workspaces/Ghost && pnpm install --prefer-offline",
 
     // Runs after the workspace mount is ready on every container create.
     "postCreateCommand": ".devcontainer/postCreate.sh",

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -8,7 +8,10 @@ corepack prepare --activate
 
 git submodule update --init --recursive
 
-pnpm install --prefer-offline
+# pnpm install already ran in onCreateCommand against this same fully-mounted
+# workspace (submodules are theme content, not workspace packages, so their
+# absence above didn't affect that install) — a second pass here would just
+# re-walk the whole dependency graph for nothing.
 
 # Build workspace packages that ghost/core imports at runtime with build
 # outputs (not source). @tryghost/parse-email-address is the only one today

--- a/.devcontainer/start-dev-stack.sh
+++ b/.devcontainer/start-dev-stack.sh
@@ -26,6 +26,23 @@ echo "Starting Ghost dev stack..."
 if [ -n "${CODESPACES:-}" ] && [ -n "${CODESPACE_NAME:-}" ]; then
     export url="https://${CODESPACE_NAME}-2368.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN:-app.github.dev}"
     echo "Codespaces detected: setting Ghost url=$url so admin session origin checks match the forwarded tunnel" >> /tmp/ghost-backend.log
+
+    # Once url above is HTTPS, Ghost's url-redirects middleware
+    # (getAdminRedirectUrl in ghost/core/core/server/web/shared/middleware/
+    # url-redirects.js) 301s any request it sees as insecure (protocol
+    # mismatch) to that HTTPS url. Real browser traffic is fine — Caddy sets
+    # X-Forwarded-Proto: https, so Express's req.secure is true. But
+    # apps/admin's own vite dev server bootstraps itself by fetching
+    # GHOST_URL + ghost/api/admin/site/ directly (vite-backend-proxy.ts),
+    # bypassing Caddy entirely by default (http://localhost:2368) — Express
+    # sees that as insecure, 301s it to the public tunnel URL, and since
+    # that's an external, GitHub-auth-gated address, Vite's plain fetch()
+    # can't complete the login flow and crashes on the HTML it gets back
+    # instead of JSON. Routing GHOST_URL through the gateway container
+    # instead keeps the request on the internal Docker network (still gets
+    # X-Forwarded-Proto: https from Caddy, so no redirect) while never
+    # touching the external, auth-gated tunnel at all.
+    export GHOST_URL="http://ghost-dev-gateway:80/"
 fi
 
 # Append to log files (don't truncate) so previous crash tails survive a

--- a/.devcontainer/start-dev-stack.sh
+++ b/.devcontainer/start-dev-stack.sh
@@ -20,8 +20,12 @@ nohup pnpm --filter ghost dev >> /tmp/ghost-backend.log 2>&1 &
 disown
 
 { echo "=== $(date -Is) starting frontends ==="; } >> /tmp/ghost-frontends.log
+# Matches root `pnpm dev`'s default fan-out (Admin + Portal only) — most
+# devcontainer sessions never touch the public UMD apps, and those watchers
+# are the heaviest processes in the stack. To also start them, run e.g.:
+#   pnpm nx run-many -t dev --projects=@tryghost/comments-ui,@tryghost/signup-form,@tryghost/sodo-search,@tryghost/announcement-bar,@tryghost/admin-toolbar
 nohup pnpm nx run-many -t dev \
-    --projects=@tryghost/admin,@tryghost/portal,@tryghost/comments-ui,@tryghost/signup-form,@tryghost/sodo-search,@tryghost/announcement-bar \
+    --projects=@tryghost/admin,@tryghost/portal \
     >> /tmp/ghost-frontends.log 2>&1 &
 disown
 
@@ -33,4 +37,8 @@ Ghost dev stack starting in the background.
   Gateway:      http://localhost:2368/
 
 Give it ~30-60s, then open http://localhost:2368/ghost/ for admin.
+
+Only Admin + Portal dev watchers start by default. To add the public UMD
+apps (Comments, Signup Form, Sodo Search, Announcement Bar, Admin Toolbar):
+  pnpm nx run-many -t dev --projects=@tryghost/comments-ui,@tryghost/signup-form,@tryghost/sodo-search,@tryghost/announcement-bar,@tryghost/admin-toolbar
 MSG

--- a/.devcontainer/start-dev-stack.sh
+++ b/.devcontainer/start-dev-stack.sh
@@ -13,6 +13,21 @@ fi
 
 echo "Starting Ghost dev stack..."
 
+# Ghost's own `url` config (default http://localhost:2368) is what session
+# CSRF checks compare the browser's Origin header against (see
+# cookieCsrfProtection in ghost/core/core/server/services/auth/session/
+# session-service.js). Codespaces serves everything through a forwarded
+# https://<name>-2368.<domain> origin instead, so without this every
+# authenticated admin request fails that origin check and bounces back to
+# login. `url` is a top-level nconf key, so a bare `url` env var overrides
+# it (see ghost/core/core/shared/config/loader.js's nconf.env() call).
+# Local (non-Codespaces) VS Code Dev Containers forward to genuine
+# localhost, so this only applies inside Codespaces itself.
+if [ -n "${CODESPACES:-}" ] && [ -n "${CODESPACE_NAME:-}" ]; then
+    export url="https://${CODESPACE_NAME}-2368.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN:-app.github.dev}"
+    echo "Codespaces detected: setting Ghost url=$url so admin session origin checks match the forwarded tunnel" >> /tmp/ghost-backend.log
+fi
+
 # Append to log files (don't truncate) so previous crash tails survive a
 # restart and the user can still tail them for context.
 { echo "=== $(date -Is) starting backend ==="; } >> /tmp/ghost-backend.log

--- a/docker/dev-gateway/Dockerfile
+++ b/docker/dev-gateway/Dockerfile
@@ -6,16 +6,14 @@ FROM caddy:2-alpine@sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95a
 
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy
 
-# Default proxy targets (can be overridden via environment variables)
+# Default proxy targets (can be overridden via environment variables).
+# Public apps (portal, comments-ui, signup-form, sodo-search,
+# announcement-bar, admin-toolbar) are served directly from their umd/
+# build output via the Caddyfile's file_server block, not proxied to a
+# dev server — they have no *_DEV_SERVER entry here.
 ENV GHOST_BACKEND=ghost-dev:2368 \
     ADMIN_DEV_SERVER=host.docker.internal:5174 \
     ADMIN_LIVE_RELOAD_SERVER=host.docker.internal:4200 \
-    PORTAL_DEV_SERVER=host.docker.internal:4175 \
-    COMMENTS_DEV_SERVER=host.docker.internal:7173 \
-    SIGNUP_DEV_SERVER=host.docker.internal:6174 \
-    SEARCH_DEV_SERVER=host.docker.internal:4178 \
-    ANNOUNCEMENT_DEV_SERVER=host.docker.internal:4177 \
-    ADMIN_TOOLBAR_DEV_SERVER=host.docker.internal:4176 \
     LEXICAL_DEV_SERVER=host.docker.internal:4173 \
     ANALYTICS_PROXY_TARGET=analytics:3000 \
     ACTIVITYPUB_PROXY_TARGET=host.docker.internal:8080

--- a/docker/dev-gateway/README.md
+++ b/docker/dev-gateway/README.md
@@ -4,8 +4,9 @@ This directory contains the Caddy reverse proxy configuration for the Ghost deve
 ## Purpose
 The Caddy reverse proxy container:
 1. **Routes Ghost requests** to the Ghost container backend
-2. **Proxies asset requests** to local dev servers running on the host
-3. **Enables hot-reload** for frontend development without rebuilding Ghost
+2. **Proxies asset requests** to local dev servers running on the host (Admin, Lexical)
+3. **Serves public app assets** (Portal, Comments UI, Signup Form, Sodo Search, Announcement Bar, Admin Toolbar) directly from their `umd/` build output via `file_server` — no dev server involved
+4. **Enables hot-reload** for frontend development without rebuilding Ghost
 
 ## Configuration
 ### Environment Variables
@@ -14,11 +15,6 @@ Caddy uses environment variables (set in `compose.dev.yaml`) to configure proxy 
 - `GHOST_BACKEND` - Ghost container hostname (e.g., `ghost-dev:2368`)
 - `ADMIN_DEV_SERVER` - React admin dev server (e.g., `host.docker.internal:5174`)
 - `ADMIN_LIVE_RELOAD_SERVER` - Ember live reload WebSocket (e.g., `host.docker.internal:4200`)
-- `PORTAL_DEV_SERVER` - Portal dev server (e.g., `host.docker.internal:4175`)
-- `COMMENTS_DEV_SERVER` - Comments UI (e.g., `host.docker.internal:7173`)
-- `SIGNUP_DEV_SERVER` - Signup form (e.g., `host.docker.internal:6174`)
-- `SEARCH_DEV_SERVER` - Sodo search (e.g., `host.docker.internal:4178`)
-- `ANNOUNCEMENT_DEV_SERVER` - Announcement bar (e.g., `host.docker.internal:4177`)
 - `LEXICAL_DEV_SERVER` - *Optional:* Local Koenig Lexical editor dev server (e.g., `host.docker.internal:4173`)
   - For developing Lexical in the separate [Koenig repository](https://github.com/TryGhost/Koenig)
   - Requires `EDITOR_URL=/ghost/assets/koenig-lexical/` when starting admin dev server
@@ -43,15 +39,11 @@ The Caddyfile defines these routing rules:
 | `/.well-known/webfinger`             | ActivityPub server (port 8080)      | *Optional:* WebFinger for federation                                   |
 | `/.well-known/nodeinfo`              | ActivityPub server (port 8080)      | *Optional:* NodeInfo for federation                                    |
 | `/ghost/assets/koenig-lexical/*`     | Lexical dev server (port 4173)      | *Optional:* Koenig Lexical editor (falls back to Ghost if not running) |
-| `/ghost/assets/portal/*`             | Portal dev server (port 4175)       | Membership UI                                                          |
-| `/ghost/assets/comments-ui/*`        | Comments dev server (port 7173)     | Comments widget                                                        |
-| `/ghost/assets/signup-form/*`        | Signup dev server (port 6174)       | Signup form widget                                                     |
-| `/ghost/assets/sodo-search/*`        | Search dev server (port 4178)       | Search widget (JS + CSS)                                               |
-| `/ghost/assets/announcement-bar/*`   | Announcement dev server (port 4177) | Announcement widget                                                    |
+| `/ghost/assets/{portal,comments-ui,signup-form,sodo-search,announcement-bar,admin-toolbar}/*` | `apps/<name>/umd` (file_server) | Public app widgets — served from disk, rebuilt on change by each app's `vite build --watch` |
 | `/ghost/assets/*`                    | Admin dev server (port 5174)        | Other admin assets — rewritten to `/__admin-dev__/assets/*`            |
 | `/__admin-dev__/*`                   | Admin dev server (port 5174)        | Vite internals (HMR, modules, refresh runtime, dev-only assets)        |
 | `/ghost`, `/ghost/`                  | Admin dev server (port 5174)        | Admin HTML entry — rewritten to `/__admin-dev__/`                      |
 | `/ghost/*` (deep links)              | Ghost backend                       | Express middleware redirects deep links to `/ghost/#/<path>`           |
 | Everything else                      | Ghost backend                       | Main Ghost application                                                 |
 
-**Note:** All port numbers listed are the host ports where dev servers run by default.
+**Note:** Port numbers listed for Admin and Lexical are the host ports where those dev servers run by default. Public apps have no dev-server port — Caddy reads their build output straight off disk.

--- a/docker/dev-gateway/README.md
+++ b/docker/dev-gateway/README.md
@@ -4,8 +4,9 @@ This directory contains the Caddy reverse proxy configuration for the Ghost deve
 ## Purpose
 The Caddy reverse proxy container:
 1. **Routes Ghost requests** to the Ghost container backend
-2. **Proxies asset requests** to local dev servers running on the host
-3. **Enables hot-reload** for frontend development without rebuilding Ghost
+2. **Proxies asset requests** to local dev servers running on the host (Admin, Lexical)
+3. **Serves public app assets** (Portal, Comments UI, Signup Form, Sodo Search, Announcement Bar, Admin Toolbar) directly from their `umd/` build output via `file_server` — no dev server involved
+4. **Enables hot-reload** for frontend development without rebuilding Ghost
 
 ## Configuration
 ### Environment Variables
@@ -14,11 +15,6 @@ Caddy uses environment variables (set in `compose.dev.yaml`) to configure proxy 
 - `GHOST_BACKEND` - Ghost container hostname (e.g., `ghost-dev:2368`)
 - `ADMIN_DEV_SERVER` - React admin dev server (e.g., `host.docker.internal:5174`)
 - `ADMIN_LIVE_RELOAD_SERVER` - Ember live reload WebSocket (e.g., `host.docker.internal:4200`)
-- `PORTAL_DEV_SERVER` - Portal dev server (e.g., `host.docker.internal:4175`)
-- `COMMENTS_DEV_SERVER` - Comments UI (e.g., `host.docker.internal:7173`)
-- `SIGNUP_DEV_SERVER` - Signup form (e.g., `host.docker.internal:6174`)
-- `SEARCH_DEV_SERVER` - Sodo search (e.g., `host.docker.internal:4178`)
-- `ANNOUNCEMENT_DEV_SERVER` - Announcement bar (e.g., `host.docker.internal:4177`)
 - `LEXICAL_DEV_SERVER` - *Optional:* Koenig Lexical editor preview server (e.g., `host.docker.internal:4173`)
   - Started by `pnpm dev:lexical` at the repo root, which runs `koenig/koenig-lexical`'s `dev:integrated` target (editor rebuild watcher + `vite preview` on port 4173) and sets Admin's `EDITOR_URL` to point at it
   - Automatically falls back to Ghost backend (built package) if dev server is not running
@@ -42,15 +38,11 @@ The Caddyfile defines these routing rules:
 | `/.well-known/webfinger`             | ActivityPub server (port 8080)      | *Optional:* WebFinger for federation                                   |
 | `/.well-known/nodeinfo`              | ActivityPub server (port 8080)      | *Optional:* NodeInfo for federation                                    |
 | `/ghost/assets/koenig-lexical/*`     | Lexical dev server (port 4173)      | *Optional:* Koenig editor via `pnpm dev:lexical` (falls back to Ghost) |
-| `/ghost/assets/portal/*`             | Portal dev server (port 4175)       | Membership UI                                                          |
-| `/ghost/assets/comments-ui/*`        | Comments dev server (port 7173)     | Comments widget                                                        |
-| `/ghost/assets/signup-form/*`        | Signup dev server (port 6174)       | Signup form widget                                                     |
-| `/ghost/assets/sodo-search/*`        | Search dev server (port 4178)       | Search widget (JS + CSS)                                               |
-| `/ghost/assets/announcement-bar/*`   | Announcement dev server (port 4177) | Announcement widget                                                    |
+| `/ghost/assets/{portal,comments-ui,signup-form,sodo-search,announcement-bar,admin-toolbar}/*` | `apps/<name>/umd` (file_server) | Public app widgets — served from disk, rebuilt on change by each app's `vite build --watch` |
 | `/ghost/assets/*`                    | Admin dev server (port 5174)        | Other admin assets — rewritten to `/__admin-dev__/assets/*`            |
 | `/__admin-dev__/*`                   | Admin dev server (port 5174)        | Vite internals (HMR, modules, refresh runtime, dev-only assets)        |
 | `/ghost`, `/ghost/`                  | Admin dev server (port 5174)        | Admin HTML entry — rewritten to `/__admin-dev__/`                      |
 | `/ghost/*` (deep links)              | Ghost backend                       | Express middleware redirects deep links to `/ghost/#/<path>`           |
 | Everything else                      | Ghost backend                       | Main Ghost application                                                 |
 
-**Note:** All port numbers listed are the host ports where dev servers run by default.
+**Note:** Port numbers listed for Admin and Lexical are the host ports where those dev servers run by default. Public apps have no dev-server port — Caddy reads their build output straight off disk.

--- a/docker/ghost-dev/Dockerfile
+++ b/docker/ghost-dev/Dockerfile
@@ -5,13 +5,21 @@ ARG NODE_VERSION=22.18.0
 
 FROM node:$NODE_VERSION-bullseye-slim
 
-# Install system dependencies needed for building native modules
+# Install system dependencies needed for building native modules.
+# watchman: ember-cli (ghost/admin's dev server) auto-detects and prefers it
+# over its default Node-based file watcher, which is far less efficient over
+# a large tree like this bind-mounted monorepo -- without it, ember serve's
+# idle watch mode pegs multiple CPU cores continuously (observed: ~240% CPU
+# at idle, not during an active build). Only benefits ghost-dev's own
+# container; the host-hybrid flow runs ember-cli on the developer's own
+# machine, not in this image, so this has no effect there either way.
 RUN apt-get update && \
     apt-get install -y \
     build-essential \
     curl \
     python3 \
-    git && \
+    git \
+    watchman && \
     rm -rf /var/lib/apt/lists/* && \
     apt clean
 

--- a/docker/ghost-dev/Dockerfile
+++ b/docker/ghost-dev/Dockerfile
@@ -6,13 +6,21 @@ ARG NODE_VERSION=22.23.1
 
 FROM node:$NODE_VERSION-bullseye-slim
 
-# Install system dependencies needed for building native modules
+# Install system dependencies needed for building native modules.
+# watchman: ember-cli (ghost/admin's dev server) auto-detects and prefers it
+# over its default Node-based file watcher, which is far less efficient over
+# a large tree like this bind-mounted monorepo -- without it, ember serve's
+# idle watch mode pegs multiple CPU cores continuously (observed: ~240% CPU
+# at idle, not during an active build). Only benefits ghost-dev's own
+# container; the host-hybrid flow runs ember-cli on the developer's own
+# machine, not in this image, so this has no effect there either way.
 RUN apt-get update && \
     apt-get install -y \
     build-essential \
     curl \
     python3 \
-    git && \
+    git \
+    watchman && \
     rm -rf /var/lib/apt/lists/* && \
     apt clean
 

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
       "docker:build": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "docker compose --progress=quiet -f compose.dev.yaml ${DEV_COMPOSE_FILES} build"
+          "command": "if [ -n \"$CODESPACES$REMOTE_CONTAINERS\" ]; then echo 'Skipping docker compose build: already running inside a devcontainer, whose own compose lifecycle built/pulled these images.'; else docker compose --progress=quiet -f compose.dev.yaml ${DEV_COMPOSE_FILES} build; fi"
         }
       },
       "docker:dev": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
       "docker:up": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} up -d --force-recreate --wait --quiet-pull"
+          "command": "if [ -n \"$CODESPACES$REMOTE_CONTAINERS\" ]; then echo 'Skipping docker compose up --force-recreate: already running inside a devcontainer, whose own compose lifecycle brought these services up.'; else docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} up -d --force-recreate --wait --quiet-pull; fi"
         },
         "dependsOn": [
           "docker:build"

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
       "docker:build": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} build"
+          "command": "if [ -n \"$CODESPACES$REMOTE_CONTAINERS\" ]; then echo 'Skipping docker compose build: already running inside a devcontainer, whose own compose lifecycle built/pulled these images.'; else docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} build; fi"
         }
       },
       "docker:dev": {

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
       "docker:up": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} up -d --force-recreate --wait --quiet-pull"
+          "command": "if [ -n \"$CODESPACES$REMOTE_CONTAINERS\" ]; then echo 'Skipping docker compose up --force-recreate: already running inside a devcontainer, whose own compose lifecycle brought these services up.'; else docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} up -d --force-recreate --wait --quiet-pull; fi"
         },
         "dependsOn": [
           "docker:build"


### PR DESCRIPTION
no ref

## Summary
- Stacks on top of #29105, which narrows root `pnpm dev`'s default frontend fan-out to Admin + Portal only.
- Updates `.devcontainer/start-dev-stack.sh`, which previously hardcoded its own full frontend project list independently of root `pnpm dev`, so it wasn't picking up the memory savings from #29105.
- Public UMD app watchers (Comments UI, Signup Form, Sodo Search, Announcement Bar, Admin Toolbar) are still available on demand via an explicit `nx run-many` command, printed in the script's startup message.
- **Removed dead `*_DEV_SERVER` proxy targets** for Portal/Comments UI/Signup Form/Sodo Search/Announcement Bar/Admin Toolbar from `docker/dev-gateway/Dockerfile`, the devcontainer's compose override, and forwarded ports in `devcontainer.json`. Unread since #28970 switched public apps to Caddy `file_server`; confirmed via grep the Caddyfile never references them. Fixing the shared Dockerfile removes the need to re-declare dead vars in the devcontainer overlay, and stops Codespaces showing five phantom forwarded ports nothing ever binds.
- **Fixed Admin never finishing startup in the devcontainer (502 on `/ghost/` indefinitely).** `apps/admin`'s `dev` target `dependsOn: ["ghost-monorepo:docker:up", ...]` (added in #29101 for the host flow, where `pnpm dev` is a single Nx invocation and dedupes `docker:up` to one harmless run). The devcontainer's `start-dev-stack.sh` invokes Admin's `dev` target via a separate `nx run-many` call from the backend's `pnpm --filter ghost dev`, so `docker:up` actually re-executes — and its `docker compose ... up -d --force-recreate --wait`, run from inside the `ghost-dev` container via the mounted host docker socket, recreates the very container issuing the command. Portal has no such dependency, which is why it always loaded fine while Admin hung. Guarded the recreate behind `CODESPACES`/`REMOTE_CONTAINERS` (set inside the container by both Codespaces and VS Code Dev Containers) — redundant there anyway since the devcontainer's own compose lifecycle already brings services up before `start-dev-stack.sh` runs.

## Test plan
- [x] `bash -n` passes on the modified script
- [x] `docker compose -f compose.dev.yaml -f .devcontainer/compose.devcontainer.yaml config` merges cleanly with only the four live gateway env vars
- [x] `node -e "JSON.parse(...)"` on `package.json` after the `docker:up` guard; verified the shell conditional takes the correct branch with/without `CODESPACES` set
- [ ] Open a Codespace from this branch and verify: only Admin + Portal watchers start by default, the Ports panel shows only the 8 real ports, and `/ghost/` (Admin) loads instead of 502ing indefinitely
- [ ] Verify the printed opt-in command successfully starts the public apps when run manually