### PR TITLE
Awaited email analytics "started" bookkeeping before starting

### DIFF
--- a/ghost/core/core/server/services/email-analytics/email-analytics-service.js
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-service.js
@@ -378,7 +378,7 @@ module.exports = class EmailAnalyticsService {
         fetchData.running = true;
         fetchData.lastStarted = new Date();
         fetchData.lastBegin = begin;
-        this.queries.setJobTimestamp(fetchData.jobName, 'started', begin);
+        await this.queries.setJobTimestamp(fetchData.jobName, 'started', begin);
 
         // Timing metrics
         const fetchStartMs = Date.now();

--- a/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.js
+++ b/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.js
@@ -235,6 +235,39 @@ describe('EmailAnalyticsService', function () {
         afterEach(function () {
             sinon.restore();
         });
+
+        it('persists the "started" cursor before fetching events', async function () {
+            let resolveStartedTimestamp;
+            const startedTimestamp = new Promise((resolve) => {
+                resolveStartedTimestamp = resolve;
+            });
+            const fetchLatestSpy = sinon.spy();
+            const service = createService({
+                queries: {
+                    getLastEventTimestamp: sinon.stub().resolves(),
+                    setJobTimestamp: sinon.stub().returns(startedTimestamp),
+                    setJobStatus: sinon.stub().resolves()
+                },
+                provider: {
+                    fetchLatest: fetchLatestSpy
+                },
+                createEventProcessor: createStubEventProcessor
+            });
+
+            const fetchPromise = service.fetchLatestOpenedEvents();
+
+            // Flush the event loop.
+            await Promise.resolve();
+            await Promise.resolve();
+
+            sinon.assert.notCalled(fetchLatestSpy);
+
+            resolveStartedTimestamp();
+            await fetchPromise;
+
+            sinon.assert.calledOnce(fetchLatestSpy);
+        });
+
         describe('fetchLatestOpenedEvents', function () {
             it('fetches only opened events', async function () {
                 const fetchLatestSpy = sinon.spy();


### PR DESCRIPTION
no ref

We record a start timestamp when fetching Mailgun events. But we didn't wait for that bookkeeping to finish before we started.

The following could have happened (unlikely, but possible):

1. We started the "fetch events" process.
2. We start the database query to update the start timestamp, but it doesn't finish.
3. We start processing events, and save some of them to the database.
4. The server stops for some reason (e.g., a crash).

This would leave the database in an inconsistent state. I don't know what the downstream effects of this problem are, but let's close the gap so we don't have to think about it.
