### PR TITLE
Cleaned up stale references to the removed posts and stats apps

### DIFF
--- a/.agents/skills/shade-page-templates/SKILL.md
+++ b/.agents/skills/shade-page-templates/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: Shade page templates
-description: Pick the right Shade page template (ListPage, PageHeader) for a new admin page instead of inventing chrome. Trigger when creating new admin pages or routes in apps/admin, apps/admin-x-settings, apps/posts, apps/stats, apps/activitypub.
+description: Pick the right Shade page template (ListPage, PageHeader) for a new admin page instead of inventing chrome. Trigger when creating new admin pages or routes in apps/admin, apps/admin-x-settings, apps/activitypub.
 autoTrigger:
-  - fileEdit: "apps/{admin,admin-x-settings,activitypub,posts,stats}/src/**/*.tsx"
+  - fileEdit: "apps/{admin,admin-x-settings,activitypub}/src/**/*.tsx"
 ---
 
 # Shade — page templates

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,8 +23,8 @@ Ghost is a pnpm + Nx monorepo with three workspace groups:
 Two categories of apps:
 
 **Admin Apps** (embedded in Ghost Admin):
-- `admin-x-settings`, `admin-x-activitypub` - Settings and integrations
-- `posts`, `stats` - Post analytics and site-wide analytics
+- `admin` - The consolidated React admin shell, organized by domain (`src/{analytics,members,posts,tags,comments,automations,...}`)
+- `admin-x-settings`, `activitypub` - Settings and ActivityPub integration (route-composed into `admin`)
 - Built with Vite + React + `@tanstack/react-query`
 
 **Public Apps** (served to site visitors):
@@ -41,7 +41,7 @@ Merged from the former TryGhost/Koenig repo with full git history:
 
 - **koenig-lexical** - The Lexical-based rich text editor UI. Bundled into
   Ghost Admin at build time (`ghost/admin` copies its UMD build into admin
-  assets; `apps/posts` and `apps/admin` import it directly)
+  assets; `apps/admin` imports it directly)
 - **kg-*** - Editor support packages: server-side renderers and converters
   consumed by `ghost/core` (kg-default-nodes, kg-lexical-html-renderer,
   kg-html-to-lexical, ...) plus frontend helpers (kg-unsplash-selector)
@@ -264,12 +264,12 @@ Critical build order (Nx handles automatically):
 
 ### TailwindCSS v4 Setup
 
-Ghost Admin uses **TailwindCSS v4** via the `@tailwindcss/vite` plugin. CSS processing is centralized — only `apps/admin/vite.config.ts` loads the `@tailwindcss/vite` plugin. All embedded React apps (posts, stats, activitypub, admin-x-settings, admin-x-design-system) are scanned from this single entry point.
+Ghost Admin uses **TailwindCSS v4** via the `@tailwindcss/vite` plugin. CSS processing is centralized — only `apps/admin/vite.config.ts` loads the `@tailwindcss/vite` plugin. All embedded React apps (activitypub, admin-x-settings, admin-x-design-system) are scanned from this single entry point.
 
 ### Entry Point
 
 `apps/admin/src/index.css` is the main CSS entry point. It contains:
-- `@source` directives that scan class usage in shade, posts, stats, activitypub, admin-x-settings, admin-x-design-system, and kg-unsplash-selector
+- `@source` directives that scan class usage in shade, activitypub, admin-x-settings, admin-x-design-system, and kg-unsplash-selector
 - `@import "@tryghost/shade/styles.css"` which loads the Shade design system styles
 
 ### Shade Styles
@@ -289,7 +289,7 @@ Theme tokens/variants/animations are defined in CSS (`apps/shade/tailwind.theme.
 
 ### Critical Rule: Embedded Apps Must NOT Import Shade Independently
 
-Apps consumed via `@source` (posts, stats, activitypub) must **NOT** import `@tryghost/shade/styles.css` in their own CSS. Doing so causes duplicate Tailwind utilities and cascade conflicts. All Tailwind CSS is generated once via the admin entry point.
+Apps consumed via `@source` (activitypub, admin-x-settings) must **NOT** import `@tryghost/shade/styles.css` in their own CSS. Doing so causes duplicate Tailwind utilities and cascade conflicts. All Tailwind CSS is generated once via the admin entry point.
 
 ### Public Apps
 
@@ -327,7 +327,7 @@ Conventions:
   - Exception: Tailwind — a workspace that uses it must list `tailwindcss` as its own (dev)Dependency regardless (the settings-based resolver requires it locally), and the legacy v3 apps pin `eslint-plugin-tailwindcss` via `catalog:tailwind3`.
 
 ### When Working on Admin UI
-- **New features:** Build in React (`apps/admin-x-*` or `apps/posts`)
+- **New features:** Build in React in `apps/admin` (domain folders under `src/`)
 - **Use:** `admin-x-framework` for API hooks (`useBrowse`, `useEdit`, etc.)
 - **Use:** `shade` design system for new components (not admin-x-design-system)
 - **Translations:** Add to `ghost/i18n/locales/en/ghost.json`

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/default-welcome-email-values.ts
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/default-welcome-email-values.ts
@@ -1,4 +1,4 @@
-// NOTE: this has been copy-pasted into apps/posts/src/views/Automations/utils/default-welcome-email-values.ts because we need to support the email design modal in both the settings app and the posts app until Automations GAs
+// NOTE: duplicated in apps/admin/src/automations/utils/default-welcome-email-values.ts — the email design modal needs it in both apps until Automations GAs; keep in sync
 import type {AutomatedEmail} from '@tryghost/admin-x-framework/api/automated-emails';
 
 export type WelcomeEmailType = 'free' | 'paid';

--- a/apps/admin-x-settings/src/hooks/use-welcome-email-sender-details.ts
+++ b/apps/admin-x-settings/src/hooks/use-welcome-email-sender-details.ts
@@ -1,4 +1,4 @@
-// NOTE: this has been copy-pasted into apps/posts/src/views/Automations/hooks/use-welcome-email-sender-details.ts because we need to support the email design modal in both the settings app and the posts app until Automations GAs
+// NOTE: duplicated in apps/admin/src/automations/hooks/use-welcome-email-sender-details.ts — the email design modal needs it in both apps until Automations GAs; keep in sync
 import {resolveWelcomeEmailSenderDetails} from '../utils/welcome-email-sender-details';
 import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
 import {useMemo} from 'react';

--- a/apps/admin-x-settings/src/utils/newsletter-emails.ts
+++ b/apps/admin-x-settings/src/utils/newsletter-emails.ts
@@ -1,4 +1,4 @@
-// NOTE: this has been copy-pasted into apps/posts/src/views/Automations/utils/newsletter-emails.ts because we need to support the email design modal in both the settings app and the posts app until Automations GAs
+// NOTE: duplicated in apps/admin/src/automations/utils/newsletter-emails.ts — the email design modal needs it in both apps until Automations GAs; keep in sync
 import {type Config, hasSendingDomain, isManagedEmail} from '@tryghost/admin-x-framework/api/config';
 import {type Newsletter} from '@tryghost/admin-x-framework/api/newsletters';
 

--- a/apps/admin-x-settings/src/utils/welcome-email-sender-details.ts
+++ b/apps/admin-x-settings/src/utils/welcome-email-sender-details.ts
@@ -1,4 +1,4 @@
-// NOTE: this has been copy-pasted into apps/posts/src/views/Automations/utils/welcome-email-sender-details.ts because we need to support the email design modal in both the settings app and the posts app until Automations GAs
+// NOTE: duplicated in apps/admin/src/automations/utils/welcome-email-sender-details.ts — the email design modal needs it in both apps until Automations GAs; keep in sync
 import {type Config, hasSendingDomain, isManagedEmail, sendingDomain} from '@tryghost/admin-x-framework/api/config';
 import {WELCOME_EMAIL_SLUGS} from '../components/settings/membership/member-emails/default-welcome-email-values';
 import {renderReplyToEmailPlaceholder, renderSenderEmail} from './newsletter-emails';

--- a/apps/admin/src/automations/hooks/use-welcome-email-sender-details.ts
+++ b/apps/admin/src/automations/hooks/use-welcome-email-sender-details.ts
@@ -1,4 +1,4 @@
-// NOTE: this has been copy-pasted into apps/posts/src/views/Automations/hooks/use-welcome-email-sender-details.ts because we need to support the email design modal in both the settings app and the posts app until Automations GAs
+// NOTE: duplicated in apps/admin-x-settings/src/hooks/use-welcome-email-sender-details.ts — the email design modal needs it in both apps until Automations GAs; keep in sync
 import {resolveWelcomeEmailSenderDetails} from '@/automations/utils/welcome-email-sender-details';
 import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
 import {useMemo} from 'react';

--- a/apps/admin/src/automations/utils/default-welcome-email-values.ts
+++ b/apps/admin/src/automations/utils/default-welcome-email-values.ts
@@ -1,4 +1,4 @@
-// NOTE: this has been copy-pasted into apps/posts/src/views/Automations/utils/default-welcome-email-values.ts because we need to support the email design modal in both the settings app and the posts app until Automations GAs
+// NOTE: duplicated in apps/admin-x-settings/src/components/settings/membership/member-emails/default-welcome-email-values.ts — the email design modal needs it in both apps until Automations GAs; keep in sync
 import type {AutomatedEmail} from '@tryghost/admin-x-framework/api/automated-emails';
 
 export type WelcomeEmailType = 'free' | 'paid';

--- a/apps/admin/src/automations/utils/newsletter-emails.ts
+++ b/apps/admin/src/automations/utils/newsletter-emails.ts
@@ -1,4 +1,4 @@
-// NOTE: this has been copy-pasted into apps/posts/src/views/Automations/utils/newsletter-emails.ts because we need to support the email design modal in both the settings app and the posts app until Automations GAs
+// NOTE: duplicated in apps/admin-x-settings/src/utils/newsletter-emails.ts — the email design modal needs it in both apps until Automations GAs; keep in sync
 import {type Config, hasSendingDomain, isManagedEmail} from '@tryghost/admin-x-framework/api/config';
 import {type Newsletter} from '@tryghost/admin-x-framework/api/newsletters';
 

--- a/apps/admin/src/automations/utils/welcome-email-sender-details.ts
+++ b/apps/admin/src/automations/utils/welcome-email-sender-details.ts
@@ -1,4 +1,4 @@
-// NOTE: this has been copy-pasted into apps/posts/src/views/Automations/utils/welcome-email-sender-details.ts because we need to support the email design modal in both the settings app and the posts app until Automations GAs
+// NOTE: duplicated in apps/admin-x-settings/src/utils/welcome-email-sender-details.ts — the email design modal needs it in both apps until Automations GAs; keep in sync
 import {type Config, hasSendingDomain, isManagedEmail, sendingDomain} from '@tryghost/admin-x-framework/api/config';
 import {WELCOME_EMAIL_SLUGS} from './default-welcome-email-values';
 import {renderReplyToEmailPlaceholder, renderSenderEmail} from './newsletter-emails';

--- a/apps/admin/src/layout/app-sidebar/shared-views.ts
+++ b/apps/admin/src/layout/app-sidebar/shared-views.ts
@@ -24,7 +24,6 @@ export function useSharedViews(route?: string) {
     const {data: settingsData} = useBrowseSettings();
 
     return useMemo(() => {
-        // TODO: Consolidate shared view parsing once the admin and posts apps are merged.
         const sharedViewsJson = getSettingValue<string>(settingsData?.settings, 'shared_views') ?? '[]';
         const parsed = parseAllSharedViewsJSON(sharedViewsJson);
 

--- a/apps/admin/src/members/shared-views.ts
+++ b/apps/admin/src/members/shared-views.ts
@@ -1,6 +1,5 @@
 import {z} from 'zod';
 
-// TODO: Consolidate shared view parsing once the admin and posts apps are merged.
 export const sharedViewSchema = z.object({
     name: z.string(),
     route: z.string(),

--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -103,9 +103,6 @@ export const routes: RouteObject[] = [
             },
             membersRoute,
             {
-                // Post analytics folded into the shell table. Its own data provider
-                // (PostAnalyticsProvider) wraps the view; PostsAppContext dissolved —
-                // the header reads appSettings from the framework AppContext directly.
                 path: "/posts/analytics/:postId",
                 lazy: async () => {
                     const [{ default: PostAnalyticsProvider }, { default: PostAnalytics }] = await Promise.all([

--- a/configs/eslint-react/index.mjs
+++ b/configs/eslint-react/index.mjs
@@ -106,7 +106,7 @@ import {
  * @returns {import('eslint').Linter.Config[]}
  *
  * @example
- * // apps/posts/eslint.config.js — Vite TS React + Tailwind v4 + shade restriction
+ * // apps/<app>/eslint.config.js — Vite TS React + Tailwind v4 + shade restriction
  * import {reactAppConfig} from '@internal/cfg-eslint-react';
  * export default reactAppConfig({
  *   tailwindCssPath: `${import.meta.dirname}/../admin/src/index.css`,

--- a/docker/dev-gateway/README.md
+++ b/docker/dev-gateway/README.md
@@ -26,7 +26,7 @@ Caddy uses environment variables (set in `compose.dev.yaml`) to configure proxy 
   - For developing with the [ActivityPub project](https://github.com/TryGhost/ActivityPub) running locally
   - Requires the ActivityPub docker-compose services to be running
 
-**Note:** AdminX React apps (admin-x-settings, activitypub, posts, stats) are served through the admin dev server so they don't need separate proxy entries.
+**Note:** AdminX React apps (admin-x-settings, activitypub) are served through the admin dev server so they don't need separate proxy entries.
 
 ### Ghost Configuration
 Ghost is configured via environment variables in `compose.dev.yaml` to load public app assets from `/ghost/assets/*` (e.g., `portal__url: /ghost/assets/portal/portal.min.js`). This uses the same path structure as built admin assets.

--- a/ghost/core/core/server/data/schema/views.js
+++ b/ghost/core/core/server/data/schema/views.js
@@ -38,8 +38,8 @@
 // The admin display reads the resolved subscription straight from the
 // `current_subscription` field the backend derives from this view (via the
 // members_current_subscription lookup), so the ordering here is the single
-// source of truth for both filtering and display — see getCurrentSubscription
-// in apps/posts/src/views/members/member-query-params.ts.
+// source of truth for both filtering and display — see the
+// `current_subscription` reads in apps/admin/src/members/member-query-params.ts.
 module.exports = {
     members_resolved_subscription: `
         SELECT member_id, subscription_id

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -4,11 +4,10 @@ import {defineConfig} from 'vitest/config';
 // Root Vitest config — a single watcher across every Vitest-based package in
 // the monorepo. `pnpm test:watch` runs this. Each package is a project that
 // keeps its own config (environment, setup, pool); scope to one with a path
-// filter, e.g. `pnpm test:watch apps/posts`.
+// filter, e.g. `pnpm test:watch apps/admin`.
 //
 // Not included: ghost-admin (Ember Mocha, pending the Ember retirement).
-// admin-x-activitypub is a dead directory with no
-// package.json or test config. signup-form has no Vitest unit tests (its
+// signup-form has no Vitest unit tests (its
 // test:unit is a build; test/unit holds only an empty placeholder).
 export default defineConfig({
     test: {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLA-246/

The posts/stats packages dissolved into `apps/admin` domain folders, but a number of docs and code comments still pointed at the deleted `apps/posts`/`apps/stats` paths — including AGENTS.md directing new admin features to `apps/posts`.

Comment/doc-only; no behavior change.

- **AGENTS.md** — admin-apps inventory, koenig-lexical consumers, the Tailwind `@source` lists (now matching `apps/admin/src/index.css`), and the "where to build new admin features" guidance
- **docker/dev-gateway/README.md** — served-apps note
- **vitest.config.mjs** — watch-filter example + a sentence about the long-gone `admin-x-activitypub` directory
- **configs/eslint-react/index.mjs** — `@example` header named a deleted config file; made generic
- **ghost/core .../schema/views.js** — cross-reference to the member subscription-resolution consumer, now at `apps/admin/src/members/member-query-params.ts` (and no longer a `getCurrentSubscription` helper)
- **automations email utils (8 files)** — the duplicated-file NOTEs pointed at the deleted posts copies; they now point at the real counterpart in the other app so the keep-in-sync constraint survives
- **apps/admin/src/routes.tsx** — dropped a comment narrating the dissolved PostsAppContext
- **shared-views.ts ×2** — dropped TODOs whose "once the apps are merged" premise is satisfied (the layout hook already delegates to the members parser)
- **shade-page-templates skill** — trigger list/glob no longer names posts/stats

Deliberately left: `apps/shade`'s `posts-stats` transitional subpath and the docs describing it — that subpath still exists and is removed separately.

## Verification

- `eslint` clean on all touched JS/TS files (also enforced by lint-staged on commit)
- `grep -rn 'apps/posts\|apps/stats'` across the repo now only matches the intentionally-kept shade `posts-stats` files