### PR TITLE
Added member repository in members API type declaration

### DIFF
--- a/ghost/core/core/server/services/members/index.d.ts
+++ b/ghost/core/core/server/services/members/index.d.ts
@@ -1,3 +1,5 @@
+import MemberRepository from './members-api/repositories/member-repository';
+
 interface MemberBREADService {
     disableCommenting(
         memberId: string,
@@ -17,6 +19,7 @@ interface MemberBREADService {
 
 interface MembersApi {
     memberBREADService: MemberBREADService;
+    members: MemberRepository;
 }
 
 interface MembersService {


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1447

This types-only change adds the `members` property to the `MembersApi`. I think this is useful on its own but will also be useful for an upcoming change.
