### PR TITLE
Removed non-visual admin-x-design-system utilities from admin-x-settings

### DIFF
--- a/apps/admin-x-settings/src/components/error-boundary.tsx
+++ b/apps/admin-x-settings/src/components/error-boundary.tsx
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/react';
 import React, {type ComponentType, type ErrorInfo, type ReactNode} from 'react';
-import {Banner} from '@tryghost/shade/components';
+import {Banner} from '@tryghost/admin-x-design-system';
 
 export interface ErrorBoundaryProps {
     children: ReactNode;
@@ -36,7 +36,7 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps> {
     render() {
         if (this.state.hasError) {
             return (
-                <Banner variant='destructive'>
+                <Banner color='red'>
                     An error occurred loading {this.props.name}. Please refresh and try again.
                 </Banner>
             );

--- a/apps/admin-x-settings/src/components/error-boundary.tsx
+++ b/apps/admin-x-settings/src/components/error-boundary.tsx
@@ -1,0 +1,59 @@
+import * as Sentry from '@sentry/react';
+import React, {type ComponentType, type ErrorInfo, type ReactNode} from 'react';
+import {Banner} from '@tryghost/shade/components';
+
+export interface ErrorBoundaryProps {
+    children: ReactNode;
+    name: ReactNode;
+}
+
+/**
+ * Catches errors in child components and displays a banner. Useful to prevent errors in one
+ * section from crashing the entire page
+ */
+class ErrorBoundary extends React.Component<ErrorBoundaryProps> {
+    state = {hasError: false};
+
+    constructor(props: {children: ReactNode, name: ReactNode}) {
+        super(props);
+    }
+
+    static getDerivedStateFromError() {
+        return {hasError: true};
+    }
+
+    componentDidCatch(error: unknown, info: ErrorInfo) {
+        Sentry.withScope((scope) => {
+            scope.setTag('adminx_settings_component', info.componentStack);
+            Sentry.captureException(error);
+        });
+        // eslint-disable-next-line no-console
+        console.error(error);
+        // eslint-disable-next-line no-console
+        console.error('In component:', info.componentStack);
+    }
+
+    render() {
+        if (this.state.hasError) {
+            return (
+                <Banner variant='destructive'>
+                    An error occurred loading {this.props.name}. Please refresh and try again.
+                </Banner>
+            );
+        }
+
+        return this.props.children;
+    }
+}
+
+export default ErrorBoundary;
+
+export const withErrorBoundary = <Props extends Record<string, unknown>>(Component: ComponentType<Props>, name: string) => {
+    return function WithErrorBoundary(props: Props) {
+        return (
+            <ErrorBoundary name={name}>
+                <Component {...props} />
+            </ErrorBoundary>
+        );
+    };
+};

--- a/apps/admin-x-settings/src/components/exit-settings-button.tsx
+++ b/apps/admin-x-settings/src/components/exit-settings-button.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import {Button, confirmIfDirty} from '@tryghost/admin-x-design-system';
-import {useGlobalDirtyState} from '@tryghost/shade/utils';
+import {Button, confirmIfDirty, useGlobalDirtyState} from '@tryghost/admin-x-design-system';
 
 const ExitSettingsButton: React.FC = () => {
     const {isDirty} = useGlobalDirtyState();

--- a/apps/admin-x-settings/src/components/exit-settings-button.tsx
+++ b/apps/admin-x-settings/src/components/exit-settings-button.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import {Button, confirmIfDirty, useGlobalDirtyState} from '@tryghost/admin-x-design-system';
+import {Button, confirmIfDirty} from '@tryghost/admin-x-design-system';
+import {useGlobalDirtyState} from '@tryghost/shade/utils';
 
 const ExitSettingsButton: React.FC = () => {
     const {isDirty} = useGlobalDirtyState();

--- a/apps/admin-x-settings/src/components/settings/advanced/code-injection.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/code-injection.tsx
@@ -2,7 +2,8 @@ import CodeModal from './code/code-modal';
 import NiceModal from '@ebay/nice-modal-react';
 import React from 'react';
 import TopLevelGroup from '../../top-level-group';
-import {Button, SettingGroupHeader, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {Button, SettingGroupHeader} from '@tryghost/admin-x-design-system';
+import {withErrorBoundary} from '../../error-boundary';
 
 const CodeInjection: React.FC<{ keywords: string[] }> = ({keywords}) => {
     return (

--- a/apps/admin-x-settings/src/components/settings/advanced/danger-zone.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/danger-zone.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import TopLevelGroup from '../../top-level-group';
 import trackEvent from '../../../utils/analytics';
 import useStaffUsers from '../../../hooks/use-staff-users';
-import {Button, ConfirmationModal, ListItem, SettingGroupHeader, showToast, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {Button, ConfirmationModal, ListItem, SettingGroupHeader, showToast} from '@tryghost/admin-x-design-system';
 import {getGhostPaths} from '@tryghost/admin-x-framework/helpers';
 import {useDeleteAllContent} from '@tryghost/admin-x-framework/api/db';
 import {useGlobalData} from '../../providers/global-data-provider';
@@ -11,6 +11,7 @@ import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useQueryClient} from '@tryghost/admin-x-framework';
 import {useRemoveAllGiftLinks} from '@tryghost/admin-x-framework/api/gift-links';
 import {useResetAuth} from '@tryghost/admin-x-framework/api/security';
+import {withErrorBoundary} from '../../error-boundary';
 
 const DangerZone: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {mutateAsync: deleteAllContent} = useDeleteAllContent();

--- a/apps/admin-x-settings/src/components/settings/advanced/history-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/history-modal.tsx
@@ -1,8 +1,9 @@
 import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import {type Action, getActionTitle, getContextResource, getLinkTarget, isBulkAction, useBrowseActions} from '@tryghost/admin-x-framework/api/actions';
-import {Avatar, Button, Icon, InfiniteScrollListener, List, ListItem, type LoadSelectOptions, LoadingIndicator, Modal, NoValueLabel, Popover, Select, type SelectOption, Toggle, ToggleGroup, debounce} from '@tryghost/admin-x-design-system';
+import {Avatar, Button, Icon, InfiniteScrollListener, List, ListItem, type LoadSelectOptions, LoadingIndicator, Modal, NoValueLabel, Popover, Select, type SelectOption, Toggle, ToggleGroup} from '@tryghost/admin-x-design-system';
 import {type RoutingModalProps, useRouting} from '@tryghost/admin-x-framework/routing';
 import {type User} from '@tryghost/admin-x-framework/api/users';
+import {debounce} from '../../../utils/debounce';
 import {generateAvatarColor, getInitials} from '../../../utils/helpers';
 import {keepPreviousData} from '@tanstack/react-query';
 import {useCallback, useState} from 'react';

--- a/apps/admin-x-settings/src/components/settings/advanced/history.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/history.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import TopLevelGroup from '../../top-level-group';
-import {Button, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {Button} from '@tryghost/admin-x-design-system';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {withErrorBoundary} from '../../error-boundary';
 
 const History: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {updateRoute} = useRouting();

--- a/apps/admin-x-settings/src/components/settings/advanced/integrations.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/integrations.tsx
@@ -3,12 +3,13 @@ import NiceModal from '@ebay/nice-modal-react';
 import React, {useState} from 'react';
 import TopLevelGroup from '../../top-level-group';
 import usePinturaEditor from '../../../hooks/use-pintura-editor';
-import {Button, ConfirmationModal, Icon, List, ListItem, NoValueLabel, SettingGroupHeader, TabView, showToast, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {Button, ConfirmationModal, Icon, List, ListItem, NoValueLabel, SettingGroupHeader, TabView, showToast} from '@tryghost/admin-x-design-system';
 import {type Integration, useBrowseIntegrations, useDeleteIntegration} from '@tryghost/admin-x-framework/api/integrations';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {useGlobalData} from '../../providers/global-data-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {withErrorBoundary} from '../../error-boundary';
 
 interface IntegrationItemProps {
     icon?: React.ReactNode,

--- a/apps/admin-x-settings/src/components/settings/advanced/labs.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs.tsx
@@ -3,9 +3,10 @@ import LabsBubbles from '../../../assets/images/labs-bg.svg';
 import PrivateFeatures from './labs/private-features';
 import React, {useState} from 'react';
 import TopLevelGroup from '../../top-level-group';
-import {Button, SettingGroupHeader, type Tab, TabView, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {Button, SettingGroupHeader, type Tab, TabView} from '@tryghost/admin-x-design-system';
 import {useAutoExpandable} from '../../../hooks/use-auto-expandable';
 import {useGlobalData} from '../../providers/global-data-provider';
+import {withErrorBoundary} from '../../error-boundary';
 
 type LabsTab = 'labs-private-features' | 'labs-beta-features';
 

--- a/apps/admin-x-settings/src/components/settings/advanced/migration-tools.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/migration-tools.tsx
@@ -2,7 +2,8 @@ import MigrationToolsExport from './migration-tools/migration-tools-export';
 import MigrationToolsImport from './migration-tools/migration-tools-import';
 import React, {useState} from 'react';
 import TopLevelGroup from '../../top-level-group';
-import {SettingGroupHeader, type Tab, TabView, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {SettingGroupHeader, type Tab, TabView} from '@tryghost/admin-x-design-system';
+import {withErrorBoundary} from '../../error-boundary';
 
 type MigrationTab = 'import' | 'export';
 

--- a/apps/admin-x-settings/src/components/settings/advanced/spam-filters.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/spam-filters.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import TopLevelGroup from '../../top-level-group';
 import useSettingGroup from '../../../hooks/use-setting-group';
-import {SettingGroupContent, TextArea, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {SettingGroupContent, TextArea} from '@tryghost/admin-x-design-system';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
+import {withErrorBoundary} from '../../error-boundary';
 
 const SpamFilters: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {

--- a/apps/admin-x-settings/src/components/settings/email/default-recipients.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/default-recipients.tsx
@@ -2,9 +2,10 @@ import React, {useEffect, useState} from 'react';
 import TopLevelGroup from '../../top-level-group';
 import useDefaultRecipientsOptions from './use-default-recipients-options';
 import useSettingGroup from '../../../hooks/use-setting-group';
-import {MultiSelect, type MultiSelectOption, Select, SettingGroupContent, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {MultiSelect, type MultiSelectOption, Select, SettingGroupContent} from '@tryghost/admin-x-design-system';
 import {type MultiValue} from 'react-select';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
+import {withErrorBoundary} from '../../error-boundary';
 
 type RefipientValueArgs = {
     defaultEmailRecipients: string;

--- a/apps/admin-x-settings/src/components/settings/email/enable-newsletters.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/enable-newsletters.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import TopLevelGroup from '../../top-level-group';
-import {Banner, Icon, SettingGroupContent, Toggle, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {Banner, Icon, SettingGroupContent, Toggle} from '@tryghost/admin-x-design-system';
 import {type Setting, getSettingValues, useEditSettings} from '@tryghost/admin-x-framework/api/settings';
 import {useGlobalData} from '../../providers/global-data-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {withErrorBoundary} from '../../error-boundary';
 
 const EnableNewsletters: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {settings} = useGlobalData();

--- a/apps/admin-x-settings/src/components/settings/email/mailgun.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/mailgun.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import TopLevelGroup from '../../top-level-group';
 import useSettingGroup from '../../../hooks/use-setting-group';
-import {IconLabel, Link, Select, SettingGroupContent, TextField, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {IconLabel, Link, Select, SettingGroupContent, TextField} from '@tryghost/admin-x-design-system';
 import {getSettingValues, useEditSettings} from '@tryghost/admin-x-framework/api/settings';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
+import {withErrorBoundary} from '../../error-boundary';
 
 const MAILGUN_REGIONS = [
     {label: '🇺🇸 US', value: 'https://api.mailgun.net/v3'},

--- a/apps/admin-x-settings/src/components/settings/email/newsletters.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters.tsx
@@ -4,12 +4,13 @@ import React, {type ReactNode, useEffect, useState} from 'react';
 import TopLevelGroup from '../../top-level-group';
 import useQueryParams from '../../../hooks/use-query-params';
 import {APIError} from '@tryghost/admin-x-framework/errors';
-import {Button, ConfirmationModal, TabView, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {Button, ConfirmationModal, TabView} from '@tryghost/admin-x-design-system';
 import {type InfiniteData, useQueryClient} from '@tryghost/admin-x-framework';
 import {type Newsletter, type NewslettersResponseType, newslettersDataType, useBrowseNewsletters, useEditNewsletter, useVerifyNewsletterEmail} from '@tryghost/admin-x-framework/api/newsletters';
 import {arrayMove} from '@dnd-kit/sortable';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {withErrorBoundary} from '../../error-boundary';
 
 const NavigateToNewsletter = ({id, children}: {id: string; children: ReactNode}) => {
     const modal = useModal();

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/newsletters-tab-content.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/newsletters-tab-content.tsx
@@ -3,12 +3,13 @@ import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import React, {type ReactNode, useEffect, useState} from 'react';
 import useQueryParams from '../../../../hooks/use-query-params';
 import {APIError} from '@tryghost/admin-x-framework/errors';
-import {Button, ConfirmationModal, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {Button, ConfirmationModal} from '@tryghost/admin-x-design-system';
 import {type InfiniteData, useQueryClient} from '@tryghost/admin-x-framework';
 import {type Newsletter, type NewslettersResponseType, newslettersDataType, useBrowseNewsletters, useEditNewsletter, useVerifyNewsletterEmail} from '@tryghost/admin-x-framework/api/newsletters';
 import {arrayMove} from '@dnd-kit/sortable';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {withErrorBoundary} from '../../../error-boundary';
 
 const NavigateToNewsletter = ({id, children}: {id: string; children: ReactNode}) => {
     const modal = useModal();

--- a/apps/admin-x-settings/src/components/settings/email/use-default-recipients-options.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/use-default-recipients-options.tsx
@@ -1,8 +1,9 @@
 import {type GroupBase, type MultiValue} from 'react-select';
 import {type Label} from '@tryghost/admin-x-framework/api/labels';
-import {type LoadMultiSelectOptions, type MultiSelectOption, debounce} from '@tryghost/admin-x-design-system';
+import {type LoadMultiSelectOptions, type MultiSelectOption} from '@tryghost/admin-x-design-system';
 import {type Offer} from '@tryghost/admin-x-framework/api/offers';
 import {type Tier} from '@tryghost/admin-x-framework/api/tiers';
+import {debounce} from '../../../utils/debounce';
 import {isObjectId} from '../../../utils/helpers';
 import {useEffect, useState} from 'react';
 import {useFilterableApi} from '@tryghost/admin-x-framework/hooks';

--- a/apps/admin-x-settings/src/components/settings/general/publication-language.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/publication-language.tsx
@@ -2,9 +2,10 @@ import LOCALE_DATA from '@tryghost/i18n/lib/locale-data.json';
 import React from 'react';
 import TopLevelGroup from '../../top-level-group';
 import useSettingGroup from '../../../hooks/use-setting-group';
-import {SelectWithOther, SettingGroupContent, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {SelectWithOther, SettingGroupContent} from '@tryghost/admin-x-design-system';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {validateLocale} from '../../../utils/locale-validation';
+import {withErrorBoundary} from '../../error-boundary';
 import type {SelectOption} from '@tryghost/admin-x-design-system';
 
 const PublicationLanguage: React.FC<{ keywords: string[] }> = ({keywords}) => {

--- a/apps/admin-x-settings/src/components/settings/general/seo-meta.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/seo-meta.tsx
@@ -4,10 +4,11 @@ import useFeatureFlag from '../../../hooks/use-feature-flag';
 import usePinturaEditor from '../../../hooks/use-pintura-editor';
 import useSettingGroup from '../../../hooks/use-setting-group';
 import {APIError} from '@tryghost/admin-x-framework/errors';
-import {FacebookLogo, GoogleLogo, Icon, ImageUpload, SettingGroupContent, TabView, TextField, Toggle, XLogo, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {FacebookLogo, GoogleLogo, Icon, ImageUpload, SettingGroupContent, TabView, TextField, Toggle, XLogo} from '@tryghost/admin-x-design-system';
 import {getImageUrl, useUploadImage} from '@tryghost/admin-x-framework/api/images';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
+import {withErrorBoundary} from '../../error-boundary';
 
 interface SearchEnginePreviewProps {
     title: string;

--- a/apps/admin-x-settings/src/components/settings/general/social-accounts.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/social-accounts.tsx
@@ -2,8 +2,9 @@ import React, {useEffect, useMemo, useState} from 'react';
 import TopLevelGroup from '../../top-level-group';
 import useSettingGroup from '../../../hooks/use-setting-group';
 import {SOCIAL_PLATFORM_CONFIGS, SOCIAL_PLATFORM_KEYS, getSocialValidationError, normalizeSocialInput} from '../../../utils/social-urls';
-import {SettingGroupContent, TextField, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {SettingGroupContent, TextField} from '@tryghost/admin-x-design-system';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
+import {withErrorBoundary} from '../../error-boundary';
 import type {Setting} from '@tryghost/admin-x-framework/api/settings';
 import type {SocialPlatformKey} from '../../../utils/social-urls';
 

--- a/apps/admin-x-settings/src/components/settings/general/time-zone.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/time-zone.tsx
@@ -1,10 +1,11 @@
 import React, {useEffect, useState} from 'react';
 import TopLevelGroup from '../../top-level-group';
 import useSettingGroup from '../../../hooks/use-setting-group';
-import {Select, SettingGroupContent, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {Select, SettingGroupContent} from '@tryghost/admin-x-design-system';
 import {getLocalTime} from '../../../utils/helpers';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {timezoneDataWithGMTOffset} from '@tryghost/timezone-data';
+import {withErrorBoundary} from '../../error-boundary';
 
 interface TimezoneDataDropdownOption {
     name: string;

--- a/apps/admin-x-settings/src/components/settings/general/title-and-description.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/title-and-description.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import TopLevelGroup from '../../top-level-group';
 import useSettingGroup from '../../../hooks/use-setting-group';
-import {SettingGroupContent, TextField, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {SettingGroupContent, TextField} from '@tryghost/admin-x-design-system';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
+import {withErrorBoundary} from '../../error-boundary';
 
 const TitleAndDescription: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {

--- a/apps/admin-x-settings/src/components/settings/general/users.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/users.tsx
@@ -3,7 +3,7 @@ import TopLevelGroup from '../../top-level-group';
 import clsx from 'clsx';
 import useQueryParams from '../../../hooks/use-query-params';
 import useStaffUsers from '../../../hooks/use-staff-users';
-import {Avatar, Button, List, ListItem, NoValueLabel, Separator, TabView, Toggle, showToast, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {Avatar, Button, List, ListItem, NoValueLabel, Separator, TabView, Toggle, showToast} from '@tryghost/admin-x-design-system';
 import {type User, hasAdminAccess, isContributorUser, isEditorUser} from '@tryghost/admin-x-framework/api/users';
 import {type UserInvite, useAddInvite, useDeleteInvite} from '@tryghost/admin-x-framework/api/invites';
 import {generateAvatarColor, getInitials} from '../../../utils/helpers';
@@ -11,6 +11,7 @@ import {getSettingValue, useEditSettings} from '@tryghost/admin-x-framework/api/
 import {useGlobalData} from '../../providers/global-data-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {withErrorBoundary} from '../../error-boundary';
 
 interface OwnerProps {
     user: User;

--- a/apps/admin-x-settings/src/components/settings/growth/embed-signup/embed-signup-sidebar.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/embed-signup/embed-signup-sidebar.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import {Button, ButtonGroup, ColorPickerField, Form, Heading, type LoadMultiSelectOptions, MultiSelect, type MultiSelectOption, StickyFooter, TextArea, debounce} from '@tryghost/admin-x-design-system';
+import {Button, ButtonGroup, ColorPickerField, Form, Heading, type LoadMultiSelectOptions, MultiSelect, type MultiSelectOption, StickyFooter, TextArea} from '@tryghost/admin-x-design-system';
 import {type Label} from '@tryghost/admin-x-framework/api/labels';
 import {type MultiValue} from 'react-select';
+import {debounce} from '../../../../utils/debounce';
 import {useFilterableApi} from '@tryghost/admin-x-framework/hooks';
 
 export type SelectedLabelTypes = {

--- a/apps/admin-x-settings/src/components/settings/growth/explore.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/explore.tsx
@@ -3,13 +3,14 @@ import React, {useEffect, useState} from 'react';
 import SettingImg from '../../../assets/images/ghost-explore.png';
 import TopLevelGroup from '../../top-level-group';
 import useSettingGroup from '../../../hooks/use-setting-group';
-import {Button, Icon, Separator, SettingGroupContent, Toggle, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {Button, Icon, Separator, SettingGroupContent, Toggle} from '@tryghost/admin-x-design-system';
 import {type Setting, getSettingValue, getSettingValues, useEditSettings} from '@tryghost/admin-x-framework/api/settings';
 import {abbreviateNumber} from '@tryghost/shade/utils';
 import {useBrowseMembers} from '@tryghost/admin-x-framework/api/members';
 import {useGlobalData} from '../../providers/global-data-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {withErrorBoundary} from '../../error-boundary';
 
 const Explore: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {settings} = useGlobalData();

--- a/apps/admin-x-settings/src/components/settings/growth/network.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/network.tsx
@@ -2,13 +2,14 @@ import React from 'react';
 import SettingImg from '../../../assets/images/network.png';
 import TopLevelGroup from '../../top-level-group';
 import validator from 'validator';
-import {Icon, SettingGroupContent, Toggle, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {Icon, SettingGroupContent, Toggle} from '@tryghost/admin-x-design-system';
 import {type Setting, getSettingValues, useEditSettings} from '@tryghost/admin-x-framework/api/settings';
 import {getGhostPaths} from '@tryghost/admin-x-framework/helpers';
 import {useGlobalData} from '../../providers/global-data-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useLimiter} from '../../../hooks/use-limiter';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {withErrorBoundary} from '../../error-boundary';
 
 const Network: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {settings} = useGlobalData();

--- a/apps/admin-x-settings/src/components/settings/growth/offers.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import TopLevelGroup from '../../top-level-group';
-import {Button, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {Button} from '@tryghost/admin-x-design-system';
 import {checkStripeEnabled} from '@tryghost/admin-x-framework/api/settings';
 import {getPaidActiveTiers, useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
 import {useBrowseOffers} from '@tryghost/admin-x-framework/api/offers';
 import {useGlobalData} from '../../providers/global-data-provider';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {withErrorBoundary} from '../../error-boundary';
 
 const Offers: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {updateRoute} = useRouting();

--- a/apps/admin-x-settings/src/components/settings/growth/recommendations.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/recommendations.tsx
@@ -3,11 +3,12 @@ import React, {useState} from 'react';
 import RecommendationList from './recommendations/recommendation-list';
 import TopLevelGroup from '../../top-level-group';
 import useSettingGroup from '../../../hooks/use-setting-group';
-import {Button, type ShowMoreData, TabView, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {Button, type ShowMoreData, TabView} from '@tryghost/admin-x-design-system';
 import {keepPreviousData} from '@tanstack/react-query';
 import {useBrowseIncomingRecommendations, useBrowseRecommendations} from '@tryghost/admin-x-framework/api/recommendations';
 import {useReferrerHistory} from '@tryghost/admin-x-framework/api/referrers';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {withErrorBoundary} from '../../error-boundary';
 
 const Recommendations: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {

--- a/apps/admin-x-settings/src/components/settings/growth/recommendations/add-recommendation-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/recommendations/add-recommendation-modal.tsx
@@ -4,8 +4,9 @@ import React, {useEffect, useState} from 'react';
 import {AlreadyExistsError} from '@tryghost/admin-x-framework/errors';
 import {type EditOrAddRecommendation, useCheckRecommendation} from '@tryghost/admin-x-framework/api/recommendations';
 import {type ErrorMessages, useForm} from '@tryghost/admin-x-framework/hooks';
-import {Form, LoadingIndicator, Modal, TextField, dismissAllToasts, formatUrl, showToast} from '@tryghost/admin-x-design-system';
+import {Form, LoadingIndicator, Modal, TextField, dismissAllToasts, showToast} from '@tryghost/admin-x-design-system';
 import {type RoutingModalProps, useRouting} from '@tryghost/admin-x-framework/routing';
+import {formatUrl} from '../../../../utils/format-url';
 
 interface AddRecommendationModalProps {
     recommendation?: EditOrAddRecommendation,

--- a/apps/admin-x-settings/src/components/settings/growth/tips-and-donations.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/tips-and-donations.tsx
@@ -1,9 +1,10 @@
 import React, {useEffect, useState} from 'react';
 import TopLevelGroup from '../../top-level-group';
 import useSettingGroup from '../../../hooks/use-setting-group';
-import {Button, CurrencyField, Heading, Select, SettingGroupContent, confirmIfDirty, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {Button, CurrencyField, Heading, Select, SettingGroupContent, confirmIfDirty} from '@tryghost/admin-x-design-system';
 import {currencySelectGroups, validateCurrencyAmount} from '../../../utils/currency';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
+import {withErrorBoundary} from '../../error-boundary';
 
 // Stripe doesn't allow amounts over 10,000 as a preset amount
 const MAX_AMOUNT = 10_000;

--- a/apps/admin-x-settings/src/components/settings/membership/access.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/access.tsx
@@ -3,12 +3,13 @@ import TopLevelGroup from '../../top-level-group';
 import useSettingGroup from '../../../hooks/use-setting-group';
 import {Banner, Button as ShadeButton} from '@tryghost/shade/components';
 import {type GroupBase, type MultiValue} from 'react-select';
-import {Hint, MultiSelect, type MultiSelectOption, Select, Separator, SettingGroupContent, TextField, showToast, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {Hint, MultiSelect, type MultiSelectOption, Select, Separator, SettingGroupContent, TextField, showToast} from '@tryghost/admin-x-design-system';
 import {RefreshCw} from 'lucide-react';
 import {getSettingValues, isSettingReadOnly, useRegenerateAccessCode} from '@tryghost/admin-x-framework/api/settings';
 import {useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
 import {useGlobalData} from '../../providers/global-data-provider';
 import {useLimiter} from '../../../hooks/use-limiter';
+import {withErrorBoundary} from '../../error-boundary';
 
 const SITE_VISIBILITY_OPTIONS = [
     {

--- a/apps/admin-x-settings/src/components/settings/membership/analytics.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/analytics.tsx
@@ -2,9 +2,10 @@ import React, {useEffect, useState} from 'react';
 import TopLevelGroup from '../../top-level-group';
 import useSettingGroup from '../../../hooks/use-setting-group';
 import {HostLimitError, useLimiter} from '../../../hooks/use-limiter';
-import {Separator, SettingGroupContent, Toggle, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {Separator, SettingGroupContent, Toggle} from '@tryghost/admin-x-design-system';
 import {getSettingValues, isSettingReadOnly} from '@tryghost/admin-x-framework/api/settings';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {withErrorBoundary} from '../../error-boundary';
 
 const Analytics: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {

--- a/apps/admin-x-settings/src/components/settings/membership/gift-subscriptions.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/gift-subscriptions.tsx
@@ -1,7 +1,8 @@
 import React, {useState} from 'react';
 import TopLevelGroup from '../../top-level-group';
-import {Button, Heading, SettingGroupContent, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {Button, Heading, SettingGroupContent} from '@tryghost/admin-x-design-system';
 import {useGlobalData} from '../../providers/global-data-provider';
+import {withErrorBoundary} from '../../error-boundary';
 
 const GiftSubscriptions: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {siteData} = useGlobalData();

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails.tsx
@@ -5,12 +5,13 @@ import WelcomeEmailCustomizeModal from './member-emails/welcome-email-customize-
 import WelcomeEmailModal from './member-emails/welcome-email-modal';
 import useQueryParams from '../../../hooks/use-query-params';
 import {APIError} from '@tryghost/admin-x-framework/errors';
-import {Button, ConfirmationModal, Icon, Table, TableRow, Toggle, showToast, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {Button, ConfirmationModal, Icon, Table, TableRow, Toggle, showToast} from '@tryghost/admin-x-design-system';
 import {WELCOME_EMAIL_SLUGS, type WelcomeEmailType, getDefaultWelcomeEmailRecord, getDefaultWelcomeEmailValues} from './member-emails/default-welcome-email-values';
 import {checkStripeEnabled, getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {useAddAutomatedEmail, useBrowseAutomatedEmails, useEditAutomatedEmail, useVerifyAutomatedEmailSender} from '@tryghost/admin-x-framework/api/automated-emails';
 import {useGlobalData} from '../../providers/global-data-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
+import {withErrorBoundary} from '../../error-boundary';
 import type {AutomatedEmail} from '@tryghost/admin-x-framework/api/automated-emails';
 
 const EmailPreviewRow: React.FC<{

--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/member-email-editor.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/member-email-editor.tsx
@@ -1,5 +1,6 @@
+import ErrorBoundary from '../../../error-boundary';
 import React, {Suspense, useCallback, useMemo, useRef} from 'react';
-import {ErrorBoundary, type KoenigInstance, LoadingIndicator, loadKoenig, useDesignSystem} from '@tryghost/admin-x-design-system';
+import {type KoenigInstance, LoadingIndicator, loadKoenig, useDesignSystem} from '@tryghost/admin-x-design-system';
 import {cn} from '@tryghost/shade/utils';
 import {focusKoenigEditorOnBottomClick, useFramework} from '@tryghost/admin-x-framework';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';

--- a/apps/admin-x-settings/src/components/settings/membership/portal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/portal.tsx
@@ -2,10 +2,11 @@ import FakeLogo from '../../../assets/images/portal-splash-default-logo.png';
 import React from 'react';
 import TopLevelGroup from '../../top-level-group';
 import UserAddIcon from '../../../assets/images/portal-splash-user-add.png';
-import {Button, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {Button} from '@tryghost/admin-x-design-system';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {useGlobalData} from '../../providers/global-data-provider';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {withErrorBoundary} from '../../error-boundary';
 
 const SignupOptionImage: React.FC<{color:string, title: string, price: string}> = ({title, color, price}) => {
     return (

--- a/apps/admin-x-settings/src/components/settings/membership/tiers.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/tiers.tsx
@@ -3,12 +3,13 @@ import React, {useState} from 'react';
 import TiersList from './tiers/tiers-list';
 import TopLevelGroup from '../../top-level-group';
 import clsx from 'clsx';
-import {Button, LimitModal, StripeButton, TabView, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {Button, LimitModal, StripeButton, TabView} from '@tryghost/admin-x-design-system';
 import {HostLimitError, useLimiter} from '../../../hooks/use-limiter';
 import {type Tier, getActiveTiers, getArchivedTiers, useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
 import {checkStripeEnabled} from '@tryghost/admin-x-framework/api/settings';
 import {useGlobalData} from '../../providers/global-data-provider';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {withErrorBoundary} from '../../error-boundary';
 
 const StripeConnectedButton: React.FC<{className?: string; onClick: () => void;}> = ({className, onClick}) => {
     className = clsx(

--- a/apps/admin-x-settings/src/components/settings/site/announcement-bar-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/announcement-bar-modal.tsx
@@ -3,7 +3,7 @@ import NiceModal from '@ebay/nice-modal-react';
 import React, {useRef, useState} from 'react';
 import useSettingGroup from '../../../hooks/use-setting-group';
 import {CheckboxGroup, ColorIndicator, Form, HtmlField, PreviewModalContent, type Tab, showToast} from '@tryghost/admin-x-design-system';
-import {debounce} from '@tryghost/admin-x-design-system';
+import {debounce} from '../../../utils/debounce';
 import {getHomepageUrl} from '@tryghost/admin-x-framework/api/site';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {useBrowsePosts} from '@tryghost/admin-x-framework/api/posts';

--- a/apps/admin-x-settings/src/components/settings/site/announcement-bar.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/announcement-bar.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import TopLevelGroup from '../../top-level-group';
-import {Button, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {Button} from '@tryghost/admin-x-design-system';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {withErrorBoundary} from '../../error-boundary';
 
 const AnnouncementBar: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {updateRoute} = useRouting();

--- a/apps/admin-x-settings/src/components/settings/site/change-theme.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/change-theme.tsx
@@ -1,11 +1,12 @@
 import NiceModal from '@ebay/nice-modal-react';
 import React, {useEffect, useState} from 'react';
 import TopLevelGroup from '../../top-level-group';
-import {Button, Heading, LimitModal, Menu, SettingGroupContent, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {Button, Heading, LimitModal, Menu, SettingGroupContent} from '@tryghost/admin-x-design-system';
 import {type Theme, useBrowseThemes} from '@tryghost/admin-x-framework/api/themes';
 import {downloadFile, getGhostPaths} from '@tryghost/admin-x-framework/helpers';
 import {useCheckThemeLimitError} from '../../../hooks/use-check-theme-limit-error';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {withErrorBoundary} from '../../error-boundary';
 
 const ChangeTheme: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const [themeLimitError, setThemeLimitError] = useState<string|null>(null);

--- a/apps/admin-x-settings/src/components/settings/site/design-setting.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/design-setting.tsx
@@ -1,8 +1,9 @@
 import DesignSettingsImg from '../../../assets/images/design-settings.png';
 import React from 'react';
 import TopLevelGroup from '../../top-level-group';
-import {Button, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {Button} from '@tryghost/admin-x-design-system';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {withErrorBoundary} from '../../error-boundary';
 
 const DesignSetting: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {updateRoute} = useRouting();

--- a/apps/admin-x-settings/src/components/settings/site/navigation.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/navigation.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import TopLevelGroup from '../../top-level-group';
-import {Button, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {Button} from '@tryghost/admin-x-design-system';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {withErrorBoundary} from '../../error-boundary';
 
 const Navigation: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {updateRoute} = useRouting();

--- a/apps/admin-x-settings/src/components/settings/site/navigation/navigation-item-editor.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/navigation/navigation-item-editor.tsx
@@ -1,7 +1,8 @@
 import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
 import {type EditableItem, type NavigationItem, type NavigationItemErrors} from '../../../../hooks/site/use-navigation-editor';
-import {TextField, URLTextField, formatUrl} from '@tryghost/admin-x-design-system';
+import {TextField, URLTextField} from '@tryghost/admin-x-design-system';
+import {formatUrl} from '../../../../utils/format-url';
 
 export type NavigationItemEditorProps = React.HTMLAttributes<HTMLDivElement> & {
     baseUrl: string;

--- a/apps/admin-x-settings/src/hooks/use-setting-group.tsx
+++ b/apps/admin-x-settings/src/hooks/use-setting-group.tsx
@@ -3,7 +3,7 @@ import {type ErrorMessages, type OkProps, type SaveHandler, type SaveState, useF
 import {type Setting, type SettingValue, useEditSettings} from '@tryghost/admin-x-framework/api/settings';
 import {type SiteData} from '@tryghost/admin-x-framework/api/site';
 import {useGlobalData} from '../components/providers/global-data-provider';
-import {useGlobalDirtyState} from '@tryghost/admin-x-design-system';
+import {useGlobalDirtyState} from '@tryghost/shade/utils';
 
 interface LocalSetting extends Setting {
     dirty?: boolean;

--- a/apps/admin-x-settings/src/hooks/use-setting-group.tsx
+++ b/apps/admin-x-settings/src/hooks/use-setting-group.tsx
@@ -3,7 +3,7 @@ import {type ErrorMessages, type OkProps, type SaveHandler, type SaveState, useF
 import {type Setting, type SettingValue, useEditSettings} from '@tryghost/admin-x-framework/api/settings';
 import {type SiteData} from '@tryghost/admin-x-framework/api/site';
 import {useGlobalData} from '../components/providers/global-data-provider';
-import {useGlobalDirtyState} from '@tryghost/shade/utils';
+import {useGlobalDirtyState} from '@tryghost/admin-x-design-system';
 
 interface LocalSetting extends Setting {
     dirty?: boolean;

--- a/apps/admin-x-settings/src/main-content.tsx
+++ b/apps/admin-x-settings/src/main-content.tsx
@@ -2,12 +2,11 @@ import ExitSettingsButton from './components/exit-settings-button';
 import Settings from './components/settings';
 import Sidebar from './components/sidebar';
 import Users from './components/settings/general/users';
-import {Heading, confirmIfDirty, topLevelBackdropClasses} from '@tryghost/admin-x-design-system';
+import {Heading, confirmIfDirty, topLevelBackdropClasses, useGlobalDirtyState} from '@tryghost/admin-x-design-system';
 import {type ReactNode, useEffect} from 'react';
 import {canAccessSettings, isEditorUser} from '@tryghost/admin-x-framework/api/users';
 import {toast} from 'react-hot-toast';
 import {useGlobalData} from './components/providers/global-data-provider';
-import {useGlobalDirtyState} from '@tryghost/shade/utils';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
 
 const EMPTY_KEYWORDS: string[] = [];

--- a/apps/admin-x-settings/src/main-content.tsx
+++ b/apps/admin-x-settings/src/main-content.tsx
@@ -2,11 +2,12 @@ import ExitSettingsButton from './components/exit-settings-button';
 import Settings from './components/settings';
 import Sidebar from './components/sidebar';
 import Users from './components/settings/general/users';
-import {Heading, confirmIfDirty, topLevelBackdropClasses, useGlobalDirtyState} from '@tryghost/admin-x-design-system';
+import {Heading, confirmIfDirty, topLevelBackdropClasses} from '@tryghost/admin-x-design-system';
 import {type ReactNode, useEffect} from 'react';
 import {canAccessSettings, isEditorUser} from '@tryghost/admin-x-framework/api/users';
 import {toast} from 'react-hot-toast';
 import {useGlobalData} from './components/providers/global-data-provider';
+import {useGlobalDirtyState} from '@tryghost/shade/utils';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
 
 const EMPTY_KEYWORDS: string[] = [];

--- a/apps/admin-x-settings/src/utils/debounce.ts
+++ b/apps/admin-x-settings/src/utils/debounce.ts
@@ -1,0 +1,24 @@
+export function debounce<T extends unknown[]>(func: (...args: T) => void, wait: number, immediate: boolean = false): (...args: T) => void {
+    let timeoutId: ReturnType<typeof setTimeout> | null;
+
+    return function (this: unknown, ...args: T): void {
+        const later = () => {
+            timeoutId = null;
+            if (!immediate) {
+                func.apply(this, args);
+            }
+        };
+
+        const callNow = immediate && !timeoutId;
+
+        if (timeoutId) {
+            clearTimeout(timeoutId);
+        }
+
+        timeoutId = setTimeout(later, wait);
+
+        if (callNow) {
+            func.apply(this, args);
+        }
+    };
+}

--- a/apps/admin-x-settings/src/utils/format-url.ts
+++ b/apps/admin-x-settings/src/utils/format-url.ts
@@ -1,0 +1,100 @@
+import isEmail from 'validator/es/lib/isEmail.js';
+
+export const formatUrl = (value: string, baseUrl?: string, nullable?: boolean) => {
+    if (nullable && !value) {
+        return {save: null, display: ''};
+    }
+
+    let url = value.trim();
+
+    if (!url) {
+        if (baseUrl) {
+            return {save: '/', display: baseUrl};
+        }
+        return {save: '', display: ''};
+    }
+
+    // if we have an email address, add the mailto:
+    if (isEmail(url)) {
+        return {save: `mailto:${url}`, display: `mailto:${url}`};
+    }
+
+    const isAnchorLink = url.match(/^#/);
+    if (isAnchorLink) {
+        return {save: url, display: url};
+    }
+
+    const isProtocolRelative = url.match(/^(\/\/)/);
+    if (isProtocolRelative) {
+        return {save: url, display: url};
+    }
+
+    if (!baseUrl) {
+        // Absolute URL with no base URL
+        if (!url.startsWith('http')) {
+            url = `https://${url}`;
+        }
+    }
+
+    // If it doesn't look like a URL, leave it as is rather than assuming it's a pathname etc
+    if (!url.match(/^[a-zA-Z0-9-]+:/) && !url.match(/^(\/|\?)/)) {
+        return {save: url, display: url};
+    }
+
+    let parsedUrl: URL;
+
+    try {
+        parsedUrl = new URL(url, baseUrl);
+    } catch {
+        return {save: url, display: url};
+    }
+
+    if (!baseUrl) {
+        return {save: parsedUrl.toString(), display: parsedUrl.toString()};
+    }
+    const parsedBaseUrl = new URL(baseUrl);
+
+    let isRelativeToBasePath = parsedUrl.pathname && parsedUrl.pathname.indexOf(parsedBaseUrl.pathname) === 0;
+
+    // if our path is only missing a trailing / mark it as relative
+    if (`${parsedUrl.pathname}/` === parsedBaseUrl.pathname) {
+        isRelativeToBasePath = true;
+    }
+
+    const isOnSameHost = parsedUrl.host === parsedBaseUrl.host;
+
+    // if relative to baseUrl, remove the base url before sending to action
+    if (isOnSameHost && isRelativeToBasePath) {
+        url = url.replace(/^[a-zA-Z0-9-]+:/, '');
+        url = url.replace(/^\/\//, '');
+        url = url.replace(parsedBaseUrl.host, '');
+        url = url.replace(parsedBaseUrl.pathname, '');
+
+        if (!url.match(/^\//)) {
+            url = `/${url}`;
+        }
+    }
+
+    if (!url.match(/\/$/) && !url.match(/[.#?]/)) {
+        url = `${url}/`;
+    }
+
+    // we update with the relative URL but then transform it back to absolute
+    // for the input value. This avoids problems where the underlying relative
+    // value hasn't changed even though the input value has
+    return {save: url, display: displayFromBase(url, baseUrl)};
+};
+
+const displayFromBase = (url: string, baseUrl: string) => {
+    // Ensure base url has a trailing slash
+    if (!baseUrl.endsWith('/')) {
+        baseUrl += '/';
+    }
+
+    // Remove leading slash from url
+    if (url.startsWith('/')) {
+        url = url.substring(1);
+    }
+
+    return new URL(url, baseUrl).toString();
+};


### PR DESCRIPTION
## What

Removed the non-visual utility imports of `@tryghost/admin-x-design-system` from `apps/admin-x-settings`:

- **`withErrorBoundary` / `ErrorBoundary` (34 files)** — now a local component at `src/components/error-boundary.tsx`. It replicates the previous implementation exactly (same Sentry reporting with the `adminx_settings_component` tag, same console errors, same fallback message and legacy `Banner color='red'` fallback rendering — Shade's `Banner` variants don't style plain fallback content equivalently, so the banner itself migrates later with the visual components).
- **`debounce` (4 files)** — verbatim local copy at `src/utils/debounce.ts`.
- **`formatUrl` (2 files)** — verbatim local copy at `src/utils/format-url.ts`. The legacy `URLTextField` component keeps using its own internal copy; both are identical, so blur-formatting behavior is unchanged.

`useGlobalDirtyState` stays on the legacy hook: Shade exports a byte-identical copy, but its provider is only mounted by `ShadeApp`, and the standalone settings entry points (`src/index.tsx` / `src/main.tsx`) mount only the legacy `DesignSystemApp` provider — Shade's hook would silently report clean there. It moves once the provider story is unified.

Only these symbols were moved out of the old design system import statements; all other named imports (visual components, `showToast`, `confirmIfDirty`, etc.) are untouched, and `apps/admin-x-design-system` itself is unmodified. Zero visual or behavioral change intended.

## Why

`admin-x-settings` is dropping its dependency on the legacy design system in favor of `@tryghost/shade`. These non-visual utilities are the low-risk portion: they have no styling surface, so they can be decoupled without touching any rendered UI.

## Verification

- `pnpm --filter @tryghost/admin-x-settings lint` — passed
- `pnpm --filter @tryghost/admin-x-settings test:unit` — 19 files, 203 tests passed
- `pnpm --filter @tryghost/admin-x-settings build` — passed
- `grep` confirms zero imports of `withErrorBoundary`, `ErrorBoundary`, `debounce`, or `formatUrl` from `@tryghost/admin-x-design-system` remain in `apps/admin-x-settings/src`
