### PR TITLE
🎨 Removed the discontinued Tenor GIF provider

### DIFF
--- a/.github/workflows/koenig-demo.yml
+++ b/.github/workflows/koenig-demo.yml
@@ -3,7 +3,7 @@ name: Koenig Demo
 # Deploys the koenig-lexical demo (https://koenig.ghost.org) to GitHub Pages
 # on main pushes that touch koenig/. Replaces the pages.yml workflow from the
 # archived TryGhost/Koenig repo. Requires Pages to be enabled on this repo
-# (gh-pages branch) and the TENOR/KLIPY API key secrets to be present.
+# (gh-pages branch) and the KLIPY API key secret to be present.
 
 on:
   push:
@@ -29,7 +29,6 @@ jobs:
     permissions:
       contents: write
     env:
-      VITE_TENOR_API_KEY: ${{ secrets.TENOR_API_KEY }}
       VITE_KLIPY_API_KEY: ${{ secrets.KLIPY_API_KEY }}
     steps:
       - name: Checkout repo

--- a/apps/admin-x-framework/src/api/config.ts
+++ b/apps/admin-x-framework/src/api/config.ts
@@ -28,10 +28,6 @@ export type Config = {
         id?: string;
     };
     emailAnalytics?: boolean;
-    tenor?: {
-        googleApiKey?: string | null;
-        contentFilter?: string;
-    };
     klipy?: {
         apiKey?: string | null;
         contentFilter?: string;

--- a/apps/admin-x-framework/src/test/responses/config.json
+++ b/apps/admin-x-framework/src/test/responses/config.json
@@ -11,10 +11,6 @@
         "stripeDirect": false,
         "mailgunIsConfigured": false,
         "emailAnalytics": true,
-        "tenor": {
-            "googleApiKey": null,
-            "contentFilter": "off"
-        },
         "klipy": {
             "apiKey": null,
             "contentFilter": "off"

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/member-email-editor.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/member-email-editor.tsx
@@ -100,7 +100,6 @@ const MemberEmailsEditor: React.FC<MemberEmailsEditorProps> = ({
     const {config, settings} = useGlobalData();
     const {fetchAutocompleteLinks, searchLinks} = useWelcomeEmailLinkSuggestions();
     const fetchEmbed = useKoenigFetchEmbed();
-    const tenorConfig = config.tenor?.googleApiKey ? config.tenor : null;
     const klipyConfig = config.klipy?.apiKey ? config.klipy : null;
     const {fetchKoenigLexical, darkMode} = useDesignSystem();
     const editorResource = useMemo(() => loadKoenig(fetchKoenigLexical), [fetchKoenigLexical]);
@@ -109,7 +108,6 @@ const MemberEmailsEditor: React.FC<MemberEmailsEditorProps> = ({
     const cardConfig = useMemo(() => ({
         unsplash: unsplashConfig,
         pinturaConfig,
-        tenor: tenorConfig,
         klipy: klipyConfig,
         fetchEmbed,
         fetchAutocompleteLinks,
@@ -118,7 +116,7 @@ const MemberEmailsEditor: React.FC<MemberEmailsEditorProps> = ({
             transistor: transistorEnabled
         },
         visibilitySettings: 'none'
-    }), [unsplashConfig, pinturaConfig, tenorConfig, klipyConfig, fetchEmbed, fetchAutocompleteLinks, searchLinks, transistorEnabled]);
+    }), [unsplashConfig, pinturaConfig, klipyConfig, fetchEmbed, fetchAutocompleteLinks, searchLinks, transistorEnabled]);
 
     const registerEditorAPI = useCallback((API: KoenigInstance | null) => {
         editorAPIRef.current = API;

--- a/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
@@ -41,12 +41,12 @@ const newslettersRequest = {
     browseNewslettersLimit: {method: 'GET', path: '/newsletters/?filter=status%3Aactive&limit=1', response: responseFixtures.newsletters}
 };
 
-const configWithTenorEnabled = {
+const configWithKlipyEnabled = {
     ...responseFixtures.config,
     config: {
         ...responseFixtures.config.config,
-        tenor: {
-            googleApiKey: 'test-tenor-key',
+        klipy: {
+            apiKey: 'test-klipy-key',
             contentFilter: 'off'
         }
     }
@@ -818,8 +818,8 @@ test.describe('Member emails settings', async () => {
             await expect(modal.locator('[data-kg-card="product"]')).toBeVisible();
         });
 
-        test('welcome email editor does not show GIF selector when Tenor is not configured', async ({page}) => {
-            await page.route('https://tenor.googleapis.com/**', async (route) => {
+        test('welcome email editor does not show GIF selector when Klipy is not configured', async ({page}) => {
+            await page.route('https://api.klipy.com/**', async (route) => {
                 await route.fulfill({
                     status: 200,
                     body: JSON.stringify({
@@ -861,8 +861,8 @@ test.describe('Member emails settings', async () => {
             await expect(slashMenu.getByText('GIF', {exact: true})).not.toBeVisible();
         });
 
-        test('welcome email editor shows GIF selector when Tenor is configured', async ({page}) => {
-            await page.route('https://tenor.googleapis.com/**', async (route) => {
+        test('welcome email editor shows GIF selector when Klipy is configured', async ({page}) => {
+            await page.route('https://api.klipy.com/**', async (route) => {
                 await route.fulfill({
                     status: 200,
                     body: JSON.stringify({
@@ -878,7 +878,7 @@ test.describe('Member emails settings', async () => {
             await mockApi({page, requests: {
                 ...globalDataRequests,
                 ...newslettersRequest,
-                browseConfig: {method: 'GET', path: '/config/', response: configWithTenorEnabled},
+                browseConfig: {method: 'GET', path: '/config/', response: configWithKlipyEnabled},
                 browseAutomatedEmails: {method: 'GET', path: '/automated_emails/', response: automatedEmailsFixture}
             }});
 

--- a/apps/posts/src/views/Automations/components/email-modal/email-editor.tsx
+++ b/apps/posts/src/views/Automations/components/email-modal/email-editor.tsx
@@ -96,13 +96,13 @@ const EmailEditor: React.FC<EmailEditorProps> = ({
     const config = configData?.config;
     const {fetchAutocompleteLinks, searchLinks} = useEmailLinkSuggestions();
     const fetchEmbed = useKoenigFetchEmbed();
-    const tenorConfig = config?.tenor?.googleApiKey ? config.tenor : null;
+    const klipyConfig = config?.klipy?.apiKey ? config.klipy : null;
     const [transistorEnabled] = getSettingValues<boolean>(settings, ['transistor']);
 
     const cardConfig = useMemo(() => ({
         unsplash: unsplashConfig,
         pinturaConfig,
-        tenor: tenorConfig,
+        klipy: klipyConfig,
         fetchEmbed,
         fetchAutocompleteLinks,
         searchLinks,
@@ -110,7 +110,7 @@ const EmailEditor: React.FC<EmailEditorProps> = ({
             transistor: transistorEnabled
         },
         visibilitySettings: 'none'
-    }), [unsplashConfig, pinturaConfig, tenorConfig, fetchEmbed, fetchAutocompleteLinks, searchLinks, transistorEnabled]);
+    }), [unsplashConfig, pinturaConfig, klipyConfig, fetchEmbed, fetchAutocompleteLinks, searchLinks, transistorEnabled]);
 
     const registerEditorAPI = useCallback((api: unknown) => {
         editorAPIRef.current = api as KoenigAPI | null;

--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -425,7 +425,6 @@ export default class KoenigLexicalEditor extends Component {
 
         const defaultCardConfig = {
             unsplash: this.settings.unsplash ? unsplashConfig.defaultHeaders : null,
-            tenor: this.config.tenor?.googleApiKey ? this.config.tenor : null,
             klipy: this.config.klipy?.apiKey ? this.config.klipy : null,
             fetchAutocompleteLinks,
             fetchEmbed,

--- a/ghost/admin/app/styles/components/unsplash.css
+++ b/ghost/admin/app/styles/components/unsplash.css
@@ -1,4 +1,4 @@
-/* Unsplash+Tenor Integration
+/* Unsplash Integration
 /* ---------------------------------------------------------- */
 
 
@@ -287,26 +287,4 @@
 
 .gh-unsplash-zoom .gh-unsplash-photo-overlay {
     opacity: 1;
-}
-
-/* Tenor Integration
-/* ---------------------------------------------------------- */
-
-.gh-tenor-gif {
-    position: relative;
-    display: block;
-    width: 100%;
-    margin: 0 0 24px;
-    color: #fff;
-    cursor: pointer;
-}
-
-.gh-tenor-gif-highlighted {
-    box-shadow: 0 0 0 3px var(--green);
-}
-
-.gh-tenor-logo {
-    display: inline-block;
-    width: 100px;
-    margin-right: 20px;
 }

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/config.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/config.js
@@ -18,7 +18,6 @@ module.exports = {
             'mailgunIsConfigured',
             'emailAnalytics',
             'hostSettings',
-            'tenor',
             'klipy',
             'pintura',
             'signupForm',

--- a/ghost/core/core/server/services/public-config/config.js
+++ b/ghost/core/core/server/services/public-config/config.js
@@ -59,7 +59,6 @@ module.exports = function getConfigProperties() {
         mailgunIsConfigured: !!(config.get('bulkEmail') && config.get('bulkEmail').mailgun),
         emailAnalytics: config.get('emailAnalytics:enabled'),
         hostSettings: config.get('hostSettings'),
-        tenor: config.get('tenor'),
         klipy: config.get('klipy'),
         pintura: config.get('pintura'),
         signupForm: config.get('signupForm'),

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -304,10 +304,6 @@
         "url": "https://cdn.jsdelivr.net/ghost/signup-form@~{version}/umd/signup-form.min.js",
         "version": "0.3"
     },
-    "tenor": {
-        "googleApiKey": null,
-        "contentFilter": "off"
-    },
     "klipy": {
         "apiKey": null,
         "contentFilter": "off"

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -52,10 +52,6 @@ Object {
       "version": "0.3",
     },
     "stripeDirect": false,
-    "tenor": Object {
-      "contentFilter": "off",
-      "googleApiKey": null,
-    },
     "useGravatar": false,
     "version": StringMatching /\\\\d\\+\\\\\\.\\\\d\\+\\\\\\.\\\\d\\+/,
   },

--- a/ghost/core/test/e2e-api/admin/utils.js
+++ b/ghost/core/test/e2e-api/admin/utils.js
@@ -39,7 +39,6 @@ const expectedProperties = {
         'useGravatar',
         'stripeDirect',
         'emailAnalytics',
-        'tenor',
         'klipy',
         'mailgunIsConfigured',
         'signupForm'

--- a/ghost/core/test/unit/server/services/public-config/config.test.js
+++ b/ghost/core/test/unit/server/services/public-config/config.test.js
@@ -21,7 +21,6 @@ const allowedKeys = [
     'mailgunIsConfigured',
     'emailAnalytics',
     'hostSettings',
-    'tenor',
     'klipy',
     'pintura',
     'signupForm',
@@ -63,20 +62,6 @@ describe('Public-config Service', function () {
 
             assert.match(configProperties.version, /^\d+\.\d+\.\d+/);
             assert.notEqual(configProperties.version, '6.21.2+abc1234');
-        });
-
-        it('should return null for tenor apikey when unset', function () {
-            let configProperties = getConfigProperties();
-
-            assert.equal(configProperties.tenor.googleApiKey, null);
-        });
-
-        it('should return tenor apikey when set', function () {
-            configUtils.set('tenor:googleApiKey', 'TENOR_KEY');
-
-            let configProperties = getConfigProperties();
-
-            assert.equal(configProperties.tenor.googleApiKey, 'TENOR_KEY');
         });
 
         it('should return null for klipy apikey when unset', function () {

--- a/koenig/koenig-lexical/README.md
+++ b/koenig/koenig-lexical/README.md
@@ -27,14 +27,12 @@ Now, if you navigate to Ghost Admin at http://localhost:2368/ghost and open a po
 
 #### Gif card
 
-To see this card locally, create a `.env.local` file in the `koenig-lexical` root package with a GIF provider key:
+To see this card locally, create a `.env.local` file in the `koenig-lexical` root package with a Klipy API key:
 ```
 VITE_KLIPY_API_KEY=xxx
-# or, for the legacy Tenor provider:
-VITE_TENOR_API_KEY=xxx
 ```
 
-The card resolves to Klipy when `VITE_KLIPY_API_KEY` is set, otherwise Tenor. Get a Klipy key at https://partner.klipy.com; the Tenor key is described at https://ghost.org/docs/config/#tenor
+Get a Klipy key at https://partner.klipy.com
 
 #### Bookmark & Embed cards
 

--- a/koenig/koenig-lexical/demo/DemoApp.tsx
+++ b/koenig/koenig-lexical/demo/DemoApp.tsx
@@ -22,7 +22,7 @@ import {
 import {defaultHeaders as defaultUnsplashHeaders} from './utils/unsplashConfig';
 import {fetchEmbed} from './utils/fetchEmbed';
 import {fileTypes, useFileUpload} from './utils/useFileUpload';
-import {klipyConfig, tenorConfig} from './utils/gifConfig';
+import {klipyConfig} from './utils/gifConfig';
 import {useLocation, useSearchParams} from 'react-router-dom';
 import {useSnippets} from './utils/useSnippets';
 
@@ -46,7 +46,6 @@ function hideDeprecatedCardInMenu(searchParams) {
 const defaultCardConfig = {
     unsplash: defaultUnsplashHeaders,
     fetchEmbed: fetchEmbed,
-    tenor: tenorConfig,
     klipy: klipyConfig,
     fetchAutocompleteLinks: () => Promise.resolve([
         {label: 'Homepage', value: window.location.origin + '/'},

--- a/koenig/koenig-lexical/demo/HtmlOutputDemo.tsx
+++ b/koenig/koenig-lexical/demo/HtmlOutputDemo.tsx
@@ -6,13 +6,12 @@ import {$getRoot, $isDecoratorNode} from 'lexical';
 import {HtmlOutputPlugin, KoenigComposableEditor, KoenigComposer} from '../src';
 import {defaultHeaders as defaultUnsplashHeaders} from './utils/unsplashConfig';
 import {fileTypes, useFileUpload} from './utils/useFileUpload';
-import {klipyConfig, tenorConfig} from './utils/gifConfig';
+import {klipyConfig} from './utils/gifConfig';
 import {useSnippets} from './utils/useSnippets';
 import {useState} from 'react';
 
 const cardConfig = {
     unsplash: {defaultHeaders: defaultUnsplashHeaders},
-    tenor: tenorConfig,
     klipy: klipyConfig
 };
 

--- a/koenig/koenig-lexical/demo/RestrictedContentDemo.tsx
+++ b/koenig/koenig-lexical/demo/RestrictedContentDemo.tsx
@@ -6,14 +6,13 @@ import {$getRoot, $isDecoratorNode} from 'lexical';
 import {KoenigComposableEditor, KoenigComposer, RestrictContentPlugin} from '../src';
 import {defaultHeaders as defaultUnsplashHeaders} from './utils/unsplashConfig';
 import {fileTypes, useFileUpload} from './utils/useFileUpload';
-import {klipyConfig, tenorConfig} from './utils/gifConfig';
+import {klipyConfig} from './utils/gifConfig';
 import {useLocation} from 'react-router-dom';
 import {useSnippets} from './utils/useSnippets';
 import {useState} from 'react';
 
 const cardConfig = {
     unsplash: {defaultHeaders: defaultUnsplashHeaders},
-    tenor: tenorConfig,
     klipy: klipyConfig
 };
 

--- a/koenig/koenig-lexical/demo/utils/gifConfig.ts
+++ b/koenig/koenig-lexical/demo/utils/gifConfig.ts
@@ -1,36 +1,16 @@
 import {isTestEnv} from '../../test/utils/isTestEnv';
 
-export const tenorConfig = isTestEnv ? {googleApiKey: 'xxx'} : getTenorConfig();
-
-// In tests the GIF provider defaults to Tenor; the ?gifProvider=klipy query
-// param opts a specific test into the Klipy path.
-export const klipyConfig = isTestEnv ? getTestKlipyConfig() : getKlipyConfig();
-
-function getTenorConfig() {
-    let config = null;
-
-    if (import.meta.env.VITE_TENOR_API_KEY) {
-        config = {
-            googleApiKey: import.meta.env.VITE_TENOR_API_KEY
-        };
-    }
-
-    return config;
-}
+export const klipyConfig = isTestEnv ? {apiKey: 'xxx'} : getKlipyConfig();
 
 function getKlipyConfig() {
     let config = null;
 
     if (import.meta.env.VITE_KLIPY_API_KEY) {
         config = {
+            // secretlint-disable-next-line @secretlint/secretlint-rule-pattern
             apiKey: import.meta.env.VITE_KLIPY_API_KEY
         };
     }
 
     return config;
-}
-
-function getTestKlipyConfig() {
-    const provider = new URLSearchParams(window.location.search).get('gifProvider');
-    return provider === 'klipy' ? {apiKey: 'xxx'} : null;
 }

--- a/koenig/koenig-lexical/src/components/ui/GifPlugin.tsx
+++ b/koenig/koenig-lexical/src/components/ui/GifPlugin.tsx
@@ -39,7 +39,6 @@ const GifPlugin = ({nodeKey}) => {
 
     return (
         <GifSelector
-            provider={providerConfig?.provider}
             onClickOutside={onClickOutside}
             onGifInsert={insertImageToNode}
             {...gifHook}

--- a/koenig/koenig-lexical/src/components/ui/GifSelector.stories.tsx
+++ b/koenig/koenig-lexical/src/components/ui/GifSelector.stories.tsx
@@ -1,6 +1,6 @@
 import GifSelector from './GifSelector';
 import {getGifProviderConfig, useGif} from '../../utils/services/gif.js';
-import {tenorConfig} from '../../../demo/utils/gifConfig';
+import {klipyConfig} from '../../../demo/utils/gifConfig';
 
 const story = {
     title: 'File Selectors/Gif',
@@ -14,7 +14,7 @@ const story = {
 export default story;
 
 const Template = (args) => {
-    const gifHook = useGif({config: getGifProviderConfig({tenor: tenorConfig})});
+    const gifHook = useGif({config: getGifProviderConfig({klipy: klipyConfig})});
 
     return (
         <GifSelector {...gifHook} {...args} />
@@ -23,19 +23,19 @@ const Template = (args) => {
 
 export const Base = Template.bind({});
 Base.args = {
-    config: tenorConfig
+    config: klipyConfig
 };
 
 export const Loading = Template.bind({});
 Loading.args = {
-    config: tenorConfig,
+    config: klipyConfig,
     isLoading: true,
     isLazyLoading: false
 };
 
 export const LazyLoading = Template.bind({});
 LazyLoading.args = {
-    config: tenorConfig,
+    config: klipyConfig,
     isLoading: true,
     isLazyLoading: true,
     loadNextPage: () => {}
@@ -43,18 +43,18 @@ LazyLoading.args = {
 
 export const ErrorCommon = Template.bind({});
 ErrorCommon.args = {
-    config: tenorConfig,
+    config: klipyConfig,
     error: 'common'
 };
 
 export const ErrorInvalidKey = Template.bind({});
 ErrorInvalidKey.args = {
-    config: tenorConfig,
+    config: klipyConfig,
     error: 'invalid_key'
 };
 
 export const ErrorSpecific = Template.bind({});
 ErrorSpecific.args = {
-    config: tenorConfig,
+    config: klipyConfig,
     error: 'Something went wrong'
 };

--- a/koenig/koenig-lexical/src/components/ui/GifSelector.tsx
+++ b/koenig/koenig-lexical/src/components/ui/GifSelector.tsx
@@ -8,7 +8,7 @@ import {Loader} from './file-selectors/Gif/Loader';
 const TWO_COLUMN_WIDTH = 540;
 const THREE_COLUMN_WIDTH = 940;
 
-const GifSelector = ({onGifInsert, onClickOutside, updateSearch, columns, isLoading, isLazyLoading, error, changeColumnCount, loadNextPage, gifs, provider}) => {
+const GifSelector = ({onGifInsert, onClickOutside, updateSearch, columns, isLoading, isLazyLoading, error, changeColumnCount, loadNextPage, gifs}) => {
     const selectorRef = useRef(null);
     const searchRef = useRef(null);
     const [highlightedGif, setHighlightedGif] = useState(undefined);
@@ -306,7 +306,7 @@ const GifSelector = ({onGifInsert, onClickOutside, updateSearch, columns, isLoad
                     <input
                         ref={searchRef}
                         className="h-10 w-full rounded-full border border-grey-300 pl-10 pr-8 font-sans text-md font-normal text-black focus:border-green focus:shadow-insetgreen dark:border-grey-800 dark:bg-grey-950 dark:text-white dark:placeholder:text-grey-800 dark:focus:border-green"
-                        placeholder={provider === 'klipy' ? 'Search KLIPY' : 'Search Tenor for GIFs'}
+                        placeholder='Search KLIPY'
                         autoFocus
                         onChange={handleSearch}
                     />

--- a/koenig/koenig-lexical/src/nodes/ImageNode.tsx
+++ b/koenig/koenig-lexical/src/nodes/ImageNode.tsx
@@ -55,10 +55,10 @@ export class ImageNode extends BaseImageNode {
         insertParams: {
             triggerFileDialog: false
         },
-        matches: ['gif', 'giphy', 'tenor', 'klipy'],
+        matches: ['gif', 'giphy', 'klipy'],
         priority: 17,
         queryParams: ['src'],
-        isHidden: ({config}) => !config?.tenor && !config?.klipy,
+        isHidden: ({config}) => !config?.klipy,
         shortcut: '/gif'
     }];
 

--- a/koenig/koenig-lexical/src/utils/services/gif.ts
+++ b/koenig/koenig-lexical/src/utils/services/gif.ts
@@ -4,52 +4,38 @@ import {useRef, useState} from 'react';
 const API_VERSION = 'v2';
 const DEBOUNCE_MS = 600;
 
-// Both Tenor and Klipy expose a Tenor-compatible v2 API; only the base URL and
-// API key differ, so one client serves either provider.
-const PROVIDER_API_URLS = {
-    klipy: 'https://api.klipy.com',
-    tenor: 'https://tenor.googleapis.com'
-};
+// Klipy exposes a Tenor-compatible v2 API, hence the v2 paths and
+// Tenor-style request params used throughout this client.
+const KLIPY_API_URL = 'https://api.klipy.com';
 
 export const ERROR_TYPE = {
     COMMON: 'common',
     INVALID_API_KEY: 'invalid_key'
 };
 
-// Resolve which GIF provider to use from the editor's cardConfig. Klipy takes
-// precedence when both are configured; returns null when neither is set.
+// Resolve the GIF provider config from the editor's cardConfig; returns null
+// when Klipy is not configured.
 export function getGifProviderConfig(cardConfig) {
     if (cardConfig?.klipy?.apiKey) {
         return {
-            provider: 'klipy',
-            apiUrl: PROVIDER_API_URLS.klipy,
+            apiUrl: KLIPY_API_URL,
+            // secretlint-disable-next-line @secretlint/secretlint-rule-pattern
             apiKey: cardConfig.klipy.apiKey,
             contentFilter: cardConfig.klipy.contentFilter || 'off'
-        };
-    }
-    if (cardConfig?.tenor?.googleApiKey) {
-        return {
-            provider: 'tenor',
-            apiUrl: PROVIDER_API_URLS.tenor,
-            apiKey: cardConfig.tenor.googleApiKey,
-            contentFilter: cardConfig.tenor.contentFilter || 'off'
         };
     }
     return null;
 }
 
-// Tenor returns {error: {message}}; Klipy returns {result: false, errors: {message: [...]}}.
+// Klipy returns {result: false, errors: {message: [...]}}.
 export function extractErrorMessage(json) {
-    const klipyMessage = json?.errors?.message;
-    return json?.error?.message
-        || json?.error
-        || (Array.isArray(klipyMessage) ? klipyMessage[0] : klipyMessage)
+    const message = json?.errors?.message;
+    return (Array.isArray(message) ? message[0] : message)
         || 'Unknown error';
 }
 
-// Detect an invalid-API-key error from the provider's message. Tenor and Klipy
-// word these differently (Tenor: "API key not valid"; Klipy: "The provided API
-// key is invalid"), so match the phrasing they share.
+// Detect an invalid-API-key error from the provider's message ("The provided
+// API key is invalid"), matched loosely to tolerate wording changes.
 export function isInvalidKeyError(message) {
     const text = message || '';
     return /api key/i.test(text) && /(invalid|not valid)/i.test(text);

--- a/koenig/koenig-lexical/test/e2e/cards/image-card.test.ts
+++ b/koenig/koenig-lexical/test/e2e/cards/image-card.test.ts
@@ -772,8 +772,8 @@ test.describe('Image card', async () => {
         `, {ignoreCardToolbarContents: true});
     });
 
-    test('can insert tenor image', async () => {
-        await mockTenorApi(page);
+    test('can insert a gif image', async () => {
+        await mockKlipyApi(page);
         await focusEditor(page);
         await page.click('[data-kg-plus-button]');
 
@@ -783,7 +783,9 @@ test.describe('Image card', async () => {
         await expect(await page.locator('[data-gif-index="1"]')).toBeVisible();
         await page.click('[data-gif-index="1"]');
 
-        await expect(await page.getByTestId('image-card-populated')).toBeVisible();
+        // toBeAttached rather than toBeVisible: the fixture GIF URL is not
+        // network-loaded in tests, so visibility would depend on an external fetch
+        await expect(await page.getByTestId('image-card-populated')).toBeAttached();
 
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
@@ -792,7 +794,7 @@ test.describe('Image card', async () => {
                         <div>
                             <img
                                 alt=""
-                                src="https://media.tenor.com/ocbMLlwniWQAAAAC/steve-harvey-oh.gif" />
+                                src="https://static.klipy.com/gif/klipy-dog-dance.gif" />
                         </div>
                         <figcaption>
                             <div data-testid="image-caption-editor" data-kg-allow-clickthrough="true">
@@ -816,7 +818,7 @@ test.describe('Image card', async () => {
     });
 
     test('can insert a gif with the keyboard', async () => {
-        await mockTenorApi(page);
+        await mockKlipyApi(page);
         await focusEditor(page);
         await page.click('[data-kg-plus-button]');
 
@@ -829,7 +831,9 @@ test.describe('Image card', async () => {
         await page.keyboard.press('Tab');
         await page.keyboard.press('Enter');
 
-        await expect(await page.getByTestId('image-card-populated')).toBeVisible();
+        // toBeAttached rather than toBeVisible: the fixture GIF URL is not
+        // network-loaded in tests, so visibility would depend on an external fetch
+        await expect(await page.getByTestId('image-card-populated')).toBeAttached();
 
         await assertHTML(page, html`
             <div data-lexical-decorator="true" contenteditable="false">
@@ -838,7 +842,7 @@ test.describe('Image card', async () => {
                         <div>
                             <img
                                 alt=""
-                                src="https://media.tenor.com/Sm9aylrzSyMAAAAC/cats-animals.gif" />
+                                src="https://static.klipy.com/gif/klipy-cats-animals.gif" />
                         </div>
                         <figcaption>
                             <div data-testid="image-caption-editor" data-kg-allow-clickthrough="true">
@@ -862,7 +866,7 @@ test.describe('Image card', async () => {
     });
 
     test('can close the gif selector on Esc', async () => {
-        await mockTenorApi(page);
+        await mockKlipyApi(page);
         await focusEditor(page);
         await page.click('[data-kg-plus-button]');
 
@@ -874,7 +878,7 @@ test.describe('Image card', async () => {
     });
 
     test('can show a gif selector error', async () => {
-        await mockTenorApi(page, {status: 400});
+        await mockKlipyApi(page, {status: 400});
         await focusEditor(page);
         await page.click('[data-kg-plus-button]');
 
@@ -1230,258 +1234,87 @@ async function insertEmptyImageCard(page) {
     });
 }
 
-function tenorTestData() {
-    return (
-        {
-            locale: 'en',
-            results: [
-                {
-                    id: '6897265628617702942',
-                    title: '',
-                    media_formats: {
-                        tinygif: {
-                            url: 'https://media.tenor.com/X7gCi8NE_h4AAAAM/cat-funny.gif',
-                            duration: 0,
-                            preview: '',
-                            dims: [
-                                220,
-                                204
-                            ],
-                            size: 522164
-                        },
-                        gif: {
-                            url: 'https://media.tenor.com/X7gCi8NE_h4AAAAC/cat-funny.gif',
-                            duration: 0,
-                            preview: '',
-                            dims: [
-                                498,
-                                460
-                            ],
-                            size: 4870544
-                        },
-                        tinygifpreview: {
-                            url: 'https://media.tenor.com/X7gCi8NE_h4AAAAF/cat-funny.png',
-                            duration: 0,
-                            preview: '',
-                            dims: [
-                                220,
-                                204
-                            ],
-                            size: 21743
-                        },
-                        gifpreview: {
-                            url: 'https://media.tenor.com/X7gCi8NE_h4AAAAe/cat-funny.png',
-                            duration: 0,
-                            preview: '',
-                            dims: [
-                                640,
-                                592
-                            ],
-                            size: 141384
-                        },
-                        mp4: {
-                            url: 'https://media.tenor.com/X7gCi8NE_h4AAAPo/cat-funny.mp4',
-                            duration: 3.7,
-                            preview: '',
-                            dims: [
-                                640,
-                                592
-                            ],
-                            size: 754491
-                        }
-                    },
-                    created: 1580334888.9161069,
-                    content_description: 'Cat Funny GIF',
-                    itemurl: 'https://tenor.com/view/cat-funny-fall-submit-play-gif-16179688',
-                    url: 'https://tenor.com/bf3eS.gif',
-                    tags: [
-                        'cat',
-                        'funny',
-                        'fall',
-                        'submit',
-                        'play'
-                    ],
-                    flags: [],
-                    hasaudio: false
-                },
-                {
-                    id: '11657229184981764452',
-                    title: '',
-                    media_formats: {
-                        tinygifpreview: {
-                            url: 'https://media.tenor.com/ocbMLlwniWQAAAAF/steve-harvey-oh.png',
-                            duration: 0,
-                            preview: '',
-                            dims: [
-                                220,
-                                124
-                            ],
-                            size: 11388
-                        },
-                        tinygif: {
-                            url: 'https://media.tenor.com/ocbMLlwniWQAAAAM/steve-harvey-oh.gif',
-                            duration: 0,
-                            preview: '',
-                            dims: [
-                                220,
-                                124
-                            ],
-                            size: 173121
-                        },
-                        gifpreview: {
-                            url: 'https://media.tenor.com/ocbMLlwniWQAAAAe/steve-harvey-oh.png',
-                            duration: 0,
-                            preview: '',
-                            dims: [
-                                640,
-                                360
-                            ],
-                            size: 65023
-                        },
-                        gif: {
-                            url: 'https://media.tenor.com/ocbMLlwniWQAAAAC/steve-harvey-oh.gif',
-                            duration: 0,
-                            preview: '',
-                            dims: [
-                                498,
-                                280
-                            ],
-                            size: 1669457
-                        },
-                        mp4: {
-                            url: 'https://media.tenor.com/ocbMLlwniWQAAAPo/steve-harvey-oh.mp4',
-                            duration: 2.4,
-                            preview: '',
-                            dims: [
-                                640,
-                                360
-                            ],
-                            size: 377541
-                        }
-                    },
-                    created: 1600453059.6729331,
-                    content_description: 'Steve Harvey Oh GIF',
-                    itemurl: 'https://tenor.com/view/steve-harvey-oh-you-crazy-point-stop-gif-18502036',
-                    url: 'https://tenor.com/bpNn6.gif',
-                    tags: [
-                        'Steve Harvey',
-                        'oh',
-                        'You Crazy',
-                        'point',
-                        'stop'
-                    ],
-                    flags: [],
-                    hasaudio: false
-                },
-                {
-                    id: '5363605506377337635',
-                    title: '',
-                    media_formats: {
-                        gif: {
-                            url: 'https://media.tenor.com/Sm9aylrzSyMAAAAC/cats-animals.gif',
-                            duration: 0,
-                            preview: '',
-                            dims: [
-                                498,
-                                431
-                            ],
-                            size: 1574979
-                        },
-                        gifpreview: {
-                            url: 'https://media.tenor.com/Sm9aylrzSyMAAAAe/cats-animals.png',
-                            duration: 0,
-                            preview: '',
-                            dims: [
-                                640,
-                                554
-                            ],
-                            size: 153379
-                        },
-                        tinygifpreview: {
-                            url: 'https://media.tenor.com/Sm9aylrzSyMAAAAF/cats-animals.png',
-                            duration: 0,
-                            preview: '',
-                            dims: [
-                                220,
-                                190
-                            ],
-                            size: 25196
-                        },
-                        tinygif: {
-                            url: 'https://media.tenor.com/Sm9aylrzSyMAAAAM/cats-animals.gif',
-                            duration: 0,
-                            preview: '',
-                            dims: [
-                                220,
-                                190
-                            ],
-                            size: 236117
-                        },
-                        mp4: {
-                            url: 'https://media.tenor.com/Sm9aylrzSyMAAAPo/cats-animals.mp4',
-                            duration: 1.2,
-                            preview: '',
-                            dims: [
-                                640,
-                                554
-                            ],
-                            size: 265062
-                        }
-                    },
-                    created: 1616817775.272332,
-                    content_description: 'Cats Animals GIF',
-                    itemurl: 'https://tenor.com/view/cats-animals-reaction-wow-surprised-gif-20914356',
-                    url: 'https://tenor.com/bzUWu.gif',
-                    tags: [
-                        'cats',
-                        'animals',
-                        'reaction',
-                        'wow',
-                        'surprised'
-                    ],
-                    flags: [],
-                    hasaudio: false
-                }
-            ]
-        }
-    );
-}
-
-const tenorUrl = /https:\/\/tenor\.googleapis\.com\/v2\//;
-async function mockTenorApi(page, {status} = {status: 200}) {
-    await page.route(tenorUrl, route => route.fulfill({
-        status,
-        body: JSON.stringify(tenorTestData())
-    }));
-}
-
 function klipyTestData() {
     return {
         results: [
             {
                 id: '2484942301552561',
-                title: 'Klipy Cat',
+                title: 'Klipy Cat Funny',
                 media_formats: {
                     tinygif: {
-                        url: 'https://static.klipy.com/gif/klipy-cat-tiny.gif',
+                        url: 'https://static.klipy.com/gif/klipy-cat-funny-tiny.gif',
                         duration: 0,
                         preview: '',
-                        dims: [220, 220],
-                        size: 271080
+                        dims: [220, 204],
+                        size: 522164
                     },
                     gif: {
-                        url: 'https://static.klipy.com/gif/klipy-cat.gif',
+                        url: 'https://static.klipy.com/gif/klipy-cat-funny.gif',
                         duration: 0,
                         preview: '',
-                        dims: [498, 498],
-                        size: 273268
+                        dims: [498, 460],
+                        size: 4870544
                     }
                 },
                 created: 1765483200,
-                content_description: 'Klipy Cat GIF',
-                itemurl: 'https://klipy.com/gifs/klipy-cat',
-                url: 'https://static.klipy.com/gif/klipy-cat.gif',
-                tags: ['cat'],
+                content_description: 'Klipy Cat Funny GIF',
+                itemurl: 'https://klipy.com/gifs/klipy-cat-funny',
+                url: 'https://static.klipy.com/gif/klipy-cat-funny.gif',
+                tags: ['cat', 'funny'],
+                flags: [],
+                hasaudio: false
+            },
+            {
+                id: '1165722918498176',
+                title: 'Klipy Dog Dance',
+                media_formats: {
+                    tinygif: {
+                        url: 'https://static.klipy.com/gif/klipy-dog-dance-tiny.gif',
+                        duration: 0,
+                        preview: '',
+                        dims: [220, 124],
+                        size: 173121
+                    },
+                    gif: {
+                        url: 'https://static.klipy.com/gif/klipy-dog-dance.gif',
+                        duration: 0,
+                        preview: '',
+                        dims: [498, 280],
+                        size: 1669457
+                    }
+                },
+                created: 1765483201,
+                content_description: 'Klipy Dog Dance GIF',
+                itemurl: 'https://klipy.com/gifs/klipy-dog-dance',
+                url: 'https://static.klipy.com/gif/klipy-dog-dance.gif',
+                tags: ['dog', 'dance'],
+                flags: [],
+                hasaudio: false
+            },
+            {
+                id: '5363605506377337',
+                title: 'Klipy Cats Animals',
+                media_formats: {
+                    tinygif: {
+                        url: 'https://static.klipy.com/gif/klipy-cats-animals-tiny.gif',
+                        duration: 0,
+                        preview: '',
+                        dims: [220, 190],
+                        size: 236117
+                    },
+                    gif: {
+                        url: 'https://static.klipy.com/gif/klipy-cats-animals.gif',
+                        duration: 0,
+                        preview: '',
+                        dims: [498, 431],
+                        size: 1574979
+                    }
+                },
+                created: 1765483202,
+                content_description: 'Klipy Cats Animals GIF',
+                itemurl: 'https://klipy.com/gifs/klipy-cats-animals',
+                url: 'https://static.klipy.com/gif/klipy-cats-animals.gif',
+                tags: ['cats', 'animals'],
                 flags: [],
                 hasaudio: false
             }
@@ -1497,61 +1330,3 @@ async function mockKlipyApi(page, {status} = {status: 200}) {
         body: JSON.stringify(klipyTestData())
     }));
 }
-
-test.describe('Image card - Klipy GIF provider', async () => {
-    let page;
-
-    test.beforeAll(async ({browser}) => {
-        page = await browser.newPage();
-    });
-
-    test.afterAll(async () => {
-        await page.close();
-    });
-
-    test('can insert klipy image', async () => {
-        await mockKlipyApi(page);
-        // ?gifProvider=klipy makes the demo resolve the GIF card to Klipy
-        await initialize({page, uri: '/?gifProvider=klipy#/?content=false'});
-        await focusEditor(page);
-        await page.click('[data-kg-plus-button]');
-
-        await page.click('button[data-kg-card-menu-item="GIF"]');
-
-        await expect(await page.locator('[data-gif-index="0"]')).toBeVisible();
-        await page.click('[data-gif-index="0"]');
-
-        // toBeAttached rather than toBeVisible: the fixture GIF URL is not
-        // network-loaded in tests, so visibility would depend on an external fetch
-        await expect(await page.getByTestId('image-card-populated')).toBeAttached();
-
-        await assertHTML(page, html`
-            <div data-lexical-decorator="true" contenteditable="false">
-                <div data-kg-card-editing="false" data-kg-card-selected="true" data-kg-card="image">
-                    <figure data-kg-card-width="regular">
-                        <div>
-                            <img
-                                alt=""
-                                src="https://static.klipy.com/gif/klipy-cat.gif" />
-                        </div>
-                        <figcaption>
-                            <div data-testid="image-caption-editor" data-kg-allow-clickthrough="true">
-                                <div>
-                                    <div data-kg="editor">
-                                        <div contenteditable="true" role="textbox" spellcheck="true" data-lexical-editor="true" data-koenig-dnd-container="true">
-                                            <p><br /></p>
-                                        </div>
-                                    </div>
-                                    <div>Type caption for image (optional)</div>
-                                </div>
-                            </div>
-                            <button name="alt-toggle-button" type="button">Alt</button>
-                        </figcaption>
-                    </figure>
-                    <div data-kg-card-toolbar="image"></div>
-                </div>
-            </div>
-            <p><br /></p>
-        `, {ignoreCardToolbarContents: true});
-    });
-});

--- a/koenig/koenig-lexical/test/unit/utils/gif-provider.test.ts
+++ b/koenig/koenig-lexical/test/unit/utils/gif-provider.test.ts
@@ -2,64 +2,33 @@ import {describe, expect, test} from 'vitest';
 import {extractErrorMessage, getGifProviderConfig, isInvalidKeyError} from '../../../src/utils/services/gif.js';
 
 describe('Utils: getGifProviderConfig', () => {
-    test('returns null when neither provider is configured', () => {
+    test('returns null when Klipy is not configured', () => {
         expect(getGifProviderConfig(undefined)).toBeNull();
         expect(getGifProviderConfig({})).toBeNull();
-        expect(getGifProviderConfig({tenor: null, klipy: null})).toBeNull();
+        expect(getGifProviderConfig({klipy: null})).toBeNull();
     });
 
-    test('resolves Tenor when only Tenor is configured', () => {
-        const config = getGifProviderConfig({tenor: {googleApiKey: 'tenor-key'}});
-
-        expect(config).toEqual({
-            provider: 'tenor',
-            apiUrl: 'https://tenor.googleapis.com',
-            apiKey: 'tenor-key',
-            contentFilter: 'off'
-        });
+    test('returns null when the Klipy config is present but has no key', () => {
+        expect(getGifProviderConfig({klipy: {}})).toBeNull();
+        expect(getGifProviderConfig({klipy: {apiKey: ''}})).toBeNull();
     });
 
-    test('resolves Klipy when only Klipy is configured', () => {
+    test('resolves Klipy when configured', () => {
         const config = getGifProviderConfig({klipy: {apiKey: 'klipy-key'}});
 
         expect(config).toEqual({
-            provider: 'klipy',
             apiUrl: 'https://api.klipy.com',
             apiKey: 'klipy-key',
             contentFilter: 'off'
         });
     });
 
-    test('prefers Klipy when both providers are configured', () => {
-        const config = getGifProviderConfig({
-            tenor: {googleApiKey: 'tenor-key'},
-            klipy: {apiKey: 'klipy-key'}
-        });
-
-        expect(config.provider).toEqual('klipy');
-        expect(config.apiKey).toEqual('klipy-key');
-    });
-
     test('passes through a configured content filter', () => {
-        expect(getGifProviderConfig({tenor: {googleApiKey: 'k', contentFilter: 'high'}}).contentFilter).toEqual('high');
         expect(getGifProviderConfig({klipy: {apiKey: 'k', contentFilter: 'low'}}).contentFilter).toEqual('low');
-    });
-
-    test('falls back to Tenor when the Klipy config is present but has no key', () => {
-        expect(getGifProviderConfig({klipy: {}, tenor: {googleApiKey: 'tenor-key'}}).provider).toEqual('tenor');
-        expect(getGifProviderConfig({klipy: {apiKey: ''}, tenor: {googleApiKey: 'tenor-key'}}).provider).toEqual('tenor');
     });
 });
 
 describe('Utils: extractErrorMessage', () => {
-    test('reads the Tenor error shape', () => {
-        expect(extractErrorMessage({error: {message: 'API key not valid'}})).toEqual('API key not valid');
-    });
-
-    test('reads a Tenor string error', () => {
-        expect(extractErrorMessage({error: 'Something went wrong'})).toEqual('Something went wrong');
-    });
-
     test('reads the Klipy error shape', () => {
         expect(extractErrorMessage({result: false, errors: {message: ['The provided API key is invalid']}})).toEqual('The provided API key is invalid');
     });
@@ -74,10 +43,6 @@ describe('Utils: extractErrorMessage', () => {
 });
 
 describe('Utils: isInvalidKeyError', () => {
-    test('detects the Tenor invalid-key wording', () => {
-        expect(isInvalidKeyError('API key not valid')).toBe(true);
-    });
-
     test('detects the Klipy invalid-key wording', () => {
         expect(isInvalidKeyError('The provided API key is invalid: [xxx]')).toBe(true);
     });


### PR DESCRIPTION
## Describe the problem you are solving

This PR removes Tenor entirely from the editor's GIF card and from Ghost's config surface. Google shut down the Tenor API for app developers on 2026-06-30, so the Tenor fallback added during the Klipy migration (TryGhost/Koenig#1932, TryGhost/Ghost#28109) now points at a dead endpoint. Klipy is the sole GIF provider going forward.

This is the final code phase of the Tenor → Klipy migration (Linear: PT-10, PT-11). Docs were already updated (PT-13); infra key removal (PT-12) happens separately.

## Changelog for devs

* Removed the Tenor branch from the GIF provider resolution in `koenig-lexical` (`getGifProviderConfig` now resolves Klipy or null), along with the provider-switching prop plumbing, Tenor error shapes, Tenor demo config, and all Tenor-specific tests and fixtures
* Removed the `tenor` config key from Ghost: config defaults, public-config service, config output serializer, the admin-x `Config` type, both editors' card configs, and the related tests, fixtures and API snapshot
* Fixed the GIF card in the Automations email editor (`apps/posts`): it was copied from the welcome-email editor before Klipy support landed and only ever had Tenor wiring, so its GIF card pointed at the dead API (behind the `automations` labs flag)
* Removed the dead `gh-tenor-*` CSS in Ghost Admin (leftover from the pre-Lexical GIF selector removed in #28109) and the `VITE_TENOR_API_KEY` env line from the koenig demo deploy workflow
* Folded the Klipy-specific e2e test into the main GIF test suite: keyboard insertion, Esc dismissal and error display now run against the Klipy path (previously Tenor-only), and a new unit test pins that an empty/keyless `klipy` config resolves to no provider

## Changelog for customers

* Removed the discontinued Tenor GIF provider from the editor; Klipy (`klipy.apiKey` in config) is now the only GIF provider

## Notes

* **Behaviour for deployments with a stale `tenor` key**: the key is silently ignored (nconf drops unknown keys, all readers are gone). The GIF card is hidden unless a Klipy key is configured — the intended outcome, since the Tenor API no longer answers. Klipy-configured deployments (incl. Ghost(Pro)) see no behaviour change.
* **Public API surface change**: the `/config/` endpoint no longer returns a `tenor` object. Any external integration reading `config.tenor` gets `undefined`; justified by the upstream shutdown, and old cached admin bundles degrade safely via optional chaining.
* The comment in `gif.ts` about Klipy exposing a "Tenor-compatible v2 API" is kept intentionally — it explains why the client speaks v2 paths and Tenor-style request params.
* The `media.tenor.com` URLs in a kg-converters mobiledoc fixture and the "Tenor Sans" font references are unrelated to the GIF API and intentionally untouched. Google confirmed existing `media.tenor.com` asset URLs keep serving (PT-2), so historic embedded GIFs in published content are unaffected.
* Two `secretlint-disable-next-line` comments were added for the scanner's `apiKey:` false positive (established repo pattern); the flagged values are identifiers, not secrets.
* Verified locally: koenig-lexical unit (116) + full acceptance suite (739), ghost/core public-config unit + config API e2e (snapshot regenerated), admin-x-settings welcome-emails acceptance (both Klipy GIF tests), lint on all affected projects. Reviewed by 4 parallel review agents (scores 8–10, no blockers).

## Technical debt

* `ImageNode.isHidden` checks `!config?.klipy` while `getGifProviderConfig` requires `klipy.apiKey` — a host passing `klipy: {apiKey: null}` straight through would show the card with no provider. Pre-existing mismatch (same held for tenor), no current host triggers it; follow-up to tighten to `!config?.klipy?.apiKey` + a null guard in `makeRequest`.
* The Automations email editor fix ships without acceptance tests — `apps/posts` has no acceptance harness for automations yet. Follow-up: mirror the two welcome-emails GIF tests (shown with Klipy / hidden without), which would have caught the original miss.
* `checkStatus` in `gif.ts` still reads `response.headers.map['content-type']` (whatwg-fetch polyfill internal). Pre-existing, documented in the TryGhost/Koenig#1932 PR body; unchanged here.

## PR Scope (mark all that apply)

- [ ] Improves the user experience
- [x] Enhances the readability of our code
- [x] Simplifies the maintenance of our software
- [x] Fixes a bug
- [ ] Provide a core layer to allow one of the points above

## Checklist before requesting a review (mark all that apply)

- [x] I have performed a self-review of my code
- [x] It's simple enough
- [x] The PR is not extensive
- [x] It includes documentation
- [x] I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
