### PR TITLE
Removed admin-x-framework's dependency on admin-x-design-system

### DIFF
--- a/apps/admin-x-framework/package.json
+++ b/apps/admin-x-framework/package.json
@@ -109,7 +109,6 @@
         "@sentry/react": "catalog:",
         "@tanstack/react-query": "catalog:",
         "@tinybirdco/charts": "0.3.0",
-        "@tryghost/admin-x-design-system": "workspace:*",
         "@tryghost/shade": "workspace:*",
         "@tryghost/test-data": "workspace:*",
         "bson-objectid": "catalog:",

--- a/apps/admin-x-framework/src/hooks/use-form.ts
+++ b/apps/admin-x-framework/src/hooks/use-form.ts
@@ -1,5 +1,8 @@
-import {ButtonColor} from '@tryghost/admin-x-design-system';
 import {useCallback, useEffect, useState} from 'react';
+
+// Structurally matches admin-x-design-system's ButtonColor so okProps.color stays
+// assignable to its Button color prop.
+export type ButtonColor = 'clear' | 'light-grey' | 'grey' | 'black' | 'green' | 'red' | 'white' | 'outline';
 
 export type Dirtyable<Data> = Data & {
     dirty?: boolean;

--- a/apps/admin-x-framework/src/hooks/use-handle-error.ts
+++ b/apps/admin-x-framework/src/hooks/use-handle-error.ts
@@ -1,9 +1,9 @@
 import * as Sentry from '@sentry/react';
-import {showToast} from '@tryghost/admin-x-design-system';
 import {useCallback} from 'react';
 import toast from 'react-hot-toast';
 import {useFramework} from '../providers/framework-provider';
 import {APIError, getErrorMessage} from '../utils/errors';
+import {showToast} from '../utils/toast';
 
 function showErrorToast(message: React.ReactNode) {
     toast.remove();

--- a/apps/admin-x-framework/src/hooks/use-pagination.ts
+++ b/apps/admin-x-framework/src/hooks/use-pagination.ts
@@ -1,0 +1,45 @@
+import {Dispatch, SetStateAction, useEffect, useState} from 'react';
+
+export interface PaginationMeta {
+    limit: number | 'all';
+    pages: number;
+    total: number;
+    next: number | null;
+    prev: number | null;
+}
+
+export interface PaginationData {
+    page: number;
+    pages: number | null;
+    total: number | null;
+    limit: number;
+    setPage: (page: number) => void;
+    nextPage: () => void;
+    prevPage: () => void;
+}
+
+export const usePagination = ({limit, meta, page, setPage}: {meta?: PaginationMeta, limit: number, page: number, setPage: Dispatch<SetStateAction<number>>}): PaginationData => {
+    // Prevent resetting meta when a new page loads
+    const [prevMeta, setPrevMeta] = useState<PaginationMeta | undefined>(meta);
+
+    useEffect(() => {
+        if (meta) {
+            setPrevMeta(meta);
+
+            if (meta.pages > 0 && meta.pages < page) {
+                // We probably deleted an item when on the last page: go one page back automatically
+                setPage(meta.pages);
+            }
+        }
+    }, [meta, setPage, page]);
+
+    return {
+        page,
+        setPage,
+        pages: prevMeta?.pages ?? null,
+        limit: prevMeta?.limit && prevMeta.limit !== 'all' ? prevMeta.limit : limit,
+        total: prevMeta?.total ?? null,
+        nextPage: () => setPage(Math.min(page + 1, prevMeta?.pages ? prevMeta.pages : page)),
+        prevPage: () => setPage(Math.max(1, page - 1))
+    };
+};

--- a/apps/admin-x-framework/src/test/render.tsx
+++ b/apps/admin-x-framework/src/test/render.tsx
@@ -1,9 +1,15 @@
-import {DesignSystemAppProps} from '@tryghost/admin-x-design-system';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import {TopLevelFrameworkProps} from '../providers/framework-provider';
 
-const fetchKoenigLexical: DesignSystemAppProps['fetchKoenigLexical'] = async () => {
+// Structurally matches admin-x-design-system's DesignSystemAppProps so apps can
+// type their designSystem prop against either package.
+interface DesignSystemProps {
+    darkMode: boolean;
+    fetchKoenigLexical: () => Promise<unknown>;
+}
+
+const fetchKoenigLexical: DesignSystemProps['fetchKoenigLexical'] = async () => {
     // @ts-expect-error koenig-lexical doesn't currently ship TypeScript declarations.
     return await import('@tryghost/koenig-lexical');
 };
@@ -11,7 +17,7 @@ const fetchKoenigLexical: DesignSystemAppProps['fetchKoenigLexical'] = async () 
 export default function renderStandaloneApp<Props extends object>(
     App: React.ComponentType<Props & {
         framework: TopLevelFrameworkProps;
-        designSystem: DesignSystemAppProps;
+        designSystem: DesignSystemProps;
     }>,
     props: Props
 ) {

--- a/apps/admin-x-framework/src/utils/api/hooks.ts
+++ b/apps/admin-x-framework/src/utils/api/hooks.ts
@@ -1,7 +1,7 @@
 import {InfiniteData, InvalidateOptions, InvalidateQueryFilters, QueryKey, UseInfiniteQueryOptions, UseQueryOptions, UseQueryResult, useInfiniteQuery, useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
-import {usePagination} from '@tryghost/admin-x-design-system';
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import useHandleError from '../../hooks/use-handle-error';
+import {usePagination} from '../../hooks/use-pagination';
 import {usePermission} from '../../hooks/use-permissions';
 import {UserRoleType} from '../../api/roles';
 import {useFramework} from '../../providers/framework-provider';

--- a/apps/admin-x-framework/src/utils/focus-koenig-editor-on-bottom-click.ts
+++ b/apps/admin-x-framework/src/utils/focus-koenig-editor-on-bottom-click.ts
@@ -1,4 +1,15 @@
-import type {KoenigInstance} from '@tryghost/admin-x-design-system';
+// Structurally matches admin-x-design-system's KoenigInstance so instances typed
+// against either package interoperate.
+export type KoenigInstance = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [key: string]: any
+    editorInstance: {
+        getRootElement: () => HTMLElement | null
+    }
+    focusEditor: (options?: {position?: 'top' | 'bottom'}) => void
+    insertParagraphAtBottom: () => void
+    lastNodeIsDecorator: () => boolean
+};
 
 export function focusKoenigEditorOnBottomClick(
     editorAPI: KoenigInstance,

--- a/apps/admin-x-framework/src/utils/toast.tsx
+++ b/apps/admin-x-framework/src/utils/toast.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import toast from 'react-hot-toast';
+
+// Markup, classes and icons are copied from admin-x-design-system's Toast so error
+// toasts render identically inside its react-hot-toast <Toaster>.
+const ErrorIcon: React.FC<{className?: string}> = ({className}) => (
+    <svg className={className} viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'>
+        <path d='m23.77 20.57 -10 -19A2 2 0 0 0 12 0.5a2 2 0 0 0 -1.77 1.07l-10 19a2 2 0 0 0 0.06 2A2 2 0 0 0 2 23.5h20a2 2 0 0 0 1.77 -2.93ZM11 8.5a1 1 0 0 1 2 0v6a1 1 0 0 1 -2 0ZM12.05 20a1.53 1.53 0 0 1 -1.52 -1.47A1.48 1.48 0 0 1 12 17a1.53 1.53 0 0 1 1.52 1.47A1.48 1.48 0 0 1 12.05 20Z' fill='currentColor' />
+    </svg>
+);
+
+const CloseIcon: React.FC<{className?: string}> = ({className}) => (
+    <svg className={className} viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'>
+        <line fill='none' stroke='currentColor' strokeLinecap='round' strokeLinejoin='round' strokeWidth='1.5' x1='0.75' x2='23.25' y1='23.249' y2='0.749' />
+        <line fill='none' stroke='currentColor' strokeLinecap='round' strokeLinejoin='round' strokeWidth='1.5' x1='23.25' x2='0.75' y1='23.249' y2='0.749' />
+    </svg>
+);
+
+export interface ShowToastProps {
+    message: React.ReactNode;
+    type: 'error';
+}
+
+export const showToast = ({message, type}: ShowToastProps): void => {
+    toast.custom(t => (
+        <div
+            className={`relative z-[90] mb-[14px] ml-[6px] flex min-w-[272px] max-w-[320px] items-start justify-between gap-3 rounded-lg bg-white p-4 text-black shadow-md-heavy dark:bg-grey-900 dark:text-white ${t.visible ? 'animate-toaster-in' : 'animate-toaster-out'}`}
+            data-testid={`toast-${type}`}
+        >
+            <div className='mr-7 flex items-start gap-[10px]'>
+                <div className='mt-px'>
+                    <ErrorIcon className='pointer-events-none size-4 grow text-red' />
+                </div>
+                <div>
+                    <div className='text-grey-900 dark:text-grey-300'>{message}</div>
+                </div>
+            </div>
+            <button
+                className='absolute top-5 right-5 -mt-1.5 -mr-1.5 cursor-pointer rounded-full p-2 text-grey-700 hover:text-black dark:hover:text-white'
+                type='button'
+                onClick={() => toast.dismiss(t.id)}
+            >
+                <div>
+                    <CloseIcon className='pointer-events-none size-2 stroke-2' />
+                </div>
+            </button>
+        </div>
+    ), {position: 'bottom-left', duration: 5000});
+};

--- a/apps/admin-x-framework/test/unit/api/labels.test.tsx
+++ b/apps/admin-x-framework/test/unit/api/labels.test.tsx
@@ -10,10 +10,9 @@ const {mockShowToast, mockSonnerError} = vi.hoisted(() => ({
     mockSonnerError: vi.fn()
 }));
 
-vi.mock('@tryghost/admin-x-design-system', async (importOriginal) => {
-    const original = await importOriginal<typeof import('@tryghost/admin-x-design-system')>();
-    return {...original, showToast: mockShowToast};
-});
+vi.mock('../../../src/utils/toast', () => ({
+    showToast: mockShowToast
+}));
 
 vi.mock('sonner', () => ({
     toast: {

--- a/apps/admin-x-framework/test/unit/hooks/use-handle-error.test.tsx
+++ b/apps/admin-x-framework/test/unit/hooks/use-handle-error.test.tsx
@@ -14,7 +14,7 @@ vi.mock('@sentry/react', () => ({
     ErrorBoundary: ({children}: {children: any}) => children
 }));
 
-vi.mock('@tryghost/admin-x-design-system', () => ({
+vi.mock('../../../src/utils/toast', () => ({
     showToast: vi.fn()
 }));
 
@@ -28,8 +28,8 @@ const mockShowToast = vi.fn();
 const mockToastRemove = vi.fn();
 
 import * as Sentry from '@sentry/react';
-import {showToast} from '@tryghost/admin-x-design-system';
 import toast from 'react-hot-toast';
+import {showToast} from '../../../src/utils/toast';
 
 const createWrapper = (sentryDSN?: string): React.FC<{children: ReactNode}> => {
     const TestWrapper: React.FC<{children: ReactNode}> = ({children}) => (

--- a/apps/admin-x-settings/src/styles/index.css
+++ b/apps/admin-x-settings/src/styles/index.css
@@ -3,6 +3,7 @@
 
 @source "../**/*.{js,ts,jsx,tsx}";
 @source "../../../admin-x-design-system/src/**/*.{js,ts,jsx,tsx}";
+@source "../../../admin-x-framework/src/**/*.{js,ts,jsx,tsx}";
 
 /* Only settings related overrides */
 .gh-update-banner ~ * #admin-x-settings-content {

--- a/apps/admin/src/index.css
+++ b/apps/admin/src/index.css
@@ -2,6 +2,7 @@
 @source "../../activitypub/src/**/*.{ts,tsx}";
 @source "../../admin-x-settings/src/**/*.{ts,tsx}";
 @source "../../admin-x-design-system/src/**/*.{ts,tsx}";
+@source "../../admin-x-framework/src/**/*.{ts,tsx}";
 @source "../node_modules/@tryghost/kg-unsplash-selector/dist/**/*.js";
 
 @import "@tryghost/shade/styles.css";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -985,9 +985,6 @@ importers:
       '@tinybirdco/charts':
         specifier: 0.3.0
         version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@tryghost/admin-x-design-system':
-        specifier: workspace:*
-        version: link:../admin-x-design-system
       '@tryghost/shade':
         specifier: workspace:*
         version: link:../shade


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLA-190/decouple-admin-x-framework-from-admin-x-design-system

admin-x-framework is the long-lived foundation library; admin-x-design-system is the legacy DS being replaced by shade. The framework depending on the DS dragged the legacy package into every consumer's graph and would block deleting the DS later. The DS has no reverse dependency, so the decouple is one-directional. All five coupling sites are resolved:

- **`showToast` (runtime)** — moved a self-contained copy of the DS error toast into `src/utils/toast.tsx` (markup, classes, `data-testid`, icons copied verbatim; `react-hot-toast` was already a direct framework dep). Error toasts render identically inside the DS `<Toaster>` in admin-x-settings — the only surface that mounts one today. Provider injection was rejected as an unnecessary configuration seam.
- **`usePagination` (runtime)** — copied into `src/hooks/use-pagination.ts` with its `PaginationMeta`/`PaginationData` types. The DS keeps its copy for its own Table/Pagination components (a DS→framework dep must not exist); structural typing keeps the framework's pagination result assignable to DS props. Note `createPaginatedQuery` has no production consumer today — only framework tests.
- **`ButtonColor` (type)** — inlined the literal union in `use-form.ts`.
- **`KoenigInstance` (type)** — inlined in `focus-koenig-editor-on-bottom-click.ts`, including the index signature so DS-typed editor refs stay compatible.
- **`DesignSystemAppProps` (type)** — `test/render.tsx` (the standalone-dev renderer used by settings/activitypub `main.tsx`) now declares the minimal `{darkMode, fetchKoenigLexical}` shape it actually passes.

Because the toast markup now lives outside the DS, `admin-x-framework/src` was added to the Tailwind `@source` lists (central admin pipeline + admin-x-settings' standalone build) so its classes are scanned in their own right.

## Reviewer callouts

- The one visual surface to eyeball: trigger any API error in **admin-x-settings** and confirm the bottom-left error toast looks unchanged (byte-identical markup, but it's a copy now, not shared code). The built settings bundle was confirmed to contain the toast classes (`animate-toaster-in`, `shadow-md-heavy`).
- Pre-existing gap, unchanged by this PR: a react-hot-toast `<Toaster/>` is mounted only by the DS provider, so framework error toasts were already invisible in apps/admin outside settings and in activitypub — worth closing later via shade.

## Verification

- admin-x-framework: tsc, lint, and the nx build all succeed **without the DS in the graph**; 31 files / 440 tests green; grep + package.json confirm zero remaining `@tryghost/admin-x-design-system` references
- apps/admin: unit 88 files / 848 tests; acceptance (browser mode) 12 files / 79 tests; tsc clean
- admin-x-settings: 19 files / 203 tests; `tsc && vite build` clean
- activitypub: 10 files / 116 tests; tsc clean