### PR TITLE
Removed dead marked and debug dependencies from kg-simplemde

### DIFF
--- a/koenig/kg-simplemde/package.json
+++ b/koenig/kg-simplemde/package.json
@@ -25,7 +25,6 @@
   },
   "devDependencies": {
     "browserify": "17.0.1",
-    "debug": "4.4.3",
     "gulp": "5.0.1",
     "gulp-clean-css": "4.3.0",
     "gulp-concat": "2.6.1",
@@ -44,8 +43,7 @@
   },
   "dependencies": {
     "codemirror": "5.65.21",
-    "codemirror-spell-checker": "1.1.2",
-    "marked": "18.0.5"
+    "codemirror-spell-checker": "1.1.2"
   },
   "gitHead": "d46b01ff5696e5a457abee67e0aabc62f2b8a191"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3628,16 +3628,10 @@ importers:
       codemirror-spell-checker:
         specifier: 1.1.2
         version: 1.1.2
-      marked:
-        specifier: 18.0.5
-        version: 18.0.5
     devDependencies:
       browserify:
         specifier: 17.0.1
         version: 17.0.1
-      debug:
-        specifier: 4.4.3
-        version: 4.4.3(supports-color@5.5.0)
       gulp:
         specifier: 5.0.1
         version: 5.0.1
@@ -18564,11 +18558,6 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
-
-  marked@18.0.5:
-    resolution: {integrity: sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==}
-    engines: {node: '>= 20'}
-    hasBin: true
 
   match-media@0.2.0:
     resolution: {integrity: sha512-EoLj8yVf95UNcZMbNJBlAA3E6XLzgMI6ZbnL90WnL2YCzOO4Nza1Ol6TH9ElbuUcDWxN7KxgVM2vYI6P5JqvKg==}
@@ -43734,8 +43723,6 @@ snapshots:
   markdown-table@1.1.3: {}
 
   markdown-table@3.0.4: {}
-
-  marked@18.0.5: {}
 
   match-media@0.2.0: {}
 


### PR DESCRIPTION
## Why

`kg-simplemde` is a vendored SimpleMDE fork carrying two dependencies that nothing uses. Found during a `depcheck` audit of koenig packages.

## What

- **`marked`** (dependency) — the only source reference is a *commented-out* `require` (`// var marked = require("marked");`) followed by `var marked;` (undefined) and an `if(marked)` guard that is therefore always false. It was deliberately disabled ("disable marked to reduce filesize - Ghost uses its own renderer"), so the package is dead weight.
- **`debug`** (devDependency) — no live `require('debug')`. The `debug` tokens in `gulpfile.js` all refer to the separate `gulp-debug` package and to task/output-dir names, not this package.

## Notes
Vendored package with no `test`/`lint`/`build` npm scripts (build is a checked-in gulp pipeline), so verification is by source inspection — confirmed neither dep is referenced anywhere in `src/` or `gulpfile.js`. Left the rest of the vendored gulp toolchain untouched.