### PR TITLE
Moved onboarding behavior to Admin acceptance tests

### DIFF
--- a/apps/admin/src/onboarding/onboarding-route.tsx
+++ b/apps/admin/src/onboarding/onboarding-route.tsx
@@ -43,7 +43,7 @@ export default function OnboardingRoute() {
     }
 
     if (!shouldShowChecklist) {
-        return <Navigate crossApp replace to={returnTo} />;
+        return <Navigate replace to={returnTo} />;
     }
 
     const navigateAfterUpdate = async (update: () => Promise<unknown>) => {
@@ -51,7 +51,7 @@ export default function OnboardingRoute() {
         setIsLeaving(true);
         try {
             await update();
-            navigate(returnTo, {crossApp: true, replace: true});
+            navigate(returnTo, {replace: true});
         } catch (error) {
             isLeavingRef.current = false;
             setIsLeaving(false);
@@ -69,9 +69,9 @@ export default function OnboardingRoute() {
 
         await markStepCompleted(step);
 
-        const stepRoute = ONBOARDING_STEPS.find(({id}) => id === step)?.route;
-        if (stepRoute) {
-            navigate(stepRoute, {crossApp: true});
+        const stepDefinition = ONBOARDING_STEPS.find(({id}) => id === step);
+        if (stepDefinition?.route) {
+            navigate(stepDefinition.route);
         }
     };
 

--- a/apps/admin/src/onboarding/onboarding.acceptance.test.tsx
+++ b/apps/admin/src/onboarding/onboarding.acceptance.test.tsx
@@ -1,0 +1,94 @@
+import {describe, expect, it} from "vitest";
+
+import {
+    currentRoute,
+    currentUserResponse,
+    fakeAdminEndpoint,
+    fakeMembers,
+    renderAdminApp,
+    type CurrentUserResponse,
+    type EndpointCapture,
+} from "@test-utils/acceptance";
+import {onboardingScreen} from "./onboarding.screen";
+
+type ChecklistState = "pending" | "started" | "completed" | "dismissed";
+
+const activeStartedAt = "2026-05-01T00:00:00.000Z";
+
+function onboardingUser(
+    checklistState: ChecklistState,
+    completedSteps: string[] = [],
+    startedAt: string | null | undefined = checklistState === "started" ? activeStartedAt : undefined
+): CurrentUserResponse {
+    const response = currentUserResponse();
+    response.users[0].accessibility = JSON.stringify({
+        onboarding: {
+            checklistState,
+            completedSteps,
+            ...(startedAt && {startedAt}),
+        },
+    });
+    return response;
+}
+
+function fakePreferenceEdits(): EndpointCapture {
+    return fakeAdminEndpoint("PUT", /^\/users\/\w+\/\?include=roles/, ({body}) => body);
+}
+
+function sentOnboardingPreferences(capture: EndpointCapture): Record<string, unknown> | undefined {
+    const body = capture.lastRequest?.body as {users?: Array<{accessibility?: string}>} | undefined;
+    const accessibility = body?.users?.[0]?.accessibility;
+    if (!accessibility) {
+        return undefined;
+    }
+    return (JSON.parse(accessibility) as {onboarding?: Record<string, unknown>}).onboarding;
+}
+
+describe("Onboarding redirects", () => {
+    it("redirects active onboarding from Analytics", async () => {
+        await renderAdminApp("/analytics", {
+            boot: {browseMe: {response: onboardingUser("started")}},
+        });
+
+        await expect.element(onboardingScreen.checklist()).toBeVisible();
+        await expect.poll(currentRoute).toBe("/setup/onboarding?returnTo=%2Fanalytics");
+    });
+
+    it("preserves the Analytics subroute when redirecting", async () => {
+        await renderAdminApp("/analytics/web", {
+            boot: {browseMe: {response: onboardingUser("started")}},
+        });
+
+        await expect.element(onboardingScreen.checklist()).toBeVisible();
+        await expect.poll(currentRoute).toBe("/setup/onboarding?returnTo=%2Fanalytics%2Fweb");
+    });
+
+});
+
+describe("Onboarding checklist", () => {
+    it("build-audience marks complete and navigates to Members", async () => {
+        fakeMembers([]);
+        const preferencesApi = fakePreferenceEdits();
+        await renderAdminApp("/setup/onboarding?returnTo=%2Fanalytics", {
+            boot: {browseMe: {response: onboardingUser("started")}},
+        });
+
+        await onboardingScreen.step("build-audience").click();
+
+        await expect.poll(() => sentOnboardingPreferences(preferencesApi)?.completedSteps).toEqual(["build-audience"]);
+        await expect.poll(currentRoute).toBe("/members");
+    });
+
+    it("opens the share dialog and marks the share step complete", async () => {
+        const preferencesApi = fakePreferenceEdits();
+        await renderAdminApp("/setup/onboarding?returnTo=%2Fanalytics", {
+            boot: {browseMe: {response: onboardingUser("started")}},
+        });
+
+        await onboardingScreen.step("share-publication").click();
+
+        await expect.element(onboardingScreen.shareModal()).toBeVisible();
+        await expect.poll(() => sentOnboardingPreferences(preferencesApi)?.completedSteps).toEqual(["share-publication"]);
+    });
+
+});

--- a/apps/admin/src/onboarding/onboarding.screen.ts
+++ b/apps/admin/src/onboarding/onboarding.screen.ts
@@ -1,0 +1,21 @@
+import {page} from "vitest/browser";
+import {
+    allSetHeading,
+    getStartedHeading,
+    onboardingChecklist,
+    onboardingComplete,
+    onboardingShareModal,
+    onboardingSkip,
+    onboardingStepPrefix,
+} from "@tryghost/test-data/selectors/onboarding";
+
+/** Onboarding screen locators and gestures for acceptance specs; no assertions. */
+export const onboardingScreen = {
+    checklist: () => page.getByTestId(onboardingChecklist),
+    getStartedHeading: () => page.getByRole("heading", {name: getStartedHeading}),
+    allSetHeading: () => page.getByRole("heading", {name: allSetHeading}),
+    step: (stepId: string) => page.getByTestId(`${onboardingStepPrefix}${stepId}`),
+    shareModal: () => page.getByTestId(onboardingShareModal),
+    skipButton: () => page.getByTestId(onboardingSkip),
+    completeButton: () => page.getByTestId(onboardingComplete),
+};

--- a/e2e/helpers/pages/admin/onboarding/onboarding-page.ts
+++ b/e2e/helpers/pages/admin/onboarding/onboarding-page.ts
@@ -1,5 +1,12 @@
 import {AdminPage} from '@/admin-pages';
 import {Locator, Page} from '@playwright/test';
+import {
+    onboardingChecklist,
+    onboardingComplete,
+    onboardingShareModal,
+    onboardingSkip,
+    onboardingStepPrefix
+} from '@tryghost/test-data/selectors/onboarding';
 
 export class OnboardingPage extends AdminPage {
     public readonly checklist: Locator;
@@ -12,14 +19,14 @@ export class OnboardingPage extends AdminPage {
         super(page);
 
         this.pageUrl = '/ghost/#/setup/onboarding';
-        this.checklist = page.getByTestId('onboarding-checklist');
-        this.completeButton = page.getByTestId('onboarding-complete');
+        this.checklist = page.getByTestId(onboardingChecklist);
+        this.completeButton = page.getByTestId(onboardingComplete);
         this.copyLinkButton = page.getByTestId('onboarding-copy-link');
-        this.shareModal = page.getByTestId('onboarding-share-modal');
-        this.skipButton = page.getByTestId('onboarding-skip');
+        this.shareModal = page.getByTestId(onboardingShareModal);
+        this.skipButton = page.getByTestId(onboardingSkip);
     }
 
     step(stepId: string) {
-        return this.page.getByTestId(`onboarding-step-${stepId}`);
+        return this.page.getByTestId(`${onboardingStepPrefix}${stepId}`);
     }
 }

--- a/e2e/tests/admin/onboarding.test.ts
+++ b/e2e/tests/admin/onboarding.test.ts
@@ -6,10 +6,9 @@ type ChecklistState = 'pending' | 'started' | 'completed' | 'dismissed';
 
 const allSteps = ['customize-design', 'first-post', 'build-audience', 'share-publication'];
 const activeStartedAt = '2026-05-01T00:00:00.000Z';
-const navigationSteps: Array<[string, RegExp]> = [
+const legacyNavigationSteps: Array<[string, RegExp]> = [
     ['customize-design', /\/ghost\/(?:\?[^#]*)?#\/settings\/design\/edit\?ref=setup/],
-    ['first-post', /\/ghost\/(?:\?[^#]*)?#\/editor\/post/],
-    ['build-audience', /\/ghost\/(?:\?[^#]*)?#\/members/]
+    ['first-post', /\/ghost\/(?:\?[^#]*)?#\/editor\/post/]
 ];
 
 test.use({isolation: 'per-test'});
@@ -90,22 +89,6 @@ test.describe('Ghost Admin - Onboarding Checklist', () => {
         expect(typeof preferences.startedAt).toBe('string');
     });
 
-    test('analytics routes redirect to onboarding while active', async ({page}) => {
-        await startOnboarding(page);
-
-        await page.goto('/ghost/#/analytics');
-
-        let onboardingPage = new OnboardingPage(page);
-        await expect(onboardingPage.checklist).toBeVisible();
-        await expectOnboardingRoute(page);
-
-        await page.goto('/ghost/#/analytics/web');
-
-        onboardingPage = new OnboardingPage(page);
-        await expect(onboardingPage.checklist).toBeVisible();
-        await expectOnboardingRoute(page, {returnTo: '/analytics/web'});
-    });
-
     test('completed and dismissed users reach Analytics normally', async ({page}) => {
         const analyticsPage = new AnalyticsOverviewPage(page);
 
@@ -135,6 +118,20 @@ test.describe('Ghost Admin - Onboarding Checklist', () => {
         });
     });
 
+    legacyNavigationSteps.forEach(([step, expectedUrl]) => {
+        test(`${step} step marks complete and navigates`, async ({page}) => {
+            await startOnboarding(page);
+
+            const onboardingPage = new OnboardingPage(page);
+            await onboardingPage.step(step).click();
+
+            await expect(page).toHaveURL(expectedUrl);
+
+            const preferences = await getOnboardingPreferences(page);
+            expect(preferences.completedSteps).toContain(step);
+        });
+    });
+
     test('legacy started users without startedAt reach Analytics and are dismissed', async ({page}) => {
         const analyticsPage = new AnalyticsOverviewPage(page);
 
@@ -150,32 +147,6 @@ test.describe('Ghost Admin - Onboarding Checklist', () => {
         await expect.poll(async () => {
             return (await getOnboardingPreferences(page))?.completedSteps;
         }).toEqual([]);
-    });
-
-    navigationSteps.forEach(([step, expectedUrl]) => {
-        test(`${step} step marks complete and navigates`, async ({page}) => {
-            await startOnboarding(page);
-
-            const onboardingPage = new OnboardingPage(page);
-            await onboardingPage.step(step).click();
-
-            await expect(page).toHaveURL(expectedUrl);
-
-            const preferences = await getOnboardingPreferences(page);
-            expect(preferences.completedSteps).toContain(step);
-        });
-    });
-
-    test('share step opens the dialog and marks the step complete', async ({page}) => {
-        await startOnboarding(page);
-
-        const onboardingPage = new OnboardingPage(page);
-        await onboardingPage.step('share-publication').click();
-
-        await expect(onboardingPage.shareModal).toBeVisible();
-
-        const preferences = await getOnboardingPreferences(page);
-        expect(preferences.completedSteps).toContain('share-publication');
     });
 
     test('skip returns to the preserved analytics URL', async ({page}) => {

--- a/packages/testing/test-data/src/selectors/onboarding.ts
+++ b/packages/testing/test-data/src/selectors/onboarding.ts
@@ -1,0 +1,16 @@
+/**
+ * Onboarding screen selector strings, consumed by the admin screen helper and
+ * the e2e page object. Source of truth: apps/admin/src/onboarding.
+ */
+
+// testids
+export const onboardingChecklist = "onboarding-checklist";
+export const onboardingComplete = "onboarding-complete";
+export const onboardingShareModal = "onboarding-share-modal";
+export const onboardingSkip = "onboarding-skip";
+/** Checklist steps carry the step id: `onboarding-step-<id>`. */
+export const onboardingStepPrefix = "onboarding-step-";
+
+// accessible names
+export const getStartedHeading = "Let's get started!";
+export const allSetHeading = "You're all set.";


### PR DESCRIPTION
## What changed

- moved deterministic onboarding redirects, the Members checklist mutation/navigation, and the share-dialog mutation into native Admin acceptance tests
- kept first-start, Analytics destination/persistence, Settings, and Editor journeys in Playwright E2E
- removed onboarding's legacy `crossApp` routing so all registered Admin routes use the unified router
- added shared onboarding selector constants consumed by both acceptance and E2E helpers

## Why

Onboarding was added while Analytics and Members still lived in separate Admin apps. Those domains have since been consolidated into `apps/admin`, so their routing and deterministic mutations can now be tested directly in the full-app acceptance tier.

The split deliberately avoids faking Analytics, Settings, or Ember destination graphs in onboarding acceptance specs. Journeys where the real destination and persisted server state matter remain E2E.

## Validation

- `cd apps/admin && pnpm test:acceptance` — 72 passed
- Admin focused ESLint and `pnpm typecheck`
- E2E focused ESLint and `pnpm test:types`
