### PR TITLE
Added FileStore adapter for storing route settings on local disk

### DIFF
--- a/ghost/core/core/server/adapters/route-settings/FileStore.ts
+++ b/ghost/core/core/server/adapters/route-settings/FileStore.ts
@@ -1,0 +1,194 @@
+import fs from 'fs-extra';
+import path from 'path';
+import {format} from 'date-fns';
+import * as errors from '@tryghost/errors';
+import tpl from '@tryghost/tpl';
+
+import RouteSettingsStoreBase from './RouteSettingsStoreBase';
+import parseYaml from '../../services/route-settings/yaml-parser';
+import {parseRouteSettings} from '../../services/route-settings/route-settings-parser';
+import type {RouteSettings} from '../../services/route-settings/route-settings-parser';
+import type {RouteSettingsStore} from './RouteSettingsStoreBase';
+
+const YAML_FILENAME = 'routes.yaml';
+const JSON_FILENAME = 'routes.json';
+const DEFAULT_SETTINGS_FILENAME = 'default-routes.yaml';
+
+const messages = {
+    missingPaths: 'FileStore requires basePath and defaultSettingsBasePath.',
+    ensureSettings: 'Error trying to access settings files in {path}.',
+    corruptJson: `Could not parse route settings JSON from '{path}': {context}.`,
+    invalidJson: `Route settings JSON at '{path}' does not contain valid route settings.`
+};
+
+export const getBackupRouteSettingsFilePath = (filePath: string): string => {
+    const {dir, name, ext} = path.parse(filePath);
+    return path.join(dir, `${name}-${format(new Date(), 'yyyy-MM-dd-HH-mm-ss')}${ext}`);
+};
+
+interface FileStoreOptions {
+    basePath: string;
+    defaultSettingsBasePath: string;
+    getBackupFilePath?: (filePath: string) => string;
+}
+
+/**
+ * Local-disk store for route settings. Reads existing `routes.yaml`
+ * (backward compatible with pre-refactor installs) and `routes.json`,
+ * always writes the domain object as `routes.json` — the previous
+ * canonical file becomes a timestamped backup on every `replace`.
+ * When no canonical file exists the parsed bundled defaults are
+ * returned without touching the disk; a real file only materialises
+ * on the first `replace`.
+ */
+export default class FileStore extends RouteSettingsStoreBase implements RouteSettingsStore {
+    private readonly basePath: string;
+    private readonly defaultSettingsBasePath: string;
+    private readonly getBackupFilePath: (filePath: string) => string;
+
+    constructor({basePath, defaultSettingsBasePath, getBackupFilePath = getBackupRouteSettingsFilePath}: FileStoreOptions) {
+        super();
+
+        if (!basePath || !defaultSettingsBasePath) {
+            throw new errors.IncorrectUsageError({
+                message: tpl(messages.missingPaths)
+            });
+        }
+
+        this.basePath = basePath;
+        this.defaultSettingsBasePath = defaultSettingsBasePath;
+        this.getBackupFilePath = getBackupFilePath;
+    }
+
+    async get(): Promise<RouteSettings> {
+        const yamlPath = path.join(this.basePath, YAML_FILENAME);
+        const yamlContent = await this._readIfExists(yamlPath);
+        if (yamlContent !== null) {
+            return parseRouteSettings(parseYaml(yamlContent));
+        }
+
+        const jsonPath = path.join(this.basePath, JSON_FILENAME);
+        const jsonContent = await this._readIfExists(jsonPath);
+        if (jsonContent !== null) {
+            return this._parseStoredJson(jsonContent, jsonPath);
+        }
+
+        const defaultContent = await this._readDefaultSettings();
+        return parseRouteSettings(parseYaml(defaultContent));
+    }
+
+    async replace(settings: RouteSettings): Promise<void> {
+        const existingPath = await this._findExistingFile();
+        const targetPath = path.join(this.basePath, JSON_FILENAME);
+
+        // Same path: backup must happen before the atomic write because
+        // the rename would otherwise clobber the previous content with
+        // no copy elsewhere. Read via _readIfExists so a file that vanished
+        // since _findExistingFile just skips the backup, and real read
+        // failures surface as typed errors.
+        if (existingPath && existingPath === targetPath) {
+            const backupPath = this.getBackupFilePath(existingPath);
+            const content = await this._readIfExists(existingPath);
+            if (content !== null) {
+                await this._writeAtomic(backupPath, content);
+            }
+        }
+
+        await this._writeAtomic(targetPath, JSON.stringify(settings, null, 4));
+
+        // Different path (yaml → json): backup must happen AFTER the
+        // write so a failed write doesn't leave nothing at any canonical
+        // path. If the backup itself fails, the legacy yaml takes
+        // precedence over the new json on next read — roll the new json
+        // back so the operator sees a consistent old state.
+        if (existingPath && existingPath !== targetPath) {
+            try {
+                await this._backup(existingPath);
+            } catch (err) {
+                await fs.remove(targetPath).catch(() => {});
+                throw err;
+            }
+        }
+    }
+
+    private async _findExistingFile(): Promise<string | null> {
+        const yamlPath = path.join(this.basePath, YAML_FILENAME);
+        if (await fs.pathExists(yamlPath)) {
+            return yamlPath;
+        }
+
+        const jsonPath = path.join(this.basePath, JSON_FILENAME);
+        if (await fs.pathExists(jsonPath)) {
+            return jsonPath;
+        }
+
+        return null;
+    }
+
+    private async _readIfExists(filePath: string): Promise<string | null> {
+        try {
+            return await fs.readFile(filePath, 'utf8');
+        } catch (err) {
+            if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+                return null;
+            }
+
+            throw new errors.InternalServerError({
+                message: tpl(messages.ensureSettings, {path: this.basePath}),
+                err: err as Error,
+                context: (err as NodeJS.ErrnoException).path
+            });
+        }
+    }
+
+    private async _readDefaultSettings(): Promise<string> {
+        const defaultFilePath = path.join(this.defaultSettingsBasePath, DEFAULT_SETTINGS_FILENAME);
+        try {
+            return await fs.readFile(defaultFilePath, 'utf8');
+        } catch (err) {
+            throw new errors.InternalServerError({
+                message: tpl(messages.ensureSettings, {path: this.defaultSettingsBasePath}),
+                err: err as Error,
+                context: (err as NodeJS.ErrnoException).path
+            });
+        }
+    }
+
+    private _parseStoredJson(content: string, filePath: string): RouteSettings {
+        let parsed: unknown;
+        try {
+            parsed = JSON.parse(content);
+        } catch (err) {
+            throw new errors.IncorrectUsageError({
+                message: tpl(messages.corruptJson, {path: filePath, context: (err as Error).message}),
+                err: err as Error
+            });
+        }
+
+        const candidate = parsed as Partial<RouteSettings> | null;
+        const isPlainObject = (value: unknown): boolean => typeof value === 'object' && value !== null && !Array.isArray(value);
+        if (!isPlainObject(candidate) || !Array.isArray(candidate?.routes) || !Array.isArray(candidate?.collections) || !isPlainObject(candidate?.taxonomies)) {
+            throw new errors.IncorrectUsageError({
+                message: tpl(messages.invalidJson, {path: filePath})
+            });
+        }
+
+        return parsed as RouteSettings;
+    }
+
+    private async _backup(existingPath: string): Promise<void> {
+        const backupPath = this.getBackupFilePath(existingPath);
+        await fs.move(existingPath, backupPath, {overwrite: true});
+    }
+
+    private async _writeAtomic(targetPath: string, content: string): Promise<void> {
+        const tmpPath = `${targetPath}.tmp.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}`;
+        await fs.writeFile(tmpPath, content, 'utf-8');
+        try {
+            await fs.move(tmpPath, targetPath, {overwrite: true});
+        } catch (err) {
+            await fs.remove(tmpPath).catch(() => {});
+            throw err;
+        }
+    }
+}

--- a/ghost/core/core/server/adapters/route-settings/FileStore.ts
+++ b/ghost/core/core/server/adapters/route-settings/FileStore.ts
@@ -11,14 +11,11 @@ import type {RouteSettings} from '../../services/route-settings/route-settings-p
 import type {RouteSettingsStore} from './RouteSettingsStoreBase';
 
 const YAML_FILENAME = 'routes.yaml';
-const JSON_FILENAME = 'routes.json';
 const DEFAULT_SETTINGS_FILENAME = 'default-routes.yaml';
 
 const messages = {
     missingPaths: 'FileStore requires basePath and defaultSettingsBasePath.',
-    ensureSettings: 'Error trying to access settings files in {path}.',
-    corruptJson: `Could not parse route settings JSON from '{path}': {context}.`,
-    invalidJson: `Route settings JSON at '{path}' does not contain valid route settings.`
+    ensureSettings: 'Error trying to access settings files in {path}.'
 };
 
 export const getBackupRouteSettingsFilePath = (filePath: string): string => {
@@ -33,13 +30,13 @@ interface FileStoreOptions {
 }
 
 /**
- * Local-disk store for route settings. Reads existing `routes.yaml`
- * (backward compatible with pre-refactor installs) and `routes.json`,
- * always writes the domain object as `routes.json` — the previous
- * canonical file becomes a timestamped backup on every `replace`.
- * When no canonical file exists the parsed bundled defaults are
- * returned without touching the disk; a real file only materialises
- * on the first `replace`.
+ * Local-disk store for route settings. Reads and writes the user's
+ * original `routes.yaml` verbatim — comments, ordering and formatting are
+ * preserved because we persist `settings.yamlSource` (the exact bytes the
+ * domain model was parsed from) rather than a re-serialised model. Every
+ * `replace` turns the previous file into a timestamped backup. When no
+ * `routes.yaml` exists the parsed bundled defaults are returned without
+ * touching the disk; a real file only materialises on the first `replace`.
  */
 export default class FileStore extends RouteSettingsStoreBase implements RouteSettingsStore {
     private readonly basePath: string;
@@ -62,70 +59,33 @@ export default class FileStore extends RouteSettingsStoreBase implements RouteSe
 
     async get(): Promise<RouteSettings> {
         const yamlPath = path.join(this.basePath, YAML_FILENAME);
-        const yamlContent = await this._readIfExists(yamlPath);
+        const yamlContent = await this.readIfExists(yamlPath);
         if (yamlContent !== null) {
-            return parseRouteSettings(parseYaml(yamlContent));
+            return parseRouteSettings(parseYaml(yamlContent), yamlContent);
         }
 
-        const jsonPath = path.join(this.basePath, JSON_FILENAME);
-        const jsonContent = await this._readIfExists(jsonPath);
-        if (jsonContent !== null) {
-            return this._parseStoredJson(jsonContent, jsonPath);
-        }
-
-        const defaultContent = await this._readDefaultSettings();
-        return parseRouteSettings(parseYaml(defaultContent));
+        const defaultContent = await this.readDefaultSettings();
+        return parseRouteSettings(parseYaml(defaultContent), defaultContent);
     }
 
     async replace(settings: RouteSettings): Promise<void> {
-        const existingPath = await this._findExistingFile();
-        const targetPath = path.join(this.basePath, JSON_FILENAME);
+        const targetPath = path.join(this.basePath, YAML_FILENAME);
 
-        // Same path: backup must happen before the atomic write because
-        // the rename would otherwise clobber the previous content with
-        // no copy elsewhere. Read via _readIfExists so a file that vanished
-        // since _findExistingFile just skips the backup, and real read
+        // Back up the current file before the atomic write clobbers it. The
+        // content is captured up front so the backup holds exactly what was on
+        // disk; a file that isn't there just skips the backup and real read
         // failures surface as typed errors.
-        if (existingPath && existingPath === targetPath) {
-            const backupPath = this.getBackupFilePath(existingPath);
-            const content = await this._readIfExists(existingPath);
-            if (content !== null) {
-                await this._writeAtomic(backupPath, content);
-            }
+        const existing = await this.readIfExists(targetPath);
+        if (existing !== null) {
+            await this.writeAtomic(this.getBackupFilePath(targetPath), existing);
         }
 
-        await this._writeAtomic(targetPath, JSON.stringify(settings, null, 4));
-
-        // Different path (yaml → json): backup must happen AFTER the
-        // write so a failed write doesn't leave nothing at any canonical
-        // path. If the backup itself fails, the legacy yaml takes
-        // precedence over the new json on next read — roll the new json
-        // back so the operator sees a consistent old state.
-        if (existingPath && existingPath !== targetPath) {
-            try {
-                await this._backup(existingPath);
-            } catch (err) {
-                await fs.remove(targetPath).catch(() => {});
-                throw err;
-            }
-        }
+        // Persist the exact YAML the operator authored — never a re-serialised
+        // model — so comments, key order and formatting survive a round-trip.
+        await this.writeAtomic(targetPath, settings.yamlSource);
     }
 
-    private async _findExistingFile(): Promise<string | null> {
-        const yamlPath = path.join(this.basePath, YAML_FILENAME);
-        if (await fs.pathExists(yamlPath)) {
-            return yamlPath;
-        }
-
-        const jsonPath = path.join(this.basePath, JSON_FILENAME);
-        if (await fs.pathExists(jsonPath)) {
-            return jsonPath;
-        }
-
-        return null;
-    }
-
-    private async _readIfExists(filePath: string): Promise<string | null> {
+    private async readIfExists(filePath: string): Promise<string | null> {
         try {
             return await fs.readFile(filePath, 'utf8');
         } catch (err) {
@@ -141,7 +101,7 @@ export default class FileStore extends RouteSettingsStoreBase implements RouteSe
         }
     }
 
-    private async _readDefaultSettings(): Promise<string> {
+    private async readDefaultSettings(): Promise<string> {
         const defaultFilePath = path.join(this.defaultSettingsBasePath, DEFAULT_SETTINGS_FILENAME);
         try {
             return await fs.readFile(defaultFilePath, 'utf8');
@@ -154,41 +114,18 @@ export default class FileStore extends RouteSettingsStoreBase implements RouteSe
         }
     }
 
-    private _parseStoredJson(content: string, filePath: string): RouteSettings {
-        let parsed: unknown;
-        try {
-            parsed = JSON.parse(content);
-        } catch (err) {
-            throw new errors.IncorrectUsageError({
-                message: tpl(messages.corruptJson, {path: filePath, context: (err as Error).message}),
-                err: err as Error
-            });
-        }
-
-        const candidate = parsed as Partial<RouteSettings> | null;
-        const isPlainObject = (value: unknown): boolean => typeof value === 'object' && value !== null && !Array.isArray(value);
-        if (!isPlainObject(candidate) || !Array.isArray(candidate?.routes) || !Array.isArray(candidate?.collections) || !isPlainObject(candidate?.taxonomies)) {
-            throw new errors.IncorrectUsageError({
-                message: tpl(messages.invalidJson, {path: filePath})
-            });
-        }
-
-        return parsed as RouteSettings;
-    }
-
-    private async _backup(existingPath: string): Promise<void> {
-        const backupPath = this.getBackupFilePath(existingPath);
-        await fs.move(existingPath, backupPath, {overwrite: true});
-    }
-
-    private async _writeAtomic(targetPath: string, content: string): Promise<void> {
+    private async writeAtomic(targetPath: string, content: string): Promise<void> {
         const tmpPath = `${targetPath}.tmp.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}`;
-        await fs.writeFile(tmpPath, content, 'utf-8');
         try {
+            await fs.writeFile(tmpPath, content, 'utf-8');
             await fs.move(tmpPath, targetPath, {overwrite: true});
         } catch (err) {
             await fs.remove(tmpPath).catch(() => {});
-            throw err;
+            throw new errors.InternalServerError({
+                message: tpl(messages.ensureSettings, {path: this.basePath}),
+                err: err as Error,
+                context: (err as NodeJS.ErrnoException).path
+            });
         }
     }
 }

--- a/ghost/core/core/server/services/route-settings/route-settings-parser.ts
+++ b/ghost/core/core/server/services/route-settings/route-settings-parser.ts
@@ -83,6 +83,7 @@ export interface RouteSettings {
     routes: Route[];
     collections: CollectionConfig[];
     taxonomies: TaxonomyConfig;
+    readonly yamlSource: string;
 }
 
 function validationError(at: string, reason: string, help?: string): errors.ValidationError {
@@ -308,7 +309,7 @@ function toValidationError(error: z.ZodError): errors.ValidationError {
     });
 }
 
-export function parseRouteSettings(raw: unknown): RouteSettings {
+export function parseRouteSettings(raw: unknown, yamlSource: string): RouteSettings {
     const obj = raw ?? {};
 
     const parsed = RouteSettingsSchema.safeParse(obj);
@@ -409,10 +410,10 @@ export function parseRouteSettings(raw: unknown): RouteSettings {
         }
     }
 
-    return {routes, collections, taxonomies};
+    return {routes, collections, taxonomies, yamlSource};
 }
 
-export function serializeRouteSettings(settings: RouteSettings): string {
+export function serializeRouteSettings(settings: Omit<RouteSettings, 'yamlSource'>): string {
     const obj: Record<string, unknown> = {};
 
     const routes: Record<string, unknown> = {};

--- a/ghost/core/core/server/services/route-settings/yaml-parser.d.ts
+++ b/ghost/core/core/server/services/route-settings/yaml-parser.d.ts
@@ -1,0 +1,4 @@
+// Declaration shim so the TS FileStore adapter can reuse the legacy YAML
+// parser (and its error semantics) until it's deleted in HKG-1898.
+declare function parseYaml(file: string): unknown;
+export = parseYaml;

--- a/ghost/core/test/unit/server/adapters/route-settings/file-store.test.ts
+++ b/ghost/core/test/unit/server/adapters/route-settings/file-store.test.ts
@@ -1,0 +1,280 @@
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'fs-extra';
+import {afterEach, beforeEach, describe, it} from 'vitest';
+
+import FileStore, {getBackupRouteSettingsFilePath} from '../../../../../core/server/adapters/route-settings/FileStore';
+import RouteSettingsStoreBase from '../../../../../core/server/adapters/route-settings/RouteSettingsStoreBase';
+import type {RouteSettings} from '../../../../../core/server/services/route-settings/route-settings-parser';
+
+const REAL_DEFAULTS_PATH = path.join(__dirname, '../../../../../core/server/services/route-settings');
+
+const SAMPLE_YAML = `routes:
+  /about/: about
+  /featured/:
+    controller: channel
+    filter: featured:true
+    template: featured
+
+collections:
+  /:
+    permalink: /{slug}/
+    template: index
+
+taxonomies:
+  tag: /tag/{slug}/
+  author: /author/{slug}/
+`;
+
+const sampleSettings = (): RouteSettings => ({
+    routes: [{type: 'template', path: '/about/', templates: ['about']}],
+    collections: [{path: '/', permalink: '/{slug}/', templates: ['index']}],
+    taxonomies: {tag: '/tag/{slug}/', author: '/author/{slug}/'}
+});
+
+describe('UNIT: route-settings FileStore', function () {
+    let basePath: string;
+    let defaultsPath: string;
+
+    const createStore = (overrides: Partial<ConstructorParameters<typeof FileStore>[0]> = {}) => new FileStore({
+        basePath,
+        defaultSettingsBasePath: defaultsPath,
+        ...overrides
+    });
+
+    beforeEach(async function () {
+        basePath = path.join(os.tmpdir(), `route-settings-filestore-${crypto.randomUUID()}`);
+        defaultsPath = path.join(os.tmpdir(), `route-settings-defaults-${crypto.randomUUID()}`);
+        await fs.ensureDir(basePath);
+        await fs.ensureDir(defaultsPath);
+        await fs.copy(
+            path.join(REAL_DEFAULTS_PATH, 'default-routes.yaml'),
+            path.join(defaultsPath, 'default-routes.yaml')
+        );
+    });
+
+    afterEach(async function () {
+        await fs.remove(basePath);
+        await fs.remove(defaultsPath);
+    });
+
+    describe('adapter contract', function () {
+        it('extends RouteSettingsStoreBase and declares get/replace as required', function () {
+            const store = createStore();
+
+            assert.ok(store instanceof RouteSettingsStoreBase);
+            assert.deepEqual([...store.requiredFns], ['get', 'replace']);
+        });
+
+        it('throws IncorrectUsageError when constructed without the required paths', function () {
+            assert.throws(() => new FileStore({} as ConstructorParameters<typeof FileStore>[0]), (err: {errorType?: string}) => {
+                assert.equal(err.errorType, 'IncorrectUsageError');
+                return true;
+            });
+        });
+    });
+
+    describe('get', function () {
+        it('parses an existing routes.yaml into the domain model', async function () {
+            await fs.writeFile(path.join(basePath, 'routes.yaml'), SAMPLE_YAML, 'utf8');
+
+            const settings = await createStore().get();
+
+            assert.deepEqual(settings.routes, [
+                {type: 'template', path: '/about/', templates: ['about']},
+                {type: 'channel', path: '/featured/', templates: ['featured'], filter: 'featured:true'}
+            ]);
+            assert.deepEqual(settings.collections, [
+                {path: '/', permalink: '/{slug}/', templates: ['index']}
+            ]);
+            assert.deepEqual(settings.taxonomies, {
+                tag: '/tag/{slug}/',
+                author: '/author/{slug}/'
+            });
+        });
+
+        it('reads a routes.json domain object as-is', async function () {
+            await fs.writeFile(path.join(basePath, 'routes.json'), JSON.stringify(sampleSettings()), 'utf8');
+
+            assert.deepEqual(await createStore().get(), sampleSettings());
+        });
+
+        it('prefers routes.yaml over routes.json when both exist', async function () {
+            await fs.writeFile(path.join(basePath, 'routes.yaml'), SAMPLE_YAML, 'utf8');
+            await fs.writeFile(path.join(basePath, 'routes.json'), JSON.stringify(sampleSettings()), 'utf8');
+
+            const settings = await createStore().get();
+
+            assert.equal(settings.routes.length, 2);
+        });
+
+        it('returns parsed defaults without writing to disk when no canonical file exists', async function () {
+            const settings = await createStore().get();
+
+            assert.deepEqual(settings, {
+                routes: [],
+                collections: [{path: '/', permalink: '/{slug}/', templates: ['index']}],
+                taxonomies: {tag: '/tag/{slug}/', author: '/author/{slug}/'}
+            });
+
+            // The empty state stays empty — no seed file materialises.
+            assert.deepEqual(await fs.readdir(basePath), []);
+        });
+
+        it('throws IncorrectUsageError for invalid YAML', async function () {
+            await fs.writeFile(path.join(basePath, 'routes.yaml'), 'routes:\n\t- broken', 'utf8');
+
+            await assert.rejects(createStore().get(), (err: {code?: string}) => {
+                assert.equal(err.code, 'YAML_PARSER_ERROR');
+                return true;
+            });
+        });
+
+        it('throws ValidationError for structurally invalid settings', async function () {
+            await fs.writeFile(path.join(basePath, 'routes.yaml'), 'routes:\n  no-slashes: about\n', 'utf8');
+
+            await assert.rejects(createStore().get(), (err: {errorType?: string}) => {
+                assert.equal(err.errorType, 'ValidationError');
+                return true;
+            });
+        });
+
+        it('throws IncorrectUsageError for corrupt routes.json instead of falling back to defaults', async function () {
+            await fs.writeFile(path.join(basePath, 'routes.json'), '{not json', 'utf8');
+
+            await assert.rejects(createStore().get(), (err: {errorType?: string}) => {
+                assert.equal(err.errorType, 'IncorrectUsageError');
+                return true;
+            });
+        });
+
+        it('throws IncorrectUsageError for routes.json that is not a route settings object', async function () {
+            await fs.writeFile(path.join(basePath, 'routes.json'), JSON.stringify(['not', 'settings']), 'utf8');
+
+            await assert.rejects(createStore().get(), (err: {errorType?: string}) => {
+                assert.equal(err.errorType, 'IncorrectUsageError');
+                return true;
+            });
+        });
+
+        it('throws InternalServerError when the settings folder is not accessible', async function () {
+            const fileAsBasePath = path.join(basePath, 'not-a-directory');
+            await fs.writeFile(fileAsBasePath, 'plain file', 'utf8');
+
+            const store = createStore({basePath: fileAsBasePath});
+
+            await assert.rejects(store.get(), (err: {errorType?: string}) => {
+                assert.equal(err.errorType, 'InternalServerError');
+                return true;
+            });
+        });
+
+        it('throws InternalServerError when default-routes.yaml is missing on the empty state', async function () {
+            await fs.remove(path.join(defaultsPath, 'default-routes.yaml'));
+
+            await assert.rejects(createStore().get(), (err: {errorType?: string}) => {
+                assert.equal(err.errorType, 'InternalServerError');
+                return true;
+            });
+        });
+    });
+
+    describe('replace', function () {
+        it('writes the domain object as JSON to routes.json', async function () {
+            await createStore().replace(sampleSettings());
+
+            const onDisk = JSON.parse(await fs.readFile(path.join(basePath, 'routes.json'), 'utf8'));
+            assert.deepEqual(onDisk, sampleSettings());
+        });
+
+        it('round-trips through get', async function () {
+            const store = createStore();
+
+            await store.replace(sampleSettings());
+
+            assert.deepEqual(await store.get(), sampleSettings());
+        });
+
+        it('does not create a backup when no previous file exists', async function () {
+            await createStore().replace(sampleSettings());
+
+            assert.deepEqual(await fs.readdir(basePath), ['routes.json']);
+        });
+
+        it('backs up the previous routes.json before overwriting', async function () {
+            const backupPath = path.join(basePath, 'routes-backup.json');
+            const store = createStore({getBackupFilePath: () => backupPath});
+
+            const first = sampleSettings();
+            await store.replace(first);
+
+            const second = sampleSettings();
+            second.taxonomies = {tag: '/topic/{slug}/'};
+            await store.replace(second);
+
+            assert.deepEqual(JSON.parse(await fs.readFile(backupPath, 'utf8')), first);
+            assert.deepEqual(await store.get(), second);
+        });
+
+        it('skips the backup when the previous routes.json vanishes mid-replace', async function () {
+            await fs.writeFile(path.join(basePath, 'routes.json'), JSON.stringify(sampleSettings()), 'utf8');
+
+            // getBackupFilePath runs between the existence check and the
+            // backup read — deleting here reproduces the race deterministically.
+            const store = createStore({getBackupFilePath: (filePath) => {
+                fs.removeSync(path.join(basePath, 'routes.json'));
+                return `${filePath}.bak`;
+            }});
+
+            const second = sampleSettings();
+            second.taxonomies = {tag: '/topic/{slug}/'};
+            await store.replace(second);
+
+            assert.equal(await fs.pathExists(path.join(basePath, 'routes.json.bak')), false);
+            assert.deepEqual(await store.get(), second);
+        });
+
+        it('migrates a legacy routes.yaml to routes.json with a backup', async function () {
+            await fs.writeFile(path.join(basePath, 'routes.yaml'), SAMPLE_YAML, 'utf8');
+
+            const backupPath = path.join(basePath, 'routes-backup.yaml');
+            const store = createStore({getBackupFilePath: () => backupPath});
+
+            await store.replace(sampleSettings());
+
+            assert.equal(await fs.readFile(backupPath, 'utf8'), SAMPLE_YAML);
+            assert.equal(await fs.pathExists(path.join(basePath, 'routes.yaml')), false);
+            assert.deepEqual(await store.get(), sampleSettings());
+        });
+
+        it('rolls back routes.json when the yaml backup fails', async function () {
+            await fs.writeFile(path.join(basePath, 'routes.yaml'), SAMPLE_YAML, 'utf8');
+
+            const store = createStore({getBackupFilePath: () => {
+                throw new Error('backup exploded');
+            }});
+
+            await assert.rejects(store.replace(sampleSettings()), /backup exploded/);
+
+            assert.equal(await fs.pathExists(path.join(basePath, 'routes.json')), false);
+            assert.equal(await fs.readFile(path.join(basePath, 'routes.yaml'), 'utf8'), SAMPLE_YAML);
+        });
+    });
+
+    describe('getBackupRouteSettingsFilePath', function () {
+        // Same naming scheme as the legacy SettingsPathManager.getBackupFilePath:
+        // routes-yyyy-MM-dd-HH-mm-ss.<ext> next to the canonical file.
+        it('produces a timestamped sibling path preserving the extension', function () {
+            assert.match(
+                getBackupRouteSettingsFilePath('/content/settings/routes.json'),
+                /^\/content\/settings\/routes-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}\.json$/
+            );
+            assert.match(
+                getBackupRouteSettingsFilePath('/content/settings/routes.yaml'),
+                /^\/content\/settings\/routes-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}\.yaml$/
+            );
+        });
+    });
+});

--- a/ghost/core/test/unit/server/adapters/route-settings/file-store.test.ts
+++ b/ghost/core/test/unit/server/adapters/route-settings/file-store.test.ts
@@ -7,6 +7,9 @@ import {afterEach, beforeEach, describe, it} from 'vitest';
 
 import FileStore, {getBackupRouteSettingsFilePath} from '../../../../../core/server/adapters/route-settings/FileStore';
 import RouteSettingsStoreBase from '../../../../../core/server/adapters/route-settings/RouteSettingsStoreBase';
+import parseYaml from '../../../../../core/server/services/route-settings/yaml-parser';
+import {parseRouteSettings} from '../../../../../core/server/services/route-settings/route-settings-parser';
+import {buildRouteSettings} from '../../services/route-settings/route-settings-fixture';
 import type {RouteSettings} from '../../../../../core/server/services/route-settings/route-settings-parser';
 
 const REAL_DEFAULTS_PATH = path.join(__dirname, '../../../../../core/server/services/route-settings');
@@ -28,11 +31,15 @@ taxonomies:
   author: /author/{slug}/
 `;
 
-const sampleSettings = (): RouteSettings => ({
+const sampleSettings = (): RouteSettings => buildRouteSettings({
     routes: [{type: 'template', path: '/about/', templates: ['about']}],
     collections: [{path: '/', permalink: '/{slug}/', templates: ['index']}],
     taxonomies: {tag: '/tag/{slug}/', author: '/author/{slug}/'}
 });
+
+// Builds settings from real YAML so yamlSource carries the operator's exact
+// bytes (comments, ordering, formatting) rather than a re-serialised model.
+const fromYaml = (yaml: string): RouteSettings => parseRouteSettings(parseYaml(yaml), yaml);
 
 describe('UNIT: route-settings FileStore', function () {
     let basePath: string;
@@ -95,28 +102,24 @@ describe('UNIT: route-settings FileStore', function () {
             });
         });
 
-        it('reads a routes.json domain object as-is', async function () {
-            await fs.writeFile(path.join(basePath, 'routes.json'), JSON.stringify(sampleSettings()), 'utf8');
-
-            assert.deepEqual(await createStore().get(), sampleSettings());
-        });
-
-        it('prefers routes.yaml over routes.json when both exist', async function () {
+        it('exposes the exact original yaml, comments and all, as yamlSource', async function () {
             await fs.writeFile(path.join(basePath, 'routes.yaml'), SAMPLE_YAML, 'utf8');
-            await fs.writeFile(path.join(basePath, 'routes.json'), JSON.stringify(sampleSettings()), 'utf8');
 
             const settings = await createStore().get();
 
-            assert.equal(settings.routes.length, 2);
+            assert.equal(settings.yamlSource, SAMPLE_YAML);
         });
 
         it('returns parsed defaults without writing to disk when no canonical file exists', async function () {
+            const defaultYaml = await fs.readFile(path.join(defaultsPath, 'default-routes.yaml'), 'utf8');
+
             const settings = await createStore().get();
 
             assert.deepEqual(settings, {
                 routes: [],
                 collections: [{path: '/', permalink: '/{slug}/', templates: ['index']}],
-                taxonomies: {tag: '/tag/{slug}/', author: '/author/{slug}/'}
+                taxonomies: {tag: '/tag/{slug}/', author: '/author/{slug}/'},
+                yamlSource: defaultYaml
             });
 
             // The empty state stays empty — no seed file materialises.
@@ -137,24 +140,6 @@ describe('UNIT: route-settings FileStore', function () {
 
             await assert.rejects(createStore().get(), (err: {errorType?: string}) => {
                 assert.equal(err.errorType, 'ValidationError');
-                return true;
-            });
-        });
-
-        it('throws IncorrectUsageError for corrupt routes.json instead of falling back to defaults', async function () {
-            await fs.writeFile(path.join(basePath, 'routes.json'), '{not json', 'utf8');
-
-            await assert.rejects(createStore().get(), (err: {errorType?: string}) => {
-                assert.equal(err.errorType, 'IncorrectUsageError');
-                return true;
-            });
-        });
-
-        it('throws IncorrectUsageError for routes.json that is not a route settings object', async function () {
-            await fs.writeFile(path.join(basePath, 'routes.json'), JSON.stringify(['not', 'settings']), 'utf8');
-
-            await assert.rejects(createStore().get(), (err: {errorType?: string}) => {
-                assert.equal(err.errorType, 'IncorrectUsageError');
                 return true;
             });
         });
@@ -182,14 +167,21 @@ describe('UNIT: route-settings FileStore', function () {
     });
 
     describe('replace', function () {
-        it('writes the domain object as JSON to routes.json', async function () {
-            await createStore().replace(sampleSettings());
+        it('writes the original yaml verbatim to routes.yaml', async function () {
+            await createStore().replace(fromYaml(SAMPLE_YAML));
 
-            const onDisk = JSON.parse(await fs.readFile(path.join(basePath, 'routes.json'), 'utf8'));
-            assert.deepEqual(onDisk, sampleSettings());
+            assert.equal(await fs.readFile(path.join(basePath, 'routes.yaml'), 'utf8'), SAMPLE_YAML);
         });
 
-        it('round-trips through get', async function () {
+        it('preserves comments and formatting across a replace → get round-trip', async function () {
+            const store = createStore();
+
+            await store.replace(fromYaml(SAMPLE_YAML));
+
+            assert.equal((await store.get()).yamlSource, SAMPLE_YAML);
+        });
+
+        it('round-trips the domain model through get', async function () {
             const store = createStore();
 
             await store.replace(sampleSettings());
@@ -200,66 +192,34 @@ describe('UNIT: route-settings FileStore', function () {
         it('does not create a backup when no previous file exists', async function () {
             await createStore().replace(sampleSettings());
 
-            assert.deepEqual(await fs.readdir(basePath), ['routes.json']);
+            assert.deepEqual(await fs.readdir(basePath), ['routes.yaml']);
         });
 
-        it('backs up the previous routes.json before overwriting', async function () {
-            const backupPath = path.join(basePath, 'routes-backup.json');
-            const store = createStore({getBackupFilePath: () => backupPath});
-
-            const first = sampleSettings();
-            await store.replace(first);
-
-            const second = sampleSettings();
-            second.taxonomies = {tag: '/topic/{slug}/'};
-            await store.replace(second);
-
-            assert.deepEqual(JSON.parse(await fs.readFile(backupPath, 'utf8')), first);
-            assert.deepEqual(await store.get(), second);
-        });
-
-        it('skips the backup when the previous routes.json vanishes mid-replace', async function () {
-            await fs.writeFile(path.join(basePath, 'routes.json'), JSON.stringify(sampleSettings()), 'utf8');
-
-            // getBackupFilePath runs between the existence check and the
-            // backup read — deleting here reproduces the race deterministically.
-            const store = createStore({getBackupFilePath: (filePath) => {
-                fs.removeSync(path.join(basePath, 'routes.json'));
-                return `${filePath}.bak`;
-            }});
-
-            const second = sampleSettings();
-            second.taxonomies = {tag: '/topic/{slug}/'};
-            await store.replace(second);
-
-            assert.equal(await fs.pathExists(path.join(basePath, 'routes.json.bak')), false);
-            assert.deepEqual(await store.get(), second);
-        });
-
-        it('migrates a legacy routes.yaml to routes.json with a backup', async function () {
-            await fs.writeFile(path.join(basePath, 'routes.yaml'), SAMPLE_YAML, 'utf8');
-
+        it('backs up the previous routes.yaml before overwriting', async function () {
             const backupPath = path.join(basePath, 'routes-backup.yaml');
             const store = createStore({getBackupFilePath: () => backupPath});
 
-            await store.replace(sampleSettings());
+            const first = fromYaml(SAMPLE_YAML);
+            await store.replace(first);
 
-            assert.equal(await fs.readFile(backupPath, 'utf8'), SAMPLE_YAML);
-            assert.equal(await fs.pathExists(path.join(basePath, 'routes.yaml')), false);
-            assert.deepEqual(await store.get(), sampleSettings());
+            const second = buildRouteSettings({
+                routes: [],
+                collections: [],
+                taxonomies: {tag: '/topic/{slug}/'}
+            });
+            await store.replace(second);
+
+            assert.equal(await fs.readFile(backupPath, 'utf8'), first.yamlSource);
+            assert.deepEqual(await store.get(), second);
         });
 
-        it('rolls back routes.json when the yaml backup fails', async function () {
-            await fs.writeFile(path.join(basePath, 'routes.yaml'), SAMPLE_YAML, 'utf8');
+        it('throws InternalServerError when the settings folder is not writable', async function () {
+            const store = createStore({basePath: path.join(basePath, 'missing-dir')});
 
-            const store = createStore({getBackupFilePath: () => {
-                throw new Error('backup exploded');
-            }});
-
-            await assert.rejects(store.replace(sampleSettings()), /backup exploded/);
-
-            assert.equal(await fs.pathExists(path.join(basePath, 'routes.json')), false);
-            assert.equal(await fs.readFile(path.join(basePath, 'routes.yaml'), 'utf8'), SAMPLE_YAML);
+            await assert.rejects(store.replace(sampleSettings()), (err: {errorType?: string}) => {
+                assert.equal(err.errorType, 'InternalServerError');
+                return true;
+            });
         });
     });
 

--- a/ghost/core/test/unit/server/adapters/route-settings/helpers/in-memory-store.ts
+++ b/ghost/core/test/unit/server/adapters/route-settings/helpers/in-memory-store.ts
@@ -1,8 +1,9 @@
+import {buildRouteSettings} from '../../../services/route-settings/route-settings-fixture';
 import type {RouteSettings} from '../../../../../../core/server/services/route-settings/route-settings-parser';
 import type {RouteSettingsStore} from '../../../../../../core/server/adapters/route-settings/RouteSettingsStoreBase';
 
 export class InMemoryStore implements RouteSettingsStore {
-    private settings: RouteSettings = {routes: [], collections: [], taxonomies: {}};
+    private settings: RouteSettings = buildRouteSettings({routes: [], collections: [], taxonomies: {}});
 
     async get(): Promise<RouteSettings> {
         return structuredClone(this.settings);

--- a/ghost/core/test/unit/server/adapters/route-settings/helpers/store-contract.ts
+++ b/ghost/core/test/unit/server/adapters/route-settings/helpers/store-contract.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 
+import {buildRouteSettings} from '../../../services/route-settings/route-settings-fixture';
 import type {RouteSettings} from '../../../../../../core/server/services/route-settings/route-settings-parser';
 import type {RouteSettingsStore} from '../../../../../../core/server/adapters/route-settings/RouteSettingsStoreBase';
 
@@ -7,9 +8,9 @@ interface ContractOptions {
     createStore: () => RouteSettingsStore | Promise<RouteSettingsStore>;
 }
 
-const emptySettings = (): RouteSettings => ({routes: [], collections: [], taxonomies: {}});
+const emptySettings = (): RouteSettings => buildRouteSettings({routes: [], collections: [], taxonomies: {}});
 
-const sampleSettings = (): RouteSettings => ({
+const sampleSettings = (): RouteSettings => buildRouteSettings({
     routes: [
         {type: 'template', path: '/about/', templates: ['about']}
     ],
@@ -55,19 +56,27 @@ export function runStoreContract({createStore}: ContractOptions): void {
                 assert.deepEqual(await store.get(), settings);
             });
 
+            it('persists yamlSource verbatim', async function () {
+                const settings = sampleSettings();
+
+                await store.replace(settings);
+
+                assert.equal((await store.get()).yamlSource, settings.yamlSource);
+            });
+
             it('overwrites previously stored settings rather than merging', async function () {
                 await store.replace(sampleSettings());
-                await store.replace({
+                await store.replace(buildRouteSettings({
                     routes: [],
                     collections: [{path: '/blog/', permalink: '/blog/{slug}/', templates: ['index']}],
                     taxonomies: {}
-                });
+                }));
 
-                assert.deepEqual(await store.get(), {
+                assert.deepEqual(await store.get(), buildRouteSettings({
                     routes: [],
                     collections: [{path: '/blog/', permalink: '/blog/{slug}/', templates: ['index']}],
                     taxonomies: {}
-                });
+                }));
             });
 
             it('clears all settings when called with empty settings', async function () {

--- a/ghost/core/test/unit/server/services/route-settings/activation-bridge.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/activation-bridge.test.ts
@@ -5,13 +5,17 @@ import path from 'node:path';
 import {describe, it} from 'vitest';
 import {expandRouteSettings} from '../../../../../core/server/services/route-settings/activation-bridge';
 import {parseRouteSettings} from '../../../../../core/server/services/route-settings/route-settings-parser';
-import type {RouteSettings} from '../../../../../core/server/services/route-settings/route-settings-parser';
+import {buildRouteSettings} from './route-settings-fixture';
 
 const validate = require('../../../../../core/server/services/route-settings/validate');
 const parseYaml = require('../../../../../core/server/services/route-settings/yaml-parser');
 
-function empty(): RouteSettings {
-    return {routes: [], collections: [], taxonomies: {}};
+// The bridge only reads structural fields — raw objects built inline have no
+// YAML text behind them, so an empty source is attached.
+const parse = (raw: unknown) => parseRouteSettings(raw, '');
+
+function empty() {
+    return buildRouteSettings({routes: [], collections: [], taxonomies: {}});
 }
 
 describe('activation-bridge', function () {
@@ -35,7 +39,7 @@ describe('activation-bridge', function () {
                 };
 
                 const legacy = validate(structuredClone(raw));
-                const domain = parseRouteSettings(raw);
+                const domain = parse(raw);
                 const expanded = expandRouteSettings(domain);
 
                 assert.deepEqual(expanded, legacy);
@@ -54,7 +58,7 @@ describe('activation-bridge', function () {
                 };
 
                 const legacy = validate(structuredClone(raw));
-                const domain = parseRouteSettings(raw);
+                const domain = parse(raw);
                 const expanded = expandRouteSettings(domain);
 
                 assert.deepEqual(expanded, legacy);
@@ -74,7 +78,7 @@ describe('activation-bridge', function () {
                 };
 
                 const legacy = validate(structuredClone(raw));
-                const domain = parseRouteSettings(raw);
+                const domain = parse(raw);
                 const expanded = expandRouteSettings(domain);
 
                 assert.deepEqual(expanded, legacy);
@@ -94,7 +98,7 @@ describe('activation-bridge', function () {
                 };
 
                 const legacy = validate(structuredClone(raw));
-                const domain = parseRouteSettings(raw);
+                const domain = parse(raw);
                 const expanded = expandRouteSettings(domain);
 
                 assert.deepEqual(expanded, legacy);
@@ -113,7 +117,7 @@ describe('activation-bridge', function () {
                 };
 
                 const legacy = validate(structuredClone(raw));
-                const domain = parseRouteSettings(raw);
+                const domain = parse(raw);
                 const expanded = expandRouteSettings(domain);
 
                 assert.deepEqual(expanded, legacy);
@@ -135,7 +139,7 @@ describe('activation-bridge', function () {
                 };
 
                 const legacy = validate(structuredClone(raw));
-                const domain = parseRouteSettings(raw);
+                const domain = parse(raw);
                 const expanded = expandRouteSettings(domain);
 
                 assert.deepEqual(expanded, legacy);
@@ -160,7 +164,7 @@ describe('activation-bridge', function () {
                 };
 
                 const legacy = validate(structuredClone(raw));
-                const domain = parseRouteSettings(raw);
+                const domain = parse(raw);
                 const expanded = expandRouteSettings(domain);
 
                 assert.deepEqual(expanded, legacy);
@@ -186,7 +190,7 @@ describe('activation-bridge', function () {
                 };
 
                 const legacy = validate(structuredClone(raw));
-                const domain = parseRouteSettings(raw);
+                const domain = parse(raw);
                 const expanded = expandRouteSettings(domain);
 
                 assert.deepEqual(expanded, legacy);
@@ -205,7 +209,7 @@ describe('activation-bridge', function () {
                 };
 
                 const legacy = validate(structuredClone(raw));
-                const domain = parseRouteSettings(raw);
+                const domain = parse(raw);
                 const expanded = expandRouteSettings(domain);
 
                 assert.deepEqual(expanded, legacy);
@@ -226,7 +230,7 @@ describe('activation-bridge', function () {
                 };
 
                 const legacy = validate(structuredClone(raw));
-                const domain = parseRouteSettings(raw);
+                const domain = parse(raw);
                 const expanded = expandRouteSettings(domain);
 
                 assert.deepEqual(expanded, legacy);
@@ -243,7 +247,7 @@ describe('activation-bridge', function () {
                 };
 
                 const legacy = validate(structuredClone(raw));
-                const domain = parseRouteSettings(raw);
+                const domain = parse(raw);
                 const expanded = expandRouteSettings(domain);
 
                 assert.deepEqual(expanded, legacy);
@@ -282,7 +286,7 @@ describe('activation-bridge', function () {
                 };
 
                 const legacy = validate(structuredClone(raw));
-                const domain = parseRouteSettings(raw);
+                const domain = parse(raw);
                 const expanded = expandRouteSettings(domain);
 
                 assert.deepEqual(expanded, legacy);
@@ -302,7 +306,7 @@ describe('activation-bridge', function () {
                 };
 
                 const legacy = validate(structuredClone(raw));
-                const domain = parseRouteSettings(raw);
+                const domain = parse(raw);
                 const expanded = expandRouteSettings(domain);
 
                 assert.deepEqual(expanded, legacy);
@@ -321,7 +325,7 @@ describe('activation-bridge', function () {
                 };
 
                 const legacy = validate(structuredClone(raw));
-                const domain = parseRouteSettings(raw);
+                const domain = parse(raw);
                 const expanded = expandRouteSettings(domain);
 
                 assert.deepEqual(expanded, legacy);
@@ -335,7 +339,7 @@ describe('activation-bridge', function () {
                 };
 
                 const legacy = validate(structuredClone(raw));
-                const domain = parseRouteSettings(raw);
+                const domain = parse(raw);
                 const expanded = expandRouteSettings(domain);
 
                 assert.deepEqual(expanded, legacy);
@@ -361,7 +365,7 @@ describe('activation-bridge', function () {
                 };
 
                 const legacy = validate(structuredClone(raw));
-                const domain = parseRouteSettings(raw);
+                const domain = parse(raw);
                 const expanded = expandRouteSettings(domain);
 
                 assert.deepEqual(expanded, legacy);
@@ -386,7 +390,7 @@ describe('activation-bridge', function () {
                 };
 
                 const legacy = validate(structuredClone(raw));
-                const domain = parseRouteSettings(raw);
+                const domain = parse(raw);
                 const expanded = expandRouteSettings(domain);
 
                 assert.deepEqual(expanded, legacy);
@@ -408,7 +412,7 @@ describe('activation-bridge', function () {
                 };
 
                 const legacy = validate(structuredClone(raw));
-                const domain = parseRouteSettings(raw);
+                const domain = parse(raw);
                 const expanded = expandRouteSettings(domain);
 
                 assert.deepEqual(expanded, legacy);
@@ -428,7 +432,7 @@ describe('activation-bridge', function () {
                 };
 
                 const legacy = validate(structuredClone(raw));
-                const domain = parseRouteSettings(raw);
+                const domain = parse(raw);
                 const expanded = expandRouteSettings(domain);
 
                 assert.deepEqual(expanded, legacy);
@@ -437,33 +441,33 @@ describe('activation-bridge', function () {
 
         describe('slug conversion', function () {
             it('converts {slug} to :slug in collection permalinks', function () {
-                const settings: RouteSettings = {
+                const settings = buildRouteSettings({
                     routes: [],
                     collections: [{path: '/', permalink: '/{slug}/', templates: []}],
                     taxonomies: {}
-                };
+                });
 
                 const result = expandRouteSettings(settings);
                 assert.equal(result.collections['/'].permalink, '/:slug/');
             });
 
             it('converts {primary_author} to :primary_author in permalinks', function () {
-                const settings: RouteSettings = {
+                const settings = buildRouteSettings({
                     routes: [],
                     collections: [{path: '/', permalink: '/{primary_author}/{slug}/', templates: []}],
                     taxonomies: {}
-                };
+                });
 
                 const result = expandRouteSettings(settings);
                 assert.equal(result.collections['/'].permalink, '/:primary_author/:slug/');
             });
 
             it('converts {slug} to :slug in taxonomy paths', function () {
-                const settings: RouteSettings = {
+                const settings = buildRouteSettings({
                     routes: [],
                     collections: [],
                     taxonomies: {tag: '/tag/{slug}/'}
-                };
+                });
 
                 const result = expandRouteSettings(settings);
                 assert.equal(result.taxonomies.tag, '/tag/:slug/');
@@ -472,22 +476,22 @@ describe('activation-bridge', function () {
 
         describe('route expansion', function () {
             it('sets controller to channel for channel routes', function () {
-                const settings: RouteSettings = {
+                const settings = buildRouteSettings({
                     routes: [{type: 'channel', path: '/featured/', templates: [], filter: 'featured:true', rss: true}],
                     collections: [],
                     taxonomies: {}
-                };
+                });
 
                 const result = expandRouteSettings(settings);
                 assert.equal(result.routes['/featured/'].controller, 'channel');
             });
 
             it('maps contentType back to content_type', function () {
-                const settings: RouteSettings = {
+                const settings = buildRouteSettings({
                     routes: [{type: 'template', path: '/api/', templates: ['api'], contentType: 'application/json'}],
                     collections: [],
                     taxonomies: {}
-                };
+                });
 
                 const result = expandRouteSettings(settings);
                 assert.equal(result.routes['/api/'].content_type, 'application/json');
@@ -495,11 +499,11 @@ describe('activation-bridge', function () {
             });
 
             it('omits data when no data specified', function () {
-                const settings: RouteSettings = {
+                const settings = buildRouteSettings({
                     routes: [{type: 'template', path: '/about/', templates: ['about']}],
                     collections: [],
                     taxonomies: {}
-                };
+                });
 
                 const result = expandRouteSettings(settings);
                 assert.equal(result.routes['/about/'].data, undefined);
@@ -508,11 +512,11 @@ describe('activation-bridge', function () {
 
         describe('data expansion', function () {
             it('expands shortform data with redirect enabled by default', function () {
-                const settings: RouteSettings = {
+                const settings = buildRouteSettings({
                     routes: [{type: 'template', path: '/food/', templates: ['food'], data: 'tag.food'}],
                     collections: [],
                     taxonomies: {}
-                };
+                });
 
                 const result = expandRouteSettings(settings);
                 const data = result.routes['/food/'].data;
@@ -523,7 +527,7 @@ describe('activation-bridge', function () {
             });
 
             it('expands longform read data with default options', function () {
-                const settings: RouteSettings = {
+                const settings = buildRouteSettings({
                     routes: [{
                         type: 'template', path: '/food/', templates: ['food'],
                         data: {
@@ -532,7 +536,7 @@ describe('activation-bridge', function () {
                     }],
                     collections: [],
                     taxonomies: {}
-                };
+                });
 
                 const result = expandRouteSettings(settings);
                 const data = result.routes['/food/'].data;
@@ -544,7 +548,7 @@ describe('activation-bridge', function () {
             });
 
             it('expands longform browse data without default slug option', function () {
-                const settings: RouteSettings = {
+                const settings = buildRouteSettings({
                     routes: [{
                         type: 'template', path: '/food/', templates: ['food'],
                         data: {
@@ -553,7 +557,7 @@ describe('activation-bridge', function () {
                     }],
                     collections: [],
                     taxonomies: {}
-                };
+                });
 
                 const result = expandRouteSettings(settings);
                 const data = result.routes['/food/'].data;
@@ -590,7 +594,7 @@ describe('activation-bridge', function () {
         });
 
         it('bridge output serializes to the same hash as validate.js for default routes', function () {
-            const domain = parseRouteSettings(parseYaml(defaultRoutesYaml));
+            const domain = parseRouteSettings(parseYaml(defaultRoutesYaml), defaultRoutesYaml);
             const expanded = expandRouteSettings(domain);
 
             assert.equal(hash(expanded), DEFAULT_ROUTES_HASH);

--- a/ghost/core/test/unit/server/services/route-settings/route-settings-fixture.ts
+++ b/ghost/core/test/unit/server/services/route-settings/route-settings-fixture.ts
@@ -1,0 +1,11 @@
+import {serializeRouteSettings} from '../../../../../core/server/services/route-settings/route-settings-parser';
+import type {RouteSettings} from '../../../../../core/server/services/route-settings/route-settings-parser';
+
+/**
+ * Builds a RouteSettings for tests with a real YAML source derived from the
+ * structural data (via serializeRouteSettings), so fixtures carry realistic
+ * provenance instead of an empty string.
+ */
+export function buildRouteSettings(settings: Omit<RouteSettings, 'yamlSource'>): RouteSettings {
+    return {...settings, yamlSource: serializeRouteSettings(settings)};
+}

--- a/ghost/core/test/unit/server/services/route-settings/route-settings-parser.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/route-settings-parser.test.ts
@@ -1,27 +1,30 @@
 import assert from 'node:assert/strict';
 import {parseRouteSettings, serializeRouteSettings} from '../../../../../core/server/services/route-settings/route-settings-parser';
-import type {RouteSettings} from '../../../../../core/server/services/route-settings/route-settings-parser';
+import {buildRouteSettings} from './route-settings-fixture';
+
+// The raw objects here have no YAML text behind them, so an empty source is attached.
+const parse = (raw: unknown) => parseRouteSettings(raw, '');
 
 describe('UNIT: services/route-settings/route-settings-parser', function () {
     describe('parseRouteSettings', function () {
         it('handles null/undefined input', function () {
-            assert.deepEqual(parseRouteSettings(null), {routes: [], collections: [], taxonomies: {}});
-            assert.deepEqual(parseRouteSettings(undefined), {routes: [], collections: [], taxonomies: {}});
+            assert.deepEqual(parse(null), {routes: [], collections: [], taxonomies: {}, yamlSource: ''});
+            assert.deepEqual(parse(undefined), {routes: [], collections: [], taxonomies: {}, yamlSource: ''});
         });
 
         it('handles empty object', function () {
-            assert.deepEqual(parseRouteSettings({}), {routes: [], collections: [], taxonomies: {}});
+            assert.deepEqual(parse({}), {routes: [], collections: [], taxonomies: {}, yamlSource: ''});
         });
 
         it('handles empty sections', function () {
-            assert.deepEqual(parseRouteSettings({routes: null, collections: null, taxonomies: null}), {
-                routes: [], collections: [], taxonomies: {}
+            assert.deepEqual(parse({routes: null, collections: null, taxonomies: null}), {
+                routes: [], collections: [], taxonomies: {}, yamlSource: ''
             });
         });
 
         describe('routes', function () {
             it('parses bare string route as template route', function () {
-                const result = parseRouteSettings({
+                const result = parse({
                     routes: {'/about/': 'about'}
                 });
 
@@ -31,7 +34,7 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
             });
 
             it('parses object route with template string', function () {
-                const result = parseRouteSettings({
+                const result = parse({
                     routes: {'/me/': {template: 'me'}}
                 });
 
@@ -41,7 +44,7 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
             });
 
             it('parses object route with template array', function () {
-                const result = parseRouteSettings({
+                const result = parse({
                     routes: {'/about/': {template: ['about', 'default']}}
                 });
 
@@ -51,7 +54,7 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
             });
 
             it('parses template route with no template key as empty templates', function () {
-                const result = parseRouteSettings({
+                const result = parse({
                     routes: {'/rss/': {content_type: 'text/xml'}}
                 });
 
@@ -61,7 +64,7 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
             });
 
             it('parses route with data', function () {
-                const result = parseRouteSettings({
+                const result = parse({
                     routes: {'/food/': {template: 'food', data: 'tag.food'}}
                 });
 
@@ -71,7 +74,7 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
             });
 
             it('detects channel route via controller: channel', function () {
-                const result = parseRouteSettings({
+                const result = parse({
                     routes: {'/featured/': {controller: 'channel', filter: 'featured:true', template: 'featured'}}
                 });
 
@@ -81,7 +84,7 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
             });
 
             it('leaves rss unset on channel route when not specified', function () {
-                const result = parseRouteSettings({
+                const result = parse({
                     routes: {'/featured/': {controller: 'channel', filter: 'featured:true'}}
                 });
 
@@ -89,7 +92,7 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
             });
 
             it('respects explicit rss: true on channel route', function () {
-                const result = parseRouteSettings({
+                const result = parse({
                     routes: {'/featured/': {controller: 'channel', filter: 'featured:true', rss: true}}
                 });
 
@@ -99,7 +102,7 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
             });
 
             it('treats route with filter but no controller as template route', function () {
-                const result = parseRouteSettings({
+                const result = parse({
                     routes: {'/latest/': {template: 'latest', filter: 'featured:true'}}
                 });
 
@@ -107,7 +110,7 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
             });
 
             it('respects explicit rss: false on channel route', function () {
-                const result = parseRouteSettings({
+                const result = parse({
                     routes: {'/featured/': {controller: 'channel', filter: 'featured:true', rss: false}}
                 });
 
@@ -117,7 +120,7 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
             });
 
             it('parses channel route with all properties', function () {
-                const result = parseRouteSettings({
+                const result = parse({
                     routes: {
                         '/channel/': {
                             controller: 'channel',
@@ -144,7 +147,7 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
             });
 
             it('parses multiple routes preserving order', function () {
-                const result = parseRouteSettings({
+                const result = parse({
                     routes: {
                         '/about/': 'about',
                         '/contact/': 'contact',
@@ -161,7 +164,7 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
 
         describe('collections', function () {
             it('parses basic collection', function () {
-                const result = parseRouteSettings({
+                const result = parse({
                     collections: {'/': {permalink: '/{slug}/'}}
                 });
 
@@ -171,7 +174,7 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
             });
 
             it('parses collection with template', function () {
-                const result = parseRouteSettings({
+                const result = parse({
                     collections: {'/': {permalink: '/{slug}/', template: 'index'}}
                 });
 
@@ -181,7 +184,7 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
             });
 
             it('parses collection with all properties', function () {
-                const result = parseRouteSettings({
+                const result = parse({
                     collections: {
                         '/podcast/': {
                             permalink: '/podcast/{slug}/',
@@ -208,7 +211,7 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
             });
 
             it('parses multiple collections', function () {
-                const result = parseRouteSettings({
+                const result = parse({
                     collections: {
                         '/podcast/': {permalink: '/podcast/{slug}/'},
                         '/': {permalink: '/{slug}/'}
@@ -223,7 +226,7 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
 
         describe('taxonomies', function () {
             it('parses taxonomies', function () {
-                const result = parseRouteSettings({
+                const result = parse({
                     taxonomies: {tag: '/tag/{slug}/', author: '/author/{slug}/'}
                 });
 
@@ -234,7 +237,7 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
             });
 
             it('parses partial taxonomies', function () {
-                const result = parseRouteSettings({
+                const result = parse({
                     taxonomies: {tag: '/categories/{slug}/'}
                 });
 
@@ -244,7 +247,7 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
 
         describe('data passthrough', function () {
             it('preserves data shortform string', function () {
-                const result = parseRouteSettings({
+                const result = parse({
                     routes: {'/food/': {template: 'food', data: 'tag.food'}}
                 });
 
@@ -256,7 +259,7 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
                     featured: {resource: 'posts', type: 'browse', filter: 'featured:true'},
                     main_tag: 'tag.getting-started'
                 };
-                const result = parseRouteSettings({
+                const result = parse({
                     routes: {'/featured/': {template: 'featured', data}}
                 });
 
@@ -266,7 +269,7 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
 
         describe('keeps {slug} notation', function () {
             it('does not convert {slug} to :slug in collection permalink', function () {
-                const result = parseRouteSettings({
+                const result = parse({
                     collections: {'/': {permalink: '/{slug}/'}}
                 });
 
@@ -274,7 +277,7 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
             });
 
             it('does not convert {slug} to :slug in taxonomy', function () {
-                const result = parseRouteSettings({
+                const result = parse({
                     taxonomies: {tag: '/tag/{slug}/'}
                 });
 
@@ -284,7 +287,7 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
 
         describe('default-routes.yaml', function () {
             it('correctly parses the default routes.yaml content', function () {
-                const result = parseRouteSettings({
+                const result = parse({
                     routes: null,
                     collections: {'/': {permalink: '/{slug}/', template: 'index'}},
                     taxonomies: {tag: '/tag/{slug}/', author: '/author/{slug}/'}
@@ -300,7 +303,8 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
                     taxonomies: {
                         tag: '/tag/{slug}/',
                         author: '/author/{slug}/'
-                    }
+                    },
+                    yamlSource: ''
                 });
             });
         });
@@ -308,7 +312,7 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
 
     describe('serializeRouteSettings', function () {
         it('serializes empty settings', function () {
-            const settings: RouteSettings = {routes: [], collections: [], taxonomies: {}};
+            const settings = buildRouteSettings({routes: [], collections: [], taxonomies: {}});
             const yaml = serializeRouteSettings(settings);
 
             assert.ok(yaml.includes('routes: null'));
@@ -317,18 +321,18 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
         });
 
         it('serializes simple template route as bare string', function () {
-            const settings: RouteSettings = {
+            const settings = buildRouteSettings({
                 routes: [{type: 'template', path: '/about/', templates: ['about']}],
                 collections: [],
                 taxonomies: {}
-            };
+            });
             const yaml = serializeRouteSettings(settings);
 
             assert.ok(yaml.includes('/about/: about'));
         });
 
         it('serializes channel route as object with controller: channel', function () {
-            const settings: RouteSettings = {
+            const settings = buildRouteSettings({
                 routes: [{
                     type: 'channel',
                     path: '/featured/',
@@ -338,7 +342,7 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
                 }],
                 collections: [],
                 taxonomies: {}
-            };
+            });
             const yaml = serializeRouteSettings(settings);
 
             assert.ok(yaml.includes('/featured/:'));
@@ -348,44 +352,44 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
         });
 
         it('does not emit rss when unset (default)', function () {
-            const settings: RouteSettings = {
+            const settings = buildRouteSettings({
                 routes: [{type: 'channel', path: '/ch/', templates: [], filter: 'f'}],
                 collections: [],
                 taxonomies: {}
-            };
+            });
             const yaml = serializeRouteSettings(settings);
 
             assert.ok(!yaml.includes('rss:'));
         });
 
         it('emits rss when explicitly true', function () {
-            const settings: RouteSettings = {
+            const settings = buildRouteSettings({
                 routes: [{type: 'channel', path: '/ch/', templates: [], filter: 'f', rss: true}],
                 collections: [],
                 taxonomies: {}
-            };
+            });
             const yaml = serializeRouteSettings(settings);
 
             assert.ok(yaml.includes('rss: true'));
         });
 
         it('emits rss when false', function () {
-            const settings: RouteSettings = {
+            const settings = buildRouteSettings({
                 routes: [{type: 'channel', path: '/ch/', templates: [], filter: 'f', rss: false}],
                 collections: [],
                 taxonomies: {}
-            };
+            });
             const yaml = serializeRouteSettings(settings);
 
             assert.ok(yaml.includes('rss: false'));
         });
 
         it('serializes collection', function () {
-            const settings: RouteSettings = {
+            const settings = buildRouteSettings({
                 routes: [],
                 collections: [{path: '/', permalink: '/{slug}/', templates: ['index']}],
                 taxonomies: {}
-            };
+            });
             const yaml = serializeRouteSettings(settings);
 
             assert.ok(yaml.includes('permalink: /{slug}/'));
@@ -393,11 +397,11 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
         });
 
         it('serializes taxonomies', function () {
-            const settings: RouteSettings = {
+            const settings = buildRouteSettings({
                 routes: [],
                 collections: [],
                 taxonomies: {tag: '/tag/{slug}/', author: '/author/{slug}/'}
-            };
+            });
             const yaml = serializeRouteSettings(settings);
 
             assert.ok(yaml.includes('tag: /tag/{slug}/'));
@@ -405,7 +409,7 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
         });
 
         it('roundtrips through parse → serialize → parse', function () {
-            const original: RouteSettings = {
+            const original = buildRouteSettings({
                 routes: [
                     {type: 'template', path: '/about/', templates: ['about']},
                     {type: 'channel', path: '/featured/', templates: ['featured'], filter: 'featured:true', rss: true, data: 'tag.featured'}
@@ -415,10 +419,10 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
                     {path: '/podcast/', permalink: '/podcast/{slug}/', templates: ['podcast'], filter: 'tag:podcast'}
                 ],
                 taxonomies: {tag: '/tag/{slug}/', author: '/author/{slug}/'}
-            };
+            });
 
             const yamlStr = serializeRouteSettings(original);
-            const reparsed = parseRouteSettings(require('js-yaml').load(yamlStr));
+            const reparsed = parseRouteSettings(require('js-yaml').load(yamlStr), yamlStr);
 
             assert.deepEqual(reparsed, original);
         });
@@ -445,7 +449,7 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
                 ''
             ].join('\n');
 
-            const parsed = parseRouteSettings(require('js-yaml').load(originalYaml));
+            const parsed = parse(require('js-yaml').load(originalYaml));
             const reserialized = serializeRouteSettings(parsed);
 
             assert.equal(reserialized, originalYaml);
@@ -462,9 +466,9 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
                 taxonomies: {tag: '/tag/{slug}/', author: '/author/{slug}/'}
             };
 
-            const parsed = parseRouteSettings(raw);
+            const parsed = parse(raw);
             const yamlStr = serializeRouteSettings(parsed);
-            const reparsed = parseRouteSettings(require('js-yaml').load(yamlStr));
+            const reparsed = parse(require('js-yaml').load(yamlStr));
 
             assert.deepEqual(reparsed, parsed);
         });

--- a/ghost/core/test/unit/server/services/route-settings/validate-route-settings.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/validate-route-settings.test.ts
@@ -2,6 +2,10 @@ import assert from 'node:assert/strict';
 import errors from '@tryghost/errors';
 import {parseRouteSettings} from '../../../../../core/server/services/route-settings/route-settings-parser';
 
+// Validation is exercised on structures built inline — there is no YAML text
+// behind them, so an empty source is attached.
+const parse = (raw: unknown) => parseRouteSettings(raw, '');
+
 function throwsValidation(fn: () => void, expectedMessage?: string) {
     assert.throws(fn, (err: any) => {
         if (!(err instanceof errors.ValidationError)) {
@@ -16,15 +20,15 @@ function throwsValidation(fn: () => void, expectedMessage?: string) {
 
 describe('UNIT: services/route-settings/validation (via parseRouteSettings)', function () {
     it('accepts valid empty input', function () {
-        assert.doesNotThrow(() => parseRouteSettings({}));
+        assert.doesNotThrow(() => parse({}));
     });
 
     it('accepts valid null input', function () {
-        assert.doesNotThrow(() => parseRouteSettings(null));
+        assert.doesNotThrow(() => parse(null));
     });
 
     it('accepts valid default settings', function () {
-        assert.doesNotThrow(() => parseRouteSettings({
+        assert.doesNotThrow(() => parse({
             collections: {'/': {permalink: '/{slug}/', template: 'index'}},
             taxonomies: {tag: '/tag/{slug}/', author: '/author/{slug}/'}
         }));
@@ -32,55 +36,55 @@ describe('UNIT: services/route-settings/validation (via parseRouteSettings)', fu
 
     describe('route validation', function () {
         it('throws on route path without leading slash', function () {
-            throwsValidation(() => parseRouteSettings({
+            throwsValidation(() => parse({
                 routes: {'about/': 'about'}
             }));
         });
 
         it('throws on route path without trailing slash', function () {
-            throwsValidation(() => parseRouteSettings({
+            throwsValidation(() => parse({
                 routes: {'/about': 'about'}
             }));
         });
 
         it('throws on null route value', function () {
-            throwsValidation(() => parseRouteSettings({
+            throwsValidation(() => parse({
                 routes: {'/about/': null}
             }), 'Please define a template.');
         });
 
         it('throws on template route with no template and no data', function () {
-            throwsValidation(() => parseRouteSettings({
+            throwsValidation(() => parse({
                 routes: {'/empty/': {}}
             }), 'Please define a template.');
         });
 
         it('accepts template route with data but no template', function () {
-            assert.doesNotThrow(() => parseRouteSettings({
+            assert.doesNotThrow(() => parse({
                 routes: {'/food/': {data: 'tag.food'}}
             }));
         });
 
         it('accepts template route with content_type but no template', function () {
-            assert.doesNotThrow(() => parseRouteSettings({
+            assert.doesNotThrow(() => parse({
                 routes: {'/rss/': {content_type: 'text/xml'}}
             }));
         });
 
         it('accepts channel route with no template', function () {
-            assert.doesNotThrow(() => parseRouteSettings({
+            assert.doesNotThrow(() => parse({
                 routes: {'/featured/': {controller: 'channel', filter: 'featured:true'}}
             }));
         });
 
         it('throws on channel route with wrong-typed rss', function () {
-            throwsValidation(() => parseRouteSettings({
+            throwsValidation(() => parse({
                 routes: {'/featured/': {controller: 'channel', filter: 'featured:true', rss: 'notabool'}}
             }));
         });
 
         it('throws on route path with :slug notation', function () {
-            throwsValidation(() => parseRouteSettings({
+            throwsValidation(() => parse({
                 routes: {'/foo/:slug/': 'post'}
             }));
         });
@@ -88,61 +92,61 @@ describe('UNIT: services/route-settings/validation (via parseRouteSettings)', fu
 
     describe('collection validation', function () {
         it('throws on collection path without leading slash', function () {
-            throwsValidation(() => parseRouteSettings({
+            throwsValidation(() => parse({
                 collections: {'blog/': {permalink: '/{slug}/'}}
             }));
         });
 
         it('throws on collection path without trailing slash', function () {
-            throwsValidation(() => parseRouteSettings({
+            throwsValidation(() => parse({
                 collections: {'/blog': {permalink: '/{slug}/'}}
             }));
         });
 
         it('throws when permalink is missing', function () {
-            throwsValidation(() => parseRouteSettings({
+            throwsValidation(() => parse({
                 collections: {'/': {permalink: ''}}
             }), 'Please define a permalink route.');
         });
 
         it('throws when permalink key is absent', function () {
-            throwsValidation(() => parseRouteSettings({
+            throwsValidation(() => parse({
                 collections: {'/': {}}
             }), 'Please define a permalink route.');
         });
 
         it('throws on collection path with :slug notation', function () {
-            throwsValidation(() => parseRouteSettings({
+            throwsValidation(() => parse({
                 collections: {'/blog/:slug/': {permalink: '/{slug}/'}}
             }));
         });
 
         it('throws on permalink without leading slash', function () {
-            throwsValidation(() => parseRouteSettings({
+            throwsValidation(() => parse({
                 collections: {'/': {permalink: '{slug}/'}}
             }));
         });
 
         it('throws on permalink without trailing slash', function () {
-            throwsValidation(() => parseRouteSettings({
+            throwsValidation(() => parse({
                 collections: {'/': {permalink: '/{slug}'}}
             }));
         });
 
         it('throws on permalink using :slug notation', function () {
-            throwsValidation(() => parseRouteSettings({
+            throwsValidation(() => parse({
                 collections: {'/': {permalink: '/:slug/'}}
             }));
         });
 
         it('accepts valid permalink with {slug}', function () {
-            assert.doesNotThrow(() => parseRouteSettings({
+            assert.doesNotThrow(() => parse({
                 collections: {'/': {permalink: '/{slug}/'}}
             }));
         });
 
         it('accepts permalink with multiple params', function () {
-            assert.doesNotThrow(() => parseRouteSettings({
+            assert.doesNotThrow(() => parse({
                 collections: {'/': {permalink: '/{primary_tag}/{slug}/'}}
             }));
         });
@@ -150,37 +154,37 @@ describe('UNIT: services/route-settings/validation (via parseRouteSettings)', fu
 
     describe('taxonomy validation', function () {
         it('throws on unknown taxonomy key', function () {
-            throwsValidation(() => parseRouteSettings({
+            throwsValidation(() => parse({
                 taxonomies: {category: '/category/{slug}/'}
             }), 'Unknown taxonomy.');
         });
 
         it('throws on taxonomy without leading slash', function () {
-            throwsValidation(() => parseRouteSettings({
+            throwsValidation(() => parse({
                 taxonomies: {tag: 'tag/{slug}/'}
             }));
         });
 
         it('throws on taxonomy without trailing slash', function () {
-            throwsValidation(() => parseRouteSettings({
+            throwsValidation(() => parse({
                 taxonomies: {tag: '/tag/{slug}'}
             }));
         });
 
         it('throws on taxonomy using :slug notation', function () {
-            throwsValidation(() => parseRouteSettings({
+            throwsValidation(() => parse({
                 taxonomies: {tag: '/tag/:slug/'}
             }));
         });
 
         it('throws on empty taxonomy value', function () {
-            throwsValidation(() => parseRouteSettings({
+            throwsValidation(() => parse({
                 taxonomies: {tag: ''}
             }));
         });
 
         it('accepts valid taxonomies', function () {
-            assert.doesNotThrow(() => parseRouteSettings({
+            assert.doesNotThrow(() => parse({
                 taxonomies: {tag: '/tag/{slug}/', author: '/author/{slug}/'}
             }));
         });
@@ -188,37 +192,37 @@ describe('UNIT: services/route-settings/validation (via parseRouteSettings)', fu
 
     describe('data validation', function () {
         it('accepts valid shortform data', function () {
-            assert.doesNotThrow(() => parseRouteSettings({
+            assert.doesNotThrow(() => parse({
                 routes: {'/food/': {template: 'food', data: 'tag.food'}}
             }));
         });
 
         it('throws on invalid shortform data format', function () {
-            throwsValidation(() => parseRouteSettings({
+            throwsValidation(() => parse({
                 routes: {'/food/': {template: 'food', data: 'tag:food'}}
             }));
         });
 
         it('throws on shortform data with trailing junk', function () {
-            throwsValidation(() => parseRouteSettings({
+            throwsValidation(() => parse({
                 routes: {'/food/': {template: 'food', data: 'tag.food:'}}
             }));
         });
 
         it('throws on shortform data with extra dot segments', function () {
-            throwsValidation(() => parseRouteSettings({
+            throwsValidation(() => parse({
                 routes: {'/food/': {template: 'food', data: 'tag.food.extra'}}
             }));
         });
 
         it('throws on invalid shortform resource name', function () {
-            throwsValidation(() => parseRouteSettings({
+            throwsValidation(() => parse({
                 routes: {'/food/': {template: 'food', data: 'category.food'}}
             }));
         });
 
         it('accepts valid longform data', function () {
-            assert.doesNotThrow(() => parseRouteSettings({
+            assert.doesNotThrow(() => parse({
                 routes: {'/food/': {
                     template: 'food',
                     data: {featured: {resource: 'posts', type: 'browse', filter: 'featured:true'}}
@@ -227,7 +231,7 @@ describe('UNIT: services/route-settings/validation (via parseRouteSettings)', fu
         });
 
         it('throws on longform data missing resource', function () {
-            throwsValidation(() => parseRouteSettings({
+            throwsValidation(() => parse({
                 routes: {'/food/': {
                     template: 'food',
                     data: {featured: {type: 'browse'}}
@@ -236,7 +240,7 @@ describe('UNIT: services/route-settings/validation (via parseRouteSettings)', fu
         });
 
         it('throws on read data entry without slug', function () {
-            throwsValidation(() => parseRouteSettings({
+            throwsValidation(() => parse({
                 routes: {'/food/': {
                     template: 'food',
                     data: {featured: {resource: 'posts', type: 'read'}}
@@ -245,7 +249,7 @@ describe('UNIT: services/route-settings/validation (via parseRouteSettings)', fu
         });
 
         it('accepts read data entry with slug', function () {
-            assert.doesNotThrow(() => parseRouteSettings({
+            assert.doesNotThrow(() => parse({
                 routes: {'/food/': {
                     template: 'food',
                     data: {featured: {resource: 'posts', type: 'read', slug: 'my-post'}}
@@ -254,7 +258,7 @@ describe('UNIT: services/route-settings/validation (via parseRouteSettings)', fu
         });
 
         it('throws on longform data missing type', function () {
-            throwsValidation(() => parseRouteSettings({
+            throwsValidation(() => parse({
                 routes: {'/food/': {
                     template: 'food',
                     data: {featured: {resource: 'posts'}}
@@ -263,7 +267,7 @@ describe('UNIT: services/route-settings/validation (via parseRouteSettings)', fu
         });
 
         it('throws on longform data with invalid type', function () {
-            throwsValidation(() => parseRouteSettings({
+            throwsValidation(() => parse({
                 routes: {'/food/': {
                     template: 'food',
                     data: {featured: {resource: 'posts', type: 'edit'}}
@@ -272,7 +276,7 @@ describe('UNIT: services/route-settings/validation (via parseRouteSettings)', fu
         });
 
         it('throws on longform data with invalid resource', function () {
-            throwsValidation(() => parseRouteSettings({
+            throwsValidation(() => parse({
                 routes: {'/food/': {
                     template: 'food',
                     data: {featured: {resource: 'subscribers', type: 'browse'}}
@@ -281,7 +285,7 @@ describe('UNIT: services/route-settings/validation (via parseRouteSettings)', fu
         });
 
         it('throws on reserved key name in data', function () {
-            throwsValidation(() => parseRouteSettings({
+            throwsValidation(() => parse({
                 routes: {'/food/': {
                     template: 'food',
                     data: {resource: {resource: 'posts', type: 'browse'}}
@@ -290,7 +294,7 @@ describe('UNIT: services/route-settings/validation (via parseRouteSettings)', fu
         });
 
         it('throws on unwrapped data with string values (reserved keys)', function () {
-            throwsValidation(() => parseRouteSettings({
+            throwsValidation(() => parse({
                 routes: {'/food/': {
                     template: 'food',
                     data: {resource: 'posts', type: 'browse', filter: 'featured:true'}
@@ -299,7 +303,7 @@ describe('UNIT: services/route-settings/validation (via parseRouteSettings)', fu
         });
 
         it('throws on author key name in data', function () {
-            throwsValidation(() => parseRouteSettings({
+            throwsValidation(() => parse({
                 routes: {'/food/': {
                     template: 'food',
                     data: {author: {resource: 'authors', type: 'read', slug: 'ghost'}}
@@ -308,7 +312,7 @@ describe('UNIT: services/route-settings/validation (via parseRouteSettings)', fu
         });
 
         it('accepts mixed shortform and longform data entries', function () {
-            assert.doesNotThrow(() => parseRouteSettings({
+            assert.doesNotThrow(() => parse({
                 routes: {'/food/': {
                     template: 'food',
                     data: {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1827/implement-filestore-for-route-settings

## Why

Filesystem I/O for routes is scattered across `route-settings.js`, `settings-loader.js` and `default-settings-manager.js`, with no boundary where the storage backend can be selected. This adds **FileStore** — the local-disk implementation of the `RouteSettingsStore` contract (#28821). A GCS-backed store comes later as a config choice; FileStore stays permanently as the default for self-hosted installs.

Nothing imports FileStore yet — adapter-manager wiring, the service read path, and the upload/download endpoint are follow-up PRs — so this is a zero-runtime-change step.

## What

The store persists the **operator's original YAML verbatim**, not a re-serialised model. This makes remote storage migration a lossless byte copy and preserves comments, ordering and formatting across round-trips.

- **`RouteSettings` gains a readonly `yamlSource`** — the verbatim YAML the model was parsed from. `parseRouteSettings(raw, yamlSource)` requires the source alongside the raw structure, so a domain object's source and structure cannot drift at construction. Stores persist `yamlSource`; the structural fields are the parsed view.
- **`get()`** reads `routes.yaml` and parses/validates it through the same pipeline as today (same error semantics). When no file exists it returns the parsed bundled `default-routes.yaml` from memory — no seed file is written on boot, so reads work on read-only filesystems.
- **`replace(settings)`** backs up the previous `routes.yaml` under the usual timestamped name, then atomically writes `settings.yamlSource` (tmp + rename). Backups are also written atomically, so any backup file that exists is complete.
- **Errors are typed on both paths**: corrupt/invalid YAML throws (`YAML_PARSER_ERROR`/`ValidationError`) instead of falling back to defaults; read *and* write failures surface as `InternalServerError` — a broken settings folder can never silently replace a site's routing config.

## Tests

21 unit tests against a real temp filesystem: yaml parsing into the domain model, verbatim `yamlSource` exposure and comment-preserving round-trips, empty state without disk writes, every error path (corrupt yaml, invalid structure, unreadable/unwritable folder, missing defaults), and backup naming. The shared store contract test now asserts `yamlSource` round-trips verbatim, so every future backend (e.g. the GCS store) inherits the check.
