### PR TITLE
Changed cache behavior of timed out get helpers

### DIFF
--- a/ghost/core/core/frontend/helpers/collection.js
+++ b/ghost/core/core/frontend/helpers/collection.js
@@ -55,6 +55,9 @@ async function makeAPICall(resource, controllerName, action, apiOptions) {
             const threshold = config.get('optimization:getHelper:timeout:threshold');
 
             const apiResponse = controller[action](apiOptions);
+            // consume rejections that happen after the timeout has already won
+            // the race — they'd otherwise crash the process as unhandled
+            apiResponse.catch(() => {});
 
             const timeout = new Promise((resolve) => {
                 timer = setTimeout(() => {
@@ -67,7 +70,7 @@ async function makeAPICall(resource, controllerName, action, apiOptions) {
                         }
                     }));
 
-                    resolve({[resource]: []});
+                    resolve({[resource]: [], '@@ABORTED_GET_HELPER@@': true});
                 }, threshold);
             });
 
@@ -117,6 +120,13 @@ module.exports = async function collection(slug, options) {
 
     try {
         const response = await makeAPICall(resource, controllerName, action, apiOptions);
+
+        // consume the internal abort marker so it doesn't leak into the template context
+        const degraded = response['@@ABORTED_GET_HELPER@@'];
+        delete response['@@ABORTED_GET_HELPER@@'];
+        if (degraded && options.data?.root?._locals) {
+            options.data.root._locals.degradedRender = true;
+        }
 
         // prepare data properties for use with handlebars
         if (response[resource] && response[resource].length) {

--- a/ghost/core/core/frontend/helpers/get.js
+++ b/ghost/core/core/frontend/helpers/get.js
@@ -310,6 +310,9 @@ async function makeAPICall(resource, controllerName, action, apiOptions) {
             const threshold = config.get('optimization:getHelper:timeout:threshold');
 
             const apiResponse = makeRequest(options).then(parseResult);
+            // consume rejections that happen after the timeout has already won
+            // the race — they'd otherwise crash the process as unhandled
+            apiResponse.catch(() => {});
 
             const timeout = new Promise((resolve) => {
                 timer = setTimeout(() => {
@@ -354,6 +357,11 @@ function renderResponse(response, resource, options, data) {
         [resource]: _.cloneDeep(response[resource])
     };
 
+    // consume the internal abort marker so it doesn't leak into the template context
+    // (templateResponse is a shallow copy, so the shared `response` object is untouched)
+    const degraded = templateResponse['@@ABORTED_GET_HELPER@@'];
+    delete templateResponse['@@ABORTED_GET_HELPER@@'];
+
     // prepare data properties for use with handlebars
     if (templateResponse[resource] && templateResponse[resource].length) {
         templateResponse[resource].forEach(prepareContextResource);
@@ -373,7 +381,10 @@ function renderResponse(response, resource, options, data) {
         blockParams: blockParams
     });
 
-    if (templateResponse['@@ABORTED_GET_HELPER@@']) {
+    if (degraded) {
+        if (options.data?.root?._locals) {
+            options.data.root._locals.degradedRender = true;
+        }
         return new SafeString(`<span data-aborted-get-helper>Could not load content</span>` + rendered);
     }
     return rendered;

--- a/ghost/core/core/frontend/services/rendering/renderer.js
+++ b/ghost/core/core/frontend/services/rendering/renderer.js
@@ -43,6 +43,19 @@ module.exports = function renderer(req, res, data) {
             }
             return req.next(err);
         }
+
+        // CASE: a {{#get}} or {{#collection}} helper aborted during rendering, so the
+        // page contains fallback content — cap public caching at 60s so the broken page recovers quickly.
+        if (res.locals?.degradedRender) {
+            const cacheControl = res.get('Cache-Control') || '';
+            if (cacheControl.includes('public') && !/no-store|no-cache|private/.test(cacheControl)) {
+                const maxAgeMatch = cacheControl.match(/max-age=(\d+)/);
+                const maxAge = Math.min(60, maxAgeMatch ? parseInt(maxAgeMatch[1], 10) : 60);
+                res.set('Cache-Control', `public, max-age=${maxAge}`);
+            }
+            res.set('X-Ghost-Degraded-Render', 'aborted-get-helper');
+        }
+
         res.send(html);
     });
 };

--- a/ghost/core/test/e2e-frontend/degraded-render.test.js
+++ b/ghost/core/test/e2e-frontend/degraded-render.test.js
@@ -1,0 +1,65 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const supertest = require('supertest');
+
+const testUtils = require('../utils');
+const config = require('../../core/shared/config');
+const configUtils = require('../utils/config-utils');
+const postsPublicApi = require('../../core/server/api/endpoints/posts-public');
+
+/**
+ * The source test theme's post.hbs contains a {{#get "posts"}} block. When that
+ * call exceeds optimization:getHelper:timeout:threshold it aborts, renders
+ * fallback content and flags the response via res.locals.degradedRender (the
+ * helper's options.data.root._locals IS res.locals — express merges res.locals
+ * into the render options), which the renderer turns into caching headers.
+ */
+describe('Degraded render caching', function () {
+    let request;
+
+    beforeAll(async function () {
+        await testUtils.startGhost();
+        request = supertest.agent(config.get('url'));
+    });
+
+    afterEach(async function () {
+        sinon.restore();
+        await configUtils.restore();
+    });
+
+    it('marks the response and caps Cache-Control when {{#get}} aborts', async function () {
+        configUtils.set('optimization:getHelper:timeout:threshold', 1);
+        configUtils.set('caching:frontend:maxAge', 600);
+
+        // Delay the posts browse query (used by {{#get}} in post.hbs) past the
+        // threshold so the helper aborts; the post itself loads via read()
+        const originalQuery = postsPublicApi.browse.query;
+        sinon.stub(postsPublicApi.browse, 'query').callsFake(async function (frame) {
+            await new Promise((resolve) => {
+                setTimeout(resolve, 200);
+            });
+            return originalQuery.call(this, frame);
+        });
+
+        const res = await request.get('/welcome/')
+            .expect('Content-Type', /html/)
+            .expect(200);
+
+        assert(res.text.includes('data-aborted-get-helper'));
+        assert.equal(res.headers['x-ghost-degraded-render'], 'aborted-get-helper');
+        assert.equal(res.headers['cache-control'], 'public, max-age=60');
+    });
+
+    it('leaves healthy renders and their Cache-Control untouched', async function () {
+        configUtils.set('optimization:getHelper:timeout:threshold', 5000);
+        configUtils.set('caching:frontend:maxAge', 600);
+
+        const res = await request.get('/welcome/')
+            .expect('Content-Type', /html/)
+            .expect(200);
+
+        assert(!res.text.includes('data-aborted-get-helper'));
+        assert.equal(res.headers['x-ghost-degraded-render'], undefined);
+        assert.equal(res.headers['cache-control'], 'public, max-age=600');
+    });
+});

--- a/ghost/core/test/unit/frontend/helpers/collection.test.js
+++ b/ghost/core/test/unit/frontend/helpers/collection.test.js
@@ -1,0 +1,97 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const configUtils = require('../../../utils/config-utils');
+const loggingLib = require('@tryghost/logging');
+
+// Stuff we are testing
+const collection = require('../../../../core/frontend/helpers/collection');
+const api = require('../../../../core/server/api').endpoints;
+
+describe('{{#collection}} helper', function () {
+    let fn;
+    let inverse;
+    let locals = {};
+    let logging;
+
+    beforeEach(function () {
+        fn = sinon.spy();
+        inverse = sinon.spy();
+
+        locals = {root: {_locals: {}}};
+
+        logging = {
+            error: sinon.stub(loggingLib, 'error'),
+            warn: sinon.stub(loggingLib, 'warn')
+        };
+    });
+
+    afterEach(async function () {
+        sinon.restore();
+        await configUtils.restore();
+    });
+
+    describe('optimization', function () {
+        beforeEach(function () {
+            sinon.stub(api, 'postsPublic').get(() => {
+                return {
+                    browse: () => {
+                        return new Promise((resolve) => {
+                            setTimeout(() => {
+                                resolve({posts: [{id: 'abcd1234'}]});
+                            }, 5);
+                        });
+                    }
+                };
+            });
+        });
+
+        it('should log an error and flag a degraded render if it hits the timeout threshold', async function () {
+            const clock = sinon.useFakeTimers({toFake: ['setTimeout', 'clearTimeout']});
+            try {
+                configUtils.set('optimization:getHelper:timeout:threshold', 1);
+
+                const resultPromise = collection.call(
+                    {},
+                    'featured',
+                    {hash: {}, data: locals, fn: fn, inverse: inverse}
+                );
+                // 2 > threshold (1), < stub's 5 — fires only the helper's timer.
+                await clock.tickAsync(2);
+                await resultPromise;
+
+                assert.equal(locals.root._locals.degradedRender, true);
+                sinon.assert.calledOnce(logging.error);
+                sinon.assert.calledOnce(fn);
+                const args = fn.firstCall.args[0];
+                assert(args && typeof args === 'object');
+                assert.deepEqual(args.posts, []);
+                assert(!('@@ABORTED_GET_HELPER@@' in args));
+            } finally {
+                clock.restore();
+            }
+        });
+
+        it('should return safely on timeout when _locals is not available', async function () {
+            const clock = sinon.useFakeTimers({toFake: ['setTimeout', 'clearTimeout']});
+            try {
+                configUtils.set('optimization:getHelper:timeout:threshold', 1);
+                locals = {root: {}};
+
+                const resultPromise = collection.call(
+                    {},
+                    'featured',
+                    {hash: {}, data: locals, fn: fn, inverse: inverse}
+                );
+                await clock.tickAsync(2);
+                await resultPromise;
+
+                sinon.assert.calledOnce(fn);
+                const args = fn.firstCall.args[0];
+                assert.deepEqual(args.posts, []);
+                assert(!('@@ABORTED_GET_HELPER@@' in args));
+            } finally {
+                clock.restore();
+            }
+        });
+    });
+});

--- a/ghost/core/test/unit/frontend/helpers/get.test.js
+++ b/ghost/core/test/unit/frontend/helpers/get.test.js
@@ -554,6 +554,7 @@ describe('{{#get}} helper', function () {
             const clock = sinon.useFakeTimers({toFake: ['setTimeout', 'clearTimeout']});
             try {
                 configUtils.set('optimization:getHelper:timeout:threshold', 1);
+                locals = {root: {_locals: {}}};
 
                 const resultPromise = get.call(
                     {},
@@ -565,12 +566,34 @@ describe('{{#get}} helper', function () {
                 const result = await resultPromise;
 
                 assert(result.toString().includes('data-aborted-get-helper'));
+                assert.equal(locals.root._locals.degradedRender, true);
                 sinon.assert.calledOnce(logging.error);
                 sinon.assert.calledOnce(fn);
                 const args = fn.firstCall.args[0];
                 assert(args && typeof args === 'object');
                 assert('posts' in args);
                 assert.deepEqual(args.posts, []);
+                assert(!('@@ABORTED_GET_HELPER@@' in args));
+            } finally {
+                clock.restore();
+            }
+        });
+
+        it('should return safely on timeout when _locals is not available', async function () {
+            const clock = sinon.useFakeTimers({toFake: ['setTimeout', 'clearTimeout']});
+            try {
+                configUtils.set('optimization:getHelper:timeout:threshold', 1);
+                locals = {root: {}};
+
+                const resultPromise = get.call(
+                    {},
+                    'posts',
+                    {hash: {}, data: locals, fn: fn, inverse: inverse}
+                );
+                await clock.tickAsync(2);
+                const result = await resultPromise;
+
+                assert(result.toString().includes('data-aborted-get-helper'));
             } finally {
                 clock.restore();
             }

--- a/ghost/core/test/unit/frontend/services/rendering/renderer.test.js
+++ b/ghost/core/test/unit/frontend/services/rendering/renderer.test.js
@@ -1,0 +1,87 @@
+const sinon = require('sinon');
+const renderer = require('../../../../../core/frontend/services/rendering/renderer');
+
+describe('Renderer', function () {
+    let req;
+    let res;
+
+    beforeEach(function () {
+        req = {
+            originalUrl: '/',
+            params: {},
+            body: {}
+        };
+        res = {
+            locals: {},
+            routerOptions: {},
+            // pre-set so templates.setTemplate returns early
+            _template: 'index',
+            render: sinon.stub().callsArgWith(2, null, '<html></html>'),
+            send: sinon.spy(),
+            set: sinon.spy(),
+            get: sinon.stub().returns(undefined)
+        };
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it('sends the rendered html without extra headers by default', function () {
+        renderer(req, res, {});
+
+        sinon.assert.calledOnceWithExactly(res.send, '<html></html>');
+        sinon.assert.notCalled(res.set);
+    });
+
+    it('caps public caching at 60s when the render was degraded', function () {
+        res.locals.degradedRender = true;
+        res.get.withArgs('Cache-Control').returns('public, max-age=600');
+
+        renderer(req, res, {});
+
+        sinon.assert.calledWithExactly(res.set, 'Cache-Control', 'public, max-age=60');
+        sinon.assert.calledWithExactly(res.set, 'X-Ghost-Degraded-Render', 'aborted-get-helper');
+        sinon.assert.calledOnceWithExactly(res.send, '<html></html>');
+    });
+
+    it('does not raise max-age above the existing public value on a degraded render', function () {
+        res.locals.degradedRender = true;
+        res.get.withArgs('Cache-Control').returns('public, max-age=0');
+
+        renderer(req, res, {});
+
+        sinon.assert.calledWithExactly(res.set, 'Cache-Control', 'public, max-age=0');
+        sinon.assert.calledWithExactly(res.set, 'X-Ghost-Degraded-Render', 'aborted-get-helper');
+    });
+
+    it('leaves private responses uncacheable on a degraded render', function () {
+        res.locals.degradedRender = true;
+        res.get.withArgs('Cache-Control').returns('no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0');
+
+        renderer(req, res, {});
+
+        sinon.assert.neverCalledWith(res.set, 'Cache-Control');
+        sinon.assert.calledWithExactly(res.set, 'X-Ghost-Degraded-Render', 'aborted-get-helper');
+        sinon.assert.calledOnceWithExactly(res.send, '<html></html>');
+    });
+
+    it('does not add caching headers when none were set on a degraded render', function () {
+        res.locals.degradedRender = true;
+
+        renderer(req, res, {});
+
+        sinon.assert.neverCalledWith(res.set, 'Cache-Control');
+        sinon.assert.calledWithExactly(res.set, 'X-Ghost-Degraded-Render', 'aborted-get-helper');
+    });
+
+    it('forwards render errors without sending a response', function () {
+        req.next = sinon.spy();
+        res.render = sinon.stub().callsArgWith(2, new Error('render failed'));
+
+        renderer(req, res, {});
+
+        sinon.assert.calledOnce(req.next);
+        sinon.assert.notCalled(res.send);
+    });
+});


### PR DESCRIPTION
ref
https://linear.app/ghost/issue/HKG-1925/prevent-timed-out-get-helpers-to-cache-a-page

- When a {{#get}} or {{#collection}} helper times out during frontend rendering, Ghost aborts the API call and renders the page with fallback content ("Could not load content" placeholder). This will cache the response only for 60s instead of forever.