### PR TITLE
Added typed Koenig/Lexical private boundary adapters

### DIFF
--- a/koenig/koenig-lexical/src/plugins/KoenigNestedEditorPlugin.tsx
+++ b/koenig/koenig-lexical/src/plugins/KoenigNestedEditorPlugin.tsx
@@ -8,6 +8,7 @@ import {
     COMMAND_PRIORITY_LOW,
     KEY_ENTER_COMMAND
 } from 'lexical';
+import {getParentEditor} from '../utils/lexical-internals';
 import {mergeRegister} from '@lexical/utils';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext.js';
 
@@ -76,7 +77,7 @@ function KoenigNestedEditorPlugin({
                     // let the parent editor handle the edit mode product
                     if (event.metaKey || event.ctrlKey) {
                         event._fromNested = true;
-                        editor._parentEditor?.dispatchCommand(KEY_ENTER_COMMAND, event);
+                        getParentEditor(editor)?.dispatchCommand(KEY_ENTER_COMMAND, event);
                         return true;
                     }
 
@@ -99,7 +100,7 @@ function KoenigNestedEditorPlugin({
                         // - with ctrl/cmd+enter toggles edit mode
                         // - or creates paragraph after card and moves cursor
                         event._fromNested = true;
-                        editor._parentEditor.dispatchCommand(KEY_ENTER_COMMAND, event);
+                        getParentEditor(editor)?.dispatchCommand(KEY_ENTER_COMMAND, event);
 
                         // prevent normal/KoenigBehaviourPlugin enter key behaviour
                         return true;
@@ -113,9 +114,10 @@ function KoenigNestedEditorPlugin({
                 () => {
                     // when the nested editor is selected, the parent editor clears its selection so we need to
                     //   return parent editor selection to the card when the nested editor loses focus
-                    if (hasSettingsPanel && editor._parentEditor) {
-                        editor._parentEditor.getEditorState().read(() => {
-                            editor._parentEditor.update(() => {
+                    const parentEditor = getParentEditor(editor);
+                    if (hasSettingsPanel && parentEditor) {
+                        parentEditor.getEditorState().read(() => {
+                            parentEditor.update(() => {
                                 if (!$getSelection()) {
                                     const selection = $createNodeSelection();
                                     selection.add(parentCardNodeKey);

--- a/koenig/koenig-lexical/src/utils/buildCardMenu.ts
+++ b/koenig/koenig-lexical/src/utils/buildCardMenu.ts
@@ -1,5 +1,25 @@
 import SnippetCardIcon from '../assets/icons/kg-card-type-snippet.svg?react';
 import {INSERT_SNIPPET_COMMAND} from '../plugins/KoenigSnippetPlugin';
+import type React from 'react';
+
+export interface CardMenuItem {
+    nodeType?: string;
+    type?: string;
+    label: string;
+    Icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+    desc?: string;
+    shortcut?: string;
+    section?: string;
+    matches?: ((query: string, label?: string) => boolean) | string[];
+    isHidden?: (context: {config: unknown}) => boolean;
+    postType?: string;
+    insertParams?: unknown;
+    insertCommand?: unknown;
+    queryParams?: unknown;
+    priority?: number;
+    onRemove?: () => void;
+    [key: string]: unknown;
+}
 
 export function buildCardMenu(nodes, {query, config} = {}) {
     let menu = new Map();

--- a/koenig/koenig-lexical/src/utils/getEditorCardNodes.ts
+++ b/koenig/koenig-lexical/src/utils/getEditorCardNodes.ts
@@ -1,14 +1,20 @@
-export function getEditorCardNodes(editor) {
+import {getKoenigCardNodeClass, hasKoenigCardMenu} from './koenig-node-class';
+import {getRegisteredNodeClasses} from './lexical-internals';
+import type {KoenigCardMenuNodeClass} from './koenig-node-class';
+import type {LexicalEditor} from 'lexical';
+
+export function getEditorCardNodes(editor: LexicalEditor): Array<[string, KoenigCardMenuNodeClass]> {
     // TODO: open upstream PR to add public method of getting nodes
-    const allNodes = editor._nodes;
-    const cardNodes = [];
+    const allNodes = getRegisteredNodeClasses(editor);
+    const cardNodes: Array<[string, KoenigCardMenuNodeClass]> = [];
 
     for (const [nodeType, {klass}] of allNodes) {
-        if (!klass.kgMenu) {
+        const nodeClass = getKoenigCardNodeClass(klass);
+        if (!hasKoenigCardMenu(nodeClass)) {
             continue;
         }
 
-        cardNodes.push([nodeType, klass]);
+        cardNodes.push([nodeType, nodeClass]);
     }
 
     return cardNodes;

--- a/koenig/koenig-lexical/src/utils/isEditorEmpty.ts
+++ b/koenig/koenig-lexical/src/utils/isEditorEmpty.ts
@@ -1,9 +1,11 @@
 import {$canShowPlaceholderCurry} from '@lexical/text';
+import {getPendingEditorState} from './lexical-internals';
+import type {LexicalEditor} from 'lexical';
 
-export function isEditorEmpty(editor) {
+export function isEditorEmpty(editor: LexicalEditor): boolean {
     // NOTE: This feels hacky but was required because we check editor empty state
     // when rendering cards to determine whether to show nested editors. But
     // _after an undo_ at the point we check the nested editor state is not yet fully committed
-    const editorState = editor._pendingEditorState || editor.getEditorState();
+    const editorState = getPendingEditorState(editor) || editor.getEditorState();
     return editorState.read($canShowPlaceholderCurry(false));
 }

--- a/koenig/koenig-lexical/src/utils/koenig-node-class.ts
+++ b/koenig/koenig-lexical/src/utils/koenig-node-class.ts
@@ -1,0 +1,20 @@
+import type {CardMenuItem} from './buildCardMenu';
+
+type KoenigCardMenu = CardMenuItem | CardMenuItem[];
+
+export interface KoenigCardNodeClass {
+    kgMenu?: KoenigCardMenu;
+    uploadType?: string;
+}
+
+export interface KoenigCardMenuNodeClass extends KoenigCardNodeClass {
+    kgMenu: KoenigCardMenu;
+}
+
+export function getKoenigCardNodeClass(nodeClass: unknown): KoenigCardNodeClass {
+    return nodeClass as KoenigCardNodeClass;
+}
+
+export function hasKoenigCardMenu(nodeClass: KoenigCardNodeClass): nodeClass is KoenigCardMenuNodeClass {
+    return Boolean(nodeClass.kgMenu);
+}

--- a/koenig/koenig-lexical/src/utils/lexical-internals.ts
+++ b/koenig/koenig-lexical/src/utils/lexical-internals.ts
@@ -1,0 +1,18 @@
+import type {EditorState, LexicalEditor} from 'lexical';
+
+// Lexical does not expose public APIs for a few editor relationships and node
+// registry details that Koenig needs. Keep those private-field reads isolated
+// here so version-specific assumptions are named and easy to audit when
+// upgrading Lexical.
+
+export function getParentEditor(editor: LexicalEditor): LexicalEditor | null {
+    return editor._parentEditor ?? null;
+}
+
+export function getPendingEditorState(editor: LexicalEditor): EditorState | null {
+    return editor._pendingEditorState ?? null;
+}
+
+export function getRegisteredNodeClasses(editor: LexicalEditor): Iterable<[string, {klass: unknown}]> {
+    return editor._nodes;
+}


### PR DESCRIPTION
no issue

koenig-lexical reads Lexical private fields (`_parentEditor`, `_pendingEditorState`, `_nodes`) directly at scattered call sites because Lexical has no public API for those relationships. Each read is an unnamed, untyped assumption about Lexical internals — easy to miss when upgrading Lexical, and a blocker for typing the surrounding code without `any` escape hatches everywhere.

This centralizes those assumptions behind typed adapters and routes the existing call sites through them:

- `utils/lexical-internals.ts` names each private-field read (`getParentEditor`, `getPendingEditorState`, `getRegisteredNodeClasses`) so everything that could break on a Lexical upgrade lives in one auditable place
- `utils/koenig-node-class.ts` gives Koenig card node classes and their `kgMenu` metadata a typed shape, so card discovery and menu building no longer rely on implicit `any`
