### PR TITLE
🐛 Fixed unreadable tag & author colours with light accent colours

### DIFF
--- a/ghost/admin/app/styles/components/power-select.css
+++ b/ghost/admin/app/styles/components/power-select.css
@@ -382,7 +382,7 @@
 
 .tag-token:not(.tag-token--internal) {
     position: relative;
-    color: var(--accent-color);
+    color: var(--adjusted-accent-color);
     background: none;
 }
 
@@ -405,8 +405,8 @@
 }
 
 .tag-token svg path {
-    stroke: var(--accent-color);
-    fill: var(--accent-color);
+    stroke: var(--adjusted-accent-color);
+    fill: var(--adjusted-accent-color);
 }
 
 .tag-token--internal svg path {
@@ -417,7 +417,7 @@
 
 #author-list ul li:first-of-type {
     position: relative;
-    color: var(--accent-color);
+    color: var(--adjusted-accent-color);
     background: none;
 }
 
@@ -440,8 +440,8 @@
 }
 
 #author-list ul li:first-of-type svg path {
-    stroke: var(--accent-color);
-    fill: var(--accent-color);
+    stroke: var(--adjusted-accent-color);
+    fill: var(--adjusted-accent-color);
 }
 
 /* Segment input */


### PR DESCRIPTION
Closes https://linear.app/ghost/issue/DES-1231/post-tags-in-admin-inheriting-site-brand-styles

Tags and authors in the post settings sidebar are rendered using the site's accent colour. The text and icon used the raw accent colour, so when a site has a light accent colour the labels became washed out and hard to read against the tinted background.

| Before | After |
|--------|--------|
| <img width="442" height="504" alt="Screenshot 2026-07-06 at 08 54 32" src="https://github.com/user-attachments/assets/5c8bfc46-3815-4521-8115-5880deb4d8c5" /> | <img width="451" height="503" alt="Screenshot 2026-07-06 at 08 54 09" src="https://github.com/user-attachments/assets/00334e47-ffe3-40eb-978f-b1c32facb4c6" /> | 