### PR TITLE
✨ Added user lookup dependency injection to sso base adapter

### DIFF
--- a/ghost/core/core/server/services/auth/session/index.js
+++ b/ghost/core/core/server/services/auth/session/index.js
@@ -74,6 +74,22 @@ module.exports = createSessionMiddleware({sessionService});
 // Looks funky but this is a "custom" piece of middleware
 module.exports.createSessionFromToken = () => {
     const ssoAdapter = adapterManager.getAdapter('sso');
+
+    // Provide the SSO adapter with the user lookups it needs, backed by the User
+    // model. This keeps the model coupling here in core and lets adapter
+    // implementations resolve users via the base class helpers instead of
+    // requiring Ghost's model layer directly.
+    ssoAdapter.setUserRepository({
+        async getByEmail(email) {
+            const user = await models.User.findOne({email});
+            return user ? {id: user.id, email: user.get('email')} : null;
+        },
+        async getOwner() {
+            const owner = await models.User.findOne({role: 'Owner', status: 'all'});
+            return owner ? {id: owner.id, email: owner.get('email')} : null;
+        }
+    });
+
     return sessionFromToken({
         callNextWithError: false,
         createSession: sessionService.createVerifiedSessionForUser,

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -101,7 +101,7 @@
     "@tryghost/debug": "catalog:",
     "@tryghost/domain-events": "catalog:",
     "@tryghost/email-mock-receiver": "2.1.0",
-    "@tryghost/errors": "1.3.13",
+    "@tryghost/errors": "catalog:",
     "@tryghost/helpers": "catalog:",
     "@tryghost/html-to-plaintext": "1.0.11",
     "@tryghost/i18n": "workspace:*",

--- a/ghost/core/test/e2e-api/admin/sso.test.js
+++ b/ghost/core/test/e2e-api/admin/sso.test.js
@@ -3,7 +3,7 @@ const {restore} = require('../../utils/e2e-framework-mock-manager');
 const {stringMatching} = matchers;
 const sinon = require('sinon');
 const adapterManager = require('../../../core/server/services/adapter-manager');
-const models = require('../../../core/server/models');
+const {SSOBase} = require('@tryghost/adapter-base-sso');
 
 describe('SSO API', function () {
     let agent;
@@ -11,11 +11,12 @@ describe('SSO API', function () {
     beforeAll(async function () {
         // Mock SSO adapter that always returns the owner. The stub stays registered
         // before Ghost boots (the original ordering, in case the adapter resolves
-        // during boot); the owner is looked up lazily per request, because under
-        // per-file isolation the DB isn't seeded until getGhostAPIAgent() /
-        // fixtureManager.init() run below — an eager lookup hits an unmigrated
-        // database (the old serial suite inherited a prior file's schema).
-        class MockSSOAdapter {
+        // during boot); the owner is looked up lazily per request via the user
+        // repository Ghost injects into the adapter — exercising the same
+        // dependency-injection path a real adapter uses, and avoiding an eager
+        // lookup that (under per-file isolation, before fixtureManager.init() runs
+        // below) would hit an unmigrated database.
+        class MockSSOAdapter extends SSOBase {
             async getRequestCredentials() {
                 return {
                     id: 'mock-credentials'
@@ -29,7 +30,7 @@ describe('SSO API', function () {
             }
 
             async getUserForIdentity() {
-                return models.User.getOwnerUser();
+                return this.getOwnerUser();
             }
         }
 

--- a/packages/adapters/sso-base/package.json
+++ b/packages/adapters/sso-base/package.json
@@ -43,7 +43,9 @@
     "typescript": "catalog:",
     "vitest": "catalog:"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@tryghost/errors": "catalog:"
+  },
   "nx": {
     "targets": {
       "build": {

--- a/packages/adapters/sso-base/src/base.ts
+++ b/packages/adapters/sso-base/src/base.ts
@@ -1,7 +1,25 @@
 import type {Request} from 'express';
+import errors from '@tryghost/errors';
 
 export interface User {
     id: string;
+    email: string;
+}
+
+/**
+ * A small set of user lookups that Ghost injects into the SSO adapter, so that
+ * adapter implementations can resolve users without reaching into Ghost's model
+ * layer directly.
+ *
+ * Ghost core provides the implementation (backed by the User model) via
+ * `SSOBase.setUserRepository`; adapter implementations consume it through the
+ * protected `getUserByEmail` / `getOwnerUser` helpers on `SSOBase`.
+ */
+export interface UserRepository {
+    /** Look up a single user by their email address, or `null` if none exists. */
+    getByEmail(email: string): Promise<User | null>;
+    /** Look up the site owner user, or `null` if none exists. */
+    getOwner(): Promise<User | null>;
 }
 
 export interface SSOAdapter<Token, Lookup> {
@@ -13,11 +31,47 @@ export interface SSOAdapter<Token, Lookup> {
 export abstract class SSOBase<Token, Lookup> implements SSOAdapter<Token, Lookup> {
     declare readonly requiredFns: readonly ['getRequestCredentials', 'getIdentityFromCredentials', 'getUserForIdentity'];
 
+    #userRepository: UserRepository | null = null;
+
     constructor() {
         Object.defineProperty(this, 'requiredFns', {
             value: Object.freeze(['getRequestCredentials', 'getIdentityFromCredentials', 'getUserForIdentity']),
             writable: false,
         });
+    }
+
+    /**
+     * Inject the user repository. Ghost core calls this after constructing the
+     * adapter, supplying an implementation backed by the User model. Adapter
+     * implementations should not call this themselves.
+     */
+    setUserRepository(userRepository: UserRepository): void {
+        this.#userRepository = userRepository;
+    }
+
+    get #users(): UserRepository {
+        if (!this.#userRepository) {
+            throw new errors.IncorrectUsageError({
+                message: 'SSO adapter has no user repository configured. Ghost must call setUserRepository() before the adapter is used.'
+            });
+        }
+        return this.#userRepository;
+    }
+
+    /**
+     * Look up a single user by email. Available to adapter implementations so
+     * they can resolve users without depending on Ghost's model layer.
+     */
+    protected async getUserByEmail(email: string): Promise<User | null> {
+        return this.#users.getByEmail(email);
+    }
+
+    /**
+     * Look up the site owner user. Available to adapter implementations so they
+     * can resolve the owner without depending on Ghost's model layer.
+     */
+    protected async getOwnerUser(): Promise<User | null> {
+        return this.#users.getOwner();
     }
 
     abstract getRequestCredentials(request: Request): Promise<Token | null>;

--- a/packages/adapters/sso-base/test/index.test.ts
+++ b/packages/adapters/sso-base/test/index.test.ts
@@ -1,26 +1,69 @@
 import assert from 'node:assert/strict';
 import {describe, it} from 'vitest';
 
-import {SSOBase} from '../src/base.ts';
+import {SSOBase, type User} from '../src/base.ts';
 
-describe('adapter-base-redirects', function () {
+class TestSSO extends SSOBase<null, null> {
+    async getRequestCredentials() {
+        return null;
+    }
+
+    async getIdentityFromCredentials() {
+        return null;
+    }
+
+    async getUserForIdentity() {
+        return null;
+    }
+
+    // Expose the protected helpers so the injection surface can be tested from
+    // the same vantage point an adapter implementation would use them.
+    lookupByEmail(email: string) {
+        return this.getUserByEmail(email);
+    }
+
+    lookupOwner() {
+        return this.getOwnerUser();
+    }
+}
+
+describe('adapter-base-sso', function () {
     it('should have requiredFns property', function () {
-        class TestSSO extends SSOBase<null, null> {
-            async getRequestCredentials() {
-                return null
-            }
-
-            async getIdentityFromCredentials() {
-                return null
-            }
-
-            async getUserForIdentity() {
-                return null
-            }
-        }
-
         const store = new TestSSO();
         assert.deepEqual(store.requiredFns, ['getRequestCredentials', 'getIdentityFromCredentials', 'getUserForIdentity']);
         assert.ok(Object.isFrozen(store.requiredFns), 'requiredFns should be frozen');
-    })
+    });
+
+    describe('user repository', function () {
+        it('resolves users by email through the injected repository', async function () {
+            const owner: User = {id: 'owner-id', email: 'owner@example.com'};
+            const jane: User = {id: 'jane-id', email: 'jane@example.com'};
+
+            const store = new TestSSO();
+            store.setUserRepository({
+                async getByEmail(email) {
+                    return email === jane.email ? jane : null;
+                },
+                async getOwner() {
+                    return owner;
+                }
+            });
+
+            assert.deepEqual(await store.lookupByEmail('jane@example.com'), jane);
+            assert.equal(await store.lookupByEmail('nobody@example.com'), null);
+            assert.deepEqual(await store.lookupOwner(), owner);
+        });
+
+        it('throws when the repository is used before being configured', async function () {
+            const store = new TestSSO();
+            await assert.rejects(
+                () => store.lookupByEmail('jane@example.com'),
+                /no user repository configured/
+            );
+            await assert.rejects(
+                () => store.lookupOwner(),
+                /no user repository configured/
+            );
+        });
+    });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2615,7 +2615,7 @@ importers:
         version: 13.0.0
       gscan:
         specifier: 6.4.2
-        version: 6.4.2(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))
+        version: 6.4.2(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(supports-color@5.5.0)
       handlebars:
         specifier: 4.7.9
         version: 4.7.9
@@ -3988,6 +3988,10 @@ importers:
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   packages/adapters/sso-base:
+    dependencies:
+      '@tryghost/errors':
+        specifier: ^1.3.7
+        version: 1.3.13
     devDependencies:
       '@internal/cfg-eslint':
         specifier: workspace:*
@@ -23903,7 +23907,7 @@ snapshots:
       semifies: 1.0.0
       source-map: 0.6.1
 
-  '@apm-js-collab/tracing-hooks@0.10.1':
+  '@apm-js-collab/tracing-hooks@0.10.1(supports-color@5.5.0)':
     dependencies:
       '@apm-js-collab/code-transformer': 0.15.0
       debug: 4.4.3(supports-color@5.5.0)
@@ -27261,12 +27265,12 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.41.1
 
-  '@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.220.0
       import-in-the-middle: 3.2.0
-      require-in-the-middle: 8.0.1
+      require-in-the-middle: 8.0.1(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -28551,7 +28555,7 @@ snapshots:
       '@sentry/utils': 7.120.4
       localforage: 1.10.0
 
-  '@sentry/node-core@10.65.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))':
+  '@sentry/node-core@10.65.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))':
     dependencies:
       '@sentry/conventions': 0.15.1
       '@sentry/core': 10.65.0
@@ -28560,19 +28564,19 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)
       '@opentelemetry/sdk-trace-base': 2.9.0(@opentelemetry/api@1.9.1)
 
-  '@sentry/node@10.65.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))':
+  '@sentry/node@10.65.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(supports-color@5.5.0)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)
       '@opentelemetry/sdk-trace-base': 2.9.0(@opentelemetry/api@1.9.1)
       '@sentry/conventions': 0.15.1
       '@sentry/core': 10.65.0
-      '@sentry/node-core': 10.65.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))
+      '@sentry/node-core': 10.65.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))
       '@sentry/opentelemetry': 10.65.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))
-      '@sentry/server-utils': 10.65.0
+      '@sentry/server-utils': 10.65.0(supports-color@5.5.0)
       import-in-the-middle: 3.2.0
     transitivePeerDependencies:
       - '@opentelemetry/core'
@@ -28644,11 +28648,11 @@ snapshots:
       - encoding
       - supports-color
 
-  '@sentry/server-utils@10.65.0':
+  '@sentry/server-utils@10.65.0(supports-color@5.5.0)':
     dependencies:
       '@apm-js-collab/code-transformer': 0.15.0
       '@apm-js-collab/code-transformer-bundler-plugins': 0.5.0
-      '@apm-js-collab/tracing-hooks': 0.10.1
+      '@apm-js-collab/tracing-hooks': 0.10.1(supports-color@5.5.0)
       '@sentry/conventions': 0.15.1
       '@sentry/core': 10.65.0
       magic-string: 0.30.21
@@ -30456,7 +30460,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tryghost/debug@2.3.1':
+  '@tryghost/debug@2.3.1(supports-color@5.5.0)':
     dependencies:
       '@tryghost/root-utils': 2.3.1
       debug: 4.4.3(supports-color@5.5.0)
@@ -30814,7 +30818,7 @@ snapshots:
 
   '@tryghost/server@3.1.1':
     dependencies:
-      '@tryghost/debug': 2.3.1
+      '@tryghost/debug': 2.3.1(supports-color@5.5.0)
       '@tryghost/logging': 4.2.1(supports-color@5.5.0)
     transitivePeerDependencies:
       - '@75lb/nature'
@@ -33453,7 +33457,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  body-parser@2.3.0:
+  body-parser@2.3.0(supports-color@5.5.0):
     dependencies:
       bytes: 3.1.2
       content-type: 2.0.0
@@ -38519,10 +38523,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  express@5.2.1:
+  express@5.2.1(supports-color@5.5.0):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.3.0
+      body-parser: 2.3.0(supports-color@5.5.0)
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
@@ -38532,7 +38536,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1
+      finalhandler: 2.1.1(supports-color@5.5.0)
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -38543,8 +38547,8 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.3
       range-parser: 1.2.1
-      router: 2.2.0
-      send: 1.2.1
+      router: 2.2.0(supports-color@5.5.0)
+      send: 1.2.1(supports-color@5.5.0)
       serve-static: 2.2.1
       statuses: 2.0.2
       type-is: 2.1.0
@@ -38766,7 +38770,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  finalhandler@2.1.1:
+  finalhandler@2.1.1(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
@@ -39556,11 +39560,11 @@ snapshots:
 
   growly@1.3.0: {}
 
-  gscan@6.4.2(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1)):
+  gscan@6.4.2(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(supports-color@5.5.0):
     dependencies:
-      '@sentry/node': 10.65.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))
+      '@sentry/node': 10.65.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(supports-color@5.5.0)
       '@tryghost/config': 2.3.1
-      '@tryghost/debug': 2.3.1
+      '@tryghost/debug': 2.3.1(supports-color@5.5.0)
       '@tryghost/errors': 1.3.13
       '@tryghost/logging': 4.2.1(supports-color@5.5.0)
       '@tryghost/nql': 0.13.1(supports-color@5.5.0)
@@ -39568,7 +39572,7 @@ snapshots:
       '@tryghost/server': 3.1.1
       '@tryghost/zip': 3.5.0
       chalk: 5.6.2
-      express: 5.2.1
+      express: 5.2.1(supports-color@5.5.0)
       express-handlebars: 8.0.1
       glob: 13.0.6
       handlebars: 4.7.9
@@ -46098,7 +46102,7 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  require-in-the-middle@8.0.1:
+  require-in-the-middle@8.0.1(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       module-details-from-path: 1.0.4
@@ -46334,7 +46338,7 @@ snapshots:
 
   route-recognizer@0.3.4: {}
 
-  router@2.2.0:
+  router@2.2.0(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
@@ -46546,7 +46550,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  send@1.2.1:
+  send@1.2.1(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
@@ -46587,7 +46591,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1
+      send: 1.2.1(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -77,6 +77,7 @@ catalog:
   '@tryghost/custom-fonts': 1.0.11
   '@tryghost/debug': 2.2.3
   '@tryghost/domain-events': 3.2.5
+  '@tryghost/errors': 1.3.13
   '@tryghost/helpers': 1.1.106
   '@tryghost/limit-service': 1.5.6
   '@tryghost/logging': 4.2.1


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLA-233/create-public-npm-package-for-sso-adapter-base
- adds new UserRepository type to SSO Base adapter, allowing calling code to inject model layer references into the base adapter without needing core requires
- add @tryghost/errors dep to base adapter