### PR TITLE
Fix z-index layering issue when the migrate app is open

### DIFF
--- a/ghost/admin/app/components/gh-migrate-iframe.js
+++ b/ghost/admin/app/components/gh-migrate-iframe.js
@@ -12,12 +12,19 @@ export default class GhMigrateIframe extends Component {
     willDestroy() {
         super.willDestroy(...arguments);
         window.removeEventListener('message', this.handleIframeMessage);
+
+        // Remove the class that adds a higher z-index that is added on setup
+        document.getElementById('ember-app').classList.remove('migration-app-open');
     }
 
     @action
     setup() {
         this.migrate.getMigrateIframe().src = this.migrate.getIframeURL();
         window.addEventListener('message', this.handleIframeMessage);
+
+        // Add class that adds a higher z-index so the app site over the top of the nav bar. #ember-app is a
+        // few levels up from this component, document.getElementById is a light-touch way to add the class.
+        document.getElementById('ember-app').classList.add('migration-app-open');
     }
 
     @action

--- a/ghost/admin/app/styles/layouts/migrate.css
+++ b/ghost/admin/app/styles/layouts/migrate.css
@@ -1,3 +1,8 @@
+#ember-app.migration-app-open {
+    position: relative;
+    z-index: 10;
+}
+
 .gh-migrate {
     position: absolute;
     top: 0;


### PR DESCRIPTION
no ref

A recent change to the Admin sidebar caused the migrate app iframe to sit under the Admin left-side navigation bar.

This change adds a class to the #ember-app element when the migrate app is opened, and removes it when closed. This new class adds a z-index to the #ember-app element, forcing it to sit over the sidebar, allowing the migrate app to be fully visible, and not have the Admin sidebar nav sitting over it.

None of Ghost's Admin UI is visible when the migrate app is open, so this won't have any adverse effects.