### PR TITLE
Disabled Nx native command runner for the build artifacts job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -946,6 +946,9 @@ jobs:
         env:
           IS_SHIPPING: ${{ github.repository == 'TryGhost/Ghost' && (github.ref == 'refs/heads/main' || github.ref_type == 'tag') && 'true' || '' }}
           VITE_SENTRY_AUTH_TOKEN: ${{ secrets.VITE_SENTRY_AUTH_TOKEN }}
+          # This step has intermittently segfaulted before Nx starts the
+          # target script. Keep Nx orchestration, but avoid its native PTY runner.
+          NX_NATIVE_COMMAND_RUNNER: "false"
         run: |
           # The Sentry plugin only warns when the token is missing, which
           # would silently skip the upload AND poison the Nx cache with a


### PR DESCRIPTION
no ref

The **Build & Publish Artifacts** job's `Build server and admin assets` step has intermittently segfaulted before Nx starts the target script — `nx run ghost:build:tsc` is killed with `SIGSEGV` roughly a second in, before Nx or `tsc` produce any output (e.g. run #49431).

This sets `NX_NATIVE_COMMAND_RUNNER: "false"` on that step's env, which keeps Nx orchestration and caching but avoids its native PTY command runner. It mirrors the same fix already applied to the acceptance test job in 2798ba3; there it lives at the job level because that job already had a job-level `env:` block, whereas here the failing step already carries its own `env:`, so scoping it to that step keeps it targeted to the exact command that crashes.