### PR TITLE
Changed route settings service API names to upload and download

### DIFF
--- a/ghost/core/core/server/api/endpoints/settings.js
+++ b/ghost/core/core/server/api/endpoints/settings.js
@@ -171,7 +171,7 @@ const controller = {
             method: 'edit'
         },
         async query(frame) {
-            await routeSettings.api.setFromFilePath(frame.file.path);
+            await routeSettings.api.upload(frame.file.path);
             const getRoutesHash = () => routeSettings.api.getCurrentHash();
             await settingsService.syncRoutesHash(getRoutesHash);
         }
@@ -192,7 +192,7 @@ const controller = {
             method: 'browse'
         },
         query() {
-            return routeSettings.api.get();
+            return routeSettings.api.download();
         }
     }
 };

--- a/ghost/core/core/server/services/route-settings/dynamic-routing-service.js
+++ b/ghost/core/core/server/services/route-settings/dynamic-routing-service.js
@@ -33,7 +33,7 @@ class DynamicRoutingService {
     }
 
     /**
-     * Wire the storage-layer dependencies so the API surface (get, setFromFilePath,
+     * Wire the storage-layer dependencies so the API surface (upload, download,
      * getCurrentHash) works immediately after boot — even when the frontend is
      * disabled and `start()` is never called.
      *
@@ -98,7 +98,7 @@ class DynamicRoutingService {
             .digest('hex');
     }
 
-    async get() {
+    async download() {
         try {
             const settings = await this.store.get();
 
@@ -112,7 +112,7 @@ class DynamicRoutingService {
         }
     }
 
-    async setFromFilePath(filePath) {
+    async upload(filePath) {
         const parseYaml = require('./yaml-parser');
         const {parseRouteSettings} = require('./route-settings-parser');
         const urlService = require('../url');

--- a/ghost/core/core/server/services/route-settings/index.js
+++ b/ghost/core/core/server/services/route-settings/index.js
@@ -32,15 +32,15 @@ module.exports = {
     },
 
     /**
-     * Methods used in the API — delegate to the service instance so the
-     * legacy callers keep working without any changes.
+     * Methods backing the Admin API settings endpoint — delegate to the
+     * service instance so the endpoint stays decoupled from service wiring.
      */
     api: {
-        get setFromFilePath() {
-            return service.setFromFilePath.bind(service);
+        get upload() {
+            return service.upload.bind(service);
         },
-        get get() {
-            return service.get.bind(service);
+        get download() {
+            return service.download.bind(service);
         },
         get getCurrentHash() {
             return service.getCurrentHash.bind(service);

--- a/ghost/core/test/unit/server/services/route-settings/dynamic-routing-service.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/dynamic-routing-service.test.ts
@@ -48,10 +48,10 @@ describe('UNIT: DynamicRoutingService (store-backed)', function () {
         sinon.restore();
     });
 
-    it('get returns the verbatim yaml source from the store', async function () {
+    it('download returns the verbatim yaml source from the store', async function () {
         await store.replace(fromYaml(CUSTOM_YAML));
 
-        assert.equal(await service.get(), CUSTOM_YAML);
+        assert.equal(await service.download(), CUSTOM_YAML);
     });
 
     it('loadRouteSettings expands the domain model into the router format', async function () {
@@ -180,7 +180,7 @@ taxonomies:
                 assert.ok(errorStub.calledOnce);
                 assert.equal(errorStub.firstCall.args[0].code, 'ROUTE_SETTINGS_VALIDATION_FALLBACK');
 
-                assert.equal(await fallbackService.get(), legacyValidYaml);
+                assert.equal(await fallbackService.download(), legacyValidYaml);
             } finally {
                 await fs.remove(contentDir);
             }
@@ -203,14 +203,14 @@ taxonomies:
             corruptService.configure({store: fileStore, settingsLoader});
 
             try {
-                assert.equal(await corruptService.get(), corruptYaml);
+                assert.equal(await corruptService.download(), corruptYaml);
             } finally {
                 await fs.remove(contentDir);
             }
         });
     });
 
-    describe('setFromFilePath', function () {
+    describe('upload', function () {
         let uploadDir: string;
 
         const writeUpload = async (content: string): Promise<string> => {
@@ -233,18 +233,17 @@ taxonomies:
             sinon.stub(urlService, 'resetGenerators');
             sinon.stub(urlService, 'hasFinished').returns(true);
 
-            await service.setFromFilePath(await writeUpload(CUSTOM_YAML));
+            await service.upload(await writeUpload(CUSTOM_YAML));
 
             assert.equal((await store.get()).yamlSource, CUSTOM_YAML);
         });
 
         it('rejects an invalid upload before anything reaches the store', async function () {
             const reloadStub = sinon.stub(bridge, 'reloadFrontend').resolves();
-            const previous = fromYaml(CUSTOM_YAML);
-            await store.replace(previous);
+            await store.replace(fromYaml(CUSTOM_YAML));
 
             await assert.rejects(
-                service.setFromFilePath(await writeUpload('routes:\n  no-slashes: about\n')),
+                service.upload(await writeUpload('routes:\n  no-slashes: about\n')),
                 (err: {errorType?: string}) => {
                     assert.equal(err.errorType, 'ValidationError');
                     return true;
@@ -264,7 +263,7 @@ taxonomies:
             getStub.onFirstCall().rejects(new errors.IncorrectUsageError({message: 'Could not parse provided YAML file: bad indentation of a mapping entry.'}));
             getStub.callThrough();
 
-            await service.setFromFilePath(await writeUpload(CUSTOM_YAML));
+            await service.upload(await writeUpload(CUSTOM_YAML));
 
             assert.equal((await store.get()).yamlSource, CUSTOM_YAML);
         });
@@ -278,7 +277,7 @@ taxonomies:
             getStub.onFirstCall().rejects(new errors.ValidationError({message: 'slug is required for read data entries.'}));
             getStub.callThrough();
 
-            await service.setFromFilePath(await writeUpload(CUSTOM_YAML));
+            await service.upload(await writeUpload(CUSTOM_YAML));
 
             assert.equal((await store.get()).yamlSource, CUSTOM_YAML);
         });
@@ -288,13 +287,12 @@ taxonomies:
             reloadStub.rejects(new Error('YAMLException: bad indentation of a mapping entry'));
             sinon.stub(urlService, 'resetGenerators');
 
-            const previous = fromYaml(CUSTOM_YAML);
-            await store.replace(previous);
+            await store.replace(fromYaml(CUSTOM_YAML));
 
             const nextYaml = CUSTOM_YAML.replace('/about/: about', '/contact/: contact');
 
             await assert.rejects(
-                service.setFromFilePath(await writeUpload(nextYaml)),
+                service.upload(await writeUpload(nextYaml)),
                 /YAMLException/
             );
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1830

- the service methods now carry the names of the Admin API operations they back: `get` was ambiguous sitting next to `store.get()`, and `setFromFilePath` describes a transport detail rather than what the caller is doing
- mechanical rename only — signatures and behavior are unchanged, and upload still takes the multer tmp-file path; moving the file read to the API boundary (so the service's only I/O is the configured store) ships separately on top of this