### PR TITLE
Fixed thin-resource errors for URL generation on filtered collections

### DIFF
--- a/ghost/core/core/server/api/endpoints/email-post.js
+++ b/ghost/core/core/server/api/endpoints/email-post.js
@@ -1,7 +1,7 @@
 const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const models = require('../../models');
-const urlService = require('../../services/url');
+const urlSerializerUtils = require('./utils/serializers/input/utils/url');
 const ALLOWED_INCLUDES = ['authors', 'tags', 'tiers'];
 
 const messages = {
@@ -36,12 +36,9 @@ const controller = {
             }
         },
         async query(frame) {
-            const callerIncludes = Array.isArray(frame.options.withRelated) ? frame.options.withRelated : [];
-            const options = {
-                ...frame.options,
-                withRelated: [...new Set([...callerIncludes, ...urlService.facade.getRequiredRelations()])]
-            };
-            const model = await models.Post.findOne(Object.assign(frame.data, {status: 'sent'}), options);
+            urlSerializerUtils.forceUrlRelationsWhenLazy(frame, 'posts');
+
+            const model = await models.Post.findOne(Object.assign(frame.data, {status: 'sent'}), frame.options);
 
             if (!model) {
                 throw new errors.NotFoundError({

--- a/ghost/core/core/server/api/endpoints/previews.js
+++ b/ghost/core/core/server/api/endpoints/previews.js
@@ -71,10 +71,7 @@ const controller = {
         async query(frame) {
             await _addMemberContextToFrame(frame);
 
-            // The previews response serializes `url` through the same posts
-            // mapper as the other endpoints, so the relations the lazy URL
-            // service reads must be loaded here too; the mapper strips the
-            // forced ones from the response after the URL is built.
+            // previews has no input serializer, so the URL force-load happens here
             urlSerializerUtils.forceUrlRelationsWhenLazy(frame, 'posts');
 
             const model = await models.Post.findOne(Object.assign({status: 'all'}, frame.data), frame.options);

--- a/ghost/core/core/server/api/endpoints/previews.js
+++ b/ghost/core/core/server/api/endpoints/previews.js
@@ -2,6 +2,7 @@ const tpl = require('@tryghost/tpl');
 const errors = require('@tryghost/errors');
 const models = require('../../models');
 const membersService = require('../../services/members');
+const urlSerializerUtils = require('./utils/serializers/input/utils/url');
 const ALLOWED_INCLUDES = ['authors', 'tags', 'tiers'];
 const ALLOWED_MEMBER_STATUSES = ['anonymous', 'free', 'paid'];
 
@@ -69,6 +70,12 @@ const controller = {
         },
         async query(frame) {
             await _addMemberContextToFrame(frame);
+
+            // The previews response serializes `url` through the same posts
+            // mapper as the other endpoints, so the relations the lazy URL
+            // service reads must be loaded here too; the mapper strips the
+            // forced ones from the response after the URL is built.
+            urlSerializerUtils.forceUrlRelationsWhenLazy(frame, 'posts');
 
             const model = await models.Post.findOne(Object.assign({status: 'all'}, frame.data), frame.options);
             if (!model) {

--- a/ghost/core/core/server/api/endpoints/utils/index.js
+++ b/ghost/core/core/server/api/endpoints/utils/index.js
@@ -52,14 +52,11 @@ module.exports = {
     },
 
     /**
-     * @description Whether the response will carry a serialized `url` for the
-     * requested resources. True unless a `?fields` narrowing excludes it.
-     *
-     * Shared by the output serializer (which skips URL generation when false)
-     * and the input serializers (which force-load the columns/relations the
-     * URL service needs when true) — both sides must always agree, or the
-     * input under-fetches and the lazy URL service rejects the resource as
-     * thin.
+     * @description Whether the response will carry a serialized `url` — true
+     * unless a `?fields` narrowing excludes it. Shared by the output
+     * serializer's guard and the input serializers' force-load; a drift
+     * between the two under-fetches and the lazy URL service rejects the
+     * resource as thin.
      * @param {import('@tryghost/api-framework').Frame} frame
      * @returns {boolean}
      */

--- a/ghost/core/core/server/api/endpoints/utils/index.js
+++ b/ghost/core/core/server/api/endpoints/utils/index.js
@@ -49,5 +49,21 @@ module.exports = {
      */
     isPreview: (frame) => {
         return frame.isPreview === true;
+    },
+
+    /**
+     * @description Whether the response will carry a serialized `url` for the
+     * requested resources. True unless a `?fields` narrowing excludes it.
+     *
+     * Shared by the output serializer (which skips URL generation when false)
+     * and the input serializers (which force-load the columns/relations the
+     * URL service needs when true) — both sides must always agree, or the
+     * input under-fetches and the lazy URL service rejects the resource as
+     * thin.
+     * @param {import('@tryghost/api-framework').Frame} frame
+     * @returns {boolean}
+     */
+    willSerializeUrl: (frame) => {
+        return !Array.isArray(frame.options.columns) || frame.options.columns.includes('url');
     }
 };

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/pages.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/pages.js
@@ -1,5 +1,4 @@
 const _ = require('lodash');
-const urlService = require('../../../../../services/url');
 const debug = require('@tryghost/debug')('api:endpoints:utils:serializers:input:pages');
 const {ValidationError} = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
@@ -50,32 +49,6 @@ function selectAllAllowedColumns(frame) {
     }
 }
 
-function forceUrlRelationsWhenLazy(frame) {
-    // `url` is computed for every serialized page unless `?fields` narrows it
-    // away, so the relations the lazy URL service reads (e.g. tags for a
-    // tag-filtered collection) must be loaded whenever no columns were
-    // requested (plain browse/read) — not only for the `?fields=url` case.
-    const computesUrl = !Array.isArray(frame.options.columns) || frame.options.columns.includes('url');
-    if (!computesUrl) {
-        return;
-    }
-    const relations = urlService.facade.getRequiredRelations();
-    if (relations.length) {
-        const requested = frame.options.withRelated || [];
-        const forced = relations.filter(relation => !requested.includes(relation));
-        if (forced.length) {
-            // Record what was forced (not what the caller asked for) so the
-            // output mapper can strip it from the response after the URL is
-            // built — the response shape must match the query.
-            frame.forcedUrlRelations = forced;
-            frame.options.withRelated = _.union(requested, forced);
-        }
-    }
-    if (Array.isArray(frame.options.columns)) {
-        url.forceUrlColumnsWhenLazy(frame, 'pages');
-    }
-}
-
 function defaultRelations(frame) {
     // Defaults for the admin API. Applied before the URL force-load so a
     // forced relation can never preempt the full admin default list.
@@ -83,7 +56,7 @@ function defaultRelations(frame) {
         frame.options.withRelated = ['tags', 'authors', 'authors.roles', 'tiers', 'count.signups', 'count.paid_conversions'];
     }
 
-    forceUrlRelationsWhenLazy(frame);
+    url.forceUrlRelationsWhenLazy(frame, 'pages');
 }
 
 function setDefaultOrder(frame) {
@@ -153,7 +126,7 @@ module.exports = {
 
             setDefaultOrder(frame);
             forceVisibilityColumn(frame);
-            forceUrlRelationsWhenLazy(frame);
+            url.forceUrlRelationsWhenLazy(frame, 'pages');
         }
 
         if (!localUtils.isContentAPI(frame)) {
@@ -172,7 +145,7 @@ module.exports = {
             removeSourceFormats(frame);
             setDefaultOrder(frame);
             forceVisibilityColumn(frame);
-            forceUrlRelationsWhenLazy(frame);
+            url.forceUrlRelationsWhenLazy(frame, 'pages');
         }
 
         if (!localUtils.isContentAPI(frame)) {

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/pages.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/pages.js
@@ -51,27 +51,39 @@ function selectAllAllowedColumns(frame) {
 }
 
 function forceUrlRelationsWhenLazy(frame) {
-    if (Array.isArray(frame.options.columns) && frame.options.columns.includes('url')) {
-        const relations = urlService.facade.getRequiredRelations();
-        if (relations.length) {
-            frame.options.withRelated = _.union(frame.options.withRelated || [], relations);
+    // `url` is computed for every serialized page unless `?fields` narrows it
+    // away, so the relations the lazy URL service reads (e.g. tags for a
+    // tag-filtered collection) must be loaded whenever no columns were
+    // requested (plain browse/read) — not only for the `?fields=url` case.
+    const computesUrl = !Array.isArray(frame.options.columns) || frame.options.columns.includes('url');
+    if (!computesUrl) {
+        return;
+    }
+    const relations = urlService.facade.getRequiredRelations();
+    if (relations.length) {
+        const requested = frame.options.withRelated || [];
+        const forced = relations.filter(relation => !requested.includes(relation));
+        if (forced.length) {
+            // Record what was forced (not what the caller asked for) so the
+            // output mapper can strip it from the response after the URL is
+            // built — the response shape must match the query.
+            frame.forcedUrlRelations = forced;
+            frame.options.withRelated = _.union(requested, forced);
         }
+    }
+    if (Array.isArray(frame.options.columns)) {
         url.forceUrlColumnsWhenLazy(frame, 'pages');
     }
 }
 
 function defaultRelations(frame) {
+    // Defaults for the admin API. Applied before the URL force-load so a
+    // forced relation can never preempt the full admin default list.
+    if (!frame.options.withRelated && !frame.options.columns) {
+        frame.options.withRelated = ['tags', 'authors', 'authors.roles', 'tiers', 'count.signups', 'count.paid_conversions'];
+    }
+
     forceUrlRelationsWhenLazy(frame);
-
-    if (frame.options.withRelated) {
-        return;
-    }
-
-    if (frame.options.columns) {
-        return false;
-    }
-
-    frame.options.withRelated = ['tags', 'authors', 'authors.roles', 'tiers', 'count.signups', 'count.paid_conversions'];
 }
 
 function setDefaultOrder(frame) {

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/posts.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/posts.js
@@ -1,5 +1,4 @@
 const _ = require('lodash');
-const urlService = require('../../../../../services/url');
 const debug = require('@tryghost/debug')('api:endpoints:utils:serializers:input:posts');
 const {ValidationError} = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
@@ -73,32 +72,6 @@ function mapWithRelated(frame) {
     }
 }
 
-function forceUrlRelationsWhenLazy(frame) {
-    // `url` is computed for every serialized post unless `?fields` narrows it
-    // away, so the relations the lazy URL service reads (e.g. tags for a
-    // tag-filtered collection) must be loaded whenever no columns were
-    // requested (plain browse/read) — not only for the `?fields=url` case.
-    const computesUrl = !Array.isArray(frame.options.columns) || frame.options.columns.includes('url');
-    if (!computesUrl) {
-        return;
-    }
-    const relations = urlService.facade.getRequiredRelations();
-    if (relations.length) {
-        const requested = frame.options.withRelated || [];
-        const forced = relations.filter(relation => !requested.includes(relation));
-        if (forced.length) {
-            // Record what was forced (not what the caller asked for) so the
-            // output mapper can strip it from the response after the URL is
-            // built — the response shape must match the query.
-            frame.forcedUrlRelations = forced;
-            frame.options.withRelated = _.union(requested, forced);
-        }
-    }
-    if (Array.isArray(frame.options.columns)) {
-        url.forceUrlColumnsWhenLazy(frame, 'posts');
-    }
-}
-
 function defaultRelations(frame) {
     // Apply same mapping as content API
     mapWithRelated(frame);
@@ -109,7 +82,7 @@ function defaultRelations(frame) {
         frame.options.withRelated = ['tags', 'authors', 'authors.roles', 'email', 'tiers', 'newsletter', 'count.clicks'];
     }
 
-    forceUrlRelationsWhenLazy(frame);
+    url.forceUrlRelationsWhenLazy(frame, 'posts');
 }
 
 function setDefaultOrder(frame) {
@@ -188,7 +161,7 @@ module.exports = {
             setDefaultOrder(frame);
             forceVisibilityColumn(frame);
             mapWithRelated(frame);
-            forceUrlRelationsWhenLazy(frame);
+            url.forceUrlRelationsWhenLazy(frame, 'posts');
         }
 
         if (!localUtils.isContentAPI(frame)) {
@@ -215,7 +188,7 @@ module.exports = {
 
             setDefaultOrder(frame);
             forceVisibilityColumn(frame);
-            forceUrlRelationsWhenLazy(frame);
+            url.forceUrlRelationsWhenLazy(frame, 'posts');
         }
 
         if (!localUtils.isContentAPI(frame)) {

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/posts.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/posts.js
@@ -74,11 +74,27 @@ function mapWithRelated(frame) {
 }
 
 function forceUrlRelationsWhenLazy(frame) {
-    if (Array.isArray(frame.options.columns) && frame.options.columns.includes('url')) {
-        const relations = urlService.facade.getRequiredRelations();
-        if (relations.length) {
-            frame.options.withRelated = _.union(frame.options.withRelated || [], relations);
+    // `url` is computed for every serialized post unless `?fields` narrows it
+    // away, so the relations the lazy URL service reads (e.g. tags for a
+    // tag-filtered collection) must be loaded whenever no columns were
+    // requested (plain browse/read) — not only for the `?fields=url` case.
+    const computesUrl = !Array.isArray(frame.options.columns) || frame.options.columns.includes('url');
+    if (!computesUrl) {
+        return;
+    }
+    const relations = urlService.facade.getRequiredRelations();
+    if (relations.length) {
+        const requested = frame.options.withRelated || [];
+        const forced = relations.filter(relation => !requested.includes(relation));
+        if (forced.length) {
+            // Record what was forced (not what the caller asked for) so the
+            // output mapper can strip it from the response after the URL is
+            // built — the response shape must match the query.
+            frame.forcedUrlRelations = forced;
+            frame.options.withRelated = _.union(requested, forced);
         }
+    }
+    if (Array.isArray(frame.options.columns)) {
         url.forceUrlColumnsWhenLazy(frame, 'posts');
     }
 }
@@ -87,18 +103,13 @@ function defaultRelations(frame) {
     // Apply same mapping as content API
     mapWithRelated(frame);
 
+    // Additional defaults for admin API. Applied before the URL force-load so
+    // a forced relation can never preempt the full admin default list.
+    if (!frame.options.withRelated && !frame.options.columns) {
+        frame.options.withRelated = ['tags', 'authors', 'authors.roles', 'email', 'tiers', 'newsletter', 'count.clicks'];
+    }
+
     forceUrlRelationsWhenLazy(frame);
-
-    // Additional defaults for admin API
-    if (frame.options.withRelated) {
-        return;
-    }
-
-    if (frame.options.columns) {
-        return false;
-    }
-
-    frame.options.withRelated = ['tags', 'authors', 'authors.roles', 'email', 'tiers', 'newsletter', 'count.clicks'];
 }
 
 function setDefaultOrder(frame) {

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/utils/url.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/utils/url.js
@@ -67,29 +67,27 @@ const forSetting = (attrs) => {
     return attrs;
 };
 
-// When a Content API `?fields=url` query narrows the selected columns, the
-// columns the lazy URL service needs to build a URL (the type's base-filter
-// columns and permalink fields, e.g. status/visibility/slug) get stripped
-// before the URL is generated, so the service rejects the resource as thin.
-// Force those columns back into the fetch so they are available at mapping
-// time; the output serializer still strips them from the response. No-op under
-// the eager service (getRequiredFields → []) and when `url` was not requested.
+// A `?fields=url` query strips the columns the lazy URL service needs to
+// build a URL (e.g. status/visibility/slug), so the service would reject the
+// resource as thin. Force them back into the fetch and record them on the
+// frame — the output mapper strips them from the response after the URL is
+// built. No-op under the eager service (getRequiredFields → []).
 const forceUrlColumnsWhenLazy = (frame, routerType) => {
     if (!Array.isArray(frame.options.columns) || !frame.options.columns.includes('url')) {
         return;
     }
-    for (const field of urlService.facade.getRequiredFields(routerType)) {
-        if (!frame.options.columns.includes(field)) {
-            frame.options.columns.push(field);
-        }
+    const forced = urlService.facade.getRequiredFields(routerType).filter(field => !frame.options.columns.includes(field));
+    if (forced.length) {
+        frame.forcedUrlColumns = forced;
+        frame.options.columns.push(...forced);
     }
 };
 
-// `url` is computed for every serialized post/page unless `?fields` narrows it
-// away, so the relations the lazy URL service reads (e.g. tags for a
-// tag-filtered collection) must be loaded whenever the URL will be serialized
-// — not only for the `?fields=url` case. No-op under the eager service
-// (getRequiredRelations → []).
+// `url` is serialized for every post/page unless `?fields` narrows it away,
+// so the relations the lazy URL service reads (e.g. tags for a tag-filtered
+// collection) must be loaded whenever the URL will be built — not only for
+// the `?fields=url` case. Forced relations are recorded on the frame for the
+// output mapper to strip. No-op under the eager service.
 const forceUrlRelationsWhenLazy = (frame, routerType) => {
     if (!localUtils.willSerializeUrl(frame)) {
         return;
@@ -97,18 +95,12 @@ const forceUrlRelationsWhenLazy = (frame, routerType) => {
     const relations = urlService.facade.getRequiredRelations();
     if (relations.length) {
         const requested = frame.options.withRelated || [];
-        // A nested include covers its parent: `authors.roles` eager-loads
-        // authors with roles nested, so the resource already carries the
-        // relation — forcing (and then stripping) the parent would delete
-        // the very data the caller asked for.
+        // a nested include covers its parent: `authors.roles` loads authors
         const covers = (requestedRelation, relation) => {
             return requestedRelation === relation || requestedRelation.startsWith(`${relation}.`);
         };
         const forced = relations.filter(relation => !requested.some(requestedRelation => covers(requestedRelation, relation)));
         if (forced.length) {
-            // Record what was forced (not what the caller asked for) so the
-            // output mapper can strip it from the response after the URL is
-            // built — the response shape must match the query.
             frame.forcedUrlRelations = forced;
             frame.options.withRelated = [...requested, ...forced];
         }

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/utils/url.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/utils/url.js
@@ -97,7 +97,14 @@ const forceUrlRelationsWhenLazy = (frame, routerType) => {
     const relations = urlService.facade.getRequiredRelations();
     if (relations.length) {
         const requested = frame.options.withRelated || [];
-        const forced = relations.filter(relation => !requested.includes(relation));
+        // A nested include covers its parent: `authors.roles` eager-loads
+        // authors with roles nested, so the resource already carries the
+        // relation — forcing (and then stripping) the parent would delete
+        // the very data the caller asked for.
+        const covers = (requestedRelation, relation) => {
+            return requestedRelation === relation || requestedRelation.startsWith(`${relation}.`);
+        };
+        const forced = relations.filter(relation => !requested.some(requestedRelation => covers(requestedRelation, relation)));
         if (forced.length) {
             // Record what was forced (not what the caller asked for) so the
             // output mapper can strip it from the response after the URL is

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/utils/url.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/utils/url.js
@@ -1,5 +1,6 @@
 const urlUtils = require('../../../../../../../shared/url-utils');
 const urlService = require('../../../../../../services/url');
+const localUtils = require('../../../index');
 
 const handleImageUrl = (imageUrl) => {
     try {
@@ -84,8 +85,33 @@ const forceUrlColumnsWhenLazy = (frame, routerType) => {
     }
 };
 
+// `url` is computed for every serialized post/page unless `?fields` narrows it
+// away, so the relations the lazy URL service reads (e.g. tags for a
+// tag-filtered collection) must be loaded whenever the URL will be serialized
+// — not only for the `?fields=url` case. No-op under the eager service
+// (getRequiredRelations → []).
+const forceUrlRelationsWhenLazy = (frame, routerType) => {
+    if (!localUtils.willSerializeUrl(frame)) {
+        return;
+    }
+    const relations = urlService.facade.getRequiredRelations();
+    if (relations.length) {
+        const requested = frame.options.withRelated || [];
+        const forced = relations.filter(relation => !requested.includes(relation));
+        if (forced.length) {
+            // Record what was forced (not what the caller asked for) so the
+            // output mapper can strip it from the response after the URL is
+            // built — the response shape must match the query.
+            frame.forcedUrlRelations = forced;
+            frame.options.withRelated = [...requested, ...forced];
+        }
+    }
+    forceUrlColumnsWhenLazy(frame, routerType);
+};
+
 module.exports.forPost = forPost;
 module.exports.forUser = forUser;
 module.exports.forTag = forTag;
 module.exports.forSetting = forSetting;
 module.exports.forceUrlColumnsWhenLazy = forceUrlColumnsWhenLazy;
+module.exports.forceUrlRelationsWhenLazy = forceUrlRelationsWhenLazy;

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/posts.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/posts.js
@@ -52,6 +52,15 @@ module.exports = async (model, frame, options = {}) => {
     const routerType = dbType === 'page' ? 'pages' : 'posts';
     url.forPost(model.id, jsonModel, frame, routerType);
 
+    // Relations the input serializer force-loaded for the URL computation
+    // (frame.forcedUrlRelations) were not requested by the caller — strip
+    // them now that the URL is built so the response shape matches the query.
+    if (frame.forcedUrlRelations) {
+        frame.forcedUrlRelations.forEach((relation) => {
+            delete jsonModel[relation];
+        });
+    }
+
     extraAttrs.forPost(frame.options, model, jsonModel);
 
     const defaultFormats = ['html'];

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/posts.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/posts.js
@@ -52,9 +52,9 @@ module.exports = async (model, frame, options = {}) => {
     const routerType = dbType === 'page' ? 'pages' : 'posts';
     url.forPost(model.id, jsonModel, frame, routerType);
 
-    // Relations the input serializer force-loaded for the URL computation
-    // (frame.forcedUrlRelations) were not requested by the caller — strip
-    // them now that the URL is built so the response shape matches the query.
+    // Force-loaded for the URL computation, not requested by the caller.
+    // Must run before clean.post so it drops the computed primary_tag/
+    // primary_author along with the relation.
     if (frame.forcedUrlRelations) {
         frame.forcedUrlRelations.forEach((relation) => {
             delete jsonModel[relation];
@@ -134,6 +134,13 @@ module.exports = async (model, frame, options = {}) => {
     delete jsonModel.posts_meta;
 
     clean.post(jsonModel, frame);
+
+    // Columns force-loaded for the URL computation, not requested by the caller.
+    if (frame.forcedUrlColumns) {
+        frame.forcedUrlColumns.forEach((column) => {
+            delete jsonModel[column];
+        });
+    }
 
     if (frame.options && frame.options.withRelated) {
         frame.options.withRelated.forEach((relation) => {

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/url.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/url.js
@@ -18,7 +18,9 @@ const forPost = (id, attrs, frame, type = 'posts') => {
     // reach the lazy URL service without the fields it needs (status,
     // tags/authors) and be rejected as thin. The value would only be deleted
     // at the end of this function anyway. forUser/forTag guard the same way.
-    if (frame.options.columns && !frame.options.columns.includes('url')) {
+    // Shared with the input serializers' force-load so both sides always
+    // agree on when a URL is generated.
+    if (!localUtils.willSerializeUrl(frame)) {
         return attrs;
     }
 

--- a/ghost/core/core/server/services/url/lazy-url-service.ts
+++ b/ghost/core/core/server/services/url/lazy-url-service.ts
@@ -196,6 +196,17 @@ export class LazyUrlService implements LazyUrlServiceBackend {
             if (/\b(year|month|day)\b/.test(config.permalink)) {
                 fields.add('published_at');
             }
+            // primary_tag/primary_author are computed attributes the model
+            // only attaches when `options.columns` names them, so they must
+            // be forced like scalar columns — the tags/authors relations
+            // (via getRequiredRelations) alone don't surface them on a
+            // `?fields=url` query.
+            for (const computed of ['primary_tag', 'primary_author'] as const) {
+                if (new RegExp(`\\b${computed}\\b`).test(config.permalink) ||
+                    (config.filter && new RegExp(`\\b${computed}\\b`).test(config.filter))) {
+                    fields.add(computed);
+                }
+            }
             filterScalarFields(config.filter).forEach(field => fields.add(field));
         }
         return [...fields];

--- a/ghost/core/test/unit/api/canary/utils/serializers/input/pages.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/input/pages.test.js
@@ -1,6 +1,7 @@
 const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const serializers = require('../../../../../../../core/server/api/endpoints/utils/serializers');
+const urlService = require('../../../../../../../core/server/services/url');
 const postsSchema = require('../../../../../../../core/server/data/schema').tables.posts;
 
 const lexicalLib = require('../../../../../../../core/server/lib/lexical');
@@ -11,6 +12,38 @@ describe('Unit: endpoints/utils/serializers/input/pages', function () {
     });
 
     describe('browse', function () {
+        it('lazyRouting: forces required relations on a Content API browse without fields narrowing', function () {
+            sinon.stub(urlService.facade, 'getRequiredRelations').returns(['tags']);
+
+            const frame = {
+                apiType: 'content',
+                options: {
+                    context: {api_key: {id: 1, type: 'content'}}
+                }
+            };
+
+            serializers.input.pages.browse({}, frame);
+
+            assert.ok(frame.options.withRelated.includes('tags'));
+            assert.deepEqual(frame.forcedUrlRelations, ['tags']);
+        });
+
+        it('lazyRouting: keeps the full admin default relations when forcing fires on a plain admin browse', function () {
+            sinon.stub(urlService.facade, 'getRequiredRelations').returns(['tags', 'authors']);
+
+            const frame = {
+                apiType: 'admin',
+                options: {
+                    context: {user: 1}
+                }
+            };
+
+            serializers.input.pages.browse({}, frame);
+
+            assert.deepEqual(frame.options.withRelated, ['tags', 'authors', 'authors.roles', 'tiers', 'count.signups', 'count.paid_conversions']);
+            assert.equal(frame.forcedUrlRelations, undefined);
+        });
+
         it('default', function () {
             const apiConfig = {};
             const frame = {

--- a/ghost/core/test/unit/api/canary/utils/serializers/input/posts.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/input/posts.test.js
@@ -191,6 +191,80 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
             assert.ok(!frame.options.withRelated.includes('authors'), 'authors must not be loaded when no route references it');
         });
 
+        // `url` is computed for every serialized post unless `?fields`
+        // narrows it away, so a plain browse (no fields param) must also
+        // force-load the relations the URL service needs — and record them
+        // so the output serializer can strip what the caller didn't ask for.
+        it('lazyRouting: forces required relations on a Content API browse without fields narrowing', function () {
+            sinon.stub(urlService.facade, 'getRequiredRelations').returns(['tags', 'authors']);
+
+            const frame = {
+                apiType: 'content',
+                options: {
+                    context: {api_key: {id: 1, type: 'content'}},
+                    withRelated: ['authors']
+                }
+            };
+
+            serializers.input.posts.browse({}, frame);
+
+            assert.ok(frame.options.withRelated.includes('tags'));
+            assert.ok(frame.options.withRelated.includes('authors'));
+            // only the relation the caller did NOT request is recorded for stripping
+            assert.deepEqual(frame.forcedUrlRelations, ['tags']);
+        });
+
+        it('lazyRouting: does not force relations when ?fields excludes url', function () {
+            sinon.stub(urlService.facade, 'getRequiredRelations').returns(['tags', 'authors']);
+
+            const frame = {
+                apiType: 'content',
+                options: {
+                    context: {api_key: {id: 1, type: 'content'}},
+                    columns: ['id', 'title']
+                }
+            };
+
+            serializers.input.posts.browse({}, frame);
+
+            assert.ok(!frame.options.withRelated, 'no relations should be force-loaded when url is not serialized');
+            assert.equal(frame.forcedUrlRelations, undefined);
+        });
+
+        it('lazyRouting: records nothing for stripping when the caller already requested the relations', function () {
+            sinon.stub(urlService.facade, 'getRequiredRelations').returns(['tags', 'authors']);
+
+            const frame = {
+                apiType: 'content',
+                options: {
+                    context: {api_key: {id: 1, type: 'content'}},
+                    withRelated: ['tags', 'authors']
+                }
+            };
+
+            serializers.input.posts.browse({}, frame);
+
+            assert.deepEqual(frame.options.withRelated, ['tags', 'authors']);
+            assert.equal(frame.forcedUrlRelations, undefined);
+        });
+
+        it('lazyRouting: keeps the full admin default relations when forcing fires on a plain admin browse', function () {
+            sinon.stub(urlService.facade, 'getRequiredRelations').returns(['tags', 'authors']);
+
+            const frame = {
+                apiType: 'admin',
+                options: {
+                    context: {user: 1}
+                }
+            };
+
+            serializers.input.posts.browse({}, frame);
+
+            assert.deepEqual(frame.options.withRelated, ['tags', 'authors', 'authors.roles', 'email', 'tiers', 'newsletter', 'count.clicks']);
+            // admin defaults already include the required relations — nothing to strip
+            assert.equal(frame.forcedUrlRelations, undefined);
+        });
+
         it('does not force any relations when no route references tags or authors', function () {
             sinon.stub(urlService.facade, 'getRequiredRelations').returns([]);
 

--- a/ghost/core/test/unit/api/canary/utils/serializers/input/posts.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/input/posts.test.js
@@ -231,6 +231,28 @@ describe('Unit: endpoints/utils/serializers/input/posts', function () {
             assert.equal(frame.forcedUrlRelations, undefined);
         });
 
+        it('lazyRouting: treats a nested include as covering its parent relation', function () {
+            sinon.stub(urlService.facade, 'getRequiredRelations').returns(['tags', 'authors']);
+
+            // `authors.roles` eager-loads authors with roles nested, so the
+            // resource is not thin — forcing (and then stripping) `authors`
+            // would delete the very data the caller asked for.
+            const frame = {
+                apiType: 'admin',
+                options: {
+                    context: {user: 1},
+                    withRelated: ['authors.roles'],
+                    columns: ['id', 'url']
+                }
+            };
+
+            serializers.input.posts.browse({}, frame);
+
+            assert.ok(frame.options.withRelated.includes('authors.roles'));
+            assert.ok(!frame.options.withRelated.includes('authors'), 'authors is already covered by authors.roles');
+            assert.deepEqual(frame.forcedUrlRelations, ['tags']);
+        });
+
         it('lazyRouting: records nothing for stripping when the caller already requested the relations', function () {
             sinon.stub(urlService.facade, 'getRequiredRelations').returns(['tags', 'authors']);
 

--- a/ghost/core/test/unit/api/canary/utils/serializers/input/utils/url.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/input/utils/url.test.js
@@ -44,5 +44,25 @@ describe('Unit: endpoints/utils/serializers/input/utils/url', function () {
 
             assert.deepEqual(frame.options, {});
         });
+
+        it('records the forced columns so the output can strip them', function () {
+            sinon.stub(urlService.facade, 'getRequiredFields').withArgs('posts').returns(['status', 'type', 'slug']);
+            const frame = {options: {columns: ['url', 'slug']}};
+
+            urlUtil.forceUrlColumnsWhenLazy(frame, 'posts');
+
+            assert.deepEqual(frame.options.columns, ['url', 'slug', 'status', 'type']);
+            // only what the caller did not request
+            assert.deepEqual(frame.forcedUrlColumns, ['status', 'type']);
+        });
+
+        it('records no forced columns when everything was already requested', function () {
+            sinon.stub(urlService.facade, 'getRequiredFields').withArgs('posts').returns(['status']);
+            const frame = {options: {columns: ['url', 'status']}};
+
+            urlUtil.forceUrlColumnsWhenLazy(frame, 'posts');
+
+            assert.equal(frame.forcedUrlColumns, undefined);
+        });
     });
 });

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/mapper.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/mapper.test.js
@@ -161,6 +161,41 @@ describe('Unit: utils/serializers/output/mappers', function () {
             assert.equal(result.primary_tag, undefined);
             assert.equal(result.primary_author, undefined);
         });
+
+        it('strips columns force-loaded for the URL after the URL is computed', async function () {
+            const frame = {
+                original: {
+                    context: {}
+                },
+                options: {
+                    columns: ['url', 'id', 'status', 'slug'],
+                    context: {}
+                },
+                // input serializer recorded: caller asked for ?fields=url,id —
+                // status/slug were forced for the URL computation
+                forcedUrlColumns: ['status', 'slug'],
+                apiType: 'admin'
+            };
+
+            let statusPresentAtUrlTime = false;
+            urlUtil.forPost.callsFake((id, attrs) => {
+                statusPresentAtUrlTime = attrs.status !== undefined;
+                return attrs;
+            });
+
+            const post = createJsonModel(testUtils.DataGenerator.forKnex.createPost({
+                id: 'id1',
+                status: 'published',
+                slug: 'my-post'
+            }));
+
+            const result = await mappers.posts(post, frame);
+
+            assert.ok(statusPresentAtUrlTime, 'status must still be present when the URL is computed');
+            assert.equal(result.status, undefined);
+            assert.equal(result.slug, undefined);
+            assert.equal(result.id, 'id1');
+        });
     });
 
     describe('User Mapper', function () {

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/mapper.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/mapper.test.js
@@ -127,6 +127,40 @@ describe('Unit: utils/serializers/output/mappers', function () {
             sinon.assert.notCalled(urlUtil.forTag);
             sinon.assert.calledOnce(urlUtil.forUser);
         });
+
+        it('strip runs before clean so computed primary_tag/primary_author do not leak', async function () {
+            // Post.toJSON attaches primary_tag/primary_author when tags/authors
+            // are loaded; clean.post only removes them when the relation key is
+            // absent, so the strip must run first.
+            cleanUtil.post.restore();
+
+            const frame = {
+                original: {
+                    context: {}
+                },
+                options: {
+                    withRelated: ['tags', 'authors'],
+                    context: {}
+                },
+                forcedUrlRelations: ['tags', 'authors'],
+                apiType: 'content'
+            };
+
+            const post = createJsonModel(testUtils.DataGenerator.forKnex.createPost({
+                id: 'id1',
+                tags: [{id: 'id3', visibility: 'public'}],
+                authors: [{id: 'id4', name: 'Ghosty'}],
+                primary_tag: {id: 'id3', visibility: 'public'},
+                primary_author: {id: 'id4', name: 'Ghosty'}
+            }));
+
+            const result = await mappers.posts(post, frame);
+
+            assert.equal(result.tags, undefined);
+            assert.equal(result.authors, undefined);
+            assert.equal(result.primary_tag, undefined);
+            assert.equal(result.primary_author, undefined);
+        });
     });
 
     describe('User Mapper', function () {

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/mapper.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/mapper.test.js
@@ -81,6 +81,52 @@ describe('Unit: utils/serializers/output/mappers', function () {
             assert.deepEqual(urlUtil.forTag.getCall(0).args, ['id3', {id: 'id3', feature_image: 'value'}, frame.options]);
             assert.deepEqual(urlUtil.forUser.getCall(0).args, ['id4', {name: 'Ghosty', id: 'id4'}, frame.options]);
         });
+
+        it('strips relations force-loaded for the URL after the URL is computed', async function () {
+            const frame = {
+                original: {
+                    context: {}
+                },
+                options: {
+                    withRelated: ['tags', 'authors'],
+                    context: {}
+                },
+                // input serializer recorded: caller asked for authors only,
+                // tags were force-loaded for the URL computation
+                forcedUrlRelations: ['tags'],
+                apiType: 'content'
+            };
+
+            const post = createJsonModel(testUtils.DataGenerator.forKnex.createPost({
+                id: 'id1',
+                tags: [{
+                    id: 'id3'
+                }],
+                authors: [{
+                    id: 'id4',
+                    name: 'Ghosty'
+                }]
+            }));
+
+            // the mapper mutates the model in place, so capture at call time
+            let tagsPresentAtUrlTime = false;
+            urlUtil.forPost.callsFake((id, attrs) => {
+                tagsPresentAtUrlTime = Array.isArray(attrs.tags);
+                return attrs;
+            });
+
+            const result = await mappers.posts(post, frame);
+
+            // url computed while tags were still on the model
+            sinon.assert.calledOnce(urlUtil.forPost);
+            assert.ok(tagsPresentAtUrlTime, 'tags must still be present when the URL is computed');
+
+            // ...but the response does not leak the unrequested relation
+            assert.equal(result.tags, undefined);
+            assert.ok(result.authors, 'requested relation must survive');
+            sinon.assert.notCalled(urlUtil.forTag);
+            sinon.assert.calledOnce(urlUtil.forUser);
+        });
     });
 
     describe('User Mapper', function () {

--- a/ghost/core/test/unit/api/endpoints/email-post.test.js
+++ b/ghost/core/test/unit/api/endpoints/email-post.test.js
@@ -1,0 +1,52 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const {Post} = require('../../../../core/server/models/post');
+const urlService = require('../../../../core/server/services/url');
+const emailPostController = require('../../../../core/server/api/endpoints/email-post');
+
+describe('Email post controller', function () {
+    beforeEach(function () {
+        sinon.stub(Post, 'findOne').resolves({});
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('#read', function () {
+        it('lazyRouting: force-loads the URL service required relations', async function () {
+            sinon.stub(urlService.facade, 'getRequiredRelations').returns(['tags', 'authors']);
+
+            const frame = {data: {uuid: 'abc'}, options: {}};
+            await emailPostController.read.query(frame);
+
+            sinon.assert.calledOnce(Post.findOne);
+            const options = Post.findOne.getCall(0).args[1];
+            assert.deepEqual(options.withRelated, ['tags', 'authors']);
+            // recorded so the output mapper strips them from the response
+            assert.deepEqual(frame.forcedUrlRelations, ['tags', 'authors']);
+        });
+
+        it('lazyRouting: only forces the relations the caller did not include', async function () {
+            sinon.stub(urlService.facade, 'getRequiredRelations').returns(['tags', 'authors']);
+
+            const frame = {data: {uuid: 'abc'}, options: {withRelated: ['tags']}};
+            await emailPostController.read.query(frame);
+
+            const options = Post.findOne.getCall(0).args[1];
+            assert.deepEqual(options.withRelated, ['tags', 'authors']);
+            assert.deepEqual(frame.forcedUrlRelations, ['authors']);
+        });
+
+        it('fetches sent posts by uuid', async function () {
+            sinon.stub(urlService.facade, 'getRequiredRelations').returns([]);
+
+            const frame = {data: {uuid: 'abc'}, options: {}};
+            await emailPostController.read.query(frame);
+
+            const data = Post.findOne.getCall(0).args[0];
+            assert.equal(data.uuid, 'abc');
+            assert.equal(data.status, 'sent');
+        });
+    });
+});

--- a/ghost/core/test/unit/api/endpoints/previews.test.js
+++ b/ghost/core/test/unit/api/endpoints/previews.test.js
@@ -2,6 +2,7 @@ const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const {Post} = require('../../../../core/server/models/post');
 const {Product} = require('../../../../core/server/models/product');
+const urlService = require('../../../../core/server/services/url');
 const previewsController = require('../../../../core/server/api/endpoints/previews');
 
 describe('Previews controller', function () {
@@ -17,6 +18,34 @@ describe('Previews controller', function () {
     });
 
     describe('#read', function () {
+        // The previews response serializes `url` through the same posts
+        // mapper as the other endpoints, so the lazy URL service's required
+        // relations must be loaded here too — a published post previewed on a
+        // site with tag-filtered collections is otherwise rejected as thin.
+        it('lazyRouting: force-loads the URL service required relations', async function () {
+            sinon.stub(urlService.facade, 'getRequiredRelations').returns(['tags', 'authors']);
+
+            const frame = {options: {}};
+            await previewsController.read.query(frame);
+
+            sinon.assert.calledOnce(Post.findOne);
+            const options = Post.findOne.getCall(0).args[1];
+            assert.deepEqual(options.withRelated, ['tags', 'authors']);
+            // recorded so the output mapper strips them from the response
+            assert.deepEqual(frame.forcedUrlRelations, ['tags', 'authors']);
+        });
+
+        it('lazyRouting: only forces the relations the caller did not include', async function () {
+            sinon.stub(urlService.facade, 'getRequiredRelations').returns(['tags', 'authors']);
+
+            const frame = {options: {withRelated: ['tags']}};
+            await previewsController.read.query(frame);
+
+            const options = Post.findOne.getCall(0).args[1];
+            assert.deepEqual(options.withRelated, ['tags', 'authors']);
+            assert.deepEqual(frame.forcedUrlRelations, ['authors']);
+        });
+
         it('sets frame.apiType to content when a member_status is provided', async function () {
             const frame = {options: {member_status: 'free'}};
             await previewsController.read.query(frame);

--- a/ghost/core/test/unit/server/services/url/lazy-url-service.test.js
+++ b/ghost/core/test/unit/server/services/url/lazy-url-service.test.js
@@ -739,5 +739,27 @@ describe('LazyUrlService', function () {
 
             assert.deepEqual(service.getRequiredFields('posts').sort(), ['published_at', 'slug', 'status', 'type']);
         });
+
+        // primary_tag/primary_author are computed attributes the model only
+        // attaches when `options.columns` names them, so a `?fields=url` query
+        // must have them forced like scalar columns — the tags/authors
+        // relations alone are not enough for _assertNotThin.
+        it('requires primary_tag/primary_author when a router filter references them', function () {
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
+            service.onRouterAddedType('news', 'primary_tag:news', 'posts', '/:slug/');
+            service.onRouterAddedType('byAuthor', 'primary_author:cameron', 'pages', '/:slug/');
+
+            assert.deepEqual(service.getRequiredFields('posts').sort(), ['primary_tag', 'slug', 'status', 'type']);
+            assert.deepEqual(service.getRequiredFields('pages').sort(), ['primary_author', 'slug', 'status', 'type']);
+        });
+
+        it('requires primary_tag/primary_author when a permalink substitutes them', function () {
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
+            service.onRouterAddedType('tagged', null, 'posts', '/:primary_tag/:slug/');
+            service.onRouterAddedType('authored', null, 'pages', '/:primary_author/:slug/');
+
+            assert.deepEqual(service.getRequiredFields('posts').sort(), ['primary_tag', 'slug', 'status', 'type']);
+            assert.deepEqual(service.getRequiredFields('pages').sort(), ['primary_author', 'slug', 'status', 'type']);
+        });
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1822

Follow-up to #29190 / #29301. The caller diagnostics from #29301 attributed the remaining `missing:["tags"]` error class:

```
at Object.forPost (serializers/output/utils/url.js:25)
at mappers/posts.js:53
...
at makeAPICall (frontend/helpers/get.js:329)
```

`{{#get "posts" include="authors"}}` on a site whose routes.yaml has tag-filtered collections (`tag:[newsletter,hash-newsletter]`): the output serializer computes `post.url` for every response, but the input serializers only force-loaded the URL service's required relations for the `?fields=url` case (`forceUrlRelationsWhenLazy`). A plain browse without `include=tags` reached the lazy URL service with no `tags` array — it can't evaluate the collection filter and refuses the resource as thin.

## Changes

- **Force**: `forceUrlRelationsWhenLazy` (posts + pages input serializers) now fires whenever the URL will be computed — i.e. no `?fields` narrowing, or `fields` includes `url` — instead of only the `fields=url` case.
- **Strip**: relations that were force-loaded but not requested are recorded on the frame (`forcedUrlRelations`) and deleted from the response by the posts mapper right after the URL is built, so `{{#get}}` results and Content API payloads keep the exact shape the caller asked for.
- The admin default-relations path was restructured so the force-load can never preempt the full admin default list (defaults now apply first, then the force unions into them — where it's a no-op, since the defaults already include tags/authors).

No-op when the lazy URL service isn't configured (`getRequiredRelations()` → `[]`).

## Trade-off

Sites with tag/author-filtered routes pay a tags/authors eager-load on every content post/page query that serializes `url`. That's inherent to lazy URL generation: it can't evaluate `tag:` filters without the tag data, and the sync API means it can't fetch it itself. The eager service avoided this by holding every resource in memory — which is the trade the lazy project is unwinding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)