### PR TITLE
Moved ghost/core boundary enforcement to dependency-cruiser

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -1,0 +1,95 @@
+'use strict';
+
+/*
+ * Architectural boundary rules for ghost/core, enforced on the resolved module
+ * graph. These mirror the `ghost/node/no-restricted-require` rules that used to
+ * live in ghost/core/eslint.config.mjs; moving them here lets us drop the
+ * custom eslint-plugin-ghost rule when migrating off ESLint, and catches ESM
+ * imports the require-only rule could not.
+ *
+ * Run from the repo root, so paths are anchored on `^ghost/core/core/`.
+ *
+ * @type {import('dependency-cruiser').IConfiguration}
+ */
+module.exports = {
+    forbidden: [
+        // ============================================================
+        // shared/ must not require server/* or frontend/*
+        // ============================================================
+        {
+            name: 'shared-not-server-or-frontend',
+            comment: 'Invalid require of core/server or core/frontend from core/shared.',
+            severity: 'error',
+            from: {path: '^ghost/core/core/shared/'},
+            to: {path: '^ghost/core/core/(server|frontend)/'}
+        },
+        // ============================================================
+        // Frontend must not require server/models directly
+        // ============================================================
+        {
+            name: 'frontend-not-server-models',
+            comment: 'Invalid require of core/server/models from core/frontend. Fetch content through the public Content API (api.postsPublic / api.pagesPublic), injected via core/frontend/services/proxy — not the model layer directly. See #28420.',
+            severity: 'error',
+            from: {path: '^ghost/core/core/frontend/'},
+            to: {path: '^ghost/core/core/server/models/'}
+        },
+        // ============================================================
+        // Frontend must cross to server only via proxy (with allowlist)
+        // ============================================================
+        {
+            name: 'frontend-to-server-via-proxy-only',
+            comment: 'Invalid require of core/server from core/frontend. Cross only via the proxy seam (core/frontend/services/proxy.js).',
+            severity: 'error',
+            from: {
+                path: '^ghost/core/core/frontend/',
+                // Adding files to this list is an anti-pattern
+                // Goal: Work down until only proxy.js remains
+                pathNot: [
+                    // The sanctioned seam.
+                    '^ghost/core/core/frontend/services/proxy\\.js$',
+
+                    // Composition root wiring (less wrong).
+                    '^ghost/core/core/frontend/web/site\\.js$',
+                    '^ghost/core/core/frontend/web/middleware/frontend-caching\\.js$',
+                    '^ghost/core/core/frontend/web/middleware/handle-image-sizes\\.js$',
+                    '^ghost/core/core/frontend/web/routers/link-redirects\\.js$',
+                    '^ghost/core/core/frontend/web/routers/serve-favicon\\.js$',
+                    '^ghost/core/core/frontend/apps/private-blogging/lib/router\\.js$',
+
+                    // Leaks that bypass the proxy (fix first).
+                    '^ghost/core/core/frontend/services/routing/controllers/unsubscribe\\.js$', // services/members + settings-helpers
+                    '^ghost/core/core/frontend/services/routing/router-manager\\.js$', // server/lib/common/events bus
+                    '^ghost/core/core/frontend/services/sitemap/site-map-manager\\.js$' // server/lib/common/events bus
+                ]
+            },
+            to: {path: '^ghost/core/core/server/'}
+        },
+        // ============================================================
+        // Server must not require frontend (with allowlist)
+        // ============================================================
+        {
+            name: 'server-not-frontend',
+            comment: 'Invalid require of core/frontend from core/server. The server must not depend on the frontend rendering layer.',
+            severity: 'error',
+            from: {
+                path: '^ghost/core/core/server/',
+                // Adding files to this list is an anti-pattern
+                // Goal: Work down until the list is empty
+                pathNot: [
+                    // Composition root: mounts the frontend Express app onto the server (less wrong).
+                    '^ghost/core/core/server/web/parent/frontend\\.js$',
+
+                    // Leak: route-settings reaches into the frontend routing config for QUERY/TAXONOMIES (fix first — config should be injected, see the in-file TODO).
+                    '^ghost/core/core/server/services/route-settings/validate\\.js$',
+                    '^ghost/core/core/server/services/route-settings/activation-bridge\\.ts$'
+                ]
+            },
+            to: {path: '^ghost/core/core/frontend/'}
+        }
+    ],
+    options: {
+        doNotFollow: {path: 'node_modules'},
+        exclude: {path: '(^|/)(node_modules|coverage|coverage-next|test|built)/'}
+    }
+};
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,6 +337,9 @@ jobs:
           NX_BASE: ${{ needs.job_setup.outputs.nx_base }}
           NX_HEAD: ${{ env.HEAD_COMMIT }}
 
+      - name: Lint boundaries
+        run: pnpm nx run ghost-monorepo:lint:boundaries
+
       - uses: tryghost/actions/actions/slack-build@6fbe82c6461eee866b1995631d1fb30d6ce9515d # main
         if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
         with:

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -90,6 +90,14 @@ function buildCommand(workspace, files) {
     return `pnpm ${dirArg}exec eslint --cache -- ${relativeFiles}`;
 }
 
+function buildBoundaryCommand(files) {
+    const relativeFiles = files
+        .map(file => normalize(path.relative(ROOT, file)))
+        .map(shellQuote)
+        .join(' ');
+    return `pnpm exec depcruise --config .dependency-cruiser.cjs -- ${relativeFiles}`;
+}
+
 module.exports = {
     '*.{js,ts,tsx,jsx,cjs}': (files) => {
         const groups = new Map();
@@ -104,5 +112,7 @@ module.exports = {
         return [...groups.entries()].map(([workspace, wsFiles]) =>
             buildCommand(workspace || null, wsFiles)
         );
-    }
+    },
+    'ghost/core/core/{server,shared,frontend}/**/*.{js,ts}': (files) =>
+        buildBoundaryCommand(files)
 };

--- a/ghost/core/eslint.config.mjs
+++ b/ghost/core/eslint.config.mjs
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import js from '@eslint/js';
 import globals from 'globals';
 import ghostPlugin from 'eslint-plugin-ghost';
@@ -12,8 +11,6 @@ import {
     nodeLibRules,
     strictLinterOptions
 } from '../../eslint.shared.mjs';
-
-const __dirname = import.meta.dirname;
 
 // nodeLibRules + jsUnusedVarsRule covers the bulk. Two workspace-specific:
 // turn off ghost/filenames/match-regex (we use local-filenames/match-regex in
@@ -188,19 +185,6 @@ export default tseslint.config(
         }
     },
     // ============================================================
-    // shared/ must not require server/* or frontend/*
-    // ============================================================
-    {
-        files: ['core/shared/**'],
-        plugins: {ghost: ghostPlugin},
-        rules: {
-            'ghost/node/no-restricted-require': ['error', [
-                {name: path.resolve(__dirname, 'core/server/**'), message: 'Invalid require of core/server from core/shared.'},
-                {name: path.resolve(__dirname, 'core/frontend/**'), message: 'Invalid require of core/frontend from core/shared.'}
-            ]]
-        }
-    },
-    // ============================================================
     // schema.js: no created_by/updated_by columns
     // ============================================================
     {
@@ -268,67 +252,6 @@ export default tseslint.config(
                 ...globals.browser,
                 ...globals.node
             }
-        }
-    },
-    // ============================================================
-    // Frontend must not require server/models directly
-    // ============================================================
-    {
-        files: ['core/frontend/**'],
-        plugins: {ghost: ghostPlugin},
-        rules: {
-            'ghost/node/no-restricted-require': ['error', [
-                {
-                    name: [path.resolve(__dirname, 'core/server/models/**')],
-                    message: 'Invalid require of core/server/models from core/frontend. Fetch content through the public Content API (api.postsPublic / api.pagesPublic), injected via core/frontend/services/proxy — not the model layer directly. See #28420.'
-                }
-            ]]
-        }
-    },
-    // ============================================================
-    // Frontend must cross to server only via proxy (with allowlist)
-    // ============================================================
-    {
-        files: ['core/frontend/**'],
-        ignores: [
-            'core/frontend/services/proxy.js',
-            'core/frontend/web/site.js',
-            'core/frontend/web/middleware/frontend-caching.js',
-            'core/frontend/web/middleware/handle-image-sizes.js',
-            'core/frontend/web/routers/link-redirects.js',
-            'core/frontend/web/routers/serve-favicon.js',
-            'core/frontend/apps/private-blogging/lib/router.js',
-            'core/frontend/services/routing/controllers/unsubscribe.js',
-            'core/frontend/services/routing/router-manager.js',
-            'core/frontend/services/sitemap/site-map-manager.js'
-        ],
-        plugins: {ghost: ghostPlugin},
-        rules: {
-            'ghost/node/no-restricted-require': ['error', [
-                {
-                    name: [path.resolve(__dirname, 'core/server/**')],
-                    message: 'Invalid require of core/server from core/frontend. Cross only via the proxy seam (core/frontend/services/proxy.js).'
-                }
-            ]]
-        }
-    },
-    // ============================================================
-    // Server must not require frontend (with allowlist)
-    // ============================================================
-    {
-        files: ['core/server/**'],
-        ignores: [
-            'core/server/web/parent/frontend.js',
-            'core/server/services/route-settings/validate.js'
-        ],
-        plugins: {ghost: ghostPlugin},
-        rules: {
-            'ghost/node/no-restricted-require': ['error', [
-                {
-                    name: [path.resolve(__dirname, 'core/frontend/**')],
-                    message: 'Invalid require of core/frontend from core/server. The server must not depend on the frontend rendering layer.'
-                }
-            ]]
         }
     },
     // ============================================================

--- a/package.json
+++ b/package.json
@@ -59,7 +59,9 @@
     "docker:rebase": "git fetch ${GHOST_UPSTREAM:-origin} main && git rebase ${GHOST_UPSTREAM:-origin}/main && pnpm install && pnpm nx run-many -t build --projects=@tryghost/shade,@tryghost/admin-x-design-system,@tryghost/admin-x-framework && docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} up -d --build --force-recreate ghost-dev",
     "knip": "knip",
     "knip:fix": "knip --fix --allow-remove-files=false",
-    "lint": "pnpm nx run-many -t lint",
+    "lint": "pnpm nx run-many -t lint lint:boundaries",
+    "lint:boundaries": "depcruise ghost/core/core --config .dependency-cruiser.cjs",
+    "check": "pnpm lint && pnpm test",
     "test": "pnpm nx run-many -t test --exclude @tryghost/e2e --exclude ghost-admin",
     "test:unit": "pnpm nx run-many -t test:unit",
     "test:watch": "vitest",
@@ -85,6 +87,7 @@
     "@playwright/test": "catalog:",
     "@secretlint/secretlint-rule-pattern": "13.0.2",
     "@secretlint/secretlint-rule-preset-recommend": "13.0.2",
+    "dependency-cruiser": "catalog:",
     "eslint": "catalog:",
     "eslint-plugin-ghost": "catalog:",
     "eslint-plugin-i18next": "6.1.5",
@@ -109,6 +112,19 @@
   "nx": {
     "includedScripts": [],
     "targets": {
+      "lint:boundaries": {
+        "executor": "nx:run-commands",
+        "cache": true,
+        "inputs": [
+          "{workspaceRoot}/.dependency-cruiser.cjs",
+          "{workspaceRoot}/ghost/core/core/**/*",
+          "sharedGlobals"
+        ],
+        "outputs": [],
+        "options": {
+          "command": "depcruise ghost/core/core --config .dependency-cruiser.cjs"
+        }
+      },
       "docker:up": {
         "executor": "nx:run-commands",
         "options": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,9 @@ catalogs:
     cross-fetch:
       specifier: 4.1.0
       version: 4.1.0
+    dependency-cruiser:
+      specifier: ^18.0.0
+      version: 18.0.0
     dequal:
       specifier: 2.0.3
       version: 2.0.3
@@ -400,6 +403,9 @@ importers:
       '@secretlint/secretlint-rule-preset-recommend':
         specifier: 13.0.2
         version: 13.0.2
+      dependency-cruiser:
+        specifier: 'catalog:'
+        version: 18.0.0
       eslint:
         specifier: 'catalog:'
         version: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
@@ -11317,16 +11323,27 @@ packages:
     peerDependencies:
       acorn: ^8.14.0
 
+  acorn-jsx-walk@2.0.0:
+    resolution: {integrity: sha512-uuo6iJj4D4ygkdzd6jPtcxs8vZgDX9YFIkqczGImoypX2fQ4dVImmu3UzA4ynixCIMTrEOWW+95M2HuBaCEOVA==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn-loose@8.5.2:
+    resolution: {integrity: sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==}
+    engines: {node: '>=0.4.0'}
 
   acorn-node@1.8.2:
     resolution: {integrity: sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==}
 
   acorn-walk@7.2.0:
     resolution: {integrity: sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==}
+    engines: {node: '>=0.4.0'}
+
+  acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
     engines: {node: '>=0.4.0'}
 
   acorn@5.7.4:
@@ -13199,6 +13216,10 @@ packages:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
 
+  commander@15.0.0:
+    resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
+    engines: {node: '>=22.12.0'}
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
@@ -14281,6 +14302,11 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  dependency-cruiser@18.0.0:
+    resolution: {integrity: sha512-51Q7wbHoP3/GZrENpINnvKE/xfBsj41NVKarqu5Fff/kmqB/bg0GpiD5bOBwj0+CVunxPGzO80uTdYoy/d4Rsw==}
+    engines: {node: ^22||^24||>=26}
+    hasBin: true
+
   dependency-graph@1.0.0:
     resolution: {integrity: sha512-cW3gggJ28HZ/LExwxP2B++aiKxhJXMSIt9K48FOXQkm+vuG5gyatXnLsONRJdzO/7VfjDIiaOOa/bs4l464Lwg==}
     engines: {node: '>=4'}
@@ -15111,6 +15137,10 @@ packages:
 
   enhanced-resolve@5.24.0:
     resolution: {integrity: sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==}
+    engines: {node: '>=10.13.0'}
+
+  enhanced-resolve@5.24.1:
+    resolution: {integrity: sha512-7DdUaTjmNwMcH2gLr1qycesKII3BK4RLy/mdAb7x10Lq7bR4aNKHt1BR1ZALSv0rPM/hF5wYF0PhGop/rJm8vw==}
     engines: {node: '>=10.13.0'}
 
   enquirer@2.3.6:
@@ -16336,6 +16366,10 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
+  global-directory@4.0.1:
+    resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
+    engines: {node: '>=18'}
+
   global-modules@1.0.0:
     resolution: {integrity: sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==}
     engines: {node: '>=0.10.0'}
@@ -16971,6 +17005,10 @@ packages:
     resolution: {integrity: sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==}
     engines: {node: '>=10'}
 
+  ini@4.1.1:
+    resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
   inline-source-map-comment@1.0.5:
     resolution: {integrity: sha512-a3/m6XgooVCXkZCduOb7pkuvUtNKt4DaqaggKKJrMQHQsqt6JcJXEreExeZiiK4vWL/cM/uF6+chH05pz2/TdQ==}
     hasBin: true
@@ -17243,6 +17281,10 @@ packages:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
     engines: {node: '>=14.16'}
     hasBin: true
+
+  is-installed-globally@1.0.0:
+    resolution: {integrity: sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==}
+    engines: {node: '>=18'}
 
   is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
@@ -23218,6 +23260,10 @@ packages:
       typescript:
         optional: true
 
+  tsconfig-paths-webpack-plugin@4.2.0:
+    resolution: {integrity: sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==}
+    engines: {node: '>=10.13.0'}
+
   tsconfig-paths@4.2.0:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
@@ -24006,6 +24052,11 @@ packages:
   watchpack@2.5.2:
     resolution: {integrity: sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==}
     engines: {node: '>=10.13.0'}
+
+  watskeburt@6.0.0:
+    resolution: {integrity: sha512-jfiuDABaxSkC71T6oZ3vCS99roYkSHm/+As+G0Dz8taAHQb+SJBvLEm5RlsgG71XdfAj3rv7eudUBTgwcQUPlQ==}
+    engines: {node: ^22.13||^24||>=26}
+    hasBin: true
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
@@ -33540,7 +33591,13 @@ snapshots:
     dependencies:
       acorn: 8.17.0
 
+  acorn-jsx-walk@2.0.0: {}
+
   acorn-jsx@5.3.2(acorn@8.17.0):
+    dependencies:
+      acorn: 8.17.0
+
+  acorn-loose@8.5.2:
     dependencies:
       acorn: 8.17.0
 
@@ -33551,6 +33608,10 @@ snapshots:
       xtend: 4.0.2
 
   acorn-walk@7.2.0: {}
+
+  acorn-walk@8.3.5:
+    dependencies:
+      acorn: 8.17.0
 
   acorn@5.7.4: {}
 
@@ -36330,6 +36391,8 @@ snapshots:
 
   commander@12.1.0: {}
 
+  commander@15.0.0: {}
+
   commander@2.20.3: {}
 
   commander@2.3.0: {}
@@ -37209,6 +37272,27 @@ snapshots:
   depd@1.1.2: {}
 
   depd@2.0.0: {}
+
+  dependency-cruiser@18.0.0:
+    dependencies:
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
+      acorn-jsx-walk: 2.0.0
+      acorn-loose: 8.5.2
+      acorn-walk: 8.3.5
+      commander: 15.0.0
+      enhanced-resolve: 5.24.1
+      ignore: 7.0.5
+      interpret: 3.1.1
+      is-installed-globally: 1.0.0
+      json5: 2.2.3
+      picomatch: 4.0.4
+      prompts: 2.4.2
+      rechoir: 0.8.0
+      safe-regex: 2.1.1
+      semver: 7.8.5
+      tsconfig-paths-webpack-plugin: 4.2.0
+      watskeburt: 6.0.0
 
   dependency-graph@1.0.0: {}
 
@@ -39070,6 +39154,11 @@ snapshots:
       tapable: 1.1.3
 
   enhanced-resolve@5.24.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
+
+  enhanced-resolve@5.24.1:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
@@ -41232,6 +41321,10 @@ snapshots:
       minipass: 4.2.8
       path-scurry: 1.11.1
 
+  global-directory@4.0.1:
+    dependencies:
+      ini: 4.1.1
+
   global-modules@1.0.0:
     dependencies:
       global-prefix: 1.0.2
@@ -42039,6 +42132,8 @@ snapshots:
 
   ini@2.0.0: {}
 
+  ini@4.1.1: {}
+
   inline-source-map-comment@1.0.5:
     dependencies:
       chalk: 1.1.3
@@ -42346,6 +42441,11 @@ snapshots:
   is-inside-container@1.0.0:
     dependencies:
       is-docker: 3.0.0
+
+  is-installed-globally@1.0.0:
+    dependencies:
+      global-directory: 4.0.1
+      is-path-inside: 4.0.0
 
   is-interactive@1.0.0: {}
 
@@ -50072,6 +50172,13 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  tsconfig-paths-webpack-plugin@4.2.0:
+    dependencies:
+      chalk: 4.1.2
+      enhanced-resolve: 5.24.0
+      tapable: 2.3.3
+      tsconfig-paths: 4.2.0
+
   tsconfig-paths@4.2.0:
     dependencies:
       json5: 2.2.3
@@ -51021,6 +51128,8 @@ snapshots:
   watchpack@2.5.2:
     dependencies:
       graceful-fs: 4.2.11
+
+  watskeburt@6.0.0: {}
 
   wcwidth@1.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -87,6 +87,7 @@ catalog:
   concurrently: 10.0.3
   country-flag-icons: 1.6.20
   cross-fetch: 4.1.0
+  dependency-cruiser: ^18.0.0
   dequal: 2.0.3
   dompurify: 3.4.11
   dotenv: 17.4.2


### PR DESCRIPTION
## Why

`ghost/core`'s frontend/server/shared layer boundaries are enforced by the custom `ghost/node/no-restricted-require` rule in `ghost/core/eslint.config.mjs`. That rule is specific to `eslint-plugin-ghost` and has no equivalent in oxlint, so it stands in the way of the planned ESLint → oxlint migration. It also only inspects `require()` calls, so it misses ESM `import`s.

## What

Moves the four boundary rules onto [dependency-cruiser](https://github.com/sverweij/dependency-cruiser), which enforces them on the resolved module graph (both `require` and `import`) from the repo root:

- `core/shared` must not depend on `core/server` or `core/frontend`
- `core/frontend` must not reach `core/server/models` directly
- `core/frontend` may cross to `core/server` only via the `services/proxy` seam (allowlisted)
- `core/server` must not depend on `core/frontend` (allowlisted)

The custom `no-restricted-require` blocks (and their now-unused `path`/`__dirname` imports) are removed from the ESLint config. The original burn-down intent — *"adding files to this list is an anti-pattern / work down until the list is empty"* — and the per-file allowlist categorisation are carried over verbatim from the pre-flat-config `.eslintrc.js` (they'd been dropped in the flat-config migration).

Enforced in three places:
- a **cached nx target** on the `ghost-monorepo` root project (`lint:boundaries`), with scoped `inputs` so the root project's whole-repo `projectRoot` glob doesn't defeat caching
- a **CI step** in the lint job
- a **lint-staged** pre-commit signal on staged `ghost/core/core` files

Behaviour is unchanged: parity verified (0 violations on the same graph the ESLint rules covered), and each rule still fires on a negative test.

## Scope

The cross-package `apps/*` boundary model (foundation-libraries vs apps) surfaced during this work but is deliberately **out of scope** here and tabled as a follow-up.

## Checklist
- [x] I've explained my change
- [ ] I've written an automated test to prove my change works — n/a (tooling/config change; enforced by CI + verified for parity)
