### PR TITLE
Changed acceptance CI to avoid Nx native runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -512,6 +512,9 @@ jobs:
     env:
       DB: ${{ matrix.env.DB }}
       NODE_ENV: ${{ matrix.env.NODE_ENV }}
+      # The acceptance job has intermittently segfaulted before Nx starts the
+      # target script. Keep Nx orchestration, but avoid its native PTY runner.
+      NX_NATIVE_COMMAND_RUNNER: "false"
     name: Acceptance tests (Node ${{ matrix.node }}, ${{ matrix.env.DB }})
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
## Summary
- disables Nx's native command runner for the acceptance-test job only
- keeps the existing `pnpm nx run ghost:...` invocations intact
- documents that this targets the intermittent pre-Vitest SIGSEGV path

## Context
The observed SIGSEGV failures happen about 1.5s after `pnpm nx run ghost:test:e2e` / `ghost:test:ci:e2e` starts, before Nx prints the target header and before Vitest prints `RUN v...`.

That points at Nx process orchestration rather than the acceptance tests, DB adapter, or Ghost startup. Nx documents `NX_NATIVE_COMMAND_RUNNER=false` as falling back from the native pseudo-terminal runner to the standard Node child-process path, so this is a targeted experiment rather than a retry.

## Testing
- Not run locally; CI workflow-only change.