### PR TITLE
Cleaned up Vite config after Vite 8

### DIFF
--- a/apps/admin-x-framework/src/vite.ts
+++ b/apps/admin-x-framework/src/vite.ts
@@ -67,9 +67,6 @@ export default function adminXViteConfig({packageName, entry, overrides}: {packa
 
                     return `${outputFileName}.js`;
                 }
-            },
-            commonjsOptions: {
-                include: [/packages/, /node_modules/]
             }
         },
         test: {

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -50,7 +50,6 @@
         "typescript": "catalog:",
         "typescript-eslint": "catalog:",
         "vite": "catalog:",
-        "vite-tsconfig-paths": "6.1.1",
         "vitest": "catalog:"
     },
     "nx": {

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -3,7 +3,6 @@ import { createRequire } from "node:module";
 import { defineConfig } from "vitest/config";
 import type { PluginOption } from "vite";
 const require = createRequire(import.meta.url);
-import tsconfigPaths from "vite-tsconfig-paths";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
@@ -41,20 +40,24 @@ function getBase(command: 'build' | 'serve'): string {
 // https://vite.dev/config/
 export default defineConfig(({ command }) => ({
     base: getBase(command),
-    plugins: [tailwindcss() as PluginOption, react(), emberAssetsPlugin(), ghostBackendProxyPlugin(), tsconfigPaths()],
+    plugins: [tailwindcss() as PluginOption, react(), emberAssetsPlugin(), ghostBackendProxyPlugin()],
     define: {
         "process.env.DEBUG": false, // Shim env var utilized by the @tryghost/nql package
     },
     server: {
         host: '0.0.0.0',
         port: 5174,
-        allowedHosts: true
+        allowedHosts: true,
+        // Forward browser console warnings/errors to the dev-server terminal
+        forwardConsole: { logLevels: ['warn', 'error'] }
     },
     optimizeDeps: {
         include: ["@tryghost/koenig-lexical"],
     },
     resolve: {
         alias: {
+            "@": resolve(__dirname, "./src"),
+            "@test-utils": resolve(__dirname, "./test-utils"),
             "@ghost-cards": GHOST_CARDS_PATH,
             // TODO: Remove this when @tryghost/nql is updated
             mingo: require.resolve("mingo/dist/mingo.js"),

--- a/apps/comments-ui/vite.config.mts
+++ b/apps/comments-ui/vite.config.mts
@@ -32,11 +32,6 @@ export default publicAppViteConfig({
                 'react-dom': resolve(import.meta.dirname, 'node_modules/react-dom')
             }
         },
-        build: {
-            rollupOptions: {
-                output: {}
-            }
-        },
         test: {
             setupFiles: './src/setup-tests.ts',
             include: ['test/unit/**/*.test.{js,jsx,ts,tsx}'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -687,9 +687,6 @@ importers:
       vite:
         specifier: 'catalog:'
         version: 8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      vite-tsconfig-paths:
-        specifier: 6.1.1
-        version: 6.1.1(supports-color@5.5.0)(typescript@5.9.3)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -21242,17 +21239,6 @@ packages:
     engines: {node: '>=16.20.2'}
     hasBin: true
 
-  tsconfck@3.1.6:
-    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
-    engines: {node: ^18 || >=20}
-    deprecated: unmaintained
-    hasBin: true
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   tsconfig-paths@4.2.0:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
@@ -21790,11 +21776,6 @@ packages:
     resolution: {integrity: sha512-W+uoSpmVkSmNOGPSsDCWVW/DDAyv+9fap9AZXBvWiQqrboJ08j2vh0tFxTD/LjwqwAd3yYSVJgm54S/1GhbdnA==}
     peerDependencies:
       vite: '>=2.6.0'
-
-  vite-tsconfig-paths@6.1.1:
-    resolution: {integrity: sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==}
-    peerDependencies:
-      vite: '*'
 
   vite@8.1.3:
     resolution: {integrity: sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==}
@@ -46031,10 +46012,6 @@ snapshots:
       normalize-path: 3.0.0
       plimit-lit: 1.6.1
 
-  tsconfck@3.1.6(typescript@5.9.3):
-    optionalDependencies:
-      typescript: 5.9.3
-
   tsconfig-paths@4.2.0:
     dependencies:
       json5: 2.2.3
@@ -46641,16 +46618,6 @@ snapshots:
       vite: 8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - rollup
-      - supports-color
-      - typescript
-
-  vite-tsconfig-paths@6.1.1(supports-color@5.5.0)(typescript@5.9.3)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
-    dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
-      globrex: 0.1.2
-      tsconfck: 3.1.6(typescript@5.9.3)
-      vite: 8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-    transitivePeerDependencies:
       - supports-color
       - typescript
 


### PR DESCRIPTION
ref [PLA-96](https://linear.app/ghost/issue/PLA-96)

Tidies up Vite build config now that the repo is on Vite 8 (Rolldown built in) — removes no-op config and swaps one plugin for a smaller native equivalent.

## Changes

**Removed dead config** (no-ops under Vite 8 — Rolldown handles CJS natively, `rollupOptions` output is aliased):
- `apps/admin-x-framework/src/vite.ts`: drop `build.commonjsOptions: { include: [/packages/, /node_modules/] }`.
- `apps/comments-ui/vite.config.mts`: drop the empty `build: { rollupOptions: { output: {} } }`.

**Replaced `vite-tsconfig-paths` with `resolve.alias`** in `apps/admin`:
- Dropped the plugin + devDependency; added two explicit aliases (`@` → `./src`, `@test-utils` → `./test-utils`).
- Why: Vite 8's Rolldown bundler resolves tsconfig `paths` natively at build time, but Vitest's transform pipeline (`vite:import-analysis`) does not — so the plugin was load-bearing *for tests only*. Two aliases cover both build and test, and the config no longer silently depends on plugin resolution the test runner can't see. Smaller surface than a whole plugin.

**Added `server.forwardConsole`** (`{ logLevels: ['warn', 'error'] }`) to `apps/admin`:
- Forwards browser console warnings/errors to the dev-server terminal (source-mapped), scoped to warn/error so it doesn't drown the aggregated `pnpm dev` log.

## Verification

- admin-x-framework consumers (posts, stats, admin-x-settings, activitypub) + comments-ui build clean without `commonjsOptions` — CJS deps still bundle (comments-ui UMD unchanged, 0 leaked `require(`/`module.exports`).
- `apps/admin`: **108/108 unit tests pass** (the tsconfig-paths regression check) and production build clean.
