### PR TITLE
Changed lazy URL compare reports to carry the caller frames as the stack

### DIFF
--- a/ghost/core/core/server/services/url/url-service-facade.ts
+++ b/ghost/core/core/server/services/url/url-service-facade.ts
@@ -290,28 +290,43 @@ export class UrlServiceFacade {
         isEqual: (a: unknown, b: unknown) => boolean
     ): void {
         if (!isEqual(eagerValue, lazyValue)) {
-            this._report(new errors.InternalServerError({
+            const {caller, ...details} = context;
+            const report = new errors.InternalServerError({
                 message: 'URL service parity mismatch',
                 code: 'LAZY_URL_PARITY_MISMATCH',
-                errorDetails: {method, eager: eagerValue, lazy: lazyValue, ...context}
-            }));
+                errorDetails: {method, eager: eagerValue, lazy: lazyValue, ...details}
+            });
+            this._applyCallerStack(report, caller);
+            this._report(report);
         }
     }
 
     private _reportLazyError(method: string, err: Error, context: Record<string, unknown>): void {
+        const {caller, ...details} = context;
         const report = new errors.InternalServerError({
             message: 'Lazy URL service threw during comparison',
             code: 'LAZY_URL_COMPARE_ERROR',
             err,
-            errorDetails: {method, ...context}
+            errorDetails: {method, ...details}
         });
         // @tryghost/errors copies the wrapped error's enumerable props over the
         // new error, so a thrown error carrying its own errorDetails (e.g. the
         // thin-resource report) silently clobbers the compare context passed
         // above. Re-merge after construction so both survive in the logs.
         const innerDetails = (err as {errorDetails?: Record<string, unknown>}).errorDetails;
-        report.errorDetails = {method, ...context, ...innerDetails};
+        report.errorDetails = {method, ...details, ...innerDetails};
+        this._applyCallerStack(report, caller);
         this._report(report);
+    }
+
+    // The report's own stack is setImmediate scaffolding — the caller frames
+    // captured at call time are the stack worth logging.
+    private _applyCallerStack(report: Error, caller: unknown): void {
+        if (typeof caller !== 'string') {
+            return;
+        }
+        const frames = caller.split('\n').slice(1).join('\n');
+        report.stack = `${report.name}: ${report.message}\n${frames}`;
     }
 
     private _report(error: Error): void {

--- a/ghost/core/test/unit/server/services/url/url-service-facade.test.js
+++ b/ghost/core/test/unit/server/services/url/url-service-facade.test.js
@@ -265,39 +265,42 @@ describe('UrlServiceFacade', function () {
             lazyUrlService.getUrlForResource.throws(thinError);
             compareFacade.getUrlForResource({type: 'posts', id: 'a', slug: 'hello'});
             await flush();
-            const details = logging.error.firstCall.args[0].errorDetails;
-            assert.equal(details.resourceType, 'posts');
-            assert.deepEqual(details.missing, ['tags']);
-            assert.equal(details.method, 'getUrlForResource');
-            assert.match(details.caller, /url-service-facade\.test\.js/);
-            assert.deepEqual(details.resourceKeys, ['type', 'id', 'slug']);
+            const report = logging.error.firstCall.args[0];
+            assert.equal(report.errorDetails.resourceType, 'posts');
+            assert.deepEqual(report.errorDetails.missing, ['tags']);
+            assert.equal(report.errorDetails.method, 'getUrlForResource');
+            assert.match(report.stack, /url-service-facade\.test\.js/);
+            assert.deepEqual(report.errorDetails.resourceKeys, ['type', 'id', 'slug']);
         });
 
-        it('reports the caller stack and resource keys with a lazy throw from getUrlForResource', async function () {
+        it('replaces the report stack with the caller frames on a lazy throw', async function () {
             lazyUrlService.getUrlForResource.throws(new Error('boom'));
             compareFacade.getUrlForResource({type: 'posts', id: 'a', slug: 'hello'});
             await flush();
-            const details = logging.error.firstCall.args[0].errorDetails;
-            // The compare runs in setImmediate, so the throw's own stack has no
-            // caller frames; the facade captures them at call time instead.
-            assert.match(details.caller, /url-service-facade\.test\.js/);
-            assert.deepEqual(details.resourceKeys, ['type', 'id', 'slug']);
+            const report = logging.error.firstCall.args[0];
+            assert.match(report.stack, /^InternalServerError: Lazy URL service threw during comparison\n/);
+            assert.match(report.stack, /url-service-facade\.test\.js/);
+            assert.equal(report.errorDetails.caller, undefined);
+            assert.deepEqual(report.errorDetails.resourceKeys, ['type', 'id', 'slug']);
         });
 
-        it('reports the caller stack and resource keys with a forward URL mismatch', async function () {
+        it('replaces the report stack with the caller frames on a forward URL mismatch', async function () {
             compareFacade.getUrlForResource({type: 'posts', id: 'a', slug: 'hello'});
             await flush();
-            const details = logging.error.firstCall.args[0].errorDetails;
-            assert.match(details.caller, /url-service-facade\.test\.js/);
-            assert.deepEqual(details.resourceKeys, ['type', 'id', 'slug']);
+            const report = logging.error.firstCall.args[0];
+            assert.match(report.stack, /^InternalServerError: URL service parity mismatch\n/);
+            assert.match(report.stack, /url-service-facade\.test\.js/);
+            assert.equal(report.errorDetails.caller, undefined);
+            assert.deepEqual(report.errorDetails.resourceKeys, ['type', 'id', 'slug']);
         });
 
-        it('reports the caller stack and resource keys with an ownership mismatch', async function () {
+        it('replaces the report stack with the caller frames on an ownership mismatch', async function () {
             compareFacade.ownsResource('routerA', {type: 'posts', id: 'a', status: 'published'});
             await flush();
-            const details = logging.error.firstCall.args[0].errorDetails;
-            assert.match(details.caller, /url-service-facade\.test\.js/);
-            assert.deepEqual(details.resourceKeys, ['type', 'id', 'status']);
+            const report = logging.error.firstCall.args[0];
+            assert.match(report.stack, /url-service-facade\.test\.js/);
+            assert.equal(report.errorDetails.caller, undefined);
+            assert.deepEqual(report.errorDetails.resourceKeys, ['type', 'id', 'status']);
         });
 
         it('resolveUrl returns the eager answer without awaiting lazy', async function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1822

Follow-up to #29301. The caller frames captured at call time were attached as `errorDetails.caller`, where log tooling doesn't surface them — the report's top-level `stack` stayed useless (setImmediate scaffolding, or the wrapped throw's stack, which `@tryghost/errors` copies over and is equally rootless since the throw happens inside the deferred comparison).

The captured frames now become the report's `stack` property (with a proper `InternalServerError: <message>` header) and leave `errorDetails`, so log aggregators display and group the caller like any other error stack. Applies to both `LAZY_URL_COMPARE_ERROR` and `LAZY_URL_PARITY_MISMATCH`; async `resolveUrl` comparisons have no capture and keep their natural stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)