### PR TITLE
Added Plausible analytics tracking for gift links in admin

### DIFF
--- a/apps/admin-x-framework/src/index.ts
+++ b/apps/admin-x-framework/src/index.ts
@@ -23,6 +23,9 @@ export type {KoenigFileUploadType} from './hooks/use-koenig-file-upload';
 export {useKoenigLinkSuggestions} from './hooks/use-koenig-link-suggestions';
 export {useFeaturebase} from './hooks/use-featurebase';
 
+// Analytics utilities
+export {trackEvent, trackFilterApplications} from './utils/analytics';
+
 // Currency utilities
 export {getSymbol} from './utils/currency';
 

--- a/apps/admin-x-framework/src/utils/analytics.ts
+++ b/apps/admin-x-framework/src/utils/analytics.ts
@@ -1,0 +1,47 @@
+// Wrapper function for Plausible event
+type AnalyticsPropertyValue = string | number | boolean;
+
+declare global {
+    interface Window {
+        plausible?: ((eventName: string, options: {props: Record<string, AnalyticsPropertyValue>}) => void),
+    }
+}
+
+/**
+ * Sends a tracking event to Plausible, if installed.
+ *
+ * By default, Plausible is not installed, in which case this function no-ops.
+ */
+export function trackEvent(eventName: string, props: Record<string, AnalyticsPropertyValue> = {}) {
+    window.plausible = window.plausible || function () {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, prefer-rest-params
+        ((window.plausible as any).q = (window.plausible as any).q || []).push(arguments as unknown);
+    };
+    window.plausible!(eventName, {props: props});
+}
+
+interface TrackedFilter {
+    field: string;
+    values: unknown[];
+}
+
+function sameValues(a: unknown[], b: unknown[]) {
+    return a.length === b.length && a.every((value, i) => value === b[i]);
+}
+
+/**
+ * Tracks an `Analytics Filter Used` event for each filter whose values were
+ * added or changed between two filter states. Removing a filter entirely (or
+ * clearing all filters) is not tracked.
+ */
+export function trackFilterApplications(previous: TrackedFilter[], next: TrackedFilter[], context: string) {
+    next.forEach((filter) => {
+        if (filter.values.length === 0) {
+            return;
+        }
+        const previousFilter = previous.find(f => f.field === filter.field);
+        if (!previousFilter || !sameValues(previousFilter.values, filter.values)) {
+            trackEvent('Analytics Filter Used', {filter: filter.field, context});
+        }
+    });
+}

--- a/apps/admin-x-settings/src/components/settings/advanced/danger-zone.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/danger-zone.tsx
@@ -1,6 +1,7 @@
 import NiceModal from '@ebay/nice-modal-react';
 import React from 'react';
 import TopLevelGroup from '../../top-level-group';
+import trackEvent from '../../../utils/analytics';
 import useStaffUsers from '../../../hooks/use-staff-users';
 import {Button, ConfirmationModal, ListItem, SettingGroupHeader, showToast, withErrorBoundary} from '@tryghost/admin-x-design-system';
 import {getGhostPaths} from '@tryghost/admin-x-framework/helpers';
@@ -96,6 +97,7 @@ const DangerZone: React.FC<{ keywords: string[] }> = ({keywords}) => {
                 try {
                     const response = await removeAllGiftLinks(null);
                     const count = response?.meta?.count ?? 0;
+                    trackEvent('All Gift Links Reset');
                     showToast({
                         title: `Reset ${count} gift ${count === 1 ? 'link' : 'links'}.`,
                         type: 'success'

--- a/apps/admin-x-settings/src/utils/analytics.ts
+++ b/apps/admin-x-settings/src/utils/analytics.ts
@@ -1,16 +1,3 @@
-// Wrapper function for Plausible event
-type AnalyticsPropertyValue = string|number|boolean
+import {trackEvent} from '@tryghost/admin-x-framework';
 
-declare global {
-    interface Window {
-        plausible?: ((eventName: string, options: {props: Record<string, AnalyticsPropertyValue>}) => void),
-    }
-}
-
-export default function trackEvent(eventName: string, props: Record<string, AnalyticsPropertyValue> = {}) {
-    window.plausible = window.plausible || function () {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, prefer-rest-params
-        ((window.plausible as any).q = (window.plausible as any).q || []).push(arguments as unknown);
-    };
-    window.plausible!(eventName, {props: props});
-}
+export default trackEvent;

--- a/apps/admin/src/analytics/hooks/use-filter-params.ts
+++ b/apps/admin/src/analytics/hooks/use-filter-params.ts
@@ -1,6 +1,6 @@
 import {type Filter} from '@tryghost/shade/patterns';
+import {trackFilterApplications, useSearchParams} from '@tryghost/admin-x-framework';
 import {useCallback, useEffect, useMemo, useRef} from 'react';
-import {useSearchParams} from '@tryghost/admin-x-framework';
 
 // Supported filter fields that can be synced to URL
 const SUPPORTED_FILTER_FIELDS = [
@@ -149,6 +149,10 @@ export function useFilterParams(options: UseFilterParamsOptions = {}): UseFilter
         // Handle functional updates
         const newFilters = typeof action === 'function' ? action(filters) : action;
         const newParams = filtersToSearchParams(newFilters);
+
+        // Every filter-apply path funnels through here (filter toolbar,
+        // click-to-filter rows), so this is the one place usage is tracked
+        trackFilterApplications(filters, newFilters, 'stats');
 
         // Preserve any non-filter params (like tab, etc.)
         const currentParams = new URLSearchParams(searchParams);

--- a/apps/admin/src/analytics/views/Stats/Overview/components/latest-post.tsx
+++ b/apps/admin/src/analytics/views/Stats/Overview/components/latest-post.tsx
@@ -1,11 +1,11 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import {Button, Card, CardContent, CardDescription, CardHeader, CardTitle, EmptyIndicator, Skeleton} from '@tryghost/shade/components';
 import {LucideIcon, cn, formatDisplayDate, formatNumber, formatPercentage} from '@tryghost/shade/utils';
 import {PostShareModal} from '@tryghost/shade/posts-stats';
 
 import {type Post, getPostMetricsToDisplay} from '@tryghost/admin-x-framework';
 import {getPostDestination} from '@/analytics/utils/url-helpers';
-import {useAppContext, useNavigate} from '@tryghost/admin-x-framework';
+import {trackEvent, useAppContext, useNavigate} from '@tryghost/admin-x-framework';
 import {useAnalyticsData} from '@/analytics/hooks/use-analytics-data';
 
 // Import the interface from the hook
@@ -40,6 +40,13 @@ const LatestPost: React.FC<LatestPostProps> = ({
         webAnalytics = false,
         membersTrackSources = false
     } = appSettings?.analytics || {};
+
+    // The stats-overview share modal never offers gift links today.
+    useEffect(() => {
+        if (isShareOpen) {
+            trackEvent('Share Modal Opened', {giftLinkShown: false, source: 'stats-overview'});
+        }
+    }, [isShareOpen]);
 
     // Get site title from settings or site data
     const siteTitle = site.title || String(settings.find(setting => setting.key === 'title')?.value || 'Ghost Site');

--- a/apps/admin/src/gift-link-modal-host.tsx
+++ b/apps/admin/src/gift-link-modal-host.tsx
@@ -35,6 +35,7 @@ function GiftLinkModalHost() {
                 open={open}
                 postId={entry.id}
                 resource={entry.resource}
+                source="context-menu"
                 onOpenChange={setOpen}
             />
         </Suspense>

--- a/apps/posts/src/hooks/use-filter-params.ts
+++ b/apps/posts/src/hooks/use-filter-params.ts
@@ -1,6 +1,6 @@
 import {Filter} from '@tryghost/shade/patterns';
+import {trackFilterApplications, useSearchParams} from '@tryghost/admin-x-framework';
 import {useCallback, useEffect, useMemo, useRef} from 'react';
-import {useSearchParams} from '@tryghost/admin-x-framework';
 
 // Supported filter fields that can be synced to URL
 const SUPPORTED_FILTER_FIELDS = [
@@ -148,6 +148,10 @@ export function useFilterParams(options: UseFilterParamsOptions = {}): UseFilter
         // Handle functional updates
         const newFilters = typeof action === 'function' ? action(filters) : action;
         const newParams = filtersToSearchParams(newFilters);
+
+        // Every filter-apply path funnels through here (filter toolbar,
+        // click-to-filter rows), so this is the one place usage is tracked
+        trackFilterApplications(filters, newFilters, 'post-analytics');
 
         // Preserve any non-filter params (like tab, etc.)
         const currentParams = new URLSearchParams(searchParams);

--- a/apps/posts/src/views/PostAnalytics/Overview/overview.tsx
+++ b/apps/posts/src/views/PostAnalytics/Overview/overview.tsx
@@ -249,6 +249,7 @@ const Overview: React.FC = () => {
                     key={postId}
                     open={isGiftLinkOpen}
                     postId={postId}
+                    source='gift-link-card'
                     onOpenChange={setIsGiftLinkOpen}
                 />
             )}

--- a/apps/posts/src/views/PostAnalytics/components/post-analytics-header.tsx
+++ b/apps/posts/src/views/PostAnalytics/components/post-analytics-header.tsx
@@ -1,5 +1,5 @@
 import GiftLinkModal from '../modals/gift-link-modal';
-import React, {useMemo, useState} from 'react';
+import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator, Button, DropdownMenu, DropdownMenuContent, DropdownMenuGroup, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger, Navbar, PageMenu, PageMenuItem} from '@tryghost/shade/components';
 import {H1} from '@tryghost/shade/primitives';
 import {LucideIcon, formatDisplayDate, formatDisplayTime, formatNumber} from '@tryghost/shade/utils';
@@ -7,7 +7,7 @@ import {Post, useGlobalData} from '@src/providers/post-analytics-context';
 import {PostShareModal} from '@tryghost/shade/posts-stats';
 import {getSiteTimezone} from '@src/utils/get-site-timezone';
 import {giftAccessLabel} from '@src/utils/gift-link';
-import {hasBeenEmailed, isEmailOnly, isPublishedAndEmailed, isPublishedOnly, useActiveVisitors, useNavigate} from '@tryghost/admin-x-framework';
+import {hasBeenEmailed, isEmailOnly, isPublishedAndEmailed, isPublishedOnly, trackEvent, useActiveVisitors, useNavigate} from '@tryghost/admin-x-framework';
 import {useAppContext} from '@src/providers/posts-app-context';
 import {useCanManageGiftLink} from '@src/hooks/use-can-manage-gift-link';
 import {useDeletePost} from '@tryghost/admin-x-framework/api/posts';
@@ -33,6 +33,21 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
     const canManageGiftLink = useCanManageGiftLink(post);
 
     const siteTimezone = getSiteTimezone(settings);
+
+    // Track once per open — canManageGiftLink can flip while the modal is open
+    // (current-user query resolving), which must not re-fire the event.
+    const shareOpenTrackedRef = useRef(false);
+    useEffect(() => {
+        if (!isShareOpen) {
+            shareOpenTrackedRef.current = false;
+            return;
+        }
+        if (shareOpenTrackedRef.current) {
+            return;
+        }
+        shareOpenTrackedRef.current = true;
+        trackEvent('Share Modal Opened', {giftLinkShown: canManageGiftLink, source: 'post-analytics'});
+    }, [isShareOpen, canManageGiftLink]);
 
     // Use the active visitors hook with post-specific filtering
     const {activeVisitors, isLoading: isActiveVisitorsLoading} = useActiveVisitors({
@@ -258,6 +273,7 @@ const PostAnalyticsHeader:React.FC<PostAnalyticsHeaderProps> = ({
                     key={postId}
                     open={isGiftLinkOpen}
                     postId={postId}
+                    source='share-modal'
                     onOpenChange={setIsGiftLinkOpen}
                 />
             )}

--- a/apps/posts/src/views/PostAnalytics/modals/gift-link-modal.tsx
+++ b/apps/posts/src/views/PostAnalytics/modals/gift-link-modal.tsx
@@ -130,13 +130,13 @@ const GiftLinkModal: React.FC<GiftLinkModalProps> = ({open, onOpenChange, postId
             const response = await createGiftLink({id: postId, resource});
             setToken(response.gift_links[0]?.token);
             setResetState('idle');
-            trackEvent('Gift Link Reset', {postType, visibility});
+            trackEvent('Gift Link Reset', {postType, visibility, source});
         } catch (e) {
             handleError(e);
         } finally {
             setResetting(false);
         }
-    }, [resetting, createGiftLink, postId, resource, handleError, postType, visibility]);
+    }, [resetting, createGiftLink, postId, resource, handleError, postType, visibility, source]);
 
     const handleOpenChange = useCallback((isOpen: boolean) => {
         if (!isOpen) {
@@ -175,7 +175,7 @@ const GiftLinkModal: React.FC<GiftLinkModalProps> = ({open, onOpenChange, postId
                                 disabled={ensuring || !giftLinkUrl}
                                 icon='link'
                                 size='sm'
-                                onClick={() => trackEvent('Gift Link Copied', {postType, visibility})}
+                                onClick={() => trackEvent('Gift Link Copied', {postType, visibility, source})}
                             />
                         </ShareModal.CopyURLBox>
 

--- a/apps/posts/src/views/PostAnalytics/modals/gift-link-modal.tsx
+++ b/apps/posts/src/views/PostAnalytics/modals/gift-link-modal.tsx
@@ -4,6 +4,7 @@ import {GiftLinkResource, useCreateGiftLink, useEnsureGiftLink} from '@tryghost/
 import {ShareModal} from '@tryghost/shade/patterns';
 import {buildGiftLinkUrl} from '@src/utils/gift-link';
 import {formatNumber} from '@tryghost/shade/utils';
+import {trackEvent} from '@tryghost/admin-x-framework';
 import {useGiftLinkUsage} from '@src/hooks/use-gift-link-usage';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {usePostDetails} from '@src/hooks/use-post-details';
@@ -17,14 +18,17 @@ function visitorsLabel(count: number) {
 
 type ResetState = 'idle' | 'confirm';
 
+export type GiftLinkModalSource = 'share-modal' | 'context-menu' | 'gift-link-card';
+
 interface GiftLinkModalProps {
     open: boolean;
     onOpenChange: (open: boolean) => void;
     postId: string;
     resource?: GiftLinkResource;
+    source: GiftLinkModalSource;
 }
 
-const GiftLinkModal: React.FC<GiftLinkModalProps> = ({open, onOpenChange, postId, resource = 'posts'}) => {
+const GiftLinkModal: React.FC<GiftLinkModalProps> = ({open, onOpenChange, postId, resource = 'posts', source}) => {
     const handleError = useHandleError();
     const {mutateAsync: ensureGiftLink} = useEnsureGiftLink();
     const {mutateAsync: createGiftLink} = useCreateGiftLink();
@@ -95,10 +99,27 @@ const GiftLinkModal: React.FC<GiftLinkModalProps> = ({open, onOpenChange, postId
         }
     }, [resetState]);
 
+    const postType = resource === 'pages' ? 'page' : 'post';
+    const visibility = post?.visibility ?? 'unknown';
+
+    // Track the open once per open, but only after post details load so the
+    // visibility property is populated.
+    const openTrackedRef = useRef(false);
+    useEffect(() => {
+        if (!open) {
+            openTrackedRef.current = false;
+            return;
+        }
+        if (openTrackedRef.current || !post) {
+            return;
+        }
+        openTrackedRef.current = true;
+        trackEvent('Gift Link Modal Opened', {postType, visibility, source});
+    }, [open, post, postType, visibility, source]);
+
     const giftLinkUrl = buildGiftLinkUrl(post?.url, token);
     const memberType = post?.visibility === 'members' ? 'member' : 'paid member';
-    const resourceLabel = resource === 'pages' ? 'page' : 'post';
-    const description = `Anyone you share this link with will be able to access this ${resourceLabel} without becoming a ${memberType}.`;
+    const description = `Anyone you share this link with will be able to access this ${postType} without becoming a ${memberType}.`;
 
     const handleConfirmReset = useCallback(async () => {
         if (resetting) {
@@ -109,12 +130,13 @@ const GiftLinkModal: React.FC<GiftLinkModalProps> = ({open, onOpenChange, postId
             const response = await createGiftLink({id: postId, resource});
             setToken(response.gift_links[0]?.token);
             setResetState('idle');
+            trackEvent('Gift Link Reset', {postType, visibility});
         } catch (e) {
             handleError(e);
         } finally {
             setResetting(false);
         }
-    }, [resetting, createGiftLink, postId, resource, handleError]);
+    }, [resetting, createGiftLink, postId, resource, handleError, postType, visibility]);
 
     const handleOpenChange = useCallback((isOpen: boolean) => {
         if (!isOpen) {
@@ -153,6 +175,7 @@ const GiftLinkModal: React.FC<GiftLinkModalProps> = ({open, onOpenChange, postId
                                 disabled={ensuring || !giftLinkUrl}
                                 icon='link'
                                 size='sm'
+                                onClick={() => trackEvent('Gift Link Copied', {postType, visibility})}
                             />
                         </ShareModal.CopyURLBox>
 
@@ -178,7 +201,7 @@ const GiftLinkModal: React.FC<GiftLinkModalProps> = ({open, onOpenChange, postId
                         <DialogHeader>
                             <DialogTitle>Reset gift link</DialogTitle>
                             <DialogDescription>
-                                Are you sure you want to reset this link? Anyone with the current link will lose access to this {resourceLabel}.
+                                Are you sure you want to reset this link? Anyone with the current link will lose access to this {postType}.
                             </DialogDescription>
                         </DialogHeader>
                         <DialogFooter>

--- a/apps/posts/src/views/PostAnalytics/post-analytics.tsx
+++ b/apps/posts/src/views/PostAnalytics/post-analytics.tsx
@@ -1,10 +1,20 @@
 import PostAnalyticsLayout from './components/layout/post-analytics-layout';
-import {Outlet} from '@tryghost/admin-x-framework';
+import {Outlet, trackEvent} from '@tryghost/admin-x-framework';
 import {PostShareModal} from '@tryghost/shade/posts-stats';
+import {useEffect} from 'react';
 import {usePostSuccessModal} from '@hooks/use-post-success-modal';
 
 const PostAnalytics: React.FC = () => {
     const {isModalOpen, modalProps} = usePostSuccessModal();
+
+    // The publish-success share modal is only rendered once both the open flag
+    // and the post-backed props are ready. It never offers gift links today.
+    const isShareModalShown = isModalOpen && !!modalProps;
+    useEffect(() => {
+        if (isShareModalShown) {
+            trackEvent('Share Modal Opened', {giftLinkShown: false, source: 'publish-flow'});
+        }
+    }, [isShareModalShown]);
 
     return (
         <PostAnalyticsLayout>

--- a/apps/posts/test/unit/views/post-analytics/gift-link-modal.test.tsx
+++ b/apps/posts/test/unit/views/post-analytics/gift-link-modal.test.tsx
@@ -81,7 +81,7 @@ describe('GiftLinkModal', () => {
     it('ensures the gift link once when opened under StrictMode', async () => {
         render(
             <StrictMode>
-                <GiftLinkModal postId='post-id' open onOpenChange={vi.fn()} />
+                <GiftLinkModal postId='post-id' source='share-modal' open onOpenChange={vi.fn()} />
             </StrictMode>
         );
 
@@ -94,15 +94,15 @@ describe('GiftLinkModal', () => {
 
     it('ensures again after the modal is closed and reopened', async () => {
         const {rerender} = render(
-            <GiftLinkModal postId='post-id' open onOpenChange={vi.fn()} />
+            <GiftLinkModal postId='post-id' source='share-modal' open onOpenChange={vi.fn()} />
         );
 
         await waitFor(() => {
             expect(mockEnsureGiftLink).toHaveBeenCalledTimes(1);
         });
 
-        rerender(<GiftLinkModal open={false} postId='post-id' onOpenChange={vi.fn()} />);
-        rerender(<GiftLinkModal postId='post-id' open onOpenChange={vi.fn()} />);
+        rerender(<GiftLinkModal open={false} postId='post-id' source='share-modal' onOpenChange={vi.fn()} />);
+        rerender(<GiftLinkModal postId='post-id' source='share-modal' open onOpenChange={vi.fn()} />);
 
         await waitFor(() => {
             expect(mockEnsureGiftLink).toHaveBeenCalledTimes(2);
@@ -111,14 +111,14 @@ describe('GiftLinkModal', () => {
 
     it('ensures again when the open modal receives a different post id', async () => {
         const {rerender} = render(
-            <GiftLinkModal postId='post-id' open onOpenChange={vi.fn()} />
+            <GiftLinkModal postId='post-id' source='share-modal' open onOpenChange={vi.fn()} />
         );
 
         await waitFor(() => {
             expect(mockEnsureGiftLink).toHaveBeenCalledTimes(1);
         });
 
-        rerender(<GiftLinkModal postId='other-post-id' open onOpenChange={vi.fn()} />);
+        rerender(<GiftLinkModal postId='other-post-id' source='share-modal' open onOpenChange={vi.fn()} />);
 
         await waitFor(() => {
             expect(mockEnsureGiftLink).toHaveBeenCalledTimes(2);
@@ -128,14 +128,14 @@ describe('GiftLinkModal', () => {
 
     it('ensures again when the open modal receives a different resource', async () => {
         const {rerender} = render(
-            <GiftLinkModal postId='post-id' resource='posts' open onOpenChange={vi.fn()} />
+            <GiftLinkModal postId='post-id' resource='posts' source='share-modal' open onOpenChange={vi.fn()} />
         );
 
         await waitFor(() => {
             expect(mockEnsureGiftLink).toHaveBeenCalledTimes(1);
         });
 
-        rerender(<GiftLinkModal postId='post-id' resource='pages' open onOpenChange={vi.fn()} />);
+        rerender(<GiftLinkModal postId='post-id' resource='pages' source='share-modal' open onOpenChange={vi.fn()} />);
 
         await waitFor(() => {
             expect(mockEnsureGiftLink).toHaveBeenCalledTimes(2);

--- a/ghost/admin/app/components/gh-context-menu.js
+++ b/ghost/admin/app/components/gh-context-menu.js
@@ -10,6 +10,9 @@ export default class GhContextMenu extends Component {
     @service modals;
 
     @tracked isOpen = false;
+    // Bumped on every handled open request, including re-opens on a new target
+    // while the menu is already open (isOpen doesn't change in that case)
+    @tracked openCount = 0;
     @tracked left = 0;
     @tracked top = 0;
     @tracked yPlacement = 'bottom';
@@ -130,6 +133,9 @@ export default class GhContextMenu extends Component {
 
             this.calculatePlacement();
             this.open();
+            if (this.isOpen) {
+                this.openCount += 1;
+            }
         } else {
             this.close();
         }

--- a/ghost/admin/app/components/posts-list/context-menu.hbs
+++ b/ghost/admin/app/components/posts-list/context-menu.hbs
@@ -1,4 +1,4 @@
-<ul class="gh-posts-context-menu dropdown-menu dropdown-triangle-top-left" data-test-post-context-menu>
+<ul class="gh-posts-context-menu dropdown-menu dropdown-triangle-top-left" data-test-post-context-menu {{did-update this.trackMenuOpened this.menu.openCount}}>
 
     {{#if this.canUnpublishSelection}}
         {{#if this.canCopySelection}}

--- a/ghost/admin/app/components/posts-list/context-menu.js
+++ b/ghost/admin/app/components/posts-list/context-menu.js
@@ -112,7 +112,7 @@ export default class PostsContextMenu extends Component {
         }
         trackEvent('Posts Context Menu Opened', {
             giftLinkShown: this.canCopyGiftLink,
-            resource: this.type === 'page' ? 'pages' : 'posts',
+            postType: this.type,
             selection: this.selectionList.isSingle ? 'single' : 'multiple'
         });
     }

--- a/ghost/admin/app/components/posts-list/context-menu.js
+++ b/ghost/admin/app/components/posts-list/context-menu.js
@@ -11,6 +11,7 @@ import {canCopyGiftLink} from 'ghost-admin/utils/gift-link';
 import {capitalizeFirstLetter} from 'ghost-admin/helpers/capitalize-first-letter';
 import {inject as service} from '@ember/service';
 import {task, timeout} from 'ember-concurrency';
+import {trackEvent} from 'ghost-admin/utils/analytics';
 
 /**
  * @tryghost/tpl doesn't work in admin yet (Safari)
@@ -99,6 +100,21 @@ export default class PostsContextMenu extends Component {
             return tpl(messages[type].single, {count: this.selectionList.count, type: this.type, Type: capitalizeFirstLetter(this.type)});
         }
         return tpl(messages[type].multiple, {count: this.selectionList.count, type: this.type, Type: capitalizeFirstLetter(this.type)});
+    }
+
+    // Fired via {{did-update}} on the menu's openCount, which bumps on every
+    // open request — including right-clicking another post while the menu is
+    // already open, where isOpen alone wouldn't change.
+    @action
+    trackMenuOpened() {
+        if (!this.menu.isOpen) {
+            return;
+        }
+        trackEvent('Posts Context Menu Opened', {
+            giftLinkShown: this.canCopyGiftLink,
+            resource: this.type === 'page' ? 'pages' : 'posts',
+            selection: this.selectionList.isSingle ? 'single' : 'multiple'
+        });
     }
 
     @action


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3771/set-up-plausible-analyics

Gift links shipped without product analytics, so we can't see whether the feature gets discovered or used. This adds custom-event instrumentation using the existing `trackEvent` → `window.plausible` queue pattern (no-ops unless the Plausible script is injected, i.e. Ghost (Pro)).

## Events

| Event | Props | Fires |
|---|---|---|
| `Gift Link Modal Opened` | `postType`, `visibility`, `source: share-modal \| context-menu \| gift-link-card` | Once per open, after post details load |
| `Gift Link Copied` | `postType`, `visibility`, `source` | Copy button in the gift link modal |
| `Gift Link Reset` | `postType`, `visibility`, `source` | On confirmed reset only (new token minted) |
| `All Gift Links Reset` | — | Danger-zone remove-all, after the API call succeeds |
| `Share Modal Opened` | `giftLinkShown`, `source: post-analytics \| publish-flow \| stats-overview` | All three mounts, once per open |
| `Posts Context Menu Opened` | `giftLinkShown`, `postType`, `selection` | Every open of the Ember posts/pages list menu, incl. re-opens on another post |
| `Analytics Filter Used` | `filter` (field name only), `context: post-analytics \| stats` | Any filter apply — toolbar and click-to-filter rows |

`giftLinkShown` means the "Share as a gift" option was actually visible for that post + user (`canShareAsGift` / `canCopyGiftLink`).

## Implementation notes

- The canonical `trackEvent` util moved into `admin-x-framework`; `admin-x-settings` re-exports it so there's one implementation across React admin apps. The Ember admin keeps its existing util.
- Filter tracking lives in `useFilterParams`' `setFilters` — the single choke point for every apply path — rather than per component, so toolbar applies and click-to-filter table rows are both counted with no duplicated logic. Clears and filter removals don't fire.
- `GhContextMenu` gained a tracked `openCount` so re-opening the menu on a different post (where `isOpen` never flips) is still counted with the current selection's props.
- Share modal opens are guarded once-per-open so async eligibility resolution can't double-fire.
- Shade components stay presentational: tracking fires from the app layer via existing callbacks.
- All events from the gift link modal carry the same `source`, so entry-point discovery can be correlated with copy/reset actions (review feedback).

The changes went through a multi-angle review (8 reviewer agents + a Codex fan-out review, findings adversarially verified) and the confirmed issues were fixed in place.

Rebased onto main after the stats app moved into `apps/admin/src/analytics` (#29177) — the site-level filter tracking now lives there.

Out of scope: configuring the custom event goals in the Plausible dashboard itself.

## Tests

- Unit: admin-x-framework, posts (487), admin (354, includes the moved analytics domain), admin-x-settings — all passing
- Ember: all acceptance tests covering the posts context menu passing
- Lint green on every touched package