### PR TITLE
🐛 Fixed admin toolbar redirect loops on subdirectory sites

### DIFF
--- a/ghost/core/core/frontend/web/middleware/admin-toolbar.js
+++ b/ghost/core/core/frontend/web/middleware/admin-toolbar.js
@@ -132,10 +132,19 @@ function appendClearCookie(res) {
 
 function getCleanRedirectUrl(req) {
     const currentUrl = new URL(req.originalUrl || req.url, urlUtils.getSiteUrl());
+    const subdir = urlUtils.getSubdir();
+
     currentUrl.searchParams.delete(QUERY_PARAM);
     currentUrl.searchParams.delete(HIDE_QUERY_PARAM);
 
-    return `${currentUrl.pathname}${currentUrl.search}${currentUrl.hash}`;
+    // A proxy can strip the configured subdirectory before forwarding the
+    // request to Ghost. Preserve it in the public redirect URL unless the
+    // request path already includes it.
+    const pathname = subdir && currentUrl.pathname !== subdir && !currentUrl.pathname.startsWith(`${subdir}/`)
+        ? urlUtils.urlJoin(subdir, currentUrl.pathname)
+        : currentUrl.pathname;
+
+    return `${pathname}${currentUrl.search}${currentUrl.hash}`;
 }
 
 function getQueryValue(value) {

--- a/ghost/core/test/unit/frontend/web/middleware/admin-toolbar.test.js
+++ b/ghost/core/test/unit/frontend/web/middleware/admin-toolbar.test.js
@@ -2,6 +2,7 @@ const assert = require('node:assert/strict');
 const sinon = require('sinon');
 
 const settingsCache = require('../../../../../core/shared/settings-cache');
+const urlUtils = require('../../../../../core/shared/url-utils');
 const adminToolbar = require('../../../../../core/frontend/web/middleware/admin-toolbar');
 
 describe('admin toolbar middleware', function () {
@@ -146,6 +147,26 @@ describe('admin toolbar middleware', function () {
         };
 
         assert.equal(adminToolbar._private.getCleanRedirectUrl(req), '/welcome/?ref=test');
+    });
+
+    it('keeps the configured subdirectory when a proxy strips it from the request URL', function () {
+        sandbox.stub(urlUtils, 'getSiteUrl').returns('https://example.com/changelog/');
+        sandbox.stub(urlUtils, 'getSubdir').returns('/changelog');
+
+        assert.equal(adminToolbar._private.getCleanRedirectUrl({
+            originalUrl: '/?admin=1',
+            url: '/?admin=1'
+        }), '/changelog/');
+
+        assert.equal(adminToolbar._private.getCleanRedirectUrl({
+            originalUrl: '/?admin=1&ref=test',
+            url: '/?admin=1&ref=test'
+        }), '/changelog/?ref=test');
+
+        assert.equal(adminToolbar._private.getCleanRedirectUrl({
+            originalUrl: '/changelog/?admin=1',
+            url: '/changelog/?admin=1'
+        }), '/changelog/');
     });
 
     it('marks the request when the frontend marker cookie is valid', function () {


### PR DESCRIPTION
Activating the admin bar leads to infinite redirect loop when Ghost is running on a subdirectory - eg. https://ghost.org/changelog/?admin=1 

This fixes it

## Summary

- Preserves the configured public subdirectory when a reverse proxy strips it before forwarding an admin-toolbar activation request.
- Adds regression coverage for stripped paths, retained query parameters, and already-prefixed paths.

## Root cause

The clean redirect was derived directly from the request path. For subdirectory sites behind a rewriting proxy, Ghost receives `/?admin=1`; removing the query redirected to `/`, which the proxy rewrote back to the original public URL with `admin=1` still attached.

## Validation

- `pnpm test:single test/unit/frontend/web/middleware/admin-toolbar.test.js`
- ESLint and `git diff --check`