### PR TITLE
Moved the tags domain from the posts package into apps/admin

### DIFF
--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -77,11 +77,13 @@ export const routes: RouteObject[] = [
         element: <ForceUpgradeGuard />,
         children: [
             {
-                // Override the tag detail route from the posts app to ensure we
-                // correctly delegate to Ember since we can't remove the blank screen in
-                // the posts app. The blank screen needs to be there to prevent the
-                // router error fallback from triggering when navigating from the tag
-                // list to a tag detail page.
+                path: "/tags",
+                lazy: lazyComponent(() => import("./tags/tags")),
+            },
+            {
+                // The tag detail route delegates to Ember. It must be declared
+                // so navigating from the tag list to a detail page doesn't trip
+                // the router error fallback before Ember takes over.
                 path: "/tags/:tagSlug",
                 Component: EmberFallback,
                 handle: emberFallbackHandle,

--- a/apps/admin/src/tags/components/tags-list.tsx
+++ b/apps/admin/src/tags/components/tags-list.tsx
@@ -1,7 +1,7 @@
 import {Button, Table, TableBody, TableCell, TableHead, TableHeader, TableRow} from '@tryghost/shade/components';
 import {LoadMoreButton, useInfiniteVirtualScroll, useVirtualListWindow} from '@tryghost/admin-x-framework/virtual-list';
 import {LucideIcon, formatNumber} from '@tryghost/shade/utils';
-import {Tag} from '@tryghost/admin-x-framework/api/tags';
+import type {Tag} from '@tryghost/admin-x-framework/api/tags';
 import {forwardRef, useRef} from 'react';
 
 const SpacerRow = ({height}: { height: number }) => (

--- a/apps/admin/src/tags/tags.tsx
+++ b/apps/admin/src/tags/tags.tsx
@@ -1,6 +1,6 @@
-import MainLayout from '@components/layout/main-layout';
 import React from 'react';
 import TagsList from './components/tags-list';
+import {Box, Container} from '@tryghost/shade/primitives';
 import {Button, DropdownMenuCheckboxItem, EmptyIndicator, LoadingIndicator, ToggleGroup, ToggleGroupItem} from '@tryghost/shade/components';
 import {Link, useSearchParams} from '@tryghost/admin-x-framework';
 import {ListPage} from '@tryghost/shade/page-templates';
@@ -26,7 +26,8 @@ const Tags: React.FC = () => {
     });
 
     return (
-        <MainLayout>
+        <Box className='size-full'>
+            <Container className='relative flex h-full flex-col' size='page'>
             <ListPage data-testid="tags-page">
                 <ListPage.Header>
                     <PageHeader blurredBackground={false} sticky={false}>
@@ -108,7 +109,7 @@ const Tags: React.FC = () => {
                         </div>
                     ) : (
                         <TagsList
-                            fetchNextPage={fetchNextPage}
+                            fetchNextPage={() => void fetchNextPage()}
                             hasNextPage={hasNextPage}
                             isFetchingNextPage={isFetchingNextPage}
                             items={data?.tags ?? []}
@@ -117,7 +118,8 @@ const Tags: React.FC = () => {
                     )}
                 </ListPage.Body>
             </ListPage>
-        </MainLayout>
+            </Container>
+        </Box>
     );
 };
 

--- a/apps/posts/src/routes.tsx
+++ b/apps/posts/src/routes.tsx
@@ -53,19 +53,6 @@ export const routes: RouteObject[] = [
                 ]
             },
             {
-                path: 'tags',
-                children: [
-                    {
-                        index: true,
-                        lazy: lazyComponent(() => import('@views/Tags/tags'))
-                    },
-                    {
-                        path: ':tagSlug',
-                        element: null
-                    }
-                ]
-            },
-            {
                 path: 'comments',
                 lazy: lazyComponent(() => import('@views/comments/comments'))
             },


### PR DESCRIPTION
> **Stacked on #29187** (the virtual-list framework primitive). Based on that branch so this diff shows only the tags move; I'll retarget to `main` once #29187 merges.

First domain to leave the `posts` package as it dissolves into `apps/admin` — the start of the incremental posts move ([PLA-221](https://linear.app/ghost/issue/PLA-221)). Tags is deliberately first: 2 files, no cross-domain dependency, and no `PostsAppContext` use, so it moves cleanly and sets the pattern for the domains that follow.

## What changed

- `apps/posts/src/views/Tags/{tags,components/tags-list}.tsx` → `apps/admin/src/tags/`.
- The tags route folds into the shell's own route table (`apps/admin/src/routes.tsx`) instead of being mounted through the posts app's route export. `/tags/:tagSlug` still delegates to Ember, unchanged; the posts route table drops its tags entry.
- `MainLayout` (a posts-internal wrapper that can't move while the other posts domains still use it) is replaced with shade `Box` + `Container size='page'`. The rendered layout is unchanged — `Container`'s `w-full` is redundant against the existing `max-w-page`, so the DOM is equivalent.
- `tags-list` already consumes the framework virtual-list primitive (from #29187), so it needed no change beyond the move. Two adaptations for Admin's stricter setup: the react-query `fetchNextPage` is voided at the boundary (`no-misused-promises`), and the `Tag` type import is made `type`-only (`verbatimModuleSyntax`).

## Verification

- `tsc -b`, `eslint .` (admin) — exit 0
- `vitest run` (admin) — 354 tests pass
- `@tryghost/posts` build / lint / test — exit 0 (tags removed cleanly; nothing else referenced it)
- `nx build @tryghost/admin` — exit 0; tags still code-splits into its own lazy chunk
- Exercised against a running Ghost: `/tags` renders from `apps/admin` (list loads via the framework primitive, layout wrapper intact, Public/Internal tabs work), and `/tags/news` correctly unmounts React and delegates to Ember. No new console errors.
