### PR TITLE
Changed Nx native command runner to be disabled globally in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,16 @@ env:
   # so disabling it has no meaningful performance impact in CI.
   # See: https://github.com/nodejs/node/issues/51555
   DISABLE_V8_COMPILE_CACHE: 1
+  # Nx's native (Rust/NAPI) command runner intermittently segfaults on the CI
+  # runners when it forks a task through its pseudo-terminal — the process is
+  # killed with SIGSEGV before the target script even starts. It's an upstream
+  # Nx instability (see nrwl/nx#27917, nrwl/nx#2956), not a Ghost bug, and it
+  # can hit any job that runs `nx run`/`nx run-many`, so the switch to the
+  # legacy child_process runner is set globally rather than per-job. The legacy
+  # runner was Nx's default before the native one existed; parallelism is
+  # unaffected and output/colour is preserved (FORCE_COLOR is set above), so
+  # there's no meaningful cost in CI.
+  NX_NATIVE_COMMAND_RUNNER: "false"
 
 concurrency:
   # Tag pushes get a unique uninterruptible group so a release CI run always
@@ -532,9 +542,6 @@ jobs:
     env:
       DB: ${{ matrix.env.DB }}
       NODE_ENV: ${{ matrix.env.NODE_ENV }}
-      # The acceptance job has intermittently segfaulted before Nx starts the
-      # target script. Keep Nx orchestration, but avoid its native PTY runner.
-      NX_NATIVE_COMMAND_RUNNER: "false"
     name: Acceptance tests (Node ${{ matrix.node }}, ${{ matrix.env.DB }})
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -946,9 +953,6 @@ jobs:
         env:
           IS_SHIPPING: ${{ github.repository == 'TryGhost/Ghost' && (github.ref == 'refs/heads/main' || github.ref_type == 'tag') && 'true' || '' }}
           VITE_SENTRY_AUTH_TOKEN: ${{ secrets.VITE_SENTRY_AUTH_TOKEN }}
-          # This step has intermittently segfaulted before Nx starts the
-          # target script. Keep Nx orchestration, but avoid its native PTY runner.
-          NX_NATIVE_COMMAND_RUNNER: "false"
         run: |
           # The Sentry plugin only warns when the token is missing, which
           # would silently skip the upload AND poison the Nx cache with a


### PR DESCRIPTION
## Summary

CI has been intermittently failing with segfaults from Nx's native command runner. [This recent run](https://github.com/TryGhost/Ghost/actions/runs/29029357051/job/86158152698) died in **Build & Publish Artifacts** with:

```
[ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL] Command was killed with SIGSEGV (Segmentation fault): nx run 'ghost:build:tsc'
```

The process is killed ~1.5s in, **before** `tsc` even runs — Nx's native (Rust/NAPI) command runner segfaults while forking the task through its pseudo-terminal. In `nx@22.7.6`, `NX_NATIVE_COMMAND_RUNNER=false` swaps that native PTY fork (`forkProcess`) for a plain node `child_process` fork (`forkProcessLegacy`) — see `task-orchestrator.js:800`.

This was already worked around, but only on `job_acceptance-tests`. The failure mode isn't job-specific — it can hit **any** job that runs `nx run`/`nx run-many`, which is exactly why `job_build_artifacts` (unguarded) went down. Rather than keep playing whack-a-mole per job, this promotes the switch to the top-level `env:` so every job is covered by one consistent lever.

## Why not just upgrade Nx?

There's no fixed patch to move to. The only stable releases after `22.7.6` are the **major** `23.0`/`23.1` line, whose release notes claim **no** fix for the native command runner / PTY / segfault, and the upstream issues ([nrwl/nx#27917](https://github.com/nrwl/nx/issues/27917), [nrwl/nx#2956](https://github.com/nrwl/nx/issues/2956)) remain open. A major bump would be risk without a payoff for this bug.

## Why this is safe in CI

- The legacy `child_process` runner was Nx's default before the native one existed.
- Parallelism (`parallel: 4`) is orchestration-level and unaffected — only *how* each task is forked changes.
- Colour is preserved via the existing `FORCE_COLOR: 1`; output falls back to pipe capture.

## Notes

Left in place as defense-in-depth, since they cover different crash classes this flag doesn't touch:
- the 3× retry loop on `job_unit-tests` (vitest worker crashes, not the fork path)
- `DISABLE_V8_COMPILE_CACHE=1` (a separate V8 bytecode-cache race)

🤖 Generated with [Claude Code](https://claude.com/claude-code)