### PR TITLE
Fixed react-world-flags interop so shade's Flag renders under both bundlers

### DIFF
--- a/apps/shade/src/components/ui/flag.tsx
+++ b/apps/shade/src/components/ui/flag.tsx
@@ -1,6 +1,21 @@
 import {cn} from '@/lib/utils';
 import React from 'react';
-import ReactFlag from 'react-world-flags';
+import * as ReactWorldFlags from 'react-world-flags';
+
+// react-world-flags is CommonJS shaped `{ __esModule: true, default: Component }`.
+// esbuild/Rollup unwrap the default to the component; Rolldown returns the wrapper
+// object (whose `.default` is still the wrapper), so unwrap explicitly. Works under
+// both bundlers.
+function interopDefault<T>(mod: unknown): T {
+    let value: unknown = (mod && typeof mod === 'object' && 'default' in mod)
+        ? (mod as {default: unknown}).default
+        : mod;
+    if (value && typeof value === 'object' && '__esModule' in value && 'default' in value) {
+        value = (value as {default: unknown}).default;
+    }
+    return value as T;
+}
+const ReactFlag = interopDefault<React.ComponentType<Record<string, unknown>>>(ReactWorldFlags);
 
 interface FlagProps {
     width?: string;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLA-96/spike-rolldown-vite-drop-in-build-benchmarks

### What

Shade's `Flag` component imports `react-world-flags`, a CommonJS module shaped `{ __esModule: true, default: <Component> }`. It replaces the bare default import with a namespace import plus an explicit `interopDefault()` unwrap.

### Why

esbuild and Rollup unwrap the CJS default down to the component automatically, so `<ReactFlag/>` works today. The **Rolldown** bundler (being evaluated for the admin apps under PLA-96) instead hands back the `__esModule` wrapper object — whose `.default` is still the wrapper — so `<ReactFlag/>` renders an object and React throws `Element type is invalid: got object`, crashing the analytics location/source views that use `Flag`.

### The fix

`interopDefault()` reads `.default` off the module (namespace or CJS export), and if that value is *itself* still an `__esModule`-tagged wrapper, unwraps one more level. This resolves to the actual component under **both** toolchains:

- **Rollup (current):** behavior-preserving — the first `.default` yields the component, second branch is a no-op.
- **Rolldown (target):** the extra unwrap peels the wrapper object down to the component.

### Scope

- Single file: `apps/shade/src/components/ui/flag.tsx`. The `<ReactFlag .../>` JSX usage is unchanged.
- **Workstream A / Phase-0 of the Rolldown migration (PLA-96)** — de-risking landed under the current working toolchain so the Rolldown eval isn't blocked by this crash.

### Verification (Rollup toolchain)

- `pnpm --filter @tryghost/shade build` — clean (includes `tsc` + `tsc-alias` + vite build)
- `pnpm --filter @tryghost/shade lint` — clean
- `pnpm --filter @tryghost/shade test:unit` — 226 passed (includes `tsc --noEmit` typecheck)