### PR TITLE
Removed admin-x-design-system type and hook imports from admin-x-framework

### DIFF
--- a/apps/admin-x-framework/src/hooks/use-form.ts
+++ b/apps/admin-x-framework/src/hooks/use-form.ts
@@ -1,5 +1,6 @@
-import {ButtonColor} from '@tryghost/admin-x-design-system';
 import {useCallback, useEffect, useState} from 'react';
+
+export type ButtonColor = 'clear' | 'light-grey' | 'grey' | 'black' | 'green' | 'red' | 'white' | 'outline';
 
 export type Dirtyable<Data> = Data & {
     dirty?: boolean;

--- a/apps/admin-x-framework/src/hooks/use-pagination.ts
+++ b/apps/admin-x-framework/src/hooks/use-pagination.ts
@@ -1,0 +1,45 @@
+import {useEffect, useState} from 'react';
+
+export interface PaginationMeta {
+    limit: number | 'all';
+    pages: number;
+    total: number;
+    next: number | null;
+    prev: number | null;
+}
+
+export interface PaginationData {
+    page: number;
+    pages: number | null;
+    total: number | null;
+    limit: number;
+    setPage: (page: number) => void;
+    nextPage: () => void;
+    prevPage: () => void;
+}
+
+export const usePagination = ({limit, meta, page, setPage}: {meta?: PaginationMeta, limit: number, page: number, setPage: React.Dispatch<React.SetStateAction<number>>}): PaginationData => {
+    // Prevent resetting meta when a new page loads
+    const [prevMeta, setPrevMeta] = useState<PaginationMeta | undefined>(meta);
+
+    useEffect(() => {
+        if (meta) {
+            setPrevMeta(meta);
+
+            if (meta.pages > 0 && meta.pages < page) {
+                // We probably deleted an item when on the last page: go one page back automatically
+                setPage(meta.pages);
+            }
+        }
+    }, [meta, setPage, page]);
+
+    return {
+        page,
+        setPage,
+        pages: prevMeta?.pages ?? null,
+        limit: prevMeta?.limit && prevMeta.limit !== 'all' ? prevMeta.limit : limit,
+        total: prevMeta?.total ?? null,
+        nextPage: () => setPage(Math.min(page + 1, prevMeta?.pages ? prevMeta.pages : page)),
+        prevPage: () => setPage(Math.max(1, page - 1))
+    };
+};

--- a/apps/admin-x-framework/src/test/render.tsx
+++ b/apps/admin-x-framework/src/test/render.tsx
@@ -1,7 +1,12 @@
-import {DesignSystemAppProps} from '@tryghost/admin-x-design-system';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import {TopLevelFrameworkProps} from '../providers/framework-provider';
+
+export interface DesignSystemAppProps extends React.HTMLProps<HTMLDivElement> {
+    darkMode: boolean;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    fetchKoenigLexical: () => Promise<any>;
+}
 
 const fetchKoenigLexical: DesignSystemAppProps['fetchKoenigLexical'] = async () => {
     // @ts-expect-error koenig-lexical doesn't currently ship TypeScript declarations.

--- a/apps/admin-x-framework/src/utils/api/hooks.ts
+++ b/apps/admin-x-framework/src/utils/api/hooks.ts
@@ -1,7 +1,7 @@
 import {InfiniteData, InvalidateOptions, InvalidateQueryFilters, QueryKey, UseInfiniteQueryOptions, UseQueryOptions, UseQueryResult, useInfiniteQuery, useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
-import {usePagination} from '@tryghost/admin-x-design-system';
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import useHandleError from '../../hooks/use-handle-error';
+import {usePagination} from '../../hooks/use-pagination';
 import {usePermission} from '../../hooks/use-permissions';
 import {UserRoleType} from '../../api/roles';
 import {useFramework} from '../../providers/framework-provider';

--- a/apps/admin-x-framework/src/utils/focus-koenig-editor-on-bottom-click.ts
+++ b/apps/admin-x-framework/src/utils/focus-koenig-editor-on-bottom-click.ts
@@ -1,4 +1,13 @@
-import type {KoenigInstance} from '@tryghost/admin-x-design-system';
+export type KoenigInstance = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [key: string]: any
+    editorInstance: {
+        getRootElement: () => HTMLElement | null
+    }
+    focusEditor: (options?: {position?: 'top' | 'bottom'}) => void
+    insertParagraphAtBottom: () => void
+    lastNodeIsDecorator: () => boolean
+};
 
 export function focusKoenigEditorOnBottomClick(
     editorAPI: KoenigInstance,


### PR DESCRIPTION
## What

Removed the type- and hook-level imports of `@tryghost/admin-x-design-system` from `@tryghost/admin-x-framework` by defining them locally in the framework:

- `src/hooks/use-form.ts` — the `ButtonColor` union type is now declared locally (same union as the design system's `Button`), used by `OkProps`
- `src/utils/api/hooks.ts` — `usePagination` now comes from a new local copy at `src/hooks/use-pagination.ts` (identical implementation, including the `PaginationMeta`/`PaginationData` types); the hook stays internal to the framework
- `src/utils/focus-koenig-editor-on-bottom-click.ts` — the `KoenigInstance` type is now declared locally with the same shape
- `src/test/render.tsx` — the `DesignSystemAppProps` type is now declared locally with the same shape

`src/hooks/use-handle-error.ts` still imports `showToast` from the design system, so the package dependency itself is unchanged.

## Why

The framework only needed a few types and one small hook from the legacy design system. Localizing them removes that coupling without changing the framework's public API — the local declarations are structurally identical to the originals, so nothing changes for consumers.

## Verification

All passing locally:

- `pnpm --filter @tryghost/admin-x-framework lint`
- `pnpm --filter @tryghost/admin-x-framework test:unit` — 31 files, 440 tests passed
- `pnpm --filter @tryghost/admin-x-framework test:types`
- `pnpm --filter @tryghost/admin-x-framework build`
- `pnpm --filter @tryghost/admin-x-settings build` — type-checks the framework's biggest consumer against the change

Confirmed the only remaining `@tryghost/admin-x-design-system` import in `apps/admin-x-framework/src` is in `hooks/use-handle-error.ts`.