### PR TITLE
Add mobile card deletion control

### DIFF
--- a/koenig/koenig-lexical/src/components/KoenigCardWrapper.tsx
+++ b/koenig/koenig-lexical/src/components/KoenigCardWrapper.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import {$getNodeByKey, CLICK_COMMAND, COMMAND_PRIORITY_LOW} from 'lexical';
 import {$isKoenigCard} from '@tryghost/kg-default-nodes';
 import {CardWrapper} from './ui/CardWrapper';
-import {EDIT_CARD_COMMAND, SELECT_CARD_COMMAND, SHOW_CARD_VISIBILITY_SETTINGS_COMMAND} from '../plugins/KoenigBehaviourPlugin';
+import {DELETE_CARD_COMMAND, EDIT_CARD_COMMAND, SELECT_CARD_COMMAND, SHOW_CARD_VISIBILITY_SETTINGS_COMMAND} from '../plugins/KoenigBehaviourPlugin';
 import {VISIBILITY_SETTINGS} from '../utils/visibility';
 import {mergeRegister} from '@lexical/utils';
 import {useKoenigSelectedCardContext} from '../context/KoenigSelectedCardContext';
@@ -32,11 +32,18 @@ const KoenigCardWrapper = ({nodeKey, width, wrapperStyle, IndicatorIcon, childre
 
     const isSelected = selectedCardKey === nodeKey;
     const isEditing = isSelected && isEditingCard;
+    const isTouchDevice = window.matchMedia?.('(pointer: coarse), (hover: none)').matches;
 
     const handleVisibilityToggle = React.useCallback((event) => {
         event.preventDefault();
         event.stopPropagation();
         editor.dispatchCommand(SHOW_CARD_VISIBILITY_SETTINGS_COMMAND, {cardKey: nodeKey});
+    }, [editor, nodeKey]);
+
+    const handleDeleteCard = React.useCallback((event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        editor.dispatchCommand(DELETE_CARD_COMMAND, {cardKey: nodeKey});
     }, [editor, nodeKey]);
 
     React.useLayoutEffect(() => {
@@ -177,7 +184,9 @@ const KoenigCardWrapper = ({nodeKey, width, wrapperStyle, IndicatorIcon, childre
                 isEditing={isEditing}
                 isSelected={isSelected}
                 isVisibilityActive={isVisibilityActive}
+                showDeleteButton={isTouchDevice && isSelected && !isDragging}
                 wrapperStyle={wrapperStyle}
+                onDeleteClick={handleDeleteCard}
                 onIndicatorClick={handleVisibilityToggle}
             >
                 {children}

--- a/koenig/koenig-lexical/src/components/KoenigCardWrapper.tsx
+++ b/koenig/koenig-lexical/src/components/KoenigCardWrapper.tsx
@@ -27,12 +27,16 @@ const KoenigCardWrapper = ({nodeKey, width, wrapperStyle, IndicatorIcon, childre
     const [cardWidth, setCardWidth] = React.useState<CardWidth>(width || 'regular');
     const containerRef = React.useRef(null);
     const skipClick = React.useRef(false);
+    const isTouchDeviceRef = React.useRef<boolean | null>(null);
 
     const {selectedCardKey, isEditingCard, isDragging} = useKoenigSelectedCardContext();
 
     const isSelected = selectedCardKey === nodeKey;
     const isEditing = isSelected && isEditingCard;
-    const isTouchDevice = window.matchMedia?.('(pointer: coarse), (hover: none)').matches;
+    if (isTouchDeviceRef.current === null) {
+        isTouchDeviceRef.current = window.matchMedia?.('(pointer: coarse), (hover: none)').matches ?? false;
+    }
+    const isTouchDevice = isTouchDeviceRef.current;
 
     const handleVisibilityToggle = React.useCallback((event) => {
         event.preventDefault();

--- a/koenig/koenig-lexical/src/components/ui/CardWrapper.tsx
+++ b/koenig/koenig-lexical/src/components/ui/CardWrapper.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import TrashIcon from '../../assets/icons/kg-trash.svg?react';
 import VisibilityIndicator from '../../assets/icons/kg-indicator-visibility.svg?react';
+import {Tooltip} from './Tooltip';
 import type {CardWidth} from '@tryghost/kg-default-nodes';
 
 const CARD_WIDTH_CLASSES: Partial<Record<CardWidth, string>> = {
@@ -25,7 +27,9 @@ interface CardWrapperProps extends React.HTMLAttributes<HTMLDivElement> {
     isEditing?: boolean;
     isSelected?: boolean;
     isVisibilityActive?: boolean;
+    onDeleteClick?: (event: React.MouseEvent) => void;
     onIndicatorClick?: (event: React.MouseEvent) => void;
+    showDeleteButton?: boolean;
     wrapperStyle?: string;
 }
 
@@ -39,7 +43,9 @@ export const CardWrapper = React.forwardRef<HTMLDivElement, CardWrapperProps>(({
     isEditing,
     isSelected,
     isVisibilityActive,
+    onDeleteClick,
     onIndicatorClick,
+    showDeleteButton,
     wrapperStyle,
     children,
     ...props
@@ -113,6 +119,24 @@ export const CardWrapper = React.forwardRef<HTMLDivElement, CardWrapperProps>(({
                 data-kg-card-selected={isSelected}
                 {...props}
             >
+                {showDeleteButton && (
+                    <div className="not-kg-prose absolute right-2 top-2 z-[1001]" data-kg-allow-clickthrough="false" data-kg-mobile-card-delete>
+                        <button
+                            aria-label="Delete card"
+                            className="group relative flex size-9 cursor-pointer items-center justify-center rounded-md bg-white/95 text-grey-900 shadow-md transition hover:bg-white hover:text-black dark:bg-grey-950 dark:text-white dark:hover:bg-grey-900"
+                            data-testid="delete-card"
+                            type="button"
+                            onClick={onDeleteClick}
+                            onMouseDown={(event) => {
+                                event.preventDefault();
+                                event.stopPropagation();
+                            }}
+                        >
+                            <TrashIcon className="size-4 stroke-[2.5]" />
+                            <Tooltip label="Delete card" />
+                        </button>
+                    </div>
+                )}
                 {children}
             </div>
         </>

--- a/koenig/koenig-lexical/test/e2e/cards/gallery-card.test.ts
+++ b/koenig/koenig-lexical/test/e2e/cards/gallery-card.test.ts
@@ -155,6 +155,37 @@ test.describe('Gallery card', async () => {
         `);
     });
 
+    test('can remove selected gallery card on mobile', async function ({browser}) {
+        const context = await browser.newContext({
+            hasTouch: true,
+            isMobile: true,
+            viewport: {
+                width: 390,
+                height: 844
+            }
+        });
+        const mobilePage = await context.newPage();
+
+        try {
+            await initialize({page: mobilePage});
+            await mobilePage.setViewportSize({width: 390, height: 844});
+            await focusEditor(mobilePage);
+            await insertCard(mobilePage, {cardName: 'gallery'});
+
+            await expect(mobilePage.locator('[data-kg-card="gallery"][data-kg-card-selected="true"]')).toBeVisible();
+            await expect(mobilePage.getByTestId('delete-card')).toBeVisible();
+
+            await mobilePage.getByTestId('delete-card').tap();
+
+            await expect(mobilePage.locator('[data-kg-card="gallery"]')).toHaveCount(0);
+            await assertHTML(mobilePage, html`
+                <p><br /></p>
+            `);
+        } finally {
+            await context.close();
+        }
+    });
+
     test('can upload images', async function () {
         const fileChooserPromise = page.waitForEvent('filechooser');
         const filePath = path.relative(process.cwd(), __dirname + '/../fixtures/large-image.jpeg');


### PR DESCRIPTION
## Why I am making it

Fixes #28568.

On mobile/touch devices, selecting a Koenig card does not give users a way to remove it. The desktop flow works because users can select the card and press Backspace/Delete, but on mobile there is no keyboard-driven deletion path.

## What it does

Adds a touch-device-only delete button to selected Koenig cards.

The button dispatches the existing `DELETE_CARD_COMMAND`, which is the same command used by the Backspace/Delete key handlers for selected cards. This keeps the actual deletion behavior centralized and avoids duplicating card removal logic.

## Demo

<img width="1000" height="626" alt="Screen Recording 2026-07-09 at 15 28 09" src="https://github.com/user-attachments/assets/3432fca8-13d6-47ad-8bc1-0d09016f2f51" />


## Testing

- `rtk pnpm --filter @tryghost/koenig-lexical exec eslint src/components/KoenigCardWrapper.tsx src/components/ui/CardWrapper.tsx test/e2e/cards/gallery-card.test.ts`
- `rtk pnpm --filter @tryghost/koenig-lexical pretest`
- `rtk pnpm --filter @tryghost/koenig-lexical test:acceptance test/e2e/cards/gallery-card.test.ts -g "can remove selected gallery card on mobile" --reporter=line`
- `rtk pnpm --filter @tryghost/koenig-lexical test:acceptance test/e2e/cards/gallery-card.test.ts --reporter=line`

## Checklist

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works
