### PR TITLE
Cleaned up GA `giftLinks` flag

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/danger-zone.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/danger-zone.tsx
@@ -21,7 +21,6 @@ const DangerZone: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {totalUsers} = useStaffUsers();
 
     const resetAuthEnabled = Boolean(config?.labs?.dangerZoneResetAuth);
-    const giftLinksEnabled = Boolean(config?.labs?.giftLinks);
 
     const resetAuthStaffSentence = totalUsers === 1
         ? 'You will be signed out and must reset your password before signing back in.'
@@ -135,15 +134,13 @@ const DangerZone: React.FC<{ keywords: string[] }> = ({keywords}) => {
                         title='Reset all authentication'
                     />
                 )}
-                {giftLinksEnabled && (
-                    <ListItem
-                        action={<Button aria-label='Reset all gift links' color='red' label='Reset' onClick={handleRemoveAllGiftLinks} />}
-                        bgOnHover={false}
-                        detail='Invalidate every active gift link across your site. Anyone holding one will lose access.'
-                        testId='reset-all-gift-links'
-                        title='Reset all gift links'
-                    />
-                )}
+                <ListItem
+                    action={<Button aria-label='Reset all gift links' color='red' label='Reset' onClick={handleRemoveAllGiftLinks} />}
+                    bgOnHover={false}
+                    detail='Invalidate every active gift link across your site. Anyone holding one will lose access.'
+                    testId='reset-all-gift-links'
+                    title='Reset all gift links'
+                />
             </div>
         </TopLevelGroup>
     );

--- a/apps/admin-x-settings/test/acceptance/advanced/dangerzone.test.ts
+++ b/apps/admin-x-settings/test/acceptance/advanced/dangerzone.test.ts
@@ -47,8 +47,6 @@ test.describe('DangerZone', async () => {
     });
 
     test('Reset all gift links', async ({page}) => {
-        toggleLabsFlag('giftLinks', true);
-
         const {lastApiRequests} = await mockApi({page, requests: {
             ...globalDataRequests,
             removeAllGiftLinks: {

--- a/apps/posts/src/hooks/use-can-manage-gift-link.ts
+++ b/apps/posts/src/hooks/use-can-manage-gift-link.ts
@@ -1,19 +1,15 @@
 import {canManageGiftLinks} from '@tryghost/admin-x-framework/api/users';
 import {useCurrentUser} from '@tryghost/admin-x-framework/api/current-user';
-import {useGlobalData} from '@src/providers/post-analytics-context';
-import {useMemo} from 'react';
 
 // Whether the current user can manage a gift link for this post. Mirrors
 // canCopyGiftLink in the Ember app/utils/gift-link.js.
 export const useCanManageGiftLink = (post?: {status?: string; visibility?: string}) => {
-    const {data: globalData} = useGlobalData();
     const {data: currentUser} = useCurrentUser();
 
-    return useMemo(() => {
-        if (!globalData?.labs?.giftLinks || !post || !currentUser) {
-            return false;
-        }
-        const eligible = post.status === 'published' && Boolean(post.visibility) && post.visibility !== 'public';
-        return eligible && canManageGiftLinks(currentUser);
-    }, [globalData?.labs?.giftLinks, post, currentUser]);
+    if (!post || !currentUser) {
+        return false;
+    }
+
+    const eligible = post.status === 'published' && Boolean(post.visibility) && post.visibility !== 'public';
+    return eligible && canManageGiftLinks(currentUser);
 };

--- a/apps/posts/src/views/PostAnalytics/components/stats-filter.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/stats-filter.tsx
@@ -8,7 +8,6 @@ import {STATS_LABEL_MAPPINGS, UNKNOWN_LOCATION_VALUES} from '@src/utils/constant
 import {formatQueryDate, getRangeDates} from '@tryghost/shade/app';
 import {getAudienceFromFilterValues, getAudienceQueryParam} from '@src/utils/audience';
 import {useAppContext} from '@src/providers/posts-app-context';
-import {useFeatureFlag} from '@src/hooks/use-feature-flag';
 import {useGlobalData} from '@src/providers/post-analytics-context';
 import {useTinybirdQuery} from '@tryghost/admin-x-framework';
 
@@ -212,7 +211,6 @@ function StatsFilter({filters, onChange, ...props}: StatsFilterProps) {
     const {appSettings} = useAppContext();
     const {post} = useGlobalData();
     const postUuid = post?.uuid;
-    const {isEnabled: giftLinksEnabled} = useFeatureFlag('giftLinks', '/analytics/');
 
     // Track which filter field is currently being selected (lazy loading)
     const [activeFilterField, setActiveFilterField] = useState<string | null>(null);
@@ -355,18 +353,6 @@ function StatsFilter({filters, onChange, ...props}: StatsFilterProps) {
             }
         ];
 
-        const giftLinkField: FilterFieldConfig = {
-            key: 'gift_link',
-            label: 'Gift link',
-            type: 'select',
-            icon: <LucideIcon.Gift className="size-4" />,
-            operators: supportedOperators,
-            defaultOperator: 'is',
-            hideOperatorSelect: true,
-            options: GIFT_LINK_OPTIONS,
-            searchable: false
-        };
-
         return [
             {
                 group: 'Basic',
@@ -424,7 +410,17 @@ function StatsFilter({filters, onChange, ...props}: StatsFilterProps) {
                         searchable: true,
                         selectedOptionsClassName: 'hidden'
                     },
-                    ...(giftLinksEnabled ? [giftLinkField] : [])
+                    {
+                        key: 'gift_link',
+                        label: 'Gift link',
+                        type: 'select',
+                        icon: <LucideIcon.Gift className="size-4" />,
+                        operators: supportedOperators,
+                        defaultOperator: 'is',
+                        hideOperatorSelect: true,
+                        options: GIFT_LINK_OPTIONS,
+                        searchable: false
+                    }
                 ]
             },
             {
@@ -432,7 +428,7 @@ function StatsFilter({filters, onChange, ...props}: StatsFilterProps) {
                 fields: utmFields
             }
         ];
-    }, [utmSourceOptions, utmSourceLoading, utmMediumOptions, utmMediumLoading, utmCampaignOptions, utmCampaignLoading, utmContentOptions, utmContentLoading, utmTermOptions, utmTermLoading, supportedOperators, audienceOptions, sourceOptions, sourceLoading, deviceOptions, deviceLoading, locationOptions, locationLoading, giftLinksEnabled]);
+    }, [utmSourceOptions, utmSourceLoading, utmMediumOptions, utmMediumLoading, utmCampaignOptions, utmCampaignLoading, utmContentOptions, utmContentLoading, utmTermOptions, utmTermLoading, supportedOperators, audienceOptions, sourceOptions, sourceLoading, deviceOptions, deviceLoading, locationOptions, locationLoading]);
 
     // Show clear button when there's at least one filter
     const hasFilters = filters.length > 0;

--- a/apps/stats/src/views/Stats/components/stats-filter.tsx
+++ b/apps/stats/src/views/Stats/components/stats-filter.tsx
@@ -9,7 +9,6 @@ import {formatQueryDate, getRangeDates} from '@tryghost/shade/app';
 import {getAudienceFromFilterValues, getAudienceQueryParam} from '@src/utils/audience';
 import {useAppContext} from '@src/app';
 import {useGlobalData} from '@src/providers/global-data-provider';
-import {useLabsFlag} from '@hooks/use-labs-flag';
 import {useTinybirdQuery, useWebAnalyticsEnabled} from '@tryghost/admin-x-framework';
 import {useTopContent} from '@tryghost/admin-x-framework/api/stats';
 
@@ -288,7 +287,6 @@ const usePostOptions = (currentFilters: Filter[] = [], config: UsePostOptionsCon
 
 function StatsFilter({filters, onChange, ...props}: StatsFilterProps) {
     const {appSettings} = useAppContext();
-    const giftLinksEnabled = useLabsFlag('giftLinks');
 
     // Track which filter field is currently being selected (lazy loading)
     const [activeFilterField, setActiveFilterField] = useState<string | null>(null);
@@ -433,18 +431,6 @@ function StatsFilter({filters, onChange, ...props}: StatsFilterProps) {
             }
         ];
 
-        const giftLinkField: FilterFieldConfig = {
-            key: 'gift_link',
-            label: 'Gift link',
-            type: 'select',
-            icon: <LucideIcon.Gift className="size-4" />,
-            operators: supportedOperators,
-            defaultOperator: 'is',
-            hideOperatorSelect: true,
-            options: GIFT_LINK_OPTIONS,
-            searchable: false
-        };
-
         return [
             {
                 group: 'Basic',
@@ -517,7 +503,17 @@ function StatsFilter({filters, onChange, ...props}: StatsFilterProps) {
                         searchable: true,
                         selectedOptionsClassName: 'hidden'
                     },
-                    ...(giftLinksEnabled ? [giftLinkField] : [])
+                    {
+                        key: 'gift_link',
+                        label: 'Gift link',
+                        type: 'select',
+                        icon: <LucideIcon.Gift className="size-4" />,
+                        operators: supportedOperators,
+                        defaultOperator: 'is',
+                        hideOperatorSelect: true,
+                        options: GIFT_LINK_OPTIONS,
+                        searchable: false
+                    }
                 ]
             },
             {
@@ -525,7 +521,7 @@ function StatsFilter({filters, onChange, ...props}: StatsFilterProps) {
                 fields: utmFields
             }
         ];
-    }, [utmSourceOptions, utmSourceLoading, utmMediumOptions, utmMediumLoading, utmCampaignOptions, utmCampaignLoading, utmContentOptions, utmContentLoading, utmTermOptions, utmTermLoading, supportedOperators, postOptions, postLoading, audienceOptions, sourceOptions, sourceLoading, deviceOptions, deviceLoading, locationOptions, locationLoading, giftLinksEnabled]);
+    }, [utmSourceOptions, utmSourceLoading, utmMediumOptions, utmMediumLoading, utmCampaignOptions, utmCampaignLoading, utmContentOptions, utmContentLoading, utmTermOptions, utmTermLoading, supportedOperators, postOptions, postLoading, audienceOptions, sourceOptions, sourceLoading, deviceOptions, deviceLoading, locationOptions, locationLoading]);
 
     // Show clear button when there's at least one filter
     const hasFilters = filters.length > 0;

--- a/ghost/admin/app/components/posts-list/context-menu.js
+++ b/ghost/admin/app/components/posts-list/context-menu.js
@@ -67,7 +67,6 @@ export default class PostsContextMenu extends Component {
     @service store;
     @service notifications;
     @service membersUtils;
-    @service feature;
     @service stateBridge;
 
     get menu() {
@@ -82,7 +81,6 @@ export default class PostsContextMenu extends Component {
             return false;
         }
         return canCopyGiftLink({
-            feature: this.feature,
             user: this.session.user,
             post: this.selectionList.first
         });

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -84,7 +84,6 @@ export default class FeatureService extends Service {
     @feature('editorExcerpt') editorExcerpt;
     @feature('tagsX') tagsX;
     @feature('commentModeration') commentModeration;
-    @feature('giftLinks') giftLinks;
     _user = null;
 
     @computed('settings.labs')

--- a/ghost/admin/app/utils/gift-link.js
+++ b/ghost/admin/app/utils/gift-link.js
@@ -1,13 +1,12 @@
 // Whether the current user can copy a gift link for the given post/page.
 //
-// Requires the giftLinks flag, a user who can manage links
-// (Owner/Administrator/Editor/Super Editor), and a published, gated (non-public)
-// post/page.
+// Requires a user who can manage links (Owner/Administrator/Editor/Super
+// Editor), and a published, gated (non-public) post/page.
 //
 // The gift-link URL itself is built on the React side (the modal owns it), so
 // this util only decides whether to show the entry point.
-export function canCopyGiftLink({feature, user, post} = {}) {
-    if (!feature || !feature.giftLinks || !post) {
+export function canCopyGiftLink({user, post} = {}) {
+    if (!post) {
         return false;
     }
     const canManage = Boolean(user && (user.isAdmin || user.isEitherEditor));

--- a/ghost/admin/mirage/fixtures/settings.js
+++ b/ghost/admin/mirage/fixtures/settings.js
@@ -105,10 +105,7 @@ export default [
     setting('pintura', 'pintura_css_url', null),
 
     // LABS
-    setting('labs', 'labs', JSON.stringify({
-        // Keep the GA flags that are not yet cleaned up in frontend code here
-        giftLinks: true
-    })),
+    setting('labs', 'labs', JSON.stringify({})),
 
     // SLACK
     setting('slack', 'slack_url', ''),

--- a/ghost/admin/tests/unit/utils/gift-link-test.js
+++ b/ghost/admin/tests/unit/utils/gift-link-test.js
@@ -3,7 +3,6 @@ import {describe, it} from 'mocha';
 import {expect} from 'chai';
 
 describe('Unit | Utility | gift-link', function () {
-    const flagOn = {giftLinks: true};
     const admin = {isAdmin: true, isEitherEditor: false, isAuthor: false};
     const editor = {isAdmin: false, isEitherEditor: true, isAuthor: false};
     const author = {isAdmin: false, isEitherEditor: false, isAuthor: true};
@@ -11,30 +10,25 @@ describe('Unit | Utility | gift-link', function () {
     const gatedPublished = {isPublished: true, visibility: 'paid'};
 
     it('allows a managing user on a published, gated post', function () {
-        expect(canCopyGiftLink({feature: flagOn, user: admin, post: gatedPublished})).to.be.true;
-        expect(canCopyGiftLink({feature: flagOn, user: editor, post: gatedPublished})).to.be.true;
-        expect(canCopyGiftLink({feature: flagOn, user: admin, post: {isPublished: true, visibility: 'members'}})).to.be.true;
-    });
-
-    it('is false when the labs flag is off', function () {
-        expect(canCopyGiftLink({feature: {giftLinks: false}, user: admin, post: gatedPublished})).to.be.false;
+        expect(canCopyGiftLink({user: admin, post: gatedPublished})).to.be.true;
+        expect(canCopyGiftLink({user: editor, post: gatedPublished})).to.be.true;
+        expect(canCopyGiftLink({user: admin, post: {isPublished: true, visibility: 'members'}})).to.be.true;
     });
 
     it('is false for users who cannot manage links', function () {
-        expect(canCopyGiftLink({feature: flagOn, user: contributor, post: gatedPublished})).to.be.false;
-        expect(canCopyGiftLink({feature: flagOn, user: author, post: gatedPublished})).to.be.false;
+        expect(canCopyGiftLink({user: contributor, post: gatedPublished})).to.be.false;
+        expect(canCopyGiftLink({user: author, post: gatedPublished})).to.be.false;
     });
 
     it('is false for public, draft, or non-gated posts', function () {
-        expect(canCopyGiftLink({feature: flagOn, user: admin, post: {isPublished: true, visibility: 'public'}})).to.be.false;
-        expect(canCopyGiftLink({feature: flagOn, user: admin, post: {isPublished: false, visibility: 'paid'}})).to.be.false;
-        expect(canCopyGiftLink({feature: flagOn, user: admin, post: {isPublished: true, visibility: null}})).to.be.false;
+        expect(canCopyGiftLink({user: admin, post: {isPublished: true, visibility: 'public'}})).to.be.false;
+        expect(canCopyGiftLink({user: admin, post: {isPublished: false, visibility: 'paid'}})).to.be.false;
+        expect(canCopyGiftLink({user: admin, post: {isPublished: true, visibility: null}})).to.be.false;
     });
 
-    it('is false when feature, user, or post is missing', function () {
-        expect(canCopyGiftLink({user: admin, post: gatedPublished})).to.be.false;
-        expect(canCopyGiftLink({feature: flagOn, post: gatedPublished})).to.be.false;
-        expect(canCopyGiftLink({feature: flagOn, user: admin})).to.be.false;
+    it('is false when user or post is missing', function () {
+        expect(canCopyGiftLink({post: gatedPublished})).to.be.false;
+        expect(canCopyGiftLink({user: admin})).to.be.false;
         expect(canCopyGiftLink()).to.be.false;
     });
 });

--- a/ghost/core/core/frontend/helpers/ghost_foot.js
+++ b/ghost/core/core/frontend/helpers/ghost_foot.js
@@ -2,7 +2,7 @@
 // Usage: `{{ghost_foot}}`
 //
 // Outputs scripts and other assets at the bottom of a Ghost theme
-const {blogIcon, labs, settingsCache, urlUtils} = require('../services/proxy');
+const {blogIcon, settingsCache, urlUtils} = require('../services/proxy');
 const {SafeString, templates, hbs} = require('../services/handlebars');
 const _ = require('lodash');
 
@@ -32,7 +32,7 @@ module.exports = function ghost_foot(options) { // eslint-disable-line camelcase
     // controller only on a verified gift render, so it shows on gift reads and
     // never on canonical URLs. Overridable: a theme can supply its own
     // `partials/gift-toast.hbs`.
-    if (labs.isSet('giftLinks') && options.data.root._giftLink) {
+    if (options.data.root._giftLink) {
         const data = createFrame(options.data);
         const siteUrl = urlUtils.getSiteUrl().replace(/\/$/, '');
 

--- a/ghost/core/core/frontend/services/routing/controllers/entry/gift-links.ts
+++ b/ghost/core/core/frontend/services/routing/controllers/entry/gift-links.ts
@@ -30,11 +30,11 @@ function setGiftTemplateFlag(res: EntryResponse, token: string): void {
 }
 
 /**
- * Whether this request is an attempt to use a gift link: the feature is enabled
- * and a `?gift` param is present (in any form).
+ * Whether this request is an attempt to use a gift link: a `?gift` param is
+ * present (in any form).
  */
 export function isGiftRequest(req: Request): boolean {
-    return proxy.labs.isSet('giftLinks') && req.query.gift !== undefined;
+    return req.query.gift !== undefined;
 }
 
 /**

--- a/ghost/core/core/frontend/web/middleware/frontend-caching.js
+++ b/ghost/core/core/frontend/web/middleware/frontend-caching.js
@@ -2,9 +2,9 @@
  * @file Middleware to set the appropriate cache headers on the frontend
  */
 const config = require('../../../shared/config');
-const labs = require('../../../shared/labs');
 const shared = require('../../../server/web/shared');
 const {api} = require('../../services/proxy');
+const {isGiftRequest} = require('../../services/routing/controllers/entry/gift-links');
 const preview = require('../../services/theme-engine/preview');
 
 /**
@@ -72,9 +72,8 @@ const getMiddleware = async (getFreeTier = async () => {
 
         // CASE: never cache gift-link reads. A ?gift render holds unlocked gated
         // content with no member cookie, so the edge would otherwise serve it to
-        // everyone. Keyed on the param's presence so an empty `?gift=` still
-        // bypasses.
-        if (req.query?.gift !== undefined && labs.isSet('giftLinks')) {
+        // everyone.
+        if (isGiftRequest(req)) {
             return shared.middleware.cacheControl('noCache')(req, res, next);
         }
 

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -4,7 +4,6 @@ const {http} = require('@tryghost/api-framework');
 const auth = require('../../../../services/auth');
 const apiMw = require('../../middleware');
 const mw = require('./middleware');
-const labs = require('../../../../../shared/labs');
 
 const shared = require('../../../shared');
 
@@ -63,14 +62,14 @@ module.exports = function apiRoutes() {
     router.delete('/pages/:id', mw.authAdminApi, http(api.pages.destroy));
     router.post('/pages/:id/copy', mw.authAdminApi, http(api.pages.copy));
 
-    // Gift links (behind the giftLinks flag)
-    router.get('/posts/:id/gift_links', mw.authAdminApi, labs.enabledMiddleware('giftLinks'), http(api.giftLinks.browse));
-    router.put('/posts/:id/gift_links', mw.authAdminApi, labs.enabledMiddleware('giftLinks'), http(api.giftLinks.ensure));
-    router.post('/posts/:id/gift_links', mw.authAdminApi, labs.enabledMiddleware('giftLinks'), http(api.giftLinks.create));
-    router.get('/pages/:id/gift_links', mw.authAdminApi, labs.enabledMiddleware('giftLinks'), http(api.giftLinks.browse));
-    router.put('/pages/:id/gift_links', mw.authAdminApi, labs.enabledMiddleware('giftLinks'), http(api.giftLinks.ensure));
-    router.post('/pages/:id/gift_links', mw.authAdminApi, labs.enabledMiddleware('giftLinks'), http(api.giftLinks.create));
-    router.put('/gift_links/remove_all', mw.authAdminApi, labs.enabledMiddleware('giftLinks'), http(api.giftLinks.removeAll));
+    // Gift links
+    router.get('/posts/:id/gift_links', mw.authAdminApi, http(api.giftLinks.browse));
+    router.put('/posts/:id/gift_links', mw.authAdminApi, http(api.giftLinks.ensure));
+    router.post('/posts/:id/gift_links', mw.authAdminApi, http(api.giftLinks.create));
+    router.get('/pages/:id/gift_links', mw.authAdminApi, http(api.giftLinks.browse));
+    router.put('/pages/:id/gift_links', mw.authAdminApi, http(api.giftLinks.ensure));
+    router.post('/pages/:id/gift_links', mw.authAdminApi, http(api.giftLinks.create));
+    router.put('/gift_links/remove_all', mw.authAdminApi, http(api.giftLinks.removeAll));
 
     // # Integrations
 

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -29,8 +29,7 @@ const GA_FEATURES = [
     'featurebaseFeedback',
     'dangerZoneResetAuth',
     'indexnow',
-    'llmsTxt',
-    'giftLinks'
+    'llmsTxt'
 ];
 
 // These features are considered publicly available and can be enabled/disabled by users

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -28,7 +28,6 @@ Object {
       "explore": true,
       "featurebaseFeedback": true,
       "getHelperDeduplication": true,
-      "giftLinks": true,
       "importMemberTier": true,
       "indexnow": true,
       "lexicalIndicators": true,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -2253,7 +2253,7 @@ exports[`Settings API Edit can edit Stripe settings when Stripe Connect limit is
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "5485",
+  "content-length": "5466",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/gift-links.test.ts
+++ b/ghost/core/test/e2e-api/admin/gift-links.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 
-const {agentProvider, fixtureManager, mockManager} = require('../../utils/e2e-framework');
+const {agentProvider, fixtureManager} = require('../../utils/e2e-framework');
 const models = require('../../../core/server/models');
 
 describe('Gift Links Admin API', function () {
@@ -23,12 +23,7 @@ describe('Gift Links Admin API', function () {
         pageId = (await models.Base.knex('posts').where('type', 'page').first('id')).id;
     });
 
-    beforeEach(function () {
-        mockManager.mockLabsEnabled('giftLinks');
-    });
-
     afterEach(async function () {
-        mockManager.restore();
         await models.Base.knex('post_gift_links').del();
         await models.Base.knex('gift_links').del();
         await models.Base.knex('actions').where('resource_type', 'gift_link').del();
@@ -168,10 +163,5 @@ describe('Gift Links Admin API', function () {
             assert.equal(deleted.actor_id, actorId);
             assert.equal(actionNameOf(deleted), undefined);
         });
-    });
-
-    it('404s when the giftLinks flag is disabled', async function () {
-        mockManager.mockLabsDisabled('giftLinks');
-        await agent.get(`posts/${postId}/gift_links/`).expectStatus(404);
     });
 });

--- a/ghost/core/test/e2e-frontend/gift-links-toast-override.test.ts
+++ b/ghost/core/test/e2e-frontend/gift-links-toast-override.test.ts
@@ -64,7 +64,7 @@ describe('Front-end gift links — theme toast override', function () {
         const originalSettingsCacheGetFn = settingsCache.get;
         sinon.stub(settingsCache, 'get').callsFake(function (key: any, options: any) {
             if (key === 'labs') {
-                return {members: true, giftLinks: true};
+                return {members: true};
             }
             if (key === 'active_theme') {
                 return OVERRIDE_THEME;

--- a/ghost/core/test/e2e-frontend/gift-links.test.ts
+++ b/ghost/core/test/e2e-frontend/gift-links.test.ts
@@ -37,7 +37,7 @@ describe('Front-end gift links', function () {
         const originalSettingsCacheGetFn = settingsCache.get;
         sinon.stub(settingsCache, 'get').callsFake(function (key: any, options: any) {
             if (key === 'labs') {
-                return {members: true, giftLinks: true};
+                return {members: true};
             }
             if (key === 'active_theme') {
                 return 'members-test-theme';


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3768/

## Summary
- Removed the `giftLinks` labs registration now that the feature is fully rolled out.
- Made admin API routes, frontend gift-link handling, analytics filters, and danger-zone controls unconditional.
- Updated tests and config snapshots to remove disabled-flag expectations.