### PR TITLE
🐛 Fixed post card assets going missing until restart (minimal disk recovery)

### DIFF
--- a/ghost/core/core/frontend/services/assets-minification/assets-minification-base.js
+++ b/ghost/core/core/frontend/services/assets-minification/assets-minification-base.js
@@ -1,6 +1,10 @@
 const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
 
+// Minimum time between build attempts so a persistently failing or
+// non-producing build doesn't add minification cost to every request.
+const BUILD_MIN_INTERVAL_MS = 10000;
+
 module.exports = class AssetsMinificationBase {
     minifier;
 
@@ -9,11 +13,23 @@ module.exports = class AssetsMinificationBase {
 
     constructor(options = {}) {
         this.options = options;
+        this.generation = 0;
+        this.lastBuildSettledAt = 0;
+        this.lastBuildError = null;
     }
 
     invalidate() {
+        this.generation += 1;
         this.ready = false;
-        this.loading = null;
+        // Deliberately do NOT clear `this.loading` here — nulling it while a
+        // build is in flight would let a second concurrent minifier run
+        // interleave writes on the same files. ensureLoaded() re-runs load()
+        // once the in-flight build settles (see the generation loop).
+        //
+        // Resetting the settle clock makes the next build happen immediately
+        // (e.g. on theme switch) despite the retry backoff.
+        this.lastBuildSettledAt = 0;
+        this.lastBuildError = null;
     }
 
     generateGlobs() {
@@ -43,6 +59,49 @@ module.exports = class AssetsMinificationBase {
         }
     }
 
+    /**
+     * Ensure a build has run (or is running), applying all rebuild policy in
+     * one place: single-flight (concurrent callers share one build), a retry
+     * backoff after a settled build, and re-running the build when it is
+     * invalidated mid-flight.
+     *
+     * The backoff also covers builds that resolve without producing assets
+     * (e.g. EACCES is swallowed by minify() and `ready` stays false): callers
+     * checking `!this.ready` on every request won't trigger a minification
+     * run per request.
+     *
+     * @returns {Promise<void>} resolves when the build settles; rejects with
+     * the build error (stored errors are re-thrown within the backoff window)
+     */
+    ensureLoaded() {
+        if (this.loading) {
+            return this.loading;
+        }
+
+        if (this.lastBuildSettledAt && Date.now() - this.lastBuildSettledAt < BUILD_MIN_INTERVAL_MS) {
+            return this.lastBuildError ? Promise.reject(this.lastBuildError) : Promise.resolve();
+        }
+
+        const pending = (async () => {
+            let generation;
+            do {
+                generation = this.generation;
+                await this.load();
+            } while (generation !== this.generation);
+            this.lastBuildError = null;
+        })().catch((error) => {
+            this.lastBuildError = error;
+            throw error;
+        }).finally(() => {
+            this.lastBuildSettledAt = Date.now();
+            if (this.loading === pending) {
+                this.loading = null;
+            }
+        });
+        this.loading = pending;
+        return pending;
+    }
+
     serveMiddleware() {
         const self = this;
         /**
@@ -52,15 +111,15 @@ module.exports = class AssetsMinificationBase {
          */
         return async function serveMiddleware(req, res, next) {
             if (!self.ready) {
-                if (!self.loading) {
-                    const pending = self.load().finally(() => {
-                        if (self.loading === pending) {
-                            self.loading = null;
-                        }
-                    });
-                    self.loading = pending;
+                try {
+                    await self.ensureLoaded();
+                } catch (error) {
+                    // A failed build must not block the request — the rejection
+                    // would escape the async handler and hang the request under
+                    // Express 4. Downstream middleware serves the previous
+                    // build or 404s.
+                    logging.error(error);
                 }
-                await self.loading;
             }
 
             next();

--- a/ghost/core/core/frontend/services/assets-minification/minifier.js
+++ b/ghost/core/core/frontend/services/assets-minification/minifier.js
@@ -129,8 +129,20 @@ class Minifier {
             let writePath = this.getFullDest(dest);
             // Ensure the output folder exists
             await fs.mkdir(this.destPath, {recursive: true});
-            // Create the file
-            await fs.writeFile(writePath, contents);
+            // Write to a temporary file in the same directory, then rename it
+            // into place. A rename within a directory atomically replaces the
+            // destination, so concurrent readers see either the old or the new
+            // complete file — never a partially written one.
+            const tmpPath = `${writePath}.${process.pid}.${Math.random().toString(36).slice(2)}.tmp`;
+            try {
+                await fs.writeFile(tmpPath, contents);
+                await fs.rename(tmpPath, writePath);
+            } catch (error) {
+                // Best-effort cleanup of the temporary file — the original
+                // error is what matters to the caller
+                await fs.unlink(tmpPath).catch(() => {});
+                throw error;
+            }
             return writePath;
         }
     }

--- a/ghost/core/core/frontend/web/routers/serve-public-file.js
+++ b/ghost/core/core/frontend/web/routers/serve-public-file.js
@@ -2,6 +2,7 @@ const crypto = require('crypto');
 const fs = require('fs-extra');
 const path = require('path');
 const errors = require('@tryghost/errors');
+const logging = require('@tryghost/logging');
 const config = require('../../../shared/config');
 const urlUtils = require('../../../shared/url-utils');
 const tpl = require('@tryghost/tpl');
@@ -65,16 +66,42 @@ function createPublicFileMiddleware(location, file, mime, maxAge, options = {}) 
             });
         }
 
+        // Read the file from disk. If a built (runtime-generated) file has
+        // gone missing, ask the owning service to rebuild it once and retry
+        // the read — all rebuild policy (single-flight, backoff) lives on the
+        // service, not here.
+        async function readFileWithRebuild() {
+            try {
+                return await fs.readFile(filePath);
+            } catch (err) {
+                if (err.code !== 'ENOENT' || !options.rebuild || location !== 'built') {
+                    throw err;
+                }
+
+                try {
+                    await options.rebuild();
+                } catch (rebuildError) {
+                    logging.error(rebuildError);
+                }
+
+                return await fs.readFile(filePath);
+            }
+        }
+
         // modify text files before caching+serving to ensure URL placeholders are transformed
-        fs.readFile(filePath, (err, buf) => {
-            if (err) {
+        (async function readAndServe() {
+            let buf;
+
+            try {
+                buf = await readFileWithRebuild();
+            } catch (err) {
                 // Downgrade to a simple 404 if the file didn't exist
                 if (err.code === 'ENOENT') {
-                    err = new errors.NotFoundError({
+                    return next(new errors.NotFoundError({
                         message: tpl(messages.fileNotFound),
                         code: 'PUBLIC_FILE_NOT_FOUND',
                         property: err.path
-                    });
+                    }));
                 }
                 return next(err);
             }
@@ -85,7 +112,7 @@ function createPublicFileMiddleware(location, file, mime, maxAge, options = {}) 
                 str = str.replace(blogRegex, urlUtils.urlFor('home', true).replace(/\/$/, ''));
             }
 
-            cache = {
+            const servedFile = {
                 headers: {
                     'Content-Type': mime,
                     'Content-Length': Buffer.from(str).length,
@@ -96,9 +123,18 @@ function createPublicFileMiddleware(location, file, mime, maxAge, options = {}) 
                 key: req.query && req.query.v ? req.query.v : null
             };
 
-            res.writeHead(200, cache.headers);
-            res.end(cache.body);
-        });
+            // Built files are generated (and re-generated) at runtime, so they
+            // must not be pinned in this permanent in-memory cache — a torn or
+            // stale read would otherwise be served until restart. They are
+            // re-read from disk per request (page-cache-warm, small files);
+            // ETag/Cache-Control still enable client/CDN caching.
+            if (location !== 'built') {
+                cache = servedFile;
+            }
+
+            res.writeHead(200, servedFile.headers);
+            res.end(servedFile.body);
+        })().catch(next);
     };
 }
 
@@ -128,8 +164,12 @@ function servePublicFiles(siteApp) {
     siteApp.get('/public/ghost-stats.min.js', createPublicFileMiddleware('static', 'public/ghost-stats.min.js', 'application/javascript', config.get('caching:publicAssets:maxAge')));
 
     // Card assets (built on the fly)
-    siteApp.get('/public/cards.min.css', cardAssets.serveMiddleware(), createPublicFileMiddleware('built', 'public/cards.min.css', 'text/css', config.get('caching:publicAssets:maxAge')));
-    siteApp.get('/public/cards.min.js', cardAssets.serveMiddleware(), createPublicFileMiddleware('built', 'public/cards.min.js', 'application/javascript', config.get('caching:publicAssets:maxAge')));
+    // Only rebuild when the build is expected to produce the file — a theme
+    // whose card config legitimately yields no output must 404 fast instead
+    // of triggering a rebuild per request.
+    const rebuildCardAssets = type => () => (cardAssets.hasFile(type) ? cardAssets.ensureLoaded() : Promise.resolve());
+    siteApp.get('/public/cards.min.css', cardAssets.serveMiddleware(), createPublicFileMiddleware('built', 'public/cards.min.css', 'text/css', config.get('caching:publicAssets:maxAge'), {rebuild: rebuildCardAssets('css')}));
+    siteApp.get('/public/cards.min.js', cardAssets.serveMiddleware(), createPublicFileMiddleware('built', 'public/cards.min.js', 'application/javascript', config.get('caching:publicAssets:maxAge'), {rebuild: rebuildCardAssets('js')}));
 
     // Comment counts
     siteApp.get('/public/comment-counts.min.js', createPublicFileMiddleware('static', 'public/comment-counts.min.js', 'application/javascript', config.get('caching:publicAssets:maxAge')));

--- a/ghost/core/test/unit/frontend/services/assets-minification/assets-minification-base.test.js
+++ b/ghost/core/test/unit/frontend/services/assets-minification/assets-minification-base.test.js
@@ -3,7 +3,10 @@ const sinon = require('sinon');
 const path = require('path');
 const fs = require('fs').promises;
 const os = require('os');
+const logging = require('@tryghost/logging');
 const AssetsMinificationBase = require('../../../../../core/frontend/services/assets-minification/assets-minification-base');
+
+const BUILD_MIN_INTERVAL_MS = 10000;
 
 describe('AssetsMinificationBase', function () {
     let testDir;
@@ -18,6 +21,184 @@ describe('AssetsMinificationBase', function () {
 
     afterEach(function () {
         sinon.restore();
+    });
+
+    describe('ensureLoaded', function () {
+        it('joins an in-flight build: concurrent callers share one load()', async function () {
+            let loadCallCount = 0;
+
+            class TestAssets extends AssetsMinificationBase {
+                async load() {
+                    loadCallCount += 1;
+                    await new Promise((resolve) => {
+                        setTimeout(resolve, 50);
+                    });
+                    this.ready = true;
+                }
+            }
+
+            const assets = new TestAssets();
+
+            await Promise.all([
+                assets.ensureLoaded(),
+                assets.ensureLoaded(),
+                assets.ensureLoaded()
+            ]);
+
+            assert.equal(loadCallCount, 1, 'load() should be called exactly once');
+        });
+
+        it('does not rebuild within the backoff window after a failed build and rejects with the stored error', async function () {
+            const clock = sinon.useFakeTimers({now: 1000000, toFake: ['Date']});
+            let loadCallCount = 0;
+            const buildError = new Error('build failed');
+
+            class TestAssets extends AssetsMinificationBase {
+                async load() {
+                    loadCallCount += 1;
+                    throw buildError;
+                }
+            }
+
+            const assets = new TestAssets();
+
+            await assert.rejects(() => assets.ensureLoaded(), buildError);
+            assert.equal(loadCallCount, 1);
+
+            // Within the backoff window: no build, rejects with the stored error
+            clock.tick(BUILD_MIN_INTERVAL_MS - 1);
+            await assert.rejects(() => assets.ensureLoaded(), buildError);
+            assert.equal(loadCallCount, 1, 'load() should not be called within the backoff window');
+
+            // After the window has elapsed a new build runs
+            clock.tick(2);
+            await assert.rejects(() => assets.ensureLoaded(), buildError);
+            assert.equal(loadCallCount, 2, 'load() should run again once the backoff has expired');
+        });
+
+        it('does not rebuild within the backoff window after a resolved-but-not-ready build (EACCES-style)', async function () {
+            const clock = sinon.useFakeTimers({now: 1000000, toFake: ['Date']});
+            let loadCallCount = 0;
+
+            class TestAssets extends AssetsMinificationBase {
+                async load() {
+                    loadCallCount += 1;
+                    // resolves, but ready stays false — mirrors minify()
+                    // swallowing EACCES
+                }
+            }
+
+            const assets = new TestAssets();
+
+            await assets.ensureLoaded();
+            assert.equal(loadCallCount, 1);
+            assert.equal(assets.ready, false);
+
+            clock.tick(BUILD_MIN_INTERVAL_MS - 1);
+            await assets.ensureLoaded();
+            assert.equal(loadCallCount, 1, 'load() should not be called within the backoff window');
+
+            clock.tick(2);
+            await assets.ensureLoaded();
+            assert.equal(loadCallCount, 2);
+        });
+
+        it('invalidate() resets the backoff so the next ensureLoaded() builds immediately', async function () {
+            sinon.useFakeTimers({now: 1000000, toFake: ['Date']});
+            let loadCallCount = 0;
+
+            class TestAssets extends AssetsMinificationBase {
+                async load() {
+                    loadCallCount += 1;
+                    if (loadCallCount === 1) {
+                        throw new Error('build failed');
+                    }
+                    this.ready = true;
+                }
+            }
+
+            const assets = new TestAssets();
+
+            await assert.rejects(() => assets.ensureLoaded());
+            assert.equal(loadCallCount, 1);
+
+            assets.invalidate();
+
+            await assets.ensureLoaded();
+            assert.equal(loadCallCount, 2, 'load() should run immediately after invalidate()');
+            assert.equal(assets.ready, true);
+        });
+
+        it('re-runs load() when invalidate() happens during an in-flight build, without concurrent loads', async function () {
+            let loadCallCount = 0;
+            let concurrentLoads = 0;
+            let maxConcurrentLoads = 0;
+            let resolveFirstLoad;
+
+            class TestAssets extends AssetsMinificationBase {
+                async load() {
+                    loadCallCount += 1;
+                    concurrentLoads += 1;
+                    maxConcurrentLoads = Math.max(maxConcurrentLoads, concurrentLoads);
+                    try {
+                        if (loadCallCount === 1) {
+                            await new Promise((resolve) => {
+                                resolveFirstLoad = resolve;
+                            });
+                        }
+                        this.ready = true;
+                    } finally {
+                        concurrentLoads -= 1;
+                    }
+                }
+            }
+
+            const assets = new TestAssets();
+
+            // First build starts and hangs
+            const firstBuild = assets.ensureLoaded();
+
+            // Theme switch mid-build: generation bumps, loading is kept
+            assets.invalidate();
+
+            // A caller arriving now joins the same in-flight build
+            const secondCaller = assets.ensureLoaded();
+            assert.equal(secondCaller, firstBuild, 'concurrent caller should join the in-flight build');
+
+            resolveFirstLoad();
+            await firstBuild;
+            await secondCaller;
+
+            assert.equal(loadCallCount, 2, 'load() should re-run after the mid-flight invalidation');
+            assert.equal(maxConcurrentLoads, 1, 'two loads should never run concurrently');
+            assert.equal(assets.ready, true);
+        });
+
+        it('clears loading after the build settles', async function () {
+            class TestAssets extends AssetsMinificationBase {
+                async load() {
+                    this.ready = true;
+                }
+            }
+
+            const assets = new TestAssets();
+            await assets.ensureLoaded();
+
+            assert.equal(assets.loading, null);
+        });
+
+        it('clears loading even when the build fails', async function () {
+            class TestAssets extends AssetsMinificationBase {
+                async load() {
+                    throw new Error('load failed');
+                }
+            }
+
+            const assets = new TestAssets();
+            await assert.rejects(() => assets.ensureLoaded());
+
+            assert.equal(assets.loading, null);
+        });
     });
 
     describe('serveMiddleware', function () {
@@ -139,19 +320,13 @@ describe('AssetsMinificationBase', function () {
             assert.equal(loadCallCount, 2);
         });
 
-        it('does not clobber a new loading promise when invalidate() is called mid-flight', async function () {
-            let loadCallCount = 0;
-            let resolveFirstLoad;
+        it('continues the request and logs when load() rejects', async function () {
+            const loggingStub = sinon.stub(logging, 'error');
+            const buildError = new Error('load failed');
 
             class TestAssets extends AssetsMinificationBase {
                 async load() {
-                    loadCallCount += 1;
-                    if (loadCallCount === 1) {
-                        await new Promise((resolve) => {
-                            resolveFirstLoad = resolve;
-                        });
-                    }
-                    this.ready = true;
+                    throw buildError;
                 }
             }
 
@@ -159,60 +334,13 @@ describe('AssetsMinificationBase', function () {
             const middleware = assets.serveMiddleware();
             const next = sinon.stub();
 
-            // First request starts load, which hangs
-            const firstRequest = middleware({}, {}, next);
-
-            // invalidate() mid-flight: clears loading and ready
-            assets.invalidate();
-
-            // Second request starts a new load since loading was cleared
-            const secondRequest = middleware({}, {}, next);
-
-            // First load settles — its .finally() must NOT clobber the second load
-            resolveFirstLoad();
-            await firstRequest;
-            await secondRequest;
-
-            assert.equal(loadCallCount, 2, 'load() should be called twice (once per invalidation cycle)');
-            sinon.assert.calledTwice(next);
-        });
-
-        it('clears loading promise after load() completes', async function () {
-            class TestAssets extends AssetsMinificationBase {
-                async load() {
-                    this.ready = true;
-                }
-            }
-
-            const assets = new TestAssets();
-            const middleware = assets.serveMiddleware();
-            const next = sinon.stub();
-
+            // Must not reject — a rejection would hang the request under Express 4
             await middleware({}, {}, next);
 
-            assert.equal(assets.loading, null);
-        });
-
-        it('clears loading promise even when load() throws', async function () {
-            let shouldThrow = true;
-
-            class TestAssets extends AssetsMinificationBase {
-                async load() {
-                    if (shouldThrow) {
-                        shouldThrow = false;
-                        throw new Error('load failed');
-                    }
-                    this.ready = true;
-                }
-            }
-
-            const assets = new TestAssets();
-            const middleware = assets.serveMiddleware();
-            const next = sinon.stub();
-
-            await assert.rejects(() => middleware({}, {}, next));
-
-            assert.equal(assets.loading, null);
+            sinon.assert.calledOnce(next);
+            assert.equal(next.firstCall.args.length, 0, 'next() should be called without an error');
+            sinon.assert.calledOnceWithExactly(loggingStub, buildError);
+            assert.equal(assets.loading, null, 'loading should be cleared after the build settles');
         });
     });
 });

--- a/ghost/core/test/unit/frontend/services/assets-minification/minifier.test.js
+++ b/ghost/core/test/unit/frontend/services/assets-minification/minifier.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const sinon = require('sinon');
 const {assertExists} = require('../../../../utils/assertions');
 
 const path = require('path');
@@ -30,6 +31,10 @@ describe('Minifier', function () {
 
     afterAll(async function () {
         await fs.rm(testDir, {recursive: true, force: true});
+    });
+
+    afterEach(function () {
+        sinon.restore();
     });
 
     describe('getMatchingFiles expands globs correctly', function () {
@@ -94,6 +99,60 @@ describe('Minifier', function () {
 
             assert(Array.isArray(result));
             assert.equal(result.length, 2);
+        });
+
+        it('writes the destination file with the minified content', async function () {
+            const result = await minifier.minify({
+                'content-check.min.css': 'css/*.css'
+            });
+
+            assert.deepEqual(result, ['content-check.min.css']);
+
+            const content = await fs.readFile(minifier.getFullDest('content-check.min.css'), 'utf8');
+            assert(content.length > 0, 'destination file should not be empty');
+            assert.match(content, /\.kg-/, 'destination file should contain the minified css');
+        });
+
+        it('keeps the previous destination content and cleans up the temp file when the write fails', async function () {
+            // First build succeeds
+            await minifier.minify({
+                'stable.min.css': 'css/*.css'
+            });
+            const before = await fs.readFile(minifier.getFullDest('stable.min.css'), 'utf8');
+
+            // Second build fails at the rename step (after the temp file is written)
+            const renameError = new Error('rename failed');
+            sinon.stub(fs, 'rename').rejects(renameError);
+
+            await assert.rejects(() => minifier.minify({
+                'stable.min.css': 'css/*.css'
+            }), renameError);
+
+            sinon.restore();
+
+            // Destination keeps its previous, complete content
+            const after = await fs.readFile(minifier.getFullDest('stable.min.css'), 'utf8');
+            assert.equal(after, before);
+
+            // No temp files left behind
+            const entries = await fs.readdir(testDir);
+            assert.deepEqual(entries.filter(name => name.endsWith('.tmp')), []);
+        });
+
+        it('rethrows the original error when the temp file write fails', async function () {
+            const writeError = new Error('disk full');
+            sinon.stub(fs, 'writeFile').rejects(writeError);
+
+            await assert.rejects(() => minifier.minify({
+                'unwritable.min.css': 'css/*.css'
+            }), writeError);
+
+            sinon.restore();
+
+            // No temp files left behind and no destination created
+            const entries = await fs.readdir(testDir);
+            assert.deepEqual(entries.filter(name => name.endsWith('.tmp')), []);
+            assert(!entries.includes('unwritable.min.css'));
         });
 
         it('can replace the content', async function () {

--- a/ghost/core/test/unit/frontend/web/middleware/serve-public-file.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/serve-public-file.test.js
@@ -3,8 +3,15 @@ const sinon = require('sinon');
 const request = require('supertest');
 const express = require('express');
 const fs = require('fs-extra');
+const logging = require('@tryghost/logging');
 const config = require('../../../../../core/shared/config');
 const {servePublicFile} = require('../../../../../core/frontend/web/routers/serve-public-file');
+
+function enoentError() {
+    const err = new Error();
+    err.code = 'ENOENT';
+    return err;
+}
 
 describe('servePublicFile', function () {
     afterEach(function () {
@@ -50,9 +57,7 @@ describe('servePublicFile', function () {
         const app = createApp(middleware);
         const body = 'User-agent: * Disallow: /';
 
-        const fileStub = sinon.stub(fs, 'readFile').callsFake(function (file, cb) {
-            cb(null, body);
-        });
+        const fileStub = sinon.stub(fs, 'readFile').resolves(body);
 
         const {headers, text} = await request(app)
             .get('/robots.txt')
@@ -71,9 +76,7 @@ describe('servePublicFile', function () {
         const app = createApp(middleware);
         const body = 'User-agent: * Disallow: /';
 
-        const fileStub = sinon.stub(fs, 'readFile').callsFake(function (file, cb) {
-            cb(null, body);
-        });
+        const fileStub = sinon.stub(fs, 'readFile').resolves(body);
 
         const firstResponse = await request(app)
             .get('/robots.txt')
@@ -103,9 +106,7 @@ describe('servePublicFile', function () {
         const app = createApp(middleware);
         const body = 'User-agent: * Disallow: /';
 
-        const fileStub = sinon.stub(fs, 'readFile').callsFake(function (file, cb) {
-            cb(null, body);
-        });
+        const fileStub = sinon.stub(fs, 'readFile').resolves(body);
 
         const firstResponse = await request(app)
             .get('/robots.txt?v=1')
@@ -138,9 +139,7 @@ describe('servePublicFile', function () {
         const app = createApp(middleware);
         const body = 'User-agent: {{blog-url}}';
 
-        sinon.stub(fs, 'readFile').callsFake(function (file, cb) {
-            cb(null, body);
-        });
+        sinon.stub(fs, 'readFile').resolves(body);
 
         await request(app)
             .get('/robots.txt')
@@ -152,11 +151,7 @@ describe('servePublicFile', function () {
         const middleware = servePublicFile('static', 'robots.txt', 'text/plain', 3600);
         const app = createApp(middleware);
 
-        sinon.stub(fs, 'readFile').callsFake(function (file, cb) {
-            const err = new Error();
-            err.code = 'ENOENT';
-            cb(err, null);
-        });
+        const fileStub = sinon.stub(fs, 'readFile').rejects(enoentError());
 
         await request(app)
             .get('/robots.txt')
@@ -166,6 +161,9 @@ describe('servePublicFile', function () {
                 code: 'PUBLIC_FILE_NOT_FOUND',
                 property: null
             });
+
+        // No rebuild option: only a single read, no retry
+        sinon.assert.calledOnce(fileStub);
     });
 
     it('can serve a built asset file as well as public files', async function () {
@@ -173,9 +171,7 @@ describe('servePublicFile', function () {
         const app = createApp(middleware);
         const body = '.foo {bar: baz}';
 
-        const fileStub = sinon.stub(fs, 'readFile').callsFake(function (file, cb) {
-            cb(null, body);
-        });
+        const fileStub = sinon.stub(fs, 'readFile').resolves(body);
 
         const {text} = await request(app)
             .get('/something.css')
@@ -191,9 +187,7 @@ describe('servePublicFile', function () {
         const app = createApp(middleware);
         const body = 'console.log("private");';
 
-        const fileStub = sinon.stub(fs, 'readFile').callsFake(function (file, cb) {
-            cb(null, body);
-        });
+        const fileStub = sinon.stub(fs, 'readFile').resolves(body);
 
         const {text} = await request(app)
             .get('/public/private.min.js')
@@ -202,5 +196,124 @@ describe('servePublicFile', function () {
 
         assert.equal(text, body);
         assert(fileStub.firstCall.args[0].endsWith('core/frontend/public/private.min.js'));
+    });
+
+    it('does not memory-cache built files: every request reads from disk', async function () {
+        const middleware = servePublicFile('built', 'cards.min.css', 'text/css', 3600);
+        const app = createApp(middleware);
+        const body = '.kg-card {}';
+
+        const fileStub = sinon.stub(fs, 'readFile').resolves(body);
+
+        const firstResponse = await request(app)
+            .get('/cards.min.css')
+            .expect(200);
+
+        const secondResponse = await request(app)
+            .get('/cards.min.css')
+            .expect(200);
+
+        // Built files are mutable at runtime, so they are read per request
+        sinon.assert.calledTwice(fileStub);
+        assert.equal(firstResponse.text, body);
+        assert.equal(secondResponse.text, body);
+        assert.match(firstResponse.headers.etag, /^".+"$/);
+        assert.equal(firstResponse.headers['cache-control'], 'public, max-age=3600');
+        assert.equal(secondResponse.headers.etag, firstResponse.headers.etag);
+    });
+
+    describe('rebuild recovery for built files', function () {
+        it('rebuilds and serves the file when the first read is ENOENT', async function () {
+            const body = '.kg-card {}';
+            const rebuild = sinon.stub().resolves();
+            const fileStub = sinon.stub(fs, 'readFile');
+            fileStub.onFirstCall().rejects(enoentError());
+            fileStub.onSecondCall().resolves(body);
+
+            const middleware = servePublicFile('built', 'cards.min.css', 'text/css', 3600, {rebuild});
+            const app = createApp(middleware);
+
+            const {text} = await request(app)
+                .get('/cards.min.css')
+                .expect(200)
+                .expect('Content-Type', /^text\/css/);
+
+            assert.equal(text, body);
+            sinon.assert.calledOnce(rebuild);
+            sinon.assert.calledTwice(fileStub);
+        });
+
+        it('404s when the file is still missing after the rebuild, without retry loops', async function () {
+            const rebuild = sinon.stub().resolves();
+            const fileStub = sinon.stub(fs, 'readFile').rejects(enoentError());
+
+            const middleware = servePublicFile('built', 'cards.min.css', 'text/css', 3600, {rebuild});
+            const app = createApp(middleware);
+
+            await request(app)
+                .get('/cards.min.css')
+                .expect(404)
+                .expect({
+                    errorType: 'NotFoundError',
+                    code: 'PUBLIC_FILE_NOT_FOUND',
+                    property: null
+                });
+
+            sinon.assert.calledOnce(rebuild);
+            sinon.assert.calledTwice(fileStub);
+        });
+
+        it('logs and still 404s when the rebuild itself rejects', async function () {
+            const loggingStub = sinon.stub(logging, 'error');
+            const rebuildError = new Error('build failed');
+            const rebuild = sinon.stub().rejects(rebuildError);
+            sinon.stub(fs, 'readFile').rejects(enoentError());
+
+            const middleware = servePublicFile('built', 'cards.min.css', 'text/css', 3600, {rebuild});
+            const app = createApp(middleware);
+
+            await request(app)
+                .get('/cards.min.css')
+                .expect(404)
+                .expect({
+                    errorType: 'NotFoundError',
+                    code: 'PUBLIC_FILE_NOT_FOUND',
+                    property: null
+                });
+
+            sinon.assert.calledOnce(rebuild);
+            sinon.assert.calledOnceWithExactly(loggingStub, rebuildError);
+        });
+
+        it('never calls rebuild for static files', async function () {
+            const rebuild = sinon.stub().resolves();
+            const fileStub = sinon.stub(fs, 'readFile').rejects(enoentError());
+
+            const middleware = servePublicFile('static', 'robots.txt', 'text/plain', 3600, {rebuild});
+            const app = createApp(middleware);
+
+            await request(app)
+                .get('/robots.txt')
+                .expect(404);
+
+            sinon.assert.notCalled(rebuild);
+            sinon.assert.calledOnce(fileStub);
+        });
+
+        it('passes non-ENOENT read errors through without rebuilding', async function () {
+            const rebuild = sinon.stub().resolves();
+            const err = new Error('boom');
+            err.code = 'EACCES';
+            sinon.stub(fs, 'readFile').rejects(err);
+
+            const middleware = servePublicFile('built', 'cards.min.css', 'text/css', 3600, {rebuild});
+            const app = createApp(middleware);
+
+            await request(app)
+                .get('/cards.min.css')
+                .expect(500);
+
+            sinon.assert.notCalled(rebuild);
+        });
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1865

> **Note:** This is one of two alternative fixes for the same incident, opened for comparative review. The other is the in-memory serving approach: #29128. Both supersede #29056, whose review surfaced races in the recovery-on-ENOENT design (torn reads from non-atomic writes, response-cache poisoning, throttle 404ing concurrent requests, rebuild loops for never-produced files).

## Problem

`/public/cards.min.css` and `/public/cards.min.js` are minified at runtime into `content/public/` and served by reading them back from disk. If the built files go missing at runtime, or the content folder is unwritable (`EACCES`), every request 404s until the process restarts — ~486 production sites accumulated in this state during Jun 25–29.

## Solution: keep disk serving, fix the root causes

This keeps the existing serve-from-disk architecture and makes the smallest set of changes that fix the failure modes at the layer that owns them:

- **Atomic writes** — the minifier writes to a temp file in the same directory and renames it into place, so a concurrent reader sees either the old or the new complete file, never a torn one.
- **All rebuild policy in one place** — new `AssetsMinificationBase.ensureLoaded()`: concurrent callers join a single in-flight build; a 10s retry backoff (also covering builds that resolve without producing assets, e.g. swallowed `EACCES`) stops a persistently failing build from minifying per request; `invalidate()` no longer forgets an in-flight build — a generation counter re-runs `load()` with the new config instead of allowing two concurrent minifier runs.
- **Dumb recovery in the file middleware** — on `ENOENT` for a built file it calls the service's rebuild hook once and retries the read once. No throttle at this layer: a request arriving during an in-flight rebuild joins it instead of 404ing.
- **`hasFile()` gate** — files the current build legitimately never produces (theme card config yielding no output) 404 fast instead of triggering a rebuild per request.
- **No permanent memory cache for built files** — runtime-mutable files are re-read from disk per request (page-cache-warm, small), so a bad read can never be pinned until restart; ETag/Cache-Control still enable client/CDN caching.
- `serveMiddleware()` no longer lets a rejected `load()` escape as an unhandled rejection (which left requests hanging under Express 4) — this also fixes the hang for `AdminAuthAssets`.

## Testing

- New unit tests for minifier atomicity (destination preserved on failed rename, temp cleanup, error rethrow), `ensureLoaded()` (join-in-flight, backoff after failure and after resolved-but-not-ready builds, invalidate resets backoff, mid-build invalidate re-runs load with no concurrency), and the recovery path (rebuild→200, still-missing→404 with exactly one rebuild, rebuild rejection logged→404, static files never rebuild, built files not memory-cached while static still are).
- `ghost/core` unit suite: 7185 passed; the 3 failures are pre-existing on `main` (verified by baseline run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)