### PR TITLE
Fixed bulk email batch size fallback

### DIFF
--- a/ghost/core/core/server/services/lib/mailgun-client.js
+++ b/ghost/core/core/server/services/lib/mailgun-client.js
@@ -4,11 +4,11 @@ const logging = require('@tryghost/logging');
 const metrics = require('@tryghost/metrics');
 const errors = require('@tryghost/errors');
 
+const DEFAULT_BATCH_SIZE = 1000;
+
 module.exports = class MailgunClient {
     #config;
     #settings;
-
-    static DEFAULT_BATCH_SIZE = 1000;
 
     constructor({config, settings}) {
         this.#config = config;
@@ -393,7 +393,7 @@ module.exports = class MailgunClient {
      * @returns {number}
      */
     getBatchSize() {
-        return this.#config.get('bulkEmail')?.batchSize ?? this.DEFAULT_BATCH_SIZE;
+        return this.#config.get('bulkEmail')?.batchSize ?? DEFAULT_BATCH_SIZE;
     }
 
     /**

--- a/ghost/core/test/unit/server/services/lib/mailgun-client.test.js
+++ b/ghost/core/test/unit/server/services/lib/mailgun-client.test.js
@@ -43,19 +43,35 @@ describe('MailgunClient', function () {
         sinon.restore();
     });
 
-    it('exports a number for configurable batch size', function () {
-        const configStub = sinon.stub(config, 'get');
-        configStub.withArgs('bulkEmail').returns({
-            mailgun: {
-                apiKey: 'apiKey',
-                domain: 'domain.com',
-                baseUrl: 'https://api.mailgun.net/v3'
-            },
-            batchSize: 1000
+    describe('getBatchSize', function () {
+        it('reads the batch size from config if available', function () {
+            const configStub = sinon.stub(config, 'get');
+            configStub.withArgs('bulkEmail').returns({
+                mailgun: {
+                    apiKey: 'apiKey',
+                    domain: 'domain.com',
+                    baseUrl: 'https://api.mailgun.net/v3'
+                },
+                batchSize: 1234
+            });
+
+            const mailgunClient = new MailgunClient({config, settings});
+            assert.equal(mailgunClient.getBatchSize(), 1234);
         });
 
-        const mailgunClient = new MailgunClient({config, settings});
-        assert(typeof mailgunClient.getBatchSize() === 'number');
+        it('has a default batch size if missing from config', function () {
+            const configStub = sinon.stub(config, 'get');
+            configStub.withArgs('bulkEmail').returns({
+                mailgun: {
+                    apiKey: 'apiKey',
+                    domain: 'domain.com',
+                    baseUrl: 'https://api.mailgun.net/v3'
+                }
+            });
+
+            const mailgunClient = new MailgunClient({config, settings});
+            assert.equal(mailgunClient.getBatchSize(), 1000);
+        });
     });
 
     it('exports a number for configurable target delivery window', function () {


### PR DESCRIPTION
no ref

_I recommend [reviewing this with whitespace changes disabled][0]._

`MailgunClient.prototype.getBatchSize()` reads its value from config, but if that value is missing, it returns a fallback. But there was a bug and we weren't actually reading the fallback--we read `undefined`.

This *would have* caused a cascade of problems which we probably would have noticed by now. Luckily, `defaults.json` includes this value, so we never hit the fallback. (It's possible some self-hoster set `bulkEmail: null`, which would trigger this, but that's unlikely.)

Primarily, this fixes a type error. Secondarily, it avoids this potential problem.

[0]: https://github.com/TryGhost/Ghost/pull/29413/changes?w=1
