### PR TITLE
Fixed controlled values for Stripe and Mailgun inputs

### DIFF
--- a/apps/admin-x-settings/src/components/settings/email/mailgun.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/mailgun.tsx
@@ -70,7 +70,7 @@ const MailGun: React.FC<{ keywords: string[] }> = ({keywords}) => {
                 />
                 <TextField
                     title='Mailgun domain'
-                    value={mailgunDomain}
+                    value={mailgunDomain ?? ''}
                     onChange={(e) => {
                         updateSetting('mailgun_domain', e.target.value);
                     }}
@@ -80,7 +80,7 @@ const MailGun: React.FC<{ keywords: string[] }> = ({keywords}) => {
                         hint={apiKeysHint}
                         title='Mailgun private API key'
                         type='password'
-                        value={mailgunApiKey}
+                        value={mailgunApiKey ?? ''}
                         onChange={(e) => {
                             updateSetting('mailgun_api_key', e.target.value);
                         }}

--- a/apps/admin-x-settings/src/components/settings/membership/stripe/stripe-connect-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/stripe/stripe-connect-modal.tsx
@@ -239,8 +239,8 @@ const Direct: React.FC<{onClose: () => void}> = ({onClose}) => {
         <div>
             <Heading level={3}>Connect Stripe</Heading>
             <Form marginBottom={false} marginTop>
-                <TextField title='Publishable key' value={publishableKey?.toString()} onChange={e => updateSetting('stripe_publishable_key', e.target.value)} />
-                <TextField title='Secure key' value={secretKey?.toString()} onChange={e => updateSetting('stripe_secret_key', e.target.value)} />
+                <TextField title='Publishable key' value={publishableKey?.toString() ?? ''} onChange={e => updateSetting('stripe_publishable_key', e.target.value)} />
+                <TextField title='Secure key' value={secretKey?.toString() ?? ''} onChange={e => updateSetting('stripe_secret_key', e.target.value)} />
                 <Button className='mt-5' color='green' disabled={saveState === 'saving'} label='Save Stripe settings' onClick={onSubmit} />
             </Form>
         </div>


### PR DESCRIPTION
## What changed

- Default missing Stripe Direct keys to empty strings.
- Default missing Mailgun domain and API key values to empty strings.

## Why

The settings API can return `undefined` or `null` for unset values. Passing those values to the text fields made the underlying inputs uncontrolled on their first render, then controlled after the acceptance tests populated them. This removes all three controlled-input diagnostics found in the current full Admin acceptance-test log.

## Testing

- `pnpm nx run @tryghost/admin:test:acceptance -- src/settings/membership/stripe.acceptance.test.tsx src/settings/email/mailgun.acceptance.test.tsx`
- `pnpm nx run @tryghost/admin-x-settings:lint`
- `pnpm nx run @tryghost/admin-x-settings:test:unit`