### PR TITLE
Added source export condition so ghost/core reads Koenig packages build-free

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,30 @@ release archive installs them from npm. They are published to npm for
 external consumers only, automatically as part of the Ghost release lane
 (see `publish_koenig_packages` in ci.yml).
 
+**Zero-build dev via the `source` export condition.** The `kg-*` libraries
+consumed by `ghost/core` (and `ghost/parse-email-address`) declare a `source`
+condition in their `package.json` `exports` that points at the raw
+`src/*.ts`, listed *before* `types`/`import`/`require`:
+
+```jsonc
+".": {
+  "source": "./src/index.ts",     // dev/test: read raw TS
+  "types": "./build/esm/index.d.ts",
+  "import": "./build/esm/index.js",
+  "require": "./build/cjs/index.js" // prod/published: compiled JS
+}
+```
+
+`ghost/core`'s dev runner (`nodemon.json`: `node --conditions=source --import=tsx`)
+and its Vitest configs (`resolve.conditions: ['source', 'node']` +
+`--import tsx --conditions=source`) activate this condition, so a source change
+in a `kg-*` package is picked up with **no `tsc` rebuild**. Production and the
+published npm tarball run plain `node`, which ignores `source` and uses
+`build/` — and `src/` is excluded from each package's `files` array, so it is
+never shipped. When adding a new backend-consumed TS workspace package, copy
+this `exports` shape (see `ghost/parse-email-address`) so it works build-free
+in dev from day one; keep the `^build` graph for `tsc`/type-checking and prod.
+
 ### e2e/ - End-to-end tests
 - Playwright-based E2E tests with Docker container isolation
 - See `e2e/CLAUDE.md` for detailed testing guidance

--- a/koenig/kg-card-factory/package.json
+++ b/koenig/kg-card-factory/package.json
@@ -9,6 +9,7 @@
   "types": "build/esm/index.d.ts",
   "exports": {
     ".": {
+      "source": "./src/index.ts",
       "types": "./build/esm/index.d.ts",
       "import": "./build/esm/index.js",
       "require": "./build/cjs/index.js"

--- a/koenig/kg-clean-basic-html/package.json
+++ b/koenig/kg-clean-basic-html/package.json
@@ -9,6 +9,7 @@
   "types": "build/esm/index.d.ts",
   "exports": {
     ".": {
+      "source": "./src/index.ts",
       "types": "./build/esm/index.d.ts",
       "import": "./build/esm/index.js",
       "require": "./build/cjs/index.js"

--- a/koenig/kg-converters/package.json
+++ b/koenig/kg-converters/package.json
@@ -9,6 +9,7 @@
   "types": "build/esm/index.d.ts",
   "exports": {
     ".": {
+      "source": "./src/index.ts",
       "types": "./build/esm/index.d.ts",
       "import": "./build/esm/index.js",
       "require": "./build/cjs/index.js"

--- a/koenig/kg-default-cards/package.json
+++ b/koenig/kg-default-cards/package.json
@@ -9,6 +9,7 @@
   "types": "build/esm/index.d.ts",
   "exports": {
     ".": {
+      "source": "./src/index.ts",
       "types": "./build/esm/index.d.ts",
       "import": "./build/esm/index.js",
       "require": "./build/cjs/index.js"

--- a/koenig/kg-default-nodes/package.json
+++ b/koenig/kg-default-nodes/package.json
@@ -12,11 +12,13 @@
   "types": "build/esm/index.d.ts",
   "exports": {
     ".": {
+      "source": "./src/index.ts",
       "types": "./build/esm/index.d.ts",
       "import": "./build/esm/index.js",
       "require": "./build/cjs/index.js"
     },
     "./visibility": {
+      "source": "./src/visibility.ts",
       "types": "./build/esm/visibility.d.ts",
       "import": "./build/esm/visibility.js",
       "require": "./build/cjs/visibility.js"

--- a/koenig/kg-default-transforms/package.json
+++ b/koenig/kg-default-transforms/package.json
@@ -9,6 +9,7 @@
   "types": "build/esm/index.d.ts",
   "exports": {
     ".": {
+      "source": "./src/index.ts",
       "types": "./build/esm/index.d.ts",
       "import": "./build/esm/index.js",
       "require": "./build/cjs/index.js"

--- a/koenig/kg-html-to-lexical/package.json
+++ b/koenig/kg-html-to-lexical/package.json
@@ -9,6 +9,7 @@
   "types": "build/esm/index.d.ts",
   "exports": {
     ".": {
+      "source": "./src/index.ts",
       "types": "./build/esm/index.d.ts",
       "import": "./build/esm/index.js",
       "require": "./build/cjs/index.js"

--- a/koenig/kg-lexical-html-renderer/package.json
+++ b/koenig/kg-lexical-html-renderer/package.json
@@ -9,6 +9,7 @@
   "types": "build/esm/index.d.ts",
   "exports": {
     ".": {
+      "source": "./src/index.ts",
       "types": "./build/esm/index.d.ts",
       "import": "./build/esm/index.js",
       "require": "./build/cjs/index.js"

--- a/koenig/kg-markdown-html-renderer/package.json
+++ b/koenig/kg-markdown-html-renderer/package.json
@@ -9,6 +9,7 @@
   "types": "build/esm/index.d.ts",
   "exports": {
     ".": {
+      "source": "./src/index.ts",
       "types": "./build/esm/index.d.ts",
       "import": "./build/esm/index.js",
       "require": "./build/cjs/index.js"

--- a/koenig/kg-utils/package.json
+++ b/koenig/kg-utils/package.json
@@ -9,6 +9,7 @@
   "types": "build/esm/index.d.ts",
   "exports": {
     ".": {
+      "source": "./src/index.ts",
       "types": "./build/esm/index.d.ts",
       "import": "./build/esm/index.js",
       "require": "./build/cjs/index.js"

--- a/package.json
+++ b/package.json
@@ -115,22 +115,7 @@
           "command": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} up -d --force-recreate --wait --quiet-pull"
         },
         "dependsOn": [
-          "docker:build",
-          {
-            "target": "build",
-            "projects": [
-              "@tryghost/kg-card-factory",
-              "@tryghost/kg-clean-basic-html",
-              "@tryghost/kg-converters",
-              "@tryghost/kg-default-cards",
-              "@tryghost/kg-default-nodes",
-              "@tryghost/kg-default-transforms",
-              "@tryghost/kg-html-to-lexical",
-              "@tryghost/kg-lexical-html-renderer",
-              "@tryghost/kg-markdown-html-renderer",
-              "@tryghost/kg-utils"
-            ]
-          }
+          "docker:build"
         ]
       },
       "docker:down": {


### PR DESCRIPTION
Cross-workspace requires forced a `tsc` build of every `kg-*` package before `ghost/core` could `require` them — a source change in a Koenig package wasn't visible in dev until you rebuilt it. This wires up the same build-free dev pattern already used by `ghost/parse-email-address`.

## What changed

- Adds a `"source"` exports condition pointing at `./src/*.ts` to the **10 `kg-*` packages** in `ghost/core`'s runtime closure, ahead of `types`/`import`/`require`:

  ```jsonc
  ".": {
    "source": "./src/index.ts",     // dev/test: raw TS
    "types": "./build/esm/index.d.ts",
    "import": "./build/esm/index.js",
    "require": "./build/cjs/index.js" // prod/published: compiled JS
  }
  ```
- Drops the now-redundant hardcoded `kg-*` build list from the `docker:up` nx target in the root `package.json`, so `pnpm dev` boots without building Koenig.
- Documents the convention in `AGENTS.md`.

## Why it's safe

- `ghost/core` already runs its dev + test lanes with `--conditions=source --import=tsx` (`nodemon.json` + `vitest.config.ts`/`vitest.config.db.ts`), so it now resolves these packages to raw TS with **no build step**.
- Plain `node` in prod/CI and the published npm tarball ignore the `source` condition and use `build/`; `src/` stays out of each package's `files` array, so published output is unchanged.
- The `^build` nx graph is untouched (still needed for `tsc` type-checking and non-source-condition deps) — Koenig builds just become cache-hit no-ops for tests and are skipped for `pnpm dev`.

## Verification

- All 8 direct + 2 transitive `kg-*` deps resolve to `src/*.ts` under the dev flags; the full lexical→HTML render chain executes correctly **with every `build/` dir deleted**.
- Plain `node` (no flags) correctly falls back to `build/` — the two lanes are cleanly separated.
- Booted `pnpm dev`: Ghost serves HTTP 200 and the running container resolves `@tryghost/kg-default-nodes` to `koenig/kg-default-nodes/src/index.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)