### PR TITLE
🐛 Fixed mobile preview overflow

### DIFF
--- a/apps/admin-x-design-system/src/global/chrome/mobile-chrome.tsx
+++ b/apps/admin-x-design-system/src/global/chrome/mobile-chrome.tsx
@@ -7,7 +7,7 @@ export interface MobileChromeProps {
 const MobileChrome: React.FC<MobileChromeProps & React.HTMLAttributes<HTMLDivElement>> = ({children, ...props}) => {
     return (
         <div className='flex h-[775px] w-[380px] flex-col rounded-3xl bg-white p-2 shadow-xl dark:bg-grey-900' {...props}>
-            <div className='size-100 grow overflow-auto rounded-2xl border border-grey-100 dark:border-grey-950'>
+            <div className='size-full grow overflow-auto rounded-2xl border border-grey-100 dark:border-grey-950'>
                 {children}
             </div>
         </div>


### PR DESCRIPTION
no ref

the class `size-100` was calculating a fixed width and causing the mobile preview (theme, announcement bar, etc) to overflow the "phone" screen. Changing it to `size-full` fills the screen properly.

Before (dark mode so it's easier to see the overflow):
<img width="1504" height="883" alt="Screenshot 2026-07-06 at 9 26 07 AM" src="https://github.com/user-attachments/assets/0942a3d4-3113-4e17-b907-18f25021e59b" />
<img width="1497" height="643" alt="Screenshot 2026-07-06 at 9 25 50 AM" src="https://github.com/user-attachments/assets/8d3f3bdb-5f78-4330-8759-89eec289e71a" />


After:
<img width="1503" height="785" alt="Screenshot 2026-07-06 at 9 19 49 AM" src="https://github.com/user-attachments/assets/16fa7ee8-ca13-4cb8-95a3-f59ef656e1ab" />
<img width="1483" height="1203" alt="Screenshot 2026-07-06 at 9 19 18 AM" src="https://github.com/user-attachments/assets/79fe82b6-efc6-48ad-b3f1-35dae01c1221" />
