### PR TITLE
Fixed Koenig demo build in CI

### DIFF
--- a/koenig/koenig-lexical/package.json
+++ b/koenig/koenig-lexical/package.json
@@ -146,6 +146,11 @@
       "playwright"
     ],
     "targets": {
+      "build:demo": {
+        "dependsOn": [
+          "^build"
+        ]
+      },
       "dev:integrated": {
         "continuous": true,
         "dependsOn": [


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3774/

The Koenig Demo deploy workflow has been failing on main since the Koenig monorepo merge, so https://koenig.ghost.org is not receiving updates. The build step failed with Rolldown unable to resolve `@tryghost/kg-default-nodes` because that package's entry points are compiled output (`build/esm/`) that never gets built in the workflow's fresh checkout.

Only the `build` target inherits `dependsOn: ["^build"]` from the nx.json target defaults — the differently-named `build:demo` target inherits nothing, so `nx run @tryghost/koenig-lexical:build:demo` ran vite directly without first compiling the workspace `kg-*` packages it imports. This worked in the standalone Koenig repo's pages workflow but was missed in the merge.

Fixed by giving `build:demo` its own Nx target config with `^build`, matching the existing `dev:integrated` and `test:acceptance` targets. The target is deliberately left uncached: the demo build inlines `VITE_TENOR_API_KEY`/`VITE_KLIPY_API_KEY` via `import.meta.env` and writes to the same `dist` dir as the `build` target, so caching could ship stale GIF provider config after the secrets change and lets the two cached targets clobber each other's restored outputs. It's a ~4s build that only runs in the deploy workflow, so caching buys nothing anyway.

Verified against the exact CI steps (filtered frozen-lockfile install + `nx run @tryghost/koenig-lexical:build:demo`) both with and without the Nx cache.