### PR TITLE
🐛 Fixed false unsaved warning in welcome email editor

### DIFF
--- a/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/member-emails/welcome-email-modal.tsx
@@ -109,7 +109,7 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
     const [previewSubjectOverride, setPreviewSubjectOverride] = useState<string | null>(null);
     const dropdownRef = useRef<HTMLDivElement>(null);
     const normalizedLexical = useRef<string>(automatedEmail?.lexical || '');
-    const hasEditorBeenFocused = useRef(false);
+    const hasEditorBeenInteractedWith = useRef(false);
     const handleError = useHandleError();
     const automatedEmails = automatedEmailsData?.automated_emails || [];
     const {resolvedSenderName, resolvedSenderEmail, resolvedReplyToEmail, hasDistinctReplyTo} = useWelcomeEmailSenderDetails(automatedEmails, {
@@ -198,12 +198,12 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
 
     // The editor normalizes content on mount (e.g., processing {name} templates),
     // which triggers onChange even without user edits. We track whether the editor
-    // has ever been focused - normalization happens before focus is possible, so any
-    // onChange before first focus is normalization. After focus, we compare against
-    // the normalized baseline to determine dirty state.
+    // has received user input - the modal can autofocus the editor before normalization
+    // finishes, so focus alone is not evidence of an edit. After user interaction, we
+    // compare against the normalized baseline to determine dirty state.
     const handleEditorChange = useCallback((lexical: string) => {
-        if (!hasEditorBeenFocused.current) {
-            // Editor hasn't been focused yet = must be normalization
+        if (!hasEditorBeenInteractedWith.current) {
+            // Editor hasn't received user input yet = must be normalization
             normalizedLexical.current = lexical;
             setFormState(state => ({...state, lexical}));
             return;
@@ -326,8 +326,11 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
                                 mode === 'preview' && 'hidden'
                             )}
                             data-testid='welcome-email-editor'
-                            onFocus={() => {
-                                hasEditorBeenFocused.current = true;
+                            onKeyDown={() => {
+                                hasEditorBeenInteractedWith.current = true;
+                            }}
+                            onPointerDown={() => {
+                                hasEditorBeenInteractedWith.current = true;
                             }}
                         >
                             <MemberEmailEditor


### PR DESCRIPTION
## What changed

- Treat keyboard and pointer activity as editor interaction instead of focus alone.
- Keep initial Koenig normalization from marking an untouched welcome-email draft dirty.

## Root cause

The modal can autofocus the Koenig editor before its initial `{name}` template normalization finishes. The previous focus-based heuristic then treated the normalization callback as a user edit, causing an unexpected unsaved-changes confirmation and making the migrated Admin acceptance test flaky.

## Impact

Closing an untouched welcome-email editor no longer shows an unsaved-changes warning. Real keyboard and pointer edits still mark the draft dirty.

## Validation

- `pnpm exec vitest run -c vitest.acceptance.config.ts src/settings/membership/member-welcome-emails.acceptance.test.tsx` — 26 passed
- `pnpm exec eslint src/components/settings/membership/member-emails/welcome-email-modal.tsx`
- `pnpm exec tsc --noEmit` in `apps/admin-x-settings`
- Pre-commit ESLint, dependency-cruiser, secret scan, and submodule checks