### PR TITLE
Fixed postcss plugin resolution for consumers of the design system config

### DIFF
--- a/apps/admin-x-design-system/postcss.config.cjs
+++ b/apps/admin-x-design-system/postcss.config.cjs
@@ -1,7 +1,20 @@
+// Plugins are `require`d here rather than named as strings so that they resolve
+// from this package, which declares them as devDependencies.
+//
+// postcss-load-config resolves string plugin names relative to the searchPath --
+// the directory the consuming build discovered a config in -- not the file that
+// defined the plugin list. admin-x-settings re-exports this config, so string
+// names get resolved from apps/admin-x-settings, which does not declare
+// postcss-import, @tailwindcss/postcss or autoprefixer (and should not have to).
+// Passing plugin instances keeps resolution anchored to this package.
+const postcssImport = require('postcss-import');
+const tailwindcss = require('@tailwindcss/postcss');
+const autoprefixer = require('autoprefixer');
+
 module.exports = {
-    plugins: {
-        'postcss-import': {},
-        '@tailwindcss/postcss': {},
-        autoprefixer: {}
-    }
+    plugins: [
+        postcssImport(),
+        tailwindcss(),
+        autoprefixer()
+    ]
 };


### PR DESCRIPTION
`apps/admin-x-settings/postcss.config.cjs` re-exports the design system's config. That config named its plugins as strings, and `postcss-load-config` resolves string plugin names relative to the **searchPath** — the directory the consuming build discovered a config in — not the file that declared the list.

So the plugin names resolve from `apps/admin-x-settings`, which declares none of `postcss-import`, `@tailwindcss/postcss` or `autoprefixer`. Under pnpm's strict isolation they are not linked there, and none of the three resolve from that directory.

## Why now, if the build is green?

It is currently masked. The plugins genuinely cannot be resolved from `admin-x-settings` — that is verifiable with a `require.resolve` probe from that directory — so today's successful build depends on the loader not using the consumer as its anchor. That is one loader change away from breaking, and it broke in a real working tree.

## The fix

`require()` the three plugins inside `apps/admin-x-design-system/postcss.config.cjs` and pass instances rather than names, so resolution is anchored to the package that declares them. No string resolution happens at the consumer at all. `postcss(fn)` auto-invokes factories carrying `.postcss === true`, which all three do, so `postcssImport()` is exactly equivalent to `'postcss-import': {}`.

Alternatives rejected:

- **Adding `postcss-import` et al as devDependencies of each consumer** — papers over the resolution bug and has to be repeated for every package that reuses the config.
- **Deleting the postcss configs** — they are not vestigial. The centralized Tailwind v4 pipeline applies to `apps/admin`'s `@tailwindcss/vite` setup; `admin-x-settings` still builds a standalone bundle through `adminXViteConfig`, which has no Tailwind plugin. Its `src/styles/index.css` does `@import 'tailwindcss/utilities.css'`, and postcss expands that into ~470 kB of real utilities. Deleting the config would silently strip every utility class from that bundle.

## Verification

- `pnpm --filter @tryghost/admin-x-settings build` — exit 0
- `pnpm --filter @tryghost/admin-x-settings lint` and `pnpm --filter @tryghost/admin-x-design-system lint` — exit 0
- `NX_NO_CLOUD=true pnpm nx build @tryghost/admin --skip-nx-cache` — exit 0, all 15 dependent tasks genuinely executed. (The plain `nx reset && nx build` run replayed 9/16 tasks from Nx Cloud's remote cache, which would have masked a failure.)
- **Emitted CSS is unchanged.** The build was first confirmed deterministic (two unchanged builds → identical checksum) so the comparison is meaningful. The postcss product is byte-identical at 469,587 bytes, and all 31 files of `apps/admin-x-settings/dist` match before and after.

Same three plugins, same order, same empty options — only where they resolve from has changed.
