### PR TITLE
🐛 Fixed expired sessions leaving Admin stuck instead of returning to signin

### DIFF
--- a/apps/admin-x-framework/src/hooks/use-handle-error.ts
+++ b/apps/admin-x-framework/src/hooks/use-handle-error.ts
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/react';
 import {useCallback} from 'react';
 import toast from 'react-hot-toast';
 import {useFramework} from '../providers/framework-provider';
-import {APIError, UnauthorizedError, getErrorMessage} from '../utils/errors';
+import {APIError, SessionExpiredError, getErrorMessage} from '../utils/errors';
 import {showToast} from '../utils/toast';
 
 function showErrorToast(message: React.ReactNode) {
@@ -32,7 +32,7 @@ const useHandleError = () => {
         // eslint-disable-next-line no-console
         console.error(error);
 
-        if (sentryDSN) {
+        if (sentryDSN && !(error instanceof SessionExpiredError)) {
             Sentry.withScope((scope) => {
                 if (error instanceof APIError && error.response) {
                     scope.setTag('api_url', error.response.url);
@@ -51,7 +51,7 @@ const useHandleError = () => {
             // don't show a toast because it may block clicking things in the test,
             // but still clear lingering toasts that would block clicks the same way
             toast.remove();
-        } else if (error instanceof UnauthorizedError) {
+        } else if (error instanceof SessionExpiredError) {
             // Session-expiry 401s trigger a redirect to signin in the fetch
             // layer - a toast would only flash while the page unloads
             toast.remove();

--- a/apps/admin-x-framework/src/hooks/use-handle-error.ts
+++ b/apps/admin-x-framework/src/hooks/use-handle-error.ts
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/react';
 import {useCallback} from 'react';
 import toast from 'react-hot-toast';
 import {useFramework} from '../providers/framework-provider';
-import {APIError, getErrorMessage} from '../utils/errors';
+import {APIError, UnauthorizedError, getErrorMessage} from '../utils/errors';
 import {showToast} from '../utils/toast';
 
 function showErrorToast(message: React.ReactNode) {
@@ -50,6 +50,10 @@ const useHandleError = () => {
             // We use this status in tests to indicate the API request was not mocked -
             // don't show a toast because it may block clicking things in the test,
             // but still clear lingering toasts that would block clicks the same way
+            toast.remove();
+        } else if (error instanceof UnauthorizedError) {
+            // Session-expiry 401s trigger a redirect to signin in the fetch
+            // layer - a toast would only flash while the page unloads
             toast.remove();
         } else if (error instanceof APIError) {
             showErrorToast(getErrorMessage(error, error.message));

--- a/apps/admin-x-framework/src/utils/api/fetch-api.ts
+++ b/apps/admin-x-framework/src/utils/api/fetch-api.ts
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/react';
 import {useCallback} from 'react';
 import {useFramework} from '../../providers/framework-provider';
-import {APIError, MaintenanceError, ServerUnreachableError, TimeoutError} from '../errors';
+import {APIError, MaintenanceError, ServerUnreachableError, TimeoutError, UnauthorizedError} from '../errors';
 import {getGhostPaths} from '../helpers';
 import handleResponse from './handle-response';
 
@@ -49,6 +49,24 @@ const xhrToFetchResponse = (xhr: Readonly<XMLHttpRequest>): Response => (
         headers: xhrHeadersToFetchHeaders(xhr)
     })
 );
+
+const GHOST_API_REQUEST = /\/ghost\/api\//;
+const SESSION_API_REQUEST = /\/ghost\/api\/admin\/session(\/|$)/;
+
+let sessionExpiryHandled = false;
+
+// A 401 outside the session endpoint means the cookie session expired. Mirrors
+// Ember's handling: replace to the admin root, which reboots Admin onto signin.
+const redirectOnSessionExpiry = (endpoint: string | URL) => {
+    const url = endpoint.toString();
+
+    if (sessionExpiryHandled || !GHOST_API_REQUEST.test(url) || SESSION_API_REQUEST.test(url)) {
+        return;
+    }
+
+    sessionExpiryHandled = true;
+    window.location.replace(getGhostPaths().adminRoot);
+};
 
 const fetchWithXhr = (
     onUploadProgress: (progress: number) => void,
@@ -187,7 +205,8 @@ export const useFetchApi = () => {
             while (attempts === 0 || retry) {
                 try {
                     const response = await fetchFn(endpoint, requestInit);
-                    return handleResponse(response) as ResponseData;
+                    // Awaited so response errors reject inside the try/catch
+                    return await handleResponse(response) as ResponseData;
                 } catch (error) {
                     retryingMs = Date.now() - startTime;
 
@@ -205,6 +224,10 @@ export const useFetchApi = () => {
 
                     if (error && typeof error === 'object' && 'name' in error && error.name === 'AbortError') {
                         throw new TimeoutError();
+                    }
+
+                    if (error instanceof UnauthorizedError) {
+                        redirectOnSessionExpiry(endpoint);
                     }
 
                     let newError = error;

--- a/apps/admin-x-framework/src/utils/api/fetch-api.ts
+++ b/apps/admin-x-framework/src/utils/api/fetch-api.ts
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/react';
 import {useCallback} from 'react';
 import {useFramework} from '../../providers/framework-provider';
-import {APIError, MaintenanceError, ServerUnreachableError, TimeoutError, UnauthorizedError} from '../errors';
+import {APIError, MaintenanceError, ServerUnreachableError, SessionExpiredError, TimeoutError, UnauthorizedError} from '../errors';
 import {getGhostPaths} from '../helpers';
 import handleResponse from './handle-response';
 
@@ -51,7 +51,7 @@ const xhrToFetchResponse = (xhr: Readonly<XMLHttpRequest>): Response => (
 );
 
 const GHOST_API_REQUEST = /\/ghost\/api\//;
-const SESSION_API_REQUEST = /\/ghost\/api\/admin\/session(\/|$)/;
+const SESSION_API_REQUEST = /\/ghost\/api\/admin\/session([/?#]|$)/;
 
 let sessionExpiryHandled = false;
 
@@ -60,12 +60,16 @@ let sessionExpiryHandled = false;
 const redirectOnSessionExpiry = (endpoint: string | URL) => {
     const url = endpoint.toString();
 
-    if (sessionExpiryHandled || !GHOST_API_REQUEST.test(url) || SESSION_API_REQUEST.test(url)) {
-        return;
+    if (!GHOST_API_REQUEST.test(url) || SESSION_API_REQUEST.test(url)) {
+        return false;
     }
 
-    sessionExpiryHandled = true;
-    window.location.replace(getGhostPaths().adminRoot);
+    if (!sessionExpiryHandled) {
+        sessionExpiryHandled = true;
+        window.location.replace(getGhostPaths().adminRoot);
+    }
+
+    return true;
 };
 
 const fetchWithXhr = (
@@ -226,8 +230,8 @@ export const useFetchApi = () => {
                         throw new TimeoutError();
                     }
 
-                    if (error instanceof UnauthorizedError) {
-                        redirectOnSessionExpiry(endpoint);
+                    if (error instanceof UnauthorizedError && redirectOnSessionExpiry(endpoint)) {
+                        throw new SessionExpiredError(error.response!, error.data, {cause: error});
                     }
 
                     let newError = error;

--- a/apps/admin-x-framework/src/utils/api/fetch-api.ts
+++ b/apps/admin-x-framework/src/utils/api/fetch-api.ts
@@ -52,7 +52,7 @@ const xhrToFetchResponse = (xhr: Readonly<XMLHttpRequest>): Response => (
 
 const GHOST_API_REQUEST = /\/ghost\/api\//;
 const SESSION_API_REQUEST = /\/ghost\/api\/admin\/session([/?#]|$)/;
-const UNAUTHENTICATED_ADMIN_ROUTE = /^#\/(?:setup|signin|signup)(?:[/?]|$)/;
+const UNAUTHENTICATED_ADMIN_ROUTE = /^#\/(?:reset|setup|signin|signup)(?:[/?]|$)/;
 
 let sessionExpiryHandled = false;
 
@@ -65,23 +65,21 @@ const isUnauthenticatedAdminRoute = (adminRoot: string) => {
 };
 
 // An unauthorized Ghost API response outside the session endpoint means the
-// cookie session expired. Replace to the admin root unless Ember is already
-// booting or displaying an unauthenticated route.
-const redirectOnSessionExpiry = (endpoint: string | URL) => {
+// cookie session expired
+const isSessionExpiry = (endpoint: string | URL) => {
     const url = endpoint.toString();
+    return GHOST_API_REQUEST.test(url) && !SESSION_API_REQUEST.test(url);
+};
 
-    if (!GHOST_API_REQUEST.test(url) || SESSION_API_REQUEST.test(url)) {
-        return false;
-    }
-
+// Replace to the admin root at most once across concurrent failures, unless
+// Ember is already booting or displaying an unauthenticated route
+const redirectOnSessionExpiry = () => {
     const {adminRoot} = getGhostPaths();
 
     if (!sessionExpiryHandled && !isUnauthenticatedAdminRoute(adminRoot)) {
         sessionExpiryHandled = true;
         window.location.replace(adminRoot);
     }
-
-    return true;
 };
 
 const fetchWithXhr = (
@@ -242,7 +240,8 @@ export const useFetchApi = () => {
                         throw new TimeoutError();
                     }
 
-                    if (error instanceof UnauthorizedError && redirectOnSessionExpiry(endpoint)) {
+                    if (error instanceof UnauthorizedError && isSessionExpiry(endpoint)) {
+                        redirectOnSessionExpiry();
                         throw new SessionExpiredError(error.response!, error.data, {cause: error});
                     }
 

--- a/apps/admin-x-framework/src/utils/api/fetch-api.ts
+++ b/apps/admin-x-framework/src/utils/api/fetch-api.ts
@@ -52,11 +52,21 @@ const xhrToFetchResponse = (xhr: Readonly<XMLHttpRequest>): Response => (
 
 const GHOST_API_REQUEST = /\/ghost\/api\//;
 const SESSION_API_REQUEST = /\/ghost\/api\/admin\/session([/?#]|$)/;
+const UNAUTHENTICATED_ADMIN_ROUTE = /^#\/(?:setup|signin|signup)(?:[/?]|$)/;
 
 let sessionExpiryHandled = false;
 
-// A 401 outside the session endpoint means the cookie session expired. Mirrors
-// Ember's handling: replace to the admin root, which reboots Admin onto signin.
+const isUnauthenticatedAdminRoute = (adminRoot: string) => {
+    return window.location.pathname === adminRoot && (
+        !window.location.hash
+        || window.location.hash === '#/'
+        || UNAUTHENTICATED_ADMIN_ROUTE.test(window.location.hash)
+    );
+};
+
+// An unauthorized Ghost API response outside the session endpoint means the
+// cookie session expired. Replace to the admin root unless Ember is already
+// booting or displaying an unauthenticated route.
 const redirectOnSessionExpiry = (endpoint: string | URL) => {
     const url = endpoint.toString();
 
@@ -64,9 +74,11 @@ const redirectOnSessionExpiry = (endpoint: string | URL) => {
         return false;
     }
 
-    if (!sessionExpiryHandled) {
+    const {adminRoot} = getGhostPaths();
+
+    if (!sessionExpiryHandled && !isUnauthenticatedAdminRoute(adminRoot)) {
         sessionExpiryHandled = true;
-        window.location.replace(getGhostPaths().adminRoot);
+        window.location.replace(adminRoot);
     }
 
     return true;

--- a/apps/admin-x-framework/src/utils/api/handle-response.ts
+++ b/apps/admin-x-framework/src/utils/api/handle-response.ts
@@ -1,4 +1,4 @@
-import {APIError, EmailError, ErrorResponse, HostLimitError, JSONError, MaintenanceError, RequestEntityTooLargeError, ServerUnreachableError, ThemeValidationError, UnsupportedMediaTypeError, ValidationError, VersionMismatchError} from '../errors';
+import {APIError, EmailError, ErrorResponse, HostLimitError, JSONError, MaintenanceError, RequestEntityTooLargeError, ServerUnreachableError, ThemeValidationError, UnauthorizedError, UnsupportedMediaTypeError, ValidationError, VersionMismatchError} from '../errors';
 
 const handleResponse = async (response: Response) => {
     if (response.status === 0) {
@@ -9,6 +9,8 @@ const handleResponse = async (response: Response) => {
         throw new UnsupportedMediaTypeError(response, await response.text());
     } else if (response.status === 413) {
         throw new RequestEntityTooLargeError(response, await response.text());
+    } else if (response.status === 401) {
+        throw new UnauthorizedError(response, await response.text());
     } else if (!response.ok) {
         if (!response.headers.get('content-type')?.includes('json')) {
             throw new APIError(response, await response.text());

--- a/apps/admin-x-framework/src/utils/api/handle-response.ts
+++ b/apps/admin-x-framework/src/utils/api/handle-response.ts
@@ -10,6 +10,9 @@ const handleResponse = async (response: Response) => {
     } else if (response.status === 413) {
         throw new RequestEntityTooLargeError(response, await response.text());
     } else if (response.status === 401) {
+        if (response.headers.get('content-type')?.includes('json')) {
+            throw new UnauthorizedError(response, await response.json());
+        }
         throw new UnauthorizedError(response, await response.text());
     } else if (!response.ok) {
         if (!response.headers.get('content-type')?.includes('json')) {

--- a/apps/admin-x-framework/src/utils/api/handle-response.ts
+++ b/apps/admin-x-framework/src/utils/api/handle-response.ts
@@ -18,7 +18,9 @@ const handleResponse = async (response: Response) => {
 
         const data = await response.json() as ErrorResponse;
 
-        if (data.errors?.[0]?.type === 'VersionMismatchError') {
+        if (response.status === 403 && data.errors?.[0]?.message === 'Authorization failed') {
+            throw new UnauthorizedError(response, data);
+        } else if (data.errors?.[0]?.type === 'VersionMismatchError') {
             throw new VersionMismatchError(response, data);
         } else if (data.errors?.[0]?.type === 'ValidationError') {
             throw new ValidationError(response, data);

--- a/apps/admin-x-framework/src/utils/errors.ts
+++ b/apps/admin-x-framework/src/utils/errors.ts
@@ -90,6 +90,8 @@ export class UnauthorizedError extends APIError {
     }
 }
 
+export class SessionExpiredError extends UnauthorizedError {}
+
 export class ThemeValidationError extends JSONError {
     constructor(response: Response, data: ErrorResponse, errorOptions?: ErrorOptions) {
         super(response, data, 'Theme is not compatible or contains errors.', errorOptions);

--- a/apps/admin-x-framework/src/utils/errors.ts
+++ b/apps/admin-x-framework/src/utils/errors.ts
@@ -84,6 +84,12 @@ export class MaintenanceError extends APIError {
     }
 }
 
+export class UnauthorizedError extends APIError {
+    constructor(response: Response, data: unknown, errorOptions?: ErrorOptions) {
+        super(response, data, 'You are not authorised to make this request.', errorOptions);
+    }
+}
+
 export class ThemeValidationError extends JSONError {
     constructor(response: Response, data: ErrorResponse, errorOptions?: ErrorOptions) {
         super(response, data, 'Theme is not compatible or contains errors.', errorOptions);

--- a/apps/admin-x-framework/test/unit/hooks/use-handle-error.test.tsx
+++ b/apps/admin-x-framework/test/unit/hooks/use-handle-error.test.tsx
@@ -2,7 +2,7 @@ import {renderHook} from '@testing-library/react';
 import React, {ReactNode} from 'react';
 import useHandleError from '../../../src/hooks/use-handle-error';
 import {FrameworkProvider} from '../../../src/providers/framework-provider';
-import {APIError, ValidationError} from '../../../src/utils/errors';
+import {APIError, UnauthorizedError, ValidationError} from '../../../src/utils/errors';
 
 // Mock external dependencies
 vi.mock('@sentry/react', () => ({
@@ -187,6 +187,21 @@ describe('useHandleError', () => {
 
         // A stale toast can cover UI and block clicks in tests, so the
         // unmocked-request path must clear toasts even without showing one
+        expect(toast.remove).toHaveBeenCalled();
+    });
+
+    it('does not show toast for unauthorized errors', () => {
+        const wrapper = createWrapper();
+        const {result} = renderHook(() => useHandleError(), {wrapper});
+
+        const mockResponse = new Response(null, {status: 401});
+        const error = new UnauthorizedError(mockResponse, '');
+
+        result.current(error);
+
+        // The fetch layer redirects to signin on session expiry, so the
+        // error handler must not flash a toast over the unloading page
+        expect(showToast).not.toHaveBeenCalled();
         expect(toast.remove).toHaveBeenCalled();
     });
 

--- a/apps/admin-x-framework/test/unit/hooks/use-handle-error.test.tsx
+++ b/apps/admin-x-framework/test/unit/hooks/use-handle-error.test.tsx
@@ -2,7 +2,7 @@ import {renderHook} from '@testing-library/react';
 import React, {ReactNode} from 'react';
 import useHandleError from '../../../src/hooks/use-handle-error';
 import {FrameworkProvider} from '../../../src/providers/framework-provider';
-import {APIError, UnauthorizedError, ValidationError} from '../../../src/utils/errors';
+import {APIError, SessionExpiredError, UnauthorizedError, ValidationError} from '../../../src/utils/errors';
 
 // Mock external dependencies
 vi.mock('@sentry/react', () => ({
@@ -190,7 +190,34 @@ describe('useHandleError', () => {
         expect(toast.remove).toHaveBeenCalled();
     });
 
-    it('does not show toast for unauthorized errors', () => {
+    it('does not send session expiry errors to Sentry', () => {
+        const wrapper = createWrapper('https://sentry.dsn');
+        const {result} = renderHook(() => useHandleError(), {wrapper});
+
+        const mockResponse = new Response(null, {status: 401});
+        const error = new SessionExpiredError(mockResponse, '');
+
+        result.current(error);
+
+        expect(Sentry.captureException).not.toHaveBeenCalled();
+    });
+
+    it('does not show toast for session expiry errors', () => {
+        const wrapper = createWrapper();
+        const {result} = renderHook(() => useHandleError(), {wrapper});
+
+        const mockResponse = new Response(null, {status: 401});
+        const error = new SessionExpiredError(mockResponse, '');
+
+        result.current(error);
+
+        // The fetch layer redirects to signin on session expiry, so the
+        // error handler must not flash a toast over the unloading page
+        expect(showToast).not.toHaveBeenCalled();
+        expect(toast.remove).toHaveBeenCalled();
+    });
+
+    it('shows toast for unauthorized errors that do not trigger a redirect', () => {
         const wrapper = createWrapper();
         const {result} = renderHook(() => useHandleError(), {wrapper});
 
@@ -199,10 +226,10 @@ describe('useHandleError', () => {
 
         result.current(error);
 
-        // The fetch layer redirects to signin on session expiry, so the
-        // error handler must not flash a toast over the unloading page
-        expect(showToast).not.toHaveBeenCalled();
-        expect(toast.remove).toHaveBeenCalled();
+        expect(showToast).toHaveBeenCalledWith({
+            message: 'You are not authorised to make this request.',
+            type: 'error'
+        });
     });
 
     it('shows validation error message from context', () => {

--- a/apps/admin-x-framework/test/unit/utils/api/fetch-api.test.tsx
+++ b/apps/admin-x-framework/test/unit/utils/api/fetch-api.test.tsx
@@ -35,15 +35,28 @@ type TestResponseBody = Pick<http.IncomingMessage, 'method' | 'headers'> & {
 describe('useFetchApi', () => {
     let server: http.Server;
     let baseUrl: string;
+    let requestCounts: Map<string, number>;
 
     beforeEach(async () => {
+        requestCounts = new Map();
+
         server = http.createServer((req, res) => {
             const chunks: Buffer[] = [];
             req.on('data', (chunk: Buffer) => {
                 chunks.push(chunk);
             });
             req.on('end', async () => {
-                if (req.url?.includes('slow')) {
+                const url = req.url ?? '';
+                const requestCount = (requestCounts.get(url) ?? 0) + 1;
+                requestCounts.set(url, requestCount);
+
+                if (url.includes('maintenance') && requestCount === 1) {
+                    res.writeHead(503);
+                    res.end('Maintenance');
+                    return;
+                }
+
+                if (url.includes('slow')) {
                     await sleep(100);
                 }
                 res.writeHead(200, {
@@ -93,6 +106,15 @@ describe('useFetchApi', () => {
         expect(data.headers['app-pragma']).toBe('no-cache');
         expect(data.headers['content-type']).toBe('application/json');
         expect(data.body).toBe('test');
+    });
+
+    it('retries maintenance errors until the API recovers', async () => {
+        const {result} = renderHook(() => useFetchApi(), {wrapper});
+
+        const data = await result.current<TestResponseBody>(`${baseUrl}/ghost/api/admin/maintenance/`);
+
+        expect(data.method).toBe('GET');
+        expect(requestCounts.get('/ghost/api/admin/maintenance/')).toBe(2);
     });
 
     it('throws a timeout error when request exceeds timeout', async () => {

--- a/apps/admin-x-framework/test/unit/utils/api/session-expiry.test.tsx
+++ b/apps/admin-x-framework/test/unit/utils/api/session-expiry.test.tsx
@@ -18,8 +18,33 @@ const unauthorizedBody = {
 
 const unauthorized = () => HttpResponse.json(unauthorizedBody, {status: 401});
 
+const expiredSessionBody = {
+    errors: [{
+        message: 'Authorization failed',
+        context: 'Unable to determine the authenticated user or integration.',
+        type: 'NoPermissionError',
+        details: null,
+        property: null,
+        help: null,
+        code: null,
+        id: 'error-id',
+        ghostErrorCode: null
+    }]
+};
+
+const expiredSession = () => HttpResponse.json(expiredSessionBody, {status: 403});
+
+const forbidden = () => HttpResponse.json({
+    errors: [{
+        ...expiredSessionBody.errors[0],
+        message: 'You do not have permission to perform this action.'
+    }]
+}, {status: 403});
+
 setupMswServer([
-    http.get('http://localhost:3000/ghost/api/admin/posts/', unauthorized),
+    http.get('http://localhost:3000/ghost/api/admin/posts/', expiredSession),
+    http.get('http://localhost:3000/ghost/api/admin/posts/401/', unauthorized),
+    http.get('http://localhost:3000/ghost/api/admin/members/', forbidden),
     http.post('http://localhost:3000/ghost/api/admin/session', unauthorized),
     http.post('http://localhost:3000/ghost/api/admin/session/', unauthorized),
     http.put('http://localhost:3000/ghost/api/admin/session/verify/', unauthorized),
@@ -29,11 +54,11 @@ setupMswServer([
 // The redirect-once guard is module state, so each test re-imports a fresh
 // fetch-api module (and its errors module, to keep instanceof checks valid)
 const loadModules = async () => {
-    const [{useFetchApi}, {SessionExpiredError, UnauthorizedError}] = await Promise.all([
+    const [{useFetchApi}, {SessionExpiredError, UnauthorizedError, ValidationError}] = await Promise.all([
         import('../../../../src/utils/api/fetch-api'),
         import('../../../../src/utils/errors')
     ]);
-    return {useFetchApi, SessionExpiredError, UnauthorizedError};
+    return {useFetchApi, SessionExpiredError, UnauthorizedError, ValidationError};
 };
 
 describe('session expiry handling', () => {
@@ -56,7 +81,7 @@ describe('session expiry handling', () => {
         (window as any).location = originalLocation;
     });
 
-    it('redirects to the admin root when an API request returns 401', async () => {
+    it('redirects to the admin root when an API request returns 403 Authorization failed', async () => {
         const {useFetchApi, SessionExpiredError} = await loadModules();
         const {result} = renderHook(() => useFetchApi());
 
@@ -66,7 +91,17 @@ describe('session expiry handling', () => {
         expect(window.location.replace).toHaveBeenCalledExactlyOnceWith('/ghost/');
     });
 
-    it('redirects only once when multiple in-flight requests return 401', async () => {
+    it('redirects to the admin root when an API request returns 401', async () => {
+        const {useFetchApi, SessionExpiredError} = await loadModules();
+        const {result} = renderHook(() => useFetchApi());
+
+        await expect(result.current('http://localhost:3000/ghost/api/admin/posts/401/', {retry: false}))
+            .rejects.toBeInstanceOf(SessionExpiredError);
+
+        expect(window.location.replace).toHaveBeenCalledExactlyOnceWith('/ghost/');
+    });
+
+    it('redirects only once when multiple in-flight requests return session expiry errors', async () => {
         const {useFetchApi, SessionExpiredError} = await loadModules();
         const {result} = renderHook(() => useFetchApi());
 
@@ -123,6 +158,18 @@ describe('session expiry handling', () => {
         const error = await result.current('http://localhost:3000/external/data/', {retry: false})
             .catch(fetchError => fetchError);
         expect(error).toBeInstanceOf(UnauthorizedError);
+        expect(error).not.toBeInstanceOf(SessionExpiredError);
+
+        expect(window.location.replace).not.toHaveBeenCalled();
+    });
+
+    it('does not redirect for other 403 permission errors', async () => {
+        const {useFetchApi, SessionExpiredError, ValidationError} = await loadModules();
+        const {result} = renderHook(() => useFetchApi());
+
+        const error = await result.current('http://localhost:3000/ghost/api/admin/members/', {retry: false})
+            .catch(fetchError => fetchError);
+        expect(error).toBeInstanceOf(ValidationError);
         expect(error).not.toBeInstanceOf(SessionExpiredError);
 
         expect(window.location.replace).not.toHaveBeenCalled();

--- a/apps/admin-x-framework/test/unit/utils/api/session-expiry.test.tsx
+++ b/apps/admin-x-framework/test/unit/utils/api/session-expiry.test.tsx
@@ -96,8 +96,10 @@ describe('session expiry handling', () => {
         const {useFetchApi, SessionExpiredError} = await loadModules();
         const {result} = renderHook(() => useFetchApi());
 
-        await expect(result.current('http://localhost:3000/ghost/api/admin/posts/401/', {retry: false}))
-            .rejects.toBeInstanceOf(SessionExpiredError);
+        const error = await result.current('http://localhost:3000/ghost/api/admin/posts/401/', {retry: false})
+            .catch(fetchError => fetchError);
+        expect(error).toBeInstanceOf(SessionExpiredError);
+        expect(error.data).toEqual(unauthorizedBody);
 
         expect(window.location.replace).toHaveBeenCalledExactlyOnceWith('/ghost/');
     });
@@ -126,7 +128,8 @@ describe('session expiry handling', () => {
         '#/signin',
         '#/signin/verify',
         '#/signup/invitation-token',
-        '#/setup/one'
+        '#/setup/one',
+        '#/reset/reset-token'
     ])('does not redirect from unauthenticated Admin route %s', async (hash) => {
         (window as any).location.hash = hash;
         const {useFetchApi, SessionExpiredError} = await loadModules();

--- a/apps/admin-x-framework/test/unit/utils/api/session-expiry.test.tsx
+++ b/apps/admin-x-framework/test/unit/utils/api/session-expiry.test.tsx
@@ -71,6 +71,7 @@ describe('session expiry handling', () => {
         delete (window as any).location;
         (window as any).location = {
             href: 'http://localhost:3000/ghost/',
+            hash: '#/posts',
             origin: 'http://localhost:3000',
             pathname: '/ghost/',
             replace: vi.fn()
@@ -117,6 +118,24 @@ describe('session expiry handling', () => {
         }
 
         expect(window.location.replace).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+        '',
+        '#/',
+        '#/signin',
+        '#/signin/verify',
+        '#/signup/invitation-token',
+        '#/setup/one'
+    ])('does not redirect from unauthenticated Admin route %s', async (hash) => {
+        (window as any).location.hash = hash;
+        const {useFetchApi, SessionExpiredError} = await loadModules();
+        const {result} = renderHook(() => useFetchApi());
+
+        await expect(result.current('http://localhost:3000/ghost/api/admin/posts/', {retry: false}))
+            .rejects.toBeInstanceOf(SessionExpiredError);
+
+        expect(window.location.replace).not.toHaveBeenCalled();
     });
 
     it('does not redirect when the session endpoint returns 401', async () => {

--- a/apps/admin-x-framework/test/unit/utils/api/session-expiry.test.tsx
+++ b/apps/admin-x-framework/test/unit/utils/api/session-expiry.test.tsx
@@ -1,0 +1,113 @@
+import {renderHook} from '@testing-library/react';
+import {HttpResponse, http} from 'msw';
+import {setupMswServer} from '../../../../src/test/msw-utils';
+
+const unauthorizedBody = {
+    errors: [{
+        message: 'Authorization failed',
+        context: 'Unable to determine the authenticated user or integration.',
+        type: 'UnauthorizedError',
+        details: null,
+        property: null,
+        help: null,
+        code: null,
+        id: 'error-id',
+        ghostErrorCode: null
+    }]
+};
+
+const unauthorized = () => HttpResponse.json(unauthorizedBody, {status: 401});
+
+setupMswServer([
+    http.get('http://localhost:3000/ghost/api/admin/posts/', unauthorized),
+    http.post('http://localhost:3000/ghost/api/admin/session/', unauthorized),
+    http.put('http://localhost:3000/ghost/api/admin/session/verify/', unauthorized),
+    http.get('http://localhost:3000/external/data/', unauthorized)
+]);
+
+// The redirect-once guard is module state, so each test re-imports a fresh
+// fetch-api module (and its errors module, to keep instanceof checks valid)
+const loadModules = async () => {
+    const [{useFetchApi}, {UnauthorizedError}] = await Promise.all([
+        import('../../../../src/utils/api/fetch-api'),
+        import('../../../../src/utils/errors')
+    ]);
+    return {useFetchApi, UnauthorizedError};
+};
+
+describe('session expiry handling', () => {
+    let originalLocation: Location;
+
+    beforeEach(() => {
+        vi.resetModules();
+
+        originalLocation = window.location;
+        delete (window as any).location;
+        (window as any).location = {
+            href: 'http://localhost:3000/ghost/',
+            origin: 'http://localhost:3000',
+            pathname: '/ghost/',
+            replace: vi.fn()
+        };
+    });
+
+    afterEach(() => {
+        (window as any).location = originalLocation;
+    });
+
+    it('redirects to the admin root when an API request returns 401', async () => {
+        const {useFetchApi, UnauthorizedError} = await loadModules();
+        const {result} = renderHook(() => useFetchApi());
+
+        await expect(result.current('http://localhost:3000/ghost/api/admin/posts/', {retry: false}))
+            .rejects.toBeInstanceOf(UnauthorizedError);
+
+        expect(window.location.replace).toHaveBeenCalledExactlyOnceWith('/ghost/');
+    });
+
+    it('redirects only once when multiple in-flight requests return 401', async () => {
+        const {useFetchApi, UnauthorizedError} = await loadModules();
+        const {result} = renderHook(() => useFetchApi());
+
+        const results = await Promise.allSettled([
+            result.current('http://localhost:3000/ghost/api/admin/posts/', {retry: false}),
+            result.current('http://localhost:3000/ghost/api/admin/posts/', {retry: false}),
+            result.current('http://localhost:3000/ghost/api/admin/posts/', {retry: false})
+        ]);
+
+        for (const settled of results) {
+            expect(settled.status).toBe('rejected');
+            expect((settled as PromiseRejectedResult).reason).toBeInstanceOf(UnauthorizedError);
+        }
+
+        expect(window.location.replace).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not redirect when the session endpoint returns 401', async () => {
+        const {useFetchApi, UnauthorizedError} = await loadModules();
+        const {result} = renderHook(() => useFetchApi());
+
+        await expect(result.current('http://localhost:3000/ghost/api/admin/session/', {
+            method: 'POST',
+            body: JSON.stringify({username: 'test@example.com', password: 'wrong'}),
+            retry: false
+        })).rejects.toBeInstanceOf(UnauthorizedError);
+
+        await expect(result.current('http://localhost:3000/ghost/api/admin/session/verify/', {
+            method: 'PUT',
+            retry: false
+        })).rejects.toBeInstanceOf(UnauthorizedError);
+
+        expect(window.location.replace).not.toHaveBeenCalled();
+    });
+
+    it('does not redirect when a non-Ghost API request returns 401', async () => {
+        const {useFetchApi, UnauthorizedError} = await loadModules();
+        const {result} = renderHook(() => useFetchApi());
+
+        await expect(result.current('http://localhost:3000/external/data/', {retry: false}))
+            .rejects.toBeInstanceOf(UnauthorizedError);
+
+        expect(window.location.replace).not.toHaveBeenCalled();
+    });
+});

--- a/apps/admin-x-framework/test/unit/utils/api/session-expiry.test.tsx
+++ b/apps/admin-x-framework/test/unit/utils/api/session-expiry.test.tsx
@@ -20,6 +20,7 @@ const unauthorized = () => HttpResponse.json(unauthorizedBody, {status: 401});
 
 setupMswServer([
     http.get('http://localhost:3000/ghost/api/admin/posts/', unauthorized),
+    http.post('http://localhost:3000/ghost/api/admin/session', unauthorized),
     http.post('http://localhost:3000/ghost/api/admin/session/', unauthorized),
     http.put('http://localhost:3000/ghost/api/admin/session/verify/', unauthorized),
     http.get('http://localhost:3000/external/data/', unauthorized)
@@ -28,11 +29,11 @@ setupMswServer([
 // The redirect-once guard is module state, so each test re-imports a fresh
 // fetch-api module (and its errors module, to keep instanceof checks valid)
 const loadModules = async () => {
-    const [{useFetchApi}, {UnauthorizedError}] = await Promise.all([
+    const [{useFetchApi}, {SessionExpiredError, UnauthorizedError}] = await Promise.all([
         import('../../../../src/utils/api/fetch-api'),
         import('../../../../src/utils/errors')
     ]);
-    return {useFetchApi, UnauthorizedError};
+    return {useFetchApi, SessionExpiredError, UnauthorizedError};
 };
 
 describe('session expiry handling', () => {
@@ -56,17 +57,17 @@ describe('session expiry handling', () => {
     });
 
     it('redirects to the admin root when an API request returns 401', async () => {
-        const {useFetchApi, UnauthorizedError} = await loadModules();
+        const {useFetchApi, SessionExpiredError} = await loadModules();
         const {result} = renderHook(() => useFetchApi());
 
         await expect(result.current('http://localhost:3000/ghost/api/admin/posts/', {retry: false}))
-            .rejects.toBeInstanceOf(UnauthorizedError);
+            .rejects.toBeInstanceOf(SessionExpiredError);
 
         expect(window.location.replace).toHaveBeenCalledExactlyOnceWith('/ghost/');
     });
 
     it('redirects only once when multiple in-flight requests return 401', async () => {
-        const {useFetchApi, UnauthorizedError} = await loadModules();
+        const {useFetchApi, SessionExpiredError} = await loadModules();
         const {result} = renderHook(() => useFetchApi());
 
         const results = await Promise.allSettled([
@@ -77,14 +78,14 @@ describe('session expiry handling', () => {
 
         for (const settled of results) {
             expect(settled.status).toBe('rejected');
-            expect((settled as PromiseRejectedResult).reason).toBeInstanceOf(UnauthorizedError);
+            expect((settled as PromiseRejectedResult).reason).toBeInstanceOf(SessionExpiredError);
         }
 
         expect(window.location.replace).toHaveBeenCalledTimes(1);
     });
 
     it('does not redirect when the session endpoint returns 401', async () => {
-        const {useFetchApi, UnauthorizedError} = await loadModules();
+        const {useFetchApi, SessionExpiredError, UnauthorizedError} = await loadModules();
         const {result} = renderHook(() => useFetchApi());
 
         await expect(result.current('http://localhost:3000/ghost/api/admin/session/', {
@@ -98,15 +99,31 @@ describe('session expiry handling', () => {
             retry: false
         })).rejects.toBeInstanceOf(UnauthorizedError);
 
+        const queryError = await result.current('http://localhost:3000/ghost/api/admin/session?source=signin', {
+            method: 'POST',
+            retry: false
+        }).catch(error => error);
+        expect(queryError).toBeInstanceOf(UnauthorizedError);
+        expect(queryError).not.toBeInstanceOf(SessionExpiredError);
+
+        const fragmentError = await result.current('http://localhost:3000/ghost/api/admin/session#signin', {
+            method: 'POST',
+            retry: false
+        }).catch(error => error);
+        expect(fragmentError).toBeInstanceOf(UnauthorizedError);
+        expect(fragmentError).not.toBeInstanceOf(SessionExpiredError);
+
         expect(window.location.replace).not.toHaveBeenCalled();
     });
 
     it('does not redirect when a non-Ghost API request returns 401', async () => {
-        const {useFetchApi, UnauthorizedError} = await loadModules();
+        const {useFetchApi, SessionExpiredError, UnauthorizedError} = await loadModules();
         const {result} = renderHook(() => useFetchApi());
 
-        await expect(result.current('http://localhost:3000/external/data/', {retry: false}))
-            .rejects.toBeInstanceOf(UnauthorizedError);
+        const error = await result.current('http://localhost:3000/external/data/', {retry: false})
+            .catch(fetchError => fetchError);
+        expect(error).toBeInstanceOf(UnauthorizedError);
+        expect(error).not.toBeInstanceOf(SessionExpiredError);
 
         expect(window.location.replace).not.toHaveBeenCalled();
     });

--- a/apps/admin-x-framework/test/utils/mock-fetch.ts
+++ b/apps/admin-x-framework/test/utils/mock-fetch.ts
@@ -6,8 +6,10 @@ export const withMockFetch = async (
     {json = {}, headers = {}, status = 200, ok = true}: {json?: unknown; headers?: Record<string, string>; status?: number; ok?: boolean},
     callback: (mock: any) => void | Promise<void>
 ) => {
-    const mockFetch = vi.fn<typeof globalThis.fetch>(() => Promise.resolve({
+    const mockFetch = vi.fn<typeof globalThis.fetch>(input => Promise.resolve({
+        url: String(input ?? ''),
         json: () => Promise.resolve(json),
+        text: () => Promise.resolve(JSON.stringify(json)),
         headers: new Headers(headers),
         status,
         ok


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLA-188/

The React Admin fetch layer (`admin-x-framework`) did not handle expired sessions. Core returns **403 + `Authorization failed`** when a cookie session is no longer valid, so requests fell through as `ValidationError`, displayed a generic toast, and left the page stuck. Ember's Ajax service already treats that response, as well as 401 responses, as an invalid session and returns to sign-in.

## What this does

- `handle-response.ts` classifies both 401 responses and the specific **403 + `Authorization failed`** Admin API response as `UnauthorizedError`.
- `fetch-api.ts` converts those errors to `SessionExpiredError` for Ghost API requests and, from authenticated Admin routes, performs a full-page `window.location.replace` to the Admin root. Admin then revalidates through `users/me` and lands on sign-in.
- Redirect handling is scoped to URLs containing `/ghost/api/`. Session endpoints such as `/session/` and `/session/verify/` are excluded so failed sign-in and verification requests do not redirect, and external/Tinybird requests cannot log the user out.
- Bare Admin root and unauthenticated routes (`#/setup`, `#/signin`, `#/signup`, and `#/reset`) still classify the response as `SessionExpiredError` for toast/Sentry suppression, but do not replace the page. This lets Ember finish booting the authentication UI without a reload loop.
- A module-level guard ensures concurrent expired requests redirect only once.
- `useHandleError` suppresses toast and Sentry reporting specifically for `SessionExpiredError`, avoiding noise while the page unloads or authentication UI boots.
- Other 403 permission failures remain `ValidationError` and keep their existing behavior.

This works for all framework consumers (Admin, Admin X Settings, and ActivityPub) without relying on the Ember bridge, which exposes no session-invalidation method.

## Latent bug fixed en route

`fetch-api.ts` returned `handleResponse(response)` without awaiting it, so response-derived errors bypassed its retry and error-handling `catch`. Awaiting it makes the existing `MaintenanceError` retry path functional and allows session errors to be classified centrally. Two incomplete Response fakes in `test/utils/mock-fetch.ts` were completed as fallout.

## Behavioral changes / reviewer callouts

- Expired sessions now reload Admin and return to sign-in for Core's normal **403 + `Authorization failed`** response when encountered on an authenticated route.
- Expected authorization failures while the bare Admin root or an unauthenticated route is booting do not trigger another navigation.
- Ghost API 401 responses also use the same handling, including inactive or suspended-user cases.
- All 401 responses are now typed as `UnauthorizedError`, including excluded session endpoints and external requests; those requests do not redirect.
- The exact matching 403 response is also typed as `UnauthorizedError`; unrelated 403 responses are unchanged.
- Awaiting `handleResponse` makes the pre-existing 503 retry behavior live. With retries enabled in production, this applies to mutations as well as reads, so a mutation returning 503 may be submitted again for up to 15 seconds.

## Verification

- MSW-backed session-expiry coverage for the real Core 403 payload, retained 401 behavior, redirect-once behavior, unauthenticated Admin routes, session-endpoint exclusion, non-Ghost-API exclusion, and unrelated 403 permission errors.
- `admin-x-framework`: 32 test files / 455 tests passing.
- Type-check, lint, and production build passing.
- Full-system E2E failures identified the unauthenticated bootstrap reload loop; the pushed fix is awaiting the fresh CI E2E run.

