### PR TITLE
Fixed forbidden member count requests for editors

### DIFF
--- a/apps/admin-x-framework/src/api/members.ts
+++ b/apps/admin-x-framework/src/api/members.ts
@@ -166,7 +166,8 @@ export const useBrowseMembers = createQuery<MembersResponseType>({
 const useBrowseMemberCount = createQuery<MembersResponseType>({
     dataType,
     path: membersPath,
-    defaultSearchParams: memberCountSearchParams
+    defaultSearchParams: memberCountSearchParams,
+    permissions: ['Owner', 'Administrator', 'Super Editor']
 });
 
 export function useMemberCount(options?: {enabled?: boolean}) {

--- a/apps/admin-x-framework/src/api/members.ts
+++ b/apps/admin-x-framework/src/api/members.ts
@@ -3,6 +3,8 @@ import {useEffect} from 'react';
 import {Meta, createInfiniteQuery, createMutation, createQuery, createQueryWithId} from '../utils/api/hooks';
 import {apiUrl} from '../utils/api/fetch-api';
 import type {Address} from '@tryghost/custom-field-types';
+import {useCurrentUser} from './current-user';
+import {canManageMembers} from './users';
 
 export type MemberLabel = {
     id: string;
@@ -166,12 +168,14 @@ export const useBrowseMembers = createQuery<MembersResponseType>({
 const useBrowseMemberCount = createQuery<MembersResponseType>({
     dataType,
     path: membersPath,
-    defaultSearchParams: memberCountSearchParams,
-    permissions: ['Owner', 'Administrator', 'Super Editor']
+    defaultSearchParams: memberCountSearchParams
 });
 
-export function useMemberCount(options?: {enabled?: boolean}) {
-    const {data} = useBrowseMemberCount(options);
+export function useMemberCount() {
+    const {data: currentUser} = useCurrentUser();
+    const {data} = useBrowseMemberCount({
+        enabled: Boolean(currentUser && canManageMembers(currentUser))
+    });
 
     return data?.meta?.pagination.total;
 }

--- a/apps/admin-x-framework/src/api/members.ts
+++ b/apps/admin-x-framework/src/api/members.ts
@@ -169,8 +169,8 @@ const useBrowseMemberCount = createQuery<MembersResponseType>({
     defaultSearchParams: memberCountSearchParams
 });
 
-export function useMemberCount() {
-    const {data} = useBrowseMemberCount();
+export function useMemberCount(options?: {enabled?: boolean}) {
+    const {data} = useBrowseMemberCount(options);
 
     return data?.meta?.pagination.total;
 }

--- a/apps/admin-x-framework/test/unit/api/members.test.tsx
+++ b/apps/admin-x-framework/test/unit/api/members.test.tsx
@@ -1,6 +1,7 @@
 import {act, waitFor} from '@testing-library/react';
 import {describe, expect, it, vi} from 'vitest';
 import {currentUserQueryKey} from '../../../src/api/current-user';
+import type {UserRoleType} from '../../../src/api/roles';
 import {createTestQueryClient, renderHookWithProviders} from '../../../src/test/test-utils';
 import {getMemberCountQueryKey, getMemberSigninUrl, useAddMember, useBrowseMembersInfinite, useBulkDeleteMembers, useDeleteMember, useEditMember, useEditMemberSubscription, useImportMembers, useMemberActivityFeed, useMemberCount, useMemberLogout, useRemoveMemberEmailSuppression} from '../../../src/api/members';
 import type {MemberActivityEvent, MembersInfiniteResponseType, MembersResponseType} from '../../../src/api/members';
@@ -27,7 +28,7 @@ function seedMemberCount(queryClient: ReturnType<typeof createTestQueryClient>, 
     queryClient.setQueryData(memberCountKey, membersResponse(total), options);
 }
 
-function createQueryClientWithCurrentUser(roles: Array<{id: string; name: string}> = [{id: 'role-1', name: 'Administrator'}]) {
+function createQueryClientWithCurrentUser(roles: Array<{id: string; name: UserRoleType}> = []) {
     const queryClient = createTestQueryClient();
 
     queryClient.setQueryDefaults(currentUserQueryKey, {staleTime: Infinity});
@@ -221,12 +222,12 @@ describe('members api', () => {
     });
 
     it('fetches the member count with the dedicated count hook', async () => {
-        const queryClient = createQueryClientWithCurrentUser();
+        const queryClient = createQueryClientWithCurrentUser([{id: 'role-1', name: 'Administrator'}]);
 
         await withMockFetch({
             json: membersResponse(102466)
         }, async (mockFetch) => {
-            const {result} = renderHookWithProviders(() => useMemberCount({enabled: true}), {queryClient});
+            const {result} = renderHookWithProviders(() => useMemberCount(), {queryClient});
 
             await waitFor(() => {
                 expect(result.current).toBe(102466);
@@ -236,26 +237,11 @@ describe('members api', () => {
         });
     });
 
-    it('does not fetch the member count when disabled', async () => {
-        const queryClient = createQueryClientWithCurrentUser();
-
-        await withMockFetch({}, async (mockFetch) => {
-            const {result} = renderHookWithProviders(() => useMemberCount({enabled: false}), {queryClient});
-
-            await act(async () => {
-                await Promise.resolve();
-            });
-
-            expect(result.current).toBeUndefined();
-            expect(mockFetch.calls).toHaveLength(0);
-        });
-    });
-
     it('does not fetch the member count for roles that cannot manage members', async () => {
         const queryClient = createQueryClientWithCurrentUser([{id: 'role-1', name: 'Editor'}]);
 
         await withMockFetch({}, async (mockFetch) => {
-            const {result} = renderHookWithProviders(() => useMemberCount({enabled: true}), {queryClient});
+            const {result} = renderHookWithProviders(() => useMemberCount(), {queryClient});
 
             await act(async () => {
                 await Promise.resolve();

--- a/apps/admin-x-framework/test/unit/api/members.test.tsx
+++ b/apps/admin-x-framework/test/unit/api/members.test.tsx
@@ -226,13 +226,28 @@ describe('members api', () => {
         await withMockFetch({
             json: membersResponse(102466)
         }, async (mockFetch) => {
-            const {result} = renderHookWithProviders(() => useMemberCount(), {queryClient});
+            const {result} = renderHookWithProviders(() => useMemberCount({enabled: true}), {queryClient});
 
             await waitFor(() => {
                 expect(result.current).toBe(102466);
             });
 
             expect(mockFetch.calls[0][0].toString()).toBe('http://localhost:3000/ghost/api/admin/members/?limit=1');
+        });
+    });
+
+    it('does not fetch the member count when disabled', async () => {
+        const queryClient = createQueryClientWithCurrentUser();
+
+        await withMockFetch({}, async (mockFetch) => {
+            const {result} = renderHookWithProviders(() => useMemberCount({enabled: false}), {queryClient});
+
+            await act(async () => {
+                await Promise.resolve();
+            });
+
+            expect(result.current).toBeUndefined();
+            expect(mockFetch.calls).toHaveLength(0);
         });
     });
 

--- a/apps/admin-x-framework/test/unit/api/members.test.tsx
+++ b/apps/admin-x-framework/test/unit/api/members.test.tsx
@@ -27,7 +27,7 @@ function seedMemberCount(queryClient: ReturnType<typeof createTestQueryClient>, 
     queryClient.setQueryData(memberCountKey, membersResponse(total), options);
 }
 
-function createQueryClientWithCurrentUser() {
+function createQueryClientWithCurrentUser(roles: Array<{id: string; name: string}> = [{id: 'role-1', name: 'Administrator'}]) {
     const queryClient = createTestQueryClient();
 
     queryClient.setQueryDefaults(currentUserQueryKey, {staleTime: Infinity});
@@ -37,7 +37,7 @@ function createQueryClientWithCurrentUser() {
             id: 'user-1',
             name: 'Test User',
             email: 'test@example.com',
-            roles: []
+            roles
         }]
     });
 
@@ -241,6 +241,21 @@ describe('members api', () => {
 
         await withMockFetch({}, async (mockFetch) => {
             const {result} = renderHookWithProviders(() => useMemberCount({enabled: false}), {queryClient});
+
+            await act(async () => {
+                await Promise.resolve();
+            });
+
+            expect(result.current).toBeUndefined();
+            expect(mockFetch.calls).toHaveLength(0);
+        });
+    });
+
+    it('does not fetch the member count for roles that cannot manage members', async () => {
+        const queryClient = createQueryClientWithCurrentUser([{id: 'role-1', name: 'Editor'}]);
+
+        await withMockFetch({}, async (mockFetch) => {
+            const {result} = renderHookWithProviders(() => useMemberCount({enabled: true}), {queryClient});
 
             await act(async () => {
                 await Promise.resolve();

--- a/apps/admin/src/layout/app-sidebar/nav-content.tsx
+++ b/apps/admin/src/layout/app-sidebar/nav-content.tsx
@@ -76,13 +76,13 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
     const postCustomViews = useCustomSidebarViews('posts');
     const memberViews = useMemberSidebarViews();
     const hasMemberViews = memberViews.length > 0;
-    const showMembers = Boolean(currentUser && canManageMembers(currentUser));
-    const memberCount = useMemberCount({enabled: showMembers});
+    const memberCount = useMemberCount();
     const routing = useEmberRouting();
     const automationsEnabled = useFeatureFlag('automations');
     const isMembersRouteActive = useIsActiveLink({path: 'members', activeOnSubpath: true});
 
     const showTags = currentUser && canManageTags(currentUser);
+    const showMembers = currentUser && canManageMembers(currentUser);
     const showAutomations = currentUser && canManageAutomations(currentUser);
     const commentsEnabled = getSettingValue<string>(settingsData?.settings, 'comments_enabled');
     const showComments = !!showMembers && commentsEnabled !== 'off';

--- a/apps/admin/src/layout/app-sidebar/nav-content.tsx
+++ b/apps/admin/src/layout/app-sidebar/nav-content.tsx
@@ -76,13 +76,13 @@ function NavContent({ ...props }: React.ComponentProps<typeof SidebarGroup>) {
     const postCustomViews = useCustomSidebarViews('posts');
     const memberViews = useMemberSidebarViews();
     const hasMemberViews = memberViews.length > 0;
-    const memberCount = useMemberCount();
+    const showMembers = Boolean(currentUser && canManageMembers(currentUser));
+    const memberCount = useMemberCount({enabled: showMembers});
     const routing = useEmberRouting();
     const automationsEnabled = useFeatureFlag('automations');
     const isMembersRouteActive = useIsActiveLink({path: 'members', activeOnSubpath: true});
 
     const showTags = currentUser && canManageTags(currentUser);
-    const showMembers = currentUser && canManageMembers(currentUser);
     const showAutomations = currentUser && canManageAutomations(currentUser);
     const commentsEnabled = getSettingValue<string>(settingsData?.settings, 'comments_enabled');
     const showComments = !!showMembers && commentsEnabled !== 'off';


### PR DESCRIPTION
## Problem

Editors cannot manage members, but the React admin sidebar still requests `/members/?limit=1` when it mounts. Ghost correctly rejects that request, producing an unrelated permission toast.

This addresses the remaining member-count request reported in #26607. That issue also covers identities and settings-sidebar behavior, so this PR does not close it.

## Change

- Forward an optional `enabled` option through `useMemberCount`.
- Derive member-management permission once in `NavContent` and reuse it for query enablement and Members rendering.
- Add focused coverage for enabled and disabled member-count queries.

## Validation

- Focused member API suite: 13/13 passed.
- Four-role probe: Editor sent zero member-count requests; Administrator, Owner, and Super Editor each retained one.
- Admin framework typecheck: setup-blocked after upstream's React Query v5 migration because the approved no-install local dependency slice still contains v4; repository CI is the exact v5/typecheck signal.
- Targeted lint: passed.
- `git diff --check`: passed.
- Admin-wide typecheck: setup-blocked by the same local v5/v4 mismatch plus missing `jest`, `vite/client`, and `node` type packages.

## Risk

This changes only the frontend request lifecycle. Server authorization remains unchanged, and the allowed roles retain the existing request. Repository CI remains the final broad and React Query v5 validation signal.

## Out of scope

No server permissions, roles, identities, ActivityPub, routes, dependencies, lockfiles, or generated files changed. Settings-sidebar visibility is unchanged.

## Issue

ref https://github.com/TryGhost/Ghost/issues/26607

## Checklist

- [x] I've read and followed the Contributor Guide.
- [x] I've explained the change.
- [x] I've written an automated test to prove the change works.

_AI-assisted; authored and reviewed by the contributor._
