### PR TITLE
Fixed flaky welcome email bookmark test

### DIFF
--- a/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/member-welcome-emails.test.ts
@@ -746,7 +746,6 @@ test.describe('Member emails settings', async () => {
             await expect(modal).toBeVisible();
 
             const editor = modal.locator('[data-kg="editor"] div[contenteditable="true"]').first();
-            await editor.click({timeout: 5000});
             await editor.fill('');
             await expect(editor).toBeEmpty();
             await openSlashMenu(page, 'bookmark');
@@ -756,7 +755,10 @@ test.describe('Member emails settings', async () => {
             await expect(bookmarkUrlInput).toBeVisible({timeout: 10000});
             await bookmarkUrlInput.fill('https://ghost.org/');
             await expect(bookmarkUrlInput).toHaveValue('https://ghost.org/');
-            await bookmarkUrlInput.press('Enter');
+
+            const urlSuggestion = modal.getByTestId('bookmark-url-listOption').filter({hasText: 'https://ghost.org/'});
+            await expect(urlSuggestion).toBeVisible();
+            await urlSuggestion.click();
 
             await expect.poll(() => lastApiRequests.fetchOembed?.url || '').toContain('type=bookmark');
             await expect(modal.getByTestId('bookmark-title')).toContainText('Ghost: The Creator Economy Platform');


### PR DESCRIPTION
## What changed

- Removed the redundant click on the already-focused welcome email editor.
- Wait for the bookmark URL autocomplete option to render and select it directly.

## Root cause

The bookmark autocomplete installs a window-level capture handler for Enter. After the test filled the URL, React had not always replaced the default “Latest posts” suggestions with the URL option before Enter was pressed. The capture handler therefore selected stale autocomplete state and no oEmbed request was made. Under load, the redundant editor click also exceeded its hard-coded five-second timeout even though the editor was already focused and ready for input.

## Impact

This is a test-only change. It makes the bookmark metadata acceptance test follow the rendered autocomplete path deterministically.

## Validation

- Targeted Playwright test repeated 10 times with 7 workers: 10/10 passed
- `pnpm --filter @tryghost/admin-x-settings lint:js -- test/acceptance/membership/member-welcome-emails.test.ts`
- `git diff --check`

Refs https://github.com/TryGhost/Ghost/actions/runs/29100148768/job/86386882802