### PR TITLE
Fixed comment typo in mailer code

### DIFF
--- a/ghost/core/core/server/services/mail/ghost-mailer.js
+++ b/ghost/core/core/server/services/mail/ghost-mailer.js
@@ -53,7 +53,7 @@ function getFromAddress(requestedFromAddress, requestedReplyToAddress) {
 }
 
 /**
- * Decorates incoming message object wit    h nodemailer compatible fields.
+ * Decorates incoming message object with nodemailer compatible fields.
  * For nodemailer 0.7.1 reference see - https://github.com/nodemailer/nodemailer/tree/da2f1d278f91b4262e940c0b37638e7027184b1d#e-mail-message-fields
  * @param {Object} message
  * @param {boolean} [message.forceTextContent] - force text content


### PR DESCRIPTION
no ref

This just fixes a typo in a comment.
