### PR TITLE
✨ Added tier-specific web and email previews for posts

### DIFF
--- a/ghost/admin/app/components/editor/modals/preview.hbs
+++ b/ghost/admin/app/components/editor/modals/preview.hbs
@@ -19,7 +19,7 @@
             </div>
             {{#if this.showMemberSegmentDropdown}}
                 <div class="gh-contentfilter-divider"></div>
-                <span class="gh-select gh-web-preview-segment" data-test-select="preview-segment">
+                <span class="gh-select gh-web-preview-segment gh-preview-member-type" data-test-select="preview-segment">
                     <PowerSelect
                         @selected={{this.selectedPreviewAsOption}}
                         @options={{this.previewAsOptions}}
@@ -34,6 +34,23 @@
                         {{option.label}}
                     </PowerSelect>
                 </span>
+                {{#if this.showTierDropdown}}
+                    <span class="gh-select gh-web-preview-segment gh-preview-tier" data-test-select="preview-tier">
+                        <PowerSelect
+                            @selected={{this.selectedPreviewTier}}
+                            @options={{this.previewTierOptions}}
+                            @onChange={{this.changePreviewTier}}
+                            @triggerComponent={{component "gh-power-select/trigger"}}
+                            @triggerClass="gh-preview-segment-trigger"
+                            @dropdownClass="gh-preview-segment-dropdown gh-preview-tier-dropdown"
+                            @matchTriggerWidth={{false}}
+                            @onOpen={{this.dropdown.closeDropdowns}}
+                            as |tier|
+                        >
+                            {{tier.name}}
+                        </PowerSelect>
+                    </span>
+                {{/if}}
             {{/if}}
         </div>
         <div class="right">
@@ -109,7 +126,9 @@
             {{else}}
                 <Editor::Modals::Preview::Email
                     @post={{@data.publishOptions.post}}
-                    @memberSegment={{this.previewAsSegment}}
+                    @memberSegment={{this.emailMemberSegment}}
+                    @memberTier={{this.emailMemberTier}}
+                    @memberDescription={{this.emailMemberDescription}}
                     @newsletter={{@data.publishOptions.newsletter}}
                     @skipAnimation={{this.skipAnimation}}
                     @savePostTask={{@data.saveTask}}

--- a/ghost/admin/app/components/editor/modals/preview.js
+++ b/ghost/admin/app/components/editor/modals/preview.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import copyTextToClipboard from 'ghost-admin/utils/copy-text-to-clipboard';
 import {action} from '@ember/object';
+import {groupTiersByActive} from 'ghost-admin/utils/group-tiers';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
@@ -22,14 +23,26 @@ export default class EditorPostPreviewModal extends Component {
     @tracked previewEmailAddress = this.session.user.email;
     @tracked previewAsSegment = 'free';
     @tracked previewAsOptions = [];
+    @tracked previewTierSlug;
+
+    tiers = this.args.data.tiers || [];
 
     constructor() {
         super(...arguments);
         this.saveFirstTask.perform();
 
-        const {initialPreviewAsSegment} = this.args.data;
+        const {initialPreviewAsSegment, initialPreviewTierSlug} = this.args.data;
+
+        const defaultTier = this.tiers.find(tier => tier.slug === initialPreviewTierSlug)
+            || this.tiers.find(tier => tier.active)
+            || this.tiers[0];
+        this.previewTierSlug = defaultTier?.slug;
+
         if (initialPreviewAsSegment) {
-            this.changePreviewAsSegment(initialPreviewAsSegment);
+            const segment = initialPreviewAsSegment === 'tier' && !this.previewTierSlug
+                ? (this.settings.paidMembersEnabled ? 'paid' : 'free')
+                : initialPreviewAsSegment;
+            this.changePreviewAsSegment(segment);
         }
 
         this.setPreviewAsOptions();
@@ -37,6 +50,18 @@ export default class EditorPostPreviewModal extends Component {
 
     get selectedPreviewAsOption() {
         return this.previewAsOptions.find(option => option.value === this.previewAsSegment);
+    }
+
+    get selectedPreviewTier() {
+        return this.tiers.find(tier => tier.slug === this.previewTierSlug);
+    }
+
+    get previewTierOptions() {
+        return groupTiersByActive(this.tiers).filter(group => group.options.length > 0);
+    }
+
+    get showTierDropdown() {
+        return this.previewAsSegment === 'tier' && this.tiers.length > 0;
     }
 
     get showMemberSegmentDropdown() {
@@ -54,8 +79,35 @@ export default class EditorPostPreviewModal extends Component {
 
     get browserPreviewUrl() {
         const url = new URL(this.args.data.publishOptions.post.previewUrl);
-        url.searchParams.set('member_status', this.previewAsSegment);
+        url.searchParams.set('member_status', this.previewAsSegment === 'tier' ? 'paid' : this.previewAsSegment);
+
+        if (this.previewAsSegment === 'tier' && this.previewTierSlug) {
+            url.searchParams.set('member_tier', this.previewTierSlug);
+        } else {
+            url.searchParams.delete('member_tier');
+        }
+
         return url.toString();
+    }
+
+    get emailMemberSegment() {
+        if (this.previewAsSegment === 'paid' || this.previewAsSegment === 'tier') {
+            return 'status:-free';
+        }
+
+        return 'status:free';
+    }
+
+    get emailMemberTier() {
+        return this.previewAsSegment === 'tier' ? this.previewTierSlug : null;
+    }
+
+    get emailMemberDescription() {
+        if (this.previewAsSegment === 'tier' && this.selectedPreviewTier) {
+            return `${this.selectedPreviewTier.name} tier member`;
+        }
+
+        return `${this.previewAsSegment} member`;
     }
 
     // manually set the tracked property rather than using a getter so we have
@@ -77,6 +129,12 @@ export default class EditorPostPreviewModal extends Component {
             this.previewAsOptions.push(
                 {label: 'Paid member', value: 'paid'}
             );
+
+            if (this.tiers.length > 0) {
+                this.previewAsOptions.push(
+                    {label: 'Tier', value: 'tier'}
+                );
+            }
         }
     }
 
@@ -111,6 +169,12 @@ export default class EditorPostPreviewModal extends Component {
     @action
     changePreviewAsOption(option) {
         this.changePreviewAsSegment(option.value);
+    }
+
+    @action
+    changePreviewTier(tier) {
+        this.previewTierSlug = tier.slug;
+        this.args.data.changePreviewTier?.(tier.slug);
     }
 
     @action

--- a/ghost/admin/app/components/editor/modals/preview/email.hbs
+++ b/ghost/admin/app/components/editor/modals/preview/email.hbs
@@ -55,7 +55,7 @@
                                             {{autofocus}}
                                             {{on-key "Enter" (perform this.sendPreviewEmailTask)}}
                                         />
-                                        <p class="description">You'll receive this as a {{@memberSegment}} member.</p>
+                                        <p class="description">You'll receive this as a {{@memberDescription}}.</p>
                                         <GhTaskButton
                                             @task={{this.sendPreviewEmailTask}}
                                             @buttonText="Send"
@@ -105,7 +105,7 @@
                 tabindex="0"
                 sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"
                 {{did-insert this.renderEmailPreview}}
-                {{did-update this.renderEmailPreview @memberSegment}}
+                {{did-update this.renderEmailPreview @memberSegment @memberTier}}
                 {{on "focusin" this.focusPreviewFrame}}
                 {{close-dropdowns-on-click}}
             ></iframe>

--- a/ghost/admin/app/components/editor/modals/preview/email.js
+++ b/ghost/admin/app/components/editor/modals/preview/email.js
@@ -25,19 +25,6 @@ html::-webkit-scrollbar-thumb:hover {
 }
 `;
 
-const FREE_SEGMENT = 'status:free';
-const PAID_SEGMENT = 'status:-free';
-
-const SEGMENT_OPTIONS = [{
-    name: 'Free member',
-    value: FREE_SEGMENT,
-    alias: 'free'
-}, {
-    name: 'Paid member',
-    value: PAID_SEGMENT,
-    alias: 'paid'
-}];
-
 // TODO: remove duplication with <ModalPostEmailPreview>
 export default class ModalPostPreviewEmailComponent extends Component {
     @service ajax;
@@ -56,8 +43,6 @@ export default class ModalPostPreviewEmailComponent extends Component {
     @tracked newsletter = this.args.post.newsletter || this.args.newsletter;
     @tracked newslettersList;
 
-    segments = SEGMENT_OPTIONS;
-
     constructor() {
         super(...arguments);
         this.loadNewslettersTask.perform();
@@ -66,10 +51,6 @@ export default class ModalPostPreviewEmailComponent extends Component {
     get mailgunIsEnabled() {
         return this.config.mailgunIsConfigured ||
             !!(this.settings.mailgunApiKey && this.settings.mailgunDomain && this.settings.mailgunBaseUrl);
-    }
-
-    get selectedSegment() {
-        return this.segments.find(segment => segment.alias === this.args.memberSegment);
     }
 
     @action
@@ -109,7 +90,7 @@ export default class ModalPostPreviewEmailComponent extends Component {
         try {
             const resourceId = this.args.post.id;
             const testEmail = this.previewEmailAddress.trim();
-            const memberSegment = this.selectedSegment.value;
+            const {memberSegment, memberTier} = this.args;
 
             if (!validator.isEmail(testEmail)) {
                 this.sendPreviewEmailError = 'Please enter a valid email';
@@ -123,6 +104,9 @@ export default class ModalPostPreviewEmailComponent extends Component {
 
             const url = this.ghostPaths.url.api('/email_previews/posts', resourceId);
             const data = {emails: [testEmail], memberSegment, newsletter: this.newsletter.slug};
+            if (memberTier) {
+                data.memberTier = memberTier;
+            }
             const options = {
                 data,
                 dataType: 'json'
@@ -150,13 +134,14 @@ export default class ModalPostPreviewEmailComponent extends Component {
     async _fetchEmailData() {
         let {html, subject, newsletter} = this;
         let {post} = this.args;
-        const memberSegment = this.selectedSegment.value;
+        const {memberSegment, memberTier} = this.args;
 
-        if (html && subject && memberSegment === this._lastMemberSegment && newsletter.slug === this._lastNewsletterSlug) {
+        if (html && subject && memberSegment === this._lastMemberSegment && memberTier === this._lastMemberTier && newsletter.slug === this._lastNewsletterSlug) {
             return {html, subject};
         }
 
         this._lastMemberSegment = memberSegment;
+        this._lastMemberTier = memberTier;
         this._lastNewsletterSlug = newsletter.slug;
 
         // model is an email
@@ -171,6 +156,9 @@ export default class ModalPostPreviewEmailComponent extends Component {
         } else {
             let url = new URL(this.ghostPaths.url.api('/email_previews/posts', post.id), window.location.href);
             url.searchParams.set('memberSegment', memberSegment);
+            if (memberTier) {
+                url.searchParams.set('memberTier', memberTier);
+            }
             url.searchParams.set('newsletter', this.newsletter.slug);
 
             let response = await this.ajax.request(url.href);

--- a/ghost/admin/app/components/editor/publish-management.js
+++ b/ghost/admin/app/components/editor/publish-management.js
@@ -24,6 +24,8 @@ export const CONFIRM_EMAIL_MAX_POLL_LENGTH = 15 * 1000;
 export default class PublishManagement extends Component {
     @service modals;
     @service notifications;
+    @service settings;
+    @service store;
 
     // ensure we get a new PublishOptions instance when @post is replaced
     @use publishOptions = new PublishOptionsResource(() => [this.args.post]);
@@ -31,6 +33,8 @@ export default class PublishManagement extends Component {
     @tracked previewFormat = 'browser';
     @tracked previewSize = 'desktop';
     @tracked previewAsSegment = 'free';
+    @tracked previewTierSlug;
+    @tracked tiers = [];
 
     publishFlowModal = null;
     updateFlowModal = null;
@@ -105,6 +109,7 @@ export default class PublishManagement extends Component {
         event?.preventDefault();
 
         const isValid = await this._validatePost();
+        await this._ensureTiersLoaded();
 
         if (isValid && (!this.previewModal || this.previewModal.isClosing)) {
             // open publish flow modal underneath to offer quick switching
@@ -121,8 +126,26 @@ export default class PublishManagement extends Component {
                 changePreviewSize: this.changePreviewSize,
                 initialPreviewAsSegment: this.previewAsSegment,
                 changePreviewAsSegment: this.changePreviewAsSegment,
+                initialPreviewTierSlug: this.previewTierSlug,
+                changePreviewTier: this.changePreviewTier,
+                tiers: this.tiers,
                 skipAnimation
             });
+        }
+    }
+
+    // tiers are loaded once per editor session so the preview modal can render
+    // its tier selector synchronously; a failed fetch degrades the preview to
+    // the free/paid audience options and is retried on the next open
+    async _ensureTiersLoaded() {
+        if (!this.settings.paidMembersEnabled || this.loadTiersTask.lastSuccessful) {
+            return;
+        }
+
+        try {
+            await this.loadTiersTask.perform();
+        } catch (error) {
+            // no-op, degraded preview
         }
     }
 
@@ -158,6 +181,17 @@ export default class PublishManagement extends Component {
     @action
     changePreviewAsSegment(segment) {
         this.previewAsSegment = segment;
+    }
+
+    @action
+    changePreviewTier(tierSlug) {
+        this.previewTierSlug = tierSlug;
+    }
+
+    @task
+    *loadTiersTask() {
+        const tiers = yield this.store.query('tier', {filter: 'type:paid', limit: 'all'});
+        this.tiers = tiers.toArray();
     }
 
     @action

--- a/ghost/admin/app/components/gh-members-recipient-select.js
+++ b/ghost/admin/app/components/gh-members-recipient-select.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import {action} from '@ember/object';
+import {groupTiersByActive} from 'ghost-admin/utils/group-tiers';
 import {isBlank} from '@ember/utils';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
@@ -153,30 +154,12 @@ export default class GhMembersRecipientSelect extends Component {
         const tierOptions = [];
 
         if (tiers.length > 1) {
-            const activeTiersGroup = {
-                groupName: 'Active tiers',
-                options: []
-            };
-
-            const archivedTiersGroup = {
-                groupName: 'Archived tiers',
-                options: []
-            };
-
-            tiers.forEach((tier) => {
-                const tierData = {
-                    name: tier.name,
-                    segment: `tier:${tier.slug}`,
-                    count: tier.count?.members,
-                    class: 'segment-tier'
-                };
-
-                if (tier.active) {
-                    activeTiersGroup.options.push(tierData);
-                } else {
-                    archivedTiersGroup.options.push(tierData);
-                }
-            });
+            const [activeTiersGroup, archivedTiersGroup] = groupTiersByActive(tiers, tier => ({
+                name: tier.name,
+                segment: `tier:${tier.slug}`,
+                count: tier.count?.members,
+                class: 'segment-tier'
+            }));
 
             tierOptions.push(activeTiersGroup);
             tierOptions.push(archivedTiersGroup);

--- a/ghost/admin/app/components/gh-members-segment-select.js
+++ b/ghost/admin/app/components/gh-members-segment-select.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import {action} from '@ember/object';
+import {groupTiersByActive} from 'ghost-admin/utils/group-tiers';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
@@ -65,30 +66,12 @@ export default class GhMembersSegmentSelect extends Component {
         const tiers = yield this.store.query('tier', {filter: 'type:paid', limit: 'all', include: 'monthly_price,yearly_price,benefits'});
 
         if (tiers.length > 0) {
-            const activeTiersGroup = {
-                groupName: 'Active tiers',
-                options: []
-            };
-
-            const archivedTiersGroup = {
-                groupName: 'Archived tiers',
-                options: []
-            };
-
-            tiers.forEach((tier) => {
-                const tierData = {
-                    name: tier.name,
-                    segment: `${tier.id}`,
-                    count: tier.count?.members,
-                    class: 'segment-tier'
-                };
-
-                if (tier.active) {
-                    activeTiersGroup.options.push(tierData);
-                } else {
-                    archivedTiersGroup.options.push(tierData);
-                }
-            });
+            const [activeTiersGroup, archivedTiersGroup] = groupTiersByActive(tiers, tier => ({
+                name: tier.name,
+                segment: `${tier.id}`,
+                count: tier.count?.members,
+                class: 'segment-tier'
+            }));
 
             options.push(activeTiersGroup);
             options.push(archivedTiersGroup);

--- a/ghost/admin/app/components/gh-post-settings-menu/visibility-segment-select.js
+++ b/ghost/admin/app/components/gh-post-settings-menu/visibility-segment-select.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import {action} from '@ember/object';
+import {groupTiersByActive} from 'ghost-admin/utils/group-tiers';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
@@ -75,30 +76,12 @@ export default class VisibilitySegmentSelect extends Component {
         this.tiers = tiers;
 
         if (tiers.length > 0) {
-            const activeTiersGroup = {
-                groupName: 'Active tiers',
-                options: []
-            };
-
-            const archivedTiersGroup = {
-                groupName: 'Archived tiers',
-                options: []
-            };
-
-            tiers.forEach((tier) => {
-                const tierData = {
-                    name: tier.name,
-                    id: tier.id,
-                    count: tier.count?.members,
-                    class: 'segment-tier'
-                };
-
-                if (tier.active) {
-                    activeTiersGroup.options.push(tierData);
-                } else {
-                    archivedTiersGroup.options.push(tierData);
-                }
-            });
+            const [activeTiersGroup, archivedTiersGroup] = groupTiersByActive(tiers, tier => ({
+                name: tier.name,
+                id: tier.id,
+                count: tier.count?.members,
+                class: 'segment-tier'
+            }));
 
             options.push(activeTiersGroup);
             options.push(archivedTiersGroup);

--- a/ghost/admin/app/styles/layouts/post-preview.css
+++ b/ghost/admin/app/styles/layouts/post-preview.css
@@ -132,6 +132,34 @@
     background: transparent;
 }
 
+.gh-preview-member-type {
+    flex: 0 0 auto;
+    width: auto;
+}
+
+.gh-preview-tier {
+    flex: 0 0 180px;
+    width: 180px;
+    min-width: 180px;
+    max-width: 180px;
+}
+
+.gh-preview-tier .gh-preview-segment-trigger {
+    width: 100%;
+    max-width: 100%;
+}
+
+.gh-preview-tier .ember-power-select-selected-item,
+.gh-preview-tier-dropdown .ember-power-select-option {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.gh-preview-tier .ember-power-select-selected-item {
+    display: block;
+}
+
 .gh-preview-segment-dropdown.ember-power-select-dropdown.ember-basic-dropdown-content--below {
     min-width: 200px;
     margin: 2px 0 0;
@@ -165,6 +193,10 @@
 }
 
 @media (max-width: 640px) {
+    .gh-preview-tier {
+        display: none;
+    }
+
     .gh-web-preview-segment .gh-preview-segment-trigger {
         display: none;
     }

--- a/ghost/admin/app/utils/group-tiers.js
+++ b/ghost/admin/app/utils/group-tiers.js
@@ -1,0 +1,14 @@
+// Groups tiers into the 'Active tiers' / 'Archived tiers' option groups used
+// by every tier-picking power-select. `mapTier` converts each tier into the
+// caller's option shape.
+export function groupTiersByActive(tiers, mapTier = tier => tier) {
+    const activeTiersGroup = {groupName: 'Active tiers', options: []};
+    const archivedTiersGroup = {groupName: 'Archived tiers', options: []};
+
+    tiers.forEach((tier) => {
+        const group = tier.active ? activeTiersGroup : archivedTiersGroup;
+        group.options.push(mapTier(tier));
+    });
+
+    return [activeTiersGroup, archivedTiersGroup];
+}

--- a/ghost/admin/tests/acceptance/editor/post-email-preview-test.js
+++ b/ghost/admin/tests/acceptance/editor/post-email-preview-test.js
@@ -79,7 +79,8 @@ describe('Acceptance: Post email preview', function () {
         expect(find('[data-test-text="newsletter-from"]')).to.contain.rendered.text('noreply@example.com');
     });
 
-    it('can select paid/free member for preview', async function () {
+    it('can select free, paid, or tier member for preview', async function () {
+        this.server.create('tier', {name: 'Archive', slug: 'archive', type: 'paid', active: false});
         await openEmailPreviewModal.call(this);
 
         expect(find('[data-test-email-preview-newsletter-select]'), 'newsletter select').not.to.exist;
@@ -89,9 +90,10 @@ describe('Acceptance: Post email preview', function () {
         await clickTrigger('[data-test-select="preview-segment"]');
 
         const options = findAll('.ember-power-select-option');
-        expect(options.length).to.equal(2);
+        expect(options.length).to.equal(3);
         expect(options[0].textContent.trim()).to.equal('Free member');
         expect(options[1].textContent.trim()).to.equal('Paid member');
+        expect(options[2].textContent.trim()).to.equal('Tier');
 
         // can switch free/paid member in preview
         await selectChoose('[data-test-select="preview-segment"]', 'Paid member');
@@ -102,6 +104,16 @@ describe('Acceptance: Post email preview', function () {
         const [lastRequest] = this.server.pretender.handledRequests.slice(-1);
         const requestBody = JSON.parse(lastRequest.requestBody);
         expect(requestBody.memberSegment).to.equal('status:-free');
+
+        // selecting a specific tier sends the paid segment narrowed to that tier
+        await selectChoose('[data-test-select="preview-segment"]', 'Tier');
+        await selectChoose('[data-test-select="preview-tier"]', 'Archive');
+        await click(find('[data-test-button="post-preview-test-email"]'));
+        await click(find('[data-test-button="send-test-email"]'));
+        const [tierRequest] = this.server.pretender.handledRequests.slice(-1);
+        const tierRequestBody = JSON.parse(tierRequest.requestBody);
+        expect(tierRequestBody.memberSegment).to.equal('status:-free');
+        expect(tierRequestBody.memberTier).to.equal('archive');
     });
 
     it('hides segment dropdown when only one option is available', async function () {

--- a/ghost/admin/tests/acceptance/editor/post-preview-test.js
+++ b/ghost/admin/tests/acceptance/editor/post-preview-test.js
@@ -1,5 +1,5 @@
 import loginAsRole from '../../helpers/login-as-role';
-import {click, find} from '@ember/test-helpers';
+import {click, find, findAll} from '@ember/test-helpers';
 import {enableMailgun} from '../../helpers/mailgun';
 import {enableMembers, enablePaidMembers} from '../../helpers/members';
 import {expect} from 'chai';
@@ -27,6 +27,8 @@ describe('Acceptance: Post preview', function () {
     };
 
     it('uses correct member status for new tab preview link', async function () {
+        const archivedTierName = 'Archived tier';
+        this.server.create('tier', {name: archivedTierName, slug: 'archive', type: 'paid', active: false});
         await openPreviewModal.call(this);
 
         // ensure we're on the browser tab and "free" segment is selected
@@ -44,5 +46,42 @@ describe('Acceptance: Post preview', function () {
         await selectChoose('[data-test-select="preview-segment"]', 'Paid member');
         url = new URL(find('[data-test-link="open-draft"]').href);
         expect(url.searchParams.get('member_status')).to.equal('paid');
+
+        // tier previews add a grouped tier selector and identify the selected tier
+        await selectChoose('[data-test-select="preview-segment"]', 'Tier');
+        expect(find('[data-test-select="preview-tier"]')).to.exist;
+
+        await click('[data-test-select="preview-tier"] .ember-power-select-trigger');
+        expect(findAll('.ember-power-select-group-name').map(element => element.textContent.trim())).to.deep.equal([
+            'Active tiers',
+            'Archived tiers'
+        ]);
+        await selectChoose('[data-test-select="preview-tier"]', archivedTierName);
+        expect(find('[data-test-select="preview-tier"]')).to.contain.text(archivedTierName);
+
+        url = new URL(find('[data-test-link="open-draft"]').href);
+        expect(url.searchParams.get('member_status')).to.equal('paid');
+        expect(url.searchParams.get('member_tier')).to.equal('archive');
+    });
+
+    it('remembers the selected tier when the preview is reopened', async function () {
+        const archivedTierName = 'Archived tier';
+        this.server.create('tier', {name: archivedTierName, slug: 'archive', type: 'paid', active: false});
+        await openPreviewModal.call(this);
+
+        await selectChoose('[data-test-select="preview-segment"]', 'Tier');
+        await selectChoose('[data-test-select="preview-tier"]', archivedTierName);
+
+        await click('.gh-post-preview-close');
+        await click('[data-test-button="publish-preview"]');
+
+        // selections persist and the preview link is tier-aware immediately on reopen
+        expect(find('[data-test-select="preview-segment"]')).to.contain.text('Tier');
+        expect(find('[data-test-select="preview-tier"]')).to.contain.text(archivedTierName);
+
+        await click('[data-test-button="share-preview"]');
+        const url = new URL(find('[data-test-link="open-draft"]').href);
+        expect(url.searchParams.get('member_status')).to.equal('paid');
+        expect(url.searchParams.get('member_tier')).to.equal('archive');
     });
 });

--- a/ghost/core/core/frontend/services/routing/controllers/previews.js
+++ b/ghost/core/core/frontend/services/routing/controllers/previews.js
@@ -20,7 +20,8 @@ module.exports = function previewController(req, res, next) {
         uuid: req.params.uuid,
         status: 'all',
         include: 'authors,tags,tiers',
-        member_status: req.query?.member_status
+        member_status: req.query?.member_status,
+        member_tier: req.query?.member_tier
     };
 
     return api[res.routerOptions.query.controller]

--- a/ghost/core/core/server/api/endpoints/email-previews.js
+++ b/ghost/core/core/server/api/endpoints/email-previews.js
@@ -11,6 +11,7 @@ const controller = {
         options: [
             'fields',
             'memberSegment',
+            'memberTier',
             'newsletter'
         ],
         validation: {

--- a/ghost/core/core/server/api/endpoints/previews.js
+++ b/ghost/core/core/server/api/endpoints/previews.js
@@ -7,7 +7,8 @@ const ALLOWED_INCLUDES = ['authors', 'tags', 'tiers'];
 const ALLOWED_MEMBER_STATUSES = ['anonymous', 'free', 'paid'];
 
 const messages = {
-    postNotFound: 'Post not found.'
+    postNotFound: 'Post not found.',
+    invalidMemberTier: 'member_tier must be a single tier slug.'
 };
 
 // Simulate serving content as different member states by setting the minimal
@@ -15,6 +16,14 @@ const messages = {
 const _addMemberContextToFrame = async (frame) => {
     if (!frame?.options?.member_status) {
         return;
+    }
+
+    // the framework's options validation only supports required/values checks,
+    // so guard the shape here — repeated query params arrive as arrays
+    if (frame.options.member_tier !== undefined && typeof frame.options.member_tier !== 'string') {
+        throw new errors.ValidationError({
+            message: tpl(messages.invalidMemberTier)
+        });
     }
 
     // only set apiType when given a member_status to preserve backwards compatibility
@@ -32,8 +41,8 @@ const _addMemberContextToFrame = async (frame) => {
     }
 
     if (frame.options?.member_status === 'paid') {
-        // For member_status=paid, render as a member with all active paid tiers
-        frame.original.context.member = await membersService.createPaidMemberShim();
+        // For member_status=paid, render with the selected tier or all active paid tiers
+        frame.original.context.member = await membersService.createPaidMemberShim(frame.options.member_tier);
     }
 };
 
@@ -48,7 +57,8 @@ const controller = {
         permissions: true,
         options: [
             'include',
-            'member_status'
+            'member_status',
+            'member_tier'
         ],
         data: [
             'uuid'

--- a/ghost/core/core/server/services/email-service/email-controller.js
+++ b/ghost/core/core/server/services/email-service/email-controller.js
@@ -5,7 +5,8 @@ const messages = {
     postNotFound: 'Post not found.',
     noEmailsProvided: 'No emails provided.',
     emailNotFound: 'Email not found.',
-    tooManyEmailsProvided: 'Too many emails provided. Maximum of 1 test email can be sent at once.'
+    tooManyEmailsProvided: 'Too many emails provided. Maximum of 1 test email can be sent at once.',
+    invalidMemberTier: 'memberTier must be a single tier slug.'
 };
 
 class EmailController {
@@ -27,6 +28,17 @@ class EmailController {
     async _getFrameData(frame) {
         // Bit absurd situation in email-previews endpoints that one endpoint is using options and other one is using data.
         // So we need to handle both cases.
+
+        // repeated query params / JSON arrays arrive as non-strings — reject
+        // rather than 500 downstream (the api-framework only validates
+        // required/values, so the endpoint can't do this for us)
+        const memberTier = frame.options.memberTier ?? frame.data?.memberTier ?? null;
+        if (memberTier !== null && typeof memberTier !== 'string') {
+            throw new errors.ValidationError({
+                message: tpl(messages.invalidMemberTier)
+            });
+        }
+
         let post;
         // 'tiers' is required by the email tier-gating logic (renderer/segmenter), not for URL generation
         const withRelated = [...new Set(['posts_meta', 'authors', 'tiers', ...this.getRequiredUrlRelations()])];
@@ -52,17 +64,18 @@ class EmailController {
         return {
             post,
             newsletter,
-            segment: frame.options.memberSegment ?? frame.data.memberSegment ?? null
+            segment: frame.options.memberSegment ?? frame.data.memberSegment ?? null,
+            memberTier
         };
     }
 
     async previewEmail(frame) {
-        const {post, newsletter, segment} = await this._getFrameData(frame);
-        return await this.service.previewEmail(post, newsletter, segment);
+        const {post, newsletter, segment, memberTier} = await this._getFrameData(frame);
+        return await this.service.previewEmail(post, newsletter, segment, memberTier);
     }
 
     async sendTestEmail(frame) {
-        const {post, newsletter, segment} = await this._getFrameData(frame);
+        const {post, newsletter, segment, memberTier} = await this._getFrameData(frame);
 
         const emails = frame.data.emails ?? [];
 
@@ -79,7 +92,7 @@ class EmailController {
             });
         }
 
-        await this.service.sendTestEmail(post, newsletter, segment, emails);
+        await this.service.sendTestEmail(post, newsletter, segment, emails, memberTier);
     }
 
     async retryFailedEmail(frame) {

--- a/ghost/core/core/server/services/email-service/email-renderer.js
+++ b/ghost/core/core/server/services/email-service/email-renderer.js
@@ -469,17 +469,22 @@ class EmailRenderer {
 
     /**
      * Maps the fixed audience choices offered by the editor's email preview and
-     * test-email UI ('status:free' / 'status:-free') onto the segment the send
-     * pipeline renders for that audience, so previews match what members receive.
-     * For a tier-restricted post the paid audience maps to the tier access
-     * segment (the access variant getSegments produces): paid members on the
-     * post's tiers get the full content, and the free choice previews the
-     * no-access variant. Anything else passes through unchanged.
+     * test-email UI ('status:free' / 'status:-free', optionally narrowed to a
+     * single tier) onto the segment the send pipeline renders for that
+     * audience, so previews match what members receive. For a tier-restricted
+     * post the paid audience maps to the tier access segment (the access
+     * variant getSegments produces): paid members on the post's tiers get the
+     * full content, and the free choice previews the no-access variant.
+     * Anything else passes through unchanged.
      * @param {Post} post
      * @param {Segment} segment
+     * @param {string} [tierSlug] - narrow the paid audience to a single tier
      * @returns {Segment}
      */
-    getPreviewSegment(post, segment) {
+    getPreviewSegment(post, segment, tierSlug) {
+        if (tierSlug && segment === 'status:-free') {
+            return `status:-free+product:'${tierSlug.replace(/'/g, '\\\'')}'`;
+        }
         if (segment === 'status:-free' && post.get('visibility') === 'tiers') {
             const accessFilter = getPostAccessFilter(getPostGatingShape(post));
             if (accessFilter) {

--- a/ghost/core/core/server/services/email-service/email-renderer.js
+++ b/ghost/core/core/server/services/email-service/email-renderer.js
@@ -17,7 +17,7 @@ const EmailAddressParser = require('../email-address/email-address-parser');
 const {getEmailDesign} = require('../email-rendering/email-design');
 const {registerHelpers} = require('./helpers/register-helpers');
 const crypto = require('crypto');
-const {getPostAccessFilter} = require('../members/content-gating');
+const {checkSegmentPostAccess, getPostAccessFilter} = require('../members/content-gating');
 const {mobiledocToLexical} = require('@tryghost/kg-converters');
 /** @import {TemplateDelegate} from 'handlebars' */
 
@@ -131,12 +131,10 @@ function getSegmentStatus(segment) {
 
 /**
  * Whether the members matched by a segment can read the post's gated content.
- * Derived from the post's visibility (not just free/paid): for paid posts the
- * access segment is the paid one; for tier-restricted posts it's the segment
- * carrying the post's positive tier filter. A null segment is an unsegmented
- * render — the send pipeline only produces one for posts without gated content,
- * and API previews without a memberSegment expect the full body — so it always
- * has access.
+ * Delegates to the shared content-gating check so email and web gating stay in
+ * sync. A null segment is an unsegmented render — the send pipeline only
+ * produces one for posts without gated content, and API previews without a
+ * memberSegment expect the full body — so it always has access.
  * @param {Post} post
  * @param {Segment} segment
  * @returns {boolean}
@@ -149,13 +147,16 @@ function segmentHasPostAccess(post, segment) {
     if (!segment) {
         return true;
     }
-    const accessFilter = getPostAccessFilter(getPostGatingShape(post));
-    if (!accessFilter) {
-        // misconfigured tiers post (no tiers) -> nobody has access
-        return false;
-    }
-    return segment.includes(accessFilter);
+    return checkSegmentPostAccess(getPostGatingShape(post), segment);
 }
+
+/**
+ * @typedef {object} SegmentAudience
+ * @prop {string|null} status - the free/paid audience axis ('status:free' /
+ *   'status:-free', the data-gh-segment card vocabulary), null for mixed
+ * @prop {boolean} hasPostAccess - whether this audience can read the post's
+ *   gated content
+ */
 
 /**
  * @param {Readonly<Date>} date
@@ -488,6 +489,23 @@ class EmailRenderer {
         return segment;
     }
 
+    /**
+     * Interprets a member segment into the audience facts rendering needs.
+     * Segments are persisted on email batches and arrive free-form via the
+     * preview APIs, so audience semantics must be derivable from the string —
+     * this is the only place that derives them; everything downstream reads the
+     * descriptor instead of re-parsing the segment.
+     * @param {Post} post
+     * @param {Segment} segment
+     * @returns {SegmentAudience}
+     */
+    describeSegment(post, segment) {
+        return {
+            status: getSegmentStatus(segment),
+            hasPostAccess: segmentHasPostAccess(post, segment)
+        };
+    }
+
     async renderPostBaseHtml(post, newsletter) {
         const postUrl = this.#getPostUrl(post);
 
@@ -515,6 +533,8 @@ class EmailRenderer {
      * @returns {Promise<EmailBody>}
      */
     async renderBody(post, newsletter, segment, options) {
+        const audience = this.describeSegment(post, segment);
+
         let html = await this.renderPostBaseHtml(post, newsletter);
 
         // Paywall and members only content handling
@@ -525,9 +545,8 @@ class EmailRenderer {
 
         // Members without access to the gated content (free members, or members
         // on a tier that can't read this post) get the public preview + paywall,
-        // exactly as on the web. Access is derived from the post's visibility,
-        // not just free/paid.
-        if (isPaidPost && hasMembersOnlyContent && !segmentHasPostAccess(post, segment)) {
+        // exactly as on the web.
+        if (isPaidPost && hasMembersOnlyContent && !audience.hasPostAccess) {
             // Add paywall
             addPaywall = true;
 
@@ -542,12 +561,10 @@ class EmailRenderer {
         // using the HTML and we don't want to include content that should not be
         // visible depending on the segment
         // data-gh-segment cards are a free/paid-only axis, independent of tier
-        // access. Match them against this segment's free/paid status rather than
-        // the raw segment filter (which may carry a tier expression).
-        const segmentStatus = getSegmentStatus(segment);
+        // access, so they match against the audience's status
         $('[data-gh-segment]').get().forEach((node) => {
             // TODO: replace with NQL interpretation
-            if (node.attribs['data-gh-segment'] !== segmentStatus) {
+            if (node.attribs['data-gh-segment'] !== audience.status) {
                 $(node).remove();
             } else {
                 // Getting rid of the attribute for a cleaner html output
@@ -562,7 +579,7 @@ class EmailRenderer {
             newsletter,
             html,
             addPaywall,
-            segment
+            audience
         });
         html = await this.renderTemplate(templateData);
 
@@ -1085,21 +1102,21 @@ class EmailRenderer {
     /**
      * Get email preheader text from post model
      * @param {Post} postModel
-     * @param {Segment} segment
+     * @param {SegmentAudience} audience
      * @param {string} html
      * @returns {string}
      */
-    #getEmailPreheader(postModel, segment, html) {
+    #getEmailPreheader(postModel, audience, html) {
         let plaintext = postModel.get('plaintext');
         let customExcerpt = postModel.get('custom_excerpt');
         if (customExcerpt) {
             return customExcerpt;
         } else {
             if (plaintext) {
-                // The plaintext field on the model may contain paid only content
-                // so we use the provided HTML to generate the plaintext as this
-                // should have already had the paid content removed
-                if (segment === 'status:free') {
+                // The plaintext field on the model may contain gated content
+                // the audience can't read, so regenerate from the provided
+                // HTML (already gated) whenever this audience lacks access
+                if (audience.status === 'status:free' || !audience.hasPostAccess) {
                     plaintext = htmlToPlaintext.email(html);
                 }
                 return plaintext.substring(0, 500);
@@ -1149,9 +1166,9 @@ class EmailRenderer {
      * @param {Newsletter} options.newsletter
      * @param {string} options.html
      * @param {boolean} options.addPaywall
-     * @param {string} options.segment
+     * @param {SegmentAudience} options.audience
      */
-    async getTemplateData({post, newsletter, html, addPaywall, segment}) {
+    async getTemplateData({post, newsletter, html, addPaywall, audience}) {
         const emailDesign = this.#getEmailDesign(newsletter);
 
         const {href: headerImage, width: headerImageWidth} = await this.limitImageWidth(newsletter.get('header_image'));
@@ -1258,7 +1275,7 @@ class EmailRenderer {
                 locale,
                 direction
             },
-            preheader: this.#getEmailPreheader(post, segment, html),
+            preheader: this.#getEmailPreheader(post, audience, html),
             preheaderSpacing: `${'&#8199;&#847; '.repeat(150)}${'&shy; '.repeat(200)} &nbsp;`,
             html,
 

--- a/ghost/core/core/server/services/email-service/email-service.js
+++ b/ghost/core/core/server/services/email-service/email-service.js
@@ -441,10 +441,11 @@ class EmailService {
      * @param {*} post
      * @param {*} newsletter
      * @param {import('./email-renderer').Segment} segment
+     * @param {string} [memberTier] - narrow the paid audience to a single tier
      * @returns {Promise<{subject: string, html: string, plaintext: string}>} Email preview
      */
-    async previewEmail(post, newsletter, segment) {
-        const renderSegment = this.#emailRenderer.getPreviewSegment(post, segment);
+    async previewEmail(post, newsletter, segment, memberTier) {
+        const renderSegment = this.#emailRenderer.getPreviewSegment(post, segment, memberTier);
         const audience = this.#emailRenderer.describeSegment(post, renderSegment);
         const exampleMember = await this.getExampleMember(null, audience.status);
 
@@ -464,9 +465,10 @@ class EmailService {
      * @param {*} newsletter
      * @param {import('./email-renderer').Segment} segment
      * @param {string[]} emails
+     * @param {string} [memberTier] - narrow the paid audience to a single tier
      */
-    async sendTestEmail(post, newsletter, segment, emails) {
-        const renderSegment = this.#emailRenderer.getPreviewSegment(post, segment);
+    async sendTestEmail(post, newsletter, segment, emails, memberTier) {
+        const renderSegment = this.#emailRenderer.getPreviewSegment(post, segment, memberTier);
         const audience = this.#emailRenderer.describeSegment(post, renderSegment);
 
         const members = [];

--- a/ghost/core/core/server/services/email-service/email-service.js
+++ b/ghost/core/core/server/services/email-service/email-service.js
@@ -353,10 +353,11 @@ class EmailService {
     }
 
     /**
-     * @params {string} [segment]
+     * @params {string|null} [audienceStatus] - the audience's free/paid status
+     *   ('status:free' / 'status:-free'), see EmailRenderer#describeSegment
      * @return {import('./email-renderer').MemberLike}
      */
-    getDefaultExampleMember(segment) {
+    getDefaultExampleMember(audienceStatus) {
         /**
          * @type {import('./email-renderer').MemberLike}
          */
@@ -366,8 +367,8 @@ class EmailService {
             email: 'jamie@example.com',
             name: 'Jamie Larson',
             createdAt: new Date(),
-            status: segment === 'status:free' ? 'free' : 'paid',
-            subscriptions: segment === 'status:free' ? [] : [
+            status: audienceStatus === 'status:free' ? 'free' : 'paid',
+            subscriptions: audienceStatus === 'status:free' ? [] : [
                 {
                     cancel_at_period_end: false,
                     trial_end_at: null,
@@ -382,14 +383,14 @@ class EmailService {
     /**
      * @private
      * @param {string} [email] (optional) Search for a member with this email address and use it as the example. If not found, defaults to the default but still uses the provided email address.
-     * @param {string} [segment] (optional) The segment to use for the example member
+     * @param {string|null} [audienceStatus] (optional) The audience's free/paid status, see EmailRenderer#describeSegment
      * @return {Promise<import('./email-renderer').MemberLike>}
      */
-    async getExampleMember(email, segment) {
+    async getExampleMember(email, audienceStatus) {
         /**
          * @type {import('./email-renderer').MemberLike}
          */
-        const exampleMember = this.getDefaultExampleMember(segment);
+        const exampleMember = this.getDefaultExampleMember(audienceStatus);
 
         // fetch any matching members so that replacements use expected values
         if (email) {
@@ -401,7 +402,7 @@ class EmailService {
                 exampleMember.name = member.get('name');
                 exampleMember.createdAt = member.get('created_at');
 
-                if (segment === 'status:-free' && member.get('status') !== 'free') {
+                if (audienceStatus === 'status:-free' && member.get('status') !== 'free') {
                     // Make sure the example member matches the chosen segment (otherwise we'll send an email to free segment, but include a paid member details, which looks like a bug)
                     exampleMember.status = member.get('status');
                     const subscriptions = (await member.getLazyRelation('stripeSubscriptions')).toJSON();
@@ -443,8 +444,9 @@ class EmailService {
      * @returns {Promise<{subject: string, html: string, plaintext: string}>} Email preview
      */
     async previewEmail(post, newsletter, segment) {
-        const exampleMember = await this.getExampleMember(null, segment);
         const renderSegment = this.#emailRenderer.getPreviewSegment(post, segment);
+        const audience = this.#emailRenderer.describeSegment(post, renderSegment);
+        const exampleMember = await this.getExampleMember(null, audience.status);
 
         const subject = this.#emailRenderer.getSubject(post);
         let {html, plaintext, replacements} = await this.#emailRenderer.renderBody(post, newsletter, renderSegment, {clickTrackingEnabled: false});
@@ -464,15 +466,18 @@ class EmailService {
      * @param {string[]} emails
      */
     async sendTestEmail(post, newsletter, segment, emails) {
+        const renderSegment = this.#emailRenderer.getPreviewSegment(post, segment);
+        const audience = this.#emailRenderer.describeSegment(post, renderSegment);
+
         const members = [];
         for (const email of emails) {
-            members.push(await this.getExampleMember(email, segment));
+            members.push(await this.getExampleMember(email, audience.status));
         }
 
         await this.#sendingService.send({
             post,
             newsletter,
-            segment: this.#emailRenderer.getPreviewSegment(post, segment),
+            segment: renderSegment,
             members,
             emailId: null
         }, {

--- a/ghost/core/core/server/services/members/content-gating.js
+++ b/ghost/core/core/server/services/members/content-gating.js
@@ -84,6 +84,84 @@ function checkPostAccess(post, member) {
     return BLOCK_ACCESS;
 }
 
+/**
+ * The tier slugs a parsed member segment names positively. Negations are
+ * skipped — they describe members who lack a tier, which adds nothing to the
+ * member shape checkSegmentPostAccess rebuilds.
+ * @param {object} query - A parsed NQL query (after member expansions)
+ * @returns {string[]}
+ */
+function collectSegmentProductSlugs(query) {
+    const slugs = [];
+    for (const [key, value] of Object.entries(query)) {
+        if (key === '$and' || key === '$or') {
+            for (const subQuery of value) {
+                slugs.push(...collectSegmentProductSlugs(subQuery));
+            }
+        } else if (key === 'products.slug') {
+            if (typeof value === 'string') {
+                slugs.push(value);
+            } else if (value && Array.isArray(value.$in)) {
+                slugs.push(...value.$in);
+            }
+        }
+    }
+    return slugs;
+}
+
+/**
+ * Whether the audience matched by a member segment can read a post's gated
+ * content. Emails are rendered per audience segment rather than per member,
+ * so there is no member to hand to checkPostAccess — instead we rebuild the
+ * member the segment describes (status + the tiers it names) and reuse
+ * checkPostAccess, keeping email and web gating from drifting apart. Mixed
+ * audiences get the least-privileged member's view: a paid segment naming no
+ * tiers cannot read a tier-restricted post.
+ *
+ * @param {object} post - A post object ({visibility, tiers})
+ * @param {string} segment - An NQL member filter
+ * @returns {AccessFlag}
+ */
+function checkSegmentPostAccess(post, segment) {
+    let nqlQuery;
+    let parsedQuery;
+    try {
+        nqlQuery = nql(segment, {expansions: MEMBER_NQL_EXPANSIONS, transformer: rejectUnknownKeys});
+        parsedQuery = nqlQuery.parse();
+    } catch (error) {
+        // segments arrive free-form from the API — unparseable ones get the
+        // paywall, not a 500
+        return BLOCK_ACCESS;
+    }
+
+    // a segment with only unknown keys parses to an empty query which would
+    // match every member — block, matching checkGatedBlockAccess semantics
+    if (Object.keys(parsedQuery).length === 0) {
+        return BLOCK_ACCESS;
+    }
+
+    // a candidate only counts when it matches the segment — 'status:free'
+    // must never be evaluated as the paid member
+    const slugs = collectSegmentProductSlugs(parsedQuery);
+    const candidateMembers = [
+        {status: 'free', products: []},
+        {status: 'paid', products: slugs.map(slug => ({slug}))}
+    ];
+    // an OR of tiers matches members holding any one of them, so each named
+    // tier must grant access on its own
+    for (const slug of slugs) {
+        candidateMembers.push({status: 'paid', products: [{slug}]});
+    }
+
+    // least privilege: every member the segment matches must have access —
+    // a mixed segment like 'status:free,status:-free' gets the free view
+    const matchingMembers = candidateMembers.filter(member => nqlQuery.queryJSON(member));
+    if (matchingMembers.length === 0) {
+        return BLOCK_ACCESS;
+    }
+    return matchingMembers.every(member => checkPostAccess(post, member));
+}
+
 function checkGatedBlockAccess(gatedBlockParams, member) {
     const {nonMember, memberSegment} = gatedBlockParams;
     const isLoggedIn = !!member;
@@ -113,6 +191,7 @@ function checkGatedBlockAccess(gatedBlockParams, member) {
 module.exports = {
     getPostAccessFilter,
     checkPostAccess,
+    checkSegmentPostAccess,
     checkGatedBlockAccess,
     PERMIT_ACCESS,
     BLOCK_ACCESS

--- a/ghost/core/core/server/services/members/create-paid-member-shim.ts
+++ b/ghost/core/core/server/services/members/create-paid-member-shim.ts
@@ -7,17 +7,26 @@ interface PaidMemberShim {
 }
 
 /**
- * Build a stand-in "all active paid tiers" member for content gating — NOT a real
- * member. It carries only the `status` and `products` that
+ * Build a stand-in paid member for content gating — NOT a real member. It
+ * carries only the `status` and `products` that
  * `contentGating.checkPostAccess` / `checkGatedBlockAccess` read, letting previews
  * (`member_status=paid`) and gift-link reads reveal gated content without a
- * logged-in member. Single source of truth for this security-sensitive grant.
+ * logged-in member. When a tier slug is supplied the shim has only that tier,
+ * including archived tiers; otherwise it has every active paid tier. Single
+ * source of truth for this security-sensitive grant.
  */
-export async function createPaidMemberShim(): Promise<PaidMemberShim> {
+export async function createPaidMemberShim(tierSlug?: string): Promise<PaidMemberShim> {
     let products: Array<{slug: string}> = [];
     try {
-        const paidProducts = await models.Product.findAll({status: 'active', type: 'paid'});
-        products = paidProducts.map((product: {get(key: string): string}) => ({slug: product.get('slug')}));
+        if (tierSlug) {
+            const paidProduct = await models.Product.findOne({slug: tierSlug, type: 'paid'});
+            if (paidProduct) {
+                products = [{slug: paidProduct.get('slug')}];
+            }
+        } else {
+            const paidProducts = await models.Product.findAll({status: 'active', type: 'paid'});
+            products = paidProducts.map((product: {get(key: string): string}) => ({slug: product.get('slug')}));
+        }
     } catch (error) {
         // Fall back to no tiers rather than failing the render — still grants
         // status:paid/members content, just not tier-specific blocks.

--- a/ghost/core/core/server/services/members/index.d.ts
+++ b/ghost/core/core/server/services/members/index.d.ts
@@ -25,7 +25,7 @@ interface MembersApi {
 interface MembersService {
     init(): Promise<void>;
     api: MembersApi;
-    createPaidMemberShim(): Promise<{status: 'paid'; products: Array<{slug: string}>}>;
+    createPaidMemberShim(tierSlug?: string): Promise<{status: 'paid'; products: Array<{slug: string}>}>;
 }
 
 declare const membersService: MembersService;

--- a/ghost/core/test/e2e-api/admin/email-previews.test.js
+++ b/ghost/core/test/e2e-api/admin/email-previews.test.js
@@ -343,9 +343,11 @@ describe('Email Preview API', function () {
 
     describe('Tier-restricted posts', function () {
         let post;
+        let paidTierSlug;
 
         beforeAll(async function () {
             const paidTier = await models.Product.findOne({type: 'paid'});
+            paidTierSlug = paidTier.get('slug');
 
             const lexical = JSON.stringify({
                 root: {
@@ -402,6 +404,49 @@ describe('Email Preview API', function () {
                     assert.ok(html.includes('Free preview text'), 'free member preview should include the public preview');
                     assert.ok(!html.includes('Members only tier content'), 'free member preview should not include the gated content');
                     assert.ok(html.includes('Become a paid member'), 'free member preview should include the paywall CTA');
+                });
+        });
+
+        it('renders content access for the specifically selected tier', async function () {
+            await agent
+                .get(`email_previews/posts/${post.id}/?memberSegment=${encodeURIComponent('status:-free')}&memberTier=${paidTierSlug}`)
+                .expectStatus(200)
+                .expect(({body}) => {
+                    const {html} = body.email_previews[0];
+                    assert.ok(html.includes('Members only tier content'), 'selected tier preview should include the gated content');
+                    assert.ok(!html.includes('Become a paid member'), 'selected tier preview should not include the paywall CTA');
+                });
+        });
+
+        it('renders the paywall for a specifically selected tier without access', async function () {
+            await agent
+                .get(`email_previews/posts/${post.id}/?memberSegment=${encodeURIComponent('status:-free')}&memberTier=missing-tier`)
+                .expectStatus(200)
+                .expect(({body}) => {
+                    const {html} = body.email_previews[0];
+                    assert.ok(!html.includes('Members only tier content'), 'other tier preview should not include the gated content');
+                    assert.ok(html.includes('Become a paid member'), 'other tier preview should include the paywall CTA');
+                });
+        });
+
+        it('rejects a repeated memberTier param', async function () {
+            // repeated query params parse as an array
+            await agent
+                .get(`email_previews/posts/${post.id}/?memberSegment=${encodeURIComponent('status:-free')}&memberTier=${paidTierSlug}&memberTier=other`)
+                .expectStatus(422);
+        });
+
+        it('renders tier access for a raw NQL memberSegment', async function () {
+            // memberSegment remains free-form for API back-compat
+            const memberSegment = `status:-free+product:'${paidTierSlug}'`;
+
+            await agent
+                .get(`email_previews/posts/${post.id}/?memberSegment=${encodeURIComponent(memberSegment)}`)
+                .expectStatus(200)
+                .expect(({body}) => {
+                    const {html} = body.email_previews[0];
+                    assert.ok(html.includes('Members only tier content'), 'selected tier preview should include the gated content');
+                    assert.ok(!html.includes('Become a paid member'), 'selected tier preview should not include the paywall CTA');
                 });
         });
     });

--- a/ghost/core/test/e2e-frontend/preview-routes.test.js
+++ b/ghost/core/test/e2e-frontend/preview-routes.test.js
@@ -104,6 +104,27 @@ describe('Frontend Routing: Preview Routes', function () {
             .expect(assertNoPaywallRendered);
     });
 
+    it('should render draft using only the tier selected for the preview', async function () {
+        await request.get('/p/d52c42ae-2755-455c-80ec-70b2ec55c906/?member_status=paid&member_tier=silver')
+            .expect('Content-Type', /html/)
+            .expect(200)
+            .expect(assertCorrectFrontendHeaders)
+            .expect(assertNoPaywallRendered);
+
+        await request.get('/p/d52c42ae-2755-455c-80ec-70b2ec55c906/?member_status=paid&member_tier=missing-tier')
+            .expect('Content-Type', /html/)
+            .expect(200)
+            .expect(assertCorrectFrontendHeaders)
+            .expect(assertPaywallRendered);
+    });
+
+    it('should reject a repeated member_tier param', async function () {
+        // frontend routing turns API validation errors into a 404 rather than
+        // exposing them — the point is it must not render as an all-tier member
+        await request.get('/p/d52c42ae-2755-455c-80ec-70b2ec55c906/?member_status=paid&member_tier=silver&member_tier=gold')
+            .expect(404);
+    });
+
     it('should render draft as free member with ?member_status=free', async function () {
         await request.get('/p/d52c42ae-2755-455c-80ec-70b2ec55c905/?member_status=free')
             .expect('Content-Type', /html/)

--- a/ghost/core/test/unit/api/endpoints/previews.test.js
+++ b/ghost/core/test/unit/api/endpoints/previews.test.js
@@ -76,6 +76,29 @@ describe('Previews controller', function () {
             assert.equal(frame.original.context.member.products[0].slug, 'silver');
         });
 
+        it('sets the selected tier on the paid member context', async function () {
+            const findOne = sinon.stub(Product, 'findOne').resolves({
+                get: sinon.stub().returns('archived-tier')
+            });
+            const frame = {options: {member_status: 'paid', member_tier: 'archived-tier'}};
+
+            await previewsController.read.query(frame);
+
+            sinon.assert.calledOnceWithExactly(findOne, {slug: 'archived-tier', type: 'paid'});
+            assert.deepEqual(frame.original.context.member, {
+                status: 'paid',
+                products: [{slug: 'archived-tier'}]
+            });
+        });
+
+        it('rejects a non-string member_tier', async function () {
+            const findOne = sinon.stub(Product, 'findOne');
+            const frame = {options: {member_status: 'paid', member_tier: ['silver', 'gold']}};
+
+            await assert.rejects(previewsController.read.query(frame), {errorType: 'ValidationError'});
+            sinon.assert.notCalled(findOne);
+        });
+
         it('sets frame.apiType but does not set member context when member_status is anonymous', async function () {
             const frame = {options: {member_status: 'anonymous'}};
             await previewsController.read.query(frame);

--- a/ghost/core/test/unit/server/services/email-service/email-controller.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-controller.test.js
@@ -143,6 +143,39 @@ describe('Email Controller', function () {
             });
             assert.equal(segment, 'free');
         });
+
+        it('rejects a non-string memberTier from options', async function () {
+            const controller = new EmailController({}, {
+                models: {
+                    Post: createModelClass(),
+                    Newsletter: createModelClass()
+                }
+            });
+            await assert.rejects(controller._getFrameData({
+                options: {
+                    id: 'options-id',
+                    memberTier: ['silver', 'gold']
+                },
+                data: {}
+            }), {errorType: 'ValidationError'});
+        });
+
+        it('rejects a non-string memberTier from data', async function () {
+            const controller = new EmailController({}, {
+                models: {
+                    Post: createModelClass(),
+                    Newsletter: createModelClass()
+                }
+            });
+            await assert.rejects(controller._getFrameData({
+                options: {
+                    id: 'options-id'
+                },
+                data: {
+                    memberTier: {slug: 'gold'}
+                }
+            }), {errorType: 'ValidationError'});
+        });
     });
 
     describe('previewEmail', function () {

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -1384,6 +1384,27 @@ describe('Email renderer', function () {
             const post = createTiersPost([{slug: 'gold'}]);
             assert.equal(emailRenderer.getPreviewSegment(post, null), null);
         });
+
+        it('narrows the paid audience to a selected tier', function () {
+            const post = createTiersPost([{slug: 'gold'}, {slug: 'silver'}]);
+            assert.equal(
+                emailRenderer.getPreviewSegment(post, 'status:-free', 'silver'),
+                'status:-free+product:\'silver\''
+            );
+        });
+
+        it('escapes quotes when narrowing to a tier', function () {
+            const post = createTiersPost([{slug: 'gold'}]);
+            assert.equal(
+                emailRenderer.getPreviewSegment(post, 'status:-free', 'we\'re-fancy'),
+                'status:-free+product:\'we\\\'re-fancy\''
+            );
+        });
+
+        it('ignores a selected tier for the free audience', function () {
+            const post = createTiersPost([{slug: 'gold'}]);
+            assert.equal(emailRenderer.getPreviewSegment(post, 'status:free', 'gold'), 'status:free');
+        });
     });
 
     describe('renderBody', function () {

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -2416,6 +2416,94 @@ describe('Email renderer', function () {
             assert(!preview.html.includes('Become a paid member of Test Blog to get access to all'));
         });
 
+        it('renders tier-gated content according to a specific tier segment', async function () {
+            renderedPost = '<div> Lexical Test </div> some text for both <!--members-only--> finishing part only for members';
+            const post = {
+                related: (key) => {
+                    if (key === 'tiers') {
+                        return {toJSON: () => [{slug: 'gold'}, {slug: 'silver'}]};
+                    }
+                    return null;
+                },
+                get: (key) => {
+                    if (key === 'lexical') {
+                        return '{}';
+                    }
+                    if (key === 'visibility') {
+                        return 'tiers';
+                    }
+                    if (key === 'title') {
+                        return 'Test Post';
+                    }
+                },
+                getLazyRelation: () => {
+                    return {models: [{get: k => (k === 'name' ? 'Test Author' : undefined)}]};
+                }
+            };
+            const newsletter = {
+                get: (key) => {
+                    if (key === 'show_post_title_section' || key === 'feedback_enabled') {
+                        return true;
+                    }
+                    return false;
+                }
+            };
+
+            const silver = await emailRenderer.renderBody(post, newsletter, 'status:-free+product:\'silver\'', {});
+            assert(silver.html.includes('finishing part only for members'));
+            assert(!silver.html.includes('Become a paid member of Test Blog to get access to all'));
+
+            const bronze = await emailRenderer.renderBody(post, newsletter, 'status:-free+product:\'bronze\'', {});
+            assert(!bronze.html.includes('finishing part only for members'));
+            assert(bronze.html.includes('Become a paid member of Test Blog to get access to all'));
+
+            // the plain paid segment includes members without a matching tier -> paywall
+            const plainPaid = await emailRenderer.renderBody(post, newsletter, 'status:-free', {});
+            assert(!plainPaid.html.includes('finishing part only for members'));
+            assert(plainPaid.html.includes('Become a paid member of Test Blog to get access to all'));
+        });
+
+        it('does not paywall a tier segment on a paid-visibility post', async function () {
+            renderedPost = '<div> Lexical Test </div> some text for both <!--members-only--> finishing part only for members';
+            const post = {
+                related: () => {
+                    return null;
+                },
+                get: (key) => {
+                    if (key === 'lexical') {
+                        return '{}';
+                    }
+                    if (key === 'visibility') {
+                        return 'paid';
+                    }
+                    if (key === 'title') {
+                        return 'Test Post';
+                    }
+                },
+                getLazyRelation: () => {
+                    return {models: [{get: k => (k === 'name' ? 'Test Author' : undefined)}]};
+                }
+            };
+            const newsletter = {
+                get: (key) => {
+                    if (key === 'show_post_title_section' || key === 'feedback_enabled') {
+                        return true;
+                    }
+                    return false;
+                }
+            };
+
+            // every tier member is a paid member, so a tier segment on a
+            // paid-members-only post gets the full content
+            const tierSegment = await emailRenderer.renderBody(post, newsletter, 'status:-free+product:\'gold\'', {});
+            assert(tierSegment.html.includes('finishing part only for members'));
+            assert(!tierSegment.html.includes('Become a paid member of Test Blog to get access to all'));
+
+            const freeSegment = await emailRenderer.renderBody(post, newsletter, 'status:free', {});
+            assert(!freeSegment.html.includes('finishing part only for members'));
+            assert(freeSegment.html.includes('Become a paid member of Test Blog to get access to all'));
+        });
+
         it('does not paywall an unsegmented (null segment) render of a gated post', async function () {
             renderedPost = '<div> Lexical Test </div> some text for both <!--members-only--> finishing part only for members';
             const post = {

--- a/ghost/core/test/unit/server/services/email-service/email-service.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-service.test.js
@@ -51,6 +51,12 @@ describe('Email Service', function () {
             },
             getPreviewSegment: (post, segment) => {
                 return segment;
+            },
+            describeSegment: (post, segment) => {
+                return {
+                    status: segment?.includes('status:-free') ? 'status:-free' : (segment?.includes('status:free') ? 'status:free' : null),
+                    hasPostAccess: true
+                };
             }
         };
         sendingService = {

--- a/ghost/core/test/unit/server/services/email-service/email-service.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-service.test.js
@@ -833,8 +833,29 @@ describe('Email Service', function () {
 
             await service.previewEmail(post, post.get('newsletter'), 'status:-free');
 
-            sinon.assert.calledOnceWithExactly(emailRenderer.getPreviewSegment, post, 'status:-free');
+            sinon.assert.calledOnceWithExactly(emailRenderer.getPreviewSegment, post, 'status:-free', undefined);
             assert.equal(renderBody.firstCall.args[2], 'status:-free+(product:\'gold\')');
+        });
+
+        it('passes the selected tier through to the preview segment', async function () {
+            const post = createModel({
+                id: '123',
+                newsletter: createModel({
+                    status: 'active',
+                    feedback_enabled: true
+                })
+            });
+            sinon.stub(emailRenderer, 'getPreviewSegment').returns('status:-free+product:\'silver\'');
+            const renderBody = sinon.stub(emailRenderer, 'renderBody').resolves({
+                html: 'HTML',
+                plaintext: 'Plaintext',
+                replacements: []
+            });
+
+            await service.previewEmail(post, post.get('newsletter'), 'status:-free', 'silver');
+
+            sinon.assert.calledOnceWithExactly(emailRenderer.getPreviewSegment, post, 'status:-free', 'silver');
+            assert.equal(renderBody.firstCall.args[2], 'status:-free+product:\'silver\'');
         });
     });
 
@@ -873,6 +894,23 @@ describe('Email Service', function () {
             assert.equal(segment, 'status:-free+(product:\'gold\')');
             // The example member is still built from the audience choice, not the mapped filter
             assert.equal(members[0].status, 'paid');
+        });
+
+        it('passes the selected tier through to the preview segment', async function () {
+            const post = createModel({
+                id: '123',
+                newsletter: createModel({
+                    status: 'active',
+                    feedback_enabled: true
+                })
+            });
+            const getPreviewSegment = sinon.stub(emailRenderer, 'getPreviewSegment').returns('status:-free+product:\'silver\'');
+
+            await service.sendTestEmail(post, post.get('newsletter'), 'status:-free', ['example@example.com'], 'silver');
+
+            sinon.assert.calledOnceWithExactly(getPreviewSegment, post, 'status:-free', 'silver');
+            const {segment} = sendingService.send.firstCall.args[0];
+            assert.equal(segment, 'status:-free+product:\'silver\'');
         });
     });
 });

--- a/ghost/core/test/unit/server/services/members/content-gating.test.js
+++ b/ghost/core/test/unit/server/services/members/content-gating.test.js
@@ -1,5 +1,5 @@
 const assert = require('node:assert/strict');
-const {getPostAccessFilter, checkPostAccess, checkGatedBlockAccess} = require('../../../../../core/server/services/members/content-gating');
+const {getPostAccessFilter, checkPostAccess, checkSegmentPostAccess, checkGatedBlockAccess} = require('../../../../../core/server/services/members/content-gating');
 
 describe('Members Service - Content gating', function () {
     describe('getPostAccessFilter', function () {
@@ -120,6 +120,76 @@ describe('Members Service - Content gating', function () {
             }]};
             access = checkPostAccess(post, member);
             assert.equal(access, false);
+        });
+    });
+
+    describe('checkSegmentPostAccess', function () {
+        const paidPost = {visibility: 'paid'};
+        const tiersPost = {visibility: 'tiers', tiers: [{slug: 'gold'}, {slug: 'silver'}]};
+
+        it('permits the paid segment on a paid post', function () {
+            assert.equal(checkSegmentPostAccess(paidPost, 'status:-free'), true);
+        });
+
+        it('blocks the free segment on a paid post', function () {
+            assert.equal(checkSegmentPostAccess(paidPost, 'status:free'), false);
+        });
+
+        it('permits a tier segment on a paid post', function () {
+            assert.equal(checkSegmentPostAccess(paidPost, 'status:-free+product:\'gold\''), true);
+        });
+
+        it('blocks the plain paid segment on a tiers post', function () {
+            // members without a matching tier are paid too — least privilege wins
+            assert.equal(checkSegmentPostAccess(tiersPost, 'status:-free'), false);
+        });
+
+        it('permits a matching tier segment on a tiers post', function () {
+            assert.equal(checkSegmentPostAccess(tiersPost, 'status:-free+product:\'silver\''), true);
+        });
+
+        it('blocks a non-matching tier segment on a tiers post', function () {
+            assert.equal(checkSegmentPostAccess(tiersPost, 'status:-free+product:\'bronze\''), false);
+        });
+
+        it('permits the send pipeline access variant on a tiers post', function () {
+            assert.equal(checkSegmentPostAccess(tiersPost, 'status:-free+(product:\'gold\',product:\'silver\')'), true);
+        });
+
+        it('blocks the send pipeline no-access variant on a tiers post', function () {
+            assert.equal(checkSegmentPostAccess(tiersPost, 'status:-free+(product:-\'gold\'+product:-\'silver\')'), false);
+        });
+
+        it('permits a multi-tier segment when one named tier grants access', function () {
+            const goldOnlyPost = {visibility: 'tiers', tiers: [{slug: 'gold'}]};
+            assert.equal(checkSegmentPostAccess(goldOnlyPost, 'product:\'gold\'+product:\'silver\''), true);
+        });
+
+        it('blocks a mixed free/paid segment on a paid post', function () {
+            assert.equal(checkSegmentPostAccess(paidPost, 'status:free,status:-free+product:\'gold\''), false);
+        });
+
+        it('blocks a negated tier segment on a paid post', function () {
+            // matches free members too, so least privilege wins
+            assert.equal(checkSegmentPostAccess(paidPost, 'product:-\'gold\''), false);
+        });
+
+        it('blocks an OR of tiers when one named tier lacks access', function () {
+            const goldOnlyPost = {visibility: 'tiers', tiers: [{slug: 'gold'}]};
+            assert.equal(checkSegmentPostAccess(goldOnlyPost, 'product:\'gold\',product:\'silver\''), false);
+        });
+
+        it('blocks any segment on a tiers post with no tiers configured', function () {
+            const misconfiguredPost = {visibility: 'tiers', tiers: []};
+            assert.equal(checkSegmentPostAccess(misconfiguredPost, 'status:-free+product:\'gold\''), false);
+        });
+
+        it('blocks segments with only unknown keys', function () {
+            assert.equal(checkSegmentPostAccess(paidPost, 'label:vip'), false);
+        });
+
+        it('blocks malformed segments', function () {
+            assert.equal(checkSegmentPostAccess(paidPost, 'status:(('), false);
         });
     });
 

--- a/ghost/core/test/unit/server/services/members/create-paid-member-shim.test.ts
+++ b/ghost/core/test/unit/server/services/members/create-paid-member-shim.test.ts
@@ -21,6 +21,25 @@ describe('Unit - members/create-paid-member-shim', function () {
         assert.deepEqual(member, {status: 'paid', products: [{slug: 'silver'}, {slug: 'gold'}]});
     });
 
+    it('returns a paid member with only the selected tier, including archived tiers', async function () {
+        const findOne = sinon.stub(models.Product, 'findOne').resolves({
+            get: (key: string) => (key === 'slug' ? 'archive' : undefined)
+        });
+
+        const member = await createPaidMemberShim('archive');
+
+        assert.deepEqual(member, {status: 'paid', products: [{slug: 'archive'}]});
+        sinon.assert.calledOnceWithExactly(findOne, {slug: 'archive', type: 'paid'});
+    });
+
+    it('returns a paid member with no tiers when the selected tier does not exist', async function () {
+        sinon.stub(models.Product, 'findOne').resolves(null);
+
+        const member = await createPaidMemberShim('missing');
+
+        assert.deepEqual(member, {status: 'paid', products: []});
+    });
+
     it('falls back to a paid member with no tiers (never throws) when the tier lookup fails', async function () {
         const logError = sinon.stub(logging, 'error');
         sinon.stub(models.Product, 'findAll').rejects(new Error('db down'));


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3779/

Stacked on #29359 — merge that first; this diff reads clean once its base lands.

Previewing a post as a "paid member" always simulates access to every active tier, so publishers with tier-restricted content can't check what members on a specific tier will see before publishing — the web preview shows content an off-tier member wouldn't get, archived tiers can't be previewed at all, and the email preview and test emails can't be scoped to a tier.

This adds a "Tier" audience to the editor's preview modal with a grouped Active/Archived tier selector, covering both surfaces:

- **Web previews** pass `member_status=paid&member_tier=<slug>` and the server builds the gating context via `createPaidMemberShim(tierSlug)` — a single-tier member shim, including archived tiers. `member_tier` is validated as a single string; repeated params are rejected instead of silently degrading.
- **Email previews and test emails** pass `memberSegment=status:-free` plus `memberTier=<slug>`, and the server composes the render segment in `getPreviewSegment` — the client never assembles NQL filter strings, keeping the segment vocabulary server-owned (raw `memberSegment` NQL still works for API back-compat). Test emails sent with a tier selected personalize from the real recipient's subscription data, same as the plain paid option.
- Tiers load once per editor session in `publish-management` so the modal opens with its selector ready and remembers the selection across opens, degrading to the free/paid options if the fetch fails.
- The Active/Archived tier grouping that was hand-rolled in three existing tier-picking selects (and would have gained a fourth copy here) now lives in a shared `group-tiers` util used by all four.