### PR TITLE
Changed route settings upload to receive yaml content instead of a file path

### DIFF
--- a/ghost/core/core/server/api/endpoints/settings.js
+++ b/ghost/core/core/server/api/endpoints/settings.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const fs = require('fs-extra');
 const models = require('../../models');
 const routeSettings = require('../../services/route-settings');
 const {BadRequestError} = require('@tryghost/errors');
@@ -171,7 +172,8 @@ const controller = {
             method: 'edit'
         },
         async query(frame) {
-            await routeSettings.api.upload(frame.file.path);
+            const content = await fs.readFile(frame.file.path, 'utf8');
+            await routeSettings.api.upload(content);
             const getRoutesHash = () => routeSettings.api.getCurrentHash();
             await settingsService.syncRoutesHash(getRoutesHash);
         }

--- a/ghost/core/core/server/services/route-settings/dynamic-routing-service.js
+++ b/ghost/core/core/server/services/route-settings/dynamic-routing-service.js
@@ -112,7 +112,7 @@ class DynamicRoutingService {
         }
     }
 
-    async upload(filePath) {
+    async upload(yamlContent) {
         const parseYaml = require('./yaml-parser');
         const {parseRouteSettings} = require('./route-settings-parser');
         const urlService = require('../url');
@@ -120,8 +120,7 @@ class DynamicRoutingService {
 
         // Parse and validate before anything is persisted — an invalid
         // upload is rejected here and never reaches the store.
-        const content = await fs.readFile(filePath, 'utf8');
-        const next = parseRouteSettings(parseYaml(content), content);
+        const next = parseRouteSettings(parseYaml(yamlContent), yamlContent);
         let previous = null;
         try {
             previous = await this.store.get();

--- a/ghost/core/test/unit/server/services/route-settings/dynamic-routing-service.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/dynamic-routing-service.test.ts
@@ -211,29 +211,12 @@ taxonomies:
     });
 
     describe('upload', function () {
-        let uploadDir: string;
-
-        const writeUpload = async (content: string): Promise<string> => {
-            const filePath = path.join(uploadDir, 'routes-incoming.yaml');
-            await fs.writeFile(filePath, content, 'utf8');
-            return filePath;
-        };
-
-        beforeEach(async function () {
-            uploadDir = path.join(os.tmpdir(), `route-settings-upload-${crypto.randomUUID()}`);
-            await fs.ensureDir(uploadDir);
-        });
-
-        afterEach(async function () {
-            await fs.remove(uploadDir);
-        });
-
         it('persists the parsed upload through the store', async function () {
             sinon.stub(bridge, 'reloadFrontend').resolves();
             sinon.stub(urlService, 'resetGenerators');
             sinon.stub(urlService, 'hasFinished').returns(true);
 
-            await service.upload(await writeUpload(CUSTOM_YAML));
+            await service.upload(CUSTOM_YAML);
 
             assert.equal((await store.get()).yamlSource, CUSTOM_YAML);
         });
@@ -243,7 +226,7 @@ taxonomies:
             await store.replace(fromYaml(CUSTOM_YAML));
 
             await assert.rejects(
-                service.upload(await writeUpload('routes:\n  no-slashes: about\n')),
+                service.upload('routes:\n  no-slashes: about\n'),
                 (err: {errorType?: string}) => {
                     assert.equal(err.errorType, 'ValidationError');
                     return true;
@@ -263,7 +246,7 @@ taxonomies:
             getStub.onFirstCall().rejects(new errors.IncorrectUsageError({message: 'Could not parse provided YAML file: bad indentation of a mapping entry.'}));
             getStub.callThrough();
 
-            await service.upload(await writeUpload(CUSTOM_YAML));
+            await service.upload(CUSTOM_YAML);
 
             assert.equal((await store.get()).yamlSource, CUSTOM_YAML);
         });
@@ -277,7 +260,7 @@ taxonomies:
             getStub.onFirstCall().rejects(new errors.ValidationError({message: 'slug is required for read data entries.'}));
             getStub.callThrough();
 
-            await service.upload(await writeUpload(CUSTOM_YAML));
+            await service.upload(CUSTOM_YAML);
 
             assert.equal((await store.get()).yamlSource, CUSTOM_YAML);
         });
@@ -292,7 +275,7 @@ taxonomies:
             const nextYaml = CUSTOM_YAML.replace('/about/: about', '/contact/: contact');
 
             await assert.rejects(
-                service.upload(await writeUpload(nextYaml)),
+                service.upload(nextYaml),
                 /YAMLException/
             );
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1830/refactor-admin-api-endpoint-to-use-the-new-route-settings-service

## What

A small refactor with no functional change: the upload endpoint now reads the multer tmp file itself and hands the raw YAML string to `service.upload(yamlContent)` — the service no longer reads the upload from disk. Same parse → validate → persist → activate → rollback flow, in the same order, with the same errors.

## Why

"A file arrived in /tmp" is a fact about HTTP and multer, not about route settings — so the read belongs to the API layer. With it gone, the service's only I/O on the upload path is the configured store, which is exactly the shape we need before the store moves off local disk: boot, the Admin endpoint, and the future cross-instance reload flow all speak to the same service without pretending their input is a file.

Design decisions (per the Linear issue):

- **Thin API layer** — parse and validate are service concerns; the endpoint just receives bytes and hands them over
- **Rollback stays inside `service.upload()`** — persist-then-activate-then-rollback remains one atomic operation from every caller's perspective
- **`routes_hash` sync stays at the endpoint** — moving it into the service would couple route-settings to the settings service for a one-liner

The service's only remaining filesystem access is the legacy validation fallback (via the old `SettingsLoader`), which is deliberately scoped to the FileStore era and will be removed with HKG-1831.

## Tests

Unit tests now pass YAML strings directly (the tmp-file harness is deleted). Verified: 166 route-settings unit tests and the Admin settings e2e suite (real upload/download endpoints) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
