### PR TITLE
Required an argument in email analytics timestamp method

### DIFF
--- a/ghost/core/core/server/services/email-analytics/lib/queries.js
+++ b/ghost/core/core/server/services/email-analytics/lib/queries.js
@@ -34,10 +34,10 @@ module.exports = {
     /**
      * Retrieves the timestamp of the last seen event for the specified email analytics events.
      * @param {EmailAnalyticsJobName} jobName - The name of the job to update.
-     * @param {EmailAnalyticsEvent[]} [events=['delivered', 'opened', 'failed']] - The email analytics events to consider.
+     * @param {EmailAnalyticsEvent[]} events - The email analytics events to consider.
      * @returns {Promise<Date|null>} The timestamp of the last seen event, or null if no events are found.
      */
-    async getLastEventTimestamp(jobName, events = ['delivered', 'opened', 'failed']) {
+    async getLastEventTimestamp(jobName, events) {
         const startDate = new Date();
         
         let maxOpenedAt;


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1447

This change should have no user impact, because this optional argument was always provided.

I think this is a useful change on its own but will also make an upcoming one easier.
