### PR TITLE
Disabled Nx native runner for legacy tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -648,6 +648,9 @@ jobs:
     env:
       DB: ${{ matrix.env.DB }}
       NODE_ENV: ${{ matrix.env.NODE_ENV }}
+      # The legacy tests job has intermittently segfaulted before Nx starts the
+      # target script. Keep Nx orchestration, but avoid its native PTY runner.
+      NX_NATIVE_COMMAND_RUNNER: "false"
     name: Legacy tests (Node ${{ matrix.node }}, ${{ matrix.env.DB }})
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
ref 2798ba32ae4d14deed1591a7de2d256c634a18c1

Legacy tests seem to have segfaults too. Let's apply the same fix we did for acceptance tests.
