### PR TITLE
Added acceptance coverage for settings screens through the admin shell

### DIFF
--- a/apps/admin/src/settings/settings.acceptance.test.tsx
+++ b/apps/admin/src/settings/settings.acceptance.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { mockEditSettings, mockSettingsScreens, renderAdminApp } from "@test-utils/acceptance";
+
+// Probe: admin-x-settings screens driven through the real admin shell — the
+// lazy /settings/* route, the legacy RoutingProvider and design system
+// included. Mirrors the legacy Playwright spec
+// apps/admin-x-settings/test/acceptance/general/title-and-description.test.ts.
+
+describe("Settings", () => {
+    it("shows the General settings populated from the API", async () => {
+        mockSettingsScreens();
+        const screen = await renderAdminApp({ route: "/settings" });
+
+        const section = screen.getByTestId("title-and-description");
+        await expect.element(section).toBeVisible();
+        await expect.element(section).toHaveTextContent("Test Site");
+        await expect.element(section).toHaveTextContent("Thoughts, stories and ideas.");
+
+        // The staff section renders from the users request — asserting on it
+        // proves the settings-chrome requests resolved inside the test window
+        // (they land after the settings groups above render from cached boot
+        // data, so title assertions alone would pass before they fire).
+        await expect.element(screen.getByTestId("users")).toHaveTextContent("Owner User");
+    });
+
+    it("saves an edited site title and sends only the changed settings", async () => {
+        mockSettingsScreens();
+        const editSettings = mockEditSettings();
+        const screen = await renderAdminApp({ route: "/settings" });
+
+        const section = screen.getByTestId("title-and-description");
+        await expect.element(section).toHaveTextContent("Test Site");
+
+        await section.getByRole("button", { name: "Edit" }).click();
+        await section.getByLabelText("Site title").fill("New Site Title");
+        await section.getByRole("button", { name: "Save" }).click();
+
+        // Saving flips the group back to view mode with the new value.
+        await expect.element(section).toHaveTextContent("New Site Title");
+        expect(editSettings.lastRequest).toEqual({
+            settings: [{ key: "title", value: "New Site Title" }],
+        });
+    });
+});

--- a/apps/admin/test-utils/acceptance/index.ts
+++ b/apps/admin/test-utils/acceptance/index.ts
@@ -12,6 +12,6 @@
  */
 export { renderAdminApp } from "./render-admin-app";
 export type { RenderAdminAppOptions } from "./render-admin-app";
-export { defineResource, mockMembers, mockTags } from "./resources";
-export type { BrowseQuery, MockMembersOptions, ResourceCapture, ResourceOptions, ResourceSemantics, RespondWith } from "./resources";
+export { defineResource, mockEditSettings, mockMembers, mockSettingsScreens, mockTags } from "./resources";
+export type { BrowseQuery, EditSettingsCapture, MockMembersOptions, ResourceCapture, ResourceOptions, ResourceSemantics, RespondWith } from "./resources";
 export { allowUnmockedRequests } from "./worker";

--- a/apps/admin/test-utils/acceptance/resources.ts
+++ b/apps/admin/test-utils/acceptance/resources.ts
@@ -1,5 +1,14 @@
 import { HttpResponse } from "msw";
-import { browseResponse, type Label, type Member, type Tag } from "@tryghost/test-data";
+import {
+    activeThemeResponse,
+    browseResponse,
+    currentUserResponse,
+    settingsResponse,
+    type Label,
+    type Member,
+    type SettingsResponse,
+    type Tag,
+} from "@tryghost/test-data";
 
 import { record418, registerAdminApiHandler, registerRoute } from "./worker";
 
@@ -210,4 +219,97 @@ export function mockMembers(members: RespondWith<Member>, { labels = [] }: MockM
     offersResource([]);
     newslettersResource([]);
     return membersResource(members);
+}
+
+// Settings-screen chrome: admin-x-settings renders EVERY settings group on
+// one page (routes only scroll/expand), so all of these fire on any
+// /settings/* mount regardless of which screen a spec is about.
+const usersResource = defineResource({ resource: "users", semantics: { kind: "passthrough" } });
+const invitesResource = defineResource({ resource: "invites", semantics: { kind: "passthrough" } });
+const rolesResource = defineResource({ resource: "roles", semantics: { kind: "passthrough" } });
+const themesResource = defineResource({ resource: "themes", semantics: { kind: "passthrough" } });
+const automatedEmailsResource = defineResource({ resource: "automated_emails", semantics: { kind: "passthrough" } });
+const recommendationsResource = defineResource({ resource: "recommendations", semantics: { kind: "passthrough" } });
+const integrationsResource = defineResource({ resource: "integrations", semantics: { kind: "passthrough" } });
+
+/**
+ * Declares the world the settings area's page chrome reads at mount — every
+ * settings group renders on one page, so this covers the requests ALL
+ * /settings/* specs trigger: the staff section (users/invites/roles), design
+ * (themes), membership (tiers/newsletters), growth (recommendations, offers,
+ * referrer stats) and advanced (integrations, automated emails).
+ *
+ * Defaults are the minimal believable world: the boot table's owner as the
+ * only staff user, the canned active theme, and empty lists everywhere else.
+ * Screen-specific data a spec asserts on should be declared in the spec, not
+ * here.
+ */
+export function mockSettingsScreens(): void {
+    usersResource(currentUserResponse().users);
+    invitesResource([]);
+    rolesResource([]);
+    themesResource(activeThemeResponse().themes);
+    tiersResource([]);
+    offersResource([]);
+    newslettersResource([]);
+    automatedEmailsResource([]);
+    recommendationsResource([]);
+    integrationsResource([]);
+
+    // Two endpoints defineResource can't express:
+    //  - /incoming_recommendations/ responds under the `recommendations` key
+    //    (useBrowseIncomingRecommendations crashes on any other envelope);
+    //  - /stats/referrers/ (growth's "Top sources") isn't a list envelope.
+    registerRoute("GET", "/incoming_recommendations/?…");
+    registerRoute("GET", "/stats/referrers/");
+    registerAdminApiHandler((request, apiPath) => {
+        if (request.method !== "GET") {
+            return undefined;
+        }
+        if (apiPath === "/incoming_recommendations/" || apiPath.startsWith("/incoming_recommendations/?")) {
+            return HttpResponse.json(browseResponse("recommendations", [], { limit: 5 }));
+        }
+        if (apiPath === "/stats/referrers/") {
+            return HttpResponse.json({ stats: [] });
+        }
+        return undefined;
+    });
+}
+
+type SettingsPutBody = { settings: Array<{ key: string; value: string | boolean | null }> };
+
+export interface EditSettingsCapture {
+    /** Every PUT /settings/ body, oldest first. */
+    requests: SettingsPutBody[];
+    readonly lastRequest: SettingsPutBody | undefined;
+}
+
+/**
+ * Handles PUT /settings/ the way Ghost does — echoes back the full settings
+ * world with the submitted keys applied — and captures every request body so
+ * specs can assert exactly what the UI saved.
+ */
+export function mockEditSettings(): EditSettingsCapture {
+    const requests: SettingsPutBody[] = [];
+
+    registerRoute("PUT", "/settings/");
+    registerAdminApiHandler(async (request, apiPath) => {
+        if (request.method !== "PUT" || apiPath !== "/settings/") {
+            return undefined;
+        }
+
+        const body = (await request.json()) as SettingsPutBody;
+        requests.push(body);
+
+        const overrides = Object.fromEntries(body.settings.map(({ key, value }) => [key, value]));
+        const response: SettingsResponse = settingsResponse({ settings: overrides });
+        return HttpResponse.json(response);
+    });
+
+    return {
+        requests,
+        get lastRequest() {
+            return requests[requests.length - 1];
+        },
+    };
 }


### PR DESCRIPTION
Settles whether settings screens can be tested in Admin's acceptance tier rather than admin-x-settings' standalone Playwright suite: **yes, cleanly** — no changes to settings, the shell, or the Vite config. The settings app mounts through the real admin shell exactly as in production (its raw-TSX `./src/*` export is already covered by the config's `optimizeDeps.entries` glob, so no optimizer churn), and both directions of the contract work:

- **Read**: `/settings` renders API data — site title/description from the canned settings, the staff owner from the users response.
- **Write**: editing the site title through the real UI sends `PUT /settings/` with exactly `[{key: "title", value: "New Site Title"}]` (asserted on the captured body) and returns to view mode.

New harness helpers: `mockSettingsScreens()` — the settings-area default world, because every `/settings/*` mount unconditionally fires 11 chrome requests (users/invites/roles, themes, tiers, automated emails, newsletters, recommendations + incoming, referrer stats, integrations); and `mockEditSettings()` — captures setting PUTs and echoes the edit back Ghost-style. One quirk encoded in a raw handler: `/incoming_recommendations/` responds under the `recommendations` envelope key.

**Known caveat, deliberately left for a follow-up**: the probe exposed a false-green race in the harness's unmocked-request detection — requests that land after a spec's last assertion can record too late for the `afterEach` check. These specs mitigate by asserting on data the chrome requests produce; the real fix is a settle/flush step in the harness teardown, which is separate harness work rather than something to bury in this diff.

Verification: full acceptance suite 9/9 on cold dep-optimizer cache and twice warm (the pre-existing 7 stayed green); the settings specs 3× consecutively; `typecheck` and `lint` clean.

Practical consequence: new settings test coverage can be written in this tier now, testing settings as users reach it — inside admin — while the standalone Playwright suite continues covering the legacy surface until its screens migrate.