### PR TITLE
Changed settings menus to styled Shade dropdowns

### DIFF
--- a/apps/admin-x-settings/src/components/settings/general/user-detail-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/user-detail-modal.tsx
@@ -8,7 +8,8 @@ import usePinturaEditor from '../../../hooks/use-pintura-editor';
 import useStaffUsers from '../../../hooks/use-staff-users';
 import validator from 'validator';
 import {APIError} from '@tryghost/admin-x-framework/errors';
-import {ConfirmationModal, Heading, Icon, ImageUpload, LimitModal, Menu, type MenuItem, Modal, TabView, showToast} from '@tryghost/admin-x-design-system';
+import {ConfirmationModal, Heading, Icon, ImageUpload, LimitModal, Modal, TabView, showToast} from '@tryghost/admin-x-design-system';
+import {DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger} from '@tryghost/shade/components';
 import {type ErrorMessages, useForm, useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {HostLimitError, useLimiter} from '../../../hooks/use-limiter';
 import {type RoutingModalProps, useRouting} from '@tryghost/admin-x-framework/routing';
@@ -299,46 +300,12 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
     };
 
     const showMenu = hasAdminAccess(currentUser) || (isEditorUser(currentUser) && isAuthorOrContributor(user));
-    const menuItems: MenuItem[] = [];
-
-    if (isOwnerUser(currentUser) && isAdminUser(formState) && formState.status !== 'inactive') {
-        menuItems.push({
-            id: 'make-owner',
-            label: 'Make owner',
-            onClick: confirmMakeOwner
-        });
-    }
-
-    menuItems.push({
-        id: 'view-user-activity',
-        label: 'View user activity',
-        onClick: () => {
-            mainModal.remove();
-            updateRoute(`history/view/${formState.id}`);
-        }
-    });
-
-    if (formState.id !== currentUser.id && (
+    const canMakeOwner = isOwnerUser(currentUser) && isAdminUser(formState) && formState.status !== 'inactive';
+    const canSuspendUser = formState.id !== currentUser.id && (
         (hasAdminAccess(currentUser) && !isOwnerUser(user)) ||
         (isEditorUser(currentUser) && isAuthorOrContributor(user))
-    )) {
-        const suspendUserLabel = formState.status === 'inactive' ? 'Un-suspend user' : 'Suspend user';
-
-        menuItems.push({
-            id: 'suspend-user',
-            label: suspendUserLabel,
-            onClick: () => {
-                confirmSuspend(formState);
-            }
-        }, {
-            id: 'delete-user',
-            label: 'Delete user',
-            destructive: true,
-            onClick: () => {
-                confirmDelete(user, {owner: ownerUser});
-            }
-        });
-    }
+    );
+    const suspendUserLabel = formState.status === 'inactive' ? 'Un-suspend user' : 'Suspend user';
 
     const noCoverButtonClasses = 'rounded flex flex-nowrap items-center justify-center px-3 h-8 transition-all cursor-pointer font-medium border border-grey-300 bg-transparent text-black dark:border-grey-800 dark:text-white';
 
@@ -447,10 +414,8 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
                                         }}
                                     >Upload cover image</ImageUpload>
                                     {showMenu && <div className="z-10">
-                                        <Menu
-                                            items={menuItems}
-                                            position='end'
-                                            trigger={
+                                        <DropdownMenu>
+                                            <DropdownMenuTrigger asChild>
                                                 <button
                                                     className={clsx(
                                                         'flex h-8 cursor-pointer items-center justify-center rounded px-3',
@@ -467,8 +432,39 @@ const UserDetailModalContent: React.FC<{user: User}> = ({user}) => {
                                                         size='md'
                                                     />
                                                 </button>
-                                            }
-                                        />
+                                            </DropdownMenuTrigger>
+                                            {/* legacy Modal overlay is z-[1000]; keep the portalled menu above it */}
+                                            <DropdownMenuContent align='end' className='z-[9999]'>
+                                                {canMakeOwner && (
+                                                    <DropdownMenuItem onSelect={confirmMakeOwner}>
+                                                        Make owner
+                                                    </DropdownMenuItem>
+                                                )}
+                                                <DropdownMenuItem onSelect={() => {
+                                                    mainModal.remove();
+                                                    updateRoute(`history/view/${formState.id}`);
+                                                }}>
+                                                    View user activity
+                                                </DropdownMenuItem>
+                                                {canSuspendUser && (
+                                                    <>
+                                                        <DropdownMenuItem onSelect={() => {
+                                                            confirmSuspend(formState);
+                                                        }}>
+                                                            {suspendUserLabel}
+                                                        </DropdownMenuItem>
+                                                        <DropdownMenuItem
+                                                            className='text-destructive focus:text-destructive'
+                                                            onSelect={() => {
+                                                                confirmDelete(user, {owner: ownerUser});
+                                                            }}
+                                                        >
+                                                            Delete user
+                                                        </DropdownMenuItem>
+                                                    </>
+                                                )}
+                                            </DropdownMenuContent>
+                                        </DropdownMenu>
                                     </div>}
                                 </div>
                             </div>

--- a/apps/admin-x-settings/src/components/settings/site/change-theme.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/change-theme.tsx
@@ -1,7 +1,8 @@
 import NiceModal from '@ebay/nice-modal-react';
 import React, {useEffect, useState} from 'react';
 import TopLevelGroup from '../../top-level-group';
-import {Button, Heading, LimitModal, Menu, SettingGroupContent} from '@tryghost/admin-x-design-system';
+import {Button, Heading, LimitModal, SettingGroupContent} from '@tryghost/admin-x-design-system';
+import {DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger} from '@tryghost/shade/components';
 import {type Theme, useBrowseThemes} from '@tryghost/admin-x-framework/api/themes';
 import {downloadFile, getGhostPaths} from '@tryghost/admin-x-framework/helpers';
 import {useCheckThemeLimitError} from '../../../hooks/use-check-theme-limit-error';
@@ -70,19 +71,6 @@ const ChangeTheme: React.FC<{ keywords: string[] }> = ({keywords}) => {
         downloadFile(`${apiRoot}/themes/${activeTheme.name}/download`);
     };
 
-    const themeMenuItems = [
-        {
-            id: 'edit-code',
-            label: 'Edit code',
-            onClick: openThemeEditor
-        },
-        {
-            id: 'download',
-            label: 'Download',
-            onClick: downloadTheme
-        }
-    ];
-
     const values = (
         <SettingGroupContent>
             <div className='flex flex-col'>
@@ -90,15 +78,15 @@ const ChangeTheme: React.FC<{ keywords: string[] }> = ({keywords}) => {
                 <div className='mt-1 flex w-full items-center justify-between gap-4'>
                     <div>{activeTheme ? `${activeTheme.name} (v${activeTheme.package?.version || '1.0'})` : 'Loading...'}</div>
                     <div className='-mr-3'>
-                        <Menu
-                            items={themeMenuItems}
-                            position='end'
-                            triggerButtonProps={{
-                                disabled: !activeTheme,
-                                iconColorClass: 'text-base',
-                                size: 'sm'
-                            }}
-                        />
+                        <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                                <Button disabled={!activeTheme} icon='ellipsis' iconColorClass='text-base' label='Menu' size='sm' hideLabel />
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align='end'>
+                                <DropdownMenuItem onSelect={openThemeEditor}>Edit code</DropdownMenuItem>
+                                <DropdownMenuItem onSelect={downloadTheme}>Download</DropdownMenuItem>
+                            </DropdownMenuContent>
+                        </DropdownMenu>
                     </div>
                 </div>
             </div>

--- a/apps/admin-x-settings/src/components/settings/site/theme/advanced-theme-settings.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/theme/advanced-theme-settings.tsx
@@ -2,7 +2,8 @@ import InvalidThemeModal, {type FatalErrors} from './invalid-theme-modal';
 import NiceModal from '@ebay/nice-modal-react';
 import React from 'react';
 import useCustomFonts from '../../../../hooks/use-custom-fonts';
-import {Button, type ButtonProps, ConfirmationModal, LimitModal, List, ListItem, Menu, ModalPage, showToast} from '@tryghost/admin-x-design-system';
+import {Button, ConfirmationModal, LimitModal, List, ListItem, ModalPage, showToast} from '@tryghost/admin-x-design-system';
+import {DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger} from '@tryghost/shade/components';
 import {JSONError} from '@tryghost/admin-x-framework/errors';
 import {type Theme, isActiveTheme, isDefaultTheme, isDeletableTheme, isLegacyTheme, useActivateTheme, useDeleteTheme} from '@tryghost/admin-x-framework/api/themes';
 import {downloadFile, getGhostPaths} from '@tryghost/admin-x-framework/helpers';
@@ -155,36 +156,22 @@ const ThemeActions: React.FC<ThemeActionProps> = ({
         );
     }
 
-    const menuItems = [
-        {
-            id: 'edit-code',
-            label: 'Edit code',
-            onClick: handleEditCode
-        },
-        {
-            id: 'download',
-            label: 'Download',
-            onClick: handleDownload
-        }
-    ];
-
-    if (isDeletableTheme(theme)) {
-        menuItems.push({
-            id: 'delete',
-            label: 'Delete',
-            onClick: handleDelete
-        });
-    }
-
-    const buttonProps: ButtonProps = {
-        iconColorClass: 'text-base',
-        size: 'sm'
-    };
-
     return (
         <div className='-mr-3 flex items-center gap-4'>
             {actions}
-            <Menu items={menuItems} position='end' triggerButtonProps={buttonProps} />
+            <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                    <Button icon='ellipsis' iconColorClass='text-base' label='Menu' size='sm' hideLabel />
+                </DropdownMenuTrigger>
+                {/* legacy ModalPage overlay is z-[1000]; keep the portalled menu above it */}
+                <DropdownMenuContent align='end' className='z-[9999]'>
+                    <DropdownMenuItem onSelect={handleEditCode}>Edit code</DropdownMenuItem>
+                    <DropdownMenuItem onSelect={handleDownload}>Download</DropdownMenuItem>
+                    {isDeletableTheme(theme) && (
+                        <DropdownMenuItem onSelect={handleDelete}>Delete</DropdownMenuItem>
+                    )}
+                </DropdownMenuContent>
+            </DropdownMenu>
         </div>
     );
 };

--- a/apps/admin-x-settings/test/acceptance/general/users/actions.test.ts
+++ b/apps/admin-x-settings/test/acceptance/general/users/actions.test.ts
@@ -33,7 +33,7 @@ test.describe('User actions', async () => {
         const modal = page.getByTestId('user-detail-modal');
 
         await modal.getByRole('button', {name: 'Actions'}).click();
-        await page.getByTestId('popover-content').getByRole('button', {name: 'Suspend user'}).click();
+        await page.getByRole('menuitem', {name: 'Suspend user'}).click();
 
         const confirmation = page.getByTestId('confirmation-modal');
         await confirmation.getByRole('button', {name: 'Suspend'}).click();
@@ -89,7 +89,7 @@ test.describe('User actions', async () => {
         await expect(modal).toHaveText(/Suspended/);
 
         await modal.getByRole('button', {name: 'Actions'}).click();
-        await page.getByTestId('popover-content').getByRole('button', {name: 'Un-suspend user'}).click();
+        await page.getByRole('menuitem', {name: 'Un-suspend user'}).click();
 
         const confirmation = page.getByTestId('confirmation-modal');
         await confirmation.getByRole('button', {name: 'Un-suspend'}).click();
@@ -130,7 +130,7 @@ test.describe('User actions', async () => {
         const modal = page.getByTestId('user-detail-modal');
 
         await modal.getByRole('button', {name: 'Actions'}).click();
-        await page.getByTestId('popover-content').getByRole('button', {name: 'Delete user'}).click();
+        await page.getByRole('menuitem', {name: 'Delete user'}).click();
 
         const confirmation = page.getByTestId('confirmation-modal');
         await confirmation.getByRole('button', {name: 'Delete user'}).click();
@@ -187,8 +187,14 @@ test.describe('User actions', async () => {
         await listItem.getByRole('button', {name: 'Edit'}).click();
 
         await modal.getByRole('button', {name: 'Actions'}).click();
-        await expect(page.getByTestId('popover-content').getByRole('button', {name: 'Make owner'})).toHaveCount(0);
-        await modal.getByRole('button', {name: 'Actions'}).click();
+        await expect(page.getByRole('menu')).toBeVisible();
+        await expect(page.getByRole('menuitem', {name: 'Make owner'})).toHaveCount(0);
+
+        // Radix hides and disables pointer events on everything outside the
+        // open menu, so dismiss it with a raw outside click (Escape would
+        // also close the modal underneath)
+        await page.mouse.click(10, 10);
+        await expect(page.getByRole('menu')).toHaveCount(0);
 
         await modal.getByRole('button', {name: 'Close'}).click();
 
@@ -200,7 +206,7 @@ test.describe('User actions', async () => {
         await listItem.getByRole('button', {name: 'Edit'}).click();
 
         await modal.getByRole('button', {name: 'Actions'}).click();
-        await page.getByTestId('popover-content').getByRole('button', {name: 'Make owner'}).click();
+        await page.getByRole('menuitem', {name: 'Make owner'}).click();
 
         const confirmation = page.getByTestId('confirmation-modal');
         await confirmation.getByRole('button', {name: 'Yep — I\'m sure'}).click();
@@ -268,7 +274,7 @@ test.describe('User actions', async () => {
         await expect(modal).toHaveText(/Suspended/);
 
         await modal.getByRole('button', {name: 'Actions'}).click();
-        await page.getByTestId('popover-content').getByRole('button', {name: 'Un-suspend user'}).click();
+        await page.getByRole('menuitem', {name: 'Un-suspend user'}).click();
 
         await expect(page.getByTestId('limit-modal')).toHaveText(/Your plan does not support more staff/);
     });

--- a/apps/admin-x-settings/test/acceptance/site/theme.test.ts
+++ b/apps/admin-x-settings/test/acceptance/site/theme.test.ts
@@ -57,7 +57,7 @@ async function openInstalledThemeEditor(page: Page, themeName: string) {
 
     const themeListItem = modal.getByTestId('theme-list-item').filter({hasText: new RegExp(escapeRegExp(themeName), 'i')});
     await themeListItem.getByRole('button', {name: 'Menu'}).click();
-    await page.getByTestId('popover-content').getByRole('button', {name: 'Edit code'}).click();
+    await page.getByRole('menuitem', {name: 'Edit code'}).click();
 
     return page.getByTestId('theme-code-editor-modal');
 }
@@ -67,7 +67,7 @@ async function openActiveThemeEditorFromSettings(page: Page) {
 
     const themeSection = page.getByTestId('theme');
     await themeSection.getByRole('button', {name: 'Menu'}).click();
-    await page.getByTestId('popover-content').getByRole('button', {name: 'Edit code'}).click();
+    await page.getByRole('menuitem', {name: 'Edit code'}).click();
 
     return page.getByTestId('theme-code-editor-modal');
 }
@@ -205,14 +205,19 @@ test.describe('Theme settings', async () => {
         // Download the active theme
 
         await casper.getByRole('button', {name: 'Menu'}).click();
-        await page.getByTestId('popover-content').getByRole('button', {name: 'Download'}).click();
+        // Ensure the standalone harness compiles Shade's component utilities,
+        // rather than exercising functional but unstyled Radix markup.
+        const menu = page.getByRole('menu');
+        await expect(menu).toHaveCSS('min-width', '80px');
+        await expect(menu).toHaveCSS('padding', '4px');
+        await page.getByRole('menuitem', {name: 'Download'}).click();
 
         await expect(page.locator('iframe#iframeDownload')).toHaveAttribute('src', /\/api\/admin\/themes\/casper\/download/);
 
         // Delete the inactive theme
 
         await edition.getByRole('button', {name: 'Menu'}).click();
-        await page.getByTestId('popover-content').getByRole('button', {name: 'Delete'}).click();
+        await page.getByRole('menuitem', {name: 'Delete'}).click();
 
         const confirmation = page.getByTestId('confirmation-modal');
         await confirmation.getByRole('button', {name: 'Delete'}).click();

--- a/apps/admin/src/settings/offers.acceptance.test.tsx
+++ b/apps/admin/src/settings/offers.acceptance.test.tsx
@@ -211,11 +211,13 @@ describe("Offers", () => {
         const updateModal = offersScreen.updateModal();
         await expect.element(updateModal).toBeVisible();
 
-        await updateModal.getByPlaceholder("black-friday").fill("");
+        const codeInput = updateModal.getByPlaceholder("black-friday");
+        await expect.element(codeInput).toHaveValue("first-offer");
+        await codeInput.fill("");
         await updateModal.getByRole("button", { name: "Save" }).click();
         await expect.element(updateModal).toHaveTextContent(/Please enter a code/);
 
-        await updateModal.getByPlaceholder("black-friday").fill("black-friday-offer");
+        await codeInput.fill("black-friday-offer");
         await updateModal.getByRole("button", { name: "Save" }).click();
 
         await expect.poll(() => editApi.lastRequest?.body).toMatchObject({

--- a/apps/admin/src/settings/offers.acceptance.test.tsx
+++ b/apps/admin/src/settings/offers.acceptance.test.tsx
@@ -212,7 +212,7 @@ describe("Offers", () => {
         await expect.element(updateModal).toBeVisible();
 
         const codeInput = updateModal.getByPlaceholder("black-friday");
-        await expect.element(codeInput).toHaveValue("first-offer");
+        await expect.element(codeInput).toHaveValue(firstOffer.code);
         await codeInput.fill("");
         await updateModal.getByRole("button", { name: "Save" }).click();
         await expect.element(updateModal).toHaveTextContent(/Please enter a code/);


### PR DESCRIPTION
## What changed

Reworked the admin-x-settings menu migration from #29363 on top of current main:

- replaced the three legacy Menu call sites with Shade DropdownMenu composition
- retained the existing triggers, actions, end alignment, permission checks, and modal z-index behavior
- used the Radix onSelect API for menu actions
- updated acceptance selectors from the legacy popover markup to menu and menuitem roles
- added computed-style assertions for the menu minimum width and padding

## Why

The earlier PR only proved that the Radix menu behavior worked. A functional-but-unstyled menu could still pass its acceptance coverage. This replacement is based on the standalone Shade stylesheet lane already on main and explicitly verifies that Shade component utilities are compiled and applied. Production Admin continues to use its single centralized Shade CSS lane, so the embedded app does not import a duplicate stylesheet.

## Validation

- pnpm --filter @tryghost/admin-x-settings lint
- pnpm nx run @tryghost/admin-x-settings:test:unit — 203 passed
- pnpm --filter @tryghost/admin-x-settings exec playwright test test/acceptance/site/theme.test.ts test/acceptance/general/users/actions.test.ts --reporter=line — 36 passed
- pnpm nx run @tryghost/admin:build

Supersedes #29363.