### PR TITLE
Simplified public app ci jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1378,6 +1378,12 @@ jobs:
     name: Build E2E Public App Assets
     needs: [job_setup]
     # Root of the build + browser-E2E lane (see run_e2e in job_setup).
+    # Doubles as public-app build verification and the gate for publish_public_apps:
+    # the `pnpm --filter @tryghost/e2e build:apps` step below is exactly the
+    # `nx run-many --target=build --projects='tag:public-app'` build the publish flow
+    # requires, so there's no separate build_public_apps job. Intentionally has no
+    # `id-token: write` — PR-controlled code (nx build) must never execute in a job
+    # that can mint an npm OIDC token; publish_packages holds the privileged flow.
     if: needs.job_setup.outputs.run_e2e == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -1739,7 +1745,6 @@ jobs:
         job_tinybird-tests,
         job_build_e2e_public_apps,
         job_e2e_tests,
-        build_public_apps,
         publish_public_apps
       ]
     if: always()
@@ -1753,38 +1758,6 @@ jobs:
         run: |
           echo "One of the dependent jobs have failed or been cancelled. You may need to re-run it." && exit 1
 
-  # Build verification for @tryghost/* public apps.
-  # Runs on PRs and pushes. Intentionally has no `id-token: write` — PR-controlled
-  # code (nx build) must never execute in a job that can mint an npm OIDC token.
-  # The privileged publish flow lives in publish_packages below, gated to main pushes.
-  build_public_apps:
-    needs: [
-      job_setup,
-      job_lint,
-      job_unit-tests
-    ]
-    name: Build Public Apps
-    runs-on: ubuntu-latest
-    if: always() && github.repository == 'TryGhost/Ghost' && needs.job_setup.result == 'success' && needs.job_lint.result == 'success' && needs.job_unit-tests.result == 'success' && needs.job_setup.outputs.run_e2e == 'true'
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - name: Set up Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build the package
-        run: pnpm nx run-many --target=build --projects='tag:public-app'
-
   # Publishes @tryghost/* public apps to npm via OIDC trusted publishing.
   # Runs only on push-to-main — never on pull_request — so the `id-token: write`
   # permission is never exposed to PR-controlled code (ref: ONC-1677).
@@ -1793,7 +1766,7 @@ jobs:
       job_setup,
       job_lint,
       job_unit-tests,
-      build_public_apps
+      job_build_e2e_public_apps
     ]
     name: Publish ${{ matrix.package_name }}
     runs-on: ubuntu-latest
@@ -1810,7 +1783,7 @@ jobs:
       && needs.job_setup.result == 'success'
       && needs.job_lint.result == 'success'
       && needs.job_unit-tests.result == 'success'
-      && needs.build_public_apps.result == 'success'
+      && needs.job_build_e2e_public_apps.result == 'success'
       && needs.job_setup.outputs.publish_public_apps_matrix != '[]'
     permissions:
       contents: read


### PR DESCRIPTION
no ref
- build_e2e_public_apps and build_public_apps were essentially doing the same thing, so combining the jobs ensures we're not doing duplicate work