### PR TITLE
Moved sso-base adapter to separate package

### DIFF
--- a/ghost/core/core/server/adapters/sso/DefaultSSOAdapter.ts
+++ b/ghost/core/core/server/adapters/sso/DefaultSSOAdapter.ts
@@ -1,10 +1,6 @@
-const Base = require('./SSOBase');
+import {SSOBase} from '@tryghost/adapter-base-sso'
 
-module.exports = class DefaultSSOAdapter extends Base {
-    constructor() {
-        super();
-    }
-
+export default class DefaultSSOAdapter extends SSOBase<null, null> {
     async getRequestCredentials() {
         return null;
     }

--- a/ghost/core/core/server/adapters/sso/SSOBase.js
+++ b/ghost/core/core/server/adapters/sso/SSOBase.js
@@ -1,8 +1,5 @@
-module.exports = class SSOBase {
-    constructor() {
-        Object.defineProperty(this, 'requiredFns', {
-            value: ['getRequestCredentials', 'getIdentityFromCredentials', 'getUserForIdentity'],
-            writable: false
-        });
-    }
-};
+const {SSOBase} = require('@tryghost/adapter-base-sso');
+
+// NOTE: this is a temporary shim to ensure that Moya requires continue to work
+// until @tryghost/adapter-base-sso is published to NPM and Moya depends on it directly.
+module.exports = SSOBase;

--- a/ghost/core/core/server/services/adapter-manager/index.js
+++ b/ghost/core/core/server/services/adapter-manager/index.js
@@ -14,7 +14,7 @@ const adapterManager = new AdapterManager({
 
 adapterManager.registerAdapter('storage', require('ghost-storage-base'));
 adapterManager.registerAdapter('scheduling', require('../../adapters/scheduling/scheduling-base'));
-adapterManager.registerAdapter('sso', require('../../adapters/sso/SSOBase'));
+adapterManager.registerAdapter('sso', require('@tryghost/adapter-base-sso').SSOBase);
 adapterManager.registerAdapter('cache', require('@tryghost/adapter-base-cache'));
 adapterManager.registerAdapter('redirects', require('../../adapters/redirects/RedirectsStoreBase'));
 

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -86,6 +86,7 @@
     "@sentry/node": "7.120.4",
     "@slack/webhook": "7.1.0",
     "@tryghost/adapter-base-cache": "0.1.26",
+    "@tryghost/adapter-base-sso": "workspace:*",
     "@tryghost/admin-api-schema": "4.7.5",
     "@tryghost/api-framework": "catalog:",
     "@tryghost/bookshelf-plugins": "2.2.4",

--- a/packages/adapters/sso-base/README.md
+++ b/packages/adapters/sso-base/README.md
@@ -1,0 +1,29 @@
+# @tryghost/adapter-base-sso
+
+The adapter-base-sso package for Ghost.
+
+## Develop
+
+This is a workspace package in the Ghost monorepo. From the repo root:
+
+```bash
+pnpm --filter @tryghost/adapter-base-sso build   # compile to build/ with tsc (ESM)
+pnpm --filter @tryghost/adapter-base-sso test    # type-check + unit tests
+pnpm --filter @tryghost/adapter-base-sso dev     # rebuild on change
+```
+
+In-monorepo consumers resolve this package via the `source` export condition
+(raw `src/*.ts`, no build needed in dev/test). Production and any published
+tarball use the compiled `build/` output.
+
+This package is ESM-only and compiled with `tsc` (`module: nodenext`). Relative
+imports in `src/` must carry an explicit extension; write the real `.ts` one —
+`import {x} from './x.ts'` — and `tsc` rewrites it to `.js` on emit
+(`rewriteRelativeImportExtensions`).
+
+`ghost/core` is CommonJS but consumes this package via `require()`, which works
+on Ghost's Node version (22.13+/24) through Node's `require(esm)` support. That
+support has one hard constraint: **no top-level `await`** anywhere in this
+package's module graph — it makes the graph async and `require()` of it throws
+`ERR_REQUIRE_ASYNC_MODULE`. Keep module-level initialization synchronous. (An
+ESLint rule enforces this.)

--- a/packages/adapters/sso-base/eslint.config.mjs
+++ b/packages/adapters/sso-base/eslint.config.mjs
@@ -1,0 +1,3 @@
+import {nodeLibConfig} from '@internal/cfg-eslint';
+
+export default nodeLibConfig();

--- a/packages/adapters/sso-base/package.json
+++ b/packages/adapters/sso-base/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@tryghost/adapter-base-sso",
+  "version": "0.0.0",
+  "description": "The adapter-base-sso package for Ghost.",
+  "private": true,
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TryGhost/Ghost.git",
+    "directory": "packages/adapters/sso-base"
+  },
+  "author": "Ghost Foundation",
+  "license": "MIT",
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    }
+  },
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "test:unit": "NODE_ENV=testing vitest run --coverage",
+    "test": "pnpm run '/^test:/'",
+    "test:types": "tsc --noEmit -p test/tsconfig.json",
+    "lint:code": "eslint src/ --cache",
+    "lint:test": "eslint test/ --cache",
+    "lint": "pnpm run '/^lint:/'"
+  },
+  "files": [
+    "build"
+  ],
+  "devDependencies": {
+    "@internal/cfg-eslint": "workspace:*",
+    "@internal/cfg-typescript": "workspace:*",
+    "@internal/cfg-vitest": "workspace:*",
+    "@types/express": "catalog:",
+    "@types/node": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "eslint": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "dependencies": {},
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": [
+          "{projectRoot}/build"
+        ]
+      }
+    }
+  }
+}

--- a/packages/adapters/sso-base/src/base.ts
+++ b/packages/adapters/sso-base/src/base.ts
@@ -1,0 +1,26 @@
+import type {Request} from 'express';
+
+export interface User {
+    id: string;
+}
+
+export interface SSOAdapter<Token, Lookup> {
+    getRequestCredentials(request: Request): Promise<Token | null>;
+    getIdentityFromCredentials(credentials: Token): Promise<Lookup | null>;
+    getUserForIdentity(identity: Lookup): Promise<User | null>;
+}
+
+export abstract class SSOBase<Token, Lookup> implements SSOAdapter<Token, Lookup> {
+    declare readonly requiredFns: readonly ['getRequestCredentials', 'getIdentityFromCredentials', 'getUserForIdentity'];
+
+    constructor() {
+        Object.defineProperty(this, 'requiredFns', {
+            value: Object.freeze(['getRequestCredentials', 'getIdentityFromCredentials', 'getUserForIdentity']),
+            writable: false,
+        });
+    }
+
+    abstract getRequestCredentials(request: Request): Promise<Token | null>;
+    abstract getIdentityFromCredentials(credentials: Token): Promise<Lookup | null>;
+    abstract getUserForIdentity(identity: Lookup): Promise<User | null>;
+}

--- a/packages/adapters/sso-base/src/index.ts
+++ b/packages/adapters/sso-base/src/index.ts
@@ -1,0 +1,1 @@
+export * from './base.ts';

--- a/packages/adapters/sso-base/test/index.test.ts
+++ b/packages/adapters/sso-base/test/index.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import {describe, it} from 'vitest';
+
+import {SSOBase} from '../src/base.ts';
+
+describe('adapter-base-redirects', function () {
+    it('should have requiredFns property', function () {
+        class TestSSO extends SSOBase<null, null> {
+            async getRequestCredentials() {
+                return null
+            }
+
+            async getIdentityFromCredentials() {
+                return null
+            }
+
+            async getUserForIdentity() {
+                return null
+            }
+        }
+
+        const store = new TestSSO();
+        assert.deepEqual(store.requiredFns, ['getRequestCredentials', 'getIdentityFromCredentials', 'getUserForIdentity']);
+        assert.ok(Object.isFrozen(store.requiredFns), 'requiredFns should be frozen');
+    })
+});

--- a/packages/adapters/sso-base/test/tsconfig.json
+++ b/packages/adapters/sso-base/test/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../tsconfig.json",
+    "compilerOptions": {
+        "rootDir": "..",
+        "noEmit": true
+    },
+    "include": [
+        "../src/**/*",
+        "**/*"
+    ]
+}

--- a/packages/adapters/sso-base/tsconfig.json
+++ b/packages/adapters/sso-base/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "@internal/cfg-typescript/esm.json",
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "build"
+    },
+    "include": [
+        "src/**/*"
+    ]
+}

--- a/packages/adapters/sso-base/vitest.config.ts
+++ b/packages/adapters/sso-base/vitest.config.ts
@@ -1,0 +1,4 @@
+import {createVitestConfig} from '@internal/cfg-vitest';
+
+// Pass overrides to tune coverage thresholds, setupFiles, etc.
+export default createVitestConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2287,6 +2287,9 @@ importers:
       '@tryghost/adapter-base-cache':
         specifier: 0.1.26
         version: 0.1.26
+      '@tryghost/adapter-base-sso':
+        specifier: workspace:*
+        version: link:../../packages/adapters/sso-base
       '@tryghost/admin-api-schema':
         specifier: 4.7.5
         version: 4.7.5
@@ -3827,6 +3830,36 @@ importers:
       yjs:
         specifier: 13.6.31
         version: 13.6.31
+
+  packages/adapters/sso-base:
+    devDependencies:
+      '@internal/cfg-eslint':
+        specifier: workspace:*
+        version: link:../../../configs/eslint
+      '@internal/cfg-typescript':
+        specifier: workspace:*
+        version: link:../../../configs/typescript
+      '@internal/cfg-vitest':
+        specifier: workspace:*
+        version: link:../../../configs/vitest
+      '@types/express':
+        specifier: 'catalog:'
+        version: 4.17.25
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.20.0
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
+      eslint:
+        specifier: 'catalog:'
+        version: 9.39.4(jiti@2.7.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   packages/parse-email-address:
     dependencies:


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLA-233
- add new adapter-base-sso package to monorepo with sso adapter code
- define proper sso base adapter typings
- wire base adapter into Ghost with temporary Moya re-export