### PR TITLE
Decreased legacy tests timeout to 10m

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -713,8 +713,8 @@ jobs:
       - name: Legacy tests
         # Bounded so a vitest run that completes its suites but hangs in
         # teardown fails fast instead of wedging the job until the 6h runner
-        # limit. A normal run takes ~15min.
-        timeout-minutes: 30
+        # limit. A normal run takes ~2-3min; 10m leaves ample headroom.
+        timeout-minutes: 10
         run: pnpm nx run ghost:test:legacy
 
       - name: Check for unexpected file changes


### PR DESCRIPTION
no ref
- typically these are pretty quick (esp when hitting nx cache)
- whenever vitest times out, it'll run for the full 30m. Decreasing to 15m gives feedback quicker that something's gone wrong