### PR TITLE
Updated copy for open and click toggles

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/analytics.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/analytics.tsx
@@ -97,7 +97,7 @@ const Analytics: React.FC<{ keywords: string[] }> = ({keywords}) => {
                 direction='rtl'
                 gap='gap-0'
                 hint='Record when a member opens an email'
-                label='Newsletter opens'
+                label='Email opens'
                 onChange={(e) => {
                     handleToggleChange('email_track_opens', e);
                 }}
@@ -111,7 +111,7 @@ const Analytics: React.FC<{ keywords: string[] }> = ({keywords}) => {
                 disabled={isEmailTrackClicksReadOnly}
                 gap='gap-0'
                 hint='Record when a member clicks on any link in an email'
-                label='Newsletter clicks'
+                label='Email clicks'
                 onChange={(e) => {
                     handleToggleChange('email_track_clicks', e);
                 }}

--- a/apps/admin-x-settings/test/acceptance/membership/analytics.test.ts
+++ b/apps/admin-x-settings/test/acceptance/membership/analytics.test.ts
@@ -84,14 +84,14 @@ test.describe('Analytics settings', async () => {
         await expect(section).toBeVisible();
 
         await expect(section.getByLabel('Web analytics')).toBeChecked();
-        await expect(section.getByLabel('Newsletter opens')).toBeChecked();
-        await expect(section.getByLabel('Newsletter clicks')).toBeChecked();
+        await expect(section.getByLabel('Email opens')).toBeChecked();
+        await expect(section.getByLabel('Email clicks')).toBeChecked();
         await expect(section.getByLabel('Member sources')).toBeChecked();
         await expect(section.getByLabel('Outbound link tagging')).toBeChecked();
 
         await section.getByLabel(/Web analytics/).uncheck();
-        await section.getByLabel(/Newsletter opens/).uncheck();
-        await section.getByLabel(/Newsletter clicks/).uncheck();
+        await section.getByLabel(/Email opens/).uncheck();
+        await section.getByLabel(/Email clicks/).uncheck();
         await section.getByLabel(/Member sources/).uncheck();
         await section.getByLabel(/Outbound link tagging/).uncheck();
 
@@ -191,11 +191,11 @@ test.describe('Analytics settings', async () => {
 
         await expect(section).toBeVisible();
 
-        const newsletterClicksToggle = await section.getByLabel(/Newsletter clicks/);
+        const emailClicksToggle = await section.getByLabel(/Email clicks/);
 
-        await expect(newsletterClicksToggle).not.toBeChecked();
+        await expect(emailClicksToggle).not.toBeChecked();
 
-        await expect(newsletterClicksToggle).toBeDisabled();
+        await expect(emailClicksToggle).toBeDisabled();
     });
     test('Shows web analytics toggle as disabled when web_analytics_configured is false', async ({page}) => {
         await mockApi({page, requests: createMockApiConfig({


### PR DESCRIPTION
closes [NY-1443](https://linear.app/ghost/issue/NY-1443)

Updated the copy in settings -> analytics from "newsletter" opens and clicks to "email" opens and clicks. Soon it will be possible to track engagement for automated emails, and we'll use this same toggle to turn them on and off - so we need more generalized copy.

<img width="672" height="171" alt="Screenshot 2026-07-15 at 9 09 43 AM" src="https://github.com/user-attachments/assets/70f36842-ed3c-4064-8f74-4fc687b7b614" />
