### PR TITLE
Fixed thin-resource errors from the search index tag and post fetches

### DIFF
--- a/ghost/core/core/server/api/endpoints/search-index-public.js
+++ b/ghost/core/core/server/api/endpoints/search-index-public.js
@@ -1,5 +1,6 @@
 const models = require('../../models');
 const urlService = require('../../services/url');
+const {requiredUrlColumns} = require('./utils/serializers/input/utils/url');
 const getPostServiceInstance = require('../../services/posts/posts-service-instance');
 const postsService = getPostServiceInstance();
 
@@ -21,7 +22,7 @@ const controller = {
                 filter: 'type:post',
                 limit: '10000',
                 order: 'updated_at DESC',
-                columns: ['id', 'slug', 'title', 'excerpt', 'url', 'updated_at', 'visibility'],
+                columns: requiredUrlColumns('posts', ['id', 'slug', 'title', 'excerpt', 'url', 'updated_at', 'visibility']),
                 ...urlRelationsWhenLazyRouting()
             };
 
@@ -37,7 +38,7 @@ const controller = {
             const options = {
                 limit: '10000',
                 order: 'updated_at DESC',
-                columns: ['id', 'slug', 'name', 'url', 'profile_image']
+                columns: requiredUrlColumns('authors', ['id', 'slug', 'name', 'url', 'profile_image'])
             };
 
             return models.Author.findPage(options);
@@ -52,7 +53,7 @@ const controller = {
             const options = {
                 limit: '10000',
                 order: 'updated_at DESC',
-                columns: ['id', 'slug', 'name', 'url'],
+                columns: requiredUrlColumns('tags', ['id', 'slug', 'name', 'url']),
                 filter: 'visibility:public'
             };
 

--- a/ghost/core/core/server/api/endpoints/search-index.js
+++ b/ghost/core/core/server/api/endpoints/search-index.js
@@ -1,5 +1,6 @@
 const models = require('../../models');
 const urlService = require('../../services/url');
+const {requiredUrlColumns} = require('./utils/serializers/input/utils/url');
 const getPostServiceInstance = require('../../services/posts/posts-service-instance');
 const postsService = getPostServiceInstance();
 
@@ -24,7 +25,7 @@ const controller = {
                 filter: 'type:post+status:[draft,published,scheduled,sent]',
                 limit: '10000',
                 order: 'updated_at DESC',
-                columns: ['id', 'uuid', 'url', 'title', 'slug', 'status', 'published_at', 'visibility'],
+                columns: requiredUrlColumns('posts', ['id', 'uuid', 'url', 'title', 'slug', 'status', 'published_at', 'visibility']),
                 ...urlRelationsWhenLazyRouting()
             };
 
@@ -44,7 +45,7 @@ const controller = {
                 filter: 'type:page+status:[draft,published,scheduled]',
                 limit: '10000',
                 order: 'updated_at DESC',
-                columns: ['id', 'uuid', 'url', 'title', 'slug', 'status', 'published_at', 'visibility'],
+                columns: requiredUrlColumns('pages', ['id', 'uuid', 'url', 'title', 'slug', 'status', 'published_at', 'visibility']),
                 ...urlRelationsWhenLazyRouting()
             };
 
@@ -63,7 +64,7 @@ const controller = {
             const options = {
                 limit: '10000',
                 order: 'updated_at DESC',
-                columns: ['id', 'slug', 'name', 'url']
+                columns: requiredUrlColumns('tags', ['id', 'slug', 'name', 'url'])
             };
 
             return models.Tag.findPage(options);
@@ -81,7 +82,7 @@ const controller = {
             const options = {
                 limit: '10000',
                 order: 'updated_at DESC',
-                columns: ['id', 'slug', 'url', 'name', 'profile_image']
+                columns: requiredUrlColumns('authors', ['id', 'slug', 'url', 'name', 'profile_image'])
             };
 
             return models.User.findPage(options);

--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/utils/url.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/utils/url.js
@@ -108,7 +108,15 @@ const forceUrlRelationsWhenLazy = (frame, routerType) => {
     forceUrlColumnsWhenLazy(frame, routerType);
 };
 
+// Options-object variant of forceUrlColumnsWhenLazy for endpoints that build
+// their query options directly (search index).
+const requiredUrlColumns = (routerType, columns) => {
+    const required = urlService.facade.getRequiredFields(routerType).filter(field => !columns.includes(field));
+    return required.length ? [...columns, ...required] : columns;
+};
+
 module.exports.forPost = forPost;
+module.exports.requiredUrlColumns = requiredUrlColumns;
 module.exports.forUser = forUser;
 module.exports.forTag = forTag;
 module.exports.forSetting = forSetting;

--- a/ghost/core/test/unit/api/endpoints/search-index-public.test.js
+++ b/ghost/core/test/unit/api/endpoints/search-index-public.test.js
@@ -1,0 +1,54 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const models = require('../../../../core/server/models');
+const urlService = require('../../../../core/server/services/url');
+const {PostsService} = require('../../../../core/server/services/posts/posts-service-instance');
+const searchIndexController = require('../../../../core/server/api/endpoints/search-index-public');
+
+describe('Search index public controller', function () {
+    let browsePostsStub;
+
+    beforeEach(function () {
+        // the controller constructs its own PostsService instance
+        browsePostsStub = sinon.stub(PostsService.prototype, 'browsePosts').resolves({data: []});
+        sinon.stub(models.Tag, 'findPage').resolves({data: []});
+        sinon.stub(models.Author, 'findPage').resolves({data: []});
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it('lazyRouting: forces the URL service required columns into the posts fetch', async function () {
+        // the public posts fetch does not select `status`, which the lazy URL
+        // service's base filter reads
+        sinon.stub(urlService.facade, 'getRequiredFields').withArgs('posts').returns(['status', 'type', 'slug']);
+        sinon.stub(urlService.facade, 'getRequiredRelations').returns([]);
+
+        await searchIndexController.fetchPosts.query();
+
+        const options = browsePostsStub.getCall(0).args[0];
+        assert.ok(options.columns.includes('status'));
+        assert.ok(options.columns.includes('type'));
+    });
+
+    it('lazyRouting: forces the URL service required columns into the tags fetch', async function () {
+        sinon.stub(urlService.facade, 'getRequiredFields').withArgs('tags').returns(['visibility', 'slug']);
+        sinon.stub(urlService.facade, 'getRequiredRelations').returns([]);
+
+        await searchIndexController.fetchTags.query();
+
+        const options = models.Tag.findPage.getCall(0).args[0];
+        assert.deepEqual(options.columns, ['id', 'slug', 'name', 'url', 'visibility']);
+    });
+
+    it('lazyRouting: leaves columns untouched under the eager service', async function () {
+        sinon.stub(urlService.facade, 'getRequiredFields').returns([]);
+        sinon.stub(urlService.facade, 'getRequiredRelations').returns([]);
+
+        await searchIndexController.fetchPosts.query();
+
+        const options = browsePostsStub.getCall(0).args[0];
+        assert.deepEqual(options.columns, ['id', 'slug', 'title', 'excerpt', 'url', 'updated_at', 'visibility']);
+    });
+});

--- a/ghost/core/test/unit/api/endpoints/search-index.test.js
+++ b/ghost/core/test/unit/api/endpoints/search-index.test.js
@@ -1,0 +1,53 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const models = require('../../../../core/server/models');
+const urlService = require('../../../../core/server/services/url');
+const {PostsService} = require('../../../../core/server/services/posts/posts-service-instance');
+const searchIndexController = require('../../../../core/server/api/endpoints/search-index');
+
+describe('Search index controller', function () {
+    let browsePostsStub;
+
+    beforeEach(function () {
+        // the controller constructs its own PostsService instance
+        browsePostsStub = sinon.stub(PostsService.prototype, 'browsePosts').resolves({data: []});
+        sinon.stub(models.Tag, 'findPage').resolves({data: []});
+        sinon.stub(models.User, 'findPage').resolves({data: []});
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it('lazyRouting: forces the URL service required columns into the tags fetch', async function () {
+        sinon.stub(urlService.facade, 'getRequiredFields').withArgs('tags').returns(['visibility', 'slug']);
+        sinon.stub(urlService.facade, 'getRequiredRelations').returns([]);
+
+        await searchIndexController.fetchTags.query();
+
+        const options = models.Tag.findPage.getCall(0).args[0];
+        assert.deepEqual(options.columns, ['id', 'slug', 'name', 'url', 'visibility']);
+    });
+
+    it('lazyRouting: forces router-filter columns into the posts fetch', async function () {
+        const getRequiredFields = sinon.stub(urlService.facade, 'getRequiredFields');
+        getRequiredFields.withArgs('posts').returns(['status', 'type', 'slug', 'featured']);
+        sinon.stub(urlService.facade, 'getRequiredRelations').returns([]);
+
+        await searchIndexController.fetchPosts.query();
+
+        const options = browsePostsStub.getCall(0).args[0];
+        assert.ok(options.columns.includes('featured'));
+        assert.ok(options.columns.includes('type'));
+    });
+
+    it('lazyRouting: leaves columns untouched under the eager service', async function () {
+        sinon.stub(urlService.facade, 'getRequiredFields').returns([]);
+        sinon.stub(urlService.facade, 'getRequiredRelations').returns([]);
+
+        await searchIndexController.fetchTags.query();
+
+        const options = models.Tag.findPage.getCall(0).args[0];
+        assert.deepEqual(options.columns, ['id', 'slug', 'name', 'url']);
+    });
+});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1822

The caller-frame stacks from #29344 attributed the next thin-resource class directly:

```
at Object.forTag (serializers/output/utils/url.js:72)
at mappers/tags.js:7
at Object.fetchTags (serializers/output/search-index.js:88)
```

The search index endpoints (`search-index.js`, `search-index-public.js`) hand-pick query columns and compute `url` in their mappers, but the picked columns miss what the lazy URL service reads: the tags fetches select no `visibility` (the tags base-filter column), and the public posts fetch selects no `status`. Router-filter scalar columns (`featured:`, `primary_tag:` collections) were missing from all of them.

The column lists now run through a shared `requiredUrlColumns(routerType, columns)` helper (an options-object variant of the input serializers' `forceUrlColumnsWhenLazy`), appending `getRequiredFields` for the router type. The output serializer already `_.pick`s the response keys, so the extra columns never leak into the search index payload. No-op under the eager service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)