### PR TITLE
Fixed strict route settings validation rejecting legacy-shaped YAML values

### DIFF
--- a/ghost/core/core/server/services/route-settings/route-settings-parser.ts
+++ b/ghost/core/core/server/services/route-settings/route-settings-parser.ts
@@ -32,6 +32,14 @@ const VALID_SHORTFORM_RESOURCES = ['tag', 'page', 'post', 'author'] as const;
 const VALID_LONGFORM_RESOURCES = ['tags', 'posts', 'pages', 'authors'] as const;
 const RESERVED_DATA_KEYS = ['resource', 'type', 'limit', 'order', 'include', 'filter', 'status', 'visibility', 'slug', 'redirect'];
 
+// YAML parses a bare `filter:` as null and authors commonly quote numeric scalars
+// (`limit: "100"`); the legacy validator accepted both, so treat an explicitly empty
+// value as unset and coerce digit-only limit strings to numbers.
+const OptionalStringField = z.string().nullish().transform(v => v ?? undefined);
+const OptionalBooleanField = z.boolean().nullish().transform(v => v ?? undefined);
+const LimitField = z.union([z.number(), z.literal('all'), z.string().regex(/^\d+$/).transform(Number)])
+    .nullish().transform(v => v ?? undefined);
+
 const DataShortFormSchema = z.string().superRefine((v, ctx) => {
     if (!/^[a-zA-Z0-9_]+\.[a-zA-Z0-9_-]+$/.test(v)) {
         ctx.addIssue({code: 'custom', message: tpl(messages.validationError, {at: v, reason: 'Incorrect Format. Please use e.g. tag.recipes'})});
@@ -56,13 +64,13 @@ const DataReadEntrySchema = z.object({
 const DataBrowseEntrySchema = z.object({
     type: z.literal('browse'),
     resource: z.enum(VALID_LONGFORM_RESOURCES),
-    filter: z.string().optional(),
-    limit: z.union([z.number(), z.literal('all')]).optional(),
-    order: z.string().optional(),
-    include: z.string().optional(),
-    fields: z.string().optional(),
-    visibility: z.string().optional(),
-    status: z.string().optional(),
+    filter: OptionalStringField,
+    limit: LimitField,
+    order: OptionalStringField,
+    include: OptionalStringField,
+    fields: OptionalStringField,
+    visibility: OptionalStringField,
+    status: OptionalStringField,
     page: z.number().optional()
 });
 
@@ -96,6 +104,14 @@ function parseDataEntry(key: string, value: unknown): DataEntry {
                 throw validationError(JSON.stringify(value), `${resVal} not supported. Please use ${VALID_LONGFORM_RESOURCES.join(', ')}.`);
             }
             throw toValidationError(result.error);
+        }
+        // Fields set to an explicitly empty value parse to undefined — drop the
+        // keys so "unset" means absent in the domain model and serialized output.
+        const entry: Record<string, unknown> = result.data;
+        for (const entryKey of Object.keys(entry)) {
+            if (entry[entryKey] === undefined) {
+                delete entry[entryKey];
+            }
         }
         return result.data;
     }
@@ -139,7 +155,7 @@ function parseRouteData(data: unknown): RouteData {
     return parsed;
 }
 
-const TemplateField = z.union([z.string(), z.array(z.string())]).optional().default([])
+const TemplateField = z.union([z.string(), z.array(z.string())]).nullish().default([])
     .transform(v => {
         if (!v || (Array.isArray(v) && v.length === 0)) {
             return [];
@@ -151,11 +167,11 @@ const RouteObjectSchema = z.object({
     controller: z.literal('channel').optional(),
     template: TemplateField,
     data: z.unknown().optional(),
-    content_type: z.string().optional(),
-    filter: z.string().optional(),
-    order: z.string().optional(),
-    limit: z.union([z.number(), z.literal('all')]).optional(),
-    rss: z.boolean().optional()
+    content_type: OptionalStringField,
+    filter: OptionalStringField,
+    order: OptionalStringField,
+    limit: LimitField,
+    rss: OptionalBooleanField
 }).transform((val): Omit<Route, 'path'> => {
     const templates = val.template;
     const data = val.data !== undefined ? parseRouteData(val.data) : undefined;
@@ -203,10 +219,10 @@ const RawCollectionValueSchema = z.object({
     permalink: z.string({message: 'Please define a permalink route.'}).optional(),
     template: TemplateField,
     data: z.unknown().optional(),
-    filter: z.string().optional(),
-    order: z.string().optional(),
-    limit: z.union([z.number(), z.literal('all')]).optional(),
-    rss: z.boolean().optional()
+    filter: OptionalStringField,
+    order: OptionalStringField,
+    limit: LimitField,
+    rss: OptionalBooleanField
 }).transform((val): Omit<CollectionConfig, 'path'> => {
     const data = val.data !== undefined ? parseRouteData(val.data) : undefined;
     const collection: Omit<CollectionConfig, 'path'> = {

--- a/ghost/core/test/unit/server/services/route-settings/route-settings-parser.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/route-settings-parser.test.ts
@@ -285,6 +285,108 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
             });
         });
 
+        describe('legacy YAML coercions', function () {
+            it('coerces digit-only string limits to numbers in collections', function () {
+                const result = parse({
+                    collections: {'/': {permalink: '/{slug}/', template: 'index', limit: '100'}}
+                });
+
+                assert.deepEqual(result.collections, [
+                    {path: '/', permalink: '/{slug}/', templates: ['index'], limit: 100}
+                ]);
+            });
+
+            it('coerces digit-only string limits to numbers in channel routes', function () {
+                const result = parse({
+                    routes: {'/podcast/': {controller: 'channel', limit: '5'}}
+                });
+
+                assert.deepEqual(result.routes, [
+                    {type: 'channel', path: '/podcast/', templates: [], limit: 5}
+                ]);
+            });
+
+            it('coerces digit-only string limits to numbers in browse data entries', function () {
+                const result = parse({
+                    routes: {'/podcast/': {template: 'podcast', data: {episodes: {type: 'browse', resource: 'posts', limit: '15'}}}}
+                });
+
+                assert.deepEqual(result.routes, [{
+                    type: 'template',
+                    path: '/podcast/',
+                    templates: ['podcast'],
+                    data: {episodes: {type: 'browse', resource: 'posts', limit: 15}}
+                }]);
+            });
+
+            it('still rejects non-numeric string limits', function () {
+                assert.throws(() => {
+                    parse({collections: {'/': {permalink: '/{slug}/', limit: 'banana'}}});
+                }, /Invalid input/);
+            });
+
+            it('still accepts the literal "all" limit', function () {
+                const result = parse({
+                    collections: {'/': {permalink: '/{slug}/', limit: 'all'}}
+                });
+
+                assert.equal(result.collections[0].limit, 'all');
+            });
+
+            it('treats empty optional scalars as unset in collections', function () {
+                const result = parse({
+                    collections: {'/': {permalink: '/{slug}/', template: 'index', filter: null, order: null, limit: null, rss: null}}
+                });
+
+                assert.deepEqual(result.collections, [
+                    {path: '/', permalink: '/{slug}/', templates: ['index']}
+                ]);
+            });
+
+            it('treats empty optional scalars as unset in routes', function () {
+                const result = parse({
+                    routes: {'/podcast/': {controller: 'channel', filter: null, order: null, limit: null, rss: null}}
+                });
+
+                assert.deepEqual(result.routes, [
+                    {type: 'channel', path: '/podcast/', templates: []}
+                ]);
+            });
+
+            it('treats empty optional scalars as unset in browse data entries', function () {
+                const result = parse({
+                    routes: {'/podcast/': {template: 'podcast', data: {episodes: {type: 'browse', resource: 'posts', filter: null, order: null, limit: null, include: null}}}}
+                });
+
+                assert.deepEqual(result.routes, [{
+                    type: 'template',
+                    path: '/podcast/',
+                    templates: ['podcast'],
+                    data: {episodes: {type: 'browse', resource: 'posts'}}
+                }]);
+            });
+
+            it('treats an empty template as unset in collections', function () {
+                const result = parse({
+                    collections: {'/anime/': {permalink: '/anime/{slug}/', template: null, filter: 'primary_tag:anime'}}
+                });
+
+                assert.deepEqual(result.collections, [
+                    {path: '/anime/', permalink: '/anime/{slug}/', templates: [], filter: 'primary_tag:anime'}
+                ]);
+            });
+
+            it('treats an empty content_type as unset', function () {
+                const result = parse({
+                    routes: {'/rss/': {template: 'rss', content_type: null}}
+                });
+
+                assert.deepEqual(result.routes, [
+                    {type: 'template', path: '/rss/', templates: ['rss']}
+                ]);
+            });
+        });
+
         describe('default-routes.yaml', function () {
             it('correctly parses the default routes.yaml content', function () {
                 const result = parse({


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1831/delete-obsolete-route-settings-modules

## Why

A fleet audit of 41,346 Ghost(Pro) `routes.yaml` files found **97 that the strict parser rejects but legacy `validate.js` accepts** — all live sites that currently land on the #29305 legacy-validation fallback. Classifying the 97 splits them cleanly in two:

- **48 are pure value-shape mismatches with unambiguous intent.** The validator itself should accept these — rejecting them is arguably a type bug, not strictness.
- **49 use constructs the new schema forbids on purpose.** Loosening the validator for those would be genuine leniency, so they must be fixed per-site instead (see below).

This PR fixes the validator for the first group only. Shrinking the fallback population is a precondition for retiring the legacy validator modules (HKG-1831) and for flipping sites to the remote store.

## What the validator now accepts — 48 of the 97

### 1. `limit` as a numeric string (44 files)

The three `limit` fields (`RouteObjectSchema`, `RawCollectionValueSchema`, `DataBrowseEntrySchema`) were `z.union([z.number(), z.literal('all')])`. They now also accept **digit-only strings and coerce them to numbers** (`z.string().regex(/^\d+$/).transform(Number)` as a third union member).

`limit: "100"` and `limit: 100` mean the same thing, YAML authors quote numbers constantly, and garbage like `limit: "banana"` is still rejected.

### 2. Empty YAML values treated as unset (4 files)

YAML parses a bare `filter:` as `null`, and `z.string().optional()` rejects `null`. An explicitly empty value is now **treated as "unset"** (`.nullish()` + transform to `undefined`) — standard YAML empty-value handling, not tolerance of a bad value. The rule is applied uniformly to the optional scalars (`filter`, `order`, `content_type`, `limit`, `rss`) and to `template:`, so the same class of report can't recur on a different key. In the fleet: 3 files with an empty `filter:` and 1 with an empty `template:`.

### Nuance: one-time routes-hash churn for the coerced sites

The activation bridge reproduces legacy `validate.js` output byte-for-byte, and legacy passed the string `"100"` through untouched. Coercing to a number changes the expanded output (`100` vs `"100"`) and therefore `getCurrentHash()` for the 44 quoted-limit sites — a harmless one-time routes-hash change when they leave the fallback, but worth knowing since hash stability for the fallback population was checked in the pre-merge simulation for #29305.

## What stays rejected — 49 files, needs per-site fixes (or a product decision)

Each of these would require the schema to accept a construct it forbids **on purpose**:

| Files | Construct | Why it stays rejected |
|---|---|---|
| 10 | `controller: page` | `z.literal('channel')` encodes "channel is the only controller that exists." Accepting unknown controllers reopens the hole the schema closed — and we'd still have to invent a semantic for it (ignore? treat as template route?). |
| 13 | Template-less route objects | "Please define a template" is a real requirement; a route object defining nothing renderable is a user error the validator should catch. |
| 10 | Colon-notation paths (`/tag/:slug/`) | The `/{slug}/` notation check is deliberate; allowing `:slug` re-legitimizes raw Express params. |
| 8 | `data: false` | Admitting a boolean where a data definition belongs is swallowing a typo'd config, not coercing an intended value. |
| 3 | `filter:` as an array | Accepting arrays would also *activate* filters that were inert under legacy (it passed the raw array through, which NQL can't use) — a behavior change on live sites on top of the leniency. |
| 2 | `rss:` as an object | "Any truthy value means true" is precisely the legacy sloppiness the boolean schema fixed. |
| 3 | Malformed short-form data (`tag.{slug}`) | The format check is the feature; these are unambiguous authoring errors. |

For these 49 the options remain fixing the files or a deliberate product decision — they stay on the #29305 fallback in the meantime, which is exactly what it's for.

## Verification

- 9 new unit tests covering coercion, empty-value handling, and the still-rejected cases; all 200 route-settings/adapter-manager unit tests pass; `lint:types` (eslint + `tsc --noEmit`) clean.
- Fleet re-audit over all 41,346 files: failures drop **97 → 49**, with exactly the 48 expected files flipping to pass and **zero newly-failing files**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
