### PR TITLE
Fixed profile card image copy in ActivityPub preferences

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@tryghost/activitypub",
     "type": "module",
-    "version": "3.1.54",
+    "version": "3.1.55",
     "license": "MIT",
     "repository": {
         "type": "git",

--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -94,7 +94,7 @@
         "@tryghost/shade": "workspace:*",
         "clsx": "catalog:",
         "dompurify": "catalog:",
-        "html2canvas-objectfit-fix": "1.2.0",
+        "html2canvas-pro": "2.2.1",
         "react": "catalog:",
         "react-dom": "catalog:",
         "react-hook-form": "7.80.0",

--- a/apps/activitypub/src/utils/screenshot.ts
+++ b/apps/activitypub/src/utils/screenshot.ts
@@ -1,5 +1,22 @@
 import html2canvas from 'html2canvas-pro';
 
+/**
+ * In Firefox, html2canvas positions whole-word text segments incorrectly
+ * (spaces between words collapse, punctuation overlaps the previous glyph).
+ * A tiny non-zero letter-spacing forces the per-glyph rendering path, where
+ * every glyph is positioned from its own DOM-measured bounds and renders
+ * correctly. Apply to the cloned subtree via the html2canvas `onclone` hook.
+ */
+export function fixFirefoxTextSpacing(element: HTMLElement): void {
+    if (!navigator.userAgent.includes('Firefox')) {
+        return;
+    }
+    element.style.letterSpacing = '0.1px';
+    element.querySelectorAll<HTMLElement>('*').forEach((el) => {
+        el.style.letterSpacing = '0.1px';
+    });
+}
+
 export interface ScreenshotOptions {
     filename?: string;
     scale?: number;
@@ -25,7 +42,8 @@ export async function takeScreenshot(
             logging: false,
             useCORS: true,
             allowTaint: true,
-            imageTimeout: 0
+            imageTimeout: 0,
+            onclone: (_document, clonedElement) => fixFirefoxTextSpacing(clonedElement)
         });
 
         await new Promise<void>((resolve, reject) => {

--- a/apps/activitypub/src/utils/screenshot.ts
+++ b/apps/activitypub/src/utils/screenshot.ts
@@ -1,4 +1,4 @@
-import html2canvas from 'html2canvas-objectfit-fix';
+import html2canvas from 'html2canvas-pro';
 
 export interface ScreenshotOptions {
     filename?: string;

--- a/apps/activitypub/src/views/preferences/components/profile.tsx
+++ b/apps/activitypub/src/views/preferences/components/profile.tsx
@@ -4,7 +4,7 @@ import APAvatar from '@src/components/global/ap-avatar';
 import DotsPattern from './dots-pattern';
 import ProfileCardShadow from '@assets/images/profile-card-shadow.png';
 import ProfileCardShadowSquare from '@assets/images/profile-card-shadow-square.png';
-import html2canvas from 'html2canvas-objectfit-fix';
+import html2canvas from 'html2canvas-pro';
 import {Account} from '@src/api/activitypub';
 import {Button, LoadingIndicator, Skeleton, ToggleGroup, ToggleGroupItem, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@tryghost/shade/components';
 import {H2} from '@tryghost/shade/primitives';
@@ -276,43 +276,41 @@ const Profile: React.FC<ProfileProps> = ({account, isLoading}) => {
                 throw new Error('Clipboard API not supported in this browser');
             }
 
-            try {
-                // eslint-disable-next-line no-async-promise-executor
-                const blobPromise = new Promise<Blob>(async (resolve, reject) => {
-                    try {
-                        const canvas = await html2canvas(profileCardRef.current!, {
-                            backgroundColor: 'transparent',
-                            scale: 2,
-                            logging: false,
-                            useCORS: true,
-                            allowTaint: true,
-                            imageTimeout: 0
-                        });
+            // eslint-disable-next-line no-async-promise-executor
+            const blobPromise = new Promise<Blob>(async (resolve, reject) => {
+                try {
+                    const canvas = await html2canvas(profileCardRef.current!, {
+                        backgroundColor: 'transparent',
+                        scale: 2,
+                        logging: false,
+                        useCORS: true,
+                        allowTaint: true,
+                        imageTimeout: 0
+                    });
 
-                        canvas.toBlob((blob) => {
-                            if (blob) {
-                                resolve(blob);
-                            } else {
-                                reject(new Error('Failed to create blob'));
-                            }
-                        }, 'image/png');
-                    } catch (error) {
-                        reject(error);
-                    }
-                });
+                    canvas.toBlob((blob) => {
+                        if (blob) {
+                            resolve(blob);
+                        } else {
+                            reject(new Error('Failed to create blob'));
+                        }
+                    }, 'image/png');
+                } catch (error) {
+                    reject(error);
+                }
+            });
 
-                const clipboardItem = new ClipboardItem({
-                    'image/png': blobPromise
-                });
+            const clipboardItem = new ClipboardItem({
+                'image/png': blobPromise
+            });
 
-                await navigator.clipboard.write([clipboardItem]);
-                toast.success('Image copied to clipboard');
-            } catch {
-                toast.error('Failed to copy image');
-            }
-            setIsProcessing(false);
-        } catch {
+            await navigator.clipboard.write([clipboardItem]);
+            toast.success('Image copied to clipboard');
+        } catch (error) {
+            // eslint-disable-next-line no-console
+            console.error('Failed to copy profile card image:', error);
             toast.error('Failed to copy image');
+        } finally {
             setIsProcessing(false);
         }
     };

--- a/apps/activitypub/src/views/preferences/components/profile.tsx
+++ b/apps/activitypub/src/views/preferences/components/profile.tsx
@@ -9,6 +9,7 @@ import {Account} from '@src/api/activitypub';
 import {Button, LoadingIndicator, Skeleton, ToggleGroup, ToggleGroupItem, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@tryghost/shade/components';
 import {H2} from '@tryghost/shade/primitives';
 import {LucideIcon} from '@tryghost/shade/utils';
+import {fixFirefoxTextSpacing} from '@src/utils/screenshot';
 import {imageUrlToDataUrl} from '@src/utils/image';
 import {toast} from 'sonner';
 import {useBrowseSite} from '@tryghost/admin-x-framework/api/site';
@@ -285,7 +286,8 @@ const Profile: React.FC<ProfileProps> = ({account, isLoading}) => {
                         logging: false,
                         useCORS: true,
                         allowTaint: true,
-                        imageTimeout: 0
+                        imageTimeout: 0,
+                        onclone: (_document, clonedElement) => fixFirefoxTextSpacing(clonedElement)
                     });
 
                     canvas.toBlob((blob) => {

--- a/apps/activitypub/test/unit/utils/screenshot.test.ts
+++ b/apps/activitypub/test/unit/utils/screenshot.test.ts
@@ -2,7 +2,7 @@ import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
 import html2canvas from 'html2canvas-pro';
 
-import {takeScreenshot} from '../../../src/utils/screenshot';
+import {fixFirefoxTextSpacing, takeScreenshot} from '../../../src/utils/screenshot';
 
 // Mock html2canvas
 vi.mock('html2canvas-pro');
@@ -78,7 +78,8 @@ describe('takeScreenshot', function () {
             logging: false,
             useCORS: true,
             allowTaint: true,
-            imageTimeout: 0
+            imageTimeout: 0,
+            onclone: expect.any(Function)
         });
     });
 
@@ -99,7 +100,8 @@ describe('takeScreenshot', function () {
             logging: false,
             useCORS: true,
             allowTaint: true,
-            imageTimeout: 0
+            imageTimeout: 0,
+            onclone: expect.any(Function)
         });
     });
 
@@ -188,5 +190,38 @@ describe('takeScreenshot', function () {
         });
 
         await expect(takeScreenshot(mockElement)).rejects.toThrow('DOM manipulation failed');
+    });
+});
+
+describe('fixFirefoxTextSpacing', function () {
+    afterEach(function () {
+        vi.restoreAllMocks();
+    });
+
+    const buildElement = () => {
+        const element = document.createElement('div');
+        const child = document.createElement('span');
+        element.appendChild(child);
+        return {element, child};
+    };
+
+    it('applies letter-spacing to the element and its descendants in Firefox', function () {
+        vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:140.0) Gecko/20100101 Firefox/140.0');
+
+        const {element, child} = buildElement();
+        fixFirefoxTextSpacing(element);
+
+        expect(element.style.letterSpacing).toBe('0.1px');
+        expect(child.style.letterSpacing).toBe('0.1px');
+    });
+
+    it('does nothing in non-Firefox browsers', function () {
+        vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36');
+
+        const {element, child} = buildElement();
+        fixFirefoxTextSpacing(element);
+
+        expect(element.style.letterSpacing).toBe('');
+        expect(child.style.letterSpacing).toBe('');
     });
 });

--- a/apps/activitypub/test/unit/utils/screenshot.test.ts
+++ b/apps/activitypub/test/unit/utils/screenshot.test.ts
@@ -1,11 +1,11 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
-import html2canvas from 'html2canvas-objectfit-fix';
+import html2canvas from 'html2canvas-pro';
 
 import {takeScreenshot} from '../../../src/utils/screenshot';
 
 // Mock html2canvas
-vi.mock('html2canvas-objectfit-fix');
+vi.mock('html2canvas-pro');
 
 // Mock DOM methods
 Object.defineProperty(window, 'URL', {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -490,9 +490,9 @@ importers:
       dompurify:
         specifier: 'catalog:'
         version: 3.4.11
-      html2canvas-objectfit-fix:
-        specifier: 1.2.0
-        version: 1.2.0
+      html2canvas-pro:
+        specifier: 2.2.1
+        version: 2.2.1
       react:
         specifier: 'catalog:'
         version: 18.3.1
@@ -10897,8 +10897,8 @@ packages:
   base-64@1.0.0:
     resolution: {integrity: sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==}
 
-  base64-arraybuffer@0.2.0:
-    resolution: {integrity: sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ==}
+  base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
     engines: {node: '>= 0.6.0'}
 
   base64-js@1.5.1:
@@ -12477,8 +12477,8 @@ packages:
     peerDependencies:
       postcss: ^8.4
 
-  css-line-break@1.1.1:
-    resolution: {integrity: sha512-1feNVaM4Fyzdj4mKPIQNL2n70MmuYzAXZ1aytlROFX1JsOo070OsugwGjj7nl6jnDJWHDM8zRZswkmeYVWZJQA==}
+  css-line-break@2.1.0:
+    resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
 
   css-loader@5.2.7:
     resolution: {integrity: sha512-Q7mOvpBNBG7YrVGMxRxcBJZFL75o+cH2abNASdibkj/fffYD8qWbInZrD0S9ccI6vZclF3DsHE7njGlLtaHbhg==}
@@ -15152,9 +15152,9 @@ packages:
       vitest:
         optional: true
 
-  html2canvas-objectfit-fix@1.2.0:
-    resolution: {integrity: sha512-eBQPJyJJPgAlgtMioB42Kv+wHXGgfjUyPdYWZKbF8jUlss4J6xdj5tJM8n2uZ/94NU2UEooN97ypGdzbFE562A==}
-    engines: {node: '>=8.0.0'}
+  html2canvas-pro@2.2.1:
+    resolution: {integrity: sha512-AoSeM/GpU5eKZ3rPNHJbMDgxMS0MJgvA9tQAcceHSzdS33ULqv889oiRSyxxz6PvVL/dbnYOrGKnqmNSpIaX1g==}
+    engines: {node: '>=16.0.0'}
 
   html5parser@2.0.2:
     resolution: {integrity: sha512-L0y+IdTVxHsovmye8MBtFgBvWZnq1C9WnI/SmJszxoQjmUH1psX2uzDk21O5k5et6udxdGjwxkbmT9eVRoG05w==}
@@ -21021,6 +21021,9 @@ packages:
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
+  text-segmentation@1.0.3:
+    resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
+
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
 
@@ -21669,6 +21672,9 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  utrie@1.0.2:
+    resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
@@ -31942,7 +31948,7 @@ snapshots:
 
   base-64@1.0.0: {}
 
-  base64-arraybuffer@0.2.0: {}
+  base64-arraybuffer@1.0.2: {}
 
   base64-js@1.5.1: {}
 
@@ -33758,9 +33764,9 @@ snapshots:
       postcss: 8.5.16
       postcss-selector-parser: 6.1.4
 
-  css-line-break@1.1.1:
+  css-line-break@2.1.0:
     dependencies:
-      base64-arraybuffer: 0.2.0
+      utrie: 1.0.2
 
   css-loader@5.2.7(webpack@5.105.4(@swc/core@1.15.43(@swc/helpers@0.5.23))(cssnano@4.1.10)(esbuild@0.28.1)(postcss@8.5.16)):
     dependencies:
@@ -38376,9 +38382,10 @@ snapshots:
       jest-snapshot: 30.3.0
       vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
-  html2canvas-objectfit-fix@1.2.0:
+  html2canvas-pro@2.2.1:
     dependencies:
-      css-line-break: 1.1.1
+      css-line-break: 2.1.0
+      text-segmentation: 1.0.3
 
   html5parser@2.0.2:
     dependencies:
@@ -45814,6 +45821,10 @@ snapshots:
     transitivePeerDependencies:
       - react-native-b4a
 
+  text-segmentation@1.0.3:
+    dependencies:
+      utrie: 1.0.2
+
   text-table@0.2.0: {}
 
   textextensions@2.6.0: {}
@@ -46457,6 +46468,10 @@ snapshots:
       which-typed-array: 1.1.22
 
   utils-merge@1.0.1: {}
+
+  utrie@1.0.2:
+    dependencies:
+      base64-arraybuffer: 1.0.2
 
   uuid@3.4.0: {}
 


### PR DESCRIPTION
closes https://linear.app/ghost/issue/DES-1411
closes https://github.com/TryGhost/ActivityPub/issues/1312

Copying the "Share your profile" card failed in all browsers because
`html2canvas-objectfit-fix` cannot parse the oklch colors from Shade's
Tailwind v4 theme. Replaced it with `html2canvas-pro`, which supports
modern color functions and keeps the object-fit handling.

Also fixed broken text spacing in the image on Firefox: `html2canvas`
positions whole words from range rects that Firefox reports
incorrectly, so a tiny letter-spacing is applied to the capture clone
to switch the library to per-glyph rendering. The visible card and
other browsers are unaffected.
