### PR TITLE
Cleaned up React Admin acceptance test output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -795,11 +795,19 @@ jobs:
         # resolve the project root since apps live in apps/* and koenig/*
         run: |
           APP_NAME="${{ matrix.app }}"
-          echo "name=${APP_NAME#@tryghost/}" >> $GITHUB_OUTPUT
-          echo "root=$(pnpm -s nx show project ${{ matrix.app }} --json | jq -r .root)" >> $GITHUB_OUTPUT
+          APP_ROOT=$(pnpm -s nx show project ${{ matrix.app }} --json | jq -r .root)
+          {
+            echo "name=${APP_NAME#@tryghost/}"
+            echo "root=$APP_ROOT"
+            if [ -d "$APP_ROOT/playwright-report" ]; then
+              echo "has_report=true"
+            else
+              echo "has_report=false"
+            fi
+          } >> "$GITHUB_OUTPUT"
 
       - name: Upload test results
-        if: always()
+        if: always() && steps.app_name.outputs.has_report == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ steps.app_name.outputs.name }}-playwright-report

--- a/apps/admin-x-design-system/src/global/breadcrumbs.tsx
+++ b/apps/admin-x-design-system/src/global/breadcrumbs.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import Button from './button';
 
 export type BreadcrumbItem = {
+    key?: React.Key;
     label: React.ReactNode;
     onClick?: () => void;
 }
@@ -29,7 +30,6 @@ const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
     separatorClassName
 }) => {
     const allItems = items.length;
-    let i = 0;
 
     containerClassName = clsx(
         'flex items-center gap-2',
@@ -50,13 +50,16 @@ const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
             {backIcon &&
             <Button className={snapBackIcon ? 'mr-1' : 'mr-6'} icon='arrow-left' iconColorClass='dark:text-white' size='sm' link onClick={onBack} />
             }
-            {items.map((item) => {
-                const bcItem = (i === allItems - 1 ?
-                    <span className={activeItemClassName}>{item.label}</span>
-                    :
-                    <>
+            {items.map((item, index) => {
+                const itemKey = item.key ?? String(item.label);
+
+                if (index === allItems - 1) {
+                    return <span key={itemKey} className={activeItemClassName}>{item.label}</span>;
+                }
+
+                return (
+                    <React.Fragment key={itemKey}>
                         <button
-                            key={`bc-${i}`}
                             className={`${itemClassName} ${item.onClick && '-mx-1 cursor-pointer rounded-sm px-1 py-px hover:bg-grey-100 dark:hover:bg-grey-900'}`}
                             type="button"
                             onClick={item.onClick}
@@ -64,9 +67,8 @@ const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
                             {item.label}
                         </button>
                         <span className={separatorClassName}>/</span>
-                    </>);
-                i = i + 1;
-                return bcItem;
+                    </React.Fragment>
+                );
             })}
         </div>
     );

--- a/apps/admin-x-framework/src/providers/router-provider.tsx
+++ b/apps/admin-x-framework/src/providers/router-provider.tsx
@@ -117,6 +117,7 @@ export function RouterProvider({
                     {children}
                 </NavigationStackProvider>
             ),
+            hydrateFallbackElement: <></>,
             children: routes.map(route => ({
                 ...route,
                 errorElement: route.errorElement || errorElement || <ErrorPage />

--- a/apps/admin-x-settings/src/components/settings/advanced/integrations/api-keys.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/integrations/api-keys.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import {Button, Heading} from '@tryghost/admin-x-design-system';
 
 export interface APIKeyFieldProps {
+    id: string;
     label?: string;
     text?: string;
     hint?: ReactNode;
@@ -38,7 +39,7 @@ const APIKeyField: React.FC<APIKeyFieldProps> = ({label, text = '', hint, onRege
 const APIKeys: React.FC<{hasLabel?: boolean; keys: APIKeyFieldProps[];}> = ({keys}) => {
     return (
         <div data-testid='api-keys'>
-            {keys.map(key => <APIKeyField key={key.label} {...key} />)}
+            {keys.map(key => <APIKeyField key={key.id} {...key} />)}
         </div>
     );
 };

--- a/apps/admin-x-settings/src/components/settings/advanced/integrations/content-api-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/integrations/content-api-modal.tsx
@@ -42,10 +42,11 @@ const ContentApiModal = NiceModal.create(() => {
                 <p className='mb-6 text-grey-700'>This key provides read-only access to your published content. For full read/write access, create a custom integration.</p>
                 <APIKeys keys={[
                     {
+                        id: 'content-api-key',
                         label: 'Content API key',
                         text: contentApiKey?.secret
                     },
-                    {label: 'API URL', text: window.location.origin + getGhostPaths().subdir}
+                    {id: 'api-url', label: 'API URL', text: window.location.origin + getGhostPaths().subdir}
                 ]} />
             </div>
         </Modal>

--- a/apps/admin-x-settings/src/components/settings/advanced/integrations/custom-integration-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/integrations/custom-integration-modal.tsx
@@ -131,18 +131,21 @@ const CustomIntegrationModalContent: React.FC<{integration: Integration}> = ({in
                     <TextField maxLength={2000} title='Description' value={formState.description || ''} onChange={e => updateForm(state => ({...state, description: e.target.value}))} />
                     <APIKeys keys={[
                         {
+                            id: 'content-api-key',
                             label: 'Content API key',
                             text: contentApiKey?.secret,
                             hint: contentKeyRegenerated ? <div className='text-green'>Content API Key was successfully regenerated</div> : undefined,
                             onRegenerate: () => contentApiKey && handleRegenerate(contentApiKey, setContentKeyRegenerated)
                         },
                         {
+                            id: 'admin-api-key',
                             label: 'Admin API key',
                             text: adminApiKey?.secret,
                             hint: adminKeyRegenerated ? <div className='text-green'>Admin API Key was successfully regenerated</div> : undefined,
                             onRegenerate: () => adminApiKey && handleRegenerate(adminApiKey, setAdminKeyRegenerated)
                         },
                         {
+                            id: 'api-url',
                             label: 'API URL',
                             text: window.location.origin + getGhostPaths().subdir
                         }

--- a/apps/admin-x-settings/src/components/settings/advanced/integrations/transistor-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/integrations/transistor-modal.tsx
@@ -118,12 +118,13 @@ const TransistorModal = NiceModal.create(() => {
                     {enabled && (
                         <APIKeys keys={[
                             {
+                                id: 'admin-api-key',
                                 label: 'Admin API key',
                                 text: adminApiKey?.secret,
                                 hint: regenerated ? <div className='text-green'>Admin API Key was successfully regenerated</div> : undefined,
                                 onRegenerate: handleRegenerate
                             },
-                            {label: 'API URL', text: window.location.origin + getGhostPaths().subdir}
+                            {id: 'api-url', label: 'API URL', text: window.location.origin + getGhostPaths().subdir}
                         ]} />
                     )}
                 </Form>

--- a/apps/admin-x-settings/src/components/settings/advanced/integrations/zapier-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/integrations/zapier-modal.tsx
@@ -97,12 +97,13 @@ const ZapierModal = NiceModal.create(() => {
                 detail='Automation for your favorite apps'
                 extra={<div className='mt-1 -mb-4'><APIKeys keys={[
                     {
+                        id: 'admin-api-key',
                         label: 'Admin API key',
                         text: adminApiKey?.secret,
                         hint: regenerated ? <div className='text-green'>Admin API Key was successfully regenerated</div> : undefined,
                         onRegenerate: handleRegenerate
                     },
-                    {label: 'API URL', text: window.location.origin + getGhostPaths().subdir}
+                    {id: 'api-url', label: 'API URL', text: window.location.origin + getGhostPaths().subdir}
                 ]} /></div>}
                 icon={<Icon name='zapier' size={56} />}
                 title='Zapier'

--- a/apps/admin-x-settings/src/components/settings/general/users/staff-token.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/users/staff-token.tsx
@@ -45,6 +45,7 @@ const StaffToken: React.FC = () => {
             <Heading className='mb-2' level={6} grey>Staff access token</Heading>
             <APIKeys hasLabel={false} keys={[
                 {
+                    id: 'staff-access-token',
                     text: token || '',
                     onRegenerate: genConfirmation
                 }]} />

--- a/apps/admin-x-settings/src/components/settings/growth/offers/add-offer-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/add-offer-modal.tsx
@@ -4,6 +4,7 @@ import {Button} from '@tryghost/admin-x-design-system';
 import {type ErrorMessages, useForm} from '@tryghost/admin-x-framework/hooks';
 import {Form, Icon, PreviewModalContent, Select, type SelectOption, TextArea, TextField, showToast} from '@tryghost/admin-x-design-system';
 import {JSONError} from '@tryghost/admin-x-framework/errors';
+import {formatNumber} from '@tryghost/shade/utils';
 import {getHomepageUrl} from '@tryghost/admin-x-framework/api/site';
 import {getOfferPortalPreviewUrl, type offerPortalPreviewUrlTypes} from '../../../../utils/get-offers-portal-preview-url';
 import {getPaidActiveTiers, useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
@@ -156,14 +157,14 @@ const Sidebar: React.FC<SidebarProps> = ({tierOptions,
     };
 
     return (
-        <div className='pt-7' data-testId={testId}>
+        <div className='pt-7' data-testid={testId}>
             <Form>
                 <section>
                     <h2 className='mb-4 text-lg'>General</h2>
                     <div className='flex flex-col gap-6'>
                         <TextField
                             error={Boolean(errors.name)}
-                            hint={errors.name || <div className='flex justify-between'><span>Visible to members on Stripe Checkout page</span><strong><span className={`${nameLengthColor}`}>{nameLength}</span> / 40</strong></div>}
+                            hint={errors.name || <div className='flex justify-between'><span>Visible to members on Stripe Checkout page</span><strong><span className={`${nameLengthColor}`}>{formatNumber(nameLength)}</span> / {formatNumber(40)}</strong></div>}
                             maxLength={40}
                             placeholder='Black Friday'
                             title='Offer name'

--- a/apps/admin-x-settings/src/components/settings/growth/offers/edit-offer-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/edit-offer-modal.tsx
@@ -6,6 +6,7 @@ import {type ErrorMessages, useForm, useHandleError} from '@tryghost/admin-x-fra
 import {JSONError} from '@tryghost/admin-x-framework/errors';
 import {type Offer, useBrowseOffersById, useEditOffer} from '@tryghost/admin-x-framework/api/offers';
 import {createOfferRedemptionFilterUrl} from './offer-helpers';
+import {formatNumber} from '@tryghost/shade/utils';
 import {getHomepageUrl} from '@tryghost/admin-x-framework/api/site';
 import {getOfferPortalPreviewUrl, type offerPortalPreviewUrlTypes} from '../../../../utils/get-offers-portal-preview-url';
 import {useEffect, useState} from 'react';
@@ -112,7 +113,7 @@ const Sidebar: React.FC<{
                                     <div className='flex flex-col gap-5'>
                                         <div className='flex flex-col gap-1.5'>
                                             <span className='text-sm leading-none font-semibold text-grey-700'>Performance</span>
-                                            <span>{offer?.redemption_count} {offer?.redemption_count === 1 ? 'redemption' : 'redemptions'}</span>
+                                            <span>{formatNumber(offer?.redemption_count || 0)} {offer?.redemption_count === 1 ? 'redemption' : 'redemptions'}</span>
                                         </div>
                                         {offer?.redemption_count > 0 && offer?.last_redeemed ?
                                             <div className='flex flex-col gap-1.5'>
@@ -131,11 +132,11 @@ const Sidebar: React.FC<{
                             <div className='flex flex-col gap-6'>
                                 <TextField
                                     error={Boolean(errors.name)}
-                                    hint={errors.name || <div className='flex justify-between'><span>Visible to members on Stripe Checkout page</span><strong><span className={`${nameLengthColor}`}>{nameLength}</span> / 40</strong></div>}
+                                    hint={errors.name || <div className='flex justify-between'><span>Visible to members on Stripe Checkout page</span><strong><span className={`${nameLengthColor}`}>{formatNumber(nameLength)}</span> / {formatNumber(40)}</strong></div>}
                                     maxLength={40}
                                     placeholder='Black Friday'
                                     title='Offer name'
-                                    value={offer?.name}
+                                    value={offer?.name ?? ''}
                                     onChange={(e) => {
                                         setNameLength(e.target.value.length);
                                         updateOffer({name: e.target.value});
@@ -149,7 +150,7 @@ const Sidebar: React.FC<{
                                     placeholder='black-friday'
                                     rightPlaceholder={offer?.code !== '' ? <Button className='mt-1 mr-0.5' color='green' label={isCopied ? 'Copied!' : 'Copy link'} size='sm' onClick={handleCopyClick} /> : null}
                                     title='Offer code'
-                                    value={offer?.code}
+                                    value={offer?.code ?? ''}
                                     onChange={e => updateOffer({code: e.target.value})}
                                     onKeyDown={() => clearError('code')}
                                 />
@@ -158,14 +159,14 @@ const Sidebar: React.FC<{
                                     hint={errors.displayTitle}
                                     placeholder='Black Friday Special'
                                     title='Display title'
-                                    value={offer?.display_title}
+                                    value={offer?.display_title ?? ''}
                                     onChange={e => updateOffer({display_title: e.target.value})}
                                     onKeyDown={() => clearError('displayTitle')}
                                 />
                                 <TextArea
                                     placeholder='Take advantage of this limited-time offer.'
                                     title='Display description'
-                                    value={offer?.display_description}
+                                    value={offer?.display_description ?? ''}
                                     onChange={e => updateOffer({display_description: e.target.value})}
                                 />
                             </div>

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -72,7 +72,6 @@
         "typescript": "catalog:",
         "typescript-eslint": "catalog:",
         "vite": "catalog:",
-        "vite-tsconfig-paths": "6.1.1",
         "vitest": "catalog:",
         "vitest-browser-react": "catalog:"
     },

--- a/apps/admin/src/layout/sidebar.acceptance.test.tsx
+++ b/apps/admin/src/layout/sidebar.acceptance.test.tsx
@@ -8,6 +8,7 @@ import {
     fakeEndpoint,
     fakeTags,
     renderAdminApp,
+    currentUserResponse,
     settingsResponse,
     type RenderAdminAppOptions,
 } from "@test-utils/acceptance";
@@ -168,6 +169,7 @@ describe("Network notification badge", () => {
         // The ActivityPub app owns its request graph; this spec asserts only the shell badge.
         allowUnhandledRequests();
         fakeUnreadNotifications(5);
+        fakeAdminEndpoint("GET", "/users/?limit=100&include=roles", currentUserResponse());
         await renderAdminApp("/", socialWebEnabled());
 
         await expect.element(sidebarScreen.networkBadge()).toBeVisible();

--- a/apps/admin/src/members/components/members-list-item.tsx
+++ b/apps/admin/src/members/components/members-list-item.tsx
@@ -3,10 +3,10 @@ import moment from 'moment-timezone';
 import {Avatar, TableCell, TableRow} from '@tryghost/shade/components';
 import {type Member} from '@tryghost/admin-x-framework/api/members';
 import {buildMemberDetailPath} from '@/members/member-detail-hash';
-import {cn} from '@tryghost/shade/utils';
+import {cn, formatPercentage} from '@tryghost/shade/utils';
 import {getActiveColumnValue} from '@/members/member-query-params';
 import type {ActiveColumn} from '@/members/member-query-params';
-import type {CSSProperties} from 'react';
+import {forwardRef, type CSSProperties} from 'react';
 import type {MemberTableColumnStyles} from './member-table-layout';
 
 const PINNED_EDGE_FADE_POSITION_STYLE = {
@@ -140,7 +140,7 @@ function MembersListItemOpenRate({
         <div
             className={cn('text-base', isKnown ? 'text-foreground' : 'text-muted-foreground')}
         >
-            {isKnown ? `${Math.round(emailOpenRate)}%` : 'N/A'}
+            {isKnown ? formatPercentage(emailOpenRate / 100) : 'N/A'}
         </div>
     );
 }
@@ -216,7 +216,7 @@ interface MembersListItemProps {
     onClick: (memberId: string) => void;
 }
 
-function MembersListItem({
+const MembersListItem = forwardRef<HTMLTableRowElement, MembersListItemProps & Omit<React.HTMLAttributes<HTMLTableRowElement>, 'onClick'>>(function MembersListItem({
     item,
     activeColumns,
     backPath,
@@ -226,8 +226,7 @@ function MembersListItem({
     timezone,
     onClick,
     ...props
-}: MembersListItemProps &
-    Omit<React.HTMLAttributes<HTMLTableRowElement>, 'onClick'>) {
+}, ref) {
     const handleRowClick = (event: React.MouseEvent<HTMLTableRowElement>) => {
         if (isModifiedClick(event)) {
             openMemberInNewTab(item.id, backPath);
@@ -248,6 +247,7 @@ function MembersListItem({
     return (
         <TableRow
             {...props}
+            ref={ref}
             className={cn('group cursor-pointer', props.className)}
             data-testid="members-list-item"
             onAuxClick={handleRowAuxClick}
@@ -303,7 +303,7 @@ function MembersListItem({
             ))}
         </TableRow>
     );
-}
+});
 
 export default MembersListItem;
 export {

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -1,6 +1,5 @@
 import { configDefaults, defineConfig } from "vitest/config";
 import type { PluginOption } from "vite";
-import tsconfigPaths from "vite-tsconfig-paths";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
@@ -38,7 +37,7 @@ function getBase(command: 'build' | 'serve'): string {
 // https://vite.dev/config/
 export default defineConfig(({ command }) => ({
     base: getBase(command),
-    plugins: [tailwindcss() as PluginOption, react(), emberAssetsPlugin(), ghostBackendProxyPlugin(), tsconfigPaths()],
+    plugins: [tailwindcss() as PluginOption, react(), emberAssetsPlugin(), ghostBackendProxyPlugin()],
     define: sharedDefine,
     server: {
         host: '0.0.0.0',

--- a/apps/admin/vite.shared.ts
+++ b/apps/admin/vite.shared.ts
@@ -16,6 +16,7 @@ export const sharedDefine = {
 };
 
 export const sharedResolve = {
+    tsconfigPaths: true,
     alias: {
         "@ghost-cards": GHOST_CARDS_PATH,
         // TODO: Remove this when @tryghost/nql is updated

--- a/apps/admin/vitest.acceptance.config.ts
+++ b/apps/admin/vitest.acceptance.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from "vitest/config";
 import { playwright } from "@vitest/browser-playwright";
 import type { PluginOption } from "vite";
-import tsconfigPaths from "vite-tsconfig-paths";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
@@ -13,7 +12,7 @@ import { sharedDefine, sharedResolve } from "./vite.shared";
  * in vite.config.ts (jsdom).
  */
 export default defineConfig({
-    plugins: [tailwindcss() as PluginOption, react(), tsconfigPaths()],
+    plugins: [tailwindcss() as PluginOption, react()],
     // Serves the MSW service worker script; scoped to the test config so it
     // never ends up in the production build's public assets.
     publicDir: "./test-utils/acceptance/public",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -764,9 +764,6 @@ importers:
       vite:
         specifier: 'catalog:'
         version: 8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
-      vite-tsconfig-paths:
-        specifier: 6.1.1
-        version: 6.1.1(supports-color@5.5.0)(typescript@5.9.3)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(typescript@5.9.3))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -22666,17 +22663,6 @@ packages:
     engines: {node: '>=16.20.2'}
     hasBin: true
 
-  tsconfck@3.1.6:
-    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
-    engines: {node: ^18 || >=20}
-    deprecated: unmaintained
-    hasBin: true
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   tsconfig-paths-webpack-plugin@4.2.0:
     resolution: {integrity: sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==}
     engines: {node: '>=10.13.0'}
@@ -23315,11 +23301,6 @@ packages:
     resolution: {integrity: sha512-qj2eAKF8C6PZWemVTvQA0xgQIcP1hHU6Buh7fl6BhvayWwnuxE+z417miKxeDvRWbDrupQ1oK99hfxElopJ3sQ==}
     peerDependencies:
       vite: '>=3.0.0'
-
-  vite-tsconfig-paths@6.1.1:
-    resolution: {integrity: sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==}
-    peerDependencies:
-      vite: '*'
 
   vite@8.1.3:
     resolution: {integrity: sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==}
@@ -48057,10 +48038,6 @@ snapshots:
       normalize-path: 3.0.0
       plimit-lit: 1.6.1
 
-  tsconfck@3.1.6(typescript@5.9.3):
-    optionalDependencies:
-      typescript: 5.9.3
-
   tsconfig-paths-webpack-plugin@4.2.0:
     dependencies:
       chalk: 4.1.2
@@ -48758,16 +48735,6 @@ snapshots:
       vite: 8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - rollup
-      - supports-color
-      - typescript
-
-  vite-tsconfig-paths@6.1.1(supports-color@5.5.0)(typescript@5.9.3)(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)):
-    dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
-      globrex: 0.1.2
-      tsconfck: 3.1.6(typescript@5.9.3)
-      vite: 8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
-    transitivePeerDependencies:
       - supports-color
       - typescript
 


### PR DESCRIPTION
## What changed

Cleaned up the output from the [React Admin Playwright acceptance job](https://github.com/TryGhost/Ghost/actions/runs/29433231938/job/87413597884) by fixing the setup and component issues that produced misleading diagnostics.

- replaced `vite-tsconfig-paths` with Vite 8's native `resolve.tsconfigPaths`
- supplied the router hydration fallback expected by lazy routes
- fixed stable list keys, `data-testid` casing, controlled offer inputs, and the virtualized member row ref
- captured the users request in the sidebar acceptance case
- skipped the optional report upload when an app does not generate a Playwright report; apps that generate reports still upload them

## Before / after

Before, the original green job still emitted **46 targeted noise lines**:

- 2 obsolete `vite-tsconfig-paths` migration notices
- 24 unrelated tsconfig parse errors
- 11 missing hydration fallback warnings
- 4 function-component ref warnings
- 1 each for the breadcrumb key, invalid `data-testId`, uncontrolled input, uncaptured users request, and optional missing report artifact

After, the [current PR merge-ref job](https://github.com/TryGhost/Ghost/actions/runs/29448226119/job/87464209075) passes with the targeted messages absent:

```
Test Files  19 passed (19)
Tests       106 passed (106)
```

The optional Admin report upload is skipped entirely, so it no longer emits a missing-file line. Other Playwright matrix apps continue to upload their reports.

## Verification

- `pnpm nx run @tryghost/admin:test:acceptance --skip-nx-cache`
- `pnpm nx run @tryghost/admin:build --skip-nx-cache`
- lint for `@tryghost/admin`, `@tryghost/admin-x-framework`, `@tryghost/admin-x-settings`, and `@tryghost/admin-x-design-system`
- GitHub Actions: React Admin acceptance passed 19 files / 106 tests with the targeted warnings absent
- post-fix independent subagent review: no actionable findings