### PR TITLE
Scoped automation `send_email` switch case declarations

### DIFF
--- a/ghost/core/core/server/services/automations/poll.ts
+++ b/ghost/core/core/server/services/automations/poll.ts
@@ -168,7 +168,7 @@ const processStep = async ({
         switch (step.type) {
         case 'wait':
             break;
-        case 'send_email':
+        case 'send_email': {
             if (!hasUpdatesAndAnnouncementsEnabled(member)) {
                 logging.info({
                     system: {
@@ -216,6 +216,7 @@ const processStep = async ({
                 }, `[AUTOMATIONS] Failed to record automated email recipient for step ${step.id}`);
             }
             break;
+        }
         default: {
             const _exhaustive: never = step;
             throw new errors.InternalServerError({


### PR DESCRIPTION
no refs

_This should have no user impact_.

The `send_email` switch case now has its own lexical scope so email result variables cannot collide with declarations in adjacent cases. This preserves the existing email-sending and recording behavior while satisfying case scoping rules.