### PR TITLE
Improved CI portability across runner sizes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -833,7 +833,7 @@ jobs:
       - name: Test project
         run: tb test run
       - name: Trigger and watch traffic analytics infra Tinybird workflow
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: github.repository == 'TryGhost/Ghost' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         env:
           GH_TOKEN: ${{ secrets.TRAFFIC_ANALYTICS_GITHUB_TOKEN }}
         uses: ./.github/actions/dispatch-workflow

--- a/koenig/koenig-lexical/playwright.config.ts
+++ b/koenig/koenig-lexical/playwright.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
     /* Fail the build on CI if you accidentally left test.only in the source code. */
     forbidOnly: !!process.env.CI,
     retries: process.env.CI ? 2 : 0,
-    workers: process.env.CI ? 4 : undefined,
+    workers: process.env.CI ? '100%' : undefined,
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
     reporter: process.env.CI ? [['github'], ['html']] :
               process.env.PLAYWRIGHT_HTML_REPORT ? [['html'], ['list']] :


### PR DESCRIPTION
## Summary

- skip the traffic analytics infra dispatch outside `TryGhost/Ghost`, where the required repository token is unavailable
- size Koenig Playwright's CI worker pool from the runner CPU count instead of forcing four workers

## Testing

- `actionlint -shellcheck= .github/workflows/ci.yml`
- lint-staged ESLint hook for `playwright.config.ts`
- loaded the Playwright config under `CI=1` and verified `workers` resolves to `100%`
- `git diff --check origin/main...HEAD`