### PR TITLE
Fixed flaky announcement bar acceptance tests

### DIFF
--- a/apps/admin-x-settings/test/acceptance/site/announcementbar.test.ts
+++ b/apps/admin-x-settings/test/acceptance/site/announcementbar.test.ts
@@ -1,5 +1,14 @@
-import {type ElementHandle, expect, test} from '@playwright/test';
+import {type ElementHandle, type Page, expect, test} from '@playwright/test';
 import {globalDataRequests, mockApi, mockSitePreview, responseFixtures} from '@tryghost/admin-x-framework/test/acceptance';
+
+const openAnnouncementBarModal = async (page: Page) => {
+    await page.getByTestId('announcement-bar').getByRole('button', {name: 'Customize'}).click();
+    const modal = page.getByTestId('announcement-bar-modal');
+    // Opening lazily imports the modals chunk; a cold dev server can take
+    // longer than the default 5s expect timeout to serve that module graph
+    await expect(modal).toBeVisible({timeout: 20000});
+    return modal;
+};
 
 test.describe('Announcement Bar', async () => {
     test('Working with the announcement bar preview', async ({page}) => {
@@ -20,11 +29,7 @@ test.describe('Announcement Bar', async () => {
 
         await page.goto('/#/settings/announcement-bar');
 
-        const section = page.getByTestId('announcement-bar');
-
-        await section.getByRole('button', {name: 'Customize'}).click();
-        const modal = page.getByTestId('announcement-bar-modal');
-        await expect(modal).toBeVisible();
+        const modal = await openAnnouncementBarModal(page);
         await expect(modal.getByTestId('announcement-bar-preview-iframe')).toBeVisible();
 
         const checkTextInIframes = async (iframesHandles: ElementHandle[], textToSearch: string) => {
@@ -42,16 +47,20 @@ test.describe('Announcement Bar', async () => {
             return textExists;
         };
 
-        const iframesHandleHome = await modal.getByTestId('announcement-bar-preview-iframe').locator('iframe').elementHandles();
-        const textExistsInHomeIframes = await checkTextInIframes(iframesHandleHome, 'homepage preview');
-        expect(textExistsInHomeIframes).toBeTruthy();
+        // The preview content is fetched and written into the iframes
+        // asynchronously, so poll instead of checking a single snapshot
+        await expect(async () => {
+            const iframesHandleHome = await modal.getByTestId('announcement-bar-preview-iframe').locator('iframe').elementHandles();
+            expect(await checkTextInIframes(iframesHandleHome, 'homepage preview')).toBeTruthy();
+        }).toPass({timeout: 10000});
 
         await modal.getByTestId('design-toolbar').getByRole('tab', {name: 'Post'}).click();
         await expect(modal.getByTestId('announcement-bar-preview-iframe')).toBeVisible();
 
-        const iframesHandlePost = await modal.getByTestId('announcement-bar-preview-iframe').locator('iframe').elementHandles();
-        const textExistsInPostIframes = await checkTextInIframes(iframesHandlePost, 'post preview');
-        expect(textExistsInPostIframes).toBeTruthy();
+        await expect(async () => {
+            const iframesHandlePost = await modal.getByTestId('announcement-bar-preview-iframe').locator('iframe').elementHandles();
+            expect(await checkTextInIframes(iframesHandlePost, 'post preview')).toBeTruthy();
+        }).toPass({timeout: 10000});
     });
 
     // TODO - lexical isn't loading in the preview
@@ -88,15 +97,11 @@ test.describe('Announcement Bar', async () => {
 
         await page.goto('/#/settings/announcement-bar');
 
-        const section = page.getByTestId('announcement-bar');
-
-        await section.getByRole('button', {name: 'Customize'}).click();
+        const modal = await openAnnouncementBarModal(page);
 
         const labelElement = page.locator('label:text("Background color")');
 
         await expect(labelElement).toHaveCount(1);
-
-        const modal = page.getByTestId('announcement-bar-modal');
 
         // Check the titles of the buttons.
         // Get the parent div of the label
@@ -134,15 +139,11 @@ test.describe('Announcement Bar', async () => {
 
         await page.goto('/#/settings/announcement-bar');
 
-        const section = page.getByTestId('announcement-bar');
-
-        await section.getByRole('button', {name: 'Customize'}).click();
+        const modal = await openAnnouncementBarModal(page);
 
         const labelElement = page.locator('h6:text("Visibility")');
 
         await expect(labelElement).toHaveCount(1);
-
-        const modal = page.getByTestId('announcement-bar-modal');
 
         // get checkbox input with value of free_members
 


### PR DESCRIPTION
## The race

`test/acceptance/site/announcementbar.test.ts` failed intermittently (passing on retry), most often on "Working with the announcement bar preview".

Opening the announcement bar modal goes through `RoutingProvider` (`apps/admin-x-framework/src/providers/routing-provider.tsx`), which lazily `import()`s the settings modals module (`src/components/providers/routing/modals.tsx` — a graph of ~25 modal components). Acceptance tests run against a freshly started Vite dev server shared by all parallel workers, so the first Customize click pays the full cold-transform cost of that module graph. When that takes longer than Playwright's default 5s expect timeout, the first post-click assertion (`toBeVisible` on the modal, or `toHaveCount` on a label inside it) times out before `NiceModal.show` ever runs. Retries pass because the module graph is warm by then.

The same test also sampled the preview iframes' text exactly once (`elementHandles` + `$eval` + non-retrying `expect(...).toBeTruthy()`), racing the async fetch + `document.write` pipeline that populates them.

## Evidence

Reproduced with `--repeat-each --retries=0 --trace=retain-on-failure` while the CPU was saturated (12 busy-loop processes) to widen the timing window:

- 1/25 failed: `expect(getByTestId('announcement-bar-modal')).toBeVisible()` timed out at 5s
- 1/45 failed: `expect(label:text("Background color")).toHaveCount(1)` timed out at 5s (same race in "Can toggle colours")

Both failing traces show the same thing: the Customize click succeeds, then the dev server takes **5.8s / 7.7s** just to serve `modals.tsx`, and `announcement-bar-modal.tsx` (plus ~24 sibling modal files) is still loading when the page closes on assertion timeout. Unloaded, the tests passed 200+ consecutive runs — this only tips over on a cold, contended dev server, which matches full-suite runs and first runs on a busy machine.

## The fix

Test-side synchronization only (no product race — production serves a prebuilt bundle):

- Each test now opens the modal via a shared helper that waits for the modal with a 20s timeout, covering the cold chunk load. Condition-based wait, no sleeps.
- The one-shot iframe text checks now poll with `expect(async () => …).toPass()`, so they retry until the fetched preview content has been written into an iframe instead of asserting on a single snapshot.

## Verification

After the fix, under the same CPU saturation that reproduced the failures:

- `--repeat-each=25 --retries=0 --workers=10` on the spec: **75/75 passed** (25 repeats x 3 tests), fresh dev server each run
- Full `test/acceptance/site/` under load: **48/48 passed**
- Full `test/acceptance/site/` unloaded: **48/48 passed**
- `pnpm --filter @tryghost/admin-x-settings lint` passes