### PR TITLE
Changed settings to use local error boundary

### DIFF
--- a/apps/admin-x-design-system/src/global/error-boundary.tsx
+++ b/apps/admin-x-design-system/src/global/error-boundary.tsx
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/react';
-import React, {ComponentType, ErrorInfo, ReactNode} from 'react';
+import React, {ErrorInfo, ReactNode} from 'react';
 import Banner from './banner';
 
 export interface ErrorBoundaryProps {
@@ -47,13 +47,3 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps> {
 }
 
 export default ErrorBoundary;
-
-export const withErrorBoundary = <Props extends Record<string, unknown>>(Component: ComponentType<Props>, name: string) => {
-    return function WithErrorBoundary(props: Props) {
-        return (
-            <ErrorBoundary name={name}>
-                <Component {...props} />
-            </ErrorBoundary>
-        );
-    };
-};

--- a/apps/admin-x-design-system/src/index.ts
+++ b/apps/admin-x-design-system/src/index.ts
@@ -78,7 +78,7 @@ export {default as Button} from './global/button';
 export type {ButtonColor, ButtonProps} from './global/button';
 export {default as ButtonGroup} from './global/button-group';
 export type {ButtonGroupProps} from './global/button-group';
-export {default as ErrorBoundary, withErrorBoundary} from './global/error-boundary';
+export {default as ErrorBoundary} from './global/error-boundary';
 export type {ErrorBoundaryProps} from './global/error-boundary';
 export {default as Heading} from './global/heading';
 export type {HeadingProps} from './global/heading';

--- a/apps/admin-x-settings/src/components/settings/membership/custom-fields.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/custom-fields.tsx
@@ -3,8 +3,9 @@ import NiceModal from '@ebay/nice-modal-react';
 import React from 'react';
 import TopLevelGroup from '../../top-level-group';
 import useFeatureFlag from '../../../hooks/use-feature-flag';
-import {Button, withErrorBoundary} from '@tryghost/admin-x-design-system';
+import {Button} from '@tryghost/admin-x-design-system';
 import {useBrowseMemberCustomFields, userTypeForField} from '@tryghost/admin-x-framework/api/member-custom-fields';
+import {withErrorBoundary} from '../../error-boundary';
 import type {MemberCustomField} from '@tryghost/admin-x-framework/api/member-custom-fields';
 
 const CustomFields: React.FC<{keywords: string[]}> = ({keywords}) => {


### PR DESCRIPTION
## What changed

- Switched the final admin-x-settings `withErrorBoundary` consumer to the existing app-local implementation.
- Removed the now-unused duplicate HOC implementation and public export from admin-x-design-system.
- Kept `ErrorBoundary` and `ErrorBoundaryProps` because Koenig still uses the component internally.

## Why

admin-x-settings already owns the identical error-boundary behavior. Removing the final legacy HOC dependency reduces the admin-x-design-system surface while preserving runtime behavior.

## Validation

- Independent agent review: no findings
- admin-x-settings unit tests: 203 passed
- admin-x-design-system unit tests: 23 passed
- Focused ESLint and TypeScript checks
- `git diff --check`

## Manual testing

- Open Settings → Membership → Custom fields with the feature flag enabled and disabled.
- Confirm the custom-field list renders.
- Confirm Add/Edit custom-field modals open.
- Optionally force a child render error and confirm the fallback banner appears and Sentry capture still fires.