### PR TITLE
Moved tier option grouping into a shared util

### DIFF
--- a/ghost/admin/app/components/gh-members-recipient-select.js
+++ b/ghost/admin/app/components/gh-members-recipient-select.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import {action} from '@ember/object';
+import {groupTiersByActive} from 'ghost-admin/utils/group-tiers';
 import {isBlank} from '@ember/utils';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
@@ -153,30 +154,12 @@ export default class GhMembersRecipientSelect extends Component {
         const tierOptions = [];
 
         if (tiers.length > 1) {
-            const activeTiersGroup = {
-                groupName: 'Active tiers',
-                options: []
-            };
-
-            const archivedTiersGroup = {
-                groupName: 'Archived tiers',
-                options: []
-            };
-
-            tiers.forEach((tier) => {
-                const tierData = {
-                    name: tier.name,
-                    segment: `tier:${tier.slug}`,
-                    count: tier.count?.members,
-                    class: 'segment-tier'
-                };
-
-                if (tier.active) {
-                    activeTiersGroup.options.push(tierData);
-                } else {
-                    archivedTiersGroup.options.push(tierData);
-                }
-            });
+            const [activeTiersGroup, archivedTiersGroup] = groupTiersByActive(tiers, tier => ({
+                name: tier.name,
+                segment: `tier:${tier.slug}`,
+                count: tier.count?.members,
+                class: 'segment-tier'
+            }));
 
             tierOptions.push(activeTiersGroup);
             tierOptions.push(archivedTiersGroup);

--- a/ghost/admin/app/components/gh-members-segment-select.js
+++ b/ghost/admin/app/components/gh-members-segment-select.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import {action} from '@ember/object';
+import {groupTiersByActive} from 'ghost-admin/utils/group-tiers';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
@@ -65,30 +66,12 @@ export default class GhMembersSegmentSelect extends Component {
         const tiers = yield this.store.query('tier', {filter: 'type:paid', limit: 'all', include: 'monthly_price,yearly_price,benefits'});
 
         if (tiers.length > 0) {
-            const activeTiersGroup = {
-                groupName: 'Active tiers',
-                options: []
-            };
-
-            const archivedTiersGroup = {
-                groupName: 'Archived tiers',
-                options: []
-            };
-
-            tiers.forEach((tier) => {
-                const tierData = {
-                    name: tier.name,
-                    segment: `${tier.id}`,
-                    count: tier.count?.members,
-                    class: 'segment-tier'
-                };
-
-                if (tier.active) {
-                    activeTiersGroup.options.push(tierData);
-                } else {
-                    archivedTiersGroup.options.push(tierData);
-                }
-            });
+            const [activeTiersGroup, archivedTiersGroup] = groupTiersByActive(tiers, tier => ({
+                name: tier.name,
+                segment: `${tier.id}`,
+                count: tier.count?.members,
+                class: 'segment-tier'
+            }));
 
             options.push(activeTiersGroup);
             options.push(archivedTiersGroup);

--- a/ghost/admin/app/components/gh-post-settings-menu/visibility-segment-select.js
+++ b/ghost/admin/app/components/gh-post-settings-menu/visibility-segment-select.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import {action} from '@ember/object';
+import {groupTiersByActive} from 'ghost-admin/utils/group-tiers';
 import {inject as service} from '@ember/service';
 import {task} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
@@ -75,30 +76,12 @@ export default class VisibilitySegmentSelect extends Component {
         this.tiers = tiers;
 
         if (tiers.length > 0) {
-            const activeTiersGroup = {
-                groupName: 'Active tiers',
-                options: []
-            };
-
-            const archivedTiersGroup = {
-                groupName: 'Archived tiers',
-                options: []
-            };
-
-            tiers.forEach((tier) => {
-                const tierData = {
-                    name: tier.name,
-                    id: tier.id,
-                    count: tier.count?.members,
-                    class: 'segment-tier'
-                };
-
-                if (tier.active) {
-                    activeTiersGroup.options.push(tierData);
-                } else {
-                    archivedTiersGroup.options.push(tierData);
-                }
-            });
+            const [activeTiersGroup, archivedTiersGroup] = groupTiersByActive(tiers, tier => ({
+                name: tier.name,
+                id: tier.id,
+                count: tier.count?.members,
+                class: 'segment-tier'
+            }));
 
             options.push(activeTiersGroup);
             options.push(archivedTiersGroup);

--- a/ghost/admin/app/utils/group-tiers.js
+++ b/ghost/admin/app/utils/group-tiers.js
@@ -1,0 +1,14 @@
+// Groups tiers into the 'Active tiers' / 'Archived tiers' option groups used
+// by every tier-picking power-select. `mapTier` converts each tier into the
+// caller's option shape.
+export function groupTiersByActive(tiers, mapTier = tier => tier) {
+    const activeTiersGroup = {groupName: 'Active tiers', options: []};
+    const archivedTiersGroup = {groupName: 'Archived tiers', options: []};
+
+    tiers.forEach((tier) => {
+        const group = tier.active ? activeTiersGroup : archivedTiersGroup;
+        group.options.push(mapTier(tier));
+    });
+
+    return [activeTiersGroup, archivedTiersGroup];
+}

--- a/ghost/admin/tests/unit/utils/group-tiers-test.js
+++ b/ghost/admin/tests/unit/utils/group-tiers-test.js
@@ -1,0 +1,44 @@
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {groupTiersByActive} from 'ghost-admin/utils/group-tiers';
+
+describe('Unit: Util: group-tiers', function () {
+    it('splits tiers into active and archived groups', function () {
+        const tiers = [
+            {name: 'Bronze', active: true},
+            {name: 'Silver', active: false},
+            {name: 'Gold', active: true}
+        ];
+
+        const [activeGroup, archivedGroup] = groupTiersByActive(tiers);
+
+        expect(activeGroup.groupName).to.equal('Active tiers');
+        expect(activeGroup.options).to.deep.equal([
+            {name: 'Bronze', active: true},
+            {name: 'Gold', active: true}
+        ]);
+        expect(archivedGroup.groupName).to.equal('Archived tiers');
+        expect(archivedGroup.options).to.deep.equal([
+            {name: 'Silver', active: false}
+        ]);
+    });
+
+    it('maps each tier through the given callback', function () {
+        const tiers = [
+            {name: 'Bronze', slug: 'bronze', active: true},
+            {name: 'Silver', slug: 'silver', active: false}
+        ];
+
+        const [activeGroup, archivedGroup] = groupTiersByActive(tiers, tier => ({segment: `tier:${tier.slug}`}));
+
+        expect(activeGroup.options).to.deep.equal([{segment: 'tier:bronze'}]);
+        expect(archivedGroup.options).to.deep.equal([{segment: 'tier:silver'}]);
+    });
+
+    it('returns empty groups for no tiers', function () {
+        const [activeGroup, archivedGroup] = groupTiersByActive([]);
+
+        expect(activeGroup.options).to.deep.equal([]);
+        expect(archivedGroup.options).to.deep.equal([]);
+    });
+});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3779/

Three tier-picking power-selects (`gh-members-recipient-select`, `gh-members-segment-select`, and the post settings menu's `visibility-segment-select`) each hand-rolled the same active/archived tier option grouping. The tier preview work in #29380 adds a fourth consumer, so this extracts the duplicated logic into a shared `groupTiersByActive` util first to keep that PR's diff focused on behaviour changes.

No behaviour change — each component passes its own option-mapping callback so the produced option shapes are identical.