### PR TITLE
Removed unused "should fetch email stats?" helper

### DIFF
--- a/ghost/core/core/server/services/email-analytics/lib/queries.js
+++ b/ghost/core/core/server/services/email-analytics/lib/queries.js
@@ -25,12 +25,6 @@ async function createJobIfNotExists(jobName) {
 }
 
 module.exports = {
-    async shouldFetchStats() {
-        // don't fetch stats from Mailgun if we haven't sent any emails
-        const [emailCount] = await db.knex('emails').count('id as count');
-        return emailCount && emailCount.count > 0;
-    },
-
     /**
      * Retrieves the timestamp of the last seen event for the specified email analytics events.
      * @param {EmailAnalyticsJobName} jobName - The name of the job to update.


### PR DESCRIPTION
ref b665b1a3cca118a5672b6baa11af1ce730129095

This removes some unused code. It looks like its last call was removed in b665b1a3cca118a5672b6baa11af1ce730129095, back in 2023.

`git grep -w shouldFetchStats` returns no results in `ghost/core/`. The other matches are in `apps/admin/src/analytics/views/Stats/Newsletters/newsletters.tsx`, which is unrelated.
