### PR TITLE
Made "record sent automation email" code more consistent

### DIFF
--- a/ghost/core/core/server/services/automations/automations-api.ts
+++ b/ghost/core/core/server/services/automations/automations-api.ts
@@ -2,15 +2,12 @@ import errors from '@tryghost/errors';
 import tpl from '@tryghost/tpl';
 import ObjectId from 'bson-objectid';
 import {z} from 'zod';
-import {type Knex} from 'knex';
 import {createDatabaseAutomationsRepository} from './database-automations-repository';
 import {parseFakeWaitHoursMultiplier} from './fake-wait-hours-multiplier';
 import type {
     AutomationsRepository,
     EditAutomationData
 } from './automations-repository';
-// @ts-expect-error Models currently lack type definitions.
-import {AutomatedEmailRecipient} from '../../models';
 
 const {knex} = require('../../data/db');
 const domainEvents = require('@tryghost/domain-events');
@@ -363,34 +360,8 @@ export async function retryStep(...args: Parameters<AutomationsRepository['retry
     return await repository.retryStep(...args);
 }
 
-export type RecordEmailSentOptions = Readonly<{
-    automationActionRevisionId: string;
-    mailgunMessageId?: string;
-    memberEmail: string;
-    memberId: string;
-    memberName: string | null;
-    memberUuid: string;
-    trackOpens: boolean;
-}>;
-
-export async function recordEmailSent(options: RecordEmailSentOptions): Promise<void> {
-    await knex.transaction(async (transacting: Knex.Transaction) => {
-        await AutomatedEmailRecipient.add({
-            member_id: options.memberId,
-            member_uuid: options.memberUuid,
-            member_email: options.memberEmail,
-            member_name: options.memberName,
-            automation_action_revision_id: options.automationActionRevisionId,
-            ...(options.mailgunMessageId ? {mailgun_message_id: options.mailgunMessageId} : {}),
-            track_opens: options.trackOpens
-        }, {transacting});
-
-        await transacting('automation_action_revisions')
-            .where('id', options.automationActionRevisionId)
-            .update({
-                email_sent_count: transacting.raw('COALESCE(??, 0) + ?', ['email_sent_count', 1])
-            });
-    });
+export async function recordEmailSent(...args: Parameters<AutomationsRepository['recordEmailSent']>) {
+    return await repository.recordEmailSent(...args);
 }
 
 export async function getAutomatedEmailRecipientsByMailgunIds(

--- a/ghost/core/core/server/services/automations/automations-repository.ts
+++ b/ghost/core/core/server/services/automations/automations-repository.ts
@@ -81,6 +81,16 @@ export type AutomatedEmailEvents = {
     automationActionRevisionId: string;
 };
 
+export type RecordEmailSentOptions = Readonly<{
+    automationActionRevisionId: string;
+    mailgunMessageId?: string;
+    memberEmail: string;
+    memberId: string;
+    memberName: string | null;
+    memberUuid: string;
+    trackOpens: boolean;
+}>;
+
 type AutomationStepBase = {
     id: string;
     locked_by: string;
@@ -167,6 +177,10 @@ export interface AutomationsRepository {
         step: Pick<AutomationStepToRun, 'id' | 'locked_by'>,
         retryAt: Readonly<Date>
     ): Promise<boolean>;
+    /**
+     * Record a sent email and increment its action revision's sent count.
+     */
+    recordEmailSent(options: RecordEmailSentOptions): Promise<void>;
     /**
      * Fetch sent emails by their Mailgun IDs.
      */

--- a/ghost/core/core/server/services/automations/database-automations-repository.ts
+++ b/ghost/core/core/server/services/automations/database-automations-repository.ts
@@ -224,6 +224,30 @@ export function createDatabaseAutomationsRepository({
             return await knex.transaction(trx => retryStep(trx, step, retryAt));
         },
 
+        async recordEmailSent(options): Promise<void> {
+            await knex.transaction(async (trx) => {
+                const now = toDatabaseDate(new Date());
+                await trx('automated_email_recipients').insert({
+                    id: ObjectId().toHexString(),
+                    member_id: options.memberId,
+                    member_uuid: options.memberUuid,
+                    member_email: options.memberEmail,
+                    member_name: options.memberName,
+                    automation_action_revision_id: options.automationActionRevisionId,
+                    ...(options.mailgunMessageId ? {mailgun_message_id: options.mailgunMessageId} : {}),
+                    track_opens: options.trackOpens,
+                    created_at: now,
+                    updated_at: now
+                });
+
+                await trx('automation_action_revisions')
+                    .where('id', options.automationActionRevisionId)
+                    .update({
+                        email_sent_count: trx.raw('COALESCE(??, 0) + ?', ['email_sent_count', 1])
+                    });
+            });
+        },
+
         async getAutomatedEmailRecipientsByMailgunIds(mailgunMessageIds) {
             if (mailgunMessageIds.length === 0) {
                 return [];

--- a/ghost/core/core/server/services/automations/poll.ts
+++ b/ghost/core/core/server/services/automations/poll.ts
@@ -1,5 +1,4 @@
-import type {AutomationStepToRun, AutomationsRepository} from './automations-repository';
-import type {RecordEmailSentOptions} from './automations-api';
+import type {AutomationStepToRun, AutomationsRepository, RecordEmailSentOptions} from './automations-repository';
 import {getMailgunMessageId} from './mailgun-message-id';
 import logging from '@tryghost/logging';
 import errors from '@tryghost/errors';

--- a/ghost/core/core/server/services/automations/poll.ts
+++ b/ghost/core/core/server/services/automations/poll.ts
@@ -1,4 +1,4 @@
-import type {AutomationStepToRun, AutomationsRepository, RecordEmailSentOptions} from './automations-repository';
+import type {AutomationStepToRun, AutomationsRepository} from './automations-repository';
 import {getMailgunMessageId} from './mailgun-message-id';
 import logging from '@tryghost/logging';
 import errors from '@tryghost/errors';
@@ -43,10 +43,9 @@ type PollOptions = {
         'fetchAndLockSteps' |
         'finishStepAndEnqueueNext' |
         'markStepTerminal' |
+        'recordEmailSent' |
         'retryStep'
-    > & {
-        recordEmailSent(options: RecordEmailSentOptions): Promise<void>;
-    };
+    >;
     enqueueAnotherPollAt: (date: Readonly<Date>) => unknown;
     scheduleAutomationEmailAnalyticsJob: () => Promise<void>;
     memberWelcomeEmailService: MemberWelcomeEmailService;

--- a/ghost/core/test/unit/server/services/automations/automations-api.test.js
+++ b/ghost/core/test/unit/server/services/automations/automations-api.test.js
@@ -3,8 +3,6 @@ const ObjectId = require('bson-objectid').default;
 const sinon = require('sinon');
 
 const automationsApi = require('../../../../../core/server/services/automations/automations-api');
-const db = require('../../../../../core/server/data/db');
-const {AutomatedEmailRecipient} = require('../../../../../core/server/models');
 const {EMPTY_EMAIL_LEXICAL, NON_EMPTY_EMAIL_LEXICAL} = require('../../../../utils/automations-fixtures');
 
 const buildSendEmailAction = (dataOverrides = {}) => ({
@@ -21,46 +19,6 @@ const buildSendEmailAction = (dataOverrides = {}) => ({
 describe('automations API', function () {
     afterEach(function () {
         sinon.restore();
-    });
-
-    describe('recordEmailSent', function () {
-        it('records the recipient and increments the action revision count in one transaction', async function () {
-            const emailSentCountExpression = Symbol('email_sent_count_expression');
-            const updateRevision = sinon.stub().resolves();
-            const whereRevision = sinon.stub().returns({update: updateRevision});
-            const transacting = sinon.stub().withArgs('automation_action_revisions').returns({where: whereRevision});
-            transacting.raw = sinon.stub().returns(emailSentCountExpression);
-            const transaction = sinon.stub(db.knex, 'transaction').callsFake(async (callback) => {
-                return await callback(transacting);
-            });
-            const addRecipient = sinon.stub(AutomatedEmailRecipient, 'add').resolves();
-
-            await automationsApi.recordEmailSent({
-                automationActionRevisionId: 'revision-id',
-                mailgunMessageId: 'mailgun-message-id',
-                memberEmail: 'member@example.com',
-                memberId: 'member-id',
-                memberName: 'Test Member',
-                memberUuid: '00000000-0000-4000-8000-000000000001',
-                trackOpens: true
-            });
-
-            sinon.assert.calledOnce(transaction);
-            sinon.assert.calledOnceWithExactly(addRecipient, {
-                member_id: 'member-id',
-                member_uuid: '00000000-0000-4000-8000-000000000001',
-                member_email: 'member@example.com',
-                member_name: 'Test Member',
-                automation_action_revision_id: 'revision-id',
-                mailgun_message_id: 'mailgun-message-id',
-                track_opens: true
-            }, {transacting});
-            sinon.assert.calledOnceWithExactly(whereRevision, 'id', 'revision-id');
-            sinon.assert.calledOnceWithExactly(transacting.raw, 'COALESCE(??, 0) + ?', ['email_sent_count', 1]);
-            sinon.assert.calledOnceWithExactly(updateRevision, {
-                email_sent_count: emailSentCountExpression
-            });
-        });
     });
 
     describe('edit', function () {

--- a/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
+++ b/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
@@ -124,9 +124,16 @@ const createDatabase = async (): Promise<Knex> => {
     await database.schema.createTable('automated_email_recipients', (table) => {
         table.text('id').primary();
         table.text('automation_action_revision_id').references('id').inTable('automation_action_revisions');
+        table.text('member_id');
+        table.text('member_uuid');
+        table.text('member_email');
+        table.text('member_name');
         table.text('mailgun_message_id');
         table.datetime('delivered_at');
         table.datetime('opened_at');
+        table.boolean('track_opens').notNullable().defaultTo(false);
+        table.datetime('created_at');
+        table.datetime('updated_at');
     });
 
     const freeAutomationId = id();
@@ -1843,6 +1850,67 @@ describe('automations repository', function () {
             assert.equal(disabled.started_at, lockedStep.started_at);
             assert.equal(disabled.ready_at, stepRow.ready_at);
             assert.equal(typeof disabled.finished_at, 'string');
+        });
+    });
+
+    describe('recordEmailSent', function () {
+        it('records the recipient and increments the action revision count', async function () {
+            const revision = await knex('automation_action_revisions').select('id').first();
+            assert(revision);
+
+            await repo.recordEmailSent({
+                automationActionRevisionId: revision.id,
+                mailgunMessageId: 'mailgun-message-id',
+                memberEmail: 'member@example.com',
+                memberId: 'member-id',
+                memberName: 'Test Member',
+                memberUuid: '00000000-0000-4000-8000-000000000001',
+                trackOpens: true
+            });
+
+            const recipient = await knex('automated_email_recipients').first();
+            assert.deepEqual(recipient, {
+                id: recipient.id,
+                automation_action_revision_id: revision.id,
+                member_id: 'member-id',
+                member_uuid: '00000000-0000-4000-8000-000000000001',
+                member_email: 'member@example.com',
+                member_name: 'Test Member',
+                mailgun_message_id: 'mailgun-message-id',
+                delivered_at: null,
+                opened_at: null,
+                track_opens: 1,
+                created_at: recipient.created_at,
+                updated_at: recipient.updated_at
+            });
+            assert(ObjectId.isValid(recipient.id));
+            assert.equal(typeof recipient.created_at, 'string');
+            assert.equal(recipient.updated_at, recipient.created_at);
+
+            const updatedRevision = await knex('automation_action_revisions')
+                .select('email_sent_count')
+                .where('id', revision.id)
+                .first();
+            assert.equal(updatedRevision.email_sent_count, 1);
+        });
+
+        it('supports recipients without a Mailgun message ID', async function () {
+            const revision = await knex('automation_action_revisions').select('id').first();
+            assert(revision);
+
+            await repo.recordEmailSent({
+                automationActionRevisionId: revision.id,
+                memberEmail: 'member@example.com',
+                memberId: 'member-id',
+                memberName: null,
+                memberUuid: '00000000-0000-4000-8000-000000000001',
+                trackOpens: false
+            });
+
+            const recipient = await knex('automated_email_recipients').first();
+            assert.equal(recipient.mailgun_message_id, null);
+            assert.equal(recipient.member_name, null);
+            assert.equal(recipient.track_opens, 0);
         });
     });
 


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1459

`automationsApi.recordEmailSent` was different from the others: it hit the database directly. Now it's part of the automations repository just like the rest.

This cleanup should have no user impact.
