### PR TITLE
Fixed missing spaces in copied profile image in ActivityPub

### DIFF
--- a/apps/activitypub/src/views/preferences/components/profile.tsx
+++ b/apps/activitypub/src/views/preferences/components/profile.tsx
@@ -422,7 +422,12 @@ const Profile: React.FC<ProfileProps> = ({account, isLoading}) => {
                     className='fixed top-0 left-[-9999px] z-[-1] flex w-fit justify-center overflow-hidden rounded-2xl bg-gray-50'
                     style={{
                         width: cardFormat === 'square' ? '518px' : '412px',
-                        fontFamily: 'system-ui'
+                        // html2canvas draws text via canvas fillText, and Firefox on
+                        // macOS resolves generic aliases like `system-ui` to a different
+                        // face in canvas than in DOM layout, so words render wider and
+                        // swallow the spaces between them. Concrete family names resolve
+                        // identically in both, keeping the copied image's text intact.
+                        fontFamily: "'Helvetica Neue', Helvetica, Arial, sans-serif"
                     }}
                 >
                     <ProfileCard


### PR DESCRIPTION
fixes https://github.com/TryGhost/ActivityPub/issues/1312

## Problem

Copying the "Share your profile" card as an image from Firefox produced text with missing spaces (`Availableon Ghost,Flipboard,Threads,…`) in both the account name and the description, while Safari and Chrome were fine. The on-screen preview always looked correct — only the copied image was broken.

## Cause

The image is produced by rendering a hidden clone of the card through html2canvas, which measures each word's position from DOM layout and then draws the words individually onto a canvas with `fillText`. The clone forced `font-family: system-ui`, and Firefox on macOS resolves that generic alias to a different (wider, heavier) face in canvas text rendering than it does in DOM layout. Every word was drawn wider than the slot that was measured for it, bleeding into the following inter-word gap — which is why only *some* spaces disappeared and the text also looked bolder than in the other browsers. Chrome and Safari resolve the alias identically in both contexts, so they were unaffected. (This is a known html2canvas failure mode on Firefox/macOS, e.g. [niklasvh/html2canvas#3037](https://github.com/niklasvh/html2canvas/issues/3037).)

## Fix

Use concrete font family names (`'Helvetica Neue', Helvetica, Arial, sans-serif`) instead of the `system-ui` alias for the screenshot clone. Concrete names resolve to the same face in DOM layout and in canvas in every browser, so the measured word slots match the drawn glyph runs and the spaces survive.

Verified by rendering the card clone through the same html2canvas pipeline in headless Firefox (141/151) and Chromium: the two browsers produce near-identical output with all spaces intact, including with the offscreen `fixed; left: -9999px` clone positioning, bold weights, and non-ASCII names (`Strømfeldt`). html2canvas builds an unquoted `ctx.font` string from the family list; verified both Firefox and Chromium accept the two-word `Helvetica Neue` in that form.