### PR TITLE
Simplified ghost-dev container mounts

### DIFF
--- a/.github/workflows/devcontainer-build.yml
+++ b/.github/workflows/devcontainer-build.yml
@@ -23,9 +23,9 @@ on:
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
       - '.npmrc'
-      - 'ghost/core/package.json'
-      - 'ghost/i18n/package.json'
-      - 'ghost/parse-email-address/package.json'
+      # Individual workspace manifests aren't listed: the image installs via
+      # `pnpm install --filter "ghost..." --frozen-lockfile`, so any dependency
+      # change that affects the image necessarily updates pnpm-lock.yaml above.
 
 permissions:
   contents: read

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -62,25 +62,23 @@ services:
     working_dir: /home/ghost/ghost/core
     command: ["pnpm", "dev"]
     volumes:
-      # Keep the runtime workspace graph aligned with the packages installed
-      # by docker/ghost-dev/Dockerfile. Mounting all of ghost/ exposes
-      # ghost/admin, which depends on apps/* and causes pnpm to repair the
-      # workspace before running scripts.
-      - ./ghost/core:/home/ghost/ghost/core
-      - ./ghost/i18n:/home/ghost/ghost/i18n
-      - ./ghost/parse-email-address:/home/ghost/ghost/parse-email-address
-      # Koenig packages in ghost/core's server-side graph — must match the
-      # package.json set installed by docker/ghost-dev/Dockerfile
-      - ./koenig/kg-card-factory:/home/ghost/koenig/kg-card-factory
-      - ./koenig/kg-clean-basic-html:/home/ghost/koenig/kg-clean-basic-html
-      - ./koenig/kg-converters:/home/ghost/koenig/kg-converters
-      - ./koenig/kg-default-cards:/home/ghost/koenig/kg-default-cards
-      - ./koenig/kg-default-nodes:/home/ghost/koenig/kg-default-nodes
-      - ./koenig/kg-default-transforms:/home/ghost/koenig/kg-default-transforms
-      - ./koenig/kg-html-to-lexical:/home/ghost/koenig/kg-html-to-lexical
-      - ./koenig/kg-lexical-html-renderer:/home/ghost/koenig/kg-lexical-html-renderer
-      - ./koenig/kg-markdown-html-renderer:/home/ghost/koenig/kg-markdown-html-renderer
-      - ./koenig/kg-utils:/home/ghost/koenig/kg-utils
+      # Mount the backend source as whole-directory mounts instead of
+      # enumerating each server-graph workspace package. `pnpm dev` runs in
+      # ghost/core, and pnpm's verify-deps-before-run only checks ghost/core's
+      # own dependency closure — which is fully installed in the root
+      # /home/ghost/node_modules baked into the image and never mounted over —
+      # so the non-server packages these dirs also expose (e.g. ghost/admin,
+      # whose @tryghost/admin-x-framework dep lives under apps/ and is left
+      # dangling; koenig-lexical) fall outside that closure and don't trigger a
+      # workspace repair. Because root node_modules is never mounted,
+      # linux-built native modules survive; each package's local node_modules
+      # holds only relative symlinks that re-resolve into the root store.
+      # verify-deps-before-run=false is set below as belt-and-suspenders in
+      # case a future pnpm widens that check back to the whole workspace.
+      - ./ghost:/home/ghost/ghost
+      - ./koenig:/home/ghost/koenig
+      - ./configs:/home/ghost/configs
+      - ./packages:/home/ghost/packages
       # Mount specific content subdirectories to preserve themes/adapters from source
       - ghost-dev-data:/home/ghost/ghost/core/content/data
       - ghost-dev-images:/home/ghost/ghost/core/content/images

--- a/docker/ghost-dev/Dockerfile
+++ b/docker/ghost-dev/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Minimal Development Dockerfile for Ghost Core
 # Source code is mounted at runtime for hot-reload support
 
@@ -17,28 +18,28 @@ RUN apt-get update && \
 
 WORKDIR /home/ghost
 
-# Copy package files for dependency installation
+# Copy root workspace files for dependency installation
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-COPY ghost/core/package.json ghost/core/package.json
-COPY ghost/i18n/package.json ghost/i18n/package.json
-COPY ghost/parse-email-address/package.json ghost/parse-email-address/package.json
-# Koenig packages in ghost/core's server-side dependency graph (direct deps
-# plus kg-utils/kg-default-transforms, which they depend on). The editor UI
-# packages (koenig-lexical, kg-unsplash-selector, kg-simplemde) are admin
-# build-time deps and stay out of the server image.
-COPY koenig/kg-card-factory/package.json koenig/kg-card-factory/package.json
-COPY koenig/kg-clean-basic-html/package.json koenig/kg-clean-basic-html/package.json
-COPY koenig/kg-converters/package.json koenig/kg-converters/package.json
-COPY koenig/kg-default-cards/package.json koenig/kg-default-cards/package.json
-COPY koenig/kg-default-nodes/package.json koenig/kg-default-nodes/package.json
-COPY koenig/kg-default-transforms/package.json koenig/kg-default-transforms/package.json
-COPY koenig/kg-html-to-lexical/package.json koenig/kg-html-to-lexical/package.json
-COPY koenig/kg-lexical-html-renderer/package.json koenig/kg-lexical-html-renderer/package.json
-COPY koenig/kg-markdown-html-renderer/package.json koenig/kg-markdown-html-renderer/package.json
-COPY koenig/kg-utils/package.json koenig/kg-utils/package.json
 
-# Install dependencies
-# Note: Dependencies are installed at build time, but source code is mounted at runtime.
+# Copy the manifests of the top-level dirs that hold ghost/core's dependency
+# closure — ghost/* (core, i18n, parse-email-address), koenig/* (the kg-*
+# packages), and configs/* (the shared eslint config, a dev dep in the graph).
+# --parents preserves each file's directory structure (plain COPY globs would
+# flatten them); node_modules is excluded by .dockerignore. apps/* and e2e
+# are deliberately omitted: nothing in ghost/core's closure lives there,
+# so leaving them out keeps this layer (and the install below) from
+# busting cache when an unrelated frontend package.json changes. `pnpm install
+# --filter "ghost..."` then installs exactly the closure — pnpm's own graph is
+# the source of truth, not a hand-maintained COPY list. (If a closure member is
+# ever added under a new top-level dir — e.g. parse-email-address moving to
+# packages/ — the filtered install will fail loudly with the missing manifest,
+# which is the signal to add that dir here.)
+COPY --parents \
+    ghost/*/package.json \
+    koenig/*/package.json \
+    configs/*/package.json \
+    packages/*/package.json \
+    ./
 
 # Copy root lifecycle scripts/hooks needed by `pnpm install`
 COPY .github/scripts .github/scripts
@@ -47,9 +48,12 @@ COPY .github/hooks .github/hooks
 # Enable corepack so it can read packageManager from package.json and provide pnpm
 RUN corepack enable
 
-# Install deps with a persistent pnpm store cache to speed up rebuilds
+# Install ONLY ghost/core's workspace closure (its name is "ghost"; the trailing
+# "..." selects it plus every workspace dependency). Deps live in the shared
+# root store; non-selected projects (apps/*, ghost/admin, e2e, ...) have their
+# manifests present but are not installed.
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store,id=pnpm-store \
-    pnpm install --frozen-lockfile --prefer-offline
+    pnpm install --filter "ghost..." --frozen-lockfile --prefer-offline
 
 # Copy entrypoint script that optionally loads Tinybird config
 COPY docker/ghost-dev/entrypoint.sh entrypoint.sh

--- a/e2e/helpers/environment/service-managers/ghost-manager.ts
+++ b/e2e/helpers/environment/service-managers/ghost-manager.ts
@@ -83,7 +83,7 @@ export class GhostManager {
 
     /**
      * Set up Ghost and Gateway containers for this worker.
-     * 
+     *
      * @param database Optional database name to use. If not provided, uses 'ghost_testing'.
      */
     async setup(database?: string): Promise<void> {
@@ -160,12 +160,12 @@ export class GhostManager {
         try {
             const existing = this.docker.getContainer(name);
             const info = await existing.inspect();
-            
+
             if (info.State.Running) {
                 debug(`Reusing running container: ${name}`);
                 return existing;
             }
-            
+
             // Exists but stopped - start it
             debug(`Starting stopped container: ${name}`);
             await existing.start();
@@ -383,10 +383,18 @@ export class GhostManager {
         ];
 
         if (this.config.mode === 'dev') {
+            // Whole-directory mounts covering the backend source graph, rather
+            // than enumerating each server-graph workspace package. See the
+            // matching rationale in compose.dev.yaml: `pnpm dev` runs in
+            // ghost/core and only its dependency closure is verified against
+            // the image's root node_modules, so the non-server packages these
+            // dirs also expose don't trigger a workspace repair, and root
+            // node_modules (never mounted) keeps its linux-built native modules.
             binds.push(
-                `${REPO_ROOT}/ghost/core:/home/ghost/ghost/core`,
-                `${REPO_ROOT}/ghost/i18n:/home/ghost/ghost/i18n`,
-                `${REPO_ROOT}/ghost/parse-email-address:/home/ghost/ghost/parse-email-address`
+                `${REPO_ROOT}/ghost:/home/ghost/ghost`,
+                `${REPO_ROOT}/koenig:/home/ghost/koenig`,
+                `${REPO_ROOT}/configs:/home/ghost/configs`,
+                `${REPO_ROOT}/packages:/home/ghost/packages`
             );
         }
 
@@ -401,7 +409,7 @@ export class GhostManager {
         // - dev: Proxies to host dev servers for HMR
         // - build: Minimal passthrough (assets served by Ghost or default CDN)
         const caddyfilePath = mode === 'dev' ? CADDYFILE_PATHS.dev : CADDYFILE_PATHS.build;
-        
+
         const binds: string[] = [
             `${caddyfilePath}:/etc/caddy/Caddyfile:ro`
         ];


### PR DESCRIPTION
no ref
- use pnpm filtered install + simplified copy/bind mounts to avoid explicit lists of copied dependent packages

I was looking into moving parse-email-address into a workspace package, and started running into these explicit package copy lists. After a decent amount of back-and-forth with Claude, it wasn't able to replicate the failure mode from #28476, so I figured I'd try to simplify things back to what they were before that change (with some pnpm augmentations to simplify dependency installs)

_In theory_ this should result in a simpler ghost-dev container setup, but I'm not sure I've tested all the paths that use this container so would appreciate other 👀 on it.