### PR TITLE
Changed admin-x-settings menus to shade DropdownMenu

### DIFF
--- a/apps/admin-x-settings/src/components/settings/general/user-detail-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/user-detail-modal.tsx
@@ -8,7 +8,8 @@ import usePinturaEditor from '../../../hooks/use-pintura-editor';
 import useStaffUsers from '../../../hooks/use-staff-users';
 import validator from 'validator';
 import {APIError} from '@tryghost/admin-x-framework/errors';
-import {ConfirmationModal, Heading, Icon, ImageUpload, LimitModal, Menu, type MenuItem, Modal, TabView, showToast} from '@tryghost/admin-x-design-system';
+import {ConfirmationModal, Heading, Icon, ImageUpload, LimitModal, Modal, TabView, showToast} from '@tryghost/admin-x-design-system';
+import {DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger} from '@tryghost/shade/components';
 import {type ErrorMessages, useForm, useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {HostLimitError, useLimiter} from '../../../hooks/use-limiter';
 import {type RoutingModalProps, useRouting} from '@tryghost/admin-x-framework/routing';
@@ -299,46 +300,12 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
     };
 
     const showMenu = hasAdminAccess(currentUser) || (isEditorUser(currentUser) && isAuthorOrContributor(user));
-    const menuItems: MenuItem[] = [];
-
-    if (isOwnerUser(currentUser) && isAdminUser(formState) && formState.status !== 'inactive') {
-        menuItems.push({
-            id: 'make-owner',
-            label: 'Make owner',
-            onClick: confirmMakeOwner
-        });
-    }
-
-    menuItems.push({
-        id: 'view-user-activity',
-        label: 'View user activity',
-        onClick: () => {
-            mainModal.remove();
-            updateRoute(`history/view/${formState.id}`);
-        }
-    });
-
-    if (formState.id !== currentUser.id && (
+    const canMakeOwner = isOwnerUser(currentUser) && isAdminUser(formState) && formState.status !== 'inactive';
+    const canSuspendUser = formState.id !== currentUser.id && (
         (hasAdminAccess(currentUser) && !isOwnerUser(user)) ||
         (isEditorUser(currentUser) && isAuthorOrContributor(user))
-    )) {
-        const suspendUserLabel = formState.status === 'inactive' ? 'Un-suspend user' : 'Suspend user';
-
-        menuItems.push({
-            id: 'suspend-user',
-            label: suspendUserLabel,
-            onClick: () => {
-                confirmSuspend(formState);
-            }
-        }, {
-            id: 'delete-user',
-            label: 'Delete user',
-            destructive: true,
-            onClick: () => {
-                confirmDelete(user, {owner: ownerUser});
-            }
-        });
-    }
+    );
+    const suspendUserLabel = formState.status === 'inactive' ? 'Un-suspend user' : 'Suspend user';
 
     const noCoverButtonClasses = 'rounded flex flex-nowrap items-center justify-center px-3 h-8 transition-all cursor-pointer font-medium border border-grey-300 bg-transparent text-black dark:border-grey-800 dark:text-white';
 
@@ -447,10 +414,8 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
                                         }}
                                     >Upload cover image</ImageUpload>
                                     {showMenu && <div className="z-10">
-                                        <Menu
-                                            items={menuItems}
-                                            position='end'
-                                            trigger={
+                                        <DropdownMenu>
+                                            <DropdownMenuTrigger asChild>
                                                 <button
                                                     className={clsx(
                                                         'flex h-8 cursor-pointer items-center justify-center rounded px-3',
@@ -467,8 +432,39 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
                                                         size='md'
                                                     />
                                                 </button>
-                                            }
-                                        />
+                                            </DropdownMenuTrigger>
+                                            {/* legacy Modal overlay is z-[1000]; keep the portalled menu above it */}
+                                            <DropdownMenuContent align='end' className='z-[9999]'>
+                                                {canMakeOwner && (
+                                                    <DropdownMenuItem onClick={confirmMakeOwner}>
+                                                        Make owner
+                                                    </DropdownMenuItem>
+                                                )}
+                                                <DropdownMenuItem onClick={() => {
+                                                    mainModal.remove();
+                                                    updateRoute(`history/view/${formState.id}`);
+                                                }}>
+                                                    View user activity
+                                                </DropdownMenuItem>
+                                                {canSuspendUser && (
+                                                    <>
+                                                        <DropdownMenuItem onClick={() => {
+                                                            confirmSuspend(formState);
+                                                        }}>
+                                                            {suspendUserLabel}
+                                                        </DropdownMenuItem>
+                                                        <DropdownMenuItem
+                                                            className='text-destructive focus:text-destructive'
+                                                            onClick={() => {
+                                                                confirmDelete(user, {owner: ownerUser});
+                                                            }}
+                                                        >
+                                                            Delete user
+                                                        </DropdownMenuItem>
+                                                    </>
+                                                )}
+                                            </DropdownMenuContent>
+                                        </DropdownMenu>
                                     </div>}
                                 </div>
                             </div>

--- a/apps/admin-x-settings/src/components/settings/site/change-theme.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/change-theme.tsx
@@ -1,7 +1,8 @@
 import NiceModal from '@ebay/nice-modal-react';
 import React, {useEffect, useState} from 'react';
 import TopLevelGroup from '../../top-level-group';
-import {Button, Heading, LimitModal, Menu, SettingGroupContent} from '@tryghost/admin-x-design-system';
+import {Button, Heading, LimitModal, SettingGroupContent} from '@tryghost/admin-x-design-system';
+import {DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger} from '@tryghost/shade/components';
 import {type Theme, useBrowseThemes} from '@tryghost/admin-x-framework/api/themes';
 import {downloadFile, getGhostPaths} from '@tryghost/admin-x-framework/helpers';
 import {useCheckThemeLimitError} from '../../../hooks/use-check-theme-limit-error';
@@ -70,19 +71,6 @@ const ChangeTheme: React.FC<{ keywords: string[] }> = ({keywords}) => {
         downloadFile(`${apiRoot}/themes/${activeTheme.name}/download`);
     };
 
-    const themeMenuItems = [
-        {
-            id: 'edit-code',
-            label: 'Edit code',
-            onClick: openThemeEditor
-        },
-        {
-            id: 'download',
-            label: 'Download',
-            onClick: downloadTheme
-        }
-    ];
-
     const values = (
         <SettingGroupContent>
             <div className='flex flex-col'>
@@ -90,15 +78,15 @@ const ChangeTheme: React.FC<{ keywords: string[] }> = ({keywords}) => {
                 <div className='mt-1 flex w-full items-center justify-between gap-4'>
                     <div>{activeTheme ? `${activeTheme.name} (v${activeTheme.package?.version || '1.0'})` : 'Loading...'}</div>
                     <div className='-mr-3'>
-                        <Menu
-                            items={themeMenuItems}
-                            position='end'
-                            triggerButtonProps={{
-                                disabled: !activeTheme,
-                                iconColorClass: 'text-base',
-                                size: 'sm'
-                            }}
-                        />
+                        <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                                <Button disabled={!activeTheme} icon='ellipsis' iconColorClass='text-base' label='Menu' size='sm' hideLabel />
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align='end'>
+                                <DropdownMenuItem onClick={openThemeEditor}>Edit code</DropdownMenuItem>
+                                <DropdownMenuItem onClick={downloadTheme}>Download</DropdownMenuItem>
+                            </DropdownMenuContent>
+                        </DropdownMenu>
                     </div>
                 </div>
             </div>

--- a/apps/admin-x-settings/src/components/settings/site/theme/advanced-theme-settings.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/advanced-theme-settings.tsx
@@ -2,7 +2,8 @@ import InvalidThemeModal, {type FatalErrors} from './invalid-theme-modal';
 import NiceModal from '@ebay/nice-modal-react';
 import React from 'react';
 import useCustomFonts from '../../../../hooks/use-custom-fonts';
-import {Button, type ButtonProps, ConfirmationModal, LimitModal, List, ListItem, Menu, ModalPage, showToast} from '@tryghost/admin-x-design-system';
+import {Button, ConfirmationModal, LimitModal, List, ListItem, ModalPage, showToast} from '@tryghost/admin-x-design-system';
+import {DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger} from '@tryghost/shade/components';
 import {JSONError} from '@tryghost/admin-x-framework/errors';
 import {type Theme, isActiveTheme, isDefaultTheme, isDeletableTheme, isLegacyTheme, useActivateTheme, useDeleteTheme} from '@tryghost/admin-x-framework/api/themes';
 import {downloadFile, getGhostPaths} from '@tryghost/admin-x-framework/helpers';
@@ -155,36 +156,22 @@ const ThemeActions: React.FC<ThemeActionProps> = ({
         );
     }
 
-    const menuItems = [
-        {
-            id: 'edit-code',
-            label: 'Edit code',
-            onClick: handleEditCode
-        },
-        {
-            id: 'download',
-            label: 'Download',
-            onClick: handleDownload
-        }
-    ];
-
-    if (isDeletableTheme(theme)) {
-        menuItems.push({
-            id: 'delete',
-            label: 'Delete',
-            onClick: handleDelete
-        });
-    }
-
-    const buttonProps: ButtonProps = {
-        iconColorClass: 'text-base',
-        size: 'sm'
-    };
-
     return (
         <div className='-mr-3 flex items-center gap-4'>
             {actions}
-            <Menu items={menuItems} position='end' triggerButtonProps={buttonProps} />
+            <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                    <Button icon='ellipsis' iconColorClass='text-base' label='Menu' size='sm' hideLabel />
+                </DropdownMenuTrigger>
+                {/* legacy ModalPage overlay is z-[1000]; keep the portalled menu above it */}
+                <DropdownMenuContent align='end' className='z-[9999]'>
+                    <DropdownMenuItem onClick={handleEditCode}>Edit code</DropdownMenuItem>
+                    <DropdownMenuItem onClick={handleDownload}>Download</DropdownMenuItem>
+                    {isDeletableTheme(theme) && (
+                        <DropdownMenuItem onClick={handleDelete}>Delete</DropdownMenuItem>
+                    )}
+                </DropdownMenuContent>
+            </DropdownMenu>
         </div>
     );
 };

--- a/apps/admin-x-settings/test/acceptance/general/users/actions.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/users/actions.test.ts
@@ -33,7 +33,7 @@ test.describe('User actions', async () => {
         const modal = page.getByTestId('user-detail-modal');
 
         await modal.getByRole('button', {name: 'Actions'}).click();
-        await page.getByTestId('popover-content').getByRole('button', {name: 'Suspend user'}).click();
+        await page.getByRole('menuitem', {name: 'Suspend user'}).click();
 
         const confirmation = page.getByTestId('confirmation-modal');
         await confirmation.getByRole('button', {name: 'Suspend'}).click();
@@ -89,7 +89,7 @@ test.describe('User actions', async () => {
         await expect(modal).toHaveText(/Suspended/);
 
         await modal.getByRole('button', {name: 'Actions'}).click();
-        await page.getByTestId('popover-content').getByRole('button', {name: 'Un-suspend user'}).click();
+        await page.getByRole('menuitem', {name: 'Un-suspend user'}).click();
 
         const confirmation = page.getByTestId('confirmation-modal');
         await confirmation.getByRole('button', {name: 'Un-suspend'}).click();
@@ -130,7 +130,7 @@ test.describe('User actions', async () => {
         const modal = page.getByTestId('user-detail-modal');
 
         await modal.getByRole('button', {name: 'Actions'}).click();
-        await page.getByTestId('popover-content').getByRole('button', {name: 'Delete user'}).click();
+        await page.getByRole('menuitem', {name: 'Delete user'}).click();
 
         const confirmation = page.getByTestId('confirmation-modal');
         await confirmation.getByRole('button', {name: 'Delete user'}).click();
@@ -187,8 +187,14 @@ test.describe('User actions', async () => {
         await listItem.getByRole('button', {name: 'Edit'}).click();
 
         await modal.getByRole('button', {name: 'Actions'}).click();
-        await expect(page.getByTestId('popover-content').getByRole('button', {name: 'Make owner'})).toHaveCount(0);
-        await modal.getByRole('button', {name: 'Actions'}).click();
+        await expect(page.getByRole('menu')).toBeVisible();
+        await expect(page.getByRole('menuitem', {name: 'Make owner'})).toHaveCount(0);
+
+        // Radix hides and disables pointer events on everything outside the
+        // open menu, so dismiss it with a raw outside click (Escape would
+        // also close the modal underneath)
+        await page.mouse.click(10, 10);
+        await expect(page.getByRole('menu')).toHaveCount(0);
 
         await modal.getByRole('button', {name: 'Close'}).click();
 
@@ -200,7 +206,7 @@ test.describe('User actions', async () => {
         await listItem.getByRole('button', {name: 'Edit'}).click();
 
         await modal.getByRole('button', {name: 'Actions'}).click();
-        await page.getByTestId('popover-content').getByRole('button', {name: 'Make owner'}).click();
+        await page.getByRole('menuitem', {name: 'Make owner'}).click();
 
         const confirmation = page.getByTestId('confirmation-modal');
         await confirmation.getByRole('button', {name: 'Yep — I\'m sure'}).click();
@@ -268,7 +274,7 @@ test.describe('User actions', async () => {
         await expect(modal).toHaveText(/Suspended/);
 
         await modal.getByRole('button', {name: 'Actions'}).click();
-        await page.getByTestId('popover-content').getByRole('button', {name: 'Un-suspend user'}).click();
+        await page.getByRole('menuitem', {name: 'Un-suspend user'}).click();
 
         await expect(page.getByTestId('limit-modal')).toHaveText(/Your plan does not support more staff/);
     });

--- a/apps/admin-x-settings/test/acceptance/site/theme.test.ts
+++ b/apps/admin-x-settings/test/acceptance/site/theme.test.ts
@@ -57,7 +57,7 @@ async function openInstalledThemeEditor(page: Page, themeName: string) {
 
     const themeListItem = modal.getByTestId('theme-list-item').filter({hasText: new RegExp(escapeRegExp(themeName), 'i')});
     await themeListItem.getByRole('button', {name: 'Menu'}).click();
-    await page.getByTestId('popover-content').getByRole('button', {name: 'Edit code'}).click();
+    await page.getByRole('menuitem', {name: 'Edit code'}).click();
 
     return page.getByTestId('theme-code-editor-modal');
 }
@@ -67,7 +67,7 @@ async function openActiveThemeEditorFromSettings(page: Page) {
 
     const themeSection = page.getByTestId('theme');
     await themeSection.getByRole('button', {name: 'Menu'}).click();
-    await page.getByTestId('popover-content').getByRole('button', {name: 'Edit code'}).click();
+    await page.getByRole('menuitem', {name: 'Edit code'}).click();
 
     return page.getByTestId('theme-code-editor-modal');
 }
@@ -205,14 +205,14 @@ test.describe('Theme settings', async () => {
         // Download the active theme
 
         await casper.getByRole('button', {name: 'Menu'}).click();
-        await page.getByTestId('popover-content').getByRole('button', {name: 'Download'}).click();
+        await page.getByRole('menuitem', {name: 'Download'}).click();
 
         await expect(page.locator('iframe#iframeDownload')).toHaveAttribute('src', /\/api\/admin\/themes\/casper\/download/);
 
         // Delete the inactive theme
 
         await edition.getByRole('button', {name: 'Menu'}).click();
-        await page.getByTestId('popover-content').getByRole('button', {name: 'Delete'}).click();
+        await page.getByRole('menuitem', {name: 'Delete'}).click();
 
         const confirmation = page.getByTestId('confirmation-modal');
         await confirmation.getByRole('button', {name: 'Delete'}).click();


### PR DESCRIPTION
## What

Swapped the legacy `Menu` component from `@tryghost/admin-x-design-system` for shade's composable `DropdownMenu` (`DropdownMenu` / `DropdownMenuTrigger` / `DropdownMenuContent` / `DropdownMenuItem`) at all three call sites in `apps/admin-x-settings`:

1. **`src/components/settings/site/change-theme.tsx`** — the active theme overflow menu (Edit code / Download)
2. **`src/components/settings/site/theme/advanced-theme-settings.tsx`** — the per-theme overflow menu in the Installed themes list (Edit code / Download / Delete)
3. **`src/components/settings/general/user-detail-modal.tsx`** — the staff user Actions menu (Make owner / View user activity / Suspend user / Delete user)

`apps/admin-x-settings/src` no longer imports `Menu`/`MenuItem` from the legacy design system.

## Per-site adaptations beyond the import swap

- **Triggers preserved:** the two theme menus recreate the legacy `Menu` default trigger inline (`<Button icon='ellipsis' label='Menu' hideLabel />` with the same `size`/`iconColorClass`/`disabled` props), so the trigger renders identically and keeps its accessible name "Menu". The user detail modal keeps its existing custom `<button>` trigger untouched, passed via `DropdownMenuTrigger asChild`.
- **Alignment:** legacy `position='end'` maps to `DropdownMenuContent align='end'` at all three sites.
- **Items-array to composition:** the `MenuItem[]` arrays became inline `DropdownMenuItem`s. In `user-detail-modal.tsx` the conditional `menuItems.push(...)` logic became `canMakeOwner` / `canSuspendUser` booleans guarding the corresponding items; labels and `onClick` behaviour are unchanged. In `advanced-theme-settings.tsx` the now-unused `buttonProps` object and its `type ButtonProps` import were removed (props inlined on the trigger Button).
- **Destructive styling:** "Delete user" uses the shade idiom `text-destructive focus:text-destructive` (matching existing `apps/admin` usage), replacing the legacy `destructive: true` flag. The theme "Delete" item was not destructive-styled in the legacy code and stays plain.
- **z-index:** shade's `DropdownMenuContent` is `z-50`, but the legacy `Modal`/`ModalPage` overlays render at `z-[1000]`, which hid the portalled menu. The two in-modal call sites pass `className='z-[9999]'` (the same value the legacy Popover used) so the menu paints above the overlay. The settings-page menu (change-theme) needs no override.

## Test changes

The acceptance tests were coupled to the legacy Menu markup — the legacy Popover's `data-testid="popover-content"` and items rendered as `role=button`. Radix menus render `role=menu`/`role=menuitem` instead, so:

- `test/acceptance/site/theme.test.ts` — 4 selectors changed from `page.getByTestId('popover-content').getByRole('button', ...)` to `page.getByRole('menuitem', ...)` (Edit code x2, Download, Delete)
- `test/acceptance/general/users/actions.test.ts` — 5 item selectors changed the same way (Suspend user, Un-suspend user x2, Delete user, Make owner); the "no Make owner item" assertion now checks `getByRole('menu')` is visible before asserting `menuitem` count 0; closing that menu now uses a raw outside click instead of re-clicking the trigger — Radix modal menus hide and disable pointer events on everything outside the open menu, so the trigger is unreachable by role locators while open (and `Escape` would close the modal underneath too, since the legacy `Modal` listens for it on `document`)

`test/acceptance/advanced/history.test.ts` also references `popover-content`, but that comes from a direct `Popover` usage (the History filter), not `Menu` — left unchanged.

## How to validate

**1. Active theme menu** — Settings → scroll to Site → **Theme** section → click the `...` button next to the active theme name.
- Trigger renders unchanged (small ellipsis button, disabled until themes have loaded)
- Menu opens below, right-aligned to the trigger
- "Edit code" opens the theme code editor; "Download" downloads the active theme
- Menu closes on outside click and ESC

**2. Installed themes menu** — Settings → Theme → **Change theme** → **Installed** tab → click the `...` button on a theme row.
- Menu opens above the modal (not hidden behind it), right-aligned to the trigger
- "Edit code" opens the editor for that theme; "Download" downloads it; "Delete" (only on deletable, non-active themes) opens the delete confirmation
- Menu closes on outside click and ESC

**3. User actions menu** — Settings → General → **Staff** → open a staff user → click the `...` button in the header (next to "Upload cover image").
- Trigger renders unchanged, including over a cover image (white icon on dark chip)
- Menu opens right-aligned, above the modal
- "Make owner" only shows for the owner viewing an active administrator; "View user activity" navigates to History; "Suspend user"/"Un-suspend user" opens the confirmation; "Delete user" is styled red and opens the delete confirmation
- Menu closes on outside click and ESC

## Verification

- `pnpm --filter @tryghost/admin-x-settings lint` — clean
- `pnpm --filter @tryghost/admin-x-settings test:unit` — 203 passed
- `pnpm --filter @tryghost/admin-x-settings build` — clean (tsc + vite)
- `pnpm --filter @tryghost/admin-x-settings test:acceptance` — full suite passed
- Before/after screenshots captured for each call site with the menu open (standalone acceptance harness, same navigation/viewport). One intentional delta: "Delete user" now renders red via `text-destructive`; the legacy `text-red-500` class was not taking effect in the standalone harness, so the item previously rendered black there.
