### PR TITLE
Changed e2e factories and page objects to use the shared test-data packages

### DIFF
--- a/apps/admin/src/automations/automations.screen.ts
+++ b/apps/admin/src/automations/automations.screen.ts
@@ -1,10 +1,10 @@
 import { page } from "vitest/browser";
-import { automationsSelectors } from "@tryghost/test-data";
+import { automationListRow, automationsList, automationsPage } from "@tryghost/test-data/selectors/automations";
 
 /** Automations screen locators for acceptance specs; no assertions. */
 export const automationsScreen = {
-    heading: () => page.getByTestId(automationsSelectors.testIds.page).getByRole("heading", { name: "Automations" }),
-    list: () => page.getByTestId(automationsSelectors.testIds.list),
-    rows: () => page.getByTestId(automationsSelectors.testIds.listRow),
+    heading: () => page.getByTestId(automationsPage).getByRole("heading", { name: "Automations" }),
+    list: () => page.getByTestId(automationsList),
+    rows: () => page.getByTestId(automationListRow),
     link: (name: string) => page.getByRole("link", { name, exact: true }),
 };

--- a/apps/admin/src/comments/comments.acceptance.test.tsx
+++ b/apps/admin/src/comments/comments.acceptance.test.tsx
@@ -43,9 +43,9 @@ describe("Comments deep linking", () => {
 
 describe("Comments thread sidebar", () => {
     it("navigates within threads and shows the replied-to context", async () => {
-        const [root, firstReply, nestedReply] = commentThread({ html: "<p>Root comment</p>" }, [
-            reply({ html: "<p>First level reply</p>" }, [reply({ html: "<p>Nested reply to first level</p>" })]),
-        ]).all;
+        const [root, firstReply, nestedReply] = commentThread("Root comment", [
+            reply("First level reply", ["Nested reply to first level"]),
+        ]);
         fakeCommentRead(root);
         fakeCommentRead(firstReply);
         // Thread queries filter on the thread root's id; the main list sends no filter.
@@ -60,26 +60,24 @@ describe("Comments thread sidebar", () => {
         await expect.element(commentsScreen.threadRow(root.id)).toBeVisible();
         await expect.element(commentsScreen.threadRow(firstReply.id)).toBeVisible();
         // Direct children carry no replied-to context in their parent's thread.
-        await expect.element(commentsScreen.repliedToLink(commentsScreen.threadRow(firstReply.id))).not.toBeInTheDocument();
+        await expect.element(commentsScreen.threadRow(firstReply.id).repliedToLink()).not.toBeInTheDocument();
 
-        await commentsScreen.repliesMetric(commentsScreen.threadRow(firstReply.id)).click();
+        await commentsScreen.threadRow(firstReply.id).repliesMetric().click();
 
         await expect.poll(currentRoute).toContain(`thread=is%3A${firstReply.id}`);
         await expect.element(commentsScreen.threadRow(firstReply.id)).toBeVisible();
         await expect.element(commentsScreen.threadRow(nestedReply.id)).toBeVisible();
         // The thread root — itself a reply — shows what it replied to.
-        await expect.element(commentsScreen.repliedToLink(commentsScreen.threadRow(firstReply.id))).toBeVisible();
+        await expect.element(commentsScreen.threadRow(firstReply.id).repliedToLink()).toBeVisible();
     });
 
     it("opens threads from the main comment list", async () => {
-        const [root, rootReply] = commentThread({ html: "<p>Comment with replies</p>" }, [
-            reply({ html: "<p>A reply to the comment</p>" }),
-        ]).all;
+        const [root, rootReply] = commentThread("Comment with replies", ["A reply to the comment"]);
         fakeCommentRead(root);
         fakeComments(({ filter }) => (filter ? [rootReply] : [root, rootReply]));
         await renderAdminApp("/comments");
 
-        await commentsScreen.repliesMetric(commentsScreen.commentRow("Comment with replies")).click();
+        await commentsScreen.commentRow("Comment with replies").repliesMetric().click();
 
         await expect.poll(currentRoute).toContain(`thread=is%3A${root.id}`);
         await expect.element(commentsScreen.threadRow(root.id)).toBeVisible();
@@ -89,17 +87,14 @@ describe("Comments thread sidebar", () => {
         await commentsScreen.closeThreadSidebar();
         await expect.element(commentsScreen.threadSidebar()).not.toBeInTheDocument();
 
-        await commentsScreen.repliedToLink(commentsScreen.commentRow("A reply to the comment")).click();
+        await commentsScreen.commentRow("A reply to the comment").repliedToLink().click();
 
         await expect.poll(currentRoute).toContain(`thread=is%3A${root.id}`);
         await expect.element(commentsScreen.threadSidebar()).toBeVisible();
     });
 
     it("loads more replies from the load more button", async () => {
-        const [root, ...replies] = commentThread(
-            { html: "<p>Root comment for pagination test</p>" },
-            Array.from({ length: 5 }, (_, i) => reply({ html: `<p>Reply number ${i + 1}</p>` })),
-        ).all;
+        const [root, ...replies] = commentThread("Root comment for pagination test", 5);
         fakeCommentRead(root);
         fakeComments([root]);
         // The thread query (the only filtered browse here) pages at 3 replies per request.

--- a/apps/admin/src/comments/comments.acceptance.test.tsx
+++ b/apps/admin/src/comments/comments.acceptance.test.tsx
@@ -3,10 +3,12 @@ import { describe, expect, it } from "vitest";
 import {
     browseResponse,
     comment,
+    commentThread,
     currentRoute,
     fakeAdminEndpoint,
     fakeComments,
     renderAdminApp,
+    reply,
     type Comment,
 } from "@test-utils/acceptance";
 import { commentsScreen } from "./comments.screen";
@@ -41,20 +43,9 @@ describe("Comments deep linking", () => {
 
 describe("Comments thread sidebar", () => {
     it("navigates within threads and shows the replied-to context", async () => {
-        const root = comment({ html: "<p>Root comment</p>", count: { replies: 1, direct_replies: 1, likes: 0, dislikes: 0, reports: 0 } });
-        const firstReply = comment({
-            html: "<p>First level reply</p>",
-            parent_id: root.id,
-            in_reply_to_id: root.id,
-            in_reply_to_snippet: "Root comment",
-            count: { replies: 1, direct_replies: 1, likes: 0, dislikes: 0, reports: 0 },
-        });
-        const nestedReply = comment({
-            html: "<p>Nested reply to first level</p>",
-            parent_id: root.id,
-            in_reply_to_id: firstReply.id,
-            in_reply_to_snippet: "First level reply",
-        });
+        const [root, firstReply, nestedReply] = commentThread({ html: "<p>Root comment</p>" }, [
+            reply({ html: "<p>First level reply</p>" }, [reply({ html: "<p>Nested reply to first level</p>" })]),
+        ]).all;
         fakeCommentRead(root);
         fakeCommentRead(firstReply);
         // Thread queries filter on the thread root's id; the main list sends no filter.
@@ -81,22 +72,18 @@ describe("Comments thread sidebar", () => {
     });
 
     it("opens threads from the main comment list", async () => {
-        const root = comment({ html: "<p>Comment with replies</p>", count: { replies: 1, direct_replies: 1, likes: 0, dislikes: 0, reports: 0 } });
-        const reply = comment({
-            html: "<p>A reply to the comment</p>",
-            parent_id: root.id,
-            in_reply_to_id: root.id,
-            in_reply_to_snippet: "Comment with replies",
-        });
+        const [root, rootReply] = commentThread({ html: "<p>Comment with replies</p>" }, [
+            reply({ html: "<p>A reply to the comment</p>" }),
+        ]).all;
         fakeCommentRead(root);
-        fakeComments(({ filter }) => (filter ? [reply] : [root, reply]));
+        fakeComments(({ filter }) => (filter ? [rootReply] : [root, rootReply]));
         await renderAdminApp("/comments");
 
         await commentsScreen.repliesMetric(commentsScreen.commentRow("Comment with replies")).click();
 
         await expect.poll(currentRoute).toContain(`thread=is%3A${root.id}`);
         await expect.element(commentsScreen.threadRow(root.id)).toBeVisible();
-        await expect.element(commentsScreen.threadRow(reply.id)).toBeVisible();
+        await expect.element(commentsScreen.threadRow(rootReply.id)).toBeVisible();
 
         // Back on the list, the reply's replied-to link is the other thread entry point.
         await commentsScreen.closeThreadSidebar();
@@ -109,12 +96,10 @@ describe("Comments thread sidebar", () => {
     });
 
     it("loads more replies from the load more button", async () => {
-        const root = comment({ html: "<p>Root comment for pagination test</p>", count: { replies: 5, direct_replies: 5, likes: 0, dislikes: 0, reports: 0 } });
-        const replies = Array.from({ length: 5 }, (_, i) => comment({
-            html: `<p>Reply number ${i + 1}</p>`,
-            parent_id: root.id,
-            in_reply_to_id: root.id,
-        }));
+        const [root, ...replies] = commentThread(
+            { html: "<p>Root comment for pagination test</p>" },
+            Array.from({ length: 5 }, (_, i) => reply({ html: `<p>Reply number ${i + 1}</p>` })),
+        ).all;
         fakeCommentRead(root);
         fakeComments([root]);
         // The thread query (the only filtered browse here) pages at 3 replies per request.

--- a/apps/admin/src/comments/comments.screen.ts
+++ b/apps/admin/src/comments/comments.screen.ts
@@ -1,20 +1,31 @@
 import { page, type Locator } from "vitest/browser";
 import { commentsSelectors } from "@tryghost/test-data";
 
+/** A row locator augmented with factories for the row's parts — still a locator for expect.element. */
+export type CommentRowScope = Locator & {
+    repliesMetric(): Locator;
+    repliedToLink(): Locator;
+};
+
+function rowScope(row: Locator): CommentRowScope {
+    return Object.assign(row, {
+        repliesMetric: () => row.getByTestId(commentsSelectors.testIds.repliesMetric).first(),
+        repliedToLink: () => row.getByTestId(commentsSelectors.testIds.repliedToLink),
+    });
+}
+
 /** Comments screen locators and gestures for acceptance specs; no assertions. */
 export const commentsScreen = {
     commentRows: () => page.getByTestId(commentsSelectors.testIds.listRow),
     // A reply row repeats its parent's text in the replied-to snippet, so
     // match rows on their comment body paragraph only.
     commentRow: (text: string) =>
-        commentsScreen.commentRows().filter({ has: page.getByRole("paragraph").filter({ hasText: text }) }),
+        rowScope(commentsScreen.commentRows().filter({ has: page.getByRole("paragraph").filter({ hasText: text }) })),
     filterButton: () => page.getByRole("button", { name: commentsSelectors.names.filterButton, exact: true }),
     showAllButton: () => page.getByRole("button", { name: commentsSelectors.names.showAllCommentsButton }),
-    repliesMetric: (row: Locator) => row.getByTestId(commentsSelectors.testIds.repliesMetric).first(),
-    repliedToLink: (row: Locator) => row.getByTestId(commentsSelectors.testIds.repliedToLink),
 
     threadSidebar: () => page.getByRole("dialog", { name: commentsSelectors.names.threadSidebar }),
-    threadRow: (commentId: string) => page.getByTestId(`${commentsSelectors.testIds.threadRowPrefix}${commentId}`),
+    threadRow: (commentId: string) => rowScope(page.getByTestId(`${commentsSelectors.testIds.threadRowPrefix}${commentId}`)),
     threadRows: () => page.getByTestId(new RegExp(`^${commentsSelectors.testIds.threadRowPrefix}`)),
     loadMoreRepliesButton: () =>
         commentsScreen.threadSidebar().getByRole("button", { name: commentsSelectors.names.loadMoreRepliesButton }),

--- a/apps/admin/src/comments/comments.screen.ts
+++ b/apps/admin/src/comments/comments.screen.ts
@@ -1,5 +1,14 @@
 import { page, type Locator } from "vitest/browser";
-import { commentsSelectors } from "@tryghost/test-data";
+import {
+    commentListRow,
+    commentThreadRowPrefix,
+    filterButton,
+    loadMoreRepliesButton,
+    repliedToLink,
+    repliesMetric,
+    showAllCommentsButton,
+    threadSidebarLabel,
+} from "@tryghost/test-data/selectors/comments";
 
 /** A row locator augmented with factories for the row's parts — still a locator for expect.element. */
 export type CommentRowScope = Locator & {
@@ -9,26 +18,26 @@ export type CommentRowScope = Locator & {
 
 function rowScope(row: Locator): CommentRowScope {
     return Object.assign(row, {
-        repliesMetric: () => row.getByTestId(commentsSelectors.testIds.repliesMetric).first(),
-        repliedToLink: () => row.getByTestId(commentsSelectors.testIds.repliedToLink),
+        repliesMetric: () => row.getByTestId(repliesMetric).first(),
+        repliedToLink: () => row.getByTestId(repliedToLink),
     });
 }
 
 /** Comments screen locators and gestures for acceptance specs; no assertions. */
 export const commentsScreen = {
-    commentRows: () => page.getByTestId(commentsSelectors.testIds.listRow),
+    commentRows: () => page.getByTestId(commentListRow),
     // A reply row repeats its parent's text in the replied-to snippet, so
     // match rows on their comment body paragraph only.
     commentRow: (text: string) =>
         rowScope(commentsScreen.commentRows().filter({ has: page.getByRole("paragraph").filter({ hasText: text }) })),
-    filterButton: () => page.getByRole("button", { name: commentsSelectors.names.filterButton, exact: true }),
-    showAllButton: () => page.getByRole("button", { name: commentsSelectors.names.showAllCommentsButton }),
+    filterButton: () => page.getByRole("button", { name: filterButton, exact: true }),
+    showAllButton: () => page.getByRole("button", { name: showAllCommentsButton }),
 
-    threadSidebar: () => page.getByRole("dialog", { name: commentsSelectors.names.threadSidebar }),
-    threadRow: (commentId: string) => rowScope(page.getByTestId(`${commentsSelectors.testIds.threadRowPrefix}${commentId}`)),
-    threadRows: () => page.getByTestId(new RegExp(`^${commentsSelectors.testIds.threadRowPrefix}`)),
+    threadSidebar: () => page.getByRole("dialog", { name: threadSidebarLabel }),
+    threadRow: (commentId: string) => rowScope(page.getByTestId(`${commentThreadRowPrefix}${commentId}`)),
+    threadRows: () => page.getByTestId(new RegExp(`^${commentThreadRowPrefix}`)),
     loadMoreRepliesButton: () =>
-        commentsScreen.threadSidebar().getByRole("button", { name: commentsSelectors.names.loadMoreRepliesButton }),
+        commentsScreen.threadSidebar().getByRole("button", { name: loadMoreRepliesButton }),
 
     async closeThreadSidebar(): Promise<void> {
         await commentsScreen.threadSidebar().getByRole("button", { name: "Close" }).click();

--- a/apps/admin/src/layout/sidebar.screen.ts
+++ b/apps/admin/src/layout/sidebar.screen.ts
@@ -1,19 +1,37 @@
 import { page } from "vitest/browser";
-import { sidebarSelectors } from "@tryghost/test-data";
+import {
+    appearanceMenuItem,
+    darkAppearanceOption,
+    lightAppearanceOption,
+    networkNotificationBadge,
+    postsToggle,
+    profileMenuItem,
+    signOutMenuItem,
+    systemAppearanceOption,
+    themeErrorsBannerText,
+    themeErrorsDialog,
+    userMenuTrigger,
+} from "@tryghost/test-data/selectors/sidebar";
+
+const appearanceOptions = {
+    dark: darkAppearanceOption,
+    light: lightAppearanceOption,
+    system: systemAppearanceOption,
+} as const;
 
 /** Admin sidebar locators and gestures for acceptance specs; no assertions. */
 export const sidebarScreen = {
     navLink: (name: string) => page.getByRole("navigation").getByRole("link", { name, exact: true }),
-    postsToggle: () => page.getByRole("button", { name: sidebarSelectors.names.postsToggle }),
-    networkBadge: () => page.getByTestId(sidebarSelectors.testIds.networkBadge),
-    userMenuTrigger: () => page.getByRole("button", { name: sidebarSelectors.names.userMenuTrigger }),
-    profileMenuItem: () => page.getByRole("menuitem", { name: sidebarSelectors.names.profileMenuItem }),
-    signOutMenuItem: () => page.getByRole("menuitem", { name: sidebarSelectors.names.signOutMenuItem }),
-    appearanceMenuItem: () => page.getByRole("menuitem", { name: sidebarSelectors.names.appearanceMenuItem }),
+    postsToggle: () => page.getByRole("button", { name: postsToggle }),
+    networkBadge: () => page.getByTestId(networkNotificationBadge),
+    userMenuTrigger: () => page.getByRole("button", { name: userMenuTrigger }),
+    profileMenuItem: () => page.getByRole("menuitem", { name: profileMenuItem }),
+    signOutMenuItem: () => page.getByRole("menuitem", { name: signOutMenuItem }),
+    appearanceMenuItem: () => page.getByRole("menuitem", { name: appearanceMenuItem }),
     appearanceOption: (option: "dark" | "light" | "system") =>
-        page.getByRole("menuitem", { name: sidebarSelectors.names[`${option}AppearanceOption`] }),
-    themeErrorsBanner: () => page.getByRole("status").filter({ hasText: sidebarSelectors.text.themeErrorsBanner }),
-    themeErrorsDialog: () => page.getByRole("dialog", { name: sidebarSelectors.names.themeErrorsDialog }),
+        page.getByRole("menuitem", { name: appearanceOptions[option] }),
+    themeErrorsBanner: () => page.getByRole("status").filter({ hasText: themeErrorsBannerText }),
+    themeErrorsDialog: () => page.getByRole("dialog", { name: themeErrorsDialog }),
 
     /** Open the user menu and select the appearance choice from its submenu. */
     async selectAppearance(option: "dark" | "light" | "system"): Promise<void> {

--- a/apps/admin/src/members/members.screen.ts
+++ b/apps/admin/src/members/members.screen.ts
@@ -1,18 +1,26 @@
 import { page } from "vitest/browser";
-import { membersSelectors } from "@tryghost/test-data";
+import {
+    addFilterButton,
+    filterButton,
+    membersListItem,
+    noResultsText,
+    searchLabel,
+    showAllButton,
+    textFilterFields,
+} from "@tryghost/test-data/selectors/members";
 
 /** Members screen locators and gestures for acceptance specs; no assertions. */
 export const membersScreen = {
-    memberRows: () => page.getByTestId(membersSelectors.testIds.listItem),
+    memberRows: () => page.getByTestId(membersListItem),
     link: (name: string) => page.getByRole("link", { name, exact: true }),
-    searchInput: () => page.getByLabelText(membersSelectors.names.searchInput),
-    noResults: () => page.getByText(membersSelectors.text.noResults),
-    showAllButton: () => page.getByRole("button", { name: membersSelectors.names.showAllButton }),
+    searchInput: () => page.getByLabelText(searchLabel),
+    noResults: () => page.getByText(noResultsText),
+    showAllButton: () => page.getByRole("button", { name: showAllButton }),
 
     /** Add a text filter through the filters UI: Filter button → field option → fill the value input. */
-    async addFilter(field: keyof typeof membersSelectors.textFilterFields, value: string): Promise<void> {
+    async addFilter(field: keyof typeof textFilterFields, value: string): Promise<void> {
         await membersScreen.openFilterField(field);
-        await page.getByRole("textbox", { name: membersSelectors.textFilterFields[field] }).fill(value);
+        await page.getByRole("textbox", { name: textFilterFields[field] }).fill(value);
     },
 
     /** Add a searchable multiselect filter: Filter button → field option → search → pick an option. */
@@ -25,7 +33,7 @@ export const membersScreen = {
 
     async openFilterField(field: string): Promise<void> {
         // The trigger relabels from "Filter" to "Add filter" once a filter exists.
-        const buttonName = new RegExp(`^(${membersSelectors.names.filterButton}|${membersSelectors.names.addFilterButton})$`);
+        const buttonName = new RegExp(`^(${filterButton}|${addFilterButton})$`);
         await page.getByRole("button", { name: buttonName }).click();
         await page.getByRole("option", { name: field, exact: true }).click();
     },

--- a/apps/admin/src/tags/tags.acceptance.test.tsx
+++ b/apps/admin/src/tags/tags.acceptance.test.tsx
@@ -61,12 +61,11 @@ describe("Tags list", () => {
 
     it("fetches the next page when scrolling to the end of the list", async () => {
         // 120 tags: the browse page size is 100, so the tail needs a second fetch.
-        const tagsApi = fakeTags(
-            tag.many(Array.from({ length: 120 }, (_, i) => ({ name: `Tag ${String(i + 1).padStart(3, "0")}` })))
-        );
+        // Default tag names can repeat; the strict link locators need unique names.
+        const tagsApi = fakeTags(tag.many(120, i => ({ name: `Tag ${i + 1}` })));
         await renderAdminApp("/tags");
 
-        await expect.element(tagsScreen.link("Tag 001")).toBeVisible();
+        await expect.element(tagsScreen.link("Tag 1")).toBeVisible();
         expect(tagsApi.lastRequest?.page).toBe(1);
 
         tagsScreen.scrollListToEnd();

--- a/apps/admin/src/tags/tags.screen.ts
+++ b/apps/admin/src/tags/tags.screen.ts
@@ -1,18 +1,26 @@
 import { page } from "vitest/browser";
 import { getScrollParent } from "@tryghost/shade/utils";
-import { tagsSelectors } from "@tryghost/test-data";
+import {
+    createNewTagLink,
+    emptyStateText,
+    internalTab,
+    newTagLink,
+    publicTab,
+    tagListRow,
+    tagsList,
+} from "@tryghost/test-data/selectors/tags";
 
 /** Tags screen locators and gestures for acceptance specs; no assertions. */
 export const tagsScreen = {
-    list: () => page.getByTestId(tagsSelectors.testIds.list),
-    tagRows: () => page.getByTestId(tagsSelectors.testIds.listRow),
+    list: () => page.getByTestId(tagsList),
+    tagRows: () => page.getByTestId(tagListRow),
     link: (name: string) => page.getByRole("link", { name, exact: true }),
-    publicTab: () => page.getByLabelText(tagsSelectors.names.publicTab),
-    internalTab: () => page.getByLabelText(tagsSelectors.names.internalTab),
+    publicTab: () => page.getByLabelText(publicTab),
+    internalTab: () => page.getByLabelText(internalTab),
     // exact: "New tag" is a substring of the empty state's "Create a new tag".
-    newTagLink: () => page.getByRole("link", { name: tagsSelectors.names.newTagLink, exact: true }),
-    emptyStateHeading: () => page.getByRole("heading", { name: tagsSelectors.text.emptyState }),
-    createNewTagLink: () => page.getByRole("link", { name: tagsSelectors.names.createNewTagLink }),
+    newTagLink: () => page.getByRole("link", { name: newTagLink, exact: true }),
+    emptyStateHeading: () => page.getByRole("heading", { name: emptyStateText }),
+    createNewTagLink: () => page.getByRole("link", { name: createNewTagLink }),
 
     /** Scroll the list's scroll container to its end — same resolution the virtualizer uses. */
     scrollListToEnd(): void {

--- a/apps/admin/src/whats-new/whats-new.screen.ts
+++ b/apps/admin/src/whats-new/whats-new.screen.ts
@@ -1,19 +1,30 @@
 import { page, userEvent } from "vitest/browser";
-import { whatsNewSelectors } from "@tryghost/test-data";
+import {
+    dismissButton,
+    whatsNewAvatarBadge,
+    whatsNewBanner,
+    whatsNewBannerExcerpt,
+    whatsNewBannerTitle,
+    whatsNewDialog,
+    whatsNewEntry,
+    whatsNewEntryImage,
+    whatsNewMenuBadge,
+    whatsNewMenuItem,
+} from "@tryghost/test-data/selectors/whats-new";
 
 /** What's-new banner, menu and dialog locators for acceptance specs; no assertions. */
 export const whatsNewScreen = {
-    banner: () => page.getByTestId(whatsNewSelectors.testIds.banner),
-    bannerTitle: () => page.getByTestId(whatsNewSelectors.testIds.bannerTitle),
-    bannerExcerpt: () => page.getByTestId(whatsNewSelectors.testIds.bannerExcerpt),
-    dismissButton: () => page.getByRole("button", { name: whatsNewSelectors.names.dismissButton }),
-    avatarBadge: () => page.getByTestId(whatsNewSelectors.testIds.avatarBadge),
-    menuBadge: () => page.getByTestId(whatsNewSelectors.testIds.menuBadge),
-    menuItem: () => page.getByRole("menuitem", { name: whatsNewSelectors.names.menuItem }),
-    dialog: () => page.getByRole("dialog", { name: whatsNewSelectors.names.dialog }),
-    entries: () => page.getByTestId(whatsNewSelectors.testIds.entry),
-    entry: (index: number) => page.getByTestId(whatsNewSelectors.testIds.entry).nth(index),
-    entryImage: (index: number) => whatsNewScreen.entry(index).getByTestId(whatsNewSelectors.testIds.entryImage),
+    banner: () => page.getByTestId(whatsNewBanner),
+    bannerTitle: () => page.getByTestId(whatsNewBannerTitle),
+    bannerExcerpt: () => page.getByTestId(whatsNewBannerExcerpt),
+    dismissButton: () => page.getByRole("button", { name: dismissButton }),
+    avatarBadge: () => page.getByTestId(whatsNewAvatarBadge),
+    menuBadge: () => page.getByTestId(whatsNewMenuBadge),
+    menuItem: () => page.getByRole("menuitem", { name: whatsNewMenuItem }),
+    dialog: () => page.getByRole("dialog", { name: whatsNewDialog }),
+    entries: () => page.getByTestId(whatsNewEntry),
+    entry: (index: number) => page.getByTestId(whatsNewEntry).nth(index),
+    entryImage: (index: number) => whatsNewScreen.entry(index).getByTestId(whatsNewEntryImage),
 
     /** The dialog has no close control; Escape is how users dismiss it. */
     async closeDialog(): Promise<void> {

--- a/apps/admin/test-utils/acceptance/README.md
+++ b/apps/admin/test-utils/acceptance/README.md
@@ -69,6 +69,8 @@ For a **one-off endpoint** (stats subpaths, settings chrome, a mutation the spec
 
 Per-area locator vocabulary lives in `src/<area>/<area>.screen.ts` (e.g. `membersScreen`): locator factories + multi-step gestures, **no assertions**. Selector strings come from the shared registry in `@tryghost/test-data` (`membersSelectors`, `tagsSelectors`, `whatsNewSelectors`) — the same strings the e2e page objects use, so both tiers break together when the UI changes.
 
+**Row scopes.** A helper that identifies a repeated row returns a *scope*: the row locator itself, augmented with factories for the row's parts — `commentsScreen.threadRow(id).repliedToLink()`. Never write a helper that takes another helper's locator as an argument; scopes keep call sites at one nesting level, reading left-to-right, and the scope is still a locator, so all three assertion idioms work on it unchanged (`await expect.element(commentsScreen.commentRow("…")).toBeVisible()`).
+
 Adding a new screen:
 
 1. Give the component semantic roles/labels; add `data-testid` attributes only where no accessible locator exists.

--- a/apps/admin/test-utils/acceptance/README.md
+++ b/apps/admin/test-utils/acceptance/README.md
@@ -67,16 +67,16 @@ For a **one-off endpoint** (stats subpaths, settings chrome, a mutation the spec
 
 ## Screen helpers
 
-Per-area locator vocabulary lives in `src/<area>/<area>.screen.ts` (e.g. `membersScreen`): locator factories + multi-step gestures, **no assertions**. Selector strings come from the shared registry in `@tryghost/test-data` (`membersSelectors`, `tagsSelectors`, `whatsNewSelectors`) — the same strings the e2e page objects use, so both tiers break together when the UI changes.
+Per-area locator vocabulary lives in `src/<area>/<area>.screen.ts` (e.g. `membersScreen`): locator factories + multi-step gestures, **no assertions**. Selector strings come from the shared per-area registry modules — flat named constants imported via `@tryghost/test-data/selectors/<area>` (e.g. `import {repliesMetric} from "@tryghost/test-data/selectors/comments"`, or `import * as sel from ...` when a file uses many) — the same strings the e2e page objects use, so both tiers break together when the UI changes. Testid constants are the camelCase of the testid string itself (`"replies-metric"` → `repliesMetric`); accessible-name constants carry their element kind or a `Label` suffix (`newTagLink`, `searchLabel`); bare text fragments end in `Text`. The modules are deliberately not re-exported from the package root — flat names collide across surfaces.
 
 **Row scopes.** A helper that identifies a repeated row returns a *scope*: the row locator itself, augmented with factories for the row's parts — `commentsScreen.threadRow(id).repliedToLink()`. Never write a helper that takes another helper's locator as an argument; scopes keep call sites at one nesting level, reading left-to-right, and the scope is still a locator, so all three assertion idioms work on it unchanged (`await expect.element(commentsScreen.commentRow("…")).toBeVisible()`).
 
 Adding a new screen:
 
 1. Give the component semantic roles/labels; add `data-testid` attributes only where no accessible locator exists.
-2. Add a `<area>Selectors` module under `packages/testing/test-data/src/selectors/` (strings only) and export it from the package index.
+2. Add a selectors module under `packages/testing/test-data/src/selectors/<area>.ts` — flat named string constants only, no wrapper object, not exported from the package index (the `./selectors/*` subpath serves it).
 3. Add `src/<area>/<area>.screen.ts` consuming the registry via the global `page` from `vitest/browser`.
-4. Point the e2e page object at the same registry strings (locator code stays Playwright-native).
+4. Point the e2e page object at the same registry constants (locator code stays Playwright-native).
 
 > **Follow-up:** the registry is the interim single source. The end-state is app-owned selector modules — testids only; accessible names stay product copy, asserted as users see it — consumed by the components AND both test tiers, pending an import surface and an e2e dependency-cost check. Until then, component source remains the source of truth and the registry mirrors it.
 

--- a/apps/admin/test-utils/acceptance/index.ts
+++ b/apps/admin/test-utils/acceptance/index.ts
@@ -8,4 +8,4 @@ export type { CapturedEndpointRequest, EndpointCapture, FakeAdminEndpointRespons
 
 // Test-data re-exports, so a spec needs a single import surface.
 export { activeThemeResponse, automation, browseResponse, changelogEntry, comment, commentThread, currentUserResponse, label, member, reply, settingsResponse, tag, tier } from "@tryghost/test-data";
-export type { ActiveThemeResponse, Automation, ChangelogEntry, Comment, CurrentUserResponse, Label, Member, ReplySpec, SettingsResponse, Tag, Tier } from "@tryghost/test-data";
+export type { ActiveThemeResponse, Automation, ChangelogEntry, Comment, CommentThread, CurrentUserResponse, Label, Member, ReplySpec, SettingsResponse, Tag, Tier } from "@tryghost/test-data";

--- a/apps/admin/test-utils/acceptance/index.ts
+++ b/apps/admin/test-utils/acceptance/index.ts
@@ -7,5 +7,5 @@ export { allowUnhandledRequests, fakeAdminEndpoint, fakeEndpoint } from "./worke
 export type { CapturedEndpointRequest, EndpointCapture, FakeAdminEndpointResponse, FakeEndpointOptions } from "./worker";
 
 // Test-data re-exports, so a spec needs a single import surface.
-export { activeThemeResponse, automation, browseResponse, changelogEntry, comment, currentUserResponse, label, member, settingsResponse, tag, tier } from "@tryghost/test-data";
-export type { ActiveThemeResponse, Automation, ChangelogEntry, Comment, CurrentUserResponse, Label, Member, SettingsResponse, Tag, Tier } from "@tryghost/test-data";
+export { activeThemeResponse, automation, browseResponse, changelogEntry, comment, commentThread, currentUserResponse, label, member, reply, settingsResponse, tag, tier } from "@tryghost/test-data";
+export type { ActiveThemeResponse, Automation, ChangelogEntry, Comment, CurrentUserResponse, Label, Member, ReplySpec, SettingsResponse, Tag, Tier } from "@tryghost/test-data";

--- a/e2e/data-factory/factories/comment-factory.ts
+++ b/e2e/data-factory/factories/comment-factory.ts
@@ -1,7 +1,12 @@
 import {Factory} from '@/data-factory';
-import {faker} from '@faker-js/faker';
-import {generateId} from '@/data-factory';
+import {comment} from '@tryghost/test-data';
+import type {Comment as CanonicalComment} from '@tryghost/test-data';
 
+/**
+ * The *write/create* shape POSTed to /ghost/api/admin/comments/. The
+ * canonical *response* shape (member/post embeds, counts, reply metadata)
+ * lives in `@tryghost/test-data`; `build()` derives this payload from it.
+ */
 export interface Comment {
     id: string;
     post_id: string;
@@ -14,18 +19,27 @@ export interface Comment {
     edited_at?: string;
 }
 
+/**
+ * Derive the create payload from the canonical API response shape: embeds,
+ * counts and reply metadata are response-only, and the embeds' random ids
+ * are dropped — specs must reference persisted posts/members themselves.
+ */
+function toCreatePayload(canonical: CanonicalComment): Comment {
+    return {
+        id: canonical.id,
+        post_id: '',
+        member_id: '',
+        status: canonical.status,
+        html: canonical.html
+    };
+}
+
 export class CommentFactory extends Factory<Partial<Comment>, Comment> {
     entityType = 'comments';
 
     build(options: Partial<Comment> = {}): Comment {
-        const content = options.html || `<p>${faker.lorem.sentence()}</p>`;
-
         return {
-            id: generateId(),
-            post_id: options.post_id || '',
-            member_id: options.member_id || '',
-            status: 'published',
-            html: content,
+            ...toCreatePayload(comment()),
             ...options
         };
     }

--- a/e2e/data-factory/factories/tier-factory.ts
+++ b/e2e/data-factory/factories/tier-factory.ts
@@ -1,9 +1,16 @@
 import {Factory} from '@/data-factory';
 import {faker} from '@faker-js/faker';
-import {generateId, generateSlug} from '@/data-factory';
+import {generateSlug} from '@/data-factory';
+import {tier} from '@tryghost/test-data';
+import type {Tier as CanonicalTier} from '@tryghost/test-data';
 import type {HttpClient, PersistenceAdapter} from '@/data-factory';
 import type {Tier} from './member-factory';
 
+/**
+ * The *write/create* shape POSTed to /ghost/api/admin/tiers/ (Date objects
+ * for timestamps). The canonical *response* shape lives in
+ * `@tryghost/test-data`; `build()` derives this payload from it.
+ */
 export interface AdminTier extends Tier {
     description?: string | null;
     visibility?: 'public' | 'none';
@@ -29,6 +36,31 @@ export interface TierCreateInput {
     trial_days?: number;
 }
 
+/**
+ * Derive the create payload from the canonical API response shape:
+ * ISO-string dates become Date objects (serialized back on POST); every
+ * other field maps 1:1 — the tiers write lane accepts the response fields.
+ */
+function toCreatePayload(canonical: CanonicalTier): AdminTier {
+    return {
+        id: canonical.id,
+        name: canonical.name,
+        slug: canonical.slug,
+        type: canonical.type,
+        active: canonical.active,
+        description: canonical.description,
+        visibility: canonical.visibility,
+        welcome_page_url: canonical.welcome_page_url,
+        benefits: canonical.benefits,
+        currency: canonical.currency,
+        monthly_price: canonical.monthly_price,
+        yearly_price: canonical.yearly_price,
+        trial_days: canonical.trial_days,
+        created_at: new Date(canonical.created_at),
+        updated_at: new Date(canonical.updated_at)
+    };
+}
+
 export class TierFactory extends Factory<Partial<AdminTier>, AdminTier> {
     entityType = 'tiers';
     private readonly request?: HttpClient;
@@ -39,25 +71,15 @@ export class TierFactory extends Factory<Partial<AdminTier>, AdminTier> {
     }
 
     build(options: Partial<AdminTier> = {}): AdminTier {
-        const tierName = options.name ?? `Tier ${faker.commerce.productName()}`;
-        const now = new Date();
+        // Canonical response default is a null description; the write lane
+        // keeps seeding one (pre-rewire behavior).
+        const canonical = tier({description: faker.lorem.sentence()});
+        const name = options.name ?? canonical.name;
 
         const defaults: AdminTier = {
-            id: generateId(),
-            name: tierName,
-            slug: `${generateSlug(tierName)}-${faker.string.alphanumeric(6).toLowerCase()}`,
-            type: 'paid',
-            active: true,
-            description: faker.lorem.sentence(),
-            visibility: 'public',
-            welcome_page_url: null,
-            benefits: [],
-            currency: 'usd',
-            monthly_price: 500,
-            yearly_price: 5000,
-            trial_days: 0,
-            created_at: now,
-            updated_at: now
+            ...toCreatePayload(canonical),
+            name,
+            slug: `${generateSlug(name)}-${faker.string.alphanumeric(6).toLowerCase()}`
         };
 
         return {...defaults, ...options};
@@ -74,7 +96,7 @@ export class TierFactory extends Factory<Partial<AdminTier>, AdminTier> {
         }
 
         const {tiers} = await response.json() as {tiers: AdminTier[]};
-        const paidTier = tiers.find(tier => tier.type === 'paid' && tier.active);
+        const paidTier = tiers.find(candidate => candidate.type === 'paid' && candidate.active);
         if (!paidTier) {
             throw new Error('No paid tiers found');
         }

--- a/e2e/helpers/pages/admin/automations/automations-page.ts
+++ b/e2e/helpers/pages/admin/automations/automations-page.ts
@@ -1,6 +1,6 @@
 import {AdminPage} from '@/admin-pages';
 import {Locator, Page} from '@playwright/test';
-import {automationsSelectors} from '@tryghost/test-data';
+import {automationListRow, automationsList, automationsListLoading, automationsPage} from '@tryghost/test-data/selectors/automations';
 
 export class AutomationsPage extends AdminPage {
     readonly pageContent: Locator;
@@ -14,11 +14,11 @@ export class AutomationsPage extends AdminPage {
         super(page);
 
         this.pageUrl = '/ghost/#/automations';
-        this.pageContent = page.getByTestId(automationsSelectors.testIds.page);
-        this.automationsList = page.getByTestId(automationsSelectors.testIds.list);
-        this.automationListRow = this.automationsList.getByTestId(automationsSelectors.testIds.listRow);
+        this.pageContent = page.getByTestId(automationsPage);
+        this.automationsList = page.getByTestId(automationsList);
+        this.automationListRow = this.automationsList.getByTestId(automationListRow);
 
-        this.loadingPlaceholder = page.getByTestId(automationsSelectors.testIds.listLoading);
+        this.loadingPlaceholder = page.getByTestId(automationsListLoading);
     }
 
     title(name: string) {

--- a/e2e/helpers/pages/admin/automations/automations-page.ts
+++ b/e2e/helpers/pages/admin/automations/automations-page.ts
@@ -1,5 +1,6 @@
 import {AdminPage} from '@/admin-pages';
 import {Locator, Page} from '@playwright/test';
+import {automationsSelectors} from '@tryghost/test-data';
 
 export class AutomationsPage extends AdminPage {
     readonly pageContent: Locator;
@@ -13,11 +14,11 @@ export class AutomationsPage extends AdminPage {
         super(page);
 
         this.pageUrl = '/ghost/#/automations';
-        this.pageContent = page.getByTestId('automations-page');
-        this.automationsList = page.getByTestId('automations-list');
-        this.automationListRow = this.automationsList.getByTestId('automation-list-row');
+        this.pageContent = page.getByTestId(automationsSelectors.testIds.page);
+        this.automationsList = page.getByTestId(automationsSelectors.testIds.list);
+        this.automationListRow = this.automationsList.getByTestId(automationsSelectors.testIds.listRow);
 
-        this.loadingPlaceholder = page.getByTestId('automations-list-loading');
+        this.loadingPlaceholder = page.getByTestId(automationsSelectors.testIds.listLoading);
     }
 
     title(name: string) {

--- a/e2e/helpers/pages/admin/comments/comments-page.ts
+++ b/e2e/helpers/pages/admin/comments/comments-page.ts
@@ -1,6 +1,6 @@
 import {AdminPage} from '@/helpers/pages';
 import {Locator, Page} from '@playwright/test';
-import {commentsSelectors} from '@tryghost/test-data';
+import {commentListRow, commentsList} from '@tryghost/test-data/selectors/comments';
 
 export class CommentsPage extends AdminPage {
     readonly commentsList: Locator;
@@ -20,8 +20,8 @@ export class CommentsPage extends AdminPage {
         super(page);
         this.pageUrl = '/ghost/#/comments';
 
-        this.commentsList = page.getByTestId(commentsSelectors.testIds.list);
-        this.commentRows = page.getByTestId(commentsSelectors.testIds.listRow);
+        this.commentsList = page.getByTestId(commentsList);
+        this.commentRows = page.getByTestId(commentListRow);
         this.viewOnPostMenuItem = page.getByRole('menuitem', {name: 'View on post'});
         this.viewMemberMenuItem = page.getByRole('menuitem', {name: 'View member'});
         this.disableCommentingMenuItem = page.getByRole('menuitem', {name: 'Disable commenting'});

--- a/e2e/helpers/pages/admin/members/members-list-page.ts
+++ b/e2e/helpers/pages/admin/members/members-list-page.ts
@@ -1,6 +1,6 @@
+import * as membersSel from '@tryghost/test-data/selectors/members';
 import {AdminPage} from '@/admin-pages';
 import {Download, Locator, Page} from '@playwright/test';
-import {membersSelectors} from '@tryghost/test-data';
 import {readFileSync} from 'node:fs';
 
 export interface ExportedFile {
@@ -25,19 +25,19 @@ export class MembersListPage extends AdminPage {
         super(page);
         this.pageUrl = '/ghost/#/members';
 
-        this.memberRows = page.getByTestId(membersSelectors.testIds.listItem);
-        this.searchInput = page.getByTestId(membersSelectors.testIds.searchInput);
-        this.actionsButton = page.getByTestId(membersSelectors.testIds.actionsButton);
-        this.newMemberButton = page.getByRole('link', {name: membersSelectors.names.newMemberLink});
+        this.memberRows = page.getByTestId(membersSel.membersListItem);
+        this.searchInput = page.getByTestId(membersSel.membersSearchInput);
+        this.actionsButton = page.getByTestId(membersSel.membersActions);
+        this.newMemberButton = page.getByRole('link', {name: membersSel.newMemberLink});
         this.filterButton = page.getByRole('button', {
-            name: new RegExp(`^(${membersSelectors.names.filterButton}|${membersSelectors.names.addFilterButton})$`)
+            name: new RegExp(`^(${membersSel.filterButton}|${membersSel.addFilterButton})$`)
         });
-        this.clearFiltersButton = page.getByRole('button', {name: membersSelectors.names.clearFiltersButton});
-        this.emptyState = page.getByText(membersSelectors.text.emptyState);
-        this.addYourselfButton = page.getByRole('button', {name: membersSelectors.names.addYourselfButton});
-        this.importCsvLink = page.getByRole('link', {name: membersSelectors.names.importCsvLink});
-        this.noResults = page.getByText(membersSelectors.text.noResults);
-        this.showAllButton = page.getByRole('button', {name: membersSelectors.names.showAllButton});
+        this.clearFiltersButton = page.getByRole('button', {name: membersSel.clearFiltersButton});
+        this.emptyState = page.getByText(membersSel.emptyStateText);
+        this.addYourselfButton = page.getByRole('button', {name: membersSel.addYourselfButton});
+        this.importCsvLink = page.getByRole('link', {name: membersSel.importCsvLink});
+        this.noResults = page.getByText(membersSel.noResultsText);
+        this.showAllButton = page.getByRole('button', {name: membersSel.showAllButton});
     }
 
     getMemberByName(name: string): Locator {
@@ -83,7 +83,7 @@ export class MembersListPage extends AdminPage {
         await this.filterButton.click();
         await this.page.getByRole('option', {name: fieldName, exact: true}).click();
 
-        const placeholder = membersSelectors.textFilterFields[fieldName as keyof typeof membersSelectors.textFilterFields];
+        const placeholder = membersSel.textFilterFields[fieldName as keyof typeof membersSel.textFilterFields];
         if (placeholder) {
             await this.page.getByRole('textbox', {name: placeholder}).fill(value);
         } else {

--- a/e2e/helpers/pages/admin/members/members-page.ts
+++ b/e2e/helpers/pages/admin/members/members-page.ts
@@ -12,7 +12,7 @@ export class MembersPage extends AdminPage {
         super(page);
         this.pageUrl = `/ghost/#/${route}`;
 
-        this.newMemberButton = page.getByRole('link', {name: 'New member'});
+        this.newMemberButton = page.getByRole('link', {name: membersSelectors.names.newMemberLink});
 
         this.loadMoreButton = page.getByRole('button', {name: 'Load more'});
         this.membersListScrollRoot = page.getByTestId('members-list-scroll-root');

--- a/e2e/helpers/pages/admin/members/members-page.ts
+++ b/e2e/helpers/pages/admin/members/members-page.ts
@@ -1,6 +1,6 @@
 import {AdminPage} from '@/admin-pages';
 import {JSHandle, Locator, Page} from '@playwright/test';
-import {membersSelectors} from '@tryghost/test-data';
+import {membersListItem, newMemberLink} from '@tryghost/test-data/selectors/members';
 
 export class MembersPage extends AdminPage {
     readonly newMemberButton: Locator;
@@ -12,11 +12,11 @@ export class MembersPage extends AdminPage {
         super(page);
         this.pageUrl = `/ghost/#/${route}`;
 
-        this.newMemberButton = page.getByRole('link', {name: membersSelectors.names.newMemberLink});
+        this.newMemberButton = page.getByRole('link', {name: newMemberLink});
 
         this.loadMoreButton = page.getByRole('button', {name: 'Load more'});
         this.membersListScrollRoot = page.getByTestId('members-list-scroll-root');
-        this.memberListItems = page.getByTestId(membersSelectors.testIds.listItem);
+        this.memberListItems = page.getByTestId(membersListItem);
     }
 
     async clickMemberByEmail(email: string): Promise<void> {
@@ -83,7 +83,7 @@ export class MembersPage extends AdminPage {
                 const rows = Array.from(document.querySelectorAll(`[data-testid="${listItemTestId}"]`));
 
                 return rows.some(row => Number(row.getAttribute('data-index') || '-1') > previousMaxIndex);
-            }, {previousMaxIndex: maxRenderedIndex, listItemTestId: membersSelectors.testIds.listItem});
+            }, {previousMaxIndex: maxRenderedIndex, listItemTestId: membersListItem});
             maxRenderedIndex = await this.getMaxRenderedIndex();
         }
 

--- a/e2e/helpers/pages/admin/sidebar/sidebar-page.ts
+++ b/e2e/helpers/pages/admin/sidebar/sidebar-page.ts
@@ -1,5 +1,6 @@
 import {AdminPage} from '@/admin-pages';
 import {Locator, Page} from '@playwright/test';
+import {sidebarSelectors, whatsNewSelectors} from '@tryghost/test-data';
 
 export type UserRole = 'Administrator' | 'Editor' | 'Author' | 'Contributor';
 
@@ -52,23 +53,21 @@ export class SidebarPage extends AdminPage {
     constructor(page: Page) {
         super(page);
         this.sidebar = page.getByRole('navigation');
-        this.postsToggle = this.sidebar.getByRole('button', {name: /toggle post views/i});
-        this.userDropdownTrigger = page.locator('[data-test-nav="arrow-down"]');
-        this.appearanceMenuItem = page.getByRole('menuitem', {name: /appearance/i});
-        this.themeLightOption = page.getByRole('menuitem', {name: /light appearance/i});
-        this.themeSystemOption = page.getByRole('menuitem', {name: /system appearance/i});
-        this.themeDarkOption = page.getByRole('menuitem', {name: /dark appearance/i});
-        this.whatsNewButton = page.getByRole('menuitem', {name: /what's new/i});
-        this.userProfileLink = page.getByRole('menuitem', {name: /your profile/i});
-        this.signOutLink = page.getByRole('menuitem', {name: /sign out/i});
+        this.postsToggle = this.sidebar.getByRole('button', {name: sidebarSelectors.names.postsToggle});
+        this.userDropdownTrigger = page.getByRole('button', {name: sidebarSelectors.names.userMenuTrigger});
+        this.appearanceMenuItem = page.getByRole('menuitem', {name: sidebarSelectors.names.appearanceMenuItem});
+        this.themeLightOption = page.getByRole('menuitem', {name: sidebarSelectors.names.lightAppearanceOption});
+        this.themeSystemOption = page.getByRole('menuitem', {name: sidebarSelectors.names.systemAppearanceOption});
+        this.themeDarkOption = page.getByRole('menuitem', {name: sidebarSelectors.names.darkAppearanceOption});
+        this.whatsNewButton = page.getByRole('menuitem', {name: whatsNewSelectors.names.menuItem});
+        this.userProfileLink = page.getByRole('menuitem', {name: sidebarSelectors.names.profileMenuItem});
+        this.signOutLink = page.getByRole('menuitem', {name: sidebarSelectors.names.signOutMenuItem});
 
-        this.networkNotificationBadge = this.sidebar
-            .getByRole('listitem').filter({hasText: /network/i})
-            .locator('[data-sidebar="menu-badge"]');
-        this.ghostProLink = this.sidebar.getByRole('link', {name: 'Ghost(Pro)'});
-        this.upgradeNowLink = this.sidebar.getByRole('link', {name: /upgrade/i});
-        this.themeErrorBanner = page.getByRole('status').filter({hasText: /your theme has errors/i});
-        this.themeErrorDialog = page.getByRole('dialog').filter({hasText: /theme errors/i});
+        this.networkNotificationBadge = this.sidebar.getByTestId(sidebarSelectors.testIds.networkBadge);
+        this.ghostProLink = this.sidebar.getByRole('link', {name: sidebarSelectors.names.ghostProLink});
+        this.upgradeNowLink = this.sidebar.getByRole('link', {name: sidebarSelectors.names.upgradeNowLink});
+        this.themeErrorBanner = page.getByRole('status').filter({hasText: sidebarSelectors.text.themeErrorsBanner});
+        this.themeErrorDialog = page.getByRole('dialog', {name: sidebarSelectors.names.themeErrorsDialog});
     }
 
     getNavLink(name: string): Locator {

--- a/e2e/helpers/pages/admin/sidebar/sidebar-page.ts
+++ b/e2e/helpers/pages/admin/sidebar/sidebar-page.ts
@@ -1,6 +1,7 @@
+import * as sidebarSel from '@tryghost/test-data/selectors/sidebar';
 import {AdminPage} from '@/admin-pages';
 import {Locator, Page} from '@playwright/test';
-import {sidebarSelectors, whatsNewSelectors} from '@tryghost/test-data';
+import {whatsNewMenuItem} from '@tryghost/test-data/selectors/whats-new';
 
 export type UserRole = 'Administrator' | 'Editor' | 'Author' | 'Contributor';
 
@@ -53,21 +54,21 @@ export class SidebarPage extends AdminPage {
     constructor(page: Page) {
         super(page);
         this.sidebar = page.getByRole('navigation');
-        this.postsToggle = this.sidebar.getByRole('button', {name: sidebarSelectors.names.postsToggle});
-        this.userDropdownTrigger = page.getByRole('button', {name: sidebarSelectors.names.userMenuTrigger});
-        this.appearanceMenuItem = page.getByRole('menuitem', {name: sidebarSelectors.names.appearanceMenuItem});
-        this.themeLightOption = page.getByRole('menuitem', {name: sidebarSelectors.names.lightAppearanceOption});
-        this.themeSystemOption = page.getByRole('menuitem', {name: sidebarSelectors.names.systemAppearanceOption});
-        this.themeDarkOption = page.getByRole('menuitem', {name: sidebarSelectors.names.darkAppearanceOption});
-        this.whatsNewButton = page.getByRole('menuitem', {name: whatsNewSelectors.names.menuItem});
-        this.userProfileLink = page.getByRole('menuitem', {name: sidebarSelectors.names.profileMenuItem});
-        this.signOutLink = page.getByRole('menuitem', {name: sidebarSelectors.names.signOutMenuItem});
+        this.postsToggle = this.sidebar.getByRole('button', {name: sidebarSel.postsToggle});
+        this.userDropdownTrigger = page.getByRole('button', {name: sidebarSel.userMenuTrigger});
+        this.appearanceMenuItem = page.getByRole('menuitem', {name: sidebarSel.appearanceMenuItem});
+        this.themeLightOption = page.getByRole('menuitem', {name: sidebarSel.lightAppearanceOption});
+        this.themeSystemOption = page.getByRole('menuitem', {name: sidebarSel.systemAppearanceOption});
+        this.themeDarkOption = page.getByRole('menuitem', {name: sidebarSel.darkAppearanceOption});
+        this.whatsNewButton = page.getByRole('menuitem', {name: whatsNewMenuItem});
+        this.userProfileLink = page.getByRole('menuitem', {name: sidebarSel.profileMenuItem});
+        this.signOutLink = page.getByRole('menuitem', {name: sidebarSel.signOutMenuItem});
 
-        this.networkNotificationBadge = this.sidebar.getByTestId(sidebarSelectors.testIds.networkBadge);
-        this.ghostProLink = this.sidebar.getByRole('link', {name: sidebarSelectors.names.ghostProLink});
-        this.upgradeNowLink = this.sidebar.getByRole('link', {name: sidebarSelectors.names.upgradeNowLink});
-        this.themeErrorBanner = page.getByRole('status').filter({hasText: sidebarSelectors.text.themeErrorsBanner});
-        this.themeErrorDialog = page.getByRole('dialog', {name: sidebarSelectors.names.themeErrorsDialog});
+        this.networkNotificationBadge = this.sidebar.getByTestId(sidebarSel.networkNotificationBadge);
+        this.ghostProLink = this.sidebar.getByRole('link', {name: sidebarSel.ghostProLink});
+        this.upgradeNowLink = this.sidebar.getByRole('link', {name: sidebarSel.upgradeNowLink});
+        this.themeErrorBanner = page.getByRole('status').filter({hasText: sidebarSel.themeErrorsBannerText});
+        this.themeErrorDialog = page.getByRole('dialog', {name: sidebarSel.themeErrorsDialog});
     }
 
     getNavLink(name: string): Locator {

--- a/e2e/helpers/pages/admin/tags/tags-page.ts
+++ b/e2e/helpers/pages/admin/tags/tags-page.ts
@@ -1,6 +1,6 @@
 import {AdminPage} from '@/admin-pages';
 import {Locator, Page} from '@playwright/test';
-import {tagsSelectors} from '@tryghost/test-data';
+import {createNewTagLink, newTagLink, tagListRow, tagsHeaderTabs, tagsList, tagsPage} from '@tryghost/test-data/selectors/tags';
 
 export class TagsPage extends AdminPage {
     readonly pageContent: Locator;
@@ -20,15 +20,15 @@ export class TagsPage extends AdminPage {
         super(page);
 
         this.pageUrl = '/ghost/#/tags';
-        this.pageContent = page.getByTestId(tagsSelectors.testIds.page);
-        this.tagList = page.getByTestId(tagsSelectors.testIds.list);
-        this.tagListRow = this.tagList.getByTestId(tagsSelectors.testIds.listRow);
+        this.pageContent = page.getByTestId(tagsPage);
+        this.tagList = page.getByTestId(tagsList);
+        this.tagListRow = this.tagList.getByTestId(tagListRow);
         this.tagNames = page.locator('[data-test-tag-name]');
 
-        this.tabs = page.getByTestId(tagsSelectors.testIds.headerTabs);
+        this.tabs = page.getByTestId(tagsHeaderTabs);
         this.activeTab = this.tabs.locator('[data-state="on"]');
-        this.newTagButton = page.getByRole('link', {name: tagsSelectors.names.newTagLink});
-        this.createNewTagButton = this.pageContent.getByRole('link', {name: tagsSelectors.names.createNewTagLink});
+        this.newTagButton = page.getByRole('link', {name: newTagLink});
+        this.createNewTagButton = this.pageContent.getByRole('link', {name: createNewTagLink});
 
         this.loadingPlaceholder = page.getByTestId('loading-placeholder');
     }

--- a/e2e/helpers/pages/admin/whats-new/whats-new-banner.ts
+++ b/e2e/helpers/pages/admin/whats-new/whats-new-banner.ts
@@ -1,5 +1,6 @@
 import {AdminPage} from '@/admin-pages';
 import {Locator, Page} from '@playwright/test';
+import {whatsNewSelectors} from '@tryghost/test-data';
 
 export class WhatsNewBanner extends AdminPage {
     readonly container: Locator;
@@ -11,11 +12,11 @@ export class WhatsNewBanner extends AdminPage {
     constructor(page: Page) {
         super(page);
 
-        this.container = page.getByRole('status', {name: /what’s new notification/i});
-        this.closeButton = this.container.getByRole('button', {name: /dismiss/i});
+        this.container = page.getByRole('status', {name: whatsNewSelectors.names.banner});
+        this.closeButton = this.container.getByRole('button', {name: whatsNewSelectors.names.dismissButton});
         this.link = this.container.getByRole('link');
-        this.title = this.container.locator('[data-test-toast-title]');
-        this.excerpt = this.container.locator('[data-test-toast-excerpt]');
+        this.title = this.container.getByTestId(whatsNewSelectors.testIds.bannerTitle);
+        this.excerpt = this.container.getByTestId(whatsNewSelectors.testIds.bannerExcerpt);
     }
 
     async dismiss(): Promise<void> {

--- a/e2e/helpers/pages/admin/whats-new/whats-new-banner.ts
+++ b/e2e/helpers/pages/admin/whats-new/whats-new-banner.ts
@@ -1,6 +1,6 @@
 import {AdminPage} from '@/admin-pages';
 import {Locator, Page} from '@playwright/test';
-import {whatsNewSelectors} from '@tryghost/test-data';
+import {bannerLabel, dismissButton, whatsNewBannerExcerpt, whatsNewBannerTitle} from '@tryghost/test-data/selectors/whats-new';
 
 export class WhatsNewBanner extends AdminPage {
     readonly container: Locator;
@@ -12,11 +12,11 @@ export class WhatsNewBanner extends AdminPage {
     constructor(page: Page) {
         super(page);
 
-        this.container = page.getByRole('status', {name: whatsNewSelectors.names.banner});
-        this.closeButton = this.container.getByRole('button', {name: whatsNewSelectors.names.dismissButton});
+        this.container = page.getByRole('status', {name: bannerLabel});
+        this.closeButton = this.container.getByRole('button', {name: dismissButton});
         this.link = this.container.getByRole('link');
-        this.title = this.container.getByTestId(whatsNewSelectors.testIds.bannerTitle);
-        this.excerpt = this.container.getByTestId(whatsNewSelectors.testIds.bannerExcerpt);
+        this.title = this.container.getByTestId(whatsNewBannerTitle);
+        this.excerpt = this.container.getByTestId(whatsNewBannerExcerpt);
     }
 
     async dismiss(): Promise<void> {

--- a/packages/testing/test-data/package.json
+++ b/packages/testing/test-data/package.json
@@ -10,6 +10,7 @@
     "types": "./src/index.ts",
     "exports": {
         ".": "./src/index.ts",
+        "./selectors/*": "./src/selectors/*.ts",
         "./package.json": "./package.json"
     },
     "scripts": {

--- a/packages/testing/test-data/src/builders/comment-thread.ts
+++ b/packages/testing/test-data/src/builders/comment-thread.ts
@@ -1,0 +1,69 @@
+import {comment} from "./comment";
+import type {Comment} from "./comment";
+
+/** A reply declaration: overrides for the node plus its own nested replies. */
+export interface ReplySpec {
+    overrides: Partial<Comment>;
+    replies: ReplySpec[];
+}
+
+/** Declare one reply in a `commentThread`, optionally with nested replies of its own. */
+export function reply(overrides: Partial<Comment> = {}, replies: ReplySpec[] = []): ReplySpec {
+    return {overrides, replies};
+}
+
+/** Ghost derives the snippet from the replied-to comment's html text content. */
+function toSnippet(html: string): string {
+    return html.replace(/<[^>]*>/g, "").replace(/\s+/g, " ").trim();
+}
+
+function countDescendants(specs: ReplySpec[]): number {
+    return specs.reduce((total, spec) => total + 1 + countDescendants(spec.replies), 0);
+}
+
+/**
+ * Build a nested comment thread the way Ghost's Admin API serves it: threads
+ * are flat, so every descendant gets `parent_id = root.id` while
+ * `in_reply_to_id`/`in_reply_to_snippet` point at the actual replied-to
+ * comment (snippet = its html's text content); `count.replies` counts each
+ * node's total descendants and `count.direct_replies` its direct children;
+ * replies share the root's post. Explicit overrides win over every
+ * derivation.
+ *
+ * Returns `{root, all}`: `all` lists every built comment depth-first with
+ * the root first, so `const [root, first, nested] = thread.all` follows the
+ * declaration order.
+ */
+export function commentThread(rootOverrides: Partial<Comment> = {}, replies: ReplySpec[] = []): {root: Comment; all: Comment[]} {
+    const buildNode = (specReplies: ReplySpec[], overrides: Partial<Comment>): Comment => comment({
+        count: {
+            replies: countDescendants(specReplies),
+            direct_replies: specReplies.length,
+            likes: 0,
+            dislikes: 0,
+            reports: 0
+        },
+        ...overrides
+    });
+
+    const root = buildNode(replies, rootOverrides);
+    const all: Comment[] = [root];
+
+    const buildReplies = (specs: ReplySpec[], repliedTo: Comment): void => {
+        for (const spec of specs) {
+            const built = buildNode(spec.replies, {
+                post_id: root.post_id,
+                post: root.post,
+                parent_id: root.id,
+                in_reply_to_id: repliedTo.id,
+                in_reply_to_snippet: toSnippet(repliedTo.html),
+                ...spec.overrides
+            });
+            all.push(built);
+            buildReplies(spec.replies, built);
+        }
+    };
+    buildReplies(replies, root);
+
+    return {root, all};
+}

--- a/packages/testing/test-data/src/builders/comment-thread.ts
+++ b/packages/testing/test-data/src/builders/comment-thread.ts
@@ -7,9 +7,29 @@ export interface ReplySpec {
     replies: ReplySpec[];
 }
 
-/** Declare one reply in a `commentThread`, optionally with nested replies of its own. */
-export function reply(overrides: Partial<Comment> = {}, replies: ReplySpec[] = []): ReplySpec {
-    return {overrides, replies};
+/** A reply may be declared as a spec or as a string — just its paragraph text. */
+export type ReplyInput = ReplySpec | string;
+
+/** Replies may be declared as a list of specs/strings, or a count of default replies ("Reply 1..n"). */
+export type RepliesInput = ReplyInput[] | number;
+
+/** The built thread: the `[root, ...descendants]` array (depth-first) with named access. */
+export type CommentThread = Comment[] & {root: Comment; all: Comment[]};
+
+function toOverrides(input: Partial<Comment> | string): Partial<Comment> {
+    return typeof input === "string" ? {html: `<p>${input}</p>`} : input;
+}
+
+function toReplySpecs(input: RepliesInput): ReplySpec[] {
+    if (typeof input === "number") {
+        return Array.from({length: input}, (_, index) => reply(`Reply ${index + 1}`));
+    }
+    return input.map(item => (typeof item === "string" ? reply(item) : item));
+}
+
+/** Declare one reply in a `commentThread`: `reply("text")`, or overrides, with nested replies. */
+export function reply(overrides: Partial<Comment> | string = {}, replies: RepliesInput = []): ReplySpec {
+    return {overrides: toOverrides(overrides), replies: toReplySpecs(replies)};
 }
 
 /** Ghost derives the snippet from the replied-to comment's html text content. */
@@ -30,11 +50,17 @@ function countDescendants(specs: ReplySpec[]): number {
  * replies share the root's post. Explicit overrides win over every
  * derivation.
  *
- * Returns `{root, all}`: `all` lists every built comment depth-first with
- * the root first, so `const [root, first, nested] = thread.all` follows the
- * declaration order.
+ * Wherever text is all that matters, pass strings: the root and each reply
+ * accept a string as their paragraph text, and the replies argument accepts
+ * a number meaning that many default replies ("Reply 1..n").
+ *
+ * Returns the built comments as an array — depth-first in declaration order,
+ * root first, so `const [root, first, nested] = commentThread(...)` — with
+ * `.root` and `.all` named access.
  */
-export function commentThread(rootOverrides: Partial<Comment> = {}, replies: ReplySpec[] = []): {root: Comment; all: Comment[]} {
+export function commentThread(rootInput: Partial<Comment> | string = {}, replies: RepliesInput = []): CommentThread {
+    const replySpecs = toReplySpecs(replies);
+
     const buildNode = (specReplies: ReplySpec[], overrides: Partial<Comment>): Comment => comment({
         count: {
             replies: countDescendants(specReplies),
@@ -46,7 +72,7 @@ export function commentThread(rootOverrides: Partial<Comment> = {}, replies: Rep
         ...overrides
     });
 
-    const root = buildNode(replies, rootOverrides);
+    const root = buildNode(replySpecs, toOverrides(rootInput));
     const all: Comment[] = [root];
 
     const buildReplies = (specs: ReplySpec[], repliedTo: Comment): void => {
@@ -63,7 +89,7 @@ export function commentThread(rootOverrides: Partial<Comment> = {}, replies: Rep
             buildReplies(spec.replies, built);
         }
     };
-    buildReplies(replies, root);
+    buildReplies(replySpecs, root);
 
-    return {root, all};
+    return Object.assign(all, {root, all});
 }

--- a/packages/testing/test-data/src/factory.ts
+++ b/packages/testing/test-data/src/factory.ts
@@ -11,10 +11,17 @@ export interface Builder<T> {
     (overrides?: Partial<T>): T;
     /** Build one entity per overrides object, e.g. `tag.many([{name: 'A'}, {name: 'B'}])`. */
     many(overridesList: Array<Partial<T>>): T[];
+    /** Build `count` entities, each from fresh (unique) defaults; `overrides(i)` customises per index. */
+    many(count: number, overrides?: (index: number) => Partial<T>): T[];
 }
 
 export function createBuilder<T extends object>(defaults: () => T): Builder<T> {
     const build = (overrides: Partial<T> = {}): T => ({...defaults(), ...overrides});
-    build.many = (overridesList: Array<Partial<T>>): T[] => overridesList.map(overrides => build(overrides));
+    build.many = (countOrList: number | Array<Partial<T>>, overrides?: (index: number) => Partial<T>): T[] => {
+        if (typeof countOrList === "number") {
+            return Array.from({length: countOrList}, (_, index) => build(overrides?.(index)));
+        }
+        return countOrList.map(itemOverrides => build(itemOverrides));
+    };
     return build as Builder<T>;
 }

--- a/packages/testing/test-data/src/index.ts
+++ b/packages/testing/test-data/src/index.ts
@@ -29,12 +29,8 @@ export type {BrowseResponse, BrowseResponseOptions, Pagination} from "./envelope
 
 export {generateId, generateSlug, generateUuid} from "./utils";
 
-export {automationsSelectors} from "./selectors/automations";
-export {commentsSelectors} from "./selectors/comments";
-export {membersSelectors} from "./selectors/members";
-export {sidebarSelectors} from "./selectors/sidebar";
-export {tagsSelectors} from "./selectors/tags";
-export {whatsNewSelectors} from "./selectors/whats-new";
+// Selector modules are deliberately NOT re-exported here: their flat names
+// collide across surfaces. Import them via "@tryghost/test-data/selectors/*".
 
 export {
     activeThemeResponse,

--- a/packages/testing/test-data/src/index.ts
+++ b/packages/testing/test-data/src/index.ts
@@ -13,6 +13,8 @@ export {automation} from "./builders/automation";
 export type {Automation} from "./builders/automation";
 export {comment} from "./builders/comment";
 export type {Comment, CommentPost} from "./builders/comment";
+export {commentThread, reply} from "./builders/comment-thread";
+export type {ReplySpec} from "./builders/comment-thread";
 export {defaultThemesResponse, theme} from "./builders/theme";
 export type {Theme, ThemePackage, ThemesResponse} from "./builders/theme";
 export {post} from "./builders/post";

--- a/packages/testing/test-data/src/index.ts
+++ b/packages/testing/test-data/src/index.ts
@@ -14,7 +14,7 @@ export type {Automation} from "./builders/automation";
 export {comment} from "./builders/comment";
 export type {Comment, CommentPost} from "./builders/comment";
 export {commentThread, reply} from "./builders/comment-thread";
-export type {ReplySpec} from "./builders/comment-thread";
+export type {CommentThread, ReplySpec} from "./builders/comment-thread";
 export {defaultThemesResponse, theme} from "./builders/theme";
 export type {Theme, ThemePackage, ThemesResponse} from "./builders/theme";
 export {post} from "./builders/post";

--- a/packages/testing/test-data/src/selectors/automations.ts
+++ b/packages/testing/test-data/src/selectors/automations.ts
@@ -2,11 +2,9 @@
  * Automations screen selector strings, consumed by the admin screen helpers
  * and the e2e page objects. Source of truth: apps/admin/src/automations.
  */
-export const automationsSelectors = {
-    testIds: {
-        page: "automations-page",
-        list: "automations-list",
-        listRow: "automation-list-row",
-        listLoading: "automations-list-loading"
-    }
-} as const;
+
+// testids
+export const automationsPage = "automations-page";
+export const automationsList = "automations-list";
+export const automationListRow = "automation-list-row";
+export const automationsListLoading = "automations-list-loading";

--- a/packages/testing/test-data/src/selectors/comments.ts
+++ b/packages/testing/test-data/src/selectors/comments.ts
@@ -2,26 +2,24 @@
  * Comments screen selector strings, consumed by the admin screen helpers and
  * the e2e page objects. Source of truth: apps/admin/src/comments.
  */
-export const commentsSelectors = {
-    testIds: {
-        page: "comments-page",
-        list: "comments-list",
-        listRow: "comment-list-row",
-        repliesMetric: "replies-metric",
-        repliedToLink: "replied-to-link",
-        /** Thread sidebar rows carry the comment id: `comment-thread-row-<id>`. */
-        threadRowPrefix: "comment-thread-row-"
-    },
-    names: {
-        filterButton: "Filter",
-        addFilterButton: "Add filter",
-        showAllCommentsButton: "Show all comments",
-        threadSidebar: "Thread",
-        loadMoreRepliesButton: "Load more replies"
-    },
-    text: {
-        emptyState: "No comments yet",
-        notFound: "Comment not found",
-        repliedTo: "Replied to:"
-    }
-} as const;
+
+// testids
+export const commentsPage = "comments-page";
+export const commentsList = "comments-list";
+export const commentListRow = "comment-list-row";
+export const repliesMetric = "replies-metric";
+export const repliedToLink = "replied-to-link";
+/** Thread sidebar rows carry the comment id: `comment-thread-row-<id>`. */
+export const commentThreadRowPrefix = "comment-thread-row-";
+
+// accessible names
+export const filterButton = "Filter";
+export const addFilterButton = "Add filter";
+export const showAllCommentsButton = "Show all comments";
+export const threadSidebarLabel = "Thread";
+export const loadMoreRepliesButton = "Load more replies";
+
+// text fragments
+export const emptyStateText = "No comments yet";
+export const notFoundText = "Comment not found";
+export const repliedToText = "Replied to:";

--- a/packages/testing/test-data/src/selectors/members.ts
+++ b/packages/testing/test-data/src/selectors/members.ts
@@ -2,29 +2,28 @@
  * Members screen selector strings, consumed by the admin screen helpers and
  * the e2e page objects. Source of truth: apps/admin/src/members.
  */
-export const membersSelectors = {
-    testIds: {
-        listItem: "members-list-item",
-        searchInput: "members-search-input",
-        actionsButton: "members-actions"
-    },
-    names: {
-        searchInput: "Search members",
-        filterButton: "Filter",
-        addFilterButton: "Add filter",
-        clearFiltersButton: "Clear",
-        newMemberLink: "New member",
-        showAllButton: "Show all members",
-        addYourselfButton: "Add yourself as a member",
-        importCsvLink: "Import with CSV"
-    },
-    text: {
-        emptyState: "Start building your audience",
-        noResults: "No matching members found."
-    },
-    /** Text fields in the add-filter popover: option label → value-input placeholder. */
-    textFilterFields: {
-        Name: "Enter name...",
-        Email: "Enter email..."
-    }
+
+// testids
+export const membersListItem = "members-list-item";
+export const membersSearchInput = "members-search-input";
+export const membersActions = "members-actions";
+
+// accessible names
+export const searchLabel = "Search members";
+export const filterButton = "Filter";
+export const addFilterButton = "Add filter";
+export const clearFiltersButton = "Clear";
+export const newMemberLink = "New member";
+export const showAllButton = "Show all members";
+export const addYourselfButton = "Add yourself as a member";
+export const importCsvLink = "Import with CSV";
+
+// text fragments
+export const emptyStateText = "Start building your audience";
+export const noResultsText = "No matching members found.";
+
+/** Text fields in the add-filter popover: option label → value-input placeholder. */
+export const textFilterFields = {
+    Name: "Enter name...",
+    Email: "Enter email..."
 } as const;

--- a/packages/testing/test-data/src/selectors/sidebar.ts
+++ b/packages/testing/test-data/src/selectors/sidebar.ts
@@ -2,25 +2,23 @@
  * Admin sidebar selector strings, consumed by the admin screen helpers and
  * the e2e page objects. Source of truth: apps/admin/src/layout/app-sidebar.
  */
-export const sidebarSelectors = {
-    testIds: {
-        networkBadge: "network-notification-badge"
-    },
-    names: {
-        postsToggle: "Toggle post views",
-        userMenuTrigger: "User menu",
-        profileMenuItem: "Your profile",
-        signOutMenuItem: "Sign out",
-        /** The appearance item's accessible name includes the current choice ("Appearance Light"). */
-        appearanceMenuItem: "Appearance",
-        darkAppearanceOption: "Dark appearance",
-        lightAppearanceOption: "Light appearance",
-        systemAppearanceOption: "System appearance",
-        themeErrorsDialog: "Theme errors",
-        ghostProLink: "Ghost(Pro)",
-        upgradeNowLink: "Upgrade now"
-    },
-    text: {
-        themeErrorsBanner: "Your theme has errors"
-    }
-} as const;
+
+// testids
+export const networkNotificationBadge = "network-notification-badge";
+
+// accessible names
+export const postsToggle = "Toggle post views";
+export const userMenuTrigger = "User menu";
+export const profileMenuItem = "Your profile";
+export const signOutMenuItem = "Sign out";
+/** The appearance item's accessible name includes the current choice ("Appearance Light"). */
+export const appearanceMenuItem = "Appearance";
+export const darkAppearanceOption = "Dark appearance";
+export const lightAppearanceOption = "Light appearance";
+export const systemAppearanceOption = "System appearance";
+export const themeErrorsDialog = "Theme errors";
+export const ghostProLink = "Ghost(Pro)";
+export const upgradeNowLink = "Upgrade now";
+
+// text fragments
+export const themeErrorsBannerText = "Your theme has errors";

--- a/packages/testing/test-data/src/selectors/sidebar.ts
+++ b/packages/testing/test-data/src/selectors/sidebar.ts
@@ -16,7 +16,9 @@ export const sidebarSelectors = {
         darkAppearanceOption: "Dark appearance",
         lightAppearanceOption: "Light appearance",
         systemAppearanceOption: "System appearance",
-        themeErrorsDialog: "Theme errors"
+        themeErrorsDialog: "Theme errors",
+        ghostProLink: "Ghost(Pro)",
+        upgradeNowLink: "Upgrade now"
     },
     text: {
         themeErrorsBanner: "Your theme has errors"

--- a/packages/testing/test-data/src/selectors/tags.ts
+++ b/packages/testing/test-data/src/selectors/tags.ts
@@ -2,20 +2,18 @@
  * Tags screen selector strings, consumed by the admin screen helpers and the
  * e2e page objects. Source of truth: apps/admin/src/tags.
  */
-export const tagsSelectors = {
-    testIds: {
-        page: "tags-page",
-        list: "tags-list",
-        listRow: "tag-list-row",
-        headerTabs: "tags-header-tabs"
-    },
-    names: {
-        publicTab: "Public tags",
-        internalTab: "Internal tags",
-        newTagLink: "New tag",
-        createNewTagLink: "Create a new tag"
-    },
-    text: {
-        emptyState: "Start organizing your content"
-    }
-} as const;
+
+// testids
+export const tagsPage = "tags-page";
+export const tagsList = "tags-list";
+export const tagListRow = "tag-list-row";
+export const tagsHeaderTabs = "tags-header-tabs";
+
+// accessible names
+export const publicTab = "Public tags";
+export const internalTab = "Internal tags";
+export const newTagLink = "New tag";
+export const createNewTagLink = "Create a new tag";
+
+// text fragments
+export const emptyStateText = "Start organizing your content";

--- a/packages/testing/test-data/src/selectors/whats-new.ts
+++ b/packages/testing/test-data/src/selectors/whats-new.ts
@@ -4,25 +4,23 @@
  * apps/admin/src/whats-new plus the user-menu badges in
  * apps/admin/src/layout/app-sidebar/user-menu.tsx.
  */
-export const whatsNewSelectors = {
-    testIds: {
-        banner: "whats-new-banner",
-        bannerTitle: "whats-new-banner-title",
-        bannerExcerpt: "whats-new-banner-excerpt",
-        avatarBadge: "whats-new-avatar-badge",
-        menuBadge: "whats-new-menu-badge",
-        entry: "whats-new-entry",
-        entryTitle: "whats-new-entry-title",
-        entryExcerpt: "whats-new-entry-excerpt",
-        entryImage: "whats-new-entry-image"
-    },
-    names: {
-        /** The banner region's aria-label (curly apostrophe, as in the component). */
-        banner: "What’s new notification",
-        /** The shade Banner dismiss button's aria-label. */
-        dismissButton: "Dismiss notification",
-        /** The user-menu item and the dialog title share this label (curly apostrophe). */
-        menuItem: "What’s new?",
-        dialog: "What’s new?"
-    }
-} as const;
+
+// testids
+export const whatsNewBanner = "whats-new-banner";
+export const whatsNewBannerTitle = "whats-new-banner-title";
+export const whatsNewBannerExcerpt = "whats-new-banner-excerpt";
+export const whatsNewAvatarBadge = "whats-new-avatar-badge";
+export const whatsNewMenuBadge = "whats-new-menu-badge";
+export const whatsNewEntry = "whats-new-entry";
+export const whatsNewEntryTitle = "whats-new-entry-title";
+export const whatsNewEntryExcerpt = "whats-new-entry-excerpt";
+export const whatsNewEntryImage = "whats-new-entry-image";
+
+// accessible names
+/** The banner region's aria-label (curly apostrophe, as in the component). */
+export const bannerLabel = "What’s new notification";
+/** The shade Banner dismiss button's aria-label. */
+export const dismissButton = "Dismiss notification";
+/** The user-menu item and the dialog title share this label (curly apostrophe). */
+export const whatsNewMenuItem = "What’s new?";
+export const whatsNewDialog = "What’s new?";

--- a/packages/testing/test-data/test/builders.test.ts
+++ b/packages/testing/test-data/test/builders.test.ts
@@ -89,14 +89,17 @@ describe("builders", () => {
     });
 
     it("builds flat comment threads with reply linkage and counts derived", () => {
-        const {root, all} = commentThread({html: "<p>Root comment</p>"}, [
-            reply({html: "<p>First reply</p>"}, [reply({html: "<p>Nested reply</p>"})]),
+        const thread = commentThread("Root comment", [
+            reply("First reply", ["Nested reply"]),
             reply()
         ]);
 
-        expect(all).toHaveLength(4);
-        expect(all[0]).toBe(root);
-        const [, first, nested, second] = all;
+        expect(thread).toHaveLength(4);
+        const [root, first, nested, second] = thread;
+        expect(thread.root).toBe(root);
+        expect(thread.all).toBe(thread);
+        expect(root.html).toBe("<p>Root comment</p>");
+        expect(first.html).toBe("<p>First reply</p>");
 
         for (const descendant of [first, nested, second]) {
             expect(descendant.parent_id).toBe(root.id);
@@ -115,8 +118,16 @@ describe("builders", () => {
         expect(nested.count).toMatchObject({replies: 0, direct_replies: 0});
     });
 
+    it("expands a reply count into default replies", () => {
+        const [root, ...replies] = commentThread("Root comment", 3);
+
+        expect(replies.map(r => r.html)).toEqual(["<p>Reply 1</p>", "<p>Reply 2</p>", "<p>Reply 3</p>"]);
+        expect(replies.map(r => r.in_reply_to_snippet)).toEqual(["Root comment", "Root comment", "Root comment"]);
+        expect(root.count).toMatchObject({replies: 3, direct_replies: 3});
+    });
+
     it("derives thread snippets from html text content and lets overrides win", () => {
-        const {all} = commentThread({html: "<p>Hello <strong>world</strong>!</p>"}, [
+        const [, first, second] = commentThread({html: "<p>Hello <strong>world</strong>!</p>"}, [
             reply(),
             reply({
                 parent_id: "custom-parent",
@@ -125,10 +136,10 @@ describe("builders", () => {
             })
         ]);
 
-        expect(all[1].in_reply_to_snippet).toBe("Hello world!");
-        expect(all[2].parent_id).toBe("custom-parent");
-        expect(all[2].in_reply_to_snippet).toBe("Custom snippet");
-        expect(all[2].count).toEqual({replies: 9, direct_replies: 9, likes: 1, dislikes: 0, reports: 0});
+        expect(first.in_reply_to_snippet).toBe("Hello world!");
+        expect(second.parent_id).toBe("custom-parent");
+        expect(second.in_reply_to_snippet).toBe("Custom snippet");
+        expect(second.count).toEqual({replies: 9, direct_replies: 9, likes: 1, dislikes: 0, reports: 0});
     });
 
     it("builds themes and the canned casper+edition list", () => {

--- a/packages/testing/test-data/test/builders.test.ts
+++ b/packages/testing/test-data/test/builders.test.ts
@@ -1,4 +1,4 @@
-import {automation, buildLexical, buildLexicalParagraph, comment, defaultThemesResponse, label, member, post, tag, theme, tier} from "../src/index";
+import {automation, buildLexical, buildLexicalParagraph, comment, commentThread, defaultThemesResponse, label, member, post, reply, tag, theme, tier} from "../src/index";
 import {describe, expect, it} from "vitest";
 
 describe("builders", () => {
@@ -54,6 +54,17 @@ describe("builders", () => {
         expect(member.many([{name: "A"}, {name: "B"}]).map(m => m.name)).toEqual(["A", "B"]);
     });
 
+    it("builds n entities with fresh defaults from many's count form", () => {
+        const built = tag.many(3);
+
+        expect(built).toHaveLength(3);
+        expect(new Set(built.map(t => t.id)).size).toBe(3);
+        expect(new Set(built.map(t => t.slug)).size).toBe(3);
+
+        const named = tag.many(3, index => ({name: `Tag ${index + 1}`}));
+        expect(named.map(t => t.name)).toEqual(["Tag 1", "Tag 2", "Tag 3"]);
+    });
+
     it("builds paid tiers", () => {
         const built = tier({name: "Silver Tier"});
 
@@ -75,6 +86,49 @@ describe("builders", () => {
         expect(built.status).toBe("published");
         expect(built.parent_id).toBeNull();
         expect(built.count.direct_replies).toBe(0);
+    });
+
+    it("builds flat comment threads with reply linkage and counts derived", () => {
+        const {root, all} = commentThread({html: "<p>Root comment</p>"}, [
+            reply({html: "<p>First reply</p>"}, [reply({html: "<p>Nested reply</p>"})]),
+            reply()
+        ]);
+
+        expect(all).toHaveLength(4);
+        expect(all[0]).toBe(root);
+        const [, first, nested, second] = all;
+
+        for (const descendant of [first, nested, second]) {
+            expect(descendant.parent_id).toBe(root.id);
+            expect(descendant.post_id).toBe(root.post_id);
+            expect(descendant.post).toEqual(root.post);
+        }
+
+        expect(first.in_reply_to_id).toBe(root.id);
+        expect(first.in_reply_to_snippet).toBe("Root comment");
+        expect(nested.in_reply_to_id).toBe(first.id);
+        expect(nested.in_reply_to_snippet).toBe("First reply");
+        expect(second.in_reply_to_id).toBe(root.id);
+
+        expect(root.count).toMatchObject({replies: 3, direct_replies: 2});
+        expect(first.count).toMatchObject({replies: 1, direct_replies: 1});
+        expect(nested.count).toMatchObject({replies: 0, direct_replies: 0});
+    });
+
+    it("derives thread snippets from html text content and lets overrides win", () => {
+        const {all} = commentThread({html: "<p>Hello <strong>world</strong>!</p>"}, [
+            reply(),
+            reply({
+                parent_id: "custom-parent",
+                in_reply_to_snippet: "Custom snippet",
+                count: {replies: 9, direct_replies: 9, likes: 1, dislikes: 0, reports: 0}
+            })
+        ]);
+
+        expect(all[1].in_reply_to_snippet).toBe("Hello world!");
+        expect(all[2].parent_id).toBe("custom-parent");
+        expect(all[2].in_reply_to_snippet).toBe("Custom snippet");
+        expect(all[2].count).toEqual({replies: 9, direct_replies: 9, likes: 1, dislikes: 0, reports: 0});
     });
 
     it("builds themes and the canned casper+edition list", () => {


### PR DESCRIPTION
Consistency sweep: everything with a canonical builder or selector registry now consumes it, and the spec-facing APIs are tightened to read as intent.

**Factory rewiring** (same pattern as tags/members/posts): the e2e `tier` and `comment` factories build from `@tryghost/test-data`'s canonical builders, deriving write payloads at the persistence boundary — verified with field-level shape-equivalence proofs (17 cases + 200-sample fuzz, zero deltas through the exact adapter round-trip). Three factories deliberately stay, each with a structural reason in the diff: `user` (setup-wizard payload, no API resource to model), `automated-email` (enum-validated resource — randomized data would be API-rejected), `offer` (write options fork hard from the response shape; the canonical response builder ships in the dep-optimization PR).

**Page-object registry flips**: sidebar (13 strings, including two legacy `data-test-*` hooks replaced with the testids the components actually carry), automations, whats-new banner, and the members-page straggler. One latent bug fixed en route: the what's-new nav regex used a straight apostrophe against a component rendering a curly one.

**Builder + helper ergonomics** (each with its consumers rewritten in this PR):
- `commentThread("Comment with replies", ["A reply"])` — strings are paragraphs (and the snippet source), a number means n default replies, nesting via `reply("text", [children])`; derives Ghost's flat-thread `parent_id` rule, `in_reply_to_id`/snippet from the replied-to node, and both counts; returns a destructurable array (`const [root, ...replies] =`). One hand-written count in the old Given turned out domain-incorrect; the derived one is right.
- `Builder.many(count, fn?)` — count-form generation for list/pagination Givens.
- **Row scopes**: screen-helper rows return the row locator augmented with part factories — `commentsScreen.commentRow("…").repliesMetric().click()` — one nesting level, never passing locators into functions; all assertion idioms work on the scope unchanged.
- **Flat selector registries**: no wrapper objects or kind grouping — named constants per surface module (`import { commentListRow } from "@tryghost/test-data/selectors/comments"`), where a testid constant is the camelCase of the testid string (greppable both directions), accessible names carry `Label`, text fragments carry `Text`; no root barrel (cross-surface collisions); new `./selectors/*` exports entry.

**Audit greps**: no entity literals where a builder exists, no hardcoded strings where a registry key exists, no builder without a consumer — every survivor has a stated structural reason (full results in the PR discussion).

Verification at HEAD: acceptance 39/39 cold-cache + warm; admin unit 848/848 + typecheck + lint; test-data 20/20 + lint + types; e2e lint (0 errors) + types; install idempotent.