### PR TITLE
Added Mailgun tag to automation emails

### DIFF
--- a/ghost/core/core/server/services/member-welcome-emails/constants.ts
+++ b/ghost/core/core/server/services/member-welcome-emails/constants.ts
@@ -13,6 +13,7 @@ const MEMBER_WELCOME_EMAIL_ELIGIBLE_STATUSES = {
 } as const;
 
 const MEMBER_WELCOME_EMAIL_TAG = 'member-welcome-email';
+const AUTOMATION_EMAIL_TAG = 'automation-email';
 
 const MESSAGES = {
     NO_MEMBER_WELCOME_EMAIL: 'No member welcome email found',
@@ -24,6 +25,7 @@ const MESSAGES = {
 } as const;
 
 export {
+    AUTOMATION_EMAIL_TAG,
     DEFAULT_EMAIL_DESIGN_SETTING_SLUG,
     MEMBER_WELCOME_EMAIL_LOG_KEY,
     MEMBER_WELCOME_EMAIL_TAG,

--- a/ghost/core/core/server/services/member-welcome-emails/service.js
+++ b/ghost/core/core/server/services/member-welcome-emails/service.js
@@ -12,7 +12,7 @@ const mail = require('../mail');
 const labs = require('../../../shared/labs');
 const {Automation, EmailDesignSetting, Newsletter} = require('../../models');
 const MemberWelcomeEmailRenderer = require('./member-welcome-email-renderer');
-const {DEFAULT_EMAIL_DESIGN_SETTING_SLUG, MEMBER_WELCOME_EMAIL_LOG_KEY, MEMBER_WELCOME_EMAIL_TAG, MEMBER_WELCOME_EMAIL_SLUGS, MESSAGES} = require('./constants');
+const {AUTOMATION_EMAIL_TAG, DEFAULT_EMAIL_DESIGN_SETTING_SLUG, MEMBER_WELCOME_EMAIL_LOG_KEY, MEMBER_WELCOME_EMAIL_TAG, MEMBER_WELCOME_EMAIL_SLUGS, MESSAGES} = require('./constants');
 
 const VERIFIED_SENDER_PROPERTIES = ['sender_reply_to'];
 const WELCOME_EMAIL_FILTER = `slug:${MEMBER_WELCOME_EMAIL_SLUGS.free},slug:${MEMBER_WELCOME_EMAIL_SLUGS.paid}`;
@@ -407,13 +407,29 @@ class MemberWelcomeEmailService {
             'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click'
         } : undefined;
 
+        /** @type {string[]} */ let tags;
+        switch (emailType) {
+        case 'welcome':
+            tags = [MEMBER_WELCOME_EMAIL_TAG];
+            break;
+        case 'automation':
+            tags = [AUTOMATION_EMAIL_TAG];
+            break;
+        default: {
+            /** @type {never} */ const _exhaustive = emailType;
+            throw new errors.InternalServerError({
+                message: `Unexpected email type ${_exhaustive}`
+            });
+        }
+        }
+
         await this.#mailer.send({
             to: member.email,
             subject,
             html,
             text,
             forceTextContent: true,
-            tags: [MEMBER_WELCOME_EMAIL_TAG],
+            tags,
             ...(headers ? {headers} : {}),
             ...senderOptions
         });

--- a/ghost/core/test/e2e-api/members/automations.test.js
+++ b/ghost/core/test/e2e-api/members/automations.test.js
@@ -124,10 +124,10 @@ async function updateAutomation(automation, overrides = {}) {
     return body.automations[0];
 }
 
-function getMemberWelcomeEmailSends() {
+function getAutomationEmailSends() {
     return mailService.GhostMailer.prototype.send.getCalls()
         .map(call => call.args[0])
-        .filter(emailToSend => emailToSend.tags?.includes('member-welcome-email'));
+        .filter(emailToSend => emailToSend.tags?.includes('automation-email'));
 }
 
 describe('Members Automations', function () {
@@ -204,7 +204,7 @@ describe('Members Automations', function () {
             clock.restore();
         }
 
-        const sentEmails = getMemberWelcomeEmailSends();
+        const sentEmails = getAutomationEmailSends();
         assert.equal(sentEmails.length, 2);
         assert.deepEqual(sentEmails.map(({to}) => to), [email, email]);
         assert.deepEqual(sentEmails.map(({subject}) => subject), ['Welcome!', 'Follow up']);
@@ -213,8 +213,8 @@ describe('Members Automations', function () {
         assert.deepEqual(sentEmails.map(({forceTextContent}) => forceTextContent), [true, true]);
         assert.deepEqual(sentEmails.map(({replyTo}) => replyTo), [AUTOMATION_EMAIL_REPLY_TO, AUTOMATION_EMAIL_REPLY_TO]);
         assert.deepEqual(sentEmails.map(({tags}) => tags), [
-            ['member-welcome-email'],
-            ['member-welcome-email']
+            ['automation-email'],
+            ['automation-email']
         ]);
         sinon.assert.calledWithMatch(mailService.GhostMailer.prototype.send, {
             to: email,
@@ -242,7 +242,7 @@ describe('Members Automations', function () {
         await DomainEvents.allSettled();
         await runSchedulerPoll();
 
-        assert.equal(getMemberWelcomeEmailSends().length, 0);
+        assert.equal(getAutomationEmailSends().length, 0);
     });
 
     it('stops an automation run when its automation is deactivated before poll', async function () {
@@ -271,7 +271,7 @@ describe('Members Automations', function () {
             clock.restore();
         }
 
-        assert.equal(getMemberWelcomeEmailSends().length, 0);
+        assert.equal(getAutomationEmailSends().length, 0);
     });
 
     it('stops an automation run when the associated member changes their status', async function () {
@@ -305,6 +305,6 @@ describe('Members Automations', function () {
             clock.restore();
         }
 
-        assert.equal(getMemberWelcomeEmailSends().length, 0);
+        assert.equal(getAutomationEmailSends().length, 0);
     });
 });

--- a/ghost/core/test/integration/services/member-welcome-emails.test.js
+++ b/ghost/core/test/integration/services/member-welcome-emails.test.js
@@ -475,6 +475,14 @@ describe('Member Welcome Emails Integration', function () {
             }));
         });
 
+        it('tags automation emails for automation analytics', async function () {
+            await sendAutomationEmail();
+
+            sinon.assert.calledOnce(mailService.GhostMailer.prototype.send);
+            const sendCall = mailService.GhostMailer.prototype.send.firstCall;
+            assert.deepEqual(sendCall.args[0].tags, ['automation-email']);
+        });
+
         it('uses email design sender details for automation emails', async function () {
             const defaultNewsletter = await models.Newsletter.getDefaultNewsletter();
 


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1410

This adds the `automation-email` tag to automation emails.

In addition to tests, I also verified this manually in the Mailgun logs:

![Screenshot](https://github.com/user-attachments/assets/940f8c70-ed5a-41b3-a2ae-4bf2806d8916)