### PR TITLE
Simplified generated Koenig node types

### DIFF
--- a/koenig/kg-default-nodes/src/KoenigDecoratorNode.ts
+++ b/koenig/kg-default-nodes/src/KoenigDecoratorNode.ts
@@ -13,10 +13,15 @@ export class KoenigDecoratorNode extends DecoratorNode<unknown> {
     }
 }
 
-export type KoenigCard = KoenigDecoratorNode & {
+export type KoenigCard<TOutput extends ExportDOMOutput = ExportDOMOutput> = KoenigDecoratorNode & {
+    [key: string]: unknown;
+
     isKoenigCard(): true;
-    exportDOM(editor: LexicalEditor, options?: ExportDOMOptions): ExportDOMOutput;
+    exportDOM(editor: LexicalEditor, options?: ExportDOMOptions): TOutput;
+    getDataset(): Record<string, unknown>;
     hasDynamicData(): boolean;
+    hasEditMode(): boolean;
+    getIsVisibilityActive(): boolean;
     getDynamicData?(options: ExportDOMOptions): Promise<{key: number; data: unknown}>;
 };
 
@@ -30,6 +35,9 @@ export function $isKoenigCard(node: unknown): node is KoenigCard {
     return typeof card.isKoenigCard === 'function' &&
         card.isKoenigCard() === true &&
         typeof card.exportDOM === 'function' &&
-        typeof card.hasDynamicData === 'function';
+        typeof card.getDataset === 'function' &&
+        typeof card.hasDynamicData === 'function' &&
+        typeof card.hasEditMode === 'function' &&
+        typeof card.getIsVisibilityActive === 'function';
 }
 /* c8 ignore end */

--- a/koenig/kg-default-nodes/src/generate-decorator-node.ts
+++ b/koenig/kg-default-nodes/src/generate-decorator-node.ts
@@ -151,10 +151,10 @@ export function generateDecoratorNode({nodeType, properties, defaultRenderFn, ve
         constructor(data: Record<string, unknown> = {}, key?: string) {
             super(key);
             internalProps.forEach((prop) => {
-                if (typeof prop.default === 'boolean') {
-                    this[prop.privateName] = data[prop.name] ?? prop.default;
-                } else {
+                if (typeof prop.default === 'string') {
                     this[prop.privateName] = data[prop.name] || prop.default;
+                } else {
+                    this[prop.privateName] = data[prop.name] ?? prop.default;
                 }
             });
         }

--- a/koenig/kg-default-nodes/src/generate-decorator-node.ts
+++ b/koenig/kg-default-nodes/src/generate-decorator-node.ts
@@ -1,5 +1,6 @@
 import {KoenigDecoratorNode} from './KoenigDecoratorNode.js';
 import type {ExportDOMOptions, ExportDOMOutput} from './export-dom.js';
+import type {KoenigCard} from './KoenigDecoratorNode.js';
 import readTextContent from './utils/read-text-content.js';
 import {buildDefaultVisibility, isVisibilityRestricted, migrateOldVisibilityFormat} from './utils/visibility.js';
 import type {LexicalEditor, SerializedLexicalNode} from 'lexical';
@@ -9,24 +10,18 @@ type RenderFn<TNode = unknown, TOutput extends ExportDOMOutput = ExportDOMOutput
     bivarianceHack(node: TNode, options: ExportDOMOptions): TOutput;
 }['bivarianceHack'];
 type VersionedRenderFn<TNode = unknown, TOutput extends ExportDOMOutput = ExportDOMOutput> = Record<string | number, RenderFn<TNode, TOutput>>;
-type WidenLiteral<T> =
-    T extends string ? string :
-    T extends number ? number :
-    T extends boolean ? boolean :
-    T extends readonly (infer U)[] ? U[] :
-    T;
 /**
  * Validates the required arguments passed to `generateDecoratorNode`
 */
-function validateArguments(nodeType: string, properties: readonly DecoratorNodeProperty[]) {
+function validateArguments(nodeType: string, properties: DecoratorNodePropertyMap) {
     /* c8 ignore start */
     if (!nodeType) {
         throw new Error('[generateDecoratorNode] A unique "nodeType" should be provided');
     }
 
-    properties.forEach((prop: DecoratorNodeProperty) => {
-        if (!('name' in prop) || !('default' in prop)){
-            throw new Error('[generateDecoratorNode] Properties should have both "name" and "default" attributes.');
+    Object.values(properties).forEach((prop) => {
+        if (!('default' in prop)){
+            throw new Error('[generateDecoratorNode] Properties should have a "default" attribute.');
         }
 
         if (prop.urlType && !['url', 'html', 'markdown'].includes(prop.urlType)) {
@@ -42,35 +37,36 @@ function validateArguments(nodeType: string, properties: readonly DecoratorNodeP
 
 /**
  * @typedef {Object} DecoratorNodeProperty
- * @property {string} name - The property's name.
  * @property {*} default - The property's default value
  * @property {('url'|'html'|'markdown'|null)} urlType - If the property contains a URL, the URL's type: 'url', 'html' or 'markdown'. Use 'url' is the property contains only a URL, 'html' or 'markdown' if the property contains HTML or markdown code, that may contain URLs.
  * @property {boolean} wordCount - Whether the property should be counted in the word count
  *
  * @param {string} nodeType – The node's type (must be unique)
- * @param {DecoratorNodeProperty[]} properties - An array of properties for the generated class
+ * @param {DecoratorNodePropertyMap} properties - A map of properties for the generated class
  * @param {boolean} hasVisibility - Whether to add a visibility property to the node
  * @param {Function} defaultRenderFn - A function that returns a @tryghost/kg-lexical-html-renderer compatible object, e.g. {element: Div, type: 'inner}
  * @returns {Object} - The generated class.
  */
-export interface DecoratorNodeProperty<Name extends string = string, Default = unknown> {
-    name: Name;
+export interface DecoratorNodeProperty<Default = unknown> {
     default: Default;
     urlType?: string;
     urlPath?: string;
     wordCount?: boolean;
-    privateName?: string;
 }
 
-export type DecoratorNodeValueMap<Props extends readonly DecoratorNodeProperty[], HasVisibility extends boolean = false> = {
-    [Prop in Props[number] as Prop['name']]: WidenLiteral<Prop['default']>;
+export type DecoratorNodePropertyMap = Record<string, DecoratorNodeProperty>;
+
+export type DecoratorNodeValueMap<Props extends DecoratorNodePropertyMap, HasVisibility extends boolean = false> = {
+    [Name in keyof Props]: Props[Name]['default'];
 } & (HasVisibility extends true ? {visibility: Visibility} : unknown);
 
-export type DecoratorNodeData<Props extends readonly DecoratorNodeProperty[], HasVisibility extends boolean = false> = Partial<DecoratorNodeValueMap<Props, HasVisibility>>;
+export type DecoratorNodeData<Props extends DecoratorNodePropertyMap, HasVisibility extends boolean = false> = Partial<DecoratorNodeValueMap<Props, HasVisibility>>;
 
-type GeneratedDecoratorNodeInstance<TDataset extends Record<string, unknown>, TOutput extends ExportDOMOutput = ExportDOMOutput> = GeneratedDecoratorNodeBase<TDataset> & TDataset & {
-    exportDOM(editor: LexicalEditor, options?: ExportDOMOptions): TOutput;
-};
+export interface GeneratedDecoratorNodeRuntime<TOutput extends ExportDOMOutput = ExportDOMOutput> extends KoenigCard<TOutput> {
+    exportJSON(): SerializedLexicalNode & Record<string, unknown>;
+}
+
+export type GeneratedDecoratorNode<TDataset extends Record<string, unknown> = Record<string, unknown>, TOutput extends ExportDOMOutput = ExportDOMOutput> = GeneratedDecoratorNodeRuntime<TOutput> & TDataset;
 
 // An intersection rather than Lexical's `Spread` utility: `Spread` isn't provably
 // assignable to `SerializedLexicalNode` when TDataset is an unresolved generic, which
@@ -80,103 +76,61 @@ type GeneratedDecoratorNodeInstance<TDataset extends Record<string, unknown>, TO
 export type SerializedGeneratedDecoratorNode<TDataset extends Record<string, unknown> = Record<string, unknown>> = SerializedLexicalNode & TDataset;
 
 export interface GeneratedDecoratorNodeClass<TDataset extends Record<string, unknown>, TOutput extends ExportDOMOutput = ExportDOMOutput> {
-    new (data?: Partial<TDataset>, key?: string): GeneratedDecoratorNodeInstance<TDataset, TOutput>;
-    prototype: GeneratedDecoratorNodeInstance<TDataset, TOutput>;
+    new (data?: Partial<TDataset>, key?: string): GeneratedDecoratorNode<TDataset, TOutput>;
+    prototype: GeneratedDecoratorNode<TDataset, TOutput>;
     getType(): string;
-    clone(node: GeneratedDecoratorNodeInstance<TDataset, TOutput>): GeneratedDecoratorNodeInstance<TDataset, TOutput>;
+    clone(node: GeneratedDecoratorNode<TDataset, TOutput>): GeneratedDecoratorNode<TDataset, TOutput>;
     transform(): null;
     getPropertyDefaults(): TDataset;
     readonly urlTransformMap: Record<string, string | Record<string, string>>;
-    importJSON(serializedNode: Record<string, unknown>): GeneratedDecoratorNodeInstance<TDataset, TOutput>;
+    importJSON(serializedNode: Record<string, unknown>): GeneratedDecoratorNode<TDataset, TOutput>;
 }
 
-// Type-only base class used as the return type of generateDecoratorNode.
-// This ensures TypeScript recognizes generated nodes as LexicalNode subclasses
-// while preserving the dynamic property index signature.
-export class GeneratedDecoratorNodeBase<TDataset extends Record<string, unknown> = Record<string, unknown>> extends KoenigDecoratorNode {
-    [key: string]: unknown;
-
-    constructor(data?: Partial<TDataset>, key?: string) {
-        super(key);
-    }
-
-    getDataset(): Record<string, unknown> {
-        return {};
-    }
-
-    exportJSON(): {type: string; version: number; [key: string]: unknown} {
-        return {type: '', version: 1};
-    }
-
-    static getPropertyDefaults(): Record<string, unknown> {
-        return {};
-    }
-
-    static get urlTransformMap(): Record<string, string | Record<string, string>> {
-        return {};
-    }
-
-    static importJSON(_serializedNode: Record<string, unknown>): GeneratedDecoratorNodeBase<Record<string, unknown>> {
-        return new GeneratedDecoratorNodeBase();
-    }
-
-    static transform() {
-        return null;
-    }
-
-    isKoenigCard(): true {
-        return true;
-    }
-
-    hasDynamicData(): boolean {
-        return false;
-    }
-
-    hasEditMode(): boolean {
-        return true;
-    }
-
-    getIsVisibilityActive(): boolean {
-        return false;
-    }
+export interface GenerateDecoratorNodeOptions<
+    Props extends DecoratorNodePropertyMap,
+    HasVisibility extends boolean,
+    TOutput extends ExportDOMOutput,
+    TRenderNode
+> {
+    nodeType: string;
+    properties?: Props;
+    defaultRenderFn?: RenderFn<TRenderNode, TOutput> | VersionedRenderFn<TRenderNode, TOutput>;
+    version?: number;
+    hasVisibility?: HasVisibility;
 }
 
 export function generateDecoratorNode<
-    Props extends readonly DecoratorNodeProperty[] = readonly [],
+    Props extends DecoratorNodePropertyMap = Record<never, never>,
     HasVisibility extends boolean = false,
     TOutput extends ExportDOMOutput = ExportDOMOutput,
     // When not passed explicitly, TRenderNode is inferred from `defaultRenderFn`'s
     // node parameter — the render fn's declared node type is trusted, not validated
     // against the generated node shape. Pass explicit type arguments (see HeaderNode)
     // to have render fns checked against a known node type.
-    TRenderNode = GeneratedDecoratorNodeInstance<DecoratorNodeValueMap<Props, HasVisibility>, TOutput>
->({nodeType, properties, defaultRenderFn, version = 1, hasVisibility}: {
-    nodeType: string;
-    properties?: Props;
-    defaultRenderFn?: RenderFn<TRenderNode, TOutput> | VersionedRenderFn<TRenderNode, TOutput>;
-    version?: number;
-    hasVisibility?: HasVisibility;
-}): GeneratedDecoratorNodeClass<DecoratorNodeValueMap<Props, HasVisibility>, TOutput> {
-    type GeneratedDataset = DecoratorNodeValueMap<Props, HasVisibility>;
-    type GeneratedRenderFn = RenderFn<TRenderNode, TOutput>;
-    type GeneratedVersionedRenderFn = VersionedRenderFn<TRenderNode, TOutput>;
-
-    const nodeProperties = properties ?? [];
+    TRenderNode = GeneratedDecoratorNode<DecoratorNodeValueMap<Props, HasVisibility>, TOutput>
+>(options: GenerateDecoratorNodeOptions<Props, HasVisibility, TOutput, TRenderNode>): GeneratedDecoratorNodeClass<DecoratorNodeValueMap<Props, HasVisibility>, TOutput>;
+export function generateDecoratorNode({nodeType, properties, defaultRenderFn, version = 1, hasVisibility}: GenerateDecoratorNodeOptions<DecoratorNodePropertyMap, boolean, ExportDOMOutput, unknown>): GeneratedDecoratorNodeClass<Record<string, unknown>, ExportDOMOutput> {
+    const nodeProperties = properties ?? {};
 
     validateArguments(nodeType, nodeProperties);
 
-    // Adds a `privateName` field to the properties for convenience (e.g. `__name`):
-    // properties: [{name: 'name', privateName: '__name', type: 'string', default: 'hello'}, {...}]
-    const internalProps = nodeProperties.map((prop) => {
+    // Adds `name` and `privateName` fields to the property descriptors for runtime use.
+    const internalProps = Object.entries(nodeProperties).map(([name, prop]) => {
         return Object.defineProperties({}, {
             ...Object.getOwnPropertyDescriptors(prop),
+            name: {
+                configurable: true,
+                enumerable: true,
+                value: name,
+                writable: true
+            },
             privateName: {
                 configurable: true,
                 enumerable: true,
-                value: `__${prop.name}`,
+                value: `__${name}`,
                 writable: true
             }
-        }) as DecoratorNodeProperty & {privateName: string};
+        }) as DecoratorNodeProperty & {name: string; privateName: string};
     });
 
     // Adds `visibility` property to the properties array if `hasVisibility` is true
@@ -191,17 +145,16 @@ export function generateDecoratorNode<
         });
     }
 
-    class GeneratedDecoratorNode extends KoenigDecoratorNode {
+    class GeneratedNode extends KoenigDecoratorNode {
         [key: string]: unknown;
 
-        constructor(data: Partial<GeneratedDataset> = {}, key?: string) {
+        constructor(data: Record<string, unknown> = {}, key?: string) {
             super(key);
-            const dataset = data as Record<string, unknown>;
             internalProps.forEach((prop) => {
                 if (typeof prop.default === 'boolean') {
-                    this[prop.privateName] = dataset[prop.name] ?? prop.default;
+                    this[prop.privateName] = data[prop.name] ?? prop.default;
                 } else {
-                    this[prop.privateName] = dataset[prop.name] || prop.default;
+                    this[prop.privateName] = data[prop.name] || prop.default;
                 }
             });
         }
@@ -225,8 +178,8 @@ export function generateDecoratorNode<
          * @extends DecoratorNode
          * @see https://lexical.dev/docs/concepts/nodes#extending-decoratornode
          */
-        static clone(node: GeneratedDecoratorNodeInstance<DecoratorNodeValueMap<Props, HasVisibility>, TOutput>) {
-            return new this(node.getDataset() as Partial<GeneratedDataset>, node.__key);
+        static clone(node: GeneratedDecoratorNode) {
+            return new this(node.getDataset(), node.__key);
         }
 
         /**
@@ -237,7 +190,7 @@ export function generateDecoratorNode<
             return internalProps.reduce((obj: Record<string, unknown>, prop) => {
                 obj[prop.name] = prop.default;
                 return obj;
-            }, {}) as GeneratedDataset;
+            }, {});
         }
 
         /**
@@ -292,7 +245,7 @@ export function generateDecoratorNode<
                 data[prop.name] = serializedNode[prop.name];
             });
 
-            return new this(data as Partial<GeneratedDataset>);
+            return new this(data);
         }
 
         /**
@@ -300,7 +253,7 @@ export function generateDecoratorNode<
          * @extends DecoratorNode
          * @see https://lexical.dev/docs/concepts/serialization#lexicalnodeexportjson
          */
-        exportJSON(): SerializedGeneratedDecoratorNode<GeneratedDataset> {
+        exportJSON(): SerializedGeneratedDecoratorNode {
             const dataset = {
                 type: nodeType,
                 version: version,
@@ -308,17 +261,16 @@ export function generateDecoratorNode<
                     obj[prop.name] = this[prop.name];
                     return obj;
                 }, {})
-            } as SerializedGeneratedDecoratorNode<GeneratedDataset>;
+            } as SerializedGeneratedDecoratorNode;
             return dataset;
         }
 
-        exportDOM(_editor: LexicalEditor, options: ExportDOMOptions = {}): TOutput {
+        exportDOM(_editor: LexicalEditor, options: ExportDOMOptions = {}): ExportDOMOutput {
             // this.__version is used when a node has a version property which
             // means it's set from the serialized version data at runtime
             const nodeVersion = typeof this.__version === 'string' || typeof this.__version === 'number' ? this.__version : version;
-            const node = this as unknown as TRenderNode;
 
-            const nodeRenderers = options.nodeRenderers as Record<string, GeneratedRenderFn | GeneratedVersionedRenderFn> | undefined;
+            const nodeRenderers = options.nodeRenderers as Record<string, RenderFn | VersionedRenderFn> | undefined;
             if (nodeRenderers?.[nodeType]) {
                 const render = nodeRenderers[nodeType];
 
@@ -327,9 +279,9 @@ export function generateDecoratorNode<
                     if (!versionRenderer) {
                         throw new Error(`[generateDecoratorNode] ${nodeType}: options.nodeRenderers['${nodeType}'] for version ${nodeVersion} is required`);
                     }
-                    return versionRenderer(node, options);
+                    return versionRenderer(this, options);
                 } else {
-                    return render(node, options);
+                    return render(this, options);
                 }
             }
 
@@ -338,14 +290,14 @@ export function generateDecoratorNode<
                 if (!render) {
                     throw new Error(`[generateDecoratorNode] ${nodeType}: "defaultRenderFn" for version ${nodeVersion} is required`);
                 }
-                return render(node, options);
+                return render(this, options);
             }
 
             if (!defaultRenderFn) {
                 throw new Error(`[generateDecoratorNode] ${nodeType}: "defaultRenderFn" is required`);
             }
 
-            return defaultRenderFn(node, options);
+            return defaultRenderFn(this, options);
         }
 
         /* c8 ignore start */
@@ -398,7 +350,7 @@ export function generateDecoratorNode<
         */
         getTextContent() {
             const self = this.getLatest();
-            const propertiesWithText = nodeProperties.filter(prop => !!prop.wordCount);
+            const propertiesWithText = internalProps.filter(prop => !!prop.wordCount);
 
             const text = propertiesWithText.map(
                 prop => readTextContent(self, prop.name)
@@ -443,7 +395,7 @@ export function generateDecoratorNode<
      * They can be used as `node.content` (getter) and `node.content = 'new value'` (setter)
      */
     internalProps.forEach((prop) => {
-        Object.defineProperty(GeneratedDecoratorNode.prototype, prop.name, {
+        Object.defineProperty(GeneratedNode.prototype, prop.name, {
             get: function () {
                 const self = this.getLatest();
                 return self[prop.privateName];
@@ -455,5 +407,5 @@ export function generateDecoratorNode<
         });
     });
 
-    return GeneratedDecoratorNode as unknown as GeneratedDecoratorNodeClass<DecoratorNodeValueMap<Props, HasVisibility>, TOutput>;
+    return GeneratedNode as unknown as GeneratedDecoratorNodeClass<Record<string, unknown>, ExportDOMOutput>;
 }

--- a/koenig/kg-default-nodes/src/kg-default-nodes.ts
+++ b/koenig/kg-default-nodes/src/kg-default-nodes.ts
@@ -1,4 +1,4 @@
-export {GeneratedDecoratorNodeBase} from './generate-decorator-node.js';
+export type {GeneratedDecoratorNode} from './generate-decorator-node.js';
 export * from './export-dom.js';
 import * as image from './nodes/image/ImageNode.js';
 import * as codeblock from './nodes/codeblock/CodeBlockNode.js';

--- a/koenig/kg-default-nodes/src/nodes/audio/AudioNode.ts
+++ b/koenig/kg-default-nodes/src/nodes/audio/AudioNode.ts
@@ -1,18 +1,16 @@
-import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodeProperty, type DecoratorNodeValueMap} from '../../generate-decorator-node.js';
+import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodePropertyMap} from '../../generate-decorator-node.js';
 import {parseAudioNode} from './audio-parser.js';
 import {renderAudioNode} from './audio-renderer.js';
 
-const audioProperties = [
-    {name: 'duration', default: 0},
-    {name: 'mimeType', default: ''},
-    {name: 'src', default: '', urlType: 'url'},
-    {name: 'title', default: ''},
-    {name: 'thumbnailSrc', default: ''}
-] as const satisfies readonly DecoratorNodeProperty[];
+const audioProperties = {
+    duration: {default: 0},
+    mimeType: {default: ''},
+    src: {default: '', urlType: 'url'},
+    title: {default: ''},
+    thumbnailSrc: {default: ''}
+} satisfies DecoratorNodePropertyMap;
 
 export type AudioData = DecoratorNodeData<typeof audioProperties>;
-
-export interface AudioNode extends DecoratorNodeValueMap<typeof audioProperties> {}
 
 export class AudioNode extends generateDecoratorNode({
     nodeType: 'audio',

--- a/koenig/kg-default-nodes/src/nodes/bookmark/BookmarkNode.ts
+++ b/koenig/kg-default-nodes/src/nodes/bookmark/BookmarkNode.ts
@@ -1,4 +1,4 @@
-import {generateDecoratorNode, type DecoratorNodeProperty} from '../../generate-decorator-node.js';
+import {generateDecoratorNode, type DecoratorNodePropertyMap} from '../../generate-decorator-node.js';
 import {parseBookmarkNode} from './bookmark-parser.js';
 import {renderBookmarkNode} from './bookmark-renderer.js';
 
@@ -17,27 +17,16 @@ export interface BookmarkData {
     caption?: string;
 }
 
-export interface BookmarkNode {
-    title: string;
-    description: string;
-    url: string;
-    caption: string;
-    author: string;
-    publisher: string;
-    icon: string;
-    thumbnail: string;
-}
-
-const bookmarkProperties = [
-    {name: 'title', default: '', wordCount: true},
-    {name: 'description', default: '', wordCount: true},
-    {name: 'url', default: '', urlType: 'url', wordCount: true},
-    {name: 'caption', default: '', wordCount: true},
-    {name: 'author', default: ''},
-    {name: 'publisher', default: ''},
-    {name: 'icon', urlPath: 'metadata.icon', default: '', urlType: 'url'},
-    {name: 'thumbnail', urlPath: 'metadata.thumbnail', default: '', urlType: 'url'}
-] as const satisfies readonly DecoratorNodeProperty[];
+const bookmarkProperties = {
+    title: {default: '', wordCount: true},
+    description: {default: '', wordCount: true},
+    url: {default: '', urlType: 'url', wordCount: true},
+    caption: {default: '', wordCount: true},
+    author: {default: ''},
+    publisher: {default: ''},
+    icon: {urlPath: 'metadata.icon', default: '', urlType: 'url'},
+    thumbnail: {urlPath: 'metadata.thumbnail', default: '', urlType: 'url'}
+} satisfies DecoratorNodePropertyMap;
 
 export class BookmarkNode extends generateDecoratorNode({
     nodeType: 'bookmark',
@@ -65,16 +54,16 @@ export class BookmarkNode extends generateDecoratorNode({
     getDataset(): Record<string, unknown> {
         const self = this.getLatest();
         return {
-            url: self.__url as string,
+            url: self.url,
             metadata: {
-                icon: self.__icon as string,
-                title: self.__title as string,
-                description: self.__description as string,
-                author: self.__author as string,
-                publisher: self.__publisher as string,
-                thumbnail: self.__thumbnail as string
+                icon: self.icon,
+                title: self.title,
+                description: self.description,
+                author: self.author,
+                publisher: self.publisher,
+                thumbnail: self.thumbnail
             },
-            caption: self.__caption as string
+            caption: self.caption
         };
     }
 

--- a/koenig/kg-default-nodes/src/nodes/button/ButtonNode.ts
+++ b/koenig/kg-default-nodes/src/nodes/button/ButtonNode.ts
@@ -1,16 +1,14 @@
-import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodeProperty, type DecoratorNodeValueMap} from '../../generate-decorator-node.js';
+import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodePropertyMap} from '../../generate-decorator-node.js';
 import {parseButtonNode} from './button-parser.js';
 import {renderButtonNode} from './button-renderer.js';
 
-const buttonProperties = [
-    {name: 'buttonText', default: ''},
-    {name: 'alignment', default: 'center'},
-    {name: 'buttonUrl', default: '', urlType: 'url'}
-] as const satisfies readonly DecoratorNodeProperty[];
+const buttonProperties = {
+    buttonText: {default: ''},
+    alignment: {default: 'center'},
+    buttonUrl: {default: '', urlType: 'url'}
+} satisfies DecoratorNodePropertyMap;
 
 export type ButtonData = DecoratorNodeData<typeof buttonProperties>;
-
-export interface ButtonNode extends DecoratorNodeValueMap<typeof buttonProperties> {}
 
 export class ButtonNode extends generateDecoratorNode({
     nodeType: 'button',

--- a/koenig/kg-default-nodes/src/nodes/call-to-action/CallToActionNode.ts
+++ b/koenig/kg-default-nodes/src/nodes/call-to-action/CallToActionNode.ts
@@ -1,29 +1,27 @@
-import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodeProperty, type DecoratorNodeValueMap} from '../../generate-decorator-node.js';
+import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodePropertyMap} from '../../generate-decorator-node.js';
 import {renderCallToActionNode} from './calltoaction-renderer.js';
 import {parseCallToActionNode} from './calltoaction-parser.js';
 
-const callToActionProperties = [
-    {name: 'layout', default: 'minimal'},
-    {name: 'alignment', default: 'left'},
-    {name: 'textValue', default: '', wordCount: true},
-    {name: 'showButton', default: true},
-    {name: 'showDividers', default: true},
-    {name: 'buttonText', default: 'Learn more'},
-    {name: 'buttonUrl', default: ''},
-    {name: 'buttonColor', default: '#000000'},
-    {name: 'buttonTextColor', default: '#ffffff'},
-    {name: 'hasSponsorLabel', default: true},
-    {name: 'sponsorLabel', default: '<p><span style="white-space: pre-wrap;">SPONSORED</span></p>'},
-    {name: 'backgroundColor', default: 'grey'},
-    {name: 'linkColor', default: 'text'},
-    {name: 'imageUrl', default: '' as string | null},
-    {name: 'imageWidth', default: null as number | null},
-    {name: 'imageHeight', default: null as number | null}
-] as const satisfies readonly DecoratorNodeProperty[];
+const callToActionProperties = {
+    layout: {default: 'minimal'},
+    alignment: {default: 'left'},
+    textValue: {default: '', wordCount: true},
+    showButton: {default: true},
+    showDividers: {default: true},
+    buttonText: {default: 'Learn more'},
+    buttonUrl: {default: ''},
+    buttonColor: {default: '#000000'},
+    buttonTextColor: {default: '#ffffff'},
+    hasSponsorLabel: {default: true},
+    sponsorLabel: {default: '<p><span style="white-space: pre-wrap;">SPONSORED</span></p>'},
+    backgroundColor: {default: 'grey'},
+    linkColor: {default: 'text'},
+    imageUrl: {default: '' as string | null},
+    imageWidth: {default: null as number | null},
+    imageHeight: {default: null as number | null}
+} satisfies DecoratorNodePropertyMap;
 
 export type CallToActionData = DecoratorNodeData<typeof callToActionProperties, true>;
-
-export interface CallToActionNode extends DecoratorNodeValueMap<typeof callToActionProperties, true> {}
 
 export class CallToActionNode extends generateDecoratorNode({
     nodeType: 'call-to-action',

--- a/koenig/kg-default-nodes/src/nodes/callout/CalloutNode.ts
+++ b/koenig/kg-default-nodes/src/nodes/callout/CalloutNode.ts
@@ -1,24 +1,14 @@
-import {generateDecoratorNode, type DecoratorNodeProperty} from '../../generate-decorator-node.js';
+import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodePropertyMap} from '../../generate-decorator-node.js';
 import {renderCalloutNode} from './callout-renderer.js';
 import {parseCalloutNode} from './callout-parser.js';
 
-export interface CalloutData {
-    calloutText?: string;
-    calloutEmoji?: string;
-    backgroundColor?: string;
-}
+const calloutProperties = {
+    calloutText: {default: '', wordCount: true},
+    calloutEmoji: {default: '💡'},
+    backgroundColor: {default: 'blue'}
+} satisfies DecoratorNodePropertyMap;
 
-export interface CalloutNode {
-    calloutText: string;
-    calloutEmoji: string;
-    backgroundColor: string;
-}
-
-const calloutProperties = [
-    {name: 'calloutText', default: '', wordCount: true},
-    {name: 'calloutEmoji', default: '💡'},
-    {name: 'backgroundColor', default: 'blue'}
-] as const satisfies readonly DecoratorNodeProperty[];
+export type CalloutData = DecoratorNodeData<typeof calloutProperties>;
 
 export class CalloutNode extends generateDecoratorNode({
     nodeType: 'callout',

--- a/koenig/kg-default-nodes/src/nodes/codeblock/CodeBlockNode.ts
+++ b/koenig/kg-default-nodes/src/nodes/codeblock/CodeBlockNode.ts
@@ -1,16 +1,14 @@
-import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodeProperty, type DecoratorNodeValueMap} from '../../generate-decorator-node.js';
+import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodePropertyMap} from '../../generate-decorator-node.js';
 import {parseCodeBlockNode} from './codeblock-parser.js';
 import {renderCodeBlockNode} from './codeblock-renderer.js';
 
-const codeBlockProperties = [
-    {name: 'code', default: '', wordCount: true},
-    {name: 'language', default: ''},
-    {name: 'caption', default: '', urlType: 'html', wordCount: true}
-] as const satisfies readonly DecoratorNodeProperty[];
+const codeBlockProperties = {
+    code: {default: '', wordCount: true},
+    language: {default: ''},
+    caption: {default: '', urlType: 'html', wordCount: true}
+} satisfies DecoratorNodePropertyMap;
 
 export type CodeBlockData = DecoratorNodeData<typeof codeBlockProperties>;
-
-export interface CodeBlockNode extends DecoratorNodeValueMap<typeof codeBlockProperties> {}
 
 export class CodeBlockNode extends generateDecoratorNode({
     nodeType: 'codeblock',

--- a/koenig/kg-default-nodes/src/nodes/email-cta/EmailCtaNode.ts
+++ b/koenig/kg-default-nodes/src/nodes/email-cta/EmailCtaNode.ts
@@ -1,19 +1,17 @@
-import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodeProperty, type DecoratorNodeValueMap} from '../../generate-decorator-node.js';
+import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodePropertyMap} from '../../generate-decorator-node.js';
 import {renderEmailCtaNode} from './email-cta-renderer.js';
 
-const emailCtaProperties = [
-    {name: 'alignment', default: 'left'},
-    {name: 'buttonText', default: ''},
-    {name: 'buttonUrl', default: '', urlType: 'url'},
-    {name: 'html', default: '', urlType: 'html'},
-    {name: 'segment', default: 'status:free'},
-    {name: 'showButton', default: false},
-    {name: 'showDividers', default: true}
-] as const satisfies readonly DecoratorNodeProperty[];
+const emailCtaProperties = {
+    alignment: {default: 'left'},
+    buttonText: {default: ''},
+    buttonUrl: {default: '', urlType: 'url'},
+    html: {default: '', urlType: 'html'},
+    segment: {default: 'status:free'},
+    showButton: {default: false},
+    showDividers: {default: true}
+} satisfies DecoratorNodePropertyMap;
 
 export type EmailCtaData = DecoratorNodeData<typeof emailCtaProperties>;
-
-export interface EmailCtaNode extends DecoratorNodeValueMap<typeof emailCtaProperties> {}
 
 export class EmailCtaNode extends generateDecoratorNode({
     nodeType: 'email-cta',

--- a/koenig/kg-default-nodes/src/nodes/email/EmailNode.ts
+++ b/koenig/kg-default-nodes/src/nodes/email/EmailNode.ts
@@ -1,13 +1,11 @@
-import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodeProperty, type DecoratorNodeValueMap} from '../../generate-decorator-node.js';
+import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodePropertyMap} from '../../generate-decorator-node.js';
 import {renderEmailNode} from './email-renderer.js';
 
-const emailProperties = [
-    {name: 'html', default: '', urlType: 'html'}
-] as const satisfies readonly DecoratorNodeProperty[];
+const emailProperties = {
+    html: {default: '', urlType: 'html'}
+} satisfies DecoratorNodePropertyMap;
 
 export type EmailData = DecoratorNodeData<typeof emailProperties>;
-
-export interface EmailNode extends DecoratorNodeValueMap<typeof emailProperties> {}
 
 export class EmailNode extends generateDecoratorNode({
     nodeType: 'email',

--- a/koenig/kg-default-nodes/src/nodes/embed/EmbedNode.ts
+++ b/koenig/kg-default-nodes/src/nodes/embed/EmbedNode.ts
@@ -1,23 +1,20 @@
-import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodeProperty, type DecoratorNodeValueMap} from '../../generate-decorator-node.js';
+import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodePropertyMap} from '../../generate-decorator-node.js';
 import {parseEmbedNode} from './embed-parser.js';
 import {renderEmbedNode} from './embed-renderer.js';
 
-const embedProperties = [
-    {name: 'url', default: '', urlType: 'url'},
-    {name: 'embedType', default: ''},
-    {name: 'html', default: ''},
-    {
-        name: 'metadata',
+const embedProperties = {
+    url: {default: '', urlType: 'url'},
+    embedType: {default: ''},
+    html: {default: ''},
+    metadata: {
         get default() {
             return {} as Record<string, unknown>;
         }
     },
-    {name: 'caption', default: '', wordCount: true}
-] as const satisfies readonly DecoratorNodeProperty[];
+    caption: {default: '', wordCount: true}
+} satisfies DecoratorNodePropertyMap;
 
 export type EmbedData = DecoratorNodeData<typeof embedProperties>;
-
-export interface EmbedNode extends DecoratorNodeValueMap<typeof embedProperties> {}
 
 export class EmbedNode extends generateDecoratorNode({
     nodeType: 'embed',

--- a/koenig/kg-default-nodes/src/nodes/file/FileNode.ts
+++ b/koenig/kg-default-nodes/src/nodes/file/FileNode.ts
@@ -1,19 +1,17 @@
-import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodeProperty, type DecoratorNodeValueMap} from '../../generate-decorator-node.js';
+import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodePropertyMap} from '../../generate-decorator-node.js';
 import {renderFileNode} from './file-renderer.js';
 import {parseFileNode} from './file-parser.js';
 import {bytesToSize} from '../../utils/size-byte-converter.js';
 
-const fileProperties = [
-    {name: 'src', default: '', urlType: 'url'},
-    {name: 'fileTitle', default: '', wordCount: true},
-    {name: 'fileCaption', default: '', wordCount: true},
-    {name: 'fileName', default: ''},
-    {name: 'fileSize', default: 0}
-] as const satisfies readonly DecoratorNodeProperty[];
+const fileProperties = {
+    src: {default: '', urlType: 'url'},
+    fileTitle: {default: '', wordCount: true},
+    fileCaption: {default: '', wordCount: true},
+    fileName: {default: ''},
+    fileSize: {default: 0}
+} satisfies DecoratorNodePropertyMap;
 
 export type FileData = DecoratorNodeData<typeof fileProperties>;
-
-export interface FileNode extends DecoratorNodeValueMap<typeof fileProperties> {}
 
 export class FileNode extends generateDecoratorNode({
     nodeType: 'file',

--- a/koenig/kg-default-nodes/src/nodes/gallery/GalleryNode.ts
+++ b/koenig/kg-default-nodes/src/nodes/gallery/GalleryNode.ts
@@ -1,15 +1,13 @@
-import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodeProperty, type DecoratorNodeValueMap} from '../../generate-decorator-node.js';
+import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodePropertyMap} from '../../generate-decorator-node.js';
 import {parseGalleryNode} from './gallery-parser.js';
 import {renderGalleryNode} from './gallery-renderer.js';
 
-const galleryProperties = [
-    {name: 'images', default: [] as unknown[]},
-    {name: 'caption', default: '', wordCount: true}
-] as const satisfies readonly DecoratorNodeProperty[];
+const galleryProperties = {
+    images: {default: [] as unknown[]},
+    caption: {default: '', wordCount: true}
+} satisfies DecoratorNodePropertyMap;
 
 export type GalleryData = DecoratorNodeData<typeof galleryProperties>;
-
-export interface GalleryNode extends DecoratorNodeValueMap<typeof galleryProperties> {}
 
 export class GalleryNode extends generateDecoratorNode({
     nodeType: 'gallery',

--- a/koenig/kg-default-nodes/src/nodes/gallery/GalleryNode.ts
+++ b/koenig/kg-default-nodes/src/nodes/gallery/GalleryNode.ts
@@ -2,12 +2,25 @@ import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodePropert
 import {parseGalleryNode} from './gallery-parser.js';
 import {renderGalleryNode} from './gallery-renderer.js';
 
+export interface GalleryImage {
+    fileName: string;
+    src: string;
+    width: number;
+    height: number;
+    row: number;
+    alt?: string;
+    caption?: string;
+    title?: string;
+    href?: string;
+}
+
 const galleryProperties = {
-    images: {default: [] as unknown[]},
+    images: {default: [] as GalleryImage[]},
     caption: {default: '', wordCount: true}
 } satisfies DecoratorNodePropertyMap;
 
 export type GalleryData = DecoratorNodeData<typeof galleryProperties>;
+export type GalleryNodeData = Required<GalleryData>;
 
 export class GalleryNode extends generateDecoratorNode({
     nodeType: 'gallery',

--- a/koenig/kg-default-nodes/src/nodes/gallery/gallery-renderer.ts
+++ b/koenig/kg-default-nodes/src/nodes/gallery/gallery-renderer.ts
@@ -6,22 +6,7 @@ import {isUnsplashImage} from '../../utils/is-unsplash-image.js';
 import {getResizedImageDimensions} from '../../utils/get-resized-image-dimensions.js';
 import {setSrcsetAttribute} from '../../utils/srcset-attribute.js';
 import {renderEmptyContainer} from '../../utils/render-empty-container.js';
-
-interface GalleryImage {
-    fileName: string;
-    src: string;
-    width: number;
-    height: number;
-    alt?: string;
-    title?: string;
-    row: number;
-    href?: string;
-}
-
-interface GalleryNodeData {
-    images: GalleryImage[];
-    caption: string;
-}
+import type {GalleryImage, GalleryNodeData} from './GalleryNode.js';
 
 interface GalleryRenderOptions extends ExportDOMOptions {
     imageOptimization?: {

--- a/koenig/kg-default-nodes/src/nodes/header/HeaderNode.ts
+++ b/koenig/kg-default-nodes/src/nodes/header/HeaderNode.ts
@@ -1,35 +1,33 @@
-import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodeProperty, type DecoratorNodeValueMap} from '../../generate-decorator-node.js';
+import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodePropertyMap} from '../../generate-decorator-node.js';
 import {renderHeaderNodeV1} from './renderers/v1/header-renderer.js';
 import {parseHeaderNode} from './parsers/header-parser.js';
 // V2 imports below
 import {renderHeaderNodeV2} from './renderers/v2/header-renderer.js';
 
-const headerProperties = [
-    {name: 'size', default: 'small'},
-    {name: 'style', default: 'dark'},
-    {name: 'buttonEnabled', default: false},
-    {name: 'buttonUrl', default: '', urlType: 'url'},
-    {name: 'buttonText', default: ''},
-    {name: 'header', default: '', urlType: 'html', wordCount: true},
-    {name: 'subheader', default: '', urlType: 'html', wordCount: true},
-    {name: 'backgroundImageSrc', default: '', urlType: 'url'},
-    {name: 'version', default: 1},
-    {name: 'accentColor', default: '#FF1A75'},
-    {name: 'alignment', default: 'center'},
-    {name: 'backgroundColor', default: '#000000'},
-    {name: 'backgroundImageWidth', default: null as number | null},
-    {name: 'backgroundImageHeight', default: null as number | null},
-    {name: 'backgroundSize', default: 'cover'},
-    {name: 'textColor', default: '#FFFFFF'},
-    {name: 'buttonColor', default: '#ffffff'},
-    {name: 'buttonTextColor', default: '#000000'},
-    {name: 'layout', default: 'full'},
-    {name: 'swapped', default: false}
-] as const satisfies readonly DecoratorNodeProperty[];
+const headerProperties = {
+    size: {default: 'small'},
+    style: {default: 'dark'},
+    buttonEnabled: {default: false},
+    buttonUrl: {default: '', urlType: 'url'},
+    buttonText: {default: ''},
+    header: {default: '', urlType: 'html', wordCount: true},
+    subheader: {default: '', urlType: 'html', wordCount: true},
+    backgroundImageSrc: {default: '', urlType: 'url'},
+    version: {default: 1},
+    accentColor: {default: '#FF1A75'},
+    alignment: {default: 'center'},
+    backgroundColor: {default: '#000000'},
+    backgroundImageWidth: {default: null as number | null},
+    backgroundImageHeight: {default: null as number | null},
+    backgroundSize: {default: 'cover'},
+    textColor: {default: '#FFFFFF'},
+    buttonColor: {default: '#ffffff'},
+    buttonTextColor: {default: '#000000'},
+    layout: {default: 'full'},
+    swapped: {default: false}
+} satisfies DecoratorNodePropertyMap;
 
 export type HeaderData = DecoratorNodeData<typeof headerProperties>;
-
-export interface HeaderNode extends DecoratorNodeValueMap<typeof headerProperties> {}
 
 type HeaderRenderNode = Parameters<typeof renderHeaderNodeV1>[0] & Parameters<typeof renderHeaderNodeV2>[0];
 type HeaderRenderOutput = ReturnType<typeof renderHeaderNodeV1> | ReturnType<typeof renderHeaderNodeV2>;

--- a/koenig/kg-default-nodes/src/nodes/html/HtmlNode.ts
+++ b/koenig/kg-default-nodes/src/nodes/html/HtmlNode.ts
@@ -1,14 +1,12 @@
-import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodeProperty, type DecoratorNodeValueMap} from '../../generate-decorator-node.js';
+import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodePropertyMap} from '../../generate-decorator-node.js';
 import {renderHtmlNode} from './html-renderer.js';
 import {parseHtmlNode} from './html-parser.js';
 
-const htmlProperties = [
-    {name: 'html', default: '', urlType: 'html', wordCount: true}
-] as const satisfies readonly DecoratorNodeProperty[];
+const htmlProperties = {
+    html: {default: '', urlType: 'html', wordCount: true}
+} satisfies DecoratorNodePropertyMap;
 
 export type HtmlData = DecoratorNodeData<typeof htmlProperties, true>;
-
-export interface HtmlNode extends DecoratorNodeValueMap<typeof htmlProperties, true> {}
 
 export class HtmlNode extends generateDecoratorNode({
     nodeType: 'html',

--- a/koenig/kg-default-nodes/src/nodes/image/ImageNode.ts
+++ b/koenig/kg-default-nodes/src/nodes/image/ImageNode.ts
@@ -1,21 +1,20 @@
-import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodeProperty, type DecoratorNodeValueMap} from '../../generate-decorator-node.js';
+import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodePropertyMap} from '../../generate-decorator-node.js';
 import {parseImageNode} from './image-parser.js';
 import {renderImageNode} from './image-renderer.js';
+import type {CardWidth} from '../../utils/card-widths.js';
 
-const imageProperties = [
-    {name: 'src', default: '', urlType: 'url'},
-    {name: 'caption', default: '', urlType: 'html', wordCount: true},
-    {name: 'title', default: ''},
-    {name: 'alt', default: ''},
-    {name: 'cardWidth', default: 'regular'},
-    {name: 'width', default: null as number | null},
-    {name: 'height', default: null as number | null},
-    {name: 'href', default: '', urlType: 'url'}
-] as const satisfies readonly DecoratorNodeProperty[];
+const imageProperties = {
+    src: {default: '', urlType: 'url'},
+    caption: {default: '', urlType: 'html', wordCount: true},
+    title: {default: ''},
+    alt: {default: ''},
+    cardWidth: {default: 'regular' as CardWidth},
+    width: {default: null as number | null},
+    height: {default: null as number | null},
+    href: {default: '', urlType: 'url'}
+} satisfies DecoratorNodePropertyMap;
 
 export type ImageData = DecoratorNodeData<typeof imageProperties>;
-
-export interface ImageNode extends DecoratorNodeValueMap<typeof imageProperties> {}
 
 export class ImageNode extends generateDecoratorNode({
     nodeType: 'image',

--- a/koenig/kg-default-nodes/src/nodes/image/image-renderer.ts
+++ b/koenig/kg-default-nodes/src/nodes/image/image-renderer.ts
@@ -4,6 +4,7 @@ import {getSrcsetAttribute, setSrcsetAttribute} from '../../utils/srcset-attribu
 import {getResizedImageDimensions} from '../../utils/get-resized-image-dimensions.js';
 import {addCreateDocumentOption} from '../../utils/add-create-document-option.js';
 import type {ExportDOMOptions} from '../../export-dom.js';
+import type {CardWidth} from '../../utils/card-widths.js';
 import {renderEmptyContainer} from '../../utils/render-empty-container.js';
 
 const MODERN_IMAGE_FORMATS = ['avif', 'webp'];
@@ -24,7 +25,7 @@ interface ImageNodeData {
     alt: string;
     title: string;
     caption: string;
-    cardWidth: string;
+    cardWidth: CardWidth;
     href: string;
 }
 

--- a/koenig/kg-default-nodes/src/nodes/markdown/MarkdownNode.ts
+++ b/koenig/kg-default-nodes/src/nodes/markdown/MarkdownNode.ts
@@ -1,13 +1,11 @@
-import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodeProperty, type DecoratorNodeValueMap} from '../../generate-decorator-node.js';
+import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodePropertyMap} from '../../generate-decorator-node.js';
 import {renderMarkdownNode} from './markdown-renderer.js';
 
-const markdownProperties = [
-    {name: 'markdown', default: '', urlType: 'markdown', wordCount: true}
-] as const satisfies readonly DecoratorNodeProperty[];
+const markdownProperties = {
+    markdown: {default: '', urlType: 'markdown', wordCount: true}
+} satisfies DecoratorNodePropertyMap;
 
 export type MarkdownData = DecoratorNodeData<typeof markdownProperties>;
-
-export interface MarkdownNode extends DecoratorNodeValueMap<typeof markdownProperties> {}
 
 export class MarkdownNode extends generateDecoratorNode({
     nodeType: 'markdown',

--- a/koenig/kg-default-nodes/src/nodes/paywall/PaywallNode.ts
+++ b/koenig/kg-default-nodes/src/nodes/paywall/PaywallNode.ts
@@ -1,8 +1,10 @@
-import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodeProperty} from '../../generate-decorator-node.js';
+import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodePropertyMap} from '../../generate-decorator-node.js';
 import {parsePaywallNode} from './paywall-parser.js';
 import {renderPaywallNode} from './paywall-renderer.js';
 
-const paywallProperties = [] as const satisfies readonly DecoratorNodeProperty[];
+const paywallProperties = {
+
+} satisfies DecoratorNodePropertyMap;
 
 export type PaywallData = DecoratorNodeData<typeof paywallProperties>;
 

--- a/koenig/kg-default-nodes/src/nodes/product/ProductNode.ts
+++ b/koenig/kg-default-nodes/src/nodes/product/ProductNode.ts
@@ -1,23 +1,21 @@
-import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodeProperty, type DecoratorNodeValueMap} from '../../generate-decorator-node.js';
+import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodePropertyMap} from '../../generate-decorator-node.js';
 import {parseProductNode} from './product-parser.js';
 import {renderProductNode} from './product-renderer.js';
 
-const productProperties = [
-    {name: 'productImageSrc', default: '', urlType: 'url'},
-    {name: 'productImageWidth', default: null as number | null},
-    {name: 'productImageHeight', default: null as number | null},
-    {name: 'productTitle', default: '', urlType: 'html', wordCount: true},
-    {name: 'productDescription', default: '', urlType: 'html', wordCount: true},
-    {name: 'productRatingEnabled', default: false},
-    {name: 'productStarRating', default: 5},
-    {name: 'productButtonEnabled', default: false},
-    {name: 'productButton', default: ''},
-    {name: 'productUrl', default: ''}
-] as const satisfies readonly DecoratorNodeProperty[];
+const productProperties = {
+    productImageSrc: {default: '', urlType: 'url'},
+    productImageWidth: {default: null as number | null},
+    productImageHeight: {default: null as number | null},
+    productTitle: {default: '', urlType: 'html', wordCount: true},
+    productDescription: {default: '', urlType: 'html', wordCount: true},
+    productRatingEnabled: {default: false},
+    productStarRating: {default: 5},
+    productButtonEnabled: {default: false},
+    productButton: {default: ''},
+    productUrl: {default: ''}
+} satisfies DecoratorNodePropertyMap;
 
 export type ProductData = DecoratorNodeData<typeof productProperties>;
-
-export interface ProductNode extends DecoratorNodeValueMap<typeof productProperties> {}
 
 export class ProductNode extends generateDecoratorNode({
     nodeType: 'product',

--- a/koenig/kg-default-nodes/src/nodes/signup/SignupNode.ts
+++ b/koenig/kg-default-nodes/src/nodes/signup/SignupNode.ts
@@ -1,58 +1,25 @@
 import {signupParser} from './signup-parser.js';
 import {renderSignupCardToDOM} from './signup-renderer.js';
-import {generateDecoratorNode, type DecoratorNodeProperty} from '../../generate-decorator-node.js';
+import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodePropertyMap} from '../../generate-decorator-node.js';
 
-export interface SignupData {
-    alignment?: string;
-    backgroundColor?: string;
-    backgroundImageSrc?: string;
-    backgroundSize?: string;
-    textColor?: string;
-    buttonColor?: string;
-    buttonTextColor?: string;
-    buttonText?: string;
-    disclaimer?: string;
-    header?: string;
-    labels?: string[];
-    layout?: string;
-    subheader?: string;
-    successMessage?: string;
-    swapped?: boolean;
-}
+const signupProperties = {
+    alignment: {default: 'left'},
+    backgroundColor: {default: '#F0F0F0'},
+    backgroundImageSrc: {default: ''},
+    backgroundSize: {default: 'cover'},
+    textColor: {default: ''},
+    buttonColor: {default: 'accent'},
+    buttonTextColor: {default: '#FFFFFF'},
+    buttonText: {default: 'Subscribe'},
+    disclaimer: {default: '', wordCount: true},
+    header: {default: '', wordCount: true},
+    layout: {default: 'wide'},
+    subheader: {default: '', wordCount: true},
+    successMessage: {default: 'Email sent! Check your inbox to complete your signup.'},
+    swapped: {default: false}
+} satisfies DecoratorNodePropertyMap;
 
-export interface SignupNode {
-    alignment: string;
-    backgroundColor: string;
-    backgroundImageSrc: string;
-    backgroundSize: string;
-    textColor: string;
-    buttonColor: string;
-    buttonTextColor: string;
-    buttonText: string;
-    disclaimer: string;
-    header: string;
-    layout: string;
-    subheader: string;
-    successMessage: string;
-    swapped: boolean;
-}
-
-const signupProperties = [
-    {name: 'alignment', default: 'left'},
-    {name: 'backgroundColor', default: '#F0F0F0'},
-    {name: 'backgroundImageSrc', default: ''},
-    {name: 'backgroundSize', default: 'cover'},
-    {name: 'textColor', default: ''},
-    {name: 'buttonColor', default: 'accent'},
-    {name: 'buttonTextColor', default: '#FFFFFF'},
-    {name: 'buttonText', default: 'Subscribe'},
-    {name: 'disclaimer', default: '', wordCount: true},
-    {name: 'header', default: '', wordCount: true},
-    {name: 'layout', default: 'wide'},
-    {name: 'subheader', default: '', wordCount: true},
-    {name: 'successMessage', default: 'Email sent! Check your inbox to complete your signup.'},
-    {name: 'swapped', default: false}
-] as const satisfies readonly DecoratorNodeProperty[];
+export type SignupData = DecoratorNodeData<typeof signupProperties> & {labels?: string[]};
 
 export class SignupNode extends generateDecoratorNode({
     nodeType: 'signup',

--- a/koenig/kg-default-nodes/src/nodes/toggle/ToggleNode.ts
+++ b/koenig/kg-default-nodes/src/nodes/toggle/ToggleNode.ts
@@ -1,15 +1,13 @@
-import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodeProperty, type DecoratorNodeValueMap} from '../../generate-decorator-node.js';
+import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodePropertyMap} from '../../generate-decorator-node.js';
 import {parseToggleNode} from './toggle-parser.js';
 import {renderToggleNode} from './toggle-renderer.js';
 
-const toggleProperties = [
-    {name: 'heading', default: '', urlType: 'html', wordCount: true},
-    {name: 'content', default: '', urlType: 'html', wordCount: true}
-] as const satisfies readonly DecoratorNodeProperty[];
+const toggleProperties = {
+    heading: {default: '', urlType: 'html', wordCount: true},
+    content: {default: '', urlType: 'html', wordCount: true}
+} satisfies DecoratorNodePropertyMap;
 
 export type ToggleData = DecoratorNodeData<typeof toggleProperties>;
-
-export interface ToggleNode extends DecoratorNodeValueMap<typeof toggleProperties> {}
 
 export class ToggleNode extends generateDecoratorNode({
     nodeType: 'toggle',

--- a/koenig/kg-default-nodes/src/nodes/transistor/TransistorNode.ts
+++ b/koenig/kg-default-nodes/src/nodes/transistor/TransistorNode.ts
@@ -1,8 +1,7 @@
 import cloneDeep from 'lodash/cloneDeep.js';
-import {generateDecoratorNode, type DecoratorNodeProperty} from '../../generate-decorator-node.js';
+import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodePropertyMap} from '../../generate-decorator-node.js';
 import {renderTransistorNode} from './transistor-renderer.js';
 import {ALL_MEMBERS_SEGMENT} from '../../utils/visibility.js';
-import type {Visibility} from '../../utils/visibility.js';
 
 // Default visibility for Transistor: members only (no public visitors)
 // since the embed requires a member UUID to function
@@ -16,22 +15,12 @@ const TRANSISTOR_DEFAULT_VISIBILITY = {
     }
 };
 
-export interface TransistorNode {
-    accentColor: string;
-    backgroundColor: string;
-    visibility: Visibility;
-}
+const transistorProperties = {
+    accentColor: {default: ''},
+    backgroundColor: {default: ''}
+} satisfies DecoratorNodePropertyMap;
 
-export interface TransistorData {
-    accentColor?: string;
-    backgroundColor?: string;
-    visibility?: Visibility;
-}
-
-const transistorProperties = [
-    {name: 'accentColor', default: ''},
-    {name: 'backgroundColor', default: ''}
-] as const satisfies readonly DecoratorNodeProperty[];
+export type TransistorData = DecoratorNodeData<typeof transistorProperties, true>;
 
 export class TransistorNode extends generateDecoratorNode({
     nodeType: 'transistor',

--- a/koenig/kg-default-nodes/src/nodes/video/VideoNode.ts
+++ b/koenig/kg-default-nodes/src/nodes/video/VideoNode.ts
@@ -1,26 +1,25 @@
-import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodeProperty, type DecoratorNodeValueMap} from '../../generate-decorator-node.js';
+import {generateDecoratorNode, type DecoratorNodeData, type DecoratorNodePropertyMap} from '../../generate-decorator-node.js';
 import {parseVideoNode} from './video-parser.js';
 import {renderVideoNode} from './video-renderer.js';
+import type {CardWidth} from '../../utils/card-widths.js';
 
-const videoProperties = [
-    {name: 'src', default: '', urlType: 'url'},
-    {name: 'caption', default: '', urlType: 'html', wordCount: true},
-    {name: 'fileName', default: ''},
-    {name: 'mimeType', default: ''},
-    {name: 'width', default: null as number | null},
-    {name: 'height', default: null as number | null},
-    {name: 'duration', default: 0},
-    {name: 'thumbnailSrc', default: '', urlType: 'url'},
-    {name: 'customThumbnailSrc', default: '', urlType: 'url'},
-    {name: 'thumbnailWidth', default: null as number | null},
-    {name: 'thumbnailHeight', default: null as number | null},
-    {name: 'cardWidth', default: 'regular'},
-    {name: 'loop', default: false}
-] as const satisfies readonly DecoratorNodeProperty[];
+const videoProperties = {
+    src: {default: '', urlType: 'url'},
+    caption: {default: '', urlType: 'html', wordCount: true},
+    fileName: {default: ''},
+    mimeType: {default: ''},
+    width: {default: null as number | null},
+    height: {default: null as number | null},
+    duration: {default: 0},
+    thumbnailSrc: {default: '', urlType: 'url'},
+    customThumbnailSrc: {default: '', urlType: 'url'},
+    thumbnailWidth: {default: null as number | null},
+    thumbnailHeight: {default: null as number | null},
+    cardWidth: {default: 'regular' as CardWidth},
+    loop: {default: false}
+} satisfies DecoratorNodePropertyMap;
 
 export type VideoData = DecoratorNodeData<typeof videoProperties>;
-
-export interface VideoNode extends DecoratorNodeValueMap<typeof videoProperties> {}
 
 export class VideoNode extends generateDecoratorNode({
     nodeType: 'video',

--- a/koenig/kg-default-nodes/src/nodes/video/video-renderer.ts
+++ b/koenig/kg-default-nodes/src/nodes/video/video-renderer.ts
@@ -1,5 +1,6 @@
 import {addCreateDocumentOption} from '../../utils/add-create-document-option.js';
 import type {ExportDOMOptions} from '../../export-dom.js';
+import type {CardWidth} from '../../utils/card-widths.js';
 import {renderEmptyContainer} from '../../utils/render-empty-container.js';
 
 interface VideoNodeData {
@@ -11,7 +12,7 @@ interface VideoNodeData {
     thumbnailSrc: string;
     customThumbnailSrc: string;
     formattedDuration: string;
-    cardWidth: string;
+    cardWidth: CardWidth;
 }
 
 interface BaseVideoRenderOptions extends ExportDOMOptions {}

--- a/koenig/kg-default-nodes/test/generate-decorator-node.test.ts
+++ b/koenig/kg-default-nodes/test/generate-decorator-node.test.ts
@@ -1,19 +1,9 @@
 import {createHeadlessEditor} from '@lexical/headless';
-import {utils, type ExportDOMOptions, type ExportDOMOutput} from '../src/index.js';
+import {$isKoenigCard, utils, type ExportDOMOutput} from '../src/index.js';
 import type {LexicalEditor} from 'lexical';
 import {dom} from './test-utils/index.js';
 
 const defaultVisibility = utils.visibility.buildDefaultVisibility();
-
-type GeneratedNodeClass = ReturnType<typeof utils.generateDecoratorNode>;
-
-interface GeneratedNodeInstance {
-    exportDOM(editor: LexicalEditor, options?: ExportDOMOptions): ExportDOMOutput;
-    exportJSON(): Record<string, unknown>;
-    getDataset(): Record<string, unknown>;
-    visibility: Record<string, unknown>;
-    [key: string]: unknown;
-}
 
 function createRenderResult(tagName: 'div' | 'span', content: string) {
     const element = dom.window.document.createElement(tagName);
@@ -51,21 +41,47 @@ describe('Utils: generateDecoratorNode', function () {
         });
     });
 
+    describe('properties', function () {
+        it('widens primitive defaults without a helper type', function () {
+            const TypedNode = utils.generateDecoratorNode({
+                nodeType: 'typed-properties-test',
+                properties: {
+                    title: {default: ''},
+                    count: {default: 0},
+                    enabled: {default: false}
+                }
+            });
+            const typedEditor = createHeadlessEditor({nodes: [TypedNode]});
+
+            typedEditor.update(() => {
+                const node = new TypedNode({
+                    title: 'Custom title',
+                    count: 2,
+                    enabled: true
+                });
+                const title: string = node.title;
+                const count: number = node.count;
+                const enabled: boolean = node.enabled;
+
+                expect(title).toBe('Custom title');
+                expect(count).toBe(2);
+                expect(enabled).toBe(true);
+                expect($isKoenigCard(node)).toBe(true);
+            });
+        });
+    });
+
     describe('exportDOM', function () {
-        let NodeWithRender: GeneratedNodeClass;
-        let $createNodeWithRender: (dataset?: Record<string, unknown>) => GeneratedNodeInstance;
+        const NodeWithRender = utils.generateDecoratorNode({
+            nodeType: 'render-test',
+            properties: {},
+            defaultRenderFn: () => createRenderResult('div', 'default render')
+        });
+        const $createNodeWithRender = (dataset?: ConstructorParameters<typeof NodeWithRender>[0]) => {
+            return new NodeWithRender(dataset);
+        };
 
         beforeAll(function () {
-            NodeWithRender = utils.generateDecoratorNode({
-                nodeType: 'render-test',
-                properties: [],
-                defaultRenderFn: () => createRenderResult('div', 'default render')
-            });
-
-            $createNodeWithRender = (dataset?: Record<string, unknown>) => {
-                return new NodeWithRender(dataset) as unknown as GeneratedNodeInstance;
-            };
-
             editor = createHeadlessEditor({nodes: [NodeWithRender]});
         });
 
@@ -80,7 +96,7 @@ describe('Utils: generateDecoratorNode', function () {
         it('uses versioned default renderer (static version)', editorTest(function () {
             const VersionedNode = utils.generateDecoratorNode({
                 nodeType: 'versioned-render-test',
-                properties: [],
+                properties: {},
                 version: 2,
                 defaultRenderFn: {
                     1: () => createRenderResult('div', 'version 1'),
@@ -88,7 +104,7 @@ describe('Utils: generateDecoratorNode', function () {
                 }
             });
 
-            const node = new VersionedNode() as unknown as GeneratedNodeInstance;
+            const node = new VersionedNode();
             const result = node.exportDOM(editor);
 
             expect(result.type).toBe('inner');
@@ -98,7 +114,7 @@ describe('Utils: generateDecoratorNode', function () {
         it('uses versioned default renderer (dataset version)', editorTest(function () {
             const VersionedNode = utils.generateDecoratorNode({
                 nodeType: 'versioned-render-test',
-                properties: [{name: 'version', default: 1}],
+                properties: {version: {default: 1}},
                 version: 1,
                 defaultRenderFn: {
                     1: node => createRenderResult('div', `version ${node.version}`),
@@ -106,7 +122,7 @@ describe('Utils: generateDecoratorNode', function () {
                 }
             });
 
-            const node = new VersionedNode({version: 2}) as unknown as GeneratedNodeInstance;
+            const node = new VersionedNode({version: 2});
             const result = node.exportDOM(editor);
 
             expect(result.type).toBe('inner');
@@ -116,24 +132,24 @@ describe('Utils: generateDecoratorNode', function () {
         it('throws error when defaultRenderFn is not provided', editorTest(function () {
             const NodeWithoutRender = utils.generateDecoratorNode({
                 nodeType: 'no-render-test',
-                properties: []
+                properties: {}
             });
 
-            const node = new NodeWithoutRender() as unknown as GeneratedNodeInstance;
+            const node = new NodeWithoutRender();
             expect(() => node.exportDOM(editor)).toThrow('[generateDecoratorNode] no-render-test: "defaultRenderFn" is required');
         }));
 
         it('throws error when default versioned renderer is missing for node version', editorTest(function () {
             const VersionedNode = utils.generateDecoratorNode({
                 nodeType: 'versioned-render-test',
-                properties: [],
+                properties: {},
                 version: 2,
                 defaultRenderFn: {
                     1: () => createRenderResult('div', 'version 1')
                 }
             });
 
-            const node = new VersionedNode() as unknown as GeneratedNodeInstance;
+            const node = new VersionedNode();
             expect(() => node.exportDOM(editor)).toThrow('[generateDecoratorNode] versioned-render-test: "defaultRenderFn" for version 2 is required');
         }));
 
@@ -160,7 +176,7 @@ describe('Utils: generateDecoratorNode', function () {
         it('throws error when custom versioned renderer is missing for node version (emailCustomizationAlpha)', editorTest(function () {
             const VersionedNode = utils.generateDecoratorNode({
                 nodeType: 'versioned-render-test',
-                properties: [{name: 'version', default: 1}],
+                properties: {version: {default: 1}},
                 version: 1,
                 defaultRenderFn: {
                     1: () => createRenderResult('div', 'version 1'),
@@ -168,7 +184,7 @@ describe('Utils: generateDecoratorNode', function () {
                 }
             });
 
-            const node = new VersionedNode({version: 2}) as unknown as GeneratedNodeInstance;
+            const node = new VersionedNode({version: 2});
 
             expect(() => node.exportDOM(editor, {
                 feature: {
@@ -184,20 +200,16 @@ describe('Utils: generateDecoratorNode', function () {
     });
 
     describe('hasVisibility', function () {
-        let NodeWithVisibility: GeneratedNodeClass;
-        let $createNodeWithVisibility: (dataset?: Record<string, unknown>) => GeneratedNodeInstance;
+        const NodeWithVisibility = utils.generateDecoratorNode({
+            nodeType: 'visibility-test',
+            properties: {},
+            hasVisibility: true
+        });
+        const $createNodeWithVisibility = (dataset?: ConstructorParameters<typeof NodeWithVisibility>[0]) => {
+            return new NodeWithVisibility(dataset);
+        };
 
         beforeAll(function () {
-            NodeWithVisibility = utils.generateDecoratorNode({
-                nodeType: 'visibility-test',
-                properties: [],
-                hasVisibility: true
-            });
-
-            $createNodeWithVisibility = (dataset?: Record<string, unknown>) => {
-                return new NodeWithVisibility(dataset) as unknown as GeneratedNodeInstance;
-            };
-
             editor = createHeadlessEditor({nodes: [NodeWithVisibility]});
         });
 
@@ -248,7 +260,7 @@ describe('Utils: generateDecoratorNode', function () {
                     showOnEmail: true,
                     segment: 'status:free'
                 }
-            }) as unknown as GeneratedNodeInstance;
+            });
 
             // old values are kept, new values are added
             expect(node.visibility).toEqual({

--- a/koenig/kg-default-nodes/test/generate-decorator-node.test.ts
+++ b/koenig/kg-default-nodes/test/generate-decorator-node.test.ts
@@ -69,6 +69,30 @@ describe('Utils: generateDecoratorNode', function () {
                 expect($isKoenigCard(node)).toBe(true);
             });
         });
+
+        it('preserves explicitly provided falsy non-string values', function () {
+            const NodeWithDefaults = utils.generateDecoratorNode({
+                nodeType: 'falsy-properties-test',
+                properties: {
+                    title: {default: 'Default title'},
+                    count: {default: 1},
+                    enabled: {default: true}
+                }
+            });
+            const typedEditor = createHeadlessEditor({nodes: [NodeWithDefaults]});
+
+            typedEditor.update(() => {
+                const node = new NodeWithDefaults({
+                    title: '',
+                    count: 0,
+                    enabled: false
+                });
+
+                expect(node.title).toBe('Default title');
+                expect(node.count).toBe(0);
+                expect(node.enabled).toBe(false);
+            });
+        });
     });
 
     describe('exportDOM', function () {

--- a/koenig/koenig-lexical/src/components/KoenigCardWrapper.tsx
+++ b/koenig/koenig-lexical/src/components/KoenigCardWrapper.tsx
@@ -2,6 +2,7 @@ import CardContext from '../context/CardContext';
 import KoenigComposerContext from '../context/KoenigComposerContext';
 import React from 'react';
 import {$getNodeByKey, CLICK_COMMAND, COMMAND_PRIORITY_LOW} from 'lexical';
+import {$isKoenigCard} from '@tryghost/kg-default-nodes';
 import {CardWrapper} from './ui/CardWrapper';
 import {EDIT_CARD_COMMAND, SELECT_CARD_COMMAND, SHOW_CARD_VISIBILITY_SETTINGS_COMMAND} from '../plugins/KoenigBehaviourPlugin';
 import {VISIBILITY_SETTINGS} from '../utils/visibility';
@@ -62,7 +63,7 @@ const KoenigCardWrapper = ({nodeKey, width, wrapperStyle, IndicatorIcon, childre
                         const clickedToolbar = event.target.closest('[data-kg-allow-clickthrough="false"]');
                         const clickedSettingsPanel = event.target.closest('[data-kg-settings-panel]');
 
-                        if (isSelected && (cardNode?.hasEditMode?.() && !isEditing && !clickedToolbar && !clickedSettingsPanel)) {
+                        if (isSelected && ($isKoenigCard(cardNode) && cardNode.hasEditMode() && !isEditing && !clickedToolbar && !clickedSettingsPanel)) {
                             editor.dispatchCommand(EDIT_CARD_COMMAND, {cardKey: nodeKey, focusEditor: !clickedDifferentEditor});
                         } else if (!isSelected) {
                             editor.dispatchCommand(SELECT_CARD_COMMAND, {cardKey: nodeKey, focusEditor: !clickedDifferentEditor});
@@ -150,7 +151,7 @@ const KoenigCardWrapper = ({nodeKey, width, wrapperStyle, IndicatorIcon, childre
     if (cardConfig?.visibilitySettings !== VISIBILITY_SETTINGS.NONE) {
         editor.getEditorState().read(() => {
             const cardNode = $getNodeByKey(nodeKey);
-            isVisibilityActive = cardNode?.getIsVisibilityActive?.();
+            isVisibilityActive = $isKoenigCard(cardNode) ? cardNode.getIsVisibilityActive() : false;
         });
     }
 

--- a/koenig/koenig-lexical/src/components/ui/UnsplashPlugin.tsx
+++ b/koenig/koenig-lexical/src/components/ui/UnsplashPlugin.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import UnsplashModal from './file-selectors/UnsplashModal.jsx';
 import generateEditorState from '../../utils/generateEditorState';
 import {$createNodeSelection, $getNodeByKey, $setSelection} from 'lexical';
+import {$isKoenigCard} from '@tryghost/kg-default-nodes';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 
 const UnsplashPlugin = ({nodeKey, isModalOpen = true}) => {
@@ -22,6 +23,9 @@ const UnsplashPlugin = ({nodeKey, isModalOpen = true}) => {
     const insertImageToNode = async (image) => {
         editor.update(() => {
             const node = $getNodeByKey(nodeKey);
+            if (!$isKoenigCard(node)) {
+                return;
+            }
             node.src = image.src;
             node.height = image.height;
             node.width = image.width;

--- a/koenig/koenig-lexical/src/hooks/useVisibilityToggle.ts
+++ b/koenig/koenig-lexical/src/hooks/useVisibilityToggle.ts
@@ -1,4 +1,5 @@
 import {$getNodeByKey} from 'lexical';
+import {$isKoenigCard} from '@tryghost/kg-default-nodes';
 import {VISIBILITY_SETTINGS, getVisibilityOptions, parseVisibilityToToggles, serializeOptionsToVisibility} from '../utils/visibility';
 
 export const useVisibilityToggle = (editor, nodeKey, cardConfig) => {
@@ -11,11 +12,11 @@ export const useVisibilityToggle = (editor, nodeKey, cardConfig) => {
     let currentVisibility;
 
     editor.getEditorState().read(() => {
-        const htmlNode = $getNodeByKey(nodeKey);
-        if (!htmlNode) {
+        const node = $getNodeByKey(nodeKey);
+        if (!$isKoenigCard(node)) {
             return;
         }
-        currentVisibility = htmlNode.visibility;
+        currentVisibility = node.visibility;
     });
 
     const visibilityData = parseVisibilityToToggles(currentVisibility);
@@ -28,7 +29,7 @@ export const useVisibilityToggle = (editor, nodeKey, cardConfig) => {
         toggleVisibility: (type, key, value) => {
             editor.update(() => {
                 const node = $getNodeByKey(nodeKey);
-                if (!node) {
+                if (!$isKoenigCard(node)) {
                     return;
                 }
                 const newVisibilityOptions = structuredClone(getVisibilityOptions(node.visibility, {isStripeEnabled, showWeb, showEmail}));

--- a/koenig/koenig-lexical/src/plugins/DragDropReorderPlugin.tsx
+++ b/koenig/koenig-lexical/src/plugins/DragDropReorderPlugin.tsx
@@ -2,6 +2,7 @@ import KoenigComposerContext from '../context/KoenigComposerContext.jsx';
 import React from 'react';
 import {$createImageNode} from '../nodes/ImageNode.jsx';
 import {$createNodeSelection, $getNearestNodeFromDOMNode, $getNodeByKey, $setSelection} from 'lexical';
+import {$isKoenigCard} from '@tryghost/kg-default-nodes';
 import {DragDropHandler} from '../utils/draggable/DragDropHandler.jsx';
 import {createRoot} from 'react-dom/client';
 import {flushSync} from 'react-dom';
@@ -36,13 +37,14 @@ function useDragDropReorder(editor, isEditable) {
         editor.update(() => {
             const cardNode = $getNearestNodeFromDOMNode(draggableElement);
 
-            if (cardNode) {
+            if ($isKoenigCard(cardNode)) {
+                const getIcon = cardNode.getIcon;
                 draggableInfo = {
                     type: 'card',
                     nodeKey: cardNode.getKey(),
                     cardName: cardNode.getType(),
-                    dataset: cardNode.getDataset?.(),
-                    Icon: cardNode.getIcon()
+                    dataset: cardNode.getDataset(),
+                    Icon: typeof getIcon === 'function' ? getIcon.call(cardNode) : undefined
                 };
             }
         });

--- a/koenig/koenig-lexical/src/utils/audioUploadHandler.ts
+++ b/koenig/koenig-lexical/src/utils/audioUploadHandler.ts
@@ -1,5 +1,6 @@
 import prettifyFileName from './prettifyFileName';
 import {$getNodeByKey} from 'lexical';
+import {$isKoenigCard} from '@tryghost/kg-default-nodes';
 import {getAudioMetadata} from './getAudioMetadata';
 
 export const audioUploadHandler = async (files, nodeKey, editor, upload) => {
@@ -26,10 +27,12 @@ export const audioUploadHandler = async (files, nodeKey, editor, upload) => {
 
     await editor.update(() => {
         const node = $getNodeByKey(nodeKey);
-        node.duration = duration;
-        node.src = fileSrc;
-        node.mimeType = mimeType;
-        node.title = title;
+        if ($isKoenigCard(node)) {
+            node.duration = duration;
+            node.src = fileSrc;
+            node.mimeType = mimeType;
+            node.title = title;
+        }
     });
 
     return;

--- a/koenig/koenig-lexical/src/utils/fileUploadHandler.ts
+++ b/koenig/koenig-lexical/src/utils/fileUploadHandler.ts
@@ -1,4 +1,5 @@
 import {$getNodeByKey} from 'lexical';
+import {$isKoenigCard} from '@tryghost/kg-default-nodes';
 
 export const stripFileExtension = (fileName) => {
     const fileExtension = fileName.split('.').pop();
@@ -31,10 +32,12 @@ export const fileUploadHandler = async (files, nodeKey, editor, upload) => {
     };
     await editor.update(() => {
         const node = $getNodeByKey(nodeKey);
-        node.fileTitle = stripFileExtension(dataset.fileName); // initially sets the title to the file name
-        node.fileName = dataset.fileName;
-        node.fileSize = dataset.fileSize;
-        node.src = dataset.src;
+        if ($isKoenigCard(node)) {
+            node.fileTitle = stripFileExtension(dataset.fileName); // initially sets the title to the file name
+            node.fileName = dataset.fileName;
+            node.fileSize = dataset.fileSize;
+            node.src = dataset.src;
+        }
     });
 
     return;

--- a/koenig/koenig-lexical/src/utils/imageUploadHandler.ts
+++ b/koenig/koenig-lexical/src/utils/imageUploadHandler.ts
@@ -7,6 +7,13 @@ export const imageUploadHandler = async (files, nodeKey, editor, upload) => {
         return;
     }
 
+    const isTargetCard = editor.getEditorState().read(() => {
+        return $isKoenigCard($getNodeByKey(nodeKey));
+    });
+    if (!isTargetCard) {
+        return;
+    }
+
     // show preview via an object URL whilst upload is in progress
     let previewUrl = URL.createObjectURL(files[0]);
     if (previewUrl) {

--- a/koenig/koenig-lexical/src/utils/imageUploadHandler.ts
+++ b/koenig/koenig-lexical/src/utils/imageUploadHandler.ts
@@ -1,4 +1,5 @@
 import {$getNodeByKey} from 'lexical';
+import {$isKoenigCard} from '@tryghost/kg-default-nodes';
 import {getImageDimensions} from './getImageDimensions';
 
 export const imageUploadHandler = async (files, nodeKey, editor, upload) => {
@@ -11,7 +12,9 @@ export const imageUploadHandler = async (files, nodeKey, editor, upload) => {
     if (previewUrl) {
         await editor.update(() => {
             const node = $getNodeByKey(nodeKey);
-            node.previewSrc = previewUrl;
+            if ($isKoenigCard(node)) {
+                node.previewSrc = previewUrl;
+            }
         });
     }
 
@@ -25,10 +28,12 @@ export const imageUploadHandler = async (files, nodeKey, editor, upload) => {
     // replace preview URL with real URL and set image metadata
     await editor.update(() => {
         const node = $getNodeByKey(nodeKey);
-        node.width = width;
-        node.height = height;
-        node.src = imageSrc;
-        node.previewSrc = null;
+        if ($isKoenigCard(node)) {
+            node.width = width;
+            node.height = height;
+            node.src = imageSrc;
+            node.previewSrc = null;
+        }
     });
 
     return;

--- a/koenig/koenig-lexical/src/utils/thumbnailUploadHandler.ts
+++ b/koenig/koenig-lexical/src/utils/thumbnailUploadHandler.ts
@@ -1,4 +1,5 @@
 import {$getNodeByKey} from 'lexical';
+import {$isKoenigCard} from '@tryghost/kg-default-nodes';
 
 export const thumbnailUploadHandler = async (files, nodeKey, editor, upload) => {
     if (!files) {
@@ -9,14 +10,18 @@ export const thumbnailUploadHandler = async (files, nodeKey, editor, upload) => 
 
     editor.getEditorState().read(() => {
         const node = $getNodeByKey(nodeKey);
-        mediaSrc = node.src;
+        if ($isKoenigCard(node) && typeof node.src === 'string') {
+            mediaSrc = node.src;
+        }
     });
 
     const uploadResult = await upload(files, {formData: {url: mediaSrc}});
 
     await editor.update(() => {
         const node = $getNodeByKey(nodeKey);
-        node.thumbnailSrc = uploadResult[0].url;
+        if ($isKoenigCard(node)) {
+            node.thumbnailSrc = uploadResult[0].url;
+        }
     });
 
     return;

--- a/koenig/koenig-lexical/src/utils/visibility.ts
+++ b/koenig/koenig-lexical/src/utils/visibility.ts
@@ -8,6 +8,8 @@ export const VISIBILITY_SETTINGS = {
 };
 
 export function parseVisibilityToToggles(visibility) {
+    visibility = visibility || buildDefaultVisibility();
+
     return {
         web: {
             nonMembers: visibility.web.nonMember,

--- a/koenig/koenig-lexical/test/unit/hooks/useVisibilityToggle.test.ts
+++ b/koenig/koenig-lexical/test/unit/hooks/useVisibilityToggle.test.ts
@@ -8,6 +8,9 @@ import {useVisibilityToggle} from '../../../src/hooks/useVisibilityToggle';
 const lexicalMocks = vi.hoisted(() => ({
     $getNodeByKey: vi.fn()
 }));
+const koenigMocks = vi.hoisted(() => ({
+    $isKoenigCard: vi.fn()
+}));
 
 vi.mock(import('lexical'), async (importOriginal) => {
     const actual = await importOriginal();
@@ -19,7 +22,7 @@ vi.mock(import('lexical'), async (importOriginal) => {
 });
 
 vi.mock(import('@tryghost/kg-default-nodes'), () => ({
-    $isKoenigCard: node => Boolean(node)
+    $isKoenigCard: koenigMocks.$isKoenigCard
 }));
 
 describe('useVisibilityToggle', () => {
@@ -38,6 +41,7 @@ describe('useVisibilityToggle', () => {
     };
 
     beforeEach(() => {
+        koenigMocks.$isKoenigCard.mockReturnValue(true);
         node = {
             visibility: DEFAULT_VISIBILITY,
             getIsVisibilityActive: vi.fn(() => true)
@@ -60,6 +64,7 @@ describe('useVisibilityToggle', () => {
     afterEach(() => {
         vi.restoreAllMocks();
         lexicalMocks.$getNodeByKey.mockReset();
+        koenigMocks.$isKoenigCard.mockReset();
     });
 
     function callHook(visibility = DEFAULT_VISIBILITY, {stripeEnabled = true} = {}) {
@@ -129,6 +134,24 @@ describe('useVisibilityToggle', () => {
 
         act(() => toggleVisibility('web', 'paidMembers', false));
         expect(node.visibility.web.memberSegment).toBe('status:free');
+    });
+
+    it('does not read or mutate visibility for a non-card node', () => {
+        const getVisibility = vi.fn();
+        const setVisibility = vi.fn();
+        Object.defineProperty(node, 'visibility', {
+            configurable: true,
+            get: getVisibility,
+            set: setVisibility
+        });
+        koenigMocks.$isKoenigCard.mockReturnValue(false);
+
+        const {result} = renderHook(() => useVisibilityToggle(editor, 'testKey', cardConfig));
+
+        expect(getVisibility).not.toHaveBeenCalled();
+        act(() => result.current.toggleVisibility('web', 'nonMembers', false));
+        expect(getVisibility).not.toHaveBeenCalled();
+        expect(setVisibility).not.toHaveBeenCalled();
     });
 
     it('returns only web options when email visibility is disabled in cardConfig', () => {

--- a/koenig/koenig-lexical/test/unit/hooks/useVisibilityToggle.test.ts
+++ b/koenig/koenig-lexical/test/unit/hooks/useVisibilityToggle.test.ts
@@ -18,6 +18,10 @@ vi.mock(import('lexical'), async (importOriginal) => {
     };
 });
 
+vi.mock(import('@tryghost/kg-default-nodes'), () => ({
+    $isKoenigCard: node => Boolean(node)
+}));
+
 describe('useVisibilityToggle', () => {
     let editor;
     let node;

--- a/koenig/koenig-lexical/test/unit/utils/imageUploadHandler.test.ts
+++ b/koenig/koenig-lexical/test/unit/utils/imageUploadHandler.test.ts
@@ -1,0 +1,59 @@
+import {$getNodeByKey} from 'lexical';
+import {expect, vi} from 'vitest';
+import {getImageDimensions} from '../../../src/utils/getImageDimensions';
+import {imageUploadHandler} from '../../../src/utils/imageUploadHandler';
+
+const koenigMocks = vi.hoisted(() => ({
+    $isKoenigCard: vi.fn()
+}));
+
+vi.mock(import('lexical'), async (importOriginal) => {
+    const actual = await importOriginal();
+
+    return {
+        ...actual,
+        $getNodeByKey: vi.fn()
+    };
+});
+
+vi.mock(import('@tryghost/kg-default-nodes'), () => ({
+    $isKoenigCard: koenigMocks.$isKoenigCard
+}));
+
+vi.mock(import('../../../src/utils/getImageDimensions'), () => ({
+    getImageDimensions: vi.fn()
+}));
+
+describe('imageUploadHandler', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.mocked($getNodeByKey).mockReset();
+        vi.mocked(getImageDimensions).mockReset();
+        koenigMocks.$isKoenigCard.mockReset();
+        vi.unstubAllGlobals();
+    });
+
+    it('does not prepare or upload an image when the target is not a card', async () => {
+        const node = {};
+        const createObjectURL = vi.fn();
+        const upload = vi.fn();
+        const update = vi.fn();
+        const editor = {
+            getEditorState: vi.fn(() => ({
+                read: vi.fn(callback => callback())
+            })),
+            update
+        };
+        vi.mocked($getNodeByKey).mockReturnValue(node);
+        koenigMocks.$isKoenigCard.mockReturnValue(false);
+        vi.stubGlobal('URL', {createObjectURL});
+
+        await imageUploadHandler([{}], 'test-key', editor, upload);
+
+        expect(koenigMocks.$isKoenigCard).toHaveBeenCalledWith(node);
+        expect(createObjectURL).not.toHaveBeenCalled();
+        expect(getImageDimensions).not.toHaveBeenCalled();
+        expect(upload).not.toHaveBeenCalled();
+        expect(update).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
no issue

## What changed

- Replaced the generated decorator node's `WidenLiteral` and synthetic base-class typing with a keyed property map and data types derived directly from that map.
- Simplified each `kg-default-nodes` definition so property names, defaults, serialization, cloning, and generated accessors share one source of truth.
- Kept the unavoidable dynamic implementation typing inside the generator while preserving strongly typed generated node APIs for callers.
- Strengthened `$isKoenigCard` into the common runtime type guard and used it at editor lookup and upload-handler boundaries instead of repeating assertions.

## Why

The remaining Koenig TypeScript migration phases build on these node contracts. Landing the reusable simplification first reduces migration-only scaffolding, makes the generated API easier to understand, and avoids carrying redundant assertions through later conversions.

This deliberately leaves constructor and command annotations that depend on later migrated editor files on the whole-migration branch.
