### PR TITLE
Fixed unsaved changes guard for sidebar navigation on React member details

### DIFF
--- a/apps/admin/src/hooks/use-hash-link-navigation-guard.ts
+++ b/apps/admin/src/hooks/use-hash-link-navigation-guard.ts
@@ -1,0 +1,57 @@
+import React from 'react';
+
+/**
+ * Guards navigations that bypass react-router: plain `<a href="#/…">` anchors
+ * (the admin sidebar, links into Ember-owned routes). Those clicks create a
+ * browser-native history entry that reaches react-router as an untracked POP,
+ * which `useBlocker` cannot intercept — so without this, a dirty screen is
+ * silently abandoned.
+ *
+ * Ports Ember's proven approach 1:1 (`ghost/admin/app/initializers/trailing-hash.js`):
+ * a capture-phase document click listener that, while `when` is true,
+ * intercepts unmodified left-clicks on hash anchors and hands the target href
+ * back to the caller to confirm. Links rendered by react-router (marked with
+ * `data-discover`) are left alone — the router's own blocker guards those.
+ */
+export function useHashLinkNavigationGuard(when: boolean) {
+    const [blockedHref, setBlockedHref] = React.useState<string | null>(null);
+    const whenRef = React.useRef(when);
+    whenRef.current = when;
+
+    React.useEffect(() => {
+        const onClick = (event: MouseEvent) => {
+            if (!whenRef.current || event.defaultPrevented) {
+                return;
+            }
+            // Preserve new-tab/new-window behavior for modified clicks,
+            // matching the Ember handler.
+            if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button !== 0) {
+                return;
+            }
+            const anchor = (event.target as Element).closest?.('a[href^="#/"]');
+            if (!anchor || anchor.hasAttribute('data-discover')) {
+                return;
+            }
+            event.preventDefault();
+            event.stopPropagation();
+            setBlockedHref(anchor.getAttribute('href'));
+        };
+
+        document.addEventListener('click', onClick, true);
+        return () => document.removeEventListener('click', onClick, true);
+    }, []);
+
+    return {
+        blockedHref,
+        isBlocked: blockedHref !== null,
+        /** Confirm leaving: performs the intercepted navigation for real. */
+        proceed: () => {
+            if (blockedHref) {
+                setBlockedHref(null);
+                window.location.hash = blockedHref;
+            }
+        },
+        /** Cancel leaving: drops the intercepted navigation. */
+        reset: () => setBlockedHref(null)
+    };
+}

--- a/apps/admin/src/members/detail/member-detail-leave-guard.acceptance.test.tsx
+++ b/apps/admin/src/members/detail/member-detail-leave-guard.acceptance.test.tsx
@@ -1,0 +1,65 @@
+import {describe, expect, it} from 'vitest';
+import {page} from 'vitest/browser';
+
+import {fakeAdminEndpoint, fakeMembers, member, renderAdminApp, type Member} from '@test-utils/acceptance';
+
+const FLAGS = {labs: {memberDetailsReact: true}};
+
+function fakeMemberDetailWorld(m: Member) {
+    fakeMembers([m]);
+    fakeAdminEndpoint('GET', new RegExp(`^/members/${m.id}/`), {members: [m]});
+    fakeAdminEndpoint('GET', new RegExp('^/members/events/'), {
+        events: [],
+        meta: {pagination: {page: 1, limit: 5, pages: 1, total: 0, next: null, prev: null}}
+    });
+}
+
+/**
+ * The unsaved-changes guard must cover BOTH ways of leaving the screen:
+ *
+ * - react-router navigations (the breadcrumb Link) — guarded by `useBlocker`.
+ * - native `<a href="#/…">` anchors (the admin sidebar, links into
+ *   Ember-owned routes) — those create a history entry react-router didn't
+ *   make and reach it as an untracked POP it cannot block, so they're guarded
+ *   separately by `useHashLinkNavigationGuard` (the React port of Ember's
+ *   `trailing-hash.js` click interception).
+ */
+describe('Member detail leave guard', () => {
+    it('guards leaving via the breadcrumb (react-router link) with unsaved edits', async () => {
+        const m = member({name: 'Ada Lovelace'});
+        fakeMemberDetailWorld(m);
+        await renderAdminApp(`/members/${m.id}`, FLAGS);
+
+        await page.getByLabelText('Name').fill('Ada B');
+        await page.getByTestId('member-detail').getByRole('link', {name: 'Members'}).click();
+
+        await expect.element(page.getByText('Discard unsaved changes?')).toBeVisible();
+    });
+
+    it('guards leaving via the sidebar (native hash anchor) with unsaved edits', async () => {
+        const m = member({name: 'Ada Lovelace'});
+        fakeMemberDetailWorld(m);
+        await renderAdminApp(`/members/${m.id}`, FLAGS);
+
+        await page.getByLabelText('Name').fill('Ada B');
+        await page.getByRole('link', {name: 'Members'}).first().click();
+
+        await expect.element(page.getByText('Discard unsaved changes?')).toBeVisible();
+    });
+
+    it('keeps editing on cancel and completes the navigation on Leave', async () => {
+        const m = member({name: 'Ada Lovelace'});
+        fakeMemberDetailWorld(m);
+        await renderAdminApp(`/members/${m.id}`, FLAGS);
+
+        await page.getByLabelText('Name').fill('Ada B');
+        await page.getByRole('link', {name: 'Members'}).first().click();
+
+        await page.getByRole('button', {name: 'Keep editing'}).click();
+        await expect.element(page.getByLabelText('Name')).toHaveValue('Ada B');
+
+        await page.getByRole('link', {name: 'Members'}).first().click();
+        await page.getByRole('button', {name: 'Leave'}).click();
+        await expect.element(page.getByText('New member')).toBeVisible();
+    });
+});

--- a/apps/admin/src/members/detail/member-detail.tsx
+++ b/apps/admin/src/members/detail/member-detail.tsx
@@ -20,6 +20,7 @@ import {toast} from 'sonner';
 import {useBlocker} from 'react-router';
 import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
 import {useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
+import {useHashLinkNavigationGuard} from '@/hooks/use-hash-link-navigation-guard';
 import type {MemberEditableFields} from './member-detail-edit';
 
 // The create screen reuses this route with the sentinel id "new". Safe because
@@ -275,7 +276,13 @@ const MemberDetailPage: React.FC<MemberDetailPageProps> = ({paidMembersEnabled, 
 
     useConfirmUnload(activeMutation.isPending || hasUnsavedChanges);
     const blocker = useBlocker(({currentLocation, nextLocation}) => !bypassGuardRef.current && hasUnsavedChanges && currentLocation.pathname !== nextLocation.pathname);
-    const isBlocked = blocker.state === 'blocked';
+    // Native `<a href="#/…">` navigations (the sidebar, links into Ember
+    // routes) never reach the react-router blocker above — see the hook.
+    // Ember's own guard (`trailing-hash.js`) can't cover this screen either:
+    // with `memberDetailsReact` on, the Ember member route aborts and never
+    // registers into the `unsaved-changes` service.
+    const anchorGuard = useHashLinkNavigationGuard(hasUnsavedChanges);
+    const isBlocked = blocker.state === 'blocked' || anchorGuard.isBlocked;
 
     // Save button state (Save / Saving / Saved / Retry), mirroring the Ember task button.
     let saveLabel: React.ReactNode = 'Save';
@@ -448,6 +455,7 @@ const MemberDetailPage: React.FC<MemberDetailPageProps> = ({paidMembersEnabled, 
                 <AlertDialog open={isBlocked} onOpenChange={(open) => {
                     if (!open && isBlocked) {
                         blocker.reset?.();
+                        anchorGuard.reset();
                     }
                 }}>
                     <AlertDialogContent>
@@ -457,7 +465,13 @@ const MemberDetailPage: React.FC<MemberDetailPageProps> = ({paidMembersEnabled, 
                         </AlertDialogHeader>
                         <AlertDialogFooter>
                             <AlertDialogCancel>Keep editing</AlertDialogCancel>
-                            <Button variant='destructive' onClick={() => blocker.proceed?.()}>Leave</Button>
+                            <Button variant='destructive' onClick={() => {
+                                if (anchorGuard.isBlocked) {
+                                    anchorGuard.proceed();
+                                } else {
+                                    blocker.proceed?.();
+                                }
+                            }}>Leave</Button>
                         </AlertDialogFooter>
                     </AlertDialogContent>
                 </AlertDialog>

--- a/e2e/helpers/pages/admin/sidebar/sidebar-page.ts
+++ b/e2e/helpers/pages/admin/sidebar/sidebar-page.ts
@@ -53,7 +53,10 @@ export class SidebarPage extends AdminPage {
 
     constructor(page: Page) {
         super(page);
-        this.sidebar = page.getByRole('navigation');
+        // The admin renders more than one navigation landmark (React screens
+        // carry a breadcrumb <nav aria-label="breadcrumb"> too), so anchor on
+        // the site search control, which only the sidebar contains.
+        this.sidebar = page.getByRole('navigation').filter({has: page.getByRole('button', {name: /Search site/})});
         this.postsToggle = this.sidebar.getByRole('button', {name: sidebarSel.postsToggle});
         this.userDropdownTrigger = page.getByRole('button', {name: sidebarSel.userMenuTrigger});
         this.appearanceMenuItem = page.getByRole('menuitem', {name: sidebarSel.appearanceMenuItem});

--- a/e2e/tests/admin/members/member-detail.test.ts
+++ b/e2e/tests/admin/members/member-detail.test.ts
@@ -1,4 +1,4 @@
-import {MemberDetailsPage} from '@/admin-pages';
+import {MemberDetailsPage, SidebarPage} from '@/admin-pages';
 import {MemberFactory, createMemberFactory} from '@/data-factory';
 import {Page} from '@playwright/test';
 import {expect, test} from '@/helpers/playwright';
@@ -309,6 +309,22 @@ for (const {implementation, memberDetailsReact} of [
             await page.goto(memberPath(member.id));
             await memberDetailsPage.nameInput.fill('Grace B. Hopper');
             await memberDetailsPage.membersBackLink.click();
+
+            await expect(memberDetailsPage.confirmLeaveButton).toBeVisible();
+            await memberDetailsPage.confirmLeaveButton.click();
+            await expect(page).toHaveURL(/#\/members$/);
+        });
+
+        test('leaving with unsaved changes via the sidebar - warns before navigating away', async ({page}) => {
+            // The sidebar navigates with native hash anchors rather than
+            // client-side router links, so it exercises a different guard path
+            // than the back link above; both must warn.
+            const sidebar = new SidebarPage(page);
+            const member = await memberFactory.create({name: 'Grace Hopper', email: 'grace-unsaved-sidebar@ghost.org'});
+
+            await page.goto(memberPath(member.id));
+            await memberDetailsPage.nameInput.fill('Grace B. Hopper');
+            await sidebar.getNavLink('Members').click();
 
             await expect(memberDetailsPage.confirmLeaveButton).toBeVisible();
             await memberDetailsPage.confirmLeaveButton.click();


### PR DESCRIPTION
## Describe the problem you are solving

On the React member details screen (behind the `memberDetailsReact` flag), leaving via the admin sidebar with unsaved edits silently discarded them. The sidebar and links into Ember-owned routes are native `<a href="#/…">` anchors: they create a history entry react-router didn't make, so they reach it as an untracked POP that `useBlocker` cannot intercept. Ember's own guard (the `trailing-hash.js` click interception) can't cover the screen either — with the flag on, the Ember member route aborts and never registers with the `unsaved-changes` service. On the Ember screen (flag off) every navigation shows the confirm modal, so this was a regression introduced by the React port.

## Changelog for devs

* Added a `useHashLinkNavigationGuard` hook: a React port of Ember's `trailing-hash.js` capture-phase click interception for `a[href^="#/"]` anchors. Links rendered by react-router (`data-discover`) are excluded — `useBlocker` keeps guarding those.
* Fixed the member details screen silently discarding unsaved edits on sidebar/native-anchor navigation; both guards feed the screen's existing "Discard unsaved changes?" dialog.
* Added acceptance tests covering both leave paths (react-router breadcrumb, native sidebar anchor) and the cancel/leave lifecycle.
* Added a sidebar-leave test to the Ember/React e2e parity suite (`e2e/tests/admin/members/member-detail.test.ts`). The existing unsaved-changes test only left via the breadcrumb (the react-router path), so the sidebar gap was invisible to it; the new test runs in the shared block, so both implementations must warn.
* Fixed the e2e `SidebarPage` navigation locator: React detail screens also render a breadcrumb `<nav>` landmark, which made the bare `getByRole('navigation')` ambiguous. It now anchors on the site search control, which only the sidebar contains.

## Changelog for customers

* Fixed a bug where unsaved edits on the member details screen were silently lost when navigating away via the sidebar (behind the `memberDetailsReact` flag).

## Notes

* The same gap likely affects other React screens that rely on `useBlocker` alone (e.g. the automations editor). The hook is reusable; this PR only wires it into member details to keep the change minimal.
* Found while testing membership custom fields (BER-3800); split into its own PR so it can land independently.
* Guard coverage now exists at two layers on purpose: the vitest acceptance tests are the fast per-change net for the React implementation; the e2e parity test pins Ember/React equivalence, which the component layer can't reach.

## Technical debt

* Two guard mechanisms coexist (react-router `useBlocker` + anchor interception) until admin navigation is unified under react-router; the hook documents why.

## PR Scope (mark all that apply)

- [x] Improves the user experience
- [ ] Enhances the readability of our code
- [ ] Simplifies the maintenance of our software
- [x] Fixes a bug
- [ ] Provide a core layer to allow one of the points above

## Checklist before requesting a review (mark all that apply)

- [x] I have performed a self-review of my code
- [x] It's simple enough
- [x] The PR is not extensive
- [ ] It includes documentation
- [x] I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.