### PR TITLE
Moved About Ghost logo to Shade

### DIFF
--- a/apps/admin-x-design-system/src/assets/images/ghost-logo.svg
+++ b/apps/admin-x-design-system/src/assets/images/ghost-logo.svg
@@ -1,1 +1,0 @@
-<svg viewBox="0 0 770 294" style="background-size:100% 100%;background-repeat:no-repeat;background-image:url(https://assets.ghost.io/admin/1597/assets/img/logos/ghost-logo-black-1-fb561a374422b405ec90fa586b05ebdf.png)" alt="Ghost"></svg>

--- a/apps/admin-x-design-system/src/index.ts
+++ b/apps/admin-x-design-system/src/index.ts
@@ -1,5 +1,4 @@
 export {default as FacebookLogo} from './assets/images/facebook-logo.svg?react';
-export {default as GhostLogo} from './assets/images/ghost-logo.svg?react';
 export {default as GoogleLogo} from './assets/images/google-logo.svg?react';
 export {default as TwitterLogo} from './assets/images/twitter-logo.svg?react';
 export {default as XLogo} from './assets/images/x-logo.svg?react';

--- a/apps/admin-x-settings/src/components/settings/general/about.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/about.tsx
@@ -1,7 +1,7 @@
 import NiceModal from '@ebay/nice-modal-react';
-import {GhostLogo, Icon, Modal} from '@tryghost/admin-x-design-system';
+import {GhostLogo, Separator} from '@tryghost/shade/components';
+import {Icon, Modal} from '@tryghost/admin-x-design-system';
 import {type RoutingModalProps, useRouting} from '@tryghost/admin-x-framework/routing';
-import {Separator} from '@tryghost/shade/components';
 import {linkToGitHubReleases} from '../../../utils/link-to-github-releases';
 import {showDatabaseWarning} from '../../../utils/show-database-warning';
 import {useGlobalData} from '../../providers/global-data-provider';


### PR DESCRIPTION
## What changed

- Switched the About modal `GhostLogo` import from admin-x-design-system to `@tryghost/shade/components`.
- Removed the now-unused admin-x-design-system `GhostLogo` export.
- Deleted the duplicate legacy SVG asset.

## Why

Shade already owns a byte-for-byte identical Ghost logo SVG. Using the Shade export removes the final consumer and shrinks the legacy design-system surface without changing markup, styling, or runtime behavior.

## Validation

- Independent agent review: no findings
- Legacy and Shade SVGs confirmed byte-for-byte identical
- admin-x-settings: 203 unit tests passed
- admin-x-design-system: 23 unit tests passed
- Full lint and TypeScript checks for both packages
- admin-x-design-system production build
- `git diff --check`

## Manual testing

- Open Settings → General → About Ghost.
- Confirm the full Ghost wordmark renders at the expected size.
- Verify its appearance in both light and dark mode, including dark-mode inversion.
- Close the modal normally and confirm navigation/modal behavior is unchanged.