### PR TITLE
Added types to mail error helper function

### DIFF
--- a/ghost/core/core/server/services/mail/ghost-mailer.js
+++ b/ghost/core/core/server/services/mail/ghost-mailer.js
@@ -82,6 +82,13 @@ function createMessage(message) {
     };
 }
 
+/**
+ * @param {object} [options]
+ * @param {string} [options.message]
+ * @param {Error} [options.err]
+ * @param {boolean} [options.ignoreDefaultMessage]
+ * @return {errors.EmailError}
+ */
 function createMailError({message, err, ignoreDefaultMessage} = {message: ''}) {
     const helpMessage = tpl(messages.checkEmailConfigInstructions, {url: 'https://ghost.org/docs/config/#mail'});
     const defaultErrorMessage = tpl(messages.failedSendingEmailError);


### PR DESCRIPTION
no ref

This is a types-only change that should have no user impact.
