### PR TITLE
Switched `dev:mailgun` script to use Mailgun API instead of SMTP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,8 +17,14 @@
 ## Stripe Account ID: acct_1*******
 #STRIPE_ACCOUNT_ID=
 
-# Mailgun SMTP credentials - used with `yarn dev:mailgun`
-## SMTP username from Mailgun (often starts with `postmaster@`)
-# MAILGUN_SMTP_USER=
-## SMTP password from Mailgun
-# MAILGUN_SMTP_PASS=
+# Mailgun API credentials - used with `pnpm dev:mailgun`
+## Mailgun sending domain
+# MAILGUN_DOMAIN=
+## From address for transactional emails. Defaults to postmaster@MAILGUN_DOMAIN.
+# MAILGUN_FROM=
+## Mailgun API key
+# MAILGUN_API_KEY=
+## Mailgun API origin for transactional emails. Use https://api.eu.mailgun.net for EU domains.
+# MAILGUN_API_URL=https://api.mailgun.net
+## Mailgun API base URL for newsletter/bulk emails. Use https://api.eu.mailgun.net/v3 for EU domains.
+# MAILGUN_BASE_URL=https://api.mailgun.net/v3

--- a/compose.dev.mailgun.yaml
+++ b/compose.dev.mailgun.yaml
@@ -1,10 +1,13 @@
 services:
   ghost-dev:
     environment:
-      # Route Ghost transactional/test emails via Mailgun SMTP instead of Mailpit.
+      # Route Ghost transactional and newsletter/bulk emails via the Mailgun API.
       # Values come from the host environment/.env file.
-      mail__transport: SMTP
-      mail__options__host: smtp.mailgun.org
-      mail__options__port: 587
-      mail__options__auth__user: ${MAILGUN_SMTP_USER}
-      mail__options__auth__pass: ${MAILGUN_SMTP_PASS}
+      mail__from: ${MAILGUN_FROM:-postmaster@${MAILGUN_DOMAIN}}
+      mail__transport: mailgun
+      mail__options__url: ${MAILGUN_API_URL:-https://api.mailgun.net}
+      mail__options__auth__api_key: ${MAILGUN_API_KEY}
+      mail__options__auth__domain: ${MAILGUN_DOMAIN}
+      bulkEmail__mailgun__apiKey: ${MAILGUN_API_KEY}
+      bulkEmail__mailgun__domain: ${MAILGUN_DOMAIN}
+      bulkEmail__mailgun__baseUrl: ${MAILGUN_BASE_URL:-https://api.mailgun.net/v3}


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1408/ensure-automation-emails-are-sent-via-the-mailgun-api-in-production

## Summary
- Currently with regular `pnpm dev`, automation emails are sent to Mailpit. This is fine for the current features, but now that we're working on adding email analytics for automation emails, we need to start using the Mailgun API to send these. This is already how Ghost is configured on Ghost(Pro), but it's currently somewhat tricky to mimic this config locally.
- The existing `pnpm dev:mailgun` setup is almost there, but it uses Mailgun via SMTP, which doesn't pass along the tags and other metadata needed for automations email analytics.
- This updates the `pnpm dev:mailgun` command to use the Mailgun API (`transport = mailgun`) for newsletters, transactional emails, and automation emails alike, which also aligns with how mail is configured on Ghost(Pro)