### PR TITLE
Fixed comments UI frame type errors

### DIFF
--- a/apps/comments-ui/src/components/frame.tsx
+++ b/apps/comments-ui/src/components/frame.tsx
@@ -9,7 +9,7 @@ type FrameProps = {
 type TailwindFrameProps = FrameProps & {
     style: React.CSSProperties,
     title: string,
-    onResize: (iframeRoot: HTMLElement) => void
+    onResize?: (iframeRoot: HTMLElement) => void
 };
 
 /**
@@ -76,7 +76,7 @@ type PopupFrameProps = FrameProps & {
 };
 
 export const PopupFrame: React.FC<PopupFrameProps> = ({children, title}) => {
-    const style = {
+    const style: React.CSSProperties = {
         zIndex: '3999999',
         position: 'fixed',
         left: '0',


### PR DESCRIPTION
## Why I am making it

This is a focused comments-ui typecheck cleanup.

`PopupFrame` passes a plain style object to `TailwindFrame`, and TypeScript widened `position: 'fixed'` to `string` before checking it against `React.CSSProperties`. That made the iframe style look incompatible even though the runtime value is valid CSS.

The same file also uses `TailwindFrame` for two different frame variants. `ResizableFrame` passes `onResize` because it needs to resize the comments iframe to its content. `PopupFrame` does not pass `onResize`, and that is valid because the underlying `IFrame` component already treats `onResize` as optional.

## What it does

Types `PopupFrame`'s style object as `React.CSSProperties` so TypeScript keeps the CSS property values in the right shape.

Makes `TailwindFrameProps.onResize` optional to match the existing call sites and the underlying `IFrame` contract. `ResizableFrame` still passes `onResize`; `PopupFrame` does not need it.

I also noticed this file mixes `React.*` types with named React imports. I kept that cleanup out of this PR so this stays focused on the type errors.

## Type errors fixed

This removes the `apps/comments-ui/src/components/frame.tsx` errors from the comments-ui `tsc --noEmit` cleanup:

```text
src/components/frame.tsx(90,24): error TS2322: Type '{ zIndex: string; position: string; left: string; top: string; width: string; height: string; overflow: string; }' is not assignable to type 'CSSProperties'.
  Types of property 'position' are incompatible.
    Type 'string' is not assignable to type 'Position | undefined'.
```

## Why developers need it

This keeps reducing the comments-ui TypeScript error count and lets developers focus on the remaining real type issues in `app.tsx`.

## Testing

- `rtk proxy pnpm --filter @tryghost/comments-ui exec tsc --noEmit`

This still fails on the known remaining comments-ui TypeScript errors in `src/app.tsx`, but the `frame.tsx` errors are gone.

## Checklist

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [ ] I've written an automated test to prove my change works
