### PR TITLE
Added share link to Koenig link suggestions

### DIFF
--- a/apps/admin-x-framework/src/hooks/use-koenig-link-suggestions.ts
+++ b/apps/admin-x-framework/src/hooks/use-koenig-link-suggestions.ts
@@ -30,13 +30,17 @@ interface UseKoenigLinkSuggestionsProps {
     membersSignupAccess: string;
     donationsEnabled: boolean;
     recommendationsEnabled: boolean;
+    includeShareLink?: boolean;
+    shareLinkLabel?: string;
 }
 
 export const useKoenigLinkSuggestions = ({
     siteUrl,
     membersSignupAccess,
     donationsEnabled,
-    recommendationsEnabled
+    recommendationsEnabled,
+    includeShareLink = false,
+    shareLinkLabel = 'Share'
 }: UseKoenigLinkSuggestionsProps) => {
     const {data: offersData} = useBrowseOffers();
     const {data: latestPostsData} = useBrowsePosts({
@@ -80,6 +84,8 @@ export const useKoenigLinkSuggestions = ({
             {label: 'Free signup', value: '#/portal/signup/free'}
         ];
 
+        const shareLink = includeShareLink ? [{label: shareLinkLabel, value: '#/share'}] : [];
+
         const memberLinks = membersSignupAccess === 'all' ? [
             {label: 'Paid signup', value: '#/portal/signup'},
             {label: 'Upgrade or change plan', value: '#/portal/account/plans'}
@@ -94,8 +100,8 @@ export const useKoenigLinkSuggestions = ({
                 value: new URL(offer.code, siteUrl).toString()
             }));
 
-        return [...defaults, ...memberLinks, ...donationLink, ...recommendationLink, ...offersLinks];
-    }, [donationsEnabled, membersSignupAccess, offersData?.offers, recommendationsEnabled, siteUrl]);
+        return [...defaults, ...memberLinks, ...donationLink, ...shareLink, ...recommendationLink, ...offersLinks];
+    }, [donationsEnabled, includeShareLink, membersSignupAccess, offersData?.offers, recommendationsEnabled, shareLinkLabel, siteUrl]);
 
     const searchLinks = useCallback(async (term: string) => {
         if (!term) {

--- a/apps/admin-x-framework/test/unit/hooks/use-koenig-link-suggestions.test.ts
+++ b/apps/admin-x-framework/test/unit/hooks/use-koenig-link-suggestions.test.ts
@@ -73,6 +73,68 @@ describe('useKoenigLinkSuggestions', () => {
         ]);
     });
 
+    it('places the share link immediately before Recommendations with the caller-supplied label', async () => {
+        mockUseBrowseOffers.mockReturnValue({data: {offers: []}} as any);
+        mockUseBrowsePosts.mockReturnValue({data: {posts: []}, refetch: vi.fn()} as any);
+        mockUseFilterableApi
+            .mockReturnValueOnce({loadData: vi.fn().mockResolvedValue([])} as any)
+            .mockReturnValueOnce({loadData: vi.fn().mockResolvedValue([])} as any);
+
+        const {result} = renderHook(() => useKoenigLinkSuggestions({
+            siteUrl: 'https://example.com/',
+            membersSignupAccess: 'none',
+            donationsEnabled: false,
+            recommendationsEnabled: true,
+            includeShareLink: true,
+            shareLinkLabel: 'Share page'
+        }));
+
+        const links = await result.current.fetchAutocompleteLinks();
+
+        const shareIndex = links.findIndex(link => link.value === '#/share');
+        expect(links[shareIndex]).toEqual({label: 'Share page', value: '#/share'});
+        expect(links[shareIndex + 1]).toEqual({label: 'Recommendations', value: '#/portal/recommendations'});
+    });
+
+    it('defaults the share link label to "Share" when includeShareLink is true without a label', async () => {
+        mockUseBrowseOffers.mockReturnValue({data: {offers: []}} as any);
+        mockUseBrowsePosts.mockReturnValue({data: {posts: []}, refetch: vi.fn()} as any);
+        mockUseFilterableApi
+            .mockReturnValueOnce({loadData: vi.fn().mockResolvedValue([])} as any)
+            .mockReturnValueOnce({loadData: vi.fn().mockResolvedValue([])} as any);
+
+        const {result} = renderHook(() => useKoenigLinkSuggestions({
+            siteUrl: 'https://example.com/',
+            membersSignupAccess: 'none',
+            donationsEnabled: false,
+            recommendationsEnabled: false,
+            includeShareLink: true
+        }));
+
+        const links = await result.current.fetchAutocompleteLinks();
+
+        expect(links).toContainEqual({label: 'Share', value: '#/share'});
+    });
+
+    it('omits the share link by default', async () => {
+        mockUseBrowseOffers.mockReturnValue({data: {offers: []}} as any);
+        mockUseBrowsePosts.mockReturnValue({data: {posts: []}, refetch: vi.fn()} as any);
+        mockUseFilterableApi
+            .mockReturnValueOnce({loadData: vi.fn().mockResolvedValue([])} as any)
+            .mockReturnValueOnce({loadData: vi.fn().mockResolvedValue([])} as any);
+
+        const {result} = renderHook(() => useKoenigLinkSuggestions({
+            siteUrl: 'https://example.com/',
+            membersSignupAccess: 'none',
+            donationsEnabled: false,
+            recommendationsEnabled: false
+        }));
+
+        const links = await result.current.fetchAutocompleteLinks();
+
+        expect(links.some(link => link.value === '#/share')).toBe(false);
+    });
+
     it('returns cached latest posts links for empty search term', async () => {
         const refetch = vi.fn();
         mockUseBrowseOffers.mockReturnValue({data: {offers: []}} as any);

--- a/ghost/admin/app/components/koenig-lexical-editor.js
+++ b/ghost/admin/app/components/koenig-lexical-editor.js
@@ -256,10 +256,14 @@ export default class KoenigLexicalEditor extends Component {
         };
 
         const fetchAutocompleteLinks = async () => {
+            const postType = this.args.cardConfig?.post?.displayName === 'page' ? 'page' : 'post';
+
             const defaults = [
                 {label: 'Homepage', value: window.location.origin + '/'},
                 {label: 'Free signup', value: '#/portal/signup/free'}
             ];
+
+            const shareLink = [{label: `Share ${postType}`, value: '#/share'}];
 
             const memberLinks = () => {
                 let links = [];
@@ -313,7 +317,7 @@ export default class KoenigLexicalEditor extends Component {
 
             const offersLinks = await offerUrls.call(this);
 
-            return [...defaults, ...memberLinks(), ...donationLink(), ...recommendationLink(), ...giftLink(), ...offersLinks];
+            return [...defaults, ...memberLinks(), ...donationLink(), ...giftLink(), ...shareLink, ...recommendationLink(), ...offersLinks];
         };
 
         const fetchLabels = async () => {

--- a/koenig/koenig-lexical/demo/DemoApp.tsx
+++ b/koenig/koenig-lexical/demo/DemoApp.tsx
@@ -49,7 +49,8 @@ const defaultCardConfig = {
     klipy: klipyConfig,
     fetchAutocompleteLinks: () => Promise.resolve([
         {label: 'Homepage', value: window.location.origin + '/'},
-        {label: 'Free signup', value: window.location.origin + '/#/portal/signup/free'}
+        {label: 'Free signup', value: window.location.origin + '/#/portal/signup/free'},
+        {label: 'Share post', value: window.location.origin + '/#/share'}
     ]),
     renderLabels: true,
     fetchLabels: () => Promise.resolve(['Label 1', 'Label 2']),

--- a/koenig/koenig-lexical/test/e2e/cards/button-card.test.ts
+++ b/koenig/koenig-lexical/test/e2e/cards/button-card.test.ts
@@ -146,6 +146,15 @@ test.describe('Button Card', async () => {
         await expect(buttonLink).toHaveAttribute('href',anyString);
     });
 
+    test('suggests the Share link', async function () {
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'button'});
+
+        await page.getByTestId('button-input-url').fill('Share');
+        await page.waitForSelector('[data-testid="button-input-url-listOption"]');
+        await expect(await page.getByTestId('button-input-url-listOption-Share post')).toHaveText('Share post');
+    });
+
     test('can add snippet', async function () {
         await focusEditor(page);
         await insertCard(page, {cardName: 'button'});

--- a/koenig/koenig-lexical/test/e2e/cards/call-to-action-card.test.ts
+++ b/koenig/koenig-lexical/test/e2e/cards/call-to-action-card.test.ts
@@ -177,6 +177,15 @@ test.describe('Call To Action Card', async () => {
         expect(currentUrl).toMatch(validUrlRegex);
     });
 
+    test('suggests the Share link', async function () {
+        await focusEditor(page);
+        await insertCard(page, {cardName: 'call-to-action'});
+
+        await page.getByTestId('button-url').fill('Share');
+        await page.waitForSelector('[data-testid="button-url-listOption"]');
+        await expect(await page.getByTestId('button-url-listOption')).toContainText('Share post');
+    });
+
     test('button doesnt disappear when toggled, has text, has url and loses focus', async function () {
         await focusEditor(page);
         await insertCard(page, {cardName: 'call-to-action'});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1891

Added share link to Koenig link suggestions to make it easier to insert the link rather than having to manually type the URL

<img width="692" height="1112" alt="CleanShot 2026-07-15 at 14 33 54@2x" src="https://github.com/user-attachments/assets/b7d8174b-5b21-4459-bec3-64c5bf4203fb" />

