### PR TITLE
Added e2e runtime acceptance gate for console errors and pageerrors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1395,13 +1395,15 @@ jobs:
             analytics: 'false'
             shardIndex: 10
             shardTotal: 10
+          # The smoke runtime-gate project (tests/admin/smoke) runs in this lane so
+          # Tinybird is available for its stats/analytics views.
           - projectName: Analytics
-            projects: analytics
+            projects: analytics,smoke
             analytics: 'true'
             shardIndex: 1
             shardTotal: 2
           - projectName: Analytics
-            projects: analytics
+            projects: analytics,smoke
             analytics: 'true'
             shardIndex: 2
             shardTotal: 2

--- a/e2e/helpers/pages/admin/activitypub/activitypub-page.ts
+++ b/e2e/helpers/pages/admin/activitypub/activitypub-page.ts
@@ -1,0 +1,29 @@
+import {AdminPage} from '@/admin-pages';
+import {Locator, Page} from '@playwright/test';
+
+/**
+ * The admin-x-activitypub app ("Network" in the sidebar). The index route redirects
+ * to the Reader/inbox view.
+ *
+ * Authored for the smoke gate: this app had no build-mode e2e coverage, so the goal
+ * is a stable key-content locator to assert the view mounted without runtime errors.
+ */
+export class ActivityPubPage extends AdminPage {
+    readonly readerNavLink: Locator;
+    readonly inboxList: Locator;
+
+    constructor(page: Page) {
+        super(page);
+        this.pageUrl = '/ghost/#/activitypub';
+
+        // The sidebar "Reader" nav link is part of the ActivityPub app shell and is
+        // present as soon as the React app mounts, independent of feed/empty state.
+        this.readerNavLink = page.getByRole('link', {name: 'Reader'});
+        // The inbox list renders once the reader feed (or its placeholder) is ready.
+        this.inboxList = page.getByTestId('inbox-list');
+    }
+
+    async waitForAppToMount(): Promise<void> {
+        await this.readerNavLink.waitFor({state: 'visible'});
+    }
+}

--- a/e2e/helpers/pages/admin/activitypub/index.ts
+++ b/e2e/helpers/pages/admin/activitypub/index.ts
@@ -1,0 +1,1 @@
+export * from './activitypub-page';

--- a/e2e/helpers/pages/admin/index.ts
+++ b/e2e/helpers/pages/admin/index.ts
@@ -7,6 +7,7 @@ export * from './login-verify-page';
 export * from './settings';
 export * from './whats-new';
 export * from './analytics';
+export * from './activitypub';
 export * from './onboarding';
 export * from './posts';
 export * from './tags';

--- a/e2e/helpers/playwright/console-errors.ts
+++ b/e2e/helpers/playwright/console-errors.ts
@@ -1,0 +1,124 @@
+import {Page, TestInfo, test as base} from '@playwright/test';
+import {test as ghostTest} from '@/helpers/playwright/fixture';
+
+/**
+ * A runtime error captured while a test drove the admin app: either an uncaught
+ * exception (`page.on('pageerror')`) or a `console.error(...)` call.
+ */
+export interface CapturedRuntimeError {
+    type: 'pageerror' | 'console.error';
+    text: string;
+}
+
+/**
+ * Known-benign runtime noise that must NOT fail the console-error gate.
+ *
+ * Keep this list SMALL, EXPLICIT and COMMENTED. Every entry is a promise that the
+ * matched message is understood, harmless, and outside our control to fix from the
+ * bundle (third-party deprecation, browser/devtools chatter, etc.). Anything that
+ * looks like a real app bug must NOT be added here — fix the bug instead.
+ *
+ * A message is allowlisted when it contains one of these substrings (case-sensitive)
+ * or matches one of these regexes.
+ */
+export const CONSOLE_ERROR_ALLOWLIST: Array<string | RegExp> = [
+    // React 18 → 19 upgrade deprecation emitted by third-party libs that still call
+    // the legacy ReactDOM.render / findDOMNode APIs. Noise, not a runtime failure.
+    'ReactDOM.render is no longer supported',
+    'findDOMNode is deprecated',
+
+    // Chromium surfaces failed network requests (favicons, offline changelog fetches,
+    // avatar/gravatar services) as console errors. These are network conditions, not
+    // bundle/runtime bugs, and are already policed by the egress allowlist.
+    /Failed to load resource: the server responded with a status of \d+/,
+    /net::ERR_(INTERNET_DISCONNECTED|NAME_NOT_RESOLVED|CONNECTION_REFUSED|ABORTED|FAILED)/,
+
+    // Ember Data / admin deprecation warnings routed through console.error in dev
+    // builds. They are guidance for future refactors, not runtime failures.
+    /DEPRECATION:/
+];
+
+function isAllowlisted(text: string): boolean {
+    return CONSOLE_ERROR_ALLOWLIST.some((matcher) => {
+        if (typeof matcher === 'string') {
+            return text.includes(matcher);
+        }
+        return matcher.test(text);
+    });
+}
+
+/**
+ * Attach `pageerror` / `console.error` listeners to a page and collect every
+ * non-allowlisted message into `errors`. Returns a detach function.
+ *
+ * Exposed separately from the fixture so a test can watch a second page it opens
+ * itself (e.g. an isolated public-site page) with the same allowlist.
+ */
+export function collectRuntimeErrors(page: Page, errors: CapturedRuntimeError[]): () => void {
+    const onPageError = (error: Error) => {
+        const text = error.stack || error.message || String(error);
+        if (!isAllowlisted(text)) {
+            errors.push({type: 'pageerror', text});
+        }
+    };
+
+    const onConsole = (message: {type(): string; text(): string}) => {
+        if (message.type() !== 'error') {
+            return;
+        }
+        const text = message.text();
+        if (!isAllowlisted(text)) {
+            errors.push({type: 'console.error', text});
+        }
+    };
+
+    page.on('pageerror', onPageError);
+    page.on('console', onConsole);
+
+    return () => {
+        page.off('pageerror', onPageError);
+        page.off('console', onConsole);
+    };
+}
+
+/**
+ * Render captured errors into a readable failure message so a red gate points at
+ * exactly what threw, not just "N errors".
+ */
+export function formatCapturedErrors(errors: CapturedRuntimeError[], testInfo: TestInfo): string {
+    const lines = errors.map((error, index) => `  ${index + 1}. [${error.type}] ${error.text}`);
+    return (
+        `Captured ${errors.length} non-allowlisted runtime error(s) during "${testInfo.title}":\n` +
+        `${lines.join('\n')}\n\n` +
+        'If a message is known-benign third-party noise, add it to CONSOLE_ERROR_ALLOWLIST ' +
+        'in helpers/playwright/console-errors.ts with a comment explaining why. ' +
+        'Otherwise this is a real runtime failure the build + unit tests did not catch — fix it.'
+    );
+}
+
+interface ConsoleErrorFixtures {
+    /**
+     * Errors captured on the authenticated admin page for the current test. Assert
+     * `expect(runtimeErrors).toHaveLength(0)` at the end of a smoke test; the fixture
+     * teardown does NOT auto-fail so the assertion stays visible in the test body.
+     */
+    runtimeErrors: CapturedRuntimeError[];
+}
+
+/**
+ * The Ghost admin fixture, extended with a `runtimeErrors` collector wired to the
+ * authenticated `page`. Listeners attach before the test body runs so navigation
+ * performed inside the test is fully covered.
+ */
+export const test = ghostTest.extend<ConsoleErrorFixtures>({
+    runtimeErrors: async ({page}, use) => {
+        const errors: CapturedRuntimeError[] = [];
+        const detach = collectRuntimeErrors(page, errors);
+
+        await use(errors);
+
+        detach();
+    }
+});
+
+export const expect = base.expect;

--- a/e2e/helpers/playwright/fixture.ts
+++ b/e2e/helpers/playwright/fixture.ts
@@ -15,7 +15,7 @@ const debug = baseDebug('e2e:ghost-fixture');
 const STRIPE_SECRET_KEY = 'sk_test_e2eTestKey';
 const STRIPE_PUBLISHABLE_KEY = 'pk_test_e2eTestKey';
 
-type ResolvedIsolation = 'per-file' | 'per-test';
+export type ResolvedIsolation = 'per-file' | 'per-test';
 type LabsFlags = Record<string, boolean>;
 
 /**
@@ -43,7 +43,7 @@ interface PerFileAuthenticatedSessionCache {
     storageState: Awaited<ReturnType<BrowserContext['storageState']>>;
 }
 
-interface TestEnvironmentContext {
+export interface TestEnvironmentContext {
     holder: GhostInstance;
     resolvedIsolation: ResolvedIsolation;
     cycle: () => Promise<void>;
@@ -51,11 +51,11 @@ interface TestEnvironmentContext {
     markResetEnvironmentBlocker: (fixtureName: string) => void;
 }
 
-interface InternalFixtures {
+export interface InternalFixtures {
     _testEnvironmentContext: TestEnvironmentContext;
 }
 
-interface WorkerFixtures {
+export interface WorkerFixtures {
     _cleanupPerFileInstance: void;
     _egressSummary: void;
 }

--- a/e2e/playwright.config.mjs
+++ b/e2e/playwright.config.mjs
@@ -48,7 +48,7 @@ const config = {
         },
         {
             name: 'main',
-            testIgnore: ['**/*.setup.ts', '**/*.teardown.ts', 'analytics/**/*.test.ts'],
+            testIgnore: ['**/*.setup.ts', '**/*.teardown.ts', 'analytics/**/*.test.ts', 'smoke/**/*.test.ts'],
             testDir: './tests',
             use: {
                 viewport: {width: 1920, height: 1080}
@@ -59,6 +59,19 @@ const config = {
             name: 'analytics',
             testDir: './tests',
             testMatch: ['analytics/**/*.test.ts'],
+            use: {
+                viewport: {width: 1920, height: 1080}
+            },
+            dependencies: ['global-setup']
+        },
+        // Runtime acceptance gate: boots the real admin bundle for each major view
+        // and fails on non-allowlisted console.error / pageerror (see
+        // tests/admin/smoke/). Runs in the analytics CI lane so Tinybird is present
+        // for the stats/analytics views; non-analytics views run there too.
+        {
+            name: 'smoke',
+            testDir: './tests',
+            testMatch: ['smoke/**/*.test.ts'],
             use: {
                 viewport: {width: 1920, height: 1080}
             },

--- a/e2e/tests/admin/smoke/admin-views-smoke.test.ts
+++ b/e2e/tests/admin/smoke/admin-views-smoke.test.ts
@@ -1,0 +1,158 @@
+import {
+    ActivityPubPage,
+    AnalyticsOverviewPage,
+    AnalyticsWebTrafficPage,
+    CommentsPage,
+    MembersListPage,
+    PostEditorPage,
+    PostsPage,
+    SettingsPage,
+    TagsPage
+} from '@/admin-pages';
+import {createMemberFactory} from '@/data-factory';
+import {expect, test} from '@/helpers/playwright/console-errors';
+
+/**
+ * Runtime acceptance gate.
+ *
+ * The build-mode e2e suite boots the real production admin bundle, but a view can
+ * still throw at runtime while a navigation-only test stays green. Each smoke test
+ * here navigates to a major admin view against the real build, waits for a key
+ * content locator (proving the view actually rendered — not just that the route
+ * resolved), and then asserts ZERO non-allowlisted console.error / pageerror events
+ * were captured. That second assertion is what turns a silent runtime throw red.
+ *
+ * The `runtimeErrors` fixture attaches its listeners before the test body runs, so
+ * everything the navigation triggers is covered.
+ *
+ * NEGATIVE CONTROL: to prove the gate catches the class of bug it targets, break a
+ * component that one of these views renders (e.g. throw inside a stats card, or
+ * reference an undefined symbol so the bundle throws on mount). The key-content
+ * `waitFor` may still pass for shell-level chrome, but the view's own render throws
+ * a `pageerror` / logs a React `console.error`, `runtimeErrors` is non-empty, and
+ * the `toHaveLength(0)` assertion fails with the captured stack printed. The skipped
+ * `negative control` test at the bottom documents this without shipping a real break.
+ */
+
+// Analytics/stats views fetch from Tinybird; without it they surface fetch errors
+// that are environmental, not bundle bugs. CI enables it via GHOST_E2E_ANALYTICS.
+const analyticsEnabled = process.env.GHOST_E2E_ANALYTICS === 'true';
+
+test.describe('Ghost Admin - Runtime smoke gate', () => {
+    test('posts list renders without runtime errors', async ({page, runtimeErrors}) => {
+        const postsPage = new PostsPage(page);
+        await postsPage.goto();
+        await postsPage.waitForPageToFullyLoad();
+
+        await expect(postsPage.postsList).toBeVisible();
+        expect(runtimeErrors).toHaveLength(0);
+    });
+
+    test('post editor renders without runtime errors', async ({page, runtimeErrors}) => {
+        const editorPage = new PostEditorPage(page);
+        await editorPage.goto();
+        await editorPage.titleInput.waitFor({state: 'visible'});
+
+        await expect(editorPage.titleInput).toBeVisible();
+        expect(runtimeErrors).toHaveLength(0);
+    });
+
+    test('tags list renders without runtime errors', async ({page, runtimeErrors}) => {
+        const tagsPage = new TagsPage(page);
+        await tagsPage.goto();
+        await tagsPage.waitForPageToFullyLoad();
+
+        await expect(tagsPage.pageContent).toBeVisible();
+        expect(runtimeErrors).toHaveLength(0);
+    });
+
+    test('members list renders without runtime errors', async ({page, runtimeErrors}) => {
+        // Seed a member so the list view renders real content rather than the empty
+        // state, exercising the row-rendering path where a runtime error would hide.
+        await createMemberFactory(page.request).create({name: 'Smoke Member', email: 'smoke-member@example.com'});
+
+        const membersListPage = new MembersListPage(page);
+        await membersListPage.goto();
+        await membersListPage.memberRows.first().waitFor({state: 'visible'});
+
+        await expect(membersListPage.memberRows.first()).toBeVisible();
+        expect(runtimeErrors).toHaveLength(0);
+    });
+
+    test('comments list renders without runtime errors', async ({page, runtimeErrors}) => {
+        const commentsPage = new CommentsPage(page);
+        await commentsPage.goto();
+        await commentsPage.waitForComments();
+
+        await expect(commentsPage.commentsList).toBeVisible();
+        expect(runtimeErrors).toHaveLength(0);
+    });
+
+    test('settings general section renders without runtime errors', async ({page, runtimeErrors}) => {
+        const settingsPage = new SettingsPage(page);
+        await settingsPage.goto();
+
+        await expect(settingsPage.sidebar).toBeVisible();
+        await expect(settingsPage.publicationSection.languageSection).toBeVisible();
+        expect(runtimeErrors).toHaveLength(0);
+    });
+
+    test('settings staff section renders without runtime errors', async ({page, runtimeErrors}) => {
+        const settingsPage = new SettingsPage(page);
+        await settingsPage.goto();
+        await settingsPage.staffSidebarLink.click();
+
+        await expect(settingsPage.staffSection.ownerUser).toBeVisible();
+        expect(runtimeErrors).toHaveLength(0);
+    });
+
+    test('activitypub network view renders without runtime errors', async ({page, runtimeErrors}) => {
+        const activityPubPage = new ActivityPubPage(page);
+        await activityPubPage.goto();
+        await activityPubPage.waitForAppToMount();
+
+        await expect(activityPubPage.readerNavLink).toBeVisible();
+        expect(runtimeErrors).toHaveLength(0);
+    });
+
+    test('analytics overview renders without runtime errors', async ({page, runtimeErrors}) => {
+        test.skip(!analyticsEnabled, 'Requires Tinybird (GHOST_E2E_ANALYTICS=true)');
+
+        const analyticsOverviewPage = new AnalyticsOverviewPage(page);
+        await analyticsOverviewPage.goto();
+        await analyticsOverviewPage.header.waitFor({state: 'visible'});
+
+        await expect(analyticsOverviewPage.header).toBeVisible();
+        await expect(analyticsOverviewPage.topPosts.post).toBeVisible();
+        expect(runtimeErrors).toHaveLength(0);
+    });
+
+    test('analytics web traffic (stats dashboard) renders without runtime errors', async ({page, runtimeErrors}) => {
+        test.skip(!analyticsEnabled, 'Requires Tinybird (GHOST_E2E_ANALYTICS=true)');
+
+        const analyticsWebTrafficPage = new AnalyticsWebTrafficPage(page);
+        await analyticsWebTrafficPage.goto();
+        await analyticsWebTrafficPage.topContentCard.waitFor({state: 'visible'});
+
+        await expect(analyticsWebTrafficPage.topContentCard).toBeVisible();
+        expect(runtimeErrors).toHaveLength(0);
+    });
+
+    // NEGATIVE CONTROL (documentation-only; intentionally skipped).
+    //
+    // Proves the gate catches a runtime throw that a navigation-only test misses.
+    // To run it for real: unskip, then temporarily break a view the smoke suite
+    // renders — e.g. in apps/stats add `throw new Error('boom')` at the top of the
+    // Overview component's render, or reference an undefined global. Rebuild the
+    // e2e image and run this project. Expected result: the shell may still mount,
+    // but the broken view emits a pageerror / React console.error, `runtimeErrors`
+    // is non-empty, and `toHaveLength(0)` fails with the captured stack. Revert the
+    // break and re-run: green. That red→green swing is the proof the gate works.
+    test.skip('negative control - a broken view turns the gate red', async ({page, runtimeErrors}) => {
+        const analyticsOverviewPage = new AnalyticsOverviewPage(page);
+        await analyticsOverviewPage.goto();
+        await analyticsOverviewPage.header.waitFor({state: 'visible'});
+
+        expect(runtimeErrors).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/PLA-96

## Problem

The build-mode e2e suite (CI `job_e2e_tests`) boots the **real production admin bundle** in Docker, but **no test fails on `console.error` / uncaught `pageerror`**. A view can throw at runtime while a navigation-only test stays green — exactly the class of bug that build-success + unit tests miss, and that a real bug slipped through. The `stats` dashboard and `admin-x-activitypub` had thin/no real-build coverage.

This gate is **bundler-agnostic** (part of the Rolldown migration workstream but valuable independent of it), so it targets `main`.

## What this adds

1. **Console-error / pageerror collector fixture** — `e2e/helpers/playwright/console-errors.ts` extends the Ghost base fixture with a `runtimeErrors` collector wired to the authenticated `page`. Captures `pageerror` + `console.error` (React error boundaries log via `console.error`, so boundary-swallowed throws are still caught). Small, explicit, **commented allowlist** for known-benign third-party noise. Failing tests print the captured errors with stacks.

2. **Smoke project/spec** — `e2e/tests/admin/smoke/admin-views-smoke.test.ts`. For each major admin view it navigates, waits for a key content locator (reusing existing Page Objects), and asserts (i) content rendered and (ii) **zero non-allowlisted console errors / pageerrors**. Covered: posts list, editor, tags, members (seeded), comments, settings (general + staff), **activitypub**, and the Tinybird-gated **analytics overview + web/stats dashboard**.

3. **Wiring** — new `smoke` Playwright project (excluded from `main` so existing shards are unchanged); runs in the **analytics CI lane** (`projects: analytics,smoke`) so Tinybird is present for the stats/analytics views. Those views `test.skip()` gracefully when `GHOST_E2E_ANALYTICS !== 'true'`.

4. **Missing page object** — authored `ActivityPubPage` (`e2e/helpers/pages/admin/activitypub/`); the stats/analytics views reuse the existing analytics page objects.

## Negative control

A skipped, annotated `negative control` test documents exactly how reintroducing a broken component makes the gate go red: break a view the suite renders (e.g. `throw` in the stats Overview render), rebuild the e2e image, run the `smoke` project — the shell may still mount, but the broken view emits a `pageerror` / React `console.error`, `runtimeErrors` becomes non-empty, and `toHaveLength(0)` fails with the captured stack. Revert → green.

## Verification

Full smoke run against the live admin bundle requires the CI-only `ghost-e2e:local` image, so it's proven out in CI (draft). Locally, the novel collector logic was driven against a real Chromium page: a real uncaught `pageerror` is captured with its stack, a real `console.error` is captured, the allowlist drops third-party noise while keeping real crashes, and `console.warn`/`console.log` are ignored. Lint + types are clean.