### PR TITLE
🐛 Fixed incorrect audio durations after HTML import

### DIFF
--- a/koenig/kg-default-nodes/src/nodes/audio/audio-parser.ts
+++ b/koenig/kg-default-nodes/src/nodes/audio/audio-parser.ts
@@ -24,12 +24,19 @@ export function parseAudioNode(AudioNode: new (data: Record<string, unknown>) =>
                         }
 
                         if (durationText) {
-                            const [rawMinutes, rawSeconds = '0'] = durationText.split(':');
-                            const minutes = Number(rawMinutes.trim());
-                            const seconds = Number(rawSeconds.trim());
+                            if (durationText.includes(':')) {
+                                const [rawMinutes, rawSeconds = '0'] = durationText.split(':');
+                                const minutes = Number(rawMinutes.trim());
+                                const seconds = Number(rawSeconds.trim());
 
-                            if (Number.isInteger(minutes) && Number.isInteger(seconds)) {
-                                payload.duration = minutes * 60 + seconds;
+                                if (Number.isInteger(minutes) && Number.isInteger(seconds)) {
+                                    payload.duration = minutes * 60 + seconds;
+                                }
+                            } else {
+                                const duration = Number(durationText);
+                                if (Number.isFinite(duration)) {
+                                    payload.duration = duration;
+                                }
                             }
                         }
 

--- a/koenig/kg-default-nodes/test/nodes/audio.test.ts
+++ b/koenig/kg-default-nodes/test/nodes/audio.test.ts
@@ -228,9 +228,27 @@ describe('AudioNode', function () {
             expect(nodes.length).toBe(1);
             expect(nodes[0].src).toBe('/content/audio/2022/11/koenig-lexical.mp3');
             expect(nodes[0].thumbnailSrc).toBe('/content/images/2022/11/koenig-audio-lexical.jpg');
-            expect(nodes[0].duration).toBe(3600);
+            expect(nodes[0].duration).toBe(60);
             expect(nodes[0].title).toBe('Test Audio');
             expect(nodes[0].mimeType).toBe('');
+        }));
+
+        it('preserves fractional duration seconds', editorTest(function () {
+            const document = createDocument(html`
+                <div class="kg-card kg-audio-card">
+                    <div class="kg-audio-player-container">
+                        <audio src="/content/audio/2022/11/koenig-lexical.mp3" preload="metadata"></audio>
+                        <div class="kg-audio-title">Test Audio</div>
+                        <div class="kg-audio-player">
+                            <div class="kg-audio-time">/<span class="kg-audio-duration">152.607347</span></div>
+                        </div>
+                    </div>
+                </div>
+            `);
+            const nodes = $generateNodesFromDOM(editor, document) as AudioNode[];
+
+            expect(nodes.length).toBe(1);
+            expect(nodes[0].duration).toBe(152.607347);
         }));
 
         it('ignores malformed duration strings', editorTest(function () {


### PR DESCRIPTION
## What changed

- Treat unformatted `kg-audio-duration` values as raw seconds during HTML import.
- Preserve the existing `m:ss` import format and fractional second precision.
- Add regression coverage for integer and fractional raw durations.

## Why

The web audio renderer serializes the duration as a raw number of seconds, but the parser treated every value as minutes when no colon was present. Re-importing rendered HTML changed a 60-second audio card to 3,600 seconds, while fractional durations fell back to zero.

Distinguishing the two existing formats by the colon keeps legacy `m:ss` HTML compatible without changing rendering or playback behavior.

## Validation

- `@tryghost/kg-default-nodes`: 846 tests passed, 23 todo
- `@tryghost/kg-html-to-lexical`: 41 tests passed
- TypeScript typecheck and ESM/CJS compilation
- ESLint: 0 errors
- `git diff --check`

- [x] I've read and followed the Contributor Guide
- [x] I've explained my change
- [x] I've written an automated test to prove my change works
