### PR TITLE
Updated DB migration types to support "instant" algorithm

### DIFF
--- a/ghost/core/core/server/data/schema/commands.js
+++ b/ghost/core/core/server/data/schema/commands.js
@@ -99,7 +99,7 @@ function dropNullable(tableName, column, transaction = db.knex) {
  * @param {import('knex').Knex.Transaction} [transaction]
  * @param {object} columnSpec
   * @param {object} [options]
- * @param {'inplace'|'copy'|'auto'} [options.algorithm] - MySQL only
+ * @param {'instant'|'inplace'|'copy'|'auto'} [options.algorithm] - MySQL only
  */
 async function addColumn(tableName, column, transaction = db.knex, columnSpec, options = {}) {
     const addColumnBuilder = transaction.schema.table(tableName, function (table) {
@@ -136,7 +136,7 @@ async function addColumn(tableName, column, transaction = db.knex, columnSpec, o
  * @param {import('knex').Knex} [transaction]
  * @param {object} [columnSpec]
  * @param {object} [options]
- * @param {'inplace'|'copy'|'auto'} [options.algorithm] - MySQL only
+ * @param {'instant'|'inplace'|'copy'|'auto'} [options.algorithm] - MySQL only
  */
 async function dropColumn(tableName, column, transaction = db.knex, columnSpec = {}, options = {}) {
     if (Object.prototype.hasOwnProperty.call(columnSpec, 'references')) {


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1406

This is a types-only change that should have no user impact.

`algorithm: 'instant'` is now supported for adding and dropping columns.
