### PR TITLE
Extended dep-cruiser boundary enforcement to apps/ layer hierarchy

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -1,13 +1,18 @@
 'use strict';
 
 /*
- * Architectural boundary rules for ghost/core, enforced on the resolved module
- * graph. These mirror the `ghost/node/no-restricted-require` rules that used to
- * live in ghost/core/eslint.config.mjs; moving them here lets us drop the
- * custom eslint-plugin-ghost rule when migrating off ESLint, and catches ESM
- * imports the require-only rule could not.
+ * Architectural boundary rules for the monorepo, enforced on the resolved
+ * module graph (require AND import). Two sections:
  *
- * Run from the repo root, so paths are anchored on `^ghost/core/core/`.
+ *   ghost/core  — replaces the custom `ghost/node/no-restricted-require` ESLint
+ *                 rule so it can be dropped when migrating off ESLint. Paths
+ *                 are anchored on `^ghost/core/core/`.
+ *
+ *   apps/       — design system layer hierarchy and library/app boundaries.
+ *                 Workspace packages appear as unresolved `@tryghost/*` module
+ *                 specifiers in the graph (pnpm workspace symlinks are stopped
+ *                 by doNotFollow:node_modules), so `to.path` matches on
+ *                 package name rather than a file path.
  *
  * @type {import('dependency-cruiser').IConfiguration}
  */
@@ -85,11 +90,66 @@ module.exports = {
                 ]
             },
             to: {path: '^ghost/core/core/frontend/'}
+        },
+
+        // ============================================================
+        // apps/ — shade/ is the foundation; must not depend on higher layers
+        // ============================================================
+        {
+            name: 'shade-is-leaf',
+            comment: 'shade/ must not depend on admin-x-framework or admin-x-design-system. It is the foundation layer.',
+            severity: 'error',
+            from: {path: '^apps/shade/'},
+            to: {path: '^@tryghost/(admin-x-framework|admin-x-design-system)'}
+        },
+        // ============================================================
+        // apps/ — admin-x-design-system/ is a leaf; must not depend on higher layers
+        // ============================================================
+        {
+            name: 'admin-x-design-system-is-leaf',
+            comment: 'admin-x-design-system/ must not depend on shade or admin-x-framework.',
+            severity: 'error',
+            from: {path: '^apps/admin-x-design-system/'},
+            to: {path: '^@tryghost/(shade|admin-x-framework)'}
+        },
+        // ============================================================
+        // apps/ — admin-x-framework/ must not depend on feature apps
+        // ============================================================
+        {
+            name: 'framework-not-feature-apps',
+            comment: 'admin-x-framework/ must not depend on feature apps (activitypub, posts, admin-x-settings). The framework layer sits below the feature layer.',
+            severity: 'error',
+            from: {path: '^apps/admin-x-framework/'},
+            to: {path: '^@tryghost/(activitypub|posts|admin-x-settings)'}
+        },
+        // ============================================================
+        // apps/ — new admin apps must not use the legacy design system
+        // ============================================================
+        {
+            name: 'new-admin-apps-not-admin-x-design-system',
+            comment: 'New admin apps must use shade, not admin-x-design-system.',
+            severity: 'error',
+            from: {
+                // Adding apps to this list is the goal as each migrates off admin-x-design-system
+                // Goal: Work up until admin-x-settings joins and admin-x-design-system can be removed
+                path: '^apps/(activitypub|posts)/'
+            },
+            to: {path: '^@tryghost/admin-x-design-system'}
+        },
+        // ============================================================
+        // apps/ — public UMD apps must not depend on admin-only libraries
+        // ============================================================
+        {
+            name: 'public-apps-not-admin-libs',
+            comment: 'Public UMD apps (portal, comments-ui, etc.) must not depend on admin-only libraries (shade, admin-x-framework, admin-x-design-system).',
+            severity: 'error',
+            from: {path: '^apps/(portal|comments-ui|signup-form|sodo-search|announcement-bar|admin-toolbar)/'},
+            to: {path: '^@tryghost/(shade|admin-x-framework|admin-x-design-system)'}
         }
     ],
     options: {
         doNotFollow: {path: 'node_modules'},
-        exclude: {path: '(^|/)(node_modules|coverage|coverage-next|test|built)/'}
+        exclude: {path: '(^|/)(node_modules|coverage|coverage-next|test|built|dist)/'}
     }
 };
 

--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -4,11 +4,17 @@
  * Architectural boundary rules for the monorepo, enforced on the resolved
  * module graph (require AND import). Two sections:
  *
- *   ghost/core  — replaces the custom `ghost/node/no-restricted-require` ESLint
- *                 rule so it can be dropped when migrating off ESLint. Paths
- *                 are anchored on `^ghost/core/core/`.
+ *   ghost/core  — layer separation inside the Ghost server: shared/ must stay
+ *                 dependency-free, frontend/ crosses to server/ only via the
+ *                 proxy seam, and server/ must not reach into the frontend
+ *                 rendering layer. Paths are anchored on `^ghost/core/core/`.
  *
- *   apps/       — design system layer hierarchy and library/app boundaries.
+ *   apps/       — design system layer hierarchy and public/admin separation.
+ *                 shade/ and admin-x-design-system/ are leaf packages that
+ *                 nothing above them may pull back into. admin-x-framework/
+ *                 sits above them but below feature apps. Public UMD bundles
+ *                 (portal, comments-ui, etc.) must not depend on admin libs.
+ *
  *                 Workspace packages appear as unresolved `@tryghost/*` module
  *                 specifiers in the graph (pnpm workspace symlinks are stopped
  *                 by doNotFollow:node_modules), so `to.path` matches on

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -114,5 +114,7 @@ module.exports = {
         );
     },
     'ghost/core/core/{server,shared,frontend}/**/*.{js,ts}': (files) =>
+        buildBoundaryCommand(files),
+    'apps/{shade,admin-x-design-system,admin-x-framework,activitypub,posts,admin-x-settings,portal,comments-ui,signup-form,sodo-search,announcement-bar,admin-toolbar}/src/**/*.{js,ts,tsx,jsx}': (files) =>
         buildBoundaryCommand(files)
 };

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "knip": "knip",
     "knip:fix": "knip --fix --allow-remove-files=false",
     "lint": "pnpm nx run-many -t lint lint:boundaries",
-    "lint:boundaries": "depcruise ghost/core/core --config .dependency-cruiser.cjs",
+    "lint:boundaries": "depcruise ghost/core/core apps --config .dependency-cruiser.cjs",
     "check": "pnpm lint && pnpm test",
     "test": "pnpm nx run-many -t test --exclude @tryghost/e2e --exclude ghost-admin",
     "test:unit": "pnpm nx run-many -t test:unit",
@@ -110,11 +110,12 @@
         "inputs": [
           "{workspaceRoot}/.dependency-cruiser.cjs",
           "{workspaceRoot}/ghost/core/core/**/*",
+          "{workspaceRoot}/apps/**/*",
           "sharedGlobals"
         ],
         "outputs": [],
         "options": {
-          "command": "depcruise ghost/core/core --config .dependency-cruiser.cjs"
+          "command": "depcruise ghost/core/core apps --config .dependency-cruiser.cjs"
         }
       },
       "docker:up": {


### PR DESCRIPTION
Extends the dep-cruiser config that was introduced in #29134 to also cover
the `apps/` layer. The ghost/core boundaries are unchanged; this adds five
new rules that enforce the design system stack and prevent library/app
coupling.

**Design system layer hierarchy (shade and admin-x-design-system are leaves)**

shade/ is the foundation — it must not pull in admin-x-framework or
admin-x-design-system. admin-x-design-system/ is likewise a leaf. These
rules prevent either package from growing a dependency on the layer above
them, which would create circular or inverted coupling in the build graph.

**Framework layer must not import feature apps**

admin-x-framework/ may import from shade/ and admin-x-design-system/, but
it must not depend on feature apps (activitypub, posts, admin-x-settings).
The framework sits below the feature layer; importing a feature app would
invert that relationship.

**New admin apps must not use the legacy design system**

activitypub and posts import shade, not admin-x-design-system. The rule
locks that in and makes the migration intent explicit: the `from.path`
comment marks the burn-down direction — more apps should join the list as
they migrate off admin-x-design-system, until admin-x-settings is the last
one and the package can be removed.

**Public UMD apps must not import admin-only libraries**

portal, comments-ui, signup-form, sodo-search, announcement-bar, and
admin-toolbar are built as UMD bundles for CDN distribution. They must not
import shade, admin-x-framework, or admin-x-design-system, which are
admin-only packages and would significantly bloat the public bundle.

**Implementation notes**

Workspace packages appear as unresolved `@tryghost/*` module specifiers in
the dep-cruiser graph — pnpm workspace symlinks are stopped by
`doNotFollow:node_modules` — so `to.path` in the new rules matches on
package name rather than a file path. Verified green on 3905 modules and
8448 dependencies. The `exclude` pattern gains `dist/` to skip built
artefacts in apps/. lint-staged gains a matching glob so boundary checks
fire at pre-commit time for apps source files too.