### PR TITLE
Added Sentry sourcemap upload for Koenig editor builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -934,7 +934,22 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build server and admin assets
+        # IS_SHIPPING enables the Sentry vite plugin in koenig-lexical: it
+        # injects debug IDs into the built editor bundles and uploads their
+        # sourcemaps. Only shippable builds (main + tags) get it — debug-ID
+        # artifact bundles are release-agnostic, so per-merge uploads are
+        # deduplicated by content and create no release noise in Sentry.
+        env:
+          IS_SHIPPING: ${{ (github.ref == 'refs/heads/main' || github.ref_type == 'tag') && 'true' || '' }}
+          VITE_SENTRY_AUTH_TOKEN: ${{ secrets.VITE_SENTRY_AUTH_TOKEN }}
         run: |
+          # The Sentry plugin only warns when the token is missing, which
+          # would silently skip the upload AND poison the Nx cache with a
+          # never-uploaded debug ID — fail loudly instead.
+          if [ -n "$IS_SHIPPING" ] && [ -z "$VITE_SENTRY_AUTH_TOKEN" ]; then
+            echo "::error::IS_SHIPPING is set but VITE_SENTRY_AUTH_TOKEN is empty — Koenig sourcemaps would not reach Sentry"
+            exit 1
+          fi
           PKG_VERSION=$(node -p "require('./ghost/core/package.json').version")
           SHORT_SHA="${GITHUB_SHA:0:7}"
           if [ "${{ github.ref_type }}" != "tag" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -936,11 +936,12 @@ jobs:
       - name: Build server and admin assets
         # IS_SHIPPING enables the Sentry vite plugin in koenig-lexical: it
         # injects debug IDs into the built editor bundles and uploads their
-        # sourcemaps. Only shippable builds (main + tags) get it — debug-ID
-        # artifact bundles are release-agnostic, so per-merge uploads are
-        # deduplicated by content and create no release noise in Sentry.
+        # sourcemaps. Only shippable builds (main + tags in the canonical
+        # repo) get it — debug-ID artifact bundles are release-agnostic, so
+        # per-merge uploads are deduplicated by content and create no
+        # release noise in Sentry.
         env:
-          IS_SHIPPING: ${{ (github.ref == 'refs/heads/main' || github.ref_type == 'tag') && 'true' || '' }}
+          IS_SHIPPING: ${{ github.repository == 'TryGhost/Ghost' && (github.ref == 'refs/heads/main' || github.ref_type == 'tag') && 'true' || '' }}
           VITE_SENTRY_AUTH_TOKEN: ${{ secrets.VITE_SENTRY_AUTH_TOKEN }}
         run: |
           # The Sentry plugin only warns when the token is missing, which

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -86,6 +86,16 @@
                 ]
             },
             "build": {
+                "inputs": [
+                    {
+                        "env": "GHOST_CDN_URL"
+                    },
+                    {
+                        "env": "IS_SHIPPING"
+                    },
+                    "default",
+                    "^default"
+                ],
                 "outputs": [
                     "{projectRoot}/dist",
                     "{workspaceRoot}/ghost/core/core/built/admin"

--- a/ghost/admin/package.json
+++ b/ghost/admin/package.json
@@ -207,6 +207,16 @@
         ]
       },
       "build": {
+        "inputs": [
+          {
+            "env": "GHOST_CDN_URL"
+          },
+          {
+            "env": "IS_SHIPPING"
+          },
+          "default",
+          "^default"
+        ],
         "outputs": [
           "{projectRoot}/dist",
           "{workspaceRoot}/ghost/core/core/built/admin"

--- a/koenig/koenig-lexical/package.json
+++ b/koenig/koenig-lexical/package.json
@@ -146,6 +146,15 @@
       "playwright"
     ],
     "targets": {
+      "build": {
+        "inputs": [
+          {
+            "env": "IS_SHIPPING"
+          },
+          "default",
+          "^default"
+        ]
+      },
       "build:demo": {
         "dependsOn": [
           "^build"


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3774/

Since the Koenig monorepo merge, editor errors in Sentry have been missing debug IDs: the old standalone repo uploaded sourcemaps at npm-publish time via an `IS_SHIPPING`-gated Sentry vite plugin, and the plugin block came across in the migration but nothing in Ghost's CI activated it, so shipped editor bundles carry no debug IDs and rely solely on Sentry's legacy source-fetching to symbolicate.

Rewiring it into `publish_koenig_packages` would upload maps for the wrong bytes — npm-published dists only ever reach external consumers. Production Ghost Admin serves the UMD built by `pnpm build:production` in `job_build_artifacts`, so that's where the upload now happens, gated to main pushes and tags since any main commit can be rolled out to production. Debug-ID artifact bundles are release-agnostic and content-addressed, so per-merge uploads are deduplicated and create no release noise in Sentry.

Two guards make the flow fail loudly instead of silently degrading:
- `IS_SHIPPING` is added to koenig-lexical's Nx build inputs, so a shipping build can never restore a cached dist that was built without debug IDs
- the build step errors when `IS_SHIPPING` is set but `VITE_SENTRY_AUTH_TOKEN` is empty, because the Sentry plugin itself only warns and would skip the upload while still populating the build cache

- [x] **Merge prerequisite:** the `VITE_SENTRY_AUTH_TOKEN` secret must be added to this repo (same token as the old Koenig repo; scopes `project:releases` + `org:read`) — until then main builds will fail on the new guard.

This covers the UMD editor lane only; extending uploads to the admin-x Vite apps (posts, admin) will be a follow-up issue.