### PR TITLE
Fixed flaky staff password acceptance tests

### DIFF
--- a/apps/admin/src/settings/general/staff-password.acceptance.test.tsx
+++ b/apps/admin/src/settings/general/staff-password.acceptance.test.tsx
@@ -17,6 +17,7 @@ describe("Staff passwords", () => {
         const newPassword = modal.getByTestId("new-password");
         const confirmPassword = modal.getByTestId("confirm-password");
         const save = modal.getByTestId("save-password-button");
+        await expect.element(newPassword).toHaveFocus();
 
         await newPassword.fill("short");
         await confirmPassword.fill("short");
@@ -54,13 +55,18 @@ describe("Staff passwords", () => {
 
         const modal = settingsScreen.userDetailModal();
         await modal.getByTestId("change-password-button").click();
-        await modal.getByTestId("new-password").fill("this-is-sufficiently-secure");
-        await modal.getByTestId("confirm-password").fill("this-is-sufficiently-secure");
+        const oldPassword = modal.getByTestId("old-password");
+        const newPassword = modal.getByTestId("new-password");
+        const confirmPassword = modal.getByTestId("confirm-password");
         const save = modal.getByTestId("save-password-button");
+        await expect.element(oldPassword).toHaveFocus();
+
+        await newPassword.fill("this-is-sufficiently-secure");
+        await confirmPassword.fill("this-is-sufficiently-secure");
         await save.click();
         await expect.element(modal.getByText("Your current password is required to set a new one")).toBeVisible();
 
-        await modal.getByTestId("old-password").fill("current-password");
+        await oldPassword.fill("current-password");
         await save.click();
         await expect.element(save).toHaveTextContent("Saved");
         expect(passwordApi.lastRequest?.body).toMatchObject({password: [{oldPassword: "current-password", user_id: owner.id}]});


### PR DESCRIPTION
## What changed

- wait for the password form's intended field to receive focus before filling either password path
- reuse the password field locators throughout the current-user scenario

## Why

The password form applies focus 100 ms after it opens. Playwright fills password inputs in separate focus/select and text-insertion steps, so the delayed focus could land between those steps and redirect text into a different field. That caused the self-password validation assertion to intermittently observe the wrong validation state on main.

Failed run: https://github.com/TryGhost/Ghost/actions/runs/29460895269/job/87504062007

## Validation

- focused password acceptance spec: 6 consecutive passes, 12/12 tests
- full Admin acceptance suite: 174/174 tests