### PR TITLE
Fixed Koenig npm publish failing provenance repository verification

### DIFF
--- a/koenig/kg-card-factory/package.json
+++ b/koenig/kg-card-factory/package.json
@@ -1,7 +1,11 @@
 {
   "name": "@tryghost/kg-card-factory",
   "version": "5.2.3",
-  "repository": "https://github.com/TryGhost/Koenig/tree/main/packages/kg-card-factory",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TryGhost/Ghost.git",
+    "directory": "koenig/kg-card-factory"
+  },
   "author": "Ghost Foundation",
   "license": "MIT",
   "main": "build/cjs/index.js",

--- a/koenig/kg-clean-basic-html/package.json
+++ b/koenig/kg-clean-basic-html/package.json
@@ -1,7 +1,11 @@
 {
   "name": "@tryghost/kg-clean-basic-html",
   "version": "4.3.3",
-  "repository": "https://github.com/TryGhost/Koenig/tree/main/packages/kg-clean-basic-html",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TryGhost/Ghost.git",
+    "directory": "koenig/kg-clean-basic-html"
+  },
   "author": "Ghost Foundation",
   "license": "MIT",
   "main": "build/cjs/index.js",

--- a/koenig/kg-converters/package.json
+++ b/koenig/kg-converters/package.json
@@ -1,7 +1,11 @@
 {
   "name": "@tryghost/kg-converters",
   "version": "1.2.3",
-  "repository": "https://github.com/TryGhost/Koenig/tree/main/packages/kg-converters",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TryGhost/Ghost.git",
+    "directory": "koenig/kg-converters"
+  },
   "author": "Ghost Foundation",
   "license": "MIT",
   "main": "build/cjs/index.js",

--- a/koenig/kg-default-cards/package.json
+++ b/koenig/kg-default-cards/package.json
@@ -1,7 +1,11 @@
 {
   "name": "@tryghost/kg-default-cards",
   "version": "10.3.3",
-  "repository": "https://github.com/TryGhost/Koenig/tree/main/packages/kg-default-cards",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TryGhost/Ghost.git",
+    "directory": "koenig/kg-default-cards"
+  },
   "author": "Ghost Foundation",
   "license": "MIT",
   "main": "build/cjs/index.js",

--- a/koenig/kg-default-nodes/package.json
+++ b/koenig/kg-default-nodes/package.json
@@ -1,7 +1,11 @@
 {
   "name": "@tryghost/kg-default-nodes",
   "version": "2.1.3",
-  "repository": "https://github.com/TryGhost/Koenig/tree/main/packages/kg-default-nodes",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TryGhost/Ghost.git",
+    "directory": "koenig/kg-default-nodes"
+  },
   "author": "Ghost Foundation",
   "license": "MIT",
   "engines": {

--- a/koenig/kg-default-transforms/package.json
+++ b/koenig/kg-default-transforms/package.json
@@ -1,7 +1,11 @@
 {
   "name": "@tryghost/kg-default-transforms",
   "version": "1.3.3",
-  "repository": "https://github.com/TryGhost/Koenig/tree/main/packages/kg-default-transforms",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TryGhost/Ghost.git",
+    "directory": "koenig/kg-default-transforms"
+  },
   "author": "Ghost Foundation",
   "license": "MIT",
   "main": "build/cjs/index.js",

--- a/koenig/kg-html-to-lexical/package.json
+++ b/koenig/kg-html-to-lexical/package.json
@@ -1,7 +1,11 @@
 {
   "name": "@tryghost/kg-html-to-lexical",
   "version": "1.3.3",
-  "repository": "https://github.com/TryGhost/Koenig/tree/main/packages/kg-html-to-lexical",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TryGhost/Ghost.git",
+    "directory": "koenig/kg-html-to-lexical"
+  },
   "author": "Ghost Foundation",
   "license": "MIT",
   "main": "build/cjs/index.js",

--- a/koenig/kg-lexical-html-renderer/package.json
+++ b/koenig/kg-lexical-html-renderer/package.json
@@ -1,7 +1,11 @@
 {
   "name": "@tryghost/kg-lexical-html-renderer",
   "version": "1.4.3",
-  "repository": "https://github.com/TryGhost/Koenig/tree/main/packages/kg-lexical-html-renderer",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TryGhost/Ghost.git",
+    "directory": "koenig/kg-lexical-html-renderer"
+  },
   "author": "Ghost Foundation",
   "license": "MIT",
   "main": "build/cjs/index.js",

--- a/koenig/kg-markdown-html-renderer/package.json
+++ b/koenig/kg-markdown-html-renderer/package.json
@@ -1,7 +1,11 @@
 {
   "name": "@tryghost/kg-markdown-html-renderer",
   "version": "7.2.3",
-  "repository": "https://github.com/TryGhost/Koenig/tree/main/packages/kg-markdown-html-renderer",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TryGhost/Ghost.git",
+    "directory": "koenig/kg-markdown-html-renderer"
+  },
   "author": "Ghost Foundation",
   "license": "MIT",
   "main": "build/cjs/index.js",

--- a/koenig/kg-simplemde/package.json
+++ b/koenig/kg-simplemde/package.json
@@ -9,7 +9,7 @@
     "javascript",
     "wysiwyg"
   ],
-  "homepage": "https://github.com/TryGhost/Koenig/tree/main/packages/kg-simplemde",
+  "homepage": "https://github.com/TryGhost/Ghost/tree/main/koenig/kg-simplemde",
   "main": "./src/js/simplemde.js",
   "license": "MIT",
   "company": "Next Step Webs, Inc.",
@@ -18,7 +18,7 @@
     "url": "http://www.WesCossick.com"
   },
   "bugs": {
-    "url": "https://github.com/TryGhost/Koenig/issues"
+    "url": "https://github.com/TryGhost/Ghost/issues"
   },
   "publishConfig": {
     "access": "public"
@@ -39,7 +39,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/TryGhost/Koenig.git"
+    "url": "git+https://github.com/TryGhost/Ghost.git",
+    "directory": "koenig/kg-simplemde"
   },
   "dependencies": {
     "codemirror": "5.65.21",

--- a/koenig/kg-unsplash-selector/package.json
+++ b/koenig/kg-unsplash-selector/package.json
@@ -4,7 +4,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/TryGhost/Koenig/tree/master/packages/kg-unsplash-selector"
+    "url": "git+https://github.com/TryGhost/Ghost.git",
+    "directory": "koenig/kg-unsplash-selector"
   },
   "author": "Ghost Foundation",
   "files": [

--- a/koenig/kg-utils/package.json
+++ b/koenig/kg-utils/package.json
@@ -1,7 +1,11 @@
 {
   "name": "@tryghost/kg-utils",
   "version": "1.1.3",
-  "repository": "https://github.com/TryGhost/Koenig/tree/main/packages/kg-utils",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TryGhost/Ghost.git",
+    "directory": "koenig/kg-utils"
+  },
   "author": "Ghost Foundation",
   "license": "MIT",
   "main": "build/cjs/index.js",

--- a/koenig/koenig-lexical/package.json
+++ b/koenig/koenig-lexical/package.json
@@ -1,7 +1,11 @@
 {
   "name": "@tryghost/koenig-lexical",
   "version": "1.8.3",
-  "repository": "https://github.com/TryGhost/Koenig/tree/master/packages/koenig-lexical",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TryGhost/Ghost.git",
+    "directory": "koenig/koenig-lexical"
+  },
   "author": "Ghost Foundation",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/actions/runs/29023545026/job/86139566830

The `publish_koenig_packages` release job failed on the last release: npm rejected the very first package with a 422 because sigstore provenance verification compares each package's `repository.url` against the repository the workflow actually ran in. All the `koenig/*` packages still declared `https://github.com/TryGhost/Koenig/...` from before the monorepo merge, but the provenance bundle attests they were built from `TryGhost/Ghost`, so every publish attempt is doomed until the fields match. No packages were published by the failed run.

- Updated every `koenig/*` package to the standard monorepo form: `repository.url` pointing at `TryGhost/Ghost` with the package path in `repository.directory`
- Fixed `kg-simplemde`'s stale `homepage` and `bugs` URLs that also still pointed at the old repo

Verified with `hosted-git-info` (the library npm uses for this check) that the new URLs normalise to `TryGhost/Ghost` while the old ones normalise to `TryGhost/Koenig` — exactly the reported mismatch. The registry-side check can't be exercised by a dry run (npm skips provenance generation entirely with `--dry-run`), but the fix can be proven end-to-end by dispatching the `publish-koenig-package.yml` escape-hatch workflow for a single small package.