### PR TITLE
Fixed race condition when scheduling email analytics jobs

### DIFF
--- a/ghost/core/core/server/services/email-analytics/jobs/email-analytics-job-scheduler.ts
+++ b/ghost/core/core/server/services/email-analytics/jobs/email-analytics-job-scheduler.ts
@@ -90,7 +90,7 @@ export class EmailAnalyticsJobScheduler {
             .where('status', '<>', 'failed')
             .count());
 
-        if (emailCount > 0) {
+        if (emailCount > 0 && !this.#hasScheduledNewslettersJob) {
             this.#jobManager.addJob({
                 at: randomFiveMinuteCron(),
                 job: path.resolve(__dirname, 'fetch-latest/index.js'),
@@ -115,7 +115,7 @@ export class EmailAnalyticsJobScheduler {
             .where('created_at', '>', moment.utc().subtract(30, 'days').toDate())
             .whereNotNull('mailgun_message_id')
             .first('id');
-        if (!automatedEmailRecipient) {
+        if (!automatedEmailRecipient || this.#hasScheduledAutomationsJob) {
             return;
         }
 

--- a/ghost/core/test/unit/server/services/email-analytics/email-analytics-job-scheduler.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/email-analytics-job-scheduler.test.ts
@@ -1,4 +1,5 @@
 import sinon from 'sinon';
+import {deferred} from '../../../../utils/deferred';
 import {EmailAnalyticsJobScheduler} from '../../../../../core/server/services/email-analytics/jobs/email-analytics-job-scheduler';
 
 function buildNewsletterQuery(emailCount: string | number = 1) {
@@ -128,6 +129,23 @@ describe('EmailAnalyticsJobScheduler', function () {
         sinon.assert.calledOnce(newsletterQuery.count);
     });
 
+    it('does not add another newsletter job when called concurrently', async function () {
+        const {scheduler, jobManager, newsletterQuery} = buildScheduler();
+        const emailCount = deferred();
+        newsletterQuery.count.returns(emailCount.promise.then(() => 1));
+
+        const firstSchedule = scheduler.scheduleRecurringJobs();
+        sinon.assert.calledOnce(newsletterQuery.count);
+
+        const secondSchedule = scheduler.scheduleRecurringJobs(true);
+        emailCount.done();
+
+        await Promise.all([firstSchedule, secondSchedule]);
+
+        sinon.assert.calledOnce(jobManager.addJob);
+        sinon.assert.calledOnce(newsletterQuery.count);
+    });
+
     it('does not add another automation job when called twice', async function () {
         const {scheduler, jobManager, automationsQuery} = buildScheduler({
             emailCount: 0,
@@ -140,6 +158,25 @@ describe('EmailAnalyticsJobScheduler', function () {
 
         sinon.assert.calledOnce(jobManager.addJob);
         sinon.assert.calledOnce(automationsQuery.first);
+    });
+
+    it('does not add another automation job when called concurrently', async function () {
+        const {scheduler, jobManager, automationsQuery} = buildScheduler({
+            emailCount: 0,
+            automationAnalyticsEnabled: true
+        });
+        const automatedEmailRecipient = deferred();
+        automationsQuery.first.returns(automatedEmailRecipient.promise.then(() => ({id: 'recipient-id'})));
+
+        const firstSchedule = scheduler.scheduleRecurringJobs();
+        const secondSchedule = scheduler.scheduleRecurringJobs();
+
+        sinon.assert.calledTwice(automationsQuery.first);
+        automatedEmailRecipient.done();
+
+        await Promise.all([firstSchedule, secondSchedule]);
+
+        sinon.assert.calledOnce(jobManager.addJob);
     });
 
     it('does not add a job when no emails are found', async function () {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1449

If `scheduleRecurringJobs` was called twice in rapid succession, we might schedule jobs twice. This fixes that.

This is a long-standing issue that could rear its head when we call this function more often, which we plan to do soon. However, I think this is a useful bugfix on its own.
