### PR TITLE
Documented paused Tinybird v2 and v3 experiment pipes

### DIFF
--- a/ghost/core/core/server/data/tinybird/endpoints/api_active_visitors_v2.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_active_visitors_v2.pipe
@@ -1,3 +1,6 @@
+# NOTE: This _v2 Tinybird pipe is NOT currently in use. To make non-breaking, additive changes to the current Tinybird endpoints, modify the un-suffixed "v1" versions of the pipes instead. The _v2 pipes will be removed in a future release.
+# The _v2 pipes were added as part of a performance improvement experiment, which has been put on hold.
+
 TOKEN "stats_page" READ
 TOKEN "axis" READ
 

--- a/ghost/core/core/server/data/tinybird/endpoints/api_kpis_v2.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_kpis_v2.pipe
@@ -1,3 +1,6 @@
+# NOTE: This _v2 Tinybird pipe is NOT currently in use. To make non-breaking, additive changes to the current Tinybird endpoints, modify the un-suffixed "v1" versions of the pipes instead. The _v2 pipes will be removed in a future release.
+# The _v2 pipes were added as part of a performance improvement experiment, which has been put on hold.
+
 TOKEN "stats_page" READ
 TOKEN "axis" READ
 

--- a/ghost/core/core/server/data/tinybird/endpoints/api_post_visitor_counts_v2.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_post_visitor_counts_v2.pipe
@@ -1,3 +1,6 @@
+# NOTE: This _v2 Tinybird pipe is NOT currently in use. To make non-breaking, additive changes to the current Tinybird endpoints, modify the un-suffixed "v1" versions of the pipes instead. The _v2 pipes will be removed in a future release.
+# The _v2 pipes were added as part of a performance improvement experiment, which has been put on hold.
+
 TOKEN "stats_page" READ
 TOKEN "axis" READ
 

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_devices_v2.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_devices_v2.pipe
@@ -1,3 +1,6 @@
+# NOTE: This _v2 Tinybird pipe is NOT currently in use. To make non-breaking, additive changes to the current Tinybird endpoints, modify the un-suffixed "v1" versions of the pipes instead. The _v2 pipes will be removed in a future release.
+# The _v2 pipes were added as part of a performance improvement experiment, which has been put on hold.
+
 TOKEN "stats_page" READ
 TOKEN "axis" READ
 

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_locations_v2.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_locations_v2.pipe
@@ -1,3 +1,6 @@
+# NOTE: This _v2 Tinybird pipe is NOT currently in use. To make non-breaking, additive changes to the current Tinybird endpoints, modify the un-suffixed "v1" versions of the pipes instead. The _v2 pipes will be removed in a future release.
+# The _v2 pipes were added as part of a performance improvement experiment, which has been put on hold.
+
 TOKEN "stats_page" READ
 TOKEN "axis" READ
 

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_pages_router.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_pages_router.pipe
@@ -1,3 +1,8 @@
+# NOTE: This _v3 Tinybird experiment is NOT currently in use.
+# It was added to test a faster unfiltered top-pages path using a daily materialized view.
+# The router was intended to send filtered requests to api_top_pages and unfiltered requests to api_top_pages_v3 without changing Ghost's endpoint version wiring.
+# The experiment has been put on hold, and these pipes may be removed in a future release.
+
 # api_top_pages_router - Smart router that delegates to optimal top pages implementation
 #
 # ROUTING LOGIC:

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_pages_v2.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_pages_v2.pipe
@@ -1,3 +1,6 @@
+# NOTE: This _v2 Tinybird pipe is NOT currently in use. To make non-breaking, additive changes to the current Tinybird endpoints, modify the un-suffixed "v1" versions of the pipes instead. The _v2 pipes will be removed in a future release.
+# The _v2 pipes were added as part of a performance improvement experiment, which has been put on hold.
+
 TOKEN "stats_page" READ
 TOKEN "axis" READ
 

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_pages_v3.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_pages_v3.pipe
@@ -1,3 +1,8 @@
+# NOTE: This _v3 Tinybird experiment is NOT currently in use.
+# It was added to test a faster unfiltered top-pages path using a daily materialized view.
+# The router was intended to send filtered requests to api_top_pages and unfiltered requests to api_top_pages_v3 without changing Ghost's endpoint version wiring.
+# The experiment has been put on hold, and these pipes may be removed in a future release.
+
 # api_top_pages_v3 - Optimized top pages endpoint using daily materialized view
 #
 # WHY: The original api_top_pages scans all raw hits and joins with filtered_sessions,

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_sources_v2.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_sources_v2.pipe
@@ -1,3 +1,6 @@
+# NOTE: This _v2 Tinybird pipe is NOT currently in use. To make non-breaking, additive changes to the current Tinybird endpoints, modify the un-suffixed "v1" versions of the pipes instead. The _v2 pipes will be removed in a future release.
+# The _v2 pipes were added as part of a performance improvement experiment, which has been put on hold.
+
 TOKEN "stats_page" READ
 TOKEN "axis" READ
 

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_campaigns_v2.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_campaigns_v2.pipe
@@ -1,3 +1,6 @@
+# NOTE: This _v2 Tinybird pipe is NOT currently in use. To make non-breaking, additive changes to the current Tinybird endpoints, modify the un-suffixed "v1" versions of the pipes instead. The _v2 pipes will be removed in a future release.
+# The _v2 pipes were added as part of a performance improvement experiment, which has been put on hold.
+
 TOKEN "stats_page" READ
 TOKEN "axis" READ
 

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_contents_v2.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_contents_v2.pipe
@@ -1,3 +1,6 @@
+# NOTE: This _v2 Tinybird pipe is NOT currently in use. To make non-breaking, additive changes to the current Tinybird endpoints, modify the un-suffixed "v1" versions of the pipes instead. The _v2 pipes will be removed in a future release.
+# The _v2 pipes were added as part of a performance improvement experiment, which has been put on hold.
+
 TOKEN "stats_page" READ
 TOKEN "axis" READ
 

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_mediums_v2.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_mediums_v2.pipe
@@ -1,3 +1,6 @@
+# NOTE: This _v2 Tinybird pipe is NOT currently in use. To make non-breaking, additive changes to the current Tinybird endpoints, modify the un-suffixed "v1" versions of the pipes instead. The _v2 pipes will be removed in a future release.
+# The _v2 pipes were added as part of a performance improvement experiment, which has been put on hold.
+
 TOKEN "stats_page" READ
 TOKEN "axis" READ
 

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_sources_v2.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_sources_v2.pipe
@@ -1,3 +1,6 @@
+# NOTE: This _v2 Tinybird pipe is NOT currently in use. To make non-breaking, additive changes to the current Tinybird endpoints, modify the un-suffixed "v1" versions of the pipes instead. The _v2 pipes will be removed in a future release.
+# The _v2 pipes were added as part of a performance improvement experiment, which has been put on hold.
+
 TOKEN "stats_page" READ
 TOKEN "axis" READ
 

--- a/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_terms_v2.pipe
+++ b/ghost/core/core/server/data/tinybird/endpoints/api_top_utm_terms_v2.pipe
@@ -1,3 +1,6 @@
+# NOTE: This _v2 Tinybird pipe is NOT currently in use. To make non-breaking, additive changes to the current Tinybird endpoints, modify the un-suffixed "v1" versions of the pipes instead. The _v2 pipes will be removed in a future release.
+# The _v2 pipes were added as part of a performance improvement experiment, which has been put on hold.
+
 TOKEN "stats_page" READ
 TOKEN "axis" READ
 

--- a/ghost/core/core/server/data/tinybird/pipes/filtered_sessions_v2.pipe
+++ b/ghost/core/core/server/data/tinybird/pipes/filtered_sessions_v2.pipe
@@ -1,3 +1,6 @@
+# NOTE: This _v2 Tinybird pipe is NOT currently in use. To make non-breaking, additive changes to the current Tinybird endpoints, modify the un-suffixed "v1" versions of the pipes instead. The _v2 pipes will be removed in a future release.
+# The _v2 pipes were added as part of a performance improvement experiment, which has been put on hold.
+
 TOKEN "axis" READ
 
 NODE sessions_filtered_by_hit_attributes

--- a/ghost/core/core/server/data/tinybird/pipes/mv_daily_pages.pipe
+++ b/ghost/core/core/server/data/tinybird/pipes/mv_daily_pages.pipe
@@ -1,3 +1,8 @@
+# NOTE: This _v3 Tinybird experiment is NOT currently in use.
+# It was added to test a faster unfiltered top-pages path using a daily materialized view.
+# The router was intended to send filtered requests to api_top_pages and unfiltered requests to api_top_pages_v3 without changing Ghost's endpoint version wiring.
+# The experiment has been put on hold, and these pipes may be removed in a future release.
+
 # mv_daily_pages - Daily aggregation of page visits for api_top_pages_v3
 #
 # Pre-aggregates unique sessions per page per day using uniqExactState,

--- a/ghost/core/core/server/data/tinybird/pipes/mv_session_data_v2.pipe
+++ b/ghost/core/core/server/data/tinybird/pipes/mv_session_data_v2.pipe
@@ -1,3 +1,6 @@
+# NOTE: This _v2 Tinybird pipe is NOT currently in use. To make non-breaking, additive changes to the current Tinybird endpoints, modify the un-suffixed "v1" versions of the pipes instead. The _v2 pipes will be removed in a future release.
+# The _v2 pipes were added as part of a performance improvement experiment, which has been put on hold.
+
 TOKEN "axis" READ
 
 NODE mv_session_data_v2_0


### PR DESCRIPTION
no refs

## Summary
- Added comments to the unused Tinybird `_v2` pipes to clarify they are not active and should not be updated for additive endpoint changes.
- Documented the `_v3` top-pages experiment and the daily materialized view pipes as paused, so future edits do not accidentally target the wrong implementation.

## Testing
- Not run (not requested)