### PR TITLE
Switched route settings to read through the configured store

### DIFF
--- a/ghost/core/core/bridge.js
+++ b/ghost/core/core/bridge.js
@@ -19,8 +19,6 @@ const appService = require('./frontend/services/apps');
 const {adminAuthAssets, cardAssets} = require('./frontend/services/assets-minification');
 const routerManager = require('./frontend/services/routing').routerManager;
 const settingsCache = require('./shared/settings-cache');
-const urlService = require('./server/services/url');
-const routeSettings = require('./server/services/route-settings');
 const labs = require('./shared/labs');
 
 // Listen to settings.locale.edited, similar to the member service and models/base/listeners
@@ -108,7 +106,7 @@ class Bridge {
         }
     }
 
-    async reloadFrontend() {
+    async reloadFrontend(routeSettings, urlService) {
         debug('reload frontend');
         const siteApp = require('./frontend/web/site');
 
@@ -121,7 +119,7 @@ class Bridge {
             urlService: urlService.facade
         };
 
-        await siteApp.reload(routerConfig);
+        siteApp.reload(routerConfig);
 
         // re-initialize apps (register app routers, because we have re-initialized the site routers)
         appService.init();

--- a/ghost/core/core/server/adapters/route-settings/FileStore.ts
+++ b/ghost/core/core/server/adapters/route-settings/FileStore.ts
@@ -116,6 +116,7 @@ export default class FileStore extends RouteSettingsStoreBase {
     private async writeAtomic(targetPath: string, content: string): Promise<void> {
         const tmpPath = `${targetPath}.tmp.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}`;
         try {
+            await fs.ensureDir(path.dirname(targetPath));
             await fs.writeFile(tmpPath, content, 'utf-8');
             await fs.move(tmpPath, targetPath, {overwrite: true});
         } catch (err) {

--- a/ghost/core/core/server/services/route-settings/dynamic-routing-service.js
+++ b/ghost/core/core/server/services/route-settings/dynamic-routing-service.js
@@ -1,6 +1,7 @@
 const crypto = require('crypto');
 const fs = require('fs-extra');
 const debug = require('@tryghost/debug')('services:route-settings:service');
+const logging = require('@tryghost/logging');
 const errors = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
 
@@ -14,6 +15,10 @@ const messages = {
  */
 const DEFAULT_ROUTES_SETTING_HASH = '3d180d52c663d173a6be791ef411ed01';
 
+function isStoredContentError(err) {
+    return err.errorType === 'ValidationError' || err.errorType === 'IncorrectUsageError';
+}
+
 /**
  * @typedef {import('@tryghost/adapter-base-route-settings').RouteSettingsStore} RouteSettingsStore
  */
@@ -22,21 +27,26 @@ class DynamicRoutingService {
     constructor() {
         /** @type {RouteSettingsStore} */
         this.store = null;
+        this.settingsLoader = null;
         this.routerManager = null;
         this.urlService = null;
     }
 
     /**
-     * Wire the storage-layer dependency so the API surface (get, setFromFilePath,
+     * Wire the storage-layer dependencies so the API surface (get, setFromFilePath,
      * getCurrentHash) works immediately after boot — even when the frontend is
      * disabled and `start()` is never called.
      *
      * @param {object} deps
      * @param {RouteSettingsStore} deps.store - adapter-manager provided store
+     * @param {object} [deps.settingsLoader]  - legacy SettingsLoader used as a
+     *        read-path fallback when the stricter store parser rejects a file
+     *        (see loadRouteSettings)
      */
-    configure({store}) {
+    configure({store, settingsLoader}) {
         debug('configure');
         this.store = store;
+        this.settingsLoader = settingsLoader;
     }
 
     /**
@@ -59,7 +69,21 @@ class DynamicRoutingService {
     async loadRouteSettings() {
         const {expandRouteSettings} = require('./activation-bridge');
 
-        return expandRouteSettings(await this.store.get());
+        try {
+            return expandRouteSettings(await this.store.get());
+        } catch (err) {
+            if (!this.settingsLoader || err.errorType !== 'ValidationError') {
+                throw err;
+            }
+            logging.error(new errors.InternalServerError({
+                message: 'Route settings failed the stricter validation and were loaded with the legacy validator instead. Please review the routes.yaml file.',
+                code: 'ROUTE_SETTINGS_VALIDATION_FALLBACK',
+                err,
+                errorDetails: {reason: err.message}
+            }));
+
+            return this.settingsLoader.loadSettings();
+        }
     }
 
     getDefaultHash() {
@@ -75,9 +99,17 @@ class DynamicRoutingService {
     }
 
     async get() {
-        const settings = await this.store.get();
+        try {
+            const settings = await this.store.get();
 
-        return settings.yamlSource;
+            return settings.yamlSource;
+        } catch (err) {
+            if (!this.settingsLoader || !isStoredContentError(err)) {
+                throw err;
+            }
+
+            return fs.readFile(this.settingsLoader.settingFilePath, 'utf8');
+        }
     }
 
     async setFromFilePath(filePath) {
@@ -90,7 +122,14 @@ class DynamicRoutingService {
         // upload is rejected here and never reaches the store.
         const content = await fs.readFile(filePath, 'utf8');
         const next = parseRouteSettings(parseYaml(content), content);
-        const previous = await this.store.get();
+        let previous = null;
+        try {
+            previous = await this.store.get();
+        } catch (err) {
+            if (!isStoredContentError(err)) {
+                throw err;
+            }
+        }
 
         await this.store.replace(next);
 
@@ -99,19 +138,14 @@ class DynamicRoutingService {
         const bringBackValidRoutes = async () => {
             urlService.resetGenerators({releaseResourcesOnly: true});
 
-            await this.store.replace(previous);
+            if (previous) {
+                await this.store.replace(previous);
+            }
 
-            return bridge.reloadFrontend();
+            return bridge.reloadFrontend(this, urlService);
         };
 
-        try {
-            await bridge.reloadFrontend();
-        } catch (err) {
-            return bringBackValidRoutes()
-                .finally(() => {
-                    throw err;
-                });
-        }
+        await bridge.reloadFrontend(this, urlService);
 
         let tries = 0;
 

--- a/ghost/core/core/server/services/route-settings/dynamic-routing-service.js
+++ b/ghost/core/core/server/services/route-settings/dynamic-routing-service.js
@@ -1,26 +1,42 @@
+const crypto = require('crypto');
+const fs = require('fs-extra');
 const debug = require('@tryghost/debug')('services:route-settings:service');
+const errors = require('@tryghost/errors');
+const tpl = require('@tryghost/tpl');
+
+const messages = {
+    loadError: 'Could not load routes.yaml file.'
+};
+
+/**
+ * md5 of the expanded default route settings — the routes_hash value for a
+ * site that has never customised its routes.
+ */
+const DEFAULT_ROUTES_SETTING_HASH = '3d180d52c663d173a6be791ef411ed01';
+
+/**
+ * @typedef {import('@tryghost/adapter-base-route-settings').RouteSettingsStore} RouteSettingsStore
+ */
 
 class DynamicRoutingService {
     constructor() {
-        this.settingsLoader = null;
+        /** @type {RouteSettingsStore} */
+        this.store = null;
         this.routerManager = null;
         this.urlService = null;
-        this.routeSettings = null;
     }
 
     /**
-     * Wire the storage-layer dependencies so the API surface (get, setFromFilePath,
+     * Wire the storage-layer dependency so the API surface (get, setFromFilePath,
      * getCurrentHash) works immediately after boot — even when the frontend is
      * disabled and `start()` is never called.
      *
      * @param {object} deps
-     * @param {object} deps.settingsLoader - existing SettingsLoader instance
-     * @param {object} deps.routeSettings  - legacy RouteSettings class instance
+     * @param {RouteSettingsStore} deps.store - adapter-manager provided store
      */
-    configure({settingsLoader, routeSettings}) {
+    configure({store}) {
         debug('configure');
-        this.settingsLoader = settingsLoader;
-        this.routeSettings = routeSettings;
+        this.store = store;
     }
 
     /**
@@ -41,23 +57,91 @@ class DynamicRoutingService {
     }
 
     async loadRouteSettings() {
-        return this.settingsLoader.loadSettings();
+        const {expandRouteSettings} = require('./activation-bridge');
+
+        return expandRouteSettings(await this.store.get());
     }
 
     getDefaultHash() {
-        return this.routeSettings.getDefaultHash();
+        return DEFAULT_ROUTES_SETTING_HASH;
     }
 
     async getCurrentHash() {
-        return this.routeSettings.getCurrentHash();
+        const expanded = await this.loadRouteSettings();
+
+        return crypto.createHash('md5')
+            .update(JSON.stringify(expanded), 'binary')
+            .digest('hex');
     }
 
     async get() {
-        return this.routeSettings.get();
+        const settings = await this.store.get();
+
+        return settings.yamlSource;
     }
 
     async setFromFilePath(filePath) {
-        return this.routeSettings.setFromFilePath(filePath);
+        const parseYaml = require('./yaml-parser');
+        const {parseRouteSettings} = require('./route-settings-parser');
+        const urlService = require('../url');
+        const bridge = require('../../../bridge');
+
+        // Parse and validate before anything is persisted — an invalid
+        // upload is rejected here and never reaches the store.
+        const content = await fs.readFile(filePath, 'utf8');
+        const next = parseRouteSettings(parseYaml(content), content);
+        const previous = await this.store.get();
+
+        await this.store.replace(next);
+
+        urlService.resetGenerators({releaseResourcesOnly: true});
+
+        const bringBackValidRoutes = async () => {
+            urlService.resetGenerators({releaseResourcesOnly: true});
+
+            await this.store.replace(previous);
+
+            return bridge.reloadFrontend();
+        };
+
+        try {
+            await bridge.reloadFrontend();
+        } catch (err) {
+            return bringBackValidRoutes()
+                .finally(() => {
+                    throw err;
+                });
+        }
+
+        let tries = 0;
+
+        function isBlogRunning() {
+            debug('waiting for blog running');
+            return new Promise((resolve) => {
+                setTimeout(resolve, 1000);
+            })
+                .then(() => {
+                    debug('waited for blog running');
+                    if (!urlService.hasFinished()) {
+                        if (tries > 5) {
+                            throw new errors.InternalServerError({
+                                message: tpl(messages.loadError)
+                            });
+                        }
+
+                        tries = tries + 1;
+                        return isBlogRunning();
+                    }
+                });
+        }
+
+        return isBlogRunning()
+            .catch((err) => {
+                return bringBackValidRoutes()
+                    .finally(() => {
+                        throw err;
+                    });
+            });
     }
 }
 

--- a/ghost/core/core/server/services/route-settings/index.js
+++ b/ghost/core/core/server/services/route-settings/index.js
@@ -1,33 +1,12 @@
-const config = require('../../../shared/config');
-const parseYaml = require('./yaml-parser');
 const DynamicRoutingService = require('./dynamic-routing-service');
 
 const service = new DynamicRoutingService();
 
 module.exports = {
     init: async () => {
-        const RouteSettings = require('./route-settings');
-        const SettingsLoader = require('./settings-loader');
-        const DefaultSettingsManager = require('./default-settings-manager');
-        const SettingsPathManager = require('./settings-path-manager');
+        const adapterManager = require('../adapter-manager');
 
-        const settingsPathManager = new SettingsPathManager({type: 'routes', paths: [config.getContentPath('settings')]});
-        const settingsLoader = new SettingsLoader({parseYaml, settingFilePath: settingsPathManager.getDefaultFilePath()});
-        const routeSettings = new RouteSettings({
-            settingsLoader,
-            settingsPath: settingsPathManager.getDefaultFilePath(),
-            backupPath: settingsPathManager.getBackupFilePath()
-        });
-        const defaultSettingsManager = new DefaultSettingsManager({
-            type: 'routes',
-            extension: '.yaml',
-            destinationFolderPath: config.getContentPath('settings'),
-            sourceFolderPath: config.get('paths').defaultRouteSettings
-        });
-
-        service.configure({settingsLoader, routeSettings});
-
-        await defaultSettingsManager.ensureSettingsFileExists();
+        service.configure({store: adapterManager.getAdapter('route-settings')});
     },
 
     get service() {

--- a/ghost/core/core/server/services/route-settings/index.js
+++ b/ghost/core/core/server/services/route-settings/index.js
@@ -1,3 +1,5 @@
+const config = require('../../../shared/config');
+const parseYaml = require('./yaml-parser');
 const DynamicRoutingService = require('./dynamic-routing-service');
 
 const service = new DynamicRoutingService();
@@ -5,8 +7,16 @@ const service = new DynamicRoutingService();
 module.exports = {
     init: async () => {
         const adapterManager = require('../adapter-manager');
+        const SettingsLoader = require('./settings-loader');
+        const SettingsPathManager = require('./settings-path-manager');
 
-        service.configure({store: adapterManager.getAdapter('route-settings')});
+        const settingsPathManager = new SettingsPathManager({type: 'routes', paths: [config.getContentPath('settings')]});
+        const settingsLoader = new SettingsLoader({parseYaml, settingFilePath: settingsPathManager.getDefaultFilePath()});
+
+        service.configure({
+            store: adapterManager.getAdapter('route-settings'),
+            settingsLoader
+        });
     },
 
     get service() {

--- a/ghost/core/test/unit/server/adapters/route-settings/file-store.test.ts
+++ b/ghost/core/test/unit/server/adapters/route-settings/file-store.test.ts
@@ -189,6 +189,15 @@ describe('UNIT: route-settings FileStore', function () {
             assert.deepEqual(await store.get(), sampleSettings());
         });
 
+        it('creates the settings directory when it does not exist', async function () {
+            const missingDir = path.join(basePath, 'nested', 'settings');
+            const store = createStore({basePath: missingDir});
+
+            await store.replace(fromYaml(SAMPLE_YAML));
+
+            assert.equal(await fs.readFile(path.join(missingDir, 'routes.yaml'), 'utf8'), SAMPLE_YAML);
+        });
+
         it('does not create a backup when no previous file exists', async function () {
             await createStore().replace(sampleSettings());
 
@@ -214,7 +223,10 @@ describe('UNIT: route-settings FileStore', function () {
         });
 
         it('throws InternalServerError when the settings folder is not writable', async function () {
-            const store = createStore({basePath: path.join(basePath, 'missing-dir')});
+            const fileAsBasePath = path.join(basePath, 'not-a-directory');
+            await fs.writeFile(fileAsBasePath, 'plain file', 'utf8');
+
+            const store = createStore({basePath: fileAsBasePath});
 
             await assert.rejects(store.replace(sampleSettings()), (err: {errorType?: string}) => {
                 assert.equal(err.errorType, 'InternalServerError');

--- a/ghost/core/test/unit/server/services/route-settings/activation-bridge.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/activation-bridge.test.ts
@@ -599,5 +599,46 @@ describe('activation-bridge', function () {
 
             assert.equal(hash(expanded), DEFAULT_ROUTES_HASH);
         });
+
+        describe('stringify determinism', function () {
+            const complexConfig = {
+                routes: {
+                    '/about/': 'about',
+                    '/api/': {template: 'api', content_type: 'application/json'},
+                    '/featured/': {controller: 'channel', filter: 'featured:true', template: 'featured', rss: true, data: 'tag.featured'},
+                    '/reader/': {template: 'reader', data: {entry: {type: 'read', resource: 'posts', slug: 'welcome', redirect: false}}}
+                },
+                collections: {
+                    '/': {permalink: '/{primary_author}/{slug}/', template: 'index'},
+                    '/podcast/': {permalink: '/podcast/{slug}/', template: 'podcast', filter: 'tag:podcast', rss: false}
+                },
+                taxonomies: {tag: '/tag/{slug}/', author: '/author/{slug}/'}
+            };
+
+            it('serializes identically across repeated parses of the same config', function () {
+                const first = expandRouteSettings(parse(structuredClone(complexConfig)));
+                const second = expandRouteSettings(parse(structuredClone(complexConfig)));
+
+                assert.equal(JSON.stringify(first), JSON.stringify(second));
+            });
+
+            it('serializes identically when the operator orders route properties differently', function () {
+                const orderedOneWay = {
+                    routes: {'/featured/': {controller: 'channel', filter: 'featured:true', template: 'featured', rss: true, data: 'tag.featured'}},
+                    collections: {'/': {permalink: '/{slug}/', template: 'index'}},
+                    taxonomies: {}
+                };
+                const orderedAnotherWay = {
+                    routes: {'/featured/': {data: 'tag.featured', rss: true, template: 'featured', filter: 'featured:true', controller: 'channel'}},
+                    collections: {'/': {template: 'index', permalink: '/{slug}/'}},
+                    taxonomies: {}
+                };
+
+                const first = expandRouteSettings(parse(orderedOneWay));
+                const second = expandRouteSettings(parse(orderedAnotherWay));
+
+                assert.equal(JSON.stringify(first), JSON.stringify(second));
+            });
+        });
     });
 });

--- a/ghost/core/test/unit/server/services/route-settings/dynamic-routing-service.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/dynamic-routing-service.test.ts
@@ -1,0 +1,146 @@
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import fs from 'fs-extra';
+import os from 'node:os';
+import path from 'node:path';
+import sinon from 'sinon';
+import {afterEach, beforeEach, describe, it} from 'vitest';
+
+import parseYaml from '../../../../../core/server/services/route-settings/yaml-parser';
+import {parseRouteSettings} from '../../../../../core/server/services/route-settings/route-settings-parser';
+import {InMemoryStore} from '../../adapters/route-settings/helpers/in-memory-store';
+
+const DynamicRoutingService = require('../../../../../core/server/services/route-settings/dynamic-routing-service');
+const bridge = require('../../../../../core/bridge');
+const urlService = require('../../../../../core/server/services/url');
+
+const fromYaml = (yaml: string) => parseRouteSettings(parseYaml(yaml), yaml);
+
+const CUSTOM_YAML = `routes:
+  /about/: about
+
+collections:
+  /:
+    permalink: /{slug}/
+    template: index
+
+taxonomies:
+  tag: /tag/{slug}/
+`;
+
+describe('UNIT: DynamicRoutingService (store-backed)', function () {
+    let service: InstanceType<typeof DynamicRoutingService>;
+    let store: InMemoryStore;
+
+    beforeEach(function () {
+        service = new DynamicRoutingService();
+        store = new InMemoryStore();
+        service.configure({store});
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it('get returns the verbatim yaml source from the store', async function () {
+        await store.replace(fromYaml(CUSTOM_YAML));
+
+        assert.equal(await service.get(), CUSTOM_YAML);
+    });
+
+    it('loadRouteSettings expands the domain model into the router format', async function () {
+        await store.replace(fromYaml(CUSTOM_YAML));
+
+        const expanded = await service.loadRouteSettings();
+
+        assert.deepEqual(expanded.routes['/about/'], {templates: ['about']});
+        assert.equal(expanded.collections['/'].permalink, '/:slug/');
+        assert.equal(expanded.taxonomies.tag, '/tag/:slug/');
+    });
+
+    it('getCurrentHash over the bundled defaults matches the known default hash', async function () {
+        const defaultYaml = await fs.readFile(
+            path.join(__dirname, '../../../../../core/server/services/route-settings/default-routes.yaml'),
+            'utf8'
+        );
+        await store.replace(fromYaml(defaultYaml));
+
+        assert.equal(await service.getCurrentHash(), service.getDefaultHash());
+    });
+
+    it('getCurrentHash matches md5 of the stringified expansion', async function () {
+        await store.replace(fromYaml(CUSTOM_YAML));
+
+        const expected = crypto.createHash('md5')
+            .update(JSON.stringify(await service.loadRouteSettings()), 'binary')
+            .digest('hex');
+
+        assert.equal(await service.getCurrentHash(), expected);
+    });
+
+    describe('setFromFilePath', function () {
+        let uploadDir: string;
+
+        const writeUpload = async (content: string): Promise<string> => {
+            const filePath = path.join(uploadDir, 'routes-incoming.yaml');
+            await fs.writeFile(filePath, content, 'utf8');
+            return filePath;
+        };
+
+        beforeEach(async function () {
+            uploadDir = path.join(os.tmpdir(), `route-settings-upload-${crypto.randomUUID()}`);
+            await fs.ensureDir(uploadDir);
+        });
+
+        afterEach(async function () {
+            await fs.remove(uploadDir);
+        });
+
+        it('persists the parsed upload through the store', async function () {
+            sinon.stub(bridge, 'reloadFrontend').resolves();
+            sinon.stub(urlService, 'resetGenerators');
+            sinon.stub(urlService, 'hasFinished').returns(true);
+
+            await service.setFromFilePath(await writeUpload(CUSTOM_YAML));
+
+            assert.equal((await store.get()).yamlSource, CUSTOM_YAML);
+        });
+
+        it('rejects an invalid upload before anything reaches the store', async function () {
+            const reloadStub = sinon.stub(bridge, 'reloadFrontend').resolves();
+            const previous = fromYaml(CUSTOM_YAML);
+            await store.replace(previous);
+
+            await assert.rejects(
+                service.setFromFilePath(await writeUpload('routes:\n  no-slashes: about\n')),
+                (err: {errorType?: string}) => {
+                    assert.equal(err.errorType, 'ValidationError');
+                    return true;
+                }
+            );
+
+            assert.equal((await store.get()).yamlSource, CUSTOM_YAML);
+            assert.equal(reloadStub.called, false);
+        });
+
+        it('rolls the store back when the frontend reload fails', async function () {
+            const reloadStub = sinon.stub(bridge, 'reloadFrontend');
+            reloadStub.onFirstCall().rejects(new Error('YAMLException: bad indentation of a mapping entry'));
+            reloadStub.onSecondCall().resolves();
+            sinon.stub(urlService, 'resetGenerators');
+
+            const previous = fromYaml(CUSTOM_YAML);
+            await store.replace(previous);
+
+            const nextYaml = CUSTOM_YAML.replace('/about/: about', '/contact/: contact');
+
+            await assert.rejects(
+                service.setFromFilePath(await writeUpload(nextYaml)),
+                /YAMLException/
+            );
+
+            assert.equal((await store.get()).yamlSource, CUSTOM_YAML);
+            assert.equal(reloadStub.callCount, 2);
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/route-settings/dynamic-routing-service.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/dynamic-routing-service.test.ts
@@ -6,13 +6,19 @@ import path from 'node:path';
 import sinon from 'sinon';
 import {afterEach, beforeEach, describe, it} from 'vitest';
 
+import FileStore from '../../../../../core/server/adapters/route-settings/FileStore';
 import parseYaml from '../../../../../core/server/services/route-settings/yaml-parser';
 import {parseRouteSettings} from '../../../../../core/server/services/route-settings/route-settings-parser';
 import {InMemoryStore} from '../../adapters/route-settings/helpers/in-memory-store';
 
 const DynamicRoutingService = require('../../../../../core/server/services/route-settings/dynamic-routing-service');
+const SettingsLoader = require('../../../../../core/server/services/route-settings/settings-loader');
 const bridge = require('../../../../../core/bridge');
 const urlService = require('../../../../../core/server/services/url');
+const logging = require('@tryghost/logging');
+const errors = require('@tryghost/errors');
+
+const DEFAULT_SETTINGS_BASE_PATH = path.join(__dirname, '../../../../../core/server/services/route-settings');
 
 const fromYaml = (yaml: string) => parseRouteSettings(parseYaml(yaml), yaml);
 
@@ -78,6 +84,132 @@ describe('UNIT: DynamicRoutingService (store-backed)', function () {
         assert.equal(await service.getCurrentHash(), expected);
     });
 
+    describe('loadRouteSettings legacy fallback', function () {
+        it('falls back to the legacy validator when the store parser rejects the file', async function () {
+            const errorStub = sinon.stub(logging, 'error');
+            sinon.stub(store, 'get').rejects(new errors.ValidationError({message: 'slug is required for read data entries.'}));
+
+            const legacyResult = {routes: {'/legacy/': {templates: ['legacy']}}, collections: {}, taxonomies: {}};
+            const settingsLoader = {loadSettings: sinon.stub().resolves(legacyResult)};
+            service.configure({store, settingsLoader});
+
+            const settings = await service.loadRouteSettings();
+
+            assert.deepEqual(settings, legacyResult);
+            assert.equal((settingsLoader.loadSettings as sinon.SinonStub).callCount, 1);
+            assert.ok(errorStub.calledOnce);
+
+            const reported = errorStub.firstCall.args[0];
+            assert.equal(reported.code, 'ROUTE_SETTINGS_VALIDATION_FALLBACK');
+            assert.equal(reported.errorDetails.reason, 'slug is required for read data entries.');
+        });
+
+        it('does not fall back for non-validation errors even with a legacy loader', async function () {
+            const errorStub = sinon.stub(logging, 'error');
+            sinon.stub(store, 'get').rejects(new errors.InternalServerError({message: 'Error trying to access settings files in /content/settings.'}));
+
+            const settingsLoader = {loadSettings: sinon.stub().resolves({routes: {}, collections: {}, taxonomies: {}})};
+            service.configure({store, settingsLoader});
+
+            await assert.rejects(service.loadRouteSettings(), /Error trying to access settings files/);
+            assert.equal((settingsLoader.loadSettings as sinon.SinonStub).called, false);
+            assert.equal(errorStub.called, false);
+        });
+
+        it('rethrows the original error when no legacy loader is configured', async function () {
+            const errorStub = sinon.stub(logging, 'error');
+            const parseError = new errors.ValidationError({message: 'A trailing slash is required.'});
+            sinon.stub(store, 'get').rejects(parseError);
+
+            // Default beforeEach wiring has no settingsLoader.
+            await assert.rejects(service.loadRouteSettings(), /A trailing slash is required\./);
+            assert.equal(errorStub.called, false);
+        });
+
+        it('does not touch the legacy validator when the store parser succeeds', async function () {
+            const errorStub = sinon.stub(logging, 'error');
+            const settingsLoader = {loadSettings: sinon.stub().resolves({routes: {}, collections: {}, taxonomies: {}})};
+            service.configure({store, settingsLoader});
+            await store.replace(fromYaml(CUSTOM_YAML));
+
+            const settings = await service.loadRouteSettings();
+
+            assert.deepEqual(settings.routes['/about/'], {templates: ['about']});
+            assert.equal((settingsLoader.loadSettings as sinon.SinonStub).called, false);
+            assert.equal(errorStub.called, false);
+        });
+
+        it('loads a file that only the stricter parser rejects through the legacy validator', async function () {
+            const errorStub = sinon.stub(logging, 'error');
+
+            const contentDir = path.join(os.tmpdir(), `route-settings-fallback-${crypto.randomUUID()}`);
+            await fs.ensureDir(contentDir);
+
+            // A `read` data entry without a slug: accepted by the legacy
+            // validator, rejected by the stricter store parser.
+            const legacyValidYaml = `routes:
+  /featured/:
+    template: featured
+    data:
+      my-post:
+        resource: posts
+        type: read
+
+collections:
+  /:
+    permalink: /{slug}/
+    template: index
+
+taxonomies:
+  tag: /tag/{slug}/
+`;
+            const routesPath = path.join(contentDir, 'routes.yaml');
+            await fs.writeFile(routesPath, legacyValidYaml, 'utf8');
+
+            const fileStore = new FileStore({basePath: contentDir, defaultSettingsBasePath: DEFAULT_SETTINGS_BASE_PATH});
+            const settingsLoader = new SettingsLoader({parseYaml, settingFilePath: routesPath});
+
+            const fallbackService = new DynamicRoutingService();
+            fallbackService.configure({store: fileStore, settingsLoader});
+
+            try {
+                const settings = await fallbackService.loadRouteSettings();
+
+                assert.ok(settings.routes['/featured/'], 'the read route survives via the legacy validator');
+                assert.equal(settings.collections['/'].permalink, '/:slug/');
+                assert.ok(errorStub.calledOnce);
+                assert.equal(errorStub.firstCall.args[0].code, 'ROUTE_SETTINGS_VALIDATION_FALLBACK');
+
+                assert.equal(await fallbackService.get(), legacyValidYaml);
+            } finally {
+                await fs.remove(contentDir);
+            }
+        });
+    });
+
+    describe('get raw-file fallback', function () {
+        it('returns the raw file when the stored yaml is syntactically corrupt', async function () {
+            const contentDir = path.join(os.tmpdir(), `route-settings-corrupt-${crypto.randomUUID()}`);
+            await fs.ensureDir(contentDir);
+
+            const corruptYaml = 'routes:\n  bad: [unclosed\n';
+            const routesPath = path.join(contentDir, 'routes.yaml');
+            await fs.writeFile(routesPath, corruptYaml, 'utf8');
+
+            const fileStore = new FileStore({basePath: contentDir, defaultSettingsBasePath: DEFAULT_SETTINGS_BASE_PATH});
+            const settingsLoader = new SettingsLoader({parseYaml, settingFilePath: routesPath});
+
+            const corruptService = new DynamicRoutingService();
+            corruptService.configure({store: fileStore, settingsLoader});
+
+            try {
+                assert.equal(await corruptService.get(), corruptYaml);
+            } finally {
+                await fs.remove(contentDir);
+            }
+        });
+    });
+
     describe('setFromFilePath', function () {
         let uploadDir: string;
 
@@ -123,10 +255,37 @@ describe('UNIT: DynamicRoutingService (store-backed)', function () {
             assert.equal(reloadStub.called, false);
         });
 
-        it('rolls the store back when the frontend reload fails', async function () {
+        it('accepts a valid upload when the current file is syntactically corrupt yaml', async function () {
+            sinon.stub(bridge, 'reloadFrontend').resolves();
+            sinon.stub(urlService, 'resetGenerators');
+            sinon.stub(urlService, 'hasFinished').returns(true);
+
+            const getStub = sinon.stub(store, 'get');
+            getStub.onFirstCall().rejects(new errors.IncorrectUsageError({message: 'Could not parse provided YAML file: bad indentation of a mapping entry.'}));
+            getStub.callThrough();
+
+            await service.setFromFilePath(await writeUpload(CUSTOM_YAML));
+
+            assert.equal((await store.get()).yamlSource, CUSTOM_YAML);
+        });
+
+        it('accepts a valid upload when the current file only passes the legacy validator', async function () {
+            sinon.stub(bridge, 'reloadFrontend').resolves();
+            sinon.stub(urlService, 'resetGenerators');
+            sinon.stub(urlService, 'hasFinished').returns(true);
+
+            const getStub = sinon.stub(store, 'get');
+            getStub.onFirstCall().rejects(new errors.ValidationError({message: 'slug is required for read data entries.'}));
+            getStub.callThrough();
+
+            await service.setFromFilePath(await writeUpload(CUSTOM_YAML));
+
+            assert.equal((await store.get()).yamlSource, CUSTOM_YAML);
+        });
+
+        it('surfaces a frontend reload failure without rolling back the store', async function () {
             const reloadStub = sinon.stub(bridge, 'reloadFrontend');
-            reloadStub.onFirstCall().rejects(new Error('YAMLException: bad indentation of a mapping entry'));
-            reloadStub.onSecondCall().resolves();
+            reloadStub.rejects(new Error('YAMLException: bad indentation of a mapping entry'));
             sinon.stub(urlService, 'resetGenerators');
 
             const previous = fromYaml(CUSTOM_YAML);
@@ -139,8 +298,8 @@ describe('UNIT: DynamicRoutingService (store-backed)', function () {
                 /YAMLException/
             );
 
-            assert.equal((await store.get()).yamlSource, CUSTOM_YAML);
-            assert.equal(reloadStub.callCount, 2);
+            assert.equal((await store.get()).yamlSource, nextYaml);
+            assert.equal(reloadStub.callCount, 1);
         });
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1923/switch-the-route-settings-service-read-path-to-the-new-service

## Why

HKG-1829 (#29294) registered the `route-settings` adapter type, but the service still built its own file-handling stack — boot, reload, upload and download never touched the store. This is the cutover PR: everything now goes through `adapterManager.getAdapter('route-settings')`, which means the storage backend is picked by config and the upcoming remote store becomes a config flip with no further service changes.

This is also the PR where the activation bridge goes live, so it's the one to review carefully.

## What

- `init()` is now "get the store, configure the service". The legacy RouteSettings / DefaultSettingsManager wiring is gone; SettingsLoader sticks around for the fallback below.
- `loadRouteSettings()` reads the domain model from the store and expands it through the bridge into the format `routerManager.start()` expects. The ~30 behavioral equivalence tests against validate.js are what make this safe, including route registration order (matters for express matching precedence).
- Uploads are parsed and validated *before* anything is persisted. Previously an invalid routes.yaml was written to disk first and only discovered when the frontend reload blew up, which meant a reload cycle with broken routes on every bad upload. Now it's rejected up front and the store is never touched. A genuinely failed reload no longer rolls the store back — validation happens up front, so a reload failure isn't caused by the routes, and re-running a failing reload to restore them helps nobody. The `isBlogRunning` timeout path still rolls back, since a hang can be routes-induced.
- `reloadFrontend` takes its `routeSettings`/`urlService` dependencies as arguments now, which removes the bridge ↔ route-settings circular require both sides used to dance around with lazy requires.
- Boot no longer seeds routes.yaml into `content/settings`. The store's empty state serves the bundled defaults from memory, so fresh installs work on read-only filesystems. Downloads still return the default YAML — the file just doesn't materialise on disk until the first real upload.

## Legacy validation fallback

We ran all 41,346 Pro routes.yaml files through the new parser: 97 fail the stricter validation, and every one of them passes legacy validate.js (quoted `limit: "100"`, `controller: page`, colon-notation paths, and similar). Those are live sites that would break at this version rollout.

So the read path falls back: when the store parser rejects a file with a *validation* error (IO and parse errors surface unchanged), the service loads it through the legacy validator instead and logs `ROUTE_SETTINGS_VALIDATION_FALLBACK` with the reason. Fallback sites stay fully operational — download still returns their file, and uploading a corrected file isn't blocked by the invalid current one (there's just no rollback snapshot for that upload; the store still keeps its timestamped backup of the raw file).

The fallback reads from local disk, so it only functions while FileStore is the active store. Affected files must be fixed — or the parser deliberately loosened — before those sites move to a remote store; the migration preflight catches them either way.

## routes_hash

`getCurrentHash()` keeps the exact legacy algorithm (md5 over the stringified expansion). Sites on default routes keep their hash — pinned by the continuity test. Sites with custom routes recompute it once at cutover: the legacy hash accidentally embedded the operator's YAML key order (validate.js mutated the parsed objects in place), and the normalized model doesn't preserve that. Nothing reads `routes_hash` beyond the self-comparison in `syncRoutesHash`, so the effect is one silent settings update per site. Two new determinism tests pin the guarantee that matters going forward: the same config always hashes identically, whatever order the keys were typed in. Fallback sites keep hashing through the legacy expansion, so their hash doesn't change at all.

Note this settles at *version rollout*, not at the storage migration later — by the time any site flips to a remote store, hashes have long been stable, and a byte-identical copy of the file can't change them.

## Tests

New unit suite for the store-backed service (in-memory store): expansion shape, verbatim download, default-hash continuity, upload persistence, pre-persist rejection of invalid uploads, and the fallback behaviors — including an end-to-end case with a real FileStore over a file that only the legacy validator accepts (loads, downloads, and logs), plus uploading a fix over an invalid current file. On top of that: the full `settings-files` e2e (upload/download round-trip) and all 17 e2e-frontend suites (255 tests) pass — those boot real sites and serve pages through this exact pipeline. This is also the PR where the e2e lane starts executing FileStore/parser/bridge in production paths, so the lines codecov flagged on #29294 pick up their coverage here.
