### PR TITLE
Added email stats to automation canvas and step sidebar

### DIFF
--- a/apps/admin/src/automations/components/canvas/automation-canvas.tsx
+++ b/apps/admin/src/automations/components/canvas/automation-canvas.tsx
@@ -16,13 +16,20 @@ import {type StepPickerType} from './step-picker';
 import {StepSidebar} from './step-sidebar';
 import {formatWait} from './format-wait';
 import {isEmptyEmailLexical} from '@/automations/utils';
+import {useFeatureFlag} from '@/hooks/use-feature-flag';
 import {useLocation, useNavigate, useSearchParams} from '@tryghost/admin-x-framework';
 import type {EmailModalMode} from '@/automations/components/types';
 
 const NODE_X = 0;
 const NODE_WIDTH = 256;
 const NODE_COLUMN_CENTER_X = NODE_X + (NODE_WIDTH / 2);
-const NODE_GAP_Y = 180;
+// Visible space between node bottom and the next node's top. Constant across all pairs so the
+// chain reads as evenly spaced regardless of how tall any individual node renders.
+const NODE_VISUAL_GAP_Y = 112;
+// Approximate rendered heights — used to compute the absolute y-position of each node so the
+// visible gap stays uniform. If node body layout changes, retune these.
+const REGULAR_NODE_HEIGHT = 68;
+const EMAIL_NODE_WITH_STATS_HEIGHT = 133;
 const INITIAL_VIEWPORT_Y = 40;
 const NODE_ENTER_ANIMATION_DURATION = 250;
 const DISABLED_REASON = 'Maximum steps added';
@@ -42,6 +49,7 @@ const buildActionData = (action: AutomationAction): StepNodeDisplayData => {
             icon: LucideIcon.Mail,
             isPlaceholderValue: !action.data.email_subject,
             label: 'Send email',
+            stats: action.stats,
             value: action.data.email_subject || 'Untitled',
             warningMessage: isEmptyEmailLexical(action.data.email_lexical) ? 'Empty email body' : undefined
         };
@@ -150,6 +158,7 @@ const getInitialActionOrder = (automation: AutomationDetail): AutomationAction[]
 type BuildGraphParams = {
     actionErrors: Record<string, string>;
     automation: AutomationDetail;
+    automationAnalyticsEnabled: boolean;
     disabled: boolean;
     onDelete: (stepId: string) => void;
     onEditEmailBody: (stepId: string, mode?: EmailModalMode) => void;
@@ -160,7 +169,7 @@ type BuildGraphParams = {
     selectedStepId: string | null;
 }
 
-const buildGraph = ({actionErrors, automation, disabled, onDelete, onEditEmailBody, onPick, onPreviewEmail, onSelectStep, newStepId, selectedStepId}: BuildGraphParams): { nodes: AutomationFlowNode[]; edges: Edge[] } => {
+const buildGraph = ({actionErrors, automation, automationAnalyticsEnabled, disabled, onDelete, onEditEmailBody, onPick, onPreviewEmail, onSelectStep, newStepId, selectedStepId}: BuildGraphParams): { nodes: AutomationFlowNode[]; edges: Edge[] } => {
     const ordered = getInitialActionOrder(automation);
     const baseNodeProps = {
         draggable: false,
@@ -176,11 +185,12 @@ const buildGraph = ({actionErrors, automation, disabled, onDelete, onEditEmailBo
         targetId: TAIL_CANVAS_ID
     };
 
+    let cursorY = 0;
     const nodes: AutomationFlowNode[] = [
         {
             id: TRIGGER_CANVAS_ID,
             type: 'trigger',
-            position: {x: NODE_X, y: 0},
+            position: {x: NODE_X, y: cursorY},
             data: {
                 contextMenuItems: buildNodeContextMenuItems({
                     onSelectStep,
@@ -196,14 +206,23 @@ const buildGraph = ({actionErrors, automation, disabled, onDelete, onEditEmailBo
             ...baseNodeProps
         }
     ];
+    cursorY += REGULAR_NODE_HEIGHT + NODE_VISUAL_GAP_Y;
 
-    ordered.forEach((action, index) => {
+    ordered.forEach((action) => {
+        const displayData = buildActionData(action);
+        const errorMessage = actionErrors[action.id];
+        const showStatsFooter = automationAnalyticsEnabled
+            && action.type === 'send_email'
+            && Boolean(action.stats)
+            && !errorMessage
+            && !displayData.warningMessage;
+
         nodes.push({
             id: action.id,
             type: 'step',
-            position: {x: NODE_X, y: NODE_GAP_Y * (index + 1)},
+            position: {x: NODE_X, y: cursorY},
             data: {
-                ...buildActionData(action),
+                ...displayData,
                 contextMenuItems: buildNodeContextMenuItems({
                     canDelete: true,
                     canEditEmailBody: action.type === 'send_email',
@@ -213,19 +232,21 @@ const buildGraph = ({actionErrors, automation, disabled, onDelete, onEditEmailBo
                     onSelectStep,
                     stepId: action.id
                 }),
-                errorMessage: actionErrors[action.id],
+                errorMessage,
                 isNew: newStepId === action.id,
                 selected: selectedStepId === action.id,
+                showStatsFooter,
                 onSelect: () => onSelectStep(action.id)
             },
             ...baseNodeProps
         });
+        cursorY += (showStatsFooter ? EMAIL_NODE_WITH_STATS_HEIGHT : REGULAR_NODE_HEIGHT) + NODE_VISUAL_GAP_Y;
     });
 
     nodes.push({
         id: TAIL_CANVAS_ID,
         type: 'tail',
-        position: {x: NODE_X, y: NODE_GAP_Y * (ordered.length + 1)},
+        position: {x: NODE_X, y: cursorY},
         data: {disabled, disabledReason, onPick, anchor: tailAnchor},
         draggable: false,
         connectable: false
@@ -431,6 +452,7 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({
         : undefined;
 
     const initialViewport = useRef(getInitialViewport(window.innerWidth));
+    const automationAnalyticsEnabled = useFeatureFlag('automationAnalytics');
 
     const graph = useMemo(() => {
         if (!automation) {
@@ -439,6 +461,7 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({
         return buildGraph({
             actionErrors,
             automation,
+            automationAnalyticsEnabled,
             disabled: automation.actions.length >= MAX_AUTOMATION_ACTIONS,
             onDelete: handleRequestDelete,
             onEditEmailBody: handleContextMenuEditEmail,
@@ -448,7 +471,7 @@ const AutomationCanvas: React.FC<AutomationCanvasProps> = ({
             newStepId,
             selectedStepId
         });
-    }, [actionErrors, automation, handleContextMenuEditEmail, handleContextMenuPreviewEmail, handlePick, handleRequestDelete, newStepId, selectedStepId]);
+    }, [actionErrors, automation, automationAnalyticsEnabled, handleContextMenuEditEmail, handleContextMenuPreviewEmail, handlePick, handleRequestDelete, newStepId, selectedStepId]);
 
     const clearDetail = useCallback(() => {
         setSelectedStep(null);

--- a/apps/admin/src/automations/components/canvas/email-performance-section.tsx
+++ b/apps/admin/src/automations/components/canvas/email-performance-section.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import {ChartContainer, Separator} from '@tryghost/shade/components';
+import type {ChartConfig} from '@tryghost/shade/components';
+import type {AutomationEmailStats} from '@tryghost/admin-x-framework/api/automations';
+import {Recharts, formatNumber} from '@tryghost/shade/utils';
+import {formatRate} from './format-stats';
+
+const EMAIL_PERFORMANCE_CHART_CONFIG = {
+    value: {label: 'Rate'}
+} satisfies ChartConfig;
+
+const EmailPerformanceRing: React.FC<{
+    datatype: string;
+    value: number;
+    color: 'purple' | 'blue' | 'teal';
+    innerRadius: number;
+    outerRadius: number;
+}> = ({datatype, value, color, innerRadius, outerRadius}) => {
+    const gradientId = `emailRing-${color}`;
+    const colorVar = `var(--chart-${color})`;
+    return (
+        <ChartContainer className='absolute inset-0 aspect-square' config={EMAIL_PERFORMANCE_CHART_CONFIG}>
+            <Recharts.RadialBarChart
+                data={[{datatype, value}]}
+                endAngle={-270}
+                innerRadius={innerRadius}
+                outerRadius={outerRadius}
+                startAngle={90}
+            >
+                <defs>
+                    <radialGradient cx='30%' cy='30%' id={gradientId} r='70%'>
+                        <stop offset='0%' stopColor={colorVar} stopOpacity={0.5} />
+                        <stop offset='100%' stopColor={colorVar} stopOpacity={1} />
+                    </radialGradient>
+                </defs>
+                <Recharts.PolarAngleAxis angleAxisId={0} domain={[0, 1]} tick={false} type='number' />
+                <Recharts.RadialBar
+                    angleAxisId={0}
+                    cornerRadius={10}
+                    dataKey='value'
+                    fill={`url(#${gradientId})`}
+                    minPointSize={-2}
+                    background
+                >
+                    <Recharts.LabelList
+                        className='fill-foreground opacity-60'
+                        dataKey='datatype'
+                        fontSize={11}
+                        position='insideStart'
+                    />
+                </Recharts.RadialBar>
+            </Recharts.RadialBarChart>
+        </ChartContainer>
+    );
+};
+
+// Per-ring radii in px, calibrated for a 240×240 chart container. Each ring is 22px thick with a
+// 3px gap. Recharts' <RadialBar> doesn't accept innerRadius/outerRadius (those live on the parent
+// <RadialBarChart>), so we draw each ring with its own absolutely-positioned chart.
+const EMAIL_CHART_RINGS = {
+    sent: {innerRadius: 88, outerRadius: 110},
+    opened: {innerRadius: 63, outerRadius: 85},
+    clicked: {innerRadius: 38, outerRadius: 60}
+};
+
+const EmailPerformanceChart: React.FC<{openRate: number}> = ({openRate}) => (
+    <div className='relative mx-auto aspect-square size-[240px]'>
+        <EmailPerformanceRing
+            color='purple'
+            datatype='Sent'
+            innerRadius={EMAIL_CHART_RINGS.sent.innerRadius}
+            outerRadius={EMAIL_CHART_RINGS.sent.outerRadius}
+            value={1}
+        />
+        <EmailPerformanceRing
+            color='blue'
+            datatype='Opened'
+            innerRadius={EMAIL_CHART_RINGS.opened.innerRadius}
+            outerRadius={EMAIL_CHART_RINGS.opened.outerRadius}
+            value={openRate}
+        />
+        {/* @TODO: NY-1457 */}
+        {/* <EmailPerformanceRing
+            color='teal'
+            datatype='Clicked'
+            innerRadius={EMAIL_CHART_RINGS.clicked.innerRadius}
+            outerRadius={EMAIL_CHART_RINGS.clicked.outerRadius}
+            value={clickRate}
+        /> */}
+    </div>
+);
+
+const KPI_CLASS_NAME = 'group/kpi -mx-2 -my-1 flex flex-col gap-0.5 rounded-md px-2 py-1 transition-colors hover:bg-muted';
+
+export const EmailPerformanceSection: React.FC<{stats: AutomationEmailStats}> = ({stats}) => (
+    <div className='flex flex-col gap-5'>
+        <Separator />
+        <div className='flex flex-col gap-5'>
+            <h3 className='text-sm font-medium tracking-normal text-text-secondary'>
+                Email performance
+            </h3>
+            <div className='grid grid-cols-3 gap-4'>
+                <div className={KPI_CLASS_NAME}>
+                    <span className='flex items-center gap-1.5 text-sm text-text-secondary'>
+                        <span aria-hidden='true' className='size-2 rounded-full' style={{backgroundColor: 'var(--chart-purple)'}} />
+                        Sent
+                    </span>
+                    <span className='text-xl font-semibold tracking-tight tabular-nums'>{formatNumber(stats.email_sent_count)}</span>
+                </div>
+                <div className={KPI_CLASS_NAME}>
+                    <span className='flex items-center gap-1.5 text-sm text-text-secondary'>
+                        <span aria-hidden='true' className='size-2 rounded-full' style={{backgroundColor: 'var(--chart-blue)'}} />
+                        Opened
+                    </span>
+                    <span className='text-xl font-semibold tracking-tight tabular-nums'>
+                        <span className='group-hover/kpi:hidden'>{formatRate(stats.opened_rate)}</span>
+                        <span className='hidden group-hover/kpi:inline'>{stats.email_sent_count > 0 ? formatNumber(stats.email_opened_count) : '--'}</span>
+                    </span>
+                </div>
+                {/* @TODO: NY-1457 */}
+                {/* <div className={KPI_CLASS_NAME}>
+                    <span className='flex items-center gap-1.5 text-sm text-text-secondary'>
+                        <span aria-hidden='true' className='size-2 rounded-full' style={{backgroundColor: 'var(--chart-teal)'}} />
+                        Clicked
+                    </span>
+                    <span className='text-xl font-semibold tracking-tight tabular-nums'>{formatRate(stats.clicked_rate)}</span>
+                </div> */}
+            </div>
+            <EmailPerformanceChart openRate={(stats.opened_rate ?? 0) / 100} />
+        </div>
+        {/* @TODO: NY-1457 */}
+        {/* <Separator />
+        <div className='flex items-center justify-between'>
+            <span className='text-sm font-medium text-text-secondary'>Top clicked links</span>
+            <span className='text-sm font-medium text-muted-foreground'>Members</span>
+        </div> */}
+    </div>
+);

--- a/apps/admin/src/automations/components/canvas/format-stats.ts
+++ b/apps/admin/src/automations/components/canvas/format-stats.ts
@@ -1,0 +1,5 @@
+import {formatNumber} from '@tryghost/shade/utils';
+
+export const formatRate = (rate: number | null): string => (
+    rate === null ? '--' : `${formatNumber(rate)}%`
+);

--- a/apps/admin/src/automations/components/canvas/nodes.tsx
+++ b/apps/admin/src/automations/components/canvas/nodes.tsx
@@ -4,7 +4,9 @@ import StepPicker, {type StepPickerType} from './step-picker';
 import {ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuSeparator, ContextMenuTrigger, Popover, PopoverContent, PopoverTrigger} from '@tryghost/shade/components';
 import {Handle, Position} from '@xyflow/react';
 import type {Node, NodeProps} from '@xyflow/react';
-import {LucideIcon, cn} from '@tryghost/shade/utils';
+import type {AutomationEmailStats} from '@tryghost/admin-x-framework/api/automations';
+import {LucideIcon, cn, formatNumber} from '@tryghost/shade/utils';
+import {formatRate} from './format-stats';
 
 // React Flow node IDs for the trigger and tail nodes. The canvas builds the visual graph using
 // these; they are not action IDs and never reach the API.
@@ -20,6 +22,8 @@ export type StepNodeDisplayData = {
   icon: React.ElementType;
   label: string;
   isPlaceholderValue?: boolean;
+  showStatsFooter?: boolean;
+  stats?: AutomationEmailStats;
   value?: string;
   warningMessage?: string;
 };
@@ -72,7 +76,7 @@ const HiddenHandle: React.FC<{type: 'source' | 'target'; position: Position}> = 
     <Handle isConnectable={false} position={position} style={HIDDEN_HANDLE_STYLE} type={type} />
 );
 
-const NodeShell: React.FC<React.PropsWithChildren<{className?: string; data: StepNodeData}>> = ({children, className, data}) => {
+const NodeShell: React.FC<React.PropsWithChildren<{className?: string; data: StepNodeData; footer?: React.ReactNode}>> = ({children, className, data, footer}) => {
     const ignoreNextClickRef = useRef(false);
 
     return (
@@ -87,8 +91,7 @@ const NodeShell: React.FC<React.PropsWithChildren<{className?: string; data: Ste
                     aria-label={data.value ? `${data.label}: ${data.value}` : data.label}
                     aria-pressed={data.selected}
                     className={cn(
-                        'flex w-64 items-center gap-3 rounded-lg border border-transparent bg-surface-elevated p-3 text-left text-sm text-foreground shadow-sm transition-all focus-visible:border-border-strong focus-visible:outline-none',
-                        (data.errorMessage || data.warningMessage) && 'items-start',
+                        'flex w-64 flex-col rounded-lg border border-transparent bg-surface-elevated p-3 text-left text-sm text-foreground shadow-sm transition-all focus-visible:border-border-strong focus-visible:outline-none',
                         !data.selected && 'hover:border-border-strong',
                         data.selected && !data.errorMessage && 'border-gray-700 shadow-[inset_0_0_0_1px_var(--color-gray-700),0_1px_2px_0_rgb(0_0_0_/_0.05)]',
                         data.errorMessage && 'border-destructive',
@@ -115,7 +118,13 @@ const NodeShell: React.FC<React.PropsWithChildren<{className?: string; data: Ste
                         }
                     }}
                 >
-                    {children}
+                    <div className={cn(
+                        'flex w-full items-center gap-3',
+                        (data.errorMessage || data.warningMessage) && 'items-start'
+                    )}>
+                        {children}
+                    </div>
+                    {footer}
                 </button>
             </ContextMenuTrigger>
             <ContextMenuContent
@@ -158,6 +167,24 @@ const StepNodeContent: React.FC<{data: StepNodeData}> = ({data}) => {
     );
 };
 
+const EmailStepStatsFooter: React.FC<{stats: AutomationEmailStats}> = ({stats}) => (
+    <div className='mt-3 grid w-full grid-cols-3 gap-3 border-t border-border-default pt-3'>
+        <div className='flex flex-col text-left'>
+            <span className='text-xs text-text-secondary'>Sent</span>
+            <span className='text-base font-medium'>{formatNumber(stats.email_sent_count)}</span>
+        </div>
+        <div className='flex flex-col text-left'>
+            <span className='text-xs text-text-secondary'>Opened</span>
+            <span className='text-base font-medium'>{formatRate(stats.opened_rate)}</span>
+        </div>
+        {/* @TODO: NY-1457 */}
+        {/* <div className='flex flex-col text-left'>
+            <span className='text-xs text-text-secondary'>Clicked</span>
+            <span className='text-base font-medium'>{formatRate(stats?.clicked_rate)}</span>
+        </div> */}
+    </div>
+);
+
 const TriggerNode = React.memo<NodeProps<StepFlowNode>>(({data}) => (
     <NodeShell data={data}>
         <StepNodeContent data={data} />
@@ -167,7 +194,7 @@ const TriggerNode = React.memo<NodeProps<StepFlowNode>>(({data}) => (
 TriggerNode.displayName = 'TriggerNode';
 
 const StepNode = React.memo<NodeProps<StepFlowNode>>(({data}) => (
-    <NodeShell data={data}>
+    <NodeShell data={data} footer={data.showStatsFooter && data.stats ? <EmailStepStatsFooter stats={data.stats} /> : undefined}>
         <HiddenHandle position={Position.Top} type='target' />
         <StepNodeContent data={data} />
         <HiddenHandle position={Position.Bottom} type='source' />

--- a/apps/admin/src/automations/components/canvas/step-sidebar.tsx
+++ b/apps/admin/src/automations/components/canvas/step-sidebar.tsx
@@ -2,10 +2,12 @@ import '@xyflow/react/dist/style.css';
 import React, {useEffect, useRef, useState} from 'react';
 import type {AutomationDetail, AutomationSendEmailAction, AutomationWaitAction} from '@tryghost/admin-x-framework/api/automations';
 import {Button, Field, FieldError, FieldLabel, Input, InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput, InputGroupText} from '@tryghost/shade/components';
+import {EmailPerformanceSection} from './email-performance-section';
 import {LucideIcon, cn, formatNumber} from '@tryghost/shade/utils';
 import type {MemberTier, StepSidebarDetail} from '@/automations/components/types';
 import {TRIGGER_CANVAS_ID} from './nodes';
 import {formatWait} from './format-wait';
+import {useFeatureFlag} from '@/hooks/use-feature-flag';
 
 const MAX_WAIT_DAYS = 30;
 const WHOLE_NUMBER_PATTERN = /^\d+$/;
@@ -179,6 +181,7 @@ const SendEmailSidebarBody: React.FC<{
   onDelete: () => void;
 }> = ({action, onUpdateSubject, onEditEmail, onDelete}) => {
     const subjectInputRef = useRef<HTMLInputElement>(null);
+    const automationAnalyticsEnabled = useFeatureFlag('automationAnalytics');
 
     useEffect(() => {
         subjectInputRef.current?.focus({preventScroll: true});
@@ -203,6 +206,7 @@ const SendEmailSidebarBody: React.FC<{
                 <LucideIcon.Pencil className='size-4' />
               Edit email
             </Button>
+            {automationAnalyticsEnabled && action.stats && <EmailPerformanceSection stats={action.stats} />}
             <div className='mt-auto pt-6'>
                 <DeleteStepButton onClick={onDelete} />
             </div>

--- a/apps/admin/src/automations/editor.test.tsx
+++ b/apps/admin/src/automations/editor.test.tsx
@@ -122,6 +122,18 @@ vi.mock('@tryghost/admin-x-framework/api/automations', async () => {
     };
 });
 
+const mockLabs = vi.hoisted((): {current: Record<string, boolean>} => ({current: {}}));
+
+vi.mock('@tryghost/admin-x-framework/api/config', async () => {
+    const actual = await vi.importActual<typeof import('@tryghost/admin-x-framework/api/config')>(
+        '@tryghost/admin-x-framework/api/config'
+    );
+    return {
+        ...actual,
+        useBrowseConfig: () => ({data: {config: {labs: mockLabs.current}}})
+    };
+});
+
 // xyflow's ReactFlow needs a sized container; stub it out for unit tests.
 type StubNode = {id: string; data?: Record<string, unknown>; type?: string};
 type StubEdge = {id: string; source: string; target: string; type?: string; data?: Record<string, unknown>};
@@ -282,6 +294,7 @@ describe('AutomationEditor', () => {
         mockEditMutation.isLoading = false;
         mockEditMutation.variables = undefined;
         mockToastError.mockReset();
+        mockLabs.current = {};
     });
 
     it('renders the loading state while the automation is fetching', () => {
@@ -367,6 +380,86 @@ describe('AutomationEditor', () => {
             ['action-wait', 'action-email'],
             ['action-email', '__tail__']
         ]);
+    });
+
+    it('renders send-email node stats only when the automationAnalytics labs flag is enabled', () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {
+                automations: [{
+                    ...automationDetail,
+                    actions: automationDetail.actions.map(action => (action.type === 'send_email'
+                        ? {
+                            ...action,
+                            stats: {
+                                email_sent_count: 1247,
+                                email_opened_count: 780,
+                                opened_rate: 65,
+                                clicked_rate: null
+                            }
+                        }
+                        : action))
+                }]
+            },
+            isLoading: false,
+            isError: false
+        });
+
+        const {unmount} = renderEditor();
+        expect(screen.queryByText('Sent')).not.toBeInTheDocument();
+        unmount();
+
+        mockLabs.current = {automationAnalytics: true};
+        renderEditor();
+
+        const emailStep = screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'});
+        expect(within(emailStep).getByText('Sent').nextElementSibling).toHaveTextContent('1,247');
+        expect(within(emailStep).getByText('Opened').nextElementSibling).toHaveTextContent('65%');
+        // @TODO: NY-1457 — Clicked is deferred until click data is available
+        expect(within(emailStep).queryByText('Clicked')).not.toBeInTheDocument();
+    });
+
+    it('does not render send-email node stats when the action has no stats', () => {
+        mockLabs.current = {automationAnalytics: true};
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [automationDetail]},
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        const emailStep = screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'});
+        expect(within(emailStep).queryByText('Sent')).not.toBeInTheDocument();
+    });
+
+    it('renders zero sends and an unavailable open rate when there are no sends', () => {
+        mockLabs.current = {automationAnalytics: true};
+        mockUseReadAutomation.mockReturnValue({
+            data: {
+                automations: [{
+                    ...automationDetail,
+                    actions: automationDetail.actions.map(action => (action.type === 'send_email'
+                        ? {
+                            ...action,
+                            stats: {
+                                email_sent_count: 0,
+                                email_opened_count: 0,
+                                opened_rate: null,
+                                clicked_rate: null
+                            }
+                        }
+                        : action))
+                }]
+            },
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+
+        const emailStep = screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'});
+        expect(within(emailStep).getByText('Sent').nextElementSibling).toHaveTextContent('0');
+        expect(within(emailStep).getByText('Opened').nextElementSibling).toHaveTextContent('--');
     });
 
     it('renders styled canvas zoom controls without the interaction toggle', () => {
@@ -1641,7 +1734,7 @@ describe('AutomationEditor', () => {
 
         let emailStep = screen.getByRole('button', {name: 'Send email: Untitled'});
         expect(emailStep).toHaveAttribute('aria-invalid', 'true');
-        expect(emailStep).toHaveClass('items-start');
+        expect(emailStep.firstElementChild).toHaveClass('items-start');
         expect(emailStep).toHaveClass('border-destructive');
         expect(emailStep).not.toHaveClass('border-yellow-600');
         expect(within(emailStep).getByText('Add a subject line and email body.').closest('div')?.previousElementSibling).toHaveClass('mt-[3px]');

--- a/apps/admin/src/posts/analytics/Newsletter/components/newsletter-radial-chart.tsx
+++ b/apps/admin/src/posts/analytics/Newsletter/components/newsletter-radial-chart.tsx
@@ -130,7 +130,7 @@ export const NewsletterRadialChart:React.FC<NewsletterRadialChartProps> = ({
                 >
                     {data.length > 1 &&
                         <Recharts.LabelList
-                            className="fill-black opacity-60"
+                            className="fill-foreground opacity-60"
                             dataKey="datatype"
                             fontSize={11}
                             position="insideStart"


### PR DESCRIPTION
closes  [NY-1387](https://linear.app/ghost/issue/NY-1387/update-send-email-node-in-canvas-to-show-sent-and-opened)
closes [NY-1388](https://linear.app/ghost/issue/NY-1388)

- send email nodes render a Sent / Opened footer behind the automationAnalytics labs flag
- selecting an email step shows an email performance section in the sidebar with KPIs and a rings chart

depends on https://github.com/TryGhost/Ghost/pull/29277

The below shows three nodes in various states: one with sends and opens, one with sends and no opens yet, and one without any sends yet so it shows -- for opens
<img width="1025" height="1113" alt="image" src="https://github.com/user-attachments/assets/70f849de-1aba-4059-8ecb-996011df2088" />
