### PR TITLE
🐛 Fixed link selection in automations email editor

### DIFF
--- a/apps/posts/src/views/Automations/components/email-modal/email-content-modal.tsx
+++ b/apps/posts/src/views/Automations/components/email-modal/email-content-modal.tsx
@@ -93,6 +93,13 @@ export interface EmailContentModalProps {
     onSave: (data: {subject: string; lexical: string}) => void;
 }
 
+// Koenig popups (link input, emoji picker, card settings) handle Escape
+// themselves — the dialog shouldn't also act on it.
+const isKoenigPortalFocused = () => {
+    const activeElement = document.activeElement;
+    return activeElement instanceof HTMLElement && activeElement.closest('[data-kg-portal]') !== null;
+};
+
 const EmailContentModal: React.FC<EmailContentModalProps> = ({
     automationId,
     initialMode = 'edit',
@@ -213,6 +220,36 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({
         };
     }, []);
 
+    const dialogContentRef = useRef<HTMLDivElement>(null);
+
+    // The dialog is non-modal so Radix's focus trap can't fight Koenig's
+    // body-level portals (link input, toolbar, emoji picker), which means
+    // nothing stops focus from reaching the admin UI behind the editor. Make
+    // everything else at body level inert while the editor is open —
+    // unfocusable, unclickable, and hidden from screen readers. Koenig
+    // portals and stacked dialogs mount after this runs, so they stay
+    // interactive.
+    useEffect(() => {
+        const dialogPortalWrapper = dialogContentRef.current?.closest('body > *');
+        if (!dialogPortalWrapper) {
+            return;
+        }
+
+        const madeInert: HTMLElement[] = [];
+        for (const el of Array.from(document.body.children)) {
+            if (el !== dialogPortalWrapper && el instanceof HTMLElement && !el.inert) {
+                el.inert = true;
+                madeInert.push(el);
+            }
+        }
+
+        return () => {
+            madeInert.forEach((el) => {
+                el.inert = false;
+            });
+        };
+    }, []);
+
     const handleModeChange = useCallback((nextMode: EmailModalMode) => {
         setMode(nextMode);
 
@@ -250,18 +287,34 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({
 
     return (
         <>
-            <Dialog open onOpenChange={(next) => {
+            <Dialog modal={false} open onOpenChange={(next) => {
                 if (!next) {
                     attemptClose();
                 }
             }}>
                 <DialogContent
+                    ref={dialogContentRef}
                     aria-describedby={undefined}
                     className='top-0 left-0 h-[100dvh] w-full max-w-full translate-0 grid-rows-[1fr] gap-0 rounded-none border-0 p-0 shadow-none outline-hidden sm:rounded-none dark:bg-[#151719]'
                     onEscapeKeyDown={(event) => {
+                        if (isKoenigPortalFocused()) {
+                            // prevent Radix dismissing the dialog but let the
+                            // event through so Koenig can close its popup
+                            event.preventDefault();
+                            return;
+                        }
+
                         event.preventDefault();
                         event.stopPropagation();
                         attemptClose();
+                    }}
+                    onInteractOutside={(event) => {
+                        // never auto-dismiss on pointer/focus outside — this is a
+                        // full-screen editor whose only exits are the Close button
+                        // and Escape. Without this, a non-modal dialog dismisses
+                        // when Tab lands focus on anything outside it (e.g. Radix's
+                        // focus-guard spans), which re-triggers attemptClose
+                        event.preventDefault();
                     }}
                 >
                     <DialogTitle className='sr-only'>Edit email</DialogTitle>

--- a/apps/posts/src/views/Automations/components/email-modal/email-content-modal.tsx
+++ b/apps/posts/src/views/Automations/components/email-modal/email-content-modal.tsx
@@ -220,7 +220,7 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({
         };
     }, []);
 
-    const dialogContentRef = useRef<HTMLDivElement>(null);
+    const [dialogContentNode, setDialogContentNode] = useState<HTMLDivElement | null>(null);
 
     // The dialog is non-modal so Radix's focus trap can't fight Koenig's
     // body-level portals (link input, toolbar, emoji picker), which means
@@ -230,13 +230,13 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({
     // portals and stacked dialogs mount after this runs, so they stay
     // interactive.
     useEffect(() => {
-        const dialogPortalWrapper = dialogContentRef.current?.closest('body > *');
+        const dialogPortalWrapper = dialogContentNode?.closest('body > *');
         if (!dialogPortalWrapper) {
             return;
         }
 
         const madeInert: HTMLElement[] = [];
-        for (const el of Array.from(document.body.children)) {
+        for (const el of document.body.children) {
             if (el !== dialogPortalWrapper && el instanceof HTMLElement && !el.inert) {
                 el.inert = true;
                 madeInert.push(el);
@@ -248,7 +248,7 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({
                 el.inert = false;
             });
         };
-    }, []);
+    }, [dialogContentNode]);
 
     const handleModeChange = useCallback((nextMode: EmailModalMode) => {
         setMode(nextMode);
@@ -293,7 +293,7 @@ const EmailContentModal: React.FC<EmailContentModalProps> = ({
                 }
             }}>
                 <DialogContent
-                    ref={dialogContentRef}
+                    ref={setDialogContentNode}
                     aria-describedby={undefined}
                     className='top-0 left-0 h-[100dvh] w-full max-w-full translate-0 grid-rows-[1fr] gap-0 rounded-none border-0 p-0 shadow-none outline-hidden sm:rounded-none dark:bg-[#151719]'
                     onEscapeKeyDown={(event) => {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1394/

- Koenig portals its link input/toolbar to document.body, but the automations email modal's Radix dialog is modal, so its focus trap couldn't contain those portals — clicks and focus never reliably reached them
- attempted a Koenig-side fix (render portals into a container inside the dialog instead), but that surfaced a new focus fight between Radix's trap and Lexical's own focus handling
- fixed in Ghost instead: the dialog is non-modal, and the rest of the admin UI is made inert while it's open, so nothing outside the editor can steal focus/clicks and Koenig's body-level portals work fine
- inert is also more robust for accessibility than a JS focus trap — it's natively enforced by the browser, so background content is reliably unreachable by keyboard and screen readers regardless of where Koenig portals its UI

before - link input didn't work, and escape would close the entire editor instead of the link input/list:
<img width="757" height="560" alt="Screenshot 2026-07-08 at 10 22 01 AM" src="https://github.com/user-attachments/assets/48a209a6-cf26-4069-b0dd-e70da7ac4e2a" />

after - input works, scroll works, escape works, other koenig cards still work. it's hard to demo but there was also an issue with my original approach where if i just set `modal={false}`, then tab could potentially move your control to the body (behind the editor). that's the main reason for this larger fix:
<img width="1672" height="1016" alt="link-fix-after" src="https://github.com/user-attachments/assets/728ffe06-0b13-4974-a233-6a97020a8cc7" />
