### PR TITLE
Added custom field editing to member details

### DIFF
--- a/apps/admin-x-framework/src/api/member-custom-fields.ts
+++ b/apps/admin-x-framework/src/api/member-custom-fields.ts
@@ -1,6 +1,12 @@
 import {FIELD_TYPE_IDS, type FieldType} from '@tryghost/custom-field-types';
 import {Meta, createMutation, createQuery, createQueryWithId} from '../utils/api/hooks';
 
+// Re-exported so admin apps can type address values and validate against the
+// same schemas the server enforces, without a direct dependency on the shared
+// catalog package — the framework is their surface for everything custom-fields.
+export type {Address as MemberCustomFieldAddress} from '@tryghost/custom-field-types';
+export {FIELD_TYPES as MEMBER_CUSTOM_FIELD_TYPES} from '@tryghost/custom-field-types';
+
 export type MemberCustomField = {
     // Fields are addressed by their immutable key; the DB id is never exposed.
     key: string;

--- a/apps/admin-x-framework/src/api/members.ts
+++ b/apps/admin-x-framework/src/api/members.ts
@@ -2,6 +2,7 @@ import {InfiniteData, useIsFetching, useQueryClient} from '@tanstack/react-query
 import {useEffect} from 'react';
 import {Meta, createInfiniteQuery, createMutation, createQuery, createQueryWithId} from '../utils/api/hooks';
 import {apiUrl} from '../utils/api/fetch-api';
+import type {Address} from '@tryghost/custom-field-types';
 
 export type MemberLabel = {
     id: string;
@@ -119,6 +120,11 @@ export type Member = {
     };
     last_seen_at: string | null;
     last_commented_at: string | null;
+    // Custom field values keyed by field key, present only when requested via
+    // `include=custom_fields` (behind the `membersCustomFields` flag). Values
+    // are type-dependent: string for text-backed fields, an object for
+    // composites like address — hence `unknown`; consumers narrow per field type.
+    custom_fields?: Record<string, unknown>;
     can_comment?: boolean;
     commenting?: {
         disabled: boolean;
@@ -488,12 +494,20 @@ export interface EditMemberData {
     labels?: Array<{name: string; slug?: string}>;
     newsletters?: Array<{id: string}>;
     tiers?: Array<{id: string; expiry_at?: string | null}>;
+    // Merge semantics: only the keys present are written; `null` clears a
+    // value. Values are strings for text-backed fields and composite objects
+    // for address (Partial because a draft mid-edit may hold an incomplete
+    // address — the server validates completeness, not this type). Requires
+    // the `membersCustomFields` flag server-side.
+    custom_fields?: Record<string, string | Partial<Address> | null>;
 }
 
 export const useEditMember = createMutation<MembersResponseType, EditMemberData>({
     method: 'PUT',
     path: ({id}) => `/members/${id}/`,
-    defaultSearchParams: {include: 'tiers'},
+    // `custom_fields` is asked back only when the payload writes it, so the
+    // request stays valid on sites where the flag (and the include) is off.
+    searchParams: payload => ({include: payload.custom_fields ? 'tiers,custom_fields' : 'tiers'}),
     body: ({id, ...rest}) => ({members: [{id, ...rest}]}),
     invalidateQueries: {dataType}
 });

--- a/apps/admin/src/members/detail/member-custom-fields-field.tsx
+++ b/apps/admin/src/members/detail/member-custom-fields-field.tsx
@@ -28,8 +28,11 @@ const ADDRESS_SUBFIELD_LABELS: Record<typeof ADDRESS_SUBFIELD_KEYS[number], stri
     country: 'Country'
 };
 
+// role='alert': after a save-attempt these render while focus stays on the Save
+// button, so an assertive live region is the only way a screen reader hears the
+// failure.
 const ErrorMessage: React.FC<{message?: string}> = ({message}) => {
-    return message ? <p className='text-sm text-destructive'>{message}</p> : null;
+    return message ? <p className='text-sm text-destructive' role='alert'>{message}</p> : null;
 };
 
 // The address composite: one input per sub-field, paired into a two-column
@@ -145,6 +148,14 @@ const MemberCustomFieldEditModal: React.FC<{
         if (editMutation.isPending) {
             return;
         }
+        // An unchanged value has nothing to write; skip the PUT entirely. The
+        // merge is keyed on the field, so a no-op save would still declare a
+        // member change and fire member.edited (webhooks, audit) for a value
+        // that didn't move. Mirrors the page-level save's dirty gate.
+        if (!isDirty) {
+            onClose();
+            return;
+        }
         if (Object.keys(validationErrors).length > 0) {
             setSaveAttempted(true);
             return;
@@ -166,19 +177,22 @@ const MemberCustomFieldEditModal: React.FC<{
 
     return (
         <Dialog open onOpenChange={(open) => {
-            if (!open) {
+            // Never dismiss while the save is in flight: closing here would let
+            // the field be reopened and saved again, racing two PUTs whose order
+            // isn't guaranteed. A dirty editor also refuses casual dismissal.
+            if (!open && !editMutation.isPending) {
                 onClose();
             }
         }}>
             <DialogContent
                 data-testid='member-custom-field-edit-modal'
                 onEscapeKeyDown={(event) => {
-                    if (isDirty) {
+                    if (isDirty || editMutation.isPending) {
                         event.preventDefault();
                     }
                 }}
                 onInteractOutside={(event) => {
-                    if (isDirty) {
+                    if (isDirty || editMutation.isPending) {
                         event.preventDefault();
                     }
                 }}
@@ -207,8 +221,8 @@ const MemberCustomFieldEditModal: React.FC<{
                     <ErrorMessage message={inputErrors['']} />
                 </div>
                 <DialogFooter>
-                    <Button variant='outline' onClick={onClose}>Cancel</Button>
-                    <Button className='min-w-16' onClick={onSave}>
+                    <Button disabled={editMutation.isPending} variant='outline' onClick={onClose}>Cancel</Button>
+                    <Button className='min-w-16' disabled={editMutation.isPending} onClick={onSave}>
                         {editMutation.isPending ? <><LoadingIndicator size='sm' /><span className='sr-only'>Saving</span></> : 'Save'}
                     </Button>
                 </DialogFooter>
@@ -218,7 +232,7 @@ const MemberCustomFieldEditModal: React.FC<{
 };
 
 /** One readable line per value; address collapses to a formatted string. */
-function formatValue(field: MemberCustomField, value: EditableCustomFieldValue | undefined): string | null {
+function formatValue(value: EditableCustomFieldValue | undefined): string | null {
     if (value === undefined) {
         return null;
     }
@@ -257,7 +271,7 @@ const MemberCustomFieldsField: React.FC<MemberCustomFieldsFieldProps> = ({member
                 <CardContent className='px-6 py-4'>
                     <ul>
                         {fields.map((field) => {
-                            const display = formatValue(field, values[field.key]);
+                            const display = formatValue(values[field.key]);
                             return (
                                 // Dividers fade around the hovered row (its own border-b, and the
                                 // previous row's via :has), so the hover tint floats free of the
@@ -267,7 +281,10 @@ const MemberCustomFieldsField: React.FC<MemberCustomFieldsFieldProps> = ({member
                                         the pencil is a hover/focus-revealed affordance, not the
                                         control itself. */}
                                     <button
-                                        aria-label={`Edit ${field.name}`}
+                                        // An explicit label overrides the inner spans as the accessible
+                                        // name, so carry the value into it — otherwise a screen reader
+                                        // announces only the field name and never its current value.
+                                        aria-label={display ? `Edit ${field.name}: ${display}` : `Edit ${field.name}`}
                                         // -mx/px + calc width: the hover tint bleeds past the text
                                         // column like the settings rows, while the row text (and the
                                         // li dividers) stay aligned with the rest of the card.

--- a/apps/admin/src/members/detail/member-custom-fields-field.tsx
+++ b/apps/admin/src/members/detail/member-custom-fields-field.tsx
@@ -1,0 +1,318 @@
+import React from 'react';
+import {Button, Card, CardContent, Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, Input, Label, LoadingIndicator, Textarea} from '@tryghost/shade/components';
+import {LucideIcon} from '@tryghost/shade/utils';
+import {dequal} from 'dequal';
+import {ADDRESS_SUBFIELD_KEYS, buildCustomFieldSavePayload, getCustomFieldValidationErrors, getEditableCustomFieldValues, parseCustomFieldServerErrors} from './member-detail-edit';
+import {formatAddressValue} from './member-detail-format';
+import {toast} from 'sonner';
+import {useBrowseMemberCustomFields, userTypeForField} from '@tryghost/admin-x-framework/api/member-custom-fields';
+import {useEditMember} from '@tryghost/admin-x-framework/api/members';
+import type {EditableAddressValue, EditableCustomFieldValue} from './member-detail-edit';
+import type {MemberCustomField} from '@tryghost/admin-x-framework/api/member-custom-fields';
+
+interface MemberCustomFieldsFieldProps {
+    memberId: string;
+    // The member's saved values (`member.custom_fields` from the read), keyed
+    // by field key. Server truth — edits never live on the page draft; each
+    // field saves individually through its own editor.
+    customFields: Record<string, unknown> | undefined;
+    disabled?: boolean;
+}
+
+const ADDRESS_SUBFIELD_LABELS: Record<typeof ADDRESS_SUBFIELD_KEYS[number], string> = {
+    line1: 'Address line 1',
+    line2: 'Address line 2',
+    city: 'City',
+    state: 'State',
+    postal_code: 'Postal code',
+    country: 'Country'
+};
+
+const ErrorMessage: React.FC<{message?: string}> = ({message}) => {
+    return message ? <p className='text-sm text-destructive'>{message}</p> : null;
+};
+
+// The address composite: one input per sub-field, paired into a two-column
+// sub-grid. Country is a plain two-letter code input for now; the shared
+// AddressValue schema only shape-checks it, and a proper country select is a
+// follow-up.
+const AddressInput: React.FC<{
+    inputId: string;
+    value: EditableAddressValue;
+    // Messages keyed by sub-field (`line1`, `postal_code`, …).
+    errors?: Record<string, string>;
+    disabled?: boolean;
+    onChange: (value: EditableAddressValue) => void;
+}> = ({inputId, value, errors, disabled, onChange}) => {
+    return (
+        <div className='grid gap-x-4 gap-y-3 md:grid-cols-2'>
+            {ADDRESS_SUBFIELD_KEYS.map((subfield) => {
+                const subfieldId = `${inputId}-${subfield}`;
+                const error = errors?.[subfield];
+                return (
+                    <div key={subfield} className='flex flex-col gap-1.5'>
+                        <Label htmlFor={subfieldId}>{ADDRESS_SUBFIELD_LABELS[subfield]}</Label>
+                        <Input
+                            aria-invalid={error ? true : undefined}
+                            disabled={disabled}
+                            id={subfieldId}
+                            value={value[subfield] ?? ''}
+                            onChange={e => onChange({...value, [subfield]: e.target.value})}
+                        />
+                        <ErrorMessage message={error} />
+                    </div>
+                );
+            })}
+        </div>
+    );
+};
+
+// The control for one field, picked from the presentation catalog's `input`
+// hint — the same hint the collection forms render from, so the editor and
+// the member-facing forms never diverge per type. Unknown future inputs
+// render nothing rather than degrading to a wrong text input.
+const CustomFieldInput: React.FC<{
+    field: MemberCustomField;
+    inputId: string;
+    value: EditableCustomFieldValue;
+    // Messages for this field: '' = the field itself, 'subfield' = a composite sub-field.
+    errors?: Record<string, string>;
+    disabled?: boolean;
+    onChange: (value: EditableCustomFieldValue) => void;
+}> = ({field, inputId, value, errors, disabled, onChange}) => {
+    const fieldError = errors?.[''];
+    switch (userTypeForField(field).input) {
+    case 'text':
+        return <Input aria-invalid={fieldError ? true : undefined} disabled={disabled} id={inputId} value={typeof value === 'string' ? value : ''} onChange={e => onChange(e.target.value)} />;
+    case 'textarea':
+        // max-w-full: Ember's unlayered global CSS sets `textarea { max-width: 500px }`
+        // (ghost/admin patterns/forms.css) and it bleeds into the React island.
+        return <Textarea aria-invalid={fieldError ? true : undefined} className='max-w-full resize-y' disabled={disabled} id={inputId} value={typeof value === 'string' ? value : ''} onChange={e => onChange(e.target.value)} />;
+    case 'address':
+        return (
+            <AddressInput
+                disabled={disabled}
+                errors={errors}
+                inputId={inputId}
+                value={typeof value === 'object' && value !== null ? value : {}}
+                onChange={onChange}
+            />
+        );
+    default:
+        return null;
+    }
+};
+
+/**
+ * The editor for ONE field's value, with its own Save: one field, one save,
+ * one clear outcome — deliberately outside the page's draft/Save flow so
+ * "which Save saves what" never needs answering. Validation mirrors the
+ * page's email field: computed live, rendered on save-attempt; a server 422
+ * naming this field pins its message to the input as a backstop.
+ */
+const MemberCustomFieldEditModal: React.FC<{
+    memberId: string;
+    field: MemberCustomField;
+    initialValue: EditableCustomFieldValue | undefined;
+    onClose: () => void;
+}> = ({memberId, field, initialValue, onClose}) => {
+    const isAddressField = userTypeForField(field).input === 'address';
+    const [value, setValue] = React.useState<EditableCustomFieldValue>(
+        initialValue ?? (isAddressField ? {} : '')
+    );
+    const [saveAttempted, setSaveAttempted] = React.useState(false);
+    const [serverErrors, setServerErrors] = React.useState<Record<string, string> | undefined>();
+    const editMutation = useEditMember();
+
+    const validationErrors = getCustomFieldValidationErrors({[field.key]: value}, [field]);
+    const errors = {...(saveAttempted ? validationErrors : {}), ...serverErrors};
+    // Strip this field's key prefix so the input sees '' / 'subfield' keys.
+    const inputErrors = Object.fromEntries(
+        Object.entries(errors).map(([key, message]) => [key === field.key ? '' : key.slice(field.key.length + 1), message])
+    );
+
+    const inputId = `member-custom-field-${field.key}`;
+
+    // Pristine editors dismiss freely (outside click, Escape); a dirty one
+    // refuses casual dismissal — Cancel is the one explicit way to discard,
+    // so typed values can never be lost by a stray click.
+    const isDirty = !dequal(
+        getEditableCustomFieldValues({[field.key]: value}),
+        getEditableCustomFieldValues({[field.key]: initialValue})
+    );
+
+    const onSave = () => {
+        if (editMutation.isPending) {
+            return;
+        }
+        if (Object.keys(validationErrors).length > 0) {
+            setSaveAttempted(true);
+            return;
+        }
+        editMutation.mutate(buildCustomFieldSavePayload(memberId, field.key, value), {
+            onSuccess: () => {
+                toast.success(`${field.name} saved`);
+                onClose();
+            },
+            onError: (saveError) => {
+                const parsed = parseCustomFieldServerErrors(saveError);
+                setServerErrors(parsed);
+                if (!parsed) {
+                    toast.error(`${field.name} couldn’t be saved`);
+                }
+            }
+        });
+    };
+
+    return (
+        <Dialog open onOpenChange={(open) => {
+            if (!open) {
+                onClose();
+            }
+        }}>
+            <DialogContent
+                data-testid='member-custom-field-edit-modal'
+                onEscapeKeyDown={(event) => {
+                    if (isDirty) {
+                        event.preventDefault();
+                    }
+                }}
+                onInteractOutside={(event) => {
+                    if (isDirty) {
+                        event.preventDefault();
+                    }
+                }}
+            >
+                <DialogHeader>
+                    <DialogTitle>{field.name}</DialogTitle>
+                </DialogHeader>
+                <div className='flex flex-col gap-1.5'>
+                    {/* The dialog title names the field visually; this gives the
+                        scalar control a real label association (address sub-fields
+                        carry their own labels). */}
+                    {!isAddressField && (
+                        <Label className='sr-only' htmlFor={inputId}>{field.name}</Label>
+                    )}
+                    <CustomFieldInput
+                        disabled={editMutation.isPending}
+                        errors={inputErrors}
+                        field={field}
+                        inputId={inputId}
+                        value={value}
+                        onChange={(next) => {
+                            setServerErrors(undefined);
+                            setValue(next);
+                        }}
+                    />
+                    <ErrorMessage message={inputErrors['']} />
+                </div>
+                <DialogFooter>
+                    <Button variant='outline' onClick={onClose}>Cancel</Button>
+                    <Button className='min-w-16' onClick={onSave}>
+                        {editMutation.isPending ? <><LoadingIndicator size='sm' /><span className='sr-only'>Saving</span></> : 'Save'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+/** One readable line per value; address collapses to a formatted string. */
+function formatValue(field: MemberCustomField, value: EditableCustomFieldValue | undefined): string | null {
+    if (value === undefined) {
+        return null;
+    }
+    if (typeof value === 'string') {
+        return value;
+    }
+    return formatAddressValue(value) || null;
+}
+
+/**
+ * The Custom fields section of the member detail screen: a read-only list of
+ * the member's values, one row per field defined in Settings. This screen is
+ * a record, not a form — an admin's daily relationship to this data is
+ * reading it, so nothing here is a hot input. Editing is a deliberate act:
+ * the pencil opens a per-field editor with its own Save. Owns its external
+ * heading + card so it hides entirely (returning null) when the site has no
+ * fields — the Settings section is the entry point for defining them.
+ */
+const MemberCustomFieldsField: React.FC<MemberCustomFieldsFieldProps> = ({memberId, customFields, disabled}) => {
+    const {data, isLoading} = useBrowseMemberCustomFields();
+    const fields = data?.members_custom_fields ?? [];
+    const values = getEditableCustomFieldValues(customFields);
+    const [editingField, setEditingField] = React.useState<MemberCustomField | null>(null);
+
+    if (isLoading || fields.length === 0) {
+        return null;
+    }
+
+    return (
+        <section aria-labelledby='member-custom-fields-heading' className='flex flex-col gap-3' data-testid='member-custom-fields-field'>
+            <h3 className='text-base font-semibold' id='member-custom-fields-heading'>Custom fields</h3>
+            <Card>
+                {/* Rows are uniform (py-3, no first/last trims) so hover chips are all
+                    the same height; the card's vertical padding is what gives the
+                    first and last chips breathing room from the card edge. */}
+                <CardContent className='px-6 py-4'>
+                    <ul>
+                        {fields.map((field) => {
+                            const display = formatValue(field, values[field.key]);
+                            return (
+                                // Dividers fade around the hovered row (its own border-b, and the
+                                // previous row's via :has), so the hover tint floats free of the
+                                // lines — the same effect as the settings list rows.
+                                <li key={field.key} className='border-b border-border transition-colors last:border-b-0 hover:border-b-transparent [&:has(+li:hover)]:border-b-transparent'>
+                                    {/* The whole row opens the editor (the tags list pattern);
+                                        the pencil is a hover/focus-revealed affordance, not the
+                                        control itself. */}
+                                    <button
+                                        aria-label={`Edit ${field.name}`}
+                                        // -mx/px + calc width: the hover tint bleeds past the text
+                                        // column like the settings rows, while the row text (and the
+                                        // li dividers) stay aligned with the rest of the card.
+                                        className='group -mx-3 flex w-[calc(100%+1.5rem)] items-center justify-between gap-4 rounded-md px-3 py-3 text-left transition-colors hover:bg-table-row-hover disabled:cursor-not-allowed disabled:opacity-50'
+                                        disabled={disabled}
+                                        type='button'
+                                        onClick={() => {
+                                            // A drag-selection released over the row still fires a
+                                            // click; copying a value is as legitimate as editing it,
+                                            // so an active selection must not open the editor.
+                                            if (window.getSelection()?.toString()) {
+                                                return;
+                                            }
+                                            setEditingField(field);
+                                        }}
+                                    >
+                                        <span className='min-w-0'>
+                                            <span className='block text-sm text-muted-foreground'>{field.name}</span>
+                                            {/* select-text: button text is unselectable by default,
+                                                and values (addresses especially) get copied. */}
+                                            {display ? (
+                                                <span className='block break-words select-text'>{display}</span>
+                                            ) : (
+                                                <span className='block text-muted-foreground'>–</span>
+                                            )}
+                                        </span>
+                                        <LucideIcon.Pen aria-hidden='true' className='shrink-0 text-muted-foreground opacity-0 transition-all group-hover:opacity-100 group-focus-visible:opacity-100' size={16} />
+                                    </button>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                </CardContent>
+            </Card>
+            {editingField && (
+                <MemberCustomFieldEditModal
+                    key={editingField.key}
+                    field={editingField}
+                    initialValue={values[editingField.key]}
+                    memberId={memberId}
+                    onClose={() => setEditingField(null)}
+                />
+            )}
+        </section>
+    );
+};
+
+export default MemberCustomFieldsField;

--- a/apps/admin/src/members/detail/member-detail-custom-fields.acceptance.test.tsx
+++ b/apps/admin/src/members/detail/member-detail-custom-fields.acceptance.test.tsx
@@ -1,0 +1,193 @@
+import {describe, expect, it} from 'vitest';
+import {page, userEvent} from 'vitest/browser';
+
+import {fakeAdminEndpoint, fakeMembers, member, renderAdminApp, type Member} from '@test-utils/acceptance';
+
+const FLAGS = {labs: {memberDetailsReact: true, membersCustomFields: true}};
+
+const FIELDS = [
+    {key: 'job_title', name: 'Job title', type: 'short_text', created_at: '2026-07-14T00:00:00.000Z', updated_at: null},
+    {key: 'company', name: 'Company', type: 'long_text', created_at: '2026-07-14T00:00:00.000Z', updated_at: null},
+    {key: 'home_address', name: 'Home address', type: 'address', created_at: '2026-07-14T00:00:00.000Z', updated_at: null}
+];
+
+const ADDRESS = {line1: '1 Main St', city: 'Berlin', postal_code: '10115', country: 'DE'};
+
+/**
+ * The world the member detail screen reads at mount, plus the custom-fields
+ * definitions. Values ride the member read payload (`custom_fields`), exactly
+ * as the API returns them when the membersCustomFields flag is on. The world
+ * is stateful: a PUT's merge patch is applied (null deletes), so the refetch
+ * a save triggers returns the saved state.
+ */
+function fakeMemberDetailWorld(m: Member, initialValues: Record<string, unknown>) {
+    let current: Record<string, unknown> = {...m};
+    const values: Record<string, unknown> = {...initialValues};
+    fakeMembers([m]);
+    fakeAdminEndpoint('GET', new RegExp(`^/members/${m.id}/`), () => ({members: [{...current, custom_fields: {...values}}]}));
+    fakeAdminEndpoint('GET', '/members/custom_fields/', {members_custom_fields: FIELDS});
+    fakeAdminEndpoint('GET', new RegExp('^/members/events/'), {
+        events: [],
+        meta: {pagination: {page: 1, limit: 5, pages: 1, total: 0, next: null, prev: null}}
+    });
+    return fakeAdminEndpoint('PUT', new RegExp(`^/members/${m.id}/`), ({body}) => {
+        const {custom_fields: patch = {}, ...edited} = (body as {members: Array<Record<string, unknown>>}).members[0];
+        current = {...current, ...edited};
+        for (const [key, value] of Object.entries(patch as Record<string, unknown>)) {
+            if (value === null) {
+                delete values[key];
+            } else {
+                values[key] = value;
+            }
+        }
+        return {members: [{...current, custom_fields: {...values}}]};
+    });
+}
+
+const modal = () => page.getByTestId('member-custom-field-edit-modal');
+
+describe('Member detail custom fields', () => {
+    it('renders the member’s values as a read-only record, addresses as one line', async () => {
+        const m = member({name: 'Ada Lovelace'});
+        fakeMemberDetailWorld(m, {job_title: 'Editor', home_address: ADDRESS});
+        await renderAdminApp(`/members/${m.id}`, FLAGS);
+
+        await expect.element(page.getByText('Editor')).toBeVisible();
+        await expect.element(page.getByText('1 Main St, Berlin, 10115, DE')).toBeVisible();
+        // Company has no value: its row shows the empty dash, and nothing on
+        // the page is an editable input for custom fields.
+        await expect.element(page.getByText('–').first()).toBeVisible();
+        expect(page.getByRole('textbox', {name: 'Job title'}).elements()).toHaveLength(0);
+    });
+
+    it('saves one field through its own editor without touching the page Save', async () => {
+        const m = member({name: 'Ada Lovelace'});
+        const editApi = fakeMemberDetailWorld(m, {job_title: 'Editor', company: 'Ghost'});
+        await renderAdminApp(`/members/${m.id}`, FLAGS);
+
+        await page.getByRole('button', {name: 'Edit Job title'}).click();
+        await modal().getByLabelText('Job title').fill('Publisher');
+        await modal().getByRole('button', {name: 'Save', exact: true}).click();
+
+        // The row reflects the save; the page Save never became involved.
+        await expect.element(page.getByText('Publisher')).toBeVisible();
+        expect(modal().elements()).toHaveLength(0);
+        await expect.element(page.getByTestId('member-detail').getByRole('button', {name: 'Save', exact: true})).toBeDisabled();
+        // The payload was a single-field merge patch: only this key, nothing else.
+        const saved = editApi.lastRequest?.body as {members: Array<Record<string, unknown>>};
+        expect(saved.members[0].custom_fields).toEqual({job_title: 'Publisher'});
+        expect(saved.members[0].name).toBeUndefined();
+    });
+
+    it('clears a value by saving an emptied editor (null merge patch)', async () => {
+        const m = member({name: 'Ada Lovelace'});
+        const editApi = fakeMemberDetailWorld(m, {job_title: 'Editor'});
+        await renderAdminApp(`/members/${m.id}`, FLAGS);
+
+        await page.getByRole('button', {name: 'Edit Job title'}).click();
+        await modal().getByLabelText('Job title').fill('');
+        await modal().getByRole('button', {name: 'Save', exact: true}).click();
+
+        // The editor closes only on save success — the reliable "saved" signal
+        // here, since other empty rows already show the dash.
+        await expect.poll(() => modal().elements().length).toBe(0);
+        await expect.element(page.getByText('–').first()).toBeVisible();
+        const saved = editApi.lastRequest?.body as {members: Array<Record<string, unknown>>};
+        expect(saved.members[0].custom_fields).toEqual({job_title: null});
+    });
+
+    it('a dirty editor refuses casual dismissal; a pristine one closes freely', async () => {
+        const m = member({name: 'Ada Lovelace'});
+        fakeMemberDetailWorld(m, {job_title: 'Editor'});
+        await renderAdminApp(`/members/${m.id}`, FLAGS);
+
+        // Dirty: Escape must NOT close it — typed values can't be lost to a
+        // stray key or click; Cancel is the one explicit discard.
+        await page.getByRole('button', {name: 'Edit Job title'}).click();
+        await modal().getByLabelText('Job title').fill('Publisher');
+        await userEvent.keyboard('{Escape}');
+        await expect.element(modal()).toBeVisible();
+        await modal().getByRole('button', {name: 'Cancel'}).click();
+        await expect.poll(() => modal().elements().length).toBe(0);
+
+        // Pristine: Escape dismisses without ceremony.
+        await page.getByRole('button', {name: 'Edit Job title'}).click();
+        await expect.element(modal()).toBeVisible();
+        await userEvent.keyboard('{Escape}');
+        await expect.poll(() => modal().elements().length).toBe(0);
+    });
+
+    it('cancelling the editor discards the edit', async () => {
+        const m = member({name: 'Ada Lovelace'});
+        const editApi = fakeMemberDetailWorld(m, {job_title: 'Editor'});
+        await renderAdminApp(`/members/${m.id}`, FLAGS);
+
+        await page.getByRole('button', {name: 'Edit Job title'}).click();
+        await modal().getByLabelText('Job title').fill('Publisher');
+        await modal().getByRole('button', {name: 'Cancel'}).click();
+
+        await expect.element(page.getByText('Editor')).toBeVisible();
+        expect(editApi.requests).toHaveLength(0);
+    });
+
+    it('blocks saving an incomplete address with inline sub-field errors, then saves once fixed', async () => {
+        const m = member({name: 'Ada Lovelace'});
+        const editApi = fakeMemberDetailWorld(m, {});
+        await renderAdminApp(`/members/${m.id}`, FLAGS);
+
+        await page.getByRole('button', {name: 'Edit Home address'}).click();
+        await modal().getByLabelText('Address line 1').fill('1 Main St');
+        await modal().getByRole('button', {name: 'Save', exact: true}).click();
+
+        // No request went out; the errors say what to do, in plain words.
+        await expect.element(modal().getByText('Enter a city.')).toBeVisible();
+        await expect.element(modal().getByText('Enter a postal code.')).toBeVisible();
+        await expect.element(modal().getByText('Enter a 2-letter country code, like US.')).toBeVisible();
+        expect(editApi.requests).toHaveLength(0);
+
+        await modal().getByLabelText('City').fill('Berlin');
+        await modal().getByLabelText('Postal code').fill('10115');
+        await modal().getByLabelText('Country').fill('DE');
+        await modal().getByRole('button', {name: 'Save', exact: true}).click();
+
+        await expect.element(page.getByText('1 Main St, Berlin, 10115, DE')).toBeVisible();
+        const saved = editApi.lastRequest?.body as {members: Array<Record<string, unknown>>};
+        expect(saved.members[0].custom_fields).toEqual({home_address: ADDRESS});
+    });
+
+    it('pins a server-side 422 to the field it names, inside the editor', async () => {
+        const m = member({name: 'Ada Lovelace'});
+        fakeMemberDetailWorld(m, {});
+        // Registered after the stateful world, so it wins the PUT: the server
+        // rejects with the contract's dotted property path.
+        fakeAdminEndpoint('PUT', new RegExp(`^/members/${m.id}/`), {
+            errors: [{
+                property: 'custom_fields.job_title',
+                context: 'Rejected by the server for reasons the client could not know.',
+                message: 'Invalid value for custom field \'Job title\'.'
+            }]
+        }, {status: 422});
+        await renderAdminApp(`/members/${m.id}`, FLAGS);
+
+        await page.getByRole('button', {name: 'Edit Job title'}).click();
+        await modal().getByLabelText('Job title').fill('Editor');
+        await modal().getByRole('button', {name: 'Save', exact: true}).click();
+
+        await expect.element(modal().getByText('Rejected by the server for reasons the client could not know.')).toBeVisible();
+    });
+
+    it('hides the section when the site has no custom fields defined', async () => {
+        const m = member({name: 'Ada Lovelace'});
+        fakeMembers([m]);
+        fakeAdminEndpoint('GET', new RegExp(`^/members/${m.id}/`), {members: [{...m, custom_fields: {}}]});
+        fakeAdminEndpoint('GET', '/members/custom_fields/', {members_custom_fields: []});
+        fakeAdminEndpoint('GET', new RegExp('^/members/events/'), {
+            events: [],
+            meta: {pagination: {page: 1, limit: 5, pages: 1, total: 0, next: null, prev: null}}
+        });
+        await renderAdminApp(`/members/${m.id}`, FLAGS);
+
+        await expect.element(page.getByLabelText('Name')).toBeVisible();
+        expect(page.getByTestId('member-custom-fields-field').elements()).toHaveLength(0);
+    });
+});

--- a/apps/admin/src/members/detail/member-detail-custom-fields.acceptance.test.tsx
+++ b/apps/admin/src/members/detail/member-detail-custom-fields.acceptance.test.tsx
@@ -79,6 +79,29 @@ describe('Member detail custom fields', () => {
         expect(saved.members[0].name).toBeUndefined();
     });
 
+    it('leaves an unsaved page edit intact when a custom field is saved', async () => {
+        const m = member({name: 'Ada Lovelace'});
+        const editApi = fakeMemberDetailWorld(m, {job_title: 'Editor'});
+        await renderAdminApp(`/members/${m.id}`, FLAGS);
+
+        // Dirty the page draft by editing the name, without saving it.
+        await page.getByLabelText('Name').fill('Ada L.');
+        const pageSave = page.getByTestId('member-detail').getByRole('button', {name: 'Save', exact: true});
+        await expect.element(pageSave).toBeEnabled();
+
+        // A custom-field save triggers a member refetch. That refetch must not
+        // reseed the page draft — the unsaved name edit has to survive, and the
+        // field payload must not carry the name.
+        await page.getByRole('button', {name: 'Edit Job title'}).click();
+        await modal().getByLabelText('Job title').fill('Publisher');
+        await modal().getByRole('button', {name: 'Save', exact: true}).click();
+        await expect.element(page.getByText('Publisher')).toBeVisible();
+
+        await expect.element(page.getByLabelText('Name')).toHaveValue('Ada L.');
+        await expect.element(pageSave).toBeEnabled();
+        expect(editApi.lastRequest?.body).toEqual({members: [{id: m.id, custom_fields: {job_title: 'Publisher'}}]});
+    });
+
     it('clears a value by saving an emptied editor (null merge patch)', async () => {
         const m = member({name: 'Ada Lovelace'});
         const editApi = fakeMemberDetailWorld(m, {job_title: 'Editor'});

--- a/apps/admin/src/members/detail/member-detail-edit.test.ts
+++ b/apps/admin/src/members/detail/member-detail-edit.test.ts
@@ -348,6 +348,11 @@ describe('getCustomFieldValidationErrors', () => {
         expect(errors).toEqual({job_title: 'Use 255 characters or fewer.'});
     });
 
+    it('reports an over-long required address sub-field as a length problem, not a missing one', () => {
+        const errors = getCustomFieldValidationErrors({home_address: {...validAddress, line1: 'x'.repeat(256)}}, fields);
+        expect(errors).toEqual({'home_address.line1': 'Use 255 characters or fewer.'});
+    });
+
     it('validates the normalized value, so whitespace does not dodge a limit', () => {
         const errors = getCustomFieldValidationErrors({home_address: {line1: '1 Main St', city: '  ', postal_code: '10115', country: 'DE'}}, fields);
         expect(Object.keys(errors)).toEqual(['home_address.city']);

--- a/apps/admin/src/members/detail/member-detail-edit.test.ts
+++ b/apps/admin/src/members/detail/member-detail-edit.test.ts
@@ -1,5 +1,6 @@
-import {NOTE_MAX_LENGTH, buildMemberFieldEditPayload, getDefaultNewsletterIdsForNewMember, getEmailErrorMessage, getMemberEditableSlice, getMemberNewslettersUiEnabled, getMemberSuppressionInfo, getNoteCharactersLeft, isDraftInSyncWithServer, isValidMemberEmail, resolveSlugsToLabels, toggleMemberNewsletter} from './member-detail-edit';
+import {NOTE_MAX_LENGTH, buildCustomFieldSavePayload, buildMemberFieldEditPayload, getCustomFieldValidationErrors, getDefaultNewsletterIdsForNewMember, getEditableCustomFieldValues, getEmailErrorMessage, getMemberEditableSlice, getMemberNewslettersUiEnabled, getMemberSuppressionInfo, getNoteCharactersLeft, isDraftInSyncWithServer, isValidMemberEmail, parseCustomFieldServerErrors, resolveSlugsToLabels, toggleMemberNewsletter} from './member-detail-edit';
 import {describe, expect, it} from 'vitest';
+import type {MemberCustomField} from '@tryghost/admin-x-framework/api/member-custom-fields';
 
 describe('getMemberEditableSlice', () => {
     it('normalizes missing fields to empty strings and empty relation lists', () => {
@@ -68,6 +69,49 @@ describe('buildMemberFieldEditPayload', () => {
     it('sends an empty newsletters array only when the user has explicitly unsubscribed from all', () => {
         const payload = buildMemberFieldEditPayload('mem_1', {...baseline, newsletters: []}, baseline);
         expect(payload.newsletters).toEqual([]);
+    });
+
+    it('never carries custom_fields — those save individually, not through the page', () => {
+        const payload = buildMemberFieldEditPayload('mem_1', {...baseline, name: 'Ada B'}, baseline);
+        expect(payload.custom_fields).toBeUndefined();
+    });
+});
+
+describe('getEditableCustomFieldValues', () => {
+    it('keeps string values trimmed and drops empty/null ones', () => {
+        expect(getEditableCustomFieldValues({job_title: ' Editor ', cleared: null, blank: '', spaces: '   '}))
+            .toEqual({job_title: 'Editor'});
+    });
+
+    it('normalizes address values: trims sub-fields, drops empty and unknown ones', () => {
+        expect(getEditableCustomFieldValues({
+            home_address: {line1: ' 1 Main St ', line2: '', city: 'Berlin', state: '   ', postal_code: '10115', country: 'DE', not_a_subfield: 'ignored'}
+        })).toEqual({
+            home_address: {line1: '1 Main St', city: 'Berlin', postal_code: '10115', country: 'DE'}
+        });
+    });
+
+    it('collapses an all-empty address to an absent key, like an empty string', () => {
+        expect(getEditableCustomFieldValues({home_address: {line1: '', city: '  ', postal_code: null}})).toEqual({});
+    });
+});
+
+describe('buildCustomFieldSavePayload', () => {
+    it('sends only this field as a merge patch, trimmed', () => {
+        expect(buildCustomFieldSavePayload('mem_1', 'job_title', ' Publisher '))
+            .toEqual({id: 'mem_1', custom_fields: {job_title: 'Publisher'}});
+    });
+
+    it('sends null to clear an emptied value', () => {
+        expect(buildCustomFieldSavePayload('mem_1', 'job_title', '  '))
+            .toEqual({id: 'mem_1', custom_fields: {job_title: null}});
+    });
+
+    it('sends a normalized address whole, and null when every sub-field is empty', () => {
+        expect(buildCustomFieldSavePayload('mem_1', 'home_address', {line1: ' 1 Main St ', line2: '', city: 'Berlin', postal_code: '10115', country: 'DE'}))
+            .toEqual({id: 'mem_1', custom_fields: {home_address: {line1: '1 Main St', city: 'Berlin', postal_code: '10115', country: 'DE'}}});
+        expect(buildCustomFieldSavePayload('mem_1', 'home_address', {line1: '', city: '  '}))
+            .toEqual({id: 'mem_1', custom_fields: {home_address: null}});
     });
 });
 
@@ -267,6 +311,69 @@ describe('isDraftInSyncWithServer', () => {
 
     it('is out of sync when the user has toggled a newsletter', () => {
         expect(isDraftInSyncWithServer({...server, newsletters: []}, server)).toBe(false);
+    });
+});
+
+describe('getCustomFieldValidationErrors', () => {
+    const fields = [
+        {key: 'job_title', name: 'Job title', type: 'short_text', created_at: '', updated_at: null},
+        {key: 'home_address', name: 'Home address', type: 'address', created_at: '', updated_at: null}
+    ] as MemberCustomField[];
+    const validAddress = {line1: '1 Main St', city: 'Berlin', postal_code: '10115', country: 'DE'};
+
+    it('returns no errors for valid values', () => {
+        expect(getCustomFieldValidationErrors({job_title: 'Editor', home_address: validAddress}, fields)).toEqual({});
+    });
+
+    it('returns no errors for empty or cleared values — fields are optional', () => {
+        expect(getCustomFieldValidationErrors({job_title: '', home_address: {}}, fields)).toEqual({});
+    });
+
+    it('reports missing required address sub-fields in plain words, keyed by dotted path', () => {
+        const errors = getCustomFieldValidationErrors({home_address: {line1: '1 Main St'}}, fields);
+        expect(errors).toEqual({
+            'home_address.city': 'Enter a city.',
+            'home_address.postal_code': 'Enter a postal code.',
+            'home_address.country': 'Enter a 2-letter country code, like US.'
+        });
+    });
+
+    it('explains a malformed country code rather than echoing the schema message', () => {
+        const errors = getCustomFieldValidationErrors({home_address: {...validAddress, country: 'DEU'}}, fields);
+        expect(errors).toEqual({'home_address.country': 'Enter a 2-letter country code, like US.'});
+    });
+
+    it('reports an over-long short_text value with the limit a person can act on', () => {
+        const errors = getCustomFieldValidationErrors({job_title: 'x'.repeat(256)}, fields);
+        expect(errors).toEqual({job_title: 'Use 255 characters or fewer.'});
+    });
+
+    it('validates the normalized value, so whitespace does not dodge a limit', () => {
+        const errors = getCustomFieldValidationErrors({home_address: {line1: '1 Main St', city: '  ', postal_code: '10115', country: 'DE'}}, fields);
+        expect(Object.keys(errors)).toEqual(['home_address.city']);
+    });
+});
+
+describe('parseCustomFieldServerErrors', () => {
+    const serverError = (apiErrors: Array<{property?: string | null; context?: string | null; message?: string | null}>) => ({data: {errors: apiErrors}});
+
+    it('maps a custom-fields 422 onto its dotted field path, preferring context', () => {
+        expect(parseCustomFieldServerErrors(serverError([{
+            property: 'custom_fields.home_address.postal_code',
+            context: 'Required',
+            message: 'Invalid value for custom field \'Home address\'.'
+        }]))).toEqual({'home_address.postal_code': 'Required'});
+    });
+
+    it('falls back to the message when context is empty', () => {
+        expect(parseCustomFieldServerErrors(serverError([{property: 'custom_fields.job_title', context: null, message: 'Nope.'}])))
+            .toEqual({job_title: 'Nope.'});
+    });
+
+    it('returns undefined for failures that are not custom-fields shaped', () => {
+        expect(parseCustomFieldServerErrors(serverError([{property: 'email', context: 'Invalid', message: 'Invalid'}]))).toBeUndefined();
+        expect(parseCustomFieldServerErrors(new Error('network'))).toBeUndefined();
+        expect(parseCustomFieldServerErrors(undefined)).toBeUndefined();
     });
 });
 

--- a/apps/admin/src/members/detail/member-detail-edit.ts
+++ b/apps/admin/src/members/detail/member-detail-edit.ts
@@ -276,19 +276,32 @@ const ADDRESS_SUBFIELD_MESSAGES: Record<typeof ADDRESS_SUBFIELD_KEYS[number], st
     country: 'Enter a 2-letter country code, like US.'
 };
 
+// Required free-text sub-fields fail as too_small when missing and too_big when
+// over the limit, but their copy above only fits the missing case — so an
+// over-long value defers to the length message. The others already read
+// correctly for their over-long case (line2/state say "shorter"; country is a
+// format hint that fits a too-long code too), so they keep their copy.
+const ADDRESS_SUBFIELDS_LENGTH_ON_TOO_BIG: ReadonlySet<string> = new Set(['line1', 'city', 'postal_code']);
+
 /** A schema issue translated into copy a person can act on. */
 function friendlyValidationMessage(
     field: MemberCustomField,
     issue: {code?: string; path: ReadonlyArray<PropertyKey>; maximum?: unknown}
 ): string {
+    const tooBigMaximum = issue.code === 'too_big' && typeof issue.maximum === 'number' ? issue.maximum : undefined;
     if (field.type === 'address') {
         const subfield = issue.path[0];
-        if (typeof subfield === 'string' && subfield in ADDRESS_SUBFIELD_MESSAGES) {
-            return ADDRESS_SUBFIELD_MESSAGES[subfield as typeof ADDRESS_SUBFIELD_KEYS[number]];
+        if (typeof subfield === 'string') {
+            if (tooBigMaximum !== undefined && ADDRESS_SUBFIELDS_LENGTH_ON_TOO_BIG.has(subfield)) {
+                return `Use ${tooBigMaximum} characters or fewer.`;
+            }
+            if (subfield in ADDRESS_SUBFIELD_MESSAGES) {
+                return ADDRESS_SUBFIELD_MESSAGES[subfield as typeof ADDRESS_SUBFIELD_KEYS[number]];
+            }
         }
     }
-    if (issue.code === 'too_big' && typeof issue.maximum === 'number') {
-        return `Use ${issue.maximum} characters or fewer.`;
+    if (tooBigMaximum !== undefined) {
+        return `Use ${tooBigMaximum} characters or fewer.`;
     }
     // The remaining scalar rule is long_text's byte bound; characters are the
     // unit a person can reason about, bytes are not.

--- a/apps/admin/src/members/detail/member-detail-edit.ts
+++ b/apps/admin/src/members/detail/member-detail-edit.ts
@@ -1,6 +1,15 @@
 import moment from 'moment-timezone';
+import {MEMBER_CUSTOM_FIELD_TYPES} from '@tryghost/admin-x-framework/api/member-custom-fields';
 import {dequal} from 'dequal';
 import type {EditMemberData, Member} from '@tryghost/admin-x-framework/api/members';
+import type {MemberCustomField, MemberCustomFieldAddress} from '@tryghost/admin-x-framework/api/member-custom-fields';
+
+// The sub-fields of the address composite, in display order. Partial because a
+// draft mid-edit (or a normalized sparse value) may hold any subset; the shared
+// AddressValue schema — enforced by the server — decides completeness.
+export const ADDRESS_SUBFIELD_KEYS = ['line1', 'line2', 'city', 'state', 'postal_code', 'country'] as const;
+export type EditableAddressValue = Partial<Pick<MemberCustomFieldAddress, typeof ADDRESS_SUBFIELD_KEYS[number]>>;
+export type EditableCustomFieldValue = string | EditableAddressValue;
 
 export interface MemberEditableLabel {
     name: string;
@@ -14,6 +23,9 @@ export interface MemberEditableFields {
     labels: MemberEditableLabel[];
     // Subscribed-newsletter ids, sorted, so order changes never look dirty.
     newsletters: string[];
+    // Custom field values are deliberately NOT part of this slice: they save
+    // individually through their own per-field editor (one field, one Save),
+    // never through the page's draft/Save flow.
 }
 
 // The members API returns null (not just undefined) for unset name/email/note,
@@ -53,6 +65,44 @@ export function getMemberEditableSlice(member: MemberFieldSource): MemberEditabl
             .map(nl => nl.id)
             .sort()
     };
+}
+
+/**
+ * The custom field values from a member's `custom_fields` payload, normalized:
+ * strings trimmed, address sub-fields trimmed with empty ones dropped, and
+ * empty values ('' / {} / null) collapsing to an absent key — so "no value"
+ * reads identically however it's represented. Feeds the read-only value rows
+ * and seeds the per-field editor.
+ */
+export function getEditableCustomFieldValues(customFields: Record<string, unknown> | null | undefined): Record<string, EditableCustomFieldValue> {
+    const values: Record<string, EditableCustomFieldValue> = {};
+    for (const [key, value] of Object.entries(customFields ?? {})) {
+        if (typeof value === 'string' && value.trim() !== '') {
+            values[key] = value.trim();
+        } else if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+            const address = normalizeAddressValue(value as Record<string, unknown>);
+            if (address) {
+                values[key] = address;
+            }
+        }
+    }
+    return values;
+}
+
+/**
+ * An address value reduced to its known sub-fields, trimmed, with empty
+ * sub-fields dropped. Undefined when nothing remains, so an all-blank address
+ * normalizes to "no value" exactly like an empty string does.
+ */
+function normalizeAddressValue(value: Record<string, unknown>): EditableAddressValue | undefined {
+    const address: EditableAddressValue = {};
+    for (const subfield of ADDRESS_SUBFIELD_KEYS) {
+        const subvalue = value[subfield];
+        if (typeof subvalue === 'string' && subvalue.trim() !== '') {
+            address[subfield] = subvalue.trim();
+        }
+    }
+    return Object.keys(address).length ? address : undefined;
 }
 
 /**
@@ -195,6 +245,109 @@ export function buildMemberFieldEditPayload(
         payload.newsletters = normalized.newsletters.map(nlId => ({id: nlId}));
     }
     return payload;
+}
+
+/**
+ * The save payload for ONE custom field, from the per-field editor. Merge
+ * semantics do the rest: only this key is touched, `null` clears it, and an
+ * address is sent whole (the merge is per field, not per sub-field).
+ */
+export function buildCustomFieldSavePayload(
+    memberId: string,
+    fieldKey: string,
+    value: EditableCustomFieldValue
+): EditMemberData {
+    const normalized = typeof value === 'string'
+        ? (value.trim() || undefined)
+        : normalizeAddressValue(value);
+    return {id: memberId, custom_fields: {[fieldKey]: normalized ?? null}};
+}
+
+// What to do about a missing or malformed address sub-field, in plain words.
+// Schema messages (zod's "Invalid input: expected string…") never reach the
+// screen — the schema decides WHETHER a value is valid, this copy says what
+// to do about it.
+const ADDRESS_SUBFIELD_MESSAGES: Record<typeof ADDRESS_SUBFIELD_KEYS[number], string> = {
+    line1: 'Enter a street address.',
+    line2: 'Enter a shorter address line.',
+    city: 'Enter a city.',
+    state: 'Enter a shorter state.',
+    postal_code: 'Enter a postal code.',
+    country: 'Enter a 2-letter country code, like US.'
+};
+
+/** A schema issue translated into copy a person can act on. */
+function friendlyValidationMessage(
+    field: MemberCustomField,
+    issue: {code?: string; path: ReadonlyArray<PropertyKey>; maximum?: unknown}
+): string {
+    if (field.type === 'address') {
+        const subfield = issue.path[0];
+        if (typeof subfield === 'string' && subfield in ADDRESS_SUBFIELD_MESSAGES) {
+            return ADDRESS_SUBFIELD_MESSAGES[subfield as typeof ADDRESS_SUBFIELD_KEYS[number]];
+        }
+    }
+    if (issue.code === 'too_big' && typeof issue.maximum === 'number') {
+        return `Use ${issue.maximum} characters or fewer.`;
+    }
+    // The remaining scalar rule is long_text's byte bound; characters are the
+    // unit a person can reason about, bytes are not.
+    return 'This text is too long to save. Shorten it a little.';
+}
+
+/**
+ * Client-side validation of custom field values against the shared catalog
+ * schemas — the same schemas the server enforces, so the two can never
+ * disagree on substance. Returns messages keyed by `fieldKey` (scalar) or
+ * `fieldKey.subfield` (composite sub-field), matching the path shape of the
+ * server's 422 `property` so both error sources render through one map.
+ * Cleared/empty values are always valid — fields are optional.
+ */
+export function getCustomFieldValidationErrors(
+    draftCustomFields: Record<string, EditableCustomFieldValue>,
+    fields: MemberCustomField[]
+): Record<string, string> {
+    const errors: Record<string, string> = {};
+    const values = getEditableCustomFieldValues(draftCustomFields);
+    for (const field of fields) {
+        const value = values[field.key];
+        if (value === undefined) {
+            continue;
+        }
+        // Runtime guard for a future type this build doesn't know; the server
+        // remains authoritative for those.
+        const definition = MEMBER_CUSTOM_FIELD_TYPES[field.type];
+        if (!definition) {
+            continue;
+        }
+        const result = definition.value.safeParse(value);
+        if (!result.success) {
+            for (const issue of result.error.issues) {
+                const key = [field.key, ...issue.path].join('.');
+                errors[key] ??= friendlyValidationMessage(field, issue);
+            }
+        }
+    }
+    return errors;
+}
+
+/**
+ * Field-level errors from a failed member save. The values service names the
+ * offending field in `property` as `custom_fields.<key>[.<subfield>]` with the
+ * reason in `context` (see members-custom-fields/values-service.ts), so the
+ * message can be rendered under the exact input it belongs to. Returns
+ * undefined when the failure isn't custom-fields shaped, letting callers fall
+ * back to the generic toast.
+ */
+export function parseCustomFieldServerErrors(error: unknown): Record<string, string> | undefined {
+    const data = (error as {data?: {errors?: Array<{property?: string | null; context?: string | null; message?: string | null}>}} | null)?.data;
+    const errors: Record<string, string> = {};
+    for (const apiError of data?.errors ?? []) {
+        if (apiError.property?.startsWith('custom_fields.')) {
+            errors[apiError.property.slice('custom_fields.'.length)] = apiError.context || apiError.message || 'Invalid value.';
+        }
+    }
+    return Object.keys(errors).length ? errors : undefined;
 }
 
 /**

--- a/apps/admin/src/members/detail/member-detail-format.test.ts
+++ b/apps/admin/src/members/detail/member-detail-format.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest';
-import {formatMemberLocation, getMemberReferrerSource, parseMemberGeolocation} from './member-detail-format';
+import {formatAddressValue, formatMemberLocation, getMemberReferrerSource, parseMemberGeolocation} from './member-detail-format';
 
 describe('parseMemberGeolocation', () => {
     it('returns null for missing input', () => {
@@ -79,5 +79,22 @@ describe('getMemberReferrerSource', () => {
     it('hides the "Created manually" placeholder source', () => {
         // Mirrors the Ember gh-member-details referrerSource getter.
         expect(getMemberReferrerSource({referrer_source: 'Created manually'})).toBeNull();
+    });
+});
+
+describe('formatAddressValue', () => {
+    it('formats a full address as one readable line', () => {
+        expect(formatAddressValue({line1: '1 Main St', line2: '12 apt B', city: 'New York', state: 'NY', postal_code: '00001', country: 'US'}))
+            .toBe('1 Main St, 12 apt B, New York, NY 00001, US');
+    });
+
+    it('pairs state and postal code, and drops missing sub-fields cleanly', () => {
+        expect(formatAddressValue({line1: '1 Main St', city: 'Berlin', postal_code: '10115', country: 'DE'}))
+            .toBe('1 Main St, Berlin, 10115, DE');
+        expect(formatAddressValue({city: 'Berlin'})).toBe('Berlin');
+    });
+
+    it('formats an empty address as an empty string', () => {
+        expect(formatAddressValue({})).toBe('');
     });
 });

--- a/apps/admin/src/members/detail/member-detail-format.ts
+++ b/apps/admin/src/members/detail/member-detail-format.ts
@@ -50,6 +50,19 @@ export function formatMemberLocation(rawGeolocation: string | null | undefined):
 }
 
 /**
+ * An address value as one readable line for the custom fields card:
+ * "1 Main St, 12 apt B, New York, NY 00001, US". State and postal code pair
+ * up the way people write them; whatever sub-fields are missing simply drop
+ * out, so a partial address still reads naturally.
+ */
+export function formatAddressValue(address: Partial<Record<'line1' | 'line2' | 'city' | 'state' | 'postal_code' | 'country', string>>): string {
+    const statePostal = [address.state, address.postal_code].filter(Boolean).join(' ');
+    return [address.line1, address.line2, address.city, statePostal, address.country]
+        .filter(Boolean)
+        .join(', ');
+}
+
+/**
  * The signup referrer source for the "Signup info" block. Members created from the
  * admin carry the placeholder source "Created manually", which the Ember screen
  * hides — so we return null for it (and for any empty source).

--- a/apps/admin/src/members/detail/member-detail.tsx
+++ b/apps/admin/src/members/detail/member-detail.tsx
@@ -1,5 +1,6 @@
 import MemberActionsMenu from './member-actions-menu';
 import MemberActivityFeed from './member-activity-feed';
+import MemberCustomFieldsField from './member-custom-fields-field';
 import MemberDetailForm from './member-detail-form';
 import MemberDetailSidebar from './member-detail-sidebar';
 import MemberNewslettersField from './member-newsletters-field';
@@ -20,6 +21,7 @@ import {toast} from 'sonner';
 import {useBlocker} from 'react-router';
 import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
 import {useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
+import {useFeatureFlag} from '@/hooks/use-feature-flag';
 import {useHashLinkNavigationGuard} from '@/hooks/use-hash-link-navigation-guard';
 import type {MemberEditableFields} from './member-detail-edit';
 
@@ -42,10 +44,14 @@ const MemberDetailPage: React.FC<MemberDetailPageProps> = ({paidMembersEnabled, 
     const backPath = deriveMemberDetailBackPath(location.search);
     const isCreating = memberId === CREATE_ID;
 
+    // Values ride the member payload (`include=custom_fields`) but the include
+    // only exists behind the flag, so it must not be sent on flag-off sites.
+    const customFieldsEnabled = useFeatureFlag('membersCustomFields');
+
     // `include=tiers` mirrors the Ember route so complimentary tiers arrive with the member.
     const {data, isLoading, error, refetch} = getMember(memberId, {
         enabled: !!memberId && !isCreating,
-        searchParams: {include: 'tiers'},
+        searchParams: {include: customFieldsEnabled ? 'tiers,custom_fields' : 'tiers'},
         defaultErrorHandler: false
     });
     const member = data?.members?.[0];
@@ -401,6 +407,19 @@ const MemberDetailPage: React.FC<MemberDetailPageProps> = ({paidMembersEnabled, 
                                         />
                                     </CardContent>
                                 </Card>
+
+                                {/* Custom fields: a read-only record of the member's values —
+                                    each field edits and saves individually through its own
+                                    modal, never through this page's Save. Existing members
+                                    only — the create contract doesn't take values yet, and a
+                                    value can't exist before its member does. */}
+                                {customFieldsEnabled && member && (
+                                    <MemberCustomFieldsField
+                                        customFields={member.custom_fields}
+                                        disabled={activeMutation.isPending}
+                                        memberId={member.id}
+                                    />
+                                )}
 
                                 {/* Newsletters section owns its external heading + card so an empty
                                     newsletter list hides the whole thing (returns null). Renders

--- a/e2e/helpers/pages/admin/members/member-details-page.ts
+++ b/e2e/helpers/pages/admin/members/member-details-page.ts
@@ -72,6 +72,10 @@ export class MemberDetailsPage extends AdminPage {
 
     readonly screenTitle: Locator;
     readonly logoutConfirmModal: Locator;
+
+    // Custom fields (React screen only, behind the membersCustomFields flag).
+    readonly customFieldsCard: Locator;
+    readonly customFieldModal: Locator;
     readonly newsletterSubscriptionCheckboxes: Locator;
     readonly engagementSection: Locator;
     readonly subscriptionActionsButton: Locator;
@@ -144,6 +148,27 @@ export class MemberDetailsPage extends AdminPage {
         this.emberCompTierOptions = page.locator('[data-test-tier-option]');
         this.reactCompTierOptions = page.locator('[data-tier-id]');
         this.emberSaveCompTierButton = page.locator('[data-test-button="save-comp-tier"]');
+
+        this.customFieldsCard = page.getByTestId('member-custom-fields-field');
+        this.customFieldModal = page.getByTestId('member-custom-field-edit-modal');
+    }
+
+    // The row's accessible name is "Edit {field}" (plus ": {value}" once set), so
+    // a non-exact match finds the row whether or not it holds a value yet.
+    customFieldEditButton(fieldName: string): Locator {
+        return this.customFieldsCard.getByRole('button', {name: `Edit ${fieldName}`});
+    }
+
+    /**
+     * Set a scalar (text) custom field's value through its own editor. Each
+     * field saves on its own Save, outside the page draft; the modal closes on
+     * success.
+     */
+    async setCustomFieldValue(fieldName: string, value: string): Promise<void> {
+        await this.customFieldEditButton(fieldName).click();
+        await this.customFieldModal.getByLabel(fieldName).fill(value);
+        await this.customFieldModal.getByRole('button', {name: 'Save', exact: true}).click();
+        await this.customFieldModal.waitFor({state: 'detached'});
     }
 
     /**

--- a/e2e/helpers/pages/admin/settings/sections/custom-fields-section.ts
+++ b/e2e/helpers/pages/admin/settings/sections/custom-fields-section.ts
@@ -1,0 +1,38 @@
+import {BasePage} from '@/helpers/pages';
+import {Locator, Page} from '@playwright/test';
+
+/**
+ * Settings -> Membership -> Custom fields. The whole section is behind the
+ * `membersCustomFields` flag, so a test using it must enable that flag via
+ * test.use({labs: {membersCustomFields: true}}).
+ */
+export class CustomFieldsSection extends BasePage {
+    readonly section: Locator;
+    readonly addButton: Locator;
+    readonly modal: Locator;
+
+    constructor(page: Page) {
+        super(page, '/ghost/#/settings');
+
+        this.section = page.getByTestId('custom-fields');
+        this.addButton = this.section.getByRole('button', {name: 'Add custom field'});
+        this.modal = page.getByTestId('custom-field-modal');
+    }
+
+    listItem(name: string): Locator {
+        return this.section.getByTestId('custom-field-list-item').filter({hasText: name});
+    }
+
+    /**
+     * Create a field of the default (short text) type. That keeps the member
+     * detail editor a plain text input, which is all the cross-surface flow
+     * needs. The modal closes itself on success.
+     */
+    async createShortTextField(name: string): Promise<void> {
+        await this.addButton.waitFor();
+        await this.addButton.click();
+        await this.modal.getByLabel('Name').fill(name);
+        await this.modal.getByRole('button', {name: 'Save'}).click();
+        await this.listItem(name).waitFor();
+    }
+}

--- a/e2e/helpers/pages/admin/settings/sections/index.ts
+++ b/e2e/helpers/pages/admin/settings/sections/index.ts
@@ -1,6 +1,7 @@
 export {AnnouncementBarSection} from './announcement-bar-section';
 export {DangerZoneSection} from './danger-zone-section';
 export {AccessSection} from './access-section';
+export {CustomFieldsSection} from './custom-fields-section';
 export {LabsSection} from './labs-section';
 export {IntegrationsSection} from './integrations-section';
 export {DesignSection} from './design-section';

--- a/e2e/helpers/pages/admin/settings/settings-page.ts
+++ b/e2e/helpers/pages/admin/settings/settings-page.ts
@@ -1,5 +1,5 @@
 import {BasePage} from '@/helpers/pages';
-import {DangerZoneSection, IntegrationsSection, LabsSection, PortalSection, TiersSection} from './sections';
+import {CustomFieldsSection, DangerZoneSection, IntegrationsSection, LabsSection, PortalSection, TiersSection} from './sections';
 import {Locator, Page} from '@playwright/test';
 import {StaffSection} from './sections/staff-section';
 
@@ -12,6 +12,7 @@ export class SettingsPage extends BasePage {
     readonly labsSection: LabsSection;
     readonly staffSection: StaffSection;
     readonly tiersSection: TiersSection;
+    readonly customFieldsSection: CustomFieldsSection;
     readonly dangerZoneSection: DangerZoneSection;
 
     readonly sidebar: Locator;
@@ -33,6 +34,7 @@ export class SettingsPage extends BasePage {
         this.integrationsSection = new IntegrationsSection(page);
         this.staffSection = new StaffSection(page);
         this.tiersSection = new TiersSection(page);
+        this.customFieldsSection = new CustomFieldsSection(page);
         this.dangerZoneSection = new DangerZoneSection(page);
     }
 

--- a/e2e/tests/admin/members/member-custom-fields.test.ts
+++ b/e2e/tests/admin/members/member-custom-fields.test.ts
@@ -1,0 +1,42 @@
+import {MemberDetailsPage, SettingsPage} from '@/admin-pages';
+import {createMemberFactory} from '@/data-factory';
+import {expect, test} from '@/helpers/playwright';
+import {usePerTestIsolation} from '@/helpers/playwright/isolation';
+
+/**
+ * The custom-fields journey that crosses two surfaces: a field defined in
+ * Settings has to appear on the member detail screen, take a value through its
+ * own editor, and survive a reload. The acceptance tests cover the component
+ * against a fake API; this pins the settings -> member-detail -> server
+ * round-trip they mock away.
+ *
+ * React member detail only (the editor is a React-only feature) plus the
+ * membersCustomFields flag that gates the whole feature.
+ */
+usePerTestIsolation();
+
+test.describe('Ghost Admin - Member custom fields', () => {
+    test.use({labs: {membersCustomFields: true, memberDetailsReact: true}});
+
+    test('a field defined in settings takes a value on a member and persists it', async ({page}) => {
+        const fieldName = `Job title ${Date.now()}`;
+        const memberFactory = createMemberFactory(page.request);
+        const member = await memberFactory.create({name: 'Ada Lovelace', email: `ada-custom-fields-${Date.now()}@ghost.org`});
+
+        const settingsPage = new SettingsPage(page);
+        const memberDetailsPage = new MemberDetailsPage(page);
+
+        await settingsPage.goto();
+        await settingsPage.customFieldsSection.createShortTextField(fieldName);
+
+        await page.goto(`/ghost/#/members/${member.id}`);
+        await expect(memberDetailsPage.customFieldEditButton(fieldName)).toBeVisible();
+
+        await memberDetailsPage.setCustomFieldValue(fieldName, 'Editor');
+        await expect(memberDetailsPage.customFieldsCard.getByText('Editor')).toBeVisible();
+
+        await page.reload();
+
+        await expect(memberDetailsPage.customFieldsCard.getByText('Editor')).toBeVisible();
+    });
+});


### PR DESCRIPTION
## Describe the problem you are solving

Custom field definitions shipped in Settings (BER-3785), but values were only reachable over the API — nothing in the admin let a person see or change what a member's fields hold. This PR adds the value side to the React member details screen: the fields defined in Settings appear against each member as a read-only record, and each one is editable through a focused per-field editor. Behind the `membersCustomFields` flag (and the screen itself behind `memberDetailsReact`).

**Depends on #29373** (member custom field values API) — this PR consumes its contract and stays draft until it lands. With the flag on but no values API, the member read's `include=custom_fields` is rejected; with the flag off, requests are byte-identical to today.

## Changelog for devs

* Added a Custom fields section to the React member detail screen: read-only value rows (addresses formatted as one line), whole-row click opens a per-field modal editor with its own immediate Save — a single-key merge patch over the member PUT (`null` clears)
* Added client-side validation against the shared `@tryghost/custom-field-types` schemas — the same schemas the server enforces — with plain-English messages per the writing guide; a server 422 naming a field via its `property` path pins the message to the exact input as a backstop
* Added a dirty-dismissal guard to the editor: outside click and Escape are no-ops once a value has been typed, Cancel is the only explicit discard
* Added `custom_fields` to the framework's `Member`/`EditMemberData` types; the member PUT requests `include=custom_fields` only when the payload writes values
* Added acceptance coverage (8 specs: rows, editor save/clear/cancel, validation, 422 pinning, dismissal guard, empty-state) plus unit coverage for the normalization/payload/validation helpers

## Changelog for customers

* Added the ability to view and edit a member's custom field values on the member details screen (behind the `membersCustomFields` flag)

## Notes

* **Why view-first instead of inline inputs:** the member screen is a record, not a form — admins read this data constantly and change it rarely. We built the inline version first and rejected it: hot inputs put accidental edits one keystroke away, made "which Save saves what" (page vs fields) genuinely confusing, and buried the values in control chrome. The read-only record is more predictable and easier to scan — the value is the content, not the input state — and the per-field editor gives one field, one Save, one outcome, with the API's merge semantics making isolated saves safe by design.
* Rows follow the admin's existing list language: hover tint with fading dividers (settings lists), row-click with revealed pencil (tags list). Values stay text-selectable so addresses can be copied.
* Existing members only — the create contract doesn't take values yet.

## Technical debt

* Country is a bare 2-letter code input; a proper country select is a follow-up
* Server 422 `context` renders verbatim in the (rare) backstop path — humanizing that copy is a server-side follow-up, flagged separately

## PR Scope (mark all that apply)

- [x] Improves the user experience
- [ ] Enhances the readability of our code
- [ ] Simplifies the maintenance of our software
- [ ] Fixes a bug
- [ ] Provide a core layer to allow one of the points above

## Checklist before requesting a review (mark all that apply)

- [x] I have performed a self-review of my code
- [x] It's simple enough
- [x] The PR is not extensive
- [ ] It includes documentation
- [x] I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.