### PR TITLE
Reworked docker build with pnpm deploy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,7 +28,10 @@ docker
 !docker/**/*.entrypoint.sh
 !docker/**/*entrypoint.sh
 
-ghost/core/core/built/admin
+# NOTE: core/built/admin is intentionally NOT ignored — the production image's
+# `full` stage COPYs it from the build context, where CI injects the admin build
+# artifact. The `core` stage copies from the deploy stage (which never builds
+# admin), so a stray local admin build cannot leak into the core image.
 
 # Ignore local config files (.json and .jsonc)
 ghost/core/config.local.json*

--- a/.github/actions/wait-for-artifact/action.yml
+++ b/.github/actions/wait-for-artifact/action.yml
@@ -1,0 +1,77 @@
+name: 'Wait for artifact'
+description: >-
+  Poll the current workflow run until a named artifact is available, failing fast
+  if the job that produces it has already concluded unsuccessfully. Used to let a
+  job depend on another job's artifact without a `needs` edge (so the two jobs can
+  run concurrently and only synchronise at the point the artifact is consumed).
+inputs:
+  artifact-name:
+    description: 'Name of the artifact to wait for'
+    required: true
+  job-name:
+    description: >-
+      Display name of the job that produces the artifact. Used to fail fast if
+      that job concludes without success (the artifact will never appear).
+    required: true
+  timeout-seconds:
+    description: 'Give up after this many seconds'
+    required: false
+    default: '600'
+  interval-seconds:
+    description: 'Seconds between polls'
+    required: false
+    default: '10'
+  github-token:
+    description: 'Token with actions:read on this repository'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Wait for ${{ inputs.artifact-name }} artifact
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPO: ${{ github.repository }}
+        RUN_ID: ${{ github.run_id }}
+        ARTIFACT_NAME: ${{ inputs.artifact-name }}
+        JOB_NAME: ${{ inputs.job-name }}
+        TIMEOUT: ${{ inputs.timeout-seconds }}
+        INTERVAL: ${{ inputs.interval-seconds }}
+      run: |
+        START=$(date +%s)
+
+        while true; do
+          # --paginate: a run can upload more than 100 artifacts (e2e shards,
+          # package matrices), so the target may be beyond the first page. Emit one
+          # line per matching unexpired artifact and count them; env.ARTIFACT_NAME
+          # is read via jq's env object rather than interpolated into the filter.
+          # On API failure the pipe yields no lines → COUNT=0 → keep waiting.
+          COUNT=$(gh api --paginate "repos/${REPO}/actions/runs/${RUN_ID}/artifacts?per_page=100" \
+            --jq '.artifacts[] | select(.name == env.ARTIFACT_NAME and .expired == false) | .id' 2>/dev/null | wc -l | tr -d '[:space:]')
+
+          if [ "$COUNT" -gt 0 ]; then
+            echo "${ARTIFACT_NAME} artifact is ready"
+            break
+          fi
+
+          # The artifact is never coming if the producing job already finished
+          # without success — fail now instead of waiting out the timeout.
+          # --paginate: the run can exceed 100 jobs (shards + package matrices).
+          # A queued/in-progress job has a null conclusion → empty → keep waiting.
+          CONCLUSION=$(gh api --paginate "repos/${REPO}/actions/runs/${RUN_ID}/jobs?per_page=100" \
+            --jq '.jobs[] | select(.name == env.JOB_NAME) | .conclusion // ""' 2>/dev/null | tail -n1 || echo "")
+          if [ -n "$CONCLUSION" ] && [ "$CONCLUSION" != "success" ]; then
+            echo "::error::${JOB_NAME} concluded '${CONCLUSION}' — the ${ARTIFACT_NAME} artifact will not be produced"
+            exit 1
+          fi
+
+          ELAPSED=$(( $(date +%s) - START ))
+          if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+            echo "::error::Timed out waiting for ${ARTIFACT_NAME} artifact (${TIMEOUT}s)"
+            exit 1
+          fi
+
+          echo "Waiting for ${ARTIFACT_NAME} artifact... (${ELAPSED}s elapsed)"
+          sleep "$INTERVAL"
+        done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -815,7 +815,7 @@ jobs:
 
   job_ghost-cli:
     name: Ghost-CLI tests
-    needs: [job_setup, job_build_artifacts]
+    needs: [job_setup, job_pack]
     if: needs.job_setup.outputs.is_tag == 'true' || needs.job_setup.outputs.changed_core == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -875,27 +875,17 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-  job_build_artifacts:
-    name: Build & Publish Artifacts
-    # NOT gated on job_build_e2e_public_apps: this job's first ~8 min (deps,
-    # build:production, core/full images) don't need the UMD bundles — only the
-    # late "Build & push E2E image" step does. The public-apps job starts after
-    # job_setup (~1.8m) and finishes ~3.2m, long before we reach that step, so we
-    # download its artifact there without a needs edge. Adding the edge here would
-    # delay this job's START until ~3.2m and cancel most of the Option A saving.
+  job_build_admin:
+    name: Build Admin
     needs: [job_setup]
     # Root of the build + browser-E2E lane (see run_e2e in job_setup).
     if: needs.job_setup.outputs.run_e2e == 'true'
     runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          submodules: true
+          persist-credentials: false
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
@@ -906,9 +896,12 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
+        # Admin's nx build fans out across the whole frontend graph (ghost-admin,
+        # admin-x-*, shade, koenig-lexical) via nx dependsOn rather than package
+        # deps, so a filtered install would miss pieces — install the full workspace.
         run: pnpm install --frozen-lockfile
 
-      - name: Build server and admin assets
+      - name: Build admin
         # IS_SHIPPING enables the Sentry vite plugin in koenig-lexical: it
         # injects debug IDs into the built editor bundles and uploads their
         # sourcemaps. Only shippable builds (main + tags in the canonical
@@ -926,13 +919,70 @@ jobs:
             echo "::error::IS_SHIPPING is set but VITE_SENTRY_AUTH_TOKEN is empty — Koenig sourcemaps would not reach Sentry"
             exit 1
           fi
-          PKG_VERSION=$(node -p "require('./ghost/core/package.json').version")
-          SHORT_SHA="${GITHUB_SHA:0:7}"
-          if [ "${{ github.ref_type }}" != "tag" ]; then
-            export GHOST_BUILD_VERSION="${PKG_VERSION}+${SHORT_SHA}"
-            echo "GHOST_BUILD_VERSION=${GHOST_BUILD_VERSION}" >> $GITHUB_ENV
-          fi
-          pnpm build:production
+          # Builds apps/admin/dist AND ghost/core/core/built/admin (asset-delivery).
+          pnpm nx run @tryghost/admin:build
+
+      # The built admin (ghost/core/core/built/admin) is consumed by both job_pack
+      # (packed into the Ghost-CLI archive) and job_docker (COPYed into the full
+      # image). Ship it as a tarball to preserve file modes and speed transfer.
+      - name: Pack admin build
+        run: tar -czf admin-build.tar.gz -C ghost/core/core/built admin
+
+      - name: Upload admin build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: admin-build
+          path: admin-build.tar.gz
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Upload admin artifact for CD
+        id: upload-admin
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: admin-build-cd
+          path: apps/admin/dist
+          retention-days: 7
+          if-no-files-found: error
+
+      - uses: tryghost/actions/actions/slack-build@8293e12a1bd1319dd5bc50ccef4bf82a2ba9029c # main
+        if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        with:
+          status: ${{ job.status }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+    outputs:
+      admin-artifact-id: ${{ steps.upload-admin.outputs.artifact-id }}
+
+  job_pack:
+    name: Build Ghost-CLI archive
+    needs: [job_setup, job_build_admin]
+    # Same availability window as the rest of the build lane; feeds job_ghost-cli
+    # and (on tags) publish_ghost.
+    if: needs.job_setup.outputs.run_e2e == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          # Themes (content/themes/casper|source) are submodules packed into the
+          # archive — without them the tarball ships empty theme dirs.
+          submodules: true
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        env:
+          FORCE_COLOR: 0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        # pack only needs ghost and its dependency subgraph (dev deps included, to
+        # build the prod closure below) — not the whole monorepo.
+        run: pnpm install --frozen-lockfile --filter "ghost..."
 
       - name: Verify tag matches package.json
         if: startsWith(github.ref, 'refs/tags/v')
@@ -945,8 +995,30 @@ jobs:
             exit 1
           fi
 
+      - name: Build production closure and server
+        # pack.mjs's `pnpm pack` only tars existing build/ output; it does not build.
+        # Build ghost's prod workspace closure (kg-*/adapters; i18n has no build
+        # script) + ghost's own server output first. nx-free recursive filters.
+        run: |
+          pnpm --filter-prod "ghost^..." -r run build
+          pnpm --filter ghost run build:tsc
+          pnpm --filter ghost run build:assets
+
+      - name: Download admin build
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: admin-build
+
+      - name: Extract admin build
+        # The archive includes core/built/admin via ghost/core's files allowlist.
+        run: |
+          mkdir -p ghost/core/core/built
+          tar -xzf admin-build.tar.gz -C ghost/core/core/built
+
       - name: Build standalone distribution
-        run: pnpm --filter ghost archive
+        # Invoke the pack script directly (not `nx run ghost:archive`, whose
+        # dependsOn would rebuild admin/tsc/assets we already have).
+        run: pnpm --filter ghost run archive
 
       - name: Upload npm tarball
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -956,8 +1028,44 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
-      - name: Prepare Docker build context
-        run: mv ghost/core/package/ /tmp/ghost-production/
+      - uses: tryghost/actions/actions/slack-build@8293e12a1bd1319dd5bc50ccef4bf82a2ba9029c # main
+        if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        with:
+          status: ${{ job.status }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  job_docker:
+    name: Build Docker Images
+    # NOT gated on job_build_admin or job_build_e2e_public_apps: the core image
+    # needs neither. It builds concurrently and only synchronises on the admin
+    # artifact (via wait-for-artifact) just before the full image, and on the
+    # e2e-public-apps artifact just before the E2E image.
+    needs: [job_setup]
+    # Root of the build + browser-E2E lane (see run_e2e in job_setup).
+    if: needs.job_setup.outputs.run_e2e == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          # The deploy stage packs content/themes/casper|source (submodules).
+          submodules: true
+
+      - name: Determine build version
+        # Baked into the images as GHOST_BUILD_VERSION (server-reported version).
+        # Empty on tags → the ARG default "" is used. No node/pnpm setup in this
+        # job (the build is in-container), so read the version with jq.
+        run: |
+          if [ "${{ github.ref_type }}" != "tag" ]; then
+            PKG_VERSION=$(jq -r .version ghost/core/package.json)
+            echo "GHOST_BUILD_VERSION=${PKG_VERSION}+${GITHUB_SHA:0:7}" >> $GITHUB_ENV
+          fi
 
       - name: Determine push strategy
         id: strategy
@@ -999,15 +1107,6 @@ jobs:
           echo "image-core-name=$IMAGE_CORE_NAME" >> $GITHUB_OUTPUT
           echo "image-full-name=$IMAGE_FULL_NAME" >> $GITHUB_OUTPUT
           echo "image-e2e-name=${IMAGE_FULL_NAME}-e2e" >> $GITHUB_OUTPUT
-
-      - name: Upload admin artifact for CD
-        id: upload-admin
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: admin-build-cd
-          path: apps/admin/dist
-          retention-days: 7
-          if-no-files-found: error
 
       - name: Setup Docker Registry Mirrors
         uses: ./.github/actions/setup-docker-registry-mirrors
@@ -1064,7 +1163,10 @@ jobs:
         env:
           BUILDKIT_PROGRESS: plain
         with:
-          context: /tmp/ghost-production
+          # Context is the repo root: the Dockerfile deploy stage runs `pnpm deploy`
+          # against the workspace. core needs no admin, so it builds now while
+          # job_build_admin runs concurrently.
+          context: .
           file: Dockerfile.production
           target: core
           build-args: |
@@ -1077,12 +1179,42 @@ jobs:
           cache-from: type=registry,ref=${{ steps.strategy.outputs.image-core-name }}:cache-main
           cache-to: ${{ steps.strategy.outputs.should-push == 'true' && format('type=registry,ref={0}:cache-{1},mode=max', steps.strategy.outputs.image-core-name, github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'main') || '' }}
 
+      # Synchronise with job_build_admin only now, after core is built: the full
+      # image is core + admin. No `needs` edge, so the two jobs run concurrently
+      # and core builds during the wait.
+      - name: Wait for admin build
+        uses: ./.github/actions/wait-for-artifact
+        with:
+          artifact-name: admin-build
+          job-name: Build Admin
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download admin build
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: admin-build
+          # Outside the build context: a stray admin-build.tar.gz in the repo root
+          # would change the `.` context between the core and full builds and bust
+          # the deploy-stage COPY cache, re-running the whole closure build.
+          path: ${{ runner.temp }}/admin-artifact
+
+      - name: Extract admin build into context
+        # The full stage COPYs ghost/core/core/built/admin from the context; the
+        # deploy stage excludes core/built entirely, so admin never leaks into core
+        # and adding it is the only context change between the core and full builds.
+        run: |
+          mkdir -p ghost/core/core/built
+          tar -xzf "${RUNNER_TEMP}/admin-artifact/admin-build.tar.gz" -C ghost/core/core/built
+
       - name: Build & push full image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         env:
           BUILDKIT_PROGRESS: plain
         with:
-          context: /tmp/ghost-production
+          # Same repo-root context as core (admin now present at
+          # ghost/core/core/built/admin, excluded by the deploy stage) so the
+          # deploy/install/build layers cache-hit from the core build above.
+          context: .
           file: Dockerfile.production
           target: full
           build-args: |
@@ -1189,42 +1321,11 @@ jobs:
 
       - name: Wait for public app artifacts (e2e)
         continue-on-error: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          TIMEOUT=600
-          INTERVAL=10
-          START=$(date +%s)
-
-          while true; do
-            COUNT=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts?per_page=100" \
-              --jq '[.artifacts[] | select(.name == "e2e-public-apps" and .expired == false)] | length' 2>/dev/null || echo "0")
-
-            if [ "$COUNT" -gt 0 ]; then
-              echo "e2e-public-apps artifact is ready"
-              break
-            fi
-
-            # The artifact is never coming if the producing job already finished
-            # without success — fail now instead of waiting out the timeout.
-            # --paginate: the run can exceed 100 jobs (e2e shards + package matrices).
-            # A queued/in-progress job has a null conclusion → empty → keep waiting.
-            CONCLUSION=$(gh api --paginate "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?per_page=100" \
-              --jq '.jobs[] | select(.name == "Build E2E Public App Assets") | .conclusion // ""' 2>/dev/null | tail -n1 || echo "")
-            if [ -n "$CONCLUSION" ] && [ "$CONCLUSION" != "success" ]; then
-              echo "::error::Build E2E Public App Assets concluded '${CONCLUSION}' — the e2e-public-apps artifact will not be produced"
-              exit 1
-            fi
-
-            ELAPSED=$(( $(date +%s) - START ))
-            if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
-              echo "::error::Timed out waiting for e2e-public-apps artifact (${TIMEOUT}s)"
-              exit 1
-            fi
-
-            echo "Waiting for e2e-public-apps artifact... (${ELAPSED}s elapsed)"
-            sleep "$INTERVAL"
-          done
+        uses: ./.github/actions/wait-for-artifact
+        with:
+          artifact-name: e2e-public-apps
+          job-name: Build E2E Public App Assets
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Extract into a clean staging dir and build from there: the tarball holds
       # exactly the apps/*/umd paths the Dockerfile COPYs, while the workspace at
@@ -1323,7 +1424,6 @@ jobs:
 
     outputs:
       use-artifact: ${{ steps.strategy.outputs.use-artifact }}
-      admin-artifact-id: ${{ steps.upload-admin.outputs.artifact-id }}
       image-e2e-name: ${{ steps.strategy.outputs.image-e2e-name }}
       image-e2e-tags: ${{ steps.meta-e2e.outputs.tags }}
 
@@ -1379,10 +1479,10 @@ jobs:
   job_e2e_tests:
     name: E2E Tests (${{ matrix.projectName }} ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
     runs-on: ubuntu-latest
-    needs: [job_build_artifacts, job_setup]
-    # Inherits the run_e2e gate transitively via job_build_artifacts (which now
-    # also builds the ghost-e2e image).
-    if: needs.job_build_artifacts.result == 'success'
+    needs: [job_docker, job_setup]
+    # Inherits the run_e2e gate transitively via job_docker (which builds the
+    # ghost-e2e image).
+    if: needs.job_docker.result == 'success'
     strategy:
       fail-fast: true
       matrix:
@@ -1474,8 +1574,8 @@ jobs:
         uses: ./.github/actions/load-docker-image
         id: load
         with:
-          use-artifact: ${{ needs.job_build_artifacts.outputs.use-artifact }}
-          image-tags: ${{ needs.job_build_artifacts.outputs.image-e2e-tags }}
+          use-artifact: ${{ needs.job_docker.outputs.use-artifact }}
+          image-tags: ${{ needs.job_docker.outputs.image-e2e-tags }}
           artifact-name: docker-image-e2e
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -1688,7 +1788,9 @@ jobs:
         job_migration_integrity_check,
         job_lint,
         job_i18n,
-        job_build_artifacts,
+        job_build_admin,
+        job_pack,
+        job_docker,
         job_ghost-cli,
         job_admin-tests,
         job_unit-tests,
@@ -1813,15 +1915,16 @@ jobs:
   # Trigger Pro CD — dispatch to Ghost-Moya cd.yml (runs on main + PRs)
   # --------------------------------------------------------------------------- #
   trigger_cd:
-    needs: [job_setup, job_build_artifacts]
+    needs: [job_setup, job_build_admin, job_docker]
     name: Trigger Pro CD
     runs-on: ubuntu-slim
     if: |
       always()
       && github.repository == 'TryGhost/Ghost'
       && needs.job_setup.result == 'success'
-      && needs.job_build_artifacts.result == 'success'
-      && needs.job_build_artifacts.outputs.use-artifact != 'true'
+      && needs.job_build_admin.result == 'success'
+      && needs.job_docker.result == 'success'
+      && needs.job_docker.outputs.use-artifact != 'true'
     steps:
       - name: Determine dispatch parameters
         id: params
@@ -1859,7 +1962,7 @@ jobs:
               "source_repo": "${{ github.repository }}",
               "pr_number": "${{ steps.params.outputs.pr_number }}",
               "deploy": "${{ steps.params.outputs.deploy }}",
-              "admin_artifact_id": "${{ needs.job_build_artifacts.outputs.admin-artifact-id }}",
+              "admin_artifact_id": "${{ needs.job_build_admin.outputs.admin-artifact-id }}",
               "admin_artifact_run_id": "${{ github.run_id }}"
             }
 
@@ -2046,7 +2149,7 @@ jobs:
   # --------------------------------------------------------------------------- #
   notify_release_failure:
     name: Notify release failure
-    needs: [job_setup, job_build_artifacts, job_ghost-cli, publish_ghost, publish_koenig_packages, create_github_release]
+    needs: [job_setup, job_build_admin, job_pack, job_docker, job_ghost-cli, publish_ghost, publish_koenig_packages, create_github_release]
     if: failure() && startsWith(github.ref, 'refs/tags/v') && github.repository == 'TryGhost/Ghost'
     runs-on: ubuntu-slim
     permissions: {}  # only posts to Slack via curl; needs no GITHUB_TOKEN scopes

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -64,9 +64,9 @@ jobs:
               if [ "$CONCLUSION" = "success" ] || [ "$CONCLUSION" = "failure" ]; then
                 # Check if Docker build job specifically succeeded (paginate — CI has 30+ jobs)
                 BUILD_JOB=$(gh api --paginate "repos/${{ github.repository }}/actions/runs/${RUN_ID}/jobs?per_page=100" \
-                  --jq '.jobs[] | select(.name == "Build & Publish Artifacts") | .conclusion')
+                  --jq '.jobs[] | select(.name == "Build Docker Images") | .conclusion')
                 if [ -z "$BUILD_JOB" ]; then
-                  echo "::error::Build & Publish Artifacts job not found in CI run ${RUN_ID}"
+                  echo "::error::Build Docker Images job not found in CI run ${RUN_ID}"
                   exit 1
                 elif [ "$BUILD_JOB" = "success" ]; then
                   echo "Docker build ready (CI run $RUN_ID)"

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Wait for Docker build job
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BUILD_JOB_NAME: Build & Publish Artifacts
+          BUILD_JOB_NAME: Build Docker Images
         run: |
           echo "Waiting for '${BUILD_JOB_NAME}' job to complete for $HEAD_SHA..."
           TIMEOUT=1800  # 30 minutes

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -2,11 +2,16 @@
 
 # Production Dockerfile for Ghost
 # Targets:
-#   deps — production node_modules only (build-only stage, never shipped)
+#   deploy — build the prod dependency closure + a self-contained /home/ghost
+#            (build-only stage, never shipped)
 #   core — server + production deps, no admin (Ghost-Pro base)
 #   full — core + built admin (self-hosting)
 #
-# Build context: extracted `npm pack` output from ghost/core
+# Build context: the monorepo repo root. The deploy stage runs `pnpm deploy`
+# against the workspace to produce a self-contained app dir (source + resolved
+# node_modules), so this image no longer depends on the `pnpm pack` output that
+# Ghost-CLI uses (scripts/pack.mjs). The `full` stage's admin build is injected
+# into the context by CI at core/built/admin.
 #
 # Ownership model: application code (node_modules, server source, admin) is owned
 # by nobody:nogroup so the runtime user (ghost, uid 1000) can read but not modify
@@ -18,24 +23,60 @@
 
 ARG NODE_VERSION=22.23.1
 
-# ---- deps: production node_modules (build-only stage, not shipped) ----
-FROM node:$NODE_VERSION-bookworm-slim AS deps
+# ---- deploy: build closure + self-contained app dir (build-only, not shipped) ----
+FROM node:$NODE_VERSION-bookworm-slim AS deploy
 
-WORKDIR /home/ghost
+WORKDIR /build
 
 RUN corepack enable
 
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-COPY components ./components
+# Full workspace source is needed so pnpm can resolve the workspace graph for the
+# `ghost...` filter. .dockerignore prunes node_modules/build/dist/.git/.nx so the
+# build starts from a clean tree and rebuilds outputs in-container.
+#
+# --exclude core/built: for the `full` target CI injects the admin build into the
+# context at ghost/core/core/built/admin. Excluding the whole built dir (not just
+# built/admin — the built dir itself is absent on a fresh checkout, so excluding
+# only its child would still leave a differing directory entry) keeps this COPY
+# layer's hash identical between the core and full builds. That lets `full` reuse
+# `core`'s cached deploy/install/build layers instead of re-running the whole
+# closure build, and keeps admin out of the deploy output so `core` stays
+# admin-free. The server's own core/built output is regenerated in-container by the
+# build steps below, so nothing is lost by excluding the host copy.
+COPY --exclude=ghost/core/core/built . .
 
-# build-essential/python3 are only needed to compile native deps (better-sqlite3).
-# Because this stage is discarded, they never reach the shipped image, so there's
-# no purge step to keep the layer clean.
+# Install only ghost and its dependency subgraph (`ghost...`), not the whole
+# monorepo (admin, apps, ...). Dev deps are included — tsc etc. are needed to build
+# the closure. Scripts are NOT ignored: better-sqlite3's install script runs and
+# prebuild-install fetches its prebuilt binary (permitted by allowBuilds in
+# pnpm-workspace.yaml). No build-essential/python3 is installed, so a node-gyp
+# source-compile fallback fails loudly instead of silently pulling a toolchain into
+# a discarded layer.
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store,id=pnpm-store \
-    apt-get update && \
-    apt-get install -y --no-install-recommends build-essential python3 && \
-    pnpm install --frozen-lockfile --ignore-scripts --prod --prefer-offline && \
-    (cd node_modules/better-sqlite3 && npm run install)
+    pnpm install --filter "ghost..." --frozen-lockfile --prefer-offline
+
+# Build ghost's production workspace dependency closure (kg-*/adapters; @tryghost/i18n
+# has no build script and is skipped) plus ghost's own server output. Driven with
+# pnpm recursive filters rather than nx to avoid the NX_NATIVE_COMMAND_RUNNER
+# segfault workaround inside the container.
+RUN pnpm --filter-prod "ghost^..." -r run build && \
+    pnpm --filter ghost run build:tsc && \
+    pnpm --filter ghost run build:assets
+
+# Produce a self-contained deploy dir: ghost/core's `files` set + a fully resolved,
+# production-only node_modules (devDeps pruned, optional better-sqlite3 kept). Admin
+# is never built here, so core/built/admin is absent — the core image stays
+# admin-free and the full stage injects admin from the build context.
+#
+# inject-workspace-packages: hard-copy the workspace deps (kg-*/adapters/i18n) into
+# node_modules instead of linking them back to the workspace. The deploy dir is
+# COPYed into the runtime image away from the workspace, so links would dangle.
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store,id=pnpm-store \
+    pnpm --filter=ghost --config.inject-workspace-packages=true deploy --prod /home/ghost
+
+# Fail the build now if the native module didn't install correctly (missing/broken
+# prebuilt binary) rather than at container runtime.
+RUN cd /home/ghost && node -e "require('better-sqlite3'); console.log('better-sqlite3 OK')"
 
 # ---- Core: server + production deps ----
 FROM node:$NODE_VERSION-bookworm-slim AS core
@@ -51,12 +92,10 @@ RUN apt-get update && \
 
 WORKDIR /home/ghost
 
-RUN corepack enable
-
-# node_modules is compiled in the deps stage and copied once with its final
-# ownership — no separate `chown -R` layer, so it isn't duplicated in the image.
-COPY --chown=nobody:nogroup --from=deps /home/ghost/node_modules ./node_modules
-COPY --chown=nobody:nogroup --exclude=core/built/admin . .
+# The deploy stage produced a self-contained app dir (server source + resolved
+# node_modules, no admin). Copy it once with its final ownership — no separate
+# `chown -R` layer, so node_modules isn't duplicated in the image.
+COPY --chown=nobody:nogroup --from=deploy /home/ghost ./
 
 # cp -a preserves the nobody:nogroup ownership set at COPY time, so base_content
 # and default need no re-chown; only the writable content/log dirs flip to ghost.
@@ -82,5 +121,9 @@ CMD ["node", "index.js"]
 FROM core AS full
 
 # COPY --chown sets ownership in the copy layer; a post-hoc `chown -R` would
-# duplicate the ~80MB admin build into a second layer.
-COPY --chown=nobody:nogroup core/built/admin core/built/admin
+# duplicate the ~80MB admin build into a second layer. Admin is injected into the
+# build context by CI (downloaded from the admin build job) at
+# ghost/core/core/built/admin — the deploy stage excludes that path, so this is the
+# only stage that carries admin. Local `full` builds must populate that path first
+# (e.g. `pnpm nx run @tryghost/admin:build`).
+COPY --chown=nobody:nogroup ghost/core/core/built/admin core/built/admin

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0-private",
   "description": "The professional publishing platform",
   "private": true,
-  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
+  "packageManager": "pnpm@11.13.0+sha512.88d94724d8f2e6c186744a5584c6e59ecac869ec7ba15e9cb4cd628e8dc7066820b2481d8ee3b51ea8da323a7378068aa58c556a3720d32b7c20a051d088363a",
   "engines": {
     "node": "^22.23.1"
   },


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLA-53/streamline-packjs-release-tarball-build-pipeline
- split build_artifacts job into separate admin/pack/docker build jobs
- streamline docker build with pnpm deploy
- extract artifact_wait step into reusable action
- bump pnpm to 11.13.0