### PR TITLE
Changed email rendering to interpret segments at a single boundary

### DIFF
--- a/ghost/core/core/server/services/email-service/email-renderer.js
+++ b/ghost/core/core/server/services/email-service/email-renderer.js
@@ -17,7 +17,7 @@ const EmailAddressParser = require('../email-address/email-address-parser');
 const {getEmailDesign} = require('../email-rendering/email-design');
 const {registerHelpers} = require('./helpers/register-helpers');
 const crypto = require('crypto');
-const {getPostAccessFilter} = require('../members/content-gating');
+const {checkSegmentPostAccess, getPostAccessFilter} = require('../members/content-gating');
 const {mobiledocToLexical} = require('@tryghost/kg-converters');
 /** @import {TemplateDelegate} from 'handlebars' */
 
@@ -131,12 +131,10 @@ function getSegmentStatus(segment) {
 
 /**
  * Whether the members matched by a segment can read the post's gated content.
- * Derived from the post's visibility (not just free/paid): for paid posts the
- * access segment is the paid one; for tier-restricted posts it's the segment
- * carrying the post's positive tier filter. A null segment is an unsegmented
- * render — the send pipeline only produces one for posts without gated content,
- * and API previews without a memberSegment expect the full body — so it always
- * has access.
+ * Delegates to the shared content-gating check so email and web gating stay in
+ * sync. A null segment is an unsegmented render — the send pipeline only
+ * produces one for posts without gated content, and API previews without a
+ * memberSegment expect the full body — so it always has access.
  * @param {Post} post
  * @param {Segment} segment
  * @returns {boolean}
@@ -149,13 +147,16 @@ function segmentHasPostAccess(post, segment) {
     if (!segment) {
         return true;
     }
-    const accessFilter = getPostAccessFilter(getPostGatingShape(post));
-    if (!accessFilter) {
-        // misconfigured tiers post (no tiers) -> nobody has access
-        return false;
-    }
-    return segment.includes(accessFilter);
+    return checkSegmentPostAccess(getPostGatingShape(post), segment);
 }
+
+/**
+ * @typedef {object} SegmentAudience
+ * @prop {string|null} status - the free/paid audience axis ('status:free' /
+ *   'status:-free', the data-gh-segment card vocabulary), null for mixed
+ * @prop {boolean} hasPostAccess - whether this audience can read the post's
+ *   gated content
+ */
 
 /**
  * @param {Readonly<Date>} date
@@ -488,6 +489,23 @@ class EmailRenderer {
         return segment;
     }
 
+    /**
+     * Interprets a member segment into the audience facts rendering needs.
+     * Segments are persisted on email batches and arrive free-form via the
+     * preview APIs, so audience semantics must be derivable from the string —
+     * this is the only place that derives them; everything downstream reads the
+     * descriptor instead of re-parsing the segment.
+     * @param {Post} post
+     * @param {Segment} segment
+     * @returns {SegmentAudience}
+     */
+    describeSegment(post, segment) {
+        return {
+            status: getSegmentStatus(segment),
+            hasPostAccess: segmentHasPostAccess(post, segment)
+        };
+    }
+
     async renderPostBaseHtml(post, newsletter) {
         const postUrl = this.#getPostUrl(post);
 
@@ -515,6 +533,8 @@ class EmailRenderer {
      * @returns {Promise<EmailBody>}
      */
     async renderBody(post, newsletter, segment, options) {
+        const audience = this.describeSegment(post, segment);
+
         let html = await this.renderPostBaseHtml(post, newsletter);
 
         // Paywall and members only content handling
@@ -525,9 +545,8 @@ class EmailRenderer {
 
         // Members without access to the gated content (free members, or members
         // on a tier that can't read this post) get the public preview + paywall,
-        // exactly as on the web. Access is derived from the post's visibility,
-        // not just free/paid.
-        if (isPaidPost && hasMembersOnlyContent && !segmentHasPostAccess(post, segment)) {
+        // exactly as on the web.
+        if (isPaidPost && hasMembersOnlyContent && !audience.hasPostAccess) {
             // Add paywall
             addPaywall = true;
 
@@ -542,12 +561,10 @@ class EmailRenderer {
         // using the HTML and we don't want to include content that should not be
         // visible depending on the segment
         // data-gh-segment cards are a free/paid-only axis, independent of tier
-        // access. Match them against this segment's free/paid status rather than
-        // the raw segment filter (which may carry a tier expression).
-        const segmentStatus = getSegmentStatus(segment);
+        // access, so they match against the audience's status
         $('[data-gh-segment]').get().forEach((node) => {
             // TODO: replace with NQL interpretation
-            if (node.attribs['data-gh-segment'] !== segmentStatus) {
+            if (node.attribs['data-gh-segment'] !== audience.status) {
                 $(node).remove();
             } else {
                 // Getting rid of the attribute for a cleaner html output
@@ -562,7 +579,7 @@ class EmailRenderer {
             newsletter,
             html,
             addPaywall,
-            segment
+            audience
         });
         html = await this.renderTemplate(templateData);
 
@@ -1085,21 +1102,21 @@ class EmailRenderer {
     /**
      * Get email preheader text from post model
      * @param {Post} postModel
-     * @param {Segment} segment
+     * @param {SegmentAudience} audience
      * @param {string} html
      * @returns {string}
      */
-    #getEmailPreheader(postModel, segment, html) {
+    #getEmailPreheader(postModel, audience, html) {
         let plaintext = postModel.get('plaintext');
         let customExcerpt = postModel.get('custom_excerpt');
         if (customExcerpt) {
             return customExcerpt;
         } else {
             if (plaintext) {
-                // The plaintext field on the model may contain paid only content
-                // so we use the provided HTML to generate the plaintext as this
-                // should have already had the paid content removed
-                if (segment === 'status:free') {
+                // The plaintext field on the model may contain gated content
+                // the audience can't read, so regenerate from the provided
+                // HTML (already gated) whenever this audience lacks access
+                if (audience.status === 'status:free' || !audience.hasPostAccess) {
                     plaintext = htmlToPlaintext.email(html);
                 }
                 return plaintext.substring(0, 500);
@@ -1149,9 +1166,9 @@ class EmailRenderer {
      * @param {Newsletter} options.newsletter
      * @param {string} options.html
      * @param {boolean} options.addPaywall
-     * @param {string} options.segment
+     * @param {SegmentAudience} options.audience
      */
-    async getTemplateData({post, newsletter, html, addPaywall, segment}) {
+    async getTemplateData({post, newsletter, html, addPaywall, audience}) {
         const emailDesign = this.#getEmailDesign(newsletter);
 
         const {href: headerImage, width: headerImageWidth} = await this.limitImageWidth(newsletter.get('header_image'));
@@ -1258,7 +1275,7 @@ class EmailRenderer {
                 locale,
                 direction
             },
-            preheader: this.#getEmailPreheader(post, segment, html),
+            preheader: this.#getEmailPreheader(post, audience, html),
             preheaderSpacing: `${'&#8199;&#847; '.repeat(150)}${'&shy; '.repeat(200)} &nbsp;`,
             html,
 

--- a/ghost/core/core/server/services/email-service/email-service.js
+++ b/ghost/core/core/server/services/email-service/email-service.js
@@ -353,10 +353,11 @@ class EmailService {
     }
 
     /**
-     * @params {string} [segment]
+     * @params {string|null} [audienceStatus] - the audience's free/paid status
+     *   ('status:free' / 'status:-free'), see EmailRenderer#describeSegment
      * @return {import('./email-renderer').MemberLike}
      */
-    getDefaultExampleMember(segment) {
+    getDefaultExampleMember(audienceStatus) {
         /**
          * @type {import('./email-renderer').MemberLike}
          */
@@ -366,8 +367,8 @@ class EmailService {
             email: 'jamie@example.com',
             name: 'Jamie Larson',
             createdAt: new Date(),
-            status: segment === 'status:free' ? 'free' : 'paid',
-            subscriptions: segment === 'status:free' ? [] : [
+            status: audienceStatus === 'status:free' ? 'free' : 'paid',
+            subscriptions: audienceStatus === 'status:free' ? [] : [
                 {
                     cancel_at_period_end: false,
                     trial_end_at: null,
@@ -382,14 +383,14 @@ class EmailService {
     /**
      * @private
      * @param {string} [email] (optional) Search for a member with this email address and use it as the example. If not found, defaults to the default but still uses the provided email address.
-     * @param {string} [segment] (optional) The segment to use for the example member
+     * @param {string|null} [audienceStatus] (optional) The audience's free/paid status, see EmailRenderer#describeSegment
      * @return {Promise<import('./email-renderer').MemberLike>}
      */
-    async getExampleMember(email, segment) {
+    async getExampleMember(email, audienceStatus) {
         /**
          * @type {import('./email-renderer').MemberLike}
          */
-        const exampleMember = this.getDefaultExampleMember(segment);
+        const exampleMember = this.getDefaultExampleMember(audienceStatus);
 
         // fetch any matching members so that replacements use expected values
         if (email) {
@@ -401,7 +402,7 @@ class EmailService {
                 exampleMember.name = member.get('name');
                 exampleMember.createdAt = member.get('created_at');
 
-                if (segment === 'status:-free' && member.get('status') !== 'free') {
+                if (audienceStatus === 'status:-free' && member.get('status') !== 'free') {
                     // Make sure the example member matches the chosen segment (otherwise we'll send an email to free segment, but include a paid member details, which looks like a bug)
                     exampleMember.status = member.get('status');
                     const subscriptions = (await member.getLazyRelation('stripeSubscriptions')).toJSON();
@@ -443,8 +444,9 @@ class EmailService {
      * @returns {Promise<{subject: string, html: string, plaintext: string}>} Email preview
      */
     async previewEmail(post, newsletter, segment) {
-        const exampleMember = await this.getExampleMember(null, segment);
         const renderSegment = this.#emailRenderer.getPreviewSegment(post, segment);
+        const audience = this.#emailRenderer.describeSegment(post, renderSegment);
+        const exampleMember = await this.getExampleMember(null, audience.status);
 
         const subject = this.#emailRenderer.getSubject(post);
         let {html, plaintext, replacements} = await this.#emailRenderer.renderBody(post, newsletter, renderSegment, {clickTrackingEnabled: false});
@@ -464,15 +466,18 @@ class EmailService {
      * @param {string[]} emails
      */
     async sendTestEmail(post, newsletter, segment, emails) {
+        const renderSegment = this.#emailRenderer.getPreviewSegment(post, segment);
+        const audience = this.#emailRenderer.describeSegment(post, renderSegment);
+
         const members = [];
         for (const email of emails) {
-            members.push(await this.getExampleMember(email, segment));
+            members.push(await this.getExampleMember(email, audience.status));
         }
 
         await this.#sendingService.send({
             post,
             newsletter,
-            segment: this.#emailRenderer.getPreviewSegment(post, segment),
+            segment: renderSegment,
             members,
             emailId: null
         }, {

--- a/ghost/core/core/server/services/members/content-gating.js
+++ b/ghost/core/core/server/services/members/content-gating.js
@@ -84,6 +84,84 @@ function checkPostAccess(post, member) {
     return BLOCK_ACCESS;
 }
 
+/**
+ * The tier slugs a parsed member segment names positively. Negations are
+ * skipped — they describe members who lack a tier, which adds nothing to the
+ * member shape checkSegmentPostAccess rebuilds.
+ * @param {object} query - A parsed NQL query (after member expansions)
+ * @returns {string[]}
+ */
+function collectSegmentProductSlugs(query) {
+    const slugs = [];
+    for (const [key, value] of Object.entries(query)) {
+        if (key === '$and' || key === '$or') {
+            for (const subQuery of value) {
+                slugs.push(...collectSegmentProductSlugs(subQuery));
+            }
+        } else if (key === 'products.slug') {
+            if (typeof value === 'string') {
+                slugs.push(value);
+            } else if (value && Array.isArray(value.$in)) {
+                slugs.push(...value.$in);
+            }
+        }
+    }
+    return slugs;
+}
+
+/**
+ * Whether the audience matched by a member segment can read a post's gated
+ * content. Emails are rendered per audience segment rather than per member,
+ * so there is no member to hand to checkPostAccess — instead we rebuild the
+ * member the segment describes (status + the tiers it names) and reuse
+ * checkPostAccess, keeping email and web gating from drifting apart. Mixed
+ * audiences get the least-privileged member's view: a paid segment naming no
+ * tiers cannot read a tier-restricted post.
+ *
+ * @param {object} post - A post object ({visibility, tiers})
+ * @param {string} segment - An NQL member filter
+ * @returns {AccessFlag}
+ */
+function checkSegmentPostAccess(post, segment) {
+    let nqlQuery;
+    let parsedQuery;
+    try {
+        nqlQuery = nql(segment, {expansions: MEMBER_NQL_EXPANSIONS, transformer: rejectUnknownKeys});
+        parsedQuery = nqlQuery.parse();
+    } catch (error) {
+        // segments arrive free-form from the API — unparseable ones get the
+        // paywall, not a 500
+        return BLOCK_ACCESS;
+    }
+
+    // a segment with only unknown keys parses to an empty query which would
+    // match every member — block, matching checkGatedBlockAccess semantics
+    if (Object.keys(parsedQuery).length === 0) {
+        return BLOCK_ACCESS;
+    }
+
+    // a candidate only counts when it matches the segment — 'status:free'
+    // must never be evaluated as the paid member
+    const slugs = collectSegmentProductSlugs(parsedQuery);
+    const candidateMembers = [
+        {status: 'free', products: []},
+        {status: 'paid', products: slugs.map(slug => ({slug}))}
+    ];
+    // an OR of tiers matches members holding any one of them, so each named
+    // tier must grant access on its own
+    for (const slug of slugs) {
+        candidateMembers.push({status: 'paid', products: [{slug}]});
+    }
+
+    // least privilege: every member the segment matches must have access —
+    // a mixed segment like 'status:free,status:-free' gets the free view
+    const matchingMembers = candidateMembers.filter(member => nqlQuery.queryJSON(member));
+    if (matchingMembers.length === 0) {
+        return BLOCK_ACCESS;
+    }
+    return matchingMembers.every(member => checkPostAccess(post, member));
+}
+
 function checkGatedBlockAccess(gatedBlockParams, member) {
     const {nonMember, memberSegment} = gatedBlockParams;
     const isLoggedIn = !!member;
@@ -113,6 +191,7 @@ function checkGatedBlockAccess(gatedBlockParams, member) {
 module.exports = {
     getPostAccessFilter,
     checkPostAccess,
+    checkSegmentPostAccess,
     checkGatedBlockAccess,
     PERMIT_ACCESS,
     BLOCK_ACCESS

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -2416,6 +2416,94 @@ describe('Email renderer', function () {
             assert(!preview.html.includes('Become a paid member of Test Blog to get access to all'));
         });
 
+        it('renders tier-gated content according to a specific tier segment', async function () {
+            renderedPost = '<div> Lexical Test </div> some text for both <!--members-only--> finishing part only for members';
+            const post = {
+                related: (key) => {
+                    if (key === 'tiers') {
+                        return {toJSON: () => [{slug: 'gold'}, {slug: 'silver'}]};
+                    }
+                    return null;
+                },
+                get: (key) => {
+                    if (key === 'lexical') {
+                        return '{}';
+                    }
+                    if (key === 'visibility') {
+                        return 'tiers';
+                    }
+                    if (key === 'title') {
+                        return 'Test Post';
+                    }
+                },
+                getLazyRelation: () => {
+                    return {models: [{get: k => (k === 'name' ? 'Test Author' : undefined)}]};
+                }
+            };
+            const newsletter = {
+                get: (key) => {
+                    if (key === 'show_post_title_section' || key === 'feedback_enabled') {
+                        return true;
+                    }
+                    return false;
+                }
+            };
+
+            const silver = await emailRenderer.renderBody(post, newsletter, 'status:-free+product:\'silver\'', {});
+            assert(silver.html.includes('finishing part only for members'));
+            assert(!silver.html.includes('Become a paid member of Test Blog to get access to all'));
+
+            const bronze = await emailRenderer.renderBody(post, newsletter, 'status:-free+product:\'bronze\'', {});
+            assert(!bronze.html.includes('finishing part only for members'));
+            assert(bronze.html.includes('Become a paid member of Test Blog to get access to all'));
+
+            // the plain paid segment includes members without a matching tier -> paywall
+            const plainPaid = await emailRenderer.renderBody(post, newsletter, 'status:-free', {});
+            assert(!plainPaid.html.includes('finishing part only for members'));
+            assert(plainPaid.html.includes('Become a paid member of Test Blog to get access to all'));
+        });
+
+        it('does not paywall a tier segment on a paid-visibility post', async function () {
+            renderedPost = '<div> Lexical Test </div> some text for both <!--members-only--> finishing part only for members';
+            const post = {
+                related: () => {
+                    return null;
+                },
+                get: (key) => {
+                    if (key === 'lexical') {
+                        return '{}';
+                    }
+                    if (key === 'visibility') {
+                        return 'paid';
+                    }
+                    if (key === 'title') {
+                        return 'Test Post';
+                    }
+                },
+                getLazyRelation: () => {
+                    return {models: [{get: k => (k === 'name' ? 'Test Author' : undefined)}]};
+                }
+            };
+            const newsletter = {
+                get: (key) => {
+                    if (key === 'show_post_title_section' || key === 'feedback_enabled') {
+                        return true;
+                    }
+                    return false;
+                }
+            };
+
+            // every tier member is a paid member, so a tier segment on a
+            // paid-members-only post gets the full content
+            const tierSegment = await emailRenderer.renderBody(post, newsletter, 'status:-free+product:\'gold\'', {});
+            assert(tierSegment.html.includes('finishing part only for members'));
+            assert(!tierSegment.html.includes('Become a paid member of Test Blog to get access to all'));
+
+            const freeSegment = await emailRenderer.renderBody(post, newsletter, 'status:free', {});
+            assert(!freeSegment.html.includes('finishing part only for members'));
+            assert(freeSegment.html.includes('Become a paid member of Test Blog to get access to all'));
+        });
+
         it('does not paywall an unsegmented (null segment) render of a gated post', async function () {
             renderedPost = '<div> Lexical Test </div> some text for both <!--members-only--> finishing part only for members';
             const post = {

--- a/ghost/core/test/unit/server/services/email-service/email-service.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-service.test.js
@@ -51,6 +51,12 @@ describe('Email Service', function () {
             },
             getPreviewSegment: (post, segment) => {
                 return segment;
+            },
+            describeSegment: (post, segment) => {
+                return {
+                    status: segment?.includes('status:-free') ? 'status:-free' : (segment?.includes('status:free') ? 'status:free' : null),
+                    hasPostAccess: true
+                };
             }
         };
         sendingService = {

--- a/ghost/core/test/unit/server/services/members/content-gating.test.js
+++ b/ghost/core/test/unit/server/services/members/content-gating.test.js
@@ -1,5 +1,5 @@
 const assert = require('node:assert/strict');
-const {getPostAccessFilter, checkPostAccess, checkGatedBlockAccess} = require('../../../../../core/server/services/members/content-gating');
+const {getPostAccessFilter, checkPostAccess, checkSegmentPostAccess, checkGatedBlockAccess} = require('../../../../../core/server/services/members/content-gating');
 
 describe('Members Service - Content gating', function () {
     describe('getPostAccessFilter', function () {
@@ -120,6 +120,76 @@ describe('Members Service - Content gating', function () {
             }]};
             access = checkPostAccess(post, member);
             assert.equal(access, false);
+        });
+    });
+
+    describe('checkSegmentPostAccess', function () {
+        const paidPost = {visibility: 'paid'};
+        const tiersPost = {visibility: 'tiers', tiers: [{slug: 'gold'}, {slug: 'silver'}]};
+
+        it('permits the paid segment on a paid post', function () {
+            assert.equal(checkSegmentPostAccess(paidPost, 'status:-free'), true);
+        });
+
+        it('blocks the free segment on a paid post', function () {
+            assert.equal(checkSegmentPostAccess(paidPost, 'status:free'), false);
+        });
+
+        it('permits a tier segment on a paid post', function () {
+            assert.equal(checkSegmentPostAccess(paidPost, 'status:-free+product:\'gold\''), true);
+        });
+
+        it('blocks the plain paid segment on a tiers post', function () {
+            // members without a matching tier are paid too — least privilege wins
+            assert.equal(checkSegmentPostAccess(tiersPost, 'status:-free'), false);
+        });
+
+        it('permits a matching tier segment on a tiers post', function () {
+            assert.equal(checkSegmentPostAccess(tiersPost, 'status:-free+product:\'silver\''), true);
+        });
+
+        it('blocks a non-matching tier segment on a tiers post', function () {
+            assert.equal(checkSegmentPostAccess(tiersPost, 'status:-free+product:\'bronze\''), false);
+        });
+
+        it('permits the send pipeline access variant on a tiers post', function () {
+            assert.equal(checkSegmentPostAccess(tiersPost, 'status:-free+(product:\'gold\',product:\'silver\')'), true);
+        });
+
+        it('blocks the send pipeline no-access variant on a tiers post', function () {
+            assert.equal(checkSegmentPostAccess(tiersPost, 'status:-free+(product:-\'gold\'+product:-\'silver\')'), false);
+        });
+
+        it('permits a multi-tier segment when one named tier grants access', function () {
+            const goldOnlyPost = {visibility: 'tiers', tiers: [{slug: 'gold'}]};
+            assert.equal(checkSegmentPostAccess(goldOnlyPost, 'product:\'gold\'+product:\'silver\''), true);
+        });
+
+        it('blocks a mixed free/paid segment on a paid post', function () {
+            assert.equal(checkSegmentPostAccess(paidPost, 'status:free,status:-free+product:\'gold\''), false);
+        });
+
+        it('blocks a negated tier segment on a paid post', function () {
+            // matches free members too, so least privilege wins
+            assert.equal(checkSegmentPostAccess(paidPost, 'product:-\'gold\''), false);
+        });
+
+        it('blocks an OR of tiers when one named tier lacks access', function () {
+            const goldOnlyPost = {visibility: 'tiers', tiers: [{slug: 'gold'}]};
+            assert.equal(checkSegmentPostAccess(goldOnlyPost, 'product:\'gold\',product:\'silver\''), false);
+        });
+
+        it('blocks any segment on a tiers post with no tiers configured', function () {
+            const misconfiguredPost = {visibility: 'tiers', tiers: []};
+            assert.equal(checkSegmentPostAccess(misconfiguredPost, 'status:-free+product:\'gold\''), false);
+        });
+
+        it('blocks segments with only unknown keys', function () {
+            assert.equal(checkSegmentPostAccess(paidPost, 'label:vip'), false);
+        });
+
+        it('blocks malformed segments', function () {
+            assert.equal(checkSegmentPostAccess(paidPost, 'status:(('), false);
         });
     });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3779/

The email pipeline identifies each render variant only by its member segment string — persisted on `email_batches.member_segment` and accepted free-form by the preview APIs. Four consumers were reverse-engineering meaning from that string with their own heuristics: the paywall check (`segment.includes(accessFilter)`), the data-gh-segment card stripping, the preheader condition, and `getExampleMember`'s enrichment check. The tier-aware segments from #28315 already strained this, and the tier-specific previews in BER-3779 add more segment shapes — every new shape had to be anticipated by all four heuristics or previews and sends silently rendered the wrong variant.

Adding tier-specific previews was hard, so this refactor sets it up to be easy:

- `checkSegmentPostAccess` in content-gating answers "can this audience read this post's gated content" by rebuilding the member the segment describes (status + the tiers it names) and reusing `checkPostAccess`, replacing the substring matching. This also fixes tier segments on paid-visibility posts being wrongly paywalled — the substring check could never match a filter shape it didn't anticipate.
- `describeSegment(post, segment)` in the renderer derives the audience facts (`status`, `hasPostAccess`) once per render; the paywall, card stripping, and preheader read the descriptor instead of re-parsing the segment.
- `getExampleMember` takes the audience status from its callers instead of strict-matching segment strings, so test emails keep personalizing from the real recipient as new segment shapes appear.
- The preheader now regenerates from the gated html for any audience without post access, not just `status:free` — previously the no-access variants introduced by #28315 could leak gated content from model plaintext into paid recipients' preheaders.

No behavioural change for any segment the pipeline currently produces; the tier-preview feature lands separately on top.