### PR TITLE
Fixed bookmark URLs failing when suggestions are unavailable

### DIFF
--- a/koenig/koenig-lexical/src/components/ui/AtLinkResultsPopup.tsx
+++ b/koenig/koenig-lexical/src/components/ui/AtLinkResultsPopup.tsx
@@ -127,6 +127,7 @@ export function AtLinkResultsPopup({atLinkNode, isSearching, listOptions, query,
                         getItem={getItem}
                         groups={listOptions}
                         isLoading={isSearching}
+                        onEnterWithoutSelection={onSelect}
                         onSelect={onSelect}
                     />
                 </ul>

--- a/koenig/koenig-lexical/src/components/ui/KeyboardSelection.tsx
+++ b/koenig/koenig-lexical/src/components/ui/KeyboardSelection.tsx
@@ -42,10 +42,15 @@ export function KeyboardSelection({items, getItem, onSelect, defaultSelected}) {
             });
         }
         if (event.key === 'Enter') {
+            const selectedItem = items[selectedIndex];
+            if (!selectedItem) {
+                return;
+            }
+
             // The stop propagation is required for Safari
             event.preventDefault();
             event.stopPropagation();
-            onSelect(items[selectedIndex]);
+            onSelect(selectedItem);
         }
     }, [items, selectedIndex, onSelect]);
 

--- a/koenig/koenig-lexical/src/components/ui/KeyboardSelectionWithGroups.tsx
+++ b/koenig/koenig-lexical/src/components/ui/KeyboardSelectionWithGroups.tsx
@@ -54,10 +54,15 @@ export function KeyboardSelectionWithGroups({groups, getItem, getGroup, onSelect
             setScrollSelectedIntoView(true);
         }
         if (event.key === 'Enter') {
+            const selectedItem = items[selectedIndex];
+            if (!selectedItem) {
+                return;
+            }
+
             // The stop propagation is required for Safari
             event.preventDefault();
             event.stopPropagation();
-            onSelect(items[selectedIndex]);
+            onSelect(selectedItem);
         }
     }, [items, selectedIndex, onSelect]);
 

--- a/koenig/koenig-lexical/src/components/ui/KeyboardSelectionWithGroups.tsx
+++ b/koenig/koenig-lexical/src/components/ui/KeyboardSelectionWithGroups.tsx
@@ -16,7 +16,7 @@ const Group = ({children}) => {
  * @param {T[]} [options.items]
  * @param {(T, selected) => import('react').ReactElement} [options.getItem]
  */
-export function KeyboardSelectionWithGroups({groups, getItem, getGroup, onSelect, defaultSelected, isLoading}) {
+export function KeyboardSelectionWithGroups({groups, getItem, getGroup, onSelect, onEnterWithoutSelection, defaultSelected, isLoading}) {
     const items = groups.flatMap(group => group.items);
     const defaultIndex = Math.max(0, items.findIndex(item => item === defaultSelected));
     const [selectedIndex, setSelectedIndex] = React.useState(defaultIndex);
@@ -55,16 +55,21 @@ export function KeyboardSelectionWithGroups({groups, getItem, getGroup, onSelect
         }
         if (event.key === 'Enter') {
             const selectedItem = items[selectedIndex];
-            if (!selectedItem) {
+            if (!selectedItem && !onEnterWithoutSelection) {
                 return;
             }
 
             // The stop propagation is required for Safari
             event.preventDefault();
             event.stopPropagation();
-            onSelect(selectedItem);
+
+            if (selectedItem) {
+                onSelect(selectedItem);
+            } else {
+                onEnterWithoutSelection();
+            }
         }
-    }, [items, selectedIndex, onSelect]);
+    }, [items, selectedIndex, onSelect, onEnterWithoutSelection]);
 
     React.useEffect(() => {
         // The capture phase is required for Safari

--- a/koenig/koenig-lexical/test/unit/KeyboardSelection.test.tsx
+++ b/koenig/koenig-lexical/test/unit/KeyboardSelection.test.tsx
@@ -1,0 +1,45 @@
+import {KeyboardSelection} from '../../src/components/ui/KeyboardSelection';
+import {KeyboardSelectionWithGroups} from '../../src/components/ui/KeyboardSelectionWithGroups';
+import {fireEvent, render, screen} from '@testing-library/react';
+import {vi} from 'vitest';
+
+describe.each([
+    {
+        name: 'ungrouped',
+        renderSelection: (onSelect: ReturnType<typeof vi.fn>) => (
+            <KeyboardSelection
+                getItem={() => null}
+                items={[]}
+                onSelect={onSelect}
+            />
+        )
+    },
+    {
+        name: 'grouped',
+        renderSelection: (onSelect: ReturnType<typeof vi.fn>) => (
+            <KeyboardSelectionWithGroups
+                getGroup={() => null}
+                getItem={() => null}
+                groups={[{label: 'Results', items: []}]}
+                onSelect={onSelect}
+            />
+        )
+    }
+])('KeyboardSelection ($name)', ({renderSelection}) => {
+    it('lets Enter fall through when there is no selectable item', () => {
+        const onKeyDown = vi.fn();
+        const onSelect = vi.fn();
+
+        render(
+            <div onKeyDown={onKeyDown}>
+                <input aria-label="URL" />
+                {renderSelection(onSelect)}
+            </div>
+        );
+
+        fireEvent.keyDown(screen.getByRole('textbox', {name: 'URL'}), {key: 'Enter'});
+
+        expect(onSelect).not.toHaveBeenCalled();
+        expect(onKeyDown).toHaveBeenCalledOnce();
+    });
+});

--- a/koenig/koenig-lexical/test/unit/KeyboardSelection.test.tsx
+++ b/koenig/koenig-lexical/test/unit/KeyboardSelection.test.tsx
@@ -41,5 +41,60 @@ describe.each([
 
         expect(onSelect).not.toHaveBeenCalled();
         expect(onKeyDown).toHaveBeenCalledOnce();
+        expect(onKeyDown.mock.calls[0][0].defaultPrevented).toBe(false);
+    });
+});
+
+describe('KeyboardSelectionWithGroups', () => {
+    it('consumes Enter when the selected item has no value', () => {
+        const onKeyDown = vi.fn();
+        const onSelect = vi.fn();
+        const placeholderItem = {label: 'Enter URL to create link', value: null};
+
+        render(
+            <div onKeyDown={onKeyDown}>
+                <input aria-label="URL" />
+                <KeyboardSelectionWithGroups
+                    getGroup={() => null}
+                    getItem={() => null}
+                    groups={[{
+                        label: 'Results',
+                        items: [placeholderItem]
+                    }]}
+                    onSelect={onSelect}
+                />
+            </div>
+        );
+
+        fireEvent.keyDown(screen.getByRole('textbox', {name: 'URL'}), {key: 'Enter'});
+
+        expect(onSelect).toHaveBeenCalledOnce();
+        expect(onSelect).toHaveBeenCalledWith(placeholderItem);
+        expect(onKeyDown).not.toHaveBeenCalled();
+    });
+
+    it('handles Enter without a selectable item when requested', () => {
+        const onEnterWithoutSelection = vi.fn();
+        const onKeyDown = vi.fn();
+        const onSelect = vi.fn();
+
+        render(
+            <div onKeyDown={onKeyDown}>
+                <input aria-label="At-link" />
+                <KeyboardSelectionWithGroups
+                    getGroup={() => null}
+                    getItem={() => null}
+                    groups={[{label: 'No results found'}]}
+                    onEnterWithoutSelection={onEnterWithoutSelection}
+                    onSelect={onSelect}
+                />
+            </div>
+        );
+
+        fireEvent.keyDown(screen.getByRole('textbox', {name: 'At-link'}), {key: 'Enter'});
+
+        expect(onEnterWithoutSelection).toHaveBeenCalledOnce();
+        expect(onSelect).not.toHaveBeenCalled();
+        expect(onKeyDown).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
no issue

Fixes bookmark URL submission when bookmark suggestions are unavailable or still loading.

The shared keyboard-selection handlers attempted to select `undefined` when Enter was pressed with an empty result list. That threw before the parent URL input could handle Enter, which caused the flaky welcome-email bookmark test and could prevent direct URL submission in the editor.

The handlers now consume Enter only when a selectable item exists. Otherwise, the event continues to the URL input. Regression coverage exercises both grouped and ungrouped selection lists.
