### PR TITLE
Replaced `@tryghost/promise` with plain `await` in tests

### DIFF
--- a/ghost/core/test/legacy/api/admin/schedules.test.js
+++ b/ghost/core/test/legacy/api/admin/schedules.test.js
@@ -9,7 +9,6 @@ const models = require('../../../../core/server/models');
 const config = require('../../../../core/shared/config');
 const testUtils = require('../../../utils');
 const localUtils = require('./utils');
-const {sequence} = require('@tryghost/promise');
 
 describe('Schedules API', function () {
     const resources = [];
@@ -80,7 +79,7 @@ describe('Schedules API', function () {
             }]
         }));
 
-        const result = await sequence(resources.map(post => async () => {
+        const result = await Promise.all(resources.map((post) => {
             return models.Post.add(post, {context: {internal: true}});
         }));
 

--- a/ghost/core/test/legacy/models/model-posts.test.js
+++ b/ghost/core/test/legacy/models/model-posts.test.js
@@ -854,12 +854,13 @@ describe('Post Model', function () {
 
             it('can generate a non conflicting slug', async function () {
                 // Create 12 posts with the same title
-                const createdPosts = await Promise.all(_.times(12, function (i) {
-                    return models.Post.add({
+                const createdPosts = [];
+                for (let i = 0; i < 12; i += 1) {
+                    createdPosts.push(await models.Post.add({
                         title: 'Test Title',
                         lexical: markdownToLexical('Test Content ' + (i + 1))
-                    }, context);
-                }));
+                    }, context));
+                }
 
                 // Should have created 12 posts
                 assert.equal(createdPosts.length, 12);

--- a/ghost/core/test/legacy/models/model-posts.test.js
+++ b/ghost/core/test/legacy/models/model-posts.test.js
@@ -5,7 +5,6 @@ const sinon = require('sinon');
 const testUtils = require('../../utils');
 const moment = require('moment');
 const _ = require('lodash');
-const {sequence} = require('@tryghost/promise');
 const urlService = require('../../../core/server/services/url');
 const ghostBookshelf = require('../../../core/server/models/base');
 const models = require('../../../core/server/models');
@@ -855,13 +854,11 @@ describe('Post Model', function () {
 
             it('can generate a non conflicting slug', async function () {
                 // Create 12 posts with the same title
-                const createdPosts = await sequence(_.times(12, function (i) {
-                    return function () {
-                        return models.Post.add({
-                            title: 'Test Title',
-                            lexical: markdownToLexical('Test Content ' + (i + 1))
-                        }, context);
-                    };
+                const createdPosts = await Promise.all(_.times(12, function (i) {
+                    return models.Post.add({
+                        title: 'Test Title',
+                        lexical: markdownToLexical('Test Content ' + (i + 1))
+                    }, context);
                 }));
 
                 // Should have created 12 posts

--- a/ghost/core/test/utils/api.js
+++ b/ghost/core/test/utils/api.js
@@ -4,7 +4,6 @@ const _ = require('lodash');
 const moment = require('moment');
 const DataGenerator = require('./fixtures/data-generator');
 const config = require('../../core/shared/config');
-const {sequence} = require('@tryghost/promise');
 const host = config.get('server').host;
 const port = config.get('server').port;
 const protocol = 'http://';
@@ -61,7 +60,7 @@ function checkResponse(jsonResponse, objectType, additionalProperties, missingPr
  * @TODO make this do the DB init as well
  */
 const doAuth = (apiOptions) => {
-    return function doAuthInner() {
+    return async function doAuthInner() {
         let API_URL = arguments[0];
         let request = arguments[1];
 
@@ -77,9 +76,11 @@ const doAuth = (apiOptions) => {
 
         const fixtureOps = apiOptions.getFixtureOps(options);
 
-        return sequence(fixtureOps).then(function () {
-            return login(request, API_URL);
-        });
+        for (const fixtureOp of fixtureOps) {
+            await fixtureOp();
+        }
+
+        return login(request, API_URL);
     };
 };
 

--- a/ghost/core/test/utils/db-template.js
+++ b/ghost/core/test/utils/db-template.js
@@ -3,7 +3,6 @@ const path = require('path');
 const fs = require('fs-extra');
 const knex = require('knex');
 const KnexMigrator = require('knex-migrator');
-const {sequence} = require('@tryghost/promise');
 
 const config = require('../../core/shared/config');
 const db = require('../../core/server/data/db');
@@ -246,10 +245,10 @@ const restoreFromTemplateSQLite = async () => {
                 'SELECT name FROM template.sqlite_master WHERE type = ?', ['table']
             )).map(row => row.name);
 
-            await sequence(dataTables.map(table => async () => {
+            for (const table of dataTables) {
                 await run('DELETE FROM ??', [table]);
                 await run('INSERT INTO ?? SELECT * FROM template.??', [table, table]);
-            }));
+            }
         } finally {
             await run('PRAGMA foreign_keys = ON');
         }
@@ -306,12 +305,12 @@ const restoreFromTemplate = async () => {
     // This makes the restore byte-faithful to a fresh init.
     await db.knex.raw('SET FOREIGN_KEY_CHECKS=0;');
     try {
-        await sequence(tables.map(table => async () => {
+        for (const table of tables) {
             const [[{'Create Table': createTableSql}]] = await db.knex.raw('SHOW CREATE TABLE ??.??', [templateDb, table]);
             await db.knex.schema.dropTableIfExists(table);
             await db.knex.raw(createTableSql);
             await db.knex.raw('INSERT INTO ?? SELECT * FROM ??.??', [table, templateDb, table]);
-        }));
+        }
     } finally {
         await db.knex.raw('SET FOREIGN_KEY_CHECKS=1;');
     }

--- a/ghost/core/test/utils/db-utils.js
+++ b/ghost/core/test/utils/db-utils.js
@@ -16,7 +16,6 @@ const config = require('../../core/shared/config');
 const db = require('../../core/server/data/db');
 const schema = require('../../core/server/data/schema').tables;
 const schemaTables = Object.keys(schema);
-const {sequence} = require('@tryghost/promise');
 
 // Other Test Utilities
 const urlServiceUtils = require('./url-service-utils');
@@ -188,13 +187,13 @@ const createMySQLSnapshot = async () => {
 
     const tables = getResetTables();
 
-    await sequence(tables.map(table => async () => {
+    for (const table of tables) {
         const snapshotTable = getMySQLSnapshotTableName(table);
 
         await db.knex.schema.dropTableIfExists(snapshotTable);
         await db.knex.raw('CREATE TABLE ?? LIKE ??', [snapshotTable, table]);
         await db.knex.raw('INSERT INTO ?? SELECT * FROM ??', [snapshotTable, table]);
-    }));
+    }
 
     mysqlSnapshotDatabase = getMySQLDatabaseName();
 };
@@ -209,12 +208,12 @@ const restoreMySQLSnapshot = async () => {
         try {
             await db.knex.raw('SET FOREIGN_KEY_CHECKS=0;').transacting(trx);
 
-            await sequence(tables.map(table => async () => {
+            for (const table of tables) {
                 const snapshotTable = getMySQLSnapshotTableName(table);
 
                 await db.knex.raw('DELETE FROM ??', [table]).transacting(trx);
                 await db.knex.raw('INSERT INTO ?? SELECT * FROM ??', [table, snapshotTable]).transacting(trx);
-            }));
+            }
         } finally {
             await db.knex.raw('SET FOREIGN_KEY_CHECKS=1;').transacting(trx);
             debug('Database snapshot restore end');
@@ -230,9 +229,9 @@ const dropMySQLSnapshots = async () => {
     mysqlSnapshotDatabase = null;
 
     try {
-        await sequence(getResetTables().map(table => () => {
-            return db.knex.schema.dropTableIfExists(getMySQLSnapshotTableName(table));
-        }));
+        for (const table of getResetTables()) {
+            await db.knex.schema.dropTableIfExists(getMySQLSnapshotTableName(table));
+        }
     } catch (err) {
         // CASE: table does not exist || DB does not exist
         if (err.errno === 1146 || err.errno === 1049) {
@@ -261,9 +260,9 @@ const truncateAll = async () => {
                 await db.knex.raw('PRAGMA foreign_keys = OFF;');
             }
 
-            await sequence(tables.map(table => () => {
-                return db.knex.raw('DELETE FROM ' + table + ';');
-            }));
+            for (const table of tables) {
+                await db.knex.raw('DELETE FROM ' + table + ';');
+            }
 
             if (foreignKeysEnabled.foreign_keys) {
                 await db.knex.raw('PRAGMA foreign_keys = ON;');
@@ -285,7 +284,9 @@ const truncateAll = async () => {
     await db.knex.transaction(async (trx) => {
         try {
             await db.knex.raw('SET FOREIGN_KEY_CHECKS=0;').transacting(trx);
-            await sequence(tables.map(table => () => db.knex.raw('DELETE FROM ' + table + ';').transacting(trx)));
+            for (const table of tables) {
+                await db.knex.raw('DELETE FROM ' + table + ';').transacting(trx);
+            }
             await db.knex.raw('SET FOREIGN_KEY_CHECKS=1;').transacting(trx);
         } catch (err) {
             // CASE: table does not exist || DB does not exist

--- a/ghost/core/test/utils/e2e-framework.js
+++ b/ghost/core/test/utils/e2e-framework.js
@@ -14,7 +14,6 @@
 // The output state checker is responsible for checking the response from the app after performing a request.
 const _ = require('lodash');
 const debug = require('@tryghost/debug')('test');
-const {sequence} = require('@tryghost/promise');
 const {any, stringMatching} = require('@tryghost/express-test').snapshot;
 const {AsymmetricMatcher} = require('expect');
 const fs = require('fs-extra');
@@ -161,7 +160,12 @@ const initFixtures = async (...options) => {
 
     const fixtureOps = fixtureUtils.getFixtureOps(options);
 
-    return sequence(fixtureOps);
+    const results = [];
+    for (const fixtureOp of fixtureOps) {
+        results.push(await fixtureOp());
+    }
+
+    return results;
 };
 
 const getFixture = (type, index = 0) => {

--- a/ghost/core/test/utils/fixture-utils.js
+++ b/ghost/core/test/utils/fixture-utils.js
@@ -25,9 +25,11 @@ let postsInserted = 0;
 /** TEST FIXTURES **/
 const fixtures = {
     insertPosts: async function insertPosts(posts) {
-        return Promise.all(posts.map((post) => {
-            return models.Post.add(post, context.internal);
-        }));
+        const results = [];
+        for (const post of posts) {
+            results.push(await models.Post.add(post, context.internal));
+        }
+        return results;
     },
 
     insertPostsAndTags: async function insertPostsAndTags() {

--- a/ghost/core/test/utils/fixture-utils.js
+++ b/ghost/core/test/utils/fixture-utils.js
@@ -684,9 +684,8 @@ const fixtures = {
 
         for (const member of members) {
             for (const subscription of member.subscriptions) {
-                const product = subscription.price.product.product_id;
                 await models.Member.edit({products: member.products.concat({
-                    id: product
+                    id: subscription.price.product.product_id
                 })}, {id: member.id});
             }
         }

--- a/ghost/core/test/utils/fixture-utils.js
+++ b/ghost/core/test/utils/fixture-utils.js
@@ -5,7 +5,6 @@ const fs = require('fs-extra');
 const crypto = require('crypto');
 const ObjectId = require('bson-objectid').default;
 const KnexMigrator = require('knex-migrator');
-const {sequence} = require('@tryghost/promise');
 // Resolve MigratorConfig.js from the package root, not process.cwd() — see db-utils.js.
 const knexMigrator = new KnexMigrator({knexMigratorFilePath: path.join(__dirname, '../..')});
 
@@ -25,45 +24,40 @@ let postsInserted = 0;
 
 /** TEST FIXTURES **/
 const fixtures = {
-    insertPosts: function insertPosts(posts) {
-        const tasks = posts.map(post => () => {
+    insertPosts: async function insertPosts(posts) {
+        return Promise.all(posts.map((post) => {
             return models.Post.add(post, context.internal);
-        });
-
-        return sequence(tasks);
+        }));
     },
 
-    insertPostsAndTags: function insertPostsAndTags() {
-        return Promise.all(DataGenerator.forKnex.tags.map((tag) => {
+    insertPostsAndTags: async function insertPostsAndTags() {
+        await Promise.all(DataGenerator.forKnex.tags.map((tag) => {
             return models.Tag.add(tag, context.internal);
-        }))
-            .then(function () {
-                return sequence(_.cloneDeep(DataGenerator.forKnex.posts).map(post => () => {
-                    let postTagRelations = _.filter(DataGenerator.forKnex.posts_tags, {post_id: post.id});
-                    let postAuthorsRelations = _.filter(DataGenerator.forKnex.posts_authors, {post_id: post.id});
+        }));
 
-                    postTagRelations = _.map(postTagRelations, function (postTagRelation) {
-                        return _.find(DataGenerator.forKnex.tags, {id: postTagRelation.tag_id});
-                    });
+        for (const post of _.cloneDeep(DataGenerator.forKnex.posts)) {
+            let postTagRelations = _.filter(DataGenerator.forKnex.posts_tags, {post_id: post.id});
+            let postAuthorsRelations = _.filter(DataGenerator.forKnex.posts_authors, {post_id: post.id});
 
-                    postAuthorsRelations = _.map(postAuthorsRelations, function (postAuthorsRelation) {
-                        return _.find(DataGenerator.forKnex.users, {id: postAuthorsRelation.author_id});
-                    });
-
-                    post.tags = postTagRelations;
-                    post.authors = postAuthorsRelations;
-
-                    return models.Post.add(post, context.internal);
-                }));
-            })
-            .then(function () {
-                return Promise.all(DataGenerator.forKnex.posts_meta.map((postMeta) => {
-                    return models.PostsMeta.add(postMeta, context.internal);
-                }));
-            })
-            .then(function () {
-                return fixtures.restoreLegacyMobiledocPosts();
+            postTagRelations = _.map(postTagRelations, function (postTagRelation) {
+                return _.find(DataGenerator.forKnex.tags, {id: postTagRelation.tag_id});
             });
+
+            postAuthorsRelations = _.map(postAuthorsRelations, function (postAuthorsRelation) {
+                return _.find(DataGenerator.forKnex.users, {id: postAuthorsRelation.author_id});
+            });
+
+            post.tags = postTagRelations;
+            post.authors = postAuthorsRelations;
+
+            await models.Post.add(post, context.internal);
+        }
+
+        await Promise.all(DataGenerator.forKnex.posts_meta.map((postMeta) => {
+            return models.PostsMeta.add(postMeta, context.internal);
+        }));
+
+        return fixtures.restoreLegacyMobiledocPosts();
     },
 
     // New saves convert mobiledoc to lexical, but some fixtures need to remain
@@ -585,47 +579,50 @@ const fixtures = {
 
         const product = await models.Product.findOne({type: 'paid'}, context.internal);
 
-        await sequence(_.cloneDeep(DataGenerator.forKnex.stripe_products).map(stripeProduct => () => {
+        for (const stripeProduct of _.cloneDeep(DataGenerator.forKnex.stripe_products)) {
             stripeProduct.product_id = product.id;
-            return models.StripeProduct.add(stripeProduct, context.internal);
-        }));
+            await models.StripeProduct.add(stripeProduct, context.internal);
+        }
 
-        await sequence(_.cloneDeep(DataGenerator.forKnex.stripe_prices).map(stripePrice => () => {
-            return models.StripePrice.add(stripePrice, context.internal);
-        }));
+        for (const stripePrice of _.cloneDeep(DataGenerator.forKnex.stripe_prices)) {
+            await models.StripePrice.add(stripePrice, context.internal);
+        }
     },
 
-    insertMembersAndLabelsAndProducts: function insertMembersAndLabelsAndProducts(newsletters = false) {
-        return Promise.all(DataGenerator.forKnex.labels.map((label) => {
+    insertMembersAndLabelsAndProducts: async function insertMembersAndLabelsAndProducts(newsletters = false) {
+        await Promise.all(DataGenerator.forKnex.labels.map((label) => {
             return models.Label.add(label, context.internal);
-        })).then(function () {
-            let coreProductFixtures = fixtureManager.findModelFixtures('Product').entries;
-            return Promise.all(coreProductFixtures.map(async (product) => {
-                const found = await models.Product.findOne(product, context.internal);
-                if (!found) {
-                    await models.Product.add(product, context.internal);
-                }
-            }));
-        }).then(async function () {
-            let testProductFixtures = DataGenerator.forKnex.products;
-            for (const productFixture of testProductFixtures) {
-                if (productFixture.id) { // Not currently used - this is used to add new text fixtures, e.g. a Bronze/Silver/Gold Tier
-                    await models.Product.add(productFixture, context.internal);
-                } else { // Used to update the core fixtures
-                    // If it doesn't exist we have invalid fixtures, so require: true to ensure we throw
-                    const existing = await models.Product.findOne({slug: productFixture.slug}, {...context.internal, require: true});
-                    await models.Product.edit(productFixture, {...context.internal, id: existing.id});
-                }
+        }));
+
+        let coreProductFixtures = fixtureManager.findModelFixtures('Product').entries;
+        await Promise.all(coreProductFixtures.map(async (product) => {
+            const found = await models.Product.findOne(product, context.internal);
+            if (!found) {
+                await models.Product.add(product, context.internal);
             }
-        }).then(function () {
-            return models.Product.findOne({type: 'paid'}, context.internal);
-        }).then(function (product) {
-            return Promise.all([
-                sequence(_.cloneDeep(DataGenerator.forKnex.stripe_products).map(stripeProduct => () => {
+        }));
+
+        let testProductFixtures = DataGenerator.forKnex.products;
+        for (const productFixture of testProductFixtures) {
+            if (productFixture.id) { // Not currently used - this is used to add new text fixtures, e.g. a Bronze/Silver/Gold Tier
+                await models.Product.add(productFixture, context.internal);
+            } else { // Used to update the core fixtures
+                // If it doesn't exist we have invalid fixtures, so require: true to ensure we throw
+                const existing = await models.Product.findOne({slug: productFixture.slug}, {...context.internal, require: true});
+                await models.Product.edit(productFixture, {...context.internal, id: existing.id});
+            }
+        }
+
+        const product = await models.Product.findOne({type: 'paid'}, context.internal);
+        await Promise.all([
+            (async () => {
+                for (const stripeProduct of _.cloneDeep(DataGenerator.forKnex.stripe_products)) {
                     stripeProduct.product_id = product.id;
-                    return models.StripeProduct.add(stripeProduct, context.internal);
-                })),
-                sequence(_.cloneDeep(DataGenerator.forKnex.members).map(member => () => {
+                    await models.StripeProduct.add(stripeProduct, context.internal);
+                }
+            })(),
+            (async () => {
+                for (const member of _.cloneDeep(DataGenerator.forKnex.members)) {
                     let memberLabelRelations = _.filter(DataGenerator.forKnex.members_labels, {member_id: member.id});
 
                     memberLabelRelations = _.map(memberLabelRelations, function (memberLabelRelation) {
@@ -648,108 +645,107 @@ const fixtures = {
                         member.products = [{id: product.id}];
                     }
 
-                    return models.Member.add(member, context.internal);
-                }))
-            ]);
-        }).then(function () {
-            return sequence(_.cloneDeep(DataGenerator.forKnex.members_stripe_customers).map(customer => () => {
-                return models.MemberStripeCustomer.add(customer, context.internal);
-            }));
-        }).then(function () {
-            return sequence(_.cloneDeep(DataGenerator.forKnex.stripe_prices).map(stripePrice => () => {
-                return models.StripePrice.add(stripePrice, context.internal);
-            }));
-        }).then(async function () {
-            // Add monthly/yearly prices to default product for testing
-            const defaultProduct = await models.Product.findOne({slug: 'default-product'}, context.internal);
-            return models.Product.edit({
-                ...defaultProduct.toJSON(),
-                monthly_price_id: DataGenerator.forKnex.stripe_prices[1].id,
-                yearly_price_id: DataGenerator.forKnex.stripe_prices[2].id
-            }, _.merge({id: defaultProduct.id}, context.internal));
-        }).then(function () {
-            return sequence(_.cloneDeep(DataGenerator.forKnex.stripe_customer_subscriptions).map(subscription => () => {
-                return models.StripeCustomerSubscription.add(subscription, context.internal);
-            }));
-        }).then(async function () {
-            const members = (await models.Member.findAll({
-                withRelated: [
-                    'labels',
-                    'stripeSubscriptions',
-                    'stripeSubscriptions.customer',
-                    'stripeSubscriptions.stripePrice',
-                    'stripeSubscriptions.stripePrice.stripeProduct',
-                    'products',
-                    'offerRedemptions'
-                ]
-            })).toJSON();
-
-            for (const member of members) {
-                for (const subscription of member.subscriptions) {
-                    const product = subscription.price.product.product_id;
-                    await models.Member.edit({products: member.products.concat({
-                        id: product
-                    })}, {id: member.id});
+                    await models.Member.add(member, context.internal);
                 }
-            }
+            })()
+        ]);
 
-            // Populate members_current_subscription lookup table for each member
-            // that has subscriptions (uses the VIEW as single source of truth
-            // for subscription priority resolution)
-            await models.Base.knex.raw(`
-                INSERT INTO members_current_subscription (member_id, subscription_id)
-                SELECT member_id, subscription_id
-                FROM members_resolved_subscription
-            `);
-        }).then(async function () {
-            for (const event of DataGenerator.forKnex.members_paid_subscription_events) {
-                await models.MemberPaidSubscriptionEvent.add(event);
+        for (const customer of _.cloneDeep(DataGenerator.forKnex.members_stripe_customers)) {
+            await models.MemberStripeCustomer.add(customer, context.internal);
+        }
+
+        for (const stripePrice of _.cloneDeep(DataGenerator.forKnex.stripe_prices)) {
+            await models.StripePrice.add(stripePrice, context.internal);
+        }
+
+        // Add monthly/yearly prices to default product for testing
+        const defaultProduct = await models.Product.findOne({slug: 'default-product'}, context.internal);
+        await models.Product.edit({
+            ...defaultProduct.toJSON(),
+            monthly_price_id: DataGenerator.forKnex.stripe_prices[1].id,
+            yearly_price_id: DataGenerator.forKnex.stripe_prices[2].id
+        }, _.merge({id: defaultProduct.id}, context.internal));
+
+        for (const subscription of _.cloneDeep(DataGenerator.forKnex.stripe_customer_subscriptions)) {
+            await models.StripeCustomerSubscription.add(subscription, context.internal);
+        }
+
+        const members = (await models.Member.findAll({
+            withRelated: [
+                'labels',
+                'stripeSubscriptions',
+                'stripeSubscriptions.customer',
+                'stripeSubscriptions.stripePrice',
+                'stripeSubscriptions.stripePrice.stripeProduct',
+                'products',
+                'offerRedemptions'
+            ]
+        })).toJSON();
+
+        for (const member of members) {
+            for (const subscription of member.subscriptions) {
+                const product = subscription.price.product.product_id;
+                await models.Member.edit({products: member.products.concat({
+                    id: product
+                })}, {id: member.id});
             }
-        }).then(async function () {
-            for (const event of DataGenerator.forKnex.members_created_events) {
-                await models.MemberCreatedEvent.add(event);
-            }
-        }).then(async function () {
-            for (const event of DataGenerator.forKnex.members_subscription_created_events) {
-                await models.SubscriptionCreatedEvent.add(event);
-            }
-        });
+        }
+
+        // Populate members_current_subscription lookup table for each member
+        // that has subscriptions (uses the VIEW as single source of truth
+        // for subscription priority resolution)
+        await models.Base.knex.raw(`
+            INSERT INTO members_current_subscription (member_id, subscription_id)
+            SELECT member_id, subscription_id
+            FROM members_resolved_subscription
+        `);
+
+        for (const event of DataGenerator.forKnex.members_paid_subscription_events) {
+            await models.MemberPaidSubscriptionEvent.add(event);
+        }
+
+        for (const event of DataGenerator.forKnex.members_created_events) {
+            await models.MemberCreatedEvent.add(event);
+        }
+
+        for (const event of DataGenerator.forKnex.members_subscription_created_events) {
+            await models.SubscriptionCreatedEvent.add(event);
+        }
     },
 
-    insertEmailsAndRecipients: function insertEmailsAndRecipients(withFailed = false) {
+    insertEmailsAndRecipients: async function insertEmailsAndRecipients(withFailed = false) {
         // NOTE: This require results in the jobs service being loaded prematurely, which breaks any tests relevant to it.
         //  This MUST be done in here and not at the top of the file to prevent that from happening as test setup is being performed.
         const emailAnalyticsService = require('../../core/server/services/email-analytics');
-        return sequence(_.cloneDeep(DataGenerator.forKnex.emails).map(email => () => {
-            return models.Email.add(email, context.internal);
-        })).then(function () {
-            return sequence(_.cloneDeep(DataGenerator.forKnex.email_batches).map(emailBatch => () => {
-                return models.EmailBatch.add(emailBatch, context.internal);
-            }));
-        }).then(function () {
-            const email_recipients = withFailed ?
-                DataGenerator.forKnex.email_recipients
-                : DataGenerator.forKnex.email_recipients.filter(r => r.failed_at === null);
 
-            return sequence(_.cloneDeep(email_recipients).map(emailRecipient => () => {
-                return models.EmailRecipient.add(emailRecipient, context.internal);
-            }));
-        }).then(function () {
-            if (!withFailed) {
-                return;
+        for (const email of _.cloneDeep(DataGenerator.forKnex.emails)) {
+            await models.Email.add(email, context.internal);
+        }
+
+        for (const emailBatch of _.cloneDeep(DataGenerator.forKnex.email_batches)) {
+            await models.EmailBatch.add(emailBatch, context.internal);
+        }
+
+        const email_recipients = withFailed ?
+            DataGenerator.forKnex.email_recipients
+            : DataGenerator.forKnex.email_recipients.filter(r => r.failed_at === null);
+
+        for (const emailRecipient of _.cloneDeep(email_recipients)) {
+            await models.EmailRecipient.add(emailRecipient, context.internal);
+        }
+
+        if (withFailed) {
+            for (const failure of _.cloneDeep(DataGenerator.forKnex.email_recipient_failures)) {
+                await models.EmailRecipientFailure.add(failure, context.internal);
             }
+        }
 
-            return sequence(_.cloneDeep(DataGenerator.forKnex.email_recipient_failures).map(failure => () => {
-                return models.EmailRecipientFailure.add(failure, context.internal);
-            }));
-        }).then(function () {
-            const toAggregate = {
-                emailIds: DataGenerator.forKnex.emails.map(email => email.id),
-                memberIds: DataGenerator.forKnex.members.map(member => member.id)
-            };
+        const toAggregate = {
+            emailIds: DataGenerator.forKnex.emails.map(email => email.id),
+            memberIds: DataGenerator.forKnex.members.map(member => member.id)
+        };
 
-            return emailAnalyticsService.service.aggregateStats(toAggregate);
-        });
+        return emailAnalyticsService.service.aggregateStats(toAggregate);
     },
 
     insertNewsletters: async function insertNewsletters() {

--- a/ghost/core/test/utils/index.js
+++ b/ghost/core/test/utils/index.js
@@ -1,7 +1,6 @@
 require('../../core/server/overrides');
 
 // Utility Packages
-const {sequence} = require('@tryghost/promise');
 const debug = require('@tryghost/debug')('test:utils');
 
 const _ = require('lodash');
@@ -24,14 +23,19 @@ require('./assertions');
 
 // ## Test Setup and Teardown
 
-const initFixtures = function initFixtures() {
+const initFixtures = async function initFixtures() {
     const options = _.merge({init: true}, _.transform(arguments, function (result, val) {
         result[val] = true;
     }));
 
     const fixtureOps = fixtureUtils.getFixtureOps(options);
 
-    return sequence(fixtureOps);
+    const results = [];
+    for (const fixtureOp of fixtureOps) {
+        results.push(await fixtureOp());
+    }
+
+    return results;
 };
 
 /**


### PR DESCRIPTION
no ref

This is a test-only cleanup.

`@tryghost/promise` is a package that has a few promise helpers. We don't need them in tests, and can just use `await` and `Promise.all`.
