### PR TITLE
Cleaned up package versions

### DIFF
--- a/.pnpmfile.mjs
+++ b/.pnpmfile.mjs
@@ -28,6 +28,16 @@ function beforePacking(pkg) {
     delete pkg.nx;
     delete pkg.devDependencies;
 
+    // remove any 'source' export conditions as the source files aren't included
+    // in the tarballs
+    if (pkg.exports) {
+        for (const key of Object.keys(pkg.exports)) {
+            if (typeof pkg.exports[key] === 'object' && pkg.exports[key].source) {
+                delete pkg.exports[key].source;
+            }
+        }
+    }
+
     if (pkg.name !== 'ghost') {
         return pkg;
     }

--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@tryghost/activitypub",
     "type": "module",
-    "version": "3.1.55",
     "license": "MIT",
     "repository": {
         "type": "git",
@@ -22,7 +21,7 @@
         },
         "./api": "./src/index.tsx"
     },
-    "private": false,
+    "private": true,
     "scripts": {
         "dev": "vite build --watch",
         "dev:start": "vite",

--- a/apps/admin-x-design-system/package.json
+++ b/apps/admin-x-design-system/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@tryghost/admin-x-design-system",
     "type": "module",
-    "version": "0.0.0",
     "repository": "https://github.com/TryGhost/Ghost/tree/main/packages/admin-x-design-system",
     "author": "Ghost Foundation",
     "private": true,

--- a/apps/admin-x-framework/package.json
+++ b/apps/admin-x-framework/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@tryghost/admin-x-framework",
     "type": "module",
-    "version": "0.0.0",
     "repository": "https://github.com/TryGhost/Ghost/tree/main/apps/admin-x-framework",
     "author": "Ghost Foundation",
     "private": true,

--- a/apps/admin-x-settings/package.json
+++ b/apps/admin-x-settings/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@tryghost/admin-x-settings",
     "type": "module",
-    "version": "0.0.0",
     "license": "MIT",
     "repository": {
         "type": "git",

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@tryghost/admin",
     "private": true,
-    "version": "0.0.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/apps/shade/package.json
+++ b/apps/shade/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@tryghost/shade",
     "type": "module",
-    "version": "0.0.0",
     "repository": "https://github.com/TryGhost/Ghost/tree/main/packages/shade",
     "author": "Ghost Foundation",
     "private": true,

--- a/configs/eslint-react/package.json
+++ b/configs/eslint-react/package.json
@@ -1,6 +1,5 @@
 {
     "name": "@internal/cfg-eslint-react",
-    "version": "0.0.0",
     "description": "Shared ESLint config for internal Ghost React apps",
     "private": true,
     "type": "module",

--- a/configs/eslint/package.json
+++ b/configs/eslint/package.json
@@ -1,6 +1,5 @@
 {
     "name": "@internal/cfg-eslint",
-    "version": "0.0.0",
     "description": "Shared ESLint atoms + Node-library config for internal Ghost packages",
     "private": true,
     "type": "module",

--- a/configs/typescript/package.json
+++ b/configs/typescript/package.json
@@ -1,6 +1,5 @@
 {
     "name": "@internal/cfg-typescript",
-    "version": "0.0.0",
     "description": "Shared TypeScript config for internal ESM-only Ghost packages",
     "private": true,
     "license": "MIT",

--- a/configs/vitest/package.json
+++ b/configs/vitest/package.json
@@ -1,6 +1,5 @@
 {
     "name": "@internal/cfg-vitest",
-    "version": "0.0.0",
     "description": "Shared Vitest config for internal Ghost packages",
     "private": true,
     "type": "module",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@tryghost/e2e",
-  "version": "0.0.0",
   "repository": "https://github.com/TryGhost/Ghost/tree/main/e2e",
   "author": "Ghost Foundation",
   "private": true,

--- a/ghost/i18n/package.json
+++ b/ghost/i18n/package.json
@@ -1,9 +1,8 @@
 {
   "name": "@tryghost/i18n",
-  "version": "0.0.0",
+  "private": true,
   "repository": "https://github.com/TryGhost/Ghost/tree/main/ghost/i18n",
   "author": "Ghost Foundation",
-  "private": true,
   "main": "index.js",
   "exports": {
     ".": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "ghost-monorepo",
-  "version": "0.0.0-private",
   "description": "The professional publishing platform",
   "private": true,
   "packageManager": "pnpm@11.13.0+sha512.88d94724d8f2e6c186744a5584c6e59ecac869ec7ba15e9cb4cd628e8dc7066820b2481d8ee3b51ea8da323a7378068aa58c556a3720d32b7c20a051d088363a",

--- a/packages/_template/package.json
+++ b/packages/_template/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@tryghost/{{NAME}}",
-  "version": "0.0.0",
   "description": "{{DESCRIPTION}}",
   "private": true,
   "type": "module",

--- a/packages/parse-email-address/package.json
+++ b/packages/parse-email-address/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@tryghost/parse-email-address",
-  "version": "0.0.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/testing/test-data/package.json
+++ b/packages/testing/test-data/package.json
@@ -1,6 +1,5 @@
 {
     "name": "@tryghost/test-data",
-    "version": "0.0.0",
     "private": true,
     "type": "module",
     "repository": "https://github.com/TryGhost/Ghost/tree/main/testing/test-data",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -450,7 +450,7 @@ overrides:
 
 packageExtensionsChecksum: sha256-gFsvptlcVXY90ntXWh9ANUP1/LYyeqXjWoDGw6BCfOY=
 
-pnpmfileChecksum: sha256-HiRuK7P5OxfDunYuWJfSntnbDVKAT4NjlnblKXMjPak=
+pnpmfileChecksum: sha256-Sd3QfaD2/rkAtQ+hQRsluz5bavHGYedrpFSCArlTUYo=
 
 importers:
 
@@ -2612,7 +2612,7 @@ importers:
         version: 13.0.0
       gscan:
         specifier: 6.4.2
-        version: 6.4.2(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))
+        version: 6.4.2(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(supports-color@5.5.0)
       handlebars:
         specifier: 4.7.9
         version: 4.7.9
@@ -23884,7 +23884,7 @@ snapshots:
       semifies: 1.0.0
       source-map: 0.6.1
 
-  '@apm-js-collab/tracing-hooks@0.10.1':
+  '@apm-js-collab/tracing-hooks@0.10.1(supports-color@5.5.0)':
     dependencies:
       '@apm-js-collab/code-transformer': 0.15.0
       debug: 4.4.3(supports-color@5.5.0)
@@ -27242,12 +27242,12 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.41.1
 
-  '@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.220.0
       import-in-the-middle: 3.2.0
-      require-in-the-middle: 8.0.1
+      require-in-the-middle: 8.0.1(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -28532,7 +28532,7 @@ snapshots:
       '@sentry/utils': 7.120.4
       localforage: 1.10.0
 
-  '@sentry/node-core@10.65.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))':
+  '@sentry/node-core@10.65.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))':
     dependencies:
       '@sentry/conventions': 0.15.1
       '@sentry/core': 10.65.0
@@ -28541,19 +28541,19 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)
       '@opentelemetry/sdk-trace-base': 2.9.0(@opentelemetry/api@1.9.1)
 
-  '@sentry/node@10.65.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))':
+  '@sentry/node@10.65.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(supports-color@5.5.0)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0)
       '@opentelemetry/sdk-trace-base': 2.9.0(@opentelemetry/api@1.9.1)
       '@sentry/conventions': 0.15.1
       '@sentry/core': 10.65.0
-      '@sentry/node-core': 10.65.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))
+      '@sentry/node-core': 10.65.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)(supports-color@5.5.0))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))
       '@sentry/opentelemetry': 10.65.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))
-      '@sentry/server-utils': 10.65.0
+      '@sentry/server-utils': 10.65.0(supports-color@5.5.0)
       import-in-the-middle: 3.2.0
     transitivePeerDependencies:
       - '@opentelemetry/core'
@@ -28625,11 +28625,11 @@ snapshots:
       - encoding
       - supports-color
 
-  '@sentry/server-utils@10.65.0':
+  '@sentry/server-utils@10.65.0(supports-color@5.5.0)':
     dependencies:
       '@apm-js-collab/code-transformer': 0.15.0
       '@apm-js-collab/code-transformer-bundler-plugins': 0.5.0
-      '@apm-js-collab/tracing-hooks': 0.10.1
+      '@apm-js-collab/tracing-hooks': 0.10.1(supports-color@5.5.0)
       '@sentry/conventions': 0.15.1
       '@sentry/core': 10.65.0
       magic-string: 0.30.21
@@ -30437,7 +30437,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tryghost/debug@2.3.1':
+  '@tryghost/debug@2.3.1(supports-color@5.5.0)':
     dependencies:
       '@tryghost/root-utils': 2.3.1
       debug: 4.4.3(supports-color@5.5.0)
@@ -30795,7 +30795,7 @@ snapshots:
 
   '@tryghost/server@3.1.1':
     dependencies:
-      '@tryghost/debug': 2.3.1
+      '@tryghost/debug': 2.3.1(supports-color@5.5.0)
       '@tryghost/logging': 4.2.1(supports-color@5.5.0)
     transitivePeerDependencies:
       - '@75lb/nature'
@@ -33434,7 +33434,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  body-parser@2.3.0:
+  body-parser@2.3.0(supports-color@5.5.0):
     dependencies:
       bytes: 3.1.2
       content-type: 2.0.0
@@ -38500,10 +38500,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  express@5.2.1:
+  express@5.2.1(supports-color@5.5.0):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.3.0
+      body-parser: 2.3.0(supports-color@5.5.0)
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
@@ -38513,7 +38513,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1
+      finalhandler: 2.1.1(supports-color@5.5.0)
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -38524,8 +38524,8 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.3
       range-parser: 1.2.1
-      router: 2.2.0
-      send: 1.2.1
+      router: 2.2.0(supports-color@5.5.0)
+      send: 1.2.1(supports-color@5.5.0)
       serve-static: 2.2.1
       statuses: 2.0.2
       type-is: 2.1.0
@@ -38747,7 +38747,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  finalhandler@2.1.1:
+  finalhandler@2.1.1(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
@@ -39537,11 +39537,11 @@ snapshots:
 
   growly@1.3.0: {}
 
-  gscan@6.4.2(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1)):
+  gscan@6.4.2(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(supports-color@5.5.0):
     dependencies:
-      '@sentry/node': 10.65.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))
+      '@sentry/node': 10.65.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(supports-color@5.5.0)
       '@tryghost/config': 2.3.1
-      '@tryghost/debug': 2.3.1
+      '@tryghost/debug': 2.3.1(supports-color@5.5.0)
       '@tryghost/errors': 1.3.13
       '@tryghost/logging': 4.2.1(supports-color@5.5.0)
       '@tryghost/nql': 0.13.1(supports-color@5.5.0)
@@ -39549,7 +39549,7 @@ snapshots:
       '@tryghost/server': 3.1.1
       '@tryghost/zip': 3.5.0
       chalk: 5.6.2
-      express: 5.2.1
+      express: 5.2.1(supports-color@5.5.0)
       express-handlebars: 8.0.1
       glob: 13.0.6
       handlebars: 4.7.9
@@ -46079,7 +46079,7 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  require-in-the-middle@8.0.1:
+  require-in-the-middle@8.0.1(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       module-details-from-path: 1.0.4
@@ -46315,7 +46315,7 @@ snapshots:
 
   route-recognizer@0.3.4: {}
 
-  router@2.2.0:
+  router@2.2.0(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
@@ -46527,7 +46527,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  send@1.2.1:
+  send@1.2.1(supports-color@5.5.0):
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
@@ -46568,7 +46568,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1
+      send: 1.2.1(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -249,3 +249,14 @@ minimumReleaseAgeExclude:
   - "knex-migrator"
   # Renovate security update: file-type@21.3.1 || 21.3.2
   - file-type@21.3.1 || 21.3.2
+
+versioning:
+  ignore:
+    - 'ghost-admin' # admin has a version but is not published
+    # public apps, published automatically on merge to main
+    - '@tryghost/announcement-bar'
+    - '@tryghost/admin-toolbar'
+    - '@tryghost/comments-ui'
+    - '@tryghost/signup-form'
+    - '@tryghost/sodo-search'
+    - '@tryghost/portal'


### PR DESCRIPTION
no ref
- remove versions from private, unpublished packages to get pnpm to ignore them
- add public apps and ghost-admin to ignored version packages for pnpm change
- remove source exports from packed tarballs

pnpm's native monorepo change management will ignore unversioned private packages, as well as ones explicitly added to the ignored version list