### PR TITLE
Fixed analytics healthcheck flooding dev logs with a request every second

### DIFF
--- a/compose.dev.analytics.yaml
+++ b/compose.dev.analytics.yaml
@@ -14,8 +14,10 @@ services:
       - "3000"
     healthcheck:
       test: ["CMD-SHELL", "node -e \"fetch('http://localhost:3000').then(r=>process.exit(r.status<500?0:1)).catch(()=>process.exit(1))\""]
-      interval: 1s
-      retries: 120
+      interval: 30s
+      retries: 5
+      start_period: 120s
+      start_interval: 1s
     volumes:
       - ./docker/analytics/entrypoint.sh:/app/entrypoint.sh:ro
       - shared-config:/mnt/shared-config:ro
@@ -37,9 +39,11 @@ services:
       - "7181:7181"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:7181/v0/health"]
-      interval: 1s
+      interval: 30s
       timeout: 5s
-      retries: 120
+      retries: 5
+      start_period: 120s
+      start_interval: 1s
 
   tb-cli:
     build:


### PR DESCRIPTION
## Summary
- The `analytics` and `tinybird-local` healthchecks in `compose.dev.analytics.yaml` used `interval: 1s` with no `start_period`. Docker's `interval` applies for the container's entire lifetime, not just startup, so the healthcheck kept firing every second forever.
- `ghost/traffic-analytics` logs every incoming request at INFO in GCP structured format, so `pnpm dev:analytics` flooded the terminal with one `IncomingRequest` log line per second.
- Switched both healthchecks to a `start_period: 120s` + `start_interval: 1s` for fast startup detection, then a quiet `interval: 30s` for steady-state polling.
- Checked the sibling healthchecks in `compose.dev.yaml` (`mysql`, `redis`, `mailpit`, `ghost-dev`) for the same issue — none of them log per-healthcheck-request output (MySQL's general query log is off by default, Redis doesn't log commands, `mailpit` already runs with `--quiet`, and `ghost-dev`'s healthcheck has no explicit `interval` override so it already defaults to Docker's 30s), so no changes were needed there.

## Test plan
- [x] Ran `pnpm dev:analytics` and confirmed `ghost-dev-analytics` was logging one `IncomingRequest` line per second before the fix.
- [x] Recreated the `analytics`/`tinybird-local` services with the new healthcheck config and confirmed the container went `healthy` almost immediately (fast polling during `start_period`).
- [x] Observed a 40s window post-startup with only 1 healthcheck log line (vs. ~40 before), matching the new 30s steady-state interval.