### PR TITLE
Changed `providers` array to single `provider` argument in `EmailAnalyticsService`

### DIFF
--- a/ghost/core/core/server/services/email-analytics/email-analytics-service-wrapper.js
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-service-wrapper.js
@@ -51,9 +51,7 @@ class EmailAnalyticsServiceWrapper {
             config,
             settings,
             eventProcessor,
-            providers: [
-                new MailgunProvider({config, settings, labs})
-            ],
+            provider: new MailgunProvider({config, settings, labs}),
             queries,
             domainEvents,
             prometheusClient

--- a/ghost/core/core/server/services/email-analytics/email-analytics-service.js
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-service.js
@@ -59,7 +59,7 @@ module.exports = class EmailAnalyticsService {
     settings;
     queries;
     eventProcessor;
-    providers;
+    provider;
 
     /**
      * @type {FetchData}
@@ -99,16 +99,16 @@ module.exports = class EmailAnalyticsService {
      * @param {object} dependencies.settings
      * @param {object} dependencies.queries
      * @param {EmailEventProcessor} dependencies.eventProcessor
-     * @param {object} dependencies.providers
+     * @param {object} dependencies.provider
      * @param {import('@tryghost/domain-events')} dependencies.domainEvents
      * @param {import('@tryghost/prometheus-metrics')} dependencies.prometheusClient
      */
-    constructor({config, settings, queries, eventProcessor, providers, domainEvents, prometheusClient}) {
+    constructor({config, settings, queries, eventProcessor, provider, domainEvents, prometheusClient}) {
         this.config = config;
         this.settings = settings;
         this.queries = queries;
         this.eventProcessor = eventProcessor;
-        this.providers = providers;
+        this.provider = provider;
         this.domainEvents = domainEvents;
         this.prometheusClient = prometheusClient;
 
@@ -451,9 +451,7 @@ module.exports = class EmailAnalyticsService {
         };
 
         try {
-            for (const provider of this.providers) {
-                await provider.fetchLatest(processBatch, {begin, end, maxEvents, events: eventTypes});
-            }
+            await this.provider.fetchLatest(processBatch, {begin, end, maxEvents, events: eventTypes});
         } catch (err) {
             if (err.message !== 'Fetching canceled') {
                 logging.error('[EmailAnalytics] Error while fetching');

--- a/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.js
+++ b/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.js
@@ -119,9 +119,9 @@ describe('EmailAnalyticsService', function () {
                         setJobTimestamp: sinon.stub().resolves(),
                         setJobStatus: sinon.stub().resolves()
                     },
-                    providers: [{
+                    provider: {
                         fetchLatest: fetchLatestSpy
-                    }]
+                    }
                 });
                 await service.fetchLatestOpenedEvents();
                 sinon.assert.calledOnce(fetchLatestSpy);
@@ -137,9 +137,9 @@ describe('EmailAnalyticsService', function () {
                         setJobTimestamp: sinon.stub().resolves(),
                         setJobStatus: sinon.stub().resolves()
                     },
-                    providers: [{
+                    provider: {
                         fetchLatest: fetchLatestSpy
-                    }]
+                    }
                 });
                 await service.fetchLatestOpenedEvents();
                 sinon.assert.notCalled(fetchLatestSpy);
@@ -156,9 +156,9 @@ describe('EmailAnalyticsService', function () {
                         setJobTimestamp: sinon.stub().resolves(),
                         setJobStatus: sinon.stub().resolves()
                     },
-                    providers: [{
+                    provider: {
                         fetchLatest: fetchLatestSpy
-                    }]
+                    }
                 });
                 await service.fetchLatestNonOpenedEvents();
                 sinon.assert.calledOnce(fetchLatestSpy);
@@ -174,9 +174,9 @@ describe('EmailAnalyticsService', function () {
                         setJobTimestamp: sinon.stub().resolves(),
                         setJobStatus: sinon.stub().resolves()
                     },
-                    providers: [{
+                    provider: {
                         fetchLatest: fetchLatestSpy
-                    }]
+                    }
                 });
                 await service.fetchLatestNonOpenedEvents();
                 sinon.assert.notCalled(fetchLatestSpy);
@@ -201,12 +201,12 @@ describe('EmailAnalyticsService', function () {
                         setJobStatus: setJobStatusStub,
                         setJobMetadata: setJobMetadataStub
                     },
-                    providers: [{
+                    provider: {
                         fetchLatest: (fn) => {
                             const events = [1,2,3,4,5,6,7,8,9,10];
                             fn(events);
                         }
-                    }]
+                    }
                 });
                 processEventBatchStub = sinon.stub(service, 'processEventBatch').resolves();
                 aggregateStatsStub = sinon.stub(service, 'aggregateStats').resolves({emailAggregationTimeMs: 0, memberAggregationTimeMs: 0});
@@ -265,11 +265,11 @@ describe('EmailAnalyticsService', function () {
                         setJobStatus: sinon.stub().resolves(),
                         setJobMetadata: sinon.stub().resolves()
                     },
-                    providers: [{
+                    provider: {
                         fetchLatest: (fn) => {
                             fn([]);
                         }
-                    }]
+                    }
                 });
 
                 await service.schedule({
@@ -294,11 +294,11 @@ describe('EmailAnalyticsService', function () {
                         setJobTimestamp: sinon.stub().resolves(),
                         setJobStatus: sinon.stub().resolves()
                     },
-                    providers: [{
+                    provider: {
                         fetchLatest: (fn) => {
                             fn([]);
                         }
-                    }]
+                    }
                 });
             });
 
@@ -499,9 +499,9 @@ describe('EmailAnalyticsService', function () {
                         setJobStatus: sinon.stub().resolves(),
                         getLastJobRunTimestamp: sinon.stub().resolves(new Date(Date.now() - 2.5 * 60 * 60 * 1000))
                     },
-                    providers: [{
+                    provider: {
                         fetchLatest: fetchLatestSpy
-                    }]
+                    }
                 });
                 await service.fetchMissing();
                 sinon.assert.calledOnce(fetchLatestSpy);


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1436

This simplification should have no user impact.

Before, `EmailAnalyticsService` took an array of Mailgun providers. But it was always called with exactly one.

Now, it takes a single provider argument.
