### PR TITLE
Added card insertion analytics context

### DIFF
--- a/koenig/koenig-lexical/src/components/ui/CardMenu.tsx
+++ b/koenig/koenig-lexical/src/components/ui/CardMenu.tsx
@@ -117,7 +117,7 @@ export const CardSnippetItem = ({label, isSelected, scrollToItem, Icon, onRemove
     );
 };
 
-export const CardMenu = ({menu = new Map(), insert = () => {}, selectedItemIndex, scrollToSelectedItem, closeMenu}) => {
+export const CardMenu = ({menu = new Map(), insert = () => {}, selectedItemIndex, scrollToSelectedItem, closeMenu, source, searchTerm}) => {
     // build up the children arrays from the passed in menu Map
     const CardMenuSections = [];
 
@@ -132,7 +132,11 @@ export const CardMenu = ({menu = new Map(), insert = () => {}, selectedItemIndex
                 event.stopPropagation();
                 insert?.(item.insertCommand, {insertParams: item.insertParams, queryParams: item.queryParams});
                 const cardIdentifier = item.type === 'snippet' ? 'Snippet' : item.label;
-                trackEvent('Card Added', {card: cardIdentifier});
+                trackEvent('Card Added', {
+                    card: cardIdentifier,
+                    source,
+                    ...(searchTerm && {searchTerm})
+                });
             };
 
             if (!item.type || item.type === 'card') {

--- a/koenig/koenig-lexical/src/plugins/PlusCardMenuPlugin.tsx
+++ b/koenig/koenig-lexical/src/plugins/PlusCardMenuPlugin.tsx
@@ -251,7 +251,7 @@ function usePlusCardMenu(editor) {
                 {isShowingButton && <PlusButton onClick={openMenu} />}
                 {isShowingMenu && (
                     <PlusMenu>
-                        <CardMenu closeMenu={closeMenu} insert={insert} menu={cardMenu.menu} />
+                        <CardMenu closeMenu={closeMenu} insert={insert} menu={cardMenu.menu} source="plus" />
                     </PlusMenu>
                 )}
             </div>

--- a/koenig/koenig-lexical/src/plugins/SlashCardMenuPlugin.tsx
+++ b/koenig/koenig-lexical/src/plugins/SlashCardMenuPlugin.tsx
@@ -364,7 +364,9 @@ function useSlashCardMenu(editor) {
                         insert={insert}
                         menu={cardMenu.menu}
                         scrollToSelectedItem={scrollToSelectedItem}
+                        searchTerm={query}
                         selectedItemIndex={selectedItemIndex}
+                        source="slash"
                     />
                 </SlashMenu>
             </div>

--- a/koenig/koenig-lexical/test/unit/CardMenu.test.tsx
+++ b/koenig/koenig-lexical/test/unit/CardMenu.test.tsx
@@ -1,0 +1,58 @@
+import trackEvent from '../../src/utils/analytics';
+import {CardMenu} from '../../src/components/ui/CardMenu';
+import {expect, vi} from 'vitest';
+import {fireEvent, render, screen} from '@testing-library/react';
+
+vi.mock('../../src/utils/analytics', () => ({
+    default: vi.fn()
+}));
+
+const TestIcon = () => <svg />;
+
+const menu = new Map([
+    ['Primary', [{
+        Icon: TestIcon,
+        insertCommand: 'insert_image',
+        label: 'Image'
+    }]]
+]);
+
+describe('CardMenu', () => {
+    beforeEach(() => {
+        vi.mocked(trackEvent).mockClear();
+    });
+
+    it('tracks plus menu card insertions', () => {
+        render(<CardMenu menu={menu} source="plus" />);
+
+        fireEvent.click(screen.getByRole('menuitem', {name: 'Image'}));
+
+        expect(trackEvent).toHaveBeenCalledWith('Card Added', {
+            card: 'Image',
+            source: 'plus'
+        });
+    });
+
+    it('tracks slash menu card insertions with the search term', () => {
+        render(<CardMenu menu={menu} searchTerm="ima" source="slash" />);
+
+        fireEvent.click(screen.getByRole('menuitem', {name: 'Image'}));
+
+        expect(trackEvent).toHaveBeenCalledWith('Card Added', {
+            card: 'Image',
+            searchTerm: 'ima',
+            source: 'slash'
+        });
+    });
+
+    it('omits an empty slash menu search term', () => {
+        render(<CardMenu menu={menu} searchTerm="" source="slash" />);
+
+        fireEvent.click(screen.getByRole('menuitem', {name: 'Image'}));
+
+        expect(trackEvent).toHaveBeenCalledWith('Card Added', {
+            card: 'Image',
+            source: 'slash'
+        });
+    });
+});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3777/

The `Card Added` event previously identified only the inserted card, making it impossible to distinguish direct menu browsing from slash-menu search. The additional context makes card discovery and insertion behaviour measurable without capturing slash-command parameters.

- Added the originating `plus` or `slash` menu to card insertion analytics.
- Added the active slash-menu search term when one was used.
- Kept empty searches out of the event properties.
