### PR TITLE
Moved tags "up" for Mailgun email analytics provider

### DIFF
--- a/ghost/core/core/server/services/email-analytics/email-analytics-provider-mailgun.js
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-provider-mailgun.js
@@ -2,18 +2,13 @@ const MailgunClient = require('../lib/mailgun-client');
 
 const DEFAULT_EVENT_FILTER = 'delivered OR opened OR failed OR unsubscribed OR complained';
 const PAGE_LIMIT = 300;
-const DEFAULT_TAGS = ['bulk-email'];
 
 class EmailAnalyticsProviderMailgun {
     mailgunClient;
 
-    constructor({config, settings}) {
+    constructor({config, settings, tags}) {
         this.mailgunClient = new MailgunClient({config, settings});
-        this.tags = [...DEFAULT_TAGS];
-
-        if (config.get('bulkEmail:mailgun:tag')) {
-            this.tags.push(config.get('bulkEmail:mailgun:tag'));
-        }
+        this.tags = tags;
     }
 
     /**

--- a/ghost/core/core/server/services/email-analytics/email-analytics-service-wrapper.js
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-service-wrapper.js
@@ -25,6 +25,11 @@ class EmailAnalyticsServiceWrapper {
         const emailSuppressionList = require('../email-suppression-list');
         const prometheusClient = require('../../../shared/prometheus-client');
 
+        const tags = ['bulk-email'];
+        if (config.get('bulkEmail:mailgun:tag')) {
+            tags.push(config.get('bulkEmail:mailgun:tag'));
+        }
+
         this.eventStorage = new EmailEventStorage({
             db,
             membersRepository,
@@ -50,7 +55,7 @@ class EmailAnalyticsServiceWrapper {
             config,
             settings,
             eventProcessor,
-            provider: new MailgunProvider({config, settings}),
+            provider: new MailgunProvider({config, settings, tags}),
             queries,
             domainEvents,
             prometheusClient

--- a/ghost/core/test/unit/server/services/email-analytics/email-analytics-provider-mailgun.test.js
+++ b/ghost/core/test/unit/server/services/email-analytics/email-analytics-provider-mailgun.test.js
@@ -3,6 +3,8 @@ const sinon = require('sinon');
 const EventProcessingResult = require('../../../../../core/server/services/email-analytics/event-processing-result');
 const EmailAnalyticsProviderMailgun = require('../../../../../core/server/services/email-analytics/email-analytics-provider-mailgun');
 
+const DEFAULT_TAGS = ['bulk-email'];
+
 const SAMPLE_EVENTS = [
     new EventProcessingResult({
         delivered: 4,
@@ -58,7 +60,7 @@ describe('EmailAnalyticsProviderMailgun', function () {
                 }
             });
 
-            const mailgunProvider = new EmailAnalyticsProviderMailgun({config, settings});
+            const mailgunProvider = new EmailAnalyticsProviderMailgun({config, settings, tags: DEFAULT_TAGS});
 
             const batchHandler = sinon.spy();
             const mailgunFetchEventsStub = sinon.stub(mailgunProvider.mailgunClient, 'fetchEvents').returns(SAMPLE_EVENTS);
@@ -77,7 +79,7 @@ describe('EmailAnalyticsProviderMailgun', function () {
                 }
             });
 
-            const mailgunProvider = new EmailAnalyticsProviderMailgun({config, settings});
+            const mailgunProvider = new EmailAnalyticsProviderMailgun({config, settings, tags: DEFAULT_TAGS});
 
             const batchHandler = sinon.spy();
             const mailgunFetchEventsStub = sinon.stub(mailgunProvider.mailgunClient, 'fetchEvents').returns(SAMPLE_EVENTS);
@@ -98,7 +100,7 @@ describe('EmailAnalyticsProviderMailgun', function () {
                 }
             });
 
-            const mailgunProvider = new EmailAnalyticsProviderMailgun({config, settings});
+            const mailgunProvider = new EmailAnalyticsProviderMailgun({config, settings, tags: DEFAULT_TAGS});
 
             const batchHandler = sinon.spy();
             const mailgunFetchEventsStub = sinon.stub(mailgunProvider.mailgunClient, 'fetchEvents').returns(SAMPLE_EVENTS);
@@ -119,7 +121,7 @@ describe('EmailAnalyticsProviderMailgun', function () {
                 }
             });
 
-            const mailgunProvider = new EmailAnalyticsProviderMailgun({config, settings});
+            const mailgunProvider = new EmailAnalyticsProviderMailgun({config, settings, tags: DEFAULT_TAGS});
 
             const batchHandler = sinon.spy();
             const mailgunFetchEventsStub = sinon.stub(mailgunProvider.mailgunClient, 'fetchEvents').returns(SAMPLE_EVENTS);
@@ -130,7 +132,7 @@ describe('EmailAnalyticsProviderMailgun', function () {
             sinon.assert.calledWithExactly(mailgunFetchEventsStub, {...MAILGUN_OPTIONS, end: END_EXAMPLE_UNIX}, batchHandler, {maxEvents: 1000});
         });
 
-        it('uses custom tags when supplied', async function () {
+        it('uses supplied tags', async function () {
             const configStub = sinon.stub(config, 'get');
             configStub.withArgs('bulkEmail').returns({
                 mailgun: {
@@ -139,9 +141,8 @@ describe('EmailAnalyticsProviderMailgun', function () {
                     baseUrl: 'https://api.mailgun.net/v3'
                 }
             });
-            configStub.withArgs('bulkEmail:mailgun:tag').returns('custom-tag');
 
-            const mailgunProvider = new EmailAnalyticsProviderMailgun({config, settings});
+            const mailgunProvider = new EmailAnalyticsProviderMailgun({config, settings, tags: ['bulk-email', 'custom-tag']});
 
             const batchHandler = sinon.spy();
             const mailgunFetchEventsStub = sinon.stub(mailgunProvider.mailgunClient, 'fetchEvents').returns(SAMPLE_EVENTS);
@@ -163,7 +164,7 @@ describe('EmailAnalyticsProviderMailgun', function () {
                     baseUrl: 'https://api.mailgun.net/v3'
                 }
             });
-            const mailgunProvider = new EmailAnalyticsProviderMailgun({config, settings});
+            const mailgunProvider = new EmailAnalyticsProviderMailgun({config, settings, tags: DEFAULT_TAGS});
 
             const batchHandler = sinon.spy();
             const mailgunFetchEventsStub = sinon.stub(mailgunProvider.mailgunClient, 'fetchEvents').returns(SAMPLE_EVENTS);


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1447

This change should have no user impact.

In an upcoming change, `EmailAnalyticsProviderMailgun` will need to be instantiated with different tags. This enables that by moving the tags definition "up" to the caller.
