### PR TITLE
Added a browser-mode acceptance test tier to Admin

### DIFF
--- a/apps/admin-x-framework/src/providers/framework-provider.tsx
+++ b/apps/admin-x-framework/src/providers/framework-provider.tsx
@@ -33,6 +33,10 @@ export interface FrameworkProviderProps {
     onInvalidate: (dataType: string) => void;
     onDelete: (dataType: string, id: string) => void;
 
+    // Optional QueryClient override. Defaults to the shared window-level
+    // singleton; test harnesses pass a fresh client per render for isolation.
+    queryClient?: QueryClient;
+
     // Optional QueryClient configuration for apps that need different defaults
     queryClientOptions?: {
         staleTime?: number;
@@ -63,8 +67,12 @@ const FrameworkContext = createContext<FrameworkContextType>({
     onDelete: () => {}
 });
 
-export function FrameworkProvider({children, queryClientOptions, ...props}: FrameworkProviderProps) {
+export function FrameworkProvider({children, queryClient: queryClientOverride, queryClientOptions, ...props}: FrameworkProviderProps) {
     const client = useMemo(() => {
+        if (queryClientOverride) {
+            return queryClientOverride;
+        }
+
         if (!queryClientOptions) {
             return queryClient;
         }
@@ -82,7 +90,7 @@ export function FrameworkProvider({children, queryClientOptions, ...props}: Fram
                 }
             }
         });
-    }, [queryClientOptions]);
+    }, [queryClientOverride, queryClientOptions]);
 
     return (
         <SentryErrorBoundary>

--- a/apps/admin/.gitignore
+++ b/apps/admin/.gitignore
@@ -12,6 +12,10 @@ dist
 dist-ssr
 *.local
 
+# Vitest Browser Mode artifacts (failure screenshots, attachments)
+.vitest-attachments
+__screenshots__
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/apps/admin/eslint.config.js
+++ b/apps/admin/eslint.config.js
@@ -46,7 +46,7 @@ const localPlugin = {
 const tailwindCssConfig = `${import.meta.dirname}/src/index.css`;
 
 export default tseslint.config([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'test-utils/acceptance/public']),
   {files: ['**/*'], ...strictLinterOptions},
   {
     files: ['**/*.{ts,tsx}'],

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -10,6 +10,7 @@
         "preview": "vite preview",
         "test": "pnpm test:unit",
         "test:unit": "vitest run",
+        "test:acceptance": "vitest run -c vitest.acceptance.config.ts",
         "typecheck": "tsc -b"
     },
     "dependencies": {
@@ -42,16 +43,18 @@
     "devDependencies": {
         "@eslint/js": "catalog:",
         "@tailwindcss/vite": "catalog:",
-        "@types/papaparse": "5.5.2",
         "@tanstack/react-query": "catalog:",
         "@testing-library/jest-dom": "catalog:",
         "@testing-library/react": "catalog:",
+        "@tryghost/test-data": "workspace:*",
         "@types/node": "catalog:",
+        "@types/papaparse": "5.5.2",
         "@types/react": "catalog:",
         "@types/react-dom": "catalog:",
         "@types/react-svg-map": "2.1.4",
         "@types/validator": "catalog:",
         "@vitejs/plugin-react": "catalog:",
+        "@vitest/browser-playwright": "catalog:",
         "eslint": "catalog:",
         "eslint-plugin-no-relative-import-paths": "1.6.1",
         "eslint-plugin-react-hooks": "catalog:",
@@ -67,10 +70,19 @@
         "typescript-eslint": "catalog:",
         "vite": "catalog:",
         "vite-tsconfig-paths": "6.1.1",
-        "vitest": "catalog:"
+        "vitest": "catalog:",
+        "vitest-browser-react": "catalog:"
     },
     "nx": {
+        "tags": [
+            "playwright"
+        ],
         "targets": {
+            "test:acceptance": {
+                "dependsOn": [
+                    "^build"
+                ]
+            },
             "dev": {
                 "continuous": true,
                 "executor": "nx:run-commands",

--- a/apps/admin/src/app-root.tsx
+++ b/apps/admin/src/app-root.tsx
@@ -1,0 +1,34 @@
+import { StrictMode } from "react";
+import { FrameworkProvider, RouterProvider, type TopLevelFrameworkProps } from "@tryghost/admin-x-framework";
+import { ShadeApp } from "@tryghost/shade/app";
+
+import App from "./app.tsx";
+import { routes } from "./routes.tsx";
+import { AppProvider } from "./providers/app-provider";
+
+/**
+ * The full admin provider pyramid, shared verbatim by the production entry
+ * point (src/main.tsx) and the acceptance harness's renderAdminApp — so "the
+ * harness renders the same provider stack as main.tsx" is true by
+ * construction. Only the `framework` props (navigation/bridge callbacks,
+ * query client) differ between the two.
+ */
+export function AdminAppRoot({ framework }: { framework: TopLevelFrameworkProps }) {
+    return (
+        <StrictMode>
+            <FrameworkProvider {...framework}>
+                <RouterProvider prefix={"/"} routes={routes}>
+                    <AppProvider>
+                        <ShadeApp
+                            className="shade-admin"
+                            darkMode={false}
+                            fetchKoenigLexical={null}
+                        >
+                            <App />
+                        </ShadeApp>
+                    </AppProvider>
+                </RouterProvider>
+            </FrameworkProvider>
+        </StrictMode>
+    );
+}

--- a/apps/admin/src/main.tsx
+++ b/apps/admin/src/main.tsx
@@ -1,13 +1,7 @@
-import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
-import App from "./app.tsx";
-import { FrameworkProvider, RouterProvider } from "@tryghost/admin-x-framework";
-import { ShadeApp } from "@tryghost/shade/app";
-
-import { routes } from "./routes.tsx";
+import { AdminAppRoot } from "./app-root.tsx";
 import { navigateTo } from "./utils/navigation";
-import { AppProvider } from "./providers/app-provider";
 
 const framework = {
     ghostVersion: "",
@@ -33,20 +27,4 @@ const framework = {
     },
 };
 
-createRoot(document.getElementById("root")!).render(
-    <StrictMode>
-        <FrameworkProvider {...framework}>
-            <RouterProvider prefix={"/"} routes={routes}>
-                <AppProvider>
-                    <ShadeApp
-                        className="shade-admin"
-                        darkMode={false}
-                        fetchKoenigLexical={null}
-                    >
-                        <App />
-                    </ShadeApp>
-                </AppProvider>
-            </RouterProvider>
-        </FrameworkProvider>
-    </StrictMode>
-);
+createRoot(document.getElementById("root")!).render(<AdminAppRoot framework={framework} />);

--- a/apps/admin/src/tags/tags.acceptance.test.tsx
+++ b/apps/admin/src/tags/tags.acceptance.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { tag } from "@tryghost/test-data";
+
+import { mockTags, renderAdminApp } from "@test-utils/acceptance";
+
+// Ported from e2e/tests/admin/tags/list.test.ts (the read-only cases): same
+// UI assertions, with the Ghost Admin API served by the acceptance harness's
+// tags resource handler instead of a real per-worker Ghost instance.
+
+describe("Tags list", () => {
+    it("lists public tags with description and posts count", async () => {
+        mockTags([
+            tag({ name: "News", description: "News description", count: { posts: 1 } }),
+        ]);
+        const screen = await renderAdminApp({ route: "/tags" });
+
+        const row = screen.getByTestId("tag-list-row");
+        await expect.element(row).toBeVisible();
+        await expect.element(row).toHaveTextContent("News");
+        await expect.element(row).toHaveTextContent("News description");
+        await expect.element(row).toHaveTextContent("1 post");
+
+        await expect.element(screen.getByLabelText("Public tags")).toHaveAttribute("data-state", "on");
+        await expect.element(screen.getByLabelText("Internal tags")).toHaveAttribute("data-state", "off");
+    });
+
+    it("lists public and internal tags separately", async () => {
+        mockTags([
+            tag({ name: "Public Tag Name", description: "Public Tag description" }),
+            tag({ name: "Other Public Tag Name" }),
+            tag({ name: "#Internal Tag Name", visibility: "internal" }),
+        ]);
+        const screen = await renderAdminApp({ route: "/tags" });
+
+        await expect.element(screen.getByRole("link", { name: "Public Tag Name", exact: true })).toBeVisible();
+        await expect(screen.getByTestId("tag-list-row")).toHaveCount(2);
+
+        await screen.getByLabelText("Internal tags").click();
+        await expect.element(screen.getByRole("link", { name: "#Internal Tag Name", exact: true })).toBeVisible();
+        await expect(screen.getByTestId("tag-list-row")).toHaveCount(1);
+
+        await screen.getByLabelText("Public tags").click();
+        await expect.element(screen.getByRole("link", { name: "Public Tag Name", exact: true })).toBeVisible();
+        await expect(screen.getByTestId("tag-list-row")).toHaveCount(2);
+    });
+
+    it("shows the empty state with a call to action when there are no tags", async () => {
+        mockTags([]);
+        const screen = await renderAdminApp({ route: "/tags" });
+
+        await expect.element(screen.getByRole("heading", { name: "Start organizing your content" })).toBeVisible();
+        await expect.element(screen.getByRole("link", { name: "Create a new tag" })).toBeVisible();
+    });
+});

--- a/apps/admin/test-utils/acceptance/boot.ts
+++ b/apps/admin/test-utils/acceptance/boot.ts
@@ -1,0 +1,131 @@
+import { HttpResponse } from "msw";
+import {
+    activeThemeResponse,
+    browseResponse,
+    configResponse,
+    currentUserResponse,
+    settingsResponse,
+    siteResponse,
+} from "@tryghost/test-data";
+
+import { registerAdminApiHandler, registerRoute } from "./worker";
+
+/**
+ * The requests the apps/admin shell fires on boot regardless of route: the
+ * global data set (settings/config/site/me) plus the sidebar/layout extras
+ * (members count, active theme check) and the fire-and-forget user-preferences
+ * write (theme/navigation sync).
+ *
+ * These are handled by DEFAULT inside the harness — specs never mention them.
+ * To change a boot response for one test, pass an override to
+ * `renderAdminApp({boot: {...}})` keyed by the entry name below.
+ *
+ * All canned responses come from `@tryghost/test-data` — that package is
+ * the root of the dependency graph, so nothing in this harness imports
+ * test data from admin-x-framework.
+ */
+export interface BootRequestConfig {
+    method: string;
+    path: string | RegExp;
+    response: unknown;
+    responseStatus?: number;
+}
+
+/**
+ * A function rather than a const so the fixture accessors run per call —
+ * every install/lookup serves freshly-minted response objects, so nothing a
+ * test mutates can leak into the next one.
+ */
+export function defaultBootRequests() {
+    return {
+        browseSettings: {
+            method: "GET",
+            path: /^\/settings\/\?group=/,
+            response: settingsResponse(),
+        },
+        browseConfig: {
+            method: "GET",
+            path: "/config/",
+            response: configResponse(),
+        },
+        browseSite: {
+            method: "GET",
+            path: "/site/",
+            response: siteResponse(),
+        },
+        browseMe: {
+            method: "GET",
+            path: "/users/me/?include=roles",
+            response: currentUserResponse(),
+        },
+        browseMembersCount: {
+            method: "GET",
+            path: "/members/?limit=1",
+            response: browseResponse("members", [], { limit: 1 }),
+        },
+        browseActiveTheme: {
+            method: "GET",
+            path: "/themes/active/",
+            response: activeThemeResponse(),
+        },
+        editUserPreferences: {
+            method: "PUT",
+            path: /^\/users\/\w+\/\?include=roles/,
+            response: currentUserResponse(),
+        },
+    } satisfies Record<string, BootRequestConfig>;
+}
+
+export type BootRequestName = keyof ReturnType<typeof defaultBootRequests>;
+
+/**
+ * Per-entry overrides for the boot table: `response`/`responseStatus` are
+ * merged onto the named default, and matching keeps the DEFAULT's method and
+ * path — the entry name is what keys.
+ */
+export type BootOverrides = Partial<Record<BootRequestName, Partial<Pick<BootRequestConfig, "response" | "responseStatus">>>>;
+
+/** "METHOD path" descriptions of the boot table, for the worker's 418 route listing. */
+export function defaultBootRoutes(): string[] {
+    return Object.values(defaultBootRequests()).map(({ method, path }) => `${method} ${path}`);
+}
+
+function matches(config: BootRequestConfig, method: string, apiPath: string): boolean {
+    if (config.method !== method) {
+        return false;
+    }
+    return typeof config.path === "string" ? config.path === apiPath : config.path.test(apiPath);
+}
+
+function respond(config: BootRequestConfig): Response {
+    return HttpResponse.json(config.response as Record<string, unknown>, {
+        status: config.responseStatus ?? 200,
+    });
+}
+
+/**
+ * The persistent lowest-priority resolver for the boot table, installed once
+ * at worker start. Resource handlers and boot overrides always win over it.
+ * Rebuilds the table per request so every response is a fresh object.
+ */
+export function defaultBootResolver(request: Request, apiPath: string): Response | undefined {
+    const config = Object.values(defaultBootRequests()).find((entry) => matches(entry, request.method, apiPath));
+    return config ? respond(config) : undefined;
+}
+
+/** Register per-test boot overrides (higher priority than the defaults). */
+export function installBootOverrides(overrides: BootOverrides): void {
+    const defaults = defaultBootRequests();
+    const entries = Object.entries(overrides)
+        .filter(([, override]) => Boolean(override))
+        .map(([name, override]) => ({ ...defaults[name as BootRequestName], ...override }));
+
+    for (const config of entries) {
+        registerRoute(config.method, config.path);
+    }
+
+    registerAdminApiHandler((request, apiPath) => {
+        const config = entries.find((entry) => matches(entry, request.method, apiPath));
+        return config ? respond(config) : undefined;
+    });
+}

--- a/apps/admin/test-utils/acceptance/index.ts
+++ b/apps/admin/test-utils/acceptance/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Acceptance-harness public surface. A typical spec:
+ *
+ *   import {mockTags, renderAdminApp} from "@test-utils/acceptance";
+ *   import {tag} from "@tryghost/test-data";
+ *
+ *   it("lists tags", async () => {
+ *       mockTags([tag({name: "News"})]);
+ *       const screen = await renderAdminApp({route: "/tags"});
+ *       await expect.element(screen.getByRole("link", {name: "News"})).toBeVisible();
+ *   });
+ */
+export { renderAdminApp } from "./render-admin-app";
+export type { RenderAdminAppOptions } from "./render-admin-app";
+export { defineResource, mockTags } from "./resources";
+export type { BrowseQuery, ResourceCapture, ResourceOptions, ResourceSemantics, RespondWith } from "./resources";
+export { allowUnmockedRequests } from "./worker";

--- a/apps/admin/test-utils/acceptance/matchers.ts
+++ b/apps/admin/test-utils/acceptance/matchers.ts
@@ -1,0 +1,45 @@
+import { expect } from "vitest";
+import { server, type Locator } from "vitest/browser";
+
+// Poll timing follows vitest's configured expect.poll defaults (set in
+// vitest.acceptance.config.ts) rather than hard-coding harness-local values.
+const POLL_INTERVAL_MS = server.config.expect.poll?.interval ?? 50;
+const POLL_TIMEOUT_MS = server.config.expect.poll?.timeout ?? 1000;
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}
+
+/**
+ * `await expect(locator).toHaveCount(n)` — polls until the locator resolves to
+ * exactly `n` elements (or, with `.not`, until it doesn't), timing out after
+ * the configured expect.poll timeout. The retrying replacement for
+ * `expect.poll(() => locator.all().length).toBe(n)`.
+ */
+expect.extend({
+    async toHaveCount(received: Locator, expected: number) {
+        const deadline = Date.now() + POLL_TIMEOUT_MS;
+        let actual = received.all().length;
+
+        // Poll until the assertion (including .not) would pass or time out.
+        while ((actual === expected) === Boolean(this.isNot) && Date.now() < deadline) {
+            await sleep(POLL_INTERVAL_MS);
+            actual = received.all().length;
+        }
+
+        return {
+            pass: actual === expected,
+            message: () =>
+                `expected locator ${received.selector} ${this.isNot ? "not " : ""}to have ${expected} element(s), found ${actual}`,
+        };
+    },
+});
+
+declare module "vitest" {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+    interface Matchers<T = any> {
+        toHaveCount(expected: number): Promise<void>;
+    }
+}

--- a/apps/admin/test-utils/acceptance/public/mockServiceWorker.js
+++ b/apps/admin/test-utils/acceptance/public/mockServiceWorker.js
@@ -1,0 +1,349 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = '2.14.6'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
+
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been terminated (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
+})
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ */
+async function handleRequest(event, requestId, requestInterceptedAt) {
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = response.clone()
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+            body: responseClone.body,
+          },
+        },
+      },
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+    )
+  }
+
+  return response
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId, requestInterceptedAt) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request)
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        interceptedAt: requestInterceptedAt,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
+}

--- a/apps/admin/test-utils/acceptance/render-admin-app.tsx
+++ b/apps/admin/test-utils/acceptance/render-admin-app.tsx
@@ -1,0 +1,106 @@
+import { QueryClient } from "@tanstack/react-query";
+import { render } from "vitest-browser-react";
+import { configResponse, settingsResponse } from "@tryghost/test-data";
+import type { TopLevelFrameworkProps } from "@tryghost/admin-x-framework";
+
+import "@/index.css";
+import { AdminAppRoot } from "@/app-root";
+
+import { installBootOverrides, type BootOverrides } from "./boot";
+
+export interface RenderAdminAppOptions {
+    /** Hash route to boot the app on, e.g. "/tags" or "/members?filter=label:VIP" (default "/") */
+    route?: string;
+    /**
+     * Labs flags to flip for this test. Sugar that compiles to lockstep
+     * settings + config boot overrides — the admin client reads labs from
+     * BOTH, so they must flip together.
+     */
+    labs?: Record<string, boolean>;
+    /**
+     * Escape hatch over the shell boot table. The requests the admin shell
+     * fires on boot (settings/config/site/me, sidebar members count, active
+     * theme, the fire-and-forget user-preferences PUT) are handled by default —
+     * specs never mention them. Pass `response`/`responseStatus` overrides
+     * keyed by boot entry name to change one for a test, e.g.
+     * `renderAdminApp({route: "/", boot: {browseConfig: {response: ...}}})`.
+     * Matching keeps the default entry's method/path. Wins over `labs`.
+     */
+    boot?: BootOverrides;
+}
+
+/**
+ * Boots the real admin app — the same provider stack as src/main.tsx, via the
+ * shared AdminAppRoot — inside the browser-mode page, with the Ghost Admin
+ * API served by MSW.
+ *
+ * Cross-app navigations (Ember-owned routes) are recorded on
+ * `document.body.dataset.externalNavigate` instead of navigating, mirroring
+ * the Playwright acceptance harness so `expectExternalNavigate`-style
+ * assertions can be ported.
+ */
+export async function renderAdminApp({ route = "/", labs, boot }: RenderAdminAppOptions = {}): Promise<
+    Awaited<ReturnType<typeof render>>
+> {
+    const overrides: BootOverrides = {
+        ...(labs && {
+            browseSettings: { response: settingsResponse({ labs }) },
+            browseConfig: { response: configResponse({ labs }) },
+        }),
+        ...boot,
+    };
+
+    if (Object.keys(overrides).length > 0) {
+        installBootOverrides(overrides);
+    }
+
+    // EmberRoot expects the Ember host element to exist in the document; in
+    // the test page there is no Ember app, so provide an empty stand-in.
+    if (!document.getElementById("ember-app")) {
+        const emberApp = document.createElement("div");
+        emberApp.id = "ember-app";
+        document.body.appendChild(emberApp);
+    }
+
+    // The framework RouterProvider is hash-based; set the initial route
+    // before the router is created.
+    window.location.hash = `#${route}`;
+
+    // A fresh QueryClient per render, passed through FrameworkProvider's
+    // queryClient seam: mirrors the production singleton's defaults
+    // (admin-x-framework utils/query-client.ts) except nothing is cached
+    // beyond the test, so tests are isolated without teardown scrubbing.
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: {
+                refetchOnWindowFocus: false,
+                staleTime: 5 * (60 * 1000), // 5 mins
+                cacheTime: 0,
+                // We have custom retry logic for specific errors in fetchApi()
+                retry: false,
+                networkMode: "always",
+            },
+        },
+    });
+
+    const framework: TopLevelFrameworkProps = {
+        ghostVersion: "",
+        externalNavigate: (link) => {
+            document.body.dataset.externalNavigate = JSON.stringify(link);
+        },
+        unsplashConfig: {
+            Authorization: "",
+            "Accept-Version": "v1",
+            "Content-Type": "application/json",
+            "App-Pragma": "no-cache",
+            "X-Unsplash-Cache": true,
+        },
+        sentryDSN: null,
+        onUpdate: () => {},
+        onInvalidate: () => {},
+        onDelete: () => {},
+        queryClient,
+    };
+
+    return await render(<AdminAppRoot framework={framework} />);
+}

--- a/apps/admin/test-utils/acceptance/resources.ts
+++ b/apps/admin/test-utils/acceptance/resources.ts
@@ -1,0 +1,171 @@
+import { HttpResponse } from "msw";
+import { browseResponse, type Tag } from "@tryghost/test-data";
+
+import { record418, registerAdminApiHandler, registerRoute } from "./worker";
+
+/**
+ * Resource handlers: declare the world, let the handler serve it.
+ *
+ * THE RULE: a resource handler may implement *trivial declared* query
+ * behaviors — ones where the handler only echoes back a slice of exactly what
+ * the spec declared (a `visibility` field match, page/limit slicing) — but
+ * NEVER NQL. For NQL-filtered lists (members `?filter=`, `?search=`) the spec
+ * declares the response and asserts the outgoing filter string instead,
+ * because that serialization IS the behavior under test; re-implementing NQL
+ * in the mock would test the mock.
+ *
+ * Each resource states which side of that line it is on via `semantics`:
+ *
+ *   - `{kind: "passthrough"}` — serves exactly the declared entities and
+ *     never interprets the query. Per-request responses are declared with a
+ *     function of the parsed query.
+ *   - `{kind: "declared-query", covers, select}` — `select` applies the
+ *     trivial declared behaviors; any filter component outside `covers`
+ *     responds 418 instead of silently serving the full world.
+ */
+
+export interface BrowseQuery {
+    /** Full request URL, for raw assertions on encoding. */
+    url: string;
+    /** Decoded ?filter param (NQL), if present. */
+    filter?: string;
+    /** Decoded ?search param, if present. */
+    search?: string;
+    page: number;
+    limit: number | "all";
+}
+
+export interface ResourceCapture {
+    /** Every matched browse request, oldest first. */
+    requests: BrowseQuery[];
+    readonly lastRequest: BrowseQuery | undefined;
+}
+
+/** The entities to serve: one world for every request, or per-request via a function of the parsed query. */
+export type RespondWith<TEntity> = TEntity[] | ((query: BrowseQuery) => TEntity[]);
+
+/** Explicit, greppable statement of how much query behavior a resource mock implements (see THE RULE above). */
+export type ResourceSemantics<TEntity> =
+    | {
+          kind: "declared-query";
+          /** The filter component keys `select` consumes (e.g. `["visibility"]`); anything else responds 418. */
+          covers: string[];
+          /** Trivial declared query semantics applied to the declared entities before pagination. */
+          select: (entities: TEntity[], query: BrowseQuery) => TEntity[];
+      }
+    | { kind: "passthrough" };
+
+export interface ResourceOptions<TEntity> {
+    /** Admin API path segment and envelope key, e.g. 'tags' → GET /tags/. */
+    resource: string;
+    semantics: ResourceSemantics<TEntity>;
+    /** Browse paths to leave to lower-priority handlers (shell chrome like the sidebar count probe). */
+    skip?: (apiPath: string) => boolean;
+}
+
+function parseBrowseQuery(request: Request): BrowseQuery {
+    const url = new URL(request.url);
+    const params = url.searchParams;
+    const rawLimit = params.get("limit");
+
+    return {
+        url: request.url,
+        filter: params.get("filter") ?? undefined,
+        search: params.get("search") ?? undefined,
+        page: Number(params.get("page") ?? "1"),
+        limit: rawLimit === "all" ? "all" : rawLimit ? Number(rawLimit) : 15,
+    };
+}
+
+/**
+ * Strict declared-query filter parsing: split the NQL into top-level `+`
+ * components and return the ones whose key `covers` does not include. NQL
+ * grouping is out of scope on purpose — a component that doesn't parse as a
+ * simple `key:value` also counts as uncovered.
+ */
+function uncoveredFilterComponents(filter: string | undefined, covers: string[]): string[] {
+    if (!filter) {
+        return [];
+    }
+
+    return filter.split("+").filter((component) => {
+        const key = component.match(/^([\w.]+):/)?.[1];
+        return !key || !covers.includes(key);
+    });
+}
+
+/**
+ * Define a mock for one admin API list resource. The returned function
+ * registers a handler that owns the resource's browse URL: it parses the
+ * query, records it on the returned capture (for outgoing-NQL assertions),
+ * applies the resource's declared semantics and wraps the result in the Ghost
+ * list envelope (which slices pagination itself). Unmatched paths fall
+ * through to the boot table / 418 catch-all.
+ */
+export function defineResource<TEntity>({ resource, semantics, skip }: ResourceOptions<TEntity>) {
+    return function mockResource(respondWith: RespondWith<TEntity>): ResourceCapture {
+        const requests: BrowseQuery[] = [];
+
+        registerRoute("GET", `/${resource}/?…`);
+        registerAdminApiHandler((request, apiPath) => {
+            const isBrowse = request.method === "GET" && (apiPath === `/${resource}/` || apiPath.startsWith(`/${resource}/?`));
+            if (!isBrowse || skip?.(apiPath)) {
+                return undefined;
+            }
+
+            const query = parseBrowseQuery(request);
+            requests.push(query);
+
+            const declared = typeof respondWith === "function" ? respondWith(query) : respondWith;
+
+            let matching = declared;
+            if (semantics.kind === "declared-query") {
+                const uncovered = uncoveredFilterComponents(query.filter, semantics.covers);
+                if (uncovered.length > 0) {
+                    record418(`${request.method} ${apiPath} — filter component(s) not covered by declared semantics: ${uncovered.join(", ")}`);
+                    return new HttpResponse(
+                        [
+                            `Declared semantics for '${resource}' only cover ${semantics.covers.map((key) => `\`${key}:\``).join(", ")};`,
+                            `this request's filter contains: ${uncovered.join(", ")}.`,
+                            "Use passthrough mode (declare the response with a function of the query) for this spec.",
+                        ].join(" "),
+                        { status: 418 }
+                    );
+                }
+                matching = semantics.select(declared, query);
+            }
+
+            return HttpResponse.json(
+                browseResponse(resource, matching, {
+                    page: query.page,
+                    limit: query.limit,
+                })
+            );
+        });
+
+        return {
+            requests,
+            get lastRequest() {
+                return requests[requests.length - 1];
+            },
+        };
+    };
+}
+
+/**
+ * Declared-world handler for the tags list: give it every tag that exists and
+ * it serves whichever slice the app asks for — the `visibility` filter the
+ * tags screen tabs send, plus page/limit slicing (trivial declared semantics
+ * only, see THE RULE above).
+ */
+export const mockTags = defineResource<Tag>({
+    resource: "tags",
+    semantics: {
+        kind: "declared-query",
+        covers: ["visibility"],
+        select: (tags, { filter }) => {
+            const visibility = filter?.match(/(?:^|\+)visibility:(\w+)/)?.[1];
+            return visibility ? tags.filter((t) => t.visibility === visibility) : tags;
+        },
+    },
+});

--- a/apps/admin/test-utils/acceptance/setup.ts
+++ b/apps/admin/test-utils/acceptance/setup.ts
@@ -1,0 +1,25 @@
+import { afterEach, beforeAll } from "vitest";
+import { cleanup } from "vitest-browser-react";
+
+import "./matchers";
+import { defaultBootResolver, defaultBootRoutes } from "./boot";
+import { resetMockWorker, startMockWorker, verifyNoUnmockedRequests } from "./worker";
+
+beforeAll(async () => {
+    await startMockWorker({ resolver: defaultBootResolver, routes: defaultBootRoutes() });
+});
+
+afterEach(async () => {
+    // Unmount the app before touching the mock worker or the URL — resetting
+    // either while the app is live triggers navigations/refetches against a
+    // handler-less worker, which surface as unhandled rejections. (Query
+    // caches need no teardown: each renderAdminApp gets a fresh QueryClient.)
+    await cleanup();
+
+    resetMockWorker();
+    window.location.hash = "";
+
+    // Last, after teardown is safely done: fail the test if any admin API
+    // request went unmocked (was served a 418) while it ran.
+    verifyNoUnmockedRequests();
+});

--- a/apps/admin/test-utils/acceptance/worker.ts
+++ b/apps/admin/test-utils/acceptance/worker.ts
@@ -1,0 +1,154 @@
+import { http, HttpResponse } from "msw";
+import { setupWorker, type SetupWorker } from "msw/browser";
+
+/**
+ * MSW worker lifecycle for the acceptance harness.
+ *
+ * Handler layering (highest priority first):
+ *   1. Runtime handlers registered per test via `registerAdminApiHandler` — the
+ *      resource handlers (`mockTags`, ...) and any boot overrides passed to
+ *      `renderAdminApp`.
+ *   2. The default shell boot table (settings/config/site/me + sidebar
+ *      extras) — installed once at worker start so `resetHandlers()` restores
+ *      it between tests.
+ *   3. A catch-all for anything else under /ghost/api/admin/: records the miss
+ *      and responds 418 listing the currently mocked routes. Recorded misses
+ *      fail the test in afterEach (see `allowUnmockedRequests`), so a spec
+ *      immediately sees which request it forgot to declare.
+ * Non-admin-API requests (modules, assets) bypass the worker entirely.
+ */
+
+const ADMIN_API_PATTERN = /\/ghost\/api\/admin\//;
+const ADMIN_API_PREFIX = /^.*\/ghost\/api\/admin/;
+
+/** The request's path + query, relative to the admin API root (e.g. "/tags/?limit=100"). */
+function toAdminApiPath(url: string): string {
+    return url.replace(ADMIN_API_PREFIX, "");
+}
+
+// Routes listed by the 418 catch-all. Seeded with the boot table at worker
+// start (always the first entries); per-test registrations are appended and
+// trimmed back to the boot entries on reset.
+const registeredRoutes: string[] = [];
+let bootRouteCount = 0;
+
+export function registerRoute(method: string, path: string | RegExp): void {
+    registeredRoutes.push(`${method} ${path}`);
+}
+
+// 418 bookkeeping: every admin API request that got a 418 during the current
+// test. setup.ts fails the test in afterEach unless the test opted out.
+let recorded418s: string[] = [];
+let unmockedRequestsAllowed = false;
+
+/** Record a 418-serving request so `verifyNoUnmockedRequests` can fail the test. */
+export function record418(description: string): void {
+    recorded418s.push(description);
+}
+
+/**
+ * Per-test opt-out from the fail-on-unmocked-request check in afterEach.
+ * Resets automatically after each test.
+ */
+export function allowUnmockedRequests(): void {
+    unmockedRequestsAllowed = true;
+}
+
+/**
+ * Called from afterEach: throws if any admin API request was served a 418
+ * during the test (unless `allowUnmockedRequests()` opted out), then resets
+ * the bookkeeping either way.
+ */
+export function verifyNoUnmockedRequests(): void {
+    const requests = recorded418s;
+    const allowed = unmockedRequestsAllowed;
+    recorded418s = [];
+    unmockedRequestsAllowed = false;
+
+    if (!allowed && requests.length > 0) {
+        throw new Error(
+            [
+                "Admin API request(s) went unmocked (served a 418) during this test:",
+                ...requests.map((request) => `  - ${request}`),
+                "",
+                "Declare them with a resource handler (mockTags, ...) or a renderAdminApp boot override,",
+                "or call allowUnmockedRequests() at the start of the test to opt out.",
+            ].join("\n")
+        );
+    }
+}
+
+let worker: SetupWorker | undefined;
+
+type AdminApiResolver = (request: Request, apiPath: string) => Promise<Response | undefined> | Response | undefined;
+
+/**
+ * Register a runtime admin-API handler. The resolver receives the request and
+ * its admin-relative path; returning `undefined` falls through to
+ * lower-priority handlers (boot table, then the 418 catch-all).
+ */
+export function registerAdminApiHandler(resolver: AdminApiResolver): void {
+    if (!worker) {
+        throw new Error(
+            "MSW worker is not running — acceptance tests must be run through vitest.acceptance.config.ts (its setup file starts the worker)"
+        );
+    }
+
+    worker.use(
+        http.all(ADMIN_API_PATTERN, async ({ request }) => {
+            return await resolver(request, toAdminApiPath(request.url));
+        })
+    );
+}
+
+export interface StartMockWorkerOptions {
+    /** The persistent lowest-priority resolver for the shell boot table. */
+    resolver: AdminApiResolver;
+    /** "METHOD path" descriptions of the boot table, for the 418 route listing. */
+    routes: string[];
+}
+
+export async function startMockWorker({ resolver, routes }: StartMockWorkerOptions): Promise<SetupWorker> {
+    if (worker) {
+        return worker;
+    }
+
+    registeredRoutes.push(...routes);
+    bootRouteCount = registeredRoutes.length;
+
+    worker = setupWorker(
+        // Default shell boot table — persistent across resetHandlers().
+        http.all(ADMIN_API_PATTERN, async ({ request }) => {
+            return await resolver(request, toAdminApiPath(request.url));
+        }),
+        // Catch-all: any admin API request nothing above handled.
+        http.all(ADMIN_API_PATTERN, ({ request }) => {
+            const apiPath = toAdminApiPath(request.url);
+            record418(`${request.method} ${apiPath}`);
+            return new HttpResponse(
+                [
+                    "No matching mock found. If this request is needed for the test, declare it with a resource handler (mockTags, ...) or a renderAdminApp boot override",
+                    "",
+                    `Request: ${request.method} ${apiPath}`,
+                    "",
+                    "Currently mocked:",
+                    ...registeredRoutes,
+                ].join("\n"),
+                { status: 418 }
+            );
+        })
+    );
+
+    await worker.start({
+        serviceWorker: { url: "/mockServiceWorker.js" },
+        onUnhandledRequest: "bypass",
+        quiet: true,
+    });
+
+    return worker;
+}
+
+export function resetMockWorker(): void {
+    worker?.resetHandlers();
+    registeredRoutes.length = bootRouteCount;
+}

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -1,17 +1,14 @@
-import { resolve } from "path";
-import { createRequire } from "node:module";
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 import type { PluginOption } from "vite";
-const require = createRequire(import.meta.url);
 import tsconfigPaths from "vite-tsconfig-paths";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
 import { emberAssetsPlugin } from "./vite-ember-assets";
 import { ghostBackendProxyPlugin } from "./vite-backend-proxy";
+import { sharedDefine, sharedResolve } from "./vite.shared";
 
 export const GHOST_URL = process.env.GHOST_URL ?? "http://localhost:2368/";
-const GHOST_CARDS_PATH = resolve(__dirname, "../../ghost/core/core/frontend/src/cards");
 
 // Dev-only prefix Vite serves under. Keeps Vite's internals (HMR client,
 // module graph, refresh runtime) off `/ghost/*` so Ghost's Express middleware
@@ -42,9 +39,7 @@ function getBase(command: 'build' | 'serve'): string {
 export default defineConfig(({ command }) => ({
     base: getBase(command),
     plugins: [tailwindcss() as PluginOption, react(), emberAssetsPlugin(), ghostBackendProxyPlugin(), tsconfigPaths()],
-    define: {
-        "process.env.DEBUG": false, // Shim env var utilized by the @tryghost/nql package
-    },
+    define: sharedDefine,
     server: {
         host: '0.0.0.0',
         port: 5174,
@@ -57,19 +52,13 @@ export default defineConfig(({ command }) => ({
     optimizeDeps: {
         include: ["@tryghost/koenig-lexical"],
     },
-    resolve: {
-        alias: {
-            "@ghost-cards": GHOST_CARDS_PATH,
-            // TODO: Remove this when @tryghost/nql is updated
-            mingo: require.resolve("mingo/dist/mingo.js"),
-        },
-        // Shim node modules utilized by the @tryghost/nql package
-        external: ["fs", "path", "util"],
-    },
+    resolve: sharedResolve,
     test: {
         environment: "jsdom",
         globals: true,
         setupFiles: ["./test-utils/setup.ts"],
         include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+        // Acceptance tests run in a real browser via vitest.acceptance.config.ts
+        exclude: [...configDefaults.exclude, "src/**/*.acceptance.test.tsx"],
     },
 }));

--- a/apps/admin/vite.shared.ts
+++ b/apps/admin/vite.shared.ts
@@ -1,0 +1,26 @@
+import { createRequire } from "node:module";
+import { resolve } from "path";
+
+const require = createRequire(import.meta.url);
+
+/**
+ * Config fragments shared by vite.config.ts (dev/build + unit tests) and
+ * vitest.acceptance.config.ts, so the TODO-gated @tryghost/nql shims live in
+ * exactly one place.
+ */
+
+const GHOST_CARDS_PATH = resolve(__dirname, "../../ghost/core/core/frontend/src/cards");
+
+export const sharedDefine = {
+    "process.env.DEBUG": false, // Shim env var utilized by the @tryghost/nql package
+};
+
+export const sharedResolve = {
+    alias: {
+        "@ghost-cards": GHOST_CARDS_PATH,
+        // TODO: Remove this when @tryghost/nql is updated
+        mingo: require.resolve("mingo/dist/mingo.js"),
+    },
+    // Shim node modules utilized by the @tryghost/nql package
+    external: ["fs", "path", "util"],
+};

--- a/apps/admin/vitest.acceptance.config.ts
+++ b/apps/admin/vitest.acceptance.config.ts
@@ -1,0 +1,53 @@
+import { defineConfig } from "vitest/config";
+import { playwright } from "@vitest/browser-playwright";
+import type { PluginOption } from "vite";
+import tsconfigPaths from "vite-tsconfig-paths";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+
+import { sharedDefine, sharedResolve } from "./vite.shared";
+
+/**
+ * Acceptance tier: full-app tests running in a real Chromium instance via
+ * Vitest Browser Mode, with the Ghost Admin API mocked by MSW (see
+ * test-utils/acceptance/). Unit tests stay in vite.config.ts (jsdom).
+ *
+ * Run with: pnpm test:acceptance
+ */
+export default defineConfig({
+    plugins: [tailwindcss() as PluginOption, react(), tsconfigPaths()],
+    // Serves the MSW service worker script; scoped to the test config so it
+    // never ends up in the production build's public assets.
+    publicDir: "./test-utils/acceptance/public",
+    define: sharedDefine,
+    optimizeDeps: {
+        // Point the dep scanner at every app module (not just the html entry)
+        // so deps behind lazy route imports are discovered and pre-bundled up
+        // front — if Vite's dep optimizer discovers them mid-run it reloads
+        // the test page, which duplicates React and flakes the suite ("Vite
+        // unexpectedly reloaded a test"). Test files are excluded: they
+        // import node-side tooling (vitest → vite → fsevents) the browser
+        // bundler can't process, and vitest already treats them as entries.
+        entries: ["src/**/*.{ts,tsx}", "!src/**/*.test.*"],
+    },
+    resolve: sharedResolve,
+    test: {
+        name: "acceptance",
+        include: ["src/**/*.acceptance.test.tsx"],
+        setupFiles: ["./test-utils/acceptance/setup.ts"],
+        expect: {
+            // Full-app renders are slower than unit renders; the harness's
+            // toHaveCount matcher derives its polling from this too.
+            poll: { timeout: 5000 },
+        },
+        browser: {
+            enabled: true,
+            headless: true,
+            provider: playwright(),
+            instances: [{ browser: "chromium" }],
+            // Match the e2e suite's desktop viewport — the admin chrome
+            // collapses into mobile menus at the vitest default (414px).
+            viewport: { width: 1280, height: 800 },
+        },
+    },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,9 @@ catalogs:
     '@vitejs/plugin-react':
       specifier: 6.0.3
       version: 6.0.3
+    '@vitest/browser-playwright':
+      specifier: 4.1.9
+      version: 4.1.9
     '@vitest/coverage-v8':
       specifier: 4.1.9
       version: 4.1.9
@@ -312,6 +315,9 @@ catalogs:
     vitest:
       specifier: 4.1.9
       version: 4.1.9
+    vitest-browser-react:
+      specifier: 2.2.0
+      version: 2.2.0
     zod:
       specifier: 4.4.3
       version: 4.4.3
@@ -480,7 +486,7 @@ importers:
         version: 8.62.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   apps/activitypub:
     dependencies:
@@ -592,7 +598,7 @@ importers:
         version: 8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   apps/admin:
     dependencies:
@@ -687,6 +693,9 @@ importers:
       '@testing-library/react':
         specifier: 'catalog:'
         version: 14.3.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tryghost/test-data':
+        specifier: workspace:*
+        version: link:../../testing/test-data
       '@types/node':
         specifier: 'catalog:'
         version: 22.20.0
@@ -708,6 +717,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 6.0.3(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@vitest/browser-playwright':
+        specifier: 'catalog:'
+        version: 4.1.9(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(playwright@1.61.1)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.9)
       eslint:
         specifier: 'catalog:'
         version: 9.39.4(jiti@2.7.0)
@@ -755,7 +767,10 @@ importers:
         version: 6.1.1(supports-color@5.5.0)(typescript@5.9.3)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      vitest-browser-react:
+        specifier: 'catalog:'
+        version: 2.2.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@4.1.9)
 
   apps/admin-toolbar:
     dependencies:
@@ -786,7 +801,7 @@ importers:
         version: 8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   apps/admin-x-design-system:
     dependencies:
@@ -973,7 +988,7 @@ importers:
         version: 4.5.0(rollup@4.62.2)(typescript@5.9.3)(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   apps/admin-x-framework:
     dependencies:
@@ -1037,7 +1052,7 @@ importers:
         version: 6.0.3(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.9(vitest@4.1.9)
+        version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       c8:
         specifier: 'catalog:'
         version: 11.0.0
@@ -1091,7 +1106,7 @@ importers:
         version: 4.5.0(rollup@4.62.2)(typescript@5.9.3)(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   apps/admin-x-settings:
     dependencies:
@@ -1230,7 +1245,7 @@ importers:
         version: 8.49.0(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.9(vitest@4.1.9)
+        version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       eslint:
         specifier: 'catalog:'
         version: 9.39.4(jiti@2.7.0)
@@ -1266,7 +1281,7 @@ importers:
         version: 8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   apps/announcement-bar:
     dependencies:
@@ -1285,7 +1300,7 @@ importers:
         version: 6.0.3(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.9(vitest@4.1.9)
+        version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       concurrently:
         specifier: 'catalog:'
         version: 10.0.3
@@ -1315,7 +1330,7 @@ importers:
         version: 4.5.0(rollup@4.62.2)(typescript@5.9.3)(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   apps/comments-ui:
     dependencies:
@@ -1397,7 +1412,7 @@ importers:
         version: 6.0.3(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.9(vitest@4.1.9)
+        version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       autoprefixer:
         specifier: 10.5.2
         version: 10.5.2(postcss@8.5.16)
@@ -1454,7 +1469,7 @@ importers:
         version: 4.5.0(rollup@4.62.2)(typescript@5.9.3)(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   apps/portal:
     dependencies:
@@ -1488,7 +1503,7 @@ importers:
         version: 6.0.3(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.9(vitest@4.1.9)
+        version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       concurrently:
         specifier: 'catalog:'
         version: 10.0.3
@@ -1533,7 +1548,7 @@ importers:
         version: 4.5.0(rollup@4.62.2)(typescript@5.9.3)(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   apps/shade:
     dependencies:
@@ -1693,7 +1708,7 @@ importers:
         version: 6.0.3(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.9(vitest@4.1.9)
+        version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       c8:
         specifier: 'catalog:'
         version: 11.0.0
@@ -1762,7 +1777,7 @@ importers:
         version: 4.5.0(rollup@4.62.2)(typescript@5.9.3)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   apps/signup-form:
     dependencies:
@@ -1853,7 +1868,7 @@ importers:
         version: 4.5.0(rollup@4.62.2)(typescript@5.9.3)(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   apps/sodo-search:
     dependencies:
@@ -1887,7 +1902,7 @@ importers:
         version: 6.0.3(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.9(vitest@4.1.9)
+        version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       autoprefixer:
         specifier: 10.5.2
         version: 10.5.2(postcss@8.5.16)
@@ -1932,7 +1947,7 @@ importers:
         version: 4.5.0(rollup@4.62.2)(typescript@5.9.3)(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   e2e:
     devDependencies:
@@ -2954,7 +2969,7 @@ importers:
         version: 8.49.0(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.9(vitest@4.1.9)
+        version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       bunyan:
         specifier: 1.8.15
         version: 1.8.15
@@ -3041,7 +3056,7 @@ importers:
         version: 13.12.0
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
     optionalDependencies:
       better-sqlite3:
         specifier: 'catalog:'
@@ -3061,7 +3076,7 @@ importers:
         version: 9.39.4
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.9(vitest@4.1.9)
+        version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       eslint:
         specifier: 'catalog:'
         version: 9.39.4(jiti@2.7.0)
@@ -3082,7 +3097,7 @@ importers:
         version: 9.4.0
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   ghost/parse-email-address:
     dependencies:
@@ -3101,7 +3116,7 @@ importers:
         version: 8.49.0(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.9(vitest@4.1.9)
+        version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       eslint:
         specifier: 'catalog:'
         version: 9.39.4(jiti@2.7.0)
@@ -3122,7 +3137,7 @@ importers:
         version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   koenig/kg-card-factory:
     devDependencies:
@@ -3134,7 +3149,7 @@ importers:
         version: 22.20.0
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.9(vitest@4.1.9)
+        version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       simple-dom:
         specifier: 1.4.0
         version: 1.4.0
@@ -3146,7 +3161,7 @@ importers:
         version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   koenig/kg-clean-basic-html:
     devDependencies:
@@ -3161,7 +3176,7 @@ importers:
         version: 22.20.0
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.9(vitest@4.1.9)
+        version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       jsdom:
         specifier: 'catalog:'
         version: 29.1.1(@noble/hashes@1.8.0)
@@ -3173,7 +3188,7 @@ importers:
         version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   koenig/kg-converters:
     dependencies:
@@ -3189,7 +3204,7 @@ importers:
         version: 22.20.0
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.9(vitest@4.1.9)
+        version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -3198,7 +3213,7 @@ importers:
         version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   koenig/kg-default-cards:
     dependencies:
@@ -3235,7 +3250,7 @@ importers:
         version: 22.20.0
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.9(vitest@4.1.9)
+        version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       jsdom:
         specifier: 'catalog:'
         version: 29.1.1(@noble/hashes@1.8.0)
@@ -3250,7 +3265,7 @@ importers:
         version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   koenig/kg-default-nodes:
     dependencies:
@@ -3323,7 +3338,7 @@ importers:
         version: 22.20.0
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.9(vitest@4.1.9)
+        version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       prettier:
         specifier: 3.9.4
         version: 3.9.4
@@ -3335,7 +3350,7 @@ importers:
         version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   koenig/kg-default-transforms:
     dependencies:
@@ -3366,7 +3381,7 @@ importers:
         version: 0.13.1(lexical@0.13.1)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.9(vitest@4.1.9)
+        version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -3375,7 +3390,7 @@ importers:
         version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   koenig/kg-html-to-lexical:
     dependencies:
@@ -3418,7 +3433,7 @@ importers:
         version: 28.0.3
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.9(vitest@4.1.9)
+        version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -3427,7 +3442,7 @@ importers:
         version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   koenig/kg-lexical-html-renderer:
     dependencies:
@@ -3473,7 +3488,7 @@ importers:
         version: 28.0.3
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.9(vitest@4.1.9)
+        version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       prettier:
         specifier: 3.9.4
         version: 3.9.4
@@ -3485,7 +3500,7 @@ importers:
         version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   koenig/kg-markdown-html-renderer:
     dependencies:
@@ -3531,7 +3546,7 @@ importers:
         version: 7.7.1
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.9(vitest@4.1.9)
+        version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -3540,7 +3555,7 @@ importers:
         version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   koenig/kg-simplemde:
     dependencies:
@@ -3611,7 +3626,7 @@ importers:
         version: 6.0.3(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.9(vitest@4.1.9)
+        version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       autoprefixer:
         specifier: 10.5.2
         version: 10.5.2(postcss@8.5.16)
@@ -3662,7 +3677,7 @@ importers:
         version: 5.2.0(rollup@4.62.2)(typescript@5.9.3)(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   koenig/kg-utils:
     dependencies:
@@ -3681,7 +3696,7 @@ importers:
         version: 7.7.1
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.9(vitest@4.1.9)
+        version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -3690,7 +3705,7 @@ importers:
         version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   koenig/koenig-lexical:
     devDependencies:
@@ -3837,7 +3852,7 @@ importers:
         version: 6.0.3(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.9(vitest@4.1.9)
+        version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       '@vitest/ui':
         specifier: 4.1.9
         version: 4.1.9(vitest@4.1.9)
@@ -3960,7 +3975,7 @@ importers:
         version: 5.2.0(rollup@4.62.2)(typescript@5.9.3)(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       y-websocket:
         specifier: 3.0.0
         version: 3.0.0(yjs@13.6.31)
@@ -3988,7 +4003,7 @@ importers:
         version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
 packages:
 
@@ -4932,6 +4947,9 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@blazediff/core@1.9.1':
+    resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
 
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
@@ -10811,6 +10829,17 @@ packages:
         optional: true
       babel-plugin-react-compiler:
         optional: true
+
+  '@vitest/browser-playwright@4.1.9':
+    resolution: {integrity: sha512-Bq1rOGf9waevzG3EOkO/dene6bvKTUsZMVg8S1i+WH3JcMjuXEjiahP9rAqZRELUqjBySOJsvvSWqK/B3wjKQw==}
+    peerDependencies:
+      playwright: '*'
+      vitest: 4.1.9
+
+  '@vitest/browser@4.1.9':
+    resolution: {integrity: sha512-j1BKtWmPcqpMhmx/L9EPLgAJpCb0zKfwoWLmqBbxaogCXHjOwHFSEoHCBfnGtx93xKQwilZ26m+UOsHqHMkRNg==}
+    peerDependencies:
+      vitest: 4.1.9
 
   '@vitest/coverage-v8@4.1.9':
     resolution: {integrity: sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==}
@@ -20026,6 +20055,10 @@ packages:
     resolution: {integrity: sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==}
     engines: {node: '>=12.13.0'}
 
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
+
   popper.js@1.16.1:
     resolution: {integrity: sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==}
     deprecated: You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1
@@ -23601,6 +23634,20 @@ packages:
       yaml:
         optional: true
 
+  vitest-browser-react@2.2.0:
+    resolution: {integrity: sha512-oY3KM6305kwJMa6nHo92vVtkOsih7mjEf12dLKuphaF+9ywWPEc+qanIBd394SZ6m5LadVEaG6dicvvizOzmjA==}
+    peerDependencies:
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+      vitest: ^4.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   vitest@4.1.9:
     resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -25464,6 +25511,8 @@ snapshots:
   '@bcoe/v8-coverage@0.2.3': {}
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@blazediff/core@1.9.1': {}
 
   '@borewit/text-codec@0.2.2': {}
 
@@ -32555,7 +32604,101 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
 
-  '@vitest/coverage-v8@4.1.9(vitest@4.1.9)':
+  '@vitest/browser-playwright@4.1.9(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(playwright@1.61.1)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.9)':
+    dependencies:
+      '@vitest/browser': 4.1.9(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/mocker': 4.1.9(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      playwright: 1.61.1
+      tinyrainbow: 3.1.0
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/browser-playwright@4.1.9(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(playwright@1.61.1)(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.9)':
+    dependencies:
+      '@vitest/browser': 4.1.9(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/mocker': 4.1.9(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      playwright: 1.61.1
+      tinyrainbow: 3.1.0
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
+  '@vitest/browser-playwright@4.1.9(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(playwright@1.61.1)(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.9)':
+    dependencies:
+      '@vitest/browser': 4.1.9(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/mocker': 4.1.9(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      playwright: 1.61.1
+      tinyrainbow: 3.1.0
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
+  '@vitest/browser@4.1.9(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.9)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.9(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@vitest/utils': 4.1.9
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/browser@4.1.9(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.9)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.9(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@vitest/utils': 4.1.9
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
+  '@vitest/browser@4.1.9(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.9)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.9(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@vitest/utils': 4.1.9
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
+  '@vitest/coverage-v8@4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.9
@@ -32567,7 +32710,9 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+    optionalDependencies:
+      '@vitest/browser': 4.1.9(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.9)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -32648,7 +32793,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -41089,7 +41234,7 @@ snapshots:
       '@vitest/expect': 4.1.9
       jest: 29.7.0(@types/node@22.20.0)(babel-plugin-macros@3.1.0)(node-notifier@10.0.1)
       jest-snapshot: 30.3.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   html2canvas-pro@2.2.1:
     dependencies:
@@ -45595,6 +45740,8 @@ snapshots:
 
   pngjs@6.0.0: {}
 
+  pngjs@7.0.0: {}
+
   popper.js@1.16.1: {}
 
   portfinder@1.0.38(supports-color@5.5.0):
@@ -50034,7 +50181,16 @@ snapshots:
       tsx: 4.23.0
       yaml: 2.9.0
 
-  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)):
+  vitest-browser-react@2.2.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@4.1.9):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.9
       '@vitest/mocker': 4.1.9(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -50059,13 +50215,14 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 22.20.0
-      '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
+      '@vitest/browser-playwright': 4.1.9(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(playwright@1.61.1)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/coverage-v8': 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       '@vitest/ui': 4.1.9(vitest@4.1.9)
       jsdom: 29.1.1(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)):
+  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.9
       '@vitest/mocker': 4.1.9(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -50090,13 +50247,14 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 26.0.0
-      '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
+      '@vitest/browser-playwright': 4.1.9(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(playwright@1.61.1)(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/coverage-v8': 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       '@vitest/ui': 4.1.9(vitest@4.1.9)
       jsdom: 29.1.1(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)):
+  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.9
       '@vitest/mocker': 4.1.9(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -50121,7 +50279,8 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 26.0.0
-      '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
+      '@vitest/browser-playwright': 4.1.9(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(playwright@1.61.1)(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/coverage-v8': 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       '@vitest/ui': 4.1.9(vitest@4.1.9)
       jsdom: 29.1.1(@noble/hashes@1.8.0)
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -83,6 +83,7 @@ catalog:
   '@typescript-eslint/eslint-plugin': 8.49.0
   '@typescript-eslint/parser': 8.49.0
   '@vitejs/plugin-react': 6.0.3
+  '@vitest/browser-playwright': 4.1.9
   '@vitest/coverage-v8': 4.1.9
   better-sqlite3: 12.11.1
   bson-objectid: 2.0.4
@@ -137,6 +138,7 @@ catalog:
   vite: 8.1.3
   vite-plugin-svgr: 4.5.0
   vitest: 4.1.9
+  vitest-browser-react: 2.2.0
   zod: 4.4.3
 
 catalogs:


### PR DESCRIPTION
Admin's behavior-level test coverage currently lives in the repo's `/e2e` Playwright suite against a real per-worker Ghost, even for cases that never cross the client's API contract. This adds the missing middle tier to `apps/admin`: acceptance tests that boot the **real app** (real provider tree, real router, real CSS) in headless Chromium via Vitest Browser Mode, with the Ghost Admin API served by MSW from `@tryghost/test-data`. The exemplar ports the read-only e2e tags-list cases — 3 tests in ~2s against a suite that needs no Docker, no real Ghost.

How it works:
- **`renderAdminApp({route, labs?, boot?})`** mounts the same provider pyramid as production via a shared `AdminAppRoot` extracted from `main.tsx` (the harness can't silently diverge from the app), stubs the Ember host, records cross-app navigations, and gives each test a fresh react-query client via a new optional `queryClient` prop on `FrameworkProvider` (separate commit; default unchanged — existing consumers unaffected). Shell boot requests (settings/config/site/me, sidebar probes, the fire-and-forget preferences PUT) are handled by default with `@tryghost/test-data`'s canned responses; `labs:` flips flags in settings+config in lockstep.
- **Resource handlers, not request tables**: `mockTags([tag({...})])` owns the URL/query knowledge for its resource. Handlers declare explicit semantics — `declared-query` mode may echo trivial field equality (tags visibility) but 418s on any filter component it doesn't cover, and **never interprets NQL**; unmatched admin-API requests 418 and fail the test in `afterEach` (opt-out available), so a missing mock is a named failure, not console noise.
- **Conventions**: specs are co-located `src/**/*.acceptance.test.tsx` (excluded from the jsdom unit lane), one assertion idiom for counts via a `toHaveCount` matcher wired to vitest's poll timeouts, and lazy route deps are pre-scanned (`optimizeDeps.entries`) so the dep optimizer can never reload the page mid-run.
- **CI**: runs through the existing `tag:playwright` + `test:acceptance` matrix; browser binaries come from the already-cached Playwright install.

Reviewer note: the harness consumes the framework's built output, so run `pnpm nx run @tryghost/admin-x-framework:build` (or any `nx run` path, which resolves it) before a local `pnpm test:acceptance`.

Verification:
- `apps/admin`: `test:acceptance` green on cold cache and warm (3/3 both), `test:unit` (848), `typecheck`, `lint`
- `admin-x-framework`: build, `test:unit` (440), `lint` — the `queryClient` prop is additive
- `admin-x-settings` and `activitypub`: `tsc --noEmit` clean
- `nx show projects --withTarget test:acceptance --projects tag:playwright` includes `@tryghost/admin`