### PR TITLE
Added dependent republishing when a Koenig package moves version line

### DIFF
--- a/.github/scripts/publish-koenig-packages.js
+++ b/.github/scripts/publish-koenig-packages.js
@@ -13,7 +13,12 @@
  * For each koenig/* package:
  *   1. Skip if its directory is unchanged between the previous release tag
  *      and the current one (first release after the monorepo merge has no
- *      koenig/ in the previous tag, so everything publishes once).
+ *      koenig/ in the previous tag, so everything publishes once). An
+ *      unchanged package still publishes when a runtime dependency's
+ *      major.minor line moved: its published `~x.y.z` ranges can't reach the
+ *      new line, so it gets a patch bump with freshly rewritten ranges.
+ *      Patch-level dependency changes don't republish dependents — tilde
+ *      ranges already resolve to the newest patch.
  *   2. Compute the next version: package.json pins the major.minor line,
  *      npm is the source of truth for the patch (compute-next-app-version).
  *   3. Write the version, build via Nx, and publish. Packages are processed
@@ -32,6 +37,8 @@ const fs = require('node:fs');
 const path = require('node:path');
 const {execFileSync} = require('node:child_process');
 
+const semver = require('semver');
+
 const {computeNextVersion, getPublishedVersions} = require('./compute-next-app-version');
 
 const ROOT_DIR = path.resolve(__dirname, '../..');
@@ -49,6 +56,56 @@ function loadPackages() {
             return {dir, name: pkg.name, private: !!pkg.private, pkg};
         })
         .filter(entry => !entry.private);
+}
+
+function versionLine(version) {
+    const parsed = semver.parse(version);
+    if (!parsed) {
+        throw new Error(`Invalid version "${version}"`);
+    }
+    return `${parsed.major}.${parsed.minor}`;
+}
+
+/**
+ * Decide which packages to publish and why.
+ *
+ * A package publishes when its own directory changed, or when a runtime
+ * dependency (dependencies/peerDependencies — devDependencies never reach
+ * consumers) moved to a new major.minor line. Only direct dependents need
+ * this: they republish as a patch bump within their own line, so the tilde
+ * ranges in packages further up the graph still resolve to the fresh patch.
+ *
+ * @param {Array<{name: string, changed: boolean, previousVersion: string|null, pkg: object}>} entries
+ *   `previousVersion` is the package.json version at the previous release tag,
+ *   or null when the package didn't exist there.
+ * @returns {Map<string, string>} package name -> human-readable publish reason
+ */
+function selectPackagesToPublish(entries) {
+    const reasons = new Map();
+    const movedLines = new Map();
+
+    for (const entry of entries) {
+        if (!entry.changed) {
+            continue;
+        }
+        reasons.set(entry.name, 'directory changed');
+        if (entry.previousVersion && versionLine(entry.previousVersion) !== versionLine(entry.pkg.version)) {
+            movedLines.set(entry.name, versionLine(entry.pkg.version));
+        }
+    }
+
+    for (const entry of entries) {
+        if (reasons.has(entry.name)) {
+            continue;
+        }
+        const runtimeDeps = {...entry.pkg.dependencies, ...entry.pkg.peerDependencies};
+        const moved = Object.keys(runtimeDeps).filter(dep => movedLines.has(dep));
+        if (moved.length > 0) {
+            reasons.set(entry.name, moved.map(dep => `${dep} moved to ${movedLines.get(dep)}`).join(', '));
+        }
+    }
+
+    return reasons;
 }
 
 // Order packages so dependencies publish before dependents. workspace:~ specs
@@ -110,22 +167,34 @@ function main() {
             throw new Error(`Unknown koenig package: ${onlyPackage}`);
         }
     }
+    let reasons = null;
+    if (previousTag) {
+        reasons = selectPackagesToPublish(packages.map((entry) => {
+            const diff = run('git', ['diff', '--name-only', previousTag, currentTag, '--', `koenig/${entry.dir}`]).trim();
+            let previousVersion = null;
+            try {
+                previousVersion = JSON.parse(run('git', ['show', `${previousTag}:koenig/${entry.dir}/package.json`], {stdio: ['pipe', 'pipe', 'pipe']})).version;
+            } catch (error) {
+                // Package didn't exist at the previous tag
+            }
+            return {name: entry.name, changed: diff.length > 0, previousVersion, pkg: entry.pkg};
+        }));
+    }
+
     const published = [];
     const skipped = [];
 
     for (const entry of packages) {
         const pkgDir = path.join(KOENIG_DIR, entry.dir);
 
-        if (previousTag) {
-            const diff = run('git', ['diff', '--name-only', previousTag, currentTag, '--', `koenig/${entry.dir}`]).trim();
-            if (!diff) {
-                skipped.push(entry.name);
-                continue;
-            }
+        if (reasons && !reasons.has(entry.name)) {
+            skipped.push(entry.name);
+            continue;
         }
 
         const nextVersion = computeNextVersion(entry.pkg.version, getPublishedVersions(entry.name));
-        console.log(`\nPublishing ${entry.name}@${nextVersion}${dryRun ? ' (dry run)' : ''}`);
+        const reason = reasons ? reasons.get(entry.name) : null;
+        console.log(`\nPublishing ${entry.name}@${nextVersion}${reason ? ` (${reason})` : ''}${dryRun ? ' (dry run)' : ''}`);
 
         // Write the version before building so anything baked into the build
         // output matches what we publish. Not committed back — npm is the
@@ -150,9 +219,13 @@ function main() {
     console.log(`Unchanged since ${previousTag || 'n/a'} (${skipped.length}): ${skipped.join(', ') || 'none'}`);
 }
 
-try {
-    main();
-} catch (error) {
-    console.error(error.message);
-    process.exit(1);
+if (require.main === module) {
+    try {
+        main();
+    } catch (error) {
+        console.error(error.message);
+        process.exit(1);
+    }
 }
+
+module.exports = {selectPackagesToPublish};

--- a/scripts/test/publish-koenig-packages.test.js
+++ b/scripts/test/publish-koenig-packages.test.js
@@ -1,0 +1,155 @@
+const {describe, it} = require('node:test');
+const assert = require('node:assert');
+
+const {selectPackagesToPublish} = require('../../.github/scripts/publish-koenig-packages');
+
+/**
+ * Build a selector entry. `changed` marks the package's directory as modified
+ * since the previous release tag; `previousVersion` is the version at that
+ * tag (null when the package didn't exist yet).
+ */
+function entry({name, version, previousVersion, changed, dependencies, devDependencies, peerDependencies}) {
+    return {
+        name,
+        changed: !!changed,
+        previousVersion: previousVersion === undefined ? version : previousVersion,
+        pkg: {name, version, dependencies, devDependencies, peerDependencies}
+    };
+}
+
+describe('selectPackagesToPublish', function () {
+    it('selects changed packages and skips unchanged ones', function () {
+        const selected = selectPackagesToPublish([
+            entry({name: '@tryghost/kg-utils', version: '1.1.4', previousVersion: '1.1.3', changed: true}),
+            entry({name: '@tryghost/kg-converters', version: '1.0.3', changed: false})
+        ]);
+
+        assert.ok(selected.has('@tryghost/kg-utils'));
+        assert.ok(!selected.has('@tryghost/kg-converters'));
+    });
+
+    it('does not republish dependents for a patch-line change', function () {
+        const selected = selectPackagesToPublish([
+            entry({name: '@tryghost/kg-utils', version: '1.1.4', previousVersion: '1.1.3', changed: true}),
+            entry({
+                name: '@tryghost/kg-default-nodes',
+                version: '2.1.3',
+                changed: false,
+                dependencies: {'@tryghost/kg-utils': 'workspace:~'}
+            })
+        ]);
+
+        assert.ok(!selected.has('@tryghost/kg-default-nodes'));
+    });
+
+    it('republishes direct runtime dependents when a dependency moves to a new minor line', function () {
+        const selected = selectPackagesToPublish([
+            entry({name: '@tryghost/kg-utils', version: '1.2.0', previousVersion: '1.1.3', changed: true}),
+            entry({
+                name: '@tryghost/kg-default-nodes',
+                version: '2.1.3',
+                changed: false,
+                dependencies: {'@tryghost/kg-utils': 'workspace:~'}
+            })
+        ]);
+
+        assert.ok(selected.has('@tryghost/kg-default-nodes'));
+        assert.match(selected.get('@tryghost/kg-default-nodes'), /@tryghost\/kg-utils/);
+        assert.match(selected.get('@tryghost/kg-default-nodes'), /1\.2/);
+    });
+
+    it('republishes direct runtime dependents when a dependency moves to a new major line', function () {
+        const selected = selectPackagesToPublish([
+            entry({name: '@tryghost/kg-utils', version: '2.0.0', previousVersion: '1.1.3', changed: true}),
+            entry({
+                name: '@tryghost/kg-default-nodes',
+                version: '2.1.3',
+                changed: false,
+                dependencies: {'@tryghost/kg-utils': 'workspace:~'}
+            })
+        ]);
+
+        assert.ok(selected.has('@tryghost/kg-default-nodes'));
+    });
+
+    it('includes peerDependencies edges when a line moves', function () {
+        const selected = selectPackagesToPublish([
+            entry({name: '@tryghost/kg-utils', version: '1.2.0', previousVersion: '1.1.3', changed: true}),
+            entry({
+                name: '@tryghost/koenig-lexical',
+                version: '3.0.5',
+                changed: false,
+                peerDependencies: {'@tryghost/kg-utils': 'workspace:~'}
+            })
+        ]);
+
+        assert.ok(selected.has('@tryghost/koenig-lexical'));
+    });
+
+    it('ignores devDependencies edges — consumers never install them', function () {
+        const selected = selectPackagesToPublish([
+            entry({name: '@tryghost/kg-utils', version: '1.2.0', previousVersion: '1.1.3', changed: true}),
+            entry({
+                name: '@tryghost/kg-converters',
+                version: '1.0.3',
+                changed: false,
+                devDependencies: {'@tryghost/kg-utils': 'workspace:~'}
+            })
+        ]);
+
+        assert.ok(!selected.has('@tryghost/kg-converters'));
+    });
+
+    it('does not cascade to transitive dependents — tilde ranges reach the fresh patch', function () {
+        // A moves line; B depends on A and republishes as a patch bump within
+        // its own line; C's published ~B range already reaches that patch.
+        const selected = selectPackagesToPublish([
+            entry({name: '@tryghost/kg-utils', version: '1.2.0', previousVersion: '1.1.3', changed: true}),
+            entry({
+                name: '@tryghost/kg-default-nodes',
+                version: '2.1.3',
+                changed: false,
+                dependencies: {'@tryghost/kg-utils': 'workspace:~'}
+            }),
+            entry({
+                name: '@tryghost/kg-lexical-html-renderer',
+                version: '1.4.3',
+                changed: false,
+                dependencies: {'@tryghost/kg-default-nodes': 'workspace:~'}
+            })
+        ]);
+
+        assert.ok(selected.has('@tryghost/kg-default-nodes'));
+        assert.ok(!selected.has('@tryghost/kg-lexical-html-renderer'));
+    });
+
+    it('treats a new package as changed without triggering dependents', function () {
+        const selected = selectPackagesToPublish([
+            entry({name: '@tryghost/kg-new-thing', version: '0.1.0', previousVersion: null, changed: true}),
+            entry({
+                name: '@tryghost/kg-default-nodes',
+                version: '2.1.3',
+                changed: false,
+                dependencies: {'@tryghost/kg-new-thing': 'workspace:~'}
+            })
+        ]);
+
+        assert.ok(selected.has('@tryghost/kg-new-thing'));
+        assert.ok(!selected.has('@tryghost/kg-default-nodes'));
+    });
+
+    it('keeps the changed reason when a package is both changed and a dependent', function () {
+        const selected = selectPackagesToPublish([
+            entry({name: '@tryghost/kg-utils', version: '1.2.0', previousVersion: '1.1.3', changed: true}),
+            entry({
+                name: '@tryghost/kg-default-nodes',
+                version: '2.1.4',
+                previousVersion: '2.1.3',
+                changed: true,
+                dependencies: {'@tryghost/kg-utils': 'workspace:~'}
+            })
+        ]);
+
+        assert.strictEqual(selected.get('@tryghost/kg-default-nodes'), 'directory changed');
+    });
+});


### PR DESCRIPTION
no ref

The `koenig/*` packages publish with `workspace:~` specs rewritten to `~x.y.z` ranges, so patch-level dependency changes reach external consumers automatically — npm resolves the tilde range to the newest patch without any republish. But when a dependency moves to a new **major.minor line** (a deliberate package.json edit), the already-published dependents' tilde ranges can't reach the new line: external consumers stay frozen on the old line until the dependent happens to change for its own reasons. Since these are small, focused packages, a dependency growing a feature very often doesn't touch its dependents' code at all.

The old TryGhost/Koenig repo didn't have this problem — lerna's change detection was transitive, bumping and republishing dependents whenever a dependency changed. The per-directory `git diff` change detection introduced with the monorepo merge silently lost that property.

Now, an unchanged package also publishes when a runtime dependency's (`dependencies`/`peerDependencies` — devDependencies never reach consumers) major.minor line moved since the previous release tag. Only **direct** dependents need this: they republish as a patch bump within their own line, so tilde ranges in packages further up the graph still resolve to the fresh patch — patch-only changes keep flowing with zero republish churn.

The publish-set decision is extracted into a pure `selectPackagesToPublish()` covered by `scripts/test/publish-koenig-packages.test.js` (runs via `pnpm test:release`), and CI logs now state why each package is being published.