### PR TITLE
Added archive, restore and delete to member custom fields API

### DIFF
--- a/apps/admin-x-framework/src/api/actions.ts
+++ b/apps/admin-x-framework/src/api/actions.ts
@@ -199,6 +199,8 @@ export const getActionTitle = (action: Action) => {
         resourceType = 'gift link';
     } else if (resourceType === 'security_action') {
         resourceType = 'security action';
+    } else if (resourceType === 'member_custom_field') {
+        resourceType = 'custom field';
     }
 
     // Because a `page` and `post` both use the same model, we store the

--- a/apps/admin-x-framework/test/unit/api/actions.test.ts
+++ b/apps/admin-x-framework/test/unit/api/actions.test.ts
@@ -44,5 +44,14 @@ describe('actions api helpers', () => {
                 context: {action_name: 'reset_authentication'}
             }))).toBe('Security action reset authentication');
         });
+
+        it('formats custom field definition actions across the lifecycle', () => {
+            const title = (event: string) => getActionTitle(baseAction({resource_type: 'member_custom_field', event}));
+            expect(title('added')).toBe('Custom field added');
+            expect(title('edited')).toBe('Custom field edited');
+            expect(title('archived')).toBe('Custom field archived');
+            expect(title('restored')).toBe('Custom field restored');
+            expect(title('deleted')).toBe('Custom field deleted');
+        });
     });
 });

--- a/ghost/core/core/server/api/endpoints/member-custom-fields.ts
+++ b/ghost/core/core/server/api/endpoints/member-custom-fields.ts
@@ -35,15 +35,17 @@ const controller = {
 
     browse: {
         headers: noCacheInvalidation,
-        // No filter/pagination/order options: the definition list is small and
-        // global, and returned whole in a fixed order. (A future sort_order column
-        // would change the order server-side, not add a client option.)
-        options: [],
+        // `filter` narrows by status (the definition list is otherwise small and
+        // global, returned whole in a fixed order). Archived fields are hidden by
+        // default; Settings passes `filter=status:[active,archived]` to see both.
+        // No pagination/order options — a future sort_order column would change the
+        // order server-side, not add a client option.
+        options: ['filter'],
         permissions(frame: Frame) {
             return canThis(frame).browse.member_custom_field();
         },
-        query() {
-            return definitions!.browse();
+        query(frame: Frame) {
+            return definitions!.browse({filter: frame.options.filter as string | undefined});
         }
     },
 

--- a/ghost/core/core/server/services/members-custom-fields/actions.ts
+++ b/ghost/core/core/server/services/members-custom-fields/actions.ts
@@ -13,23 +13,32 @@ export interface ActionRecorder {
     add(data: Record<string, unknown>, options: {autoRefresh: boolean}): Promise<unknown>;
 }
 
-// Field-definition changes map to activity-feed events. Fields are archived, not
-// deleted, so the timeline reads added -> edited -> archived.
+// Field-definition changes map to activity-feed events. A field's timeline reads
+// added -> edited -> archived -> restored, and a permanent delete (only from the
+// archived state) ends it with deleted.
 const COMMANDS = {
     create: 'added',
     rename: 'edited',
-    archive: 'archived'
-} as const satisfies Record<string, 'added' | 'edited' | 'archived'>;
+    archive: 'archived',
+    restore: 'restored',
+    delete: 'deleted'
+} as const satisfies Record<string, 'added' | 'edited' | 'archived' | 'restored' | 'deleted'>;
 
 export type CustomFieldVerb = keyof typeof COMMANDS;
 
+// `details` is stored in the action's `context` column (Ghost's slot for "diffs,
+// meta"). We always pass the field's `primary_name` so the log reads as a human
+// label, not a bare key — this is what keeps the timeline legible after a hard
+// delete, when the row itself is gone.
+export type CustomFieldActionDetails = {primary_name: string; previous_name?: string};
+
 export type RecordCustomFieldAction =
-    (input: {context: RequestContext; verb: CustomFieldVerb; subject: string}) => Promise<void>;
+    (input: {context: RequestContext; verb: CustomFieldVerb; subject: string; details: CustomFieldActionDetails}) => Promise<void>;
 
 // Best-effort action-log write: a failed action must never fail the command that triggered it.
 export async function recordCustomFieldAction(
-    {Action, context, verb, subject}:
-    {Action: ActionRecorder; context: RequestContext; verb: CustomFieldVerb; subject: string}
+    {Action, context, verb, subject, details}:
+    {Action: ActionRecorder; context: RequestContext; verb: CustomFieldVerb; subject: string; details: CustomFieldActionDetails}
 ): Promise<void> {
     if (!context.actor) {
         return;
@@ -40,7 +49,8 @@ export async function recordCustomFieldAction(
             resource_type: 'member_custom_field',
             resource_id: subject,
             actor_type: context.actor.type,
-            actor_id: context.actor.id
+            actor_id: context.actor.id,
+            context: details
         }, {autoRefresh: false});
     } catch (err) {
         logging.error(err);

--- a/ghost/core/core/server/services/members-custom-fields/definitions-service.ts
+++ b/ghost/core/core/server/services/members-custom-fields/definitions-service.ts
@@ -5,12 +5,19 @@ import {z} from 'zod';
 import {CustomField} from './models';
 import {FieldTypeSchema} from '@tryghost/custom-field-types';
 import {customFieldCodec} from './codec';
-import {FIELD_STATUS} from './schema';
+import {FIELD_STATUS, FieldStatusSchema} from './schema';
 import {activeFields} from './queries';
 import {type RecordCustomFieldAction, type RequestContext} from './actions';
 
 // @tryghost/string ships no types; slugify is the same helper tags/labels use.
 const {slugify} = require('@tryghost/string') as {slugify(input: string): string};
+
+// The same NQL -> knex bridge Bookshelf's filter plugin uses, applied directly to
+// our raw-knex query: nql parses the `filter` string to a Mongo query, mongo-knex
+// turns that into parametrised WHERE clauses. Neither needs a Bookshelf model.
+const nql = require('@tryghost/nql') as (filter: string) => {toJSON(): object};
+const knexify = require('@tryghost/mongo-knex') as
+    <T extends Knex.QueryBuilder>(qb: T, mongoQuery: object, config: {tableName: string}) => T;
 
 const TABLE = 'members_custom_fields';
 
@@ -33,10 +40,11 @@ const AddFieldInput = z.object({
     type: FieldTypeSchema
 });
 
-// Only the name is mutable. `key` and `type` are accepted so the immutability
+// Name and status are mutable. `key` and `type` are accepted so the immutability
 // rules can reject a change loudly; they are never persisted.
 const EditFieldInput = z.object({
     name: FieldName.optional(),
+    status: FieldStatusSchema.optional(),
     key: z.string().optional(),
     type: FieldTypeSchema.optional()
 });
@@ -50,11 +58,18 @@ export class CustomFieldDefinitionsService {
         this.recordAction = recordAction;
     }
 
-    async browse(): Promise<CustomField[]> {
-        // Active fields only; archived fields are retained (so their key stays
-        // reserved) but hidden. Insertion order for now — when the UI needs a
-        // persistent user-defined order, add a `sort_order` column and order by it.
-        const rows = await activeFields(this.knex)
+    async browse(options: {filter?: string} = {}): Promise<CustomField[]> {
+        // Archived fields are hidden by default: most surfaces (member details, the
+        // filter picker, the importer) only ever want active fields. A caller-
+        // supplied `filter` can widen that — Settings pulls active and archived
+        // together in one request (`filter=status:[active,archived]`).
+        //
+        // Insertion order for now — when the UI needs a persistent user-defined
+        // order, add a `sort_order` column and order by it.
+        const query = options.filter
+            ? applyFilter(this.knex(TABLE), options.filter)
+            : activeFields(this.knex);
+        const rows = await query
             .orderBy('created_at', 'asc')
             .orderBy('id', 'asc')
             .select('*');
@@ -95,7 +110,7 @@ export class CustomFieldDefinitionsService {
             }
             throw err;
         }
-        await this.recordAction({context, verb: 'create', subject: key});
+        await this.recordAction({context, verb: 'create', subject: key, details: {primary_name: parsed.data.name}});
         return this.read(key);
     }
 
@@ -177,16 +192,28 @@ export class CustomFieldDefinitionsService {
                 }
                 throw err;
             }
-            await this.recordAction({context, verb: 'rename', subject: key});
+            await this.recordAction({context, verb: 'rename', subject: key, details: {primary_name: patch.name, previous_name: existing.name}});
+        }
+
+        // A status change is the archive/restore transition. Only write (and log)
+        // when it actually flips, so re-sending the current status is a no-op.
+        if (patch.status !== undefined && patch.status !== existing.status) {
+            await this.knex(TABLE)
+                .where('key', key)
+                .update({status: patch.status, updated_at: new Date()});
+            const verb = patch.status === FIELD_STATUS.archived ? 'archive' : 'restore';
+            await this.recordAction({context, verb, subject: key, details: {primary_name: patch.name ?? existing.name}});
         }
 
         return this.read(key);
     }
 
     /**
-     * Archive a field (soft delete): it drops out of `browse`, but its row and key
-     * are kept forever, so the slug can never be reused and any values stay
-     * attached to the right definition. Idempotent — re-archiving is a no-op.
+     * Permanently delete a field and every member value attached to it (the FK
+     * cascades the values). Destructive and irreversible, so it's gated on the
+     * field already being archived: a publisher must archive first, then delete,
+     * which makes accidental data loss a deliberate two-step. Archiving is the
+     * reversible soft state (see `edit` with a status change).
      */
     async destroy(context: RequestContext, key: string): Promise<void> {
         const field = await this.knex(TABLE).where('key', key).first();
@@ -194,13 +221,48 @@ export class CustomFieldDefinitionsService {
             throw new errors.NotFoundError({message: 'Custom field not found.'});
         }
         if (field.status !== FIELD_STATUS.archived) {
-            await this.knex(TABLE).where('key', key).update({status: FIELD_STATUS.archived, updated_at: new Date()});
-            await this.recordAction({context, verb: 'archive', subject: key});
+            throw new errors.ValidationError({message: 'Only archived custom fields can be deleted. Archive the field first.'});
         }
+        await this.knex(TABLE).where('key', key).del();
+        await this.recordAction({context, verb: 'delete', subject: key, details: {primary_name: field.name}});
     }
 }
 
 function isUniqueConstraintViolation(error: unknown): boolean {
     const code = (error as {code?: string})?.code;
     return code === 'ER_DUP_ENTRY' || code === 'SQLITE_CONSTRAINT';
+}
+
+// Apply a caller-supplied NQL filter to the definition query. A malformed filter
+// is a client error (400), not a 500. The active-only default is preserved unless
+// the filter itself constrains status, so a filter on another field (e.g. type)
+// can never surface archived fields — this is the invariant queries.ts centralises,
+// held here as the per-field default override Bookshelf's filter plugin does.
+function applyFilter<T extends Knex.QueryBuilder>(query: T, filter: string): T {
+    let mongoQuery: Record<string, unknown>;
+    try {
+        mongoQuery = nql(filter).toJSON() as Record<string, unknown>;
+        knexify(query, mongoQuery, {tableName: TABLE});
+    } catch (err) {
+        throw new errors.BadRequestError({message: 'Could not parse the filter parameter.', property: 'filter', err: err as Error});
+    }
+    if (!filterReferencesStatus(mongoQuery)) {
+        query.where('status', FIELD_STATUS.active);
+    }
+    return query;
+}
+
+// Whether an NQL-parsed filter constrains `status` anywhere, including inside the
+// $and/$or/$nor combinators — so a status filter at any nesting counts as the
+// caller opting in to (or out of) archived fields.
+function filterReferencesStatus(query: Record<string, unknown>): boolean {
+    return Object.entries(query).some(([key, value]) => {
+        if (key === 'status') {
+            return true;
+        }
+        if ((key === '$and' || key === '$or' || key === '$nor') && Array.isArray(value)) {
+            return value.some(sub => filterReferencesStatus(sub as Record<string, unknown>));
+        }
+        return false;
+    });
 }

--- a/ghost/core/core/server/services/members-custom-fields/index.ts
+++ b/ghost/core/core/server/services/members-custom-fields/index.ts
@@ -26,8 +26,8 @@ export function init(): void {
     const {knex} = require('../../data/db');
     const models = require('../../models');
 
-    const recordAction: RecordCustomFieldAction = ({context, verb, subject}) =>
-        recordCustomFieldAction({Action: models.Action, context, verb, subject});
+    const recordAction: RecordCustomFieldAction = ({context, verb, subject, details}) =>
+        recordCustomFieldAction({Action: models.Action, context, verb, subject, details});
 
     definitions = new CustomFieldDefinitionsService({knex, recordAction});
     // The values service reads the field definitions straight from the table, so

--- a/ghost/core/core/server/services/members-custom-fields/models.ts
+++ b/ghost/core/core/server/services/members-custom-fields/models.ts
@@ -1,5 +1,6 @@
 import {z} from 'zod';
 import {FieldTypeSchema} from '@tryghost/custom-field-types';
+import {FieldStatusSchema} from './schema';
 
 // The domain shape of a field definition (camelCase; distinct from the DB row).
 export const CustomField = z.object({
@@ -7,6 +8,7 @@ export const CustomField = z.object({
     key: z.string(),
     name: z.string(),
     type: FieldTypeSchema,
+    status: FieldStatusSchema,
     createdAt: z.date(),
     updatedAt: z.date().nullable()
 });

--- a/ghost/core/core/server/services/members-custom-fields/schema.ts
+++ b/ghost/core/core/server/services/members-custom-fields/schema.ts
@@ -3,32 +3,31 @@ import type {Knex} from 'knex';
 import {FieldTypeSchema} from '@tryghost/custom-field-types';
 import {DbDate} from '../../lib/db-date';
 
+// A field's lifecycle state. `archived` is a soft state: the field drops out of
+// the values path but stays visible in the definition list (with its status) so
+// admins can find, rename, restore, or permanently delete it. The values mirror
+// schema.js's `isIn` constraint on the column — which is static config and can't
+// import this, so that one stays literal with a pointer back here.
+export const FIELD_STATUS = {active: 'active', archived: 'archived'} as const;
+export type FieldStatus = typeof FIELD_STATUS[keyof typeof FIELD_STATUS];
+export const FieldStatusSchema = z.enum([FIELD_STATUS.active, FIELD_STATUS.archived]);
+
 // The members_custom_fields row: the single source for the read projection and the
 // knex table type below. `type` is validated as the field-type enum here (the DB
 // only stores registered types), so the row already carries the narrow type and
-// the definition codec needs no cast.
+// the definition codec needs no cast. `status` travels with the row: it's part of
+// the read projection so the definition list can group active vs archived.
 export const DbCustomField = z.object({
     id: z.string(),
     key: z.string(),
     name: z.string(),
     type: FieldTypeSchema,
+    status: FieldStatusSchema,
     created_at: DbDate,
     updated_at: DbDate.nullable()
 });
 
-// A field's lifecycle state. Persistence-only: the domain CustomField doesn't
-// carry it (archived-ness is how the store soft-deletes, not something publishers
-// see), so it lives here with the row type rather than in models.ts. The values
-// mirror schema.js's `isIn` constraint on the column — which is static config and
-// can't import this, so that one stays literal with a pointer back here.
-export const FIELD_STATUS = {active: 'active', archived: 'archived'} as const;
-export type FieldStatus = typeof FIELD_STATUS[keyof typeof FIELD_STATUS];
-
-// The stored row also carries `status`. It's the persistence concern above, so it
-// lives only in the knex row type here, not in the codec schema. DB-defaulted to
-// 'active' on create and only ever set via update (archive), so it's absent from
-// the insert type.
-type CustomFieldRow = z.infer<typeof DbCustomField> & {status: FieldStatus};
+type CustomFieldRow = z.infer<typeof DbCustomField>;
 
 // A member's stored value for one field. `value_text`/`value_json` are the raw
 // columns — which one carries the value, and how it decodes, is the storage
@@ -60,7 +59,9 @@ declare module 'knex/types/tables' {
     interface Tables {
         members_custom_fields: Knex.CompositeTableType<
             CustomFieldRow,
-            Omit<z.input<typeof DbCustomField>, 'updated_at'>,
+            // `status` is DB-defaulted to 'active' on create and only ever set via
+            // update (archive/restore), so it's absent from the insert type.
+            Omit<z.input<typeof DbCustomField>, 'updated_at' | 'status'>,
             Partial<CustomFieldRow>
         >;
         members_custom_field_values: Knex.CompositeTableType<

--- a/ghost/core/core/server/services/members-custom-fields/serializers.ts
+++ b/ghost/core/core/server/services/members-custom-fields/serializers.ts
@@ -9,6 +9,7 @@ const CustomFieldResource = z.object({
     key: z.string(),
     name: z.string(),
     type: z.string(),
+    status: z.string(),
     created_at: z.date(),
     updated_at: z.date().nullable()
 });

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -120,6 +120,7 @@
     "@tryghost/logging": "catalog:",
     "@tryghost/members-csv": "2.0.7",
     "@tryghost/metrics": "1.0.43",
+    "@tryghost/mongo-knex": "catalog:",
     "@tryghost/mongo-utils": "0.6.5",
     "@tryghost/mw-error-handler": "1.0.13",
     "@tryghost/mw-vhost": "1.0.6",

--- a/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
@@ -24,6 +24,16 @@ describe('Member Custom Fields Admin API', function () {
         return body.members_custom_fields[0];
     }
 
+    // Archiving is a status change over the same PUT the rename uses (no dedicated
+    // /archive route), matching how newsletters move between active and archived.
+    async function setStatus(key: string, status: 'active' | 'archived') {
+        const {body} = await agent
+            .put(`members/custom_fields/${key}/`)
+            .body({members_custom_fields: [{status}]})
+            .expectStatus(200);
+        return body.members_custom_fields[0];
+    }
+
     let memberCounter = 0;
     async function createMember(): Promise<string> {
         memberCounter += 1;
@@ -76,6 +86,9 @@ describe('Member Custom Fields Admin API', function () {
             assert.equal(created.key, 'favourite-topic');
             assert.equal(created.name, 'Favourite topic');
             assert.equal(created.type, 'short_text');
+            // A new field is active; status travels with the definition so the UI
+            // can group active and archived fields from one list.
+            assert.equal(created.status, 'active');
             // id is the DB primary key and must never be exposed over the API.
             assert.equal(created.id, undefined);
 
@@ -173,16 +186,69 @@ describe('Member Custom Fields Admin API', function () {
             await agent.delete(`members/custom_fields/${missing}/`).expectStatus(404);
         });
 
+        it('hides archived fields from the default list', async function () {
+            const active = await createField({name: 'Favourite topic'});
+            const archived = await createField({name: 'Company'});
+            await setStatus(archived.key, 'archived');
+
+            const list = (await agent.get('members/custom_fields/').expectStatus(200)).body.members_custom_fields;
+            assert.equal(list.length, 1);
+            assert.equal(list[0].key, active.key);
+            assert.equal(list[0].status, 'active');
+        });
+
+        it('includes archived fields when the caller filters by status', async function () {
+            const active = await createField({name: 'Favourite topic'});
+            const archived = await createField({name: 'Company'});
+            await setStatus(archived.key, 'archived');
+
+            // Settings pulls active and archived in one request by overriding the
+            // active-only default with an explicit status filter.
+            const both = (await agent.get('members/custom_fields/?filter=status:[active,archived]').expectStatus(200))
+                .body.members_custom_fields;
+            const byKey = Object.fromEntries(both.map((f: {key: string}) => [f.key, f]));
+            assert.equal(both.length, 2);
+            assert.equal(byKey[active.key].status, 'active');
+            assert.equal(byKey[archived.key].status, 'archived');
+
+            // And archived-only for a dedicated view.
+            const onlyArchived = (await agent.get('members/custom_fields/?filter=status:archived').expectStatus(200))
+                .body.members_custom_fields;
+            assert.equal(onlyArchived.length, 1);
+            assert.equal(onlyArchived[0].key, archived.key);
+        });
+
+        it('keeps archived fields hidden when filtering on a non-status field', async function () {
+            // A filter that doesn't mention status must not surface archived fields:
+            // the active-only default still applies, so filtering by (say) type
+            // can't leak them.
+            const active = await createField({name: 'Favourite topic', type: 'short_text'});
+            const archived = await createField({name: 'Company', type: 'short_text'});
+            await setStatus(archived.key, 'archived');
+
+            const list = (await agent.get('members/custom_fields/?filter=type:short_text').expectStatus(200))
+                .body.members_custom_fields;
+            assert.equal(list.length, 1);
+            assert.equal(list[0].key, active.key);
+        });
+
+        it('rejects a malformed filter with a 400 rather than a 500', async function () {
+            await createField({name: 'Favourite topic'});
+            await agent.get('members/custom_fields/?filter=' + encodeURIComponent('status:')).expectStatus(400);
+        });
+
         it('archives a field, keeping its name and slug reserved', async function () {
             const first = await createField({name: 'Favourite topic'});
 
-            await agent.delete(`members/custom_fields/${first.key}/`).expectStatus(204);
+            const archived = await setStatus(first.key, 'archived');
+            assert.equal(archived.status, 'archived');
 
-            // Archived: dropped from the active list...
-            const list = (await agent.get('members/custom_fields/').expectStatus(200)).body;
-            assert.deepEqual(list.members_custom_fields, []);
+            // Archived: gone from the default list...
+            const list = (await agent.get('members/custom_fields/').expectStatus(200)).body.members_custom_fields;
+            assert.deepEqual(list, []);
 
-            // ...its name stays reserved (uniqueness spans archived fields too)...
+            // ...but still there, so its name stays reserved (uniqueness spans
+            // archived fields too)...
             await agent
                 .post('members/custom_fields/')
                 .body({members_custom_fields: [{name: 'Favourite topic', type: 'short_text'}]})
@@ -194,9 +260,20 @@ describe('Member Custom Fields Admin API', function () {
             assert.equal(second.key, 'favourite-topic-2');
         });
 
+        it('restores an archived field', async function () {
+            const field = await createField({name: 'Favourite topic'});
+            await setStatus(field.key, 'archived');
+
+            const restored = await setStatus(field.key, 'active');
+            assert.equal(restored.status, 'active');
+
+            const read = (await agent.get(`members/custom_fields/${field.key}/`).expectStatus(200)).body;
+            assert.equal(read.members_custom_fields[0].status, 'active');
+        });
+
         it('frees a name for reuse once the archived field is renamed', async function () {
             const original = await createField({name: 'Company'});
-            await agent.delete(`members/custom_fields/${original.key}/`).expectStatus(204);
+            await setStatus(original.key, 'archived');
 
             // The archived field still owns "Company", so rename it to release it...
             await agent
@@ -208,6 +285,34 @@ describe('Member Custom Fields Admin API', function () {
             const fresh = await createField({name: 'Company'});
             assert.equal(fresh.name, 'Company');
             assert.notEqual(fresh.key, original.key);
+        });
+
+        it('refuses to permanently delete an active field', async function () {
+            // Deleting is gated on the archived state: a publisher must archive
+            // first, so permanent data loss is always a deliberate two-step.
+            const field = await createField({name: 'Favourite topic'});
+
+            await agent.delete(`members/custom_fields/${field.key}/`).expectStatus(422);
+
+            const list = (await agent.get('members/custom_fields/').expectStatus(200)).body.members_custom_fields;
+            assert.equal(list.length, 1);
+        });
+
+        it('permanently deletes an archived field, freeing its name and slug', async function () {
+            const original = await createField({name: 'Favourite topic'});
+            await setStatus(original.key, 'archived');
+
+            await agent.delete(`members/custom_fields/${original.key}/`).expectStatus(204);
+
+            // Gone entirely — not in the list, and no longer readable.
+            const list = (await agent.get('members/custom_fields/').expectStatus(200)).body.members_custom_fields;
+            assert.deepEqual(list, []);
+            await agent.get(`members/custom_fields/${original.key}/`).expectStatus(404);
+
+            // The row is gone, so the name and its base slug are free again: a
+            // fresh field with the same name reclaims the original (unsuffixed) key.
+            const fresh = await createField({name: 'Favourite topic'});
+            assert.equal(fresh.key, 'favourite-topic');
         });
     });
 
@@ -407,7 +512,7 @@ describe('Member Custom Fields Admin API', function () {
         it('rejects a value for an archived field', async function () {
             const field = await createField({name: 'Favourite topic'});
             const memberId = await createMember();
-            await agent.delete(`members/custom_fields/${field.key}/`).expectStatus(204);
+            await setStatus(field.key, 'archived');
 
             await setValues(memberId, {[field.key]: 'Ghosts'}, 422);
         });
@@ -417,13 +522,27 @@ describe('Member Custom Fields Admin API', function () {
             const memberId = await createMember();
             await setValues(memberId, {[field.key]: 'Ghosts'});
 
-            await agent.delete(`members/custom_fields/${field.key}/`).expectStatus(204);
+            await setStatus(field.key, 'archived');
 
             assert.deepEqual(await readValues(memberId), {});
-            // The row survives archiving — the definition is what went away, and
-            // the value is still attached to it.
+            // The row survives archiving — only the definition was hidden, and the
+            // value is still attached to it (restoring the field brings it back).
             const rows = await models.Base.knex('members_custom_field_values').where('member_id', memberId);
             assert.equal(rows.length, 1);
+        });
+
+        it('drops a field\'s values when the field is permanently deleted', async function () {
+            const field = await createField({name: 'Favourite topic'});
+            const memberId = await createMember();
+            await setValues(memberId, {[field.key]: 'Ghosts'});
+
+            // Archive then delete — the FK cascade removes the member's value with
+            // the definition, so a permanent delete takes the data with it.
+            await setStatus(field.key, 'archived');
+            await agent.delete(`members/custom_fields/${field.key}/`).expectStatus(204);
+
+            const rows = await models.Base.knex('members_custom_field_values').where('member_id', memberId);
+            assert.equal(rows.length, 0);
         });
 
         it('rejects a value that is the wrong type for the field', async function () {
@@ -722,12 +841,87 @@ describe('Member Custom Fields Admin API', function () {
 
         it('records an "archived" action when a field is archived', async function () {
             const field = await createField({name: 'Favourite topic'});
-            await agent.delete(`members/custom_fields/${field.key}/`).expectStatus(204);
+            await setStatus(field.key, 'archived');
 
             const archived = (await customFieldActions()).find((a: {event: string}) => a.event === 'archived');
             assert.ok(archived, 'an archived action should be recorded');
             assert.equal(archived.resource_id, field.key);
             assert.equal(archived.actor_id, actorId);
+        });
+
+        it('records a "restored" action when an archived field is restored', async function () {
+            const field = await createField({name: 'Favourite topic'});
+            await setStatus(field.key, 'archived');
+            await setStatus(field.key, 'active');
+
+            const restored = (await customFieldActions()).find((a: {event: string}) => a.event === 'restored');
+            assert.ok(restored, 'a restored action should be recorded');
+            assert.equal(restored.resource_id, field.key);
+            assert.equal(restored.actor_id, actorId);
+        });
+
+        it('records no action when the status does not change', async function () {
+            const field = await createField({name: 'Favourite topic'});
+            await setStatus(field.key, 'active');
+
+            const archived = (await customFieldActions()).find((a: {event: string}) => a.event === 'archived');
+            const restored = (await customFieldActions()).find((a: {event: string}) => a.event === 'restored');
+            assert.equal(archived, undefined, 'a no-op status change should not record an action');
+            assert.equal(restored, undefined, 'a no-op status change should not record an action');
+        });
+
+        it('records a "deleted" action when an archived field is permanently deleted', async function () {
+            const field = await createField({name: 'Favourite topic'});
+            await setStatus(field.key, 'archived');
+            await agent.delete(`members/custom_fields/${field.key}/`).expectStatus(204);
+
+            const deleted = (await customFieldActions()).find((a: {event: string}) => a.event === 'deleted');
+            assert.ok(deleted, 'a deleted action should be recorded');
+            assert.equal(deleted.resource_id, field.key);
+            assert.equal(deleted.actor_id, actorId);
+        });
+
+        it('records the whole lifecycle as an ordered, attributed, named timeline', async function () {
+            // One field, driven through every transition over the public HTTP API;
+            // the assertions read only the action-log API, never the service.
+            const field = await createField({name: 'Delivery address'});
+            await agent
+                .put(`members/custom_fields/${field.key}/`)
+                .body({members_custom_fields: [{name: 'Shipping address'}]})
+                .expectStatus(200);
+            await setStatus(field.key, 'archived');
+            await setStatus(field.key, 'active');
+            await setStatus(field.key, 'archived');
+            await agent.delete(`members/custom_fields/${field.key}/`).expectStatus(204);
+
+            // Oldest-first by id: action ids are bson ObjectIds, so they sort in
+            // creation order even for events that land in the same second (which
+            // created_at ordering can't disambiguate).
+            const timeline = (await customFieldActions())
+                .filter((a: {resource_id: string}) => a.resource_id === field.key)
+                .sort((a: {id: string}, b: {id: string}) => (a.id < b.id ? -1 : 1));
+
+            const parseContext = (a: {context: unknown}) =>
+                (typeof a.context === 'string' ? JSON.parse(a.context) : a.context) as {primary_name?: string; previous_name?: string};
+
+            // The full ordered story, including the repeated archive.
+            assert.deepEqual(
+                timeline.map((a: {event: string}) => a.event),
+                ['added', 'edited', 'archived', 'restored', 'archived', 'deleted']
+            );
+
+            // Every entry is attributed and carries the field's name — no anonymous
+            // logs, and the delete still says what the field was after its row is gone.
+            for (const a of timeline) {
+                assert.equal(a.actor_id, actorId, `the ${a.event} action is attributed`);
+                assert.ok(parseContext(a)?.primary_name, `the ${a.event} action names the field`);
+            }
+
+            // Names track the field at each point; the rename also records what it was.
+            assert.equal(parseContext(timeline[0]).primary_name, 'Delivery address');
+            assert.equal(parseContext(timeline[1]).primary_name, 'Shipping address');
+            assert.equal(parseContext(timeline[1]).previous_name, 'Delivery address');
+            assert.equal(parseContext(timeline[5]).primary_name, 'Shipping address');
         });
     });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ catalogs:
     '@tryghost/limit-service':
       specifier: 1.5.6
       version: 1.5.6
+    '@tryghost/mongo-knex':
+      specifier: 0.10.1
+      version: 0.10.1
     '@tryghost/nql':
       specifier: 0.13.1
       version: 0.13.1
@@ -1132,7 +1135,7 @@ importers:
         version: 1.5.6
       '@tryghost/nql':
         specifier: 'catalog:'
-        version: 0.13.1(supports-color@5.5.0)
+        version: 0.13.1
       '@tryghost/string':
         specifier: 'catalog:'
         version: 0.3.5
@@ -1345,7 +1348,7 @@ importers:
         version: link:../../packages/i18n
       '@tryghost/nql':
         specifier: 'catalog:'
-        version: 0.13.1(supports-color@5.5.0)
+        version: 0.13.1
       '@types/react':
         specifier: catalog:react17
         version: 17.0.93
@@ -2054,7 +2057,7 @@ importers:
         version: 1.5.6
       '@tryghost/nql':
         specifier: 'catalog:'
-        version: 0.13.1(supports-color@5.5.0)
+        version: 0.13.1
       '@tryghost/string':
         specifier: 'catalog:'
         version: 0.3.5
@@ -2484,6 +2487,9 @@ importers:
       '@tryghost/metrics':
         specifier: 1.0.43
         version: 1.0.43(supports-color@5.5.0)
+      '@tryghost/mongo-knex':
+        specifier: 'catalog:'
+        version: 0.10.1
       '@tryghost/mongo-utils':
         specifier: 0.6.5
         version: 0.6.5
@@ -2498,7 +2504,7 @@ importers:
         version: 2.3.1(babel-core@6.26.3)(debug@4.4.3)(handlebars@4.7.9)(lodash@4.18.1)(underscore@1.13.8)
       '@tryghost/nql':
         specifier: 'catalog:'
-        version: 0.13.1(supports-color@5.5.0)
+        version: 0.13.1
       '@tryghost/nql-lang':
         specifier: 'catalog:'
         version: 0.6.6
@@ -30906,7 +30912,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tryghost/mongo-knex@0.10.1(supports-color@5.5.0)':
+  '@tryghost/mongo-knex@0.10.1':
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
       lodash: 4.18.1
@@ -31001,7 +31007,7 @@ snapshots:
 
   '@tryghost/nql@0.13.0':
     dependencies:
-      '@tryghost/mongo-knex': 0.10.1(supports-color@5.5.0)
+      '@tryghost/mongo-knex': 0.10.1
       '@tryghost/mongo-utils': 0.6.5
       '@tryghost/nql-lang': 0.6.6
       lodash: 4.18.1
@@ -31009,9 +31015,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tryghost/nql@0.13.1(supports-color@5.5.0)':
+  '@tryghost/nql@0.13.1':
     dependencies:
-      '@tryghost/mongo-knex': 0.10.1(supports-color@5.5.0)
+      '@tryghost/mongo-knex': 0.10.1
       '@tryghost/mongo-utils': 0.6.5
       '@tryghost/nql-lang': 0.6.6
       lodash: 4.18.1
@@ -40001,7 +40007,7 @@ snapshots:
       '@tryghost/debug': 2.3.1(supports-color@5.5.0)
       '@tryghost/errors': 1.3.13
       '@tryghost/logging': 4.2.1(supports-color@5.5.0)
-      '@tryghost/nql': 0.13.1(supports-color@5.5.0)
+      '@tryghost/nql': 0.13.1
       '@tryghost/pretty-cli': 3.3.1
       '@tryghost/server': 3.1.1
       '@tryghost/zip': 3.5.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -82,6 +82,7 @@ catalog:
   '@tryghost/helpers': 1.1.106
   '@tryghost/limit-service': 1.5.6
   '@tryghost/logging': 4.2.1
+  '@tryghost/mongo-knex': 0.10.1
   '@tryghost/nql': 0.13.1
   '@tryghost/nql-lang': 0.6.6
   '@tryghost/string': 0.3.5


### PR DESCRIPTION
## Problem

Custom field definitions could be archived, but the API had no way to see archived fields or bring them back. Archiving was a one-way soft delete with no path to permanently remove a field, and since field names stay globally unique, an archived field could silently block reuse of its name with no way to reach it. Settings needs to show archived fields alongside active ones, and admins need a safe, deliberate way to permanently delete a field and its data.

## Solution

Archived fields are now hidden by default but reachable: the definitions list takes a status filter so Settings can pull active and archived together in one request, and a field carries its status so the UI can group them. Archiving and restoring are a single status change over the existing update route. Deleting a field now permanently removes it and its stored member values, and is only allowed once the field has been archived, so permanent data loss is always a two-step.