### PR TITLE
Fixed thin-resource errors from frontend URL lookups in lazy compare mode

### DIFF
--- a/ghost/core/core/frontend/meta/url.js
+++ b/ghost/core/core/frontend/meta/url.js
@@ -20,7 +20,17 @@ function getUrl(data, absolute) {
         // model and only differ on the page-only `show_title_and_feature_image`
         // field). Disambiguate so the router-level type is correct in both
         // cases.
-        const postResource = {...data, type: checks.isPage(data) ? 'pages' : 'posts'};
+        //
+        // The Content API output serializer strips `status` (everything it
+        // serves is published), so theme-rendered posts arrive here without
+        // it. Default it back so the lazy URL service can evaluate its
+        // status:published base filter; a post that still carries a status
+        // (preview/email-post renders) keeps it via spread order.
+        //
+        // The preview-URL probe below stays keyed on the raw `data.status`:
+        // a status-stripped post that the URL service doesn't route (e.g. not
+        // matched by any collection) must keep falling back to /p/:uuid.
+        const postResource = {status: 'published', ...data, type: checks.isPage(data) ? 'pages' : 'posts'};
         if (data.status !== 'published' && urlService.facade.getUrlForResource(postResource) === '/404/') {
             return urlUtils.urlFor({relativeUrl: urlUtils.urlJoin('/p', data.uuid, '/')}, null, absolute);
         }

--- a/ghost/core/core/frontend/services/rss/generate-feed.js
+++ b/ghost/core/core/frontend/services/rss/generate-feed.js
@@ -21,8 +21,10 @@ const generateItem = function generateItem(post) {
 
     // RSS feeds carry posts (pages don't appear in RSS), so the router-level
     // type is always 'posts'. The post object on the public API has its DB
-    // `type` column stripped by the serializer, so we tag the resource here.
-    const itemUrl = routerManager.getUrlForResource({...post, type: 'posts'}, {absolute: true});
+    // `type` and `status` columns stripped by the serializer, so we tag the
+    // type here and default status to published (RSS only ever carries
+    // published posts) so the lazy URL service can evaluate its base filter.
+    const itemUrl = routerManager.getUrlForResource({status: 'published', ...post, type: 'posts'}, {absolute: true});
     const htmlContent = cheerio.load(post.html || '');
 
     // Tidy up cards for RSS readers (no Ghost CSS/JS available). This runs

--- a/ghost/core/core/server/services/url/url-service-facade.ts
+++ b/ghost/core/core/server/services/url/url-service-facade.ts
@@ -108,9 +108,10 @@ export class UrlServiceFacade {
         }
         const url = this.urlService.getUrlByResourceId(resource.id, options);
         if (this.isComparing()) {
+            const context = this._compareContext(resource);
             setImmediate(() => this._compare('getUrlForResource', url,
                 () => this.lazyUrlService!.getUrlForResource(resource, options),
-                {type: resource.type, id: resource.id}));
+                context));
         }
         return url;
     }
@@ -121,11 +122,30 @@ export class UrlServiceFacade {
         }
         const owns = this.urlService.owns(routerIdentifier, resource.id);
         if (this.isComparing()) {
+            const context = this._compareContext(resource, {routerIdentifier});
             setImmediate(() => this._compare('ownsResource', owns,
                 () => this.lazyUrlService!.ownsResource(routerIdentifier, resource),
-                {type: resource.type, id: resource.id, routerIdentifier}));
+                context));
         }
         return owns;
+    }
+
+    // Context for a compare report. Must be built synchronously in the calling
+    // frame: the comparison itself runs from setImmediate, where the caller's
+    // stack is gone — so a lazy throw reported there names only the URL service
+    // internals, not which caller handed over the (possibly thin) resource.
+    // `caller` recaptures those frames; `resourceKeys` fingerprints the shape
+    // the caller passed (e.g. a Content-API-serialized post vs a full model).
+    private _compareContext(resource: Resource, extra: Record<string, unknown> = {}): Record<string, unknown> {
+        const caller: {stack?: string} = {};
+        Error.captureStackTrace(caller, this._compareContext);
+        return {
+            type: resource.type,
+            id: resource.id,
+            resourceKeys: Object.keys(resource),
+            caller: caller.stack,
+            ...extra
+        };
     }
 
     /**

--- a/ghost/core/test/unit/frontend/meta/url.test.js
+++ b/ghost/core/test/unit/frontend/meta/url.test.js
@@ -27,6 +27,43 @@ describe('getUrl', function () {
         assert.equal(getUrl(post), 'post url');
     });
 
+    describe('Content-API-serialized posts (status stripped by the serializer)', function () {
+        it('defaults status to published so the lazy URL service can evaluate its base filter', function () {
+            const post = testUtils.DataGenerator.forKnex.createPost();
+            // The Content API output serializer deletes `status` (everything it
+            // serves is published) — theme-rendered posts arrive here without it.
+            delete post.status;
+
+            urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: post.id, type: 'posts', status: 'published'}))
+                .returns('post url');
+
+            assert.equal(getUrl(post), 'post url');
+            // Every call (including the /p/:uuid fallback probe, which still
+            // runs for status-stripped posts) carries the defaulted status.
+            for (const call of urlServiceGetUrlForResourceStub.getCalls()) {
+                assert.equal(call.args[0].status, 'published');
+            }
+        });
+
+        it('still falls back to the preview URL when a status-stripped post is unrouted', function () {
+            const post = testUtils.DataGenerator.forKnex.createPost();
+            delete post.status;
+
+            urlServiceGetUrlForResourceStub.returns('/404/');
+            urlUtilsUrlForStub.withArgs({relativeUrl: '/p/' + post.uuid + '/'}, null, undefined).returns('preview url');
+
+            assert.equal(getUrl(post), 'preview url');
+        });
+
+        it('keeps the real status when present', function () {
+            const post = testUtils.DataGenerator.forKnex.createPost({status: 'draft'});
+            urlServiceGetUrlForResourceStub.withArgs(sinon.match({id: post.id, type: 'posts', status: 'draft'})).returns('/404/');
+            urlUtilsUrlForStub.withArgs({relativeUrl: '/p/' + post.uuid + '/'}, null, undefined).returns('preview url');
+
+            assert.equal(getUrl(post), 'preview url');
+        });
+    });
+
     describe('preview url: drafts/scheduled posts', function () {
         it('relative', function () {
             const post = testUtils.DataGenerator.forKnex.createPost({status: 'draft'});

--- a/ghost/core/test/unit/frontend/services/rss/generate-feed.test.js
+++ b/ghost/core/test/unit/frontend/services/rss/generate-feed.test.js
@@ -88,6 +88,21 @@ describe('RSS: Generate Feed', function () {
             assert.match(xmlData, /<\/channel><\/rss>$/);
         });
 
+        it('defaults status to published on the URL lookup (the serializer strips it)', async function () {
+            const post = _.cloneDeep(posts[0]);
+            // RSS posts come out of the Content API serializer, which deletes
+            // `status` — everything it serves is published.
+            delete post.status;
+            data.posts = [post];
+
+            routerManagerGetUrlForResourceStub.returns('http://my-ghost-blog.com/' + post.slug + '/');
+
+            await generateFeed(baseUrl, data);
+
+            sinon.assert.calledWith(routerManagerGetUrlForResourceStub,
+                sinon.match({id: post.id, type: 'posts', status: 'published'}), {absolute: true});
+        });
+
         it('should get the item tags correct', async function () {
             data.posts = posts;
 

--- a/ghost/core/test/unit/server/services/url/url-service-facade.test.js
+++ b/ghost/core/test/unit/server/services/url/url-service-facade.test.js
@@ -252,6 +252,33 @@ describe('UrlServiceFacade', function () {
             assert.equal(logging.error.firstCall.args[0].code, 'LAZY_URL_COMPARE_ERROR');
         });
 
+        it('reports the caller stack and resource keys with a lazy throw from getUrlForResource', async function () {
+            lazyUrlService.getUrlForResource.throws(new Error('boom'));
+            compareFacade.getUrlForResource({type: 'posts', id: 'a', slug: 'hello'});
+            await flush();
+            const details = logging.error.firstCall.args[0].errorDetails;
+            // The compare runs in setImmediate, so the throw's own stack has no
+            // caller frames; the facade captures them at call time instead.
+            assert.match(details.caller, /url-service-facade\.test\.js/);
+            assert.deepEqual(details.resourceKeys, ['type', 'id', 'slug']);
+        });
+
+        it('reports the caller stack and resource keys with a forward URL mismatch', async function () {
+            compareFacade.getUrlForResource({type: 'posts', id: 'a', slug: 'hello'});
+            await flush();
+            const details = logging.error.firstCall.args[0].errorDetails;
+            assert.match(details.caller, /url-service-facade\.test\.js/);
+            assert.deepEqual(details.resourceKeys, ['type', 'id', 'slug']);
+        });
+
+        it('reports the caller stack and resource keys with an ownership mismatch', async function () {
+            compareFacade.ownsResource('routerA', {type: 'posts', id: 'a', status: 'published'});
+            await flush();
+            const details = logging.error.firstCall.args[0].errorDetails;
+            assert.match(details.caller, /url-service-facade\.test\.js/);
+            assert.deepEqual(details.resourceKeys, ['type', 'id', 'status']);
+        });
+
         it('resolveUrl returns the eager answer without awaiting lazy', async function () {
             urlService.getResource.returns({config: {type: 'posts'}, data: {id: 'eager', slug: 's'}});
             lazyUrlService.resolveUrl.resolves({type: 'posts', id: 'lazy', slug: 's'});


### PR DESCRIPTION
## Problem

Production is logging thousands of `LAZY_URL_THIN_RESOURCE` errors from the URL service parity comparison:

```
InternalServerError: Thin resource passed to LazyUrlService.getUrlForResource
{"resourceType":"posts","baseFilter":"status:published+type:post","missing":["status"]}
```

The reported stack is useless for finding the source: the lazy/eager comparison runs from `setImmediate`, so every frame above the facade is gone by the time the lazy service throws.

## Diagnosis

The Content API output serializer deletes `status` from posts (everything it serves is published), so every theme-rendered post (`{{url}}` helper → `frontend/meta/url.js`) and every RSS item (`frontend/services/rss/generate-feed.js`) reaches `getUrlForResource` without the column the lazy service's `status:published` base filter needs. The lazy service rejects the resource as thin, and the facade reports the throw on every comparison — accounting for the ~98% `missing:["status"]` error class.

## Changes

- **Added caller context to compare reports** — the facade now captures the caller stack and the resource's field names synchronously in the calling frame and attaches them to the report (`errorDetails.caller`, `errorDetails.resourceKeys`). The remaining error classes (`_assertNotThin` relation misses, ownership mismatches) become attributable from the logs.
- **Fixed the thin-resource errors** — the two frontend call sites default `status: 'published'` on the resource they pass, which restores what the serializer guarantees. Renders that carry a real status (previews, email posts) keep it via spread order, and the `/p/:uuid` preview-URL probe stays keyed on the raw `data.status` so unrouted status-stripped posts keep their preview fallback.

## Follow-up (not in this PR)

- The `{{url}}` helper and RSS could read the serializer-provided `post.url` instead of re-asking the URL service, which would remove this class of problem at the source — discussed as a separate refactor.
- The remaining ~1.6% error class (router filters referencing `tags`/`authors` on resources that don't carry them) needs the new caller diagnostics to attribute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)