### PR TITLE
✨ Improved protection against spam member signups

### DIFF
--- a/ghost/core/core/server/services/members/service.js
+++ b/ghost/core/core/server/services/members/service.js
@@ -132,6 +132,11 @@ module.exports = {
             });
         }
 
+        module.exports.requestIntegrityTokenProvider = new RequestIntegrityTokenProvider({
+            themeSecret: settingsCache.get('theme_session_secret'),
+            tokenDuration: 1000 * 60 * 5
+        });
+
         module.exports.ssr = MembersSSR({
             cookieSecure: urlUtils.isSSL(urlUtils.getSiteUrl()),
             cookieKeys: [settingsCache.get('theme_session_secret')],
@@ -184,10 +189,7 @@ module.exports = {
     ssr: null,
     verificationTrigger: null,
 
-    requestIntegrityTokenProvider: new RequestIntegrityTokenProvider({
-        themeSecret: settingsCache.get('theme_session_secret'),
-        tokenDuration: 1000 * 60 * 5
-    }),
+    requestIntegrityTokenProvider: null,
 
     stripeConnect: require('./stripe-connect'),
 

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -30,6 +30,7 @@
         "staffDeviceVerification": true
     },
     "useMinFiles": true,
+    "verifyRequestIntegrity": true,
     "paths": {
         "contentPath": "content/",
         "fixtures": "core/server/data/schema/fixtures/fixtures",

--- a/ghost/core/test/e2e-api/members/send-magic-link.test.js
+++ b/ghost/core/test/e2e-api/members/send-magic-link.test.js
@@ -10,26 +10,23 @@ const DomainEvents = require('@tryghost/domain-events');
 const {anyErrorId, anyString} = matchers;
 const spamPrevention = require('../../../core/server/web/shared/middleware/api/spam-prevention');
 
-let membersAgent, membersService;
+let integrityToken, membersAgent, membersService;
 
-const addIntegrityTokenToPostRequests = (agent) => {
-    const post = agent.post.bind(agent);
-    agent.post = (url, options) => {
-        const request = post(url, options);
-        const setBody = request.body.bind(request);
+const refreshIntegrityToken = async () => {
+    const response = await membersAgent.get('/api/integrity-token/').expectStatus(200);
+    integrityToken = response.text;
+};
 
-        request.body = body => {
-            const integrityToken = Object.hasOwn(body, 'integrityToken')
-                ? body.integrityToken
-                : membersService.requestIntegrityTokenProvider.create();
+const postWithIntegrityToken = (url, options) => {
+    const request = membersAgent.post(url, options);
+    const setBody = request.body.bind(request);
 
-            return setBody({...body, integrityToken});
-        };
-
-        return request;
+    request.body = body => {
+        const token = Object.hasOwn(body, 'integrityToken') ? body.integrityToken : integrityToken;
+        return setBody({...body, integrityToken: token});
     };
 
-    return agent;
+    return request;
 };
 
 describe('sendMagicLink', function () {
@@ -38,12 +35,13 @@ describe('sendMagicLink', function () {
         membersAgent = agents.membersAgent;
 
         membersService = require('../../../core/server/services/members');
-        membersAgent = addIntegrityTokenToPostRequests(membersAgent);
 
         await fixtureManager.init('members');
     });
 
-    beforeEach(function () {
+    beforeEach(async function () {
+        await refreshIntegrityToken();
+
         mockManager.mockMail();
 
         // Reset spam prevention middleware
@@ -58,7 +56,7 @@ describe('sendMagicLink', function () {
     });
 
     it('Errors when the integrity token is missing', async function () {
-        await membersAgent.post('/api/send-magic-link')
+        await postWithIntegrityToken('/api/send-magic-link')
             .body({
                 email: 'test@example.com',
                 emailType: 'signup',
@@ -68,7 +66,7 @@ describe('sendMagicLink', function () {
     });
 
     it('Errors when the integrity token is invalid', async function () {
-        await membersAgent.post('/api/send-magic-link')
+        await postWithIntegrityToken('/api/send-magic-link')
             .body({
                 email: 'test@example.com',
                 emailType: 'signup',
@@ -78,7 +76,7 @@ describe('sendMagicLink', function () {
     });
 
     it('Errors when passed multiple emails', async function () {
-        await membersAgent.post('/api/send-magic-link')
+        await postWithIntegrityToken('/api/send-magic-link')
             .body({
                 email: 'one@test.com,two@test.com',
                 emailType: 'signup'
@@ -88,7 +86,7 @@ describe('sendMagicLink', function () {
 
     it('Returns 201 when logging in with a email that does not exist', async function () {
         const email = 'this-member-does-not-exist@test.com';
-        await membersAgent.post('/api/send-magic-link')
+        await postWithIntegrityToken('/api/send-magic-link')
             .body({
                 email,
                 emailType: 'signin'
@@ -102,7 +100,7 @@ describe('sendMagicLink', function () {
         settingsCache.set('members_signup_access', {value: 'invite'});
 
         const email = 'this-member-does-not-exist@test.com';
-        await membersAgent.post('/api/send-magic-link')
+        await postWithIntegrityToken('/api/send-magic-link')
             .body({
                 email,
                 emailType: 'signin'
@@ -116,7 +114,7 @@ describe('sendMagicLink', function () {
         settingsCache.set('members_signup_access', {value: 'invite'});
 
         const email = 'this-member-does-not-exist@test.com';
-        await membersAgent.post('/api/send-magic-link')
+        await postWithIntegrityToken('/api/send-magic-link')
             .body({
                 email,
                 emailType: 'signup'
@@ -134,7 +132,7 @@ describe('sendMagicLink', function () {
         settingsCache.set('members_signup_access', {value: 'paid'});
 
         const email = 'this-member-does-not-exist@test.com';
-        await membersAgent.post('/api/send-magic-link')
+        await postWithIntegrityToken('/api/send-magic-link')
             .body({
                 email,
                 emailType: 'signup'
@@ -149,7 +147,7 @@ describe('sendMagicLink', function () {
         settingsCache.set('members_signup_access', {value: 'none'});
 
         const email = 'this-member-does-not-exist@test.com';
-        await membersAgent.post('/api/send-magic-link')
+        await postWithIntegrityToken('/api/send-magic-link')
             .body({
                 email,
                 emailType: 'signup'
@@ -162,7 +160,7 @@ describe('sendMagicLink', function () {
 
     it('Creates a valid magic link with tokenData, and without urlHistory', async function () {
         const email = 'newly-created-user-magic-link-test@test.com';
-        const res = await membersAgent.post('/api/send-magic-link')
+        const res = await postWithIntegrityToken('/api/send-magic-link')
             .body({
                 email,
                 emailType: 'signup'
@@ -193,7 +191,7 @@ describe('sendMagicLink', function () {
 
     it('Creates a valid magic link with inbox links for Gmail', async function () {
         const email = 'test@gmail.com';
-        const res = await membersAgent.post('/api/send-magic-link')
+        const res = await postWithIntegrityToken('/api/send-magic-link')
             .body({
                 email,
                 emailType: 'signup'
@@ -207,8 +205,7 @@ describe('sendMagicLink', function () {
     it('Creates a valid magic link from custom signup with redirection', async function () {
         const customSignupUrl = 'http://localhost:2368/custom-signup-form-page';
         const email = 'newly-created-user-magic-link-test@test.com';
-        const res = await membersAgent
-            .post('/api/send-magic-link')
+        const res = await postWithIntegrityToken('/api/send-magic-link')
             .header('Referer', customSignupUrl)
             .body({
                 email,
@@ -232,8 +229,7 @@ describe('sendMagicLink', function () {
     it('Creates a valid magic link from custom signup with redirection disabled', async function () {
         const customSignupUrl = 'http://localhost:2368/custom-signup-form-page';
         const email = 'newly-created-user-magic-link-test@test.com';
-        const res = await membersAgent
-            .post('/api/send-magic-link')
+        const res = await postWithIntegrityToken('/api/send-magic-link')
             .header('Referer', customSignupUrl)
             .body({
                 email,
@@ -256,7 +252,7 @@ describe('sendMagicLink', function () {
 
     it('triggers email alert for free member signup', async function () {
         const email = 'newly-created-user-magic-link-test@test.com';
-        const res = await membersAgent.post('/api/send-magic-link')
+        const res = await postWithIntegrityToken('/api/send-magic-link')
             .body({
                 email,
                 emailType: 'signup'
@@ -293,7 +289,7 @@ describe('sendMagicLink', function () {
 
     it('Converts the urlHistory to the attribution and stores it in the token', async function () {
         const email = 'newly-created-user-magic-link-test-2@test.com';
-        await membersAgent.post('/api/send-magic-link')
+        await postWithIntegrityToken('/api/send-magic-link')
             .body({
                 email,
                 emailType: 'signup',
@@ -358,7 +354,7 @@ describe('sendMagicLink', function () {
                 ...options
             };
 
-            await membersAgent.post('/api/send-magic-link')
+            await postWithIntegrityToken('/api/send-magic-link')
                 .body(body)
                 .expectStatus(201);
 
@@ -391,8 +387,8 @@ describe('sendMagicLink', function () {
 
         it('blocks signups from email domains blocked in config', async function () {
             const blockedEmail = 'hello@blocked-domain-config.com';
-            membersAgent = addIntegrityTokenToPostRequests(membersAgent.duplicate());
-            await membersAgent.post('/api/send-magic-link')
+            membersAgent = membersAgent.duplicate();
+            await postWithIntegrityToken('/api/send-magic-link')
                 .body({
                     email: blockedEmail,
                     emailType: 'signup'
@@ -410,8 +406,8 @@ describe('sendMagicLink', function () {
             settingsCache.set('all_blocked_email_domains', {value: ['blocked-domain-setting.com']});
 
             const blockedEmail = 'hello@blocked-domain-setting.com';
-            membersAgent = addIntegrityTokenToPostRequests(membersAgent.duplicate());
-            await membersAgent.post('/api/send-magic-link')
+            membersAgent = membersAgent.duplicate();
+            await postWithIntegrityToken('/api/send-magic-link')
                 .body({
                     email: blockedEmail,
                     emailType: 'signup'
@@ -427,7 +423,7 @@ describe('sendMagicLink', function () {
 
         it('allows signups from non-blocked email domains', async function () {
             const allowedEmail = 'hello@example.com';
-            await membersAgent.post('/api/send-magic-link')
+            await postWithIntegrityToken('/api/send-magic-link')
                 .body({
                     email: allowedEmail,
                     emailType: 'signup'
@@ -441,7 +437,7 @@ describe('sendMagicLink', function () {
                 const email = 'hello-enabled@blocked-domain-config.com';
                 await membersService.api.members.create({email, name: 'Member Test'});
 
-                await membersAgent.post('/api/send-magic-link')
+                await postWithIntegrityToken('/api/send-magic-link')
                     .body({
                         email,
                         emailType: 'signin',
@@ -460,7 +456,7 @@ describe('sendMagicLink', function () {
                 const email = 'hello-enabled@blocked-domain-setting.com';
                 await membersService.api.members.create({email, name: 'Member Test'});
 
-                await membersAgent.post('/api/send-magic-link')
+                await postWithIntegrityToken('/api/send-magic-link')
                     .body({
                         email,
                         emailType: 'signin',
@@ -515,7 +511,7 @@ describe('sendMagicLink', function () {
         it('should prevent homograph attacks by normalizing unicode domains', async function () {
             const asciiEmail = 'user@example.com';
 
-            await membersAgent.post('/api/send-magic-link')
+            await postWithIntegrityToken('/api/send-magic-link')
                 .body({
                     email: asciiEmail,
                     emailType: 'signup'
@@ -524,7 +520,7 @@ describe('sendMagicLink', function () {
 
             const unicodeEmail = 'user@exаmple.com'; // Using Cyrillic 'а'
 
-            await membersAgent.post('/api/send-magic-link')
+            await postWithIntegrityToken('/api/send-magic-link')
                 .body({
                     email: unicodeEmail,
                     emailType: 'signin'
@@ -535,7 +531,7 @@ describe('sendMagicLink', function () {
         it('should normalize unicode domains for signup', async function () {
             const unicodeEmail = 'user@tëst.com';
 
-            await membersAgent.post('/api/send-magic-link')
+            await postWithIntegrityToken('/api/send-magic-link')
                 .body({
                     email: unicodeEmail,
                     emailType: 'signup'
@@ -568,7 +564,7 @@ describe('sendMagicLink', function () {
             const userLoginRateLimit = configUtils.config.get('spam').member_login.freeRetries + 1;
 
             for (let i = 0; i < userLoginRateLimit; i++) {
-                await membersAgent.post('/api/send-magic-link')
+                await postWithIntegrityToken('/api/send-magic-link')
                     .body({
                         email: 'rate-limiting-test-' + i + '@test.com',
                         emailType: 'signup'
@@ -577,7 +573,7 @@ describe('sendMagicLink', function () {
             }
 
             // Now we've been rate limited for every email
-            await membersAgent.post('/api/send-magic-link')
+            await postWithIntegrityToken('/api/send-magic-link')
                 .body({
                     email: 'other@test.com',
                     emailType: 'signup'
@@ -585,7 +581,7 @@ describe('sendMagicLink', function () {
                 .expectStatus(429);
 
             // Now we've been rate limited
-            await membersAgent.post('/api/send-magic-link')
+            await postWithIntegrityToken('/api/send-magic-link')
                 .body({
                     email: 'one@test.com',
                     emailType: 'signup'
@@ -607,7 +603,7 @@ describe('sendMagicLink', function () {
             await membersAgent.get(magicLink.pathname + magicLink.search);
 
             // We are still rate limited
-            await membersAgent.post('/api/send-magic-link')
+            await postWithIntegrityToken('/api/send-magic-link')
                 .body({
                     email: 'any@test.com',
                     emailType: 'signup'
@@ -616,9 +612,10 @@ describe('sendMagicLink', function () {
 
             // Wait 10 minutes and check if we are still rate limited
             clock.tick(10 * 60 * 1000);
+            await refreshIntegrityToken();
 
             // We should be able to send a new email
-            await membersAgent.post('/api/send-magic-link')
+            await postWithIntegrityToken('/api/send-magic-link')
                 .body({
                     email: 'any@test.com',
                     emailType: 'signup'
@@ -626,7 +623,7 @@ describe('sendMagicLink', function () {
                 .expectStatus(201);
 
             // But only once
-            await membersAgent.post('/api/send-magic-link')
+            await postWithIntegrityToken('/api/send-magic-link')
                 .body({
                     email: 'any2@test.com',
                     emailType: 'signup'
@@ -635,8 +632,9 @@ describe('sendMagicLink', function () {
 
             // Waiting 10 minutes is still enough (fibonacci)
             clock.tick(10 * 60 * 1000);
+            await refreshIntegrityToken();
 
-            await membersAgent.post('/api/send-magic-link')
+            await postWithIntegrityToken('/api/send-magic-link')
                 .body({
                     email: 'any2@test.com',
                     emailType: 'signup'
@@ -644,7 +642,7 @@ describe('sendMagicLink', function () {
                 .expectStatus(201);
 
             // Blocked again
-            await membersAgent.post('/api/send-magic-link')
+            await postWithIntegrityToken('/api/send-magic-link')
                 .body({
                     email: 'any3@test.com',
                     emailType: 'signup'
@@ -653,8 +651,9 @@ describe('sendMagicLink', function () {
 
             // Waiting 10 minutes is not enough any longer
             clock.tick(10 * 60 * 1000);
+            await refreshIntegrityToken();
 
-            await membersAgent.post('/api/send-magic-link')
+            await postWithIntegrityToken('/api/send-magic-link')
                 .body({
                     email: 'any3@test.com',
                     emailType: 'signup'
@@ -663,8 +662,9 @@ describe('sendMagicLink', function () {
 
             // Waiting 20 minutes is enough
             clock.tick(10 * 60 * 1000);
+            await refreshIntegrityToken();
 
-            await membersAgent.post('/api/send-magic-link')
+            await postWithIntegrityToken('/api/send-magic-link')
                 .body({
                     email: 'any2@test.com',
                     emailType: 'signup'
@@ -672,7 +672,7 @@ describe('sendMagicLink', function () {
                 .expectStatus(201);
 
             // Blocked again
-            await membersAgent.post('/api/send-magic-link')
+            await postWithIntegrityToken('/api/send-magic-link')
                 .body({
                     email: 'any3@test.com',
                     emailType: 'signup'
@@ -681,9 +681,10 @@ describe('sendMagicLink', function () {
 
             // Waiting 12 hours is enough to reset it completely
             clock.tick(12 * 60 * 60 * 1000 + 1000);
+            await refreshIntegrityToken();
 
             // We can try multiple times again
-            await membersAgent.post('/api/send-magic-link')
+            await postWithIntegrityToken('/api/send-magic-link')
                 .body({
                     email: 'any4@test.com',
                     emailType: 'signup'
@@ -691,7 +692,7 @@ describe('sendMagicLink', function () {
                 .expectStatus(201);
 
             // Blocked again
-            await membersAgent.post('/api/send-magic-link')
+            await postWithIntegrityToken('/api/send-magic-link')
                 .body({
                     email: 'any5@test.com',
                     emailType: 'signup'
@@ -712,14 +713,14 @@ describe('sendMagicLink', function () {
             const userLoginRateLimit = configUtils.config.get('spam').user_login.freeRetries + 1;
 
             for (let i = 0; i < userLoginRateLimit; i++) {
-                await membersAgent.post('/api/send-magic-link')
+                await postWithIntegrityToken('/api/send-magic-link')
                     .body({
                         email: 'rate-limiting-test-1@test.com',
                         emailType: 'signup'
                     })
                     .expectStatus(201);
 
-                await membersAgent.post('/api/send-magic-link')
+                await postWithIntegrityToken('/api/send-magic-link')
                     .body({
                         email: 'rate-limiting-test-2@test.com',
                         emailType: 'signup'
@@ -728,7 +729,7 @@ describe('sendMagicLink', function () {
             }
 
             // Now we've been rate limited
-            await membersAgent.post('/api/send-magic-link')
+            await postWithIntegrityToken('/api/send-magic-link')
                 .body({
                     email: 'rate-limiting-test-1@test.com',
                     emailType: 'signup'
@@ -736,7 +737,7 @@ describe('sendMagicLink', function () {
                 .expectStatus(429);
 
             // Now we've been rate limited
-            await membersAgent.post('/api/send-magic-link')
+            await postWithIntegrityToken('/api/send-magic-link')
                 .body({
                     email: 'rate-limiting-test-2@test.com',
                     emailType: 'signup'
@@ -758,7 +759,7 @@ describe('sendMagicLink', function () {
             await membersAgent.get(magicLink.pathname + magicLink.search);
 
             // The first member has been un ratelimited
-            await membersAgent.post('/api/send-magic-link')
+            await postWithIntegrityToken('/api/send-magic-link')
                 .body({
                     email: 'rate-limiting-test-1@test.com',
                     emailType: 'signup'
@@ -767,7 +768,7 @@ describe('sendMagicLink', function () {
                 .expectStatus(201);
 
             // The second is still rate limited
-            await membersAgent.post('/api/send-magic-link')
+            await postWithIntegrityToken('/api/send-magic-link')
                 .body({
                     email: 'rate-limiting-test-2@test.com',
                     emailType: 'signup'
@@ -776,9 +777,10 @@ describe('sendMagicLink', function () {
 
             // Wait 10 minutes and check if we are still rate limited
             clock.tick(10 * 60 * 1000);
+            await refreshIntegrityToken();
 
             // We should be able to send a new email
-            await membersAgent.post('/api/send-magic-link')
+            await postWithIntegrityToken('/api/send-magic-link')
                 .body({
                     email: 'rate-limiting-test-2@test.com',
                     emailType: 'signup'
@@ -794,8 +796,7 @@ describe('sendMagicLink', function () {
                 body.includeOTC = otc;
             }
 
-            return membersAgent
-                .post('/api/send-magic-link')
+            return postWithIntegrityToken('/api/send-magic-link')
                 .body(body);
         }
 
@@ -967,8 +968,7 @@ describe('sendMagicLink', function () {
             const otcRef = response.body.otc_ref;
             const otc = mail.text.match(/\d{6}/)[0];
 
-            const verifyResponse = await membersAgent
-                .post('/api/verify-otc')
+            const verifyResponse = await postWithIntegrityToken('/api/verify-otc')
                 .header('Referer', options.referer)
                 .body({
                     otcRef,
@@ -1033,8 +1033,7 @@ describe('sendMagicLink', function () {
 
                 // Make multiple verification attempts with *different* otcRefs from same IP
                 for (let i = 0; i < otcVerificationEnumerationLimit; i++) {
-                    await membersAgent
-                        .post('/api/verify-otc')
+                    await postWithIntegrityToken('/api/verify-otc')
                         .body({
                             otcRef: `fake-otc-ref-${i}`,
                             otc: '000000'
@@ -1043,8 +1042,7 @@ describe('sendMagicLink', function () {
                 }
 
                 // Now we should be rate limited (enumeration)
-                await membersAgent
-                    .post('/api/verify-otc')
+                await postWithIntegrityToken('/api/verify-otc')
                     .body({
                         otcRef: 'fake-otc-ref-final',
                         otc: '000000'
@@ -1066,8 +1064,7 @@ describe('sendMagicLink', function () {
 
                 // Make multiple failed attempts with the *same* otcRef
                 for (let i = 0; i < otcVerificationLimit; i++) {
-                    await membersAgent
-                        .post('/api/verify-otc')
+                    await postWithIntegrityToken('/api/verify-otc')
                         .body({
                             otcRef,
                             otc: `00000${i + 1}`
@@ -1076,8 +1073,7 @@ describe('sendMagicLink', function () {
                 }
 
                 // Now we should be rate limited for this specific otcRef
-                await membersAgent
-                    .post('/api/verify-otc')
+                await postWithIntegrityToken('/api/verify-otc')
                     .body({
                         otcRef,
                         otc: '000000'
@@ -1102,8 +1098,7 @@ describe('sendMagicLink', function () {
 
                 // Exhaust attempts for first otcRef
                 for (let i = 0; i < otcVerificationLimit; i++) {
-                    await membersAgent
-                        .post('/api/verify-otc')
+                    await postWithIntegrityToken('/api/verify-otc')
                         .body({
                             otcRef: 'fake-otc-ref-one',
                             otc: '000000'
@@ -1112,8 +1107,7 @@ describe('sendMagicLink', function () {
                 }
 
                 // First otcRef should be rate limited
-                await membersAgent
-                    .post('/api/verify-otc')
+                await postWithIntegrityToken('/api/verify-otc')
                     .body({
                         otcRef: 'fake-otc-ref-one',
                         otc: '000000'
@@ -1121,8 +1115,7 @@ describe('sendMagicLink', function () {
                     .expectStatus(429);
 
                 // But second otcRef should still work (independent counter)
-                await membersAgent
-                    .post('/api/verify-otc')
+                await postWithIntegrityToken('/api/verify-otc')
                     .body({
                         otcRef: 'fake-otc-ref-two',
                         otc: '000000'

--- a/ghost/core/test/e2e-api/members/send-magic-link.test.js
+++ b/ghost/core/test/e2e-api/members/send-magic-link.test.js
@@ -12,12 +12,33 @@ const spamPrevention = require('../../../core/server/web/shared/middleware/api/s
 
 let membersAgent, membersService;
 
+const addIntegrityTokenToPostRequests = (agent) => {
+    const post = agent.post.bind(agent);
+    agent.post = (url, options) => {
+        const request = post(url, options);
+        const setBody = request.body.bind(request);
+
+        request.body = body => {
+            const integrityToken = Object.hasOwn(body, 'integrityToken')
+                ? body.integrityToken
+                : membersService.requestIntegrityTokenProvider.create();
+
+            return setBody({...body, integrityToken});
+        };
+
+        return request;
+    };
+
+    return agent;
+};
+
 describe('sendMagicLink', function () {
     beforeAll(async function () {
         const agents = await agentProvider.getAgentsForMembers();
         membersAgent = agents.membersAgent;
 
         membersService = require('../../../core/server/services/members');
+        membersAgent = addIntegrityTokenToPostRequests(membersAgent);
 
         await fixtureManager.init('members');
     });
@@ -34,6 +55,26 @@ describe('sendMagicLink', function () {
 
     afterEach(function () {
         mockManager.restore();
+    });
+
+    it('Errors when the integrity token is missing', async function () {
+        await membersAgent.post('/api/send-magic-link')
+            .body({
+                email: 'test@example.com',
+                emailType: 'signup',
+                integrityToken: undefined
+            })
+            .expectStatus(400);
+    });
+
+    it('Errors when the integrity token is invalid', async function () {
+        await membersAgent.post('/api/send-magic-link')
+            .body({
+                email: 'test@example.com',
+                emailType: 'signup',
+                integrityToken: 'invalid'
+            })
+            .expectStatus(400);
     });
 
     it('Errors when passed multiple emails', async function () {
@@ -350,7 +391,7 @@ describe('sendMagicLink', function () {
 
         it('blocks signups from email domains blocked in config', async function () {
             const blockedEmail = 'hello@blocked-domain-config.com';
-            membersAgent = membersAgent.duplicate();
+            membersAgent = addIntegrityTokenToPostRequests(membersAgent.duplicate());
             await membersAgent.post('/api/send-magic-link')
                 .body({
                     email: blockedEmail,
@@ -369,7 +410,7 @@ describe('sendMagicLink', function () {
             settingsCache.set('all_blocked_email_domains', {value: ['blocked-domain-setting.com']});
 
             const blockedEmail = 'hello@blocked-domain-setting.com';
-            membersAgent = membersAgent.duplicate();
+            membersAgent = addIntegrityTokenToPostRequests(membersAgent.duplicate());
             await membersAgent.post('/api/send-magic-link')
                 .body({
                     email: blockedEmail,


### PR DESCRIPTION
## What changed

Enabled `verifyRequestIntegrity` in Ghost's default configuration.

Updated the members magic-link acceptance tests to fetch integrity tokens through the public Members API and include them in protected requests, while retaining explicit coverage for missing and invalid tokens.

## Why

Request integrity validation has been available behind an opt-in flag since 2024, but leaving it disabled by default means installations do not benefit from the spam protection unless operators discover and configure the undocumented flag themselves.

With this change, member requests require the integrity token that Portal and Signup Form already send. Installations can still explicitly override the setting if needed.

Ref https://github.com/TryGhost/Ghost/issues/20767

## Testing

- `pnpm nx run ghost:test:e2e -- test/e2e-api/members/send-magic-link.test.js` (46 tests passed)
- `pnpm exec eslint test/e2e-api/members/send-magic-link.test.js`
- `pnpm test:single test/unit/shared/config/loader.test.js` (8 tests passed)
- `pnpm test:single test/unit/server/services/members/middleware.test.js` (19 tests passed)
- pre-commit lint and secret scanning passed
- `git diff --check`