### PR TITLE
Scheduled job for fetching automations analytics

### DIFF
--- a/ghost/core/core/server/services/email-analytics/events/start-automation-email-analytics-job-event.ts
+++ b/ghost/core/core/server/services/email-analytics/events/start-automation-email-analytics-job-event.ts
@@ -1,0 +1,14 @@
+/**
+ * This event lets the job manager ask the main thread to start the automation email analytics pipeline.
+ */
+export class StartAutomationEmailAnalyticsJobEvent {
+    readonly timestamp: Date;
+
+    constructor(timestamp: Date) {
+        this.timestamp = timestamp;
+    }
+
+    static create(timestamp = new Date()) {
+        return new StartAutomationEmailAnalyticsJobEvent(timestamp);
+    }
+};

--- a/ghost/core/core/server/services/email-analytics/jobs/automation-fetch-latest/index.js
+++ b/ghost/core/core/server/services/email-analytics/jobs/automation-fetch-latest/index.js
@@ -1,0 +1,7 @@
+const {run} = require('../fetch-latest-job');
+const {StartAutomationEmailAnalyticsJobEvent} = require('../../events/start-automation-email-analytics-job-event');
+
+run({
+    event: StartAutomationEmailAnalyticsJobEvent,
+    logName: 'automations'
+});

--- a/ghost/core/core/server/services/email-analytics/jobs/email-analytics-job-scheduler.ts
+++ b/ghost/core/core/server/services/email-analytics/jobs/email-analytics-job-scheduler.ts
@@ -1,0 +1,57 @@
+import * as path from 'node:path';
+import moment from 'moment';
+import type * as bookshelf from 'bookshelf';
+
+type Models = {Email: bookshelf.Model<any>};
+type Config = {get(key: string): unknown};
+type JobManager = {
+    addJob(options: {
+        job: string;
+        name: string;
+        at: string;
+    }): void;
+};
+
+export class EmailAnalyticsJobScheduler {
+    #hasScheduled = false;
+    readonly #models: Models;
+    readonly #config: Config;
+    readonly #jobManager: JobManager;
+
+    constructor(models: Models, config: Config, jobManager: JobManager) {
+        this.#models = models;
+        this.#config = config;
+        this.#jobManager = jobManager;
+    }
+
+    async scheduleRecurringJobs(skipEmailCheck = false): Promise<void> {
+        if (
+            !this.#hasScheduled &&
+            this.#config.get('emailAnalytics:enabled') &&
+            this.#config.get('backgroundJobs:emailAnalytics')
+        ) {
+            // Don't register email analytics job if we have no emails,
+            // processor usage from many sites spinning up threads can be high.
+            // Mega service will re-run this scheduling task when an email is sent
+            const emailCount = skipEmailCheck ? 1 : Number(await this.#models.Email
+                .where('created_at', '>', moment.utc().subtract(30, 'days').toISOString())
+                .where('status', '<>', 'failed')
+                .count());
+
+            if (emailCount > 0) {
+                // use a random seconds value to avoid spikes to external APIs on the minute
+                const s = Math.floor(Math.random() * 60); // 0-59
+                // run every 5 minutes, on 1,6,11..., 2,7,12..., 3,8,13..., etc
+                const m = Math.floor(Math.random() * 5); // 0-4
+
+                this.#jobManager.addJob({
+                    at: `${s} ${m}/5 * * * *`,
+                    job: path.resolve(__dirname, 'fetch-latest/index.js'),
+                    name: 'email-analytics-fetch-latest'
+                });
+
+                this.#hasScheduled = true;
+            }
+        }
+    }
+}

--- a/ghost/core/core/server/services/email-analytics/jobs/email-analytics-job-scheduler.ts
+++ b/ghost/core/core/server/services/email-analytics/jobs/email-analytics-job-scheduler.ts
@@ -1,9 +1,25 @@
 import * as path from 'node:path';
 import moment from 'moment';
-import type * as bookshelf from 'bookshelf';
 
-type Models = {Email: bookshelf.Model<any>};
+type CountableQuery = {
+    where(column: string, operator: string, value: unknown): CountableQuery;
+    count(): Promise<string | number>;
+};
+type ExistingRecipientQuery = {
+    where(column: string, operator: string, value: unknown): ExistingRecipientQuery;
+    whereNotNull(column: string): ExistingRecipientQuery;
+    first(column: string): Promise<unknown>;
+};
+type Models = {
+    Email: {
+        where(column: string, operator: string, value: unknown): CountableQuery;
+    };
+    AutomatedEmailRecipient: {
+        query(): ExistingRecipientQuery;
+    };
+};
 type Config = {get(key: string): unknown};
+type Labs = {isSet(flag: string): boolean};
 type JobManager = {
     addJob(options: {
         job: string;
@@ -12,46 +28,103 @@ type JobManager = {
     }): void;
 };
 
+function randomFiveMinuteCron(): string {
+    // Use a random seconds value to avoid spikes to external APIs on the minute.
+    const seconds = Math.floor(Math.random() * 60); // 0-59
+    // Run every 5 minutes, on 1,6,11..., 2,7,12..., 3,8,13..., etc.
+    const minutes = Math.floor(Math.random() * 5); // 0-4
+
+    return `${seconds} ${minutes}/5 * * * *`;
+}
+
 export class EmailAnalyticsJobScheduler {
     #hasScheduledNewslettersJob = false;
+    #hasScheduledAutomationsJob = false;
     readonly #models: Models;
     readonly #config: Config;
+    readonly #labs: Labs;
     readonly #jobManager: JobManager;
 
-    constructor(models: Models, config: Config, jobManager: JobManager) {
+    constructor({
+        models,
+        config,
+        labs,
+        jobManager
+    }: {
+        models: Models,
+        config: Config,
+        labs: Labs,
+        jobManager: JobManager
+    }) {
         this.#models = models;
         this.#config = config;
+        this.#labs = labs;
         this.#jobManager = jobManager;
     }
 
-    async scheduleRecurringJobs(skipEmailCheck = false): Promise<void> {
-        if (
-            !this.#hasScheduledNewslettersJob &&
+    async scheduleRecurringJobs(skipNewsletterEmailCheck = false): Promise<void> {
+        const isConfigured = (
             this.#config.get('emailAnalytics:enabled') &&
             this.#config.get('backgroundJobs:emailAnalytics')
-        ) {
-            // Don't register email analytics job if we have no emails,
-            // processor usage from many sites spinning up threads can be high.
-            // Mega service will re-run this scheduling task when an email is sent
-            const emailCount = skipEmailCheck ? 1 : Number(await this.#models.Email
-                .where('created_at', '>', moment.utc().subtract(30, 'days').toISOString())
-                .where('status', '<>', 'failed')
-                .count());
-
-            if (emailCount > 0) {
-                // use a random seconds value to avoid spikes to external APIs on the minute
-                const s = Math.floor(Math.random() * 60); // 0-59
-                // run every 5 minutes, on 1,6,11..., 2,7,12..., 3,8,13..., etc
-                const m = Math.floor(Math.random() * 5); // 0-4
-
-                this.#jobManager.addJob({
-                    at: `${s} ${m}/5 * * * *`,
-                    job: path.resolve(__dirname, 'fetch-latest/index.js'),
-                    name: 'email-analytics-fetch-latest'
-                });
-
-                this.#hasScheduledNewslettersJob = true;
-            }
+        );
+        if (!isConfigured) {
+            return;
         }
+
+        await Promise.all([
+            this.#scheduleRecurringNewslettersJob(skipNewsletterEmailCheck),
+            this.#scheduleRecurringAutomationsJob()
+        ]);
+    }
+
+    async #scheduleRecurringNewslettersJob(skipNewsletterEmailCheck: boolean): Promise<void> {
+        if (this.#hasScheduledNewslettersJob) {
+            return;
+        }
+
+        // Don't register email analytics job if we have no emails,
+        // processor usage from many sites spinning up threads can be high.
+        // Mega service will re-run this scheduling task when an email is sent
+        const emailCount = skipNewsletterEmailCheck ? 1 : Number(await this.#models.Email
+            .where('created_at', '>', moment.utc().subtract(30, 'days').toISOString())
+            .where('status', '<>', 'failed')
+            .count());
+
+        if (emailCount > 0) {
+            this.#jobManager.addJob({
+                at: randomFiveMinuteCron(),
+                job: path.resolve(__dirname, 'fetch-latest/index.js'),
+                name: 'email-analytics-fetch-latest'
+            });
+
+            this.#hasScheduledNewslettersJob = true;
+        }
+    }
+
+    async #scheduleRecurringAutomationsJob(): Promise<void> {
+        if (this.#hasScheduledAutomationsJob) {
+            return;
+        }
+
+        if (!this.#labs.isSet('automationAnalytics')) {
+            return;
+        }
+
+        const automatedEmailRecipient = await this.#models.AutomatedEmailRecipient
+            .query()
+            .where('created_at', '>', moment.utc().subtract(30, 'days').toDate())
+            .whereNotNull('mailgun_message_id')
+            .first('id');
+        if (!automatedEmailRecipient) {
+            return;
+        }
+
+        this.#jobManager.addJob({
+            at: randomFiveMinuteCron(),
+            job: path.resolve(__dirname, 'automation-fetch-latest/index.js'),
+            name: 'email-analytics-automation-fetch-latest'
+        });
+
+        this.#hasScheduledAutomationsJob = true;
     }
 }

--- a/ghost/core/core/server/services/email-analytics/jobs/email-analytics-job-scheduler.ts
+++ b/ghost/core/core/server/services/email-analytics/jobs/email-analytics-job-scheduler.ts
@@ -13,7 +13,7 @@ type JobManager = {
 };
 
 export class EmailAnalyticsJobScheduler {
-    #hasScheduled = false;
+    #hasScheduledNewslettersJob = false;
     readonly #models: Models;
     readonly #config: Config;
     readonly #jobManager: JobManager;
@@ -26,7 +26,7 @@ export class EmailAnalyticsJobScheduler {
 
     async scheduleRecurringJobs(skipEmailCheck = false): Promise<void> {
         if (
-            !this.#hasScheduled &&
+            !this.#hasScheduledNewslettersJob &&
             this.#config.get('emailAnalytics:enabled') &&
             this.#config.get('backgroundJobs:emailAnalytics')
         ) {
@@ -50,7 +50,7 @@ export class EmailAnalyticsJobScheduler {
                     name: 'email-analytics-fetch-latest'
                 });
 
-                this.#hasScheduled = true;
+                this.#hasScheduledNewslettersJob = true;
             }
         }
     }

--- a/ghost/core/core/server/services/email-analytics/jobs/email-analytics-job-scheduler.ts
+++ b/ghost/core/core/server/services/email-analytics/jobs/email-analytics-job-scheduler.ts
@@ -86,7 +86,7 @@ export class EmailAnalyticsJobScheduler {
         // processor usage from many sites spinning up threads can be high.
         // Mega service will re-run this scheduling task when an email is sent
         const emailCount = skipNewsletterEmailCheck ? 1 : Number(await this.#models.Email
-            .where('created_at', '>', moment.utc().subtract(30, 'days').toISOString())
+            .where('created_at', '>', moment.utc().subtract(30, 'days').toDate())
             .where('status', '<>', 'failed')
             .count());
 

--- a/ghost/core/core/server/services/email-analytics/jobs/fetch-latest-job.js
+++ b/ghost/core/core/server/services/email-analytics/jobs/fetch-latest-job.js
@@ -1,0 +1,55 @@
+const {parentPort} = require('worker_threads');
+
+// recurring job to fetch analytics since the most recently seen event timestamp
+
+// Exit early when cancelled to prevent stalling shutdown. No cleanup needed when cancelling as everything is idempotent and will pick up
+// where it left off on next run
+/**
+ * @param {string} logName
+ * @returns {void}
+ */
+function cancel(logName) {
+    if (parentPort) {
+        parentPort.postMessage(`Email analytics fetch-latest job for ${logName} cancelled before completion`);
+        parentPort.postMessage('cancelled');
+    } else {
+        setTimeout(() => {
+            process.exit(0);
+        }, 1000);
+    }
+}
+
+/**
+ * @param {object} options
+ * @param {{name: string}} options.event
+ * @param {string} options.logName
+ * @returns {void}
+ */
+exports.run = ({
+    event,
+    logName
+}) => {
+    if (parentPort) {
+        parentPort.once('message', (message) => {
+            if (message === 'cancel') {
+                cancel(logName);
+                return;
+            }
+        });
+
+        // We send an event message, so that it is emitted on the main thread by the job manager
+        // This will start the email analytics job on the main thread (the wrapper service is listening for this event)
+        parentPort.postMessage({
+            event: {
+                type: event.name
+            }
+        });
+
+        parentPort.postMessage('done');
+    } else {
+        // give the logging pipes time finish writing before exit
+        setTimeout(() => {
+            process.exit(0);
+        }, 1000);
+    }
+};

--- a/ghost/core/core/server/services/email-analytics/jobs/fetch-latest/index.js
+++ b/ghost/core/core/server/services/email-analytics/jobs/fetch-latest/index.js
@@ -1,44 +1,7 @@
-const {parentPort} = require('worker_threads');
+const {run} = require('../fetch-latest-job');
 const StartEmailAnalyticsJobEvent = require('../../events/start-email-analytics-job-event');
 
-// recurring job to fetch analytics since the most recently seen event timestamp
-
-// Exit early when cancelled to prevent stalling shutdown. No cleanup needed when cancelling as everything is idempotent and will pick up
-// where it left off on next run
-function cancel() {
-    if (parentPort) {
-        parentPort.postMessage('Email analytics fetch-latest job cancelled before completion');
-        parentPort.postMessage('cancelled');
-    } else {
-        setTimeout(() => {
-            process.exit(0);
-        }, 1000);
-    }
-}
-
-if (parentPort) {
-    parentPort.once('message', (message) => {
-        if (message === 'cancel') {
-            return cancel();
-        }
-    });
-}
-
-(async () => {
-    // We send an event message, so that it is emitted on the main thread by the job manager
-    // This will start the email analytics job on the main thread (the wrapper service is listening for this event)
-    parentPort.postMessage({
-        event: {
-            type: StartEmailAnalyticsJobEvent.name
-        }
-    });
-
-    if (parentPort) {
-        parentPort.postMessage('done');
-    } else {
-        // give the logging pipes time finish writing before exit
-        setTimeout(() => {
-            process.exit(0);
-        }, 1000);
-    }
-})();
+run({
+    event: StartEmailAnalyticsJobEvent,
+    logName: 'newsletters'
+});

--- a/ghost/core/core/server/services/email-analytics/jobs/index.js
+++ b/ghost/core/core/server/services/email-analytics/jobs/index.js
@@ -1,9 +1,15 @@
 const config = require('../../../../shared/config');
+const labs = require('../../../../shared/labs');
 const models = require('../../../models');
 const jobsService = require('../../jobs');
 const {EmailAnalyticsJobScheduler} = require('./email-analytics-job-scheduler');
 
-const emailAnalyticsJobScheduler = new EmailAnalyticsJobScheduler(models, config, jobsService);
+const emailAnalyticsJobScheduler = new EmailAnalyticsJobScheduler({
+    models,
+    config,
+    labs,
+    jobManager: jobsService
+});
 
 /**
  * @param {Parameters<typeof EmailAnalyticsJobScheduler.prototype.scheduleRecurringJobs>} args

--- a/ghost/core/core/server/services/email-analytics/jobs/index.js
+++ b/ghost/core/core/server/services/email-analytics/jobs/index.js
@@ -1,43 +1,16 @@
-const path = require('path');
-const moment = require('moment');
 const config = require('../../../../shared/config');
 const models = require('../../../models');
 const jobsService = require('../../jobs');
+const {EmailAnalyticsJobScheduler} = require('./email-analytics-job-scheduler');
 
-let hasScheduled = false;
+const emailAnalyticsJobScheduler = new EmailAnalyticsJobScheduler(models, config, jobsService);
 
-module.exports = {
-    async scheduleRecurringJobs(skipEmailCheck = false) {
-        if (
-            !hasScheduled &&
-            config.get('emailAnalytics:enabled') &&
-            config.get('backgroundJobs:emailAnalytics') &&
-            !process.env.NODE_ENV.startsWith('test')
-        ) {
-            // Don't register email analytics job if we have no emails,
-            // processor usage from many sites spinning up threads can be high.
-            // Mega service will re-run this scheduling task when an email is sent
-            const emailCount = skipEmailCheck ? 1 : (await models.Email
-                .where('created_at', '>', moment.utc().subtract(30, 'days').toDate())
-                .where('status', '<>', 'failed')
-                .count());
-
-            if (emailCount > 0) {
-                // use a random seconds value to avoid spikes to external APIs on the minute
-                const s = Math.floor(Math.random() * 60); // 0-59
-                // run every 5 minutes, on 1,6,11..., 2,7,12..., 3,8,13..., etc
-                const m = Math.floor(Math.random() * 5); // 0-4
-
-                jobsService.addJob({
-                    at: `${s} ${m}/5 * * * *`,
-                    job: path.resolve(__dirname, 'fetch-latest/index.js'),
-                    name: 'email-analytics-fetch-latest'
-                });
-
-                hasScheduled = true;
-            }
-        }
-
-        return hasScheduled;
+/**
+ * @param {Parameters<typeof EmailAnalyticsJobScheduler.prototype.scheduleRecurringJobs>} args
+ * @returns {Promise<void>}
+ */
+exports.scheduleRecurringJobs = async (...args) => {
+    if (!process.env.NODE_ENV.startsWith('test')) {
+        await emailAnalyticsJobScheduler.scheduleRecurringJobs(...args);
     }
 };

--- a/ghost/core/test/unit/server/services/email-analytics/email-analytics-job-scheduler.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/email-analytics-job-scheduler.test.ts
@@ -1,0 +1,128 @@
+import sinon from 'sinon';
+import {EmailAnalyticsJobScheduler} from '../../../../../core/server/services/email-analytics/jobs/email-analytics-job-scheduler';
+
+function buildModels(emailCount: string | number = 1) {
+    const query = {
+        where: sinon.stub(),
+        count: sinon.stub().resolves(emailCount)
+    };
+    query.where.returns(query);
+
+    return {
+        models: {
+            Email: {
+                where: query.where
+            }
+        },
+        query
+    };
+}
+
+function buildScheduler({
+    emailAnalyticsEnabled = true,
+    backgroundJobEnabled = true,
+    emailCount = 1
+}: {
+    emailAnalyticsEnabled?: boolean;
+    backgroundJobEnabled?: boolean;
+    emailCount?: string | number;
+} = {}) {
+    const {models, query} = buildModels(emailCount);
+    const config = {
+        get: sinon.stub()
+    };
+    config.get.withArgs('emailAnalytics:enabled').returns(emailAnalyticsEnabled);
+    config.get.withArgs('backgroundJobs:emailAnalytics').returns(backgroundJobEnabled);
+
+    const jobManager = {
+        addJob: sinon.stub()
+    };
+
+    return {
+        scheduler: new EmailAnalyticsJobScheduler(models as any, config, jobManager),
+        config,
+        jobManager,
+        query
+    };
+}
+
+describe('EmailAnalyticsJobScheduler', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it('adds a recurring job when conditions are met', async function () {
+        sinon.stub(Math, 'random')
+            .onFirstCall().returns(0.1)
+            .onSecondCall().returns(0.7);
+
+        const {scheduler, jobManager} = buildScheduler({emailCount: '3'});
+
+        await scheduler.scheduleRecurringJobs();
+
+        sinon.assert.calledOnceWithExactly(jobManager.addJob, {
+            at: '6 3/5 * * * *',
+            job: sinon.match((value: unknown) => (
+                typeof value === 'string' &&
+                value.endsWith('fetch-latest/index.js')
+            )),
+            name: 'email-analytics-fetch-latest'
+        });
+    });
+
+    it('does not add a job when config options are disabled', async function () {
+        for (const options of [
+            {emailAnalyticsEnabled: false, backgroundJobEnabled: true},
+            {emailAnalyticsEnabled: true, backgroundJobEnabled: false},
+            {emailAnalyticsEnabled: false, backgroundJobEnabled: false}
+        ]) {
+            const {scheduler, jobManager, query} = buildScheduler(options);
+
+            await scheduler.scheduleRecurringJobs();
+
+            sinon.assert.notCalled(jobManager.addJob);
+            sinon.assert.notCalled(query.count);
+        }
+    });
+
+    it('does not add another job when called twice', async function () {
+        const {scheduler, jobManager, query} = buildScheduler();
+
+        await scheduler.scheduleRecurringJobs();
+        await scheduler.scheduleRecurringJobs();
+
+        sinon.assert.calledOnce(jobManager.addJob);
+        sinon.assert.calledOnce(query.count);
+    });
+
+    it('does not add a job when no emails are found', async function () {
+        const {scheduler, jobManager, query} = buildScheduler({emailCount: 0});
+
+        await scheduler.scheduleRecurringJobs();
+
+        sinon.assert.notCalled(jobManager.addJob);
+        sinon.assert.calledOnce(query.count);
+    });
+
+    it('can add a job later when emails are found', async function () {
+        const {scheduler, jobManager, query} = buildScheduler();
+        query.count.onFirstCall().resolves(0);
+        query.count.onSecondCall().resolves(1);
+
+        await scheduler.scheduleRecurringJobs();
+        await scheduler.scheduleRecurringJobs();
+
+        sinon.assert.calledOnce(jobManager.addJob);
+        sinon.assert.calledTwice(query.count);
+    });
+
+    it('can skip the email lookup', async function () {
+        const {scheduler, jobManager, query} = buildScheduler({emailCount: 0});
+
+        await scheduler.scheduleRecurringJobs(true);
+
+        sinon.assert.calledOnce(jobManager.addJob);
+        sinon.assert.notCalled(query.where);
+        sinon.assert.notCalled(query.count);
+    });
+});

--- a/ghost/core/test/unit/server/services/email-analytics/email-analytics-job-scheduler.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/email-analytics-job-scheduler.test.ts
@@ -1,48 +1,79 @@
 import sinon from 'sinon';
 import {EmailAnalyticsJobScheduler} from '../../../../../core/server/services/email-analytics/jobs/email-analytics-job-scheduler';
 
-function buildModels(emailCount: string | number = 1) {
+function buildNewsletterQuery(emailCount: string | number = 1) {
     const query = {
         where: sinon.stub(),
         count: sinon.stub().resolves(emailCount)
     };
     query.where.returns(query);
 
-    return {
-        models: {
-            Email: {
-                where: query.where
-            }
-        },
-        query
+    return query;
+}
+
+function buildAutomationsQuery(automatedEmailRecipient: unknown = null) {
+    const query = {
+        where: sinon.stub(),
+        whereNotNull: sinon.stub(),
+        first: sinon.stub().resolves(automatedEmailRecipient)
     };
+    query.where.returns(query);
+    query.whereNotNull.returns(query);
+
+    return query;
 }
 
 function buildScheduler({
     emailAnalyticsEnabled = true,
     backgroundJobEnabled = true,
-    emailCount = 1
+    emailCount = 1,
+    automationAnalyticsEnabled = false,
+    automatedEmailRecipient = null
 }: {
     emailAnalyticsEnabled?: boolean;
     backgroundJobEnabled?: boolean;
     emailCount?: string | number;
+    automationAnalyticsEnabled?: boolean;
+    automatedEmailRecipient?: unknown;
 } = {}) {
-    const {models, query} = buildModels(emailCount);
+    const newsletterQuery = buildNewsletterQuery(emailCount);
+    const automationsQuery = buildAutomationsQuery(automatedEmailRecipient);
+    const models = {
+        Email: {
+            where: newsletterQuery.where
+        },
+        AutomatedEmailRecipient: {
+            query: sinon.stub().returns(automationsQuery)
+        }
+    };
     const config = {
         get: sinon.stub()
     };
     config.get.withArgs('emailAnalytics:enabled').returns(emailAnalyticsEnabled);
     config.get.withArgs('backgroundJobs:emailAnalytics').returns(backgroundJobEnabled);
 
+    const labs = {
+        isSet: sinon.stub()
+    };
+    labs.isSet.withArgs('automationAnalytics').returns(automationAnalyticsEnabled);
+
     const jobManager = {
         addJob: sinon.stub()
     };
 
     return {
-        scheduler: new EmailAnalyticsJobScheduler(models as any, config, jobManager),
+        scheduler: new EmailAnalyticsJobScheduler({
+            models,
+            config,
+            labs,
+            jobManager
+        }),
         config,
+        labs,
         jobManager,
-        query
+        newsletterQuery,
+        automationsQuery,
+        models
     };
 }
 
@@ -76,53 +107,150 @@ describe('EmailAnalyticsJobScheduler', function () {
             {emailAnalyticsEnabled: true, backgroundJobEnabled: false},
             {emailAnalyticsEnabled: false, backgroundJobEnabled: false}
         ]) {
-            const {scheduler, jobManager, query} = buildScheduler(options);
+            const {scheduler, jobManager, newsletterQuery, automationsQuery, models} = buildScheduler(options);
 
             await scheduler.scheduleRecurringJobs();
 
             sinon.assert.notCalled(jobManager.addJob);
-            sinon.assert.notCalled(query.count);
+            sinon.assert.notCalled(newsletterQuery.count);
+            sinon.assert.notCalled(models.AutomatedEmailRecipient.query);
+            sinon.assert.notCalled(automationsQuery.first);
         }
     });
 
     it('does not add another job when called twice', async function () {
-        const {scheduler, jobManager, query} = buildScheduler();
+        const {scheduler, jobManager, newsletterQuery} = buildScheduler();
 
         await scheduler.scheduleRecurringJobs();
         await scheduler.scheduleRecurringJobs();
 
         sinon.assert.calledOnce(jobManager.addJob);
-        sinon.assert.calledOnce(query.count);
+        sinon.assert.calledOnce(newsletterQuery.count);
+    });
+
+    it('does not add another automation job when called twice', async function () {
+        const {scheduler, jobManager, automationsQuery} = buildScheduler({
+            emailCount: 0,
+            automationAnalyticsEnabled: true,
+            automatedEmailRecipient: {id: 'recipient-id'}
+        });
+
+        await scheduler.scheduleRecurringJobs();
+        await scheduler.scheduleRecurringJobs();
+
+        sinon.assert.calledOnce(jobManager.addJob);
+        sinon.assert.calledOnce(automationsQuery.first);
     });
 
     it('does not add a job when no emails are found', async function () {
-        const {scheduler, jobManager, query} = buildScheduler({emailCount: 0});
+        const {scheduler, jobManager, newsletterQuery} = buildScheduler({emailCount: 0});
 
         await scheduler.scheduleRecurringJobs();
 
         sinon.assert.notCalled(jobManager.addJob);
-        sinon.assert.calledOnce(query.count);
+        sinon.assert.calledOnce(newsletterQuery.count);
     });
 
     it('can add a job later when emails are found', async function () {
-        const {scheduler, jobManager, query} = buildScheduler();
-        query.count.onFirstCall().resolves(0);
-        query.count.onSecondCall().resolves(1);
+        const {scheduler, jobManager, newsletterQuery} = buildScheduler();
+        newsletterQuery.count.onFirstCall().resolves(0);
+        newsletterQuery.count.onSecondCall().resolves(1);
 
         await scheduler.scheduleRecurringJobs();
         await scheduler.scheduleRecurringJobs();
 
         sinon.assert.calledOnce(jobManager.addJob);
-        sinon.assert.calledTwice(query.count);
+        sinon.assert.calledTwice(newsletterQuery.count);
     });
 
     it('can skip the email lookup', async function () {
-        const {scheduler, jobManager, query} = buildScheduler({emailCount: 0});
+        const {scheduler, jobManager, newsletterQuery} = buildScheduler({emailCount: 0});
 
         await scheduler.scheduleRecurringJobs(true);
 
         sinon.assert.calledOnce(jobManager.addJob);
-        sinon.assert.notCalled(query.where);
-        sinon.assert.notCalled(query.count);
+        sinon.assert.notCalled(newsletterQuery.where);
+        sinon.assert.notCalled(newsletterQuery.count);
+    });
+
+    it('adds an automation job when automation analytics is enabled and recipients exist', async function () {
+        sinon.stub(Math, 'random')
+            .onFirstCall().returns(0.2)
+            .onSecondCall().returns(0.8);
+
+        const {scheduler, jobManager, newsletterQuery, automationsQuery, models} = buildScheduler({
+            emailCount: 0,
+            automationAnalyticsEnabled: true,
+            automatedEmailRecipient: {id: 'recipient-id'}
+        });
+
+        await scheduler.scheduleRecurringJobs();
+
+        sinon.assert.calledOnceWithExactly(jobManager.addJob, {
+            at: '12 4/5 * * * *',
+            job: sinon.match((value: unknown) => (
+                typeof value === 'string' &&
+                value.endsWith('automation-fetch-latest/index.js')
+            )),
+            name: 'email-analytics-automation-fetch-latest'
+        });
+        sinon.assert.calledOnce(newsletterQuery.count);
+        sinon.assert.calledOnce(models.AutomatedEmailRecipient.query);
+        sinon.assert.calledOnceWithExactly(automationsQuery.where, 'created_at', '>', sinon.match.date);
+        sinon.assert.calledOnceWithExactly(automationsQuery.whereNotNull, 'mailgun_message_id');
+        sinon.assert.calledOnceWithExactly(automationsQuery.first, 'id');
+    });
+
+    it('adds both newsletter and automation jobs when conditions are met', async function () {
+        const {scheduler, jobManager} = buildScheduler({
+            emailCount: 1,
+            automationAnalyticsEnabled: true,
+            automatedEmailRecipient: {id: 'recipient-id'}
+        });
+
+        await scheduler.scheduleRecurringJobs();
+
+        sinon.assert.calledTwice(jobManager.addJob);
+        sinon.assert.calledWithMatch(jobManager.addJob, {
+            job: sinon.match((value: unknown) => (
+                typeof value === 'string' &&
+                value.endsWith('fetch-latest/index.js')
+            )),
+            name: 'email-analytics-fetch-latest'
+        });
+        sinon.assert.calledWithMatch(jobManager.addJob, {
+            job: sinon.match((value: unknown) => (
+                typeof value === 'string' &&
+                value.endsWith('automation-fetch-latest/index.js')
+            )),
+            name: 'email-analytics-automation-fetch-latest'
+        });
+    });
+
+    it('does not look for automation recipients when automation analytics is disabled', async function () {
+        const {scheduler, jobManager, automationsQuery, models} = buildScheduler({
+            emailCount: 0,
+            automationAnalyticsEnabled: false,
+            automatedEmailRecipient: {id: 'recipient-id'}
+        });
+
+        await scheduler.scheduleRecurringJobs();
+
+        sinon.assert.notCalled(jobManager.addJob);
+        sinon.assert.notCalled(models.AutomatedEmailRecipient.query);
+        sinon.assert.notCalled(automationsQuery.first);
+    });
+
+    it('does not add an automation job when no automation recipients are found', async function () {
+        const {scheduler, jobManager, automationsQuery} = buildScheduler({
+            emailCount: 0,
+            automationAnalyticsEnabled: true,
+            automatedEmailRecipient: null
+        });
+
+        await scheduler.scheduleRecurringJobs();
+
+        sinon.assert.notCalled(jobManager.addJob);
+        sinon.assert.calledOnce(automationsQuery.first);
     });
 });


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1445
towards https://linear.app/ghost/issue/NY-1436

_I recommend [reviewing this commit-by-commit](https://github.com/TryGhost/Ghost/pull/29211/commits)._

This change starts emitting a "start automation email analytics job", just like we do for newsletter analytics. Nothing is listening to that event right now—that's for an upcoming change.

Notably, this makes two refactors to make this change much simpler:

- The job now calls a common function to reduce duplication.
- We can now test the email job scheduler

I manually tested this by adding console logs and verified that they showed up when running the dev server.