### PR TITLE
Fixed scheduler retrying publish jobs when there is nothing to publish

### DIFF
--- a/ghost/core/core/server/api/endpoints/schedules.js
+++ b/ghost/core/core/server/api/endpoints/schedules.js
@@ -1,4 +1,14 @@
 const postScheduling = require('../../services/posts/post-scheduling');
+const permissions = require('../../services/permissions');
+const errors = require('@tryghost/errors');
+
+function setCacheInvalidateHeader(frame, cacheInvalidation) {
+    if (cacheInvalidation === true) {
+        frame.setHeader('X-Cache-Invalidate', '/*');
+    } else if (cacheInvalidation.value) {
+        frame.setHeader('X-Cache-Invalidate', cacheInvalidation.value);
+    }
+}
 
 /** @type {import('@tryghost/api-framework').Controller} */
 const controller = {
@@ -25,8 +35,22 @@ const controller = {
                 }
             }
         },
-        permissions: {
-            docName: 'posts'
+        // Runs the standard post:publish check, but tolerates a missing
+        // resource: a scheduler that can't invalidate its jobs may fire one for
+        // a post/page that has since been deleted, which should be a no-op
+        // rather than a 404 it will retry. Only NotFoundError is swallowed —
+        // NoPermissionError and everything else still propagate, so permission
+        // enforcement on resources that DO exist is unchanged. The controller's
+        // own read then hits the same NotFound and returns the no-op.
+        permissions(frame) {
+            return permissions.canThis(frame.options.context).publish.post(frame.options.id)
+                .catch((err) => {
+                    if (errors.utils.isGhostError(err) && err.errorType === 'NotFoundError') {
+                        return;
+                    }
+
+                    throw err;
+                });
         },
         async query(frame) {
             const resourceType = frame.options.resource;
@@ -39,15 +63,19 @@ const controller = {
             };
 
             const {scheduledResource, preScheduledResource} = await postScheduling.publish(resourceType, frame.options.id, frame.data.force, options);
-            const cacheInvalidation = postScheduling.handleCacheInvalidation(scheduledResource, preScheduledResource);
-
-            if (cacheInvalidation === true) {
-                frame.setHeader('X-Cache-Invalidate', '/*');
-            } else if (cacheInvalidation.value) {
-                frame.setHeader('X-Cache-Invalidate', cacheInvalidation.value);
-            }
 
             const response = {};
+
+            // Nothing to publish — fired ahead of the scheduled time, or the
+            // resource was deleted. Respond 2xx with an empty list so the
+            // scheduler treats the job as done and does not retry.
+            if (!scheduledResource) {
+                response[resourceType] = [];
+                return response;
+            }
+
+            setCacheInvalidateHeader(frame, postScheduling.handleCacheInvalidation(scheduledResource, preScheduledResource));
+
             response[resourceType] = [scheduledResource];
             return response;
         }

--- a/ghost/core/core/server/services/posts/post-scheduling.js
+++ b/ghost/core/core/server/services/posts/post-scheduling.js
@@ -6,9 +6,15 @@ const urlUtils = require('../../../shared/url-utils');
 const api = require('../../api').endpoints;
 
 const messages = {
-    jobNotFound: 'Job not found.',
     jobPublishInThePast: 'Use the force flag to publish a post in the past.'
 };
+
+// Returned when there is nothing to publish — the job fired ahead of its
+// scheduled time (e.g. the post was rescheduled later but the scheduler still
+// holds the original, earlier job), or the resource was deleted. Lets the
+// caller respond 2xx so the scheduler treats the job as done rather than
+// retrying a publish that will never happen.
+const NO_OP = {scheduledResource: null, preScheduledResource: null};
 
 /**
  * Publishes scheduled resource (a post or a page at the moment of writing)
@@ -17,20 +23,35 @@ const messages = {
  * @param {string} id resource id
  * @param {boolean} force force publish flag
  * @param {Object} options api query options
- * @returns {Promise<Object, Object>}
+ * @returns {Promise<Object, Object>} the published resource, or a no-op with
+ *   `scheduledResource: null` when there was nothing to publish yet
  */
 exports.publish = async (resourceType, id, force, options) => {
     const publishAPostBySchedulerToleranceInMinutes = config.get('times').publishAPostBySchedulerToleranceInMinutes;
 
-    const result = await api[resourceType].read({id}, options);
-    const preScheduledResource = result[resourceType][0];
+    let preScheduledResource;
+    try {
+        const result = await api[resourceType].read({id}, options);
+        preScheduledResource = result[resourceType][0];
+    } catch (err) {
+        // Resource was deleted between scheduling and firing — nothing to
+        // publish. (The permissions stage tolerates the same NotFound so the
+        // request reaches here.)
+        if (errors.utils.isGhostError(err) && err.errorType === 'NotFoundError') {
+            return NO_OP;
+        }
+
+        throw err;
+    }
 
     const publishedAtMoment = moment(preScheduledResource.published_at);
 
     if (publishedAtMoment.diff(moment(), 'minutes') > publishAPostBySchedulerToleranceInMinutes) {
-        return Promise.reject(new errors.NotFoundError({message: messages.jobNotFound}));
+        return NO_OP;
     }
 
+    // Past the tolerance without a force flag is a genuinely dropped publish, so
+    // keep it an error rather than silently skipping it.
     if (publishedAtMoment.diff(moment(), 'minutes') < publishAPostBySchedulerToleranceInMinutes * -1 && force !== true) {
         return Promise.reject(new errors.NotFoundError({message: messages.jobPublishInThePast}));
     }

--- a/ghost/core/test/legacy/api/admin/schedules.test.js
+++ b/ghost/core/test/legacy/api/admin/schedules.test.js
@@ -126,6 +126,10 @@ describe('Schedules API', function () {
         });
 
         it('no access', function () {
+            // Also guards the missing-resource tolerance in the `permissions`
+            // handler: this key lacks publish permission and the post exists, so
+            // it must get a 403 — proving only NotFoundError is swallowed there,
+            // never NoPermissionError.
             const zapierKey = _.find(testUtils.getExistingData().apiKeys, {integration: {slug: 'ghost-backup'}});
             const zapierToken = localUtils.getValidAdminToken('/admin/', zapierKey);
 
@@ -152,12 +156,37 @@ describe('Schedules API', function () {
                 .expect(200);
         });
 
-        it('not found', function () {
-            return request
+        it('firing ahead of the scheduled time is a no-op, not an error', async function () {
+            // resources[2] is scheduled 10 minutes out, beyond tolerance.
+            const res = await request
                 .put(localUtils.API.getApiQuery(`schedules/posts/${resources[2].id}/?token=${token}`))
                 .expect('Content-Type', /json/)
                 .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200);
+
+            assert.deepEqual(res.body.posts, []);
+        });
+
+        it('firing well after the scheduled time without force stays an error', function () {
+            // resources[3] is scheduled 10 minutes in the past, beyond tolerance.
+            return request
+                .put(localUtils.API.getApiQuery(`schedules/posts/${resources[3].id}/?token=${token}`))
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
                 .expect(404);
+        });
+
+        it('a deleted resource is a no-op, not an error', async function () {
+            // A scheduler that can't invalidate its jobs may fire one for a post
+            // that has since been deleted. That should be a 2xx no-op it won't
+            // retry, not a 404. (The id below is well-formed but does not exist.)
+            const res = await request
+                .put(localUtils.API.getApiQuery(`schedules/posts/619000000000000000000000/?token=${token}`))
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200);
+
+            assert.deepEqual(res.body.posts, []);
         });
 
         it('force publish', function () {


### PR DESCRIPTION
Ghost's scheduler pings the publish endpoint (`PUT /schedules/:resource/:id`) when a scheduled post or page is due. Previously this endpoint returned a 404 in two situations where there is genuinely nothing to publish: when it fires *ahead* of the scheduled time, and when the target resource no longer exists. Schedulers treat any non-2xx response as a failure and retry it — Ghost's production remote scheduler retries any non-2xx up to a limit — so each of these benign cases turned into a retry storm plus error logs that drown out real failures.

This changes both cases to a 2xx no-op so the job is treated as done:

- **Fired ahead of the scheduled time.** When a post is rescheduled to a *later* time, a scheduler that can't invalidate its original job still fires at the old, earlier time. There is nothing to publish yet, so the controller now returns an empty resource list instead of throwing `NotFound`.
- **Resource no longer exists.** The scheduler holds a job for a post or page that has since been deleted. Ghost's permission stage loads the resource by id and 404s for a missing one *before* the controller runs, so this case needed a custom `permissions` handler on the endpoint. The handler runs the normal `post:publish` check but tolerates a missing resource, letting the controller return an empty list.

Firing well *after* the scheduled time without a `force` flag still errors — that's a genuinely dropped publish worth surfacing, and its behavior is unchanged.

## Security

The custom permissions handler swallows **only** `NotFoundError` (resource missing). `NoPermissionError` and every other error still propagate, so permission enforcement on resources that DO exist is unchanged: a caller without `post:publish` hitting an existing post still gets a 403 (covered by a regression test). No new information is exposed either — an authenticated caller could already distinguish missing (404) from unauthorized-but-existing (403) today. This only changes the missing case's status to 200, and it remains a pure no-op with no side effects.

## Testing

Regression tests were added and updated in the legacy schedules API suite: fired-ahead returns 200 with an empty body; a deleted resource returns 200 with an empty body; past-without-force still returns 404; and the existing "no access" test (non-scheduler key on an existing post → 403) guards that the permissions handler only swallows `NotFound`, never a permission error.