### PR TITLE
Added config option to disable backups before migrations

### DIFF
--- a/ghost/core/core/server/data/migrations/hooks/migrate/after-each.js
+++ b/ghost/core/core/server/data/migrations/hooks/migrate/after-each.js
@@ -1,3 +1,0 @@
-module.exports = function afterEach() {
-    return Promise.resolve();
-};

--- a/ghost/core/core/server/data/migrations/hooks/migrate/before-each.js
+++ b/ghost/core/core/server/data/migrations/hooks/migrate/before-each.js
@@ -1,3 +1,0 @@
-module.exports = function beforeEach() {
-    return Promise.resolve();
-};

--- a/ghost/core/core/server/data/migrations/hooks/migrate/before.js
+++ b/ghost/core/core/server/data/migrations/hooks/migrate/before.js
@@ -1,5 +1,15 @@
+const logging = require('@tryghost/logging');
+const config = require('../../../../../shared/config');
 const dbBackup = require('../../../db/backup');
 
 module.exports = function before() {
+    // Skip the pre-migration backup when disabled at the platform level. This is
+    // distinct from `disableJSBackups` (which disables all JS backups, e.g. the
+    // importer path) — it only skips backups taken before running migrations.
+    if (config.get('disableMigrationBackups')) {
+        logging.info('Database backup before migration is disabled in Ghost config');
+        return;
+    }
+
     return dbBackup.backup();
 };

--- a/ghost/core/core/server/data/migrations/hooks/migrate/index.js
+++ b/ghost/core/core/server/data/migrations/hooks/migrate/index.js
@@ -1,4 +1,2 @@
 exports.before = require('./before');
-exports.beforeEach = require('./before-each');
-exports.afterEach = require('./after-each');
 exports.shutdown = require('./shutdown');

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -357,5 +357,6 @@
         "batchSize": 1000,
         "captureLinkClickBadMemberUuid": false
     },
-    "disableJSBackups": false
+    "disableJSBackups": false,
+    "disableMigrationBackups": false
 }


### PR DESCRIPTION
no ref
- follows the pattern of the `disableJSBackups` config flag, adding one specific to migrations
- this allows platforms such as Ghost(Pro) with external backup solutions to disable automatic pre-migration backups
