### PR TITLE
Improved generated Koenig node type contracts

### DIFF
--- a/koenig/kg-default-nodes/src/generate-decorator-node.ts
+++ b/koenig/kg-default-nodes/src/generate-decorator-node.ts
@@ -2,12 +2,13 @@ import {KoenigDecoratorNode} from './KoenigDecoratorNode.js';
 import type {ExportDOMOptions, ExportDOMOutput} from './export-dom.js';
 import readTextContent from './utils/read-text-content.js';
 import {buildDefaultVisibility, isVisibilityRestricted, migrateOldVisibilityFormat} from './utils/visibility.js';
-import type {LexicalEditor} from 'lexical';
+import type {LexicalEditor, SerializedLexicalNode} from 'lexical';
 import type {Visibility} from './utils/visibility.js';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- render fns take their own node subtype; `unknown` would reject them (parameter contravariance)
-type RenderFn<TOutput extends ExportDOMOutput = ExportDOMOutput> = (node: any, options: ExportDOMOptions) => TOutput;
-type VersionedRenderFn<TOutput extends ExportDOMOutput = ExportDOMOutput> = Record<string | number, RenderFn<TOutput>>;
+type RenderFn<TNode = unknown, TOutput extends ExportDOMOutput = ExportDOMOutput> = {
+    bivarianceHack(node: TNode, options: ExportDOMOptions): TOutput;
+}['bivarianceHack'];
+type VersionedRenderFn<TNode = unknown, TOutput extends ExportDOMOutput = ExportDOMOutput> = Record<string | number, RenderFn<TNode, TOutput>>;
 type WidenLiteral<T> =
     T extends string ? string :
     T extends number ? number :
@@ -63,13 +64,20 @@ export interface DecoratorNodeProperty<Name extends string = string, Default = u
 
 export type DecoratorNodeValueMap<Props extends readonly DecoratorNodeProperty[], HasVisibility extends boolean = false> = {
     [Prop in Props[number] as Prop['name']]: WidenLiteral<Prop['default']>;
-} & (HasVisibility extends true ? {visibility: Visibility} : {});
+} & (HasVisibility extends true ? {visibility: Visibility} : unknown);
 
 export type DecoratorNodeData<Props extends readonly DecoratorNodeProperty[], HasVisibility extends boolean = false> = Partial<DecoratorNodeValueMap<Props, HasVisibility>>;
 
 type GeneratedDecoratorNodeInstance<TDataset extends Record<string, unknown>, TOutput extends ExportDOMOutput = ExportDOMOutput> = GeneratedDecoratorNodeBase<TDataset> & TDataset & {
     exportDOM(editor: LexicalEditor, options?: ExportDOMOptions): TOutput;
 };
+
+// An intersection rather than Lexical's `Spread` utility: `Spread` isn't provably
+// assignable to `SerializedLexicalNode` when TDataset is an unresolved generic, which
+// breaks the `exportJSON` override inside `generateDecoratorNode`. The trade-off is
+// that a dataset property colliding with `type`/`version` at an incompatible type
+// produces `never` — keep such properties compatible (e.g. HeaderNode's `version: number`).
+export type SerializedGeneratedDecoratorNode<TDataset extends Record<string, unknown> = Record<string, unknown>> = SerializedLexicalNode & TDataset;
 
 export interface GeneratedDecoratorNodeClass<TDataset extends Record<string, unknown>, TOutput extends ExportDOMOutput = ExportDOMOutput> {
     new (data?: Partial<TDataset>, key?: string): GeneratedDecoratorNodeInstance<TDataset, TOutput>;
@@ -136,19 +144,30 @@ export class GeneratedDecoratorNodeBase<TDataset extends Record<string, unknown>
 export function generateDecoratorNode<
     Props extends readonly DecoratorNodeProperty[] = readonly [],
     HasVisibility extends boolean = false,
-    TOutput extends ExportDOMOutput = ExportDOMOutput
->({nodeType, properties = [] as unknown as Props, defaultRenderFn, version = 1, hasVisibility = false as HasVisibility}: {
+    TOutput extends ExportDOMOutput = ExportDOMOutput,
+    // When not passed explicitly, TRenderNode is inferred from `defaultRenderFn`'s
+    // node parameter — the render fn's declared node type is trusted, not validated
+    // against the generated node shape. Pass explicit type arguments (see HeaderNode)
+    // to have render fns checked against a known node type.
+    TRenderNode = GeneratedDecoratorNodeInstance<DecoratorNodeValueMap<Props, HasVisibility>, TOutput>
+>({nodeType, properties, defaultRenderFn, version = 1, hasVisibility}: {
     nodeType: string;
     properties?: Props;
-    defaultRenderFn?: RenderFn<TOutput> | VersionedRenderFn<TOutput>;
+    defaultRenderFn?: RenderFn<TRenderNode, TOutput> | VersionedRenderFn<TRenderNode, TOutput>;
     version?: number;
     hasVisibility?: HasVisibility;
 }): GeneratedDecoratorNodeClass<DecoratorNodeValueMap<Props, HasVisibility>, TOutput> {
-    validateArguments(nodeType, properties);
+    type GeneratedDataset = DecoratorNodeValueMap<Props, HasVisibility>;
+    type GeneratedRenderFn = RenderFn<TRenderNode, TOutput>;
+    type GeneratedVersionedRenderFn = VersionedRenderFn<TRenderNode, TOutput>;
+
+    const nodeProperties = properties ?? [];
+
+    validateArguments(nodeType, nodeProperties);
 
     // Adds a `privateName` field to the properties for convenience (e.g. `__name`):
     // properties: [{name: 'name', privateName: '__name', type: 'string', default: 'hello'}, {...}]
-    const internalProps = properties.map((prop) => {
+    const internalProps = nodeProperties.map((prop) => {
         return Object.defineProperties({}, {
             ...Object.getOwnPropertyDescriptors(prop),
             privateName: {
@@ -175,7 +194,7 @@ export function generateDecoratorNode<
     class GeneratedDecoratorNode extends KoenigDecoratorNode {
         [key: string]: unknown;
 
-        constructor(data: Partial<DecoratorNodeValueMap<Props, HasVisibility>> = {}, key?: string) {
+        constructor(data: Partial<GeneratedDataset> = {}, key?: string) {
             super(key);
             const dataset = data as Record<string, unknown>;
             internalProps.forEach((prop) => {
@@ -207,7 +226,7 @@ export function generateDecoratorNode<
          * @see https://lexical.dev/docs/concepts/nodes#extending-decoratornode
          */
         static clone(node: GeneratedDecoratorNodeInstance<DecoratorNodeValueMap<Props, HasVisibility>, TOutput>) {
-            return new this(node.getDataset() as Partial<DecoratorNodeValueMap<Props, HasVisibility>>, node.__key);
+            return new this(node.getDataset() as Partial<GeneratedDataset>, node.__key);
         }
 
         /**
@@ -218,7 +237,7 @@ export function generateDecoratorNode<
             return internalProps.reduce((obj: Record<string, unknown>, prop) => {
                 obj[prop.name] = prop.default;
                 return obj;
-            }, {}) as DecoratorNodeValueMap<Props, HasVisibility>;
+            }, {}) as GeneratedDataset;
         }
 
         /**
@@ -273,7 +292,7 @@ export function generateDecoratorNode<
                 data[prop.name] = serializedNode[prop.name];
             });
 
-            return new this(data as Partial<DecoratorNodeValueMap<Props, HasVisibility>>);
+            return new this(data as Partial<GeneratedDataset>);
         }
 
         /**
@@ -281,54 +300,52 @@ export function generateDecoratorNode<
          * @extends DecoratorNode
          * @see https://lexical.dev/docs/concepts/serialization#lexicalnodeexportjson
          */
-        // @ts-expect-error -- strict mode migration
-        exportJSON() {
-            const dataset: Record<string, unknown> = {
+        exportJSON(): SerializedGeneratedDecoratorNode<GeneratedDataset> {
+            const dataset = {
                 type: nodeType,
                 version: version,
                 ...internalProps.reduce((obj: Record<string, unknown>, prop) => {
                     obj[prop.name] = this[prop.name];
                     return obj;
                 }, {})
-            };
+            } as SerializedGeneratedDecoratorNode<GeneratedDataset>;
             return dataset;
         }
 
         exportDOM(_editor: LexicalEditor, options: ExportDOMOptions = {}): TOutput {
             // this.__version is used when a node has a version property which
             // means it's set from the serialized version data at runtime
-            const nodeVersion = this.__version || version;
+            const nodeVersion = typeof this.__version === 'string' || typeof this.__version === 'number' ? this.__version : version;
+            const node = this as unknown as TRenderNode;
 
-            const nodeRenderers = options.nodeRenderers as Record<string, RenderFn<TOutput> | VersionedRenderFn<TOutput>> | undefined;
+            const nodeRenderers = options.nodeRenderers as Record<string, GeneratedRenderFn | GeneratedVersionedRenderFn> | undefined;
             if (nodeRenderers?.[nodeType]) {
                 const render = nodeRenderers[nodeType];
 
                 if (typeof render === 'object') {
-                    const versionRenderer = (render as VersionedRenderFn<TOutput>)[nodeVersion as number];
+                    const versionRenderer = render[nodeVersion];
                     if (!versionRenderer) {
                         throw new Error(`[generateDecoratorNode] ${nodeType}: options.nodeRenderers['${nodeType}'] for version ${nodeVersion} is required`);
                     }
-                    return versionRenderer(this, options);
+                    return versionRenderer(node, options);
                 } else {
-                    return (render as RenderFn<TOutput>)(this, options);
+                    return render(node, options);
                 }
             }
 
             if (typeof defaultRenderFn === 'object') {
-                const render = (defaultRenderFn as VersionedRenderFn<TOutput>)[nodeVersion as number];
+                const render = defaultRenderFn[nodeVersion];
                 if (!render) {
                     throw new Error(`[generateDecoratorNode] ${nodeType}: "defaultRenderFn" for version ${nodeVersion} is required`);
                 }
-                return render(this, options);
+                return render(node, options);
             }
 
             if (!defaultRenderFn) {
                 throw new Error(`[generateDecoratorNode] ${nodeType}: "defaultRenderFn" is required`);
             }
 
-            const render = defaultRenderFn as RenderFn<TOutput>;
-
-            return render(this, options);
+            return defaultRenderFn(node, options);
         }
 
         /* c8 ignore start */
@@ -381,7 +398,7 @@ export function generateDecoratorNode<
         */
         getTextContent() {
             const self = this.getLatest();
-            const propertiesWithText = properties.filter(prop => !!prop.wordCount);
+            const propertiesWithText = nodeProperties.filter(prop => !!prop.wordCount);
 
             const text = propertiesWithText.map(
                 prop => readTextContent(self, prop.name)

--- a/koenig/kg-default-nodes/src/kg-default-nodes.ts
+++ b/koenig/kg-default-nodes/src/kg-default-nodes.ts
@@ -64,6 +64,7 @@ export * from './nodes/ExtendedQuoteNode.js';
 export * from './nodes/TKNode.js';
 export * from './nodes/at-link/index.js';
 export * from './nodes/zwnj/ZWNJNode.js';
+export * from './utils/card-widths.js';
 
 // export utility functions that are useful in other packages or tests
 import * as visibilityUtils from './utils/visibility.js';

--- a/koenig/kg-default-nodes/src/nodes/header/HeaderNode.ts
+++ b/koenig/kg-default-nodes/src/nodes/header/HeaderNode.ts
@@ -31,8 +31,11 @@ export type HeaderData = DecoratorNodeData<typeof headerProperties>;
 
 export interface HeaderNode extends DecoratorNodeValueMap<typeof headerProperties> {}
 
+type HeaderRenderNode = Parameters<typeof renderHeaderNodeV1>[0] & Parameters<typeof renderHeaderNodeV2>[0];
+type HeaderRenderOutput = ReturnType<typeof renderHeaderNodeV1> | ReturnType<typeof renderHeaderNodeV2>;
+
 // This is our first node that has a custom version property
-export class HeaderNode extends generateDecoratorNode({
+export class HeaderNode extends generateDecoratorNode<typeof headerProperties, false, HeaderRenderOutput, HeaderRenderNode>({
     nodeType: 'header',
     properties: headerProperties,
     defaultRenderFn: {

--- a/koenig/kg-default-nodes/src/utils/card-widths.ts
+++ b/koenig/kg-default-nodes/src/utils/card-widths.ts
@@ -1,0 +1,11 @@
+export const CARD_WIDTHS = ['regular', 'wide', 'full'] as const;
+
+export type CardWidth = typeof CARD_WIDTHS[number];
+
+export function isCardWidth(width: unknown): width is CardWidth {
+    return typeof width === 'string' && (CARD_WIDTHS as readonly string[]).includes(width);
+}
+
+export function normalizeCardWidth(width: unknown): CardWidth | undefined {
+    return isCardWidth(width) ? width : undefined;
+}

--- a/koenig/kg-default-nodes/src/utils/visibility.ts
+++ b/koenig/kg-default-nodes/src/utils/visibility.ts
@@ -21,7 +21,7 @@ function isNullish(value: unknown) {
 }
 
 // ensure we always work with a deep copy to avoid accidental ref mutations
-export function buildDefaultVisibility() {
+export function buildDefaultVisibility(): typeof DEFAULT_VISIBILITY {
     return JSON.parse(JSON.stringify(DEFAULT_VISIBILITY));
 }
 

--- a/koenig/kg-default-nodes/test/generate-decorator-node.test.ts
+++ b/koenig/kg-default-nodes/test/generate-decorator-node.test.ts
@@ -101,8 +101,8 @@ describe('Utils: generateDecoratorNode', function () {
                 properties: [{name: 'version', default: 1}],
                 version: 1,
                 defaultRenderFn: {
-                    1: () => createRenderResult('div', 'version 1'),
-                    2: () => createRenderResult('div', 'version 2')
+                    1: node => createRenderResult('div', `version ${node.version}`),
+                    2: node => createRenderResult('div', `version ${node.version}`)
                 }
             });
 

--- a/koenig/koenig-lexical/src/components/KoenigCardWrapper.tsx
+++ b/koenig/koenig-lexical/src/components/KoenigCardWrapper.tsx
@@ -8,13 +8,22 @@ import {VISIBILITY_SETTINGS} from '../utils/visibility';
 import {mergeRegister} from '@lexical/utils';
 import {useKoenigSelectedCardContext} from '../context/KoenigSelectedCardContext';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import type {CardWidth} from '@tryghost/kg-default-nodes';
 
-const KoenigCardWrapper = ({nodeKey, width, wrapperStyle, IndicatorIcon, children}) => {
+interface KoenigCardWrapperProps {
+    nodeKey: string;
+    width?: CardWidth;
+    wrapperStyle?: string;
+    IndicatorIcon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+    children?: React.ReactNode;
+}
+
+const KoenigCardWrapper = ({nodeKey, width, wrapperStyle, IndicatorIcon, children}: KoenigCardWrapperProps) => {
     const {cardConfig} = React.useContext(KoenigComposerContext);
     const [editor] = useLexicalComposerContext();
     const [cardType, setCardType] = React.useState(null);
     const [captionHasFocus, setCaptionHasFocus] = React.useState(null);
-    const [cardWidth, setCardWidth] = React.useState(width || 'regular');
+    const [cardWidth, setCardWidth] = React.useState<CardWidth>(width || 'regular');
     const containerRef = React.useRef(null);
     const skipClick = React.useRef(false);
 

--- a/koenig/koenig-lexical/src/components/ui/CardWrapper.tsx
+++ b/koenig/koenig-lexical/src/components/ui/CardWrapper.tsx
@@ -1,8 +1,8 @@
-import PropTypes from 'prop-types';
 import React from 'react';
 import VisibilityIndicator from '../../assets/icons/kg-indicator-visibility.svg?react';
+import type {CardWidth} from '@tryghost/kg-default-nodes';
 
-const CARD_WIDTH_CLASSES = {
+const CARD_WIDTH_CLASSES: Partial<Record<CardWidth, string>> = {
     wide: [
         'w-[calc(75vw-var(--kg-breakout-adjustment-with-fallback)+2px)] mx-[calc(50%-(50vw-var(--kg-breakout-adjustment-with-fallback))-.8rem)] min-w-[calc(100%+3.6rem)] translate-x-[calc(50vw-50%+.8rem-var(--kg-breakout-adjustment-with-fallback))]',
         'md:min-w-[calc(100%+10rem)]',
@@ -15,10 +15,24 @@ const DEFAULT_INDICATOR_POSITION = {
     top: '.6rem'
 };
 
-export const CardWrapper = React.forwardRef(({
+interface CardWrapperProps extends React.HTMLAttributes<HTMLDivElement> {
+    cardType?: string | null;
+    cardWidth?: CardWidth;
+    feature?: unknown;
+    IndicatorIcon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+    indicatorPosition?: {left?: string; top?: string};
+    isDragging?: boolean;
+    isEditing?: boolean;
+    isSelected?: boolean;
+    isVisibilityActive?: boolean;
+    onIndicatorClick?: (event: React.MouseEvent) => void;
+    wrapperStyle?: string;
+}
+
+export const CardWrapper = React.forwardRef<HTMLDivElement, CardWrapperProps>(({
     cardType,
     cardWidth = 'regular',
-    feature,
+    feature: _feature,
     IndicatorIcon,
     indicatorPosition = DEFAULT_INDICATOR_POSITION,
     isDragging,
@@ -51,7 +65,7 @@ export const CardWrapper = React.forwardRef(({
         wrapperClass()
     ].join(' ');
 
-    const position = {
+    const position: {left?: string; top?: string} = {
         ...DEFAULT_INDICATOR_POSITION,
         ...(indicatorPosition || {}),
         ...(cardType === 'call-to-action' && {top: '1.4rem'})
@@ -106,14 +120,3 @@ export const CardWrapper = React.forwardRef(({
 });
 
 CardWrapper.displayName = 'CardWrapper';
-
-CardWrapper.propTypes = {
-    isSelected: PropTypes.bool,
-    isEditing: PropTypes.bool,
-    cardWidth: PropTypes.oneOf(['regular', 'wide', 'full']),
-    icon: PropTypes.string,
-    indicatorPosition: PropTypes.shape({
-        left: PropTypes.string,
-        top: PropTypes.string
-    })
-};

--- a/koenig/koenig-lexical/src/context/CardContext.tsx
+++ b/koenig/koenig-lexical/src/context/CardContext.tsx
@@ -1,5 +1,30 @@
 import React from 'react';
+import type {CardWidth} from '@tryghost/kg-default-nodes';
 
-const CardContext = React.createContext({});
+export interface CardContextType {
+    isSelected: boolean;
+    captionHasFocus: boolean | null;
+    isEditing: boolean;
+    cardWidth: CardWidth;
+    setCardWidth: (width: CardWidth) => void;
+    setCaptionHasFocus: (hasFocus: boolean | null) => void;
+    setEditing: (editing: boolean) => void;
+    nodeKey: string;
+    cardContainerRef: React.RefObject<HTMLDivElement | null>;
+}
+
+const noop = () => {};
+
+const CardContext = React.createContext<CardContextType>({
+    isSelected: false,
+    captionHasFocus: null,
+    isEditing: false,
+    cardWidth: 'regular',
+    setCardWidth: noop,
+    setCaptionHasFocus: noop,
+    setEditing: noop,
+    nodeKey: '',
+    cardContainerRef: React.createRef<HTMLDivElement>()
+});
 
 export default CardContext;

--- a/koenig/koenig-lexical/src/nodes/HeaderNode.tsx
+++ b/koenig/koenig-lexical/src/nodes/HeaderNode.tsx
@@ -5,7 +5,7 @@ import KoenigCardWrapper from '../components/KoenigCardWrapper';
 import MINIMAL_NODES from './MinimalNodes';
 import {$canShowPlaceholderCurry} from '@lexical/text';
 import {$generateHtmlFromNodes} from '@lexical/html';
-import {HeaderNode as BaseHeaderNode} from '@tryghost/kg-default-nodes';
+import {HeaderNode as BaseHeaderNode, type CardWidth, normalizeCardWidth} from '@tryghost/kg-default-nodes';
 import {cleanBasicHtml} from '@tryghost/kg-clean-basic-html';
 import {createCommand} from 'lexical';
 import {populateNestedEditor, setupNestedEditor} from '../utils/nested-editors';
@@ -101,7 +101,7 @@ export class HeaderNode extends BaseHeaderNode {
         return dataset;
     }
 
-    getCardWidth() {
+    getCardWidth(): CardWidth | undefined {
         const version = this.version;
 
         if (version === 1) {
@@ -110,7 +110,7 @@ export class HeaderNode extends BaseHeaderNode {
 
         if (version === 2) {
             const layout = this.layout;
-            return layout === 'split' ? 'full' : layout;
+            return normalizeCardWidth(layout === 'split' ? 'full' : layout);
         }
     }
 

--- a/koenig/koenig-lexical/src/nodes/ImageNode.tsx
+++ b/koenig/koenig-lexical/src/nodes/ImageNode.tsx
@@ -2,7 +2,7 @@ import GIFIcon from '../assets/icons/kg-card-type-gif.svg?react';
 import ImageCardIcon from '../assets/icons/kg-card-type-image.svg?react';
 import UnsplashIcon from '../assets/icons/kg-card-type-unsplash.svg?react';
 import {$generateHtmlFromNodes} from '@lexical/html';
-import {ImageNode as BaseImageNode} from '@tryghost/kg-default-nodes';
+import {ImageNode as BaseImageNode, normalizeCardWidth} from '@tryghost/kg-default-nodes';
 import {ImageNodeComponent} from './ImageNodeComponent';
 import {KoenigCardWrapper, MINIMAL_NODES} from '../index.js';
 import {OPEN_GIF_SELECTOR_COMMAND, OPEN_UNSPLASH_SELECTOR_COMMAND} from '../plugins/KoenigSelectorPlugin.jsx';
@@ -144,7 +144,7 @@ export class ImageNode extends BaseImageNode {
         const Selector = this.__selector;
 
         return (
-            <KoenigCardWrapper nodeKey={this.getKey()} width={this.__cardWidth}>
+            <KoenigCardWrapper nodeKey={this.getKey()} width={normalizeCardWidth(this.__cardWidth)}>
                 {this.__selector && <Selector nodeKey={this.getKey()} />}
 
                 {

--- a/koenig/koenig-lexical/src/nodes/ImageNodeComponent.tsx
+++ b/koenig/koenig-lexical/src/nodes/ImageNodeComponent.tsx
@@ -17,6 +17,7 @@ import {getAllowedImageCardWidths, getDefaultImageCardWidth} from '../utils/imag
 import {getImageDimensions} from '../utils/getImageDimensions.js';
 import {getImageFilenameFromSrc} from '../utils/getImageFilenameFromSrc';
 import {imageUploadHandler} from '../utils/imageUploadHandler';
+import {isCardWidth} from '@tryghost/kg-default-nodes';
 import {isGif} from '../utils/isGif';
 import {openFileSelection} from '../utils/openFileSelection';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
@@ -187,8 +188,8 @@ export function ImageNodeComponent({nodeKey, initialFile, src, altText, captionE
         });
     });
 
-    const handleImageCardResize = React.useCallback((newWidth) => {
-        if (!allowedImageCardWidths.includes(newWidth)) {
+    const handleImageCardResize = React.useCallback((newWidth: unknown) => {
+        if (!isCardWidth(newWidth) || !allowedImageCardWidths.includes(newWidth)) {
             return;
         }
 

--- a/koenig/koenig-lexical/src/nodes/SignupNode.tsx
+++ b/koenig/koenig-lexical/src/nodes/SignupNode.tsx
@@ -4,7 +4,7 @@ import SignupCardIcon from '../assets/icons/kg-card-type-signup.svg?react';
 import SignupNodeComponent from './SignupNodeComponent';
 import {$canShowPlaceholderCurry} from '@lexical/text';
 import {$generateHtmlFromNodes} from '@lexical/html';
-import {SignupNode as BaseSignupNode} from '@tryghost/kg-default-nodes';
+import {SignupNode as BaseSignupNode, type CardWidth, normalizeCardWidth} from '@tryghost/kg-default-nodes';
 import {cleanBasicHtml} from '@tryghost/kg-clean-basic-html';
 import {createCommand} from 'lexical';
 import {populateNestedEditor, setupNestedEditor} from '../utils/nested-editors';
@@ -110,9 +110,9 @@ export class SignupNode extends BaseSignupNode {
         return dataset;
     }
 
-    getCardWidth() {
+    getCardWidth(): CardWidth | undefined {
         const layout = this.layout;
-        return layout === 'split' ? 'full' : layout;
+        return normalizeCardWidth(layout === 'split' ? 'full' : layout);
     }
 
     decorate() {

--- a/koenig/koenig-lexical/src/nodes/VideoNode.tsx
+++ b/koenig/koenig-lexical/src/nodes/VideoNode.tsx
@@ -1,6 +1,6 @@
 import VideoCardIcon from '../assets/icons/kg-card-type-video.svg?react';
 import {$generateHtmlFromNodes} from '@lexical/html';
-import {VideoNode as BaseVideoNode} from '@tryghost/kg-default-nodes';
+import {VideoNode as BaseVideoNode, normalizeCardWidth} from '@tryghost/kg-default-nodes';
 import {KoenigCardWrapper, MINIMAL_NODES} from '../index.js';
 import {VideoNodeComponent} from './VideoNodeComponent';
 import {cleanBasicHtml} from '@tryghost/kg-clean-basic-html';
@@ -85,12 +85,14 @@ export class VideoNode extends BaseVideoNode {
     }
 
     decorate() {
+        const cardWidth = normalizeCardWidth(this.cardWidth) ?? 'regular';
+
         return (
-            <KoenigCardWrapper nodeKey={this.getKey()} width={this.cardWidth}>
+            <KoenigCardWrapper nodeKey={this.getKey()} width={cardWidth}>
                 <VideoNodeComponent
                     captionEditor={this.__captionEditor}
                     captionEditorInitialState={this.__captionEditorInitialState}
-                    cardWidth={this.cardWidth}
+                    cardWidth={cardWidth}
                     customThumbnail={this.customThumbnailSrc}
                     initialFile={this.__initialFile}
                     isLoopChecked={this.loop}

--- a/koenig/koenig-lexical/src/nodes/VideoNodeComponent.tsx
+++ b/koenig/koenig-lexical/src/nodes/VideoNodeComponent.tsx
@@ -9,6 +9,7 @@ import {SnippetActionToolbar} from '../components/ui/SnippetActionToolbar.jsx';
 import {ToolbarMenu, ToolbarMenuItem, ToolbarMenuSeparator} from '../components/ui/ToolbarMenu.jsx';
 import {VideoCard} from '../components/ui/cards/VideoCard';
 import {getImageDimensions} from '../utils/getImageDimensions';
+import {isCardWidth} from '@tryghost/kg-default-nodes';
 import {openFileSelection} from '../utils/openFileSelection';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 
@@ -158,7 +159,11 @@ export function VideoNodeComponent({
         });
     };
 
-    const onCardWidthChange = (width) => {
+    const onCardWidthChange = (width: unknown) => {
+        if (!isCardWidth(width)) {
+            return;
+        }
+
         editor.update(() => {
             const node = $getNodeByKey(nodeKey);
             node.cardWidth = width;

--- a/koenig/koenig-lexical/src/utils/image-card-widths.ts
+++ b/koenig/koenig-lexical/src/utils/image-card-widths.ts
@@ -1,11 +1,14 @@
-const VALID_IMAGE_CARD_WIDTHS = ['regular', 'wide', 'full'];
+import {CARD_WIDTHS, type CardWidth, isCardWidth} from '@tryghost/kg-default-nodes';
 
-export function getAllowedImageCardWidths(configuredWidths) {
+const VALID_IMAGE_CARD_WIDTHS = CARD_WIDTHS;
+export type ImageCardWidth = CardWidth;
+
+export function getAllowedImageCardWidths(configuredWidths?: unknown): readonly ImageCardWidth[] {
     if (!Array.isArray(configuredWidths)) {
         return VALID_IMAGE_CARD_WIDTHS;
     }
 
-    const filteredWidths = [...new Set(configuredWidths.filter(width => VALID_IMAGE_CARD_WIDTHS.includes(width)))];
+    const filteredWidths = [...new Set(configuredWidths.filter(isCardWidth))];
 
     if (filteredWidths.length === 0) {
         return VALID_IMAGE_CARD_WIDTHS;
@@ -14,10 +17,10 @@ export function getAllowedImageCardWidths(configuredWidths) {
     return filteredWidths;
 }
 
-export function getDefaultImageCardWidth(allowedWidths) {
+export function getDefaultImageCardWidth(allowedWidths: readonly ImageCardWidth[]): ImageCardWidth {
     if (allowedWidths.includes('regular')) {
         return 'regular';
     }
 
-    return allowedWidths[0];
+    return allowedWidths[0] ?? 'regular';
 }

--- a/koenig/koenig-lexical/test/unit/utils/image-card-widths.test.ts
+++ b/koenig/koenig-lexical/test/unit/utils/image-card-widths.test.ts
@@ -13,7 +13,7 @@ describe('image-card-widths utils', () => {
     });
 
     it('filters invalid values and de-duplicates while preserving order', () => {
-        expect(getAllowedImageCardWidths(['wide', 'invalid', 'full', 'wide'])).toEqual(['wide', 'full']);
+        expect(getAllowedImageCardWidths(['wide', 'invalid', null, 7, 'full', 'wide'])).toEqual(['wide', 'full']);
     });
 
     it('defaults to regular width when available', () => {
@@ -22,5 +22,9 @@ describe('image-card-widths utils', () => {
 
     it('defaults to first allowed width when regular is not available', () => {
         expect(getDefaultImageCardWidth(['wide', 'full'])).toBe('wide');
+    });
+
+    it('defaults to regular width when no widths are supplied', () => {
+        expect(getDefaultImageCardWidth([])).toBe('regular');
     });
 });


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/29218

This is the first independently reviewable foundation slice of the `koenig-lexical` TypeScript migration. The generated-node render boundary was previously `any`-typed, so render functions and serialized output were unchecked — errors in later card/node migrations would surface at runtime instead of compile time. This PR removes that boundary and establishes the shared contracts the follow-up migration PRs build on.

- typed render-node contracts for generated decorator nodes — `RenderFn`/`VersionedRenderFn` now carry the node type, and `HeaderNode` passes explicit type arguments so its versioned renderers are checked against a known node shape (when type args are omitted, the render fn's declared node type is trusted via inference; this is documented at the type parameter)
- typed serialized-node contract (`SerializedGeneratedDecoratorNode`), removing the `@ts-expect-error` on `exportJSON` (an intersection rather than Lexical's `Spread` — `Spread` can't be proven assignable to `SerializedLexicalNode` in the generic `exportJSON` override; documented at the type)
- shared card-width contract (`CARD_WIDTHS`/`isCardWidth`/`normalizeCardWidth`), adopted across koenig-lexical's card-width handling so widths flowing from stored node data and card config are validated instead of passed through untyped
- tightened the default visibility return type

Behaviour notes (hardening only, no expected user-facing change):
- `exportDOM` no longer falls back to the default version when a node's `__version` is falsy-but-set (`0`/`''`) — unreachable today because non-boolean property defaults are applied with `||`
- invalid stored/configured card widths are now normalized to `regular` or ignored instead of being passed through