### PR TITLE
🐛 Fixed internal tags leaking through the public Content API

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/tags.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/tags.js
@@ -15,6 +15,12 @@ function setDefaultOrder(frame) {
     }
 }
 
+function enforcePublicVisibility(frame) {
+    if (!frame.options.filter) {
+        frame.options.filter = 'visibility:public';
+    }
+}
+
 module.exports = {
     browse(apiConfig, frame) {
         debug('browse');
@@ -23,6 +29,7 @@ module.exports = {
 
         if (utils.isContentAPI(frame)) {
             setDefaultOrder(frame);
+            enforcePublicVisibility(frame);
         }
     },
 

--- a/ghost/core/core/server/models/tag-public.js
+++ b/ghost/core/core/server/models/tag-public.js
@@ -5,6 +5,19 @@ const TagPublic = tag.Tag.extend({
     shouldHavePosts: {
         joinTo: 'tag_id',
         joinTable: 'posts_tags'
+    },
+    enforcedFilters: function enforcedFilters(options) {
+        return options.context && options.context.public ? 'visibility:public' : null;
+    }
+}, {
+    permittedOptions: function permittedOptions(methodName) {
+        const options = tag.Tag.permittedOptions.call(this, methodName);
+
+        if (methodName === 'findOne') {
+            options.push('filter');
+        }
+
+        return options;
     }
 });
 

--- a/ghost/core/test/e2e-api/content/tags.test.js
+++ b/ghost/core/test/e2e-api/content/tags.test.js
@@ -155,4 +155,56 @@ describe('Tags Content API', function () {
         assert(getTag('/tag/bacon/'));
         assert(getTag('/tag/chorizo/'));
     });
+
+    describe('Internal tags are not exposed', function () {
+        const models = require('../../../core/server/models');
+
+        beforeAll(async function () {
+            // Internal tag (#) attached to a published post, with private code injection
+            await models.Post.add({
+                title: 'Post with an internal tag',
+                status: 'published',
+                tags: [{
+                    name: '#secret',
+                    codeinjection_head: '<script>/* private */</script>'
+                }]
+            }, testUtils.context.internal);
+        });
+
+        it('excludes internal tags from browse', async function () {
+            const res = await request.get(localUtils.API.getApiQuery(`tags/?limit=all&key=${validKey}`))
+                .set('Origin', testUtils.API.getURL())
+                .expect(200);
+
+            const internal = res.body.tags.filter(t => t.visibility === 'internal');
+            assert.deepEqual(internal, [], 'internal tags leaked via browse');
+        });
+
+        it('does not expose an internal tag via read by slug', async function () {
+            await request.get(localUtils.API.getApiQuery(`tags/slug/hash-secret/?key=${validKey}`))
+                .set('Origin', testUtils.API.getURL())
+                .expect(404);
+        });
+
+        it('cannot be widened by a caller-supplied visibility filter', async function () {
+            const res = await request.get(localUtils.API.getApiQuery(`tags/?limit=all&key=${validKey}&filter=visibility:internal`))
+                .set('Origin', testUtils.API.getURL())
+                .expect(200);
+
+            const internal = res.body.tags.filter(t => t.visibility === 'internal');
+            assert.deepEqual(internal, [], 'internal tags leaked via caller filter');
+        });
+
+        it('cannot select an internal tag directly via the filter param', async function () {
+            // Without the enforced override this filter matches the internal tag by slug
+            // and returns it; the override must exclude it.
+            const payload = encodeURIComponent('slug:hash-secret');
+            const res = await request.get(localUtils.API.getApiQuery(`tags/?limit=all&key=${validKey}&filter=${payload}`))
+                .set('Origin', testUtils.API.getURL())
+                .expect(200);
+
+            const internal = res.body.tags.filter(t => t.visibility === 'internal');
+            assert.deepEqual(internal, [], 'internal tags leaked via caller filter');
+        });
+    });
 });


### PR DESCRIPTION
## Why

Internal tags (any tag whose name starts with `#`, stored as `visibility: 'internal'`) are Ghost's mechanism for **hidden**, staff-only categorization — used for dynamic routing/collections, custom templates, and automation. They're deliberately excluded from every public surface: the `{{tags}}` helper, the RSS feed, frontend tag-page routing, and the sibling `search-index` Content API endpoint all filter `visibility:public`.

The **public Content API `/tags/` endpoint was the one path that didn't**. Both `browse` and `read` queried `TagPublic` with no visibility constraint, and nothing in the serializer or model layer compensated. As a result, any unauthenticated caller holding the (theme-embedded, effectively public) Content API key could enumerate internal tags — and, because the output cleaner doesn't strip them, read each internal tag's `codeinjection_head` / `codeinjection_foot`, where authors may keep private scripts, keys, or tracking snippets.

## What

Enforces `visibility:public` on the public Content API tags endpoint, bringing it in line with RSS, routing, and the search-index endpoint.

- **`TagPublic.enforcedFilters`** applies `visibility:public` as an NQL *override* whenever the request is on the public context. Because it's an override (not string concatenation), a caller-supplied `filter` cannot widen it back to internal — e.g. `?filter=visibility:internal` or `?filter=slug:hash-secret` still return nothing internal.
- **Input serializer** sets a default `visibility:public` filter on read when the caller supplied none. `findOne` only runs the filter plugin when a filter is present, so this is required to gate read-by-slug; caller-supplied filters are passed through untouched (never concatenated).
- **`permittedOptions`** is overridden on `TagPublic` (not the base `Tag` model) to allow `filter` on `findOne`, so the admin API and other `Tag` consumers are completely unaffected.

## Reproduction

1. In Admin, create a tag named `#secret` (auto-set to `visibility: internal`), add something to its Code injection → Tag header, and apply it to a **published** post.
2. Unauthenticated: `GET /ghost/api/content/tags/?key=<content-key>&limit=all` — the internal tag appears, including `codeinjection_head`. It's also directly fetchable at `/ghost/api/content/tags/slug/hash-secret/`.
3. After this change, both return nothing for the internal tag, matching RSS/routing/search-index.

## Testing

Added e2e coverage in `test/e2e-api/content/tags.test.js` (there were no internal-tag fixtures, which is why this went untested):

- internal tags excluded from `browse`
- internal tag `read` by slug returns 404
- a caller-supplied `visibility:internal` filter cannot widen the result
- a caller cannot select an internal tag directly via `?filter=slug:…`

Existing content **and** admin tags suites remain green (admin still returns internal tags, as it should).

---

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works
