### PR TITLE
Added stats_service tinybird token

### DIFF
--- a/ghost/core/core/server/data/tinybird/datasources/_mv_hits.datasource
+++ b/ghost/core/core/server/data/tinybird/datasources/_mv_hits.datasource
@@ -1,3 +1,5 @@
+TOKEN "stats_service" READ
+
 SCHEMA >
     `site_uuid` LowCardinality(String),
     `timestamp` DateTime,


### PR DESCRIPTION
no ref

This should have no user-facing impact.

Adds a read-scoped static token on the `_mv_hits` datasource so internal stats services can read aggregated usage from the hits stream.

Declaring it in the datafile keeps the token code-managed and resource-scoped (read on `_mv_hits`, nothing else), following the same pattern as the `analytics-service` append token on `analytics_events` (#27495). The token value is generated per workspace at deploy time; nothing changes for individual Ghost installs.
