### PR TITLE
Added tier-specific post previews behind the previewByTier flag

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -79,6 +79,10 @@ const features: Feature[] = [{
     title: 'Member custom fields',
     description: 'Let admins create and manage custom field definitions for members',
     flag: 'membersCustomFields'
+}, {
+    title: 'Preview by tier',
+    description: 'Preview posts and emails as a member of a specific tier',
+    flag: 'previewByTier'
 }];
 
 const AlphaFeatures: React.FC = () => {

--- a/ghost/admin/app/components/editor/modals/preview.hbs
+++ b/ghost/admin/app/components/editor/modals/preview.hbs
@@ -19,7 +19,7 @@
             </div>
             {{#if this.showMemberSegmentDropdown}}
                 <div class="gh-contentfilter-divider"></div>
-                <span class="gh-select gh-web-preview-segment" data-test-select="preview-segment">
+                <span class="gh-select gh-web-preview-segment gh-preview-member-type" data-test-select="preview-segment">
                     <PowerSelect
                         @selected={{this.selectedPreviewAsOption}}
                         @options={{this.previewAsOptions}}
@@ -34,6 +34,23 @@
                         {{option.label}}
                     </PowerSelect>
                 </span>
+                {{#if this.showTierDropdown}}
+                    <span class="gh-select gh-web-preview-segment gh-preview-tier" data-test-select="preview-tier">
+                        <PowerSelect
+                            @selected={{this.selectedPreviewTier}}
+                            @options={{this.previewTierOptions}}
+                            @onChange={{this.changePreviewTier}}
+                            @triggerComponent={{component "gh-power-select/trigger"}}
+                            @triggerClass="gh-preview-segment-trigger"
+                            @dropdownClass="gh-preview-segment-dropdown gh-preview-tier-dropdown"
+                            @matchTriggerWidth={{false}}
+                            @onOpen={{this.dropdown.closeDropdowns}}
+                            as |tier|
+                        >
+                            {{tier.name}}
+                        </PowerSelect>
+                    </span>
+                {{/if}}
             {{/if}}
         </div>
         <div class="right">
@@ -109,7 +126,9 @@
             {{else}}
                 <Editor::Modals::Preview::Email
                     @post={{@data.publishOptions.post}}
-                    @memberSegment={{this.previewAsSegment}}
+                    @memberStatus={{this.emailMemberStatus}}
+                    @memberTier={{this.emailMemberTier}}
+                    @memberDescription={{this.emailMemberDescription}}
                     @newsletter={{@data.publishOptions.newsletter}}
                     @skipAnimation={{this.skipAnimation}}
                     @savePostTask={{@data.saveTask}}

--- a/ghost/admin/app/components/editor/modals/preview.js
+++ b/ghost/admin/app/components/editor/modals/preview.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import copyTextToClipboard from 'ghost-admin/utils/copy-text-to-clipboard';
 import {action} from '@ember/object';
+import {groupTiersByActive} from 'ghost-admin/utils/group-tiers';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
@@ -22,14 +23,26 @@ export default class EditorPostPreviewModal extends Component {
     @tracked previewEmailAddress = this.session.user.email;
     @tracked previewAsSegment = 'free';
     @tracked previewAsOptions = [];
+    @tracked previewTierSlug;
+
+    tiers = this.args.data.tiers || [];
 
     constructor() {
         super(...arguments);
         this.saveFirstTask.perform();
 
-        const {initialPreviewAsSegment} = this.args.data;
+        const {initialPreviewAsSegment, initialPreviewTierSlug} = this.args.data;
+
+        const defaultTier = this.tiers.find(tier => tier.slug === initialPreviewTierSlug)
+            || this.tiers.find(tier => tier.active)
+            || this.tiers[0];
+        this.previewTierSlug = defaultTier?.slug;
+
         if (initialPreviewAsSegment) {
-            this.changePreviewAsSegment(initialPreviewAsSegment);
+            const segment = initialPreviewAsSegment === 'tier' && !this.previewTierSlug
+                ? (this.settings.paidMembersEnabled ? 'paid' : 'free')
+                : initialPreviewAsSegment;
+            this.changePreviewAsSegment(segment);
         }
 
         this.setPreviewAsOptions();
@@ -37,6 +50,18 @@ export default class EditorPostPreviewModal extends Component {
 
     get selectedPreviewAsOption() {
         return this.previewAsOptions.find(option => option.value === this.previewAsSegment);
+    }
+
+    get selectedPreviewTier() {
+        return this.tiers.find(tier => tier.slug === this.previewTierSlug);
+    }
+
+    get previewTierOptions() {
+        return groupTiersByActive(this.tiers).filter(group => group.options.length > 0);
+    }
+
+    get showTierDropdown() {
+        return this.previewAsSegment === 'tier' && this.tiers.length > 0;
     }
 
     get showMemberSegmentDropdown() {
@@ -54,8 +79,35 @@ export default class EditorPostPreviewModal extends Component {
 
     get browserPreviewUrl() {
         const url = new URL(this.args.data.publishOptions.post.previewUrl);
-        url.searchParams.set('member_status', this.previewAsSegment);
+        url.searchParams.set('member_status', this.previewAsSegment === 'tier' ? 'paid' : this.previewAsSegment);
+
+        if (this.previewAsSegment === 'tier' && this.previewTierSlug) {
+            url.searchParams.set('member_tier', this.previewTierSlug);
+        } else {
+            url.searchParams.delete('member_tier');
+        }
+
         return url.toString();
+    }
+
+    get emailMemberStatus() {
+        if (this.previewAsSegment === 'paid' || this.previewAsSegment === 'tier') {
+            return 'paid';
+        }
+
+        return 'free';
+    }
+
+    get emailMemberTier() {
+        return this.previewAsSegment === 'tier' ? this.previewTierSlug : null;
+    }
+
+    get emailMemberDescription() {
+        if (this.previewAsSegment === 'tier' && this.selectedPreviewTier) {
+            return `${this.selectedPreviewTier.name} tier member`;
+        }
+
+        return `${this.previewAsSegment} member`;
     }
 
     // manually set the tracked property rather than using a getter so we have
@@ -77,6 +129,12 @@ export default class EditorPostPreviewModal extends Component {
             this.previewAsOptions.push(
                 {label: 'Paid member', value: 'paid'}
             );
+
+            if (this.tiers.length > 0) {
+                this.previewAsOptions.push(
+                    {label: 'Tier', value: 'tier'}
+                );
+            }
         }
     }
 
@@ -111,6 +169,12 @@ export default class EditorPostPreviewModal extends Component {
     @action
     changePreviewAsOption(option) {
         this.changePreviewAsSegment(option.value);
+    }
+
+    @action
+    changePreviewTier(tier) {
+        this.previewTierSlug = tier.slug;
+        this.args.data.changePreviewTier?.(tier.slug);
     }
 
     @action

--- a/ghost/admin/app/components/editor/modals/preview.js
+++ b/ghost/admin/app/components/editor/modals/preview.js
@@ -132,7 +132,7 @@ export default class EditorPostPreviewModal extends Component {
 
             if (this.tiers.length > 0) {
                 this.previewAsOptions.push(
-                    {label: 'Tier', value: 'tier'}
+                    {label: 'Specific tier', value: 'tier'}
                 );
             }
         }

--- a/ghost/admin/app/components/editor/modals/preview/email.hbs
+++ b/ghost/admin/app/components/editor/modals/preview/email.hbs
@@ -55,7 +55,7 @@
                                             {{autofocus}}
                                             {{on-key "Enter" (perform this.sendPreviewEmailTask)}}
                                         />
-                                        <p class="description">You'll receive this as a {{@memberSegment}} member.</p>
+                                        <p class="description">You'll receive this as a {{@memberDescription}}.</p>
                                         <GhTaskButton
                                             @task={{this.sendPreviewEmailTask}}
                                             @buttonText="Send"
@@ -105,7 +105,7 @@
                 tabindex="0"
                 sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"
                 {{did-insert this.renderEmailPreview}}
-                {{did-update this.renderEmailPreview @memberSegment}}
+                {{did-update this.renderEmailPreview @memberStatus @memberTier}}
                 {{on "focusin" this.focusPreviewFrame}}
                 {{close-dropdowns-on-click}}
             ></iframe>

--- a/ghost/admin/app/components/editor/modals/preview/email.js
+++ b/ghost/admin/app/components/editor/modals/preview/email.js
@@ -25,19 +25,6 @@ html::-webkit-scrollbar-thumb:hover {
 }
 `;
 
-const FREE_SEGMENT = 'status:free';
-const PAID_SEGMENT = 'status:-free';
-
-const SEGMENT_OPTIONS = [{
-    name: 'Free member',
-    value: FREE_SEGMENT,
-    alias: 'free'
-}, {
-    name: 'Paid member',
-    value: PAID_SEGMENT,
-    alias: 'paid'
-}];
-
 // TODO: remove duplication with <ModalPostEmailPreview>
 export default class ModalPostPreviewEmailComponent extends Component {
     @service ajax;
@@ -56,8 +43,6 @@ export default class ModalPostPreviewEmailComponent extends Component {
     @tracked newsletter = this.args.post.newsletter || this.args.newsletter;
     @tracked newslettersList;
 
-    segments = SEGMENT_OPTIONS;
-
     constructor() {
         super(...arguments);
         this.loadNewslettersTask.perform();
@@ -68,8 +53,20 @@ export default class ModalPostPreviewEmailComponent extends Component {
             !!(this.settings.mailgunApiKey && this.settings.mailgunDomain && this.settings.mailgunBaseUrl);
     }
 
-    get selectedSegment() {
-        return this.segments.find(segment => segment.alias === this.args.memberSegment);
+    // older backends only understand the deprecated memberSegment param;
+    // remove the legacy branch when the previewByTier flag is GA
+    get _audienceParams() {
+        const {memberStatus, memberTier} = this.args;
+
+        if (!this.feature.previewByTier) {
+            return {memberSegment: memberStatus === 'paid' ? 'status:-free' : 'status:free'};
+        }
+
+        const params = {member_status: memberStatus};
+        if (memberTier) {
+            params.member_tier = memberTier;
+        }
+        return params;
     }
 
     @action
@@ -109,7 +106,6 @@ export default class ModalPostPreviewEmailComponent extends Component {
         try {
             const resourceId = this.args.post.id;
             const testEmail = this.previewEmailAddress.trim();
-            const memberSegment = this.selectedSegment.value;
 
             if (!validator.isEmail(testEmail)) {
                 this.sendPreviewEmailError = 'Please enter a valid email';
@@ -122,7 +118,7 @@ export default class ModalPostPreviewEmailComponent extends Component {
             this.sendPreviewEmailError = '';
 
             const url = this.ghostPaths.url.api('/email_previews/posts', resourceId);
-            const data = {emails: [testEmail], memberSegment, newsletter: this.newsletter.slug};
+            const data = {emails: [testEmail], newsletter: this.newsletter.slug, ...this._audienceParams};
             const options = {
                 data,
                 dataType: 'json'
@@ -150,13 +146,14 @@ export default class ModalPostPreviewEmailComponent extends Component {
     async _fetchEmailData() {
         let {html, subject, newsletter} = this;
         let {post} = this.args;
-        const memberSegment = this.selectedSegment.value;
+        const {memberStatus, memberTier} = this.args;
 
-        if (html && subject && memberSegment === this._lastMemberSegment && newsletter.slug === this._lastNewsletterSlug) {
+        if (html && subject && memberStatus === this._lastMemberStatus && memberTier === this._lastMemberTier && newsletter.slug === this._lastNewsletterSlug) {
             return {html, subject};
         }
 
-        this._lastMemberSegment = memberSegment;
+        this._lastMemberStatus = memberStatus;
+        this._lastMemberTier = memberTier;
         this._lastNewsletterSlug = newsletter.slug;
 
         // model is an email
@@ -170,7 +167,9 @@ export default class ModalPostPreviewEmailComponent extends Component {
         // model is a post, fetch email preview
         } else {
             let url = new URL(this.ghostPaths.url.api('/email_previews/posts', post.id), window.location.href);
-            url.searchParams.set('memberSegment', memberSegment);
+            for (const [param, value] of Object.entries(this._audienceParams)) {
+                url.searchParams.set(param, value);
+            }
             url.searchParams.set('newsletter', this.newsletter.slug);
 
             let response = await this.ajax.request(url.href);

--- a/ghost/admin/app/components/editor/publish-management.js
+++ b/ghost/admin/app/components/editor/publish-management.js
@@ -22,8 +22,11 @@ export const CONFIRM_EMAIL_MAX_POLL_LENGTH = 15 * 1000;
 // modal display, and provide an editor-specific save behaviour wrapper around
 // PublishOptions saving.
 export default class PublishManagement extends Component {
+    @service feature;
     @service modals;
     @service notifications;
+    @service settings;
+    @service store;
 
     // ensure we get a new PublishOptions instance when @post is replaced
     @use publishOptions = new PublishOptionsResource(() => [this.args.post]);
@@ -31,6 +34,8 @@ export default class PublishManagement extends Component {
     @tracked previewFormat = 'browser';
     @tracked previewSize = 'desktop';
     @tracked previewAsSegment = 'free';
+    @tracked previewTierSlug;
+    @tracked tiers = [];
 
     publishFlowModal = null;
     updateFlowModal = null;
@@ -105,6 +110,7 @@ export default class PublishManagement extends Component {
         event?.preventDefault();
 
         const isValid = await this._validatePost();
+        await this._ensureTiersLoaded();
 
         if (isValid && (!this.previewModal || this.previewModal.isClosing)) {
             // open publish flow modal underneath to offer quick switching
@@ -121,8 +127,26 @@ export default class PublishManagement extends Component {
                 changePreviewSize: this.changePreviewSize,
                 initialPreviewAsSegment: this.previewAsSegment,
                 changePreviewAsSegment: this.changePreviewAsSegment,
+                initialPreviewTierSlug: this.previewTierSlug,
+                changePreviewTier: this.changePreviewTier,
+                tiers: this.tiers,
                 skipAnimation
             });
+        }
+    }
+
+    // tiers are loaded once per editor session so the preview modal can render
+    // its tier selector synchronously; a failed fetch degrades the preview to
+    // the free/paid audience options and is retried on the next open
+    async _ensureTiersLoaded() {
+        if (!this.feature.previewByTier || !this.settings.paidMembersEnabled || this.loadTiersTask.lastSuccessful) {
+            return;
+        }
+
+        try {
+            await this.loadTiersTask.perform();
+        } catch (error) {
+            // no-op, degraded preview
         }
     }
 
@@ -158,6 +182,17 @@ export default class PublishManagement extends Component {
     @action
     changePreviewAsSegment(segment) {
         this.previewAsSegment = segment;
+    }
+
+    @action
+    changePreviewTier(tierSlug) {
+        this.previewTierSlug = tierSlug;
+    }
+
+    @task
+    *loadTiersTask() {
+        const tiers = yield this.store.query('tier', {filter: 'type:paid', limit: 'all'});
+        this.tiers = tiers.toArray();
     }
 
     @action

--- a/ghost/admin/app/services/feature.js
+++ b/ghost/admin/app/services/feature.js
@@ -85,6 +85,7 @@ export default class FeatureService extends Service {
     @feature('tagsX') tagsX;
     @feature('commentModeration') commentModeration;
     @feature('memberDetailsReact') memberDetailsReact;
+    @feature('previewByTier') previewByTier;
     _user = null;
 
     @computed('settings.labs')

--- a/ghost/admin/app/styles/layouts/post-preview.css
+++ b/ghost/admin/app/styles/layouts/post-preview.css
@@ -132,6 +132,34 @@
     background: transparent;
 }
 
+.gh-preview-member-type {
+    flex: 0 0 auto;
+    width: auto;
+}
+
+.gh-preview-tier {
+    flex: 0 0 180px;
+    width: 180px;
+    min-width: 180px;
+    max-width: 180px;
+}
+
+.gh-preview-tier .gh-preview-segment-trigger {
+    width: 100%;
+    max-width: 100%;
+}
+
+.gh-preview-tier .ember-power-select-selected-item,
+.gh-preview-tier-dropdown .ember-power-select-option {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.gh-preview-tier .ember-power-select-selected-item {
+    display: block;
+}
+
 .gh-preview-segment-dropdown.ember-power-select-dropdown.ember-basic-dropdown-content--below {
     min-width: 200px;
     margin: 2px 0 0;
@@ -165,6 +193,10 @@
 }
 
 @media (max-width: 640px) {
+    .gh-preview-tier {
+        display: none;
+    }
+
     .gh-web-preview-segment .gh-preview-segment-trigger {
         display: none;
     }

--- a/ghost/admin/tests/acceptance/editor/post-email-preview-test.js
+++ b/ghost/admin/tests/acceptance/editor/post-email-preview-test.js
@@ -1,6 +1,7 @@
 import loginAsRole from '../../helpers/login-as-role';
 import {click, find, findAll, focus, waitFor, waitUntil} from '@ember/test-helpers';
 import {clickTrigger, selectChoose} from 'ember-power-select/test-support/helpers';
+import {disableLabsFlag, enableLabsFlag} from '../../helpers/labs-flag';
 import {disableMembers, disablePaidMembers, enableMembers, enablePaidMembers} from '../../helpers/members';
 import {enableMailgun} from '../../helpers/mailgun';
 import {expect} from 'chai';
@@ -17,6 +18,7 @@ describe('Acceptance: Post email preview', function () {
         enableMailgun(this.server);
         enableMembers(this.server);
         enablePaidMembers(this.server);
+        enableLabsFlag(this.server, 'previewByTier');
         await loginAsRole('Administrator', this.server);
     });
 
@@ -65,7 +67,7 @@ describe('Acceptance: Post email preview', function () {
         const [lastRequest] = this.server.pretender.handledRequests.slice(-1);
         const requestBody = JSON.parse(lastRequest.requestBody);
         expect(requestBody.newsletter).to.equal('awesome-newsletter');
-        expect(requestBody.memberSegment).to.equal('status:free');
+        expect(requestBody.member_status).to.equal('free');
     });
 
     it('should hide newsletters list when only 1 newsletter exists', async function () {
@@ -79,7 +81,8 @@ describe('Acceptance: Post email preview', function () {
         expect(find('[data-test-text="newsletter-from"]')).to.contain.rendered.text('noreply@example.com');
     });
 
-    it('can select paid/free member for preview', async function () {
+    it('can select free, paid, or tier member for preview', async function () {
+        this.server.create('tier', {name: 'Archive', slug: 'archive', type: 'paid', active: false});
         await openEmailPreviewModal.call(this);
 
         expect(find('[data-test-email-preview-newsletter-select]'), 'newsletter select').not.to.exist;
@@ -89,9 +92,10 @@ describe('Acceptance: Post email preview', function () {
         await clickTrigger('[data-test-select="preview-segment"]');
 
         const options = findAll('.ember-power-select-option');
-        expect(options.length).to.equal(2);
+        expect(options.length).to.equal(3);
         expect(options[0].textContent.trim()).to.equal('Free member');
         expect(options[1].textContent.trim()).to.equal('Paid member');
+        expect(options[2].textContent.trim()).to.equal('Tier');
 
         // can switch free/paid member in preview
         await selectChoose('[data-test-select="preview-segment"]', 'Paid member');
@@ -101,7 +105,42 @@ describe('Acceptance: Post email preview', function () {
         await click(find('[data-test-button="send-test-email"]'));
         const [lastRequest] = this.server.pretender.handledRequests.slice(-1);
         const requestBody = JSON.parse(lastRequest.requestBody);
+        expect(requestBody.member_status).to.equal('paid');
+        expect(requestBody.member_tier).to.be.undefined;
+
+        // selecting a specific tier sends the paid audience narrowed to that tier
+        await selectChoose('[data-test-select="preview-segment"]', 'Tier');
+        await selectChoose('[data-test-select="preview-tier"]', 'Archive');
+        await click(find('[data-test-button="post-preview-test-email"]'));
+        await click(find('[data-test-button="send-test-email"]'));
+        const [tierRequest] = this.server.pretender.handledRequests.slice(-1);
+        const tierRequestBody = JSON.parse(tierRequest.requestBody);
+        expect(tierRequestBody.member_status).to.equal('paid');
+        expect(tierRequestBody.member_tier).to.equal('archive');
+    });
+
+    it('sends the legacy memberSegment param and hides tiers without the previewByTier flag', async function () {
+        disableLabsFlag(this.server, 'previewByTier');
+        this.server.create('tier', {name: 'Archive', slug: 'archive', type: 'paid', active: false});
+
+        await openEmailPreviewModal.call(this);
+
+        // no Tier option without the flag
+        await clickTrigger('[data-test-select="preview-segment"]');
+        const options = findAll('.ember-power-select-option');
+        expect(options.length).to.equal(2);
+        expect(options[0].textContent.trim()).to.equal('Free member');
+        expect(options[1].textContent.trim()).to.equal('Paid member');
+
+        // older backends only understand memberSegment
+        await selectChoose('[data-test-select="preview-segment"]', 'Paid member');
+        await click(find('[data-test-button="post-preview-test-email"]'));
+        await click(find('[data-test-button="send-test-email"]'));
+        const [lastRequest] = this.server.pretender.handledRequests.slice(-1);
+        const requestBody = JSON.parse(lastRequest.requestBody);
         expect(requestBody.memberSegment).to.equal('status:-free');
+        expect(requestBody.member_status).to.be.undefined;
+        expect(requestBody.member_tier).to.be.undefined;
     });
 
     it('hides segment dropdown when only one option is available', async function () {

--- a/ghost/admin/tests/acceptance/editor/post-email-preview-test.js
+++ b/ghost/admin/tests/acceptance/editor/post-email-preview-test.js
@@ -95,7 +95,7 @@ describe('Acceptance: Post email preview', function () {
         expect(options.length).to.equal(3);
         expect(options[0].textContent.trim()).to.equal('Free member');
         expect(options[1].textContent.trim()).to.equal('Paid member');
-        expect(options[2].textContent.trim()).to.equal('Tier');
+        expect(options[2].textContent.trim()).to.equal('Specific tier');
 
         // can switch free/paid member in preview
         await selectChoose('[data-test-select="preview-segment"]', 'Paid member');
@@ -109,7 +109,7 @@ describe('Acceptance: Post email preview', function () {
         expect(requestBody.member_tier).to.be.undefined;
 
         // selecting a specific tier sends the paid audience narrowed to that tier
-        await selectChoose('[data-test-select="preview-segment"]', 'Tier');
+        await selectChoose('[data-test-select="preview-segment"]', 'Specific tier');
         await selectChoose('[data-test-select="preview-tier"]', 'Archive');
         await click(find('[data-test-button="post-preview-test-email"]'));
         await click(find('[data-test-button="send-test-email"]'));

--- a/ghost/admin/tests/acceptance/editor/post-preview-test.js
+++ b/ghost/admin/tests/acceptance/editor/post-preview-test.js
@@ -50,7 +50,7 @@ describe('Acceptance: Post preview', function () {
         expect(url.searchParams.get('member_status')).to.equal('paid');
 
         // tier previews add a grouped tier selector and identify the selected tier
-        await selectChoose('[data-test-select="preview-segment"]', 'Tier');
+        await selectChoose('[data-test-select="preview-segment"]', 'Specific tier');
         expect(find('[data-test-select="preview-tier"]')).to.exist;
 
         await click('[data-test-select="preview-tier"] .ember-power-select-trigger');
@@ -81,14 +81,14 @@ describe('Acceptance: Post preview', function () {
         this.server.create('tier', {name: archivedTierName, slug: 'archive', type: 'paid', active: false});
         await openPreviewModal.call(this);
 
-        await selectChoose('[data-test-select="preview-segment"]', 'Tier');
+        await selectChoose('[data-test-select="preview-segment"]', 'Specific tier');
         await selectChoose('[data-test-select="preview-tier"]', archivedTierName);
 
         await click('.gh-post-preview-close');
         await click('[data-test-button="publish-preview"]');
 
         // selections persist and the preview link is tier-aware immediately on reopen
-        expect(find('[data-test-select="preview-segment"]')).to.contain.text('Tier');
+        expect(find('[data-test-select="preview-segment"]')).to.contain.text('Specific tier');
         expect(find('[data-test-select="preview-tier"]')).to.contain.text(archivedTierName);
 
         await click('[data-test-button="share-preview"]');

--- a/ghost/admin/tests/acceptance/editor/post-preview-test.js
+++ b/ghost/admin/tests/acceptance/editor/post-preview-test.js
@@ -1,5 +1,6 @@
 import loginAsRole from '../../helpers/login-as-role';
-import {click, find} from '@ember/test-helpers';
+import {click, find, findAll} from '@ember/test-helpers';
+import {disableLabsFlag, enableLabsFlag} from '../../helpers/labs-flag';
 import {enableMailgun} from '../../helpers/mailgun';
 import {enableMembers, enablePaidMembers} from '../../helpers/members';
 import {expect} from 'chai';
@@ -17,6 +18,7 @@ describe('Acceptance: Post preview', function () {
         enableMailgun(this.server);
         enableMembers(this.server);
         enablePaidMembers(this.server);
+        enableLabsFlag(this.server, 'previewByTier');
         await loginAsRole('Administrator', this.server);
     });
 
@@ -27,6 +29,8 @@ describe('Acceptance: Post preview', function () {
     };
 
     it('uses correct member status for new tab preview link', async function () {
+        const archivedTierName = 'Archived tier';
+        this.server.create('tier', {name: archivedTierName, slug: 'archive', type: 'paid', active: false});
         await openPreviewModal.call(this);
 
         // ensure we're on the browser tab and "free" segment is selected
@@ -44,5 +48,52 @@ describe('Acceptance: Post preview', function () {
         await selectChoose('[data-test-select="preview-segment"]', 'Paid member');
         url = new URL(find('[data-test-link="open-draft"]').href);
         expect(url.searchParams.get('member_status')).to.equal('paid');
+
+        // tier previews add a grouped tier selector and identify the selected tier
+        await selectChoose('[data-test-select="preview-segment"]', 'Tier');
+        expect(find('[data-test-select="preview-tier"]')).to.exist;
+
+        await click('[data-test-select="preview-tier"] .ember-power-select-trigger');
+        expect(findAll('.ember-power-select-group-name').map(element => element.textContent.trim())).to.deep.equal([
+            'Active tiers',
+            'Archived tiers'
+        ]);
+        await selectChoose('[data-test-select="preview-tier"]', archivedTierName);
+        expect(find('[data-test-select="preview-tier"]')).to.contain.text(archivedTierName);
+
+        url = new URL(find('[data-test-link="open-draft"]').href);
+        expect(url.searchParams.get('member_status')).to.equal('paid');
+        expect(url.searchParams.get('member_tier')).to.equal('archive');
+    });
+
+    it('hides the tier option without the previewByTier flag', async function () {
+        disableLabsFlag(this.server, 'previewByTier');
+        this.server.create('tier', {name: 'Archived tier', slug: 'archive', type: 'paid', active: false});
+        await openPreviewModal.call(this);
+
+        await click('[data-test-select="preview-segment"] .ember-power-select-trigger');
+        const options = findAll('.ember-power-select-option').map(element => element.textContent.trim());
+        expect(options).to.deep.equal(['Public visitor', 'Free member', 'Paid member']);
+    });
+
+    it('remembers the selected tier when the preview is reopened', async function () {
+        const archivedTierName = 'Archived tier';
+        this.server.create('tier', {name: archivedTierName, slug: 'archive', type: 'paid', active: false});
+        await openPreviewModal.call(this);
+
+        await selectChoose('[data-test-select="preview-segment"]', 'Tier');
+        await selectChoose('[data-test-select="preview-tier"]', archivedTierName);
+
+        await click('.gh-post-preview-close');
+        await click('[data-test-button="publish-preview"]');
+
+        // selections persist and the preview link is tier-aware immediately on reopen
+        expect(find('[data-test-select="preview-segment"]')).to.contain.text('Tier');
+        expect(find('[data-test-select="preview-tier"]')).to.contain.text(archivedTierName);
+
+        await click('[data-test-button="share-preview"]');
+        const url = new URL(find('[data-test-link="open-draft"]').href);
+        expect(url.searchParams.get('member_status')).to.equal('paid');
+        expect(url.searchParams.get('member_tier')).to.equal('archive');
     });
 });

--- a/ghost/core/core/frontend/services/routing/controllers/previews.js
+++ b/ghost/core/core/frontend/services/routing/controllers/previews.js
@@ -20,7 +20,8 @@ module.exports = function previewController(req, res, next) {
         uuid: req.params.uuid,
         status: 'all',
         include: 'authors,tags,tiers',
-        member_status: req.query?.member_status
+        member_status: req.query?.member_status,
+        member_tier: req.query?.member_tier
     };
 
     return api[res.routerOptions.query.controller]

--- a/ghost/core/core/server/api/endpoints/email-previews.js
+++ b/ghost/core/core/server/api/endpoints/email-previews.js
@@ -10,12 +10,17 @@ const controller = {
         },
         options: [
             'fields',
+            'member_status',
+            'member_tier',
             'memberSegment',
             'newsletter'
         ],
         validation: {
             options: {
-                fields: ['html', 'plaintext', 'subject']
+                fields: ['html', 'plaintext', 'subject'],
+                member_status: {
+                    values: ['free', 'paid']
+                }
             }
         },
         data: [

--- a/ghost/core/core/server/api/endpoints/previews.js
+++ b/ghost/core/core/server/api/endpoints/previews.js
@@ -20,7 +20,7 @@ const _addMemberContextToFrame = async (frame) => {
 
     // the framework's options validation only supports required/values checks,
     // so guard the shape here — repeated query params arrive as arrays
-    if (frame.options.member_tier !== undefined && typeof frame.options.member_tier !== 'string') {
+    if (frame.options.member_tier !== undefined && (typeof frame.options.member_tier !== 'string' || frame.options.member_tier === '')) {
         throw new errors.ValidationError({
             message: tpl(messages.invalidMemberTier)
         });

--- a/ghost/core/core/server/api/endpoints/previews.js
+++ b/ghost/core/core/server/api/endpoints/previews.js
@@ -7,7 +7,8 @@ const ALLOWED_INCLUDES = ['authors', 'tags', 'tiers'];
 const ALLOWED_MEMBER_STATUSES = ['anonymous', 'free', 'paid'];
 
 const messages = {
-    postNotFound: 'Post not found.'
+    postNotFound: 'Post not found.',
+    invalidMemberTier: 'member_tier must be a single tier slug.'
 };
 
 // Simulate serving content as different member states by setting the minimal
@@ -15,6 +16,14 @@ const messages = {
 const _addMemberContextToFrame = async (frame) => {
     if (!frame?.options?.member_status) {
         return;
+    }
+
+    // the framework's options validation only supports required/values checks,
+    // so guard the shape here — repeated query params arrive as arrays
+    if (frame.options.member_tier !== undefined && typeof frame.options.member_tier !== 'string') {
+        throw new errors.ValidationError({
+            message: tpl(messages.invalidMemberTier)
+        });
     }
 
     // only set apiType when given a member_status to preserve backwards compatibility
@@ -32,8 +41,8 @@ const _addMemberContextToFrame = async (frame) => {
     }
 
     if (frame.options?.member_status === 'paid') {
-        // For member_status=paid, render as a member with all active paid tiers
-        frame.original.context.member = await membersService.createPaidMemberShim();
+        // For member_status=paid, render with the selected tier or all active paid tiers
+        frame.original.context.member = await membersService.createPaidMemberShim(frame.options.member_tier);
     }
 };
 
@@ -48,7 +57,8 @@ const controller = {
         permissions: true,
         options: [
             'include',
-            'member_status'
+            'member_status',
+            'member_tier'
         ],
         data: [
             'uuid'

--- a/ghost/core/core/server/services/email-service/email-controller.js
+++ b/ghost/core/core/server/services/email-service/email-controller.js
@@ -42,7 +42,7 @@ class EmailController {
         // rather than 500 downstream (the api-framework only validates
         // required/values, so the endpoint can't do this for us)
         const memberTier = frame.options.member_tier ?? frame.data?.member_tier ?? null;
-        if (memberTier !== null && typeof memberTier !== 'string') {
+        if (memberTier !== null && (typeof memberTier !== 'string' || memberTier === '')) {
             throw new errors.ValidationError({
                 message: tpl(messages.invalidMemberTier)
             });
@@ -56,13 +56,13 @@ class EmailController {
         }
 
         const legacySegment = frame.options.memberSegment ?? frame.data?.memberSegment ?? null;
+        if (legacySegment !== null && (typeof legacySegment !== 'string' || !Object.hasOwn(LEGACY_SEGMENT_STATUSES, legacySegment))) {
+            throw new errors.ValidationError({
+                message: tpl(messages.invalidMemberSegment)
+            });
+        }
         if (memberStatus === null && legacySegment !== null) {
             memberStatus = LEGACY_SEGMENT_STATUSES[legacySegment];
-            if (memberStatus === undefined) {
-                throw new errors.ValidationError({
-                    message: tpl(messages.invalidMemberSegment)
-                });
-            }
         }
 
         let post;

--- a/ghost/core/core/server/services/email-service/email-controller.js
+++ b/ghost/core/core/server/services/email-service/email-controller.js
@@ -5,7 +5,17 @@ const messages = {
     postNotFound: 'Post not found.',
     noEmailsProvided: 'No emails provided.',
     emailNotFound: 'Email not found.',
-    tooManyEmailsProvided: 'Too many emails provided. Maximum of 1 test email can be sent at once.'
+    tooManyEmailsProvided: 'Too many emails provided. Maximum of 1 test email can be sent at once.',
+    invalidMemberStatus: 'member_status must be \'free\' or \'paid\'.',
+    invalidMemberTier: 'member_tier must be a single tier slug.',
+    invalidMemberSegment: 'memberSegment is deprecated and only accepts \'status:free\' or \'status:-free\' — use member_status instead.'
+};
+
+// deprecated memberSegment values older clients send, mapped onto the
+// member_status vocabulary — production logs show nothing else in use
+const LEGACY_SEGMENT_STATUSES = {
+    'status:free': 'free',
+    'status:-free': 'paid'
 };
 
 class EmailController {
@@ -27,6 +37,34 @@ class EmailController {
     async _getFrameData(frame) {
         // Bit absurd situation in email-previews endpoints that one endpoint is using options and other one is using data.
         // So we need to handle both cases.
+
+        // repeated query params / JSON arrays arrive as non-strings — reject
+        // rather than 500 downstream (the api-framework only validates
+        // required/values, so the endpoint can't do this for us)
+        const memberTier = frame.options.member_tier ?? frame.data?.member_tier ?? null;
+        if (memberTier !== null && typeof memberTier !== 'string') {
+            throw new errors.ValidationError({
+                message: tpl(messages.invalidMemberTier)
+            });
+        }
+
+        let memberStatus = frame.options.member_status ?? frame.data?.member_status ?? null;
+        if (memberStatus !== null && !['free', 'paid'].includes(memberStatus)) {
+            throw new errors.ValidationError({
+                message: tpl(messages.invalidMemberStatus)
+            });
+        }
+
+        const legacySegment = frame.options.memberSegment ?? frame.data?.memberSegment ?? null;
+        if (memberStatus === null && legacySegment !== null) {
+            memberStatus = LEGACY_SEGMENT_STATUSES[legacySegment];
+            if (memberStatus === undefined) {
+                throw new errors.ValidationError({
+                    message: tpl(messages.invalidMemberSegment)
+                });
+            }
+        }
+
         let post;
         // 'tiers' is required by the email tier-gating logic (renderer/segmenter), not for URL generation
         const withRelated = [...new Set(['posts_meta', 'authors', 'tiers', ...this.getRequiredUrlRelations()])];
@@ -52,17 +90,18 @@ class EmailController {
         return {
             post,
             newsletter,
-            segment: frame.options.memberSegment ?? frame.data.memberSegment ?? null
+            memberStatus,
+            memberTier
         };
     }
 
     async previewEmail(frame) {
-        const {post, newsletter, segment} = await this._getFrameData(frame);
-        return await this.service.previewEmail(post, newsletter, segment);
+        const {post, newsletter, memberStatus, memberTier} = await this._getFrameData(frame);
+        return await this.service.previewEmail(post, newsletter, memberStatus, memberTier);
     }
 
     async sendTestEmail(frame) {
-        const {post, newsletter, segment} = await this._getFrameData(frame);
+        const {post, newsletter, memberStatus, memberTier} = await this._getFrameData(frame);
 
         const emails = frame.data.emails ?? [];
 
@@ -79,7 +118,7 @@ class EmailController {
             });
         }
 
-        await this.service.sendTestEmail(post, newsletter, segment, emails);
+        await this.service.sendTestEmail(post, newsletter, memberStatus, emails, memberTier);
     }
 
     async retryFailedEmail(frame) {

--- a/ghost/core/core/server/services/email-service/email-renderer.js
+++ b/ghost/core/core/server/services/email-service/email-renderer.js
@@ -468,25 +468,34 @@ class EmailRenderer {
     }
 
     /**
-     * Maps the fixed audience choices offered by the editor's email preview and
-     * test-email UI ('status:free' / 'status:-free') onto the segment the send
-     * pipeline renders for that audience, so previews match what members receive.
-     * For a tier-restricted post the paid audience maps to the tier access
-     * segment (the access variant getSegments produces): paid members on the
-     * post's tiers get the full content, and the free choice previews the
-     * no-access variant. Anything else passes through unchanged.
+     * Maps a preview audience (a member status, optionally narrowed to a
+     * single tier) onto the segment the send pipeline renders for that
+     * audience, so previews match what members receive. For a tier-restricted
+     * post the paid audience maps to the tier access segment (the access
+     * variant getSegments produces): paid members on the post's tiers get the
+     * full content. A null status is an unsegmented render (the full body).
      * @param {Post} post
-     * @param {Segment} segment
+     * @param {'free'|'paid'|null} memberStatus
+     * @param {string} [tierSlug] - narrow the paid audience to a single tier
      * @returns {Segment}
      */
-    getPreviewSegment(post, segment) {
-        if (segment === 'status:-free' && post.get('visibility') === 'tiers') {
+    getSegmentForAudience(post, memberStatus, tierSlug) {
+        if (memberStatus === 'free') {
+            return 'status:free';
+        }
+        if (memberStatus !== 'paid') {
+            return null;
+        }
+        if (tierSlug) {
+            return `status:-free+product:'${tierSlug.replace(/'/g, '\\\'')}'`;
+        }
+        if (post.get('visibility') === 'tiers') {
             const accessFilter = getPostAccessFilter(getPostGatingShape(post));
             if (accessFilter) {
                 return `status:-free+(${accessFilter})`;
             }
         }
-        return segment;
+        return 'status:-free';
     }
 
     /**

--- a/ghost/core/core/server/services/email-service/email-renderer.js
+++ b/ghost/core/core/server/services/email-service/email-renderer.js
@@ -487,7 +487,8 @@ class EmailRenderer {
             return null;
         }
         if (tierSlug) {
-            return `status:-free+product:'${tierSlug.replace(/'/g, '\\\'')}'`;
+            const escapedSlug = tierSlug.replace(/\\/g, '\\\\').replace(/'/g, '\\\'');
+            return `status:-free+product:'${escapedSlug}'`;
         }
         if (post.get('visibility') === 'tiers') {
             const accessFilter = getPostAccessFilter(getPostGatingShape(post));

--- a/ghost/core/core/server/services/email-service/email-service.js
+++ b/ghost/core/core/server/services/email-service/email-service.js
@@ -440,11 +440,12 @@ class EmailService {
      *
      * @param {*} post
      * @param {*} newsletter
-     * @param {import('./email-renderer').Segment} segment
+     * @param {'free'|'paid'|null} memberStatus
+     * @param {string} [memberTier] - narrow the paid audience to a single tier
      * @returns {Promise<{subject: string, html: string, plaintext: string}>} Email preview
      */
-    async previewEmail(post, newsletter, segment) {
-        const renderSegment = this.#emailRenderer.getPreviewSegment(post, segment);
+    async previewEmail(post, newsletter, memberStatus, memberTier) {
+        const renderSegment = this.#emailRenderer.getSegmentForAudience(post, memberStatus, memberTier);
         const audience = this.#emailRenderer.describeSegment(post, renderSegment);
         const exampleMember = await this.getExampleMember(null, audience.status);
 
@@ -462,11 +463,12 @@ class EmailService {
      *
      * @param {*} post
      * @param {*} newsletter
-     * @param {import('./email-renderer').Segment} segment
+     * @param {'free'|'paid'|null} memberStatus
      * @param {string[]} emails
+     * @param {string} [memberTier] - narrow the paid audience to a single tier
      */
-    async sendTestEmail(post, newsletter, segment, emails) {
-        const renderSegment = this.#emailRenderer.getPreviewSegment(post, segment);
+    async sendTestEmail(post, newsletter, memberStatus, emails, memberTier) {
+        const renderSegment = this.#emailRenderer.getSegmentForAudience(post, memberStatus, memberTier);
         const audience = this.#emailRenderer.describeSegment(post, renderSegment);
 
         const members = [];

--- a/ghost/core/core/server/services/members/create-paid-member-shim.ts
+++ b/ghost/core/core/server/services/members/create-paid-member-shim.ts
@@ -7,17 +7,26 @@ interface PaidMemberShim {
 }
 
 /**
- * Build a stand-in "all active paid tiers" member for content gating — NOT a real
- * member. It carries only the `status` and `products` that
+ * Build a stand-in paid member for content gating — NOT a real member. It
+ * carries only the `status` and `products` that
  * `contentGating.checkPostAccess` / `checkGatedBlockAccess` read, letting previews
  * (`member_status=paid`) and gift-link reads reveal gated content without a
- * logged-in member. Single source of truth for this security-sensitive grant.
+ * logged-in member. When a tier slug is supplied the shim has only that tier,
+ * including archived tiers; otherwise it has every active paid tier. Single
+ * source of truth for this security-sensitive grant.
  */
-export async function createPaidMemberShim(): Promise<PaidMemberShim> {
+export async function createPaidMemberShim(tierSlug?: string): Promise<PaidMemberShim> {
     let products: Array<{slug: string}> = [];
     try {
-        const paidProducts = await models.Product.findAll({status: 'active', type: 'paid'});
-        products = paidProducts.map((product: {get(key: string): string}) => ({slug: product.get('slug')}));
+        if (tierSlug) {
+            const paidProduct = await models.Product.findOne({slug: tierSlug, type: 'paid'});
+            if (paidProduct) {
+                products = [{slug: paidProduct.get('slug')}];
+            }
+        } else {
+            const paidProducts = await models.Product.findAll({status: 'active', type: 'paid'});
+            products = paidProducts.map((product: {get(key: string): string}) => ({slug: product.get('slug')}));
+        }
     } catch (error) {
         // Fall back to no tiers rather than failing the render — still grants
         // status:paid/members content, just not tier-specific blocks.

--- a/ghost/core/core/server/services/members/index.d.ts
+++ b/ghost/core/core/server/services/members/index.d.ts
@@ -25,7 +25,7 @@ interface MembersApi {
 interface MembersService {
     init(): Promise<void>;
     api: MembersApi;
-    createPaidMemberShim(): Promise<{status: 'paid'; products: Array<{slug: string}>}>;
+    createPaidMemberShim(tierSlug?: string): Promise<{status: 'paid'; products: Array<{slug: string}>}>;
 }
 
 declare const membersService: MembersService;

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -58,7 +58,8 @@ const PRIVATE_FEATURES = [
     'smarterCounts',
     'getHelperDeduplication',
     'memberDetailsReact',
-    'membersCustomFields'
+    'membersCustomFields',
+    'previewByTier'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -36,6 +36,7 @@ Object {
       "members": true,
       "membersCustomFields": true,
       "pictureImageFormats": true,
+      "previewByTier": true,
       "smarterCounts": true,
       "stripeAutomaticTax": true,
       "superEditors": true,

--- a/ghost/core/test/e2e-api/admin/email-previews.test.js
+++ b/ghost/core/test/e2e-api/admin/email-previews.test.js
@@ -343,9 +343,11 @@ describe('Email Preview API', function () {
 
     describe('Tier-restricted posts', function () {
         let post;
+        let paidTierSlug;
 
         beforeAll(async function () {
             const paidTier = await models.Product.findOne({type: 'paid'});
+            paidTierSlug = paidTier.get('slug');
 
             const lexical = JSON.stringify({
                 root: {
@@ -384,7 +386,7 @@ describe('Email Preview API', function () {
 
         it('renders the full content for the paid member preview', async function () {
             await agent
-                .get(`email_previews/posts/${post.id}/?memberSegment=${encodeURIComponent('status:-free')}`)
+                .get(`email_previews/posts/${post.id}/?member_status=paid`)
                 .expectStatus(200)
                 .expect(({body}) => {
                     const {html} = body.email_previews[0];
@@ -395,7 +397,7 @@ describe('Email Preview API', function () {
 
         it('renders the paywall for the free member preview', async function () {
             await agent
-                .get(`email_previews/posts/${post.id}/?memberSegment=${encodeURIComponent('status:free')}`)
+                .get(`email_previews/posts/${post.id}/?member_status=free`)
                 .expectStatus(200)
                 .expect(({body}) => {
                     const {html} = body.email_previews[0];
@@ -403,6 +405,71 @@ describe('Email Preview API', function () {
                     assert.ok(!html.includes('Members only tier content'), 'free member preview should not include the gated content');
                     assert.ok(html.includes('Become a paid member'), 'free member preview should include the paywall CTA');
                 });
+        });
+
+        it('renders content access for the specifically selected tier', async function () {
+            await agent
+                .get(`email_previews/posts/${post.id}/?member_status=paid&member_tier=${paidTierSlug}`)
+                .expectStatus(200)
+                .expect(({body}) => {
+                    const {html} = body.email_previews[0];
+                    assert.ok(html.includes('Members only tier content'), 'selected tier preview should include the gated content');
+                    assert.ok(!html.includes('Become a paid member'), 'selected tier preview should not include the paywall CTA');
+                });
+        });
+
+        it('renders the paywall for a specifically selected tier without access', async function () {
+            await agent
+                .get(`email_previews/posts/${post.id}/?member_status=paid&member_tier=missing-tier`)
+                .expectStatus(200)
+                .expect(({body}) => {
+                    const {html} = body.email_previews[0];
+                    assert.ok(!html.includes('Members only tier content'), 'other tier preview should not include the gated content');
+                    assert.ok(html.includes('Become a paid member'), 'other tier preview should include the paywall CTA');
+                });
+        });
+
+        it('rejects an invalid member_status', async function () {
+            await agent
+                .get(`email_previews/posts/${post.id}/?member_status=comped`)
+                .expectStatus(422);
+        });
+
+        it('rejects a repeated member_tier param', async function () {
+            // repeated query params parse as an array
+            await agent
+                .get(`email_previews/posts/${post.id}/?member_status=paid&member_tier=${paidTierSlug}&member_tier=other`)
+                .expectStatus(422);
+        });
+
+        it('maps a legacy memberSegment onto the paid audience', async function () {
+            // deprecated param older admin clients send — rewritten to member_status
+            await agent
+                .get(`email_previews/posts/${post.id}/?memberSegment=${encodeURIComponent('status:-free')}`)
+                .expectStatus(200)
+                .expect(({body}) => {
+                    const {html} = body.email_previews[0];
+                    assert.ok(html.includes('Members only tier content'), 'legacy paid preview should include the gated content');
+                });
+        });
+
+        it('maps a legacy memberSegment onto the free audience', async function () {
+            await agent
+                .get(`email_previews/posts/${post.id}/?memberSegment=${encodeURIComponent('status:free')}`)
+                .expectStatus(200)
+                .expect(({body}) => {
+                    const {html} = body.email_previews[0];
+                    assert.ok(!html.includes('Members only tier content'), 'legacy free preview should not include the gated content');
+                    assert.ok(html.includes('Become a paid member'), 'legacy free preview should include the paywall CTA');
+                });
+        });
+
+        it('rejects an unknown legacy memberSegment', async function () {
+            const memberSegment = `status:-free+product:'${paidTierSlug}'`;
+
+            await agent
+                .get(`email_previews/posts/${post.id}/?memberSegment=${encodeURIComponent(memberSegment)}`)
+                .expectStatus(422);
         });
     });
 

--- a/ghost/core/test/e2e-frontend/preview-routes.test.js
+++ b/ghost/core/test/e2e-frontend/preview-routes.test.js
@@ -104,6 +104,27 @@ describe('Frontend Routing: Preview Routes', function () {
             .expect(assertNoPaywallRendered);
     });
 
+    it('should render draft using only the tier selected for the preview', async function () {
+        await request.get('/p/d52c42ae-2755-455c-80ec-70b2ec55c906/?member_status=paid&member_tier=silver')
+            .expect('Content-Type', /html/)
+            .expect(200)
+            .expect(assertCorrectFrontendHeaders)
+            .expect(assertNoPaywallRendered);
+
+        await request.get('/p/d52c42ae-2755-455c-80ec-70b2ec55c906/?member_status=paid&member_tier=missing-tier')
+            .expect('Content-Type', /html/)
+            .expect(200)
+            .expect(assertCorrectFrontendHeaders)
+            .expect(assertPaywallRendered);
+    });
+
+    it('should reject a repeated member_tier param', async function () {
+        // frontend routing turns API validation errors into a 404 rather than
+        // exposing them — the point is it must not render as an all-tier member
+        await request.get('/p/d52c42ae-2755-455c-80ec-70b2ec55c906/?member_status=paid&member_tier=silver&member_tier=gold')
+            .expect(404);
+    });
+
     it('should render draft as free member with ?member_status=free', async function () {
         await request.get('/p/d52c42ae-2755-455c-80ec-70b2ec55c905/?member_status=free')
             .expect('Content-Type', /html/)

--- a/ghost/core/test/unit/api/endpoints/previews.test.js
+++ b/ghost/core/test/unit/api/endpoints/previews.test.js
@@ -99,6 +99,14 @@ describe('Previews controller', function () {
             sinon.assert.notCalled(findOne);
         });
 
+        it('rejects an empty member_tier', async function () {
+            const findOne = sinon.stub(Product, 'findOne');
+            const frame = {options: {member_status: 'paid', member_tier: ''}};
+
+            await assert.rejects(previewsController.read.query(frame), {errorType: 'ValidationError'});
+            sinon.assert.notCalled(findOne);
+        });
+
         it('sets frame.apiType but does not set member context when member_status is anonymous', async function () {
             const frame = {options: {member_status: 'anonymous'}};
             await previewsController.read.query(frame);

--- a/ghost/core/test/unit/api/endpoints/previews.test.js
+++ b/ghost/core/test/unit/api/endpoints/previews.test.js
@@ -76,6 +76,29 @@ describe('Previews controller', function () {
             assert.equal(frame.original.context.member.products[0].slug, 'silver');
         });
 
+        it('sets the selected tier on the paid member context', async function () {
+            const findOne = sinon.stub(Product, 'findOne').resolves({
+                get: sinon.stub().returns('archived-tier')
+            });
+            const frame = {options: {member_status: 'paid', member_tier: 'archived-tier'}};
+
+            await previewsController.read.query(frame);
+
+            sinon.assert.calledOnceWithExactly(findOne, {slug: 'archived-tier', type: 'paid'});
+            assert.deepEqual(frame.original.context.member, {
+                status: 'paid',
+                products: [{slug: 'archived-tier'}]
+            });
+        });
+
+        it('rejects a non-string member_tier', async function () {
+            const findOne = sinon.stub(Product, 'findOne');
+            const frame = {options: {member_status: 'paid', member_tier: ['silver', 'gold']}};
+
+            await assert.rejects(previewsController.read.query(frame), {errorType: 'ValidationError'});
+            sinon.assert.notCalled(findOne);
+        });
+
         it('sets frame.apiType but does not set member context when member_status is anonymous', async function () {
             const frame = {options: {member_status: 'anonymous'}};
             await previewsController.read.query(frame);

--- a/ghost/core/test/unit/frontend/services/routing/controllers/previews.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/previews.test.js
@@ -62,7 +62,8 @@ describe('Unit - services/routing/controllers/previews', function () {
             uuid: req.params.uuid,
             status: 'all',
             include: 'authors,tags,tiers',
-            member_status: undefined
+            member_status: undefined,
+            member_tier: undefined
         }).resolves(apiResponse);
 
         sinon.stub(api, 'previews').get(() => {

--- a/ghost/core/test/unit/server/services/email-service/email-controller.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-controller.test.js
@@ -227,6 +227,56 @@ describe('Email Controller', function () {
             assert.equal(memberStatus, 'free');
         });
 
+        it('rejects a legacy memberSegment even when member_status is present', async function () {
+            const controller = new EmailController({}, {
+                models: {
+                    Post: createModelClass(),
+                    Newsletter: createModelClass()
+                }
+            });
+            await assert.rejects(controller._getFrameData({
+                options: {
+                    id: 'options-id',
+                    member_status: 'paid',
+                    memberSegment: 'status:-free+product:\'gold\''
+                },
+                data: {}
+            }), {errorType: 'ValidationError'});
+        });
+
+        it('rejects a non-string legacy memberSegment', async function () {
+            const controller = new EmailController({}, {
+                models: {
+                    Post: createModelClass(),
+                    Newsletter: createModelClass()
+                }
+            });
+            // a single-element array would coerce to a valid object key
+            await assert.rejects(controller._getFrameData({
+                options: {
+                    id: 'options-id',
+                    memberSegment: ['status:free']
+                },
+                data: {}
+            }), {errorType: 'ValidationError'});
+        });
+
+        it('rejects an empty member_tier', async function () {
+            const controller = new EmailController({}, {
+                models: {
+                    Post: createModelClass(),
+                    Newsletter: createModelClass()
+                }
+            });
+            await assert.rejects(controller._getFrameData({
+                options: {
+                    id: 'options-id',
+                    member_tier: ''
+                },
+                data: {}
+            }), {errorType: 'ValidationError'});
+        });
+
         it('rejects a non-string member_tier from options', async function () {
             const controller = new EmailController({}, {
                 models: {

--- a/ghost/core/test/unit/server/services/email-service/email-controller.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-controller.test.js
@@ -102,7 +102,7 @@ describe('Email Controller', function () {
             assert.equal(post.get('slug'), 'my-post');
         });
 
-        it('uses segment from options', async function () {
+        it('uses member_status from options', async function () {
             const controller = new EmailController({}, {
                 models: {
                     Post: createModelClass({
@@ -113,16 +113,16 @@ describe('Email Controller', function () {
                     Newsletter: createModelClass()
                 }
             });
-            const {segment} = await controller._getFrameData({
+            const {memberStatus} = await controller._getFrameData({
                 options: {
                     id: 'options-id',
-                    memberSegment: 'free'
+                    member_status: 'free'
                 }
             });
-            assert.equal(segment, 'free');
+            assert.equal(memberStatus, 'free');
         });
 
-        it('uses segment from data', async function () {
+        it('uses member_status from data', async function () {
             const controller = new EmailController({}, {
                 models: {
                     Post: createModelClass({
@@ -133,15 +133,131 @@ describe('Email Controller', function () {
                     Newsletter: createModelClass()
                 }
             });
-            const {segment} = await controller._getFrameData({
+            const {memberStatus} = await controller._getFrameData({
                 options: {
                     id: 'options-id'
                 },
                 data: {
-                    memberSegment: 'free'
+                    member_status: 'paid'
                 }
             });
-            assert.equal(segment, 'free');
+            assert.equal(memberStatus, 'paid');
+        });
+
+        it('rejects an invalid member_status', async function () {
+            const controller = new EmailController({}, {
+                models: {
+                    Post: createModelClass(),
+                    Newsletter: createModelClass()
+                }
+            });
+            await assert.rejects(controller._getFrameData({
+                options: {
+                    id: 'options-id',
+                    member_status: 'comped'
+                },
+                data: {}
+            }), {errorType: 'ValidationError'});
+        });
+
+        it('maps legacy memberSegment values onto member_status', async function () {
+            const controller = new EmailController({}, {
+                models: {
+                    Post: createModelClass({
+                        findOne: {
+                            newsletter: createModel({slug: 'post-newsletter'})
+                        }
+                    }),
+                    Newsletter: createModelClass()
+                }
+            });
+            const free = await controller._getFrameData({
+                options: {
+                    id: 'options-id',
+                    memberSegment: 'status:free'
+                }
+            });
+            assert.equal(free.memberStatus, 'free');
+
+            const paid = await controller._getFrameData({
+                options: {
+                    id: 'options-id'
+                },
+                data: {
+                    memberSegment: 'status:-free'
+                }
+            });
+            assert.equal(paid.memberStatus, 'paid');
+        });
+
+        it('rejects an unknown legacy memberSegment', async function () {
+            const controller = new EmailController({}, {
+                models: {
+                    Post: createModelClass(),
+                    Newsletter: createModelClass()
+                }
+            });
+            await assert.rejects(controller._getFrameData({
+                options: {
+                    id: 'options-id',
+                    memberSegment: 'status:-free+product:\'gold\''
+                },
+                data: {}
+            }), {errorType: 'ValidationError'});
+        });
+
+        it('prefers member_status over legacy memberSegment', async function () {
+            const controller = new EmailController({}, {
+                models: {
+                    Post: createModelClass({
+                        findOne: {
+                            newsletter: createModel({slug: 'post-newsletter'})
+                        }
+                    }),
+                    Newsletter: createModelClass()
+                }
+            });
+            const {memberStatus} = await controller._getFrameData({
+                options: {
+                    id: 'options-id',
+                    member_status: 'free',
+                    memberSegment: 'status:-free'
+                }
+            });
+            assert.equal(memberStatus, 'free');
+        });
+
+        it('rejects a non-string member_tier from options', async function () {
+            const controller = new EmailController({}, {
+                models: {
+                    Post: createModelClass(),
+                    Newsletter: createModelClass()
+                }
+            });
+            await assert.rejects(controller._getFrameData({
+                options: {
+                    id: 'options-id',
+                    member_tier: ['silver', 'gold']
+                },
+                data: {}
+            }), {errorType: 'ValidationError'});
+        });
+
+        it('rejects a non-string member_tier from data', async function () {
+            const controller = new EmailController({}, {
+                models: {
+                    Post: createModelClass(),
+                    Newsletter: createModelClass()
+                }
+            });
+            await assert.rejects(controller._getFrameData({
+                options: {
+                    id: 'options-id'
+                },
+                data: {
+                    member_tier: {slug: 'gold'}
+                }
+            }), {errorType: 'ValidationError'});
         });
     });
 

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -1401,6 +1401,15 @@ describe('Email renderer', function () {
             );
         });
 
+        it('escapes backslashes when narrowing to a tier', function () {
+            const post = createTiersPost([{slug: 'gold'}]);
+            // a trailing backslash must not swallow the closing quote
+            assert.equal(
+                emailRenderer.getSegmentForAudience(post, 'paid', 'trailing\\'),
+                'status:-free+product:\'trailing\\\\\''
+            );
+        });
+
         it('ignores a selected tier for the free audience', function () {
             const post = createTiersPost([{slug: 'gold'}]);
             assert.equal(emailRenderer.getSegmentForAudience(post, 'free', 'gold'), 'status:free');

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -1329,7 +1329,7 @@ describe('Email renderer', function () {
         });
     });
 
-    describe('getPreviewSegment', function () {
+    describe('getSegmentForAudience', function () {
         let emailRenderer;
 
         beforeEach(function () {
@@ -1354,17 +1354,17 @@ describe('Email renderer', function () {
         it('maps the paid audience to the tier access segment for a tiers post', function () {
             const post = createTiersPost([{slug: 'gold'}, {slug: 'silver'}]);
             assert.equal(
-                emailRenderer.getPreviewSegment(post, 'status:-free'),
+                emailRenderer.getSegmentForAudience(post, 'paid'),
                 'status:-free+(product:\'gold\',product:\'silver\')'
             );
         });
 
-        it('keeps the free audience segment for a tiers post', function () {
+        it('maps the free audience to the free segment', function () {
             const post = createTiersPost([{slug: 'gold'}]);
-            assert.equal(emailRenderer.getPreviewSegment(post, 'status:free'), 'status:free');
+            assert.equal(emailRenderer.getSegmentForAudience(post, 'free'), 'status:free');
         });
 
-        it('passes the paid audience through for non-tiers posts', function () {
+        it('maps the paid audience to the paid segment for non-tiers posts', function () {
             const post = {
                 get: (key) => {
                     if (key === 'visibility') {
@@ -1372,17 +1372,38 @@ describe('Email renderer', function () {
                     }
                 }
             };
-            assert.equal(emailRenderer.getPreviewSegment(post, 'status:-free'), 'status:-free');
+            assert.equal(emailRenderer.getSegmentForAudience(post, 'paid'), 'status:-free');
         });
 
-        it('passes through for a tiers post with no tiers', function () {
+        it('maps the paid audience to the paid segment for a tiers post with no tiers', function () {
             const post = createTiersPost([]);
-            assert.equal(emailRenderer.getPreviewSegment(post, 'status:-free'), 'status:-free');
+            assert.equal(emailRenderer.getSegmentForAudience(post, 'paid'), 'status:-free');
         });
 
-        it('passes through a null segment', function () {
+        it('maps a null status to an unsegmented render', function () {
             const post = createTiersPost([{slug: 'gold'}]);
-            assert.equal(emailRenderer.getPreviewSegment(post, null), null);
+            assert.equal(emailRenderer.getSegmentForAudience(post, null), null);
+        });
+
+        it('narrows the paid audience to a selected tier', function () {
+            const post = createTiersPost([{slug: 'gold'}, {slug: 'silver'}]);
+            assert.equal(
+                emailRenderer.getSegmentForAudience(post, 'paid', 'silver'),
+                'status:-free+product:\'silver\''
+            );
+        });
+
+        it('escapes quotes when narrowing to a tier', function () {
+            const post = createTiersPost([{slug: 'gold'}]);
+            assert.equal(
+                emailRenderer.getSegmentForAudience(post, 'paid', 'we\'re-fancy'),
+                'status:-free+product:\'we\\\'re-fancy\''
+            );
+        });
+
+        it('ignores a selected tier for the free audience', function () {
+            const post = createTiersPost([{slug: 'gold'}]);
+            assert.equal(emailRenderer.getSegmentForAudience(post, 'free', 'gold'), 'status:free');
         });
     });
 

--- a/ghost/core/test/unit/server/services/email-service/email-service.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-service.test.js
@@ -49,8 +49,14 @@ describe('Email Service', function () {
                     replacements: []
                 };
             },
-            getPreviewSegment: (post, segment) => {
-                return segment;
+            getSegmentForAudience: (post, memberStatus) => {
+                if (memberStatus === 'free') {
+                    return 'status:free';
+                }
+                if (memberStatus === 'paid') {
+                    return 'status:-free';
+                }
+                return null;
             },
             describeSegment: (post, segment) => {
                 return {
@@ -824,17 +830,38 @@ describe('Email Service', function () {
                     feedback_enabled: true
                 })
             });
-            sinon.stub(emailRenderer, 'getPreviewSegment').returns('status:-free+(product:\'gold\')');
+            sinon.stub(emailRenderer, 'getSegmentForAudience').returns('status:-free+(product:\'gold\')');
             const renderBody = sinon.stub(emailRenderer, 'renderBody').resolves({
                 html: 'HTML',
                 plaintext: 'Plaintext',
                 replacements: []
             });
 
-            await service.previewEmail(post, post.get('newsletter'), 'status:-free');
+            await service.previewEmail(post, post.get('newsletter'), 'paid');
 
-            sinon.assert.calledOnceWithExactly(emailRenderer.getPreviewSegment, post, 'status:-free');
+            sinon.assert.calledOnceWithExactly(emailRenderer.getSegmentForAudience, post, 'paid', undefined);
             assert.equal(renderBody.firstCall.args[2], 'status:-free+(product:\'gold\')');
+        });
+
+        it('passes the selected tier through to the preview segment', async function () {
+            const post = createModel({
+                id: '123',
+                newsletter: createModel({
+                    status: 'active',
+                    feedback_enabled: true
+                })
+            });
+            sinon.stub(emailRenderer, 'getSegmentForAudience').returns('status:-free+product:\'silver\'');
+            const renderBody = sinon.stub(emailRenderer, 'renderBody').resolves({
+                html: 'HTML',
+                plaintext: 'Plaintext',
+                replacements: []
+            });
+
+            await service.previewEmail(post, post.get('newsletter'), 'paid', 'silver');
+
+            sinon.assert.calledOnceWithExactly(emailRenderer.getSegmentForAudience, post, 'paid', 'silver');
+            assert.equal(renderBody.firstCall.args[2], 'status:-free+product:\'silver\'');
         });
     });
 
@@ -864,15 +891,32 @@ describe('Email Service', function () {
                     feedback_enabled: true
                 })
             });
-            sinon.stub(emailRenderer, 'getPreviewSegment').returns('status:-free+(product:\'gold\')');
+            sinon.stub(emailRenderer, 'getSegmentForAudience').returns('status:-free+(product:\'gold\')');
 
-            await service.sendTestEmail(post, post.get('newsletter'), 'status:-free', ['example@example.com']);
+            await service.sendTestEmail(post, post.get('newsletter'), 'paid', ['example@example.com']);
 
             sinon.assert.calledOnce(sendingService.send);
             const {segment, members} = sendingService.send.firstCall.args[0];
             assert.equal(segment, 'status:-free+(product:\'gold\')');
             // The example member is still built from the audience choice, not the mapped filter
             assert.equal(members[0].status, 'paid');
+        });
+
+        it('passes the selected tier through to the preview segment', async function () {
+            const post = createModel({
+                id: '123',
+                newsletter: createModel({
+                    status: 'active',
+                    feedback_enabled: true
+                })
+            });
+            const getSegmentForAudience = sinon.stub(emailRenderer, 'getSegmentForAudience').returns('status:-free+product:\'silver\'');
+
+            await service.sendTestEmail(post, post.get('newsletter'), 'paid', ['example@example.com'], 'silver');
+
+            sinon.assert.calledOnceWithExactly(getSegmentForAudience, post, 'paid', 'silver');
+            const {segment} = sendingService.send.firstCall.args[0];
+            assert.equal(segment, 'status:-free+product:\'silver\'');
         });
     });
 });

--- a/ghost/core/test/unit/server/services/members/create-paid-member-shim.test.ts
+++ b/ghost/core/test/unit/server/services/members/create-paid-member-shim.test.ts
@@ -21,6 +21,25 @@ describe('Unit - members/create-paid-member-shim', function () {
         assert.deepEqual(member, {status: 'paid', products: [{slug: 'silver'}, {slug: 'gold'}]});
     });
 
+    it('returns a paid member with only the selected tier, including archived tiers', async function () {
+        const findOne = sinon.stub(models.Product, 'findOne').resolves({
+            get: (key: string) => (key === 'slug' ? 'archive' : undefined)
+        });
+
+        const member = await createPaidMemberShim('archive');
+
+        assert.deepEqual(member, {status: 'paid', products: [{slug: 'archive'}]});
+        sinon.assert.calledOnceWithExactly(findOne, {slug: 'archive', type: 'paid'});
+    });
+
+    it('returns a paid member with no tiers when the selected tier does not exist', async function () {
+        sinon.stub(models.Product, 'findOne').resolves(null);
+
+        const member = await createPaidMemberShim('missing');
+
+        assert.deepEqual(member, {status: 'paid', products: []});
+    });
+
     it('falls back to a paid member with no tiers (never throws) when the tier lookup fails', async function () {
         const logError = sinon.stub(logging, 'error');
         sinon.stub(models.Product, 'findAll').rejects(new Error('db down'));


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3779/

Previewing a paid post always simulated a member holding every active paid tier, so there was no way to see what members on a specific tier receive — on web or in email. This adds a tier selector to the editor preview modal so both surfaces can be previewed as a member of a single tier, behind a new `previewByTier` private labs flag.

### API

- `email_previews` now accepts `member_status` (`free`/`paid`) and `member_tier` (single tier slug), matching the web preview endpoint's params, for both the preview GET and test-email POST. The render segment is composed server-side (`getSegmentForAudience`), so clients no longer build NQL strings and quoting/escaping lives next to the code that defines what the segment means.
- `memberSegment` is deprecated but kept as a param rewrite for the two values older admin clients send (`status:free` → `free`, `status:-free` → `paid`). Anything else is rejected with a `ValidationError` — production logs show no other usage of this param.
- The web preview endpoint gains `member_tier` alongside its existing `member_status`; the paid member shim narrows to the selected tier (archived tiers included, since a preview of an archived-tier member's view is still meaningful).

### Admin

- The preview modal's audience select gains a **Tier** option with a grouped active/archived tier dropdown; the selection persists when the preview is reopened and is reflected in the shareable preview link.
- Admin deploys continuously ahead of the backend, so the tier UI and the new params only activate when the `previewByTier` flag is enabled. With the flag off, Admin sends the legacy `memberSegment` param and behaves exactly as before, keeping it compatible with older backends. The legacy branch in the email preview component is the only place the old param survives and is removed when the flag goes GA.
- Tiers are loaded once per editor session, only when the flag is on and paid members are enabled; a failed fetch degrades the preview to the free/paid options.