### PR TITLE
Fixed knex-migrator config loading after TypeScript conversion

### DIFF
--- a/ghost/core/MigratorConfig.js
+++ b/ghost/core/MigratorConfig.js
@@ -2,15 +2,6 @@
  * knex-migrator requires this exact filename in the project root, therefore, linter naming rules are disabled here.
  * @see https://github.com/TryGhost/knex-migrator
  */
-const config = require('./core/shared/config');
-const ghostVersion = require('@tryghost/version');
-
-/**
- * knex-migrator can be used via CLI or within the application
- * when using the CLI, we need to ensure that our global overrides are triggered
- */
-require('./core/server/overrides');
-
 /**
  * Register tsx so that require() can resolve .ts files used in server code.
  *
@@ -25,6 +16,15 @@ try {
         throw err;
     }
 }
+
+const config = require('./core/shared/config');
+const ghostVersion = require('@tryghost/version');
+
+/**
+ * knex-migrator can be used via CLI or within the application
+ * when using the CLI, we need to ensure that our global overrides are triggered
+ */
+require('./core/server/overrides');
 
 module.exports = {
     currentVersion: ghostVersion.safe,

--- a/ghost/core/test/unit/migrator-config.test.js
+++ b/ghost/core/test/unit/migrator-config.test.js
@@ -1,0 +1,14 @@
+const assert = require('node:assert/strict');
+const {execFileSync} = require('node:child_process');
+const path = require('node:path');
+
+describe('MigratorConfig', function () {
+    it('loads in a bare Node process', function () {
+        assert.doesNotThrow(() => {
+            execFileSync(process.execPath, ['-e', "require('./MigratorConfig.js')"], {
+                cwd: path.join(__dirname, '../..'),
+                stdio: 'pipe'
+            });
+        });
+    });
+});

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "create-package": "node ./scripts/create-package.mjs",
     "knex-migrator": "pnpm --filter ghost run knex-migrator",
     "setup": "pnpm install && git submodule update --init --recursive",
+    "migrate:db": "docker exec --workdir /home/ghost/ghost/core ghost-dev pnpm knex-migrator migrate",
+    "rollback:db": "docker exec --workdir /home/ghost/ghost/core ghost-dev pnpm knex-migrator rollback",
     "reset:db": "docker exec ghost-dev bash -c 'cd /home/ghost/ghost/core && pnpm knex-migrator reset && pnpm knex-migrator init'",
     "reset:db:volume": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} down && docker volume rm ghost-dev_mysql-data",
     "reset:data": "docker exec ghost-dev bash -c 'cd /home/ghost/ghost/core && node index.js generate-data --clear-database --quantities members:1000,posts:100 --seed 123'",


### PR DESCRIPTION
no refs

`MigratorConfig.js` loaded the shared configuration before registering `tsx/cjs`. After shared config moved to TypeScript, that bare CLI load failed with `MODULE_NOT_FOUND`, which knex-migrator misleadingly surfaced as a missing config file.

Register the existing guarded `tsx/cjs` hook before any TypeScript-backed server modules. The guard remains unchanged so production installs can continue without `tsx`, and a bare-Node subprocess test covers the CLI loading path.

Also: added root `migrate:db` and `rollback:db` scripts that run knex-migrator inside `ghost-dev` against the MySQL database used by `pnpm dev` (or the sqlite database used by `pnpm dev:sqlite`). Additional knex-migrator options are forwarded naturally, avoiding a manual container shell.