### PR TITLE
Fixed caller context being dropped from lazy URL compare reports

### DIFF
--- a/ghost/core/core/server/services/url/url-service-facade.ts
+++ b/ghost/core/core/server/services/url/url-service-facade.ts
@@ -299,12 +299,19 @@ export class UrlServiceFacade {
     }
 
     private _reportLazyError(method: string, err: Error, context: Record<string, unknown>): void {
-        this._report(new errors.InternalServerError({
+        const report = new errors.InternalServerError({
             message: 'Lazy URL service threw during comparison',
             code: 'LAZY_URL_COMPARE_ERROR',
             err,
             errorDetails: {method, ...context}
-        }));
+        });
+        // @tryghost/errors copies the wrapped error's enumerable props over the
+        // new error, so a thrown error carrying its own errorDetails (e.g. the
+        // thin-resource report) silently clobbers the compare context passed
+        // above. Re-merge after construction so both survive in the logs.
+        const innerDetails = (err as {errorDetails?: Record<string, unknown>}).errorDetails;
+        report.errorDetails = {method, ...context, ...innerDetails};
+        this._report(report);
     }
 
     private _report(error: Error): void {

--- a/ghost/core/test/unit/server/services/url/url-service-facade.test.js
+++ b/ghost/core/test/unit/server/services/url/url-service-facade.test.js
@@ -1,5 +1,6 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
+const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
 const UrlServiceFacade = require('../../../../../core/server/services/url/url-service-facade');
 
@@ -250,6 +251,26 @@ describe('UrlServiceFacade', function () {
             await flush();
             sinon.assert.calledOnce(logging.error);
             assert.equal(logging.error.firstCall.args[0].code, 'LAZY_URL_COMPARE_ERROR');
+        });
+
+        it('keeps the caller context when the lazy throw carries its own errorDetails', async function () {
+            // @tryghost/errors copies the wrapped error's enumerable props over
+            // the new error, so the thin-resource report's errorDetails would
+            // clobber the compare context unless re-merged.
+            const thinError = new errors.InternalServerError({
+                message: 'Thin resource passed to LazyUrlService.getUrlForResource',
+                code: 'LAZY_URL_THIN_RESOURCE',
+                errorDetails: {resourceType: 'posts', missing: ['tags']}
+            });
+            lazyUrlService.getUrlForResource.throws(thinError);
+            compareFacade.getUrlForResource({type: 'posts', id: 'a', slug: 'hello'});
+            await flush();
+            const details = logging.error.firstCall.args[0].errorDetails;
+            assert.equal(details.resourceType, 'posts');
+            assert.deepEqual(details.missing, ['tags']);
+            assert.equal(details.method, 'getUrlForResource');
+            assert.match(details.caller, /url-service-facade\.test\.js/);
+            assert.deepEqual(details.resourceKeys, ['type', 'id', 'slug']);
         });
 
         it('reports the caller stack and resource keys with a lazy throw from getUrlForResource', async function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1822

Follow-up to #29190. The caller-context diagnostics added there never reached the logs: `@tryghost/errors` copies the wrapped error's enumerable properties over the new error, so when the lazy service throws an error carrying its own `errorDetails` (the thin-resource report), it clobbered the compare context — `caller` and `resourceKeys` were silently dropped. Plain test errors carried no `errorDetails`, which is why the unit tests passed while production reports lost the context.

The report now re-merges both after construction, so log entries carry the thin-resource details **and** the caller stack + resource shape. This is what's needed to attribute the remaining `missing:["tags"]` error class (router filters like `tag:[newsletter,hash-newsletter]` evaluated against resources without a `tags` array).

🤖 Generated with [Claude Code](https://claude.com/claude-code)