### PR TITLE
Fixed lazy URL shadow-comparison errors from thin resources

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/users.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/users.js
@@ -2,8 +2,17 @@ const debug = require('@tryghost/debug')('api:endpoints:utils:serializers:input:
 const url = require('./utils/url');
 
 module.exports = {
+    browse(apiConfig, frame) {
+        debug('browse');
+
+        // Staff users route through the authors router types.
+        url.forceUrlColumnsWhenLazy(frame, 'authors');
+    },
+
     read(apiConfig, frame) {
         debug('read');
+
+        url.forceUrlColumnsWhenLazy(frame, 'authors');
 
         if (frame.data.id === 'me' && frame.options.context && frame.options.context.user) {
             frame.data.id = frame.options.context.user;

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/url.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/url.js
@@ -12,6 +12,16 @@ const forPost = (id, attrs, frame, type = 'posts') => {
     //
     // `id` is passed separately for the same reason: without it, the eager
     // facade's id-based fallback hits /404/ for every record.
+    //
+    // When `url` was not requested (`?fields=id,title`), don't compute it at
+    // all — attrs is stripped to the requested columns, so the resource would
+    // reach the lazy URL service without the fields it needs (status,
+    // tags/authors) and be rejected as thin. The value would only be deleted
+    // at the end of this function anyway. forUser/forTag guard the same way.
+    if (frame.options.columns && !frame.options.columns.includes('url')) {
+        return attrs;
+    }
+
     attrs.url = urlService.facade.getUrlForResource({...attrs, id, type}, {absolute: true});
 
     /**
@@ -42,10 +52,6 @@ const forPost = (id, attrs, frame, type = 'posts') => {
                 }, null, true);
             }
         }
-    }
-
-    if (frame.options.columns && !frame.options.columns.includes('url')) {
-        delete attrs.url;
     }
 
     return attrs;

--- a/ghost/core/core/server/services/audience-feedback/audience-feedback-controller.js
+++ b/ghost/core/core/server/services/audience-feedback/audience-feedback-controller.js
@@ -13,7 +13,7 @@ const messages = {
  * @prop {(feedback: Feedback) => Promise<void>} add
  * @prop {(feedback: Feedback) => Promise<void>} edit
  * @prop {(postId, memberId) => Promise<Feedback>} get
- * @prop {(id: string) => Promise<object|undefined>} getPostById
+ * @prop {(id: string, options?: object) => Promise<object|undefined>} getPostById
  * @prop {(postId: string, options?: object) => Promise<{data: object[], meta: object}>} getForPost
  */
 
@@ -40,14 +40,21 @@ class AudienceFeedbackController {
      * Authentication happens later when Portal submits to the feedback API — this
      * endpoint only forwards the uuid/key through to the destination.
      */
-    redirectToPost(req, res, next) {
+    async redirectToPost(req, res, next) {
         try {
             const {postId} = req.params;
             const score = req.params.score === '1' ? 1 : 0;
             const uuid = req.query.uuid;
             const key = req.query.key;
 
-            const target = this.#audienceFeedbackService.buildLink(uuid, {id: postId}, score, key);
+            // Load the full post (with tags/authors) rather than passing an
+            // id-only resource: the URL service needs status to apply the
+            // published base filter and tags/authors to evaluate filtered
+            // routes — the lazy backend rejects a bare {id} as thin.
+            const post = await this.#repository.getPostById(postId, {withRelated: ['tags', 'authors']});
+            const target = post
+                ? this.#audienceFeedbackService.buildLink(uuid, post, score, key)
+                : this.#audienceFeedbackService.buildFallbackLink(uuid, postId, score, key);
             return res.redirect(target.toString());
         } catch (err) {
             return next(err);

--- a/ghost/core/core/server/services/audience-feedback/audience-feedback-service.js
+++ b/ghost/core/core/server/services/audience-feedback/audience-feedback-service.js
@@ -17,7 +17,8 @@ class AudienceFeedbackService {
     }
     /**
      * @param {string} uuid
-     * @param {{id: string}} post
+     * @param {{id: string}} post - full post record (model or plain data);
+     *   the URL service needs its status/tags/authors to route it
      * @param {0 | 1} score
      * @param {string} key - hashed uuid value
      */
@@ -28,8 +29,33 @@ class AudienceFeedbackService {
         if (postUrl.match(/\/404\//)) {
             postUrl = this.#baseURL;
         }
-        const url = new URL(postUrl);
-        url.hash = `#/feedback/${postData.id}/${score}/?uuid=${encodeURIComponent(uuid)}&key=${encodeURIComponent(key)}`;
+        return this.#withFeedbackHash(new URL(postUrl), postData.id, score, uuid, key);
+    }
+
+    /**
+     * Feedback link for a post that no longer exists. Goes straight to the
+     * home page — the same destination buildLink picks when the URL service
+     * has no URL for the post — without asking the URL service: an id-only
+     * resource can't be routed (the lazy backend rejects it as thin).
+     *
+     * @param {string} uuid
+     * @param {string} postId
+     * @param {0 | 1} score
+     * @param {string} key - hashed uuid value
+     */
+    buildFallbackLink(uuid, postId, score, key) {
+        return this.#withFeedbackHash(new URL(this.#baseURL), postId, score, uuid, key);
+    }
+
+    /**
+     * @param {URL} url
+     * @param {string} postId
+     * @param {0 | 1} score
+     * @param {string} uuid
+     * @param {string} key
+     */
+    #withFeedbackHash(url, postId, score, uuid, key) {
+        url.hash = `#/feedback/${postId}/${score}/?uuid=${encodeURIComponent(uuid)}&key=${encodeURIComponent(key)}`;
         return url;
     }
 

--- a/ghost/core/core/server/services/audience-feedback/feedback-repository.js
+++ b/ghost/core/core/server/services/audience-feedback/feedback-repository.js
@@ -61,8 +61,8 @@ module.exports = class FeedbackRepository {
         return await this.#Member.findOne({uuid});
     }
 
-    async getPostById(id) {
-        return await this.#Post.findOne({id, status: 'all'});
+    async getPostById(id, options = {}) {
+        return await this.#Post.findOne({id, status: 'all'}, options);
     }
 
     async getForPost(postId, options = {}) {

--- a/ghost/core/test/e2e-api/members/feedback.test.js
+++ b/ghost/core/test/e2e-api/members/feedback.test.js
@@ -355,4 +355,24 @@ describe('Members Feedback', function () {
         assert.equal(body3.feedback[0].score, 1);
         assert.equal(model3.get('updated_at').getTime(), model2.get('updated_at').getTime());
     });
+
+    describe('Redirect link', function () {
+        it('redirects to the post url with the feedback fragment', async function () {
+            const post = fixtureManager.get('posts', 0);
+
+            await membersAgent
+                .get(`/feedback/${post.id}/1/?uuid=${memberUuid}&key=${memberHmac}`)
+                .expectStatus(302)
+                .expectHeader('Location', new RegExp(`/${post.slug}/#/feedback/${post.id}/1/`));
+        });
+
+        it('redirects to the home page when the post no longer exists', async function () {
+            const unknownPostId = '5951f5fca366002ebd5dbef7';
+
+            await membersAgent
+                .get(`/feedback/${unknownPostId}/0/?uuid=${memberUuid}&key=${memberHmac}`)
+                .expectStatus(302)
+                .expectHeader('Location', new RegExp(`/#/feedback/${unknownPostId}/0/`));
+        });
+    });
 });

--- a/ghost/core/test/unit/api/canary/utils/serializers/input/users.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/input/users.test.js
@@ -1,0 +1,35 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const urlService = require('../../../../../../../core/server/services/url');
+const serializers = require('../../../../../../../core/server/api/endpoints/utils/serializers');
+
+describe('Unit: endpoints/utils/serializers/input/users', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('browse', function () {
+        it('forces the lazy-required author columns into the fetch when url is requested', function () {
+            // Staff users route through the authors router types; without
+            // this, `?fields=url` strips the permalink columns (slug) and the
+            // lazy URL service generates /author/undefined/.
+            sinon.stub(urlService.facade, 'getRequiredFields').withArgs('authors').returns(['slug']);
+            const frame = {options: {columns: ['url', 'id']}};
+
+            serializers.input.users.browse({}, frame);
+
+            assert.deepEqual(frame.options.columns, ['url', 'id', 'slug']);
+        });
+    });
+
+    describe('read', function () {
+        it('forces the lazy-required author columns into the fetch when url is requested', function () {
+            sinon.stub(urlService.facade, 'getRequiredFields').withArgs('authors').returns(['slug']);
+            const frame = {data: {}, options: {columns: ['url', 'id']}};
+
+            serializers.input.users.read({}, frame);
+
+            assert.deepEqual(frame.options.columns, ['url', 'id', 'slug']);
+        });
+    });
+});

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/utils/url.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/utils/url.test.js
@@ -78,6 +78,32 @@ describe('Unit: endpoints/utils/serializers/output/utils/url', function () {
             assert.equal(resource.type, 'pages');
         });
 
+        it('skips url generation when columns excludes url', function () {
+            // A `?fields=id,title` request strips attrs to those columns, so
+            // the resource reaches the URL service without the fields the lazy
+            // backend needs (status for the base filter, tags/authors for
+            // filtered routers) — it throws LAZY_URL_THIN_RESOURCE, which the
+            // compare-mode facade reports as LAZY_URL_COMPARE_ERROR on every
+            // such request. The URL was computed only to be deleted below
+            // anyway, so don't compute it at all (forUser/forTag already
+            // guard like this).
+            const stripped = {id: 'post-id', title: 'Title'};
+
+            const attrs = urlUtil.forPost('post-id', stripped, {options: {columns: ['id', 'title']}});
+
+            sinon.assert.notCalled(getUrlForResourceStub);
+            assert.equal(Object.hasOwn(attrs, 'url'), false);
+        });
+
+        it('generates url when columns includes url', function () {
+            const stripped = {id: 'post-id', status: 'published'};
+
+            const attrs = urlUtil.forPost('post-id', stripped, {options: {columns: ['id', 'url']}});
+
+            sinon.assert.calledOnce(getUrlForResourceStub);
+            assert.equal(attrs.url, 'getUrlForResource');
+        });
+
         it('defaults to posts when no type is passed', function () {
             // Other callers of forPost (comments mapper, activity-feed-events)
             // pass post records and rely on the default.

--- a/ghost/core/test/unit/server/services/audience-feedback/audience-feedback-controller.test.js
+++ b/ghost/core/test/unit/server/services/audience-feedback/audience-feedback-controller.test.js
@@ -7,47 +7,77 @@ describe('AudienceFeedbackController', function () {
         const uuid = '7b11de3c-dff9-4563-82ae-a281122d201d';
         const key = 'a'.repeat(64);
 
-        function createController(buildLink) {
+        function createController({buildLink, buildFallbackLink, getPostById}) {
             return new AudienceFeedbackController({
-                repository: {},
-                audienceFeedbackService: {buildLink}
+                repository: {getPostById},
+                audienceFeedbackService: {buildLink, buildFallbackLink}
             });
         }
 
-        it('resolves the post by id and redirects to the feedback flow', function () {
+        it('loads the full post and redirects to the feedback flow', async function () {
+            // The URL service needs a full post record (status for the base
+            // filter, tags/authors for filtered routes) — an id-only resource
+            // is rejected as thin by the lazy backend.
+            const post = {id: postId, status: 'published'};
+            const getPostById = sinon.stub().resolves(post);
             const buildLink = sinon.stub().returns(
                 new URL(`https://site.com/current-slug/#/feedback/${postId}/1/?uuid=${uuid}&key=${key}`)
             );
-            const controller = createController(buildLink);
+            const controller = createController({buildLink, getPostById});
             const req = {params: {postId, score: '1'}, query: {uuid, key}};
             const res = {redirect: sinon.fake()};
 
-            controller.redirectToPost(req, res, () => {});
+            await controller.redirectToPost(req, res, () => {});
 
-            sinon.assert.calledOnceWithExactly(buildLink, uuid, {id: postId}, 1, key);
+            sinon.assert.calledOnceWithExactly(getPostById, postId, {withRelated: ['tags', 'authors']});
+            sinon.assert.calledOnceWithExactly(buildLink, uuid, post, 1, key);
             sinon.assert.calledOnceWithExactly(
                 res.redirect,
                 `https://site.com/current-slug/#/feedback/${postId}/1/?uuid=${uuid}&key=${key}`
             );
         });
 
-        it('coerces any non-"1" score to 0', function () {
-            const buildLink = sinon.stub().returns(new URL('https://site.com/'));
-            const controller = createController(buildLink);
-            const req = {params: {postId, score: 'bogus'}, query: {uuid, key}};
-            controller.redirectToPost(req, {redirect: sinon.fake()}, () => {});
+        it('falls back to the home page link when the post no longer exists', async function () {
+            const getPostById = sinon.stub().resolves(null);
+            const buildLink = sinon.stub();
+            const buildFallbackLink = sinon.stub().returns(
+                new URL(`https://site.com/#/feedback/${postId}/1/?uuid=${uuid}&key=${key}`)
+            );
+            const controller = createController({buildLink, buildFallbackLink, getPostById});
+            const req = {params: {postId, score: '1'}, query: {uuid, key}};
+            const res = {redirect: sinon.fake()};
 
-            sinon.assert.calledOnceWithExactly(buildLink, uuid, {id: postId}, 0, key);
+            await controller.redirectToPost(req, res, () => {});
+
+            sinon.assert.notCalled(buildLink);
+            sinon.assert.calledOnceWithExactly(buildFallbackLink, uuid, postId, 1, key);
+            sinon.assert.calledOnceWithExactly(
+                res.redirect,
+                `https://site.com/#/feedback/${postId}/1/?uuid=${uuid}&key=${key}`
+            );
         });
 
-        it('forwards errors to next', function () {
+        it('coerces any non-"1" score to 0', async function () {
+            const post = {id: postId, status: 'published'};
+            const getPostById = sinon.stub().resolves(post);
+            const buildLink = sinon.stub().returns(new URL('https://site.com/'));
+            const controller = createController({buildLink, getPostById});
+            const req = {params: {postId, score: 'bogus'}, query: {uuid, key}};
+
+            await controller.redirectToPost(req, {redirect: sinon.fake()}, () => {});
+
+            sinon.assert.calledOnceWithExactly(buildLink, uuid, post, 0, key);
+        });
+
+        it('forwards errors to next', async function () {
             const error = new Error('boom');
-            const buildLink = sinon.stub().throws(error);
-            const controller = createController(buildLink);
+            const getPostById = sinon.stub().rejects(error);
+            const buildLink = sinon.stub();
+            const controller = createController({buildLink, getPostById});
             const next = sinon.fake();
             const res = {redirect: sinon.fake()};
 
-            controller.redirectToPost({params: {postId, score: '1'}, query: {}}, res, next);
+            await controller.redirectToPost({params: {postId, score: '1'}, query: {}}, res, next);
 
             sinon.assert.notCalled(res.redirect);
             sinon.assert.calledOnceWithExactly(next, error);

--- a/ghost/core/test/unit/server/services/audience-feedback/audience-feedback-service.test.js
+++ b/ghost/core/test/unit/server/services/audience-feedback/audience-feedback-service.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const sinon = require('sinon');
 const AudienceFeedbackService = require('../../../../../core/server/services/audience-feedback/audience-feedback-service');
 
 describe('audienceFeedbackService', function () {
@@ -98,6 +99,26 @@ describe('audienceFeedbackService', function () {
             // The hash fragment also depends on the post id, so the same bug
             // would surface in the produced URL.
             assert.match(link.href, new RegExp(`#/feedback/${mockData.postId}/`));
+        });
+    });
+
+    describe('build fallback link', function () {
+        it('builds the home-page feedback link without touching the url service', async function () {
+            // Used when the post no longer exists: an id-only resource can't
+            // be routed by the URL service (the lazy backend rejects it as
+            // thin), so the fallback goes straight to the base URL — the same
+            // destination buildLink picks when the service returns /404/.
+            const getUrlForResource = sinon.stub();
+            const instance = new AudienceFeedbackService({
+                urlService: {facade: {getUrlForResource}},
+                config: {baseURL: new URL('https://localhost:2368')}
+            });
+
+            const link = instance.buildFallbackLink(mockData.uuid, mockData.postId, mockData.score, mockData.key);
+
+            sinon.assert.notCalled(getUrlForResource);
+            const expectedLink = `https://localhost:2368/#/feedback/${mockData.postId}/${mockData.score}/?uuid=${mockData.uuid}&key=${mockData.key}`;
+            assert.equal(link.href, expectedLink);
         });
     });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1822/monitor-shadow-comparison-and-address-mismatches

## Problem

Production is logging ~25k `LAZY_URL_COMPARE_ERROR` ("Lazy URL service threw during comparison") events across 169 sites. The error details all have the shape:

```json
{"resourceType":"posts","resourceId":"...","baseFilter":"status:published+type:post","missing":["status"]}
```

i.e. the lazy backend's `_assertBaseFieldsPresent` rejecting a resource that reaches `getUrlForResource` without the `status` column, wrapped by the compare-mode facade. Eager stays authoritative so there's no user impact, but the noise drowns out real parity signals.

Two call sites were handing the URL service thin resources:

1. **Output serializer `forPost`** — computed `attrs.url` for *every* post/page API response and only deleted it afterwards when `?fields=`/`columns` excluded `url`. With narrowed fields the attrs carry no `status` (or tags/authors), so the lazy shadow threw on every such request. `forceUrlColumnsWhenLazy` only covers the case where `url` *is* requested.
2. **Feedback redirect endpoint** (`/members/feedback/:postId/:score`) — built its redirect from a bare `{id: postId}` resource, so every newsletter feedback-button click threw in the lazy shadow. This explains the recurring per-post counts in the logs.

A sweep of the remaining `getUrlForResource`/`ownsResource`/`resolveUrl` callers also turned up a staff-users gap: `?fields=url` on users browse/read strips `slug`, so lazy generates `/author/undefined/` — a `LAZY_URL_PARITY_MISMATCH` rather than a throw.

## Solution

- `forPost` now skips URL generation entirely when `url` was not requested, matching the guards `forUser`/`forTag` already have (also saves wasted work under eager).
- The feedback redirect controller loads the full post (`withRelated: tags, authors`) before building the link, and uses a new `buildFallbackLink` (home page + feedback fragment, no URL service involved) when the post no longer exists — same destination `buildLink` picks when the URL service returns `/404/`.
- The users input serializer forces the lazy-required author columns into the fetch when `url` is requested, mirroring the authors serializers.

All other `getUrlForResource` callers (slack, indexnow, comments emails, member attribution, activity feed, RSS, previews, email-post, meta/url, theme helpers) already pass fully-loaded models.

## Testing

- Red/green TDD: each fix has unit tests that failed against the old behaviour.
- New e2e coverage for the feedback redirect endpoint (302 → post URL, 302 → home for a deleted post) — it previously had none.
- Full ghost/core unit suite (7180 tests) and the members feedback e2e suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)