### PR TITLE
Fixed comments UI add details mouse event type

### DIFF
--- a/apps/comments-ui/src/components/popups/add-details-popup.tsx
+++ b/apps/comments-ui/src/components/popups/add-details-popup.tsx
@@ -26,10 +26,6 @@ const AddDetailsPopup = (props: Props) => {
 
     const [error, setError] = useState({name: '', expertise: ''});
 
-    const stopPropagation = (event: Event) => {
-        event.stopPropagation();
-    };
-
     const close = (succeeded: boolean) => {
         dispatchAction('closePopup', {});
         props.callback(succeeded);
@@ -116,7 +112,7 @@ const AddDetailsPopup = (props: Props) => {
     });
 
     return (
-        <div className="rounded-none relative h-screen w-screen overflow-hidden bg-white p-[28px] text-center shadow-modal sm:h-auto sm:w-[720px] sm:rounded-xl sm:p-0" data-testid="profile-modal" onMouseDown={stopPropagation}>
+        <div className="rounded-none relative h-screen w-screen overflow-hidden bg-white p-[28px] text-center shadow-modal sm:h-auto sm:w-[720px] sm:rounded-xl sm:p-0" data-testid="profile-modal" onMouseDown={(event) => event.stopPropagation()}>
             <div className="flex">
                 <div className={`hidden w-[50%] flex-col items-center justify-center bg-neutral-800 sm:block sm:p-8`}>
                     <div className="mt-[-1px] flex flex-col gap-9 text-left">


### PR DESCRIPTION
## Why I am making it

This is a focused comments-ui typecheck cleanup.

`AddDetailsPopup` used a DOM `Event` type for an `onMouseDown` handler. React passes a React mouse event to that prop, so the handler type was incompatible even though it only needed to stop propagation.

## What it does

Inlines the stop-propagation callback on the profile modal `onMouseDown` prop so TypeScript can infer the correct React mouse event type from JSX.

This keeps the existing runtime behavior while avoiding a named one-line handler that has to be manually typed.

## Type error fixed

This removes the `apps/comments-ui/src/components/popups/add-details-popup.tsx` `TS2322` error from the comments-ui `tsc --noEmit` cleanup:

```text
src/components/popups/add-details-popup.tsx(119,197): error TS2322: Type '(event: Event) => void' is not assignable to type 'MouseEventHandler<HTMLDivElement>'.
  Types of parameters 'event' and 'event' are incompatible.
    Type 'MouseEvent<HTMLDivElement, MouseEvent>' is missing the following properties from type 'Event': cancelBubble, composed, returnValue, srcElement, and 7 more.
```

## Why developers need it

This keeps reducing the comments-ui TypeScript error count and lets developers focus on the remaining real type issues in `app.tsx` and `frame.tsx`.

## Testing

- `pnpm --filter @tryghost/comments-ui exec tsc --noEmit`

This still fails on the known remaining comments-ui TypeScript errors, but the `add-details-popup.tsx` error is gone.

## Checklist

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [ ] I've written an automated test to prove my change works
