### PR TITLE
Changed admin library dev watchers to build once before watching

### DIFF
--- a/apps/admin-x-design-system/package.json
+++ b/apps/admin-x-design-system/package.json
@@ -103,7 +103,7 @@
                     "command": "vite build --watch"
                 },
                 "dependsOn": [
-                    "^build"
+                    "build"
                 ]
             },
             "build": {

--- a/apps/admin-x-framework/package.json
+++ b/apps/admin-x-framework/package.json
@@ -138,7 +138,7 @@
                     "command": "vite build --watch"
                 },
                 "dependsOn": [
-                    "^build"
+                    "build"
                 ]
             },
             "build": {

--- a/apps/shade/package.json
+++ b/apps/shade/package.json
@@ -174,7 +174,7 @@
                     "command": "vite build --watch"
                 },
                 "dependsOn": [
-                    "^build"
+                    "build"
                 ]
             },
             "build": {


### PR DESCRIPTION
The `dev` targets for `admin-x-framework`, `shade`, and `admin-x-design-system` are continuous `vite build --watch` tasks whose `dependsOn` was only `^build` — upstream packages got complete builds, but each package's **own** first build was never awaited. Nx doesn't block dependents on continuous tasks, so `apps/admin`'s vite dev server starts serving as soon as the watcher *processes* are up, racing their first emit.

On a warm checkout a leftover `dist/` hides the race. On a fresh checkout/worktree it reliably loses — and if the first emit is interrupted, it leaves a partially written `dist/` (`.cjs` and `.js.map` present, `.js` missing) that vite's optimizeDeps then caches as a sticky `Failed to resolve import "@tryghost/admin-x-framework/api/..."` overlay until a manual rebuild. The watch command also never runs the `tsc` declaration step, so fresh checkouts under the dev lane had no `types/` for these packages at all.

Fix: each library's `dev` target now depends on its own `build` (which transitively orders `^build`), guaranteeing a complete `dist/` + `types/` exists before the watcher takes over and before any consumer's dev server starts. Warm starts stay fast because the build is nx-cached.

Verification: `nx show project` confirms the resolved graph (`dev → build → ^build`) for all three packages with no cycles; cold `pnpm dev` now blocks on the three builds before `apps/admin`'s vite serves.