### PR TITLE
Changed Nx SHA fallback behavior outside canonical CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
         with:
           main-branch-name: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}
-          error-on-no-successful-workflow: ${{ env.IS_MAIN == 'true' }}
+          error-on-no-successful-workflow: ${{ env.IS_MAIN == 'true' && github.repository == 'TryGhost/Ghost' }}
 
       - name: Check user org membership
         id: check_user_org_membership


### PR DESCRIPTION
## Summary

- keep missing-successful-run errors strict in canonical Ghost CI
- allow other repository instances to use `nx-set-shas`' default `HEAD~1` bootstrap fallback

## Context

A repository with no previous successful main workflow cannot calculate its affected range from workflow history. `nx-set-shas` already supports this case by warning and falling back to `HEAD~1`; the hard-error option only needs to apply to canonical CI.

## Testing

- `actionlint -shellcheck= .github/workflows/ci.yml`
- `git diff --check`