### PR TITLE
Fixed Claude Code nvm hook prompting on every Bash command

### DIFF
--- a/.claude/hooks/nvm-path.sh
+++ b/.claude/hooks/nvm-path.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# SessionStart hook — put the project's nvm-managed Node on PATH for the whole
+# Claude Code session.
+#
+# Why this exists: a GUI-launched Claude Code (e.g. the desktop app) does not
+# source your login shell, so nvm's PATH setup is absent and `node` isn't found
+# by the Bash tool.
+#
+# Why a SessionStart hook (not a per-command PreToolUse rewrite): Claude Code's
+# Bash permission classifier prompts on any command whose leading `PATH=...`
+# assignment it can't statically clear — so rewriting every command to inject
+# PATH prompts on every single call. Instead we set PATH ONCE here, via
+# $CLAUDE_ENV_FILE (the documented mechanism for a hook to export env vars into
+# the session). Env vars are not permission-checked, so there are zero prompts
+# and no per-command overhead.
+#
+# Graceful when nvm is absent: if ~/.nvm/nvm.sh doesn't exist (or no Node
+# resolves), nothing is written and the session is unaffected — so teammates
+# without nvm see no change.
+
+# CLAUDE_ENV_FILE is provided by Claude Code; export lines appended here are
+# sourced into the session's environment.
+[ -n "$CLAUDE_ENV_FILE" ] || exit 0
+
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] || exit 0
+
+# shellcheck disable=SC1091
+. "$NVM_DIR/nvm.sh" >/dev/null 2>&1
+nvm use >/dev/null 2>&1                 # respects the repo's .nvmrc (else default)
+node_path=$(command -v node 2>/dev/null)
+[ -n "$node_path" ] || exit 0
+
+# Prepend nvm's Node bin dir to PATH for every Bash command this session. $PATH
+# is left unexpanded here on purpose — Claude Code expands it when it sources
+# this file, so we prepend to the session's actual PATH.
+printf 'export PATH="%s:$PATH"\n' "$(dirname "$node_path")" >> "$CLAUDE_ENV_FILE"
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,12 +1,11 @@
 {
   "hooks": {
-    "PreToolUse": [
+    "SessionStart": [
       {
-        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
-            "command": "jq -c '{hookSpecificOutput:{hookEventName:\"PreToolUse\",updatedInput:{command:(\"[ -s ~/.nvm/nvm.sh ] && . ~/.nvm/nvm.sh >/dev/null 2>&1 && nvm use >/dev/null 2>&1; \" + .tool_input.command)}}}'"
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/nvm-path.sh\""
           }
         ]
       }


### PR DESCRIPTION
## Summary

The committed nvm helper for Claude Code was a `PreToolUse` (Bash) hook that prepended `. ~/.nvm/nvm.sh; nvm use` to every command, so GUI-launched Claude Code (e.g. the desktop app, which doesn't inherit the login shell's PATH) could find nvm's node.

The problem: Claude Code's Bash permission classifier prompts on `source`/`.`/`eval` **and** on any leading `PATH=`/`export` assignment — and none of them can be allowlisted — so the hook triggered a permission prompt on **every** Bash command.

## Change

- Replaced it with a **SessionStart** hook that resolves nvm's node bin once and writes `export PATH="<bin>:$PATH"` to `$CLAUDE_ENV_FILE` (the documented mechanism for a hook to inject env vars into the session). Env-file writes aren't permission-checked, so there are no prompts and no per-command overhead.
- Still respects each project's `.nvmrc` (resolved at session start via `nvm use`).
- Graceful no-op when nvm isn't installed, so teammates without nvm are unaffected.
- Moved the logic into `.claude/hooks/nvm-path.sh` so `settings.json` stays a readable one-liner.

## Testing

- Dry-ran the hook against a simulated `$CLAUDE_ENV_FILE`: it writes `export PATH="…/v22.18.0/bin:$PATH"`, matching ghost's `.nvmrc` (`22.18.0`).
- Full end-to-end (SessionStart firing) is verified by restarting Claude Code — node lands on PATH with no permission prompt on ordinary commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
