### PR TITLE
Restored vite-tsconfig-paths in admin for cross-package alias resolution

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -50,6 +50,7 @@
         "typescript": "catalog:",
         "typescript-eslint": "catalog:",
         "vite": "catalog:",
+        "vite-tsconfig-paths": "6.1.1",
         "vitest": "catalog:"
     },
     "nx": {

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -3,6 +3,7 @@ import { createRequire } from "node:module";
 import { defineConfig } from "vitest/config";
 import type { PluginOption } from "vite";
 const require = createRequire(import.meta.url);
+import tsconfigPaths from "vite-tsconfig-paths";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
@@ -40,7 +41,7 @@ function getBase(command: 'build' | 'serve'): string {
 // https://vite.dev/config/
 export default defineConfig(({ command }) => ({
     base: getBase(command),
-    plugins: [tailwindcss() as PluginOption, react(), emberAssetsPlugin(), ghostBackendProxyPlugin()],
+    plugins: [tailwindcss() as PluginOption, react(), emberAssetsPlugin(), ghostBackendProxyPlugin(), tsconfigPaths()],
     define: {
         "process.env.DEBUG": false, // Shim env var utilized by the @tryghost/nql package
     },
@@ -56,8 +57,6 @@ export default defineConfig(({ command }) => ({
     },
     resolve: {
         alias: {
-            "@": resolve(__dirname, "./src"),
-            "@test-utils": resolve(__dirname, "./test-utils"),
             "@ghost-cards": GHOST_CARDS_PATH,
             // TODO: Remove this when @tryghost/nql is updated
             mingo: require.resolve("mingo/dist/mingo.js"),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -687,6 +687,9 @@ importers:
       vite:
         specifier: 'catalog:'
         version: 8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite-tsconfig-paths:
+        specifier: 6.1.1
+        version: 6.1.1(typescript@5.9.3)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -21239,6 +21242,17 @@ packages:
     engines: {node: '>=16.20.2'}
     hasBin: true
 
+  tsconfck@3.1.6:
+    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
+    engines: {node: ^18 || >=20}
+    deprecated: unmaintained
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   tsconfig-paths@4.2.0:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
@@ -21776,6 +21790,11 @@ packages:
     resolution: {integrity: sha512-W+uoSpmVkSmNOGPSsDCWVW/DDAyv+9fap9AZXBvWiQqrboJ08j2vh0tFxTD/LjwqwAd3yYSVJgm54S/1GhbdnA==}
     peerDependencies:
       vite: '>=2.6.0'
+
+  vite-tsconfig-paths@6.1.1:
+    resolution: {integrity: sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==}
+    peerDependencies:
+      vite: '*'
 
   vite@8.1.3:
     resolution: {integrity: sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==}
@@ -46012,6 +46031,10 @@ snapshots:
       normalize-path: 3.0.0
       plimit-lit: 1.6.1
 
+  tsconfck@3.1.6(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
+
   tsconfig-paths@4.2.0:
     dependencies:
       json5: 2.2.3
@@ -46618,6 +46641,16 @@ snapshots:
       vite: 8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - rollup
+      - supports-color
+      - typescript
+
+  vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+    dependencies:
+      debug: 4.4.3(supports-color@5.5.0)
+      globrex: 0.1.2
+      tsconfck: 3.1.6(typescript@5.9.3)
+      vite: 8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+    transitivePeerDependencies:
       - supports-color
       - typescript
 


### PR DESCRIPTION
Restores `vite-tsconfig-paths` to `apps/admin` — it does a load-bearing job a plain `resolve.alias` can't.

## The problem

`apps/admin` imports `apps/stats` and `apps/posts` **source** (`@tryghost/stats/api` / `@tryghost/posts/api` resolve to `./src/api.ts`, not built dist). That source uses each package's **own** tsconfig path aliases — `@src`, `@components`, `@hooks` (e.g. `stats/src/providers/global-data-provider.tsx` → `import … from "@src/utils/constants"`).

`vite-tsconfig-paths` resolved those **per file, per package** (admin's tsconfig `references` stats'/posts' tsconfigs). A plain `resolve.alias` can't replace it: `@src` maps to a *different* directory in each package, so a single alias entry can't be correct for both.

With only admin's own `@`/`@test-utils` aliases and no plugin, the dev server / Vitest transform fails:

```
Failed to resolve import "@src/utils/constants" from "../stats/src/providers/global-data-provider.tsx". Does the file exist?
```

The Rolldown **build** resolves tsconfig paths natively, so it stayed green — but the **dev server** and **Vitest** don't, which is why it only bit on a cold cache / fresh checkout.

## Fix

- Add `vite-tsconfig-paths` back to `apps/admin/vite.config.ts` (+ the devDependency).
- Drop the now-redundant `@` / `@test-utils` `resolve.alias` entries — the plugin resolves admin's own tsconfig paths too.

## Verification

- The failing import resolves again (a test importing `@tryghost/stats/api` now passes; it errored on `@src` before).
- `apps/admin`: **108/108 unit tests pass**, production build clean.

(The per-package `@src` aliases dissolve for good once stats/posts co-locate into `apps/admin` and their aliases become relative — but that's the larger consolidation work; this restores the working state now.)
