### PR TITLE
Updated React Query cache time in tests to match production

### DIFF
--- a/apps/admin/test-utils/acceptance/render-admin-app.tsx
+++ b/apps/admin/test-utils/acceptance/render-admin-app.tsx
@@ -77,7 +77,7 @@ export async function renderAdminApp(route: string = "/", { labs, boot }: Render
             queries: {
                 refetchOnWindowFocus: false,
                 staleTime: 5 * (60 * 1000), // 5 mins
-                cacheTime: 0,
+                cacheTime: 10 * (60 * 1000), // 10 mins
                 // We have custom retry logic for specific errors in fetchApi()
                 retry: false,
                 networkMode: "always",


### PR DESCRIPTION
no ref

## Why?

Improve CI flakiness.

## What?

The acceptance harness built its `QueryClient` with `cacheTime: 0`, while production uses 10 minutes.

Setting `cacheTime` to `0` made a test flaky when it moved between apps (e.g. Network → Posts): some data is shared by both apps, and with `cacheTime: 0` it gets thrown away and re-fetched during the switch. While it re-loads, the app shows an empty/default value for a moment, which can make an assertion fail.