### PR TITLE
Incremented `email_sent_count` on automation action revisions when sending an automated email

### DIFF
--- a/ghost/core/core/server/services/automations/automations-api.ts
+++ b/ghost/core/core/server/services/automations/automations-api.ts
@@ -2,12 +2,15 @@ import errors from '@tryghost/errors';
 import tpl from '@tryghost/tpl';
 import ObjectId from 'bson-objectid';
 import {z} from 'zod';
+import {type Knex} from 'knex';
 import {createDatabaseAutomationsRepository} from './database-automations-repository';
 import {parseFakeWaitHoursMultiplier} from './fake-wait-hours-multiplier';
 import type {
     AutomationsRepository,
     EditAutomationData
 } from './automations-repository';
+// @ts-expect-error Models currently lack type definitions.
+import {AutomatedEmailRecipient} from '../../models';
 
 const {knex} = require('../../data/db');
 const domainEvents = require('@tryghost/domain-events');
@@ -358,4 +361,32 @@ export async function markStepTerminal(...args: Parameters<AutomationsRepository
 
 export async function retryStep(...args: Parameters<AutomationsRepository['retryStep']>) {
     return await repository.retryStep(...args);
+}
+
+export type RecordEmailSentOptions = Readonly<{
+    automationActionRevisionId: string;
+    memberEmail: string;
+    memberId: string;
+    memberName: string | null;
+    memberUuid: string;
+    trackOpens: boolean;
+}>;
+
+export async function recordEmailSent(options: RecordEmailSentOptions): Promise<void> {
+    await knex.transaction(async (transacting: Knex.Transaction) => {
+        await AutomatedEmailRecipient.add({
+            member_id: options.memberId,
+            member_uuid: options.memberUuid,
+            member_email: options.memberEmail,
+            member_name: options.memberName,
+            automation_action_revision_id: options.automationActionRevisionId,
+            track_opens: options.trackOpens
+        }, {transacting});
+
+        await transacting('automation_action_revisions')
+            .where('id', options.automationActionRevisionId)
+            .update({
+                email_sent_count: transacting.raw('COALESCE(??, 0) + ?', ['email_sent_count', 1])
+            });
+    });
 }

--- a/ghost/core/core/server/services/automations/poll.ts
+++ b/ghost/core/core/server/services/automations/poll.ts
@@ -1,10 +1,13 @@
 import type {AutomationStepToRun, AutomationsRepository} from './automations-repository';
 import logging from '@tryghost/logging';
 import errors from '@tryghost/errors';
+import {type Knex} from 'knex';
 import {MEMBER_WELCOME_EMAIL_ELIGIBLE_STATUSES, MEMBER_WELCOME_EMAIL_SLUGS} from '../member-welcome-emails/constants';
 import {MAX_ATTEMPTS, MAX_STEPS_PER_BATCH, RETRY_DELAY_MS} from './constants';
 // @ts-expect-error Models currently lack type definitions.
 import {AutomatedEmailRecipient, Member} from '../../models';
+
+const db = require('../../data/db');
 
 type MemberWelcomeEmailService = {
     init: () => unknown;
@@ -190,14 +193,22 @@ const processStep = async ({
                 memberStatus
             });
             try {
-                await AutomatedEmailRecipient.add({
-                    member_id: step.member_id,
-                    member_uuid: member.get('uuid'),
-                    member_email: member.get('email'),
-                    member_name: member.get('name'),
-                    automation_action_revision_id: step.automation_action_revision_id,
-                    // TODO(NY-1439) Don't always set this to false.
-                    track_opens: false
+                await db.knex.transaction(async (transacting: Knex.Transaction) => {
+                    await AutomatedEmailRecipient.add({
+                        member_id: step.member_id,
+                        member_uuid: member.get('uuid'),
+                        member_email: member.get('email'),
+                        member_name: member.get('name'),
+                        automation_action_revision_id: step.automation_action_revision_id,
+                        // TODO(NY-1439) Don't always set this to false.
+                        track_opens: false
+                    }, {transacting});
+
+                    await transacting('automation_action_revisions')
+                        .where('id', step.automation_action_revision_id)
+                        .update({
+                            email_sent_count: transacting.raw('COALESCE(??, 0) + ?', ['email_sent_count', 1])
+                        });
                 });
             } catch (err) {
                 logging.error({

--- a/ghost/core/core/server/services/automations/poll.ts
+++ b/ghost/core/core/server/services/automations/poll.ts
@@ -1,13 +1,11 @@
 import type {AutomationStepToRun, AutomationsRepository} from './automations-repository';
+import type {RecordEmailSentOptions} from './automations-api';
 import logging from '@tryghost/logging';
 import errors from '@tryghost/errors';
-import {type Knex} from 'knex';
 import {MEMBER_WELCOME_EMAIL_ELIGIBLE_STATUSES, MEMBER_WELCOME_EMAIL_SLUGS} from '../member-welcome-emails/constants';
 import {MAX_ATTEMPTS, MAX_STEPS_PER_BATCH, RETRY_DELAY_MS} from './constants';
 // @ts-expect-error Models currently lack type definitions.
-import {AutomatedEmailRecipient, Member} from '../../models';
-
-const db = require('../../data/db');
+import {Member} from '../../models';
 
 type MemberWelcomeEmailService = {
     init: () => unknown;
@@ -43,7 +41,9 @@ type PollOptions = {
         'finishStepAndEnqueueNext' |
         'markStepTerminal' |
         'retryStep'
-    >;
+    > & {
+        recordEmailSent(options: RecordEmailSentOptions): Promise<void>;
+    };
     enqueueAnotherPollAt: (date: Readonly<Date>) => unknown;
     memberWelcomeEmailService: MemberWelcomeEmailService;
 };
@@ -193,22 +193,14 @@ const processStep = async ({
                 memberStatus
             });
             try {
-                await db.knex.transaction(async (transacting: Knex.Transaction) => {
-                    await AutomatedEmailRecipient.add({
-                        member_id: step.member_id,
-                        member_uuid: member.get('uuid'),
-                        member_email: member.get('email'),
-                        member_name: member.get('name'),
-                        automation_action_revision_id: step.automation_action_revision_id,
-                        // TODO(NY-1439) Don't always set this to false.
-                        track_opens: false
-                    }, {transacting});
-
-                    await transacting('automation_action_revisions')
-                        .where('id', step.automation_action_revision_id)
-                        .update({
-                            email_sent_count: transacting.raw('COALESCE(??, 0) + ?', ['email_sent_count', 1])
-                        });
+                await automationsApi.recordEmailSent({
+                    automationActionRevisionId: step.automation_action_revision_id,
+                    memberEmail: member.get('email'),
+                    memberId: step.member_id,
+                    memberName: member.get('name'),
+                    memberUuid: member.get('uuid'),
+                    // TODO(NY-1439) Don't always set this to false.
+                    trackOpens: false
                 });
             } catch (err) {
                 logging.error({

--- a/ghost/core/test/e2e-api/members/automations.test.js
+++ b/ghost/core/test/e2e-api/members/automations.test.js
@@ -141,6 +141,34 @@ async function getEmailSentCounts(actions) {
     return actionIds.map(actionId => countsByActionId.get(actionId));
 }
 
+async function runAutomationForFreeMember(automation, email) {
+    const member = await membersService.api.members.create({
+        email,
+        name: 'Automation Test Member',
+        status: 'free',
+        email_disabled: false
+    });
+    assert.equal(member.get('status'), 'free');
+
+    await DomainEvents.allSettled();
+
+    const clock = mockSystemTime(new Date());
+
+    try {
+        for (const action of automation.actions) {
+            if (action.type === 'wait') {
+                clock.setSystemTime(new Date(Date.now() + action.data.wait_hours * HOUR_MS));
+            }
+
+            await runSchedulerPoll();
+        }
+
+        await runSchedulerPoll();
+    } finally {
+        clock.restore();
+    }
+}
+
 describe('Members Automations', function () {
     beforeAll(async function () {
         agent = await agentProvider.getAdminAPIAgent();
@@ -190,31 +218,7 @@ describe('Members Automations', function () {
         );
 
         const email = `automation-free-member-${Date.now()}@test.example`;
-        const member = await membersService.api.members.create({
-            email,
-            name: 'Automation Test Member',
-            status: 'free',
-            email_disabled: false
-        });
-        assert.equal(member.get('status'), 'free');
-
-        await DomainEvents.allSettled();
-
-        const clock = mockSystemTime(new Date());
-
-        try {
-            for (const action of automation.actions) {
-                if (action.type === 'wait') {
-                    clock.setSystemTime(new Date(Date.now() + action.data.wait_hours * HOUR_MS));
-                }
-
-                await runSchedulerPoll();
-            }
-
-            await runSchedulerPoll();
-        } finally {
-            clock.restore();
-        }
+        await runAutomationForFreeMember(automation, email);
 
         const sentEmails = getAutomationEmailSends();
         assert.equal(sentEmails.length, 2);
@@ -237,6 +241,11 @@ describe('Members Automations', function () {
             subject: 'Follow up'
         });
         assert.deepEqual(await getEmailSentCounts(sendEmailActions), [1, 1]);
+
+        const secondEmail = `automation-second-free-member-${Date.now()}@test.example`;
+        await runAutomationForFreeMember(automation, secondEmail);
+
+        assert.deepEqual(await getEmailSentCounts(sendEmailActions), [2, 2]);
     });
 
     it('does nothing when the automation is inactive', async function () {

--- a/ghost/core/test/e2e-api/members/automations.test.js
+++ b/ghost/core/test/e2e-api/members/automations.test.js
@@ -130,6 +130,17 @@ function getAutomationEmailSends() {
         .filter(emailToSend => emailToSend.tags?.includes('automation-email'));
 }
 
+async function getEmailSentCounts(actions) {
+    const actionIds = actions.map(action => action.id);
+    const rows = await db.knex('automation_action_revisions')
+        .select('action_id', 'email_sent_count')
+        .whereIn('action_id', actionIds);
+
+    const countsByActionId = new Map(rows.map(row => [row.action_id, row.email_sent_count]));
+
+    return actionIds.map(actionId => countsByActionId.get(actionId));
+}
+
 describe('Members Automations', function () {
     beforeAll(async function () {
         agent = await agentProvider.getAdminAPIAgent();
@@ -161,6 +172,7 @@ describe('Members Automations', function () {
 
         const sendEmailActions = automation.actions.filter(action => action.type === 'send_email');
         assert.equal(sendEmailActions.length, 2);
+        assert.deepEqual(await getEmailSentCounts(sendEmailActions), [null, null]);
 
         const emailDesignSettingId = sendEmailActions[0].data.email_design_setting_id;
         assert(emailDesignSettingId, 'Expected send email action to have an email design setting');
@@ -224,6 +236,7 @@ describe('Members Automations', function () {
             to: email,
             subject: 'Follow up'
         });
+        assert.deepEqual(await getEmailSentCounts(sendEmailActions), [1, 1]);
     });
 
     it('does nothing when the automation is inactive', async function () {

--- a/ghost/core/test/unit/server/services/automations/automations-api.test.js
+++ b/ghost/core/test/unit/server/services/automations/automations-api.test.js
@@ -1,7 +1,10 @@
 const assert = require('node:assert/strict');
 const ObjectId = require('bson-objectid').default;
+const sinon = require('sinon');
 
 const automationsApi = require('../../../../../core/server/services/automations/automations-api');
+const db = require('../../../../../core/server/data/db');
+const {AutomatedEmailRecipient} = require('../../../../../core/server/models');
 const {EMPTY_EMAIL_LEXICAL, NON_EMPTY_EMAIL_LEXICAL} = require('../../../../utils/automations-fixtures');
 
 const buildSendEmailAction = (dataOverrides = {}) => ({
@@ -16,6 +19,48 @@ const buildSendEmailAction = (dataOverrides = {}) => ({
 });
 
 describe('automations API', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('recordEmailSent', function () {
+        it('records the recipient and increments the action revision count in one transaction', async function () {
+            const emailSentCountExpression = Symbol('email_sent_count_expression');
+            const updateRevision = sinon.stub().resolves();
+            const whereRevision = sinon.stub().returns({update: updateRevision});
+            const transacting = sinon.stub().withArgs('automation_action_revisions').returns({where: whereRevision});
+            transacting.raw = sinon.stub().returns(emailSentCountExpression);
+            const transaction = sinon.stub(db.knex, 'transaction').callsFake(async (callback) => {
+                return await callback(transacting);
+            });
+            const addRecipient = sinon.stub(AutomatedEmailRecipient, 'add').resolves();
+
+            await automationsApi.recordEmailSent({
+                automationActionRevisionId: 'revision-id',
+                memberEmail: 'member@example.com',
+                memberId: 'member-id',
+                memberName: 'Test Member',
+                memberUuid: '00000000-0000-4000-8000-000000000001',
+                trackOpens: false
+            });
+
+            sinon.assert.calledOnce(transaction);
+            sinon.assert.calledOnceWithExactly(addRecipient, {
+                member_id: 'member-id',
+                member_uuid: '00000000-0000-4000-8000-000000000001',
+                member_email: 'member@example.com',
+                member_name: 'Test Member',
+                automation_action_revision_id: 'revision-id',
+                track_opens: false
+            }, {transacting});
+            sinon.assert.calledOnceWithExactly(whereRevision, 'id', 'revision-id');
+            sinon.assert.calledOnceWithExactly(transacting.raw, 'COALESCE(??, 0) + ?', ['email_sent_count', 1]);
+            sinon.assert.calledOnceWithExactly(updateRevision, {
+                email_sent_count: emailSentCountExpression
+            });
+        });
+    });
+
     describe('edit', function () {
         const automationId = ObjectId().toHexString();
 

--- a/ghost/core/test/unit/server/services/automations/poll.test.ts
+++ b/ghost/core/test/unit/server/services/automations/poll.test.ts
@@ -5,9 +5,7 @@ import {poll} from '../../../../../core/server/services/automations/poll';
 import type {AutomationStepToRun} from '../../../../../core/server/services/automations/automations-repository';
 import {MEMBER_WELCOME_EMAIL_SLUGS} from '../../../../../core/server/services/member-welcome-emails/constants';
 // @ts-expect-error Models currently lack type definitions.
-import {AutomatedEmailRecipient, Member} from '../../../../../core/server/models';
-
-const db = require('../../../../../core/server/data/db');
+import {Member} from '../../../../../core/server/models';
 
 const MAX_STEPS_PER_BATCH = 100;
 const RETRY_DELAY_MS = 10 * 60 * 1000;
@@ -42,10 +40,6 @@ type PollOptionsStubs = PollOptions & {
     automationsApi: AutomationsApiStubs;
     enqueueAnotherPollAt: StubbedFunction<PollOptions['enqueueAnotherPollAt']>;
     memberWelcomeEmailService: MemberWelcomeEmailServiceStubs;
-};
-type AutomatedEmailRecipientAdd = typeof AutomatedEmailRecipient.add;
-type TransactingStub = sinon.SinonStub<[string], unknown> & {
-    raw: sinon.SinonStub<[string, Array<string | number>], unknown>;
 };
 
 type MemberFixture = {
@@ -124,38 +118,17 @@ function buildEmailStep(attrs: Partial<SendEmailStep> = {}): SendEmailStep {
 
 describe('automations poll', function () {
     let automationsApi: AutomationsApiStubs;
-    let automatedEmailRecipientAdd: sinon.SinonStub<Parameters<AutomatedEmailRecipientAdd>, ReturnType<AutomatedEmailRecipientAdd>>;
-    let emailSentCountExpression: unknown;
     let memberWelcomeEmailService: MemberWelcomeEmailServiceStubs;
     let options: PollOptionsStubs;
-    let raw: sinon.SinonStub<[string, string[] | number[] | Array<string | number>], unknown>;
-    let transacting: TransactingStub;
-    let updateRevision: sinon.SinonStub<[{email_sent_count: unknown}], Promise<void>>;
-    let whereRevision: sinon.SinonStub<[string, string], unknown>;
 
     beforeEach(function () {
         sinon.useFakeTimers({now: new Date('2026-01-01T12:00:00.000Z'), shouldAdvanceTime: true});
-
-        emailSentCountExpression = Symbol('email_sent_count_expression');
-        raw = sinon.stub<[string, Array<string | number>], unknown>().returns(emailSentCountExpression);
-        updateRevision = sinon.stub<[{email_sent_count: unknown}], Promise<void>>().resolves();
-        whereRevision = sinon.stub<[string, string], unknown>().returns({
-            update: updateRevision
-        });
-        transacting = Object.assign(
-            sinon.stub<[string], unknown>().withArgs('automation_action_revisions').returns({
-                where: whereRevision
-            }),
-            {raw}
-        );
-        sinon.stub(db.knex, 'transaction').callsFake(async (callback: unknown) => {
-            return await (callback as (trx: typeof transacting) => Promise<unknown>)(transacting);
-        });
 
         automationsApi = {
             fetchAndLockSteps: fake<AutomationsApi['fetchAndLockSteps']>().resolves({steps: [], nextStepReadyAt: null}),
             finishStepAndEnqueueNext: fake<AutomationsApi['finishStepAndEnqueueNext']>().resolves(null),
             markStepTerminal: fake<AutomationsApi['markStepTerminal']>().resolves(true),
+            recordEmailSent: fake<AutomationsApi['recordEmailSent']>().resolves(),
             retryStep: fake<AutomationsApi['retryStep']>().resolves(true)
         };
 
@@ -174,7 +147,6 @@ describe('automations poll', function () {
         };
 
         sinon.stub(Member, 'findOne').resolves(buildMember());
-        automatedEmailRecipientAdd = sinon.stub(AutomatedEmailRecipient, 'add').resolves();
     });
 
     afterEach(function () {
@@ -290,7 +262,7 @@ describe('automations poll', function () {
 
         sinon.assert.notCalled(memberWelcomeEmailService.init);
         sinon.assert.notCalled(memberWelcomeEmailService.api.sendAutomationEmail);
-        sinon.assert.notCalled(automatedEmailRecipientAdd);
+        sinon.assert.notCalled(automationsApi.recordEmailSent);
         sinon.assert.notCalled(automationsApi.markStepTerminal);
         sinon.assert.calledOnceWithExactly(automationsApi.finishStepAndEnqueueNext, step);
         sinon.assert.calledOnceWithExactly(options.enqueueAnotherPollAt, nextReadyAt);
@@ -325,7 +297,7 @@ describe('automations poll', function () {
 
         sinon.assert.notCalled(memberWelcomeEmailService.init);
         sinon.assert.notCalled(memberWelcomeEmailService.api.sendAutomationEmail);
-        sinon.assert.notCalled(automatedEmailRecipientAdd);
+        sinon.assert.notCalled(automationsApi.recordEmailSent);
         sinon.assert.notCalled(automationsApi.markStepTerminal);
         sinon.assert.calledOnceWithExactly(automationsApi.finishStepAndEnqueueNext, step);
         sinon.assert.calledOnceWithExactly(options.enqueueAnotherPollAt, nextReadyAt);
@@ -374,25 +346,17 @@ describe('automations poll', function () {
 
         await poll(options);
 
-        sinon.assert.calledOnceWithExactly(automatedEmailRecipientAdd, {
-            member_id: step.member_id,
-            member_uuid: '00000000-0000-4000-8000-000000000001',
-            member_email: 'member@example.com',
-            member_name: 'Test Member',
-            automation_action_revision_id: 'revision-id',
-            track_opens: false
-        }, {
-            transacting
-        });
-        sinon.assert.calledOnceWithExactly(whereRevision, 'id', 'revision-id');
-        sinon.assert.calledOnceWithExactly(raw, 'COALESCE(??, 0) + ?', ['email_sent_count', 1]);
-        sinon.assert.calledOnceWithExactly(updateRevision, {
-            email_sent_count: emailSentCountExpression
+        sinon.assert.calledOnceWithExactly(automationsApi.recordEmailSent, {
+            automationActionRevisionId: 'revision-id',
+            memberEmail: 'member@example.com',
+            memberId: 'member-id',
+            memberName: 'Test Member',
+            memberUuid: '00000000-0000-4000-8000-000000000001',
+            trackOpens: false
         });
         sinon.assert.callOrder(
             memberWelcomeEmailService.api.sendAutomationEmail,
-            automatedEmailRecipientAdd,
-            updateRevision,
+            automationsApi.recordEmailSent,
             automationsApi.finishStepAndEnqueueNext
         );
     });
@@ -400,13 +364,12 @@ describe('automations poll', function () {
     it('does not retry the email send when recording the automated email recipient fails', async function () {
         const step = buildEmailStep();
         automationsApi.fetchAndLockSteps.resolves({steps: [step], nextStepReadyAt: null});
-        automatedEmailRecipientAdd.rejects(new Error('recipient persistence failed'));
+        automationsApi.recordEmailSent.rejects(new Error('recipient persistence failed'));
 
         await poll(options);
 
         sinon.assert.calledOnce(memberWelcomeEmailService.api.sendAutomationEmail);
-        sinon.assert.calledOnce(automatedEmailRecipientAdd);
-        sinon.assert.notCalled(updateRevision);
+        sinon.assert.calledOnce(automationsApi.recordEmailSent);
         sinon.assert.calledOnceWithExactly(automationsApi.finishStepAndEnqueueNext, step);
         sinon.assert.notCalled(automationsApi.retryStep);
         sinon.assert.notCalled(automationsApi.markStepTerminal);

--- a/ghost/core/test/unit/server/services/automations/poll.test.ts
+++ b/ghost/core/test/unit/server/services/automations/poll.test.ts
@@ -7,6 +7,8 @@ import {MEMBER_WELCOME_EMAIL_SLUGS} from '../../../../../core/server/services/me
 // @ts-expect-error Models currently lack type definitions.
 import {AutomatedEmailRecipient, Member} from '../../../../../core/server/models';
 
+const db = require('../../../../../core/server/data/db');
+
 const MAX_STEPS_PER_BATCH = 100;
 const RETRY_DELAY_MS = 10 * 60 * 1000;
 
@@ -42,6 +44,9 @@ type PollOptionsStubs = PollOptions & {
     memberWelcomeEmailService: MemberWelcomeEmailServiceStubs;
 };
 type AutomatedEmailRecipientAdd = typeof AutomatedEmailRecipient.add;
+type TransactingStub = sinon.SinonStub<[string], unknown> & {
+    raw: sinon.SinonStub<[string, Array<string | number>], unknown>;
+};
 
 type MemberFixture = {
     email: string;
@@ -120,11 +125,32 @@ function buildEmailStep(attrs: Partial<SendEmailStep> = {}): SendEmailStep {
 describe('automations poll', function () {
     let automationsApi: AutomationsApiStubs;
     let automatedEmailRecipientAdd: sinon.SinonStub<Parameters<AutomatedEmailRecipientAdd>, ReturnType<AutomatedEmailRecipientAdd>>;
+    let emailSentCountExpression: unknown;
     let memberWelcomeEmailService: MemberWelcomeEmailServiceStubs;
     let options: PollOptionsStubs;
+    let raw: sinon.SinonStub<[string, string[] | number[] | Array<string | number>], unknown>;
+    let transacting: TransactingStub;
+    let updateRevision: sinon.SinonStub<[{email_sent_count: unknown}], Promise<void>>;
+    let whereRevision: sinon.SinonStub<[string, string], unknown>;
 
     beforeEach(function () {
         sinon.useFakeTimers({now: new Date('2026-01-01T12:00:00.000Z'), shouldAdvanceTime: true});
+
+        emailSentCountExpression = Symbol('email_sent_count_expression');
+        raw = sinon.stub<[string, Array<string | number>], unknown>().returns(emailSentCountExpression);
+        updateRevision = sinon.stub<[{email_sent_count: unknown}], Promise<void>>().resolves();
+        whereRevision = sinon.stub<[string, string], unknown>().returns({
+            update: updateRevision
+        });
+        transacting = Object.assign(
+            sinon.stub<[string], unknown>().withArgs('automation_action_revisions').returns({
+                where: whereRevision
+            }),
+            {raw}
+        );
+        sinon.stub(db.knex, 'transaction').callsFake(async (callback: unknown) => {
+            return await (callback as (trx: typeof transacting) => Promise<unknown>)(transacting);
+        });
 
         automationsApi = {
             fetchAndLockSteps: fake<AutomationsApi['fetchAndLockSteps']>().resolves({steps: [], nextStepReadyAt: null}),
@@ -355,10 +381,18 @@ describe('automations poll', function () {
             member_name: 'Test Member',
             automation_action_revision_id: 'revision-id',
             track_opens: false
+        }, {
+            transacting
+        });
+        sinon.assert.calledOnceWithExactly(whereRevision, 'id', 'revision-id');
+        sinon.assert.calledOnceWithExactly(raw, 'COALESCE(??, 0) + ?', ['email_sent_count', 1]);
+        sinon.assert.calledOnceWithExactly(updateRevision, {
+            email_sent_count: emailSentCountExpression
         });
         sinon.assert.callOrder(
             memberWelcomeEmailService.api.sendAutomationEmail,
             automatedEmailRecipientAdd,
+            updateRevision,
             automationsApi.finishStepAndEnqueueNext
         );
     });
@@ -372,6 +406,7 @@ describe('automations poll', function () {
 
         sinon.assert.calledOnce(memberWelcomeEmailService.api.sendAutomationEmail);
         sinon.assert.calledOnce(automatedEmailRecipientAdd);
+        sinon.assert.notCalled(updateRevision);
         sinon.assert.calledOnceWithExactly(automationsApi.finishStepAndEnqueueNext, step);
         sinon.assert.notCalled(automationsApi.retryStep);
         sinon.assert.notCalled(automationsApi.markStepTerminal);


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1440/increment-automation-action-revisionsemail-sent-count-when-sending

## Summary
- Wrapped automation recipient creation and revision send-count increments in one transaction
- Kept the revision counter aligned with successful sends so retries do not overcount
- Added unit coverage for the transactional update path and the no-op path on send failure

## Manual testing

https://github.com/user-attachments/assets/b3022f94-8050-4f29-8276-a61e31048b05
