### PR TITLE
Removed the "Send an email and say hi!" part of the email FAQ

### DIFF
--- a/apps/portal/src/components/pages/email-receiving-faq.jsx
+++ b/apps/portal/src/components/pages/email-receiving-faq.jsx
@@ -61,17 +61,6 @@ export default function EmailReceivingPage() {
                     />
                 </p>
 
-                <h4>{t(`Send an email and say hi!`)}</h4>
-
-                <p>
-                    <Interpolate
-                        string={t(`Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.`)}
-                        mapping={{
-                            senderEmail: <strong>{defaultNewsletterSenderEmail}</strong>
-                        }}
-                    />
-                </p>
-
                 <h4>{t(`Check with your mail provider`)}</h4>
 
                 <p>

--- a/ghost/i18n/locales/af/portal.json
+++ b/ghost/i18n/locales/af/portal.json
@@ -191,8 +191,6 @@
     "Save": "Stoor",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Stuur 'n epos en sê hallo!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Stuur 'n e-pos na {senderEmail} en sê hallo. Dit kan ook help om aan u e-posverskaffer aan te dui dat e-posse na en van hierdie adres vertrou moet word.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Stuur aanmeldskakel...",
     "Sending...": "Stuur...",

--- a/ghost/i18n/locales/ar/portal.json
+++ b/ghost/i18n/locales/ar/portal.json
@@ -191,8 +191,6 @@
     "Save": "حفظ",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "!ًأرسل بريدًا الكترونيًا وقل مرحبًا",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": ".وقل مرحبًا. يمكن أن يساعدك ذلك أيضًا في إبلاغ مزود البريد الخاص بك بأن الرسائل المرسلةإلى ومن هذا العنوانيجب أن تكون موثوقة {senderEmail} أرسل بريدًا الكترونيًا إلى ",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "",
     "Sending...": "...جاري الإرسال",

--- a/ghost/i18n/locales/bg/portal.json
+++ b/ghost/i18n/locales/bg/portal.json
@@ -191,8 +191,6 @@
     "Save": "Запази",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "Спестете {amountOff} от следващите {durationInMonths} платежни цикъла. След това {currency}{originalPrice}/{cadence}.",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "Спестете {amountOff} от следващия платежен цикъл. След това {currency}{originalPrice}/{cadence}.",
-    "Send an email and say hi!": "Изпратете имейл за здрасти!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Изпратете имейл до {senderEmail} за здрасти. Това също може да сигнализира на вашия доставчик на електронна поща, че на имейлите до и от този адрес може да се има доверие.",
     "Send the link below to share it with whoever you'd like.": "Изпратете връзката по-долу, за да я споделите с когото желаете.",
     "Sending login link...": "Изпращане на линк за влизане...",
     "Sending...": "Изпращане...",

--- a/ghost/i18n/locales/bn/portal.json
+++ b/ghost/i18n/locales/bn/portal.json
@@ -191,8 +191,6 @@
     "Save": "সংরক্ষণ করুন",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "একটি ইমেল পাঠান এবং হাই বলুন!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "{senderEmail} এ একটি ইমেল পাঠান এবং হ্যালো বলুন। এটি আপনার মেইল প্রোভাইডারকে সংকেত দিতে সাহায্য করতে পারে যে এই ঠিকানায় এবং এই ঠিকানা থেকে ইমেলগুলি বিশ্বাসযোগ্য হওয়া উচিত।",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "লগইন লিঙ্ক পাঠানো হচ্ছে...",
     "Sending...": "পাঠানো হচ্ছে...",

--- a/ghost/i18n/locales/bs/portal.json
+++ b/ghost/i18n/locales/bs/portal.json
@@ -191,8 +191,6 @@
     "Save": "Spremi",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Pošalji Email poruku i reci zdravo!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Pošalji Email na {senderEmail} sa pozitivnim sadržajem. To također može pomoći u signalizaciji vašem pružatelju usluge da se Email poslan s te adrese treba označiti kao siguran.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Slanje linka za prijavu...",
     "Sending...": "Slanje...",

--- a/ghost/i18n/locales/ca/portal.json
+++ b/ghost/i18n/locales/ca/portal.json
@@ -191,8 +191,6 @@
     "Save": "Desa",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Envia un correu electrònic i digues hola!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Envia un correu electrònic a {senderEmail} i saluda'l. Això també pot ajudar a indicar al teu proveïdor de correu que els correus electrònics des d'aquesta adreça haurien de ser de confiança.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Enviant enllaç d'inici de sessió...",
     "Sending...": "Enviant",

--- a/ghost/i18n/locales/context.json
+++ b/ghost/i18n/locales/context.json
@@ -266,8 +266,6 @@
     "Secure sign in link for {siteTitle}": "Magic link email",
     "See full discussion": "Link in the focused comment thread view that returns the user to the main list of comments",
     "See you soon!": "A sign-off/ending to a signup email",
-    "Send an email and say hi!": "A section title in email receiving FAQ",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Email receiving FAQ",
     "Send the link below to share it with whoever you'd like.": "Subtitle on the Portal gift success page instructing the buyer to share the redemption link",
     "Sending": "Button text when reporting a comment",
     "Sending login link...": "A loading status message when a member has just clicked to login",

--- a/ghost/i18n/locales/cs/portal.json
+++ b/ghost/i18n/locales/cs/portal.json
@@ -191,8 +191,6 @@
     "Save": "Uložit",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Pošlete e-mail a pozdravte!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Pošlete e-mail na {senderEmail} s pozdravem. Tím také můžete dát signál svému poskytovateli e-mailu, že e-maily z této adresy a na ni by měly být důvěryhodné.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Odesílání přihlašovacího odkazu...",
     "Sending...": "Odesílání...",

--- a/ghost/i18n/locales/da/portal.json
+++ b/ghost/i18n/locales/da/portal.json
@@ -191,8 +191,6 @@
     "Save": "Gem",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Send en e-mail og sig hej!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Send en e-mail til {senderEmail} og sig hej. Dette kan også hjælpe med at signalere til din e-mailudbyder, at e-mails til og fra denne adresse skal være tillid til.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Sender link til log ind",
     "Sending...": "Sender",

--- a/ghost/i18n/locales/de-CH/portal.json
+++ b/ghost/i18n/locales/de-CH/portal.json
@@ -191,8 +191,6 @@
     "Save": "Speichern",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "Sparen Sie {amountOff} in Ihren nächsten {durationInMonths} Abrechnungszyklen. Danach {currency}{originalPrice}/{cadence}.",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "Sparen Sie {amountOff} bei Ihrer nächsten Abrechnung. Danach {currency}{originalPrice}/{cadence}.",
-    "Send an email and say hi!": "Senden Sie uns eine E-Mail und sagen Sie Hallo!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Senden Sie uns ein E-Mail an {senderEmail} und sagen Sie Hallo. Das kann auch dazu beitragen, Ihrem E-Mail-Anbieter zu signalisieren, dass E-Mails an und von dieser Adresse vertrauenswürdig sind.",
     "Send the link below to share it with whoever you'd like.": "Senden Sie den untenstehenden Link an die Person Ihrer Wahl.",
     "Sending login link...": "Anmelde-Link wird gesendet…",
     "Sending...": "Wird gesendet…",

--- a/ghost/i18n/locales/de/portal.json
+++ b/ghost/i18n/locales/de/portal.json
@@ -191,8 +191,6 @@
     "Save": "Speichern",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Sende eine E-Mail und sage Hallo!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Schicke eine E-Mail an {senderEmail} und sag Hallo. Dies kann auch dazu beitragen, deinem E-Mail-Anbieter zu signalisieren, dass E-Mails an und von dieser Adresse vertrauenswürdig sind.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Login-Link senden...",
     "Sending...": "Sende...",

--- a/ghost/i18n/locales/el/portal.json
+++ b/ghost/i18n/locales/el/portal.json
@@ -191,8 +191,6 @@
     "Save": "Αποθήκευση",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "Εξοικονομήστε {amountOff} για τους επόμενους {durationInMonths} κύκλους χρέωσης. Στη συνέχεια {currency}{originalPrice}/{cadence}.",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "Εξοικονομήστε {amountOff} στον επόμενο κύκλο χρέωσής σας. Στη συνέχεια {currency}{originalPrice}/{cadence}.",
-    "Send an email and say hi!": "Στείλτε ένα email και πείτε γεια!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Στείλτε ένα email στο {senderEmail} και πείτε γεια. Αυτό μπορεί επίσης να υποδείξει στον πάροχο email σας ότι τα emails προς και από αυτήν τη διεύθυνση θα πρέπει να θεωρούνται αξιόπιστα.",
     "Send the link below to share it with whoever you'd like.": "Στείλτε τον παρακάτω σύνδεσμο για να τον μοιραστείτε με όποιον θέλετε.",
     "Sending login link...": "Αποστολή συνδέσμου σύνδεσης...",
     "Sending...": "Αποστολή...",

--- a/ghost/i18n/locales/en/portal.json
+++ b/ghost/i18n/locales/en/portal.json
@@ -191,8 +191,6 @@
     "Save": "",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "",
     "Sending...": "",

--- a/ghost/i18n/locales/eo/portal.json
+++ b/ghost/i18n/locales/eo/portal.json
@@ -191,8 +191,6 @@
     "Save": "Konservi",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Sendanta ensaluta ligilo...",
     "Sending...": "Sendante...",

--- a/ghost/i18n/locales/es/portal.json
+++ b/ghost/i18n/locales/es/portal.json
@@ -191,8 +191,6 @@
     "Save": "Guardar",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "¡Envía un correo electrónico y saluda!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "¡Envia un correo electrónico a {senderEmail} y saluda! Esto también puede ayudar a indicarle a su proveedor de correo que se debe confiar en los correos electrónicos hacia y desde esta dirección.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Enviando enlace de inicio de sesión...",
     "Sending...": "Enviando...",

--- a/ghost/i18n/locales/et/portal.json
+++ b/ghost/i18n/locales/et/portal.json
@@ -191,8 +191,6 @@
     "Save": "Salvesta",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Saatke e-kiri ja öelge tere!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Saatke e-kiri aadressile {senderEmail} ja öelge tere. See võib aidata anda teie e-posti teenusepakkujale märku, et selle aadressiga seotud e-kirju tuleks usaldada.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Sisselogimislingi saatmine...",
     "Sending...": "Saatmine...",

--- a/ghost/i18n/locales/eu/portal.json
+++ b/ghost/i18n/locales/eu/portal.json
@@ -191,8 +191,6 @@
     "Save": "Gorde",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Bidali ePosta bat eta aurkeztu zure burua!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Bidali ePosta bat {senderEmail}(e)ri eta agurtu ezazu. Honek ePosta hornitzaileari helbide horretara bidalitako eta horretatik jasotako mezuak fidagarritzat jotzen lagunduko du.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Saioa hasteko esteka bidaltzen…",
     "Sending...": "Bidaltzen…",

--- a/ghost/i18n/locales/fa/portal.json
+++ b/ghost/i18n/locales/fa/portal.json
@@ -191,8 +191,6 @@
     "Save": "ذخیره",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "در {durationInMonths} دوره صورتحساب بعدی خود {amountOff} صرفه\u200cجویی کنید. سپس {currency}{originalPrice}/{cadence}.",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "در دوره صورتحساب بعدی خود {amountOff} صرفه\u200cجویی کنید. سپس {currency}{originalPrice}/{cadence}.",
-    "Send an email and say hi!": "ایمیلی بفرستید و سلامی بگویید!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "به {senderEmail} ایمیل بزنید و سلامی بگویید. این کار به ارائه\u200cدهنده ایمیل شما نشان می\u200cدهد که ایمیل\u200cهای رفت\u200cوبرگشت به این نشانی قابل اعتماد هستند.",
     "Send the link below to share it with whoever you'd like.": "پیوند زیر را برای اشتراک\u200cگذاری با هر کسی که می\u200cخواهید بفرستید.",
     "Sending login link...": "در حال ارسال پیوند ورود...",
     "Sending...": "در حال ارسال...",

--- a/ghost/i18n/locales/fi/portal.json
+++ b/ghost/i18n/locales/fi/portal.json
@@ -191,8 +191,6 @@
     "Save": "Tallenna",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Lähetä sähköposti ja sano moi!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Lähetä sähköposti osoitteeseen {senderEmail} ja sano hei. Tämä viestii tarjoajalle, että osoite on hyväksytty.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Lähetetään kirjautumislinkkiä...",
     "Sending...": "Lähetetään...",

--- a/ghost/i18n/locales/fr/portal.json
+++ b/ghost/i18n/locales/fr/portal.json
@@ -191,8 +191,6 @@
     "Save": "Sauvegarder",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "Économisez {amountOff} sur vos {durationInMonths} prochains cycles de facturation. Puis {originalPrice}{currency}/{cadence}.",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "Économisez {amountOff} sur votre prochain cycle de facturation. Puis {originalPrice}{currency}/{cadence}.",
-    "Send an email and say hi!": "Envoyez un e-mail et dites bonjour !",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Envoyez un e-mail à {senderEmail} et dites-lui bonjour ! Cela devrait signaler à votre fournisseur de messagerie que les échanges avec cette adresse peuvent être considérés comme dignes de confiance.",
     "Send the link below to share it with whoever you'd like.": "Envoyez le lien ci-dessous à la personne de votre choix pour le partager.",
     "Sending login link...": "Envoi du lien de connexion…",
     "Sending...": "Envoi en cours…",

--- a/ghost/i18n/locales/gd/portal.json
+++ b/ghost/i18n/locales/gd/portal.json
@@ -191,8 +191,6 @@
     "Save": "Sàbhail",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Cuir post-d is can halò!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Cuir post-d gu {senderEmail} is can halò. Cuidichidh seo le bhith ag innse don t-solaraiche puist-d agad gur e seòladh post-d earbsach a tha seo.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "A’ cur ceangal clàraidh a-steach...",
     "Sending...": "’Ga chur...",

--- a/ghost/i18n/locales/he/portal.json
+++ b/ghost/i18n/locales/he/portal.json
@@ -191,8 +191,6 @@
     "Save": "שמירה",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "שלחו מייל ואמרו שלום!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "שלחו מייל ל-{senderEmail} ואמרו שלום. זה יכול לעזור גם לספק המייל שלכם להבין שמיילים מ/או-לכתובת זו צריכים להיות מהימנים.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "שולחים לינק לכניסה...",
     "Sending...": "שולחים...",

--- a/ghost/i18n/locales/hi/portal.json
+++ b/ghost/i18n/locales/hi/portal.json
@@ -191,8 +191,6 @@
     "Save": "सेव करें",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "ईमेल भेजें और नमस्ते कहें!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "{senderEmail} को एक ईमेल भेजें और नमस्ते कहें। यह आपके मेल प्रदाता को संकेत देने में भी मदद कर सकता है कि इस पते से और इस पते पर भेजे गए ईमेल पर विश्वास किया जाना चाहिए।",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "लॉगिन लिंक भेज रहा है...",
     "Sending...": "भेजा जा रहा है...",

--- a/ghost/i18n/locales/hr/portal.json
+++ b/ghost/i18n/locales/hr/portal.json
@@ -191,8 +191,6 @@
     "Save": "Spremi",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Pošalji e-poštu i reci bok!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Pošalji e-poruku na {senderEmail} i reci bok. Ovo također može pomoći vašem pružatelju usluga e-pošte da vjeruje e-pošti koja dolazi i odlazi s ove adrese.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Link za prijavu se šalje...",
     "Sending...": "Slanje...",

--- a/ghost/i18n/locales/hu/portal.json
+++ b/ghost/i18n/locales/hu/portal.json
@@ -191,8 +191,6 @@
     "Save": "Mentés",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Küldj egy e-mailt",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Küldj egy e-mailt a következő címre: {senderEmail}. Ez is segíthet jelezni az e-mail szolgáltatónak, hogy az e-maileket erről a címről megbízhatónak kell tekinteni.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Bejelentkezési link küldése...",
     "Sending...": "Küldés...",

--- a/ghost/i18n/locales/id/portal.json
+++ b/ghost/i18n/locales/id/portal.json
@@ -191,8 +191,6 @@
     "Save": "Simpan",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Kirimkan email dan ucapan hai!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Kirim email ke {senderEmail} dan ucapan halo. Hal ini juga dapat membantu memberi sinyal kepada penyedia layanan email Anda bahwa email yang dikirim ke dan dari alamat ini harus dipercaya.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Mengirim tautan masuk...",
     "Sending...": "Mengirim...",

--- a/ghost/i18n/locales/is/portal.json
+++ b/ghost/i18n/locales/is/portal.json
@@ -191,8 +191,6 @@
     "Save": "Vista",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Sendu tölvupóst og segðu hæ!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Sendu tölvupóst á {senderEmail} og segðu halló. Þetta gefur einnig tölvupóstþjónustunni merki um að póstum til og frá þessu netfangi sé treystandi.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Sendi innskráningarhlekk",
     "Sending...": "Sending í vinnslu",

--- a/ghost/i18n/locales/it/portal.json
+++ b/ghost/i18n/locales/it/portal.json
@@ -191,8 +191,6 @@
     "Save": "Salva",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "Risparmia {amountOff} per i prossimi {durationInMonths} cicli di fatturazione. Poi {currency}{originalPrice}/{cadence}.",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "Risparmia {amountOff} sul tuo prossimo ciclo di fatturazione. Poi {currency}{originalPrice}/{cadence}.",
-    "Send an email and say hi!": "Invia un'email di saluti!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Invia un'email di saluti a {senderEmail}. Questo potrebbe aiutare a segnalare al tuo provider che le email da e verso questo indirizzo possono essere considerate attendibili.",
     "Send the link below to share it with whoever you'd like.": "Invia il link qui sotto per condividerlo con chi vuoi.",
     "Sending login link...": "Invio link di accesso...",
     "Sending...": "Invio...",

--- a/ghost/i18n/locales/ja/portal.json
+++ b/ghost/i18n/locales/ja/portal.json
@@ -191,8 +191,6 @@
     "Save": "保存",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "テストメールを送信",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "{senderEmail}にメールを送ると、メールプロバイダーに対して、このアドレスとのやり取りは信頼できるものだと知らせることができます。",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "ログイン先リンクを送信しています...",
     "Sending...": "送信しています...",

--- a/ghost/i18n/locales/ko/portal.json
+++ b/ghost/i18n/locales/ko/portal.json
@@ -191,8 +191,6 @@
     "Save": "저장",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "다음 {durationInMonths}번의 결제 주기 동안 {amountOff}을(를) 절약하세요. 이후에는 {cadence}당 {currency}{originalPrice}이에요.",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "다음 결제 주기에 {amountOff}을(를) 절약하세요. 이후에는 {cadence}당 {currency}{originalPrice}이에요.",
-    "Send an email and say hi!": "이메일을 보내 인사를 건네보세요!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "{senderEmail}에게 이메일을 보내 인사를 건네보세요. 이렇게 하면 메일 제공업체에게 이 주소로부터 이메일을 신뢰해야 한다는 신호를 보낼 수 있어요.",
     "Send the link below to share it with whoever you'd like.": "아래 링크를 보내 원하는 분과 공유하세요.",
     "Sending login link...": "로그인 링크 전송 중...",
     "Sending...": "전송 중...",

--- a/ghost/i18n/locales/kz/portal.json
+++ b/ghost/i18n/locales/kz/portal.json
@@ -191,8 +191,6 @@
     "Save": "Сақтау",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Электрондық хат жіберіп, сәлем жолдаңыз!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "{senderEmail} мекенжайына электрондық хат жіберіп, сәлем жолдаңыз. Бұл сондай-ақ, пошта провайдеріне осы мекенжай бойынша кіріс-шығыс хаттардың сенімді екенін көрсетеді.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Кіру сілтемесі жіберілуде...",
     "Sending...": "Жіберілуде...",

--- a/ghost/i18n/locales/lt/portal.json
+++ b/ghost/i18n/locales/lt/portal.json
@@ -191,8 +191,6 @@
     "Save": "Išsaugoti",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Siųskite el. laišką ir pasisveikinkite!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Nusiųskite el. laišką adresu {senderEmail} ir pasisveikinkite. Tai taip pat gali padėti jūsų pašto paslaugų teikėjui pranešti, kad šiuo adresu siunčiami el. laiškai turėtų būti patikimi.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Siunčiama prisijungimo nuoroda...",
     "Sending...": "Siunčiama...",

--- a/ghost/i18n/locales/lv/portal.json
+++ b/ghost/i18n/locales/lv/portal.json
@@ -191,8 +191,6 @@
     "Save": "Saglabāt",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Nosūtiet e-pastu un sakiet sveiki!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Nosūtiet e-pastu uz {senderEmail} un pasveiciniet. Tas var arī palīdzēt informēt jūsu pasta pakalpojumu sniedzēju, ka e-pasta ziņojumi uz šo adresi un no šīs adreses ir jāuzticas.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Notiek pieteikšanās saites sūtīšana...",
     "Sending...": "Notiek sūtīšana...",

--- a/ghost/i18n/locales/mk/portal.json
+++ b/ghost/i18n/locales/mk/portal.json
@@ -191,8 +191,6 @@
     "Save": "Зачувајте",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Испратете порака и кажете здраво!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Испратете порака кон {senderEmail} и кажете здраво. Исто така, ова може да му сигналира на вашиот email сервис дека пораките кон и од оваа адреса треба да се овозможени.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Испраќање на линкот за најава...",
     "Sending...": "Испраќање...",

--- a/ghost/i18n/locales/mn/portal.json
+++ b/ghost/i18n/locales/mn/portal.json
@@ -191,8 +191,6 @@
     "Save": "Хадгалах",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Имэйл илгээгээд мэндчилнэ үү!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "{senderEmail} хаяг руу имэйл илгээж мэндчилнэ үү. Энэ нь таны имэйл үйлчилгээ үзүүлэгчид энэ хаягаас ирж буй имэйлүүдийг итгэмжтэй гэж үзэхэд тусална.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Нэвтрэх холбоосыг илгээж байна...",
     "Sending...": "Илгээж байна...",

--- a/ghost/i18n/locales/ms/portal.json
+++ b/ghost/i18n/locales/ms/portal.json
@@ -191,8 +191,6 @@
     "Save": "Simpan",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Hantar e-mel dan katakan hai!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Hantar e-mel kepada {senderEmail} dan katakan hai. Ini juga boleh membantu memberi isyarat kepada pembekal mel anda bahawa e-mel ke dan dari alamat ini harus dipercayai.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Menghantar pautan log masuk...",
     "Sending...": "Menghantar...",

--- a/ghost/i18n/locales/nb/portal.json
+++ b/ghost/i18n/locales/nb/portal.json
@@ -191,8 +191,6 @@
     "Save": "Lagre",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Send en e-post og si hei!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Send en e-post til {senderEmail} og si hei. Dette kan også signalisere til e-postleverandøren din at e-poster til og fra denne adressen bør være pålitelige.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Sender påloggingslenke...",
     "Sending...": "Sender...",

--- a/ghost/i18n/locales/ne/portal.json
+++ b/ghost/i18n/locales/ne/portal.json
@@ -191,8 +191,6 @@
     "Save": "",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "",
     "Sending...": "",

--- a/ghost/i18n/locales/nl/portal.json
+++ b/ghost/i18n/locales/nl/portal.json
@@ -191,8 +191,6 @@
     "Save": "Opslaan",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Stuur een e-mail en zeg hallo!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Stuur een e-mail naar {senderEmail} en zeg hallo. Dit helpt ook om je e-mailprovider te laten zien dat e-mails van en naar dit adres vertrouwd moeten worden.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Inloglink versturen...",
     "Sending...": "Versturen...",

--- a/ghost/i18n/locales/nn/portal.json
+++ b/ghost/i18n/locales/nn/portal.json
@@ -191,8 +191,6 @@
     "Save": "Lagra",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Send ein e-post og sei hei!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Send ein e-post til {senderEmail} og sei hallo. Dette kan også hjelpa å signalisera for leverandøren at denne e-postadressa er trygg.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Sender innloggingslenke...",
     "Sending...": "Sender...",

--- a/ghost/i18n/locales/pa/portal.json
+++ b/ghost/i18n/locales/pa/portal.json
@@ -191,8 +191,6 @@
     "Save": "ਸੁਰੱਖਿਅਤ ਕਰੋ",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "ਇੱਕ ਈਮੇਲ ਭੇਜੋ ਅਤੇ ਹੈਲੋ ਕਹੋ!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "{senderEmail} ਨੂੰ ਇੱਕ ਈਮੇਲ ਭੇਜੋ ਅਤੇ ਹੈਲੋ ਕਹੋ। ਇਹ ਤੁਹਾਡੇ ਮੇਲ ਪ੍ਰਦਾਤਾ ਨੂੰ ਇਹ ਸੰਕੇਤ ਦੇਣ ਵਿੱਚ ਵੀ ਮਦਦ ਕਰ ਸਕਦਾ ਹੈ ਕਿ ਇਸ ਪਤੇ ਤੋਂ ਅਤੇ ਇਸ ਪਤੇ 'ਤੇ ਈਮੇਲਾਂ 'ਤੇ ਭਰੋਸਾ ਕੀਤਾ ਜਾਣਾ ਚਾਹੀਦਾ ਹੈ।",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "ਲੌਗਇਨ ਲਿੰਕ ਭੇਜਿਆ ਜਾ ਰਿਹਾ ਹੈ...",
     "Sending...": "ਭੇਜਿਆ ਜਾ ਰਿਹਾ ਹੈ...",

--- a/ghost/i18n/locales/pl/portal.json
+++ b/ghost/i18n/locales/pl/portal.json
@@ -191,8 +191,6 @@
     "Save": "Zapisz",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Wyślij email i przywitaj się!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Wyślij email na adres {senderEmail} i przywitaj się. Może to również pomóc w zasygnalizowaniu dostawcy poczty, że wiadomości email wysyłane z i na ten adres powinny być zaufane.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Wysyłanie linku do logowania...",
     "Sending...": "Wysyłanie...",

--- a/ghost/i18n/locales/pt-BR/portal.json
+++ b/ghost/i18n/locales/pt-BR/portal.json
@@ -191,8 +191,6 @@
     "Save": "Salvar",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "Economize {amountOff} nos próximos {durationInMonths} ciclos de cobrança. Depois, {currency}{originalPrice}/{cadence}.",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "Economize {amountOff} no próximo ciclo de cobrança. Depois, {currency}{originalPrice}/{cadence}.",
-    "Send an email and say hi!": "Envie um e-mail e diga oi!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Envie um e-mail para {senderEmail} e diga olá. Isso também pode ajudar a sinalizar ao seu provedor de e-mail que os e-mails de e para este endereço devem ser confiáveis.",
     "Send the link below to share it with whoever you'd like.": "Envie o link abaixo para compartilhar com quem você quiser.",
     "Sending login link...": "Enviando link de acesso...",
     "Sending...": "Enviando...",

--- a/ghost/i18n/locales/pt/portal.json
+++ b/ghost/i18n/locales/pt/portal.json
@@ -191,8 +191,6 @@
     "Save": "Guardar",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Envie um email e diga olá!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Envie um email para {senderEmail} e diga olá. Isso também pode ajudar a sinalizar ao seu provedor de email que os emails de e para este endereço devem ser confiáveis.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "A enviar o link de acesso...",
     "Sending...": "A enviar...",

--- a/ghost/i18n/locales/ro/portal.json
+++ b/ghost/i18n/locales/ro/portal.json
@@ -191,8 +191,6 @@
     "Save": "Salvează",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Trimite un email și spune salut!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Trimiteți un email la {senderEmail} și spuneți bună ziua. Acest lucru poate ajuta, de asemenea, să semnalizeze furnizorului dvs. de email că emailurile de la și către această adresă ar trebui considerate de încredere.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Se trimite link-ul de autentificare...",
     "Sending...": "Se trimite...",

--- a/ghost/i18n/locales/ru/portal.json
+++ b/ghost/i18n/locales/ru/portal.json
@@ -191,8 +191,6 @@
     "Save": "Сохранить",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Отправьте электронное письмо и скажите: привет!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Отправьте электронное письмо на {senderEmail} и поздоровайтесь. Это также может помочь сигнализировать вашему почтовому провайдеру, что письмам, отправленным на этот адрес и полученным с него — можно доверять.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Отправляем ссылку для входа...",
     "Sending...": "Отправка...",

--- a/ghost/i18n/locales/si/portal.json
+++ b/ghost/i18n/locales/si/portal.json
@@ -191,8 +191,6 @@
     "Save": "Save කරන්න",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Email එකක් send කරමින් hi! කියන්න",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "{senderEmail} වෙත hello ලෙස සඳහන් කරමින් email එකක් එවන්න. මේ හරහා එම email ලිපිනයෙන් ලැබෙන සහ ලිපිනයට යවන emails විශ්වාසදායී බව ඔබගේ email සේවා සපයන්නාට සංඥා කෙරෙනු ඇත.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Login link එක යවමින්...",
     "Sending...": "යවමින්...",

--- a/ghost/i18n/locales/sk/portal.json
+++ b/ghost/i18n/locales/sk/portal.json
@@ -191,8 +191,6 @@
     "Save": "Uložiť",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Pošlite e-mail a povedzte Ahoj!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Pošlite e-mail na adresu {senderEmail} a pozdravte ho. To môže tiež pomôcť signalizovať vášmu poskytovateľovi e-mailu, že e-maily na túto adresu a z tejto adresy sú dôveryhodné.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Odosielanie prihlasovacieho odkazu...",
     "Sending...": "Odosielanie...",

--- a/ghost/i18n/locales/sl/portal.json
+++ b/ghost/i18n/locales/sl/portal.json
@@ -191,8 +191,6 @@
     "Save": "Shrani",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Pošljite e-pošto in nas pozdravite!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Pošljite e-pošto na {senderEmail} in nas pozdravite. To lahko tudi pomaga signalizirati vašemu ponudniku, da je e-pošta iz tega naslova zaupanja vredna.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Pošiljanje povezave za prijavo...",
     "Sending...": "Pošiljanje...",

--- a/ghost/i18n/locales/sq/portal.json
+++ b/ghost/i18n/locales/sq/portal.json
@@ -191,8 +191,6 @@
     "Save": "Ruaj",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Dergo nje email dhe thuaj pershendetje!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Dërgo një email te {senderEmail} dhe thuaj përshëndetje. Kjo mund të ndihmojë gjithashtu t'i sinjalizojë ofruesit tuaj të postës elektronike se emailet drejt-dhe-nga kjo adresë duhet të jenë të besueshme.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Duke derguar linkun e identifikimit...",
     "Sending...": "Duke derguar...",

--- a/ghost/i18n/locales/sr-Cyrl/portal.json
+++ b/ghost/i18n/locales/sr-Cyrl/portal.json
@@ -191,8 +191,6 @@
     "Save": "Сачувајте",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Пошаљите email и поздравите!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Пошаљите email на {senderEmail} и поздравите. Ово такође може помоћи да сигнализирате Вашем mail провајдеру да треба веровати порукама на и са ове адресе.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Слање линка за пријаву...",
     "Sending...": "Слање...",

--- a/ghost/i18n/locales/sr/portal.json
+++ b/ghost/i18n/locales/sr/portal.json
@@ -191,8 +191,6 @@
     "Save": "Sačuvajte",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Pošaljite email i pozdravite!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Pošaljite email na {senderEmail} i pozdravite. Ovo takođe može pomoći da signalizirate Vašem mail provajderu da treba verovati porukama na i sa ove adrese.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Slanje linka za prijavu...",
     "Sending...": "Slanje...",

--- a/ghost/i18n/locales/sv/portal.json
+++ b/ghost/i18n/locales/sv/portal.json
@@ -191,8 +191,6 @@
     "Save": "Spara",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "Spara {amountOff} på dina nästa {durationInMonths} faktureringsperioder. Sedan {currency}{originalPrice}/{cadence}.",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "Spara {amountOff} på din nästa faktureringsperiod. Sedan {currency}{originalPrice}/{cadence}.",
-    "Send an email and say hi!": "Skicka e-post och säg hej!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Skicka ett e-postmeddelande till {senderEmail} och säg hej. Detta blir en signal till din e-postleverantör att meddelanden till/från {senderEmail} är viktiga.",
     "Send the link below to share it with whoever you'd like.": "Skicka länken nedan för att dela den med vem du vill.",
     "Sending login link...": "Skickar inloggningslänk...",
     "Sending...": "Skickar...",

--- a/ghost/i18n/locales/sw/portal.json
+++ b/ghost/i18n/locales/sw/portal.json
@@ -191,8 +191,6 @@
     "Save": "Hifadhi",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Tuma barua pepe na sema hi!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Tuma barua pepe kwa {senderEmail} na sema hello. Hii pia inaweza kusaidia kuashiria kwa mtoa huduma wako wa barua kwamba barua pepe zinazotoka na kuingia kwenye anwani hii zinapaswa kuaminika.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Inatuma kiungo cha kuingia...",
     "Sending...": "Inatuma...",

--- a/ghost/i18n/locales/ta/portal.json
+++ b/ghost/i18n/locales/ta/portal.json
@@ -191,8 +191,6 @@
     "Save": "சேமி",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "ஒரு மின்னஞ்சல் அனுப்பி வணக்கம் சொல்லுங்கள்!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "{senderEmail}க்கு ஒரு மின்னஞ்சல் அனுப்பி வணக்கம் சொல்லுங்கள். இந்த முகவரிக்கு மற்றும் இந்த முகவரியிலிருந்து வரும் மின்னஞ்சல்கள் நம்பகமானவை என்பதை உங்கள் அஞ்சல் வழங்குநருக்கு சமிக்ஞை காட்ட இதுவும் உதவும்.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "உள்நுழைவு இணைப்பை அனுப்புகிறது...",
     "Sending...": "அனுப்புகிறது...",

--- a/ghost/i18n/locales/th/portal.json
+++ b/ghost/i18n/locales/th/portal.json
@@ -191,8 +191,6 @@
     "Save": "บันทึก",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "ส่งอีเมลและทักทาย!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "ส่งอีเมลไปที่ {senderEmail} และทักทาย นอกจากนี้ยังช่วยส่งสัญญาณไปยังผู้ให้บริการอีเมลของคุณ ว่าอีเมลที่ส่งเข้าและออกจากที่อยู่นี้ควรเชื่อถือได้",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "กำลังส่งลิงก์เข้าสู่ระบบ...",
     "Sending...": "กำลังส่ง...",

--- a/ghost/i18n/locales/tr/portal.json
+++ b/ghost/i18n/locales/tr/portal.json
@@ -191,8 +191,6 @@
     "Save": "Kaydet",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "Bir sonraki {durationInMonths} faturalandırma döngüsünde {amountOff} tasarruf edin. Sonrasında {currency}{originalPrice}/{cadence}.",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "Bir sonraki faturalandırma döngünüzde {amountOff} tasarruf edin. Sonrasında {currency}{originalPrice}/{cadence}.",
-    "Send an email and say hi!": "Bir e-posta gönderin ve merhaba deyin!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "{senderEmail} adresine bir e-posta gönderin ve merhaba deyin. Bu aynı zamanda posta sağlayıcınıza bu adrese gelen ve bu adresten giden e-postalara güvenilmesi gerektiği sinyalini de iletebilir.",
     "Send the link below to share it with whoever you'd like.": "Aşağıdaki bağlantıyı, paylaşmak istediğiniz kişiye gönderebilirsiniz.",
     "Sending login link...": "Giriş bağlantısı gönderiliyor...",
     "Sending...": "Gönderiliyor...",

--- a/ghost/i18n/locales/uk/portal.json
+++ b/ghost/i18n/locales/uk/portal.json
@@ -191,8 +191,6 @@
     "Save": "Зберегти",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "Надішліть електронний лист і привітайтеся!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Надішліть електронний лист на адресу {senderEmail} і привітайтеся. Це також може допомогти повідомити вашому постачальнику послуг електронної пошти, що електронні листи на цю адресу та з неї слід довіряти.",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Відправляється посилання для входу...",
     "Sending...": "Відправляється...",

--- a/ghost/i18n/locales/ur/portal.json
+++ b/ghost/i18n/locales/ur/portal.json
@@ -191,8 +191,6 @@
     "Save": "محفوظ کریں",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "ایک ای میل بھیجیں اور ہائی کہیں!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "لاگ ان لنک بھیجا جا رہا ہے...",
     "Sending...": "بھیجا جا رہا ہے...",

--- a/ghost/i18n/locales/uz/portal.json
+++ b/ghost/i18n/locales/uz/portal.json
@@ -191,8 +191,6 @@
     "Save": "Saqlamoq",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "",
-    "Send an email and say hi!": "",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "",
     "Send the link below to share it with whoever you'd like.": "",
     "Sending login link...": "Kirish havolasi yuborilmoqda...",
     "Sending...": "Yuborilmoqda...",

--- a/ghost/i18n/locales/vi/portal.json
+++ b/ghost/i18n/locales/vi/portal.json
@@ -191,8 +191,6 @@
     "Save": "Lưu",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "Tiết kiệm {amountOff} cho kỳ thanh toán {durationInMonths} tiếp theo của bạn. Sau đó là {currency}{originalPrice}/{cadence}.",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "Tiết kiệm {amountOff} cho kỳ thanh toán tiếp theo của bạn. Sau đó là {currency}{originalPrice}/{cadence}.",
-    "Send an email and say hi!": "Gửi một email và nói xin chào!",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "Gửi email tới {senderEmail} và gửi lời chào. Điều này cũng có thể giúp báo hiệu cho nhà cung cấp dịch vụ email của bạn rằng các email đến và đi từ địa chỉ này là đáng tin cậy.",
     "Send the link below to share it with whoever you'd like.": "Gửi liên kết bên dưới để chia sẻ nó với bất cứ ai mà bạn thích.",
     "Sending login link...": "Đang gửi liên kết đăng nhập...",
     "Sending...": "Đang gửi...",

--- a/ghost/i18n/locales/zh-Hant/portal.json
+++ b/ghost/i18n/locales/zh-Hant/portal.json
@@ -191,8 +191,6 @@
     "Save": "儲存",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "在接下來的{durationInMonths}個帳單週期中，每期可折抵{amountOff}。之後為每{cadence} {currency}{originalPrice}。",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "下期帳單可折抵{amountOff}。之後為每{cadence} {currency}{originalPrice}。",
-    "Send an email and say hi!": "寄封電子郵件打招呼！",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "寄信到 {senderEmail} 打聲招呼。這也可讓您的郵件服務供應商辨識此寄件地址為可信任來源。",
     "Send the link below to share it with whoever you'd like.": "發送下方連結，即可與任何人分享。",
     "Sending login link...": "正在發送登入連結...",
     "Sending...": "發送中...",

--- a/ghost/i18n/locales/zh/portal.json
+++ b/ghost/i18n/locales/zh/portal.json
@@ -191,8 +191,6 @@
     "Save": "保存",
     "Save {amountOff} on your next {durationInMonths} billing cycles. Then {currency}{originalPrice}/{cadence}.": "在接下来的{durationInMonths}个账单周期中，每期可折抵{amountOff}。之后为每{cadence} {currency}{originalPrice}。",
     "Save {amountOff} on your next billing cycle. Then {currency}{originalPrice}/{cadence}.": "下期账单周期可折抵{amountOff}。之后为每{cadence} {currency}{originalPrice}。",
-    "Send an email and say hi!": "发送邮件问好！",
-    "Send an email to {senderEmail} and say hello. This can also help signal to your mail provider that emails to and from this address should be trusted.": "发送邮件到{senderEmail}问好。这有助于您的邮件服务商将该地址的往来邮件判定为可信邮件。",
     "Send the link below to share it with whoever you'd like.": "发送下方链接，即可分享给您想分享的任何人。",
     "Sending login link...": "正在发送登录链接...",
     "Sending...": "发送中...",


### PR DESCRIPTION
ref [ONC-1864](https://linear.app/ghost/issue/ONC-1864/incorrect-email-displayed-in-need-help-portion-of-portal)

This part of the FAQ is confusing for members, who are being directed to email the newsletter address. This address is often a no-reply, or inaccessible by the site owner. The impact of sending the email is still useful (it sends a signal to the recipient's ESP that they do want to receive emails from that address), but it's a hack.
