### PR TITLE
Added activation bridge to expand route settings into the router format

### DIFF
--- a/ghost/core/core/server/services/route-settings/activation-bridge.ts
+++ b/ghost/core/core/server/services/route-settings/activation-bridge.ts
@@ -1,0 +1,214 @@
+import _ from 'lodash';
+import type {
+    RouteSettings,
+    Route,
+    ChannelRoute,
+    TemplateRoute,
+    CollectionConfig,
+    RouteData,
+    DataReadEntry,
+    DataBrowseEntry
+} from './route-settings-parser';
+
+// Lazy-loaded to avoid importing frontend code at module load time
+let RESOURCE_CONFIG: {QUERY: Record<string, any>; TAXONOMIES: Record<string, any>};
+
+function getResourceConfig() {
+    if (!RESOURCE_CONFIG) {
+        // eslint-disable-next-line ghost/node/no-restricted-require -- intentional: the bridge is the single place that couples server → frontend config; removed in HKG-1898
+        const {QUERY, TAXONOMIES} = require('../../../frontend/services/routing/config');
+        RESOURCE_CONFIG = {QUERY, TAXONOMIES};
+    }
+    return RESOURCE_CONFIG;
+}
+
+interface ExpandedData {
+    query: Record<string, any>;
+    router: Record<string, any[]>;
+}
+
+function expandShortFormData(shortForm: string, resourceKey?: string): ExpandedData {
+    const config = getResourceConfig();
+    const [key, slug] = shortForm.split('.');
+    const queryConfig = config.QUERY[key];
+
+    const data: ExpandedData = {
+        query: {},
+        router: {}
+    };
+
+    const effectiveKey = resourceKey || key;
+    data.query[effectiveKey] = _.cloneDeep(_.omit(queryConfig, 'resourceAlias'));
+    data.query[effectiveKey].options.slug = slug;
+
+    const routerKey = queryConfig.resourceAlias || queryConfig.resource;
+    data.router[routerKey] = [{slug, redirect: true}];
+
+    return data;
+}
+
+function expandLongFormEntry(key: string, entry: DataReadEntry | DataBrowseEntry): ExpandedData {
+    const config = getResourceConfig();
+    const defaultResource = _.find(config.QUERY, {resource: entry.resource});
+
+    const data: ExpandedData = {
+        query: {},
+        router: {}
+    };
+
+    data.query[key] = {
+        type: entry.type,
+        resource: defaultResource.resource
+    };
+
+    data.query[key] = _.defaults(data.query[key], _.omit(defaultResource, ['options', 'resourceAlias']));
+
+    const allowedQueryOptions = ['limit', 'order', 'filter', 'include', 'slug', 'visibility', 'status', 'page'];
+    data.query[key].options = _.pick(entry, allowedQueryOptions);
+
+    if (entry.type === 'read') {
+        data.query[key].options = _.defaults(data.query[key].options, defaultResource.options);
+    }
+
+    const routerKey = defaultResource.resourceAlias || defaultResource.resource;
+    if (!data.router[routerKey]) {
+        data.router[routerKey] = [];
+    }
+
+    if (entry.type === 'read') {
+        const allowedRouterOptions = ['redirect', 'slug'];
+        let routerEntry = _.pick(entry, allowedRouterOptions);
+        routerEntry = _.defaults(routerEntry, {redirect: true});
+        data.router[routerKey].push(routerEntry);
+    } else {
+        data.router[routerKey].push({redirect: true});
+    }
+
+    return data;
+}
+
+function expandRouteData(routeData: RouteData | undefined): ExpandedData {
+    if (!routeData) {
+        return {query: {}, router: {}};
+    }
+
+    if (typeof routeData === 'string') {
+        return expandShortFormData(routeData);
+    }
+
+    const merged: ExpandedData = {query: {}, router: {}};
+
+    for (const [key, entry] of Object.entries(routeData)) {
+        let expanded: ExpandedData;
+
+        if (typeof entry === 'string') {
+            expanded = expandShortFormData(entry, key);
+        } else {
+            expanded = expandLongFormEntry(key, entry);
+        }
+
+        _.merge(merged.query, expanded.query);
+
+        for (const [routerKey, routerEntries] of Object.entries(expanded.router)) {
+            if (merged.router[routerKey]) {
+                merged.router[routerKey] = merged.router[routerKey].concat(routerEntries);
+            } else {
+                merged.router[routerKey] = routerEntries;
+            }
+        }
+    }
+
+    return merged;
+}
+
+function convertSlugsToColons(value: string): string {
+    return value.replace(/{(\w+)}/g, ':$1');
+}
+
+function expandRoute(route: Route): Record<string, any> {
+    const expanded: Record<string, any> = {};
+
+    expanded.templates = route.templates || [];
+
+    if (route.data !== undefined) {
+        expanded.data = expandRouteData(route.data);
+    }
+
+    if (route.type === 'channel') {
+        const channel = route as ChannelRoute;
+        expanded.controller = 'channel';
+        if (channel.filter !== undefined) {
+            expanded.filter = channel.filter;
+        }
+        if (channel.order !== undefined) {
+            expanded.order = channel.order;
+        }
+        if (channel.limit !== undefined) {
+            expanded.limit = channel.limit;
+        }
+        if (channel.rss !== undefined) {
+            expanded.rss = channel.rss;
+        }
+    } else {
+        const template = route as TemplateRoute;
+        if (template.contentType !== undefined) {
+            expanded.content_type = template.contentType;
+        }
+    }
+
+    return expanded;
+}
+
+function expandCollection(collection: CollectionConfig): Record<string, any> {
+    const expanded: Record<string, any> = {};
+
+    expanded.permalink = convertSlugsToColons(collection.permalink);
+    expanded.templates = collection.templates || [];
+
+    if (collection.data !== undefined) {
+        expanded.data = expandRouteData(collection.data);
+    }
+
+    if (collection.filter !== undefined) {
+        expanded.filter = collection.filter;
+    }
+    if (collection.order !== undefined) {
+        expanded.order = collection.order;
+    }
+    if (collection.limit !== undefined) {
+        expanded.limit = collection.limit;
+    }
+    if (collection.rss !== undefined) {
+        expanded.rss = collection.rss;
+    }
+
+    return expanded;
+}
+
+/**
+ * Converts a RouteSettings domain model into the legacy expanded format
+ * that routerManager.start() expects.
+ *
+ * This is a temporary adapter — it gets removed once RouterManager is
+ * refactored to consume the domain model directly (HKG-1895/HKG-1898).
+ */
+export function expandRouteSettings(settings: RouteSettings): {routes: Record<string, any>; collections: Record<string, any>; taxonomies: Record<string, string>} {
+    const routes: Record<string, any> = {};
+    for (const route of settings.routes) {
+        routes[route.path] = expandRoute(route);
+    }
+
+    const collections: Record<string, any> = {};
+    for (const collection of settings.collections) {
+        collections[collection.path] = expandCollection(collection);
+    }
+
+    const taxonomies: Record<string, string> = {};
+    for (const [key, value] of Object.entries(settings.taxonomies)) {
+        if (value) {
+            taxonomies[key] = convertSlugsToColons(value);
+        }
+    }
+
+    return {routes, collections, taxonomies};
+}

--- a/ghost/core/core/server/services/route-settings/activation-bridge.ts
+++ b/ghost/core/core/server/services/route-settings/activation-bridge.ts
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import errors from '@tryghost/errors';
 import type {
     RouteSettings,
     Route,
@@ -6,18 +7,32 @@ import type {
     TemplateRoute,
     CollectionConfig,
     RouteData,
+    DataShortForm,
     DataReadEntry,
     DataBrowseEntry
 } from './route-settings-parser';
 
-// Lazy-loaded to avoid importing frontend code at module load time
-let RESOURCE_CONFIG: {QUERY: Record<string, any>; TAXONOMIES: Record<string, any>};
+// Shape of a single entry in the frontend routing config's QUERY map.
+interface QueryResourceConfig {
+    controller: string;
+    type?: string;
+    resource: string;
+    resourceAlias?: string;
+    options?: Record<string, unknown>;
+}
 
-function getResourceConfig() {
+interface ResourceConfig {
+    QUERY: Record<string, QueryResourceConfig>;
+    TAXONOMIES: Record<string, unknown>;
+}
+
+// Lazy-loaded to avoid importing frontend code at module load time
+let RESOURCE_CONFIG: ResourceConfig;
+
+function getResourceConfig(): ResourceConfig {
     if (!RESOURCE_CONFIG) {
         // eslint-disable-next-line ghost/node/no-restricted-require -- intentional: the bridge is the single place that couples server → frontend config; removed in HKG-1898
-        const {QUERY, TAXONOMIES} = require('../../../frontend/services/routing/config');
-        RESOURCE_CONFIG = {QUERY, TAXONOMIES};
+        RESOURCE_CONFIG = require('../../../frontend/services/routing/config');
     }
     return RESOURCE_CONFIG;
 }
@@ -27,10 +42,14 @@ interface ExpandedData {
     router: Record<string, any[]>;
 }
 
-function expandShortFormData(shortForm: string, resourceKey?: string): ExpandedData {
+function expandShortFormData(shortForm: DataShortForm, resourceKey?: string): ExpandedData {
     const config = getResourceConfig();
     const [key, slug] = shortForm.split('.');
     const queryConfig = config.QUERY[key];
+
+    if (!queryConfig) {
+        throw new errors.IncorrectUsageError({message: `Unknown route data resource: ${key}`});
+    }
 
     const data: ExpandedData = {
         query: {},
@@ -50,6 +69,10 @@ function expandShortFormData(shortForm: string, resourceKey?: string): ExpandedD
 function expandLongFormEntry(key: string, entry: DataReadEntry | DataBrowseEntry): ExpandedData {
     const config = getResourceConfig();
     const defaultResource = _.find(config.QUERY, {resource: entry.resource});
+
+    if (!defaultResource) {
+        throw new errors.IncorrectUsageError({message: `Unknown route data resource: ${entry.resource}`});
+    }
 
     const data: ExpandedData = {
         query: {},

--- a/ghost/core/core/server/services/route-settings/activation-bridge.ts
+++ b/ghost/core/core/server/services/route-settings/activation-bridge.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import errors from '@tryghost/errors';
+import {QUERY} from '../../../frontend/services/routing/config';
 import type {
     RouteSettings,
     Route,
@@ -8,34 +9,10 @@ import type {
     CollectionConfig,
     RouteData,
     DataShortForm,
+    DataShortFormResource,
     DataReadEntry,
     DataBrowseEntry
 } from './route-settings-parser';
-
-// Shape of a single entry in the frontend routing config's QUERY map.
-interface QueryResourceConfig {
-    controller: string;
-    type?: string;
-    resource: string;
-    resourceAlias?: string;
-    options?: Record<string, unknown>;
-}
-
-interface ResourceConfig {
-    QUERY: Record<string, QueryResourceConfig>;
-    TAXONOMIES: Record<string, unknown>;
-}
-
-// Lazy-loaded to avoid importing frontend code at module load time
-let RESOURCE_CONFIG: ResourceConfig;
-
-function getResourceConfig(): ResourceConfig {
-    if (!RESOURCE_CONFIG) {
-        // eslint-disable-next-line ghost/node/no-restricted-require -- intentional: the bridge is the single place that couples server → frontend config; removed in HKG-1898
-        RESOURCE_CONFIG = require('../../../frontend/services/routing/config');
-    }
-    return RESOURCE_CONFIG;
-}
 
 interface ExpandedData {
     query: Record<string, any>;
@@ -43,13 +20,9 @@ interface ExpandedData {
 }
 
 function expandShortFormData(shortForm: DataShortForm, resourceKey?: string): ExpandedData {
-    const config = getResourceConfig();
-    const [key, slug] = shortForm.split('.');
-    const queryConfig = config.QUERY[key];
 
-    if (!queryConfig) {
-        throw new errors.IncorrectUsageError({message: `Unknown route data resource: ${key}`});
-    }
+    const [key, slug] = shortForm.split('.') as [DataShortFormResource, string];
+    const queryConfig = QUERY[key];
 
     const data: ExpandedData = {
         query: {},
@@ -57,18 +30,17 @@ function expandShortFormData(shortForm: DataShortForm, resourceKey?: string): Ex
     };
 
     const effectiveKey = resourceKey || key;
-    data.query[effectiveKey] = _.cloneDeep(_.omit(queryConfig, 'resourceAlias'));
+    data.query[effectiveKey] = _.cloneDeep(queryConfig);
     data.query[effectiveKey].options.slug = slug;
 
-    const routerKey = queryConfig.resourceAlias || queryConfig.resource;
+    const routerKey = queryConfig.resource;
     data.router[routerKey] = [{slug, redirect: true}];
 
     return data;
 }
 
 function expandLongFormEntry(key: string, entry: DataReadEntry | DataBrowseEntry): ExpandedData {
-    const config = getResourceConfig();
-    const defaultResource = _.find(config.QUERY, {resource: entry.resource});
+    const defaultResource = Object.values(QUERY).find(item => item.resource === entry.resource);
 
     if (!defaultResource) {
         throw new errors.IncorrectUsageError({message: `Unknown route data resource: ${entry.resource}`});
@@ -84,16 +56,17 @@ function expandLongFormEntry(key: string, entry: DataReadEntry | DataBrowseEntry
         resource: defaultResource.resource
     };
 
-    data.query[key] = _.defaults(data.query[key], _.omit(defaultResource, ['options', 'resourceAlias']));
+    data.query[key] = _.defaults(data.query[key], _.omit(defaultResource, 'options'));
 
     const allowedQueryOptions = ['limit', 'order', 'filter', 'include', 'slug', 'visibility', 'status', 'page'];
     data.query[key].options = _.pick(entry, allowedQueryOptions);
 
     if (entry.type === 'read') {
-        data.query[key].options = _.defaults(data.query[key].options, defaultResource.options);
+        const defaultOptions = 'options' in defaultResource ? defaultResource.options : undefined;
+        data.query[key].options = _.defaults(data.query[key].options, defaultOptions);
     }
 
-    const routerKey = defaultResource.resourceAlias || defaultResource.resource;
+    const routerKey = defaultResource.resource;
     if (!data.router[routerKey]) {
         data.router[routerKey] = [];
     }

--- a/ghost/core/core/server/services/route-settings/route-settings-parser.ts
+++ b/ghost/core/core/server/services/route-settings/route-settings-parser.ts
@@ -53,7 +53,7 @@ export interface ChannelRoute extends RouteBase {
     filter?: string;
     order?: string;
     limit?: number | 'all';
-    rss: boolean;
+    rss?: boolean;
 }
 
 export interface TemplateRoute extends RouteBase {
@@ -227,9 +227,14 @@ const RouteObjectSchema = z.object({
     if (val.controller === 'channel') {
         const route: Omit<ChannelRoute, 'path'> = {
             type: 'channel',
-            templates,
-            rss: val.rss ?? true
+            templates
         };
+        // Preserve rss only when the author set it explicitly — the domain model
+        // mirrors user intent (unset vs true vs false), so the activation bridge
+        // reproduces validate.js output byte-for-byte.
+        if (val.rss !== undefined) {
+            route.rss = val.rss;
+        }
         if (val.filter !== undefined) {
             route.filter = val.filter;
         }
@@ -434,7 +439,7 @@ export function serializeRouteSettings(settings: RouteSettings): string {
                 if (channel.limit !== undefined) {
                     entry.limit = channel.limit;
                 }
-                if (channel.rss !== true) {
+                if (channel.rss !== undefined) {
                     entry.rss = channel.rss;
                 }
             } else {

--- a/ghost/core/test/unit/server/services/route-settings/activation-bridge.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/activation-bridge.test.ts
@@ -1,0 +1,564 @@
+import assert from 'node:assert/strict';
+import {describe, it} from 'vitest';
+import {expandRouteSettings} from '../../../../../core/server/services/route-settings/activation-bridge';
+import {parseRouteSettings} from '../../../../../core/server/services/route-settings/route-settings-parser';
+import type {RouteSettings} from '../../../../../core/server/services/route-settings/route-settings-parser';
+
+const validate = require('../../../../../core/server/services/route-settings/validate');
+
+function empty(): RouteSettings {
+    return {routes: [], collections: [], taxonomies: {}};
+}
+
+describe('activation-bridge', function () {
+    describe('expandRouteSettings', function () {
+        it('returns empty maps for empty settings', function () {
+            const result = expandRouteSettings(empty());
+
+            assert.deepEqual(result, {
+                routes: {},
+                collections: {},
+                taxonomies: {}
+            });
+        });
+
+        describe('behavioral equivalence with validate.js', function () {
+            it('matches validate.js for bare string template route', function () {
+                const raw = {
+                    routes: {'/about/': 'about'},
+                    collections: {},
+                    taxonomies: {}
+                };
+
+                const legacy = validate(structuredClone(raw));
+                const domain = parseRouteSettings(raw);
+                const expanded = expandRouteSettings(domain);
+
+                assert.deepEqual(expanded, legacy);
+            });
+
+            it('matches validate.js for template route with content_type', function () {
+                const raw = {
+                    routes: {
+                        '/api/': {
+                            template: 'api',
+                            content_type: 'application/json'
+                        }
+                    },
+                    collections: {},
+                    taxonomies: {}
+                };
+
+                const legacy = validate(structuredClone(raw));
+                const domain = parseRouteSettings(raw);
+                const expanded = expandRouteSettings(domain);
+
+                assert.deepEqual(expanded, legacy);
+            });
+
+            it('matches validate.js for channel route', function () {
+                const raw = {
+                    routes: {
+                        '/featured/': {
+                            controller: 'channel',
+                            filter: 'featured:true',
+                            template: 'featured'
+                        }
+                    },
+                    collections: {},
+                    taxonomies: {}
+                };
+
+                const legacy = validate(structuredClone(raw));
+                const domain = parseRouteSettings(raw);
+                const expanded = expandRouteSettings(domain);
+
+                assert.deepEqual(expanded, legacy);
+            });
+
+            it('matches validate.js for channel route with rss disabled', function () {
+                const raw = {
+                    routes: {
+                        '/featured/': {
+                            controller: 'channel',
+                            filter: 'featured:true',
+                            rss: false
+                        }
+                    },
+                    collections: {},
+                    taxonomies: {}
+                };
+
+                const legacy = validate(structuredClone(raw));
+                const domain = parseRouteSettings(raw);
+                const expanded = expandRouteSettings(domain);
+
+                assert.deepEqual(expanded, legacy);
+            });
+
+            it('matches validate.js for route with shortform data', function () {
+                const raw = {
+                    routes: {
+                        '/food/': {
+                            template: 'food',
+                            data: 'tag.food'
+                        }
+                    },
+                    collections: {},
+                    taxonomies: {}
+                };
+
+                const legacy = validate(structuredClone(raw));
+                const domain = parseRouteSettings(raw);
+                const expanded = expandRouteSettings(domain);
+
+                assert.deepEqual(expanded, legacy);
+            });
+
+            it('matches validate.js for route with named shortform data', function () {
+                const raw = {
+                    routes: {
+                        '/food/': {
+                            template: 'food',
+                            data: {
+                                recipe: 'tag.recipes',
+                                post: 'post.my-post'
+                            }
+                        }
+                    },
+                    collections: {},
+                    taxonomies: {}
+                };
+
+                const legacy = validate(structuredClone(raw));
+                const domain = parseRouteSettings(raw);
+                const expanded = expandRouteSettings(domain);
+
+                assert.deepEqual(expanded, legacy);
+            });
+
+            it('matches validate.js for route with longform read data', function () {
+                const raw = {
+                    routes: {
+                        '/food/': {
+                            template: 'food',
+                            data: {
+                                people: {
+                                    resource: 'authors',
+                                    type: 'read',
+                                    slug: 'joe'
+                                }
+                            }
+                        }
+                    },
+                    collections: {},
+                    taxonomies: {}
+                };
+
+                const legacy = validate(structuredClone(raw));
+                const domain = parseRouteSettings(raw);
+                const expanded = expandRouteSettings(domain);
+
+                assert.deepEqual(expanded, legacy);
+            });
+
+            it('matches validate.js for route with longform browse data', function () {
+                const raw = {
+                    routes: {
+                        '/food/': {
+                            template: 'food',
+                            data: {
+                                featured: {
+                                    resource: 'posts',
+                                    type: 'browse',
+                                    filter: 'featured:true',
+                                    limit: 3
+                                }
+                            }
+                        }
+                    },
+                    collections: {},
+                    taxonomies: {}
+                };
+
+                const legacy = validate(structuredClone(raw));
+                const domain = parseRouteSettings(raw);
+                const expanded = expandRouteSettings(domain);
+
+                assert.deepEqual(expanded, legacy);
+            });
+
+            it('matches validate.js for collection with permalink', function () {
+                const raw = {
+                    routes: {},
+                    collections: {
+                        '/': {
+                            permalink: '/{slug}/',
+                            template: 'index'
+                        }
+                    },
+                    taxonomies: {}
+                };
+
+                const legacy = validate(structuredClone(raw));
+                const domain = parseRouteSettings(raw);
+                const expanded = expandRouteSettings(domain);
+
+                assert.deepEqual(expanded, legacy);
+            });
+
+            it('matches validate.js for collection with filter and data', function () {
+                const raw = {
+                    routes: {},
+                    collections: {
+                        '/podcast/': {
+                            permalink: '/podcast/{slug}/',
+                            filter: 'tag:podcast',
+                            template: 'podcast',
+                            data: 'tag.podcast'
+                        }
+                    },
+                    taxonomies: {}
+                };
+
+                const legacy = validate(structuredClone(raw));
+                const domain = parseRouteSettings(raw);
+                const expanded = expandRouteSettings(domain);
+
+                assert.deepEqual(expanded, legacy);
+            });
+
+            it('matches validate.js for taxonomies', function () {
+                const raw = {
+                    routes: {},
+                    collections: {},
+                    taxonomies: {
+                        tag: '/tag/{slug}/',
+                        author: '/author/{slug}/'
+                    }
+                };
+
+                const legacy = validate(structuredClone(raw));
+                const domain = parseRouteSettings(raw);
+                const expanded = expandRouteSettings(domain);
+
+                assert.deepEqual(expanded, legacy);
+            });
+
+            it('matches validate.js for a full routes.yaml', function () {
+                const raw = {
+                    routes: {
+                        '/about/': 'about',
+                        '/food/': {
+                            template: 'food',
+                            data: 'tag.food'
+                        },
+                        '/featured/': {
+                            controller: 'channel',
+                            filter: 'featured:true',
+                            template: 'featured'
+                        }
+                    },
+                    collections: {
+                        '/podcast/': {
+                            permalink: '/podcast/{slug}/',
+                            filter: 'tag:podcast',
+                            template: 'podcast',
+                            data: 'tag.podcast'
+                        },
+                        '/': {
+                            permalink: '/{slug}/',
+                            template: 'index'
+                        }
+                    },
+                    taxonomies: {
+                        tag: '/tag/{slug}/',
+                        author: '/author/{slug}/'
+                    }
+                };
+
+                const legacy = validate(structuredClone(raw));
+                const domain = parseRouteSettings(raw);
+                const expanded = expandRouteSettings(domain);
+
+                assert.deepEqual(expanded, legacy);
+            });
+
+            it('matches validate.js for channel route with explicit rss: true', function () {
+                const raw = {
+                    routes: {
+                        '/featured/': {
+                            controller: 'channel',
+                            filter: 'featured:true',
+                            rss: true
+                        }
+                    },
+                    collections: {},
+                    taxonomies: {}
+                };
+
+                const legacy = validate(structuredClone(raw));
+                const domain = parseRouteSettings(raw);
+                const expanded = expandRouteSettings(domain);
+
+                assert.deepEqual(expanded, legacy);
+            });
+
+            it('matches validate.js for channel route with rss omitted', function () {
+                const raw = {
+                    routes: {
+                        '/featured/': {
+                            controller: 'channel',
+                            filter: 'featured:true'
+                        }
+                    },
+                    collections: {},
+                    taxonomies: {}
+                };
+
+                const legacy = validate(structuredClone(raw));
+                const domain = parseRouteSettings(raw);
+                const expanded = expandRouteSettings(domain);
+
+                assert.deepEqual(expanded, legacy);
+            });
+
+            it('matches validate.js for template route with array templates', function () {
+                const raw = {
+                    routes: {'/about/': {template: ['about', 'default']}},
+                    collections: {},
+                    taxonomies: {}
+                };
+
+                const legacy = validate(structuredClone(raw));
+                const domain = parseRouteSettings(raw);
+                const expanded = expandRouteSettings(domain);
+
+                assert.deepEqual(expanded, legacy);
+            });
+
+            it('matches validate.js for longform read data with redirect: false', function () {
+                const raw = {
+                    routes: {
+                        '/food/': {
+                            template: 'food',
+                            data: {
+                                people: {
+                                    resource: 'authors',
+                                    type: 'read',
+                                    slug: 'joe',
+                                    redirect: false
+                                }
+                            }
+                        }
+                    },
+                    collections: {},
+                    taxonomies: {}
+                };
+
+                const legacy = validate(structuredClone(raw));
+                const domain = parseRouteSettings(raw);
+                const expanded = expandRouteSettings(domain);
+
+                assert.deepEqual(expanded, legacy);
+            });
+
+            it('matches validate.js for longform browse data with limit: all', function () {
+                const raw = {
+                    routes: {
+                        '/food/': {
+                            template: 'food',
+                            data: {
+                                featured: {
+                                    resource: 'posts',
+                                    type: 'browse',
+                                    limit: 'all'
+                                }
+                            }
+                        }
+                    },
+                    collections: {},
+                    taxonomies: {}
+                };
+
+                const legacy = validate(structuredClone(raw));
+                const domain = parseRouteSettings(raw);
+                const expanded = expandRouteSettings(domain);
+
+                assert.deepEqual(expanded, legacy);
+            });
+
+            it('matches validate.js when two data entries resolve to the same router key', function () {
+                const raw = {
+                    routes: {
+                        '/food/': {
+                            template: 'food',
+                            data: {
+                                one: 'post.first',
+                                two: 'post.second'
+                            }
+                        }
+                    },
+                    collections: {},
+                    taxonomies: {}
+                };
+
+                const legacy = validate(structuredClone(raw));
+                const domain = parseRouteSettings(raw);
+                const expanded = expandRouteSettings(domain);
+
+                assert.deepEqual(expanded, legacy);
+            });
+
+            it('matches validate.js for collection with rss: false', function () {
+                const raw = {
+                    routes: {},
+                    collections: {
+                        '/': {
+                            permalink: '/{slug}/',
+                            template: 'index',
+                            rss: false
+                        }
+                    },
+                    taxonomies: {}
+                };
+
+                const legacy = validate(structuredClone(raw));
+                const domain = parseRouteSettings(raw);
+                const expanded = expandRouteSettings(domain);
+
+                assert.deepEqual(expanded, legacy);
+            });
+        });
+
+        describe('slug conversion', function () {
+            it('converts {slug} to :slug in collection permalinks', function () {
+                const settings: RouteSettings = {
+                    routes: [],
+                    collections: [{path: '/', permalink: '/{slug}/', templates: []}],
+                    taxonomies: {}
+                };
+
+                const result = expandRouteSettings(settings);
+                assert.equal(result.collections['/'].permalink, '/:slug/');
+            });
+
+            it('converts {primary_author} to :primary_author in permalinks', function () {
+                const settings: RouteSettings = {
+                    routes: [],
+                    collections: [{path: '/', permalink: '/{primary_author}/{slug}/', templates: []}],
+                    taxonomies: {}
+                };
+
+                const result = expandRouteSettings(settings);
+                assert.equal(result.collections['/'].permalink, '/:primary_author/:slug/');
+            });
+
+            it('converts {slug} to :slug in taxonomy paths', function () {
+                const settings: RouteSettings = {
+                    routes: [],
+                    collections: [],
+                    taxonomies: {tag: '/tag/{slug}/'}
+                };
+
+                const result = expandRouteSettings(settings);
+                assert.equal(result.taxonomies.tag, '/tag/:slug/');
+            });
+        });
+
+        describe('route expansion', function () {
+            it('sets controller to channel for channel routes', function () {
+                const settings: RouteSettings = {
+                    routes: [{type: 'channel', path: '/featured/', templates: [], filter: 'featured:true', rss: true}],
+                    collections: [],
+                    taxonomies: {}
+                };
+
+                const result = expandRouteSettings(settings);
+                assert.equal(result.routes['/featured/'].controller, 'channel');
+            });
+
+            it('maps contentType back to content_type', function () {
+                const settings: RouteSettings = {
+                    routes: [{type: 'template', path: '/api/', templates: ['api'], contentType: 'application/json'}],
+                    collections: [],
+                    taxonomies: {}
+                };
+
+                const result = expandRouteSettings(settings);
+                assert.equal(result.routes['/api/'].content_type, 'application/json');
+                assert.equal(result.routes['/api/'].contentType, undefined);
+            });
+
+            it('omits data when no data specified', function () {
+                const settings: RouteSettings = {
+                    routes: [{type: 'template', path: '/about/', templates: ['about']}],
+                    collections: [],
+                    taxonomies: {}
+                };
+
+                const result = expandRouteSettings(settings);
+                assert.equal(result.routes['/about/'].data, undefined);
+            });
+        });
+
+        describe('data expansion', function () {
+            it('expands shortform data with redirect enabled by default', function () {
+                const settings: RouteSettings = {
+                    routes: [{type: 'template', path: '/food/', templates: ['food'], data: 'tag.food'}],
+                    collections: [],
+                    taxonomies: {}
+                };
+
+                const result = expandRouteSettings(settings);
+                const data = result.routes['/food/'].data;
+
+                assert.equal(data.router.tags[0].redirect, true);
+                assert.equal(data.router.tags[0].slug, 'food');
+                assert.equal(data.query.tag.options.slug, 'food');
+            });
+
+            it('expands longform read data with default options', function () {
+                const settings: RouteSettings = {
+                    routes: [{
+                        type: 'template', path: '/food/', templates: ['food'],
+                        data: {
+                            people: {resource: 'authors', type: 'read', slug: 'joe'}
+                        }
+                    }],
+                    collections: [],
+                    taxonomies: {}
+                };
+
+                const result = expandRouteSettings(settings);
+                const data = result.routes['/food/'].data;
+
+                assert.equal(data.query.people.type, 'read');
+                assert.equal(data.query.people.resource, 'authors');
+                assert.equal(data.query.people.options.slug, 'joe');
+                assert.equal(data.router.authors[0].redirect, true);
+            });
+
+            it('expands longform browse data without default slug option', function () {
+                const settings: RouteSettings = {
+                    routes: [{
+                        type: 'template', path: '/food/', templates: ['food'],
+                        data: {
+                            featured: {resource: 'posts', type: 'browse', filter: 'featured:true', limit: 3}
+                        }
+                    }],
+                    collections: [],
+                    taxonomies: {}
+                };
+
+                const result = expandRouteSettings(settings);
+                const data = result.routes['/food/'].data;
+
+                assert.equal(data.query.featured.type, 'browse');
+                assert.equal(data.query.featured.options.filter, 'featured:true');
+                assert.equal(data.query.featured.options.limit, 3);
+                assert.equal(data.query.featured.options.slug, undefined);
+            });
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/route-settings/route-settings-parser.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/route-settings-parser.test.ts
@@ -76,7 +76,25 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
                 });
 
                 assert.deepEqual(result.routes, [
-                    {type: 'channel', path: '/featured/', templates: ['featured'], filter: 'featured:true', rss: true}
+                    {type: 'channel', path: '/featured/', templates: ['featured'], filter: 'featured:true'}
+                ]);
+            });
+
+            it('leaves rss unset on channel route when not specified', function () {
+                const result = parseRouteSettings({
+                    routes: {'/featured/': {controller: 'channel', filter: 'featured:true'}}
+                });
+
+                assert.equal(Object.prototype.hasOwnProperty.call(result.routes[0], 'rss'), false);
+            });
+
+            it('respects explicit rss: true on channel route', function () {
+                const result = parseRouteSettings({
+                    routes: {'/featured/': {controller: 'channel', filter: 'featured:true', rss: true}}
+                });
+
+                assert.deepEqual(result.routes, [
+                    {type: 'channel', path: '/featured/', templates: [], filter: 'featured:true', rss: true}
                 ]);
             });
 
@@ -329,7 +347,18 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
             assert.ok(yaml.includes('filter: featured:true'));
         });
 
-        it('does not emit rss when true (default)', function () {
+        it('does not emit rss when unset (default)', function () {
+            const settings: RouteSettings = {
+                routes: [{type: 'channel', path: '/ch/', templates: [], filter: 'f'}],
+                collections: [],
+                taxonomies: {}
+            };
+            const yaml = serializeRouteSettings(settings);
+
+            assert.ok(!yaml.includes('rss:'));
+        });
+
+        it('emits rss when explicitly true', function () {
             const settings: RouteSettings = {
                 routes: [{type: 'channel', path: '/ch/', templates: [], filter: 'f', rss: true}],
                 collections: [],
@@ -337,7 +366,7 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
             };
             const yaml = serializeRouteSettings(settings);
 
-            assert.ok(!yaml.includes('rss:'));
+            assert.ok(yaml.includes('rss: true'));
         });
 
         it('emits rss when false', function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1906

### Why

RouterManager — and the routers, controllers, and URL service behind it — still
consume the legacy expanded `{query, router}` shape that `validate.js` produced
on every read. To move route settings behind a store that holds the clean
`RouteSettings` domain model (HKG-1825), something has to convert that domain
model into the expanded format the runtime expects today.

The activation bridge is that converter: a deliberately temporary seam that lets
the domain model flow into the existing runtime without touching a single
router, controller, or the URL service — so introducing the store stays a
zero-behaviour-change step. It's removed in HKG-1898 once the router consumes the
domain model directly.

Stacked on #28990 (parser/serializer) — the first commit here is a small
prerequisite fix to that layer.

### What

* **`expandRouteSettings(settings)`** (`activation-bridge.ts`) — converts the
  `RouteSettings` domain model into the legacy expanded format: `{slug}` →
  `:slug`, short/long-form `data` expansion into `{query, router}`, channel
  controller resolution, and `contentType` → `content_type`. This is the single
  place server-side code couples to the frontend routing config (`QUERY` /
  `TAXONOMIES`); it's lazy-`require`d so importing the module doesn't pull
  frontend code at load time, and the coupling is isolated to one function that's
  trivial to delete in HKG-1898.
* **`rss` now preserves author intent** (`route-settings-parser.ts`, first
  commit) — the parser used to default `rss` to `true` on channel routes, which
  collapsed "author wrote `rss: true`" and "author wrote nothing" into one value
  and made byte-for-byte parity with `validate.js` impossible. Channels now
  mirror how collections already treat `rss` (kept only when explicitly set).
* **Equivalence tests** — the bridge's output is asserted `deepEqual` against the
  live `validate.js` across the awkward cases (short/long-form data, redirect
  defaulting, `rss` present/absent, array templates, and multiple data entries
  concatenating into the same router key), so the eventual swap is provably
  invisible from the outside.

### What this does NOT do

* **Doesn't feed the bridge from a store yet.** `DynamicRoutingService` still
  reads via the existing settings loader — wiring the store in comes with
  FileStore (HKG-1827) and the adapter-manager (HKG-1829).
* **Doesn't touch routers, controllers, or the URL service.** They keep consuming
  the same expanded shape they always have.
* **Doesn't remove `validate.js` or the legacy read path.** The bridge runs
  alongside it until the domain model flows end-to-end (HKG-1898).
