### PR TITLE
Fixed React state warnings in site settings

### DIFF
--- a/apps/admin-x-settings/src/components/settings/site/design-and-theme-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/design-and-theme-modal.tsx
@@ -21,6 +21,7 @@ const DesignAndThemeModal: React.FC<RoutingModalProps> = ({pathName}) => {
     const [installationAllowed, setInstallationAllowed] = useState<boolean | null>(null);
     const [hasCheckedInstallation, setHasCheckedInstallation] = useState(false);
     const {themeName: editingThemeName, isInvalid: hasInvalidEditingThemeRoute} = parseEditingThemeRoute(currentPath);
+    const hasSupportedPath = currentPath === 'design/edit' || currentPath === 'design/change-theme' || currentPath === 'theme/install' || currentPath.startsWith('theme/edit/');
 
     const showThemeLimitModal = useCallback((error: string) => {
         NiceModal.show(LimitModal, {
@@ -76,6 +77,12 @@ const DesignAndThemeModal: React.FC<RoutingModalProps> = ({pathName}) => {
         modal.remove();
         updateRoute('theme');
     }, [hasInvalidEditingThemeRoute, modal, updateRoute]);
+
+    useEffect(() => {
+        if (!hasSupportedPath) {
+            modal.remove();
+        }
+    }, [hasSupportedPath, modal]);
 
     useEffect(() => {
         let isCancelled = false;
@@ -267,7 +274,6 @@ const DesignAndThemeModal: React.FC<RoutingModalProps> = ({pathName}) => {
 
         return <ThemeCodeEditorModal themeName={editingThemeName} />;
     } else {
-        modal.remove();
         return null;
     }
 };

--- a/apps/admin-x-settings/src/components/settings/site/navigation-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/site/navigation-modal.tsx
@@ -4,8 +4,8 @@ import useNavigationEditor, {type NavigationItem} from '../../../hooks/site/use-
 import useSettingGroup from '../../../hooks/use-setting-group';
 import {Modal, TabView} from '@tryghost/admin-x-design-system';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
+import {useCallback, useMemo, useState} from 'react';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
-import {useState} from 'react';
 
 const NavigationModal = NiceModal.create(() => {
     const modal = useModal();
@@ -18,21 +18,27 @@ const NavigationModal = NiceModal.create(() => {
         siteData
     } = useSettingGroup();
 
-    const [navigationItems, secondaryNavigationItems] = getSettingValues<string>(
+    const [navigationValue, secondaryNavigationValue] = getSettingValues<string>(
         localSettings,
         ['navigation', 'secondary_navigation']
-    ).map(value => JSON.parse(value || '[]') as NavigationItem[]);
+    );
+    const navigationItems = useMemo(() => JSON.parse(navigationValue || '[]') as NavigationItem[], [navigationValue]);
+    const secondaryNavigationItems = useMemo(() => JSON.parse(secondaryNavigationValue || '[]') as NavigationItem[], [secondaryNavigationValue]);
+    const setNavigationItems = useCallback((items: NavigationItem[]) => {
+        updateSetting('navigation', JSON.stringify(items));
+    }, [updateSetting]);
+    const setSecondaryNavigationItems = useCallback((items: NavigationItem[]) => {
+        updateSetting('secondary_navigation', JSON.stringify(items));
+    }, [updateSetting]);
 
     const navigation = useNavigationEditor({
         items: navigationItems,
-        setItems: (items) => {
-            updateSetting('navigation', JSON.stringify(items));
-        }
+        setItems: setNavigationItems
     });
 
     const secondaryNavigation = useNavigationEditor({
         items: secondaryNavigationItems,
-        setItems: items => updateSetting('secondary_navigation', JSON.stringify(items))
+        setItems: setSecondaryNavigationItems
     });
 
     const [selectedTab, setSelectedTab] = useState('primary-nav');

--- a/apps/admin-x-settings/src/hooks/site/use-navigation-editor.tsx
+++ b/apps/admin-x-settings/src/hooks/site/use-navigation-editor.tsx
@@ -1,4 +1,5 @@
 import validator from 'validator';
+import {useCallback, useMemo} from 'react';
 import {useSortableIndexedList} from '@tryghost/admin-x-design-system';
 
 export type NavigationItem = {
@@ -8,6 +9,8 @@ export type NavigationItem = {
 
 export type NavigationItemErrors = { [key in keyof NavigationItem]?: string }
 export type EditableItem = NavigationItem & { id: string; errors: NavigationItemErrors }
+
+const hasNewItem = (newItem: NavigationItem) => Boolean((newItem.label && !newItem.label.match(/^\s*$/)) || newItem.url !== '/');
 
 export type NavigationEditor = {
     items: EditableItem[]
@@ -25,11 +28,14 @@ const useNavigationEditor = ({items, setItems}: {
     items: NavigationItem[];
     setItems: (newItems: NavigationItem[]) => void;
 }): NavigationEditor => {
-    const hasNewItem = (newItem: NavigationItem) => Boolean((newItem.label && !newItem.label.match(/^\s*$/)) || newItem.url !== '/');
+    const editableItems = useMemo(() => items.map(item => ({...item, errors: {}})), [items]);
+    const setNavigationItems = useCallback((newItems: Omit<EditableItem, 'id'>[]) => {
+        setItems(newItems.map(({url, label}) => ({url, label})));
+    }, [setItems]);
 
     const list = useSortableIndexedList<Omit<EditableItem, 'id'>>({
-        items: items.map(item => ({...item, errors: {}})),
-        setItems: newItems => setItems(newItems.map(({url, label}) => ({url, label}))),
+        items: editableItems,
+        setItems: setNavigationItems,
         blank: {url: '/',label: '', errors: {}},
         canAddNewItem: hasNewItem
     });

--- a/apps/admin-x-settings/src/hooks/use-setting-group.tsx
+++ b/apps/admin-x-settings/src/hooks/use-setting-group.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {type ErrorMessages, type OkProps, type SaveHandler, type SaveState, useForm, useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {type Setting, type SettingValue, useEditSettings} from '@tryghost/admin-x-framework/api/settings';
 import {type SiteData} from '@tryghost/admin-x-framework/api/site';
@@ -86,7 +86,7 @@ const useSettingGroup = ({savingDelay, onValidate}: {savingDelay?: number; onVal
     };
 
     // function to update the local state
-    const updateSetting = (key: string, value: SettingValue) => {
+    const updateSetting = useCallback((key: string, value: SettingValue) => {
         updateForm((state) => {
             if (state.some(setting => setting.key === key)) {
                 return state.map(setting => (
@@ -96,7 +96,7 @@ const useSettingGroup = ({savingDelay, onValidate}: {savingDelay?: number; onVal
                 return [...state, {key, value, dirty: true}];
             }
         });
-    };
+    }, [updateForm]);
 
     return {
         localSettings,


### PR DESCRIPTION
## Description

- stabilized navigation editor values and callbacks so validation errors do not trigger an infinite settings synchronization loop
- moved unsupported theme-modal cleanup into an effect to avoid updating the modal provider during render
- preserved navigation persistence as `{label, url}` values only

## Testing

- `pnpm exec vitest run -c vitest.acceptance.config.ts src/settings/site/navigation.acceptance.test.tsx src/settings/site/theme.acceptance.test.tsx` (27 passed)
- `pnpm --filter @tryghost/admin-x-settings lint`
- `pnpm --filter @tryghost/admin-x-settings test:unit` (205 passed)