### PR TITLE
Moved recommendation tooltip to Shade

### DIFF
--- a/apps/admin-x-settings/src/components/settings/growth/recommendations/recommendation-list.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/recommendations/recommendation-list.tsx
@@ -3,9 +3,10 @@ import NiceModal from '@ebay/nice-modal-react';
 import React, {useState} from 'react';
 import RecommendationIcon from './recommendation-icon';
 import useSettingGroup from '../../../../hooks/use-setting-group';
-import {Button, Link, NoValueLabel, type PaginationData, type ShowMoreData, Table, TableCell, TableRow, Tooltip} from '@tryghost/admin-x-design-system';
+import {Button, Link, NoValueLabel, type PaginationData, type ShowMoreData, Table, TableCell, TableRow} from '@tryghost/admin-x-design-system';
 import {type Recommendation} from '@tryghost/admin-x-framework/api/recommendations';
-import {numberWithCommas} from '../../../../utils/helpers';
+import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@tryghost/shade/components';
+import {formatNumber} from '@tryghost/shade/utils';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
 
 interface RecommendationListProps {
@@ -51,7 +52,7 @@ const RecommendationItem: React.FC<{recommendation: Recommendation}> = ({recomme
                     <>
                         <div className='flex items-center'>
                             <div className='mr-2'>
-                                <span>{numberWithCommas(count)}</span>
+                                <span>{formatNumber(count)}</span>
                             </div>
                             <div className='text-grey-700 lowercase'>
                                 <span>{showSubscribers ? newMembers : clicks}</span>
@@ -86,7 +87,28 @@ const RecommendationList: React.FC<RecommendationListProps> = ({recommendations,
 
     if (isLoading || recommendations.length) {
         return <Table
-            hint={<span>Shared with new members after signup, or anytime using <Link href={recommendationsURL} target='_blank'>this link</Link><Tooltip containerClassName='ml-1 align-middle leading-none' content={copied ? 'Copied' : 'Copy link'} size='sm'><Button color='clear' hideLabel={true} icon={copied ? 'check-circle' : 'duplicate'} iconColorClass={copied ? 'text-green w-[14px] h-[14px]' : 'text-grey-600 hover:opacity-80 w-[14px] h-[14px]'} label={copied ? 'Copied' : 'Copy'} unstyled={true} onClick={copyRecommendationsUrl} /></Tooltip></span>}
+            hint={
+                <span>
+                    Shared with new members after signup, or anytime using <Link href={recommendationsURL} target='_blank'>this link</Link>
+                    <TooltipProvider delayDuration={0}>
+                        <Tooltip>
+                            <TooltipTrigger asChild>
+                                <Button
+                                    className='ml-1 align-middle leading-none'
+                                    color='clear'
+                                    hideLabel={true}
+                                    icon={copied ? 'check-circle' : 'duplicate'}
+                                    iconColorClass={copied ? 'text-green w-[14px] h-[14px]' : 'text-grey-600 hover:opacity-80 w-[14px] h-[14px]'}
+                                    label={copied ? 'Copied' : 'Copy'}
+                                    unstyled={true}
+                                    onClick={copyRecommendationsUrl}
+                                />
+                            </TooltipTrigger>
+                            <TooltipContent>{copied ? 'Copied' : 'Copy link'}</TooltipContent>
+                        </Tooltip>
+                    </TooltipProvider>
+                </span>
+            }
             isLoading={isLoading}
             pagination={pagination}
             showMore={showMore}


### PR DESCRIPTION
## What changed

- Replaced the Recommendations copy-link legacy Tooltip with Shade's Tooltip primitives.
- Preserved the existing zero-delay hover behavior, legacy copy button, icon state, and “Copy link”/“Copied” content.
- Replaced the legacy `numberWithCommas` count formatting with Shade's `formatNumber`.
- Kept the admin-x-design-system Tooltip because legacy `ButtonGroup` still consumes it internally.

## Why

Recommendations was the final app-level consumer of the legacy Tooltip. Shade provides the accessible provider/root/trigger/content composition needed here, allowing another settings dependency to move off admin-x-design-system without changing the copy interaction.

## Validation

- Independent agent review with one formatter finding incorporated; second pass reported no remaining findings
- admin-x-settings: 203 unit tests passed
- Recommendations acceptance suite: 6/6 passed
- Full admin-x-settings lint and TypeScript checks
- `git diff --check`

## Manual testing

- Open Settings → Recommendations → Your recommendations.
- Hover or focus the copy icon and confirm “Copy link” appears immediately.
- Click it and confirm the recommendations URL is copied.
- Confirm the icon, accessible button name, and tooltip change to “Copied” for approximately two seconds, then reset.
- Check tooltip positioning in light and dark mode.
- Confirm the adjacent “this link” remains clickable.