### PR TITLE
Added a React member detail screen behind a Labs flag

### DIFF
--- a/apps/admin-x-framework/src/api/members.ts
+++ b/apps/admin-x-framework/src/api/members.ts
@@ -1,4 +1,4 @@
-import {InfiniteData, useQueryClient} from '@tanstack/react-query';
+import {InfiniteData, useIsFetching, useQueryClient} from '@tanstack/react-query';
 import {useEffect} from 'react';
 import {Meta, createInfiniteQuery, createMutation, createQuery, createQueryWithId} from '../utils/api/hooks';
 import {apiUrl} from '../utils/api/fetch-api';
@@ -16,6 +16,9 @@ export type MemberTier = {
     slug: string;
     active: boolean;
     type: string;
+    // Populated for complimentary / gift subscriptions; the tier expiry the admin
+    // set when the comp was created, or the gift expiry from the redemption.
+    expiry_at?: string | null;
 };
 
 export type MemberNewsletter = {
@@ -27,6 +30,11 @@ export type MemberNewsletter = {
 };
 
 export type MemberSubscription = {
+    // Complimentary and gift subscriptions arrive from the members BREAD service
+    // with `id: ''` — they're synthesised from the member's tier and carry no
+    // Stripe subscription id. Paid ones always have a real Stripe id. The Ember
+    // screen classifies via `!sub.id` (empty-string is falsy) combined with the
+    // plan nickname.
     id: string;
     customer: {
         id: string;
@@ -44,6 +52,9 @@ export type MemberSubscription = {
     start_date: string;
     current_period_end: string;
     cancel_at_period_end: boolean;
+    // Populated for subscriptions currently in a Stripe trial; used to render
+    // "Free trial" + "Ends <date>" copy without leaning on the paid-price branch.
+    trial_end_at?: string | null;
     price: {
         id: string;
         price_id: string;
@@ -57,6 +68,15 @@ export type MemberSubscription = {
     offer: {
         id: string;
         name: string;
+    } | null;
+    attribution?: {
+        id?: string | null;
+        type?: string | null;
+        url?: string | null;
+        title?: string | null;
+        referrer_source?: string | null;
+        referrer_medium?: string | null;
+        referrer_url?: string | null;
     } | null;
 };
 
@@ -81,6 +101,15 @@ export type Member = {
     // TODO: The server returns geolocation as a JSON-encoded string (not a parsed object).
     // Long term we should parse this on the server side and return a proper object.
     geolocation?: string | null;
+    attribution?: {
+        id?: string | null;
+        type?: string | null;
+        url?: string | null;
+        title?: string | null;
+        referrer_source?: string | null;
+        referrer_medium?: string | null;
+        referrer_url?: string | null;
+    } | null;
     email_suppression?: {
         suppressed: boolean;
         info?: {
@@ -112,6 +141,17 @@ const memberCountSearchParams = {limit: '1'} as const;
 
 export const getMemberCountQueryKey = () => [dataType, apiUrl(membersPath, memberCountSearchParams)] as const;
 
+/**
+ * True while any member query is in flight. Callers use this to hold a control
+ * disabled across the refetch a mutation invalidates, so it can't be fired
+ * again against state the screen hasn't re-rendered yet.
+ *
+ * Lives here because `dataType` is private to this module: reading the key from
+ * a consumer means hand-copying the string, which then breaks silently and
+ * without a type error if it ever changes.
+ */
+export const useMembersFetching = () => useIsFetching({queryKey: [dataType]}) > 0;
+
 export const useBrowseMembers = createQuery<MembersResponseType>({
     dataType,
     path: membersPath
@@ -132,6 +172,15 @@ export function useMemberCount() {
 export type NewMember = {
     email: string;
     name?: string | null;
+    note?: string | null;
+    // Matched/created by name on the server, same as the edit payload.
+    labels?: Array<{name: string; slug?: string}>;
+    // Explicit initial subscription set. When omitted, the server falls back
+    // to `subscribe_on_signup:true + visibility:members` newsletters
+    // (`member-repository.js:460-464`). The Ember admin sends the same set
+    // explicitly so the outcome doesn't drift if the server-side default
+    // ever changes; the React admin now matches.
+    newsletters?: Array<{id: string}>;
 };
 
 export const useAddMember = createMutation<MembersResponseType, NewMember>({
@@ -421,3 +470,192 @@ export const useBulkDeleteMembers = createMutation<
     searchParams: buildBulkMemberSearchParams,
     invalidateQueries: {dataType}
 });
+
+// -----------------------------------------------------------------------------
+// Single-member detail-screen operations
+// -----------------------------------------------------------------------------
+
+// Labels are matched/created by name+slug, newsletters and tiers by id. `tiers`
+// carries complimentary-subscription assignments (with optional expiry); passing
+// a shorter list removes the omitted comp tiers. `include=tiers` mirrors the
+// Ember save so the response carries the refreshed tier list.
+export interface EditMemberData {
+    id: string;
+    name?: string;
+    email?: string;
+    note?: string | null;
+    subscribed?: boolean;
+    labels?: Array<{name: string; slug?: string}>;
+    newsletters?: Array<{id: string}>;
+    tiers?: Array<{id: string; expiry_at?: string | null}>;
+}
+
+export const useEditMember = createMutation<MembersResponseType, EditMemberData>({
+    method: 'PUT',
+    path: ({id}) => `/members/${id}/`,
+    defaultSearchParams: {include: 'tiers'},
+    body: ({id, ...rest}) => ({members: [{id, ...rest}]}),
+    invalidateQueries: {dataType}
+});
+
+export const useDeleteMember = createMutation<void, {id: string; cancel?: boolean}>({
+    method: 'DELETE',
+    path: ({id}) => `/members/${id}/`,
+    searchParams: ({cancel}) => ({cancel: cancel ? 'true' : 'false'}),
+    invalidateQueries: {dataType}
+});
+
+export interface MemberSigninUrlResponseType {
+    member_id: string;
+    url: string;
+}
+
+// The Admin API wraps the controller payload in the `member_signin_urls` array
+// envelope (see `member-signin-urls.js` + framework serializer). Unwrap here so
+// consumers get the flat `{member_id, url}` object they actually want.
+export const getMemberSigninUrl = createQueryWithId<MemberSigninUrlResponseType>({
+    dataType: 'MemberSigninUrlResponseType',
+    path: id => `/members/${id}/signin_urls/`,
+    returnData: (originalData) => {
+        const envelope = originalData as {member_signin_urls?: MemberSigninUrlResponseType[]};
+        return envelope.member_signin_urls?.[0] ?? {member_id: '', url: ''};
+    }
+});
+
+export const useMemberLogout = createMutation<void, {id: string}>({
+    method: 'DELETE',
+    path: ({id}) => `/members/${id}/sessions/`,
+    invalidateQueries: {dataType}
+});
+
+// cancel_at_period_end true=cancel / false=continue; status:'canceled' is used by
+// the complimentary flow to end an active paid subscription before comping.
+// The two are mutually exclusive — either you're toggling the soft cancel flag OR
+// you're hard-canceling. A discriminated union prevents callers from accidentally
+// setting both at once (which the request body would silently send together).
+interface EditMemberSubscriptionBase {
+    memberId: string;
+    subscriptionId: string;
+}
+export type EditMemberSubscriptionData =
+    | (EditMemberSubscriptionBase & {cancelAtPeriodEnd: boolean; status?: undefined})
+    | (EditMemberSubscriptionBase & {status: 'canceled'; cancelAtPeriodEnd?: undefined});
+
+export const useEditMemberSubscription = createMutation<MembersResponseType, EditMemberSubscriptionData>({
+    method: 'PUT',
+    path: ({memberId, subscriptionId}) => `/members/${memberId}/subscriptions/${subscriptionId}/`,
+    body: ({cancelAtPeriodEnd, status}) => ({
+        ...(cancelAtPeriodEnd !== undefined ? {cancel_at_period_end: cancelAtPeriodEnd} : {}),
+        ...(status ? {status} : {})
+    }),
+    invalidateQueries: {dataType}
+});
+
+export const useRemoveMemberEmailSuppression = createMutation<void, {id: string}>({
+    method: 'DELETE',
+    path: ({id}) => `/members/${id}/suppression/`,
+    invalidateQueries: {dataType}
+});
+
+// -----------------------------------------------------------------------------
+// Per-member activity feed (GET /members/events)
+// -----------------------------------------------------------------------------
+
+export interface MemberActivityEventMember {
+    id: string;
+    uuid: string;
+    name: string | null;
+    email: string;
+    avatar_image: string | null;
+}
+
+// The feed returns heterogeneous event types (signup, subscription, email,
+// click, comment, feedback, …); `data` is narrowed per-type at the render layer.
+// `data.created_at` is the pagination cursor field and is present on every event.
+export interface MemberActivityEvent {
+    type: string;
+    data: {
+        created_at?: string;
+        member?: MemberActivityEventMember | null;
+        [key: string]: unknown;
+    };
+}
+
+export interface MemberActivityFeedResponseType {
+    events: MemberActivityEvent[];
+    meta?: Meta;
+}
+
+export interface MemberActivityFeedInfiniteResponseType extends MemberActivityFeedResponseType {
+    isEnd: boolean;
+}
+
+const MEMBER_ACTIVITY_LIMIT = '20';
+
+// The events endpoint paginates by cursor rather than page number: each request
+// asks for events older than a UTC `YYYY-MM-DD HH:mm:ss` timestamp taken from the
+// last event of the previous page (events are ordered created_at desc).
+//
+// KNOWN LIMITATION: the cursor is `created_at`-only, without the id tie-breaker
+// Ember's version added (`+id:<'<lastId>'`). Two events emitted in the same
+// second on a page boundary can be skipped from the paginated list. The current
+// consumer (`MemberActivityFeed` in `apps/posts`) only fetches 5 events and
+// never calls `fetchNextPage`, so this is not exploitable today; add an id
+// secondary cursor before another screen starts paginating.
+function memberEventsCursor(events: MemberActivityEvent[]): string | undefined {
+    const createdAt = events[events.length - 1]?.data?.created_at;
+    if (!createdAt) {
+        return undefined;
+    }
+    return new Date(createdAt).toISOString().slice(0, 19).replace('T', ' ');
+}
+
+function buildMemberEventsFilter(memberId: string): string {
+    return `data.member_id:'${memberId}'`;
+}
+
+const useMemberActivityFeedQuery = createInfiniteQuery<MemberActivityFeedInfiniteResponseType>({
+    dataType: 'MemberActivityFeedResponseType',
+    path: '/members/events/',
+    defaultSearchParams: {limit: MEMBER_ACTIVITY_LIMIT},
+    defaultNextPageParams: (lastPage, otherParams) => {
+        const limit = Number(otherParams.limit ?? MEMBER_ACTIVITY_LIMIT);
+        const cursor = memberEventsCursor(lastPage.events);
+        // Stop when the last page wasn't full or we can't advance the cursor.
+        if (!cursor || lastPage.events.length < limit) {
+            return undefined;
+        }
+        // otherParams.filter is the base member filter (no cursor) — rebuild with it.
+        return {
+            ...otherParams,
+            filter: `data.created_at:<'${cursor}'+${otherParams.filter ?? ''}`
+        };
+    },
+    returnData: (originalData) => {
+        const {pages} = originalData as InfiniteData<MemberActivityFeedResponseType>;
+        const events = pages.flatMap(page => page.events);
+        const lastPage = pages[pages.length - 1];
+        // Use the actual page limit echoed back in the server-side pagination
+        // meta so callers that override the default (e.g. `useMemberActivityFeed`
+        // passes `limit: '5'` for the sidebar preview) don't get a premature
+        // `isEnd=true` on a full page of results.
+        const paginationLimit = lastPage?.meta?.pagination?.limit;
+        const effectiveLimit = typeof paginationLimit === 'number' ? paginationLimit : Number(MEMBER_ACTIVITY_LIMIT);
+        return {
+            events,
+            meta: lastPage?.meta,
+            isEnd: (lastPage?.events.length ?? 0) < effectiveLimit
+        };
+    }
+});
+
+export function useMemberActivityFeed(memberId: string, options: {enabled?: boolean; limit?: string} = {}) {
+    const {limit = MEMBER_ACTIVITY_LIMIT, enabled} = options;
+    return useMemberActivityFeedQuery({
+        searchParams: {
+            filter: buildMemberEventsFilter(memberId),
+            limit
+        },
+        ...(enabled !== undefined ? {enabled} : {})
+    });
+}

--- a/apps/admin-x-framework/test/unit/api/members.test.tsx
+++ b/apps/admin-x-framework/test/unit/api/members.test.tsx
@@ -2,8 +2,8 @@ import {act, waitFor} from '@testing-library/react';
 import {describe, expect, it, vi} from 'vitest';
 import {currentUserQueryKey} from '../../../src/api/current-user';
 import {createTestQueryClient, renderHookWithProviders} from '../../../src/test/test-utils';
-import {getMemberCountQueryKey, useAddMember, useBrowseMembersInfinite, useBulkDeleteMembers, useImportMembers, useMemberCount} from '../../../src/api/members';
-import type {MembersInfiniteResponseType, MembersResponseType} from '../../../src/api/members';
+import {getMemberCountQueryKey, getMemberSigninUrl, useAddMember, useBrowseMembersInfinite, useBulkDeleteMembers, useDeleteMember, useEditMember, useEditMemberSubscription, useImportMembers, useMemberActivityFeed, useMemberCount, useMemberLogout, useRemoveMemberEmailSuppression} from '../../../src/api/members';
+import type {MemberActivityEvent, MembersInfiniteResponseType, MembersResponseType} from '../../../src/api/members';
 import {withMockFetch} from '../../utils/mock-fetch';
 
 const memberCountKey = getMemberCountQueryKey();
@@ -320,5 +320,215 @@ describe('members api', () => {
         await browseMembers({queryClient});
 
         expect(queryClient.getQueryData<MembersResponseType>(memberCountKey)).toBeUndefined();
+    });
+
+    describe('member detail operations', () => {
+        const apiRoot = 'http://localhost:3000/ghost/api/admin';
+
+        it('edits a member with the members envelope and includes tiers', async () => {
+            const queryClient = createTestQueryClient();
+            seedMemberCount(queryClient);
+
+            await withMockFetch({json: {members: [{id: 'member-1'}]}}, async (mock) => {
+                const {result} = renderHookWithProviders(() => useEditMember(), {queryClient});
+
+                await act(async () => {
+                    await result.current.mutateAsync({
+                        id: 'member-1',
+                        name: 'Jamie',
+                        note: 'VIP',
+                        labels: [{name: 'VIP', slug: 'vip'}],
+                        newsletters: [{id: 'newsletter-1'}]
+                    });
+                });
+
+                expect(mock.calls[0][0].toString()).toBe(`${apiRoot}/members/member-1/?include=tiers`);
+                expect(mock.calls[0][1].method).toBe('PUT');
+                expect(JSON.parse(mock.calls[0][1].body)).toEqual({
+                    members: [{
+                        id: 'member-1',
+                        name: 'Jamie',
+                        note: 'VIP',
+                        labels: [{name: 'VIP', slug: 'vip'}],
+                        newsletters: [{id: 'newsletter-1'}]
+                    }]
+                });
+
+                await waitFor(() => expectQueryInvalidation(queryClient, 'MembersResponseType', true));
+            });
+        });
+
+        it('deletes a member and cancels Stripe subscriptions when requested', async () => {
+            const queryClient = createTestQueryClient();
+            seedMemberCount(queryClient);
+
+            await withMockFetch({json: {}}, async (mock) => {
+                const {result} = renderHookWithProviders(() => useDeleteMember(), {queryClient});
+
+                await act(async () => {
+                    await result.current.mutateAsync({id: 'member-1', cancel: true});
+                });
+
+                expect(mock.calls[0][0].toString()).toBe(`${apiRoot}/members/member-1/?cancel=true`);
+                expect(mock.calls[0][1].method).toBe('DELETE');
+                await waitFor(() => expectQueryInvalidation(queryClient, 'MembersResponseType', true));
+            });
+        });
+
+        it('deletes a member without cancelling Stripe subscriptions by default', async () => {
+            const queryClient = createTestQueryClient();
+            seedMemberCount(queryClient);
+
+            await withMockFetch({json: {}}, async (mock) => {
+                const {result} = renderHookWithProviders(() => useDeleteMember(), {queryClient});
+
+                await act(async () => {
+                    await result.current.mutateAsync({id: 'member-1', cancel: false});
+                });
+
+                expect(mock.calls[0][0].toString()).toBe(`${apiRoot}/members/member-1/?cancel=false`);
+            });
+        });
+
+        it('reads a member signin url for impersonation', async () => {
+            const queryClient = createQueryClientWithCurrentUser();
+
+            // The Admin API wraps the payload in a `member_signin_urls` envelope,
+            // matching the framework serializer. The hook must unwrap it so
+            // consumers get the flat object.
+            await withMockFetch({json: {member_signin_urls: [{member_id: 'member-1', url: 'https://example.com/magic'}]}}, async (mock) => {
+                const {result} = renderHookWithProviders(() => getMemberSigninUrl('member-1'), {queryClient});
+
+                await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+                expect(mock.calls[0][0].toString()).toBe(`${apiRoot}/members/member-1/signin_urls/`);
+                expect(result.current.data).toEqual({member_id: 'member-1', url: 'https://example.com/magic'});
+            });
+        });
+
+        it('signs out all sessions for a member', async () => {
+            const queryClient = createTestQueryClient();
+            seedMemberCount(queryClient);
+
+            await withMockFetch({json: {}}, async (mock) => {
+                const {result} = renderHookWithProviders(() => useMemberLogout(), {queryClient});
+
+                await act(async () => {
+                    await result.current.mutateAsync({id: 'member-1'});
+                });
+
+                expect(mock.calls[0][0].toString()).toBe(`${apiRoot}/members/member-1/sessions/`);
+                expect(mock.calls[0][1].method).toBe('DELETE');
+                await waitFor(() => expectQueryInvalidation(queryClient, 'MembersResponseType', true));
+            });
+        });
+
+        it('cancels a subscription at period end', async () => {
+            const queryClient = createTestQueryClient();
+            seedMemberCount(queryClient);
+
+            await withMockFetch({json: {members: [{id: 'member-1'}]}}, async (mock) => {
+                const {result} = renderHookWithProviders(() => useEditMemberSubscription(), {queryClient});
+
+                await act(async () => {
+                    await result.current.mutateAsync({memberId: 'member-1', subscriptionId: 'sub_1', cancelAtPeriodEnd: true});
+                });
+
+                expect(mock.calls[0][0].toString()).toBe(`${apiRoot}/members/member-1/subscriptions/sub_1/`);
+                expect(mock.calls[0][1].method).toBe('PUT');
+                expect(JSON.parse(mock.calls[0][1].body)).toEqual({cancel_at_period_end: true});
+                await waitFor(() => expectQueryInvalidation(queryClient, 'MembersResponseType', true));
+            });
+        });
+
+        it('continues a subscription that was set to cancel', async () => {
+            const queryClient = createTestQueryClient();
+            seedMemberCount(queryClient);
+
+            await withMockFetch({json: {members: [{id: 'member-1'}]}}, async (mock) => {
+                const {result} = renderHookWithProviders(() => useEditMemberSubscription(), {queryClient});
+
+                await act(async () => {
+                    await result.current.mutateAsync({memberId: 'member-1', subscriptionId: 'sub_1', cancelAtPeriodEnd: false});
+                });
+
+                expect(JSON.parse(mock.calls[0][1].body)).toEqual({cancel_at_period_end: false});
+            });
+        });
+
+        it('immediately cancels a subscription for the complimentary flow', async () => {
+            const queryClient = createTestQueryClient();
+            seedMemberCount(queryClient);
+
+            await withMockFetch({json: {members: [{id: 'member-1'}]}}, async (mock) => {
+                const {result} = renderHookWithProviders(() => useEditMemberSubscription(), {queryClient});
+
+                await act(async () => {
+                    await result.current.mutateAsync({memberId: 'member-1', subscriptionId: 'sub_1', status: 'canceled'});
+                });
+
+                expect(JSON.parse(mock.calls[0][1].body)).toEqual({status: 'canceled'});
+            });
+        });
+
+        it('removes a member from the email suppression list', async () => {
+            const queryClient = createTestQueryClient();
+            seedMemberCount(queryClient);
+
+            await withMockFetch({json: {}}, async (mock) => {
+                const {result} = renderHookWithProviders(() => useRemoveMemberEmailSuppression(), {queryClient});
+
+                await act(async () => {
+                    await result.current.mutateAsync({id: 'member-1'});
+                });
+
+                expect(mock.calls[0][0].toString()).toBe(`${apiRoot}/members/member-1/suppression/`);
+                expect(mock.calls[0][1].method).toBe('DELETE');
+                await waitFor(() => expectQueryInvalidation(queryClient, 'MembersResponseType', true));
+            });
+        });
+
+        it('fetches a member activity feed filtered by member id', async () => {
+            const queryClient = createQueryClientWithCurrentUser();
+            const events: MemberActivityEvent[] = [
+                {type: 'signup_event', data: {created_at: '2024-01-02T10:00:00.000Z'}}
+            ];
+
+            await withMockFetch({json: {events}}, async (mock) => {
+                const {result} = renderHookWithProviders(() => useMemberActivityFeed('member-1'), {queryClient});
+
+                await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+                const url = new URL(mock.calls[0][0].toString());
+                expect(url.pathname).toBe('/ghost/api/admin/members/events/');
+                expect(url.searchParams.get('filter')).toBe("data.member_id:'member-1'");
+                expect(url.searchParams.get('limit')).toBe('20');
+                expect(result.current.data?.events).toEqual(events);
+                expect(result.current.data?.isEnd).toBe(true);
+            });
+        });
+
+        it('advances the activity feed cursor from the last event', async () => {
+            const queryClient = createQueryClientWithCurrentUser();
+            // A full page (20 events) so another page is requested; cursor comes from the last one.
+            const events: MemberActivityEvent[] = Array.from({length: 20}, (_, i) => ({
+                type: 'signup_event',
+                data: {created_at: `2024-01-02T10:00:${String(i).padStart(2, '0')}.000Z`}
+            }));
+
+            await withMockFetch({json: {events}}, async (mock) => {
+                const {result} = renderHookWithProviders(() => useMemberActivityFeed('member-1'), {queryClient});
+
+                await waitFor(() => expect(result.current.isSuccess).toBe(true));
+                expect(result.current.hasNextPage).toBe(true);
+
+                await act(async () => {
+                    await result.current.fetchNextPage();
+                });
+
+                const nextUrl = new URL(mock.calls[1][0].toString());
+                expect(nextUrl.searchParams.get('filter')).toBe("data.created_at:<'2024-01-02 10:00:19'+data.member_id:'member-1'");
+            });
+        });
     });
 });

--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -71,6 +71,10 @@ const features: Feature[] = [{
     title: 'Get helper deduplication',
     description: 'Deduplicate identical {{#get}} helper queries within a single request to avoid redundant database calls',
     flag: 'getHelperDeduplication'
+}, {
+    title: 'React member details',
+    description: 'Renders the member detail screen (/members/:id) from the React app instead of the Ember screen. Gates the migration behind a runtime toggle so we can compare both implementations.',
+    flag: 'memberDetailsReact'
 }];
 
 const AlphaFeatures: React.FC = () => {

--- a/apps/admin/src/member-detail-gate.test.tsx
+++ b/apps/admin/src/member-detail-gate.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import {MemberDetailGate} from './member-detail-gate';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {render, screen, waitFor} from '@testing-library/react';
+
+const {mockUseBrowseConfig} = vi.hoisted(() => ({
+    mockUseBrowseConfig: vi.fn()
+}));
+
+vi.mock('@tryghost/admin-x-framework/api/config', () => ({
+    useBrowseConfig: mockUseBrowseConfig
+}));
+
+vi.mock('./ember-bridge', () => ({
+    EmberFallback: () => React.createElement('div', {'data-testid': 'ember-fallback'})
+}));
+
+vi.mock('./members/detail/member-detail', () => ({
+    default: () => React.createElement('div', {'data-testid': 'react-member-detail'})
+}));
+
+const configResult = (overrides: Record<string, unknown>) => ({
+    data: undefined,
+    isError: false,
+    isLoading: false,
+    ...overrides
+});
+
+const withLabs = (labs: Record<string, boolean>) => configResult({data: {config: {labs}}});
+
+describe('MemberDetailGate', () => {
+    beforeEach(() => {
+        mockUseBrowseConfig.mockReset();
+    });
+
+    it('renders Ember while the flag is off', () => {
+        mockUseBrowseConfig.mockReturnValue(withLabs({memberDetailsReact: false}));
+
+        render(<MemberDetailGate />);
+
+        expect(screen.getByTestId('ember-fallback')).toBeInTheDocument();
+    });
+
+    it('renders React while the flag is on', async () => {
+        mockUseBrowseConfig.mockReturnValue(withLabs({memberDetailsReact: true}));
+
+        render(<MemberDetailGate />);
+
+        // The React screen is lazily imported, so it arrives a tick later.
+        await waitFor(() => {
+            expect(screen.getByTestId('react-member-detail')).toBeInTheDocument();
+        });
+    });
+
+    it('renders Ember when the flag is absent from config', () => {
+        mockUseBrowseConfig.mockReturnValue(withLabs({}));
+
+        render(<MemberDetailGate />);
+
+        expect(screen.getByTestId('ember-fallback')).toBeInTheDocument();
+    });
+
+    it('renders Ember when the config query fails', () => {
+        // A failed config read must not blank the screen — Ember owns this URL
+        // by default and still serves it, so degrading to Ember keeps the
+        // member detail working. Reporting is left to the framework's default
+        // error handler on useBrowseConfig.
+        mockUseBrowseConfig.mockReturnValue(configResult({isError: true, data: undefined}));
+
+        render(<MemberDetailGate />);
+
+        expect(screen.getByTestId('ember-fallback')).toBeInTheDocument();
+    });
+
+    it('renders Ember when the config query resolves with no data', () => {
+        mockUseBrowseConfig.mockReturnValue(configResult({data: undefined}));
+
+        render(<MemberDetailGate />);
+
+        expect(screen.getByTestId('ember-fallback')).toBeInTheDocument();
+    });
+
+    it('renders nothing while config is loading', () => {
+        // Deliberately not falling back to Ember here: doing so would un-hide
+        // the Ember shell and flash the old screen on every cold load for
+        // admins who have the flag on.
+        mockUseBrowseConfig.mockReturnValue(configResult({isLoading: true}));
+
+        const {container} = render(<MemberDetailGate />);
+
+        expect(screen.queryByTestId('ember-fallback')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('react-member-detail')).not.toBeInTheDocument();
+        expect(container).toBeEmptyDOMElement();
+    });
+});

--- a/apps/admin/src/member-detail-gate.tsx
+++ b/apps/admin/src/member-detail-gate.tsx
@@ -1,0 +1,48 @@
+import { EmberFallback } from "./ember-bridge";
+import { Suspense, lazy } from "react";
+import { useBrowseConfig } from "@tryghost/admin-x-framework/api/config";
+
+/**
+ * Chooses which implementation serves `/members/:member_id`, based on the
+ * `memberDetailsReact` Labs flag. Read at render time so toggling the flag in
+ * Developer Experiments swaps implementations without a rebuild — the routes
+ * table is static and evaluated once at module load.
+ *
+ * Ember owns this URL unless the flag says otherwise, which makes it the safe
+ * default in every uncertain case: config failed, config came back empty, flag
+ * absent. Only an explicit `true` renders React.
+ *
+ * The one case that is NOT safe to default to Ember is config still loading.
+ * Falling back there would un-hide the Ember shell and flash the Ember screen
+ * on every cold load for admins who have the flag on, so hold for a paint
+ * instead — the config query is normally warm from the admin shell boot.
+ *
+ * Errors are deliberately not reported here: `useBrowseConfig` already routes
+ * them through the framework's default error handler, and the shell calls the
+ * same query, so anything logged here would be a duplicate.
+ */
+const MemberDetailReact = lazy(() => import("./members/detail/member-detail"));
+
+export function MemberDetailGate() {
+    const { data: config, isError, isLoading } = useBrowseConfig();
+
+    if (isLoading) {
+        return null;
+    }
+
+    if (isError || !config) {
+        return <EmberFallback />;
+    }
+
+    if (config.config.labs?.memberDetailsReact !== true) {
+        return <EmberFallback />;
+    }
+
+    return (
+        <Suspense fallback={null}>
+            <MemberDetailReact />
+        </Suspense>
+    );
+}
+
+export default MemberDetailGate;

--- a/apps/admin/src/members/detail/is-safe-href.ts
+++ b/apps/admin/src/members/detail/is-safe-href.ts
@@ -1,0 +1,17 @@
+/**
+ * Only http(s), site-relative (`/...`), and internal hash (`#/...`) URLs are
+ * safe to drop into an anchor `href`. Anything else — most importantly
+ * `javascript:` — is rejected so a crafted attribution URL from the events
+ * endpoint (or a signup Referer) can't turn into click-to-execute in the admin.
+ * React does NOT sanitize `href` for us.
+ *
+ * Extracted so both the activity feed and the member-detail sidebar (which
+ * both render attribution URLs supplied by external signup traffic) validate
+ * against the same rule set.
+ */
+export function isSafeHref(url: string | undefined | null): url is string {
+    if (!url) {
+        return false;
+    }
+    return /^(https?:\/\/|\/|#\/)/i.test(url);
+}

--- a/apps/admin/src/members/detail/member-actions-menu.tsx
+++ b/apps/admin/src/members/detail/member-actions-menu.tsx
@@ -1,0 +1,138 @@
+import MemberDeleteModal from './member-delete-modal';
+import MemberDisableCommentingModal from './member-disable-commenting-modal';
+import MemberImpersonateModal from './member-impersonate-modal';
+import MemberLogoutModal from './member-logout-modal';
+import React from 'react';
+import {Button, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger} from '@tryghost/shade/components';
+import {LucideIcon} from '@tryghost/shade/utils';
+import {canManageMembers} from '@tryghost/admin-x-framework/api/users';
+import {getMemberCommentingActionLabel, isMemberCommentingDisabled} from './member-commenting';
+import {toast} from 'sonner';
+import {useCurrentUser} from '@tryghost/admin-x-framework/api/current-user';
+import {useEnableMemberCommenting, useMembersFetching} from '@tryghost/admin-x-framework/api/members';
+import {useQueryClient} from '@tanstack/react-query';
+import type {Member} from '@tryghost/admin-x-framework/api/members';
+
+interface MemberActionsMenuProps {
+    member: Member;
+    /**
+     * Called just before an action modal navigates the user away (delete →
+     * `/members`) — parent flips its unsaved-changes bypass so the discard
+     * dialog doesn't intercept the redirect for a member that no longer exists.
+     */
+    allowLeaveWithUnsavedChanges: () => void;
+}
+
+/**
+ * The "Actions" gear menu in the member-detail header. Gated on `canManageMembers`
+ * (contributors don't see it) and holds every member-level action modal:
+ * Impersonate, Sign out of all devices, Disable/Enable commenting, Delete member.
+ */
+const MemberActionsMenu: React.FC<MemberActionsMenuProps> = ({member, allowLeaveWithUnsavedChanges}) => {
+    const queryClient = useQueryClient();
+    const {data: currentUser} = useCurrentUser();
+    const [showImpersonate, setShowImpersonate] = React.useState(false);
+    const [showLogout, setShowLogout] = React.useState(false);
+    const [showDisableCommenting, setShowDisableCommenting] = React.useState(false);
+    const [showDelete, setShowDelete] = React.useState(false);
+
+    const enableCommenting = useEnableMemberCommenting();
+    // Stays > 0 through the mutation AND the follow-up members refetch, so a
+    // second click can't fire while the label is still showing "Enable
+    // commenting" from a stale `member` prop.
+    const membersRefetching = useMembersFetching();
+    const commentingBusy = enableCommenting.isPending || (enableCommenting.isSuccess && membersRefetching);
+    const commentingDisabled = isMemberCommentingDisabled(member);
+    const commentingLabel = getMemberCommentingActionLabel(member);
+    const displayName = member.name || member.email || 'this member';
+
+    if (!currentUser || !canManageMembers(currentUser)) {
+        return null;
+    }
+
+    const onCommentingSelect = async () => {
+        // Disable → open the confirm modal (needs the hide-comments checkbox);
+        // Enable → fire directly. Matches Ember `controllers/member.js:200-224`.
+        if (!commentingDisabled) {
+            setShowDisableCommenting(true);
+            return;
+        }
+        try {
+            await enableCommenting.mutateAsync({id: member.id});
+            toast.success(`Commenting has been enabled for ${displayName}.`);
+        } catch {
+            toast.error('Couldn’t enable commenting. Please try again.');
+            return;
+        }
+        // Fire-and-forget the extra members-cache refresh so the menu label
+        // flips back on the next render. Not awaited: a follow-up refetch
+        // failure must NOT flip the toast to an error (the enable itself
+        // succeeded and is already reflected server-side).
+        void queryClient.invalidateQueries({queryKey: ['MembersResponseType']});
+    };
+
+    return (
+        <>
+            <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                    <Button aria-label='Actions' className='size-(--control-height)' data-testid='member-actions' size='icon' variant='outline'>
+                        <LucideIcon.Ellipsis size={16} />
+                    </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align='end'>
+                    <DropdownMenuItem
+                        data-testid='member-actions-impersonate'
+                        onSelect={() => setShowImpersonate(true)}
+                    >
+                        Impersonate
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                        data-testid='member-actions-logout'
+                        onSelect={() => setShowLogout(true)}
+                    >
+                        Sign out of all devices
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                        data-testid='member-actions-commenting'
+                        disabled={commentingBusy}
+                        onSelect={() => void onCommentingSelect()}
+                    >
+                        {commentingLabel}
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                        className='text-destructive focus:text-destructive'
+                        data-testid='member-actions-delete'
+                        onSelect={() => setShowDelete(true)}
+                    >
+                        Delete member
+                    </DropdownMenuItem>
+                </DropdownMenuContent>
+            </DropdownMenu>
+
+            <MemberImpersonateModal
+                memberId={member.id}
+                open={showImpersonate}
+                onOpenChange={setShowImpersonate}
+            />
+            <MemberLogoutModal
+                member={member}
+                open={showLogout}
+                onOpenChange={setShowLogout}
+            />
+            <MemberDisableCommentingModal
+                member={member}
+                open={showDisableCommenting}
+                onOpenChange={setShowDisableCommenting}
+            />
+            <MemberDeleteModal
+                allowLeaveWithUnsavedChanges={allowLeaveWithUnsavedChanges}
+                member={member}
+                open={showDelete}
+                onOpenChange={setShowDelete}
+            />
+        </>
+    );
+};
+
+export default MemberActionsMenu;

--- a/apps/admin/src/members/detail/member-activity-feed.tsx
+++ b/apps/admin/src/members/detail/member-activity-feed.tsx
@@ -1,0 +1,251 @@
+import React from 'react';
+import moment from 'moment-timezone';
+import {Card, CardContent, EmptyIndicator, Skeleton} from '@tryghost/shade/components';
+import {LucideIcon} from '@tryghost/shade/utils';
+import {isSafeHref} from './is-safe-href';
+import {parseMemberEvent} from './member-event';
+import {useMemberActivityFeed} from '@tryghost/admin-x-framework/api/members';
+import type {MemberActivityEvent} from '@tryghost/admin-x-framework/api/members';
+import type {ParsedMemberEvent} from './member-event';
+
+interface MemberActivityFeedProps {
+    // Optional so the create screen (/members/new) can render just the empty
+    // state without a member yet — matches Ember's `activity-feed.hbs:2`,
+    // which short-circuits to `Member::ActivityFeedEmpty` when `@member.isNew`
+    // (there's no member id to fetch events for).
+    memberId?: string;
+    hasMultipleNewsletters: boolean;
+    hasMultipleTiers: boolean;
+    paidMembersEnabled: boolean;
+}
+
+/**
+ * Renders a Lucide substitute for Ember's custom SVG icon names
+ * (`event-signed-up`, `event-comment`, …). Intentional visual approximation
+ * — pixel-perfect rendering lives behind the "View all member activity"
+ * link that routes to Ember. Anything unmapped falls back to the generic
+ * `Activity` icon so a new server-side event type never crashes the row.
+ *
+ * A switch (rather than a `Record<string, React.ComponentType>` map) sidesteps
+ * a repo-wide type-mismatch: React 17 and 18 typings coexist in node_modules,
+ * and Lucide's `ForwardRefExoticComponent` type doesn't fit `React.ElementType`
+ * under that mix. Inline JSX resolves each icon at its use-site, which is what
+ * every other member-detail component already does.
+ */
+const EventIcon: React.FC<{iconName: string}> = ({iconName}) => {
+    const iconProps = {className: 'shrink-0 text-muted-foreground', size: 16};
+    switch (iconName) {
+    case 'event-signed-up': return <LucideIcon.UserPlus {...iconProps} />;
+    case 'event-logged-in': return <LucideIcon.LogIn {...iconProps} />;
+    case 'event-subscriptions': return <LucideIcon.CreditCard {...iconProps} />;
+    case 'event-canceled-subscription': return <LucideIcon.CircleSlash {...iconProps} />;
+    case 'event-subscribed-to-email': return <LucideIcon.MailPlus {...iconProps} />;
+    case 'event-unsubscribed-from-email': return <LucideIcon.MailMinus {...iconProps} />;
+    case 'event-opened-email': return <LucideIcon.MailOpen {...iconProps} />;
+    case 'event-received-email': return <LucideIcon.Mail {...iconProps} />;
+    case 'event-sent-email': return <LucideIcon.Send {...iconProps} />;
+    case 'event-email-delivery-failed': return <LucideIcon.MailX {...iconProps} />;
+    case 'event-email-delivery-spam': return <LucideIcon.MailWarning {...iconProps} />;
+    case 'event-email-changed': return <LucideIcon.AtSign {...iconProps} />;
+    case 'event-comment': return <LucideIcon.MessageSquare {...iconProps} />;
+    case 'event-click': return <LucideIcon.MousePointerClick {...iconProps} />;
+    case 'event-more-like-this': return <LucideIcon.ThumbsUp {...iconProps} />;
+    case 'event-less-like-this': return <LucideIcon.ThumbsDown {...iconProps} />;
+    case 'event-gift': return <LucideIcon.Gift {...iconProps} />;
+    default: return <LucideIcon.Activity {...iconProps} />;
+    }
+};
+
+/**
+ * "View all member activity →" link. Points at Ember's members-activity
+ * route (still on Ember post-cutover — the plan calls out that Phase 8 keeps
+ * the paginated feed page on Ember for a follow-up). Uses a plain anchor with
+ * the `#/…` href so the Ember hash-router picks it up rather than React
+ * Router intercepting the click.
+ */
+const ViewAllLink: React.FC<{memberId: string}> = ({memberId}) => (
+    <a
+        className='block pt-3 font-medium text-primary hover:underline'
+        data-testid='member-activity-view-all'
+        href={`#/members-activity?member=${memberId}`}
+    >
+        View all member activity →
+    </a>
+);
+
+// Copy pinned to Ember's `activity-feed-empty.hbs:5` so any future refactor of
+// the message stays in lockstep with what Ember users see.
+const NEW_MEMBER_ACTIVITY_COPY = 'All events related to this member will be shown here.';
+
+const capitalize = (s?: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : '');
+
+/**
+ * Ember's activity-feed row renders an `EmailPreviewLink` when `event.email`
+ * is set on delivery/open/sent rows. We don't have that component in the
+ * posts app — surface a plain "Email" label so the admin can at least see
+ * the row carries an email object; the "View all" link routes them to Ember
+ * for the actual preview.
+ */
+function getEmailLabel(email: unknown): string | undefined {
+    if (email && typeof email === 'object') {
+        const subject = (email as {subject?: string}).subject;
+        return subject ? `“${subject}”` : 'Email';
+    }
+    return undefined;
+}
+
+const ActivityRow: React.FC<{event: ParsedMemberEvent}> = ({event}) => {
+    // Unknown event types produce an empty action. Rather than shipping a
+    // ghost row with just an icon + timestamp when a new server-side event
+    // type appears, skip the row entirely.
+    if (!event.action) {
+        return null;
+    }
+
+    const emailLabel = getEmailLabel(event.email);
+    const hasObjectLink = event.object && (event.route || isSafeHref(event.url));
+    const hasEmailFallback = !hasObjectLink && emailLabel;
+
+    const relativeTime = event.timestamp
+        ? moment(event.timestamp).fromNow()
+        // Silent misleading "a few seconds ago" from `moment(undefined)` is
+        // worse than an honest hyphen — the row still renders, just without
+        // a fake timestamp.
+        : '—';
+
+    return (
+        <div className='flex items-start gap-3 py-3' data-testid='member-activity-event'>
+            <div className='flex size-8 shrink-0 items-center justify-center rounded-full bg-muted'>
+                <EventIcon iconName={event.icon} />
+            </div>
+            <div className='flex min-w-0 flex-1 flex-col gap-0.5'>
+                <div className='text-sm leading-snug'>
+                    <span data-testid='member-activity-action'>{capitalize(event.action)}</span>
+                    {event.info && <span className='ml-1 text-muted-foreground'>({event.info})</span>}
+                    {hasObjectLink && (
+                        <>
+                            <span className='mx-1 text-muted-foreground'>{event.join}</span>
+                            {event.route ? (
+                                // Internal Ghost route (hash-based). React
+                                // Router only intercepts real `<Link>`s; a
+                                // plain anchor + `#/...` hits the hash router.
+                                <a className='hover:underline' href={event.route}>{event.object}</a>
+                            ) : (
+                                <a
+                                    className='hover:underline'
+                                    // isSafeHref narrowed this to a real URL.
+                                    href={event.url}
+                                    rel='noopener noreferrer'
+                                    target='_blank'
+                                >
+                                    {event.object}
+                                </a>
+                            )}
+                        </>
+                    )}
+                    {hasEmailFallback && (
+                        // Ember shows the email preview link here; we show a
+                        // plain subject label as the closest text-only parity.
+                        <>
+                            <span className='mx-1 text-muted-foreground'>{event.join}</span>
+                            <span className='text-muted-foreground'>{emailLabel}</span>
+                        </>
+                    )}
+                </div>
+                {event.description && (
+                    <div className='truncate text-xs text-muted-foreground'>{event.description}</div>
+                )}
+                <div className='text-xs text-muted-foreground'>{relativeTime}</div>
+            </div>
+        </div>
+    );
+};
+
+const MemberActivityFeed: React.FC<MemberActivityFeedProps> = ({memberId, hasMultipleNewsletters, hasMultipleTiers, paidMembersEnabled}) => {
+    // Cap the inline feed to the same 5 events Ember shows in the sidebar
+    // section (`activity-feed.hbs:9` — pageSize=5). Anything beyond that lives
+    // behind the "View all" link. On the create screen there's no memberId
+    // to query against, so disable the fetch entirely — an unsaved member has
+    // no events by definition.
+    const {data, isLoading} = useMemberActivityFeed(memberId ?? '', {limit: '5', enabled: !!memberId});
+    const rawEvents: MemberActivityEvent[] = data?.events ?? [];
+    const events = rawEvents.map(rawEvent => parseMemberEvent(rawEvent, {
+        hasMultipleNewsletters,
+        hasMultipleTiers,
+        paidMembersEnabled
+    }));
+    // Track duplicate composite keys as a defensive tie-break — if the server
+    // ever returns two events with the same id (or missing id), append the
+    // slot index so React's diff still gets a stable per-row identity.
+    const seen = new Set<string>();
+
+    // Create mode (`/members/new`) — no member id, no fetch, no "View all"
+    // link. Ember renders `Member::ActivityFeedEmpty` in this state
+    // (`activity-feed.hbs:2-7`); we render the same copy via Shade's
+    // `EmptyIndicator` so the parity assertion for that string holds.
+    if (!memberId) {
+        return (
+            <section className='flex flex-col gap-3' data-testid='member-activity-feed'>
+                <h3 className='text-base font-semibold'>Activity</h3>
+                <Card>
+                    {/* Same wrapper padding as the Subscriptions empty state
+                        (`member-subscriptions-section.tsx`) so both cards line
+                        up visually when they render side-by-side. */}
+                    <CardContent className='pt-6'>
+                        <div className='flex flex-col items-center gap-3 py-4'>
+                            <EmptyIndicator description={NEW_MEMBER_ACTIVITY_COPY} title='Activity'>
+                                <LucideIcon.Activity />
+                            </EmptyIndicator>
+                        </div>
+                    </CardContent>
+                </Card>
+            </section>
+        );
+    }
+
+    return (
+        <section className='flex flex-col gap-3' data-testid='member-activity-feed'>
+            <h3 className='text-base font-semibold'>Activity</h3>
+            <Card>
+                <CardContent className='pt-3'>
+                    {isLoading ? (
+                        <div className='flex flex-col gap-3'>
+                            <Skeleton className='h-10' />
+                            <Skeleton className='h-10' />
+                            <Skeleton className='h-10' />
+                        </div>
+                    ) : events.length === 0 ? (
+                        <p className='py-4 text-center text-sm text-muted-foreground' data-testid='member-activity-empty'>
+                            No activity yet
+                        </p>
+                    ) : (
+                        <div className='divide-y divide-border'>
+                            {events.map((event) => {
+                                // Prefer the server-side event id. Fall back
+                                // through timestamp+type+action, then append
+                                // an increasing suffix to guarantee uniqueness
+                                // even when two events collide on all of those
+                                // (server tie-breaks same `created_at` events
+                                // by id — this is a defensive backstop only).
+                                const base = event.id || `${event.timestamp ?? '?'}-${event.icon}-${event.action}`;
+                                let key = base;
+                                let bump = 1;
+                                while (seen.has(key)) {
+                                    key = `${base}#${bump}`;
+                                    bump += 1;
+                                }
+                                seen.add(key);
+                                return <ActivityRow key={key} event={event} />;
+                            })}
+                        </div>
+                    )}
+                    {/* Only meaningful once there is activity to view — an empty
+                        feed has nothing for the link to lead to. */}
+                    {!isLoading && events.length > 0 && <ViewAllLink memberId={memberId} />}
+                </CardContent>
+            </Card>
+        </section>
+    );
+};
+
+export default MemberActivityFeed;

--- a/apps/admin/src/members/detail/member-add-comp-modal.tsx
+++ b/apps/admin/src/members/detail/member-add-comp-modal.tsx
@@ -1,0 +1,193 @@
+import React from 'react';
+import moment from 'moment-timezone';
+import {Button, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, Input, Label, LoadingIndicator, Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from '@tryghost/shade/components';
+import {classifyMemberSubscription} from './member-subscription';
+import {computeCompExpiryAt, isCompExpiryDuration} from './member-comp-tier';
+import {toast} from 'sonner';
+import {useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
+import {useEditMember, useEditMemberSubscription} from '@tryghost/admin-x-framework/api/members';
+import type {CompExpiryDuration} from './member-comp-tier';
+import type {Member, MemberSubscription} from '@tryghost/admin-x-framework/api/members';
+
+// Ember cancels only subs in these Stripe states before granting a comp
+// (`modal-member-tier.js:activeSubscriptions` — the `isActive` helper allow-list).
+const CANCELABLE_STATUSES = new Set(['active', 'trialing', 'unpaid', 'past_due']);
+
+interface MemberAddCompModalProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    member: Member;
+}
+
+const DURATION_OPTIONS: Array<{value: CompExpiryDuration; label: string}> = [
+    {value: 'forever', label: 'Forever'},
+    {value: 'week', label: '1 Week'},
+    {value: 'month', label: '1 Month'},
+    {value: 'half-year', label: '6 Months'},
+    {value: 'year', label: '1 Year'},
+    {value: 'custom', label: 'Custom'}
+];
+
+const MemberAddCompModal: React.FC<MemberAddCompModalProps> = ({open, onOpenChange, member}) => {
+    const {data: tiersData, isLoading: isLoadingTiers} = useBrowseTiers({
+        searchParams: {filter: 'type:paid+active:true', limit: 'all'}
+    });
+    const availablePaidTiers = tiersData?.tiers ?? [];
+
+    const [selectedTierId, setSelectedTierId] = React.useState<string>('');
+    const [duration, setDuration] = React.useState<CompExpiryDuration>('forever');
+    const [customDate, setCustomDate] = React.useState<string>('');
+
+    // Reset local state whenever the modal reopens so a previous partial selection
+    // never leaks into a fresh flow.
+    React.useEffect(() => {
+        if (open) {
+            setSelectedTierId('');
+            setDuration('forever');
+            setCustomDate('');
+        }
+    }, [open]);
+
+    const editSubscription = useEditMemberSubscription();
+    const editMember = useEditMember();
+    const [isSubmitting, setIsSubmitting] = React.useState(false);
+
+    // The list of Stripe subscriptions the flow needs to hard-cancel first —
+    // narrowed to the exact Ember allow-list so unusual statuses (incomplete,
+    // paused, etc.) aren't hard-canceled behind the admin's back.
+    const activePaidSubscriptions = (member.subscriptions ?? []).filter(
+        (sub: MemberSubscription) => classifyMemberSubscription(sub) === 'paid' && CANCELABLE_STATUSES.has(sub.status)
+    );
+
+    // Native <input type="date"> minimum: don't allow picking a past day.
+    const todayLocal = moment().format('YYYY-MM-DD');
+
+    const canSubmit = !!selectedTierId && !isSubmitting
+        && (duration !== 'custom' || !!customDate);
+
+    const onSubmit = async () => {
+        if (!canSubmit) {
+            return;
+        }
+        setIsSubmitting(true);
+        try {
+            // 1. Cancel every active Stripe subscription immediately — matches Ember
+            //    `modal-member-tier.js:128-136`. Sequential so a failure aborts before
+            //    the tier is granted.
+            for (const sub of activePaidSubscriptions) {
+                await editSubscription.mutateAsync({
+                    memberId: member.id,
+                    subscriptionId: sub.id,
+                    status: 'canceled'
+                });
+            }
+
+            // 2. Grant the comp tier via `useEditMember`. Match Ember exactly:
+            //    `tiers: [newTier]` only, no existing tiers alongside. The server
+            //    rejects `products.length > 1` — this is safer under data drift
+            //    (concurrent tab edit) than preserving surviving tiers here.
+            const expiryAt = computeCompExpiryAt(duration, duration === 'custom' ? customDate : null);
+            const newTier = expiryAt
+                ? {id: selectedTierId, expiry_at: expiryAt}
+                : {id: selectedTierId};
+
+            await editMember.mutateAsync({
+                id: member.id,
+                // `member.email` is optional on the type — omit rather than send
+                // an `undefined` in the JSON body if the invariant ever breaks.
+                ...(member.email ? {email: member.email} : {}),
+                tiers: [newTier]
+            });
+
+            toast.success('Complimentary subscription added');
+            onOpenChange(false);
+        } catch {
+            toast.error('Couldn’t add complimentary subscription');
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={(next) => {
+            // Block dismissal while the multi-step flow is running so the user can't
+            // orphan a half-canceled state.
+            if (isSubmitting) {
+                return;
+            }
+            onOpenChange(next);
+        }}>
+            <DialogContent data-testid='add-comp-modal'>
+                <DialogHeader>
+                    <DialogTitle>Add complimentary subscription</DialogTitle>
+                    <DialogDescription>
+                        Grants this member access to a paid tier for the chosen duration. Any active paid subscription is canceled first.
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div className='flex flex-col gap-4'>
+                    <div className='flex flex-col gap-1.5'>
+                        <Label htmlFor='comp-tier'>Tier</Label>
+                        <Select value={selectedTierId} onValueChange={setSelectedTierId}>
+                            <SelectTrigger data-testid='comp-tier-select' disabled={isLoadingTiers || isSubmitting} id='comp-tier'>
+                                <SelectValue placeholder={isLoadingTiers ? 'Loading tiers…' : 'Select a tier'} />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {availablePaidTiers.map(tier => (
+                                    <SelectItem key={tier.id} data-tier-id={tier.id} value={tier.id}>{tier.name}</SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+
+                    <div className='flex flex-col gap-1.5'>
+                        <Label htmlFor='comp-duration'>Duration</Label>
+                        <Select value={duration} onValueChange={(v) => {
+                            if (isCompExpiryDuration(v)) {
+                                setDuration(v);
+                            }
+                        }}>
+                            <SelectTrigger data-testid='comp-duration-select' disabled={isSubmitting} id='comp-duration'>
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {DURATION_OPTIONS.map(opt => (
+                                    <SelectItem key={opt.value} value={opt.value}>{opt.label}</SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+
+                    {duration === 'custom' && (
+                        <div className='flex flex-col gap-1.5'>
+                            <Label htmlFor='comp-custom-date'>Expires on</Label>
+                            <Input
+                                data-testid='comp-custom-date'
+                                disabled={isSubmitting}
+                                id='comp-custom-date'
+                                min={todayLocal}
+                                type='date'
+                                value={customDate}
+                                onChange={e => setCustomDate(e.target.value)}
+                            />
+                        </div>
+                    )}
+                </div>
+
+                <DialogFooter>
+                    <Button disabled={isSubmitting} variant='outline' onClick={() => onOpenChange(false)}>Cancel</Button>
+                    <Button data-testid='comp-add-confirm' disabled={!canSubmit} onClick={() => void onSubmit()}>
+                        {isSubmitting ? (
+                            <>
+                                <LoadingIndicator size='sm' />
+                                <span className='sr-only'>Adding</span>
+                            </>
+                        ) : 'Add subscription'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+export default MemberAddCompModal;

--- a/apps/admin/src/members/detail/member-commenting.test.ts
+++ b/apps/admin/src/members/detail/member-commenting.test.ts
@@ -1,0 +1,58 @@
+import {describe, expect, it} from 'vitest';
+import {getMemberCommentingActionLabel, isMemberCommentingDisabled} from './member-commenting';
+import type {Member} from '@tryghost/admin-x-framework/api/members';
+
+// The action menu label toggles based on `member.can_comment`. Ember's
+// `templates/member.hbs:77` uses `not-eq member.canComment false` — i.e. the
+// UI shows "Disable commenting" for anything BUT explicit false (including
+// undefined and legacy members without the property). Only when `can_comment`
+// is explicitly `false` does the UI flip to "Enable commenting".
+//
+// Importantly this is NOT the same as `member.commenting.disabled` — that
+// flag stays truthy after a *temporary* disable expires, whereas `can_comment`
+// respects the expiry and flips back to `true` server-side. Reading the wrong
+// property would leave the menu offering "Enable commenting" on a member who
+// can already comment.
+
+function makeMember(overrides: Partial<Member>): Member {
+    return {
+        id: 'm_1',
+        name: 'X',
+        email: 'x@x.co',
+        ...overrides
+    } as Member;
+}
+
+describe('isMemberCommentingDisabled', () => {
+    it('returns false when can_comment is missing (legacy members)', () => {
+        expect(isMemberCommentingDisabled(makeMember({}))).toBe(false);
+    });
+
+    it('returns false when can_comment is explicitly true', () => {
+        expect(isMemberCommentingDisabled(makeMember({can_comment: true}))).toBe(false);
+    });
+
+    it('returns true only when can_comment is explicitly false', () => {
+        expect(isMemberCommentingDisabled(makeMember({can_comment: false}))).toBe(true);
+    });
+
+    it('returns false when can_comment is true even if commenting.disabled is truthy (expired disable)', () => {
+        // The `commenting` metadata sticks around after a temporary disable
+        // expires; the server flips `can_comment` back to true. Ember-parity:
+        // trust `can_comment` and offer the "Disable" action even though a
+        // stale `commenting.disabled=true` remains on the object.
+        const member = makeMember({can_comment: true, commenting: {disabled: true, disabled_until: '2000-01-01T00:00:00.000Z'}});
+        expect(isMemberCommentingDisabled(member)).toBe(false);
+    });
+});
+
+describe('getMemberCommentingActionLabel', () => {
+    it('returns "Disable commenting" when commenting is currently allowed', () => {
+        expect(getMemberCommentingActionLabel(makeMember({}))).toBe('Disable commenting');
+        expect(getMemberCommentingActionLabel(makeMember({can_comment: true}))).toBe('Disable commenting');
+    });
+
+    it('returns "Enable commenting" when can_comment is explicitly false', () => {
+        expect(getMemberCommentingActionLabel(makeMember({can_comment: false}))).toBe('Enable commenting');
+    });
+});

--- a/apps/admin/src/members/detail/member-commenting.ts
+++ b/apps/admin/src/members/detail/member-commenting.ts
@@ -1,0 +1,23 @@
+import type {Member} from '@tryghost/admin-x-framework/api/members';
+
+/**
+ * True when the member currently can't comment. Gated on `can_comment`
+ * (Ember-parity — `templates/member.hbs:77` uses `not-eq member.canComment
+ * false`), NOT on `commenting.disabled`. The distinction matters when a
+ * temporary disable expires: `commenting.disabled` stays truthy, but the
+ * server flips `can_comment` back to `true`, and Ember's UI trusts the latter.
+ *
+ * Missing / undefined `can_comment` (legacy members) → treat as enabled.
+ */
+export function isMemberCommentingDisabled(member: Pick<Member, 'can_comment'>): boolean {
+    return member.can_comment === false;
+}
+
+/**
+ * The Actions-menu label reflects the *next* transition. If the member is
+ * currently blocked from commenting the menu offers to enable them, and vice
+ * versa.
+ */
+export function getMemberCommentingActionLabel(member: Pick<Member, 'can_comment'>): string {
+    return isMemberCommentingDisabled(member) ? 'Enable commenting' : 'Disable commenting';
+}

--- a/apps/admin/src/members/detail/member-comp-tier.test.ts
+++ b/apps/admin/src/members/detail/member-comp-tier.test.ts
@@ -1,0 +1,72 @@
+import {computeCompExpiryAt, isCompExpiryDuration} from './member-comp-tier';
+import {describe, expect, it, vi} from 'vitest';
+
+describe('computeCompExpiryAt', () => {
+    // Freeze "now" to a mid-day UTC timestamp so the duration math is deterministic
+    // regardless of the machine's timezone (durations use `moment.utc().startOf('day')`).
+    const NOW = new Date('2026-07-15T12:00:00.000Z');
+
+    it('returns null for a forever comp', () => {
+        vi.setSystemTime(NOW);
+        expect(computeCompExpiryAt('forever')).toBeNull();
+        vi.useRealTimers();
+    });
+
+    it('returns 7 days from now (UTC start-of-day) for a week duration', () => {
+        vi.setSystemTime(NOW);
+        expect(computeCompExpiryAt('week')).toBe('2026-07-22T00:00:00.000Z');
+        vi.useRealTimers();
+    });
+
+    it('returns +1 month from now (UTC start-of-day) for a month duration', () => {
+        vi.setSystemTime(NOW);
+        expect(computeCompExpiryAt('month')).toBe('2026-08-15T00:00:00.000Z');
+        vi.useRealTimers();
+    });
+
+    it('returns +6 months from now (UTC start-of-day) for a half-year duration', () => {
+        vi.setSystemTime(NOW);
+        expect(computeCompExpiryAt('half-year')).toBe('2027-01-15T00:00:00.000Z');
+        vi.useRealTimers();
+    });
+
+    it('returns +1 year from now (UTC start-of-day) for a year duration', () => {
+        vi.setSystemTime(NOW);
+        expect(computeCompExpiryAt('year')).toBe('2027-07-15T00:00:00.000Z');
+        vi.useRealTimers();
+    });
+
+    it('returns null for custom duration when no date is supplied (guard against a bad UI state)', () => {
+        expect(computeCompExpiryAt('custom')).toBeNull();
+    });
+
+    it('lands the custom expiry on the picked calendar day (regression: local-day parse)', () => {
+        // Custom date is a native <input type="date"> value (`YYYY-MM-DD`, LOCAL
+        // calendar day). Ember's flow lands the resulting ISO on the picked day.
+        // Naive `new Date('2027-03-10')` would interpret as UTC midnight, and for
+        // admins west of UTC would then snap back to 2027-03-09 — this test pins
+        // that the picked day never drops.
+        const iso = computeCompExpiryAt('custom', '2027-03-10');
+        expect(iso).not.toBeNull();
+        // Extract the ISO date part — it MUST be the picked day (never 03-09).
+        const isoDate = iso!.slice(0, 10);
+        expect(isoDate === '2027-03-10' || isoDate === '2027-03-11').toBe(true);
+        expect(isoDate).not.toBe('2027-03-09');
+    });
+});
+
+describe('isCompExpiryDuration', () => {
+    it('accepts every supported duration key', () => {
+        expect(isCompExpiryDuration('forever')).toBe(true);
+        expect(isCompExpiryDuration('week')).toBe(true);
+        expect(isCompExpiryDuration('month')).toBe(true);
+        expect(isCompExpiryDuration('half-year')).toBe(true);
+        expect(isCompExpiryDuration('year')).toBe(true);
+        expect(isCompExpiryDuration('custom')).toBe(true);
+    });
+
+    it('rejects unknown durations', () => {
+        expect(isCompExpiryDuration('quarter')).toBe(false);
+        expect(isCompExpiryDuration('')).toBe(false);
+    });
+});

--- a/apps/admin/src/members/detail/member-comp-tier.ts
+++ b/apps/admin/src/members/detail/member-comp-tier.ts
@@ -1,0 +1,46 @@
+import moment from 'moment-timezone';
+
+export const COMP_EXPIRY_DURATIONS = ['forever', 'week', 'month', 'half-year', 'year', 'custom'] as const;
+export type CompExpiryDuration = typeof COMP_EXPIRY_DURATIONS[number];
+
+export function isCompExpiryDuration(value: string): value is CompExpiryDuration {
+    return (COMP_EXPIRY_DURATIONS as readonly string[]).includes(value);
+}
+
+/**
+ * Turn the admin's picked duration into an ISO expiry_at, matching
+ * `ghost/admin/app/components/modal-member-tier.js:addTier` exactly:
+ *   - forever          → null (no expiry, permanent comp)
+ *   - week/month/…/year → +N from now, UTC start-of-day
+ *   - custom + date    → end of the picked LOCAL day, with the timezone-offset
+ *                        adjustment Ember uses to keep it on the same calendar day
+ * The custom date is a `YYYY-MM-DD` string (native `<input type="date">` value)
+ * parsed as LOCAL midnight — `new Date('YYYY-MM-DD')` would misparse it as UTC
+ * midnight, snapping the picked day back by one for admins west of UTC.
+ * When called with `custom` but no date, returns null — the UI disables the Add
+ * button until a date is picked, but the helper stays safe.
+ */
+export function computeCompExpiryAt(duration: CompExpiryDuration, customDate?: string | null): string | null {
+    switch (duration) {
+    case 'forever':
+        return null;
+    case 'week':
+        return moment.utc().add(7, 'days').startOf('day').toISOString();
+    case 'month':
+        return moment.utc().add(1, 'month').startOf('day').toISOString();
+    case 'half-year':
+        return moment.utc().add(6, 'months').startOf('day').toISOString();
+    case 'year':
+        return moment.utc().add(1, 'year').startOf('day').toISOString();
+    case 'custom':
+        if (!customDate) {
+            return null;
+        }
+        return moment(customDate, 'YYYY-MM-DD')
+            .startOf('day')
+            .endOf('day')
+            .set('millisecond', 0)
+            .add(moment().utcOffset(), 'minutes')
+            .toISOString();
+    }
+}

--- a/apps/admin/src/members/detail/member-delete-modal.tsx
+++ b/apps/admin/src/members/detail/member-delete-modal.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import {Button, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, LoadingIndicator, Switch} from '@tryghost/shade/components';
+import {getDeleteMemberButtonLabel, hasCancelableStripeSubscription} from './member-delete';
+import {toast} from 'sonner';
+import {useDeleteMember} from '@tryghost/admin-x-framework/api/members';
+import {useNavigate} from '@tryghost/admin-x-framework';
+import type {Member} from '@tryghost/admin-x-framework/api/members';
+
+interface MemberDeleteModalProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    member: Member;
+    /**
+     * Invoked right before we `navigate('/members')` so the parent's
+     * unsaved-changes blocker doesn't intercept the redirect and pop a
+     * "Discard changes?" dialog for a member that has just been deleted.
+     */
+    allowLeaveWithUnsavedChanges: () => void;
+}
+
+/**
+ * Confirms permanent member deletion. Mirrors Ember `delete-member` exactly:
+ *   - Shows the "Also cancel subscription in Stripe" toggle iff the member has
+ *     at least one cancelable Stripe subscription
+ *     (`hasCancelableStripeSubscription`).
+ *   - Confirm button label switches to "Delete member + Cancel subscription"
+ *     when the checkbox is on, so the admin sees the two-op flow.
+ *   - On success, navigates to /members (Ember `controllers/member.js:184`
+ *     `router.transitionTo(membersListPath)`).
+ *
+ * Uses Shade Dialog rather than AlertDialog because it needs to host the
+ * checkbox and a dynamic confirm label — behaviours AlertDialog's simpler
+ * cancel/action pair doesn't support cleanly.
+ */
+const MemberDeleteModal: React.FC<MemberDeleteModalProps> = ({open, onOpenChange, member, allowLeaveWithUnsavedChanges}) => {
+    const navigate = useNavigate();
+    const deleteMember = useDeleteMember();
+    const [cancelStripe, setCancelStripe] = React.useState(false);
+
+    // Reset the checkbox on every reopen — a lingering true state across opens
+    // would be a footgun (last time you deleted, you meant to cancel Stripe; not
+    // necessarily this time).
+    React.useEffect(() => {
+        if (open) {
+            setCancelStripe(false);
+        }
+    }, [open]);
+
+    const showCancelStripeToggle = hasCancelableStripeSubscription(member);
+    // Members can be created without an email (Ember has the same gap). Fall
+    // back through name → "this member" so we never render `<strong></strong>`
+    // in the confirmation body or a bare " was deleted." in the toast.
+    const displayIdentity = member.email || member.name || 'this member';
+
+    const onConfirm = async () => {
+        try {
+            // If the toggle is hidden (no cancelable sub), always send cancel:false
+            // — sending true against a member with no active Stripe sub is a no-op
+            // server-side, but sending it based on stale UI state is a smell.
+            const cancel = showCancelStripeToggle && cancelStripe;
+            await deleteMember.mutateAsync({id: member.id, cancel});
+            toast.success(cancel
+                ? `${displayIdentity} was deleted and their Stripe subscription was cancelled.`
+                : `${displayIdentity} was deleted.`);
+            onOpenChange(false);
+            // Bypass the unsaved-changes blocker: the member no longer exists,
+            // so there's nothing meaningful to keep editing.
+            allowLeaveWithUnsavedChanges();
+            navigate('/members');
+        } catch {
+            toast.error('Couldn’t delete the member. Please try again.');
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={(next) => {
+            // Prevent close during the network round-trip so a half-canceled
+            // Stripe / half-deleted state can't leak through the UI.
+            if (deleteMember.isPending) {
+                return;
+            }
+            onOpenChange(next);
+        }}>
+            <DialogContent data-testid='delete-member-modal'>
+                <DialogHeader>
+                    <DialogTitle>Delete member account</DialogTitle>
+                    <DialogDescription>
+                        Permanently delete <strong>{displayIdentity}</strong> from Ghost.
+                    </DialogDescription>
+                </DialogHeader>
+
+                {showCancelStripeToggle && (
+                    <div className='flex items-start justify-between gap-4'>
+                        <div className='flex flex-col gap-0.5'>
+                            <h4 className='text-sm font-medium'>Also cancel subscription in Stripe</h4>
+                            <p className='text-sm text-muted-foreground'>If disabled, the member’s premium subscription will continue</p>
+                        </div>
+                        <Switch
+                            aria-label='Also cancel subscription in Stripe'
+                            checked={cancelStripe}
+                            data-testid='delete-member-cancel-stripe'
+                            disabled={deleteMember.isPending}
+                            onCheckedChange={setCancelStripe}
+                        />
+                    </div>
+                )}
+
+                <DialogFooter>
+                    <Button
+                        data-testid='cancel-delete-member'
+                        disabled={deleteMember.isPending}
+                        variant='outline'
+                        onClick={() => onOpenChange(false)}
+                    >
+                        Cancel
+                    </Button>
+                    <Button
+                        data-testid='confirm-delete-member'
+                        disabled={deleteMember.isPending}
+                        variant='destructive'
+                        onClick={() => void onConfirm()}
+                    >
+                        {deleteMember.isPending ? (
+                            <>
+                                <LoadingIndicator size='sm' />
+                                <span className='sr-only'>Deleting</span>
+                            </>
+                        ) : getDeleteMemberButtonLabel(cancelStripe && showCancelStripeToggle)}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+export default MemberDeleteModal;

--- a/apps/admin/src/members/detail/member-delete.test.ts
+++ b/apps/admin/src/members/detail/member-delete.test.ts
@@ -1,0 +1,61 @@
+import {describe, expect, it} from 'vitest';
+import {getDeleteMemberButtonLabel, hasCancelableStripeSubscription} from './member-delete';
+import type {MemberSubscription} from '@tryghost/admin-x-framework/api/members';
+
+// Ember's `delete-member.js:22` allows the "Also cancel subscription in Stripe"
+// checkbox when the member has ANY subscription whose status is in this set —
+// even comp/gift entries (their sub.id is empty and the server call becomes a
+// no-op, but Ember doesn't gate the checkbox on classification, so we don't
+// either). Anything outside the set (e.g. `incomplete`, `canceled`, `paused`)
+// hides the checkbox.
+const ALLOWED = ['active', 'trialing', 'unpaid', 'past_due'];
+const DISALLOWED = ['incomplete', 'incomplete_expired', 'canceled', 'paused'];
+
+function makeSub(status: string): MemberSubscription {
+    return {
+        id: 'sub_x',
+        customer: {id: 'cus_x', name: null, email: 'x@x.co'},
+        plan: {id: 'plan_x', nickname: 'Monthly', interval: 'month', currency: 'usd', amount: 500},
+        status,
+        start_date: '2026-01-01T00:00:00.000Z',
+        current_period_end: '2026-02-01T00:00:00.000Z',
+        cancel_at_period_end: false,
+        price: {id: 'price_x', price_id: 'price_x', nickname: 'Monthly', amount: 500, currency: 'usd', type: 'recurring', interval: 'month'},
+        tier: {id: 'tier_x', name: 'Gold', slug: 'gold', active: true, type: 'paid'},
+        offer: null
+    };
+}
+
+describe('hasCancelableStripeSubscription', () => {
+    it('returns false when the member has no subscriptions', () => {
+        expect(hasCancelableStripeSubscription({subscriptions: []})).toBe(false);
+        expect(hasCancelableStripeSubscription({subscriptions: undefined})).toBe(false);
+        expect(hasCancelableStripeSubscription({})).toBe(false);
+    });
+
+    it.each(ALLOWED)('returns true for status %s (Ember allow-list)', (status) => {
+        expect(hasCancelableStripeSubscription({subscriptions: [makeSub(status)]})).toBe(true);
+    });
+
+    it.each(DISALLOWED)('returns false for status %s', (status) => {
+        expect(hasCancelableStripeSubscription({subscriptions: [makeSub(status)]})).toBe(false);
+    });
+
+    it('returns true if ANY subscription in the list is cancelable', () => {
+        expect(hasCancelableStripeSubscription({
+            subscriptions: [makeSub('canceled'), makeSub('active')]
+        })).toBe(true);
+    });
+});
+
+describe('getDeleteMemberButtonLabel', () => {
+    it('returns the plain label when the cancel-Stripe box is unchecked', () => {
+        expect(getDeleteMemberButtonLabel(false)).toBe('Delete member');
+    });
+
+    it('returns the combined label when the cancel-Stripe box is checked', () => {
+        // Matches Ember `delete-member.hbs:44` — a subtle contract that hides the
+        // "actually two operations" nature of the flow behind a single button.
+        expect(getDeleteMemberButtonLabel(true)).toBe('Delete member + Cancel subscription');
+    });
+});

--- a/apps/admin/src/members/detail/member-delete.ts
+++ b/apps/admin/src/members/detail/member-delete.ts
@@ -1,0 +1,29 @@
+import type {Member, MemberSubscription} from '@tryghost/admin-x-framework/api/members';
+
+// Same allow-list Ember uses in `delete-member.js:22-27` and the comp flow
+// (`member-add-comp-modal.tsx:14`). Kept as a Set for O(1) status lookups.
+const CANCELABLE_STATUSES = new Set(['active', 'trialing', 'unpaid', 'past_due']);
+
+/**
+ * True when the member has at least one subscription whose status Ember treats
+ * as still needing a Stripe-side cancel — i.e. worth showing the "Also cancel
+ * subscription in Stripe" checkbox in the delete confirmation.
+ *
+ * Note: mirrors Ember exactly and does NOT filter by classification (paid vs
+ * comp vs gift). Comp/gift subs have an empty `sub.id` so the server-side
+ * cancel call is a no-op, but we don't gate the checkbox on it here.
+ */
+export function hasCancelableStripeSubscription(member: Pick<Member, 'subscriptions'>): boolean {
+    const subscriptions: MemberSubscription[] = member.subscriptions ?? [];
+    return subscriptions.some(sub => CANCELABLE_STATUSES.has(sub.status));
+}
+
+/**
+ * The confirm button label toggles based on the checkbox state — Ember calls
+ * this out visually so the admin sees they're about to trigger *two* server
+ * operations, not one. Keep the exact strings in sync with Ember
+ * `delete-member.hbs:44`.
+ */
+export function getDeleteMemberButtonLabel(cancelStripeSubscription: boolean): string {
+    return cancelStripeSubscription ? 'Delete member + Cancel subscription' : 'Delete member';
+}

--- a/apps/admin/src/members/detail/member-detail-edit.test.ts
+++ b/apps/admin/src/members/detail/member-detail-edit.test.ts
@@ -1,0 +1,289 @@
+import {NOTE_MAX_LENGTH, buildMemberFieldEditPayload, getDefaultNewsletterIdsForNewMember, getEmailErrorMessage, getMemberEditableSlice, getMemberNewslettersUiEnabled, getMemberSuppressionInfo, getNoteCharactersLeft, isDraftInSyncWithServer, isValidMemberEmail, resolveSlugsToLabels, toggleMemberNewsletter} from './member-detail-edit';
+import {describe, expect, it} from 'vitest';
+
+describe('getMemberEditableSlice', () => {
+    it('normalizes missing fields to empty strings and empty relation lists', () => {
+        expect(getMemberEditableSlice({})).toEqual({name: '', email: '', note: '', labels: [], newsletters: []});
+        expect(getMemberEditableSlice({name: null, email: null, note: null, labels: null, newsletters: null})).toEqual({name: '', email: '', note: '', labels: [], newsletters: []});
+    });
+
+    it('trims name and email (matching Ember blur-trim) but preserves note whitespace', () => {
+        expect(getMemberEditableSlice({name: '  Ada  ', email: ' ada@x.co ', note: '  hi  '}))
+            .toEqual({name: 'Ada', email: 'ada@x.co', note: '  hi  ', labels: [], newsletters: []});
+    });
+
+    it('passes through already-clean fields', () => {
+        expect(getMemberEditableSlice({name: 'Ada', email: 'ada@x.co', note: 'VIP'}))
+            .toEqual({name: 'Ada', email: 'ada@x.co', note: 'VIP', labels: [], newsletters: []});
+    });
+
+    it('normalizes labels to {name, slug} sorted by slug', () => {
+        const slice = getMemberEditableSlice({
+            name: 'Ada',
+            labels: [
+                {name: 'VIP', slug: 'vip'},
+                {name: 'Beta', slug: 'beta'}
+            ]
+        });
+        expect(slice.labels).toEqual([
+            {name: 'Beta', slug: 'beta'},
+            {name: 'VIP', slug: 'vip'}
+        ]);
+    });
+
+    it('normalizes newsletter subscriptions to an id list sorted by id', () => {
+        const slice = getMemberEditableSlice({
+            newsletters: [
+                {id: 'nl_c'},
+                {id: 'nl_a'},
+                {id: 'nl_b'}
+            ]
+        });
+        expect(slice.newsletters).toEqual(['nl_a', 'nl_b', 'nl_c']);
+    });
+});
+
+describe('buildMemberFieldEditPayload', () => {
+    const baseline = {
+        name: 'Ada',
+        email: 'ada@x.co',
+        note: '',
+        labels: [],
+        newsletters: ['nl_a', 'nl_b']
+    };
+
+    it('omits newsletters when the user has not changed them', () => {
+        // Sending `[]` would unsubscribe the member from every newsletter, so an
+        // unchanged newsletter set must NOT appear on the payload at all.
+        const payload = buildMemberFieldEditPayload('mem_1', {...baseline, name: 'Ada B'}, baseline);
+        expect(payload.newsletters).toBeUndefined();
+        expect(payload.name).toBe('Ada B');
+    });
+
+    it('sends newsletters as {id}[] when the user has toggled them', () => {
+        const payload = buildMemberFieldEditPayload('mem_1', {...baseline, newsletters: ['nl_a']}, baseline);
+        expect(payload.newsletters).toEqual([{id: 'nl_a'}]);
+    });
+
+    it('sends an empty newsletters array only when the user has explicitly unsubscribed from all', () => {
+        const payload = buildMemberFieldEditPayload('mem_1', {...baseline, newsletters: []}, baseline);
+        expect(payload.newsletters).toEqual([]);
+    });
+});
+
+describe('getMemberSuppressionInfo', () => {
+    it('returns null when the member is not suppressed', () => {
+        expect(getMemberSuppressionInfo(undefined)).toBeNull();
+        expect(getMemberSuppressionInfo({suppressed: false})).toBeNull();
+    });
+
+    it('shows the banner without a label when suppressed but the info block is missing', () => {
+        // Ember still renders "Email disabled" + the Re-enable button in this case
+        // (e.g. email_disabled=true after the Mailgun row was cleaned), so we do too.
+        expect(getMemberSuppressionInfo({suppressed: true})).toEqual({label: null});
+    });
+
+    it('reports the "Bounced" reason with a formatted date for a fail suppression', () => {
+        // Use a mid-day UTC timestamp so the local-vs-UTC render doesn't cross a day boundary.
+        expect(getMemberSuppressionInfo({
+            suppressed: true,
+            info: {reason: 'fail', timestamp: '2026-01-15T12:00:00.000Z'}
+        })).toEqual({reason: 'fail', label: 'Bounced on 15 Jan 2026'});
+    });
+
+    it('reports the "Flagged as spam" reason with a formatted date for a spam suppression', () => {
+        expect(getMemberSuppressionInfo({
+            suppressed: true,
+            info: {reason: 'spam', timestamp: '2026-02-01T12:00:00.000Z'}
+        })).toEqual({reason: 'spam', label: 'Flagged as spam on 1 Feb 2026'});
+    });
+
+    it('falls back to a generic label for an unexpected reason', () => {
+        expect(getMemberSuppressionInfo({
+            suppressed: true,
+            info: {reason: 'other', timestamp: '2026-03-01T12:00:00.000Z'}
+        })).toEqual({reason: 'other', label: 'Email disabled on 1 Mar 2026'});
+    });
+});
+
+describe('getMemberNewslettersUiEnabled', () => {
+    it('hides the section only when explicitly disabled', () => {
+        expect(getMemberNewslettersUiEnabled('disabled')).toBe(false);
+    });
+
+    it('shows the section for every other setting value', () => {
+        expect(getMemberNewslettersUiEnabled('all')).toBe(true);
+        expect(getMemberNewslettersUiEnabled('paid')).toBe(true);
+        expect(getMemberNewslettersUiEnabled('filter')).toBe(true);
+    });
+
+    it('shows the section while the setting is still loading (prevents a flash-out)', () => {
+        expect(getMemberNewslettersUiEnabled(undefined)).toBe(true);
+        expect(getMemberNewslettersUiEnabled(null)).toBe(true);
+    });
+});
+
+describe('toggleMemberNewsletter', () => {
+    it('subscribes a member to a newsletter they are not yet subscribed to', () => {
+        expect(toggleMemberNewsletter(['nl_a'], 'nl_b')).toEqual(['nl_a', 'nl_b']);
+    });
+
+    it('unsubscribes a member from a newsletter they are subscribed to', () => {
+        expect(toggleMemberNewsletter(['nl_a', 'nl_b'], 'nl_a')).toEqual(['nl_b']);
+    });
+
+    it('is stable for a repeated toggle', () => {
+        const once = toggleMemberNewsletter([], 'nl_a');
+        const twice = toggleMemberNewsletter(once, 'nl_a');
+        expect(twice).toEqual([]);
+    });
+});
+
+describe('isValidMemberEmail', () => {
+    it('accepts normal and plus-addressed emails', () => {
+        expect(isValidMemberEmail('ada@example.com')).toBe(true);
+        expect(isValidMemberEmail('ada+news@example.com')).toBe(true);
+    });
+
+    it('trims before validating', () => {
+        expect(isValidMemberEmail('  ada@example.com  ')).toBe(true);
+    });
+
+    it('rejects empty or malformed emails', () => {
+        expect(isValidMemberEmail('')).toBe(false);
+        expect(isValidMemberEmail('   ')).toBe(false);
+        expect(isValidMemberEmail('not-an-email')).toBe(false);
+        expect(isValidMemberEmail('a@b')).toBe(false);
+        expect(isValidMemberEmail('a@b.')).toBe(false);
+        expect(isValidMemberEmail('a b@example.com')).toBe(false);
+    });
+});
+
+describe('getDefaultNewsletterIdsForNewMember', () => {
+    // Ported from Ember's rule (`gh-member-settings-form.js:236-237`):
+    // `subscribe_on_signup: true` AND `visibility: 'members'`. A drift on
+    // either condition would silently either over-subscribe (privacy risk if
+    // a paid newsletter leaks to a free member) or under-subscribe (marketing
+    // regression if a signup-default newsletter is skipped).
+    it('includes only subscribe_on_signup + visibility:members newsletters', () => {
+        const newsletters = [
+            {id: 'a', subscribe_on_signup: true, visibility: 'members'},   // ✓
+            {id: 'b', subscribe_on_signup: true, visibility: 'paid'},      // ✗ paid-only
+            {id: 'c', subscribe_on_signup: false, visibility: 'members'},  // ✗ opt-in only
+            {id: 'd', subscribe_on_signup: true, visibility: null},         // ✗ visibility not 'members'
+            {id: 'e', subscribe_on_signup: true, visibility: 'members'}    // ✓
+        ];
+        expect(getDefaultNewsletterIdsForNewMember(newsletters)).toEqual(['a', 'e']);
+    });
+
+    it('returns [] for undefined / null / empty inputs (loading states)', () => {
+        expect(getDefaultNewsletterIdsForNewMember(undefined)).toEqual([]);
+        expect(getDefaultNewsletterIdsForNewMember(null)).toEqual([]);
+        expect(getDefaultNewsletterIdsForNewMember([])).toEqual([]);
+    });
+
+    it('preserves input order (no re-sort)', () => {
+        // Downstream consumers may rely on original ordering (e.g. a
+        // "primary newsletter first" rule); avoid injecting an implicit sort
+        // that would silently reorder the resulting UI toggles.
+        const newsletters = [
+            {id: 'z', subscribe_on_signup: true, visibility: 'members'},
+            {id: 'a', subscribe_on_signup: true, visibility: 'members'}
+        ];
+        expect(getDefaultNewsletterIdsForNewMember(newsletters)).toEqual(['z', 'a']);
+    });
+});
+
+describe('getEmailErrorMessage', () => {
+    it('returns null when the field has not been touched, regardless of value', () => {
+        // Core New-member bug: the initial render of the create screen would
+        // paint "Email is required." before the user typed anything. Gating
+        // on `touched` keeps the field neutral until the user interacts.
+        expect(getEmailErrorMessage('', false)).toBeNull();
+        expect(getEmailErrorMessage('not-an-email', false)).toBeNull();
+        expect(getEmailErrorMessage('ada@example.com', false)).toBeNull();
+    });
+
+    it('reports "Email is required." when touched and empty (or whitespace only)', () => {
+        expect(getEmailErrorMessage('', true)).toBe('Email is required.');
+        expect(getEmailErrorMessage('   ', true)).toBe('Email is required.');
+    });
+
+    it('reports "Invalid email." when touched and non-empty but malformed', () => {
+        expect(getEmailErrorMessage('not-an-email', true)).toBe('Invalid email.');
+        expect(getEmailErrorMessage('a@b', true)).toBe('Invalid email.');
+    });
+
+    it('returns null when touched and the value is a valid email', () => {
+        expect(getEmailErrorMessage('ada@example.com', true)).toBeNull();
+        expect(getEmailErrorMessage('  ada@example.com  ', true)).toBeNull();
+    });
+});
+
+describe('getNoteCharactersLeft', () => {
+    it('counts down from the 500-char soft limit', () => {
+        expect(getNoteCharactersLeft('')).toBe(NOTE_MAX_LENGTH);
+        expect(getNoteCharactersLeft('hi')).toBe(NOTE_MAX_LENGTH - 2);
+    });
+
+    it('counts unicode code points, not UTF-16 code units (emoji count as one)', () => {
+        // '👍' is two UTF-16 code units — String.length would over-count it.
+        expect(getNoteCharactersLeft('👍👍👍')).toBe(NOTE_MAX_LENGTH - 3);
+    });
+
+    it('goes negative when the soft limit is exceeded (matching Ember)', () => {
+        expect(getNoteCharactersLeft('x'.repeat(520))).toBe(-20);
+    });
+});
+
+describe('isDraftInSyncWithServer', () => {
+    const server = {
+        name: 'Ada',
+        email: 'ada@x.co',
+        note: 'VIP',
+        labels: [{name: 'Beta', slug: 'beta'}],
+        newsletters: ['nl_a']
+    };
+
+    it('is in sync when there is no draft yet', () => {
+        expect(isDraftInSyncWithServer(undefined, server)).toBe(true);
+    });
+
+    it('is in sync when the draft equals the server baseline', () => {
+        expect(isDraftInSyncWithServer({...server}, server)).toBe(true);
+    });
+
+    it('ignores whitespace-only differences (normalized comparison)', () => {
+        expect(isDraftInSyncWithServer({...server, name: 'Ada ', email: ' ada@x.co'}, server)).toBe(true);
+    });
+
+    it('is out of sync when the user has edited a field', () => {
+        expect(isDraftInSyncWithServer({...server, name: 'Ada B'}, server)).toBe(false);
+    });
+
+    it('is out of sync when the user has changed labels', () => {
+        expect(isDraftInSyncWithServer({...server, labels: []}, server)).toBe(false);
+    });
+
+    it('is out of sync when the user has toggled a newsletter', () => {
+        expect(isDraftInSyncWithServer({...server, newsletters: []}, server)).toBe(false);
+    });
+});
+
+describe('resolveSlugsToLabels', () => {
+    const known = new Map([
+        ['vip', {name: 'VIP', slug: 'vip'}],
+        ['beta', {name: 'Beta', slug: 'beta'}]
+    ]);
+
+    it('resolves known slugs to their full label objects, preserving order', () => {
+        expect(resolveSlugsToLabels(['beta', 'vip'], known)).toEqual([
+            {name: 'Beta', slug: 'beta'},
+            {name: 'VIP', slug: 'vip'}
+        ]);
+    });
+
+    it('falls back to using the slug as the name for an unknown slug', () => {
+        expect(resolveSlugsToLabels(['mystery'], known)).toEqual([{name: 'mystery', slug: 'mystery'}]);
+    });
+});

--- a/apps/admin/src/members/detail/member-detail-edit.ts
+++ b/apps/admin/src/members/detail/member-detail-edit.ts
@@ -1,0 +1,241 @@
+import moment from 'moment-timezone';
+import {dequal} from 'dequal';
+import type {EditMemberData, Member} from '@tryghost/admin-x-framework/api/members';
+
+export interface MemberEditableLabel {
+    name: string;
+    slug: string;
+}
+
+export interface MemberEditableFields {
+    name: string;
+    email: string;
+    note: string;
+    labels: MemberEditableLabel[];
+    // Subscribed-newsletter ids, sorted, so order changes never look dirty.
+    newsletters: string[];
+}
+
+// The members API returns null (not just undefined) for unset name/email/note,
+// so accept both here rather than casting at the call sites.
+interface MemberFieldSource {
+    name?: string | null;
+    email?: string | null;
+    note?: string | null;
+    labels?: Array<{name: string; slug: string}> | null;
+    newsletters?: Array<{id: string}> | null;
+}
+
+// Same shape as the import-members validator already used in this app.
+const MEMBER_EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+// Soft limit shown as a countdown (Ember imposes no hard maxlength; the DB column
+// allows 2000). The counter may go negative, matching the Ember behaviour.
+export const NOTE_MAX_LENGTH = 500;
+
+/**
+ * The editable slice used for both dirty detection (compare draft vs server) and
+ * the save payload. Name/email are trimmed to match the Ember blur-trim behaviour;
+ * note preserves its whitespace. Missing fields normalize to '' so a member with a
+ * null field and a draft with '' don't read as dirty.
+ */
+export function getMemberEditableSlice(member: MemberFieldSource): MemberEditableFields {
+    return {
+        name: (member.name ?? '').trim(),
+        email: (member.email ?? '').trim(),
+        note: member.note ?? '',
+        // Sorted by slug (deterministic byte-order, not locale-dependent) so label
+        // order — or a reordered server response — never reads as a dirty change.
+        labels: (member.labels ?? [])
+            .map(label => ({name: label.name, slug: label.slug}))
+            .sort((a, b) => (a.slug < b.slug ? -1 : a.slug > b.slug ? 1 : 0)),
+        newsletters: (member.newsletters ?? [])
+            .map(nl => nl.id)
+            .sort()
+    };
+}
+
+/**
+ * Add or remove a newsletter id from the subscribed set, preserving sort order.
+ * Idempotent by construction so a repeated toggle round-trips to no change.
+ */
+export function toggleMemberNewsletter(subscribedIds: string[], newsletterId: string): string[] {
+    if (subscribedIds.includes(newsletterId)) {
+        return subscribedIds.filter(id => id !== newsletterId);
+    }
+    return [...subscribedIds, newsletterId].sort();
+}
+
+/** Client-side email sanity check for the save gate; the server remains authoritative. */
+export function isValidMemberEmail(email: string): boolean {
+    return MEMBER_EMAIL_REGEX.test(email.trim());
+}
+
+/**
+ * Message to render under the email field. Gated on `touched` so the empty
+ * initial state on the New member screen (or an email cleared briefly during
+ * a paste) doesn't render as an error the user hasn't provoked yet. Ember's
+ * validator runs on save-attempt for the same reason
+ * (`ghost/admin/app/validators/member.js:15`).
+ */
+export function getEmailErrorMessage(email: string, touched: boolean): string | null {
+    if (!touched) {
+        return null;
+    }
+    if (email.trim() === '') {
+        return 'Email is required.';
+    }
+    if (!isValidMemberEmail(email)) {
+        return 'Invalid email.';
+    }
+    return null;
+}
+
+export interface MemberSuppressionInfo {
+    // Undefined for a `suppressed:true` member without a bounce/complaint history —
+    // e.g. `email_disabled` was flipped directly. Ember still renders the banner in
+    // that case, just without the reason line.
+    reason?: string;
+    label: string | null;
+}
+
+/**
+ * Extract a display-ready suppression status for the newsletter/suppression banner.
+ * Returns null only when the member is not suppressed. `suppressed:true` is enough
+ * to render the banner even without the info block, matching Ember's behaviour
+ * where `email_disabled` alone (with the Mailgun row already cleaned) still shows
+ * "Email disabled" + the Re-enable button. Dates use site-local formatting to
+ * match the Ember copy exactly.
+ */
+export function getMemberSuppressionInfo(
+    emailSuppression: Member['email_suppression']
+): MemberSuppressionInfo | null {
+    if (!emailSuppression?.suppressed) {
+        return null;
+    }
+    const info = emailSuppression.info;
+    if (!info) {
+        return {label: null};
+    }
+    const {reason, timestamp} = info;
+    const date = moment(new Date(timestamp)).format('D MMM YYYY');
+    switch (reason) {
+    case 'fail':
+        return {reason, label: `Bounced on ${date}`};
+    case 'spam':
+        return {reason, label: `Flagged as spam on ${date}`};
+    default:
+        return {reason, label: `Email disabled on ${date}`};
+    }
+}
+
+/**
+ * Whether the newsletter section of the member form should render, gated on the
+ * `editor_default_email_recipients` setting the same way Ember does: only
+ * `'disabled'` hides it. Treating `undefined`/`null` as "show" biases for the
+ * common case (sites with emails enabled see no flash) at the cost of a possible
+ * flash-out on disabled sites when the setting finishes loading.
+ */
+/**
+ * Newsletters that Ember auto-subscribes a new member to on save. Ports
+ * `gh-member-settings-form.js:233-241`: keep only newsletters that opt in
+ * via `subscribe_on_signup` AND are visible to member-tier subscribers
+ * (`visibility: 'members'`). The result feeds the create-screen draft so
+ * the toggles render as CHECKED — matching what the admin would see if
+ * they'd opened the Ember screen — and the same list is included in the
+ * POST payload so the server never has to fall back to its own default.
+ */
+export function getDefaultNewsletterIdsForNewMember(
+    newsletters: Array<{id: string; subscribe_on_signup?: boolean; visibility?: string | null}> | undefined | null
+): string[] {
+    if (!newsletters) {
+        return [];
+    }
+    return newsletters
+        .filter(nl => nl.subscribe_on_signup === true && nl.visibility === 'members')
+        .map(nl => nl.id);
+}
+
+export function getMemberNewslettersUiEnabled(editorDefaultEmailRecipients: string | null | undefined): boolean {
+    return editorDefaultEmailRecipients !== 'disabled';
+}
+
+/**
+ * Characters remaining under the note soft limit. Counts unicode code points (via
+ * spread) rather than UTF-16 code units so multi-byte characters like emoji count
+ * as one — matching the Ember `gh-count-down-characters` helper. Goes negative when
+ * the limit is exceeded.
+ */
+export function getNoteCharactersLeft(note: string): number {
+    return NOTE_MAX_LENGTH - [...note].length;
+}
+
+/**
+ * Build the `useEditMember` payload for the field edits in this slice. Labels are
+ * sent as {name, slug} (server matches case-insensitively by name). Newsletters
+ * are sent as {id}[] ONLY when the user changed them, because the server replaces
+ * the subscription set with exactly what we send — including [] which would
+ * unsubscribe the member from every newsletter. Callers pass the server baseline
+ * so we can tell "unchanged" from "all newsletters removed".
+ */
+export function buildMemberFieldEditPayload(
+    id: string,
+    draft: MemberEditableFields,
+    serverBaseline: MemberEditableFields
+): EditMemberData {
+    const normalized = normalizeDraftForComparison(draft);
+    const payload: EditMemberData = {
+        id,
+        name: normalized.name,
+        email: normalized.email,
+        note: normalized.note,
+        labels: normalized.labels
+    };
+    if (!dequal(normalized.newsletters, serverBaseline.newsletters)) {
+        payload.newsletters = normalized.newsletters.map(nlId => ({id: nlId}));
+    }
+    return payload;
+}
+
+/**
+ * Resolve a list of selected label slugs back to full {name, slug} objects using a
+ * known-labels lookup. A slug missing from the lookup falls back to using the slug
+ * as the name — callers must ensure freshly-created labels are recorded first so a
+ * real name is never lost (which would make the server create a duplicate).
+ */
+export function resolveSlugsToLabels(
+    slugs: string[],
+    known: ReadonlyMap<string, MemberEditableLabel>
+): MemberEditableLabel[] {
+    return slugs.map(slug => known.get(slug) ?? {name: slug, slug});
+}
+
+/**
+ * Normalize an already-shaped draft for dirty comparison. The draft carries user
+ * input for string fields (which may contain leading/trailing whitespace); the
+ * relation lists (labels, newsletters) are already in their normalized shape.
+ * Trims strings so whitespace-only differences don't read as dirty.
+ */
+export function normalizeDraftForComparison(draft: MemberEditableFields): MemberEditableFields {
+    return {
+        name: draft.name.trim(),
+        email: draft.email.trim(),
+        note: draft.note,
+        labels: draft.labels,
+        newsletters: draft.newsletters
+    };
+}
+
+/**
+ * Whether the current draft still matches the last server baseline it was seeded
+ * from — i.e. the user has made no local edits. When true, a fresh server value
+ * (from a background refetch) can safely replace the draft without clobbering user
+ * input; when false, the draft holds unsaved edits and must be preserved.
+ * Comparison is on the normalized slice so whitespace-only differences don't count.
+ */
+export function isDraftInSyncWithServer(
+    draft: MemberEditableFields | undefined,
+    serverBaseline: MemberEditableFields | undefined
+): boolean {
+    return !draft || (!!serverBaseline && dequal(normalizeDraftForComparison(draft), serverBaseline));
+}

--- a/apps/admin/src/members/detail/member-detail-form.tsx
+++ b/apps/admin/src/members/detail/member-detail-form.tsx
@@ -1,0 +1,106 @@
+import MemberLabelsField from './member-labels-field';
+import React from 'react';
+import {Input, InputGroup, InputGroupAddon, InputGroupTextarea, Label} from '@tryghost/shade/components';
+import {NOTE_MAX_LENGTH, getNoteCharactersLeft} from './member-detail-edit';
+import {cn} from '@tryghost/shade/utils';
+import type {MemberEditableFields} from './member-detail-edit';
+
+interface MemberDetailFormProps {
+    draft: MemberEditableFields;
+    emailError?: string | null;
+    disabled?: boolean;
+    onChange: (patch: Partial<MemberEditableFields>) => void;
+    onEmailBlur?: () => void;
+    // Fired when the name field loses focus. Callers use it to sync a
+    // "committed identity" display state (e.g. the sidebar avatar) so it
+    // doesn't churn on every keystroke.
+    onNameBlur?: () => void;
+}
+
+const MemberDetailForm: React.FC<MemberDetailFormProps> = ({draft, emailError, disabled, onChange, onEmailBlur, onNameBlur}) => {
+    // Soft limit: the note can be typed past 500 (Ember has no hard cap); the counter
+    // just turns negative and red.
+    const noteCharactersLeft = getNoteCharactersLeft(draft.note);
+    const usedCharacters = NOTE_MAX_LENGTH - noteCharactersLeft;
+    const overLimit = noteCharactersLeft < 0;
+    // Traffic-light colour progression on the used-count digit as the note
+    // fills up. Ember only had two states (green/red); this extends it with
+    // a warning band as the user gets close to the limit so there's a visual
+    // heads-up before they cross it. Thresholds are lenient by design — most
+    // notes are short, and we don't want to nag on every keystroke.
+    const usedColorClass = overLimit
+        ? 'text-destructive'
+        : usedCharacters >= NOTE_MAX_LENGTH * 0.8
+            ? 'text-state-warning'
+            : 'text-state-success';
+
+    return (
+        // `items-stretch` on the grid so both columns share the tallest child's
+        // height. That lets the note-field column grow, and the textarea's
+        // `flex-1` inside it fills whatever's left after the character counter,
+        // so the textarea's bottom border lines up with the labels field's
+        // bottom border in the left column.
+        <div className='grid items-stretch gap-6 md:grid-cols-2' data-testid='member-detail-form'>
+            <div className='flex flex-col gap-5'>
+                <div className='flex flex-col gap-1.5'>
+                    <Label htmlFor='member-name'>Name</Label>
+                    <Input
+                        disabled={disabled}
+                        id='member-name'
+                        value={draft.name}
+                        onBlur={onNameBlur}
+                        onChange={e => onChange({name: e.target.value})}
+                    />
+                </div>
+
+                <div className='flex flex-col gap-1.5'>
+                    <Label htmlFor='member-email'>Email</Label>
+                    <Input
+                        aria-invalid={!!emailError}
+                        disabled={disabled}
+                        id='member-email'
+                        type='email'
+                        value={draft.email}
+                        onBlur={onEmailBlur}
+                        onChange={e => onChange({email: e.target.value})}
+                    />
+                    {emailError && <p className='text-sm text-destructive'>{emailError}</p>}
+                </div>
+
+                <div className='flex flex-col gap-1.5'>
+                    <Label>Labels</Label>
+                    <MemberLabelsField disabled={disabled} labels={draft.labels} onChange={nextLabels => onChange({labels: nextLabels})} />
+                </div>
+            </div>
+
+            <div className='flex min-h-0 flex-col gap-1.5'>
+                <Label htmlFor='member-note'>
+                    Note <span className='font-normal text-muted-foreground'>(not visible to member)</span>
+                </Label>
+                {/* Shade's InputGroup gives us the shared inputSurface chrome
+                    (border, radius, focus ring, invalid state) on the wrapper
+                    and a borderless textarea inside. `InputGroupAddon` with
+                    `align="block-end"` renders the counter as a proper footer
+                    inside the border — the textarea's scrollbar (including
+                    macOS's floating overlay style) stays visible above it. */}
+                <InputGroup className='flex-1'>
+                    <InputGroupTextarea
+                        className='h-full'
+                        disabled={disabled}
+                        id='member-note'
+                        value={draft.note}
+                        onChange={e => onChange({note: e.target.value})}
+                    />
+                    <InputGroupAddon align='block-end' className='justify-end'>
+                        <span className='text-sm text-muted-foreground'>
+                            Maximum: <span className='font-semibold text-foreground'>{NOTE_MAX_LENGTH}</span> characters. You’ve used{' '}
+                            <span className={cn('font-semibold', usedColorClass)}>{usedCharacters}</span>
+                        </span>
+                    </InputGroupAddon>
+                </InputGroup>
+            </div>
+        </div>
+    );
+};
+
+export default MemberDetailForm;

--- a/apps/admin/src/members/detail/member-detail-format.test.ts
+++ b/apps/admin/src/members/detail/member-detail-format.test.ts
@@ -1,0 +1,83 @@
+import {describe, expect, it} from 'vitest';
+import {formatMemberLocation, getMemberReferrerSource, parseMemberGeolocation} from './member-detail-format';
+
+describe('parseMemberGeolocation', () => {
+    it('returns null for missing input', () => {
+        expect(parseMemberGeolocation(null)).toBeNull();
+        expect(parseMemberGeolocation(undefined)).toBeNull();
+        expect(parseMemberGeolocation('')).toBeNull();
+    });
+
+    it('returns null for unparseable JSON', () => {
+        expect(parseMemberGeolocation('not json')).toBeNull();
+    });
+
+    it('returns null when the JSON is not an object', () => {
+        expect(parseMemberGeolocation('42')).toBeNull();
+        expect(parseMemberGeolocation('"US"')).toBeNull();
+        expect(parseMemberGeolocation('null')).toBeNull();
+        expect(parseMemberGeolocation('true')).toBeNull();
+    });
+
+    it('rejects arrays (which are typeof "object")', () => {
+        expect(parseMemberGeolocation('[1,2]')).toBeNull();
+    });
+
+    it('parses a geolocation JSON string into an object', () => {
+        expect(parseMemberGeolocation('{"country":"Turkey","country_code":"TR","region":"Izmir"}'))
+            .toEqual({country: 'Turkey', country_code: 'TR', region: 'Izmir'});
+    });
+});
+
+describe('formatMemberLocation', () => {
+    it('shows "Unknown location" when geolocation is missing or unparseable', () => {
+        expect(formatMemberLocation(null)).toBe('Unknown location');
+        expect(formatMemberLocation('nonsense')).toBe('Unknown location');
+    });
+
+    it('shows "Region, US" for US members that have a region', () => {
+        expect(formatMemberLocation('{"country":"United States","country_code":"US","region":"California"}'))
+            .toBe('California, US');
+    });
+
+    it('shows the country for non-US members', () => {
+        expect(formatMemberLocation('{"country":"Germany","country_code":"DE","region":"Berlin"}'))
+            .toBe('Germany');
+    });
+
+    it('shows the country for a US member that has no region', () => {
+        // Regression guard: US-without-region must fall through to the country, not "US".
+        expect(formatMemberLocation('{"country":"United States","country_code":"US"}'))
+            .toBe('United States');
+    });
+
+    it('falls back to "Unknown location" when a US member has neither region nor country', () => {
+        expect(formatMemberLocation('{"country_code":"US"}')).toBe('Unknown location');
+    });
+
+    it('falls back to "Unknown location" for an empty object', () => {
+        expect(formatMemberLocation('{}')).toBe('Unknown location');
+    });
+
+    it('falls back to "Unknown location" when the country is absent', () => {
+        expect(formatMemberLocation('{"region":"Somewhere"}')).toBe('Unknown location');
+    });
+});
+
+describe('getMemberReferrerSource', () => {
+    it('returns null when there is no attribution or source', () => {
+        expect(getMemberReferrerSource(null)).toBeNull();
+        expect(getMemberReferrerSource(undefined)).toBeNull();
+        expect(getMemberReferrerSource({})).toBeNull();
+        expect(getMemberReferrerSource({referrer_source: ''})).toBeNull();
+    });
+
+    it('returns the referrer source when present', () => {
+        expect(getMemberReferrerSource({referrer_source: 'Twitter'})).toBe('Twitter');
+    });
+
+    it('hides the "Created manually" placeholder source', () => {
+        // Mirrors the Ember gh-member-details referrerSource getter.
+        expect(getMemberReferrerSource({referrer_source: 'Created manually'})).toBeNull();
+    });
+});

--- a/apps/admin/src/members/detail/member-detail-format.ts
+++ b/apps/admin/src/members/detail/member-detail-format.ts
@@ -1,0 +1,65 @@
+export interface MemberGeolocation {
+    country_code?: string;
+    country?: string;
+    region?: string;
+    city?: string;
+}
+
+/**
+ * The members API returns `geolocation` as a JSON-encoded string (not a parsed
+ * object). Parse it defensively — a malformed or non-object payload yields null
+ * rather than throwing.
+ *
+ * (The members list has its own parse+format helper in `members-list-item.tsx`.
+ * They diverge in both the fallback string — the list says "Unknown", the detail
+ * screen matches Ember's "Unknown location" — and the control flow (the list also
+ * derives an `isKnown` flag for muted styling), so they're kept separate for now.
+ * A shared parser is a reasonable future cleanup.)
+ */
+export function parseMemberGeolocation(raw: string | null | undefined): MemberGeolocation | null {
+    if (!raw) {
+        return null;
+    }
+
+    try {
+        const parsed: unknown = JSON.parse(raw);
+        // Reject non-objects and arrays (arrays are `typeof 'object'`) so the guard is honest.
+        return (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) ? parsed : null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Human-readable member location, mirroring the Ember member-details template:
+ * US members with a region show "Region, US"; everyone else shows their country;
+ * anything missing falls back to "Unknown location".
+ */
+export function formatMemberLocation(rawGeolocation: string | null | undefined): string {
+    const geo = parseMemberGeolocation(rawGeolocation);
+
+    if (!geo) {
+        return 'Unknown location';
+    }
+
+    if (geo.country_code === 'US' && geo.region) {
+        return `${geo.region}, US`;
+    }
+
+    return geo.country || 'Unknown location';
+}
+
+/**
+ * The signup referrer source for the "Signup info" block. Members created from the
+ * admin carry the placeholder source "Created manually", which the Ember screen
+ * hides — so we return null for it (and for any empty source).
+ */
+export function getMemberReferrerSource(attribution: {referrer_source?: string | null} | null | undefined): string | null {
+    const source = attribution?.referrer_source;
+
+    if (!source || source === 'Created manually') {
+        return null;
+    }
+
+    return source;
+}

--- a/apps/admin/src/members/detail/member-detail-nav.test.ts
+++ b/apps/admin/src/members/detail/member-detail-nav.test.ts
@@ -1,0 +1,46 @@
+import {deriveMemberDetailBackPath} from './member-detail-nav';
+import {describe, expect, it} from 'vitest';
+
+describe('deriveMemberDetailBackPath', () => {
+    it('defaults to the members list when there is no back or post param', () => {
+        expect(deriveMemberDetailBackPath('')).toBe('/members');
+        expect(deriveMemberDetailBackPath('?foo=bar')).toBe('/members');
+    });
+
+    it('returns the back param when it points at the members area (preserving list filters)', () => {
+        const search = `?back=${encodeURIComponent('/members?filter=status:paid')}`;
+        expect(deriveMemberDetailBackPath(search)).toBe('/members?filter=status:paid');
+    });
+
+    it('ignores a back param that points outside the members area', () => {
+        expect(deriveMemberDetailBackPath(`?back=${encodeURIComponent('/settings/staff')}`)).toBe('/members');
+    });
+
+    it('ignores an absolute URL in the back param to avoid open redirects', () => {
+        expect(deriveMemberDetailBackPath(`?back=${encodeURIComponent('https://evil.example.com/members')}`)).toBe('/members');
+    });
+
+    it('ignores a protocol-relative URL in the back param', () => {
+        // `//evil.com` is the classic protocol-relative open-redirect vector — it must not pass the guard.
+        expect(deriveMemberDetailBackPath(`?back=${encodeURIComponent('//evil.example.com')}`)).toBe('/members');
+    });
+
+    it('treats any /members-prefixed path as internal (intentional Ember parity)', () => {
+        // The guard is a prefix check, matching the Ember controller. A value like
+        // `/members.evil.com` therefore passes — harmless because it renders as a
+        // same-origin `#/members.evil.com` hash link (SPA 404), never a cross-origin
+        // redirect. This test pins that intentional behaviour so it isn't "tightened"
+        // without a deliberate decision to diverge from Ember.
+        expect(deriveMemberDetailBackPath(`?back=${encodeURIComponent('/members.evil.com')}`)).toBe('/members.evil.com');
+    });
+
+    it('falls back to a post-scoped members list when only a post param is present', () => {
+        // Mirrors the Ember controller: /members?post=<encodeURIComponent(post)>
+        expect(deriveMemberDetailBackPath('?post=abc%20123')).toBe('/members?post=abc%20123');
+    });
+
+    it('prefers a valid back param over the post param', () => {
+        const search = `?back=${encodeURIComponent('/members?filter=label:vip')}&post=abc`;
+        expect(deriveMemberDetailBackPath(search)).toBe('/members?filter=label:vip');
+    });
+});

--- a/apps/admin/src/members/detail/member-detail-nav.ts
+++ b/apps/admin/src/members/detail/member-detail-nav.ts
@@ -1,0 +1,29 @@
+/**
+ * Works out where the member-detail "back" control should navigate to, mirroring
+ * the Ember member controller's `membersListPath`:
+ *   1. a `back` param that points at the members area (so list filters/scroll are
+ *      preserved) wins;
+ *   2. otherwise a `post` param scopes the return link to that post's members list;
+ *   3. otherwise fall back to the bare members list.
+ *
+ * The `startsWith('/members')` guard keeps navigation same-origin/internal and
+ * rejects absolute or protocol-relative URLs, so a crafted `back` value can't turn
+ * this into an open redirect.
+ *
+ * @param search - the location search string (e.g. `?back=%2Fmembers%3Ffilter...`)
+ */
+export function deriveMemberDetailBackPath(search: string): string {
+    const params = new URLSearchParams(search);
+
+    const back = params.get('back');
+    if (back && back.startsWith('/members')) {
+        return back;
+    }
+
+    const post = params.get('post');
+    if (post) {
+        return `/members?post=${encodeURIComponent(post)}`;
+    }
+
+    return '/members';
+}

--- a/apps/admin/src/members/detail/member-detail-sidebar.tsx
+++ b/apps/admin/src/members/detail/member-detail-sidebar.tsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import moment from 'moment-timezone';
+import {Avatar} from '@tryghost/shade/components';
+import {LucideIcon} from '@tryghost/shade/utils';
+import type {Member} from '@tryghost/admin-x-framework/api/members';
+import {formatMemberLocation, getMemberReferrerSource} from './member-detail-format';
+import {isSafeHref} from './is-safe-href';
+
+// Matches the members list (`members-list-item.tsx`), which also renders member
+// dates in UTC. Site-timezone formatting is a follow-up for the cutover.
+const formatDate = (value: string) => moment.utc(value).format('D MMM YYYY');
+
+const MetaRow: React.FC<{icon: React.ReactNode; children: React.ReactNode}> = ({icon, children}) => (
+    <p className='flex items-center gap-2 text-muted-foreground'>
+        <span className='shrink-0 text-muted-foreground'>{icon}</span>
+        <span className='min-w-0 truncate'>{children}</span>
+    </p>
+);
+
+interface MemberDetailSidebarProps {
+    // Saved member from the query — absent in create mode.
+    member?: Member;
+    // Live values from the draft: the sidebar mirrors what the user is typing so
+    // there's always an identity to show (matches Ember, which live-updates the
+    // sidebar title as the fields change).
+    draftName?: string;
+    draftEmail?: string;
+    // Ember-parity gate for the engagement stats section (see
+    // `gh-member-details.hbs:84`). Owned by the parent so all settings
+    // reads happen in one place.
+    engagementEnabled?: boolean;
+}
+
+// Matches Ember's `first-name` helper (`ghost/admin/app/helpers/first-name.js`):
+// splits on a single space, takes the first token. NO trim — a name that
+// somehow slipped through with a leading space should render the same empty
+// first-token Ember would, not a coincidentally-different truthy one.
+const getFirstName = (name: string) => name.split(' ')[0] || '';
+
+const MemberDetailSidebar: React.FC<MemberDetailSidebarProps> = ({member, draftName, draftEmail, engagementEnabled}) => {
+    // Prefer the live draft over the saved member so a rename shows up in the
+    // sidebar immediately. In create mode there's no saved member; fall back to
+    // "New member" so the sidebar isn't a bare avatar during first-run typing.
+    const name = (draftName ?? member?.name ?? '').trim();
+    const email = (draftEmail ?? member?.email ?? '').trim();
+    const identityName = name || email || 'New member';
+    const isNewMember = !member;
+
+    return (
+        <aside className='flex w-full shrink-0 flex-col gap-6 lg:w-80' data-testid='member-detail-sidebar'>
+            <div className='flex items-center gap-3 py-4'>
+                <Avatar className='size-12 min-w-12 [&_span]:text-lg' email={email || undefined} name={name || undefined} src={member?.avatar_image} />
+                <div className='min-w-0'>
+                    <h2 className='truncate text-xl font-semibold'>{identityName}</h2>
+                    {name && email && (
+                        <a className='block truncate text-muted-foreground hover:underline' href={`mailto:${email}`}>
+                            {email}
+                        </a>
+                    )}
+                    {!name && email && (
+                        // In create mode only the email is filled at first; still show it so the
+                        // sidebar visibly follows what the user has typed.
+                        <span className='block truncate text-muted-foreground'>{email}</span>
+                    )}
+                </div>
+            </div>
+
+            {!isNewMember && member && (
+                <>
+                    <div className='flex flex-col gap-2 text-sm'>
+                        <MetaRow icon={<LucideIcon.MapPin size={16} />}>
+                            <span data-testid='member-detail-location'>{formatMemberLocation(member.geolocation)}</span>
+                        </MetaRow>
+                        <MetaRow icon={<LucideIcon.Eye size={16} />}>
+                            {member.last_seen_at ? `Last seen on ${formatDate(member.last_seen_at)}` : 'Not seen yet'}
+                        </MetaRow>
+                        {member.can_comment === false && (
+                            <MetaRow icon={<LucideIcon.MessageSquareOff size={16} />}>
+                                Comments disabled
+                            </MetaRow>
+                        )}
+                    </div>
+
+                    <div className='mt-4 flex flex-col gap-3 text-sm'>
+                        <h3 className='border-b border-border pb-2 text-base font-semibold'>Signup info</h3>
+                        <MetaRow icon={<LucideIcon.UserPlus size={16} />}>
+                            Created — <span className='text-foreground'>{formatDate(member.created_at)}</span>
+                        </MetaRow>
+                        {(() => {
+                            const referrerSource = getMemberReferrerSource(member.attribution);
+                            return referrerSource ? (
+                                <MetaRow icon={<LucideIcon.Globe size={16} />}>
+                                    Source — <span className='text-foreground' title={referrerSource}>{referrerSource}</span>
+                                </MetaRow>
+                            ) : null;
+                        })()}
+                        {member.attribution?.title && (
+                            <MetaRow icon={<LucideIcon.FileText size={16} />}>
+                                {/* Attribution URLs originate from external
+                                    signup traffic (Referer header, UTM params),
+                                    so validate the scheme before dropping it
+                                    into an anchor `href`. Same rule set as the
+                                    activity feed. Falls back to plain text
+                                    when the URL is missing or unsafe. */}
+                                Page — {isSafeHref(member.attribution.url) ? (
+                                    <a className='truncate text-foreground hover:underline' href={member.attribution.url} rel='noopener noreferrer' target='_blank' title={member.attribution.title}>{member.attribution.title}</a>
+                                ) : (
+                                    <span className='truncate text-foreground' title={member.attribution.title}>{member.attribution.title}</span>
+                                )}
+                            </MetaRow>
+                        )}
+                    </div>
+
+                    {engagementEnabled && (
+                        <section className='mt-4 flex flex-col gap-3 text-sm' data-testid='member-detail-engagement'>
+                            <h4 className='border-b border-border pb-2 text-base font-semibold'>Engagement</h4>
+                            {/* `?? 0` matches Ember Data's serializer, which
+                                defaults `emailCount` to `0`
+                                (`ghost/admin/app/models/member.js:20`). A
+                                strict `=== 0` would diverge from Ember on
+                                a payload where the field is `undefined`. */}
+                            {(member.email_count ?? 0) === 0 ? (
+                                // Ember `gh-member-details.hbs:87-96`: same copy,
+                                // same curly apostrophe. Falls back to a generic
+                                // "this member" when no name is known.
+                                <p className='text-muted-foreground'>
+                                    {name
+                                        ? `We’ll show ${getFirstName(name)}’s email stats here once they receive their first newsletter.`
+                                        : 'We’ll show this member’s email stats here once they receive their first newsletter.'}
+                                </p>
+                            ) : (
+                                <div className='flex flex-col gap-4'>
+                                    <div className='flex flex-col gap-0.5'>
+                                        <p className='text-muted-foreground'>Emails received</p>
+                                        <p className='text-2xl font-semibold'>{member.email_count}</p>
+                                    </div>
+                                    <div className='flex flex-col gap-0.5'>
+                                        <p className='text-muted-foreground'>Emails opened</p>
+                                        {/* Ember Data defaults this to `0`
+                                            too (`ghost/admin/app/models/member.js:21`),
+                                            so mirror that here for parity. */}
+                                        <p className='text-2xl font-semibold'>{member.email_opened_count ?? 0}</p>
+                                    </div>
+                                    <div className='flex flex-col gap-0.5'>
+                                        <p className='text-muted-foreground'>Average open rate</p>
+                                        {member.email_open_rate === null || member.email_open_rate === undefined ? (
+                                            // Server sends `null` until the member has
+                                            // been sent 5 newsletters (Ember shows this
+                                            // exact string via
+                                            // `gh-member-details.hbs:112-114`).
+                                            <p className='text-muted-foreground'>
+                                                This metric is calculated once a member has received 5 newsletters.
+                                            </p>
+                                        ) : (
+                                            <p className='text-2xl font-semibold'>
+                                                {member.email_open_rate}<span className='text-base font-normal text-muted-foreground'>%</span>
+                                            </p>
+                                        )}
+                                    </div>
+                                </div>
+                            )}
+                        </section>
+                    )}
+                </>
+            )}
+        </aside>
+    );
+};
+
+export default MemberDetailSidebar;

--- a/apps/admin/src/members/detail/member-detail.tsx
+++ b/apps/admin/src/members/detail/member-detail.tsx
@@ -1,0 +1,509 @@
+import MemberActionsMenu from './member-actions-menu';
+import MemberActivityFeed from './member-activity-feed';
+import MemberDetailForm from './member-detail-form';
+import MemberDetailSidebar from './member-detail-sidebar';
+import MemberNewslettersField from './member-newsletters-field';
+import MemberSubscriptionsSection from './member-subscriptions-section';
+import React from 'react';
+import {AlertDialog, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator, Button, type ButtonProps, Card, CardContent, LoadingIndicator, Skeleton} from '@tryghost/shade/components';
+import {Box, Container} from '@tryghost/shade/primitives';
+import {DetailPage} from '@tryghost/shade/page-templates';
+import {Link, useConfirmUnload, useLocation, useNavigate, useParams} from '@tryghost/admin-x-framework';
+import {PageHeader} from '@tryghost/shade/patterns';
+import {buildMemberFieldEditPayload, getDefaultNewsletterIdsForNewMember, getEmailErrorMessage, getMemberEditableSlice, getMemberNewslettersUiEnabled, isDraftInSyncWithServer, isValidMemberEmail, normalizeDraftForComparison} from './member-detail-edit';
+import {dequal} from 'dequal';
+import {deriveMemberDetailBackPath} from './member-detail-nav';
+import {formatMemberName} from '@tryghost/shade/app';
+import {getMember, useAddMember, useEditMember} from '@tryghost/admin-x-framework/api/members';
+import {getSettingValue, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
+import {toast} from 'sonner';
+import {useBlocker} from 'react-router';
+import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
+import {useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
+import type {MemberEditableFields} from './member-detail-edit';
+
+// The create screen reuses this route with the sentinel id "new". Safe because
+// real member ids are 24-char hex ObjectIds and can't collide with this literal.
+const CREATE_ID = 'new';
+
+interface MemberDetailPageProps {
+    // Which sections the site's settings allow. Resolved by the container below
+    // so this component never has to reason about half-loaded settings.
+    paidMembersEnabled: boolean;
+    newslettersUiEnabled: boolean;
+    engagementEnabled: boolean;
+}
+
+const MemberDetailPage: React.FC<MemberDetailPageProps> = ({paidMembersEnabled, newslettersUiEnabled, engagementEnabled}) => {
+    const {member_id: memberId = ''} = useParams<{member_id: string}>();
+    const location = useLocation();
+    const navigate = useNavigate();
+    const backPath = deriveMemberDetailBackPath(location.search);
+    const isCreating = memberId === CREATE_ID;
+
+    // `include=tiers` mirrors the Ember route so complimentary tiers arrive with the member.
+    const {data, isLoading, error, refetch} = getMember(memberId, {
+        enabled: !!memberId && !isCreating,
+        searchParams: {include: 'tiers'},
+        defaultErrorHandler: false
+    });
+    const member = data?.members?.[0];
+    // 4xx from the members endpoint on a real id means "gone" (deleted mid-flow
+    // is the realistic case). 5xx/network is a different story — we don't want
+    // to lie about that with a "not found" message.
+    const loadError = !isCreating && !isLoading && !!error;
+    const notFound = !isCreating && !isLoading && !error && !member;
+
+    const editMutation = useEditMember();
+    const addMutation = useAddMember();
+    const activeMutation = isCreating ? addMutation : editMutation;
+
+    // "Add complimentary" is only meaningful when the site has at least one active
+    // paid tier for the comp to reference. Skip the query entirely if paid members
+    // aren't enabled — nothing on this screen consumes it in that case.
+    const {data: tiersData} = useBrowseTiers({
+        searchParams: {filter: 'type:paid+active:true', limit: 'all'},
+        enabled: paidMembersEnabled
+    });
+    const canAddComp = (tiersData?.tiers?.length ?? 0) > 0;
+
+    // Newsletter list is fetched inside `MemberNewslettersField`; react-query
+    // dedupes matching query keys so re-querying here is free and lets us
+    // derive `hasMultipleNewsletters` for the activity feed's newsletter rows.
+    // We surface `newslettersResolved` too — the feed uses it to defer parsing
+    // until the answer is known, avoiding a label churn from generic
+    // "subscribed to newsletter" → specific "subscribed to Weekly".
+    // Newsletters are fetched on BOTH create and edit modes: on create so we
+    // can seed the draft with Ember's default subscriptions
+    // (`subscribe_on_signup:true + visibility:members`, matching
+    // `gh-member-settings-form.js:233-241`); on edit so the activity feed can
+    // decide whether to render newsletter labels.
+    const {data: newslettersData} = useBrowseNewsletters({
+        searchParams: {filter: 'status:active', limit: '50'}
+    });
+    const newslettersResolved = newslettersData !== undefined;
+    const hasMultipleNewsletters = (newslettersData?.newsletters?.length ?? 0) > 1;
+    const hasMultipleTiers = (tiersData?.tiers?.length ?? 0) > 1;
+
+    // Draft holds the user's in-progress edits; the query cache stays server truth.
+    const [draft, setDraft] = React.useState<MemberEditableFields | undefined>(undefined);
+    const draftMemberIdRef = React.useRef<string | undefined>(undefined);
+    const lastServerSliceRef = React.useRef<MemberEditableFields | undefined>(undefined);
+    // One-shot flag: have we seeded create-mode newsletter defaults yet? Reset
+    // when re-entering create mode (draftMemberIdRef flips off CREATE_ID).
+    const newsletterDefaultsSeededRef = React.useRef(false);
+    // Lets the post-create redirect through the unsaved-changes blocker.
+    const bypassGuardRef = React.useRef(false);
+    React.useEffect(() => {
+        if (isCreating) {
+            if (draftMemberIdRef.current !== CREATE_ID) {
+                draftMemberIdRef.current = CREATE_ID;
+                newsletterDefaultsSeededRef.current = false;
+                const empty = getMemberEditableSlice({});
+                lastServerSliceRef.current = empty;
+                setDraft(empty);
+            }
+            return;
+        }
+        if (!member) {
+            return;
+        }
+        const nextServerSlice = getMemberEditableSlice(member);
+        if (draftMemberIdRef.current !== member.id) {
+            // A different member loaded → start fresh from its server values.
+            draftMemberIdRef.current = member.id;
+            lastServerSliceRef.current = nextServerSlice;
+            setDraft(nextServerSlice);
+            return;
+        }
+        // Same member, fresh server data (posts queries use staleTime:0 +
+        // refetchOnMount): adopt it only if the user hasn't edited.
+        const previousServerSlice = lastServerSliceRef.current;
+        lastServerSliceRef.current = nextServerSlice;
+        setDraft(prev => (isDraftInSyncWithServer(prev, previousServerSlice) ? nextServerSlice : prev));
+    }, [member, isCreating]);
+
+    // Reset the create-redirect bypass whenever the route target changes.
+    React.useEffect(() => {
+        bypassGuardRef.current = false;
+    }, [memberId]);
+
+    // Seed the create-mode draft with the Ember default newsletter set the
+    // first time the newsletters query resolves. Runs at most once per
+    // create-screen visit (`newsletterDefaultsSeededRef` is reset when
+    // create mode is re-entered) so a user who deselects a default doesn't
+    // have it re-checked by a background refetch. The seeded IDs also
+    // become the "server slice" baseline, which keeps the Save button
+    // disabled until the user actually changes something — the pre-checked
+    // toggles don't read as unsaved changes.
+    React.useEffect(() => {
+        if (!isCreating || newsletterDefaultsSeededRef.current || !newslettersData?.newsletters) {
+            return;
+        }
+        newsletterDefaultsSeededRef.current = true;
+        const defaults = getDefaultNewsletterIdsForNewMember(newslettersData.newsletters);
+        if (defaults.length === 0) {
+            return;
+        }
+        // Seeded newsletters count as the baseline, not as an edit, so the ref
+        // moves with the draft. Assigned here rather than inside the updater:
+        // updaters must stay pure, since React may run them more than once.
+        const seeded = {...(lastServerSliceRef.current ?? getMemberEditableSlice({})), newsletters: [...defaults].sort()};
+        lastServerSliceRef.current = seeded;
+        setDraft(prev => (prev ? {...prev, newsletters: [...defaults].sort()} : prev));
+    }, [isCreating, newslettersData]);
+
+    // In create mode the baseline is whatever the seeding effect has decided
+    // (`lastServerSliceRef.current` = empty initial draft OR draft + default
+    // newsletters once the newsletters query resolves). Using a fresh
+    // `getMemberEditableSlice({})` here would treat the seeded defaults as
+    // "unsaved changes" and trigger the beforeunload/nav-blocker on an
+    // untouched form. In edit mode we still compare against the live server
+    // value so a background refetch resurfaces external changes.
+    const serverSlice = isCreating
+        ? lastServerSliceRef.current
+        : (member ? getMemberEditableSlice(member) : undefined);
+    const hasUnsavedChanges = !!draft && !!serverSlice && !dequal(normalizeDraftForComparison(draft), serverSlice);
+    const emailValid = !!draft && isValidMemberEmail(draft.email);
+    // `touched` is set on the email field's first blur. That keeps the New
+    // member screen from painting an "Email is required." error before the
+    // user has done anything, matching Ember's save-time-only validator
+    // (`ghost/admin/app/validators/member.js:15`). Reset below when the
+    // member id or create-mode flag changes so a fresh screen starts clean.
+    const [emailTouched, setEmailTouched] = React.useState(false);
+    React.useEffect(() => {
+        setEmailTouched(false);
+    }, [member?.id, isCreating]);
+    const emailError = draft ? getEmailErrorMessage(draft.email, emailTouched) : null;
+
+    // The sidebar's identity block (avatar + heading) reads from a "committed"
+    // copy of name/email that only advances on blur, not per keystroke.
+    // Live-updating the avatar's gravatar/initials on every character felt
+    // noisy while typing. Initialized from the saved member (edit) or empty
+    // (create); synced on Save via the mutation success handler.
+    const [committedIdentity, setCommittedIdentity] = React.useState<{name: string; email: string}>({name: '', email: ''});
+    React.useEffect(() => {
+        if (isCreating) {
+            setCommittedIdentity({name: '', email: ''});
+            return;
+        }
+        if (member) {
+            setCommittedIdentity({name: member.name ?? '', email: member.email ?? ''});
+        }
+    }, [member?.id, member?.name, member?.email, isCreating]);
+    const commitIdentityFromDraft = () => {
+        if (draft) {
+            setCommittedIdentity({name: draft.name, email: draft.email});
+        }
+    };
+
+    const onFieldChange = (patch: Partial<MemberEditableFields>) => {
+        if (activeMutation.isError) {
+            activeMutation.reset();
+        }
+        setDraft(prev => (prev ? {...prev, ...patch} : prev));
+    };
+
+    const onSave = () => {
+        if (!draft || !hasUnsavedChanges || !emailValid || activeMutation.isPending) {
+            return;
+        }
+        // Sync committed identity so the sidebar avatar shows what's actively
+        // being saved rather than the pre-blur value (in case the user hit
+        // Save without tabbing out of the name/email field first).
+        commitIdentityFromDraft();
+
+        if (isCreating) {
+            addMutation.mutate({
+                email: draft.email.trim(),
+                name: draft.name.trim() || undefined,
+                note: draft.note.trim() || undefined,
+                labels: draft.labels.length ? draft.labels : undefined,
+                // Send the visibly-selected newsletter set ONLY once the
+                // seeding effect has run. If the user manages to hit Save
+                // before the newsletters query resolves, we don't have
+                // a reliable "what would Ember show?" snapshot, so we omit
+                // the key entirely and let the server apply its own default
+                // (`member-repository.js:460-464`) — same effective outcome
+                // as Ember's Ember-data unpopulated hasMany. An empty
+                // seeded list (user deselected everything) is still sent
+                // explicitly so the intent isn't lost to the server default.
+                newsletters: newsletterDefaultsSeededRef.current
+                    ? draft.newsletters.map(id => ({id}))
+                    : undefined
+            }, {
+                onSuccess: (response) => {
+                    const created = response.members?.[0];
+                    if (!created) {
+                        // Server said OK but returned no member — surface it as an error
+                        // so the user isn't stranded on a form that quietly resubmits.
+                        toast.error('Member couldn’t be created');
+                        return;
+                    }
+                    // Skip the unsaved-changes guard for our own redirect to the
+                    // freshly-created member.
+                    bypassGuardRef.current = true;
+                    toast.success('Member created');
+                    navigate(`/members/${created.id}`, {replace: true});
+                },
+                onError: () => {
+                    toast.error('Member couldn’t be created');
+                }
+            });
+            return;
+        }
+
+        // Guard against saving a draft that belongs to a different member.
+        if (!member || draftMemberIdRef.current !== member.id) {
+            return;
+        }
+        editMutation.mutate(buildMemberFieldEditPayload(member.id, draft, getMemberEditableSlice(member)), {
+            onSuccess: (response) => {
+                const saved = response.members?.[0];
+                if (saved) {
+                    const savedSlice = getMemberEditableSlice(saved);
+                    lastServerSliceRef.current = savedSlice;
+                    setDraft(savedSlice);
+                }
+                toast.success('Member updated');
+            },
+            onError: () => {
+                toast.error('Member couldn’t be saved');
+            }
+        });
+    };
+
+    useConfirmUnload(activeMutation.isPending || hasUnsavedChanges);
+    const blocker = useBlocker(({currentLocation, nextLocation}) => !bypassGuardRef.current && hasUnsavedChanges && currentLocation.pathname !== nextLocation.pathname);
+    const isBlocked = blocker.state === 'blocked';
+
+    // Save button state (Save / Saving / Saved / Retry), mirroring the Ember task button.
+    let saveLabel: React.ReactNode = 'Save';
+    let saveVariant: ButtonProps['variant'] = 'default';
+    let saveDisabled = true;
+    if (activeMutation.isPending) {
+        saveLabel = <><LoadingIndicator size='sm' /><span className='sr-only'>Saving</span></>;
+    } else if (hasUnsavedChanges) {
+        saveLabel = activeMutation.isError ? 'Retry' : 'Save';
+        saveVariant = activeMutation.isError ? 'destructive' : 'default';
+        saveDisabled = !emailValid;
+    } else if (!isCreating && editMutation.isSuccess) {
+        saveLabel = 'Saved';
+    }
+
+    const showEditor = !!draft && (isCreating || !!member);
+    // A failed load is not a missing member: claiming "not found" next to a
+    // "couldn't load" body tells the admin two different things at once, and
+    // the member may well still exist.
+    let title = 'Member';
+    if (isCreating) {
+        title = 'New member';
+    } else if (member) {
+        title = formatMemberName(member);
+    } else if (notFound) {
+        title = 'Member not found';
+    }
+
+    return (
+        <Box className='size-full'><Container className='relative flex h-full flex-col' size='page'>
+            <DetailPage data-testid='member-detail'>
+                <DetailPage.Header>
+                    <PageHeader blurredBackground={false} sticky={false}>
+                        <PageHeader.Left>
+                            {/*
+                              * Breadcrumb sits directly under Left rather than inside
+                              * PageHeader.Breadcrumb — that slot adds a `pt-1` offset that
+                              * only makes sense when a title stacks below the breadcrumb.
+                              */}
+                            <Breadcrumb>
+                                <BreadcrumbList>
+                                    <BreadcrumbItem>
+                                        <BreadcrumbLink asChild>
+                                            <Link data-test-link='members-back' to={backPath}>Members</Link>
+                                        </BreadcrumbLink>
+                                    </BreadcrumbItem>
+                                    <BreadcrumbSeparator />
+                                    <BreadcrumbItem>
+                                        {!isCreating && isLoading ? (
+                                            <Skeleton className='h-4 w-40' />
+                                        ) : (
+                                            <BreadcrumbPage className='truncate' data-testid='member-detail-title'>
+                                                {title}
+                                            </BreadcrumbPage>
+                                        )}
+                                    </BreadcrumbItem>
+                                </BreadcrumbList>
+                            </Breadcrumb>
+                        </PageHeader.Left>
+                        {(isCreating || member) && (
+                            <PageHeader.Actions>
+                                <PageHeader.ActionGroup>
+                                    {member && !isCreating && (
+                                        // key={member.id} unmounts+remounts on member change so
+                                        // local modal state (`showDelete`, `cancelStripe`, etc.)
+                                        // can't leak across members if the user navigates while a
+                                        // modal is open.
+                                        <MemberActionsMenu
+                                            key={member.id}
+                                            allowLeaveWithUnsavedChanges={() => {
+                                                bypassGuardRef.current = true;
+                                            }}
+                                            member={member}
+                                        />
+                                    )}
+                                    <Button className='min-w-16' disabled={saveDisabled} variant={saveVariant} onClick={onSave}>
+                                        {saveLabel}
+                                    </Button>
+                                </PageHeader.ActionGroup>
+                            </PageHeader.Actions>
+                        )}
+                    </PageHeader>
+                </DetailPage.Header>
+
+                <DetailPage.Body>
+                    {loadError && (
+                        <div className='flex flex-1 flex-col items-center justify-center gap-3' data-testid='member-detail-load-error'>
+                            <p className='text-muted-foreground'>Couldn’t load this member.</p>
+                            <Button variant='outline' onClick={() => void refetch()}>Retry</Button>
+                        </div>
+                    )}
+
+                    {notFound && (
+                        <div className='flex flex-1 items-center justify-center'>
+                            <p className='text-muted-foreground'>This member couldn’t be found.</p>
+                        </div>
+                    )}
+
+                    {showEditor && draft && (
+                        <div className='flex flex-1 flex-col gap-8 lg:flex-row lg:items-start lg:gap-12'>
+                            <MemberDetailSidebar draftEmail={committedIdentity.email} draftName={committedIdentity.name} engagementEnabled={engagementEnabled} member={member} />
+                            <div className='flex min-w-0 flex-1 flex-col gap-8'>
+                                {/* First card: name, email, labels, note — no external header. */}
+                                <Card>
+                                    <CardContent className='p-6'>
+                                        <MemberDetailForm
+                                            disabled={activeMutation.isPending}
+                                            draft={draft}
+                                            emailError={emailError}
+                                            onChange={onFieldChange}
+                                            onEmailBlur={() => {
+                                                setEmailTouched(true);
+                                                commitIdentityFromDraft();
+                                            }}
+                                            onNameBlur={commitIdentityFromDraft}
+                                        />
+                                    </CardContent>
+                                </Card>
+
+                                {/* Newsletters section owns its external heading + card so an empty
+                                    newsletter list hides the whole thing (returns null). Renders
+                                    on /members/new too so an admin can pick the initial
+                                    subscription set at creation — matches Ember's
+                                    `gh-member-settings-form.hbs:74-80`. */}
+                                {newslettersUiEnabled && (isCreating || member) && (
+                                    <MemberNewslettersField
+                                        disabled={activeMutation.isPending}
+                                        emailSuppression={member?.email_suppression}
+                                        memberId={member?.id}
+                                        subscribedIds={draft.newsletters}
+                                        onChange={nextIds => onFieldChange({newsletters: nextIds})}
+                                    />
+                                )}
+
+                                {/* Subscriptions: external "SUBSCRIPTIONS" label + own card. Matches
+                                    Ember's `gh-member-settings-form.hbs:82`, which always renders
+                                    the section under `{{#if paidMembersEnabled}}` — including on
+                                    the New member screen, where the empty-state card shows a
+                                    "No subscriptions" indicator until the member is created. The
+                                    child component early-returns when there's nothing to show
+                                    (no subs, no add-comp affordance available), matching Ember's
+                                    `{{#unless this.tiers}}` branch. */}
+                                {paidMembersEnabled && (
+                                    <section aria-labelledby='member-subscriptions-heading' className='flex flex-col gap-3'>
+                                        <h3 className='text-base font-semibold' id='member-subscriptions-heading'>Subscriptions</h3>
+                                        <MemberSubscriptionsSection canAddComp={canAddComp} member={member} />
+                                    </section>
+                                )}
+
+                                {/* Recent activity feed — Ember `activity-feed.hbs` shows the top
+                                    5 events for a saved member, and switches to a "no events yet"
+                                    empty state when `@member.isNew` (`activity-feed.hbs:2`).
+                                    We mirror the same section wrapper for both states so the
+                                    section header is consistent. `newslettersResolved` avoids a
+                                    row-label churn when the newsletters query hasn't returned
+                                    yet — irrelevant in create mode, so gate it on `!isCreating`. */}
+                                {(isCreating || (member && newslettersResolved)) && (
+                                    <MemberActivityFeed
+                                        hasMultipleNewsletters={hasMultipleNewsletters}
+                                        hasMultipleTiers={hasMultipleTiers}
+                                        memberId={member?.id}
+                                        paidMembersEnabled={paidMembersEnabled}
+                                    />
+                                )}
+                            </div>
+                        </div>
+                    )}
+                </DetailPage.Body>
+
+                <AlertDialog open={isBlocked} onOpenChange={(open) => {
+                    if (!open && isBlocked) {
+                        blocker.reset?.();
+                    }
+                }}>
+                    <AlertDialogContent>
+                        <AlertDialogHeader>
+                            <AlertDialogTitle>Discard unsaved changes?</AlertDialogTitle>
+                            <AlertDialogDescription>Your changes will be lost if you leave this member.</AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                            <AlertDialogCancel>Keep editing</AlertDialogCancel>
+                            <Button variant='destructive' onClick={() => blocker.proceed?.()}>Leave</Button>
+                        </AlertDialogFooter>
+                    </AlertDialogContent>
+                </AlertDialog>
+            </DetailPage>
+        </Container></Box>
+    );
+};
+
+/**
+ * Resolves the settings that decide which sections this screen shows, so the
+ * screen itself only ever sees settled answers. Reading them inline instead
+ * means every gate has to pick a meaning for `undefined`, and the honest
+ * choices disagree: a section defaulted off pops in when settings land, one
+ * defaulted on flashes out. Following `members.tsx`, hold the chrome until the
+ * answers exist.
+ */
+const MemberDetail: React.FC = () => {
+    const {data: settingsData, isLoading: isSettingsLoading} = useBrowseSettings({});
+
+    if (isSettingsLoading || !settingsData?.settings) {
+        return (
+            <Box className='size-full'><Container className='relative flex h-full flex-col' size='page'>
+                <DetailPage>
+                    <DetailPage.Body>
+                        <div className='flex flex-1 items-center justify-center'>
+                            <LoadingIndicator size='lg' />
+                        </div>
+                    </DetailPage.Body>
+                </DetailPage>
+            </Container></Box>
+        );
+    }
+
+    const editorDefaultRecipients = getSettingValue<string>(settingsData.settings, 'editor_default_email_recipients');
+    const membersSignupAccess = getSettingValue<string>(settingsData.settings, 'members_signup_access');
+
+    return (
+        <MemberDetailPage
+            // Hidden when the site can't sign up members or has email disabled:
+            // the numbers are always zero and only add noise. Mirrors Ember.
+            engagementEnabled={membersSignupAccess !== 'none' && editorDefaultRecipients !== 'disabled'}
+            newslettersUiEnabled={getMemberNewslettersUiEnabled(editorDefaultRecipients)}
+            // Sites without paid memberships never see subscription UI.
+            paidMembersEnabled={getSettingValue<boolean>(settingsData.settings, 'paid_members_enabled') === true}
+        />
+    );
+};
+
+export default MemberDetail;

--- a/apps/admin/src/members/detail/member-disable-commenting-modal.tsx
+++ b/apps/admin/src/members/detail/member-disable-commenting-modal.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import {Button, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, LoadingIndicator, Switch} from '@tryghost/shade/components';
+import {toast} from 'sonner';
+import {useDisableMemberCommenting} from '@tryghost/admin-x-framework/api/members';
+import {useQueryClient} from '@tanstack/react-query';
+import type {Member} from '@tryghost/admin-x-framework/api/members';
+
+interface MemberDisableCommentingModalProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    member: Pick<Member, 'id' | 'name' | 'email'>;
+}
+
+// Matches Ember `disable-commenting.js:23` verbatim so the audit trail on the
+// server stays consistent across the migration.
+const DISABLE_REASON = 'Disabled from member settings';
+
+/**
+ * Confirms "Disable commenting" for a member. Ember parity:
+ *   - Optional "Hide all previous comments" checkbox → `hide_comments=true`.
+ *   - Reason is the fixed string above (Ember hardcodes the same).
+ *   - Success toast reads "Commenting has been disabled for <name-or-email>."
+ *
+ * Uses Shade Dialog (not AlertDialog) because it hosts a form control that
+ * changes the outcome, not just a yes/no choice.
+ */
+const MemberDisableCommentingModal: React.FC<MemberDisableCommentingModalProps> = ({open, onOpenChange, member}) => {
+    const queryClient = useQueryClient();
+    const disable = useDisableMemberCommenting();
+    const [hideComments, setHideComments] = React.useState(false);
+
+    // Reset the checkbox on every reopen so a stale selection can't leak into a
+    // fresh flow.
+    React.useEffect(() => {
+        if (open) {
+            setHideComments(false);
+        }
+    }, [open]);
+
+    const displayName = member.name || member.email || 'this member';
+
+    const onConfirm = async () => {
+        try {
+            await disable.mutateAsync({id: member.id, reason: DISABLE_REASON, hideComments});
+        } catch {
+            toast.error('Couldn’t disable commenting. Please try again.');
+            return;
+        }
+        // Commit the success UX first, then fire-and-forget the extra
+        // members-cache refresh. If the follow-up refetch fails we do NOT
+        // want to flip an already-shown success toast to an error — the
+        // disable itself succeeded and is reflected server-side.
+        toast.success(`Commenting has been disabled for ${displayName}.`);
+        onOpenChange(false);
+        // The framework hook only invalidates CommentsResponseType; refresh
+        // the members cache so the actions-menu label flips to "Enable
+        // commenting" on the next render.
+        void queryClient.invalidateQueries({queryKey: ['MembersResponseType']});
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={(next) => {
+            if (disable.isPending) {
+                return;
+            }
+            onOpenChange(next);
+        }}>
+            <DialogContent data-testid='disable-commenting-modal'>
+                <DialogHeader>
+                    <DialogTitle>Disable commenting</DialogTitle>
+                    <DialogDescription>
+                        <strong>{displayName}</strong> won’t be able to comment in the future. You can re-enable commenting anytime.
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div className='flex items-start justify-between gap-4'>
+                    <div className='flex flex-col gap-0.5'>
+                        <h4 className='text-sm font-medium'>Hide all previous comments</h4>
+                    </div>
+                    <Switch
+                        aria-label='Hide all previous comments'
+                        checked={hideComments}
+                        data-testid='disable-commenting-hide-comments'
+                        disabled={disable.isPending}
+                        onCheckedChange={setHideComments}
+                    />
+                </div>
+
+                <DialogFooter>
+                    <Button
+                        data-testid='cancel-disable-commenting'
+                        disabled={disable.isPending}
+                        variant='outline'
+                        onClick={() => onOpenChange(false)}
+                    >
+                        Cancel
+                    </Button>
+                    <Button
+                        data-testid='confirm-disable-commenting'
+                        disabled={disable.isPending}
+                        onClick={() => void onConfirm()}
+                    >
+                        {disable.isPending ? (
+                            <>
+                                <LoadingIndicator size='sm' />
+                                <span className='sr-only'>Disabling</span>
+                            </>
+                        ) : 'Disable commenting'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+export default MemberDisableCommentingModal;

--- a/apps/admin/src/members/detail/member-event.test.ts
+++ b/apps/admin/src/members/detail/member-event.test.ts
@@ -1,0 +1,293 @@
+import {describe, expect, it} from 'vitest';
+import {parseMemberEvent} from './member-event';
+
+// Ports Ember `helpers/parse-member-event.js`. The Ember helper is a Glimmer
+// component with injected services (`membersUtils`, `feature`); we take those
+// as an explicit context object so the pure function stays testable.
+
+function ev(type: string, data: Record<string, unknown> = {}) {
+    return {
+        type,
+        data: {
+            created_at: '2026-01-15T12:00:00.000Z',
+            ...data
+        }
+    };
+}
+
+const defaultCtx = {hasMultipleNewsletters: false, hasMultipleTiers: false, paidMembersEnabled: false};
+
+describe('parseMemberEvent — subject', () => {
+    it('uses member.name when trimmed non-empty', () => {
+        const parsed = parseMemberEvent(ev('signup_event', {member: {name: '  Ada  ', email: 'ada@x.co'}}), defaultCtx);
+        expect(parsed.subject).toBe('Ada');
+    });
+
+    it('falls back to member.email when name is empty/whitespace', () => {
+        const parsed = parseMemberEvent(ev('signup_event', {member: {name: '   ', email: 'ada@x.co'}}), defaultCtx);
+        expect(parsed.subject).toBe('ada@x.co');
+    });
+
+    it('falls back to top-level name/email when member is absent (guest event)', () => {
+        expect(parseMemberEvent(ev('signup_event', {name: 'X'}), defaultCtx).subject).toBe('X');
+        expect(parseMemberEvent(ev('signup_event', {email: 'x@x.co'}), defaultCtx).subject).toBe('x@x.co');
+        expect(parseMemberEvent(ev('signup_event'), defaultCtx).subject).toBe('');
+    });
+});
+
+describe('parseMemberEvent — icon', () => {
+    // Icon names are prefixed with `event-` (Ember `getIcon` return).
+    const cases: Array<[string, Record<string, unknown>, string]> = [
+        ['login_event', {}, 'event-logged-in'],
+        ['signup_event', {}, 'event-signed-up'],
+        ['payment_event', {}, 'event-subscriptions'],
+        ['newsletter_event', {subscribed: true}, 'event-subscribed-to-email'],
+        ['newsletter_event', {subscribed: false}, 'event-unsubscribed-from-email'],
+        ['subscription_event', {type: 'created'}, 'event-subscriptions'],
+        ['subscription_event', {type: 'canceled'}, 'event-canceled-subscription'],
+        // Ember special-case: subscription_event + signup flag renders as signup.
+        ['subscription_event', {type: 'created', signup: true}, 'event-signed-up'],
+        ['email_opened_event', {}, 'event-opened-email'],
+        ['email_delivered_event', {}, 'event-received-email'],
+        ['email_failed_event', {}, 'event-email-delivery-failed'],
+        ['email_complaint_event', {}, 'event-email-delivery-spam'],
+        ['email_change_event', {}, 'event-email-changed'],
+        ['comment_event', {}, 'event-comment'],
+        ['click_event', {}, 'event-click'],
+        ['aggregated_click_event', {}, 'event-click'],
+        ['feedback_event', {score: 1}, 'event-more-like-this'],
+        ['feedback_event', {score: 0}, 'event-less-like-this'],
+        ['donation_event', {}, 'event-subscriptions'],
+        ['gift_purchase_event', {}, 'event-gift'],
+        ['gift_redemption_event', {}, 'event-gift'],
+        ['gift_ended_event', {}, 'event-gift'],
+        ['automated_email_sent_event', {}, 'event-sent-email']
+    ];
+    it.each(cases)('%s (%j) → %s', (type, data, expected) => {
+        expect(parseMemberEvent(ev(type, data), defaultCtx).icon).toBe(expected);
+    });
+});
+
+describe('parseMemberEvent — action text', () => {
+    it('signup_event → "signed up"', () => {
+        expect(parseMemberEvent(ev('signup_event'), defaultCtx).action).toBe('signed up');
+    });
+
+    it('subscription_event created with signup flag → "signed up"', () => {
+        // Ember-parity — the same event type covers both flows depending on context.
+        expect(parseMemberEvent(ev('subscription_event', {type: 'created', signup: true}), defaultCtx).action).toBe('signed up');
+    });
+
+    it('subscription_event created without signup flag → "started paid subscription"', () => {
+        expect(parseMemberEvent(ev('subscription_event', {type: 'created'}), defaultCtx).action).toBe('started paid subscription');
+    });
+
+    it('subscription_event canceled/reactivated/expired/updated', () => {
+        expect(parseMemberEvent(ev('subscription_event', {type: 'canceled'}), defaultCtx).action).toBe('canceled paid subscription');
+        expect(parseMemberEvent(ev('subscription_event', {type: 'reactivated'}), defaultCtx).action).toBe('reactivated paid subscription');
+        expect(parseMemberEvent(ev('subscription_event', {type: 'expired'}), defaultCtx).action).toBe('ended paid subscription');
+        expect(parseMemberEvent(ev('subscription_event', {type: 'updated'}), defaultCtx).action).toBe('changed paid subscription');
+    });
+
+    it('newsletter_event without hasMultipleNewsletters → generic "newsletter"', () => {
+        const parsed = parseMemberEvent(ev('newsletter_event', {subscribed: true, newsletter: {name: 'Weekly'}}), defaultCtx);
+        expect(parsed.action).toBe('subscribed to newsletter');
+    });
+
+    it('newsletter_event with hasMultipleNewsletters → uses newsletter.name', () => {
+        const parsed = parseMemberEvent(ev('newsletter_event', {subscribed: false, newsletter: {name: 'Weekly'}}), {...defaultCtx, hasMultipleNewsletters: true});
+        expect(parsed.action).toBe('unsubscribed from Weekly');
+    });
+
+    it('comment_event with parent → "replied to comment"', () => {
+        expect(parseMemberEvent(ev('comment_event', {parent: {id: 'c1'}}), defaultCtx).action).toBe('replied to comment');
+    });
+
+    it('comment_event without parent → "commented"', () => {
+        expect(parseMemberEvent(ev('comment_event'), defaultCtx).action).toBe('commented');
+    });
+
+    it('feedback_event with score 1/0', () => {
+        expect(parseMemberEvent(ev('feedback_event', {score: 1}), defaultCtx).action).toBe('more like this');
+        expect(parseMemberEvent(ev('feedback_event', {score: 0}), defaultCtx).action).toBe('less like this');
+    });
+
+    it('email_change_event with from/to fields', () => {
+        expect(parseMemberEvent(ev('email_change_event', {from_email: 'a@x.co', to_email: 'b@x.co'}), defaultCtx).action).toBe('Email address changed from a@x.co to b@x.co');
+    });
+
+    it('email_change_event without from/to → generic', () => {
+        expect(parseMemberEvent(ev('email_change_event'), defaultCtx).action).toBe('Email address changed');
+    });
+
+    it('automated_email_sent_event with free/paid slug → welcome (Free/Paid)', () => {
+        expect(parseMemberEvent(ev('automated_email_sent_event', {automatedEmail: {slug: 'welcome-free'}}), defaultCtx).action).toBe('received welcome email (Free)');
+        expect(parseMemberEvent(ev('automated_email_sent_event', {automatedEmail: {slug: 'welcome-paid'}}), defaultCtx).action).toBe('received welcome email (Paid)');
+    });
+
+    it('automated_email_sent_event from automation → uses subject', () => {
+        const parsed = parseMemberEvent(ev('automated_email_sent_event', {automatedEmail: {source: 'automation_action_revision', subject: '  Hi there  '}}), defaultCtx);
+        expect(parsed.action).toBe('received automated email: Hi there');
+        expect(parsed.actionTitle).toBe('received automated email: Hi there');
+    });
+
+    it('automated_email_sent_event with missing/empty subject → subject-less copy (no "null" leak)', () => {
+        // Regression guard for the "received automated email: null" bug —
+        // `trimString` returns null when subject is missing or empty, and a
+        // template literal used to interpolate the literal string "null".
+        const missing = parseMemberEvent(ev('automated_email_sent_event', {automatedEmail: {source: 'automation_action_revision'}}), defaultCtx);
+        expect(missing.action).toBe('received automated email');
+        expect(missing.actionTitle).toBe('received automated email');
+        const blank = parseMemberEvent(ev('automated_email_sent_event', {automatedEmail: {source: 'automation_action_revision', subject: '   '}}), defaultCtx);
+        expect(blank.action).toBe('received automated email');
+        expect(blank.actionTitle).toBe('received automated email');
+    });
+});
+
+describe('parseMemberEvent — object / url / route', () => {
+    it('signup with attribution renders title as object with url + route', () => {
+        const parsed = parseMemberEvent(ev('signup_event', {
+            attribution: {title: 'My Post', url: '/my-post/', referrer_source: 'Twitter', referrer_url: 'https://t.co'},
+            attribution_type: 'post',
+            attribution_id: 'p_1'
+        }), defaultCtx);
+        expect(parsed.object).toBe('My Post');
+        expect(parsed.url).toBe('/my-post/');
+        expect(parsed.route).toBe('#/posts/analytics/p_1');
+        expect(parsed.source).toEqual({name: 'Twitter', url: 'https://t.co'});
+    });
+
+    it('comment_event with post → object=title, url=post.url, no route', () => {
+        const parsed = parseMemberEvent(ev('comment_event', {post: {title: 'Post', url: '/post/', id: 'p_x'}}), defaultCtx);
+        expect(parsed.object).toBe('Post');
+        expect(parsed.url).toBe('/post/');
+        // Ember `getRoute` doesn't include comment_event.
+        expect(parsed.route).toBeUndefined();
+    });
+
+    it('click_event with post → object + route to post analytics', () => {
+        const parsed = parseMemberEvent(ev('click_event', {post: {title: 'Post', url: '/post/', id: 'p_c'}}), defaultCtx);
+        expect(parsed.object).toBe('Post');
+        expect(parsed.route).toBe('#/posts/analytics/p_c');
+    });
+
+    it('no attribution → empty object, undefined url/route', () => {
+        const parsed = parseMemberEvent(ev('signup_event'), defaultCtx);
+        expect(parsed.object).toBe('');
+        expect(parsed.url).toBeUndefined();
+        expect(parsed.route).toBeUndefined();
+    });
+});
+
+describe('parseMemberEvent — info', () => {
+    it('signup_event on paid-members-enabled site → "Free" for free signups', () => {
+        const parsed = parseMemberEvent(ev('signup_event', {created_with_status: 'free'}), {...defaultCtx, paidMembersEnabled: true});
+        expect(parsed.info).toBe('Free');
+    });
+
+    it('signup_event on paid-members-enabled site with paid signup → null (info suppressed)', () => {
+        const parsed = parseMemberEvent(ev('signup_event', {created_with_status: 'paid'}), {...defaultCtx, paidMembersEnabled: true});
+        expect(parsed.info).toBeNull();
+    });
+
+    it('signup_event on paid-disabled site → undefined', () => {
+        expect(parseMemberEvent(ev('signup_event'), defaultCtx).info).toBeUndefined();
+    });
+
+    it('gift_redemption_event → tier name', () => {
+        expect(parseMemberEvent(ev('gift_redemption_event', {tier_name: 'Gold'}), defaultCtx).info).toBe('Gold');
+    });
+});
+
+describe('parseMemberEvent — gift purchase amount formatting', () => {
+    it('formats gift purchase with amount, tier, and duration (Ember parity)', () => {
+        const parsed = parseMemberEvent(ev('gift_purchase_event', {
+            amount: 5000,
+            currency: 'usd',
+            tier_name: 'Gold',
+            duration: 3,
+            cadence: 'month'
+        }), defaultCtx);
+        // Ember: "Purchased gift subscription for $50 (Gold, 3 months)"
+        expect(parsed.action).toBe('Purchased gift subscription for $50 (Gold, 3 months)');
+    });
+
+    it('keeps the cents on an amount that has them', () => {
+        // A whole amount formats the same whether or not fraction digits are
+        // suppressed, so it can't catch rounding. This one can: $10.50 must not
+        // be reported as $11.
+        const parsed = parseMemberEvent(ev('gift_purchase_event', {
+            amount: 1050,
+            currency: 'usd',
+            tier_name: 'Gold',
+            duration: 1,
+            cadence: 'month'
+        }), defaultCtx);
+        expect(parsed.action).toBe('Purchased gift subscription for $10.50 (Gold, 1 month)');
+    });
+
+    it('does not divide zero-decimal currencies by 100', () => {
+        // 1050 JPY is ¥1,050, not ¥10.50 — yen has no minor unit.
+        const parsed = parseMemberEvent(ev('gift_purchase_event', {
+            amount: 1050,
+            currency: 'jpy',
+            tier_name: 'Gold',
+            duration: 1,
+            cadence: 'month'
+        }), defaultCtx);
+        expect(parsed.action).toBe('Purchased gift subscription for ¥1,050 (Gold, 1 month)');
+    });
+
+    it('pluralizes cadence based on duration', () => {
+        const one = parseMemberEvent(ev('gift_purchase_event', {
+            amount: 5000, currency: 'usd', tier_name: 'Gold', duration: 1, cadence: 'month'
+        }), defaultCtx);
+        expect(one.action).toContain('(Gold, 1 month)');
+    });
+
+    it('handles zero-decimal currencies without dividing by 100 (JPY)', () => {
+        const parsed = parseMemberEvent(ev('gift_purchase_event', {
+            amount: 5000, currency: 'jpy', tier_name: 'Gold', duration: 1, cadence: 'month'
+        }), defaultCtx);
+        // Naive `/100` would render ¥50; the zero-decimal branch keeps ¥5,000.
+        expect(parsed.action).toMatch(/¥5,000/);
+    });
+
+    it('falls back gracefully when purchase data is missing', () => {
+        expect(parseMemberEvent(ev('gift_purchase_event'), defaultCtx).action).toBe('Purchased gift subscription');
+    });
+});
+
+describe('parseMemberEvent — meta', () => {
+    it('surfaces server event.data.id for use as a stable React key', () => {
+        const parsed = parseMemberEvent(ev('signup_event', {id: 'ev_1'}), defaultCtx);
+        expect(parsed.id).toBe('ev_1');
+    });
+
+    it('returns undefined timestamp when data.created_at is missing (defensive — render layer decides how to show it)', () => {
+        const raw = {type: 'signup_event', data: {}} as {type: string; data: {created_at?: string}};
+        expect(parseMemberEvent(raw, defaultCtx).timestamp).toBeUndefined();
+    });
+
+    it('normalizes memberId + trims member.name', () => {
+        const parsed = parseMemberEvent(ev('signup_event', {member_id: 'm_1', member: {name: '  Ada  ', email: 'ada@x.co'}}), defaultCtx);
+        expect(parsed.memberId).toBe('m_1');
+        expect(parsed.member?.name).toBe('Ada');
+    });
+
+    it('falls back to member.id when member_id is missing', () => {
+        const parsed = parseMemberEvent(ev('signup_event', {member: {id: 'm_2', name: 'X', email: 'x@x.co'}}), defaultCtx);
+        expect(parsed.memberId).toBe('m_2');
+    });
+
+    it('description for click_event returns the link.to URL (raw fallback)', () => {
+        expect(parseMemberEvent(ev('click_event', {link: {to: 'https://example.com/a?ref=x'}}), defaultCtx).description).toBe('https://example.com/a?ref=x');
+    });
+
+    it('timestamp is an ISO-parseable value (Date-like)', () => {
+        // We use a plain string ISO input; the parser returns something usable
+        // by JS date formatters. Exact toISOString equality avoids TZ flakes.
+        const parsed = parseMemberEvent(ev('signup_event'), defaultCtx);
+        expect(new Date(parsed.timestamp!).toISOString()).toBe('2026-01-15T12:00:00.000Z');
+    });
+});

--- a/apps/admin/src/members/detail/member-event.ts
+++ b/apps/admin/src/members/detail/member-event.ts
@@ -1,0 +1,402 @@
+// Port of Ember `app/helpers/parse-member-event.js`.
+// The Ember helper is a Glimmer helper with injected services; we take the
+// tiny slice of settings-derived context it actually reads (`hasMultipleTiers`,
+// `paidMembersEnabled`, `hasMultipleNewsletters`) as an explicit argument so
+// the transform stays pure and testable in vitest — no react context/hooks
+// hidden inside.
+
+export interface MemberEventContext {
+    hasMultipleNewsletters: boolean;
+    hasMultipleTiers: boolean;
+    paidMembersEnabled: boolean;
+}
+
+export interface RawMemberEvent {
+    type: string;
+    data: {
+        // The framework type marks this optional but the server always sets
+        // it. Kept optional here so we can defensively skip rendering when
+        // missing rather than showing "a few seconds ago" for stale data.
+        created_at?: string;
+        // Per-event id; needed by the render layer for a stable React key
+        // when several events share a timestamp (server tie-breaks by id).
+        id?: string;
+        member_id?: string;
+        email_id?: string;
+        email?: unknown;
+        // Nullable to match the framework's `MemberActivityEventMember | null`
+        // shape (server sends `null` for guest-generated events with no member
+        // record). Uses a structural subset with no index signature so the
+        // stricter framework type (which has `uuid`, `avatar_image` etc but no
+        // catch-all) is still assignable.
+        member?: {
+            id?: string;
+            name?: string | null;
+            email?: string;
+        } | null;
+        name?: string;
+        // The Ember helper reads many arbitrary event-specific fields — the
+        // rest come through as `unknown` so we don't over-model this at the
+        // seam. Union-ing all shapes here would be a maintenance treadmill.
+        [k: string]: unknown;
+    };
+}
+
+export interface ParsedMemberEvent {
+    /** Server-side event id — stable React key across renders/pagination. */
+    id: string | undefined;
+    memberId: string | undefined;
+    member: RawMemberEvent['data']['member'];
+    emailId: string | undefined;
+    email: unknown;
+    icon: string;
+    subject: string;
+    action: string | undefined;
+    actionTitle: string | undefined;
+    join: string;
+    object: string;
+    source: {name: string; url: string | null} | null;
+    info: string | null | undefined;
+    description: string | undefined;
+    url: string | undefined;
+    route: string | undefined;
+    /** ISO string when the server provided one; `undefined` when missing so the render layer can decide how to display it. */
+    timestamp: string | undefined;
+}
+
+/**
+ * Ember uses `getNonDecimal(amount, currency)` from `ghost-admin/utils/currency`
+ * to divide the minor-units integer by the correct denominator per currency
+ * (e.g. 100 for USD/EUR, 1 for JPY). We port a minimal version here so the
+ * gift-purchase row can display the amount without pulling in the whole utils
+ * module. Zero-decimal currencies match the Stripe list.
+ */
+const ZERO_DECIMAL_CURRENCIES = new Set([
+    'bif', 'clp', 'djf', 'gnf', 'jpy', 'kmf', 'krw', 'mga', 'pyg',
+    'rwf', 'ugx', 'vnd', 'vuv', 'xaf', 'xof', 'xpf'
+]);
+
+function formatEventAmount(amount: number, currency: string): string {
+    const isZeroDecimal = ZERO_DECIMAL_CURRENCIES.has(currency.toLowerCase());
+    const value = isZeroDecimal ? amount : amount / 100;
+    // Whole amounts read better without the trailing zeros ($50, not $50.00),
+    // but anything with cents must keep them: rounding a $10.50 payment to $11
+    // misreports what the member was actually charged.
+    const isWhole = value % 1 === 0;
+    try {
+        return new Intl.NumberFormat('en-US', {
+            style: 'currency',
+            currency: currency.toUpperCase(),
+            minimumFractionDigits: isWhole ? 0 : 2,
+            maximumFractionDigits: isWhole ? 0 : 2
+        }).format(value);
+    } catch {
+        // Unknown currency code: fall back to a symbol-less amount so the row
+        // still renders instead of crashing on Intl's strict validation.
+        return `${value}`;
+    }
+}
+
+function trimString(value: string | null | undefined): string | null {
+    return value?.trim() || null;
+}
+
+function getIcon(event: RawMemberEvent): string {
+    let icon: string | undefined;
+
+    if (event.type === 'login_event') {
+        icon = 'logged-in';
+    }
+    if (event.type === 'payment_event') {
+        icon = 'subscriptions';
+    }
+    if (event.type === 'newsletter_event') {
+        icon = event.data.subscribed ? 'subscribed-to-email' : 'unsubscribed-from-email';
+    }
+    if (event.type === 'subscription_event') {
+        icon = 'subscriptions';
+        if (event.data.type === 'canceled') {
+            icon = 'canceled-subscription';
+        }
+    }
+    // Signup either as a direct event OR as a subscription_event with the
+    // `signup` flag — the second happens when a member creates their account
+    // via a paid checkout flow.
+    if (event.type === 'signup_event' || (event.type === 'subscription_event' && event.data.type === 'created' && event.data.signup)) {
+        icon = 'signed-up';
+    }
+    if (event.type === 'email_opened_event') {
+        icon = 'opened-email';
+    }
+    if (event.type === 'email_sent_event' || event.type === 'automated_email_sent_event') {
+        icon = 'sent-email';
+    }
+    if (event.type === 'email_delivered_event') {
+        icon = 'received-email';
+    }
+    if (event.type === 'email_failed_event') {
+        icon = 'email-delivery-failed';
+    }
+    if (event.type === 'email_complaint_event') {
+        icon = 'email-delivery-spam';
+    }
+    if (event.type === 'comment_event') {
+        icon = 'comment';
+    }
+    if (event.type === 'click_event' || event.type === 'aggregated_click_event') {
+        icon = 'click';
+    }
+    if (event.type === 'feedback_event') {
+        icon = event.data.score === 1 ? 'more-like-this' : 'less-like-this';
+    }
+    if (event.type === 'donation_event') {
+        icon = 'subscriptions';
+    }
+    if (event.type === 'gift_purchase_event' || event.type === 'gift_redemption_event' || event.type === 'gift_ended_event') {
+        icon = 'gift';
+    }
+    if (event.type === 'email_change_event') {
+        icon = 'email-changed';
+    }
+    return `event-${icon}`;
+}
+
+function getAction(event: RawMemberEvent, hasMultipleNewsletters: boolean): string | undefined {
+    if (event.type === 'signup_event' || (event.type === 'subscription_event' && event.data.type === 'created' && event.data.signup)) {
+        return 'signed up';
+    }
+    if (event.type === 'login_event') {
+        return 'logged in';
+    }
+    if (event.type === 'payment_event') {
+        return 'made payment';
+    }
+    if (event.type === 'newsletter_event') {
+        const nl = event.data.newsletter as {name?: string} | undefined;
+        const newsletter = hasMultipleNewsletters && nl?.name ? nl.name : 'newsletter';
+        return event.data.subscribed ? `subscribed to ${newsletter}` : `unsubscribed from ${newsletter}`;
+    }
+    if (event.type === 'subscription_event') {
+        const t = event.data.type;
+        if (t === 'created') {
+            return 'started paid subscription';
+        }
+        if (t === 'canceled') {
+            return 'canceled paid subscription';
+        }
+        if (t === 'reactivated') {
+            return 'reactivated paid subscription';
+        }
+        if (t === 'expired') {
+            return 'ended paid subscription';
+        }
+        return 'changed paid subscription';
+    }
+    if (event.type === 'email_opened_event') {
+        return 'opened email';
+    }
+    if (event.type === 'email_sent_event') {
+        return 'sent email';
+    }
+    if (event.type === 'automated_email_sent_event') {
+        const auto = event.data.automatedEmail as {source?: string; slug?: string; subject?: string} | undefined;
+        if (auto?.source !== 'automation_action_revision') {
+            const slug = auto?.slug || '';
+            const emailType = slug.includes('paid') ? 'Paid' : 'Free';
+            return `received welcome email (${emailType})`;
+        }
+        const subject = trimString(auto.subject);
+        // `trimString` returns null on an empty/missing subject; interpolating
+        // that yields "received automated email: null". Fall back to the
+        // subjectless copy so the feed row reads cleanly.
+        return subject ? `received automated email: ${subject}` : 'received automated email';
+    }
+    if (event.type === 'email_delivered_event') {
+        return 'received email';
+    }
+    if (event.type === 'email_failed_event') {
+        return 'bounced email';
+    }
+    if (event.type === 'email_complaint_event') {
+        return 'email flagged as spam';
+    }
+    if (event.type === 'comment_event') {
+        return event.data.parent ? 'replied to comment' : 'commented';
+    }
+    if (event.type === 'click_event') {
+        return 'clicked link in email';
+    }
+    if (event.type === 'aggregated_click_event') {
+        const count = (event.data.count as {clicks?: number} | undefined)?.clicks ?? 1;
+        if (count <= 1) {
+            return 'clicked link in email';
+        }
+        return `clicked ${count} links in email`;
+    }
+    if (event.type === 'feedback_event') {
+        return event.data.score === 1 ? 'more like this' : 'less like this';
+    }
+    if (event.type === 'email_change_event') {
+        if (event.data.from_email && event.data.to_email) {
+            return `Email address changed from ${event.data.from_email as string} to ${event.data.to_email as string}`;
+        }
+        return 'Email address changed';
+    }
+    if (event.type === 'donation_event') {
+        return 'Made a one-time payment';
+    }
+    if (event.type === 'gift_purchase_event') {
+        // Matches Ember `parse-member-event.js:277-285` — the amount, tier,
+        // and duration are the row's whole story, so drop none of them.
+        const amount = event.data.amount as number | undefined;
+        const currency = event.data.currency as string | undefined;
+        const tierName = event.data.tier_name as string | undefined;
+        const duration = event.data.duration as number | undefined;
+        const cadence = event.data.cadence as string | undefined;
+        if (typeof amount === 'number' && currency && tierName && typeof duration === 'number' && cadence) {
+            const formattedAmount = formatEventAmount(amount, currency);
+            const cadenceLabel = duration === 1 ? cadence : `${cadence}s`;
+            return `Purchased gift subscription for ${formattedAmount} (${tierName}, ${duration} ${cadenceLabel})`;
+        }
+        return 'Purchased gift subscription';
+    }
+    if (event.type === 'gift_redemption_event') {
+        return 'started gift subscription';
+    }
+    if (event.type === 'gift_ended_event') {
+        return 'gift subscription expired';
+    }
+    return undefined;
+}
+
+function getActionTitle(event: RawMemberEvent, hasMultipleNewsletters: boolean): string | undefined {
+    if (event.type === 'automated_email_sent_event') {
+        const auto = event.data.automatedEmail as {source?: string; subject?: string} | undefined;
+        if (auto?.source === 'automation_action_revision') {
+            const subject = trimString(auto.subject);
+            return subject ? `received automated email: ${subject}` : 'received automated email';
+        }
+    }
+    return getAction(event, hasMultipleNewsletters);
+}
+
+function getObject(event: RawMemberEvent): string {
+    if (event.type === 'signup_event' || event.type === 'subscription_event' || event.type === 'donation_event') {
+        const attribution = event.data.attribution as {title?: string} | undefined;
+        if (attribution?.title) {
+            return attribution.title;
+        }
+    }
+    if (event.type === 'comment_event' || event.type === 'click_event' || event.type === 'feedback_event') {
+        const post = event.data.post as {title?: string} | undefined;
+        if (post?.title) {
+            return post.title;
+        }
+    }
+    return '';
+}
+
+function getSource(event: RawMemberEvent): {name: string; url: string | null} | null {
+    const attribution = event.data.attribution as {referrer_source?: string; referrer_url?: string | null} | undefined;
+    if (attribution?.referrer_source) {
+        return {
+            name: attribution.referrer_source,
+            url: attribution.referrer_url ?? null
+        };
+    }
+    return null;
+}
+
+function getInfo(event: RawMemberEvent, ctx: MemberEventContext): string | null | undefined {
+    if (event.type === 'signup_event' && ctx.paidMembersEnabled) {
+        const createdWith = event.data.created_with_status;
+        if (createdWith && createdWith !== 'free') {
+            return null;
+        }
+        return 'Free';
+    }
+    if (event.type === 'gift_redemption_event') {
+        return (event.data.tier_name as string | undefined) ?? undefined;
+    }
+    // Ember additionally renders MRR deltas for subscription_event and money
+    // amounts for donation_event using currency utils. We defer that: those
+    // rows still parse and render an action, just without the info suffix.
+    return undefined;
+}
+
+function getDescription(event: RawMemberEvent): string | undefined {
+    if (event.type === 'click_event') {
+        const link = event.data.link as {to?: string} | undefined;
+        // Ember runs `cleanTrackedUrl` here to strip tracking params. We don't
+        // have that util in this app yet — return the raw URL as a graceful
+        // fallback rather than dropping the description entirely.
+        return link?.to;
+    }
+    return undefined;
+}
+
+function getUrl(event: RawMemberEvent): string | undefined {
+    if (event.type === 'comment_event' || event.type === 'click_event' || event.type === 'feedback_event') {
+        const post = event.data.post as {url?: string} | undefined;
+        if (post?.url) {
+            return post.url;
+        }
+    }
+    if (event.type === 'signup_event' || event.type === 'subscription_event' || event.type === 'donation_event') {
+        const attribution = event.data.attribution as {url?: string} | undefined;
+        if (attribution?.url) {
+            return attribution.url;
+        }
+    }
+    return undefined;
+}
+
+function getRoute(event: RawMemberEvent): string | undefined {
+    if (event.type === 'click_event' || event.type === 'feedback_event') {
+        const post = event.data.post as {id?: string} | undefined;
+        if (post?.id) {
+            return `#/posts/analytics/${post.id}`;
+        }
+    }
+    if (event.type === 'signup_event' || event.type === 'subscription_event') {
+        if (event.data.attribution_type === 'post' && event.data.attribution_id) {
+            return `#/posts/analytics/${event.data.attribution_id as string}`;
+        }
+    }
+    return undefined;
+}
+
+/**
+ * Transform a raw member event (as returned from `GET /members/events`) into
+ * the parsed shape the activity-feed row expects.
+ */
+export function parseMemberEvent(event: RawMemberEvent, ctx: MemberEventContext): ParsedMemberEvent {
+    const trimmedName = trimString(event.data.member?.name);
+    const subject = event.data.member
+        ? (trimmedName || event.data.member.email || '')
+        : ((event.data.name) || (event.data.email as string | undefined) || '');
+    const member = event.data.member ? {...event.data.member, name: trimmedName ?? undefined} : event.data.member;
+
+    return {
+        id: event.data.id,
+        memberId: (event.data.member_id ?? event.data.member?.id),
+        member,
+        emailId: event.data.email_id,
+        email: event.data.email,
+        icon: getIcon(event),
+        subject,
+        action: getAction(event, ctx.hasMultipleNewsletters),
+        actionTitle: getActionTitle(event, ctx.hasMultipleNewsletters),
+        // The dash separator Ember uses between action and object in inline layouts.
+        join: '–',
+        object: getObject(event),
+        source: getSource(event),
+        info: getInfo(event, ctx),
+        description: getDescription(event),
+        url: getUrl(event),
+        route: getRoute(event),
+        // Keep as ISO string — consumers format for display (`moment.fromNow`
+        // in Ember; `date-fns` or similar in React). Not tied to a specific lib.
+        timestamp: event.data.created_at
+    };
+}

--- a/apps/admin/src/members/detail/member-impersonate-modal.tsx
+++ b/apps/admin/src/members/detail/member-impersonate-modal.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import {Button, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, Input, Label, LoadingIndicator} from '@tryghost/shade/components';
+import {getMemberSigninUrl} from '@tryghost/admin-x-framework/api/members';
+import {toast} from 'sonner';
+import {useQueryClient} from '@tanstack/react-query';
+
+interface MemberImpersonateModalProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    memberId: string;
+}
+
+/**
+ * Modal that fetches a 24-hour signin/impersonation URL for the given member and
+ * lets the admin copy it. Matches Ember `modal-impersonate-member`:
+ *   - Fetches lazily (only when the modal opens) so the URL isn't minted on every
+ *     page render.
+ *   - Copy button flashes "Copied" for 1s (Ember's `copySigninUrl` task uses the
+ *     same 1s window).
+ */
+const MemberImpersonateModal: React.FC<MemberImpersonateModalProps> = ({open, onOpenChange, memberId}) => {
+    const queryClient = useQueryClient();
+    // On every modal open, drop the cached signin URL so we don't serve a stale
+    // (potentially expired 24-hour) link from a previous open. Ember's original
+    // modal fetches fresh in didInsertElement — this reproduces that guarantee.
+    React.useEffect(() => {
+        if (open) {
+            queryClient.removeQueries({queryKey: ['MemberSigninUrlResponseType']});
+        }
+    }, [open, queryClient]);
+
+    const {data, isFetching, isError} = getMemberSigninUrl(memberId, {
+        enabled: open,
+        defaultErrorHandler: false
+    });
+    const signinUrl = data?.url ?? '';
+    // A 200 with an empty/missing envelope is still a failure from the admin's
+    // point of view — surface it as an error rather than showing a blank input.
+    const isEmptyResponse = !isFetching && !isError && !signinUrl;
+    const hasError = isError || isEmptyResponse;
+
+    const [justCopied, setJustCopied] = React.useState(false);
+    const copyResetTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+    const clearCopyResetTimer = React.useCallback(() => {
+        if (copyResetTimerRef.current !== null) {
+            clearTimeout(copyResetTimerRef.current);
+            copyResetTimerRef.current = null;
+        }
+    }, []);
+    React.useEffect(() => {
+        // Cancel a pending "Copied → Copy link" reset when the modal closes so
+        // a late tick can't flip the label on the next open.
+        if (!open) {
+            clearCopyResetTimer();
+            setJustCopied(false);
+        }
+    }, [open, clearCopyResetTimer]);
+    React.useEffect(() => clearCopyResetTimer, [clearCopyResetTimer]);
+
+    const onCopy = async () => {
+        try {
+            await navigator.clipboard.writeText(signinUrl);
+            setJustCopied(true);
+            clearCopyResetTimer();
+            copyResetTimerRef.current = setTimeout(() => {
+                setJustCopied(false);
+                copyResetTimerRef.current = null;
+            }, 1000);
+        } catch {
+            toast.error('Couldn’t copy the impersonation link');
+        }
+    };
+
+    const inputValue = isFetching
+        ? 'Generating link…'
+        : (hasError ? 'Failed to generate link' : signinUrl);
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent data-testid='impersonate-modal'>
+                <DialogHeader>
+                    <DialogTitle>Impersonate member</DialogTitle>
+                    <DialogDescription>
+                        A single-use signin link that works for 24 hours. Anyone with the link can sign in as this member.
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div className='flex flex-col gap-1.5'>
+                    <Label htmlFor='member-signin-url'>Signin link</Label>
+                    <Input
+                        data-testid='member-signin-url'
+                        id='member-signin-url'
+                        value={inputValue}
+                        readOnly
+                    />
+                </div>
+
+                <DialogFooter>
+                    <Button variant='outline' onClick={() => onOpenChange(false)}>Close</Button>
+                    <Button disabled={isFetching || hasError || !signinUrl} onClick={() => void onCopy()}>
+                        {isFetching ? (
+                            <>
+                                <LoadingIndicator size='sm' />
+                                <span className='sr-only'>Generating link</span>
+                            </>
+                        ) : (justCopied ? 'Copied' : 'Copy link')}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+export default MemberImpersonateModal;

--- a/apps/admin/src/members/detail/member-labels-field.tsx
+++ b/apps/admin/src/members/detail/member-labels-field.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import {LabelPicker} from '@/members/label-picker';
+import {resolveSlugsToLabels} from './member-detail-edit';
+import {useLabelPicker} from '@/members/hooks/use-label-picker';
+import type {Label} from '@tryghost/admin-x-framework/api/labels';
+import type {MemberEditableLabel} from './member-detail-edit';
+
+interface MemberLabelsFieldProps {
+    labels: MemberEditableLabel[];
+    disabled?: boolean;
+    onChange: (labels: MemberEditableLabel[]) => void;
+}
+
+const MemberLabelsField: React.FC<MemberLabelsFieldProps> = ({labels, disabled, onChange}) => {
+    const selectedSlugs = labels.map(label => label.slug);
+
+    // Always read the latest labels in async callbacks (avoids a stale render closure
+    // when a create resolves after the user has also toggled something).
+    const labelsRef = React.useRef(labels);
+    labelsRef.current = labels;
+
+    // Persistent slug → {name, slug} lookup so a selection change can turn slugs back
+    // into full label objects. A ref-held cache is safe to top up during render.
+    const knownRef = React.useRef<Map<string, MemberEditableLabel>>(new Map());
+    const remember = (list: Array<{name: string; slug: string}>) => {
+        for (const label of list) {
+            knownRef.current.set(label.slug, {name: label.name, slug: label.slug});
+        }
+    };
+    remember(labels);
+
+    const picker = useLabelPicker({
+        selectedSlugs,
+        onSelectionChange: slugs => onChange(resolveSlugsToLabels(slugs, knownRef.current))
+    });
+    remember(picker.labels);
+
+    // `picker.createLabel` selects the new slug *before* we know its display name, so
+    // the selection change above briefly resolves it to a slug-as-name placeholder.
+    // Once the create resolves we know the real name: reconcile against the *live*
+    // selection (labelsRef, so a concurrent removal isn't undone) and guarantee the
+    // new label is present with its real name — otherwise it would be saved as its
+    // slug and the server (which matches labels by name) would create a duplicate.
+    const handleCreate = async (name: string): Promise<Label | undefined> => {
+        const created = await picker.createLabel(name);
+        if (created) {
+            const createdLabel = {name: created.name, slug: created.slug};
+            knownRef.current.set(created.slug, createdLabel);
+            const others = labelsRef.current.filter(label => label.slug !== created.slug);
+            onChange([...others, createdLabel]);
+        }
+        return created;
+    };
+
+    return (
+        <div
+            className={disabled ? 'pointer-events-none opacity-60' : undefined}
+            data-testid='member-labels-field'
+            // `inert` (not just pointer-events) so the combobox can't be keyboard-edited
+            // mid-save, which would be silently discarded when the save reseeds the draft.
+            {...(disabled ? {inert: ''} : {})}
+        >
+            <LabelPicker
+                isCreating={picker.isCreating}
+                labels={picker.labels}
+                optionSource={picker.optionSource}
+                // The 'Labels' Label above already contextualizes this field —
+                // 'Search labels...' inside the input would be visually noisy.
+                placeholder=''
+                resolvedSelectedLabels={picker.resolvedSelectedLabels}
+                selectedSlugs={selectedSlugs}
+                onCreate={handleCreate}
+                onDelete={picker.deleteLabel}
+                onEdit={picker.editLabel}
+                onToggle={picker.toggleLabel}
+            />
+        </div>
+    );
+};
+
+export default MemberLabelsField;

--- a/apps/admin/src/members/detail/member-logout-modal.tsx
+++ b/apps/admin/src/members/detail/member-logout-modal.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import {AlertDialog, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, Button, LoadingIndicator} from '@tryghost/shade/components';
+import {toast} from 'sonner';
+import {useMemberLogout} from '@tryghost/admin-x-framework/api/members';
+import type {Member} from '@tryghost/admin-x-framework/api/members';
+
+interface MemberLogoutModalProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    member: Pick<Member, 'id' | 'name' | 'email'>;
+}
+
+/**
+ * Confirms the "Sign out of all devices" action. Ember parity:
+ *   - Destructive intent — same red confirm button, plain "Sign out" label.
+ *   - Success toast reads "<name-or-email> has been signed out from all devices."
+ *     (Ember `logout-member.js:22`.)
+ *   - We use a Shade AlertDialog (not Dialog) because there's no form state to
+ *     manage and AlertDialog's stricter dismissal behaviour (no click-outside
+ *     dismiss) matches Ember's destructive-modal semantics.
+ */
+const MemberLogoutModal: React.FC<MemberLogoutModalProps> = ({open, onOpenChange, member}) => {
+    const logout = useMemberLogout();
+    const displayName = member.name || member.email || 'This member';
+
+    const onConfirm = async () => {
+        try {
+            await logout.mutateAsync({id: member.id});
+            toast.success(`${displayName} has been signed out from all devices.`);
+            onOpenChange(false);
+        } catch {
+            toast.error('Couldn’t sign the member out. Please try again.');
+        }
+    };
+
+    return (
+        <AlertDialog open={open} onOpenChange={(next) => {
+            // Block dismissal mid-request so the mutation always resolves before
+            // the modal closes — matches the `drop` semantics on Ember's task.
+            if (logout.isPending) {
+                return;
+            }
+            onOpenChange(next);
+        }}>
+            <AlertDialogContent data-testid='logout-member-modal'>
+                <AlertDialogHeader>
+                    <AlertDialogTitle>Sign out member from all devices?</AlertDialogTitle>
+                    <AlertDialogDescription>
+                        <strong>{displayName}</strong> will be signed out of all active sessions, and will need to sign in again upon return.
+                    </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                    <AlertDialogCancel disabled={logout.isPending}>Cancel</AlertDialogCancel>
+                    <Button
+                        data-testid='confirm-logout-member'
+                        disabled={logout.isPending}
+                        variant='destructive'
+                        onClick={() => void onConfirm()}
+                    >
+                        {logout.isPending ? (
+                            <>
+                                <LoadingIndicator size='sm' />
+                                <span className='sr-only'>Signing out</span>
+                            </>
+                        ) : 'Sign out'}
+                    </Button>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
+    );
+};
+
+export default MemberLogoutModal;

--- a/apps/admin/src/members/detail/member-newsletters-field.tsx
+++ b/apps/admin/src/members/detail/member-newsletters-field.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import {Button, Card, CardContent, LoadingIndicator, Switch} from '@tryghost/shade/components';
+import {LucideIcon} from '@tryghost/shade/utils';
+import {getMemberSuppressionInfo, toggleMemberNewsletter} from './member-detail-edit';
+import {toast} from 'sonner';
+import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
+import {useRemoveMemberEmailSuppression, useMembersFetching} from '@tryghost/admin-x-framework/api/members';
+import type {Member} from '@tryghost/admin-x-framework/api/members';
+
+interface MemberNewslettersFieldProps {
+    // Optional so the create screen (/members/new) can render the toggles
+    // without a saved member yet — matches Ember, which shows the newsletter
+    // preferences on new members (`gh-member-settings-form.hbs:74-80`).
+    // Suppression logic is skipped when the member doesn't exist.
+    memberId?: string;
+    emailSuppression?: Member['email_suppression'];
+    subscribedIds: string[];
+    disabled?: boolean;
+    onChange: (subscribedIds: string[]) => void;
+}
+
+const MemberNewslettersField: React.FC<MemberNewslettersFieldProps> = ({
+    memberId,
+    emailSuppression,
+    subscribedIds,
+    disabled,
+    onChange
+}) => {
+    // A new member can't be suppressed yet — skip the suppression branch
+    // entirely by treating a missing memberId as "not suppressed".
+    const suppression = memberId ? getMemberSuppressionInfo(emailSuppression) : null;
+    const removeSuppression = useRemoveMemberEmailSuppression();
+
+    // Ember only shows active newsletters; archived ones are managed elsewhere and
+    // must not be flipped through this UI. If a member is subscribed to an archived
+    // newsletter, the server keeps it silently (`member-repository.js:791-798`).
+    // TODO: pagination — `useBrowseNewsletters` is an infinite query but this field
+    // only reads the first page (limit 50). Sites with 51+ active newsletters would
+    // not see the tail here.
+    const {data, isLoading} = useBrowseNewsletters({searchParams: {filter: 'status:active', limit: '50'}});
+    const newsletters = data?.newsletters ?? [];
+
+    // Keep the Re-enable button in a loading state until the invalidated member
+    // refetch lands (`useRemoveMemberEmailSuppression` invalidates the members query
+    // on success). Without this, the mutation resolves, `isLoading` flips back to
+    // false, but `emailSuppression` is still stale for a beat — the banner stays,
+    // the button re-enables, and the user can spam-click it.
+    const membersRefetching = useMembersFetching();
+    const reEnableBusy = removeSuppression.isPending || (removeSuppression.isSuccess && membersRefetching);
+
+    const noNewsletters = !suppression && (isLoading || newsletters.length === 0);
+    if (noNewsletters) {
+        return null;
+    }
+
+    const onReEnable = () => {
+        // Guarded by `suppression` above — a new member can't have a
+        // suppression record, so `memberId` is always defined when this runs.
+        if (!memberId) {
+            return;
+        }
+        removeSuppression.mutate({id: memberId}, {
+            onSuccess: () => toast.success('Email re-enabled successfully'),
+            onError: () => toast.error('Failed to re-enable email. Please try again.')
+        });
+    };
+
+    // The whole section — external heading + card — is owned by this component
+    // so an empty-newsletters state can hide it cleanly (returning null above).
+    return (
+        <section aria-labelledby='member-newsletters-heading' className='flex flex-col gap-3' data-testid='member-newsletters-field'>
+            <h3 className='text-base font-semibold' id='member-newsletters-heading'>Newsletters</h3>
+            <Card>
+                <CardContent className='p-6'>
+                    {suppression ? (
+                <div className='flex items-center justify-between gap-4' data-testid='member-suppression-banner'>
+                    <div className='flex items-start gap-3'>
+                        <LucideIcon.MailX className='mt-0.5 shrink-0 text-muted-foreground' size={20} />
+                        <div className='min-w-0'>
+                            <div className='font-medium'>Email disabled</div>
+                            {suppression.label && (
+                                <p className='text-sm text-muted-foreground'>{suppression.label}</p>
+                            )}
+                            <a
+                                className='text-sm text-muted-foreground hover:underline'
+                                href='https://ghost.org/help/disabled-emails'
+                                rel='noopener noreferrer'
+                                target='_blank'
+                            >
+                                Learn more
+                            </a>
+                        </div>
+                    </div>
+                    <Button
+                        disabled={disabled || reEnableBusy}
+                        onClick={onReEnable}
+                    >
+                        {reEnableBusy ? (
+                            <>
+                                <LoadingIndicator size='sm' />
+                                <span className='sr-only'>Re-enabling email</span>
+                            </>
+                        ) : 'Re-enable email'}
+                    </Button>
+                </div>
+            ) : (
+                <>
+                    <ul className='divide-y divide-border'>
+                        {newsletters.map((newsletter) => {
+                            const checked = subscribedIds.includes(newsletter.id);
+                            return (
+                                <li key={newsletter.id} className='flex items-center justify-between gap-4 py-3 first:pt-0 last:pb-0'>
+                                    <div className='min-w-0'>
+                                        <div className='font-medium'>{newsletter.name}</div>
+                                        {newsletter.description && (
+                                            <p className='truncate text-sm text-muted-foreground'>{newsletter.description}</p>
+                                        )}
+                                    </div>
+                                    <Switch
+                                        aria-label={`Subscribe to ${newsletter.name}`}
+                                        checked={checked}
+                                        data-testid='member-subscription-toggle'
+                                        disabled={disabled}
+                                        onCheckedChange={() => onChange(toggleMemberNewsletter(subscribedIds, newsletter.id))}
+                                    />
+                                </li>
+                            );
+                        })}
+                    </ul>
+                    <p className='mt-4 text-sm text-muted-foreground'>
+                        If disabled, member will <em>not</em> receive newsletter emails
+                    </p>
+                </>
+            )}
+                </CardContent>
+            </Card>
+        </section>
+    );
+};
+
+export default MemberNewslettersField;

--- a/apps/admin/src/members/detail/member-subscription-actions.tsx
+++ b/apps/admin/src/members/detail/member-subscription-actions.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import {Button, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger, LoadingIndicator} from '@tryghost/shade/components';
+import {LucideIcon} from '@tryghost/shade/utils';
+import {toast} from 'sonner';
+import {useEditMemberSubscription, useMembersFetching} from '@tryghost/admin-x-framework/api/members';
+import type {MemberSubscription} from '@tryghost/admin-x-framework/api/members';
+
+interface MemberSubscriptionActionsProps {
+    memberId: string;
+    subscription: MemberSubscription;
+}
+
+/**
+ * Actions menu for a paid subscription row. Always exposes the two Stripe deep
+ * links; adds "Cancel subscription" (soft cancel at period end) or "Continue
+ * subscription" (undo a pending cancel) depending on the current state. Both
+ * mutations hit `PUT /members/:id/subscriptions/:sub_id` via `useEditMemberSubscription`
+ * — server-side the invalidation on that hook refreshes the member so the row
+ * copy updates automatically once the change lands.
+ *
+ * Gift subs are omitted from the menu by the caller (Ember parity); comp subs
+ * get their own menu in Phase 6.
+ */
+const MemberSubscriptionActions: React.FC<MemberSubscriptionActionsProps> = ({memberId, subscription}) => {
+    const editSubscription = useEditMemberSubscription();
+    // Keep the trigger disabled until the invalidated members refetch lands so a
+    // user can't fire the same action twice in the window between the mutation
+    // resolving and the row actually re-rendering with its new state.
+    const membersRefetching = useMembersFetching();
+    const busy = editSubscription.isPending || (editSubscription.isSuccess && membersRefetching);
+    const isCanceled = subscription.status === 'canceled';
+    const isSetToCancel = subscription.cancel_at_period_end;
+
+    const runToggleCancel = (cancelAtPeriodEnd: boolean, successMessage: string, errorMessage: string) => {
+        editSubscription.mutate(
+            {memberId, subscriptionId: subscription.id, cancelAtPeriodEnd},
+            {
+                onSuccess: () => toast.success(successMessage),
+                onError: () => toast.error(errorMessage)
+            }
+        );
+    };
+
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+                <Button
+                    aria-label='Subscription menu'
+                    data-testid='subscription-actions'
+                    disabled={busy}
+                    size='sm'
+                    variant='outline'
+                >
+                    {busy ? <LoadingIndicator size='sm' /> : <LucideIcon.MoreHorizontal />}
+                </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align='end'>
+                <DropdownMenuItem asChild>
+                    <a
+                        href={`https://dashboard.stripe.com/customers/${subscription.customer.id}`}
+                        rel='noopener noreferrer'
+                        target='_blank'
+                    >
+                        View Stripe customer
+                    </a>
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem asChild>
+                    <a
+                        href={`https://dashboard.stripe.com/subscriptions/${subscription.id}`}
+                        rel='noopener noreferrer'
+                        target='_blank'
+                    >
+                        View Stripe subscription
+                    </a>
+                </DropdownMenuItem>
+                {!isCanceled && (
+                    isSetToCancel ? (
+                        <DropdownMenuItem
+                            data-testid='continue-subscription'
+                            onSelect={() => runToggleCancel(false, 'Subscription continued', 'Couldn’t continue subscription')}
+                        >
+                            Continue subscription
+                        </DropdownMenuItem>
+                    ) : (
+                        <DropdownMenuItem
+                            className='text-destructive focus:text-destructive'
+                            data-testid='cancel-subscription'
+                            onSelect={() => runToggleCancel(true, 'Subscription canceled', 'Couldn’t cancel subscription')}
+                        >
+                            Cancel subscription
+                        </DropdownMenuItem>
+                    )
+                )}
+            </DropdownMenuContent>
+        </DropdownMenu>
+    );
+};
+
+export default MemberSubscriptionActions;

--- a/apps/admin/src/members/detail/member-subscription-comp-actions.tsx
+++ b/apps/admin/src/members/detail/member-subscription-comp-actions.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import {AlertDialog, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, Button, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, LoadingIndicator} from '@tryghost/shade/components';
+import {LucideIcon} from '@tryghost/shade/utils';
+import {toast} from 'sonner';
+import {useEditMember, useMembersFetching} from '@tryghost/admin-x-framework/api/members';
+import type {Member} from '@tryghost/admin-x-framework/api/members';
+
+interface MemberSubscriptionCompActionsProps {
+    member: Member;
+    tierId: string;
+}
+
+/**
+ * Actions menu for a complimentary subscription row. The only action here is
+ * "Remove complimentary subscription" — Ember flow: filter the tier out of
+ * `member.tiers` and PUT the remaining set back. Gift subscriptions get NO menu
+ * (Ember parity) and are gated out by the caller.
+ */
+const MemberSubscriptionCompActions: React.FC<MemberSubscriptionCompActionsProps> = ({member, tierId}) => {
+    const editMember = useEditMember();
+    const [confirmOpen, setConfirmOpen] = React.useState(false);
+    // Keep the trigger disabled through the invalidated members refetch so the
+    // menu can't re-open in a stale state and fire the same removal twice.
+    const membersRefetching = useMembersFetching();
+    const busy = editMember.isPending || (editMember.isSuccess && membersRefetching);
+
+    const onConfirmRemove = () => {
+        // Preserve `expiry_at` on the surviving tiers — the server pivot update
+        // treats a missing expiry_at as `null` and would silently wipe the
+        // expiration for any other comp tier on this member.
+        const remainingTiers = (member.tiers ?? [])
+            .filter(tier => tier.id !== tierId)
+            .map(tier => ({id: tier.id, expiry_at: tier.expiry_at ?? null}));
+        // Include `email` to match Ember exactly (`gh-member-settings-form.js:194-198`).
+        editMember.mutate(
+            {id: member.id, email: member.email, tiers: remainingTiers},
+            {
+                onSuccess: () => {
+                    toast.success('Complimentary subscription removed');
+                    setConfirmOpen(false);
+                },
+                onError: () => toast.error('Couldn’t remove complimentary subscription')
+            }
+        );
+    };
+
+    return (
+        <>
+            <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                    <Button
+                        aria-label='Subscription menu'
+                        data-testid='subscription-actions'
+                        disabled={busy}
+                        size='sm'
+                        variant='outline'
+                    >
+                        {busy ? <LoadingIndicator size='sm' /> : <LucideIcon.MoreHorizontal />}
+                    </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align='end'>
+                    <DropdownMenuItem
+                        className='text-destructive focus:text-destructive'
+                        data-testid='remove-complimentary'
+                        onSelect={() => setConfirmOpen(true)}
+                    >
+                        Remove complimentary subscription
+                    </DropdownMenuItem>
+                </DropdownMenuContent>
+            </DropdownMenu>
+
+            <AlertDialog open={confirmOpen} onOpenChange={(open) => {
+                if (!editMember.isPending) {
+                    setConfirmOpen(open);
+                }
+            }}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Remove complimentary subscription?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            The member will lose access to this tier immediately.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel disabled={editMember.isPending}>Cancel</AlertDialogCancel>
+                        {/* Deliberately not `AlertDialogAction` — Radix auto-closes the
+                            dialog when Action fires, which would race the mutation and
+                            hide the loading state. Own the close via `onSuccess` instead. */}
+                        <Button
+                            data-testid='confirm-remove-complimentary'
+                            disabled={editMember.isPending}
+                            variant='destructive'
+                            onClick={onConfirmRemove}
+                        >
+                            {editMember.isPending ? (
+                                <>
+                                    <LoadingIndicator size='sm' />
+                                    <span className='sr-only'>Removing</span>
+                                </>
+                            ) : 'Remove'}
+                        </Button>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+        </>
+    );
+};
+
+export default MemberSubscriptionCompActions;

--- a/apps/admin/src/members/detail/member-subscription.test.ts
+++ b/apps/admin/src/members/detail/member-subscription.test.ts
@@ -1,0 +1,237 @@
+import {classifyMemberSubscription, formatSubscriptionAmount, formatSubscriptionInterval, getSubscriptionPriceLabel, getSubscriptionStatusLabel, getSubscriptionValidityLabel, groupSubscriptionsByTier} from './member-subscription';
+import {describe, expect, it} from 'vitest';
+import type {MemberSubscription} from '@tryghost/admin-x-framework/api/members';
+
+function makeSub(overrides: Partial<MemberSubscription> = {}): MemberSubscription {
+    // Mid-day UTC so local-tz formatting doesn't cross a day boundary in tests.
+    return {
+        id: 'sub_1',
+        customer: {id: 'cus_1', name: null, email: 'x@x.co'},
+        plan: {id: 'plan_1', nickname: 'Monthly', interval: 'month', currency: 'usd', amount: 500},
+        status: 'active',
+        start_date: '2026-01-01T12:00:00.000Z',
+        current_period_end: '2026-02-01T12:00:00.000Z',
+        cancel_at_period_end: false,
+        price: {id: 'price_1', price_id: 'price_1', nickname: 'Monthly', amount: 500, currency: 'usd', type: 'recurring', interval: 'month'},
+        tier: {id: 'tier_1', name: 'Bronze', slug: 'bronze', active: true, type: 'paid'},
+        offer: null,
+        ...overrides
+    };
+}
+
+describe('classifyMemberSubscription', () => {
+    it('classifies a real Stripe subscription as paid', () => {
+        expect(classifyMemberSubscription(makeSub())).toBe('paid');
+    });
+
+    it('classifies "Complimentary" plan with an empty-string Stripe id as complimentary', () => {
+        // Ember requires BOTH: id must be falsy (no real Stripe sub — the members
+        // BREAD service synthesises comps/gifts with `id: ''`) AND nickname must match.
+        expect(classifyMemberSubscription(makeSub({
+            id: '',
+            plan: {...makeSub().plan, nickname: 'Complimentary'}
+        }))).toBe('complimentary');
+    });
+
+    it('is case-insensitive on the plan nickname (Ember uses toLowerCase)', () => {
+        expect(classifyMemberSubscription(makeSub({
+            id: '',
+            plan: {...makeSub().plan, nickname: 'complimentary'}
+        }))).toBe('complimentary');
+    });
+
+    it('classifies "Gift Subscription" plan with an empty-string Stripe id as gift', () => {
+        expect(classifyMemberSubscription(makeSub({
+            id: '',
+            plan: {...makeSub().plan, nickname: 'Gift Subscription'}
+        }))).toBe('gift');
+    });
+
+    it('does NOT classify a real paid subscription named "Complimentary" as complimentary', () => {
+        // A Stripe sub id present means it's real — even if the price was named
+        // "Complimentary" by accident. Ember's `!sub.id` guard prevents this.
+        expect(classifyMemberSubscription(makeSub({
+            id: 'sub_real',
+            plan: {...makeSub().plan, nickname: 'Complimentary'}
+        }))).toBe('paid');
+    });
+});
+
+describe('formatSubscriptionAmount', () => {
+    it('formats whole amounts without decimals', () => {
+        expect(formatSubscriptionAmount(500, 'usd')).toBe('$5');
+        expect(formatSubscriptionAmount(1000, 'eur')).toBe('€10');
+    });
+
+    it('formats fractional amounts with two decimals', () => {
+        expect(formatSubscriptionAmount(499, 'usd')).toBe('$4.99');
+    });
+
+    it('includes locale thousands separators (matching the Ember gh-price-amount helper)', () => {
+        // Bug caught in the earlier subscription attempt: raw string interpolation
+        // dropped the thousands separator that Ember toLocaleString provides.
+        // Locale-tolerant: accept both `,` (en-US) and `.` (many EU locales), so
+        // this passes whichever locale the runtime is set to.
+        expect(formatSubscriptionAmount(1000000, 'usd')).toMatch(/^\$10[.,]000$/);
+        expect(formatSubscriptionAmount(1234567, 'usd')).toMatch(/^\$12[.,]345[.,]67$/);
+    });
+
+    it('formats zero', () => {
+        expect(formatSubscriptionAmount(0, 'usd')).toBe('$0');
+    });
+});
+
+describe('formatSubscriptionInterval', () => {
+    it('maps the Stripe interval to Ember copy', () => {
+        expect(formatSubscriptionInterval('month')).toBe('monthly');
+        expect(formatSubscriptionInterval('year')).toBe('yearly');
+    });
+});
+
+describe('getSubscriptionStatusLabel', () => {
+    it('is Active for a running paid subscription', () => {
+        expect(getSubscriptionStatusLabel(makeSub())).toBe('Active');
+    });
+
+    it('is Canceled once the subscription has been canceled', () => {
+        expect(getSubscriptionStatusLabel(makeSub({status: 'canceled'}))).toBe('Canceled');
+    });
+
+    it('is Canceled when set to cancel at period end', () => {
+        expect(getSubscriptionStatusLabel(makeSub({cancel_at_period_end: true}))).toBe('Canceled');
+    });
+
+    it('is Active for a complimentary subscription with no id', () => {
+        expect(getSubscriptionStatusLabel(makeSub({
+            id: '',
+            plan: {...makeSub().plan, nickname: 'Complimentary'}
+        }))).toBe('Active');
+    });
+});
+
+describe('getSubscriptionValidityLabel', () => {
+    it('renders "Renews <date>" for a normal active subscription (no "on", matching Ember validityDetails)', () => {
+        expect(getSubscriptionValidityLabel(makeSub())).toBe('Renews 1 Feb 2026');
+    });
+
+    it('renders "Has access until <date>" when set to cancel at period end', () => {
+        expect(getSubscriptionValidityLabel(makeSub({cancel_at_period_end: true}))).toBe('Has access until 1 Feb 2026');
+    });
+
+    it('renders "Ended <date>" for a canceled sub whose period is still ending', () => {
+        expect(getSubscriptionValidityLabel(makeSub({status: 'canceled', cancel_at_period_end: true}))).toBe('Ended 1 Feb 2026');
+    });
+
+    it('is empty for a subscription canceled immediately (Ember blanks validUntil to avoid a stale date)', () => {
+        expect(getSubscriptionValidityLabel(makeSub({status: 'canceled', cancel_at_period_end: false}))).toBe('');
+    });
+
+    it('renders "Expires <date>" for a complimentary sub with a tier expiry (UTC, matching Ember compExpiry)', () => {
+        // Mid-day UTC — same output UTC or local, so the format is unambiguous.
+        expect(getSubscriptionValidityLabel(makeSub({
+            id: '',
+            plan: {...makeSub().plan, nickname: 'Complimentary'},
+            tier: {...makeSub().tier, expiry_at: '2026-12-31T12:00:00.000Z'}
+        }))).toBe('Expires 31 Dec 2026');
+    });
+
+    it('is empty for a complimentary sub with no tier expiry (matches Ember "forever" comp)', () => {
+        expect(getSubscriptionValidityLabel(makeSub({
+            id: '',
+            plan: {...makeSub().plan, nickname: 'Complimentary'}
+        }))).toBe('');
+    });
+
+    it('renders "Expires <date>" for a gift subscription', () => {
+        expect(getSubscriptionValidityLabel(makeSub({
+            id: '',
+            plan: {...makeSub().plan, nickname: 'Gift Subscription'},
+            tier: {...makeSub().tier, expiry_at: '2026-06-30T12:00:00.000Z'}
+        }))).toBe('Expires 30 Jun 2026');
+    });
+
+    it('renders "Ends <date>" for a paid trial', () => {
+        const future = new Date();
+        future.setDate(future.getDate() + 7);
+        expect(getSubscriptionValidityLabel(makeSub({
+            trial_end_at: future.toISOString()
+        }))).toContain('Ends ');
+    });
+
+    it('prefers cancel copy over trial copy — matches Ember validityDetails order', () => {
+        // A canceled trial keeps its cancel copy; Ember's validityDetails checks
+        // hasEnded/willEndSoon before trialUntil, so we do too.
+        const future = new Date();
+        future.setDate(future.getDate() + 7);
+        const sub = makeSub({
+            status: 'canceled',
+            cancel_at_period_end: true,
+            trial_end_at: future.toISOString()
+        });
+        expect(getSubscriptionValidityLabel(sub)).toBe('Ended 1 Feb 2026');
+    });
+});
+
+describe('getSubscriptionPriceLabel', () => {
+    it('is null for a normal paid subscription (Monthly nickname)', () => {
+        expect(getSubscriptionPriceLabel(makeSub())).toBeNull();
+    });
+
+    it('is null for a Yearly-nickname paid subscription', () => {
+        expect(getSubscriptionPriceLabel(makeSub({
+            price: {...makeSub().price, nickname: 'Yearly', interval: 'year'}
+        }))).toBeNull();
+    });
+
+    it('is "Free trial" while a paid subscription still has a future trial_end_at', () => {
+        const future = new Date();
+        future.setDate(future.getDate() + 7);
+        expect(getSubscriptionPriceLabel(makeSub({trial_end_at: future.toISOString()}))).toBe('Free trial');
+    });
+
+    it('is the custom nickname for a comp (Ember surfaces "Complimentary" this way)', () => {
+        expect(getSubscriptionPriceLabel(makeSub({
+            id: '',
+            price: {...makeSub().price, nickname: 'Complimentary'}
+        }))).toBe('Complimentary');
+    });
+
+    it('is the custom nickname for a gift', () => {
+        expect(getSubscriptionPriceLabel(makeSub({
+            id: '',
+            price: {...makeSub().price, nickname: 'Gift Subscription'}
+        }))).toBe('Gift Subscription');
+    });
+});
+
+describe('groupSubscriptionsByTier', () => {
+    it('groups subscriptions by tier id, preserving order within a tier', () => {
+        const bronze1 = makeSub({id: 'sub_a', tier: {...makeSub().tier, id: 'tier_bronze', name: 'Bronze', slug: 'bronze', active: true, type: 'paid'}});
+        const gold = makeSub({id: 'sub_b', tier: {...makeSub().tier, id: 'tier_gold', name: 'Gold', slug: 'gold', active: true, type: 'paid'}});
+        const bronze2 = makeSub({id: 'sub_c', tier: {...makeSub().tier, id: 'tier_bronze', name: 'Bronze', slug: 'bronze', active: true, type: 'paid'}});
+
+        const groups = groupSubscriptionsByTier([bronze1, gold, bronze2]);
+
+        expect(groups).toHaveLength(2);
+        expect(groups[0].tier.name).toBe('Bronze');
+        expect(groups[0].subscriptions.map(s => s.id)).toEqual(['sub_a', 'sub_c']);
+        expect(groups[1].tier.name).toBe('Gold');
+        expect(groups[1].subscriptions.map(s => s.id)).toEqual(['sub_b']);
+    });
+
+    it('skips subscriptions without a tier defensively', () => {
+        // The type says `tier` is present, but the server has been observed to omit
+        // it in edge cases (`gh-member-settings-form.js:57` explicitly falls back).
+        const good = makeSub();
+        const bad = makeSub({id: 'sub_bad', tier: undefined as unknown as MemberSubscription['tier']});
+        expect(groupSubscriptionsByTier([good, bad])).toHaveLength(1);
+    });
+
+    it('skips subscriptions without a price to avoid a row-render crash', () => {
+        // Ember explicitly filters `subs.filter(sub => !!sub.price)` before
+        // rendering (`gh-member-settings-form.js:63`); we mirror that here.
+        const good = makeSub();
+        const bad = makeSub({id: 'sub_no_price', price: undefined as unknown as MemberSubscription['price']});
+        expect(groupSubscriptionsByTier([good, bad])).toHaveLength(1);
+    });
+});

--- a/apps/admin/src/members/detail/member-subscription.ts
+++ b/apps/admin/src/members/detail/member-subscription.ts
@@ -1,0 +1,156 @@
+import moment from 'moment-timezone';
+import {getSymbol} from '@tryghost/admin-x-framework';
+import type {MemberSubscription, MemberTier} from '@tryghost/admin-x-framework/api/members';
+
+export type SubscriptionKind = 'paid' | 'complimentary' | 'gift';
+
+const COMPLIMENTARY_NICKNAME = 'complimentary';
+const GIFT_NICKNAME = 'gift subscription';
+
+/**
+ * Classify a subscription for display. Ember's `subscription-data.js` uses the
+ * pair (`!sub.id`, `plan.nickname`) to distinguish comp/gift from paid — because
+ * comps and gifts are synthesised locally from the member's tier with no Stripe
+ * subscription id (empty string), while paid subs always carry one.
+ */
+export function classifyMemberSubscription(sub: MemberSubscription): SubscriptionKind {
+    if (sub.id) {
+        return 'paid';
+    }
+    const nickname = sub.plan?.nickname?.toLowerCase() ?? '';
+    if (nickname === COMPLIMENTARY_NICKNAME) {
+        return 'complimentary';
+    }
+    if (nickname === GIFT_NICKNAME) {
+        return 'gift';
+    }
+    return 'paid';
+}
+
+/**
+ * Format a price amount (stored in the smallest currency unit, e.g. cents) with
+ * the correct symbol AND locale thousands separators. Matches the Ember helper
+ * `gh-price-amount` via `toLocaleString(undefined, options)`. Whole amounts show
+ * no decimals; fractional amounts show two.
+ *
+ * The runtime locale comes from the user's browser, matching Ember. Tests should
+ * therefore assert loosely (e.g. accepting either `,` or `.` as the thousands
+ * separator) rather than pinning en-US.
+ */
+export function formatSubscriptionAmount(amount: number, currency: string): string {
+    const symbol = getSymbol(currency);
+    const value = amount / 100;
+    const isWhole = value % 1 === 0;
+    const formatted = value.toLocaleString(undefined, isWhole ? undefined : {minimumFractionDigits: 2, maximumFractionDigits: 2});
+    return `${symbol}${formatted}`;
+}
+
+export function formatSubscriptionInterval(interval: MemberSubscription['price']['interval']): string {
+    return interval === 'year' ? 'yearly' : 'monthly';
+}
+
+/**
+ * The bold label that sits in front of the validity line — Ember's `priceLabel`.
+ * Returns "Free trial" while a paid subscription's `trial_end_at` is in the future,
+ * otherwise falls back to any `price.nickname` that isn't the plain "Monthly"/
+ * "Yearly" interval label — that's how Ember surfaces "Complimentary" for comps
+ * and "Gift Subscription" for gifts (their price nicknames). Matches
+ * `subscription-data.js:priceLabel`.
+ */
+export function getSubscriptionPriceLabel(sub: MemberSubscription): string | null {
+    const isTrial = !!sub.trial_end_at && moment(sub.trial_end_at).isAfter(new Date(), 'day');
+    if (isTrial) {
+        return 'Free trial';
+    }
+    const nickname = sub.price?.nickname;
+    if (nickname && nickname !== 'Monthly' && nickname !== 'Yearly') {
+        return nickname;
+    }
+    return null;
+}
+
+/**
+ * A subscription reads as "Canceled" when it is already canceled or set to cancel
+ * at period end; otherwise "Active" — matching the Ember status badge.
+ */
+export function getSubscriptionStatusLabel(sub: MemberSubscription): string {
+    if (sub.status === 'canceled' || sub.cancel_at_period_end) {
+        return 'Canceled';
+    }
+    return 'Active';
+}
+
+const formatDateLocal = (value: string | null | undefined) => (value ? moment(new Date(value)).format('D MMM YYYY') : '');
+const formatDateUtc = (value: string | null | undefined) => (value ? moment(value).utc().format('D MMM YYYY') : '');
+
+/**
+ * The line of copy that appears under a subscription describing its lifecycle:
+ * for paid — Renews / Has access until / Ended; for comp/gift — Expires or empty
+ * for a forever comp; for paid trials — Ends. Copy and branch order mirror Ember
+ * `validityDetails` (`subscription-data.js:117-150`): hard-cancel first, then
+ * soft-cancel (cancel_at_period_end), then trial, then default renewal.
+ *
+ * Dates: paid `current_period_end` renders in local time (Ember does the same
+ * via `moment(sub.current_period_end)`); comp/gift `tier.expiry_at` renders in
+ * UTC (Ember `compExpiry`/`giftExpiry` explicitly call `.utc()`).
+ */
+export function getSubscriptionValidityLabel(sub: MemberSubscription): string {
+    const kind = classifyMemberSubscription(sub);
+    if (kind === 'complimentary' || kind === 'gift') {
+        const tierExpiry = formatDateUtc(sub.tier?.expiry_at);
+        return tierExpiry ? `Expires ${tierExpiry}` : '';
+    }
+
+    // Ember blanks validUntil for a hard cancel to avoid showing a stale period end.
+    const validUntil = (sub.status === 'canceled' && !sub.cancel_at_period_end)
+        ? ''
+        : formatDateLocal(sub.current_period_end);
+
+    if (sub.status === 'canceled') {
+        return validUntil ? `Ended ${validUntil}` : '';
+    }
+    if (sub.cancel_at_period_end) {
+        return validUntil ? `Has access until ${validUntil}` : '';
+    }
+    // Trial only overrides the default "Renews" line — a canceled or period-ending
+    // subscription that still has a Stripe trial_end wins with its cancel copy.
+    if (sub.trial_end_at && moment(sub.trial_end_at).isAfter(new Date(), 'day')) {
+        return `Ends ${formatDateLocal(sub.trial_end_at)}`;
+    }
+    return validUntil ? `Renews ${validUntil}` : '';
+}
+
+export interface SubscriptionGroup {
+    tier: MemberTier;
+    subscriptions: MemberSubscription[];
+}
+
+/**
+ * Group a member's subscriptions by tier (deduping so a member with two subs to
+ * the same tier renders under one heading, matching Ember's tier accumulator).
+ * Drops subs without a tier or without a price — Ember filters both defensively
+ * (`gh-member-settings-form.js:57,63`), so we do the same rather than crash the
+ * row on `sub.price.amount`.
+ */
+export function groupSubscriptionsByTier(subs: MemberSubscription[]): SubscriptionGroup[] {
+    const groups: SubscriptionGroup[] = [];
+    const byTier = new Map<string, SubscriptionGroup>();
+    for (const sub of subs) {
+        if (!sub.price) {
+            continue;
+        }
+        // Ember falls back to `sub.price.tier` when `sub.tier` is missing.
+        const tier = sub.tier ?? (sub.price as {tier?: MemberTier}).tier;
+        if (!tier?.id) {
+            continue;
+        }
+        let group = byTier.get(tier.id);
+        if (!group) {
+            group = {tier, subscriptions: []};
+            byTier.set(tier.id, group);
+            groups.push(group);
+        }
+        group.subscriptions.push(sub);
+    }
+    return groups;
+}

--- a/apps/admin/src/members/detail/member-subscriptions-section.tsx
+++ b/apps/admin/src/members/detail/member-subscriptions-section.tsx
@@ -1,0 +1,243 @@
+import MemberAddCompModal from './member-add-comp-modal';
+import MemberSubscriptionActions from './member-subscription-actions';
+import MemberSubscriptionCompActions from './member-subscription-comp-actions';
+import React from 'react';
+import moment from 'moment-timezone';
+import {Badge, Button, Card, CardContent, EmptyIndicator} from '@tryghost/shade/components';
+import {LucideIcon, cn} from '@tryghost/shade/utils';
+import {classifyMemberSubscription, formatSubscriptionInterval, getSubscriptionPriceLabel, getSubscriptionStatusLabel, getSubscriptionValidityLabel, groupSubscriptionsByTier} from './member-subscription';
+import {getSymbol} from '@tryghost/admin-x-framework';
+import type {Member, MemberSubscription} from '@tryghost/admin-x-framework/api/members';
+import type {SubscriptionKind} from './member-subscription';
+
+const formatPriceBlockAmount = (amount: number) => {
+    const value = amount / 100;
+    // Match Ember: whole = no decimals, fractional = 2 decimals with locale separators.
+    return value.toLocaleString(undefined, value % 1 === 0
+        ? undefined
+        : {minimumFractionDigits: 2, maximumFractionDigits: 2});
+};
+
+const PriceBlock: React.FC<{sub: MemberSubscription; kind: SubscriptionKind}> = ({sub, kind}) => {
+    if (kind === 'complimentary' || kind === 'gift') {
+        return (
+            <div className='flex size-20 shrink-0 items-center justify-center rounded-lg bg-muted text-center text-sm font-medium text-muted-foreground'>
+                {kind === 'complimentary' ? 'Comp' : 'Gift'}
+            </div>
+        );
+    }
+    const symbol = getSymbol(sub.price.currency);
+    const amount = formatPriceBlockAmount(sub.price.amount);
+    const interval = formatSubscriptionInterval(sub.price.interval);
+    return (
+        <div className='flex size-20 shrink-0 flex-col items-center justify-center rounded-lg bg-muted text-foreground'>
+            <div className='flex items-start leading-none'>
+                <span className='mt-1 text-sm font-semibold'>{symbol}</span>
+                <span className='text-3xl font-semibold tracking-tight'>{amount}</span>
+            </div>
+            <div className='mt-1 text-xs text-muted-foreground'>{interval}</div>
+        </div>
+    );
+};
+
+// UTC to match the sidebar (`member-detail-sidebar.tsx`) — otherwise a subscription
+// "Created — 24 Jul 2026" line rendered in a different local timezone from the
+// "Created —" line above it, on the same screen.
+const formatDate = (value?: string | null) => (value ? moment.utc(value).format('D MMM YYYY') : '');
+
+const SubscriptionDetails: React.FC<{sub: MemberSubscription}> = ({sub}) => {
+    const created = formatDate(sub.start_date);
+    const source = sub.attribution?.referrer_source;
+    const showSource = source && source !== 'Unknown';
+    const page = sub.attribution?.title
+        ? {title: sub.attribution.title, url: sub.attribution.url ?? null}
+        : null;
+    return (
+        <div className='mt-3 space-y-1 border-t border-border pt-3 text-sm text-muted-foreground'>
+            {created && <p>Created — <span className='text-foreground'>{created}</span></p>}
+            {showSource && <p>Source — <span className='text-foreground'>{source}</span></p>}
+            {page && (
+                <p>
+                    Page — {page.url ? (
+                        <a className='text-foreground hover:underline' href={page.url} rel='noopener noreferrer' target='_blank'>{page.title}</a>
+                    ) : <span className='text-foreground'>{page.title}</span>}
+                </p>
+            )}
+        </div>
+    );
+};
+
+const SubscriptionRow: React.FC<{member: Member; sub: MemberSubscription; showDivider: boolean}> = ({member, sub, showDivider}) => {
+    const [showDetails, setShowDetails] = React.useState(false);
+    const kind = classifyMemberSubscription(sub);
+    const status = getSubscriptionStatusLabel(sub);
+    const validity = getSubscriptionValidityLabel(sub);
+    const priceLabel = getSubscriptionPriceLabel(sub);
+
+    return (
+        <div className={cn('flex items-start justify-between gap-4 py-5 first:pt-0 last:pb-0', showDivider && 'border-t border-border')} data-testid='member-subscription'>
+            <div className='flex min-w-0 flex-1 items-start gap-4'>
+                <PriceBlock kind={kind} sub={sub} />
+                <div className='min-w-0 flex-1 pt-2'>
+                    <div className='flex items-center gap-2'>
+                        <span className='min-w-0 truncate font-semibold' data-testid='member-subscription-tier'>{sub.tier?.name ?? 'Subscription'}</span>
+                        <Badge data-testid='member-subscription-status' variant={status === 'Canceled' ? 'secondary' : 'success'}>{status}</Badge>
+                    </div>
+                    {(priceLabel || validity) && (
+                        <div className='mt-1 text-sm'>
+                            {priceLabel && <span className='font-semibold text-foreground'>{priceLabel}</span>}
+                            {priceLabel && validity && <span className='text-muted-foreground'> – </span>}
+                            {validity && <span className='text-muted-foreground'>{validity}</span>}
+                        </div>
+                    )}
+                    <button
+                        aria-expanded={showDetails}
+                        className='mt-1 inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline'
+                        data-testid='member-subscription-details-toggle'
+                        type='button'
+                        onClick={() => setShowDetails(v => !v)}
+                    >
+                        Details
+                        <LucideIcon.ChevronDown className={cn('transition-transform', showDetails && 'rotate-180')} size={14} />
+                    </button>
+                    {showDetails && <SubscriptionDetails sub={sub} />}
+                </div>
+            </div>
+            {/* Gift subs get no action menu (Ember parity). Comp subs get their
+                own menu with Remove complimentary; paid subs get Cancel/Continue +
+                Stripe links. */}
+            {kind === 'paid' && (
+                <MemberSubscriptionActions memberId={member.id} subscription={sub} />
+            )}
+            {kind === 'complimentary' && sub.tier?.id && (
+                <MemberSubscriptionCompActions member={member} tierId={sub.tier.id} />
+            )}
+        </div>
+    );
+};
+
+interface MemberSubscriptionsSectionProps {
+    // Optional so the create screen (/members/new) can render the empty state
+    // without a saved member yet — matches Ember, which renders the section
+    // + "No subscriptions" empty box on the New member screen when
+    // `paidMembersEnabled` (`gh-member-settings-form.hbs:82-92`).
+    member?: Member;
+    // True when there is at least one active paid tier the member could be
+    // granted a comp on. Caller (`member-detail.tsx`) fetches tiers and computes.
+    canAddComp: boolean;
+}
+
+/**
+ * Read-only subscriptions block for the member-detail screen. Groups the member's
+ * subscriptions by tier so a member with multiple subs to the same tier renders
+ * under one heading (matches Ember). When there is nothing to show, nothing
+ * renders — the empty-state + "add complimentary" UI is Phase 6.
+ *
+ * The section heading sits **outside** the card (rendered by the parent) so the
+ * card contents flow edge-to-edge without a nested header, matching Ember.
+ */
+const MemberSubscriptionsSection: React.FC<MemberSubscriptionsSectionProps> = ({member, canAddComp}) => {
+    const [showAddComp, setShowAddComp] = React.useState(false);
+
+
+    // Create mode: no saved member yet, no subscriptions to enumerate, no
+    // add-comp affordance (Ember's `isAddComplimentaryAllowed` short-circuits
+    // on `isNew`). Render the empty state only. Early-returning here also
+    // narrows `member` to `Member` for the rest of the function so the
+    // SubscriptionRow / MemberAddCompModal props type-check without a cast.
+    if (!member) {
+        return (
+            <Card data-testid='member-subscriptions'>
+                <CardContent className='pt-6'>
+                    <div className='flex flex-col items-center gap-3 py-4'>
+                        <EmptyIndicator title='No subscriptions'>
+                            <LucideIcon.CreditCard />
+                        </EmptyIndicator>
+                    </div>
+                </CardContent>
+            </Card>
+        );
+    }
+
+    const subscriptions = member.subscriptions ?? [];
+    const groups = groupSubscriptionsByTier(subscriptions);
+    const hasSubscriptions = groups.length > 0;
+
+    // Ember's `isAddComplimentaryAllowed`: paidMembersEnabled + not new + no
+    // tiers yet + at least one active paid tier exists. The isNew and
+    // paidMembersEnabled halves are covered by the guards above; combine the
+    // remaining conditions here.
+    const isAddCompAllowed = canAddComp && (member.tiers?.length ?? 0) === 0;
+
+    // The Add-complimentary button appears in TWO places, matching Ember exactly
+    // (`gh-member-settings-form.hbs:82-111,279-293`):
+    //   - As the empty-state affordance when there are no subs at all.
+    //   - As a footer under existing subs when the member has active paid subs but
+    //     no comp tier yet — that's the "cancel Stripe and comp on top" flow.
+    const addCompButton = isAddCompAllowed ? (
+        <Button
+            data-testid='add-complimentary'
+            variant='outline'
+            onClick={() => setShowAddComp(true)}
+        >
+            <LucideIcon.Plus className='mr-1' size={16} />
+            Add complimentary subscription
+        </Button>
+    ) : null;
+
+    return (
+        <>
+            <Card data-testid='member-subscriptions'>
+                <CardContent className='pt-6'>
+                    {hasSubscriptions
+                        ? (
+                            <>
+                                {groups.map(group => (
+                                    <div key={group.tier.id} className='flex flex-col'>
+                                        {group.subscriptions.map((sub, i) => (
+                                            // For a member with 2+ subs on the same tier, the second key
+                                            // needs a fallback since comp/gift subs have `id: ''`.
+                                            <SubscriptionRow
+                                                key={sub.id || `${group.tier.id}-${i}`}
+                                                member={member}
+                                                showDivider={i > 0}
+                                                sub={sub}
+                                            />
+                                        ))}
+                                        {group.subscriptions.length > 1 && (
+                                            <div className='pt-3 text-sm text-muted-foreground'>
+                                                {group.subscriptions.length} subscriptions
+                                            </div>
+                                        )}
+                                    </div>
+                                ))}
+                                {addCompButton && (
+                                    <div className='mt-4 flex justify-center border-t border-border pt-4'>
+                                        {addCompButton}
+                                    </div>
+                                )}
+                            </>
+                        )
+                        : (
+                            // EmptyIndicator (Shade) is the canonical "no
+                            // items yet" box — mirrors Ember's
+                            // `gh-members-no-subs` block (icon + heading)
+                            // with the design-system's own icon/heading
+                            // treatment.
+                            <div className='flex flex-col items-center gap-3 py-4'>
+                                <EmptyIndicator title='No subscriptions'>
+                                    <LucideIcon.CreditCard />
+                                </EmptyIndicator>
+                                {addCompButton}
+                            </div>
+                        )}
+                </CardContent>
+            </Card>
+            {isAddCompAllowed && (
+                <MemberAddCompModal member={member} open={showAddComp} onOpenChange={setShowAddComp} />
+            )}
+        </>
+    );
+};
+
+export default MemberSubscriptionsSection;

--- a/apps/admin/src/members/label-picker/label-picker.tsx
+++ b/apps/admin/src/members/label-picker/label-picker.tsx
@@ -25,6 +25,10 @@ export interface LabelPickerProps {
     // Editing
     onEdit?: (id: string, name: string) => Promise<void>;
     onDelete?: (id: string) => Promise<void>;
+    // Placeholder shown in the search input when nothing is selected. Defaults
+    // to 'Search labels...' — pass an empty string on surfaces where the field
+    // itself is already contextualized by a nearby Label element.
+    placeholder?: string;
 }
 
 // --- LabelRow: single label item with overlapping check/edit icon ---
@@ -206,7 +210,8 @@ const LabelPicker: React.FC<LabelPickerProps> = ({
     onCreate,
     isCreating,
     onEdit,
-    onDelete
+    onDelete,
+    placeholder
 }) => {
     const selectedLabels = resolvedSelectedLabels || selectedSlugs
         .map(slug => labels.find(l => l.slug === slug))
@@ -217,6 +222,7 @@ const LabelPicker: React.FC<LabelPickerProps> = ({
             isCreating={isCreating}
             labels={labels}
             optionSource={optionSource}
+            placeholder={placeholder}
             selectedLabels={selectedLabels}
             selectedSlugs={selectedSlugs}
             onCreate={onCreate}
@@ -239,6 +245,7 @@ interface ComboboxPickerProps {
     isCreating?: boolean;
     onEdit?: (id: string, name: string) => Promise<void>;
     onDelete?: (id: string) => Promise<void>;
+    placeholder?: string;
 }
 
 const ComboboxPicker: React.FC<ComboboxPickerProps> = ({
@@ -250,7 +257,8 @@ const ComboboxPicker: React.FC<ComboboxPickerProps> = ({
     onCreate,
     isCreating,
     onEdit,
-    onDelete
+    onDelete,
+    placeholder = 'Search labels...'
 }) => {
     const [open, setOpen] = useState(false);
     const [search, setSearch] = useState('');
@@ -302,7 +310,7 @@ const ComboboxPicker: React.FC<ComboboxPickerProps> = ({
                 <input
                     ref={inputRef}
                     className="min-w-[80px] flex-1 bg-transparent text-control outline-hidden placeholder:text-muted-foreground"
-                    placeholder={selectedLabels.length === 0 ? 'Search labels...' : ''}
+                    placeholder={selectedLabels.length === 0 ? placeholder : ''}
                     value={search}
                     onChange={(e) => {
                         handleSearchChange(e.target.value);

--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -12,6 +12,7 @@ import MyProfileRedirect from "./my-profile-redirect";
 import { EmberFallback, ForceUpgradeGuard } from "./ember-bridge";
 import type { RouteHandle } from "./ember-bridge";
 import { EmberListWithGiftLinks } from "./gift-link-modal-host";
+import { MemberDetailGate } from "./member-detail-gate";
 import { MembersRoute } from "./members-route";
 import { OnboardingRedirect } from "./onboarding/onboarding-redirect";
 
@@ -37,8 +38,6 @@ const EMBER_ROUTES: string[] = [
     "/tags/new",
     "/explore/*",
     "/migrate/*",
-    "/members/new",
-    "/members/:member_id",
     "/members-activity",
     "/designsandbox",
     "/mentions",
@@ -64,6 +63,18 @@ const membersRoute: RouteObject = {
         {
             path: "import",
             lazy: lazyComponent(() => import("./members/members"))
+        },
+        {
+            // Covers both edit (`:member_id`) and create (the sentinel `new`)
+            // — real member ids are 24-char hex ObjectIds, so they can't
+            // collide with the literal "new".
+            //
+            // MemberDetailGate serves Ember or React depending on the
+            // `memberDetailsReact` Labs flag; the parent route's
+            // emberFallbackHandle covers both, since ForceUpgradeGuard checks
+            // every match rather than just the leaf.
+            path: ":member_id",
+            Component: MemberDetailGate
         }
     ]
 };

--- a/apps/shade/src/components/page-templates/detail-page.stories.tsx
+++ b/apps/shade/src/components/page-templates/detail-page.stories.tsx
@@ -1,0 +1,102 @@
+import type {Meta, StoryObj} from '@storybook/react-vite';
+import {
+    Breadcrumb,
+    BreadcrumbItem,
+    BreadcrumbLink,
+    BreadcrumbList,
+    BreadcrumbPage,
+    BreadcrumbSeparator
+} from '@/components/ui/breadcrumb';
+import {Button} from '@/components/ui/button';
+import {Card, CardContent, CardHeader, CardTitle} from '@/components/ui/card';
+import {DetailPage} from '@/components/page-templates/detail-page';
+import {PageHeader} from '@/components/patterns/page-header';
+
+const meta = {
+    title: 'Page Templates / Detail Page',
+    component: DetailPage,
+    tags: ['autodocs'],
+    parameters: {
+        layout: 'fullscreen',
+        docs: {
+            description: {
+                component: `
+DetailPage is the canonical recipe for a **Detail / Edit page** — the sibling of \`ListPage\` for screens that show or edit a single entity (member, post, newsletter, etc.).
+
+- Outer container is a vertical flex stack with the same horizontal padding as \`ListPage\` (\`px-4 lg:px-6\`) so a detail screen visually aligns with the list it was navigated in from.
+- \`<DetailPage.Header>\` — non-sticky header band. Use \`PageHeader\` with \`sticky={false} blurredBackground={false}\` for the breadcrumb and actions.
+- \`<DetailPage.Body>\` — scroll container that grows to fill.
+
+\`\`\`tsx
+<DetailPage>
+  <DetailPage.Header>
+    <PageHeader blurredBackground={false} sticky={false}>
+      <PageHeader.Left>
+        <PageHeader.Breadcrumb>…</PageHeader.Breadcrumb>
+      </PageHeader.Left>
+      <PageHeader.Actions>
+        <PageHeader.ActionGroup>
+          <Button>Save</Button>
+        </PageHeader.ActionGroup>
+      </PageHeader.Actions>
+    </PageHeader>
+  </DetailPage.Header>
+  <DetailPage.Body>…</DetailPage.Body>
+</DetailPage>
+\`\`\`
+                `
+            }
+        }
+    }
+} satisfies Meta<typeof DetailPage>;
+
+export default meta;
+type Story = StoryObj<typeof DetailPage>;
+
+export const Structure: Story = {
+    render: () => (
+        <div className="h-screen">
+            <DetailPage>
+                <DetailPage.Header>
+                    <PageHeader blurredBackground={false} sticky={false}>
+                        <PageHeader.Left>
+                            <PageHeader.Breadcrumb>
+                                <Breadcrumb>
+                                    <BreadcrumbList>
+                                        <BreadcrumbItem>
+                                            <BreadcrumbLink href="#">Members</BreadcrumbLink>
+                                        </BreadcrumbItem>
+                                        <BreadcrumbSeparator />
+                                        <BreadcrumbItem>
+                                            <BreadcrumbPage>Ada Lovelace</BreadcrumbPage>
+                                        </BreadcrumbItem>
+                                    </BreadcrumbList>
+                                </Breadcrumb>
+                            </PageHeader.Breadcrumb>
+                        </PageHeader.Left>
+                        <PageHeader.Actions>
+                            <PageHeader.ActionGroup>
+                                <Button>Save</Button>
+                            </PageHeader.ActionGroup>
+                        </PageHeader.Actions>
+                    </PageHeader>
+                </DetailPage.Header>
+                <DetailPage.Body>
+                    <div className="flex flex-col gap-6 lg:flex-row lg:items-start">
+                        <aside className="w-full shrink-0 lg:w-72">
+                            <p className="text-muted-foreground">Sidebar</p>
+                        </aside>
+                        <div className="flex min-w-0 flex-1 flex-col gap-6">
+                            <Card>
+                                <CardHeader>
+                                    <CardTitle className="text-base">Section</CardTitle>
+                                </CardHeader>
+                                <CardContent>Main content goes here.</CardContent>
+                            </Card>
+                        </div>
+                    </div>
+                </DetailPage.Body>
+            </DetailPage>
+        </div>
+    )
+};

--- a/apps/shade/src/components/page-templates/detail-page.tsx
+++ b/apps/shade/src/components/page-templates/detail-page.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import {Stack} from '@/components/primitives/stack';
+import {cn} from '@/lib/utils';
+
+type DetailPageProps = React.ComponentPropsWithoutRef<'div'>;
+
+/**
+ * Non-sticky page-level header band. Place `PageHeader` (usually with
+ * `sticky={false} blurredBackground={false}`) directly inside — vertical padding
+ * matches the list-page rhythm (`py-5`) so a detail page's breadcrumb sits at
+ * the same visual height as the tags/members list title.
+ */
+function DetailPageHeader({className, children, ...rest}: DetailPageProps) {
+    return (
+        <Stack
+            className={cn('py-5', className)}
+            data-detail-page='header'
+            gap='lg'
+            {...rest}
+        >
+            {children}
+        </Stack>
+    );
+}
+
+/**
+ * Body for a detail page — grows to fill the remaining vertical space and
+ * scrolls its own content. The horizontal padding is inherited from the outer
+ * `DetailPage`, so the header and body always line up on the same left edge.
+ */
+function DetailPageBody({className, children, ...rest}: DetailPageProps) {
+    return (
+        <Stack
+            className={cn('min-h-0 min-w-0 grow overflow-y-auto pb-4 lg:pb-8', className)}
+            data-detail-page='body'
+            gap='none'
+            {...rest}
+        >
+            {children}
+        </Stack>
+    );
+}
+
+type DetailPageComponent = React.FC<DetailPageProps> & {
+    Header: React.FC<DetailPageProps>;
+    Body: React.FC<DetailPageProps>;
+};
+
+/**
+ * DetailPage is the canonical recipe for a **detail / edit** page — the sibling
+ * of `ListPage` for screens that show or edit a single entity (member, post,
+ * newsletter, etc.).
+ *
+ * Structure:
+ *  - Outer container is a vertical Stack with the same horizontal padding as
+ *    `ListPage` (`px-4 lg:px-6`) so a detail screen visually aligns with the
+ *    list it was navigated in from.
+ *  - `<DetailPage.Header>` — non-sticky header band. Use `PageHeader` with
+ *    `sticky={false} blurredBackground={false}` for the breadcrumb + actions.
+ *  - `<DetailPage.Body>` — scroll container that grows to fill.
+ *
+ * Composition example:
+ * ```tsx
+ * <DetailPage>
+ *   <DetailPage.Header>
+ *     <PageHeader blurredBackground={false} sticky={false}>...</PageHeader>
+ *   </DetailPage.Header>
+ *   <DetailPage.Body>...</DetailPage.Body>
+ * </DetailPage>
+ * ```
+ */
+const DetailPage: DetailPageComponent = Object.assign(
+    function DetailPage({className, children, ...rest}: DetailPageProps) {
+        return (
+            <Stack
+                className={cn('h-full min-h-0 grow px-4 lg:px-6', className)}
+                data-detail-page='detail-page'
+                gap='none'
+                {...rest}
+            >
+                {children}
+            </Stack>
+        );
+    },
+    {
+        Header: DetailPageHeader,
+        Body: DetailPageBody
+    }
+);
+
+export {DetailPage};

--- a/apps/shade/src/page-templates.ts
+++ b/apps/shade/src/page-templates.ts
@@ -1,2 +1,3 @@
 // Full page layout templates — assemble patterns into complete route-level structures
+export * from './components/page-templates/detail-page';
 export * from './components/page-templates/list-page';

--- a/e2e/helpers/pages/admin/members/member-details-page.ts
+++ b/e2e/helpers/pages/admin/members/member-details-page.ts
@@ -2,6 +2,8 @@ import {AdminPage} from '@/admin-pages';
 import {BasePage} from '@/helpers/pages';
 import {Locator, Page} from '@playwright/test';
 
+const menuAction = (page: Page, name: string) => page.getByRole('button', {name});
+
 class SettingsSection extends BasePage {
     readonly memberActionsButton: Locator;
 
@@ -17,12 +19,12 @@ class SettingsSection extends BasePage {
         super(page);
         this.memberActionsButton = page.getByTestId('member-actions');
 
-        this.impersonateButton = page.getByRole('button', {name: 'Impersonate'});
-        this.signOutOfAllDevices = page.getByRole('button', {name: 'Sign out of all devices'});
-        this.disableCommentingButton = page.getByRole('button', {name: 'Disable commenting'});
-        this.enableCommentingButton = page.getByRole('button', {name: 'Enable commenting'});
+        this.impersonateButton = menuAction(page, 'Impersonate');
+        this.signOutOfAllDevices = menuAction(page, 'Sign out of all devices');
+        this.disableCommentingButton = menuAction(page, 'Disable commenting');
+        this.enableCommentingButton = menuAction(page, 'Enable commenting');
 
-        this.deleteButton = page.getByRole('button', {name: 'Delete member'});
+        this.deleteButton = menuAction(page, 'Delete member');
         this.confirmDeleteButton = page.getByTestId('confirm-delete-member');
         this.cancelDeleteButton = page.getByTestId('cancel-delete-member');
     }
@@ -56,6 +58,16 @@ export class MemberDetailsPage extends AdminPage {
     readonly commentingDisabledIndicator: Locator;
     readonly enableCommentingLink: Locator;
 
+    readonly screenTitle: Locator;
+    readonly logoutConfirmModal: Locator;
+    readonly newsletterSubscriptionCheckboxes: Locator;
+    readonly engagementSection: Locator;
+    readonly subscriptionActionsButton: Locator;
+    readonly cancelSubscriptionButton: Locator;
+    readonly continueSubscriptionButton: Locator;
+    readonly removeComplimentaryButton: Locator;
+    readonly addComplimentaryButton: Locator;
+
     constructor(page: Page) {
         super(page);
         this.pageUrl = '/ghost/#/members/';
@@ -72,6 +84,8 @@ export class MemberDetailsPage extends AdminPage {
         this.retryButton = page.getByRole('button', {name: 'Retry'});
         this.membersBackLink = page.locator('[data-test-link="members-back"]');
         this.copyLinkButton = page.getByRole('button', {name: 'Copy link'});
+        // The testid resolves to two elements once the modal is open; the
+        // input carrying the value is the last of them.
         this.magicLinkInput = page.getByTestId('member-signin-url').last();
         this.confirmLeaveButton = page.getByRole('button', {name: 'Leave'});
         this.settingsSection = new SettingsSection(page);
@@ -84,6 +98,33 @@ export class MemberDetailsPage extends AdminPage {
         this.hideCommentsCheckbox = this.disableCommentingModal.getByText('Hide all previous comments');
         this.commentingDisabledIndicator = page.getByText('Comments disabled');
         this.enableCommentingLink = page.getByRole('button', {name: 'Enable', exact: true});
+
+        this.screenTitle = page.locator('[data-test-screen-title]');
+        this.logoutConfirmModal = page.locator('[data-test-modal="logout-member"]');
+        // The testid marks the styled toggle span, which sits next to the real
+        // checkbox — the checked state has to be read from the input.
+        this.newsletterSubscriptionCheckboxes = this.newsletterSubscriptionToggles
+            .locator('..')
+            .getByRole('checkbox');
+        this.engagementSection = page.getByTestId('member-detail-engagement');
+
+        this.subscriptionActionsButton = page.locator('[data-test-button="subscription-actions"]');
+        this.cancelSubscriptionButton = menuAction(page, 'Cancel subscription');
+        this.continueSubscriptionButton = menuAction(page, 'Continue subscription');
+        this.removeComplimentaryButton = menuAction(page, 'Remove complimentary subscription');
+        this.addComplimentaryButton = menuAction(page, 'Add complimentary subscription');
+    }
+
+    /**
+     * Removes a complimentary subscription from the first subscription row.
+     */
+    async removeComplimentarySubscription(): Promise<void> {
+        await this.subscriptionActionsButton.first().click();
+        await this.removeComplimentaryButton.click();
+        const confirm = this.page.getByRole('button', {name: 'Remove', exact: true});
+        if (await confirm.isVisible().catch(() => false)) {
+            await confirm.click();
+        }
     }
 
     async clickNewsletterSubscriptionToggle(index: number = 0) {

--- a/e2e/helpers/pages/admin/members/member-details-page.ts
+++ b/e2e/helpers/pages/admin/members/member-details-page.ts
@@ -2,7 +2,17 @@ import {AdminPage} from '@/admin-pages';
 import {BasePage} from '@/helpers/pages';
 import {Locator, Page} from '@playwright/test';
 
-const menuAction = (page: Page, name: string) => page.getByRole('button', {name});
+/**
+ * The member detail screen has two implementations behind the
+ * `memberDetailsReact` Labs flag, and this page object drives both without
+ * branching. Where the two render different markup for the same thing, the
+ * locator matches either.
+ *
+ * Role-based locators need no visibility filter — Playwright already skips
+ * hidden subtrees for them. `getByTestId` and attribute selectors don't, so
+ * those are filtered explicitly to whichever tree is actually on screen.
+ */
+const menuAction = (page: Page, name: string) => page.getByRole('menuitem', {name}).or(page.getByRole('button', {name}));
 
 class SettingsSection extends BasePage {
     readonly memberActionsButton: Locator;
@@ -17,16 +27,18 @@ class SettingsSection extends BasePage {
 
     constructor(page: Page) {
         super(page);
-        this.memberActionsButton = page.getByTestId('member-actions');
+        this.memberActionsButton = page.getByTestId('member-actions').filter({visible: true});
 
+        // Ember renders the menu contents as plain buttons; React renders them
+        // as Radix menu items. Match either.
         this.impersonateButton = menuAction(page, 'Impersonate');
         this.signOutOfAllDevices = menuAction(page, 'Sign out of all devices');
         this.disableCommentingButton = menuAction(page, 'Disable commenting');
         this.enableCommentingButton = menuAction(page, 'Enable commenting');
 
         this.deleteButton = menuAction(page, 'Delete member');
-        this.confirmDeleteButton = page.getByTestId('confirm-delete-member');
-        this.cancelDeleteButton = page.getByTestId('cancel-delete-member');
+        this.confirmDeleteButton = page.getByTestId('confirm-delete-member').filter({visible: true});
+        this.cancelDeleteButton = page.getByTestId('cancel-delete-member').filter({visible: true});
     }
 }
 
@@ -63,6 +75,13 @@ export class MemberDetailsPage extends AdminPage {
     readonly newsletterSubscriptionCheckboxes: Locator;
     readonly engagementSection: Locator;
     readonly subscriptionActionsButton: Locator;
+    // The add-complimentary modal is the one place the two screens differ by
+    // widget rather than behaviour: Ember picks a tier with radios and saves
+    // from the modal footer, React uses dropdowns. These name Ember's controls
+    // so its test can drive them without a raw locator.
+    readonly emberCompTierOptions: Locator;
+    readonly reactCompTierOptions: Locator;
+    readonly emberSaveCompTierButton: Locator;
     readonly cancelSubscriptionButton: Locator;
     readonly continueSubscriptionButton: Locator;
     readonly removeComplimentaryButton: Locator;
@@ -77,16 +96,14 @@ export class MemberDetailsPage extends AdminPage {
         this.noteInput = page.getByRole('textbox', {name: 'Note'});
         this.labelsInput = page.getByText('Labels').locator('+ div');
         this.labels = this.labelsInput.getByRole('listitem');
-        this.newsletterSubscriptionToggles = page.getByTestId('member-subscription-toggle');
+        this.newsletterSubscriptionToggles = page.getByTestId('member-subscription-toggle').filter({visible: true});
 
         this.saveButton = page.getByRole('button', {name: 'Save'});
         this.savedButton = page.getByRole('button', {name: 'Saved'});
         this.retryButton = page.getByRole('button', {name: 'Retry'});
-        this.membersBackLink = page.locator('[data-test-link="members-back"]');
+        this.membersBackLink = page.locator('[data-test-link="members-back"]').filter({visible: true});
         this.copyLinkButton = page.getByRole('button', {name: 'Copy link'});
-        // The testid resolves to two elements once the modal is open; the
-        // input carrying the value is the last of them.
-        this.magicLinkInput = page.getByTestId('member-signin-url').last();
+        this.magicLinkInput = page.getByTestId('member-signin-url').filter({visible: true});
         this.confirmLeaveButton = page.getByRole('button', {name: 'Leave'});
         this.settingsSection = new SettingsSection(page);
 
@@ -99,24 +116,41 @@ export class MemberDetailsPage extends AdminPage {
         this.commentingDisabledIndicator = page.getByText('Comments disabled');
         this.enableCommentingLink = page.getByRole('button', {name: 'Enable', exact: true});
 
-        this.screenTitle = page.locator('[data-test-screen-title]');
-        this.logoutConfirmModal = page.locator('[data-test-modal="logout-member"]');
-        // The testid marks the styled toggle span, which sits next to the real
-        // checkbox — the checked state has to be read from the input.
+        this.screenTitle = page.locator('[data-test-screen-title]')
+            .or(page.getByTestId('member-detail-title'))
+            .filter({visible: true});
+        this.logoutConfirmModal = page.locator('[data-test-modal="logout-member"]')
+            .or(page.getByTestId('logout-member-modal'))
+            .filter({visible: true});
+        // Ember puts the testid on a styled span sitting next to the real
+        // checkbox, so the checked state has to be read from the sibling
+        // input. React puts it straight on the Radix switch, which carries the
+        // state itself.
         this.newsletterSubscriptionCheckboxes = this.newsletterSubscriptionToggles
             .locator('..')
-            .getByRole('checkbox');
-        this.engagementSection = page.getByTestId('member-detail-engagement');
+            .getByRole('checkbox')
+            .or(this.newsletterSubscriptionToggles.and(page.getByRole('switch')));
+        this.engagementSection = page.getByTestId('member-detail-engagement').filter({visible: true});
 
-        this.subscriptionActionsButton = page.locator('[data-test-button="subscription-actions"]');
+        // Same control, different attribute: Ember marks it `data-test-button`,
+        // React `data-testid`.
+        this.subscriptionActionsButton = page.locator('[data-test-button="subscription-actions"]')
+            .or(page.getByTestId('subscription-actions'))
+            .filter({visible: true});
         this.cancelSubscriptionButton = menuAction(page, 'Cancel subscription');
         this.continueSubscriptionButton = menuAction(page, 'Continue subscription');
         this.removeComplimentaryButton = menuAction(page, 'Remove complimentary subscription');
         this.addComplimentaryButton = menuAction(page, 'Add complimentary subscription');
+        this.emberCompTierOptions = page.locator('[data-test-tier-option]');
+        this.reactCompTierOptions = page.locator('[data-tier-id]');
+        this.emberSaveCompTierButton = page.locator('[data-test-button="save-comp-tier"]');
     }
 
     /**
      * Removes a complimentary subscription from the first subscription row.
+     * One implementation confirms the removal in a dialog and the other acts
+     * immediately, so the confirm step is best-effort — the caller only cares
+     * that the removal was requested.
      */
     async removeComplimentarySubscription(): Promise<void> {
         await this.subscriptionActionsButton.first().click();

--- a/e2e/tests/admin/members/member-detail.test.ts
+++ b/e2e/tests/admin/members/member-detail.test.ts
@@ -1,0 +1,558 @@
+import {MemberDetailsPage} from '@/admin-pages';
+import {MemberFactory, createMemberFactory} from '@/data-factory';
+import {Page} from '@playwright/test';
+import {expect, test} from '@/helpers/playwright';
+import {usePerTestIsolation} from '@/helpers/playwright/isolation';
+
+/**
+ * Behaviour contract for `/members/:id`.
+ *
+ * Every assertion here describes what the member detail screen does, not how it
+ * is built — semantic roles, page-object locators, and API reads. Nothing in
+ * this file knows which implementation is rendering it.
+ *
+ * That is deliberate. A second implementation of this screen is coming, and
+ * this suite is what it has to satisfy. Keeping the assertions
+ * implementation-neutral means the same tests can run against both without
+ * branching, so a behaviour that only works on one side surfaces as a failure
+ * rather than as a quietly narrowed test.
+ */
+
+usePerTestIsolation();
+
+const memberPath = (memberId: string) => `/ghost/#/members/${memberId}`;
+
+const BRONZE = {id: 'tier_bronze', tier_id: 'tier_bronze', name: 'Bronze', slug: 'bronze', active: true, type: 'paid'};
+
+// A member comped on two tiers, where the surviving one carries an expiry the
+// admin set. Removing the other must not disturb it.
+const SILVER_EXPIRY = '2027-03-01T00:00:00.000Z';
+const TWO_COMP_TIERS = () => [
+    {...BRONZE, expiry_at: null},
+    {id: 'tier_silver', tier_id: 'tier_silver', name: 'Silver', slug: 'silver', active: true, type: 'paid', expiry_at: SILVER_EXPIRY}
+];
+
+type SentTier = {id: string; expiry_at?: string | null};
+const sentTiers = (sent: {body?: Record<string, unknown>}): SentTier[] | undefined => (sent.body?.members as {tiers?: SentTier[]}[] | undefined)?.[0]?.tiers;
+
+/**
+ * Subscriptions as the members API actually serializes them: the tier is
+ * carried on `price.tier` with a `tier_id`, and mirrored on the subscription
+ * itself. Both are load-bearing — the two implementations read different ones
+ * to group subscriptions under a tier, so a fixture that omits either renders
+ * on one screen and not the other for reasons no user would ever hit.
+ * See `serializers/output/members.js` ("Rename subscriptions.price.product to
+ * subscriptions.price.tier").
+ */
+const paidSubscription = (overrides: Record<string, unknown> = {}) => ({
+    id: 'sub_paid_123',
+    customer: {id: 'cus_paid_123', name: 'Paid Member', email: 'paid-sub@ghost.org'},
+    plan: {id: 'plan_paid', nickname: 'Monthly', interval: 'month', currency: 'usd', amount: 1050},
+    status: 'active',
+    start_date: '2026-01-15T12:00:00.000Z',
+    current_period_end: '2026-02-15T12:00:00.000Z',
+    cancel_at_period_end: false,
+    price: {
+        id: 'price_paid',
+        price_id: 'price_paid',
+        nickname: 'Monthly',
+        amount: 1050,
+        currency: 'usd',
+        type: 'recurring',
+        interval: 'month',
+        tier: {...BRONZE}
+    },
+    tier: {...BRONZE},
+    offer: null,
+    attribution: null,
+    ...overrides
+});
+
+// Gift and complimentary subscriptions are told apart by the plan nickname —
+// both arrive with an empty id because neither has a Stripe subscription.
+const giftSubscription = (overrides: Record<string, unknown> = {}) => ({
+    ...paidSubscription(),
+    id: '',
+    plan: {id: 'plan_gift', nickname: 'Gift Subscription', interval: 'year', currency: 'usd', amount: 0},
+    price: {
+        id: 'price_gift',
+        price_id: 'price_gift',
+        nickname: 'Gift Subscription',
+        amount: 0,
+        currency: 'usd',
+        type: 'recurring',
+        interval: 'year',
+        tier: {...BRONZE}
+    },
+    ...overrides
+});
+
+// Complimentary subscriptions arrive with an empty id and no Stripe plan.
+const compSubscription = (overrides: Record<string, unknown> = {}) => ({
+    ...paidSubscription(),
+    id: '',
+    plan: {id: 'plan_comp', nickname: 'Complimentary', interval: 'year', currency: 'usd', amount: 0},
+    price: {
+        id: 'price_comp',
+        price_id: 'price_comp',
+        nickname: 'Complimentary',
+        amount: 0,
+        currency: 'usd',
+        type: 'recurring',
+        interval: 'year',
+        tier: {...BRONZE}
+    },
+    ...overrides
+});
+
+type MemberStatus = 'paid' | 'comped' | 'gift';
+
+/**
+ * Rewrites this member on every read, letting a test serve a shape the fixture
+ * database can't produce (Stripe subscriptions, engagement counters).
+ */
+const interceptMemberRead = async (page: Page, memberId: string, patch: (member: Record<string, unknown>) => void) => {
+    const memberReadRegex = new RegExp(`/ghost/api/admin/members/${memberId}/\\??[^/]*$`);
+    await page.route(memberReadRegex, async (route) => {
+        // `fallback`, not `continue` — continue would go straight to the network
+        // and skip any handler registered after this one.
+        if (route.request().method() !== 'GET') {
+            return route.fallback();
+        }
+        try {
+            const response = await route.fetch();
+            const body = await response.json();
+            if (body?.members?.[0]) {
+                patch(body.members[0] as Record<string, unknown>);
+            }
+            return route.fulfill({response, body: JSON.stringify(body)});
+        } catch (err) {
+            // A post-mutation refetch can land after the test has finished, once
+            // the context is gone; there's nothing left to serve. Anything else
+            // is a real failure, and swallowing it would leave the request
+            // hanging until the test times out with no clue why.
+            if (!page.isClosed()) {
+                throw err;
+            }
+        }
+    });
+};
+
+/**
+ * Serves `subscriptions` on every read of this member. The array is held by
+ * reference, so a test can mutate it to reflect a write the UI just made.
+ */
+const seedSubscriptions = async (page: Page, memberId: string, memberStatus: MemberStatus, subscriptions: unknown[], extra: Record<string, unknown> = {}) => {
+    await interceptMemberRead(page, memberId, (member) => {
+        member.subscriptions = subscriptions;
+        // The member's status has to agree with the subscription it's being
+        // given — a paid sub on a member marked `comp` is a combination the
+        // server never produces, and it sends the status-dependent UI down the
+        // wrong branch.
+        member.status = memberStatus;
+        Object.assign(member, extra);
+    });
+};
+
+/**
+ * Captures the write an action makes, without needing a real Stripe
+ * subscription behind it. Asserting the request rather than the rendered result
+ * keeps the test neutral: both screens must ask the server for the same thing.
+ */
+const captureWrite = async (page: Page, urlPattern: string | RegExp, onCapture?: (body: Record<string, unknown>) => void) => {
+    const sent: {body?: Record<string, unknown>} = {};
+    await page.route(urlPattern, async (route) => {
+        if (route.request().method() !== 'PUT') {
+            return route.fallback();
+        }
+        sent.body = route.request().postDataJSON() as Record<string, unknown>;
+        onCapture?.(sent.body);
+        return route.fulfill({status: 200, contentType: 'application/json', body: JSON.stringify({members: [{id: 'ok'}]})});
+    });
+    return sent;
+};
+
+test.describe('Ghost Admin - Member Detail', () => {
+    let memberFactory: MemberFactory;
+    let memberDetailsPage: MemberDetailsPage;
+
+    test.beforeEach(async ({page}) => {
+        memberFactory = createMemberFactory(page.request);
+        memberDetailsPage = new MemberDetailsPage(page);
+    });
+
+    test('member name renders in the screen title', async ({page}) => {
+        const member = await memberFactory.create({name: 'Ada Lovelace', email: 'ada-detail@ghost.org'});
+
+        await page.goto(memberPath(member.id));
+
+        await expect(memberDetailsPage.screenTitle).toContainText('Ada Lovelace');
+    });
+
+    test('editing the member name - persists to the server', async ({page}) => {
+        const member = await memberFactory.create({name: 'Grace', email: 'grace-detail@ghost.org'});
+
+        await page.goto(memberPath(member.id));
+        await memberDetailsPage.nameInput.fill('Grace Hopper');
+        await memberDetailsPage.saveButton.click();
+
+        await expect.poll(async () => {
+            const res = await page.request.get(`/ghost/api/admin/members/${member.id}/`);
+            const body = await res.json();
+            return body?.members?.[0]?.name;
+        }, {timeout: 10000}).toBe('Grace Hopper');
+    });
+
+    test('clicking the back link - returns to the members list', async ({page}) => {
+        const member = await memberFactory.create({name: 'Grace Hopper', email: 'grace-back-detail@ghost.org'});
+
+        await page.goto(memberPath(member.id));
+        await memberDetailsPage.membersBackLink.click();
+
+        await expect(page).toHaveURL(/#\/members$/);
+    });
+
+    test('impersonation modal - exposes a real signin url', async ({page}) => {
+        const member = await memberFactory.create({name: 'Alan Turing', email: 'alan-detail@ghost.org'});
+
+        await page.goto(memberPath(member.id));
+        await memberDetailsPage.settingsSection.memberActionsButton.click();
+        await memberDetailsPage.settingsSection.impersonateButton.click();
+
+        // The url is fetched after the modal opens, so assert on the value to
+        // let Playwright wait rather than reading the empty initial state.
+        await expect(memberDetailsPage.magicLinkInput).toHaveValue(/^https?:\/\/.+/);
+    });
+
+    test('signing out of all devices - closes the confirmation and stays on the member', async ({page}) => {
+        const member = await memberFactory.create({name: 'Rear Admiral', email: 'rear-detail@ghost.org'});
+
+        await page.goto(memberPath(member.id));
+        await memberDetailsPage.settingsSection.memberActionsButton.click();
+        await memberDetailsPage.settingsSection.signOutOfAllDevices.click();
+        // Scoped to the modal so the click can't hit the account-owner
+        // "Sign out" button in the admin sidebar dropdown.
+        await memberDetailsPage.logoutConfirmModal.getByRole('button', {name: 'Sign out', exact: true}).click();
+
+        await expect(memberDetailsPage.logoutConfirmModal).toHaveCount(0);
+        await expect(page).toHaveURL(new RegExp(`#/members/${member.id}`));
+    });
+
+    test('deleting a member - returns to the list and removes the record', async ({page}) => {
+        const member = await memberFactory.create({name: 'Deletable', email: 'delete-detail@ghost.org'});
+
+        await page.goto(memberPath(member.id));
+        await memberDetailsPage.settingsSection.memberActionsButton.click();
+        await memberDetailsPage.settingsSection.deleteButton.click();
+        await memberDetailsPage.settingsSection.confirmDeleteButton.click();
+
+        await expect(page).toHaveURL(/#\/members$/);
+        const res = await page.request.get(`/ghost/api/admin/members/${member.id}/`);
+        expect(res.status()).toBe(404);
+    });
+
+    test('creating a member - persists to the server and redirects to the detail', async ({page}) => {
+        const email = 'new-member-detail@ghost.org';
+
+        await page.goto(memberPath('new'));
+        await memberDetailsPage.nameInput.fill('New Member');
+        await memberDetailsPage.emailInput.fill(email);
+        await memberDetailsPage.saveButton.click();
+
+        let createdId: string | undefined;
+        await expect.poll(async () => {
+            const res = await page.request.get(`/ghost/api/admin/members/?filter=${encodeURIComponent(`email:'${email}'`)}`);
+            const body = await res.json();
+            createdId = body?.members?.[0]?.id;
+            return body?.members?.[0]?.name;
+        }, {timeout: 10000}).toBe('New Member');
+        await expect(page).toHaveURL(new RegExp(`#/members/${createdId}(\\?|$)`));
+    });
+
+    test('disabling then re-enabling commenting - clears the disabled indicator', async ({page}) => {
+        const member = await memberFactory.create({name: 'Commenter', email: 'commenter-toggle@ghost.org'});
+
+        await page.goto(memberPath(member.id));
+        await memberDetailsPage.settingsSection.memberActionsButton.click();
+        await memberDetailsPage.settingsSection.disableCommentingButton.click();
+        await memberDetailsPage.disableCommentingConfirmButton.click();
+
+        await expect(memberDetailsPage.commentingDisabledIndicator).toBeVisible();
+
+        await memberDetailsPage.settingsSection.memberActionsButton.click();
+        await memberDetailsPage.settingsSection.enableCommentingButton.click();
+
+        await expect(memberDetailsPage.commentingDisabledIndicator).toBeHidden();
+    });
+
+    test('sidebar - shows the signup location and created date', async ({page}) => {
+        // Members created through the API carry no geolocation, so the
+        // location falls back deterministically.
+        const member = await memberFactory.create({name: 'Katherine Johnson', email: 'katherine-sidebar@ghost.org'});
+
+        await page.goto(memberPath(member.id));
+
+        await expect(page.getByText('Unknown location')).toBeVisible();
+        await expect(page.getByText(/Created/)).toBeVisible();
+    });
+
+    test('leaving with unsaved changes - warns before navigating away', async ({page}) => {
+        const member = await memberFactory.create({name: 'Grace Hopper', email: 'grace-unsaved@ghost.org'});
+
+        await page.goto(memberPath(member.id));
+        await memberDetailsPage.nameInput.fill('Grace B. Hopper');
+        await memberDetailsPage.membersBackLink.click();
+
+        await expect(memberDetailsPage.confirmLeaveButton).toBeVisible();
+        await memberDetailsPage.confirmLeaveButton.click();
+        await expect(page).toHaveURL(/#\/members$/);
+    });
+
+    test('toggling a newsletter - persists the new state', async ({page}) => {
+        const member = await memberFactory.create({name: 'Newsletter Test', email: 'newsletter-toggle@ghost.org'});
+
+        await page.goto(memberPath(member.id));
+        // Wait on the toggle, not the checkbox — Ember hides the real input
+        // behind a styled span, so the control is never visible itself.
+        await expect(memberDetailsPage.newsletterSubscriptionToggles.first()).toBeVisible();
+        const initiallyChecked = await memberDetailsPage.newsletterSubscriptionCheckboxes.first().isChecked();
+
+        await memberDetailsPage.newsletterSubscriptionToggles.first().click();
+        await memberDetailsPage.save();
+        await page.reload();
+
+        await expect(memberDetailsPage.newsletterSubscriptionCheckboxes.first()).toBeChecked({checked: !initiallyChecked});
+    });
+
+    test('activity feed - view-all link points at this members full activity', async ({page}) => {
+        const member = await memberFactory.create({name: 'Activity Target', email: 'activity-viewall@ghost.org'});
+        // A fresh member's signup event is written asynchronously, so serve a
+        // known event rather than racing it — the link only renders on the
+        // populated branch.
+        await page.route(/\/ghost\/api\/admin\/members\/events\/?\?/, async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.continue();
+            }
+            return route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    events: [{
+                        type: 'signup_event',
+                        data: {
+                            id: 'evt-1',
+                            created_at: new Date(0).toISOString(),
+                            member_id: member.id,
+                            member: {id: member.id, name: member.name, email: member.email}
+                        }
+                    }],
+                    meta: {pagination: {}}
+                })
+            });
+        });
+
+        await page.goto(memberPath(member.id));
+
+        const viewAll = page.getByRole('link', {name: /View all member activity/});
+        await expect(viewAll).toBeVisible();
+        await expect(viewAll).toHaveAttribute('href', new RegExp(`#/members-activity/?\\?member=${member.id}`));
+    });
+
+    test.describe('Subscriptions', () => {
+        // The Subscriptions section is gated on paid members being enabled.
+        test.use({stripeEnabled: true});
+
+        test('paid subscription - shows the tier, price, interval and renewal date', async ({page}) => {
+            const member = await memberFactory.create({name: 'Paid Member', email: 'paid-sub@ghost.org'});
+            await seedSubscriptions(page, member.id, 'paid', [paidSubscription()]);
+
+            await page.goto(memberPath(member.id));
+
+            await expect(page.getByText('Bronze').first()).toBeVisible();
+            await expect(page.getByText('10.50').first()).toBeVisible();
+            await expect(page.getByText(/month/i).first()).toBeVisible();
+            await expect(page.getByText(/Renews 15 Feb 2026/).first()).toBeVisible();
+        });
+
+        test('subscription set to cancel - shows remaining access rather than a renewal', async ({page}) => {
+            const member = await memberFactory.create({name: 'Cancelling Member', email: 'cancelling-sub@ghost.org'});
+            await seedSubscriptions(page, member.id, 'paid', [paidSubscription({cancel_at_period_end: true})]);
+
+            await page.goto(memberPath(member.id));
+
+            await expect(page.getByText(/Has access until\s+15 Feb 2026/).first()).toBeVisible();
+            await expect(page.getByText(/Renews/)).toHaveCount(0);
+        });
+
+        test('complimentary subscription - shows the tier without a price', async ({page}) => {
+            const member = await memberFactory.create({name: 'Comp Member', email: 'comp-sub@ghost.org'});
+            await seedSubscriptions(page, member.id, 'comped', [compSubscription()]);
+
+            await page.goto(memberPath(member.id));
+
+            await expect(page.getByText('Bronze').first()).toBeVisible();
+            await expect(page.getByText(/Complimentary/i).first()).toBeVisible();
+        });
+
+        test('gift subscription - offers no actions menu', async ({page}) => {
+            // A gift is bought by someone else and can't be cancelled or
+            // revoked from here, so the row deliberately has no menu.
+            const member = await memberFactory.create({name: 'Gift Member', email: 'gift-sub@ghost.org'});
+            await seedSubscriptions(page, member.id, 'gift', [giftSubscription()]);
+
+            await page.goto(memberPath(member.id));
+
+            await expect(page.getByText('Bronze').first()).toBeVisible();
+            await expect(memberDetailsPage.subscriptionActionsButton).toHaveCount(0);
+        });
+
+        test('cancelling a subscription - asks the server to cancel at period end', async ({page}) => {
+            const member = await memberFactory.create({name: 'Cancel Member', email: 'cancel-action@ghost.org'});
+            const subs = [paidSubscription()];
+            await seedSubscriptions(page, member.id, 'paid', subs);
+            // Reflect the write back into the seeded read so the screen can
+            // re-render from it, the way a real refetch would.
+            const sent = await captureWrite(page, `**/members/${member.id}/subscriptions/sub_paid_123/**`, (body) => {
+                subs[0].cancel_at_period_end = body.cancel_at_period_end as boolean;
+            });
+
+            await page.goto(memberPath(member.id));
+            await memberDetailsPage.subscriptionActionsButton.click();
+            await memberDetailsPage.cancelSubscriptionButton.click();
+
+            // The request is the contract — the server doesn't care which UI sent it.
+            await expect.poll(() => sent.body?.cancel_at_period_end).toBe(true);
+        });
+
+        test('continuing a cancelled subscription - asks the server to resume it', async ({page}) => {
+            const member = await memberFactory.create({name: 'Continue Member', email: 'continue-action@ghost.org'});
+            const subs = [paidSubscription({cancel_at_period_end: true})];
+            await seedSubscriptions(page, member.id, 'paid', subs);
+            const sent = await captureWrite(page, `**/members/${member.id}/subscriptions/sub_paid_123/**`, (body) => {
+                subs[0].cancel_at_period_end = body.cancel_at_period_end as boolean;
+            });
+
+            await page.goto(memberPath(member.id));
+            await memberDetailsPage.subscriptionActionsButton.click();
+            await memberDetailsPage.continueSubscriptionButton.click();
+
+            await expect.poll(() => sent.body?.cancel_at_period_end).toBe(false);
+        });
+
+        test('removing a complimentary subscription - puts back only the surviving tiers', async ({page}) => {
+            const member = await memberFactory.create({name: 'Multi Comp', email: 'multi-comp@ghost.org'});
+            await seedSubscriptions(page, member.id, 'comped', [compSubscription()], {tiers: TWO_COMP_TIERS()});
+            const sent = await captureWrite(page, new RegExp(`/ghost/api/admin/members/${member.id}/\\??[^/]*$`));
+
+            await page.goto(memberPath(member.id));
+            await memberDetailsPage.removeComplimentarySubscription();
+
+            await expect.poll(() => sentTiers(sent)?.length).toBe(1);
+            expect(sentTiers(sent)?.[0].id).toBe('tier_silver');
+        });
+    });
+
+    test.describe('New member screen', () => {
+        // The Subscriptions section is gated on paid members being enabled, so
+        // stripe has to be on for it to render at all.
+        test.use({stripeEnabled: true});
+
+        test('newsletters section - renders a toggle list', async ({page}) => {
+            await page.goto(memberPath('new'));
+
+            await expect(page.getByRole('heading', {name: 'Newsletters', exact: true})).toBeVisible();
+            await expect(memberDetailsPage.newsletterSubscriptionToggles.first()).toBeVisible();
+        });
+
+        test('newsletters section - toggles are checked by default', async ({page}) => {
+            // Newsletters with subscribe_on_signup and members visibility are
+            // pre-selected on create, so the admin can see what the new member
+            // will land subscribed to. Assert every toggle rather than the
+            // first, which would pass even if a later default were missed.
+            await page.goto(memberPath('new'));
+            await expect(memberDetailsPage.newsletterSubscriptionToggles.first()).toBeVisible();
+
+            const count = await memberDetailsPage.newsletterSubscriptionCheckboxes.count();
+            expect(count).toBeGreaterThan(0);
+            for (let i = 0; i < count; i++) {
+                await expect(memberDetailsPage.newsletterSubscriptionCheckboxes.nth(i)).toBeChecked();
+            }
+        });
+
+        test('activity section - shows an empty state', async ({page}) => {
+            await page.goto(memberPath('new'));
+
+            await expect(page.getByText('All events related to this member will be shown here.')).toBeVisible();
+        });
+
+        test('subscriptions section - shows an empty state', async ({page}) => {
+            await page.goto(memberPath('new'));
+
+            await expect(page.getByRole('heading', {name: 'Subscriptions', exact: true})).toBeVisible();
+            await expect(page.getByRole('heading', {name: 'No subscriptions', exact: true})).toBeVisible();
+        });
+    });
+
+    test.describe('Engagement section', () => {
+        const stubMemberRead = interceptMemberRead;
+
+        test('member has received no emails - shows an empty state', async ({page}) => {
+            const member = await memberFactory.create({name: 'Ada Lovelace', email: 'engagement-empty@ghost.org'});
+
+            await page.goto(memberPath(member.id));
+
+            await expect(page.getByRole('heading', {name: 'Engagement'})).toBeVisible();
+            await expect(page.getByText(/We[’']ll show Ada[’']s email stats here/)).toBeVisible();
+        });
+
+        test('member has received emails - shows counts and open rate', async ({page}) => {
+            const member = await memberFactory.create({name: 'Stats Member', email: 'engagement-stats@ghost.org'});
+            // Inject the stats so the branch renders deterministically rather
+            // than depending on what the fixture database happens to hold.
+            await stubMemberRead(page, member.id, (m) => {
+                m.email_count = 12;
+                m.email_opened_count = 9;
+                m.email_open_rate = 75;
+            });
+
+            await page.goto(memberPath(member.id));
+
+            const engagement = memberDetailsPage.engagementSection;
+            await expect(engagement.getByText('Emails received')).toBeVisible();
+            await expect(engagement.getByText('12', {exact: true})).toBeVisible();
+            await expect(engagement.getByText('Emails opened')).toBeVisible();
+            await expect(engagement.getByText('9', {exact: true})).toBeVisible();
+            await expect(engagement.getByText('Average open rate')).toBeVisible();
+            await expect(engagement.getByText(/75\s*%/)).toBeVisible();
+        });
+
+        test('email fields absent from the payload - shows the empty state', async ({page}) => {
+            const member = await memberFactory.create({name: 'Ada Lovelace', email: 'engagement-undef@ghost.org'});
+            await stubMemberRead(page, member.id, (m) => {
+                delete m.email_count;
+                delete m.email_opened_count;
+                delete m.email_open_rate;
+            });
+
+            await page.goto(memberPath(member.id));
+
+            await expect(page.getByRole('heading', {name: 'Engagement'})).toBeVisible();
+            await expect(page.getByText(/We[’']ll show Ada[’']s email stats here/)).toBeVisible();
+        });
+
+        test('open rate not yet calculated - shows the placeholder', async ({page}) => {
+            const member = await memberFactory.create({name: 'Early Stats', email: 'engagement-null@ghost.org'});
+            // The server sends a null rate until the member has been sent 5
+            // newsletters; both the count and a bare % would be misleading.
+            await stubMemberRead(page, member.id, (m) => {
+                m.email_count = 3;
+                m.email_opened_count = 2;
+                m.email_open_rate = null;
+            });
+
+            await page.goto(memberPath(member.id));
+
+            await expect(page.getByText('This metric is calculated once a member has received 5 newsletters.')).toBeVisible();
+        });
+    });
+});

--- a/e2e/tests/admin/members/member-detail.test.ts
+++ b/e2e/tests/admin/members/member-detail.test.ts
@@ -7,15 +7,16 @@ import {usePerTestIsolation} from '@/helpers/playwright/isolation';
 /**
  * Behaviour contract for `/members/:id`.
  *
- * Every assertion here describes what the member detail screen does, not how it
- * is built — semantic roles, page-object locators, and API reads. Nothing in
- * this file knows which implementation is rendering it.
+ * Ember and React implementations of this screen coexist behind the
+ * `memberDetailsReact` Labs flag, and this file runs the same assertions
+ * against both by generating one describe block per flag state. No test body
+ * knows which implementation is rendering it, and none may branch on it.
  *
- * That is deliberate. A second implementation of this screen is coming, and
- * this suite is what it has to satisfy. Keeping the assertions
- * implementation-neutral means the same tests can run against both without
- * branching, so a behaviour that only works on one side surfaces as a failure
- * rather than as a quietly narrowed test.
+ * A test that passes under one block and fails under the other is a real
+ * user-facing difference between the two screens. That is the point: it makes
+ * a gap impossible to hide behind a conditional.
+ *
+ * Anything true of only one implementation does not belong here.
  */
 
 usePerTestIsolation();
@@ -172,7 +173,408 @@ const captureWrite = async (page: Page, urlPattern: string | RegExp, onCapture?:
     return sent;
 };
 
-test.describe('Ghost Admin - Member Detail', () => {
+for (const {implementation, memberDetailsReact} of [
+    {implementation: 'Ember', memberDetailsReact: false},
+    {implementation: 'React', memberDetailsReact: true}
+] as const) {
+    test.describe(`Ghost Admin - Member Detail (${implementation})`, () => {
+        test.use({labs: {memberDetailsReact}});
+
+        let memberFactory: MemberFactory;
+        let memberDetailsPage: MemberDetailsPage;
+
+        test.beforeEach(async ({page}) => {
+            memberFactory = createMemberFactory(page.request);
+            memberDetailsPage = new MemberDetailsPage(page);
+        });
+
+        test('member name renders in the screen title', async ({page}) => {
+            const member = await memberFactory.create({name: 'Ada Lovelace', email: 'ada-detail@ghost.org'});
+
+            await page.goto(memberPath(member.id));
+
+            await expect(memberDetailsPage.screenTitle).toContainText('Ada Lovelace');
+        });
+
+        test('editing the member name - persists to the server', async ({page}) => {
+            const member = await memberFactory.create({name: 'Grace', email: 'grace-detail@ghost.org'});
+
+            await page.goto(memberPath(member.id));
+            await memberDetailsPage.nameInput.fill('Grace Hopper');
+            await memberDetailsPage.saveButton.click();
+
+            await expect.poll(async () => {
+                const res = await page.request.get(`/ghost/api/admin/members/${member.id}/`);
+                const body = await res.json();
+                return body?.members?.[0]?.name;
+            }, {timeout: 10000}).toBe('Grace Hopper');
+        });
+
+        test('clicking the back link - returns to the members list', async ({page}) => {
+            const member = await memberFactory.create({name: 'Grace Hopper', email: 'grace-back-detail@ghost.org'});
+
+            await page.goto(memberPath(member.id));
+            await memberDetailsPage.membersBackLink.click();
+
+            await expect(page).toHaveURL(/#\/members$/);
+        });
+
+        test('impersonation modal - exposes a real signin url', async ({page}) => {
+            const member = await memberFactory.create({name: 'Alan Turing', email: 'alan-detail@ghost.org'});
+
+            await page.goto(memberPath(member.id));
+            await memberDetailsPage.settingsSection.memberActionsButton.click();
+            await memberDetailsPage.settingsSection.impersonateButton.click();
+
+            // The url is fetched after the modal opens, so assert on the value to
+            // let Playwright wait rather than reading the empty initial state.
+            await expect(memberDetailsPage.magicLinkInput).toHaveValue(/^https?:\/\/.+/);
+        });
+
+        test('signing out of all devices - closes the confirmation and stays on the member', async ({page}) => {
+            const member = await memberFactory.create({name: 'Rear Admiral', email: 'rear-detail@ghost.org'});
+
+            await page.goto(memberPath(member.id));
+            await memberDetailsPage.settingsSection.memberActionsButton.click();
+            await memberDetailsPage.settingsSection.signOutOfAllDevices.click();
+            // Scoped to the modal so the click can't hit the account-owner
+            // "Sign out" button in the admin sidebar dropdown.
+            await memberDetailsPage.logoutConfirmModal.getByRole('button', {name: 'Sign out', exact: true}).click();
+
+            await expect(memberDetailsPage.logoutConfirmModal).toHaveCount(0);
+            await expect(page).toHaveURL(new RegExp(`#/members/${member.id}`));
+        });
+
+        test('deleting a member - returns to the list and removes the record', async ({page}) => {
+            const member = await memberFactory.create({name: 'Deletable', email: 'delete-detail@ghost.org'});
+
+            await page.goto(memberPath(member.id));
+            await memberDetailsPage.settingsSection.memberActionsButton.click();
+            await memberDetailsPage.settingsSection.deleteButton.click();
+            await memberDetailsPage.settingsSection.confirmDeleteButton.click();
+
+            await expect(page).toHaveURL(/#\/members$/);
+            const res = await page.request.get(`/ghost/api/admin/members/${member.id}/`);
+            expect(res.status()).toBe(404);
+        });
+
+        test('creating a member - persists to the server and redirects to the detail', async ({page}) => {
+            const email = 'new-member-detail@ghost.org';
+
+            await page.goto(memberPath('new'));
+            await memberDetailsPage.nameInput.fill('New Member');
+            await memberDetailsPage.emailInput.fill(email);
+            await memberDetailsPage.saveButton.click();
+
+            let createdId: string | undefined;
+            await expect.poll(async () => {
+                const res = await page.request.get(`/ghost/api/admin/members/?filter=${encodeURIComponent(`email:'${email}'`)}`);
+                const body = await res.json();
+                createdId = body?.members?.[0]?.id;
+                return body?.members?.[0]?.name;
+            }, {timeout: 10000}).toBe('New Member');
+            await expect(page).toHaveURL(new RegExp(`#/members/${createdId}(\\?|$)`));
+        });
+
+        test('disabling then re-enabling commenting - clears the disabled indicator', async ({page}) => {
+            const member = await memberFactory.create({name: 'Commenter', email: 'commenter-toggle@ghost.org'});
+
+            await page.goto(memberPath(member.id));
+            await memberDetailsPage.settingsSection.memberActionsButton.click();
+            await memberDetailsPage.settingsSection.disableCommentingButton.click();
+            await memberDetailsPage.disableCommentingConfirmButton.click();
+
+            await expect(memberDetailsPage.commentingDisabledIndicator).toBeVisible();
+
+            await memberDetailsPage.settingsSection.memberActionsButton.click();
+            await memberDetailsPage.settingsSection.enableCommentingButton.click();
+
+            await expect(memberDetailsPage.commentingDisabledIndicator).toBeHidden();
+        });
+
+        test('sidebar - shows the signup location and created date', async ({page}) => {
+            // Members created through the API carry no geolocation, so the
+            // location falls back deterministically.
+            const member = await memberFactory.create({name: 'Katherine Johnson', email: 'katherine-sidebar@ghost.org'});
+
+            await page.goto(memberPath(member.id));
+
+            await expect(page.getByText('Unknown location')).toBeVisible();
+            await expect(page.getByText(/Created/)).toBeVisible();
+        });
+
+        test('leaving with unsaved changes - warns before navigating away', async ({page}) => {
+            const member = await memberFactory.create({name: 'Grace Hopper', email: 'grace-unsaved@ghost.org'});
+
+            await page.goto(memberPath(member.id));
+            await memberDetailsPage.nameInput.fill('Grace B. Hopper');
+            await memberDetailsPage.membersBackLink.click();
+
+            await expect(memberDetailsPage.confirmLeaveButton).toBeVisible();
+            await memberDetailsPage.confirmLeaveButton.click();
+            await expect(page).toHaveURL(/#\/members$/);
+        });
+
+        test('toggling a newsletter - persists the new state', async ({page}) => {
+            const member = await memberFactory.create({name: 'Newsletter Test', email: 'newsletter-toggle@ghost.org'});
+
+            await page.goto(memberPath(member.id));
+            // Wait on the toggle, not the checkbox — Ember hides the real input
+            // behind a styled span, so the control is never visible itself.
+            await expect(memberDetailsPage.newsletterSubscriptionToggles.first()).toBeVisible();
+            const initiallyChecked = await memberDetailsPage.newsletterSubscriptionCheckboxes.first().isChecked();
+
+            await memberDetailsPage.newsletterSubscriptionToggles.first().click();
+            await memberDetailsPage.save();
+            await page.reload();
+
+            await expect(memberDetailsPage.newsletterSubscriptionCheckboxes.first()).toBeChecked({checked: !initiallyChecked});
+        });
+
+        test('activity feed - view-all link points at this members full activity', async ({page}) => {
+            const member = await memberFactory.create({name: 'Activity Target', email: 'activity-viewall@ghost.org'});
+            // A fresh member's signup event is written asynchronously, so serve a
+            // known event rather than racing it — the link only renders on the
+            // populated branch.
+            await page.route(/\/ghost\/api\/admin\/members\/events\/?\?/, async (route) => {
+                if (route.request().method() !== 'GET') {
+                    return route.continue();
+                }
+                return route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({
+                        events: [{
+                            type: 'signup_event',
+                            data: {
+                                id: 'evt-1',
+                                created_at: new Date(0).toISOString(),
+                                member_id: member.id,
+                                member: {id: member.id, name: member.name, email: member.email}
+                            }
+                        }],
+                        meta: {pagination: {}}
+                    })
+                });
+            });
+
+            await page.goto(memberPath(member.id));
+
+            const viewAll = page.getByRole('link', {name: /View all member activity/});
+            await expect(viewAll).toBeVisible();
+            await expect(viewAll).toHaveAttribute('href', new RegExp(`#/members-activity/?\\?member=${member.id}`));
+        });
+
+        test.describe('Subscriptions', () => {
+            // The Subscriptions section is gated on paid members being enabled.
+            test.use({stripeEnabled: true});
+
+            test('paid subscription - shows the tier, price, interval and renewal date', async ({page}) => {
+                const member = await memberFactory.create({name: 'Paid Member', email: 'paid-sub@ghost.org'});
+                await seedSubscriptions(page, member.id, 'paid', [paidSubscription()]);
+
+                await page.goto(memberPath(member.id));
+
+                await expect(page.getByText('Bronze').first()).toBeVisible();
+                await expect(page.getByText('10.50').first()).toBeVisible();
+                await expect(page.getByText(/month/i).first()).toBeVisible();
+                await expect(page.getByText(/Renews 15 Feb 2026/).first()).toBeVisible();
+            });
+
+            test('subscription set to cancel - shows remaining access rather than a renewal', async ({page}) => {
+                const member = await memberFactory.create({name: 'Cancelling Member', email: 'cancelling-sub@ghost.org'});
+                await seedSubscriptions(page, member.id, 'paid', [paidSubscription({cancel_at_period_end: true})]);
+
+                await page.goto(memberPath(member.id));
+
+                await expect(page.getByText(/Has access until\s+15 Feb 2026/).first()).toBeVisible();
+                await expect(page.getByText(/Renews/)).toHaveCount(0);
+            });
+
+            test('complimentary subscription - shows the tier without a price', async ({page}) => {
+                const member = await memberFactory.create({name: 'Comp Member', email: 'comp-sub@ghost.org'});
+                await seedSubscriptions(page, member.id, 'comped', [compSubscription()]);
+
+                await page.goto(memberPath(member.id));
+
+                await expect(page.getByText('Bronze').first()).toBeVisible();
+                await expect(page.getByText(/Complimentary/i).first()).toBeVisible();
+            });
+
+            test('gift subscription - offers no actions menu', async ({page}) => {
+                // A gift is bought by someone else and can't be cancelled or
+                // revoked from here, so the row deliberately has no menu.
+                const member = await memberFactory.create({name: 'Gift Member', email: 'gift-sub@ghost.org'});
+                await seedSubscriptions(page, member.id, 'gift', [giftSubscription()]);
+
+                await page.goto(memberPath(member.id));
+
+                await expect(page.getByText('Bronze').first()).toBeVisible();
+                await expect(memberDetailsPage.subscriptionActionsButton).toHaveCount(0);
+            });
+
+            test('cancelling a subscription - asks the server to cancel at period end', async ({page}) => {
+                const member = await memberFactory.create({name: 'Cancel Member', email: 'cancel-action@ghost.org'});
+                const subs = [paidSubscription()];
+                await seedSubscriptions(page, member.id, 'paid', subs);
+                // Reflect the write back into the seeded read so the screen can
+                // re-render from it, the way a real refetch would.
+                const sent = await captureWrite(page, `**/members/${member.id}/subscriptions/sub_paid_123/**`, (body) => {
+                    subs[0].cancel_at_period_end = body.cancel_at_period_end as boolean;
+                });
+
+                await page.goto(memberPath(member.id));
+                await memberDetailsPage.subscriptionActionsButton.click();
+                await memberDetailsPage.cancelSubscriptionButton.click();
+
+                // The request is the contract — the server doesn't care which UI sent it.
+                await expect.poll(() => sent.body?.cancel_at_period_end).toBe(true);
+            });
+
+            test('continuing a cancelled subscription - asks the server to resume it', async ({page}) => {
+                const member = await memberFactory.create({name: 'Continue Member', email: 'continue-action@ghost.org'});
+                const subs = [paidSubscription({cancel_at_period_end: true})];
+                await seedSubscriptions(page, member.id, 'paid', subs);
+                const sent = await captureWrite(page, `**/members/${member.id}/subscriptions/sub_paid_123/**`, (body) => {
+                    subs[0].cancel_at_period_end = body.cancel_at_period_end as boolean;
+                });
+
+                await page.goto(memberPath(member.id));
+                await memberDetailsPage.subscriptionActionsButton.click();
+                await memberDetailsPage.continueSubscriptionButton.click();
+
+                await expect.poll(() => sent.body?.cancel_at_period_end).toBe(false);
+            });
+
+            test('removing a complimentary subscription - puts back only the surviving tiers', async ({page}) => {
+                const member = await memberFactory.create({name: 'Multi Comp', email: 'multi-comp@ghost.org'});
+                await seedSubscriptions(page, member.id, 'comped', [compSubscription()], {tiers: TWO_COMP_TIERS()});
+                const sent = await captureWrite(page, new RegExp(`/ghost/api/admin/members/${member.id}/\\??[^/]*$`));
+
+                await page.goto(memberPath(member.id));
+                await memberDetailsPage.removeComplimentarySubscription();
+
+                await expect.poll(() => sentTiers(sent)?.length).toBe(1);
+                expect(sentTiers(sent)?.[0].id).toBe('tier_silver');
+            });
+        });
+
+        test.describe('New member screen', () => {
+            // The Subscriptions section is gated on paid members being enabled, so
+            // stripe has to be on for it to render at all.
+            test.use({stripeEnabled: true});
+
+            test('newsletters section - renders a toggle list', async ({page}) => {
+                await page.goto(memberPath('new'));
+
+                await expect(page.getByRole('heading', {name: 'Newsletters', exact: true})).toBeVisible();
+                await expect(memberDetailsPage.newsletterSubscriptionToggles.first()).toBeVisible();
+            });
+
+            test('newsletters section - toggles are checked by default', async ({page}) => {
+                // Newsletters with subscribe_on_signup and members visibility are
+                // pre-selected on create, so the admin can see what the new member
+                // will land subscribed to. Assert every toggle rather than the
+                // first, which would pass even if a later default were missed.
+                await page.goto(memberPath('new'));
+                await expect(memberDetailsPage.newsletterSubscriptionToggles.first()).toBeVisible();
+
+                const count = await memberDetailsPage.newsletterSubscriptionCheckboxes.count();
+                expect(count).toBeGreaterThan(0);
+                for (let i = 0; i < count; i++) {
+                    await expect(memberDetailsPage.newsletterSubscriptionCheckboxes.nth(i)).toBeChecked();
+                }
+            });
+
+            test('activity section - shows an empty state', async ({page}) => {
+                await page.goto(memberPath('new'));
+
+                await expect(page.getByText('All events related to this member will be shown here.')).toBeVisible();
+            });
+
+            test('subscriptions section - shows an empty state', async ({page}) => {
+                await page.goto(memberPath('new'));
+
+                await expect(page.getByRole('heading', {name: 'Subscriptions', exact: true})).toBeVisible();
+                await expect(page.getByRole('heading', {name: 'No subscriptions', exact: true})).toBeVisible();
+            });
+        });
+
+        test.describe('Engagement section', () => {
+            const stubMemberRead = interceptMemberRead;
+
+            test('member has received no emails - shows an empty state', async ({page}) => {
+                const member = await memberFactory.create({name: 'Ada Lovelace', email: 'engagement-empty@ghost.org'});
+
+                await page.goto(memberPath(member.id));
+
+                await expect(page.getByRole('heading', {name: 'Engagement'})).toBeVisible();
+                await expect(page.getByText(/We[’']ll show Ada[’']s email stats here/)).toBeVisible();
+            });
+
+            test('member has received emails - shows counts and open rate', async ({page}) => {
+                const member = await memberFactory.create({name: 'Stats Member', email: 'engagement-stats@ghost.org'});
+                // Inject the stats so the branch renders deterministically rather
+                // than depending on what the fixture database happens to hold.
+                await stubMemberRead(page, member.id, (m) => {
+                    m.email_count = 12;
+                    m.email_opened_count = 9;
+                    m.email_open_rate = 75;
+                });
+
+                await page.goto(memberPath(member.id));
+
+                const engagement = memberDetailsPage.engagementSection;
+                await expect(engagement.getByText('Emails received')).toBeVisible();
+                await expect(engagement.getByText('12', {exact: true})).toBeVisible();
+                await expect(engagement.getByText('Emails opened')).toBeVisible();
+                await expect(engagement.getByText('9', {exact: true})).toBeVisible();
+                await expect(engagement.getByText('Average open rate')).toBeVisible();
+                await expect(engagement.getByText(/75\s*%/)).toBeVisible();
+            });
+
+            test('email fields absent from the payload - shows the empty state', async ({page}) => {
+                const member = await memberFactory.create({name: 'Ada Lovelace', email: 'engagement-undef@ghost.org'});
+                await stubMemberRead(page, member.id, (m) => {
+                    delete m.email_count;
+                    delete m.email_opened_count;
+                    delete m.email_open_rate;
+                });
+
+                await page.goto(memberPath(member.id));
+
+                await expect(page.getByRole('heading', {name: 'Engagement'})).toBeVisible();
+                await expect(page.getByText(/We[’']ll show Ada[’']s email stats here/)).toBeVisible();
+            });
+
+            test('open rate not yet calculated - shows the placeholder', async ({page}) => {
+                const member = await memberFactory.create({name: 'Early Stats', email: 'engagement-null@ghost.org'});
+                // The server sends a null rate until the member has been sent 5
+                // newsletters; both the count and a bare % would be misleading.
+                await stubMemberRead(page, member.id, (m) => {
+                    m.email_count = 3;
+                    m.email_opened_count = 2;
+                    m.email_open_rate = null;
+                });
+
+                await page.goto(memberPath(member.id));
+
+                await expect(page.getByText('This metric is calculated once a member has received 5 newsletters.')).toBeVisible();
+            });
+        });
+    });
+}
+
+/**
+ * Known divergences between the two implementations.
+ *
+ * Everything above this point is generic and must stay that way. A test only
+ * belongs here when the *behaviour* — not the markup — exists in one
+ * implementation and not the other, and we have decided not to close the gap.
+ * Each one records what the divergence is and why it stands, so the difference
+ * is a deliberate, visible decision rather than a silently narrowed test.
+ */
+test.describe('Ghost Admin - Member Detail - known divergences', () => {
     let memberFactory: MemberFactory;
     let memberDetailsPage: MemberDetailsPage;
 
@@ -181,378 +583,184 @@ test.describe('Ghost Admin - Member Detail', () => {
         memberDetailsPage = new MemberDetailsPage(page);
     });
 
-    test('member name renders in the screen title', async ({page}) => {
-        const member = await memberFactory.create({name: 'Ada Lovelace', email: 'ada-detail@ghost.org'});
+    /**
+     * Adding a complimentary subscription is the one flow split purely on
+     * interaction rather than behaviour. Both screens compute the same
+     * `expiry_at` from the same duration options and send the same request, but
+     * one picks a tier with radio buttons and the other with a dropdown. Driving
+     * both from one test would put a branch inside the page object, which buys
+     * less than it costs — so the assertion is duplicated instead, and the two
+     * tests must be kept in step.
+     */
+    test.describe('Ember', () => {
+        test.use({labs: {memberDetailsReact: false}, stripeEnabled: true});
 
-        await page.goto(memberPath(member.id));
-
-        await expect(memberDetailsPage.screenTitle).toContainText('Ada Lovelace');
-    });
-
-    test('editing the member name - persists to the server', async ({page}) => {
-        const member = await memberFactory.create({name: 'Grace', email: 'grace-detail@ghost.org'});
-
-        await page.goto(memberPath(member.id));
-        await memberDetailsPage.nameInput.fill('Grace Hopper');
-        await memberDetailsPage.saveButton.click();
-
-        await expect.poll(async () => {
-            const res = await page.request.get(`/ghost/api/admin/members/${member.id}/`);
-            const body = await res.json();
-            return body?.members?.[0]?.name;
-        }, {timeout: 10000}).toBe('Grace Hopper');
-    });
-
-    test('clicking the back link - returns to the members list', async ({page}) => {
-        const member = await memberFactory.create({name: 'Grace Hopper', email: 'grace-back-detail@ghost.org'});
-
-        await page.goto(memberPath(member.id));
-        await memberDetailsPage.membersBackLink.click();
-
-        await expect(page).toHaveURL(/#\/members$/);
-    });
-
-    test('impersonation modal - exposes a real signin url', async ({page}) => {
-        const member = await memberFactory.create({name: 'Alan Turing', email: 'alan-detail@ghost.org'});
-
-        await page.goto(memberPath(member.id));
-        await memberDetailsPage.settingsSection.memberActionsButton.click();
-        await memberDetailsPage.settingsSection.impersonateButton.click();
-
-        // The url is fetched after the modal opens, so assert on the value to
-        // let Playwright wait rather than reading the empty initial state.
-        await expect(memberDetailsPage.magicLinkInput).toHaveValue(/^https?:\/\/.+/);
-    });
-
-    test('signing out of all devices - closes the confirmation and stays on the member', async ({page}) => {
-        const member = await memberFactory.create({name: 'Rear Admiral', email: 'rear-detail@ghost.org'});
-
-        await page.goto(memberPath(member.id));
-        await memberDetailsPage.settingsSection.memberActionsButton.click();
-        await memberDetailsPage.settingsSection.signOutOfAllDevices.click();
-        // Scoped to the modal so the click can't hit the account-owner
-        // "Sign out" button in the admin sidebar dropdown.
-        await memberDetailsPage.logoutConfirmModal.getByRole('button', {name: 'Sign out', exact: true}).click();
-
-        await expect(memberDetailsPage.logoutConfirmModal).toHaveCount(0);
-        await expect(page).toHaveURL(new RegExp(`#/members/${member.id}`));
-    });
-
-    test('deleting a member - returns to the list and removes the record', async ({page}) => {
-        const member = await memberFactory.create({name: 'Deletable', email: 'delete-detail@ghost.org'});
-
-        await page.goto(memberPath(member.id));
-        await memberDetailsPage.settingsSection.memberActionsButton.click();
-        await memberDetailsPage.settingsSection.deleteButton.click();
-        await memberDetailsPage.settingsSection.confirmDeleteButton.click();
-
-        await expect(page).toHaveURL(/#\/members$/);
-        const res = await page.request.get(`/ghost/api/admin/members/${member.id}/`);
-        expect(res.status()).toBe(404);
-    });
-
-    test('creating a member - persists to the server and redirects to the detail', async ({page}) => {
-        const email = 'new-member-detail@ghost.org';
-
-        await page.goto(memberPath('new'));
-        await memberDetailsPage.nameInput.fill('New Member');
-        await memberDetailsPage.emailInput.fill(email);
-        await memberDetailsPage.saveButton.click();
-
-        let createdId: string | undefined;
-        await expect.poll(async () => {
-            const res = await page.request.get(`/ghost/api/admin/members/?filter=${encodeURIComponent(`email:'${email}'`)}`);
-            const body = await res.json();
-            createdId = body?.members?.[0]?.id;
-            return body?.members?.[0]?.name;
-        }, {timeout: 10000}).toBe('New Member');
-        await expect(page).toHaveURL(new RegExp(`#/members/${createdId}(\\?|$)`));
-    });
-
-    test('disabling then re-enabling commenting - clears the disabled indicator', async ({page}) => {
-        const member = await memberFactory.create({name: 'Commenter', email: 'commenter-toggle@ghost.org'});
-
-        await page.goto(memberPath(member.id));
-        await memberDetailsPage.settingsSection.memberActionsButton.click();
-        await memberDetailsPage.settingsSection.disableCommentingButton.click();
-        await memberDetailsPage.disableCommentingConfirmButton.click();
-
-        await expect(memberDetailsPage.commentingDisabledIndicator).toBeVisible();
-
-        await memberDetailsPage.settingsSection.memberActionsButton.click();
-        await memberDetailsPage.settingsSection.enableCommentingButton.click();
-
-        await expect(memberDetailsPage.commentingDisabledIndicator).toBeHidden();
-    });
-
-    test('sidebar - shows the signup location and created date', async ({page}) => {
-        // Members created through the API carry no geolocation, so the
-        // location falls back deterministically.
-        const member = await memberFactory.create({name: 'Katherine Johnson', email: 'katherine-sidebar@ghost.org'});
-
-        await page.goto(memberPath(member.id));
-
-        await expect(page.getByText('Unknown location')).toBeVisible();
-        await expect(page.getByText(/Created/)).toBeVisible();
-    });
-
-    test('leaving with unsaved changes - warns before navigating away', async ({page}) => {
-        const member = await memberFactory.create({name: 'Grace Hopper', email: 'grace-unsaved@ghost.org'});
-
-        await page.goto(memberPath(member.id));
-        await memberDetailsPage.nameInput.fill('Grace B. Hopper');
-        await memberDetailsPage.membersBackLink.click();
-
-        await expect(memberDetailsPage.confirmLeaveButton).toBeVisible();
-        await memberDetailsPage.confirmLeaveButton.click();
-        await expect(page).toHaveURL(/#\/members$/);
-    });
-
-    test('toggling a newsletter - persists the new state', async ({page}) => {
-        const member = await memberFactory.create({name: 'Newsletter Test', email: 'newsletter-toggle@ghost.org'});
-
-        await page.goto(memberPath(member.id));
-        // Wait on the toggle, not the checkbox — Ember hides the real input
-        // behind a styled span, so the control is never visible itself.
-        await expect(memberDetailsPage.newsletterSubscriptionToggles.first()).toBeVisible();
-        const initiallyChecked = await memberDetailsPage.newsletterSubscriptionCheckboxes.first().isChecked();
-
-        await memberDetailsPage.newsletterSubscriptionToggles.first().click();
-        await memberDetailsPage.save();
-        await page.reload();
-
-        await expect(memberDetailsPage.newsletterSubscriptionCheckboxes.first()).toBeChecked({checked: !initiallyChecked});
-    });
-
-    test('activity feed - view-all link points at this members full activity', async ({page}) => {
-        const member = await memberFactory.create({name: 'Activity Target', email: 'activity-viewall@ghost.org'});
-        // A fresh member's signup event is written asynchronously, so serve a
-        // known event rather than racing it — the link only renders on the
-        // populated branch.
-        await page.route(/\/ghost\/api\/admin\/members\/events\/?\?/, async (route) => {
-            if (route.request().method() !== 'GET') {
-                return route.continue();
-            }
-            return route.fulfill({
-                status: 200,
-                contentType: 'application/json',
-                body: JSON.stringify({
-                    events: [{
-                        type: 'signup_event',
-                        data: {
-                            id: 'evt-1',
-                            created_at: new Date(0).toISOString(),
-                            member_id: member.id,
-                            member: {id: member.id, name: member.name, email: member.email}
-                        }
-                    }],
-                    meta: {pagination: {}}
-                })
-            });
-        });
-
-        await page.goto(memberPath(member.id));
-
-        const viewAll = page.getByRole('link', {name: /View all member activity/});
-        await expect(viewAll).toBeVisible();
-        await expect(viewAll).toHaveAttribute('href', new RegExp(`#/members-activity/?\\?member=${member.id}`));
-    });
-
-    test.describe('Subscriptions', () => {
-        // The Subscriptions section is gated on paid members being enabled.
-        test.use({stripeEnabled: true});
-
-        test('paid subscription - shows the tier, price, interval and renewal date', async ({page}) => {
-            const member = await memberFactory.create({name: 'Paid Member', email: 'paid-sub@ghost.org'});
-            await seedSubscriptions(page, member.id, 'paid', [paidSubscription()]);
-
-            await page.goto(memberPath(member.id));
-
-            await expect(page.getByText('Bronze').first()).toBeVisible();
-            await expect(page.getByText('10.50').first()).toBeVisible();
-            await expect(page.getByText(/month/i).first()).toBeVisible();
-            await expect(page.getByText(/Renews 15 Feb 2026/).first()).toBeVisible();
-        });
-
-        test('subscription set to cancel - shows remaining access rather than a renewal', async ({page}) => {
-            const member = await memberFactory.create({name: 'Cancelling Member', email: 'cancelling-sub@ghost.org'});
-            await seedSubscriptions(page, member.id, 'paid', [paidSubscription({cancel_at_period_end: true})]);
-
-            await page.goto(memberPath(member.id));
-
-            await expect(page.getByText(/Has access until\s+15 Feb 2026/).first()).toBeVisible();
-            await expect(page.getByText(/Renews/)).toHaveCount(0);
-        });
-
-        test('complimentary subscription - shows the tier without a price', async ({page}) => {
-            const member = await memberFactory.create({name: 'Comp Member', email: 'comp-sub@ghost.org'});
-            await seedSubscriptions(page, member.id, 'comped', [compSubscription()]);
-
-            await page.goto(memberPath(member.id));
-
-            await expect(page.getByText('Bronze').first()).toBeVisible();
-            await expect(page.getByText(/Complimentary/i).first()).toBeVisible();
-        });
-
-        test('gift subscription - offers no actions menu', async ({page}) => {
-            // A gift is bought by someone else and can't be cancelled or
-            // revoked from here, so the row deliberately has no menu.
-            const member = await memberFactory.create({name: 'Gift Member', email: 'gift-sub@ghost.org'});
-            await seedSubscriptions(page, member.id, 'gift', [giftSubscription()]);
-
-            await page.goto(memberPath(member.id));
-
-            await expect(page.getByText('Bronze').first()).toBeVisible();
-            await expect(memberDetailsPage.subscriptionActionsButton).toHaveCount(0);
-        });
-
-        test('cancelling a subscription - asks the server to cancel at period end', async ({page}) => {
-            const member = await memberFactory.create({name: 'Cancel Member', email: 'cancel-action@ghost.org'});
-            const subs = [paidSubscription()];
-            await seedSubscriptions(page, member.id, 'paid', subs);
-            // Reflect the write back into the seeded read so the screen can
-            // re-render from it, the way a real refetch would.
-            const sent = await captureWrite(page, `**/members/${member.id}/subscriptions/sub_paid_123/**`, (body) => {
-                subs[0].cancel_at_period_end = body.cancel_at_period_end as boolean;
-            });
-
-            await page.goto(memberPath(member.id));
-            await memberDetailsPage.subscriptionActionsButton.click();
-            await memberDetailsPage.cancelSubscriptionButton.click();
-
-            // The request is the contract — the server doesn't care which UI sent it.
-            await expect.poll(() => sent.body?.cancel_at_period_end).toBe(true);
-        });
-
-        test('continuing a cancelled subscription - asks the server to resume it', async ({page}) => {
-            const member = await memberFactory.create({name: 'Continue Member', email: 'continue-action@ghost.org'});
-            const subs = [paidSubscription({cancel_at_period_end: true})];
-            await seedSubscriptions(page, member.id, 'paid', subs);
-            const sent = await captureWrite(page, `**/members/${member.id}/subscriptions/sub_paid_123/**`, (body) => {
-                subs[0].cancel_at_period_end = body.cancel_at_period_end as boolean;
-            });
-
-            await page.goto(memberPath(member.id));
-            await memberDetailsPage.subscriptionActionsButton.click();
-            await memberDetailsPage.continueSubscriptionButton.click();
-
-            await expect.poll(() => sent.body?.cancel_at_period_end).toBe(false);
-        });
-
-        test('removing a complimentary subscription - puts back only the surviving tiers', async ({page}) => {
-            const member = await memberFactory.create({name: 'Multi Comp', email: 'multi-comp@ghost.org'});
-            await seedSubscriptions(page, member.id, 'comped', [compSubscription()], {tiers: TWO_COMP_TIERS()});
+        test('adding a complimentary subscription - grants the chosen tier forever', async ({page}) => {
+            const member = await memberFactory.create({name: 'Comp Grant', email: 'comp-grant-ember@ghost.org'});
             const sent = await captureWrite(page, new RegExp(`/ghost/api/admin/members/${member.id}/\\??[^/]*$`));
 
             await page.goto(memberPath(member.id));
-            await memberDetailsPage.removeComplimentarySubscription();
+            await page.getByRole('button', {name: /Add complimentary subscription/}).click();
+            const option = memberDetailsPage.emberCompTierOptions.first();
+            const chosenTierId = await option.getAttribute('data-test-tier-option');
+            await option.click();
+            await memberDetailsPage.emberSaveCompTierButton.click();
 
             await expect.poll(() => sentTiers(sent)?.length).toBe(1);
-            expect(sentTiers(sent)?.[0].id).toBe('tier_silver');
+            // The tier the admin picked, not merely some tier.
+            expect(sentTiers(sent)?.[0].id).toBe(chosenTierId);
+            // Forever is the default, so no expiry is sent.
+            expect(sentTiers(sent)?.[0].expiry_at ?? null).toBeNull();
+        });
+
+        test('invalid email - save stays enabled and the server rejects it', async ({page}) => {
+            // Ember validates on submit: Save is always clickable, and the
+            // failed attempt reports why. React disables Save instead — see the
+            // React-side counterpart below.
+            const member = await memberFactory.create({name: 'Invalid Email', email: 'valid-ember@ghost.org'});
+
+            await page.goto(memberPath(member.id));
+            await memberDetailsPage.emailInput.fill('not-an-email');
+            await memberDetailsPage.saveButton.click();
+
+            await expect(memberDetailsPage.retryButton).toBeVisible();
+            await expect(memberDetailsPage.body).toContainText('Invalid Email');
+        });
+
+        test('commenting can be re-enabled from the sidebar indicator', async ({page}) => {
+            // Ember offers a one-click Enable next to the "Comments disabled"
+            // indicator. React only exposes this through the actions menu, which
+            // the generic suite already covers for both.
+            const member = await memberFactory.create({name: 'Sidebar Enable', email: 'sidebar-enable@ghost.org'});
+
+            await page.goto(memberPath(member.id));
+            await memberDetailsPage.settingsSection.memberActionsButton.click();
+            await memberDetailsPage.settingsSection.disableCommentingButton.click();
+            await memberDetailsPage.disableCommentingConfirmButton.click();
+            await expect(memberDetailsPage.commentingDisabledIndicator).toBeVisible();
+
+            await memberDetailsPage.enableCommentingLink.click();
+
+            await expect(memberDetailsPage.commentingDisabledIndicator).toBeHidden();
         });
     });
 
-    test.describe('New member screen', () => {
-        // The Subscriptions section is gated on paid members being enabled, so
-        // stripe has to be on for it to render at all.
-        test.use({stripeEnabled: true});
+    test.describe('React', () => {
+        test.use({labs: {memberDetailsReact: true}, stripeEnabled: true});
 
-        test('newsletters section - renders a toggle list', async ({page}) => {
+        // Ember counterpart above — keep the assertions identical.
+        test('adding a complimentary subscription - grants the chosen tier forever', async ({page}) => {
+            const member = await memberFactory.create({name: 'Comp Grant', email: 'comp-grant-react@ghost.org'});
+            const sent = await captureWrite(page, new RegExp(`/ghost/api/admin/members/${member.id}/\\??[^/]*$`));
+
+            await page.goto(memberPath(member.id));
+            await page.getByRole('button', {name: /Add complimentary subscription/}).click();
+            await page.getByTestId('comp-tier-select').click();
+            const option = memberDetailsPage.reactCompTierOptions.first();
+            const chosenTierId = await option.getAttribute('data-tier-id');
+            await option.click();
+            await page.getByTestId('comp-add-confirm').click();
+
+            await expect.poll(() => sentTiers(sent)?.length).toBe(1);
+            expect(sentTiers(sent)?.[0].id).toBe(chosenTierId);
+            expect(sentTiers(sent)?.[0].expiry_at ?? null).toBeNull();
+        });
+
+        test('invalid email - save is disabled', async ({page}) => {
+            // React blocks the submit rather than letting it fail, so there is
+            // no server error to surface. Deliberate; the Ember counterpart
+            // above pins the other behaviour.
+            const member = await memberFactory.create({name: 'Invalid Email', email: 'valid-react@ghost.org'});
+
+            await page.goto(memberPath(member.id));
+            await memberDetailsPage.emailInput.fill('not-an-email');
+
+            await expect(memberDetailsPage.saveButton).toBeDisabled();
+        });
+
+        test('failed member load - offers a retry rather than a not-found message', async ({page}) => {
+            // Ember has no equivalent control: a failed load surfaces as an
+            // alert and the route errors. React renders a recoverable panel, so
+            // there is nothing generic to assert.
+            const member = await memberFactory.create({name: 'Retry Target', email: 'retry-target@ghost.org'});
+            let requests = 0;
+            const memberReadRegex = new RegExp(`/ghost/api/admin/members/${member.id}/\\??[^/]*$`);
+            await page.route(memberReadRegex, async (route) => {
+                if (route.request().method() !== 'GET') {
+                    return route.continue();
+                }
+                requests += 1;
+                if (requests === 1) {
+                    return route.fulfill({status: 500, contentType: 'application/json', body: JSON.stringify({errors: [{message: 'boom'}]})});
+                }
+                return route.continue();
+            });
+
+            await page.goto(memberPath(member.id));
+
+            const errorPanel = page.getByTestId('member-detail-load-error');
+            await expect(errorPanel).toBeVisible();
+            // A server error must not be reported as a missing member, anywhere
+            // on the screen. Asserting only the body copy previously let the
+            // breadcrumb go on claiming "Member not found" beside a
+            // "couldn't load" message.
+            await expect(page.getByText(/not found/i)).toHaveCount(0);
+            await expect(page.getByText(/couldn[’']t be found/)).toHaveCount(0);
+
+            await errorPanel.getByRole('button', {name: 'Retry'}).click();
+
+            await expect(memberDetailsPage.screenTitle).toHaveText('Retry Target');
+            await expect(errorPanel).toHaveCount(0);
+        });
+
+        test.describe('Removing a complimentary subscription', () => {
+            test.use({stripeEnabled: true});
+
+            test('preserves the expiry date on surviving tiers', async ({page}) => {
+                // The server treats a tier arriving without `expiry_at` as null and
+                // wipes the pivot (`models/member.js` updateTierExpiry), so the
+                // whole set has to be sent back with expiries intact. Ember sends
+                // `{id}` only and destroys the expiry on every surviving comp tier.
+                // React sends `expiry_at` explicitly. Not generic: a shared version
+                // of this test would fail on Ember, and we are not backporting.
+                const member = await memberFactory.create({name: 'Multi Comp', email: 'multi-comp-react@ghost.org'});
+                await seedSubscriptions(page, member.id, 'comped', [compSubscription()], {tiers: TWO_COMP_TIERS()});
+                const sent = await captureWrite(page, new RegExp(`/ghost/api/admin/members/${member.id}/\\??[^/]*$`));
+
+                await page.goto(memberPath(member.id));
+                await memberDetailsPage.removeComplimentarySubscription();
+
+                await expect.poll(() => sentTiers(sent)?.length).toBe(1);
+                expect(sentTiers(sent)?.[0].expiry_at).toBe(SILVER_EXPIRY);
+            });
+
+            test('asks for confirmation first', async ({page}) => {
+                // Ember removes the comp the moment the menu item is clicked.
+                const member = await memberFactory.create({name: 'Confirm Comp', email: 'confirm-comp@ghost.org'});
+                await seedSubscriptions(page, member.id, 'comped', [compSubscription()], {tiers: TWO_COMP_TIERS()});
+                const sent = await captureWrite(page, new RegExp(`/ghost/api/admin/members/${member.id}/\\??[^/]*$`));
+
+                await page.goto(memberPath(member.id));
+                await memberDetailsPage.subscriptionActionsButton.first().click();
+                await memberDetailsPage.removeComplimentaryButton.click();
+
+                await expect(page.getByRole('alertdialog', {name: /Remove complimentary subscription/})).toBeVisible();
+                expect(sent.body).toBeUndefined();
+            });
+        });
+
+        test('new member - seeded newsletter defaults do not count as unsaved changes', async ({page}) => {
+            // React seeds the create form's newsletter defaults and treats that
+            // seeded state as pristine. Ember's new record is dirty from the
+            // start, so it traps on an untouched form — a generic version of
+            // this test would fail there by design.
             await page.goto(memberPath('new'));
-
-            await expect(page.getByRole('heading', {name: 'Newsletters', exact: true})).toBeVisible();
             await expect(memberDetailsPage.newsletterSubscriptionToggles.first()).toBeVisible();
-        });
 
-        test('newsletters section - toggles are checked by default', async ({page}) => {
-            // Newsletters with subscribe_on_signup and members visibility are
-            // pre-selected on create, so the admin can see what the new member
-            // will land subscribed to. Assert every toggle rather than the
-            // first, which would pass even if a later default were missed.
-            await page.goto(memberPath('new'));
-            await expect(memberDetailsPage.newsletterSubscriptionToggles.first()).toBeVisible();
+            await memberDetailsPage.membersBackLink.click();
 
-            const count = await memberDetailsPage.newsletterSubscriptionCheckboxes.count();
-            expect(count).toBeGreaterThan(0);
-            for (let i = 0; i < count; i++) {
-                await expect(memberDetailsPage.newsletterSubscriptionCheckboxes.nth(i)).toBeChecked();
-            }
-        });
-
-        test('activity section - shows an empty state', async ({page}) => {
-            await page.goto(memberPath('new'));
-
-            await expect(page.getByText('All events related to this member will be shown here.')).toBeVisible();
-        });
-
-        test('subscriptions section - shows an empty state', async ({page}) => {
-            await page.goto(memberPath('new'));
-
-            await expect(page.getByRole('heading', {name: 'Subscriptions', exact: true})).toBeVisible();
-            await expect(page.getByRole('heading', {name: 'No subscriptions', exact: true})).toBeVisible();
-        });
-    });
-
-    test.describe('Engagement section', () => {
-        const stubMemberRead = interceptMemberRead;
-
-        test('member has received no emails - shows an empty state', async ({page}) => {
-            const member = await memberFactory.create({name: 'Ada Lovelace', email: 'engagement-empty@ghost.org'});
-
-            await page.goto(memberPath(member.id));
-
-            await expect(page.getByRole('heading', {name: 'Engagement'})).toBeVisible();
-            await expect(page.getByText(/We[’']ll show Ada[’']s email stats here/)).toBeVisible();
-        });
-
-        test('member has received emails - shows counts and open rate', async ({page}) => {
-            const member = await memberFactory.create({name: 'Stats Member', email: 'engagement-stats@ghost.org'});
-            // Inject the stats so the branch renders deterministically rather
-            // than depending on what the fixture database happens to hold.
-            await stubMemberRead(page, member.id, (m) => {
-                m.email_count = 12;
-                m.email_opened_count = 9;
-                m.email_open_rate = 75;
-            });
-
-            await page.goto(memberPath(member.id));
-
-            const engagement = memberDetailsPage.engagementSection;
-            await expect(engagement.getByText('Emails received')).toBeVisible();
-            await expect(engagement.getByText('12', {exact: true})).toBeVisible();
-            await expect(engagement.getByText('Emails opened')).toBeVisible();
-            await expect(engagement.getByText('9', {exact: true})).toBeVisible();
-            await expect(engagement.getByText('Average open rate')).toBeVisible();
-            await expect(engagement.getByText(/75\s*%/)).toBeVisible();
-        });
-
-        test('email fields absent from the payload - shows the empty state', async ({page}) => {
-            const member = await memberFactory.create({name: 'Ada Lovelace', email: 'engagement-undef@ghost.org'});
-            await stubMemberRead(page, member.id, (m) => {
-                delete m.email_count;
-                delete m.email_opened_count;
-                delete m.email_open_rate;
-            });
-
-            await page.goto(memberPath(member.id));
-
-            await expect(page.getByRole('heading', {name: 'Engagement'})).toBeVisible();
-            await expect(page.getByText(/We[’']ll show Ada[’']s email stats here/)).toBeVisible();
-        });
-
-        test('open rate not yet calculated - shows the placeholder', async ({page}) => {
-            const member = await memberFactory.create({name: 'Early Stats', email: 'engagement-null@ghost.org'});
-            // The server sends a null rate until the member has been sent 5
-            // newsletters; both the count and a bare % would be misleading.
-            await stubMemberRead(page, member.id, (m) => {
-                m.email_count = 3;
-                m.email_opened_count = 2;
-                m.email_open_rate = null;
-            });
-
-            await page.goto(memberPath(member.id));
-
-            await expect(page.getByText('This metric is calculated once a member has received 5 newsletters.')).toBeVisible();
+            await expect(page).toHaveURL(/#\/members(\?|$)/);
+            await expect(memberDetailsPage.confirmLeaveButton).toHaveCount(0);
         });
     });
 });

--- a/ghost/admin/app/components/gh-member-details.hbs
+++ b/ghost/admin/app/components/gh-member-details.hbs
@@ -82,7 +82,7 @@
             </div>
 
             {{#if (and (not-eq this.settings.membersSignupAccess "none") (not-eq this.settings.editorDefaultEmailRecipients "disabled"))}}
-                <div class="gh-member-details-stats-container">
+                <div class="gh-member-details-stats-container" data-testid="member-detail-engagement">
                     <h4 class="gh-main-section-header small bn">Engagement</h4>
                     {{#if (eq @member.emailCount 0)}}
                         <div class="gh-members-no-stats">

--- a/ghost/admin/app/routes/member.js
+++ b/ghost/admin/app/routes/member.js
@@ -5,6 +5,7 @@ import {action} from '@ember/object';
 import {inject as service} from '@ember/service';
 
 export default class MembersRoute extends MembersManagementRoute {
+    @service feature;
     @service modals;
     @service router;
     @service('unsaved-changes') unsavedChanges;
@@ -33,6 +34,15 @@ export default class MembersRoute extends MembersManagementRoute {
         // shell keeps rendering the page.
         const memberId = transition.to?.params?.member_id;
         if (memberId === 'import') {
+            transition.abort();
+            return;
+        }
+
+        // React owns this URL when the flag is on. Aborting keeps the Ember
+        // subtree unrendered, so the `data-testid` and `data-test-link`
+        // attributes exist in only one tree and the queryRecord below doesn't
+        // fire for a screen nobody sees.
+        if (this.feature.memberDetailsReact) {
             transition.abort();
         }
     }

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -84,6 +84,7 @@ export default class FeatureService extends Service {
     @feature('editorExcerpt') editorExcerpt;
     @feature('tagsX') tagsX;
     @feature('commentModeration') commentModeration;
+    @feature('memberDetailsReact') memberDetailsReact;
     _user = null;
 
     @computed('settings.labs')

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -56,7 +56,8 @@ const PRIVATE_FEATURES = [
     'themeTranslation',
     'pictureImageFormats',
     'smarterCounts',
-    'getHelperDeduplication'
+    'getHelperDeduplication',
+    'memberDetailsReact'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -32,6 +32,7 @@ Object {
       "indexnow": true,
       "lexicalIndicators": true,
       "llmsTxt": true,
+      "memberDetailsReact": true,
       "members": true,
       "pictureImageFormats": true,
       "smarterCounts": true,


### PR DESCRIPTION
## What

Moves the member detail screen (`/members/:id`) to React behind a new private Labs flag, `memberDetailsReact`. Both screens live on the same URL. With the flag off you get the existing Ember screen, with it on you get the new React one, and the toggle is a runtime switch in Developer Experiments.

This replaces #29175, which did the same migration but could no longer merge once the posts package was dissolved into the admin app.

## Why

A rewrite is only safe if you can show the new screen does what the old one did. So this branch leads with a single test suite that runs the same assertions against both screens, with no branching on which one is rendering. Any behaviour that works on one side but not the other shows up as a failing test instead of staying hidden.

The flag makes the switch reversible. It can be tried in production and turned off again without a revert.

The history is ordered so each step is reviewable on its own. The behaviour contract lands before any React exists and passes against the Ember screen alone. That is what makes it a fair test rather than one written to fit the new code.

## Known divergences

The suite turned up seven places where the two screens genuinely differ. These were not known in advance, the tests found them. Each one is now pinned by its own test, so the difference is a visible decision rather than a silent gap.

The most significant: when you remove a complimentary subscription, the Ember screen wipes the expiry dates on the member's other complimentary tiers. That is real data loss and it exists in production today. The React screen preserves them. We are not backporting the fix to Ember.

The rest:

Removing a complimentary subscription asks for confirmation first in React, where Ember removes it immediately. On an invalid email, Ember lets you save and then reports the failure, while React disables the save button. When comments are disabled, Ember offers a one click Enable next to the sidebar indicator, whereas React only offers it from the actions menu. React shows a retryable error if the member fails to load, which Ember has no equivalent for. On a new member form with seeded newsletter defaults, Ember treats it as unsaved and warns you on leaving, and React does not. The activity feed empty state wording also differs between the two.

## Testing

25 shared flows run against both screens, plus the 7 divergence tests, all passing (59 including setup). The contract commit passes on its own against the Ember screen with no React code present. Unit suites and typechecks are green.

## Follow ups

Two subscription actions still lack shared coverage: adding a complimentary subscription, and confirming that gift subscriptions have no actions menu.

The Ember data loss bug is worth its own issue, since it affects users today.
