### PR TITLE
Fixed build status badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
         <img src="https://img.shields.io/github/release/TryGhost/Ghost.svg" alt="Latest release" />
     </a>
     <a href="https://github.com/TryGhost/Ghost/actions">
-        <img src="https://github.com/TryGhost/Ghost/workflows/CI/badge.svg?branch=main" alt="Build status" />
+        <img src="https://github.com/TryGhost/Ghost/actions/workflows/ci.yml/badge.svg?branch=main" alt="Build status" />
     </a>
     <a href="https://github.com/TryGhost/Ghost/contributors/">
         <img src="https://img.shields.io/github/contributors/TryGhost/Ghost.svg" alt="Contributors" />


### PR DESCRIPTION
no ref

I noticed this bug while glancing at the README. See [GitHub's docs][0].

[0]: https://docs.github.com/en/actions/how-tos/monitor-workflows/add-a-status-badge
