### PR TITLE
Fixed navigation race in Admin sidebar acceptance test

### DIFF
--- a/apps/admin/src/layout/sidebar.acceptance.test.tsx
+++ b/apps/admin/src/layout/sidebar.acceptance.test.tsx
@@ -173,10 +173,11 @@ describe("Network notification badge", () => {
         await expect.element(sidebarScreen.networkBadge()).toBeVisible();
 
         await sidebarScreen.navLink("Network").click();
-        await expect.poll(currentRoute).toMatch(/^\/(network|activitypub)/);
+        await expect.poll(currentRoute).toBe("/activitypub/welcome/1");
         await expect.element(sidebarScreen.networkBadge()).not.toBeInTheDocument();
 
         await sidebarScreen.navLink("Posts").click();
+        await expect.poll(currentRoute).toBe("/posts");
         await expect.element(sidebarScreen.networkBadge()).toBeVisible();
     });
 });


### PR DESCRIPTION
## What changed

- Wait for the Network navigation to settle on the ActivityPub onboarding route.
- Wait for the subsequent Posts navigation to complete before asserting that the notification badge is restored.

## Why

The test accepted the transient `/network` route even though its loader redirects into ActivityPub. It could then click Posts while the ActivityPub redirect was still pending. When that redirect won the race, the test remained on ActivityPub and the badge was correctly hidden, causing the recurring CI failure.

## Impact

This makes the sidebar acceptance test deterministic without changing production behavior or Vite dependency optimization.

## Validation

- `pnpm nx run @tryghost/admin:test:acceptance -- src/layout/sidebar.acceptance.test.tsx` — 16 tests passed
- `pnpm --dir apps/admin exec eslint src/layout/sidebar.acceptance.test.tsx`
