### PR TITLE
Bumped @tanstack/react-query to v5

### DIFF
--- a/apps/activitypub/src/hooks/use-activity-pub-queries.test.ts
+++ b/apps/activitypub/src/hooks/use-activity-pub-queries.test.ts
@@ -1,9 +1,9 @@
 import React from 'react';
 import {ActivityPubAPI, isApiError} from '../api/activitypub';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {act, renderHook, waitFor} from '@testing-library/react';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
-import {renderHook, waitFor} from '@testing-library/react';
-import {useReplyChainForUser} from './use-activity-pub-queries';
+import {useDeleteMutationForUser, useReplyChainForUser} from './use-activity-pub-queries';
 
 globalThis.fetch = vi.fn().mockResolvedValue({
     json: vi.fn().mockResolvedValue({
@@ -16,46 +16,53 @@ vi.mock('../api/activitypub', () => ({
     isApiError: vi.fn()
 }));
 
-const createWrapper = () => {
-    const queryClient = new QueryClient({
+const createQueryClient = () => {
+    return new QueryClient({
         defaultOptions: {
             queries: {
+                retry: false
+            },
+            mutations: {
                 retry: false
             }
         }
     });
-    
+};
+
+const createWrapper = (queryClient = createQueryClient()) => {
     return function TestWrapper({children}: {children: React.ReactNode}) {
         return React.createElement(QueryClientProvider, {client: queryClient}, children);
     };
 };
 
-describe('useReplyChainForUser', () => {
-    let mockApi: {
-        getReplies: ReturnType<typeof vi.fn>;
-        getPost: ReturnType<typeof vi.fn>;
-    };
+let mockApi: {
+    delete: ReturnType<typeof vi.fn>;
+    getReplies: ReturnType<typeof vi.fn>;
+    getPost: ReturnType<typeof vi.fn>;
+};
 
-    beforeEach(() => {
-        vi.clearAllMocks();
-        
-        (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
-            json: vi.fn().mockResolvedValue({
-                site: {url: 'https://test.com'}
-            })
-        });
-        
-        mockApi = {
-            getReplies: vi.fn(),
-            getPost: vi.fn()
-        };
-        
-        (ActivityPubAPI as ReturnType<typeof vi.fn>).mockImplementation(function () {
-            return mockApi;
-        });
-        (isApiError as unknown as ReturnType<typeof vi.fn>).mockReturnValue(true);
+beforeEach(() => {
+    vi.clearAllMocks();
+
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        json: vi.fn().mockResolvedValue({
+            site: {url: 'https://test.com'}
+        })
     });
 
+    mockApi = {
+        delete: vi.fn(),
+        getReplies: vi.fn(),
+        getPost: vi.fn()
+    };
+
+    (ActivityPubAPI as ReturnType<typeof vi.fn>).mockImplementation(function () {
+        return mockApi;
+    });
+    (isApiError as unknown as ReturnType<typeof vi.fn>).mockReturnValue(true);
+});
+
+describe('useReplyChainForUser', () => {
     it('should retry with getPost when getReplies returns 404', async () => {
         const mockReplyChain = {
             ancestors: {chain: [], hasMore: false},
@@ -87,5 +94,31 @@ describe('useReplyChainForUser', () => {
         expect(mockApi.getReplies).toHaveBeenCalledTimes(2);
         expect(mockApi.getPost).toHaveBeenCalledTimes(1);
         expect(mockApi.getPost).toHaveBeenCalledWith('post-1');
+    });
+});
+
+describe('useDeleteMutationForUser', () => {
+    it('restores each profile posts cache when deletion fails', async () => {
+        const queryClient = createQueryClient();
+        const firstQueryKey = ['profile_posts', 'first'];
+        const secondQueryKey = ['profile_posts', 'second'];
+        const firstData = {pages: [{posts: [{id: 'deleted', object: {id: 'deleted'}}]}]};
+        const secondData = {pages: [{posts: [{id: 'other', object: {id: 'other'}}]}]};
+
+        queryClient.setQueryData(firstQueryKey, firstData);
+        queryClient.setQueryData(secondQueryKey, secondData);
+        mockApi.delete.mockRejectedValue(new Error('Delete failed'));
+
+        const {result} = renderHook(
+            () => useDeleteMutationForUser('index'),
+            {wrapper: createWrapper(queryClient)}
+        );
+
+        await act(async () => {
+            await expect(result.current.mutateAsync({id: 'deleted'})).rejects.toThrow('Delete failed');
+        });
+
+        expect(queryClient.getQueryData(firstQueryKey)).toEqual(firstData);
+        expect(queryClient.getQueryData(secondQueryKey)).toEqual(secondData);
     });
 });

--- a/apps/activitypub/src/hooks/use-activity-pub-queries.ts
+++ b/apps/activitypub/src/hooks/use-activity-pub-queries.ts
@@ -111,7 +111,7 @@ function updateLikeCache(queryClient: QueryClient, id: string, liked: boolean) {
 
     for (const queryKey of queryKeys) {
         // Handle paginated caches (feed, inbox, etc.)
-        queryClient.setQueriesData(queryKey, (current?: {pages: {posts: Activity[]}[]}) => {
+        queryClient.setQueriesData({queryKey}, (current?: {pages: {posts: Activity[]}[]}) => {
             if (current === undefined) {
                 return current;
             }
@@ -142,7 +142,7 @@ function updateLikeCache(queryClient: QueryClient, id: string, liked: boolean) {
 
         // For the likes tab, add/remove the post
         if (queryKey === QUERY_KEYS.postsLikedByAccount) {
-            queryClient.setQueriesData(queryKey, (current?: {pages: {posts: Activity[]}[]}) => {
+            queryClient.setQueriesData({queryKey}, (current?: {pages: {posts: Activity[]}[]}) => {
                 if (!current) {
                     return current;
                 }
@@ -186,7 +186,7 @@ function updateFollowCache(queryClient: QueryClient, handle: string, authorHandl
     const preferredUsername = authorHandle.split('@')[1];
 
     for (const queryKey of queryKeys) {
-        queryClient.setQueriesData(queryKey, (current?: {pages: {posts: Activity[]}[]}) => {
+        queryClient.setQueriesData({queryKey}, (current?: {pages: {posts: Activity[]}[]}) => {
             if (current === undefined) {
                 return current;
             }
@@ -237,7 +237,7 @@ function updateFollowCache(queryClient: QueryClient, handle: string, authorHandl
 
     // Handle reply chain cache (used by Note.tsx and Reader.tsx)
     const replyChainQueryKey = QUERY_KEYS.replyChain(null);
-    queryClient.setQueriesData(replyChainQueryKey, (current?: ReplyChainResponse) => {
+    queryClient.setQueriesData({queryKey: replyChainQueryKey}, (current?: ReplyChainResponse) => {
         if (!current) {
             return current;
         }
@@ -318,7 +318,7 @@ function updateAccountFollowsCaches(queryClient: QueryClient, targetHandle: stri
 function updateLikeCacheOnce(queryClient: QueryClient, id: string, liked: boolean) {
     // Handle reply chain cache (used by Note.tsx and Reader.tsx)
     const replyChainQueryKey = QUERY_KEYS.replyChain(null);
-    queryClient.setQueriesData(replyChainQueryKey, (current?: ReplyChainResponse) => {
+    queryClient.setQueriesData({queryKey: replyChainQueryKey}, (current?: ReplyChainResponse) => {
         if (!current) {
             return current;
         }
@@ -508,7 +508,7 @@ function updateReplyCache(queryClient: QueryClient, id: string, delta: number) {
     ];
 
     for (const queryKey of queryKeys) {
-        queryClient.setQueriesData(queryKey, (current?: {pages: {posts: Activity[]}[]}) => {
+        queryClient.setQueriesData({queryKey}, (current?: {pages: {posts: Activity[]}[]}) => {
             if (!current) {
                 return current;
             }
@@ -579,6 +579,7 @@ export function useBlockedAccountsForUser(handle: string) {
 
             return api.getBlockedAccounts(pageParam);
         },
+        initialPageParam: undefined as string | undefined,
         getNextPageParam(prevPage) {
             return prevPage.next;
         }
@@ -595,6 +596,7 @@ export function useBlockedDomainsForUser(handle: string) {
 
             return api.getBlockedDomains(pageParam);
         },
+        initialPageParam: undefined as string | undefined,
         getNextPageParam(prevPage) {
             return prevPage.next;
         }
@@ -806,7 +808,7 @@ function updateRepostCache(queryClient: QueryClient, id: string, reposted: boole
 
     for (const queryKey of queryKeys) {
         // Handle paginated caches (feed, inbox, etc.)
-        queryClient.setQueriesData(queryKey, (current?: {pages: {posts: Activity[]}[]}) => {
+        queryClient.setQueriesData({queryKey}, (current?: {pages: {posts: Activity[]}[]}) => {
             if (current === undefined) {
                 return current;
             }
@@ -841,7 +843,7 @@ function updateRepostCache(queryClient: QueryClient, id: string, reposted: boole
 function updateRepostCacheOnce(queryClient: QueryClient, id: string, reposted: boolean) {
     // Handle reply chain cache (used by Note.tsx and Reader.tsx via useReplyChainForUser)
     const replyChainQueryKey = QUERY_KEYS.replyChain(null);
-    queryClient.setQueriesData(replyChainQueryKey, (current?: ReplyChainResponse) => {
+    queryClient.setQueriesData({queryKey: replyChainQueryKey}, (current?: ReplyChainResponse) => {
         if (!current) {
             return current;
         }
@@ -1652,6 +1654,7 @@ export function useAccountFollowsForUser(profileHandle: string, type: AccountFol
 
             return response;
         },
+        initialPageParam: undefined as string | undefined,
         getNextPageParam(prevPage) {
             return prevPage.next;
         }
@@ -1762,6 +1765,7 @@ export function useFeedForUser(options: {enabled: boolean}) {
                 };
             });
         },
+        initialPageParam: undefined as string | undefined,
         getNextPageParam(prevPage) {
             return prevPage.next;
         }
@@ -1798,6 +1802,7 @@ export function useInboxForUser(options: {enabled: boolean}) {
                 };
             });
         },
+        initialPageParam: undefined as string | undefined,
         getNextPageParam(prevPage) {
             return prevPage.next;
         }
@@ -1834,6 +1839,7 @@ export function useDiscoveryFeedForUser(options: {enabled: boolean; topic: strin
                 };
             });
         },
+        initialPageParam: undefined as string | undefined,
         getNextPageParam(prevPage) {
             return prevPage.next;
         }
@@ -1874,6 +1880,7 @@ export function usePostsByAccount(profileHandle: string, options: {enabled: bool
                 };
             });
         },
+        initialPageParam: undefined as string | undefined,
         getNextPageParam(prevPage) {
             return prevPage.next;
         }
@@ -1909,6 +1916,7 @@ export function usePostsLikedByAccount(options: {enabled: boolean}) {
                 };
             });
         },
+        initialPageParam: undefined as string | undefined,
         getNextPageParam(prevPage) {
             return prevPage.next;
         }
@@ -2083,9 +2091,9 @@ export function useDeleteMutationForUser(handle: string) {
             // Update the profile posts cache:
             // - Remove the post from any profile posts collections it may be in
             const profilePostsQueryKey = QUERY_KEYS.profilePosts(null);
-            const previousProfilePosts = queryClient.getQueriesData<{pages: {posts: Activity[]}[]}>(profilePostsQueryKey);
+            const previousProfilePosts = queryClient.getQueriesData<{pages: {posts: Activity[]}[]}>({queryKey: profilePostsQueryKey});
 
-            queryClient.setQueriesData(profilePostsQueryKey, (current?: {pages: {posts: Activity[]}[]}) => {
+            queryClient.setQueriesData({queryKey: profilePostsQueryKey}, (current?: {pages: {posts: Activity[]}[]}) => {
                 if (!current) {
                     return current;
                 }
@@ -2236,7 +2244,7 @@ export function useDeleteMutationForUser(handle: string) {
 
             queryClient.setQueryData(context.previousOutbox.key, context.previousOutbox.data);
             queryClient.setQueryData(context.previousLiked.key, context.previousLiked.data);
-            queryClient.setQueriesData(context.previousProfilePosts.key, context.previousProfilePosts.data);
+            queryClient.setQueriesData({queryKey: context.previousProfilePosts.key}, context.previousProfilePosts.data);
 
             if (context.previousAccount) {
                 queryClient.setQueryData(context.previousAccount.key, context.previousAccount.data);
@@ -2271,6 +2279,7 @@ export function useNotificationsForUser(handle: string) {
 
             return api.getNotifications(pageParam);
         },
+        initialPageParam: undefined as string | undefined,
         getNextPageParam(prevPage) {
             return prevPage.next;
         }
@@ -2517,6 +2526,7 @@ export function useExploreProfilesForUserByTopic(handle: string, topic: string) 
                 next: response.next
             };
         },
+        initialPageParam: undefined as string | undefined,
         getNextPageParam(prevPage) {
             return prevPage.next;
         }

--- a/apps/activitypub/src/hooks/use-activity-pub-queries.ts
+++ b/apps/activitypub/src/hooks/use-activity-pub-queries.ts
@@ -2244,7 +2244,9 @@ export function useDeleteMutationForUser(handle: string) {
 
             queryClient.setQueryData(context.previousOutbox.key, context.previousOutbox.data);
             queryClient.setQueryData(context.previousLiked.key, context.previousLiked.data);
-            queryClient.setQueriesData({queryKey: context.previousProfilePosts.key}, context.previousProfilePosts.data);
+            context.previousProfilePosts.data.forEach(([queryKey, data]) => {
+                queryClient.setQueryData(queryKey, data);
+            });
 
             if (context.previousAccount) {
                 queryClient.setQueryData(context.previousAccount.key, context.previousAccount.data);

--- a/apps/activitypub/src/views/preferences/components/account-migration.tsx
+++ b/apps/activitypub/src/views/preferences/components/account-migration.tsx
@@ -132,9 +132,9 @@ const AccountMigration: React.FC = () => {
                                 data-1p-ignore
                                 onChange={event => setSourceHandle(event.target.value)}
                             />
-                            <Button className='relative h-9 text-sm sm:w-auto' disabled={addAliasMutation.isLoading} type='submit'>
-                                <span className={addAliasMutation.isLoading ? 'invisible' : undefined}>Create alias</span>
-                                {addAliasMutation.isLoading && (
+                            <Button className='relative h-9 text-sm sm:w-auto' disabled={addAliasMutation.isPending} type='submit'>
+                                <span className={addAliasMutation.isPending ? 'invisible' : undefined}>Create alias</span>
+                                {addAliasMutation.isPending && (
                                     <span className='absolute inset-0 flex items-center justify-center'>
                                         <LoadingIndicator color='light' size='sm' />
                                         <span className='sr-only'>Creating alias...</span>

--- a/apps/activitypub/src/views/preferences/components/domain.tsx
+++ b/apps/activitypub/src/views/preferences/components/domain.tsx
@@ -111,8 +111,8 @@ const Domain: React.FC = () => {
     const activeDomain = domainData?.domain ?? null;
     const defaultDomain = getDefaultDomain(domainData?.actorUrl, domainData?.handle);
     const currentUsername = getHandleParts(account?.handle).username;
-    const isUpdatingAccount = updateAccountMutation.isLoading;
-    const isMutating = updateDomainMutation.isLoading || validateDomainMutation.isLoading;
+    const isUpdatingAccount = updateAccountMutation.isPending;
+    const isMutating = updateDomainMutation.isPending || validateDomainMutation.isPending;
     const isDisabled = isLoadingDomain || isMutating;
     const isUsernameDisabled = isLoadingAccount || isUpdatingAccount || !account;
     const canSaveUsername = Boolean(isEditingUsername && usernameInput !== currentUsername);
@@ -421,7 +421,7 @@ const Domain: React.FC = () => {
                                     disabled
                                 />
                                 <Button className='h-9 text-sm sm:w-auto' disabled={isDisabled} variant='outline' onClick={handleRemove}>
-                                    {updateDomainMutation.isLoading ? (
+                                    {updateDomainMutation.isPending ? (
                                         <>
                                             <LoadingIndicator size='sm' />
                                             Removing...
@@ -520,7 +520,7 @@ const Domain: React.FC = () => {
                                         <Button disabled={isDisabled} variant='outline' onClick={handleCancel}>Cancel</Button>
                                         {canSave ? (
                                             <Button disabled={isDisabled} onClick={handleSave}>
-                                                {updateDomainMutation.isLoading ? (
+                                                {updateDomainMutation.isPending ? (
                                                     <>
                                                         <LoadingIndicator color='light' size='sm' />
                                                         Saving...
@@ -529,7 +529,7 @@ const Domain: React.FC = () => {
                                             </Button>
                                         ) : (
                                             <Button disabled={isDisabled || !canValidate || hasDomainLoadError} onClick={handleValidate}>
-                                                {validateDomainMutation.isLoading ? (
+                                                {validateDomainMutation.isPending ? (
                                                     <>
                                                         <LoadingIndicator color='light' size='sm' />
                                                         Validating...

--- a/apps/admin-x-framework/src/api/labels.ts
+++ b/apps/admin-x-framework/src/api/labels.ts
@@ -78,7 +78,7 @@ export const useInvalidateLabels = () => {
     const queryClient = useQueryClient();
 
     return useCallback(() => {
-        queryClient.invalidateQueries([dataType]);
+        queryClient.invalidateQueries({queryKey: [dataType]});
     }, [queryClient]);
 };
 

--- a/apps/admin-x-framework/src/api/members.ts
+++ b/apps/admin-x-framework/src/api/members.ts
@@ -305,7 +305,6 @@ function useSyncMemberCountFromList(result: BrowseMembersInfiniteResult, searchP
         const listTotalIsAuthoritative = listIsUnfiltered
             && !result.isError
             && !result.isPlaceholderData
-            && !result.isPreviousData
             && typeof listTotal === 'number';
 
         if (!listTotalIsAuthoritative) {
@@ -343,7 +342,7 @@ function useSyncMemberCountFromList(result: BrowseMembersInfiniteResult, searchP
                 }
             }
         }, {updatedAt: result.dataUpdatedAt});
-    }, [queryClient, listIsUnfiltered, listTotal, result.dataUpdatedAt, result.isError, result.isPlaceholderData, result.isPreviousData]);
+    }, [queryClient, listIsUnfiltered, listTotal, result.dataUpdatedAt, result.isError, result.isPlaceholderData]);
 }
 
 export function useBrowseMembersInfinite(options: BrowseMembersInfiniteOptions = {}): BrowseMembersInfiniteResult {

--- a/apps/admin-x-framework/src/api/offers.ts
+++ b/apps/admin-x-framework/src/api/offers.ts
@@ -49,7 +49,7 @@ export const useInvalidateOffers = () => {
     const queryClient = useQueryClient();
 
     return () => {
-        return queryClient.invalidateQueries([dataType]);
+        return queryClient.invalidateQueries({queryKey: [dataType]});
     };
 };
 

--- a/apps/admin-x-framework/src/hooks/use-tinybird-token.ts
+++ b/apps/admin-x-framework/src/hooks/use-tinybird-token.ts
@@ -22,9 +22,8 @@ export const useTinybirdToken = (options: UseTinybirdTokenOptions = {}): UseTiny
     const effectiveEnabled = enabled && webAnalyticsEnabled;
     const tinybirdQuery = getTinybirdToken({enabled: effectiveEnabled});
 
-    // A disabled React Query (v4) still reports isLoading:true and can keep cached
-    // data/errors, so return an idle result — else direct consumers (the providers)
-    // hang on a loading placeholder or leak a stale token.
+    // A disabled React Query can keep cached data/errors, so return an idle
+    // result — else direct consumers (the providers) leak a stale token.
     if (!effectiveEnabled) {
         return {
             token: undefined,

--- a/apps/admin-x-framework/src/providers/framework-provider.tsx
+++ b/apps/admin-x-framework/src/providers/framework-provider.tsx
@@ -83,7 +83,7 @@ export function FrameworkProvider({children, queryClient: queryClientOverride, q
                     refetchOnWindowFocus: queryClientOptions.refetchOnWindowFocus ?? false,
                     staleTime: queryClientOptions.staleTime ?? 5 * (60 * 1000), // 5 mins
                     refetchOnMount: queryClientOptions.refetchOnMount ?? false,
-                    cacheTime: 10 * (60 * 1000), // 10 mins
+                    gcTime: 10 * (60 * 1000), // 10 mins
                     // We have custom retry logic for specific errors in fetchApi()
                     retry: false,
                     networkMode: 'always'

--- a/apps/admin-x-framework/src/test/hook-testing-utils.ts
+++ b/apps/admin-x-framework/src/test/hook-testing-utils.ts
@@ -15,6 +15,7 @@ const createMockApiReturn = <T>(
     error: Error | null = null
 ): UseQueryResult<T> => ({
         data,
+        isPending: isLoading,
         isLoading,
         error,
         refetch: vi.fn(),
@@ -22,8 +23,8 @@ const createMockApiReturn = <T>(
         isLoadingError: false,
         isRefetchError: false,
         isSuccess: !isLoading && !error && data !== undefined,
-        isIdle: false,
-        status: isLoading ? 'loading' : error ? 'error' : 'success',
+        status: isLoading ? 'pending' : error ? 'error' : 'success',
+        fetchStatus: isLoading ? 'fetching' : 'idle',
         dataUpdatedAt: Date.now(),
         errorUpdatedAt: error ? Date.now() : 0,
         failureCount: error ? 1 : 0,
@@ -31,16 +32,15 @@ const createMockApiReturn = <T>(
         isFetchedAfterMount: true,
         isFetching: isLoading,
         isPlaceholderData: false,
-        isPreviousData: false,
         isStale: false,
-        remove: vi.fn(),
         // Add missing properties for TypeScript compatibility
         failureReason: null,
         errorUpdateCount: 0,
         isInitialLoading: isLoading,
         isPaused: false,
         isRefetching: false,
-        isStaleByTime: false
+        isEnabled: true,
+        promise: Promise.resolve(data as T)
     } as unknown as UseQueryResult<T>);
 
 /**

--- a/apps/admin-x-framework/src/test/test-utils.tsx
+++ b/apps/admin-x-framework/src/test/test-utils.tsx
@@ -11,20 +11,13 @@ export function createTestQueryClient(): QueryClient {
         defaultOptions: {
             queries: {
                 retry: false,
-                suspense: false,
                 // Disable cache time for tests to avoid stale data
-                cacheTime: 0,
+                gcTime: 0,
                 staleTime: 0
             },
             mutations: {
                 retry: false
             }
-        },
-        // Disable logging in tests
-        logger: {
-            log: () => {},
-            warn: () => {},
-            error: () => {}
         }
     });
 }

--- a/apps/admin-x-framework/src/utils/api/hooks.ts
+++ b/apps/admin-x-framework/src/utils/api/hooks.ts
@@ -1,4 +1,4 @@
-import {InvalidateOptions, InvalidateQueryFilters, UseInfiniteQueryOptions, UseQueryOptions, UseQueryResult, useInfiniteQuery, useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
+import {InfiniteData, InvalidateOptions, InvalidateQueryFilters, QueryKey, UseInfiniteQueryOptions, UseQueryOptions, UseQueryResult, useInfiniteQuery, useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
 import {usePagination} from '@tryghost/admin-x-design-system';
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import useHandleError from '../../hooks/use-handle-error';
@@ -31,7 +31,7 @@ interface QueryOptions<ResponseData> {
     useActivityPub?: boolean;
 }
 
-type QueryHookOptions<ResponseData> = UseQueryOptions<ResponseData> & {
+type QueryHookOptions<ResponseData> = Omit<UseQueryOptions<ResponseData>, 'queryKey' | 'queryFn'> & {
     searchParams?: Record<string, string>;
     defaultErrorHandler?: boolean;
 };
@@ -61,8 +61,7 @@ export const createQuery = <ResponseData>(options: QueryOptions<ResponseData>) =
 
     return {
         ...result,
-        data,
-        isLoading: result.isLoading && result.fetchStatus !== 'idle'
+        data
     };
 };
 
@@ -106,8 +105,7 @@ export const createPaginatedQuery = <ResponseData extends {meta?: Meta}>(options
     return {
         ...result,
         data,
-        pagination,
-        isLoading: result.isLoading && result.fetchStatus !== 'idle'
+        pagination
     };
 };
 
@@ -116,7 +114,9 @@ type InfiniteQueryOptions<ResponseData> = Omit<QueryOptions<ResponseData>, 'retu
     defaultNextPageParams?: (data: ResponseData, params: Record<string, string>) => Record<string, string> | undefined;
 }
 
-type InfiniteQueryHookOptions<ResponseData> = UseInfiniteQueryOptions<ResponseData> & {
+type InfiniteQueryPageParam = Record<string, string> | undefined;
+
+type InfiniteQueryHookOptions<ResponseData> = Omit<UseInfiniteQueryOptions<ResponseData, Error, InfiniteData<ResponseData, InfiniteQueryPageParam>, QueryKey, InfiniteQueryPageParam>, 'queryKey' | 'queryFn' | 'getNextPageParam' | 'initialPageParam'> & {
     searchParams?: Record<string, string>;
     defaultErrorHandler?: boolean;
     getNextPageParams?: (data: ResponseData, params: Record<string, string>) => Record<string, string> | undefined;
@@ -129,11 +129,12 @@ export const createInfiniteQuery = <ResponseData>(options: InfiniteQueryOptions<
 
     const nextPageParams = getNextPageParams || options.defaultNextPageParams || (() => ({}));
 
-    const result = useInfiniteQuery<ResponseData>({
+    const result = useInfiniteQuery<ResponseData, Error, InfiniteData<ResponseData, InfiniteQueryPageParam>, QueryKey, InfiniteQueryPageParam>({
         ...query,
         enabled: hasPermission && (query.enabled ?? true),
         queryKey: [options.dataType, apiUrl(options.path, searchParams || options.defaultSearchParams, options?.useActivityPub)],
         queryFn: ({pageParam}) => fetchApi(apiUrl(options.path, pageParam || searchParams || options.defaultSearchParams, options?.useActivityPub)),
+        initialPageParam: undefined,
         getNextPageParam: data => nextPageParams(data, searchParams || options.defaultSearchParams || {})
     });
 
@@ -147,8 +148,7 @@ export const createInfiniteQuery = <ResponseData>(options: InfiniteQueryOptions<
 
     return {
         ...result,
-        data,
-        isLoading: result.isLoading && result.fetchStatus !== 'idle'
+        data
     };
 };
 
@@ -163,7 +163,7 @@ interface MutationOptions<ResponseData, Payload> extends Omit<QueryOptions<Respo
     body?: (payload: Payload) => FormData | object;
     searchParams?: (payload: Payload) => { [key: string]: string; };
     invalidateQueries?: { dataType: string; } | {
-        filters?: InvalidateQueryFilters<unknown>,
+        filters?: InvalidateQueryFilters,
         options?: InvalidateOptions,
     };
     updateQueries?: { dataType: string; emberUpdateType: 'createOrUpdate' | 'delete' | 'skip'; update: (newData: ResponseData, currentData: unknown, payload: Payload) => unknown };
@@ -200,14 +200,14 @@ export const createMutation = <ResponseData, Payload>({path, searchParams, defau
 
     const afterMutate = useCallback((newData: ResponseData, payload: Payload) => {
         if (invalidateQueries && 'dataType' in invalidateQueries) {
-            queryClient.invalidateQueries([invalidateQueries.dataType]);
+            queryClient.invalidateQueries({queryKey: [invalidateQueries.dataType]});
             onInvalidate(invalidateQueries.dataType);
         } else if (invalidateQueries) {
             queryClient.invalidateQueries(invalidateQueries.filters, invalidateQueries.options);
         }
 
         if (updateQueries) {
-            queryClient.setQueriesData([updateQueries.dataType], (data: unknown) => updateQueries!.update(newData, data, payload));
+            queryClient.setQueriesData({queryKey: [updateQueries.dataType]}, (data: unknown) => updateQueries!.update(newData, data, payload));
             if (updateQueries.emberUpdateType === 'createOrUpdate') {
                 onUpdate(updateQueries.dataType, newData);
             } else if (updateQueries.emberUpdateType === 'delete') {

--- a/apps/admin-x-framework/src/utils/query-client.ts
+++ b/apps/admin-x-framework/src/utils/query-client.ts
@@ -12,7 +12,7 @@ const queryClient = window.adminXQueryClient || new QueryClient({
         queries: {
             refetchOnWindowFocus: false,
             staleTime: 5 * (60 * 1000), // 5 mins
-            cacheTime: 10 * (60 * 1000), // 10 mins
+            gcTime: 10 * (60 * 1000), // 10 mins
             // We have custom retry logic for specific errors in fetchApi()
             retry: false,
             networkMode: 'always'

--- a/apps/admin-x-framework/test/unit/api/members.test.tsx
+++ b/apps/admin-x-framework/test/unit/api/members.test.tsx
@@ -23,7 +23,7 @@ function membersInfiniteResponse(total: number): MembersInfiniteResponseType {
 }
 
 function seedMemberCount(queryClient: ReturnType<typeof createTestQueryClient>, total = 10, options?: {updatedAt?: number}) {
-    queryClient.setQueryDefaults(memberCountKey, {cacheTime: Infinity});
+    queryClient.setQueryDefaults(memberCountKey, {gcTime: Infinity});
     queryClient.setQueryData(memberCountKey, membersResponse(total), options);
 }
 
@@ -31,7 +31,7 @@ function createQueryClientWithCurrentUser() {
     const queryClient = createTestQueryClient();
 
     queryClient.setQueryDefaults(currentUserQueryKey, {staleTime: Infinity});
-    queryClient.setQueryDefaults(memberCountKey, {cacheTime: Infinity});
+    queryClient.setQueryDefaults(memberCountKey, {gcTime: Infinity});
     queryClient.setQueryData(currentUserQueryKey, {
         users: [{
             id: 'user-1',
@@ -240,7 +240,7 @@ describe('members api', () => {
         const queryClient = createQueryClientWithCurrentUser();
         const memberDetailKey = ['MembersResponseType', 'http://localhost:3000/ghost/api/admin/members/member-1/'];
 
-        queryClient.setQueryDefaults(memberDetailKey, {cacheTime: Infinity});
+        queryClient.setQueryDefaults(memberDetailKey, {gcTime: Infinity});
         seedMemberCount(queryClient, 102466);
 
         queryClient.setQueryData(memberDetailKey, {

--- a/apps/admin-x-settings/src/components/settings/advanced/history-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/history-modal.tsx
@@ -4,6 +4,7 @@ import {Avatar, Button, Icon, InfiniteScrollListener, List, ListItem, type LoadS
 import {type RoutingModalProps, useRouting} from '@tryghost/admin-x-framework/routing';
 import {type User} from '@tryghost/admin-x-framework/api/users';
 import {generateAvatarColor, getInitials} from '../../../utils/helpers';
+import {keepPreviousData} from '@tanstack/react-query';
 import {useCallback, useState} from 'react';
 import {useFilterableApi} from '@tryghost/admin-x-framework/hooks';
 
@@ -189,7 +190,7 @@ const HistoryModal = NiceModal.create<RoutingModalProps>(({params}) => {
             ...otherParams,
             filter: [otherParams.filter, lastPage.actions.length && `created_at:<'${formatDateForFilter(new Date(lastPage.actions[lastPage.actions.length - 1].created_at))}'`].join('+')
         }),
-        keepPreviousData: true
+        placeholderData: keepPreviousData
     });
 
     const fetchNext = useCallback(() => {

--- a/apps/admin-x-settings/src/components/settings/advanced/labs/feature-toggle.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/feature-toggle.tsx
@@ -85,7 +85,7 @@ const FeatureToggle: React.FC<FeatureToggleProps> = ({label, flag, disabled, con
                 value: JSON.stringify({...labs, [flag]: newValue})
             }]);
             trackEvent('Feature Toggled', {state: newValue ? 'on' : 'off', feature: flag});
-            client.setQueriesData([configDataType], current => ({
+            client.setQueriesData({queryKey: [configDataType]}, current => ({
                 config: {
                     ...(current as ConfigResponseType).config,
                     labs: {

--- a/apps/admin-x-settings/src/components/settings/email/newsletters.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters.tsx
@@ -115,7 +115,7 @@ const Newsletters: React.FC<{ keywords: string[] }> = ({keywords}) => {
 
         // Set the new order in local state and cache first so that the UI updates immediately
         setNewsletters(newsletters.map(newsletter => orderUpdatedNewsletters.find(n => n.id === newsletter.id) || newsletter));
-        queryClient.setQueriesData<InfiniteData<NewslettersResponseType>>([newslettersDataType], (currentData) => {
+        queryClient.setQueriesData<InfiniteData<NewslettersResponseType>>({queryKey: [newslettersDataType]}, (currentData) => {
             if (!currentData) {
                 return;
             }

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/newsletters-tab-content.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/newsletters-tab-content.tsx
@@ -115,7 +115,7 @@ const NewslettersTabContent: React.FC<NewslettersTabContentProps> = ({filter}) =
         const orderUpdatedNewsletters = [...updatedActiveNewsletters, ...updatedArchivedNewsletters].sort((a, b) => a.sort_order - b.sort_order);
 
         setNewsletters(newsletters.map(newsletter => orderUpdatedNewsletters.find(n => n.id === newsletter.id) || newsletter));
-        queryClient.setQueriesData<InfiniteData<NewslettersResponseType>>([newslettersDataType], (currentData) => {
+        queryClient.setQueriesData<InfiniteData<NewslettersResponseType>>({queryKey: [newslettersDataType]}, (currentData) => {
             if (!currentData) {
                 return;
             }

--- a/apps/admin-x-settings/src/components/settings/growth/recommendations.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/recommendations.tsx
@@ -4,6 +4,7 @@ import RecommendationList from './recommendations/recommendation-list';
 import TopLevelGroup from '../../top-level-group';
 import useSettingGroup from '../../../hooks/use-setting-group';
 import {Button, type ShowMoreData, TabView, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {keepPreviousData} from '@tanstack/react-query';
 import {useBrowseIncomingRecommendations, useBrowseRecommendations} from '@tryghost/admin-x-framework/api/recommendations';
 import {useReferrerHistory} from '@tryghost/admin-x-framework/api/referrers';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
@@ -40,7 +41,7 @@ const Recommendations: React.FC<{ keywords: string[] }> = ({keywords}) => {
                 limit: '100'
             };
         },
-        keepPreviousData: true
+        placeholderData: keepPreviousData
     });
 
     const showMoreRecommendations: ShowMoreData = {
@@ -73,7 +74,7 @@ const Recommendations: React.FC<{ keywords: string[] }> = ({keywords}) => {
                 limit: '100'
             };
         },
-        keepPreviousData: true
+        placeholderData: keepPreviousData
     });
 
     const {data: {stats} = {}, isLoading: areStatsLoading} = useReferrerHistory({});

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails.tsx
@@ -137,8 +137,8 @@ const MemberEmails: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const verifyEmailToken = useQueryParams().getParam('verifyEmail');
 
     const {data: automatedEmailsData, isLoading} = useBrowseAutomatedEmails();
-    const {mutateAsync: addAutomatedEmail, isLoading: isAddingAutomatedEmail} = useAddAutomatedEmail();
-    const {mutateAsync: editAutomatedEmail, isLoading: isEditingAutomatedEmail} = useEditAutomatedEmail();
+    const {mutateAsync: addAutomatedEmail, isPending: isAddingAutomatedEmail} = useAddAutomatedEmail();
+    const {mutateAsync: editAutomatedEmail, isPending: isEditingAutomatedEmail} = useEditAutomatedEmail();
     const {mutateAsync: verifySenderUpdate} = useVerifyAutomatedEmailSender();
     const handleError = useHandleError();
 

--- a/apps/admin-x-settings/src/components/settings/site/theme/theme-code-editor-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/theme-code-editor-modal.tsx
@@ -843,7 +843,7 @@ const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
                 updateRoute(buildThemeEditorRoute(nextThemeName, returnRoute));
             }
 
-            await queryClient.invalidateQueries(['ThemesResponseType']);
+            await queryClient.invalidateQueries({queryKey: ['ThemesResponseType']});
 
             if (isSaveAs || uploadedTheme.errors?.length || uploadedTheme.warnings?.length) {
                 NiceModal.show(ThemeInstalledModal, {

--- a/apps/admin/src/comments/comments.tsx
+++ b/apps/admin/src/comments/comments.tsx
@@ -7,6 +7,7 @@ import {FilterBar, PageHeader, createFilter} from '@tryghost/shade/patterns';
 import {ListPage} from '@tryghost/shade/page-templates';
 import {LucideIcon} from '@tryghost/shade/utils';
 import {adminCommentIncludes, useBrowseComments} from '@tryghost/admin-x-framework/api/comments';
+import {keepPreviousData} from '@tanstack/react-query';
 import {escapeNqlString} from '@/shared/filters';
 import {getSiteTimezone} from '@tryghost/admin-x-framework/utils/get-site-timezone';
 import {serializeCommentFilters} from './comment-filter-query';
@@ -76,7 +77,7 @@ const CommentsPage: React.FC<{timezone: string; singleCommentId?: string}> = ({
             include: adminCommentIncludes(dislikesEnabled),
             ...(effectiveFilter ? {filter: effectiveFilter} : {})
         },
-        keepPreviousData: true
+        placeholderData: keepPreviousData
     });
 
     const shouldShowLoading = isFetching && !isFetchingNextPage && !isRefetching;

--- a/apps/admin/src/ember-bridge/ember-bridge.test.tsx
+++ b/apps/admin/src/ember-bridge/ember-bridge.test.tsx
@@ -121,8 +121,8 @@ describe('useEmberDataSync', () => {
         const sidebarMemberCountKey = getMemberCountQueryKey();
         const postsKey = ['PostsResponseType', '/posts'];
 
-        queryClient.setQueryDefaults(sidebarMemberCountKey, {cacheTime: Infinity});
-        queryClient.setQueryDefaults(postsKey, {cacheTime: Infinity});
+        queryClient.setQueryDefaults(sidebarMemberCountKey, {gcTime: Infinity});
+        queryClient.setQueryDefaults(postsKey, {gcTime: Infinity});
         queryClient.setQueryData(sidebarMemberCountKey, {
             members: [],
             meta: {pagination: {page: 1, limit: 1, pages: 1, total: 102466, next: null, prev: null}}

--- a/apps/admin/src/hooks/use-theme.ts
+++ b/apps/admin/src/hooks/use-theme.ts
@@ -38,7 +38,7 @@ function applyAdminTheme(mode: ThemeMode, resolvedTheme: ResolvedThemeMode) {
 
 export function useTheme() {
     const {data: preferences} = useUserPreferences();
-    const {mutateAsync: editPreferences, isLoading: isEditingPreferences} = useEditUserPreferences();
+    const {mutateAsync: editPreferences, isPending: isEditingPreferences} = useEditUserPreferences();
     const [systemTheme, setSystemTheme] = useState<ResolvedThemeMode>(getSystemTheme);
     const [pendingTheme, setPendingTheme] = useState<ThemeMode | null>(null);
     const [isPendingTheme, setIsPendingTheme] = useState(false);

--- a/apps/admin/src/hooks/user-preferences.ts
+++ b/apps/admin/src/hooks/user-preferences.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, type UseQueryResult, type UseMutationResult, type UseQueryOptions } from "@tanstack/react-query";
+import { useQuery, useMutation, keepPreviousData, type UseQueryResult, type UseMutationResult, type UseQueryOptions } from "@tanstack/react-query";
 import { z } from "zod";
 import { useQueryClient } from "@tryghost/admin-x-framework";
 import { useCurrentUser } from "@tryghost/admin-x-framework/api/current-user";
@@ -56,7 +56,7 @@ export type NavigationPreferences = z.infer<typeof NavigationPreferencesSchema>;
 const userPreferencesQueryKey = (user: User | undefined) => ["userPreferences", user?.id, user?.accessibility] as const;
 
 export function useUserPreferences<TData = Preferences>(
-    options?: Omit<UseQueryOptions<Preferences, Error, TData>, 'queryKey' | 'queryFn' | 'staleTime' | 'cacheTime'>
+    options?: Omit<UseQueryOptions<Preferences, Error, TData>, 'queryKey' | 'queryFn' | 'staleTime' | 'gcTime'>
 ): UseQueryResult<TData> {
     const { data: user } = useCurrentUser();
 
@@ -84,14 +84,14 @@ export function useUserPreferences<TData = Preferences>(
             return PreferencesSchema.parse(parsed);
         },
         enabled: !!user,
-        keepPreviousData: true,
+        placeholderData: keepPreviousData,
         staleTime: Infinity,
         // Query key includes user?.accessibility to automatically react to changes from ANY source
         // (our mutation, other code calling editUser, external updates, etc.). When accessibility
-        // changes, the query key changes, making the old cache entry inactive. cacheTime: 0 ensures
+        // changes, the query key changes, making the old cache entry inactive. gcTime: 0 ensures
         // orphaned entries are immediately garbage collected, preventing memory leaks while keeping
         // the current active entry cached indefinitely.
-        cacheTime: 0,
+        gcTime: 0,
     });
 }
 

--- a/apps/admin/src/members/components/members-actions.test.tsx
+++ b/apps/admin/src/members/components/members-actions.test.tsx
@@ -41,11 +41,11 @@ vi.mock('@tryghost/admin-x-framework/api/newsletters', () => ({
 vi.mock('@tryghost/admin-x-framework/api/members', () => ({
     useBulkEditMembers: () => ({
         mutateAsync: vi.fn(),
-        isLoading: false
+        isPending: false
     }),
     useBulkDeleteMembers: () => ({
         mutate: vi.fn(),
-        isLoading: false
+        isPending: false
     })
 }));
 

--- a/apps/admin/src/members/components/members-actions.tsx
+++ b/apps/admin/src/members/components/members-actions.tsx
@@ -48,8 +48,8 @@ const MembersActions: React.FC<MembersActionsProps> = ({
     });
     const activeNewsletters = newslettersData?.newsletters || [];
 
-    const {mutateAsync: bulkEditAsync, isLoading: isBulkEditing} = useBulkEditMembers();
-    const {mutate: bulkDelete, isLoading: isBulkDeleting} = useBulkDeleteMembers();
+    const {mutateAsync: bulkEditAsync, isPending: isBulkEditing} = useBulkEditMembers();
+    const {mutate: bulkDelete, isPending: isBulkDeleting} = useBulkDeleteMembers();
     const [isUnsubscribing, setIsUnsubscribing] = useState(false);
     const memberOperationParams = buildMemberOperationParams({nql, search});
     const handleExport = useCallback(async () => {

--- a/apps/admin/src/members/components/members-empty-state.tsx
+++ b/apps/admin/src/members/components/members-empty-state.tsx
@@ -13,7 +13,7 @@ interface MembersEmptyStateProps {
 
 const MembersEmptyState: React.FC<MembersEmptyStateProps> = ({membershipsEnabled, onMemberCreated}) => {
     const {data: currentUser, isLoading: isCurrentUserLoading} = useCurrentUser();
-    const {mutateAsync: addMember, isLoading: isAdding} = useAddMember();
+    const {mutateAsync: addMember, isPending: isAdding} = useAddMember();
     const handleError = useHandleError();
 
     const handleAddYourself = useCallback(async () => {

--- a/apps/admin/src/members/hooks/use-multiple-active-subscriptions-banner.ts
+++ b/apps/admin/src/members/hooks/use-multiple-active-subscriptions-banner.ts
@@ -32,7 +32,7 @@ export function useMultipleActiveSubscriptionsBanner({
 }: UseMultipleActiveSubscriptionsBannerOptions) {
     const navigate = useNavigate();
     const {data: currentUser} = useCurrentUser();
-    const {mutateAsync: editUser, isLoading: isDismissing} = useEditUser();
+    const {mutateAsync: editUser, isPending: isDismissing} = useEditUser();
     const [optimisticDismissedCount, setOptimisticDismissedCount] = useState<number | null>(null);
 
     const isViewingFilter = isMultipleActiveSubscriptionsFilter(nql);

--- a/apps/admin/src/members/members.tsx
+++ b/apps/admin/src/members/members.tsx
@@ -10,6 +10,7 @@ import {Button, EmptyIndicator, LoadingIndicator} from '@tryghost/shade/componen
 import {FilterBar, PageHeader} from '@tryghost/shade/patterns';
 import {Box, Container} from '@tryghost/shade/primitives';
 import {ListPage} from '@tryghost/shade/page-templates';
+import {keepPreviousData} from '@tanstack/react-query';
 import {LucideIcon, cn, formatNumber} from '@tryghost/shade/utils';
 import {buildMemberListSearchParams, getMemberActiveColumns} from './member-query-params';
 import {canBulkDeleteMembers, shouldShowMembersLoading} from './members-view-state';
@@ -87,7 +88,7 @@ const MembersPage: React.FC<MembersPageProps> = ({
         hasNextPage
     } = useBrowseMembersInfinite({
         searchParams,
-        keepPreviousData: true
+        placeholderData: keepPreviousData
     });
 
     const shouldShowLoading = shouldShowMembersLoading({

--- a/apps/admin/src/posts/analytics/hooks/use-edit-links.test.tsx
+++ b/apps/admin/src/posts/analytics/hooks/use-edit-links.test.tsx
@@ -9,7 +9,7 @@ import {useEditLinks} from '@/posts/analytics/hooks/use-edit-links';
 vi.mock('@tryghost/admin-x-framework/api/links', () => ({
     useBulkEditLinks: () => ({
         mutateAsync: vi.fn(),
-        isLoading: false
+        isPending: false
     })
 }));
 

--- a/apps/admin/src/posts/analytics/hooks/use-edit-links.ts
+++ b/apps/admin/src/posts/analytics/hooks/use-edit-links.ts
@@ -4,7 +4,7 @@
 import {useBulkEditLinks as useEditLinksApi} from '@tryghost/admin-x-framework/api/links';
 
 export const useEditLinks = () => {
-    const {mutateAsync: editLinks, isLoading: isEditLinksLoading} = useEditLinksApi();
+    const {mutateAsync: editLinks, isPending: isEditLinksLoading} = useEditLinksApi();
 
     return {
         editLinks,

--- a/apps/admin/src/shared/filter-sources/use-email-post-value-source.ts
+++ b/apps/admin/src/shared/filter-sources/use-email-post-value-source.ts
@@ -2,6 +2,7 @@ import {type Post, type PostsResponseType, useBrowsePostsInfinite} from '@trygho
 import {type ValueSource} from '@tryghost/shade/patterns';
 import {createGhostBrowseValueSource} from './create-ghost-browse-value-source';
 import {escapeNqlString} from '@/shared/filters/filter-normalization';
+import {keepPreviousData} from '@tanstack/react-query';
 
 const EMAIL_BASE_FILTER = '(status:published,status:sent)+newsletter_id:-null';
 
@@ -32,7 +33,7 @@ const useRemoteEmailPostValueSource = createGhostBrowseValueSource<Post, PostsRe
     useQuery: ({enabled, searchParams}) => {
         return useBrowsePostsInfinite({
             enabled,
-            keepPreviousData: true,
+            placeholderData: keepPreviousData,
             searchParams
         });
     },

--- a/apps/admin/src/shared/filter-sources/use-label-value-source.ts
+++ b/apps/admin/src/shared/filter-sources/use-label-value-source.ts
@@ -5,6 +5,7 @@ import {buildQuotedListFilter, filterOptionsByQuery, mergeFilterOptions} from '.
 import {createGhostBrowseValueSource} from './create-ghost-browse-value-source';
 import {createHybridValueSource} from './create-hybrid-value-source';
 import {escapeNqlString} from '@/shared/filters/filter-normalization';
+import {keepPreviousData} from '@tanstack/react-query';
 
 const LABEL_PAGE_LIMIT = '100';
 
@@ -82,7 +83,7 @@ const useRemoteLabelValueSource = createGhostBrowseValueSource<Label, LabelsResp
     useQuery: ({enabled, searchParams}) => {
         return useBrowseLabelsInfinite({
             enabled,
-            keepPreviousData: true,
+            placeholderData: keepPreviousData,
             searchParams
         });
     },

--- a/apps/admin/src/shared/filter-sources/use-member-value-source.ts
+++ b/apps/admin/src/shared/filter-sources/use-member-value-source.ts
@@ -1,6 +1,7 @@
 import {type Member, type MembersInfiniteResponseType, useBrowseMembersInfinite} from '@tryghost/admin-x-framework/api/members';
 import {type ValueSource} from '@tryghost/shade/patterns';
 import {createGhostBrowseValueSource} from './create-ghost-browse-value-source';
+import {keepPreviousData} from '@tanstack/react-query';
 
 function toMemberOption(member: Member) {
     return {
@@ -25,7 +26,7 @@ const useRemoteMemberValueSource = createGhostBrowseValueSource<Member, MembersI
     useQuery: ({enabled, searchParams}) => {
         return useBrowseMembersInfinite({
             enabled,
-            keepPreviousData: true,
+            placeholderData: keepPreviousData,
             searchParams
         });
     },

--- a/apps/admin/src/shared/filter-sources/use-post-resource-value-source.ts
+++ b/apps/admin/src/shared/filter-sources/use-post-resource-value-source.ts
@@ -4,6 +4,7 @@ import {type ValueSource} from '@tryghost/shade/patterns';
 import {createCombinedValueSource} from './create-combined-value-source';
 import {createGhostBrowseValueSource} from './create-ghost-browse-value-source';
 import {escapeNqlString} from '@/shared/filters/filter-normalization';
+import {keepPreviousData} from '@tanstack/react-query';
 
 function buildPublishedFilter(query: string) {
     return query ? `status:published+title:~${escapeNqlString(query)}` : 'status:published';
@@ -44,7 +45,7 @@ const usePublishedPostValueSource = createGhostBrowseValueSource<Post, PostsResp
     useQuery: ({enabled, searchParams}) => {
         return useBrowsePostsInfinite({
             enabled,
-            keepPreviousData: true,
+            placeholderData: keepPreviousData,
             searchParams
         });
     },
@@ -59,7 +60,7 @@ const usePublishedPageValueSource = createGhostBrowseValueSource<Page, PagesResp
     useQuery: ({enabled, searchParams}) => {
         return useBrowsePagesInfinite({
             enabled,
-            keepPreviousData: true,
+            placeholderData: keepPreviousData,
             searchParams
         });
     },

--- a/apps/admin/src/whats-new/hooks/use-whats-new.ts
+++ b/apps/admin/src/whats-new/hooks/use-whats-new.ts
@@ -57,7 +57,7 @@ export const useWhatsNew = (): UseQueryResult<WhatsNewData> => {
         },
         enabled: isChangelogLoaded && hasWhatsNewPreferences,
         staleTime: Infinity,
-        cacheTime: 0,
+        gcTime: 0,
     });
 };
 

--- a/apps/admin/test-utils/acceptance/render-admin-app.tsx
+++ b/apps/admin/test-utils/acceptance/render-admin-app.tsx
@@ -77,7 +77,7 @@ export async function renderAdminApp(route: string = "/", { labs, boot }: Render
             queries: {
                 refetchOnWindowFocus: false,
                 staleTime: 5 * (60 * 1000), // 5 mins
-                cacheTime: 10 * (60 * 1000), // 10 mins
+                gcTime: 10 * (60 * 1000), // 10 mins
                 // We have custom retry logic for specific errors in fetchApi()
                 retry: false,
                 networkMode: "always",

--- a/apps/admin/test-utils/fixtures/query-client.tsx
+++ b/apps/admin/test-utils/fixtures/query-client.tsx
@@ -11,24 +11,18 @@ export type TestWrapperComponent = ({ children }: { children: ReactNode }) => JS
  * Configures QueryClient for optimal test performance:
  * - No retries (tests should pass on first attempt)
  * - No caching (tests should be isolated)
- * - Silenced logging (cleaner test output)
  */
 function createTestQueryClient(): QueryClient {
     return new QueryClient({
         defaultOptions: {
             queries: {
                 retry: false,
-                cacheTime: 0,
+                gcTime: 0,
                 staleTime: 0,
             },
             mutations: {
                 retry: false,
             },
-        },
-        logger: {
-            log: () => {},
-            warn: () => {},
-            error: () => {},
         },
     });
 }

--- a/apps/admin/test-utils/posts-analytics/msw-helpers.ts
+++ b/apps/admin/test-utils/posts-analytics/msw-helpers.ts
@@ -16,8 +16,7 @@ export const createTestWrapper = () => {
     const queryClient = new QueryClient({
         defaultOptions: {
             queries: {
-                retry: false,
-                suspense: false
+                retry: false
             }
         }
     });

--- a/ghost/admin/app/components/gh-billing-iframe.js
+++ b/ghost/admin/app/components/gh-billing-iframe.js
@@ -153,17 +153,9 @@ export default class GhBillingIframe extends Component {
         this.stateBridge.triggerSubscriptionChange(data);
 
         // Invalidate React Query cache for config data in admin-x-settings
-        if (window?.adminXQueryClient?.invalidateQueries && typeof window.adminXQueryClient.invalidateQueries === 'function') {
-            try {
-                // React Query v5+
-                window.adminXQueryClient.refetchQueries({queryKey: ['ConfigResponseType']}).catch(() => {});
-                window.adminXQueryClient.refetchQueries({queryKey: ['SettingsResponseType']}).catch(() => {});
-            } catch (_) {
-                // TODO: remove this fallback when Admin-X-Settings updates to React Query v5+ (@tanstack/react-query)
-                // React Query v4 fallback
-                window.adminXQueryClient.refetchQueries(['ConfigResponseType']).catch(() => {});
-                window.adminXQueryClient.refetchQueries(['SettingsResponseType']).catch(() => {});
-            }
+        if (window?.adminXQueryClient?.refetchQueries && typeof window.adminXQueryClient.refetchQueries === 'function') {
+            window.adminXQueryClient.refetchQueries({queryKey: ['ConfigResponseType']}).catch(() => {});
+            window.adminXQueryClient.refetchQueries({queryKey: ['SettingsResponseType']}).catch(() => {});
         }
 
         this.billing.subscription = data.subscription;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,8 +106,8 @@ catalogs:
       specifier: 4.2.2
       version: 4.2.2
     '@tanstack/react-query':
-      specifier: 4.44.0
-      version: 4.44.0
+      specifier: 5.101.2
+      version: 5.101.2
     '@tanstack/react-virtual':
       specifier: 3.14.5
       version: 3.14.5
@@ -456,7 +456,7 @@ importers:
     devDependencies:
       '@eslint/compat':
         specifier: 2.1.0
-        version: 2.1.0(eslint@9.39.4(jiti@2.7.0))
+        version: 2.1.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.61.1
@@ -471,7 +471,7 @@ importers:
         version: 18.0.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.4(jiti@2.7.0)
+        version: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
       globals:
         specifier: 'catalog:'
         version: 17.7.0
@@ -519,7 +519,7 @@ importers:
         version: 0.1.11(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-query':
         specifier: 'catalog:'
-        version: 4.44.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 5.101.2(react@18.3.1)
       '@tryghost/admin-x-framework':
         specifier: workspace:*
         version: link:../admin-x-framework
@@ -683,7 +683,7 @@ importers:
         version: 4.2.2(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       '@tanstack/react-query':
         specifier: 'catalog:'
-        version: 4.44.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 5.101.2(react@18.3.1)
       '@testing-library/jest-dom':
         specifier: 'catalog:'
         version: 6.9.1
@@ -722,7 +722,7 @@ importers:
         version: 9.39.4(jiti@2.7.0)
       eslint-plugin-ghost:
         specifier: 'catalog:'
-        version: 3.5.0(@babel/core@8.0.1)(eslint@9.39.4(jiti@2.7.0))
+        version: 3.5.0(@babel/core@8.0.1)(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)
       eslint-plugin-no-relative-import-paths:
         specifier: 1.6.1
         version: 1.6.1
@@ -758,7 +758,7 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
       vite:
         specifier: 'catalog:'
         version: 8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
@@ -979,7 +979,7 @@ importers:
         version: 7.120.4(react@18.3.1)
       '@tanstack/react-query':
         specifier: 'catalog:'
-        version: 4.44.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 5.101.2(react@18.3.1)
       '@tinybirdco/charts':
         specifier: 0.3.0
         version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1106,7 +1106,7 @@ importers:
         version: 7.120.4(react@18.3.1)
       '@tanstack/react-query':
         specifier: 'catalog:'
-        version: 4.44.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 5.101.2(react@18.3.1)
       '@tryghost/color-utils':
         specifier: 'catalog:'
         version: 0.2.19
@@ -1121,7 +1121,7 @@ importers:
         version: 1.5.6
       '@tryghost/nql':
         specifier: 'catalog:'
-        version: 0.13.1
+        version: 0.13.1(supports-color@5.5.0)
       '@tryghost/string':
         specifier: 'catalog:'
         version: 0.3.5
@@ -1297,7 +1297,7 @@ importers:
         version: 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@tryghost/debug':
         specifier: 'catalog:'
-        version: 2.2.3
+        version: 2.2.3(supports-color@5.5.0)
       react:
         specifier: catalog:react17
         version: 17.0.2
@@ -1325,7 +1325,7 @@ importers:
         version: link:../../ghost/i18n
       '@tryghost/nql':
         specifier: 'catalog:'
-        version: 0.13.1
+        version: 0.13.1(supports-color@5.5.0)
       '@types/react':
         specifier: catalog:react17
         version: 17.0.93
@@ -1385,7 +1385,7 @@ importers:
     dependencies:
       '@tryghost/debug':
         specifier: 'catalog:'
-        version: 2.2.3
+        version: 2.2.3(supports-color@5.5.0)
     devDependencies:
       '@doist/react-interpolate':
         specifier: 2.2.2
@@ -1648,7 +1648,7 @@ importers:
     dependencies:
       '@tryghost/debug':
         specifier: 'catalog:'
-        version: 2.2.3
+        version: 2.2.3(supports-color@5.5.0)
       react:
         specifier: 'catalog:'
         version: 18.3.1
@@ -1727,7 +1727,7 @@ importers:
     dependencies:
       '@tryghost/debug':
         specifier: 'catalog:'
-        version: 2.2.3
+        version: 2.2.3(supports-color@5.5.0)
       '@tryghost/i18n':
         specifier: workspace:*
         version: link:../../ghost/i18n
@@ -1806,7 +1806,7 @@ importers:
         version: 17.7.0
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
 
   configs/eslint-react:
     dependencies:
@@ -1842,7 +1842,7 @@ importers:
         version: 17.7.0
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
 
   configs/typescript: {}
 
@@ -1865,7 +1865,7 @@ importers:
         version: 1.61.1
       '@tryghost/debug':
         specifier: 'catalog:'
-        version: 2.2.3
+        version: 2.2.3(supports-color@5.5.0)
       '@tryghost/logging':
         specifier: 4.2.1
         version: 4.2.1(supports-color@5.5.0)
@@ -1901,7 +1901,7 @@ importers:
         version: 2.10.4(eslint@9.39.4(jiti@2.7.0))
       express:
         specifier: 4.22.2
-        version: 4.22.2
+        version: 4.22.2(supports-color@1.2.0)
       knex:
         specifier: 3.1.0
         version: 3.1.0(mysql2@3.22.5(@types/node@26.0.0))
@@ -1916,7 +1916,7 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
 
   ghost/admin:
     dependencies:
@@ -2010,7 +2010,7 @@ importers:
         version: 1.5.6
       '@tryghost/nql':
         specifier: 'catalog:'
-        version: 0.13.1
+        version: 0.13.1(supports-color@5.5.0)
       '@tryghost/string':
         specifier: 'catalog:'
         version: 0.3.5
@@ -2076,7 +2076,7 @@ importers:
         version: 3.0.1
       ember-cli:
         specifier: 3.24.0
-        version: 3.24.0(encoding@0.1.13)(handlebars@4.7.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@5.5.0)(underscore@1.13.8)
+        version: 3.24.0(encoding@0.1.13)(handlebars@4.7.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@1.2.0)(underscore@1.13.8)
       ember-cli-app-version:
         specifier: 5.0.0
         version: 5.0.0
@@ -2091,7 +2091,7 @@ importers:
         version: 1.0.3
       ember-cli-dependency-checker:
         specifier: 3.3.2
-        version: 3.3.2(ember-cli@3.24.0(encoding@0.1.13)(handlebars@4.7.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@5.5.0)(underscore@1.13.8))
+        version: 3.3.2(ember-cli@3.24.0(encoding@0.1.13)(handlebars@4.7.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@1.2.0)(underscore@1.13.8))
       ember-cli-deprecation-workflow:
         specifier: 2.2.0
         version: 2.2.0
@@ -2124,7 +2124,7 @@ importers:
         version: 3.1.0
       ember-composable-helpers:
         specifier: 5.0.0
-        version: 5.0.0
+        version: 5.0.0(supports-color@1.2.0)
       ember-concurrency:
         specifier: 2.3.7
         version: 2.3.7(@babel/core@7.29.7)
@@ -2376,7 +2376,7 @@ importers:
         version: 2.3.1
       '@tryghost/debug':
         specifier: 'catalog:'
-        version: 2.2.3
+        version: 2.2.3(supports-color@5.5.0)
       '@tryghost/domain-events':
         specifier: 'catalog:'
         version: 3.2.5
@@ -2451,7 +2451,7 @@ importers:
         version: 2.3.1(babel-core@6.26.3)(debug@4.4.3)(handlebars@4.7.9)(lodash@4.18.1)(underscore@1.13.8)
       '@tryghost/nql':
         specifier: 'catalog:'
-        version: 0.13.1
+        version: 0.13.1(supports-color@5.5.0)
       '@tryghost/nql-lang':
         specifier: 'catalog:'
         version: 0.6.6
@@ -2463,7 +2463,7 @@ importers:
         version: 3.2.3
       '@tryghost/prometheus-metrics':
         specifier: 1.0.8
-        version: 1.0.8
+        version: 1.0.8(supports-color@1.2.0)
       '@tryghost/promise':
         specifier: 2.2.3
         version: 2.2.3
@@ -2574,7 +2574,7 @@ importers:
         version: 4.5.0
       express:
         specifier: 4.22.2
-        version: 4.22.2
+        version: 4.22.2(supports-color@1.2.0)
       express-brute:
         specifier: 1.0.1
         version: 1.0.1(express@4.22.2)
@@ -2592,10 +2592,10 @@ importers:
         version: 2.0.0
       express-queue:
         specifier: 0.0.13
-        version: 0.0.13(supports-color@5.5.0)
+        version: 0.0.13(supports-color@1.2.0)
       express-session:
         specifier: 1.19.0
-        version: 1.19.0
+        version: 1.19.0(supports-color@1.2.0)
       file-type:
         specifier: 21.3.4
         version: 21.3.4(supports-color@5.5.0)
@@ -2667,7 +2667,7 @@ importers:
         version: 2.4.2(better-sqlite3@12.11.1)(mysql2@3.22.5(@types/node@22.20.0))(sqlite3@5.1.7)
       knex-migrator:
         specifier: 'catalog:'
-        version: 5.4.1(@types/node@22.20.0)
+        version: 5.4.1(@types/node@22.20.0)(supports-color@5.5.0)
       leaky-bucket:
         specifier: 2.2.0
         version: 2.2.0
@@ -2760,7 +2760,7 @@ importers:
         version: 0.9.1
       probe-image-size:
         specifier: 7.3.0
-        version: 7.3.0
+        version: 7.3.0(supports-color@1.2.0)
       rss:
         specifier: 1.2.2
         version: 1.2.2
@@ -2896,7 +2896,7 @@ importers:
         version: 6.0.3
       '@typescript-eslint/parser':
         specifier: 'catalog:'
-        version: 8.49.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 8.49.0(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
@@ -2968,7 +2968,7 @@ importers:
         version: 22.0.0
       supertest:
         specifier: 'catalog:'
-        version: 7.2.2
+        version: 7.2.2(supports-color@5.5.0)
       tmp:
         specifier: 0.2.7
         version: 0.2.7
@@ -2980,7 +2980,7 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
       validator:
         specifier: 'catalog:'
         version: 13.12.0
@@ -2996,7 +2996,7 @@ importers:
     dependencies:
       '@tryghost/debug':
         specifier: 'catalog:'
-        version: 2.2.3
+        version: 2.2.3(supports-color@5.5.0)
       i18next:
         specifier: 23.16.8
         version: 23.16.8
@@ -3045,7 +3045,7 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -3075,7 +3075,7 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -3103,7 +3103,7 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -3158,7 +3158,7 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -3246,7 +3246,7 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -3289,7 +3289,7 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -3344,7 +3344,7 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -3405,7 +3405,7 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -3463,7 +3463,7 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -3576,7 +3576,7 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
       vite:
         specifier: 'catalog:'
         version: 8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
@@ -3616,7 +3616,7 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -3880,7 +3880,7 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: 'catalog:'
-        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 8.62.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
       vite:
         specifier: 'catalog:'
         version: 8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
@@ -9564,20 +9564,13 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
-  '@tanstack/query-core@4.44.0':
-    resolution: {integrity: sha512-swSgb7OiPRR3UuIL7NuDrZNSMGmQD+wdtHxPD7j60SvBEnxbXurl5XOirtGEX2gm2hbK6mC8kMV1I+uO3l0UOw==}
+  '@tanstack/query-core@5.101.2':
+    resolution: {integrity: sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==}
 
-  '@tanstack/react-query@4.44.0':
-    resolution: {integrity: sha512-RuIqHYrS98LrK/8kJJOJMMSQ/BCpojwsXDh7p0fBmp38ZOz6dlk+uyFRRusH+V+t3POoCsDOQ2zhomEYOeReXw==}
+  '@tanstack/react-query@5.101.2':
+    resolution: {integrity: sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-native: '*'
-    peerDependenciesMeta:
-      react-dom:
-        optional: true
-      react-native:
-        optional: true
+      react: ^18 || ^19
 
   '@tanstack/react-virtual@3.14.5':
     resolution: {integrity: sha512-4EKRXh7zBLkbKbFmG3AUVkircuHd+7OdT1pocJSepxtfBd3qnrJgJ5rtPkRYyo9fmyVb2+pI2xPy5oYvMLQy6A==}
@@ -26197,6 +26190,11 @@ snapshots:
       eslint: 9.39.4(jiti@1.21.7)
       eslint-visitor-keys: 3.4.3
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))':
+    dependencies:
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.7.0))':
     dependencies:
       eslint: 9.39.4(jiti@2.7.0)
@@ -26204,13 +26202,19 @@ snapshots:
 
   '@eslint-community/regexpp@4.12.2': {}
 
+  '@eslint/compat@2.1.0(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))':
+    dependencies:
+      '@eslint/core': 1.2.1
+    optionalDependencies:
+      eslint: 9.39.4(jiti@2.7.0)(supports-color@5.5.0)
+
   '@eslint/compat@2.1.0(eslint@9.39.4(jiti@2.7.0))':
     dependencies:
       '@eslint/core': 1.2.1
     optionalDependencies:
       eslint: 9.39.4(jiti@2.7.0)
 
-  '@eslint/config-array@0.21.2':
+  '@eslint/config-array@0.21.2(supports-color@5.5.0)':
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3(supports-color@5.5.0)
@@ -26230,7 +26234,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.5':
+  '@eslint/eslintrc@3.3.5(supports-color@5.5.0)':
     dependencies:
       ajv: 6.15.0
       debug: 4.4.3(supports-color@5.5.0)
@@ -30184,15 +30188,12 @@ snapshots:
       tailwindcss: 4.2.2
       vite: 8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
 
-  '@tanstack/query-core@4.44.0': {}
+  '@tanstack/query-core@5.101.2': {}
 
-  '@tanstack/react-query@4.44.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@tanstack/react-query@5.101.2(react@18.3.1)':
     dependencies:
-      '@tanstack/query-core': 4.44.0
+      '@tanstack/query-core': 5.101.2
       react: 18.3.1
-      use-sync-external-store: 1.6.0(react@18.3.1)
-    optionalDependencies:
-      react-dom: 18.3.1(react@18.3.1)
 
   '@tanstack/react-virtual@3.14.5(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
@@ -30450,7 +30451,7 @@ snapshots:
 
   '@tryghost/api-framework@3.2.4':
     dependencies:
-      '@tryghost/debug': 2.2.3
+      '@tryghost/debug': 2.2.3(supports-color@5.5.0)
       '@tryghost/errors': 1.3.13
       '@tryghost/promise': 2.2.3
       '@tryghost/tpl': 2.2.3
@@ -30471,14 +30472,14 @@ snapshots:
 
   '@tryghost/bookshelf-eager-load@2.2.3':
     dependencies:
-      '@tryghost/debug': 2.2.3
+      '@tryghost/debug': 2.2.3(supports-color@5.5.0)
       lodash: 4.18.1
     transitivePeerDependencies:
       - supports-color
 
   '@tryghost/bookshelf-filter@2.2.4':
     dependencies:
-      '@tryghost/debug': 2.2.3
+      '@tryghost/debug': 2.2.3(supports-color@5.5.0)
       '@tryghost/errors': 1.3.13
       '@tryghost/nql': 0.13.0
       '@tryghost/tpl': 2.2.3
@@ -30487,14 +30488,14 @@ snapshots:
 
   '@tryghost/bookshelf-has-posts@2.3.3':
     dependencies:
-      '@tryghost/debug': 2.2.3
+      '@tryghost/debug': 2.2.3(supports-color@5.5.0)
       lodash: 4.18.1
     transitivePeerDependencies:
       - supports-color
 
   '@tryghost/bookshelf-include-count@2.2.3':
     dependencies:
-      '@tryghost/debug': 2.2.3
+      '@tryghost/debug': 2.2.3(supports-color@5.5.0)
       lodash: 4.18.1
     transitivePeerDependencies:
       - supports-color
@@ -30581,7 +30582,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tryghost/debug@2.2.3':
+  '@tryghost/debug@2.2.3(supports-color@5.5.0)':
     dependencies:
       '@tryghost/root-utils': 2.2.3
       debug: 4.4.3(supports-color@5.5.0)
@@ -30648,7 +30649,7 @@ snapshots:
     dependencies:
       '@tryghost/jest-snapshot': 2.1.0
       cookiejar: 2.1.4
-      express: 4.22.2
+      express: 4.22.2(supports-color@1.2.0)
       form-data: 4.0.5
       mime-types: 3.0.2
     transitivePeerDependencies:
@@ -30746,7 +30747,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tryghost/mongo-knex@0.10.1':
+  '@tryghost/mongo-knex@0.10.1(supports-color@5.5.0)':
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       lodash: 4.18.1
@@ -30841,7 +30842,7 @@ snapshots:
 
   '@tryghost/nql@0.13.0':
     dependencies:
-      '@tryghost/mongo-knex': 0.10.1
+      '@tryghost/mongo-knex': 0.10.1(supports-color@5.5.0)
       '@tryghost/mongo-utils': 0.6.5
       '@tryghost/nql-lang': 0.6.6
       lodash: 4.18.1
@@ -30849,9 +30850,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tryghost/nql@0.13.1':
+  '@tryghost/nql@0.13.1(supports-color@5.5.0)':
     dependencies:
-      '@tryghost/mongo-knex': 0.10.1
+      '@tryghost/mongo-knex': 0.10.1(supports-color@5.5.0)
       '@tryghost/mongo-utils': 0.6.5
       '@tryghost/nql-lang': 0.6.6
       lodash: 4.18.1
@@ -30881,10 +30882,10 @@ snapshots:
       lodash: 4.18.1
       prettyjson: 1.2.5
 
-  '@tryghost/prometheus-metrics@1.0.8':
+  '@tryghost/prometheus-metrics@1.0.8(supports-color@1.2.0)':
     dependencies:
       '@tryghost/logging': 4.2.1(supports-color@5.5.0)
-      express: 4.22.1
+      express: 4.22.1(supports-color@1.2.0)
       prom-client: 15.1.3
       stoppable: 1.1.0
     transitivePeerDependencies:
@@ -31579,12 +31580,12 @@ snapshots:
       '@types/node': 26.0.0
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.49.0(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.49.0(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.56.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.56.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.49.0
-      '@typescript-eslint/type-utils': 8.49.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.49.0(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
       '@typescript-eslint/utils': 8.49.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.49.0
       eslint: 9.39.4(jiti@2.7.0)
@@ -31595,12 +31596,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.62.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.62.1
-      '@typescript-eslint/type-utils': 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.62.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
       '@typescript-eslint/utils': 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.62.1
       eslint: 9.39.4(jiti@2.7.0)
@@ -31611,7 +31612,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.49.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.49.0(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.49.0
       '@typescript-eslint/types': 8.49.0
@@ -31623,11 +31624,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.56.1
       '@typescript-eslint/types': 8.56.1
-      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.56.1(supports-color@5.5.0)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.56.1
       debug: 4.4.3(supports-color@5.5.0)
       eslint: 9.39.4(jiti@2.7.0)
@@ -31635,7 +31636,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.62.1
       '@typescript-eslint/types': 8.62.1
@@ -31656,7 +31657,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.56.1(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.56.1(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.62.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.62.1
@@ -31701,7 +31702,7 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.49.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.49.0(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.49.0
       '@typescript-eslint/typescript-estree': 8.49.0(typescript@5.9.3)
@@ -31713,7 +31714,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.62.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.62.1
       '@typescript-eslint/typescript-estree': 8.62.1(typescript@5.9.3)
@@ -31746,9 +31747,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.56.1(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.56.1(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.56.1(supports-color@5.5.0)(typescript@5.9.3)
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/visitor-keys': 8.56.1
@@ -33804,7 +33805,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  broccoli-config-replace@1.1.3:
+  broccoli-config-replace@1.1.3(supports-color@1.2.0):
     dependencies:
       broccoli-plugin: 1.3.1
       debug: 2.6.9(supports-color@1.2.0)
@@ -33868,7 +33869,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  broccoli-funnel@2.0.1:
+  broccoli-funnel@2.0.1(supports-color@1.2.0):
     dependencies:
       array-equal: 1.0.2
       blank-object: 1.0.2
@@ -34198,7 +34199,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  broccoli@3.5.2:
+  broccoli@3.5.2(supports-color@1.2.0):
     dependencies:
       '@types/chai': 4.3.20
       '@types/chai-as-promised': 7.1.8
@@ -34208,7 +34209,7 @@ snapshots:
       broccoli-slow-trees: 3.1.0
       broccoli-source: 3.0.1
       commander: 4.1.1
-      connect: 3.7.0
+      connect: 3.7.0(supports-color@1.2.0)
       console-ui: 3.1.2
       esm: 3.2.25
       findup-sync: 4.0.0
@@ -35165,10 +35166,10 @@ snapshots:
 
   connect-slashes@1.4.0: {}
 
-  connect@3.7.0:
+  connect@3.7.0(supports-color@1.2.0):
     dependencies:
       debug: 2.6.9(supports-color@1.2.0)
-      finalhandler: 1.1.2
+      finalhandler: 1.1.2(supports-color@1.2.0)
       parseurl: 1.3.3
       utils-merge: 1.0.1
     transitivePeerDependencies:
@@ -36517,10 +36518,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli-dependency-checker@3.3.2(ember-cli@3.24.0(encoding@0.1.13)(handlebars@4.7.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@5.5.0)(underscore@1.13.8)):
+  ember-cli-dependency-checker@3.3.2(ember-cli@3.24.0(encoding@0.1.13)(handlebars@4.7.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@1.2.0)(underscore@1.13.8)):
     dependencies:
       chalk: 2.4.2
-      ember-cli: 3.24.0(encoding@0.1.13)(handlebars@4.7.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@5.5.0)(underscore@1.13.8)
+      ember-cli: 3.24.0(encoding@0.1.13)(handlebars@4.7.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@1.2.0)(underscore@1.13.8)
       find-yarn-workspace-root: 1.2.1
       is-git-url: 1.0.0
       resolve: 1.22.12
@@ -36853,7 +36854,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-cli@3.24.0(encoding@0.1.13)(handlebars@4.7.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@5.5.0)(underscore@1.13.8):
+  ember-cli@3.24.0(encoding@0.1.13)(handlebars@4.7.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@1.2.0)(underscore@1.13.8):
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-modules-amd': 7.29.7(@babel/core@7.29.7)
@@ -36861,13 +36862,13 @@ snapshots:
       babel-plugin-module-resolver: 4.1.0
       bower-config: 1.4.3
       bower-endpoint-parser: 0.2.2
-      broccoli: 3.5.2
+      broccoli: 3.5.2(supports-color@1.2.0)
       broccoli-amd-funnel: 2.0.1
       broccoli-babel-transpiler: 7.8.1
       broccoli-builder: 0.18.14
       broccoli-concat: 4.2.7
       broccoli-config-loader: 1.0.1
-      broccoli-config-replace: 1.1.3
+      broccoli-config-replace: 1.1.3(supports-color@1.2.0)
       broccoli-debug: 0.6.5
       broccoli-funnel: 2.0.2
       broccoli-funnel-reducer: 1.0.0
@@ -36896,7 +36897,7 @@ snapshots:
       ensure-posix-path: 1.1.1
       execa: 4.1.0
       exit: 0.1.2
-      express: 4.22.2
+      express: 4.22.2(supports-color@1.2.0)
       filesize: 6.4.0
       find-up: 5.0.0
       find-yarn-workspace-root: 2.0.0
@@ -36917,12 +36918,12 @@ snapshots:
       isbinaryfile: 4.0.10
       js-yaml: 3.14.2
       json-stable-stringify: 1.3.0
-      leek: 0.0.24
+      leek: 0.0.24(supports-color@1.2.0)
       lodash.template: 4.18.1
       markdown-it: 12.3.2
       markdown-it-terminal: 0.2.1
       minimatch: 3.1.5
-      morgan: 1.11.0
+      morgan: 1.11.0(supports-color@1.2.0)
       nopt: 3.0.6
       npm-package-arg: 8.1.5
       p-defer: 3.0.0
@@ -37009,10 +37010,10 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-composable-helpers@5.0.0:
+  ember-composable-helpers@5.0.0(supports-color@1.2.0):
     dependencies:
       '@babel/core': 7.29.7
-      broccoli-funnel: 2.0.1
+      broccoli-funnel: 2.0.1(supports-color@1.2.0)
       ember-cli-babel: 7.26.11
       resolve: 1.22.12
     transitivePeerDependencies:
@@ -37151,7 +37152,7 @@ snapshots:
       mathml-tag-names: 2.1.3
       svg-tags: 1.0.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.56.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.56.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint
       - typescript
@@ -37168,7 +37169,7 @@ snapshots:
       mathml-tag-names: 2.1.3
       svg-tags: 1.0.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.56.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.56.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint
       - typescript
@@ -38031,7 +38032,26 @@ snapshots:
       requireindex: 1.2.0
       snake-case: 3.0.4
     optionalDependencies:
-      '@typescript-eslint/parser': 8.56.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.56.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - typescript
+
+  eslint-plugin-ember@12.7.5(@babel/core@8.0.1)(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
+    dependencies:
+      '@ember-data/rfc395-data': 0.0.4
+      css-tree: 3.2.1
+      ember-eslint-parser: 0.5.13(@babel/core@8.0.1)(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      ember-rfc176-data: 0.3.18
+      eslint: 9.39.4(jiti@2.7.0)
+      eslint-utils: 3.0.0(eslint@9.39.4(jiti@2.7.0))
+      estraverse: 5.3.0
+      lodash.camelcase: 4.3.0
+      lodash.kebabcase: 4.1.1
+      requireindex: 1.2.0
+      snake-case: 3.0.4
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.56.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@babel/core'
       - typescript
@@ -38050,7 +38070,7 @@ snapshots:
       requireindex: 1.2.0
       snake-case: 3.0.4
     optionalDependencies:
-      '@typescript-eslint/parser': 8.56.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.56.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@babel/core'
       - typescript
@@ -38073,8 +38093,8 @@ snapshots:
   eslint-plugin-ghost@3.5.0(@babel/core@7.29.7)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@kapouer/eslint-plugin-no-return-in-loop': 1.0.0
-      '@typescript-eslint/eslint-plugin': 8.49.0(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.56.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.49.0(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.56.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-plugin-ember: 12.7.5(@babel/core@7.29.7)(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       eslint-plugin-filenames-ts: 1.3.2(eslint@9.39.4(jiti@2.7.0))
@@ -38090,10 +38110,27 @@ snapshots:
   eslint-plugin-ghost@3.5.0(@babel/core@8.0.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@kapouer/eslint-plugin-no-return-in-loop': 1.0.0
-      '@typescript-eslint/eslint-plugin': 8.49.0(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.56.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.49.0(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.56.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-plugin-ember: 12.7.5(@babel/core@8.0.1)(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      eslint-plugin-filenames-ts: 1.3.2(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-mocha: 7.0.1(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-n: 17.24.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      eslint-plugin-sort-imports-es6-autofix: 0.6.0(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-unicorn: 42.0.0(eslint@9.39.4(jiti@2.7.0))
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
+  eslint-plugin-ghost@3.5.0(@babel/core@8.0.1)(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0):
+    dependencies:
+      '@kapouer/eslint-plugin-no-return-in-loop': 1.0.0
+      '@typescript-eslint/eslint-plugin': 8.49.0(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.56.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)
+      eslint-plugin-ember: 12.7.5(@babel/core@8.0.1)(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       eslint-plugin-filenames-ts: 1.3.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-mocha: 7.0.1(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-n: 17.24.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
@@ -38264,10 +38301,10 @@ snapshots:
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@1.21.7))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.2
+      '@eslint/config-array': 0.21.2(supports-color@5.5.0)
       '@eslint/config-helpers': 0.4.2
       '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.5
+      '@eslint/eslintrc': 3.3.5(supports-color@5.5.0)
       '@eslint/js': 9.39.4
       '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.8
@@ -38305,10 +38342,51 @@ snapshots:
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.2
+      '@eslint/config-array': 0.21.2(supports-color@5.5.0)
       '@eslint/config-helpers': 0.4.2
       '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.5
+      '@eslint/eslintrc': 3.3.5(supports-color@5.5.0)
+      '@eslint/js': 9.39.4
+      '@eslint/plugin-kit': 0.4.1
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3(supports-color@5.5.0)
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0)(supports-color@5.5.0))
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.2(supports-color@5.5.0)
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.5(supports-color@5.5.0)
       '@eslint/js': 9.39.4
       '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.8
@@ -38540,11 +38618,11 @@ snapshots:
 
   express-brute@1.0.1(express@4.22.2):
     dependencies:
-      express: 4.22.2
+      express: 4.22.2(supports-color@1.2.0)
       long-timeout: 0.1.1
       underscore: 1.13.8
 
-  express-end@0.0.8:
+  express-end@0.0.8(supports-color@1.2.0):
     dependencies:
       debug: 2.6.9(supports-color@1.2.0)
     transitivePeerDependencies:
@@ -38572,19 +38650,19 @@ snapshots:
 
   express-lazy-router@1.0.6(express@4.22.2):
     dependencies:
-      express: 4.22.2
+      express: 4.22.2(supports-color@1.2.0)
 
   express-query-boolean@2.0.0: {}
 
-  express-queue@0.0.13(supports-color@5.5.0):
+  express-queue@0.0.13(supports-color@1.2.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
-      express-end: 0.0.8
+      express-end: 0.0.8(supports-color@1.2.0)
       mini-queue: 0.0.14
     transitivePeerDependencies:
       - supports-color
 
-  express-session@1.19.0:
+  express-session@1.19.0(supports-color@1.2.0):
     dependencies:
       cookie: 0.7.2
       cookie-signature: 1.0.7
@@ -38599,7 +38677,7 @@ snapshots:
 
   express-unless@2.1.3: {}
 
-  express@4.22.1:
+  express@4.22.1(supports-color@1.2.0):
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
@@ -38613,7 +38691,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 1.3.2
+      finalhandler: 1.3.2(supports-color@1.2.0)
       fresh: 0.5.2
       http-errors: 2.0.1
       merge-descriptors: 1.0.3
@@ -38625,7 +38703,7 @@ snapshots:
       qs: 6.15.3
       range-parser: 1.2.1
       safe-buffer: 5.2.1
-      send: 0.19.2
+      send: 0.19.2(supports-color@1.2.0)
       serve-static: 1.16.3
       setprototypeof: 1.2.0
       statuses: 2.0.2
@@ -38635,7 +38713,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  express@4.22.2:
+  express@4.22.2(supports-color@1.2.0):
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
@@ -38649,7 +38727,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 1.3.2
+      finalhandler: 1.3.2(supports-color@1.2.0)
       fresh: 0.5.2
       http-errors: 2.0.1
       merge-descriptors: 1.0.3
@@ -38661,7 +38739,7 @@ snapshots:
       qs: 6.15.3
       range-parser: 1.2.1
       safe-buffer: 5.2.1
-      send: 0.19.2
+      send: 0.19.2(supports-color@1.2.0)
       serve-static: 1.16.3
       setprototypeof: 1.2.0
       statuses: 2.0.2
@@ -38894,7 +38972,7 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@1.1.2:
+  finalhandler@1.1.2(supports-color@1.2.0):
     dependencies:
       debug: 2.6.9(supports-color@1.2.0)
       encodeurl: 1.0.2
@@ -38906,7 +38984,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  finalhandler@1.3.2:
+  finalhandler@1.3.2(supports-color@1.2.0):
     dependencies:
       debug: 2.6.9(supports-color@1.2.0)
       encodeurl: 2.0.0
@@ -39715,7 +39793,7 @@ snapshots:
       '@tryghost/debug': 2.3.1(supports-color@5.5.0)
       '@tryghost/errors': 1.3.13
       '@tryghost/logging': 4.2.1(supports-color@5.5.0)
-      '@tryghost/nql': 0.13.1
+      '@tryghost/nql': 0.13.1(supports-color@5.5.0)
       '@tryghost/pretty-cli': 3.3.1
       '@tryghost/server': 3.1.1
       '@tryghost/zip': 3.5.0
@@ -41714,7 +41792,7 @@ snapshots:
 
   kleur@4.1.5: {}
 
-  knex-migrator@5.4.1(@types/node@22.20.0):
+  knex-migrator@5.4.1(@types/node@22.20.0)(supports-color@5.5.0):
     dependencies:
       '@tryghost/database-info': 0.3.35
       '@tryghost/errors': 1.3.13
@@ -41854,7 +41932,7 @@ snapshots:
       ee-log: 3.0.9
       ee-types: 2.2.1
 
-  leek@0.0.24:
+  leek@0.0.24(supports-color@1.2.0):
     dependencies:
       debug: 2.6.9(supports-color@1.2.0)
       lodash.assign: 3.2.0
@@ -43317,7 +43395,7 @@ snapshots:
 
   moo@0.5.3: {}
 
-  morgan@1.11.0:
+  morgan@1.11.0(supports-color@1.2.0):
     dependencies:
       basic-auth: 2.0.1
       debug: 2.6.9(supports-color@1.2.0)
@@ -45358,11 +45436,11 @@ snapshots:
     dependencies:
       crypto: 0.0.3
 
-  probe-image-size@7.3.0:
+  probe-image-size@7.3.0(supports-color@1.2.0):
     dependencies:
       lodash.merge: 4.6.2
       needle: 2.9.1
-      stream-parser: 0.3.1
+      stream-parser: 0.3.1(supports-color@1.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -46680,7 +46758,7 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@0.19.2:
+  send@0.19.2(supports-color@1.2.0):
     dependencies:
       debug: 2.6.9(supports-color@1.2.0)
       depd: 2.0.0
@@ -46717,7 +46795,7 @@ snapshots:
   sentry-testkit@6.4.1:
     dependencies:
       body-parser: 1.20.5
-      express: 4.22.2
+      express: 4.22.2(supports-color@1.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -46730,7 +46808,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 0.19.2
+      send: 0.19.2(supports-color@1.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -47256,7 +47334,7 @@ snapshots:
       readable-stream: 3.6.2
       xtend: 4.0.2
 
-  stream-parser@0.3.1:
+  stream-parser@0.3.1(supports-color@1.2.0):
     dependencies:
       debug: 2.6.9(supports-color@1.2.0)
     transitivePeerDependencies:
@@ -47542,7 +47620,7 @@ snapshots:
 
   superagent-throttle@1.0.1: {}
 
-  superagent@10.3.0:
+  superagent@10.3.0(supports-color@5.5.0):
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
@@ -47572,11 +47650,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  supertest@7.2.2:
+  supertest@7.2.2(supports-color@5.5.0):
     dependencies:
       cookie-signature: 1.2.2
       methods: 1.1.2
-      superagent: 10.3.0
+      superagent: 10.3.0(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -47895,7 +47973,7 @@ snapshots:
       compression: 1.8.1
       consolidate: 1.0.4(@babel/core@7.29.7)(handlebars@4.7.9)(lodash@4.18.1)(mustache@4.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(underscore@1.13.8)
       execa: 9.6.1
-      express: 4.22.2
+      express: 4.22.2(supports-color@1.2.0)
       fireworm: 0.7.2
       glob: 13.0.6
       http-proxy: 1.18.1
@@ -48326,10 +48404,10 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript-eslint@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
+  typescript-eslint@8.62.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.62.1(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.62.1(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.62.1(eslint@9.39.4(jiti@2.7.0))(supports-color@5.5.0)(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.62.1(typescript@5.9.3)
       '@typescript-eslint/utils': 8.62.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.7.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -67,7 +67,7 @@ catalog:
   '@storybook/react-vite': 10.4.6
   '@tailwindcss/postcss': 4.2.2
   '@tailwindcss/vite': 4.2.2
-  '@tanstack/react-query': 4.44.0
+  '@tanstack/react-query': 5.101.2
   '@tanstack/react-virtual': 3.14.5
   '@testing-library/jest-dom': 6.9.1
   '@testing-library/react': 14.3.1


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLA-189/react-query-v4-v5-decide-execute

Migrates `@tanstack/react-query` 4.44.0 → 5.101.2 across the four consumers (apps/admin, admin-x-framework, admin-x-settings, activitypub), bumped once in the pnpm catalog. The shared query/mutation factories in admin-x-framework multiply into every screen migrated out of Ember, so moving off the deprecated v4 major now avoids rewriting more call sites later.

## Mechanical changes

- `cacheTime` → `gcTime`; removed v5-deleted `logger`/`suspense` options from test clients
- `invalidateQueries`/`setQueriesData`/`getQueriesData` → filter-object signatures (`setQueryData`/`getQueryData` keep positional keys in v5, left alone)
- `keepPreviousData: true` → `placeholderData: keepPreviousData`; `isPreviousData` → `isPlaceholderData`
- `useInfiniteQuery` requires `initialPageParam` — passing `undefined` keeps first-page requests byte-identical to v4; the framework's `createInfiniteQuery` pins the page-param type and the 10 direct activitypub call sites are updated
- Mutation results `isLoading` → `isPending` (~12 components)
- The factories no longer override `isLoading`: v5's definition (`isPending && isFetching`) is exactly the old `isLoading && fetchStatus !== 'idle'` workaround
- `hook-testing-utils` mocks emit the v5 result shape (`isPending`, `status: 'pending'`, `fetchStatus`, `isEnabled`, `promise`; dropped `isIdle`/`isPreviousData`/`remove()`)
- Removed the react-query v4 fallback branch in `ghost/admin/app/components/gh-billing-iframe.js` per its own "remove when v5 lands" TODO
- `createMutation`'s `onSuccess` verified unchanged — v5 kept mutation callbacks; the `FrameworkProvider` `queryClient`/`queryClientOptions` injection contract is untouched (exercised by the acceptance harness)

## Reviewer callouts

- One theoretical semantics edge: v5's `isLoading` is false while `fetchStatus === 'paused'` where the old override was true — unreachable in production (shared client uses `networkMode: 'always'`)
- Infinite pagination: `getNextPageParam` returning `null`/`undefined` means "no next page" in both majors; the framework's pre-existing `() => ({})` default (always `hasNextPage`) is preserved unchanged

## Verification

- admin-x-framework: 31 files / 440 tests green; tsc + lint clean
- apps/admin: unit 88 files / 848 tests; **acceptance (Vitest Browser Mode) 12 files / 79 tests**; `tsc -b` + eslint clean
- admin-x-settings: 19 files / 203 tests; `tsc && vite build` clean; lint clean
- activitypub: 10 files / 116 tests; `tsc && vite build` clean; lint clean