### PR TITLE
Moved redirects-base adapter to separate package

### DIFF
--- a/ghost/core/core/server/adapters/redirects/FileStore.ts
+++ b/ghost/core/core/server/adapters/redirects/FileStore.ts
@@ -1,10 +1,9 @@
 import fs from 'fs-extra';
 import path from 'path';
+import {RedirectsStoreBase, RedirectConfig} from '@tryghost/adapter-base-redirects'
 
-import RedirectsStoreBase from './RedirectsStoreBase';
 import {parseJson, parseYaml} from '../../services/custom-redirects/redirect-config-parser';
 import {getBackupRedirectsFilePath} from '../../services/custom-redirects/utils';
-import type {RedirectConfig, RedirectsStore} from '../../services/custom-redirects/types';
 
 const YAML_FILENAME = 'redirects.yaml';
 const JSON_FILENAME = 'redirects.json';
@@ -20,7 +19,7 @@ interface FileStoreOptions {
  * `.json`. The previous canonical file becomes a timestamped backup on
  * every successive `replaceAll`.
  */
-export default class FileStore extends RedirectsStoreBase implements RedirectsStore {
+export default class FileStore extends RedirectsStoreBase {
     private readonly basePath: string;
     private readonly getBackupFilePath: (filePath: string) => string;
 

--- a/ghost/core/core/server/adapters/redirects/RedirectsStoreBase.d.ts
+++ b/ghost/core/core/server/adapters/redirects/RedirectsStoreBase.d.ts
@@ -1,5 +1,0 @@
-declare class RedirectsStoreBase {
-    readonly requiredFns: ReadonlyArray<string>;
-}
-
-export default RedirectsStoreBase;

--- a/ghost/core/core/server/adapters/redirects/RedirectsStoreBase.js
+++ b/ghost/core/core/server/adapters/redirects/RedirectsStoreBase.js
@@ -1,8 +1,0 @@
-module.exports = class RedirectsStoreBase {
-    constructor() {
-        Object.defineProperty(this, 'requiredFns', {
-            value: ['getAll', 'replaceAll'],
-            writable: false
-        });
-    }
-};

--- a/ghost/core/core/server/adapters/redirects/S3RedirectsStore.ts
+++ b/ghost/core/core/server/adapters/redirects/S3RedirectsStore.ts
@@ -10,11 +10,10 @@ import {
 } from '@aws-sdk/client-s3';
 import tpl from '@tryghost/tpl';
 import * as errors from '@tryghost/errors';
+import {RedirectsStoreBase, type RedirectConfig} from '@tryghost/adapter-base-redirects';
 
-import RedirectsStoreBase from './RedirectsStoreBase';
 import {parseJson} from '../../services/custom-redirects/redirect-config-parser';
 import {getBackupRedirectsFilePath} from '../../services/custom-redirects/utils';
-import type {RedirectConfig, RedirectsStore} from '../../services/custom-redirects/types';
 
 const DEFAULT_FILENAME = 'redirects.json';
 
@@ -45,7 +44,7 @@ export interface S3RedirectsStoreOptions {
  * timestamped server-side copy of the previous contents on each
  * overwrite.
  */
-export default class S3RedirectsStore extends RedirectsStoreBase implements RedirectsStore {
+export default class S3RedirectsStore extends RedirectsStoreBase {
     private readonly client: S3Client;
     private readonly bucket: string;
     private readonly staticFileURLPrefix: string;

--- a/ghost/core/core/server/services/adapter-manager/index.js
+++ b/ghost/core/core/server/services/adapter-manager/index.js
@@ -16,7 +16,7 @@ adapterManager.registerAdapter('storage', require('ghost-storage-base'));
 adapterManager.registerAdapter('scheduling', require('../../adapters/scheduling/scheduling-base'));
 adapterManager.registerAdapter('sso', require('@tryghost/adapter-base-sso').SSOBase);
 adapterManager.registerAdapter('cache', require('@tryghost/adapter-base-cache'));
-adapterManager.registerAdapter('redirects', require('../../adapters/redirects/RedirectsStoreBase'));
+adapterManager.registerAdapter('redirects', require('@tryghost/adapter-base-redirects').RedirectsStoreBase);
 
 module.exports = {
     /**

--- a/ghost/core/core/server/services/custom-redirects/redirect-config-parser.ts
+++ b/ghost/core/core/server/services/custom-redirects/redirect-config-parser.ts
@@ -1,8 +1,7 @@
 import yaml from 'js-yaml';
 import tpl from '@tryghost/tpl';
 import * as errors from '@tryghost/errors';
-
-import type {RedirectConfig} from './types';
+import type {RedirectConfig} from '@tryghost/adapter-base-redirects';
 
 const messages = {
     jsonParse: 'Could not parse JSON: {context}.',

--- a/ghost/core/core/server/services/custom-redirects/redirects-service.ts
+++ b/ghost/core/core/server/services/custom-redirects/redirects-service.ts
@@ -1,9 +1,9 @@
 import logging from '@tryghost/logging';
 import tpl from '@tryghost/tpl';
 import * as errors from '@tryghost/errors';
+import type {RedirectConfig, RedirectsStore} from '@tryghost/adapter-base-redirects';
 
 import DynamicRedirectManager from '../lib/dynamic-redirect-manager';
-import type {RedirectConfig, RedirectsStore} from './types';
 import {errify} from '../../../shared/errify';
 
 const messages = {

--- a/ghost/core/core/server/services/custom-redirects/validation.js
+++ b/ghost/core/core/server/services/custom-redirects/validation.js
@@ -13,7 +13,7 @@ const messages = {
  * non-empty `from` / `to` strings, with `from` compilable as a RegExp.
  * Throws on the first failure rather than collecting errors.
  *
- * @param {import('./types').RedirectConfig[]} redirects
+ * @param {import('@tryghost/adapter-base-redirects').RedirectConfig[]} redirects
  */
 const validate = (redirects) => {
     if (!_.isArray(redirects)) {

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -86,6 +86,7 @@
     "@sentry/node": "7.120.4",
     "@slack/webhook": "7.1.0",
     "@tryghost/adapter-base-cache": "0.1.26",
+    "@tryghost/adapter-base-redirects": "workspace:*",
     "@tryghost/adapter-base-sso": "workspace:*",
     "@tryghost/admin-api-schema": "4.7.5",
     "@tryghost/api-framework": "catalog:",

--- a/ghost/core/test/unit/server/services/custom-redirects/helpers/in-memory-store.ts
+++ b/ghost/core/test/unit/server/services/custom-redirects/helpers/in-memory-store.ts
@@ -1,6 +1,6 @@
-import type {RedirectConfig, RedirectsStore} from '../../../../../../core/server/services/custom-redirects/types';
+import {RedirectsStoreBase, type RedirectConfig} from '@tryghost/adapter-base-redirects'
 
-export class InMemoryStore implements RedirectsStore {
+export class InMemoryStore extends RedirectsStoreBase {
     private redirects: RedirectConfig[] = [];
 
     async getAll(): Promise<RedirectConfig[]> {

--- a/ghost/core/test/unit/server/services/custom-redirects/helpers/store-contract.ts
+++ b/ghost/core/test/unit/server/services/custom-redirects/helpers/store-contract.ts
@@ -1,6 +1,5 @@
 import assert from 'node:assert/strict';
-
-import type {RedirectsStore} from '../../../../../../core/server/services/custom-redirects/types';
+import {type RedirectsStore} from '@tryghost/adapter-base-redirects'
 
 interface ContractOptions {
     createStore: () => RedirectsStore | Promise<RedirectsStore>;

--- a/packages/adapters/redirects-base/README.md
+++ b/packages/adapters/redirects-base/README.md
@@ -1,0 +1,29 @@
+# @tryghost/adapter-base-redirects
+
+The adapter-base-redirects package for Ghost.
+
+## Develop
+
+This is a workspace package in the Ghost monorepo. From the repo root:
+
+```bash
+pnpm --filter @tryghost/adapter-base-redirects build   # compile to build/ with tsc (ESM)
+pnpm --filter @tryghost/adapter-base-redirects test    # type-check + unit tests
+pnpm --filter @tryghost/adapter-base-redirects dev     # rebuild on change
+```
+
+In-monorepo consumers resolve this package via the `source` export condition
+(raw `src/*.ts`, no build needed in dev/test). Production and any published
+tarball use the compiled `build/` output.
+
+This package is ESM-only and compiled with `tsc` (`module: nodenext`). Relative
+imports in `src/` must carry an explicit extension; write the real `.ts` one —
+`import {x} from './x.ts'` — and `tsc` rewrites it to `.js` on emit
+(`rewriteRelativeImportExtensions`).
+
+`ghost/core` is CommonJS but consumes this package via `require()`, which works
+on Ghost's Node version (22.13+/24) through Node's `require(esm)` support. That
+support has one hard constraint: **no top-level `await`** anywhere in this
+package's module graph — it makes the graph async and `require()` of it throws
+`ERR_REQUIRE_ASYNC_MODULE`. Keep module-level initialization synchronous. (An
+ESLint rule enforces this.)

--- a/packages/adapters/redirects-base/eslint.config.mjs
+++ b/packages/adapters/redirects-base/eslint.config.mjs
@@ -1,0 +1,3 @@
+import {nodeLibConfig} from '@internal/cfg-eslint';
+
+export default nodeLibConfig();

--- a/packages/adapters/redirects-base/package.json
+++ b/packages/adapters/redirects-base/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@tryghost/adapter-base-redirects",
+  "version": "0.0.0",
+  "description": "The adapter-base-redirects package for Ghost.",
+  "private": true,
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TryGhost/Ghost.git",
+    "directory": "packages/adapters/redirects-base"
+  },
+  "author": "Ghost Foundation",
+  "license": "MIT",
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    }
+  },
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "test:unit": "NODE_ENV=testing vitest run --coverage",
+    "test": "pnpm run '/^test:/'",
+    "test:types": "tsc --noEmit -p test/tsconfig.json",
+    "lint:code": "eslint src/ --cache",
+    "lint:test": "eslint test/ --cache",
+    "lint": "pnpm run '/^lint:/'"
+  },
+  "files": [
+    "build"
+  ],
+  "devDependencies": {
+    "@internal/cfg-eslint": "workspace:*",
+    "@internal/cfg-typescript": "workspace:*",
+    "@internal/cfg-vitest": "workspace:*",
+    "@types/node": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "eslint": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "dependencies": {},
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": [
+          "{projectRoot}/build"
+        ]
+      }
+    }
+  }
+}

--- a/packages/adapters/redirects-base/src/base.ts
+++ b/packages/adapters/redirects-base/src/base.ts
@@ -14,3 +14,17 @@ export interface RedirectsStore {
     getAll(): Promise<RedirectConfig[]>;
     replaceAll(redirects: RedirectConfig[]): Promise<void>;
 }
+
+export abstract class RedirectsStoreBase implements RedirectsStore {
+    declare readonly requiredFns: readonly ['getAll', 'replaceAll'];
+
+    constructor() {
+        Object.defineProperty(this, 'requiredFns', {
+            value: Object.freeze(['getAll', 'replaceAll']),
+            writable: false,
+        });
+    }
+
+    abstract getAll(): Promise<RedirectConfig[]>;
+    abstract replaceAll(redirects: RedirectConfig[]): Promise<void>;
+}

--- a/packages/adapters/redirects-base/src/index.ts
+++ b/packages/adapters/redirects-base/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./base.ts"

--- a/packages/adapters/redirects-base/test/index.test.ts
+++ b/packages/adapters/redirects-base/test/index.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import {describe, it} from 'vitest';
+
+import {RedirectsStoreBase, type RedirectConfig} from '../src/base.ts';
+
+describe('adapter-base-redirects', function () {
+    it('should have requiredFns property', function () {
+        class TestStore extends RedirectsStoreBase {
+            async getAll() {
+                return [];
+            }
+            async replaceAll(_: RedirectConfig[]) {
+                return;
+            }
+        }
+
+        const store = new TestStore();
+        assert.deepEqual(store.requiredFns, ['getAll', 'replaceAll']);
+    })
+});

--- a/packages/adapters/redirects-base/test/tsconfig.json
+++ b/packages/adapters/redirects-base/test/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../tsconfig.json",
+    "compilerOptions": {
+        "rootDir": "..",
+        "noEmit": true
+    },
+    "include": [
+        "../src/**/*",
+        "**/*"
+    ]
+}

--- a/packages/adapters/redirects-base/tsconfig.json
+++ b/packages/adapters/redirects-base/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "@internal/cfg-typescript/esm.json",
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "build"
+    },
+    "include": [
+        "src/**/*"
+    ]
+}

--- a/packages/adapters/redirects-base/vitest.config.ts
+++ b/packages/adapters/redirects-base/vitest.config.ts
@@ -1,0 +1,4 @@
+import {createVitestConfig} from '@internal/cfg-vitest';
+
+// Pass overrides to tune coverage thresholds, setupFiles, etc.
+export default createVitestConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2287,6 +2287,9 @@ importers:
       '@tryghost/adapter-base-cache':
         specifier: 0.1.26
         version: 0.1.26
+      '@tryghost/adapter-base-redirects':
+        specifier: workspace:*
+        version: link:../../packages/adapters/redirects-base
       '@tryghost/adapter-base-sso':
         specifier: workspace:*
         version: link:../../packages/adapters/sso-base
@@ -3830,6 +3833,33 @@ importers:
       yjs:
         specifier: 13.6.31
         version: 13.6.31
+
+  packages/adapters/redirects-base:
+    devDependencies:
+      '@internal/cfg-eslint':
+        specifier: workspace:*
+        version: link:../../../configs/eslint
+      '@internal/cfg-typescript':
+        specifier: workspace:*
+        version: link:../../../configs/typescript
+      '@internal/cfg-vitest':
+        specifier: workspace:*
+        version: link:../../../configs/vitest
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.20.0
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
+      eslint:
+        specifier: 'catalog:'
+        version: 9.39.4(jiti@2.7.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   packages/adapters/sso-base:
     devDependencies:


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLA-234
- create new redirects-base package with types/content from ghost/core
- swap out base class imports in ghost/core

Same approach as #29246, for the redirects base adapter
