### PR TITLE
✨ Added boot-time validation functionality support for adapters

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -93,6 +93,13 @@ async function initDatabase({config}) {
 async function initCore({ghostServer, config, frontend}) {
     debug('Begin: initCore');
 
+    // Validate configured adapters up-front so misconfiguration fails at boot
+    // rather than on first lazy use (e.g. first image upload or scheduled job)
+    debug('Begin: adapters');
+    const adapterManager = require('./server/services/adapter-manager');
+    adapterManager.init();
+    debug('End: adapters');
+
     // URL Utils is a bit slow, put it here so the timing is visible separate from models
     debug('Begin: Load urlUtils');
     require('./shared/url-utils');

--- a/ghost/core/core/server/adapters/redirects/S3RedirectsStore.ts
+++ b/ghost/core/core/server/adapters/redirects/S3RedirectsStore.ts
@@ -8,6 +8,7 @@ import {
     S3Client,
     S3ClientConfig
 } from '@aws-sdk/client-s3';
+import {z} from 'zod';
 import tpl from '@tryghost/tpl';
 import * as errors from '@tryghost/errors';
 import {RedirectsStoreBase, type RedirectConfig} from '@tryghost/adapter-base-redirects';
@@ -26,17 +27,32 @@ const messages = {
 
 const stripLeadingAndTrailingSlashes = (value = '') => value.replace(/^\/+|\/+$/g, '');
 
-export interface S3RedirectsStoreOptions {
-    bucket: string;
-    staticFileURLPrefix: string;
-    region?: string;
-    endpoint?: string;
-    forcePathStyle?: boolean;
-    accessKeyId?: string;
-    secretAccessKey?: string;
-    sessionToken?: string;
-    tenantPrefix?: string;
-}
+// Validates and normalises the config: the slash-trimmed fields
+// (`staticFileURLPrefix`, `tenantPrefix`) are stripped via `transform` so the
+// constructor consumes ready-to-use values, plus the credential-pair rule
+// (accessKeyId and secretAccessKey must be supplied together).
+const configSchema = z.object({
+    bucket: z.string({error: tpl(messages.missingBucket)}).min(1, {error: tpl(messages.missingBucket)}),
+    staticFileURLPrefix: z.string({error: tpl(messages.missingStaticFileURLPrefix)})
+        .transform(stripLeadingAndTrailingSlashes)
+        .refine(value => value.length > 0, {error: tpl(messages.missingStaticFileURLPrefix)}),
+    tenantPrefix: z.string().transform(stripLeadingAndTrailingSlashes).optional(),
+    region: z.string().optional(),
+    endpoint: z.string().optional(),
+    forcePathStyle: z.boolean().optional(),
+    accessKeyId: z.string().optional(),
+    secretAccessKey: z.string().optional(),
+    sessionToken: z.string().optional()
+}).refine((config) => {
+    // accessKeyId and secretAccessKey must be supplied together (or not at all).
+    const hasAccessKey = Boolean(config.accessKeyId);
+    const hasSecretKey = Boolean(config.secretAccessKey);
+    const hasSessionToken = Boolean(config.sessionToken);
+    const hasCredentialPair = hasAccessKey && hasSecretKey;
+    return !((hasAccessKey || hasSecretKey || hasSessionToken) && !hasCredentialPair);
+}, {error: tpl(messages.partialCredentials)});
+
+export type S3RedirectsStoreOptions = z.infer<typeof configSchema>;
 
 /**
  * Implements RedirectsStore against an S3-compatible bucket. Reads and
@@ -50,34 +66,41 @@ export default class S3RedirectsStore extends RedirectsStoreBase {
     private readonly staticFileURLPrefix: string;
     private readonly tenantPrefix: string;
 
-    constructor(options: S3RedirectsStoreOptions) {
+    /**
+     * Parse + normalise the config, throwing an actionable IncorrectUsageError
+     * on the first problem. Shared by `validate` (boot-time check) and the
+     * constructor (which uses the normalised result).
+     */
+    private static parseConfig(config: unknown): z.infer<typeof configSchema> {
+        const result = configSchema.safeParse(config);
+        if (!result.success) {
+            throw new errors.IncorrectUsageError({
+                message: [...new Set(result.error.issues.map(issue => issue.message))].join('; ')
+            });
+        }
+        return result.data;
+    }
+
+    /**
+     * Validate the options S3RedirectsStore would be constructed with, without
+     * instantiating it (no S3 client is created). Called by the adapter manager
+     * at boot so misconfiguration fails early. Narrows `config` to
+     * `S3RedirectsStoreOptions`.
+     */
+    static validate(config: unknown): asserts config is S3RedirectsStoreOptions {
+        S3RedirectsStore.parseConfig(config);
+    }
+
+    constructor(config: unknown) {
         super();
-        if (!options.bucket) {
-            throw new errors.IncorrectUsageError({
-                message: tpl(messages.missingBucket)
-            });
-        }
 
-        const staticFileURLPrefix = stripLeadingAndTrailingSlashes(options.staticFileURLPrefix);
-        if (!staticFileURLPrefix) {
-            throw new errors.IncorrectUsageError({
-                message: tpl(messages.missingStaticFileURLPrefix)
-            });
-        }
+        const options = S3RedirectsStore.parseConfig(config);
 
-        const hasAccessKey = Boolean(options.accessKeyId);
-        const hasSecretKey = Boolean(options.secretAccessKey);
-        const hasSessionToken = Boolean(options.sessionToken);
-        const hasCredentialPair = hasAccessKey && hasSecretKey;
-        if ((hasAccessKey || hasSecretKey || hasSessionToken) && !hasCredentialPair) {
-            throw new errors.IncorrectUsageError({
-                message: tpl(messages.partialCredentials)
-            });
-        }
+        const hasCredentialPair = Boolean(options.accessKeyId) && Boolean(options.secretAccessKey);
 
         this.bucket = options.bucket;
-        this.staticFileURLPrefix = staticFileURLPrefix;
-        this.tenantPrefix = stripLeadingAndTrailingSlashes(options.tenantPrefix);
+        this.staticFileURLPrefix = options.staticFileURLPrefix;
+        this.tenantPrefix = options.tenantPrefix ?? '';
 
         const clientConfig: S3ClientConfig = {
             region: options.region,

--- a/ghost/core/core/server/adapters/route-settings/FileStore.ts
+++ b/ghost/core/core/server/adapters/route-settings/FileStore.ts
@@ -1,5 +1,6 @@
 import fs from 'fs-extra';
 import path from 'path';
+import {z} from 'zod';
 import {format} from 'date-fns';
 import * as errors from '@tryghost/errors';
 import tpl from '@tryghost/tpl';
@@ -22,11 +23,13 @@ export const getBackupRouteSettingsFilePath = (filePath: string): string => {
     return path.join(dir, `${name}-${format(new Date(), 'yyyy-MM-dd-HH-mm-ss')}${ext}`);
 };
 
-interface FileStoreOptions {
-    basePath: string;
-    defaultSettingsBasePath: string;
-    getBackupFilePath?: (filePath: string) => string;
-}
+// Validates the required paths sourced from config. Used by `FileStore.validate`.
+const configSchema = z.object({
+    basePath: z.string({error: tpl(messages.missingPaths)}).min(1, {error: tpl(messages.missingPaths)}),
+    defaultSettingsBasePath: z.string({error: tpl(messages.missingPaths)}).min(1, {error: tpl(messages.missingPaths)})
+});
+
+type FileStoreOptions = z.infer<typeof configSchema>;
 
 /**
  * Local-disk store for route settings. Reads and writes the user's
@@ -42,18 +45,33 @@ export default class FileStore extends RouteSettingsStoreBase {
     private readonly defaultSettingsBasePath: string;
     private readonly getBackupFilePath: (filePath: string) => string;
 
-    constructor({basePath, defaultSettingsBasePath, getBackupFilePath = getBackupRouteSettingsFilePath}: FileStoreOptions) {
-        super();
-
-        if (!basePath || !defaultSettingsBasePath) {
+    /**
+     * Validate the options FileStore would be constructed with, without
+     * instantiating it. Called by the adapter manager at boot so
+     * misconfiguration fails early, and by the constructor so the two share a
+     * single source of truth. Narrows `config` to `FileStoreOptions`.
+     */
+    static validate(config: unknown): asserts config is FileStoreOptions {
+        const result = configSchema.safeParse(config);
+        if (!result.success) {
             throw new errors.IncorrectUsageError({
-                message: tpl(messages.missingPaths)
+                message: [...new Set(result.error.issues.map(issue => issue.message))].join('; ')
             });
         }
+    }
 
-        this.basePath = basePath;
-        this.defaultSettingsBasePath = defaultSettingsBasePath;
-        this.getBackupFilePath = getBackupFilePath;
+    constructor(config: unknown) {
+        super();
+
+        FileStore.validate(config);
+        this.basePath = config.basePath;
+        this.defaultSettingsBasePath = config.defaultSettingsBasePath;
+
+        // `getBackupFilePath` is a test-only injection seam — it never comes from
+        // config (nconf holds static values), so it's read from the raw input
+        // rather than the validated schema output.
+        this.getBackupFilePath = (config as {getBackupFilePath?: (filePath: string) => string}).getBackupFilePath
+            ?? getBackupRouteSettingsFilePath;
     }
 
     async get(): Promise<RouteSettings> {

--- a/ghost/core/core/server/adapters/storage/S3Storage.ts
+++ b/ghost/core/core/server/adapters/storage/S3Storage.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import type {Request, Response, NextFunction, RequestHandler} from 'express';
+import {z} from 'zod';
 import StorageBase from 'ghost-storage-base';
 import tpl from '@tryghost/tpl';
 import errors from '@tryghost/errors';
@@ -41,7 +42,10 @@ const messages = {
     multipartUploadReadFailed: 'There was an error uploading the file. The file may have been modified or removed during upload.',
     missingMultipartThreshold: 'S3Storage requires multipartUploadThresholdBytes option',
     missingMultipartChunkSize: 'S3Storage requires multipartChunkSizeBytes option',
-    multipartChunkSizeTooSmall: 'S3Storage multipartChunkSizeBytes must be at least 5 MiB (5242880 bytes)'
+    multipartChunkSizeTooSmall: 'S3Storage multipartChunkSizeBytes must be at least 5 MiB (5242880 bytes)',
+    multipartThresholdNotInteger: 'S3Storage multipartUploadThresholdBytes must be an integer',
+    multipartChunkSizeNotInteger: 'S3Storage multipartChunkSizeBytes must be an integer',
+    partialCredentials: 'S3Storage requires both accessKeyId and secretAccessKey when either is provided'
 };
 
 const stripLeadingAndTrailingSlashes = (value = '') => value.replace(/^\/+|\/+$/g, '');
@@ -54,21 +58,50 @@ interface UploadFile {
     type?: string;
 }
 
-export interface S3StorageOptions {
-    bucket: string;
-    cdnUrl: string;
-    staticFileURLPrefix: string;
-    region?: string;
-    endpoint?: string;
-    forcePathStyle?: boolean;
-    accessKeyId?: string;
-    secretAccessKey?: string;
-    sessionToken?: string;
-    tenantPrefix?: string;
-    s3Client?: S3Client;
-    multipartUploadThresholdBytes: number;
-    multipartChunkSizeBytes: number;
-}
+// Validates and normalises the S3Storage config. The slash-trimmed fields
+// (`staticFileURLPrefix`, `cdnUrl`, `tenantPrefix`) are stripped via `transform`
+// so the constructor consumes ready-to-use values, and the required-field guards
+// run against the trimmed result.
+const configSchema = z.object({
+    bucket: z.string({error: tpl(messages.missingBucket)}).min(1, {error: tpl(messages.missingBucket)}),
+    staticFileURLPrefix: z.string({error: tpl(messages.missingStaticFileURLPrefix)})
+        .transform(stripLeadingAndTrailingSlashes)
+        .refine(value => value.length > 0, {error: tpl(messages.missingStaticFileURLPrefix)}),
+    cdnUrl: z.string({error: tpl(messages.missingCdnUrl)})
+        .transform(stripTrailingSlash)
+        .refine(value => value.length > 0, {error: tpl(messages.missingCdnUrl)}),
+    multipartUploadThresholdBytes: z.number({error: tpl(messages.missingMultipartThreshold)})
+        .int({error: tpl(messages.multipartThresholdNotInteger)})
+        .positive({error: tpl(messages.missingMultipartThreshold)}),
+    multipartChunkSizeBytes: z.number({error: tpl(messages.missingMultipartChunkSize)})
+        .int({error: tpl(messages.multipartChunkSizeNotInteger)})
+        .check((ctx) => {
+            // Emit a single issue: a falsy value reads as "missing", a positive
+            // value below the floor as "too small".
+            if (!ctx.value) {
+                ctx.issues.push({code: 'custom', message: tpl(messages.missingMultipartChunkSize), input: ctx.value});
+            } else if (ctx.value < MIN_MULTIPART_CHUNK_SIZE) {
+                ctx.issues.push({code: 'custom', message: tpl(messages.multipartChunkSizeTooSmall), input: ctx.value});
+            }
+        }),
+    tenantPrefix: z.string().transform(stripLeadingAndTrailingSlashes).optional(),
+    region: z.string().optional(),
+    endpoint: z.string().optional(),
+    forcePathStyle: z.boolean().optional(),
+    accessKeyId: z.string().optional(),
+    secretAccessKey: z.string().optional(),
+    sessionToken: z.string().optional()
+}).refine((config) => {
+    // accessKeyId and secretAccessKey must be supplied together (or not at all) —
+    // a partial pair would silently fall back to ambient AWS credentials.
+    const hasAccessKey = Boolean(config.accessKeyId);
+    const hasSecretKey = Boolean(config.secretAccessKey);
+    const hasSessionToken = Boolean(config.sessionToken);
+    const hasCredentialPair = hasAccessKey && hasSecretKey;
+    return !((hasAccessKey || hasSecretKey || hasSessionToken) && !hasCredentialPair);
+}, {error: tpl(messages.partialCredentials)});
+
+export type S3StorageOptions = z.infer<typeof configSchema>;
 
 export default class S3Storage extends StorageBase {
     private readonly client: S3Client;
@@ -85,53 +118,42 @@ export default class S3Storage extends StorageBase {
 
     private readonly multipartChunkSizeBytes: number;
 
-    constructor(options: S3StorageOptions) {
+    /**
+     * Parse + normalise the config, throwing an actionable IncorrectUsageError
+     * on the first problem. Shared by `validate` (boot-time check) and the
+     * constructor (which uses the normalised result).
+     */
+    private static parseConfig(config: unknown): z.infer<typeof configSchema> {
+        const result = configSchema.safeParse(config);
+        if (!result.success) {
+            throw new errors.IncorrectUsageError({
+                message: [...new Set(result.error.issues.map(issue => issue.message))].join('; ')
+            });
+        }
+        return result.data;
+    }
+
+    /**
+     * Validate the options S3Storage would be constructed with, without
+     * instantiating it (no S3 client is created). Called by the adapter manager
+     * at boot so misconfiguration fails early. Narrows `config` to
+     * `S3StorageOptions`.
+     */
+    static validate(config: unknown): asserts config is S3StorageOptions {
+        S3Storage.parseConfig(config);
+    }
+
+    constructor(config: unknown) {
         super();
 
-        if (!options.bucket) {
-            throw new errors.IncorrectUsageError({
-                message: tpl(messages.missingBucket)
-            });
-        }
+        const options = S3Storage.parseConfig(config);
 
         this.bucket = options.bucket;
-        this.tenantPrefix = stripLeadingAndTrailingSlashes(options.tenantPrefix);
-
-        const staticFileURLPrefix = stripLeadingAndTrailingSlashes(options.staticFileURLPrefix);
-        if (!staticFileURLPrefix) {
-            throw new errors.IncorrectUsageError({
-                message: tpl(messages.missingStaticFileURLPrefix)
-            });
-        }
-
-        this.staticFileURLPrefix = staticFileURLPrefix;
-
-        this.storagePath = staticFileURLPrefix;
-
-        this.cdnUrl = stripTrailingSlash(options.cdnUrl || '');
-        if (!this.cdnUrl) {
-            throw new errors.IncorrectUsageError({
-                message: tpl(messages.missingCdnUrl)
-            });
-        }
-
-        if (!options.multipartUploadThresholdBytes) {
-            throw new errors.IncorrectUsageError({
-                message: tpl(messages.missingMultipartThreshold)
-            });
-        }
+        this.tenantPrefix = options.tenantPrefix ?? '';
+        this.staticFileURLPrefix = options.staticFileURLPrefix;
+        this.storagePath = options.staticFileURLPrefix;
+        this.cdnUrl = options.cdnUrl;
         this.multipartUploadThresholdBytes = options.multipartUploadThresholdBytes;
-
-        if (!options.multipartChunkSizeBytes) {
-            throw new errors.IncorrectUsageError({
-                message: tpl(messages.missingMultipartChunkSize)
-            });
-        }
-        if (options.multipartChunkSizeBytes < MIN_MULTIPART_CHUNK_SIZE) {
-            throw new errors.IncorrectUsageError({
-                message: tpl(messages.multipartChunkSizeTooSmall)
-            });
-        }
         this.multipartChunkSizeBytes = options.multipartChunkSizeBytes;
 
         const clientConfig: S3ClientConfig = {
@@ -148,7 +170,11 @@ export default class S3Storage extends StorageBase {
             };
         }
 
-        this.client = options.s3Client || new S3Client(clientConfig);
+        // `s3Client` is a test-only injection seam — it never comes from config
+        // (nconf holds static values), so it's read from the raw input rather
+        // than the validated schema output.
+        const injectedClient = (config as {s3Client?: S3Client} | null | undefined)?.s3Client;
+        this.client = injectedClient || new S3Client(clientConfig);
     }
 
     async save(file: UploadFile, targetDir?: string): Promise<string> {

--- a/ghost/core/core/server/services/adapter-manager/adapter-manager.ts
+++ b/ghost/core/core/server/services/adapter-manager/adapter-manager.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import errors from '@tryghost/errors';
-import {resolveAdapterExport, resolveAdapterOptions, normalizeAdapterConfig} from './utils';
+import {resolveAdapterExport, resolveAdapterOptions, normalizeAdapterConfig, getConfiguredFeatures} from './utils';
 import type {ConfigInstance} from '../../../shared/config/loader';
 import type {
     Adapter,
@@ -112,15 +112,69 @@ export class AdapterManager<BaseClasses extends BaseClassMap = BaseClassMap> {
             });
         }
 
+        const {Adapter, adapterConfig, adapterType, adapterClassName} = this.loadAdapter(name);
+        const adapterCache = this.instanceCache[adapterType];
+
+        // @NOTE: example cache key value 'email:newsletters:custom-newsletter-adapter'
+        const adapterCacheKey = `${name}:${adapterClassName}`;
+        if (adapterCache[adapterCacheKey]) {
+            return adapterCache[adapterCacheKey];
+        }
+
+        // `Adapter` is an abstract-compatible constructor type; the runtime value
+        // is always a concrete class here, so instantiation is safe.
+        const AdapterClass = Adapter as new (config?: object) => Adapter;
+        const adapter = new AdapterClass(adapterConfig);
+
+        const BaseClass = this.baseClasses[adapterType];
+        if (!(adapter instanceof BaseClass)) {
+            if (Object.getPrototypeOf(Adapter).name !== BaseClass.name) {
+                throw new errors.IncorrectUsageError({
+                    message: `${adapterType} adapter ${adapterClassName} does not inherit from the base class.`
+                });
+            }
+        }
+
+        if (!Array.isArray(adapter.requiredFns)) {
+            throw new errors.IncorrectUsageError({
+                message: `${adapterType} adapter ${adapterClassName} does not have the requiredFns array.`
+            });
+        }
+
+        for (const requiredFn of adapter.requiredFns) {
+            if (typeof (adapter as any)[requiredFn] !== 'function') {
+                throw new errors.IncorrectUsageError({
+                    message: `${adapterType} adapter ${adapterClassName} is missing the ${requiredFn} method.`
+                });
+            }
+        }
+
+        adapterCache[adapterCacheKey] = adapter;
+
+        return adapter;
+    }
+
+    /**
+     * Resolve the active adapter class name and options for `name` from config,
+     * then locate and load the adapter constructor from `pathsToAdapters`.
+     *
+     * Does not instantiate the adapter or touch the instance cache — shared by
+     * `getAdapter` (which instantiates + caches) and `init` (which validates).
+     */
+    private loadAdapter(name: string): {
+        Adapter: AdapterConstructor;
+        adapterConfig: object;
+        adapterType: string;
+        adapterClassName: string;
+    } {
         // Re-read config on every call so runtime config changes (and test config
         // overrides) are reflected, matching the original JS implementation.
         const adapterServiceConfig = normalizeAdapterConfig(this.config);
         const {adapterClassName, adapterConfig} = resolveAdapterOptions(name, adapterServiceConfig);
 
         const [adapterType] = name.split(':');
-        const adapterCache = this.instanceCache[adapterType];
 
-        if (!adapterCache) {
+        if (!this.baseClasses[adapterType]) {
             throw new errors.NotFoundError({
                 message: `Unknown adapter type ${adapterType}. Please register adapter.`
             });
@@ -130,12 +184,6 @@ export class AdapterManager<BaseClasses extends BaseClassMap = BaseClassMap> {
             throw new errors.IncorrectUsageError({
                 message: `Unable to find ${adapterType} adapter in ${this.pathsToAdapters}.`
             });
-        }
-
-        // @NOTE: example cache key value 'email:newsletters:custom-newsletter-adapter'
-        const adapterCacheKey = `${name}:${adapterClassName}`;
-        if (adapterCache[adapterCacheKey]) {
-            return adapterCache[adapterCacheKey];
         }
 
         let Adapter: AdapterConstructor | null = null;
@@ -180,36 +228,67 @@ export class AdapterManager<BaseClasses extends BaseClassMap = BaseClassMap> {
             });
         }
 
-        // `Adapter` is an abstract-compatible constructor type; the runtime value
-        // is always a concrete class here, so instantiation is safe.
-        const AdapterClass = Adapter as new (config?: object) => Adapter;
-        const adapter = new AdapterClass(adapterConfig);
+        return {Adapter, adapterConfig: adapterConfig ?? {}, adapterType, adapterClassName};
+    }
 
-        const BaseClass = this.baseClasses[adapterType];
-        if (!(adapter instanceof BaseClass)) {
-            if (Object.getPrototypeOf(Adapter).name !== BaseClass.name) {
-                throw new errors.IncorrectUsageError({
-                    message: `${adapterType} adapter ${adapterClassName} does not inherit from the base class.`
-                });
+    /**
+     * Validate the config of every configured adapter up-front, so
+     * misconfiguration fails at boot rather than on first lazy `getAdapter`.
+     *
+     * Enumerates the active adapter for each registered type plus every
+     * configured feature variant (e.g. `storage:media`), resolves each to a
+     * distinct class + config, and calls the adapter's optional static
+     * `validate` when present. All failures — bad config or a failure to load a
+     * configured adapter — are aggregated into a single error so an operator
+     * sees every problem at once. Types with no configured adapter are skipped;
+     * presence is still enforced on use by `getAdapter`.
+     */
+    init(): void {
+        const adapterServiceConfig = normalizeAdapterConfig(this.config);
+
+        // 1. Enumerate every configured adapter name (active + feature variants).
+        const names: string[] = [];
+        for (const adapterType of Object.keys(this.baseClasses)) {
+            names.push(adapterType);
+            for (const feature of getConfiguredFeatures(adapterServiceConfig[adapterType])) {
+                names.push(`${adapterType}:${feature}`);
             }
         }
 
-        if (!Array.isArray(adapter.requiredFns)) {
+        // 2. Resolve to distinct class + config pairs, skipping unconfigured
+        //    types/features and deduping identical class+config combinations.
+        const distinct = new Map<string, string>();
+        for (const name of names) {
+            const {adapterClassName, adapterConfig} = resolveAdapterOptions(name, adapterServiceConfig);
+            if (!adapterClassName) {
+                continue;
+            }
+            const [adapterType] = name.split(':');
+            const key = `${adapterType}:${adapterClassName}:${JSON.stringify(adapterConfig ?? {})}`;
+            if (!distinct.has(key)) {
+                distinct.set(key, name);
+            }
+        }
+
+        // 3. Load + validate each distinct adapter, aggregating all failures.
+        const failures: {name: string; err: Error}[] = [];
+        for (const name of distinct.values()) {
+            try {
+                const {Adapter, adapterConfig} = this.loadAdapter(name);
+                if (typeof Adapter.validate === 'function') {
+                    Adapter.validate(adapterConfig);
+                }
+            } catch (err) {
+                failures.push({name, err: err as Error});
+            }
+        }
+
+        if (failures.length > 0) {
+            const details = failures.map(({name, err}) => `- ${name}: ${err.message}`).join('\n');
             throw new errors.IncorrectUsageError({
-                message: `${adapterType} adapter ${adapterClassName} does not have the requiredFns array.`
+                message: `Invalid adapter configuration:\n${details}`,
+                errorDetails: failures.map(({name, err}) => ({adapter: name, message: err.message}))
             });
         }
-
-        for (const requiredFn of adapter.requiredFns) {
-            if (typeof (adapter as any)[requiredFn] !== 'function') {
-                throw new errors.IncorrectUsageError({
-                    message: `${adapterType} adapter ${adapterClassName} is missing the ${requiredFn} method.`
-                });
-            }
-        }
-
-        adapterCache[adapterCacheKey] = adapter;
-
-        return adapter;
     }
 }

--- a/ghost/core/core/server/services/adapter-manager/types.ts
+++ b/ghost/core/core/server/services/adapter-manager/types.ts
@@ -4,8 +4,17 @@ export interface Adapter {
 
 /**
  * Constructor type that matches abstract as well as concrete base classes.
+ *
+ * The optional static `validate` lets an adapter check the options it would be
+ * constructed with — without being instantiated — so misconfiguration can be
+ * surfaced at boot rather than on first lazy use. It is synchronous and throws
+ * (e.g. `IncorrectUsageError`) when the config is invalid. This is the loose,
+ * manager-facing signature; a concrete adapter is free to declare a narrower
+ * assertion signature (`asserts config is XOptions`) on its own static.
  */
-export type AdapterConstructor<T extends Adapter = Adapter> = abstract new (...args: any[]) => T;
+export type AdapterConstructor<T extends Adapter = Adapter> = (abstract new (...args: any[]) => T) & {
+    validate?(config?: object): void;
+};
 
 /**
  * A type-only registry mapping an adapter type name (e.g. "storage") to the

--- a/ghost/core/core/server/services/adapter-manager/utils.ts
+++ b/ghost/core/core/server/services/adapter-manager/utils.ts
@@ -76,6 +76,33 @@ export function normalizeAdapterConfig(config: ConfigInstance) {
 }
 
 /**
+* Return the feature keys configured for a single adapter type's settings.
+*
+* A key is a "feature" (e.g. `images`/`media`/`files` for storage) when it isn't
+* `active` and its value either names another adapter (a String, e.g.
+* `media: 'LocalMediaStorage'`) or carries inline feature config (an Object with
+* an `adapter` property, e.g. `media: {adapter: 'S3Storage', bucket: '...'}`).
+* Plain adapter-config objects keyed by class name (e.g. `LocalMediaStorage: {}`)
+* are not features — `resolveAdapterOptions` resolves those back to the active
+* adapter — so they're intentionally excluded here.
+*/
+export function getConfiguredFeatures(settings: unknown): string[] {
+    if (!settings || typeof settings !== 'object') {
+        return [];
+    }
+
+    return Object.entries(settings as Record<string, unknown>)
+        .filter(([key, value]) => {
+            if (key === 'active') {
+                return false;
+            }
+            return typeof value === 'string'
+                || (typeof value === 'object' && value !== null && 'adapter' in value);
+        })
+        .map(([key]) => key);
+}
+
+/**
 * Resolve adapter options from the config, handling both top-level and nested feature-specific options.
 */
 export function resolveAdapterOptions(name: string, config: any) {

--- a/ghost/core/test/unit/server/adapters/storage/s3-storage.test.ts
+++ b/ghost/core/test/unit/server/adapters/storage/s3-storage.test.ts
@@ -91,6 +91,63 @@ describe('S3Storage', function () {
         }, /requires multipartChunkSizeBytes option/);
     });
 
+    describe('validate', function () {
+        it('passes for valid options without instantiating a client', function () {
+            const s3ClientSpy = sinon.spy(S3Client.prototype, 'send' as never);
+            assert.doesNotThrow(() => S3Storage.validate(baseOptions));
+            sinon.assert.notCalled(s3ClientSpy);
+        });
+
+        it('throws IncorrectUsageError for invalid options', function () {
+            const options: any = {...baseOptions};
+            delete options.bucket;
+            assert.throws(() => S3Storage.validate(options), /requires a bucket name/);
+        });
+
+        it('throws when multipart chunk size is below the 5 MiB minimum', function () {
+            assert.throws(
+                () => S3Storage.validate({...baseOptions, multipartChunkSizeBytes: MIN_MULTIPART_CHUNK_SIZE - 1}),
+                /at least 5 MiB/
+            );
+        });
+
+        it('reports every invalid field, not just the first', function () {
+            const options: any = {...baseOptions};
+            delete options.bucket;
+            delete options.cdnUrl;
+            delete options.multipartUploadThresholdBytes;
+
+            assert.throws(() => S3Storage.validate(options), (err: Error) => {
+                assert.match(err.message, /requires a bucket name/);
+                assert.match(err.message, /requires a cdnUrl option/);
+                assert.match(err.message, /requires multipartUploadThresholdBytes option/);
+                return true;
+            });
+        });
+
+        it('throws when multipart byte counts are not integers', function () {
+            assert.throws(
+                () => S3Storage.validate({...baseOptions, multipartUploadThresholdBytes: 1024.5}),
+                /multipartUploadThresholdBytes must be an integer/
+            );
+            assert.throws(
+                () => S3Storage.validate({...baseOptions, multipartChunkSizeBytes: MIN_MULTIPART_CHUNK_SIZE + 0.5}),
+                /multipartChunkSizeBytes must be an integer/
+            );
+        });
+
+        it('throws when only part of the credential pair is provided', function () {
+            assert.throws(
+                () => S3Storage.validate({...baseOptions, accessKeyId: 'AKIA'}),
+                /both accessKeyId and secretAccessKey/
+            );
+            assert.throws(
+                () => S3Storage.validate({...baseOptions, secretAccessKey: 'shh'}),
+                /both accessKeyId and secretAccessKey/
+            );
+        });
+    });
+
     it('strips leading and trailing slashes from config options', function () {
         const {storage} = createStorage({
             tenantPrefix: '/client-a/',

--- a/ghost/core/test/unit/server/services/adapter-manager/adapter-manager.test.ts
+++ b/ghost/core/test/unit/server/services/adapter-manager/adapter-manager.test.ts
@@ -246,4 +246,142 @@ describe('AdapterManager', function () {
         const secondMailNewslettersAdapter = adapterManager.getAdapter('mail:newsletters');
         assert.equal(mailNewslettersAdapter, secondMailNewslettersAdapter);
     });
+
+    describe('init', function () {
+        // An adapter whose static `validate` records the config it was called
+        // with, and optionally throws — so tests can assert init's behaviour.
+        function makeValidatingAdapter(calls: object[], {shouldThrow = false} = {}) {
+            return class ValidatingAdapter extends BaseMailAdapter {
+                someMethod() {}
+                static validate(config: object) {
+                    calls.push(config);
+                    if (shouldThrow) {
+                        throw new Error('bad config');
+                    }
+                }
+            };
+        }
+
+        it('calls validate on a configured adapter and passes valid config through', function () {
+            const calls: object[] = [];
+            const loadAdapterFromPath = sinon.stub().returns(makeValidatingAdapter(calls));
+
+            const adapterManager = new AdapterManager({
+                loadAdapterFromPath,
+                pathsToAdapters: ['/path'],
+                config: makeConfig({mail: {active: 'custom', custom: {some: 'value'}}}),
+                baseClasses: {mail: BaseMailAdapter}
+            });
+
+            adapterManager.init();
+
+            assert.equal(calls.length, 1);
+            assert.deepEqual(calls[0], {some: 'value'});
+        });
+
+        it('is a no-op for an adapter without a validate static', function () {
+            const loadAdapterFromPath = sinon.stub().returns(CustomMailAdapter);
+
+            const adapterManager = new AdapterManager({
+                loadAdapterFromPath,
+                pathsToAdapters: ['/path'],
+                config: makeConfig({mail: {active: 'custom'}}),
+                baseClasses: {mail: BaseMailAdapter}
+            });
+
+            assert.doesNotThrow(() => adapterManager.init());
+        });
+
+        it('skips adapter types that are not configured', function () {
+            const loadAdapterFromPath = sinon.stub().throws(new Error('should not load'));
+
+            const adapterManager = new AdapterManager({
+                loadAdapterFromPath,
+                pathsToAdapters: ['/path'],
+                config: makeConfig({}), // no active adapter configured
+                baseClasses: {mail: BaseMailAdapter}
+            });
+
+            assert.doesNotThrow(() => adapterManager.init());
+            sinon.assert.notCalled(loadAdapterFromPath);
+        });
+
+        it('validates configured feature adapters', function () {
+            const calls: object[] = [];
+            const loadAdapterFromPath = sinon.stub().returns(makeValidatingAdapter(calls));
+
+            const adapterManager = new AdapterManager({
+                loadAdapterFromPath,
+                pathsToAdapters: ['/path'],
+                config: makeConfig({
+                    storage: {
+                        active: 'active-adapter',
+                        'active-adapter': {which: 'active'},
+                        media: {adapter: 'active-adapter', which: 'media'}
+                    }
+                }),
+                baseClasses: {storage: BaseMailAdapter}
+            });
+
+            adapterManager.init();
+
+            // Both the active adapter and the media feature (distinct merged
+            // config, with the `adapter` key stripped) validate.
+            assert.equal(calls.length, 2);
+            assert.deepEqual(calls, [
+                {which: 'active'},
+                {which: 'media'}
+            ]);
+        });
+
+        it('dedupes adapters resolving to the same class and config', function () {
+            const calls: object[] = [];
+            const loadAdapterFromPath = sinon.stub().returns(makeValidatingAdapter(calls));
+
+            const adapterManager = new AdapterManager({
+                loadAdapterFromPath,
+                pathsToAdapters: ['/path'],
+                config: makeConfig({
+                    storage: {
+                        active: 'the-adapter',
+                        // both features point at the active adapter (string form),
+                        // so all three resolve to the same class + config
+                        media: 'the-adapter',
+                        files: 'the-adapter',
+                        'the-adapter': {shared: 'config'}
+                    }
+                }),
+                baseClasses: {storage: BaseMailAdapter}
+            });
+
+            adapterManager.init();
+
+            assert.equal(calls.length, 1);
+            assert.deepEqual(calls[0], {shared: 'config'});
+        });
+
+        it('aggregates failures from multiple adapters into one error', function () {
+            const loadAdapterFromPath = sinon.stub();
+            loadAdapterFromPath.withArgs('/path/mail/bad-mail').returns(makeValidatingAdapter([], {shouldThrow: true}));
+            loadAdapterFromPath.withArgs('/path/storage/bad-storage').returns(makeValidatingAdapter([], {shouldThrow: true}));
+
+            const adapterManager = new AdapterManager({
+                loadAdapterFromPath,
+                pathsToAdapters: ['/path'],
+                config: makeConfig({
+                    mail: {active: 'bad-mail'},
+                    storage: {active: 'bad-storage'}
+                }),
+                baseClasses: {mail: BaseMailAdapter, storage: BaseMailAdapter}
+            });
+
+            assert.throws(() => adapterManager.init(), (err: Error & {errorDetails?: unknown}) => {
+                assert.equal((err as {errorType?: string}).errorType, 'IncorrectUsageError');
+                assert.match(err.message, /mail/);
+                assert.match(err.message, /storage/);
+                assert.equal((err.errorDetails as unknown[]).length, 2);
+                return true;
+            });
+        });
+    });
 });

--- a/ghost/core/test/unit/server/services/adapter-manager/utils.test.ts
+++ b/ghost/core/test/unit/server/services/adapter-manager/utils.test.ts
@@ -2,7 +2,8 @@ import assert from 'node:assert/strict';
 import {Provider} from 'nconf'
 import {
     resolveAdapterOptions,
-    normalizeAdapterConfig
+    normalizeAdapterConfig,
+    getConfiguredFeatures
 } from '../../../../../core/server/services/adapter-manager/utils';
 import {bindAll as bindUrlHelpers} from '@tryghost/config-url-helpers';
 import {bindAll as bindHelpers} from '../../../../../core/shared/config/helpers';
@@ -314,6 +315,46 @@ describe('Adapter Manager: utils', function () {
                 adapterConfigValue: 'images_redis_value',
                 overrideMe: 'images_override'
             });
+        });
+    });
+
+    describe('getConfiguredFeatures', function () {
+        it('returns [] for missing or non-object settings', function () {
+            assert.deepEqual(getConfiguredFeatures(undefined), []);
+            assert.deepEqual(getConfiguredFeatures(null), []);
+            assert.deepEqual(getConfiguredFeatures('local-storage'), []);
+        });
+
+        it('ignores the active key and adapter-config objects', function () {
+            const settings = {
+                active: 'LocalImagesStorage',
+                LocalMediaStorage: {},
+                LocalFilesStorage: {}
+            };
+
+            assert.deepEqual(getConfiguredFeatures(settings), []);
+        });
+
+        it('detects string-valued features', function () {
+            const settings = {
+                active: 'LocalImagesStorage',
+                media: 'LocalMediaStorage',
+                files: 'LocalFilesStorage',
+                LocalMediaStorage: {},
+                LocalFilesStorage: {}
+            };
+
+            assert.deepEqual(getConfiguredFeatures(settings), ['media', 'files']);
+        });
+
+        it('detects object features carrying an adapter property', function () {
+            const settings = {
+                Redis: {commonConfigValue: 'x'},
+                images: {adapter: 'Redis', adapterConfigValue: 'y'},
+                settings: {adapter: 'Redis', adapterConfigValue: 'z'}
+            };
+
+            assert.deepEqual(getConfiguredFeatures(settings), ['images', 'settings']);
         });
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLA-247/implement-boot-time-adapter-config-validation
- add new optional static `validate` method to adapter manager logic
- validate is passed normalized adapter config options and can optionally throw IncorrectUsageError if configuration options are absent
- refactor S3/FileStore adapter extensions to leverage Zod schemas for config validation
- wire up validation to adapterManager init method, called during boot