### PR TITLE
Fixed invalid table nesting in settings lists

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/integrations/webhooks-table.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/integrations/webhooks-table.tsx
@@ -1,7 +1,9 @@
 import NiceModal from '@ebay/nice-modal-react';
 import WebhookModal from './webhook-modal';
-import {Button, ConfirmationModal, Table, TableCell, TableHead, TableRow, showToast} from '@tryghost/admin-x-design-system';
+import {Button, ConfirmationModal, Table, TableRow, showToast} from '@tryghost/admin-x-design-system';
+import {Inline} from '@tryghost/shade/primitives';
 import {type Integration} from '@tryghost/admin-x-framework/api/integrations';
+import {formatNumber} from '@tryghost/shade/utils';
 import {getWebhookEventLabel} from './webhook-event-options';
 import {useDeleteWebhook} from '@tryghost/admin-x-framework/api/webhooks';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
@@ -34,8 +36,10 @@ const WebhooksTable: React.FC<{integration: Integration}> = ({integration}) => {
     return (<div>
         <Table>
             <TableRow bgOnHover={false}>
-                <TableHead>{integration.webhooks?.length || 0} {integration.webhooks?.length === 1 ? 'webhook' : 'webhooks'}</TableHead>
-                <TableHead>Last triggered</TableHead>
+                <Inline className='w-full py-3 font-semibold' gap='none'>
+                    <div className='w-3/4'>{formatNumber(integration.webhooks?.length || 0)} {integration.webhooks?.length === 1 ? 'webhook' : 'webhooks'}</div>
+                    <div className='w-1/4'>Last triggered</div>
+                </Inline>
             </TableRow>
             {integration.webhooks?.map(webhook => (
                 <TableRow key={webhook.id} action={
@@ -54,28 +58,30 @@ const WebhooksTable: React.FC<{integration: Integration}> = ({integration}) => {
                     });
                 }}
                 >
-                    <TableCell className='w-3/4'>
-                        <div className='font-semibold'>{webhook.name}</div>
-                        <div className='mt-1 grid grid-cols-[max-content_1fr] gap-1 text-sm leading-snug'>
-                            <span className='text-grey-600'>Event:</span>
-                            <span>{getWebhookEventLabel(webhook.event)}</span>
-                            <span className='text-grey-600'>URL:</span>
-                            <span className='line-clamp-3 break-all' title={webhook.target_url}>
-                                {webhook.target_url}
-                            </span>
+                    <Inline align='start' className='w-full' gap='none'>
+                        <div className='w-3/4 py-3 pr-6'>
+                            <div className='font-semibold'>{webhook.name}</div>
+                            <div className='mt-1 grid grid-cols-[max-content_1fr] gap-1 text-sm leading-snug'>
+                                <span className='text-grey-600'>Event:</span>
+                                <span>{getWebhookEventLabel(webhook.event)}</span>
+                                <span className='text-grey-600'>URL:</span>
+                                <span className='line-clamp-3 break-all' title={webhook.target_url}>
+                                    {webhook.target_url}
+                                </span>
+                            </div>
                         </div>
-                    </TableCell>
-                    <TableCell className='w-1/4 text-sm'>
-                        {webhook.last_triggered_at && new Date(webhook.last_triggered_at).toLocaleString('default', {
-                            weekday: 'short',
-                            month: 'short',
-                            day: 'numeric',
-                            year: 'numeric',
-                            hour: '2-digit',
-                            minute: '2-digit',
-                            second: '2-digit'
-                        })}
-                    </TableCell>
+                        <div className='w-1/4 py-3 pr-6 text-sm'>
+                            {webhook.last_triggered_at && new Date(webhook.last_triggered_at).toLocaleString('default', {
+                                weekday: 'short',
+                                month: 'short',
+                                day: 'numeric',
+                                year: 'numeric',
+                                hour: '2-digit',
+                                minute: '2-digit',
+                                second: '2-digit'
+                            })}
+                        </div>
+                    </Inline>
                 </TableRow>
             ))}
         </Table>

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/newsletters-list.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/newsletters-list.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import {Button, DragIndicator, NoValueLabel, type SortableItemContainerProps, SortableList, Table, TableCell, TableRow} from '@tryghost/admin-x-design-system';
+import {Button, DragIndicator, NoValueLabel, type SortableItemContainerProps, SortableList, Table, TableRow} from '@tryghost/admin-x-design-system';
+import {Inline} from '@tryghost/shade/primitives';
 import {type Newsletter} from '@tryghost/admin-x-framework/api/newsletters';
 import {formatNumber} from '@tryghost/shade/utils';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
@@ -36,10 +37,12 @@ const NewsletterItemContainer: React.FC<Partial<SortableItemContainerProps>> = (
             style={style}
             onClick={showDetails}
         >
-            {(props.dragHandleAttributes || isDragging) && <TableCell className='w-10 align-middle!' >
-                <DragIndicator className='h-10' isDragging={isDragging || false} {...props} />
-            </TableCell>}
-            {children}
+            <Inline className='w-full' gap='none'>
+                {(props.dragHandleAttributes || isDragging) && <div className='w-10 shrink-0'>
+                    <DragIndicator className='h-10' isDragging={isDragging || false} {...props} />
+                </div>}
+                {children}
+            </Inline>
         </TableRow>
     );
 
@@ -59,24 +62,24 @@ const NewsletterItem: React.FC<{newsletter: Newsletter}> = ({newsletter}) => {
 
     return (
         <>
-            <TableCell className='w-full' onClick={showDetails}>
+            <div className='grow py-3 pr-6' onClick={showDetails}>
                 <div className={`flex grow flex-col`}>
                     <span className='font-medium'>{newsletter.name}</span>
                     <span className='mt-0.5 text-sm leading-tight text-grey-700'>{newsletter.description || 'No description'}</span>
                 </div>
-            </TableCell>
-            <TableCell className='hidden md:visible! md:table-cell! md:min-w-[11rem]' onClick={showDetails}>
+            </div>
+            <div className='hidden py-3 pr-6 md:block md:min-w-[11rem]' onClick={showDetails}>
                 <div className={`flex grow flex-col`}>
                     <span>{formatNumber(newsletter.count?.active_members || 0) }</span>
                     <span className='mt-0.5 text-sm leading-tight whitespace-nowrap text-grey-700'>Subscribers</span>
                 </div>
-            </TableCell>
-            <TableCell className='hidden md:visible! md:table-cell! md:min-w-[11rem]' onClick={showDetails}>
+            </div>
+            <div className='hidden py-3 pr-6 md:block md:min-w-[11rem]' onClick={showDetails}>
                 <div className={`flex grow flex-col`}>
                     <span>{formatNumber(newsletter.count?.posts || 0)}</span>
                     <span className='mt-0.5 text-sm leading-tight whitespace-nowrap text-grey-700'>Delivered</span>
                 </div>
-            </TableCell>
+            </div>
         </>
     );
 };

--- a/apps/admin-x-settings/src/components/settings/growth/recommendations/incoming-recommendation-list.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/recommendations/incoming-recommendation-list.tsx
@@ -1,9 +1,10 @@
 import React, {useMemo} from 'react';
 import RecommendationIcon from './recommendation-icon';
-import {Button, NoValueLabel, type PaginationData, type ShowMoreData, Table, TableCell, TableRow} from '@tryghost/admin-x-design-system';
+import {Button, NoValueLabel, type PaginationData, type ShowMoreData, Table, TableRow} from '@tryghost/admin-x-design-system';
 import {type IncomingRecommendation} from '@tryghost/admin-x-framework/api/recommendations';
+import {Inline} from '@tryghost/shade/primitives';
 import {type ReferrerHistoryItem} from '@tryghost/admin-x-framework/api/referrers';
-import {numberWithCommas} from '../../../../utils/helpers';
+import {formatNumber} from '@tryghost/shade/utils';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
 
 interface IncomingRecommendationListProps {
@@ -53,33 +54,31 @@ const IncomingRecommendationItem: React.FC<{incomingRecommendation: IncomingReco
                 </div>
             )
         } testId='incoming-recommendation-list-item' hideActions>
-            <TableCell className='w-80' onClick={showDetails}>
-                <div className='group flex items-center gap-3 hover:cursor-pointer'>
-                    <div className={`flex grow flex-col`}>
-                        <div className="flex items-center gap-3">
-                            <RecommendationIcon favicon={incomingRecommendation.favicon} featured_image={incomingRecommendation.featured_image} title={incomingRecommendation.title || incomingRecommendation.url} />
-                            <span className='line-clamp-1 font-medium'>{incomingRecommendation.title || incomingRecommendation.url}</span>
-                        </div>
-                    </div>
+            <Inline className='w-full' gap='none'>
+                <div className='grow py-3 pr-6' onClick={showDetails}>
+                    <Inline className='group hover:cursor-pointer' gap='md'>
+                        <RecommendationIcon favicon={incomingRecommendation.favicon} featured_image={incomingRecommendation.featured_image} title={incomingRecommendation.title || incomingRecommendation.url} />
+                        <span className='line-clamp-1 font-medium'>{incomingRecommendation.title || incomingRecommendation.url}</span>
+                    </Inline>
                 </div>
-            </TableCell>
-            <TableCell className='hidden w-auto text-left whitespace-nowrap md:visible! md:table-cell!' padding={false} valign="middle" onClick={showDetails}>
-                {(signups === 0) ? (
-                    <span className="text-grey-500 dark:text-grey-900">-</span>
-                ) : (
-                    <div className='mr-2'>
-                        <span>{numberWithCommas(signups)}</span>
-                    </div>
-                )}
-            </TableCell>
-            <TableCell className='hidden w-[1%] whitespace-nowrap md:visible! md:table-cell!' valign="middle" onClick={showDetails}>
-                {(signups === 0) ? (null) : (
-                    <div className='-mt-px text-left'>
-                        <span className='-mb-px inline-block min-w-[60px] text-left whitespace-nowrap text-grey-700 lowercase'>{freeMembersLabel}</span>
-                    </div>
-                )}
-            </TableCell>
-            {incomingRecommendation.recommending_back && <TableCell className='w-[1%] whitespace-nowrap group-hover/table-row:visible md:invisible'><div className='mt-1 text-right whitespace-nowrap text-grey-700'>Recommending</div></TableCell>}
+                <div className='hidden py-3 pr-6 text-left whitespace-nowrap md:block' onClick={showDetails}>
+                    {(signups === 0) ? (
+                        <span className="text-muted-foreground">-</span>
+                    ) : (
+                        <div className='mr-2'>
+                            <span>{formatNumber(signups)}</span>
+                        </div>
+                    )}
+                </div>
+                <div className='hidden w-[1%] py-3 pr-6 whitespace-nowrap md:block' onClick={showDetails}>
+                    {(signups === 0) ? (null) : (
+                        <div className='-mt-px text-left'>
+                            <span className='-mb-px inline-block min-w-[60px] text-left whitespace-nowrap text-grey-700 lowercase'>{freeMembersLabel}</span>
+                        </div>
+                    )}
+                </div>
+                {incomingRecommendation.recommending_back && <div className='w-[1%] py-3 pr-6 whitespace-nowrap group-hover/table-row:visible md:invisible'><div className='mt-1 text-right whitespace-nowrap text-grey-700'>Recommending</div></div>}
+            </Inline>
         </TableRow>
     );
 };

--- a/apps/admin-x-settings/src/components/settings/growth/recommendations/recommendation-list.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/recommendations/recommendation-list.tsx
@@ -3,7 +3,8 @@ import NiceModal from '@ebay/nice-modal-react';
 import React, {useState} from 'react';
 import RecommendationIcon from './recommendation-icon';
 import useSettingGroup from '../../../../hooks/use-setting-group';
-import {Button, Link, NoValueLabel, type PaginationData, type ShowMoreData, Table, TableCell, TableRow} from '@tryghost/admin-x-design-system';
+import {Button, Link, NoValueLabel, type PaginationData, type ShowMoreData, Table, TableRow} from '@tryghost/admin-x-design-system';
+import {Inline} from '@tryghost/shade/primitives';
 import {type Recommendation} from '@tryghost/admin-x-framework/api/recommendations';
 import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@tryghost/shade/components';
 import {formatNumber} from '@tryghost/shade/utils';
@@ -37,19 +38,17 @@ const RecommendationItem: React.FC<{recommendation: Recommendation}> = ({recomme
 
     return (
         <TableRow className='group hover:cursor-pointer' testId='recommendation-list-item' onClick={showDetails}>
-            <TableCell className='w-80'>
-                <div className='flex items-center gap-3'>
-                    <RecommendationIcon isGhostSite={isGhostSite} {...recommendation} />
-                    <span className='line-clamp-1 font-medium'>{recommendation.title}</span>
+            <Inline className='w-full' gap='none'>
+                <div className='grow py-3 pr-6'>
+                    <Inline gap='md'>
+                        <RecommendationIcon isGhostSite={isGhostSite} {...recommendation} />
+                        <span className='line-clamp-1 font-medium'>{recommendation.title}</span>
+                    </Inline>
                 </div>
-            </TableCell>
-            <TableCell
-                className='hidden w-auto text-left align-middle whitespace-nowrap md:visible! md:table-cell!'
-            >
-                {count === 0 ? (
-                    <span className="text-grey-500 dark:text-grey-900">-</span>
-                ) : (
-                    <>
+                <div className='hidden py-3 pr-6 text-left whitespace-nowrap md:block'>
+                    {count === 0 ? (
+                        <span className="text-muted-foreground">-</span>
+                    ) : (
                         <div className='flex items-center'>
                             <div className='mr-2'>
                                 <span>{formatNumber(count)}</span>
@@ -59,9 +58,9 @@ const RecommendationItem: React.FC<{recommendation: Recommendation}> = ({recomme
                                 <span className='invisible group-hover:visible'> from you</span>
                             </div>
                         </div>
-                    </>
-                )}
-            </TableCell>
+                    )}
+                </div>
+            </Inline>
         </TableRow>
     );
 };


### PR DESCRIPTION
## What changed

- Render newsletter list columns as flex content within the legacy `TableRow` cell.
- Apply the same valid structure to outgoing and incoming recommendation lists.
- Remove the latent invalid nesting from the webhooks table.

## Why

The legacy `TableRow` component already renders a spanning `<td>` containing layout `<div>` elements. These lists passed `TableCell` and `TableHead` children into it, producing `<td>` or `<th>` elements beneath `<div>` and triggering `validateDOMNesting` warnings in Admin acceptance-test logs.

The current full Admin acceptance log contained three occurrences across the newsletter and recommendations suites. A source scan found the same pattern in incoming recommendations and webhooks, so those are included as well.

## Testing

- `pnpm nx run @tryghost/admin:test:acceptance -- src/settings/membership/member-welcome-emails.acceptance.test.tsx src/settings/email/newsletters.acceptance.test.tsx src/settings/growth/recommendations.acceptance.test.tsx` (42 tests; no DOM-nesting warnings)
- `pnpm nx run @tryghost/admin-x-settings:lint`
- `pnpm nx run @tryghost/admin-x-settings:test:unit` (203 tests)