### PR TITLE
Removed unnecessary option when initializing Mailgun client

### DIFF
--- a/ghost/core/core/server/services/email-analytics/email-analytics-provider-mailgun.js
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-provider-mailgun.js
@@ -7,8 +7,8 @@ const DEFAULT_TAGS = ['bulk-email'];
 class EmailAnalyticsProviderMailgun {
     mailgunClient;
 
-    constructor({config, settings, labs}) {
-        this.mailgunClient = new MailgunClient({config, settings, labs});
+    constructor({config, settings}) {
+        this.mailgunClient = new MailgunClient({config, settings});
         this.tags = [...DEFAULT_TAGS];
 
         if (config.get('bulkEmail:mailgun:tag')) {

--- a/ghost/core/core/server/services/email-analytics/email-analytics-service-wrapper.js
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-service-wrapper.js
@@ -18,7 +18,6 @@ class EmailAnalyticsServiceWrapper {
         const StartEmailAnalyticsJobEvent = require('./events/start-email-analytics-job-event');
         const domainEvents = require('@tryghost/domain-events');
         const settings = require('../../../shared/settings-cache');
-        const labs = require('../../../shared/labs');
         const db = require('../../data/db');
         const queries = require('./lib/queries');
         const membersService = require('../members');
@@ -52,7 +51,7 @@ class EmailAnalyticsServiceWrapper {
             settings,
             eventProcessor,
             providers: [
-                new MailgunProvider({config, settings, labs})
+                new MailgunProvider({config, settings})
             ],
             queries,
             domainEvents,


### PR DESCRIPTION
no ref

This change should have no user impact.

`labs` was never used. Let's remove it, which fixes a type error.
