### PR TITLE
Populated `track_opens` value for automated email recipients

### DIFF
--- a/ghost/core/core/server/services/automations/poll.ts
+++ b/ghost/core/core/server/services/automations/poll.ts
@@ -199,6 +199,8 @@ const processStep = async ({
                 trackOpens
             });
             const mailgunMessageId = getMailgunMessageId(sendResult);
+            // Only Mailgun sends can produce open events for automation emails
+            const trackOpensForRecipient = trackOpens && Boolean(mailgunMessageId);
             try {
                 await automationsApi.recordEmailSent({
                     automationActionRevisionId: step.automation_action_revision_id,
@@ -207,7 +209,7 @@ const processStep = async ({
                     memberId: step.member_id,
                     memberName: member.get('name'),
                     memberUuid: member.get('uuid'),
-                    trackOpens
+                    trackOpens: trackOpensForRecipient
                 });
             } catch (err) {
                 logging.error({

--- a/ghost/core/core/server/services/automations/poll.ts
+++ b/ghost/core/core/server/services/automations/poll.ts
@@ -8,6 +8,8 @@ import {MAX_ATTEMPTS, MAX_STEPS_PER_BATCH, RETRY_DELAY_MS} from './constants';
 // @ts-expect-error Models currently lack type definitions.
 import {Member} from '../../models';
 
+const settingsCache = require('../../../shared/settings-cache');
+
 type MemberWelcomeEmailService = {
     init: () => unknown;
     api: {
@@ -23,6 +25,7 @@ type MemberWelcomeEmailService = {
                 uuid: string;
             };
             memberStatus: 'free' | 'paid';
+            trackOpens: boolean;
         }) => Promise<unknown>;
     };
 };
@@ -180,6 +183,7 @@ const processStep = async ({
                 break;
             }
             memberWelcomeEmailService.init();
+            const trackOpens = Boolean(settingsCache.get('email_track_opens'));
             const sendResult = await memberWelcomeEmailService.api.sendAutomationEmail({
                 email: {
                     designSettingId: step.email_design_setting_id,
@@ -191,7 +195,8 @@ const processStep = async ({
                     name: member.get('name'),
                     uuid: member.get('uuid')
                 },
-                memberStatus
+                memberStatus,
+                trackOpens
             });
             const mailgunMessageId = getMailgunMessageId(sendResult);
             try {
@@ -202,8 +207,7 @@ const processStep = async ({
                     memberId: step.member_id,
                     memberName: member.get('name'),
                     memberUuid: member.get('uuid'),
-                    // TODO(NY-1439) Don't always set this to false.
-                    trackOpens: false
+                    trackOpens
                 });
             } catch (err) {
                 logging.error({

--- a/ghost/core/core/server/services/mail/ghost-mailer.js
+++ b/ghost/core/core/server/services/mail/ghost-mailer.js
@@ -67,6 +67,7 @@ function createMessage(message) {
     const cleanMessage = {...message};
     delete cleanMessage.tags;
     delete cleanMessage.forceTextContent;
+    delete cleanMessage.trackOpens;
 
     const addresses = getFromAddress(message.from, message.replyTo);
 
@@ -130,6 +131,7 @@ module.exports = class GhostMailer {
      * @param {string} [message.from] - sender email address
      * @param {string} [message.text] - text version of this message
      * @param {string[]} [message.tags] - optional additional Mailgun tags
+     * @param {boolean} [message.trackOpens] - per-message override for Mailgun open tracking
      * @param {Record<string, string>} [message.headers] - optional additional email headers (merged with defaults)
      * @param {boolean} [message.forceTextContent] - maps to generateTextFromHTML nodemailer option
      * which is: "if set to true uses HTML to generate plain text body part from the HTML if the text is not defined"
@@ -150,7 +152,10 @@ module.exports = class GhostMailer {
             if (tags.length > 0) {
                 messageToSend['o:tag'] = tags;
             }
-            if (settingsCache.get('email_track_opens')) {
+            const trackOpens = typeof message.trackOpens === 'boolean' ?
+                message.trackOpens :
+                settingsCache.get('email_track_opens');
+            if (trackOpens) {
                 messageToSend['o:tracking-opens'] = true;
             }
             if (messageToSend.headers) {

--- a/ghost/core/core/server/services/member-welcome-emails/service.js
+++ b/ghost/core/core/server/services/member-welcome-emails/service.js
@@ -367,10 +367,11 @@ class MemberWelcomeEmailService {
      * @param {string} options.email.subject
      * @param {null | object} options.email.designSettings
      * @param {'welcome' | 'automation'} options.emailType
+     * @param {boolean} [options.trackOpens]
      * @param {null | {url: string, oneClickUrl: string}} [options.unsubscribe] - When set, the footer links to an unsubscribe URL and the email carries one-click List-Unsubscribe headers
      * @returns {Promise<unknown>}
      */
-    async #sendEmail({member, memberStatus, email, emailType, unsubscribe = null}) {
+    async #sendEmail({member, memberStatus, email, emailType, trackOpens, unsubscribe = null}) {
         if (!member.email) {
             throw new errors.IncorrectUsageError({
                 message: MESSAGES.MISSING_RECIPIENT_EMAIL
@@ -431,6 +432,7 @@ class MemberWelcomeEmailService {
             forceTextContent: true,
             tags,
             ...(headers ? {headers} : {}),
+            ...(typeof trackOpens === 'boolean' ? {trackOpens} : {}),
             ...senderOptions
         });
     }
@@ -471,9 +473,10 @@ class MemberWelcomeEmailService {
      * @param {null | string} options.member.name
      * @param {string} options.member.uuid
      * @param {'free' | 'paid'} options.memberStatus
+     * @param {boolean} options.trackOpens
      * @returns {Promise<unknown>}
      */
-    async sendAutomationEmail({email, member, memberStatus}) {
+    async sendAutomationEmail({email, member, memberStatus, trackOpens}) {
         const designSettings = email.designSettingId ?
             await EmailDesignSetting.findOne({id: email.designSettingId}) :
             null;
@@ -498,6 +501,7 @@ class MemberWelcomeEmailService {
                 subject: email.subject,
                 designSettings: designSettingsJson
             },
+            trackOpens,
             unsubscribe
         });
     }

--- a/ghost/core/test/integration/services/member-welcome-emails.test.js
+++ b/ghost/core/test/integration/services/member-welcome-emails.test.js
@@ -213,7 +213,7 @@ describe('Member Welcome Emails Integration', function () {
             });
         }
 
-        async function sendAutomationEmail() {
+        async function sendAutomationEmail({trackOpens} = {}) {
             memberWelcomeEmailService.api = null;
             memberWelcomeEmailService.init();
 
@@ -240,7 +240,8 @@ describe('Member Welcome Emails Integration', function () {
                     name: 'Automation Member',
                     uuid: '99999999-9999-4999-8999-999999999999'
                 },
-                memberStatus: 'free'
+                memberStatus: 'free',
+                trackOpens
             });
         }
 
@@ -481,6 +482,14 @@ describe('Member Welcome Emails Integration', function () {
             sinon.assert.calledOnce(mailService.GhostMailer.prototype.send);
             const sendCall = mailService.GhostMailer.prototype.send.firstCall;
             assert.deepEqual(sendCall.args[0].tags, ['automation-email']);
+        });
+
+        it('passes the open tracking value through for automation emails', async function () {
+            await sendAutomationEmail({trackOpens: true});
+
+            sinon.assert.calledOnceWithExactly(mailService.GhostMailer.prototype.send, sinon.match({
+                trackOpens: true
+            }));
         });
 
         it('returns the mail transport response for automation emails', async function () {

--- a/ghost/core/test/unit/server/services/automations/automations-api.test.js
+++ b/ghost/core/test/unit/server/services/automations/automations-api.test.js
@@ -42,7 +42,7 @@ describe('automations API', function () {
                 memberId: 'member-id',
                 memberName: 'Test Member',
                 memberUuid: '00000000-0000-4000-8000-000000000001',
-                trackOpens: false
+                trackOpens: true
             });
 
             sinon.assert.calledOnce(transaction);
@@ -53,7 +53,7 @@ describe('automations API', function () {
                 member_name: 'Test Member',
                 automation_action_revision_id: 'revision-id',
                 mailgun_message_id: 'mailgun-message-id',
-                track_opens: false
+                track_opens: true
             }, {transacting});
             sinon.assert.calledOnceWithExactly(whereRevision, 'id', 'revision-id');
             sinon.assert.calledOnceWithExactly(transacting.raw, 'COALESCE(??, 0) + ?', ['email_sent_count', 1]);

--- a/ghost/core/test/unit/server/services/automations/poll.test.ts
+++ b/ghost/core/test/unit/server/services/automations/poll.test.ts
@@ -377,6 +377,7 @@ describe('automations poll', function () {
         const step = buildEmailStep();
         automationsApi.fetchAndLockSteps.resolves({steps: [step], nextStepReadyAt: null});
         settingsCacheGet.withArgs('email_track_opens').returns(true);
+        memberWelcomeEmailService.api.sendAutomationEmail.resolves({id: '<mailgun-message-id>'});
 
         await poll(options);
 
@@ -392,6 +393,7 @@ describe('automations poll', function () {
         const step = buildEmailStep();
         automationsApi.fetchAndLockSteps.resolves({steps: [step], nextStepReadyAt: null});
         settingsCacheGet.withArgs('email_track_opens').returns(false);
+        memberWelcomeEmailService.api.sendAutomationEmail.resolves({id: '<mailgun-message-id>'});
 
         await poll(options);
 
@@ -408,6 +410,7 @@ describe('automations poll', function () {
             automation_action_revision_id: 'revision-id'
         });
         automationsApi.fetchAndLockSteps.resolves({steps: [step], nextStepReadyAt: null});
+        settingsCacheGet.withArgs('email_track_opens').returns(true);
         memberWelcomeEmailService.api.sendAutomationEmail.resolves({
             messageId: '<smtp-message-id>',
             response: '250 Message accepted'
@@ -415,6 +418,9 @@ describe('automations poll', function () {
 
         await poll(options);
 
+        sinon.assert.calledOnceWithExactly(memberWelcomeEmailService.api.sendAutomationEmail, sinon.match({
+            trackOpens: true
+        }));
         sinon.assert.calledOnceWithExactly(automationsApi.recordEmailSent, {
             automationActionRevisionId: 'revision-id',
             memberEmail: 'member@example.com',

--- a/ghost/core/test/unit/server/services/automations/poll.test.ts
+++ b/ghost/core/test/unit/server/services/automations/poll.test.ts
@@ -388,6 +388,21 @@ describe('automations poll', function () {
         }));
     });
 
+    it('does not enable open tracking for the send and recipient when the setting is disabled', async function () {
+        const step = buildEmailStep();
+        automationsApi.fetchAndLockSteps.resolves({steps: [step], nextStepReadyAt: null});
+        settingsCacheGet.withArgs('email_track_opens').returns(false);
+
+        await poll(options);
+
+        sinon.assert.calledOnceWithExactly(memberWelcomeEmailService.api.sendAutomationEmail, sinon.match({
+            trackOpens: false
+        }));
+        sinon.assert.calledOnceWithExactly(automationsApi.recordEmailSent, sinon.match({
+            trackOpens: false
+        }));
+    });
+
     it('records the automated email recipient without a Mailgun message ID after an SMTP send', async function () {
         const step = buildEmailStep({
             automation_action_revision_id: 'revision-id'

--- a/ghost/core/test/unit/server/services/automations/poll.test.ts
+++ b/ghost/core/test/unit/server/services/automations/poll.test.ts
@@ -7,6 +7,8 @@ import {MEMBER_WELCOME_EMAIL_SLUGS} from '../../../../../core/server/services/me
 // @ts-expect-error Models currently lack type definitions.
 import {Member} from '../../../../../core/server/models';
 
+const settingsCache = require('../../../../../core/shared/settings-cache');
+
 const MAX_STEPS_PER_BATCH = 100;
 const RETRY_DELAY_MS = 10 * 60 * 1000;
 
@@ -120,6 +122,7 @@ describe('automations poll', function () {
     let automationsApi: AutomationsApiStubs;
     let memberWelcomeEmailService: MemberWelcomeEmailServiceStubs;
     let options: PollOptionsStubs;
+    let settingsCacheGet: sinon.SinonStub;
 
     beforeEach(function () {
         sinon.useFakeTimers({now: new Date('2026-01-01T12:00:00.000Z'), shouldAdvanceTime: true});
@@ -146,6 +149,8 @@ describe('automations poll', function () {
             memberWelcomeEmailService
         };
 
+        settingsCacheGet = sinon.stub(settingsCache, 'get');
+        settingsCacheGet.withArgs('email_track_opens').returns(false);
         sinon.stub(Member, 'findOne').resolves(buildMember());
     });
 
@@ -349,6 +354,9 @@ describe('automations poll', function () {
 
         await poll(options);
 
+        sinon.assert.calledOnceWithExactly(memberWelcomeEmailService.api.sendAutomationEmail, sinon.match({
+            trackOpens: false
+        }));
         sinon.assert.calledOnceWithExactly(automationsApi.recordEmailSent, {
             automationActionRevisionId: 'revision-id',
             mailgunMessageId: 'mailgun-message-id',
@@ -363,6 +371,21 @@ describe('automations poll', function () {
             automationsApi.recordEmailSent,
             automationsApi.finishStepAndEnqueueNext
         );
+    });
+
+    it('enables open tracking for the send and recipient when the setting is enabled', async function () {
+        const step = buildEmailStep();
+        automationsApi.fetchAndLockSteps.resolves({steps: [step], nextStepReadyAt: null});
+        settingsCacheGet.withArgs('email_track_opens').returns(true);
+
+        await poll(options);
+
+        sinon.assert.calledOnceWithExactly(memberWelcomeEmailService.api.sendAutomationEmail, sinon.match({
+            trackOpens: true
+        }));
+        sinon.assert.calledOnceWithExactly(automationsApi.recordEmailSent, sinon.match({
+            trackOpens: true
+        }));
     });
 
     it('records the automated email recipient without a Mailgun message ID after an SMTP send', async function () {

--- a/ghost/core/test/unit/server/services/mail/ghost-mailer.test.js
+++ b/ghost/core/test/unit/server/services/mail/ghost-mailer.test.js
@@ -386,6 +386,44 @@ describe('Mail: Ghostmailer', function () {
             assert.equal(sentMessage['o:tracking-opens'], undefined);
         });
 
+        it('should enable Mailgun open tracking when explicitly requested', async function () {
+            sandbox.stub(settingsCache, 'get').withArgs('email_track_opens').returns(false);
+
+            mailer = new mail.GhostMailer();
+            mailer.state.usingMailgun = true;
+            const sendMailSpy = sandbox.stub(mailer.transport, 'sendMail').resolves({});
+
+            await mailer.send({
+                to: 'user@example.com',
+                subject: 'test',
+                html: 'content',
+                trackOpens: true
+            });
+
+            const sentMessage = sendMailSpy.firstCall.args[0];
+            assert.equal(sentMessage['o:tracking-opens'], true);
+            assert.equal(sentMessage.trackOpens, undefined);
+        });
+
+        it('should not enable Mailgun open tracking when explicitly disabled', async function () {
+            sandbox.stub(settingsCache, 'get').withArgs('email_track_opens').returns(true);
+
+            mailer = new mail.GhostMailer();
+            mailer.state.usingMailgun = true;
+            const sendMailSpy = sandbox.stub(mailer.transport, 'sendMail').resolves({});
+
+            await mailer.send({
+                to: 'user@example.com',
+                subject: 'test',
+                html: 'content',
+                trackOpens: false
+            });
+
+            const sentMessage = sendMailSpy.firstCall.args[0];
+            assert.equal(sentMessage['o:tracking-opens'], undefined);
+            assert.equal(sentMessage.trackOpens, undefined);
+        });
+
         it('should not add site ID tag when site ID is missing', async function () {
             configUtils.set({
                 hostSettings: {} // No siteId


### PR DESCRIPTION
closes [https://linear.app/ghost/issue/NY-1439/set-automated-email-recipientstrack-opens-to-true-when-creating-them](https://linear.app/ghost/issue/NY-1439/set-automated-email-recipientstrack-opens-to-true-when-creating-them)

Automation analytics needs recipient records to reflect the same open-tracking decision used when sending through Mailgun.

## Summary

- Snapshot the email open-tracking setting when an automation email is processed
- Pass that value through the automation send path to Mailgun
- Persist the same value on the automated email recipient
- Preserve existing behavior for legacy welcome emails and other transactional mail

## Testing

- Focused automation polling, persistence, welcome-email service, and GhostMailer tests
- Targeted ESLint
- TypeScript checks