### PR TITLE
Added archived custom fields management to Settings

### DIFF
--- a/apps/admin-x-design-system/src/global/menu.tsx
+++ b/apps/admin-x-design-system/src/global/menu.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
 import Button, {ButtonProps, ButtonSize} from './button';
+import Icon from './icon';
 import Popover, {PopoverPosition} from './popover';
 
 export type MenuItem = {
     id: string,
     label: string;
+    // Name from the design system icon set, rendered before the label. It
+    // inherits the item's text color (destructive items get a red icon).
+    icon?: string;
     destructive?: boolean;
     onClick?: (e: React.MouseEvent) => void
 }
@@ -35,11 +39,14 @@ const Menu: React.FC<MenuProps> = ({
         <Popover open={open} position={position} setOpen={setOpen} trigger={trigger} closeOnItemClick>
             <div className="flex min-w-[160px] flex-col justify-stretch py-1" role="none">
                 {items.map(item => (
-                    <button key={item.id} className={`mx-1 block cursor-pointer rounded-[2.5px] px-4 py-1.5 text-left hover:bg-grey-100 dark:hover:bg-grey-900 ${item.destructive && ' text-red-500'}`} type="button" onClick={(e) => {
+                    <button key={item.id} className={`mx-1 flex cursor-pointer items-center gap-2 rounded-[2.5px] px-4 py-1.5 text-left hover:bg-grey-100 dark:hover:bg-grey-900 ${item.destructive && ' text-red-500'}`} type="button" onClick={(e) => {
                         if (item.onClick) {
                             item.onClick(e);
                         }
-                    }}>{item.label}</button>
+                    }}>
+                        {item.icon && <Icon name={item.icon} size='sm' />}
+                        {item.label}
+                    </button>
                 ))}
             </div>
         </Popover>

--- a/apps/admin-x-design-system/src/global/menu.tsx
+++ b/apps/admin-x-design-system/src/global/menu.tsx
@@ -39,12 +39,12 @@ const Menu: React.FC<MenuProps> = ({
         <Popover open={open} position={position} setOpen={setOpen} trigger={trigger} closeOnItemClick>
             <div className="flex min-w-[160px] flex-col justify-stretch py-1" role="none">
                 {items.map(item => (
-                    <button key={item.id} className={`mx-1 flex cursor-pointer items-center gap-2 rounded-[2.5px] px-4 py-1.5 text-left hover:bg-grey-100 dark:hover:bg-grey-900 ${item.destructive && ' text-red-500'}`} type="button" onClick={(e) => {
+                    <button key={item.id} className={`mx-1 flex cursor-pointer items-center gap-2 rounded-[2.5px] px-4 py-1.5 text-left hover:bg-grey-100 dark:hover:bg-grey-900 ${item.destructive ? 'text-red-500' : ''}`} type="button" onClick={(e) => {
                         if (item.onClick) {
                             item.onClick(e);
                         }
                     }}>
-                        {item.icon && <Icon name={item.icon} size='sm' />}
+                        {item.icon && <span aria-hidden="true" className="flex"><Icon name={item.icon} size='sm' /></span>}
                         {item.label}
                     </button>
                 ))}

--- a/apps/admin-x-framework/src/api/member-custom-fields.ts
+++ b/apps/admin-x-framework/src/api/member-custom-fields.ts
@@ -73,6 +73,13 @@ export const useBrowseMemberCustomFields = createQuery<MemberCustomFieldsRespons
     path: '/members/custom_fields/'
 });
 
+// Browse hides archived fields by default. Settings is the one surface that
+// manages both, so it opts into every status through this variant rather than
+// hand-writing the filter grammar in the view.
+export const useBrowseMemberCustomFieldsIncludingArchived = (
+    options?: Parameters<typeof useBrowseMemberCustomFields>[0]
+) => useBrowseMemberCustomFields({...options, searchParams: {filter: 'status:[active,archived]'}});
+
 export const getMemberCustomField = createQueryWithId<MemberCustomFieldsResponseType>({
     dataType,
     path: key => `/members/custom_fields/${key}/`

--- a/apps/admin-x-framework/src/api/member-custom-fields.ts
+++ b/apps/admin-x-framework/src/api/member-custom-fields.ts
@@ -14,6 +14,9 @@ export type MemberCustomField = {
     // The same field-type enum the backend validates against, so admin and
     // server never drift on the set.
     type: FieldType;
+    // Browse hides archived fields by default (most surfaces only want active
+    // ones); Settings opts in via filter and splits on this.
+    status: 'active' | 'archived';
     created_at: string;
     updated_at: string | null;
 };
@@ -83,16 +86,19 @@ export const useCreateMemberCustomField = createMutation<MemberCustomFieldsRespo
     invalidateQueries: {dataType}
 });
 
-// Keys are immutable after creation (the API rejects changes), so only `name`
-// can be edited.
-export const useEditMemberCustomField = createMutation<MemberCustomFieldsResponseType, Pick<MemberCustomField, 'key' | 'name'>>({
+// Keys are immutable after creation (the API rejects changes); `name` and
+// `status` are the editable surface — a status flip to 'active' is how an
+// archived field is reactivated.
+export const useEditMemberCustomField = createMutation<MemberCustomFieldsResponseType, Pick<MemberCustomField, 'key'> & Partial<Pick<MemberCustomField, 'name' | 'status'>>>({
     method: 'PUT',
     path: field => `/members/custom_fields/${field.key}/`,
-    body: ({name}) => ({members_custom_fields: [{name}]}),
+    body: ({key: _key, ...patch}) => ({members_custom_fields: [patch]}),
     invalidateQueries: {dataType}
 });
 
-// Archiving a field (soft delete) keeps its key reserved; addressed by key.
+// DELETE permanently removes an archived field and its collected values;
+// addressed by key. The API only allows it on an already-archived field —
+// archiving and reactivating are separate status edits over PUT.
 export const useDeleteMemberCustomField = createMutation<void, string>({
     method: 'DELETE',
     path: key => `/members/custom_fields/${key}/`,

--- a/apps/admin-x-settings/src/components/settings/membership/custom-fields.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/custom-fields.tsx
@@ -1,21 +1,133 @@
 import CustomFieldModal from './custom-fields/custom-field-modal';
 import NiceModal from '@ebay/nice-modal-react';
-import React from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import TopLevelGroup from '../../top-level-group';
 import useFeatureFlag from '../../../hooks/use-feature-flag';
-import {Button, Icon} from '@tryghost/admin-x-design-system';
+import {Button, Icon, List, ListItem, TabView} from '@tryghost/admin-x-design-system';
+import {NoValueLabel, NoValueLabelIcon} from '@tryghost/shade/components';
+import {TextCursorInput} from 'lucide-react';
 import {useBrowseMemberCustomFields, userTypeForField} from '@tryghost/admin-x-framework/api/member-custom-fields';
 import {withErrorBoundary} from '../../error-boundary';
 import type {MemberCustomField} from '@tryghost/admin-x-framework/api/member-custom-fields';
 
+// How many fields render before the list collapses behind "Show all" — the
+// recommendations list's preview size.
+const PREVIEW_COUNT = 5;
+
+const FieldList: React.FC<{
+    fields: MemberCustomField[];
+    // Lifted to the parent: TabView unmounts hidden tabs, so local state
+    // would forget an expanded list on every tab switch.
+    showAll: boolean;
+    onShowAll: () => void;
+    openModal: (field: MemberCustomField) => void;
+}> = ({fields, showAll, onShowAll, openModal}) => {
+
+    if (fields.length === 0) {
+        // Mirrors the newsletters list's empty state, tab for tab.
+        return (
+            <NoValueLabel>
+                <NoValueLabelIcon><TextCursorInput /></NoValueLabelIcon>
+                No custom fields found.
+            </NoValueLabel>
+        );
+    }
+
+    // The endpoint returns the full (deliberately small) list, so "Show all"
+    // is a client-side reveal — same UI as the recommendations table, without
+    // inventing pagination the API doesn't have.
+    const visibleFields = showAll ? fields : fields.slice(0, PREVIEW_COUNT);
+    // The standard settings list rows (the integrations pattern): ListItem
+    // brings the hover background, separators, and the hover-revealed action
+    // with it, so this list behaves like every other one in Settings.
+    return (
+        <>
+            <List borderTop={false}>
+                {visibleFields.map((field) => {
+                    const userType = userTypeForField(field);
+                    return (
+                        <ListItem
+                            key={field.key}
+                            action={<Button color='green' label='Edit' link onClick={() => openModal(field)} />}
+                            avatar={
+                                <div className='flex size-10 shrink-0 items-center justify-center rounded-lg bg-grey-100 dark:bg-grey-900'>
+                                    <Icon name={userType.icon} size={18} />
+                                </div>
+                            }
+                            detail={userType.label}
+                            testId='custom-field-list-item'
+                            title={<span className='font-semibold'>{field.name}</span>}
+                            hideActions
+                            separator
+                            onClick={() => openModal(field)}
+                        />
+                    );
+                })}
+            </List>
+            {!showAll && fields.length > PREVIEW_COUNT && (
+                // The recommendations table's "Show all" affordance. The top
+                // border stands in for the last row's separator, which ListItem
+                // suppresses on its last-of-type.
+                <div className='flex items-center gap-2 border-t border-grey-100 pt-2 font-bold text-green hover:text-green-400 dark:border-grey-900'>
+                    <button type='button' onClick={onShowAll}>Show all</button>
+                </div>
+            )}
+        </>
+    );
+};
+
 const CustomFields: React.FC<{keywords: string[]}> = ({keywords}) => {
     // The endpoint is closed (404s) while the flag is off, so keep the query in
-    // step with the flag rather than firing it into a wall.
+    // step with the flag rather than firing it into a wall. Browse hides
+    // archived fields by default (most surfaces only want active ones);
+    // Settings is the one place that manages both, so it opts in explicitly.
     const hasCustomFields = useFeatureFlag('membersCustomFields');
-    const {data} = useBrowseMemberCustomFields({enabled: hasCustomFields});
+    const {data} = useBrowseMemberCustomFields({
+        enabled: hasCustomFields,
+        searchParams: {filter: 'status:[active,archived]'}
+    });
     const fields = data?.members_custom_fields || [];
+    const [selectedTab, setSelectedTab] = useState('active-fields');
+    const [showAllActive, setShowAllActive] = useState(false);
+    const [showAllArchived, setShowAllArchived] = useState(false);
+
+    // The opted-in query returns both statuses; the tabs split them, following
+    // the newsletters group. Archived fields stay manageable (rename, reactivate)
+    // rather than vanishing — their globally-unique names would otherwise
+    // block new fields for no visible reason.
+    const activeFields = fields.filter(field => field.status === 'active');
+    const archivedFields = fields.filter(field => field.status === 'archived');
+
+    // The collapse is an initial-view optimization only: fields append in
+    // insertion order, so a just-created (or just-reactivated) field is
+    // always LAST — exactly the hidden slot. When a tab's list grows while
+    // the screen is open, expand it so the new arrival is visible in place
+    // rather than silently swallowed behind "Show all".
+    const previousCounts = useRef({active: 0, archived: 0});
+    useEffect(() => {
+        if (activeFields.length > previousCounts.current.active && previousCounts.current.active > 0) {
+            setShowAllActive(true);
+        }
+        if (archivedFields.length > previousCounts.current.archived && previousCounts.current.archived > 0) {
+            setShowAllArchived(true);
+        }
+        previousCounts.current = {active: activeFields.length, archived: archivedFields.length};
+    }, [activeFields.length, archivedFields.length]);
 
     const openModal = (field?: MemberCustomField) => NiceModal.show(CustomFieldModal, {field});
+
+    const tabs = [
+        {
+            id: 'active-fields',
+            title: 'Active',
+            contents: <FieldList fields={activeFields} openModal={openModal} showAll={showAllActive} onShowAll={() => setShowAllActive(true)} />
+        },
+        {
+            id: 'archived-fields',
+            title: 'Archived',
+            contents: <FieldList fields={archivedFields} openModal={openModal} showAll={showAllArchived} onShowAll={() => setShowAllArchived(true)} />
+        }
+    ];
 
     return (
         <TopLevelGroup
@@ -26,34 +138,12 @@ const CustomFields: React.FC<{keywords: string[]}> = ({keywords}) => {
             testId='custom-fields'
             title='Custom fields'
         >
+            {/* Both tabs render (empty ones included, the newsletters pattern)
+                once ANY field exists — but a site with no fields at all gets
+                no tabs, just the group description; newsletters never faces
+                that state (a site always has one), custom fields start there. */}
             {fields.length > 0 && (
-                <div>
-                    {fields.map((field, index) => {
-                        const userType = userTypeForField(field);
-                        return (
-                            <div
-                                key={field.key}
-                                className={`flex w-full items-center gap-3 py-3 dark:border-grey-900 ${index === fields.length - 1 ? '' : 'border-b border-grey-100'}`}
-                            >
-                                <button
-                                    className='flex min-w-0 flex-1 items-center gap-3 text-left'
-                                    data-testid='custom-field-list-item'
-                                    type='button'
-                                    onClick={() => openModal(field)}
-                                >
-                                    <div className='flex size-10 shrink-0 items-center justify-center rounded-lg bg-grey-100 dark:bg-grey-900'>
-                                        <Icon name={userType.icon} size={18} />
-                                    </div>
-                                    <div className='min-w-0 grow'>
-                                        <div className='truncate leading-tight font-semibold'>{field.name}</div>
-                                        <div className='mt-0.5 text-sm text-grey-700 dark:text-grey-600'>{userType.label}</div>
-                                    </div>
-                                </button>
-                                <Button color='green' label='Edit' link onClick={() => openModal(field)} />
-                            </div>
-                        );
-                    })}
-                </div>
+                <TabView selectedTab={selectedTab} tabs={tabs} onTabChange={setSelectedTab} />
             )}
         </TopLevelGroup>
     );

--- a/apps/admin-x-settings/src/components/settings/membership/custom-fields.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/custom-fields.tsx
@@ -6,7 +6,7 @@ import useFeatureFlag from '../../../hooks/use-feature-flag';
 import {Button, Icon, List, ListItem, TabView} from '@tryghost/admin-x-design-system';
 import {NoValueLabel, NoValueLabelIcon} from '@tryghost/shade/components';
 import {TextCursorInput} from 'lucide-react';
-import {useBrowseMemberCustomFields, userTypeForField} from '@tryghost/admin-x-framework/api/member-custom-fields';
+import {useBrowseMemberCustomFieldsIncludingArchived, userTypeForField} from '@tryghost/admin-x-framework/api/member-custom-fields';
 import {withErrorBoundary} from '../../error-boundary';
 import type {MemberCustomField} from '@tryghost/admin-x-framework/api/member-custom-fields';
 
@@ -83,13 +83,12 @@ const FieldList: React.FC<{
 
 const CustomFields: React.FC<{keywords: string[]}> = ({keywords}) => {
     // The endpoint is closed (404s) while the flag is off, so keep the query in
-    // step with the flag rather than firing it into a wall. Browse hides
-    // archived fields by default (most surfaces only want active ones);
-    // Settings is the one place that manages both, so it opts in explicitly.
+    // step with the flag rather than firing it into a wall. Settings is the one
+    // place that manages archived fields too, so it uses the include-archived
+    // variant rather than the default active-only browse.
     const hasCustomFields = useFeatureFlag('membersCustomFields');
-    const {data} = useBrowseMemberCustomFields({
-        enabled: hasCustomFields,
-        searchParams: {filter: 'status:[active,archived]'}
+    const {data} = useBrowseMemberCustomFieldsIncludingArchived({
+        enabled: hasCustomFields
     });
     const fields = data?.members_custom_fields || [];
     const [selectedTab, setSelectedTab] = useState('active-fields');

--- a/apps/admin-x-settings/src/components/settings/membership/custom-fields.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/custom-fields.tsx
@@ -48,7 +48,13 @@ const FieldList: React.FC<{
                     return (
                         <ListItem
                             key={field.key}
-                            action={<Button color='green' label='Edit' link onClick={() => openModal(field)} />}
+                            // The Edit button stays visible (not hover-only) so it's
+                            // keyboard-focusable — the row div isn't. stopPropagation
+                            // keeps a button click from also firing the row's onClick.
+                            action={<Button color='green' label='Edit' link onClick={(e) => {
+                                e?.stopPropagation();
+                                openModal(field);
+                            }} />}
                             avatar={
                                 <div className='flex size-10 shrink-0 items-center justify-center rounded-lg bg-grey-100 dark:bg-grey-900'>
                                     <Icon name={userType.icon} size={18} />
@@ -57,7 +63,6 @@ const FieldList: React.FC<{
                             detail={userType.label}
                             testId='custom-field-list-item'
                             title={<span className='font-semibold'>{field.name}</span>}
-                            hideActions
                             separator
                             onClick={() => openModal(field)}
                         />

--- a/apps/admin-x-settings/src/components/settings/membership/custom-fields/custom-field-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/custom-fields/custom-field-modal.tsx
@@ -1,6 +1,6 @@
 import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import React from 'react';
-import {ConfirmationModal, Form, Icon, Modal, Select, type SelectOption, TextField, showToast} from '@tryghost/admin-x-design-system';
+import {ConfirmationModal, Form, Icon, Menu, Modal, Select, type SelectOption, TextField, showToast} from '@tryghost/admin-x-design-system';
 import {type OptionProps, type SingleValueProps, components} from 'react-select';
 import {ValidationError, getErrorMessage} from '@tryghost/admin-x-framework/errors';
 import {memberCustomFieldUserTypes, useCreateMemberCustomField, useDeleteMemberCustomField, useEditMemberCustomField, userTypeForField} from '@tryghost/admin-x-framework/api/member-custom-fields';
@@ -86,7 +86,12 @@ const CustomFieldModal = NiceModal.create<{field?: MemberCustomField}>(({field})
 
     const selectedType = typeOptions.find(option => option.value === formState.userTypeId);
 
-    const leftButtonProps = isEdit ? {
+    const isArchived = field?.status === 'archived';
+
+    // The modal's third action mirrors the field's state: an active field can
+    // be archived, an archived one reactivated. Both confirm first (the
+    // newsletters pattern) — they change what every collection surface shows.
+    const archiveButtonProps = {
         label: 'Archive',
         link: true,
         color: 'red' as const,
@@ -95,13 +100,19 @@ const CustomFieldModal = NiceModal.create<{field?: MemberCustomField}>(({field})
             modal.remove();
             NiceModal.show(ConfirmationModal, {
                 title: 'Archive custom field',
-                prompt: <>Archiving <strong>{field!.name}</strong> removes it from your custom fields. Its key stays reserved so it can&rsquo;t be reused, and this can&rsquo;t be undone.</>,
+                prompt: <>
+                    <div className='mb-6'>Your custom field <strong>{field!.name}</strong> will no longer show up on your members, collect new information, or appear in filters.</div>
+                    <div>Values already collected for this field will remain unchanged.</div>
+                </>,
                 okLabel: 'Archive',
                 okColor: 'red',
-                onOk: async (deleteModal) => {
+                onOk: async (archiveModal) => {
                     try {
-                        await deleteField(field!.key);
-                        deleteModal?.remove();
+                        // Archiving is a status change over the same PUT a rename
+                        // uses; DELETE is the permanent, values-destroying removal
+                        // and only valid on an already-archived field.
+                        await editField({key: field!.key, status: 'archived'});
+                        archiveModal?.remove();
                         showToast({type: 'success', title: 'Custom field archived'});
                     } catch (e) {
                         showToast({type: 'error', title: 'Failed to archive the custom field'});
@@ -110,7 +121,71 @@ const CustomFieldModal = NiceModal.create<{field?: MemberCustomField}>(({field})
                 }
             });
         }
-    } : undefined;
+    };
+
+    const reactivateButtonProps = {
+        label: 'Reactivate',
+        link: true,
+        color: 'green' as const,
+        size: 'sm' as const,
+        onClick: () => {
+            modal.remove();
+            NiceModal.show(ConfirmationModal, {
+                title: 'Reactivate custom field',
+                prompt: <>
+                    <div className='mb-6'>Reactivating <strong>{field!.name}</strong> will immediately make it available again on your members, for collecting, and in filters.</div>
+                    <div>Values already collected for this field will remain unchanged.</div>
+                </>,
+                okLabel: 'Reactivate',
+                onOk: async (reactivateModal) => {
+                    try {
+                        await editField({key: field!.key, status: 'active'});
+                        reactivateModal?.remove();
+                        showToast({type: 'success', title: 'Custom field reactivated'});
+                    } catch (e) {
+                        showToast({type: 'error', title: 'Failed to reactivate the custom field'});
+                        handleError(e, {withToast: false});
+                    }
+                }
+            });
+        }
+    };
+
+    let leftButtonProps;
+    if (isEdit) {
+        leftButtonProps = isArchived ? reactivateButtonProps : archiveButtonProps;
+    }
+
+    // Permanent deletion hides behind the header menu — one deliberate click
+    // away, mirroring the members page's actions menu and the API's own
+    // two-step (only archived fields can be deleted). A visible red button
+    // would put irreversible data loss on equal footing with Save.
+    const confirmDeleteField = () => {
+        modal.remove();
+        NiceModal.show(ConfirmationModal, {
+            title: 'Delete custom field',
+            prompt: <><strong>{field!.name}</strong> and every value collected from your members will be permanently deleted from the database. This can&rsquo;t be undone.</>,
+            okLabel: 'Delete',
+            okColor: 'red',
+            onOk: async (deleteModal) => {
+                try {
+                    await deleteField(field!.key);
+                    deleteModal?.remove();
+                    showToast({type: 'success', title: 'Custom field deleted'});
+                } catch (e) {
+                    showToast({type: 'error', title: 'Failed to delete the custom field'});
+                    handleError(e, {withToast: false});
+                }
+            }
+        });
+    };
+
+    const archivedFieldMenu = (
+        <Menu
+            items={[{id: 'delete-field', label: 'Delete custom field', icon: 'trash', destructive: true, onClick: confirmDeleteField}]}
+            position='end'
+        />
+    );
 
     return (
         <Modal
@@ -121,7 +196,8 @@ const CustomFieldModal = NiceModal.create<{field?: MemberCustomField}>(({field})
             okLabel={okProps.label || 'Save'}
             size='sm'
             testId='custom-field-modal'
-            title={isEdit ? 'Edit custom field' : 'New custom field'}
+            title={isEdit ? 'Edit custom field' : 'Add custom field'}
+            topRightContent={isArchived ? archivedFieldMenu : undefined}
             onOk={async () => {
                 try {
                     if (await handleSave()) {

--- a/apps/admin/src/settings/membership/custom-fields.acceptance.test.tsx
+++ b/apps/admin/src/settings/membership/custom-fields.acceptance.test.tsx
@@ -258,6 +258,18 @@ describe("Custom fields", () => {
         expect(deleteApi.requests).toHaveLength(1);
     });
 
+    it("does not expose permanent deletion for an active field", async () => {
+        fakeSettingsScreens();
+        fakeCustomFields([companyField]);
+        await renderAdminApp("/settings", {boot: customFieldsBoot()});
+
+        // Deletion lives behind the header menu, and an active field has none —
+        // the UI can't reach delete, matching the API's archived-only rule.
+        await settingsScreen.customFields().getByTestId("custom-field-list-item").click();
+        const modal = settingsScreen.customFieldModal();
+        await expect(modal.getByRole("button", {name: "Menu"})).toHaveCount(0);
+    });
+
     it("shows no tabs at all while no fields exist", async () => {
         fakeSettingsScreens();
         fakeCustomFields([]);

--- a/apps/admin/src/settings/membership/custom-fields.acceptance.test.tsx
+++ b/apps/admin/src/settings/membership/custom-fields.acceptance.test.tsx
@@ -8,8 +8,18 @@ const companyField = {
     key: "company",
     name: "Company",
     type: "short_text",
+    status: "active",
     created_at: "2026-07-13T00:00:00.000Z",
-    updated_at: null,
+    updated_at: null as string | null,
+};
+
+const archivedField = {
+    key: "old-hobby",
+    name: "Old hobby",
+    type: "short_text",
+    status: "archived",
+    created_at: "2026-07-12T00:00:00.000Z",
+    updated_at: "2026-07-13T00:00:00.000Z",
 };
 
 function customFieldsBoot() {
@@ -21,13 +31,9 @@ function customFieldsBoot() {
 }
 
 function fakeCustomFields(fields = [companyField]) {
-    return fakeAdminEndpoint("GET", "/members/custom_fields/", {members_custom_fields: fields});
-}
-
-async function renderCustomFields() {
-    fakeSettingsScreens();
-    fakeCustomFields();
-    await renderAdminApp("/settings", {boot: customFieldsBoot()});
+    // Settings opts into archived fields (`?filter=status:[active,archived]`),
+    // so the fake matches the path with any query.
+    return fakeAdminEndpoint("GET", new RegExp("^/members/custom_fields/\\?"), {members_custom_fields: fields});
 }
 
 describe("Custom fields", () => {
@@ -40,8 +46,13 @@ describe("Custom fields", () => {
         expect(customFieldsApi.requests).toHaveLength(0);
     });
 
-    it("lists each field with its user-facing type", async () => {
-        await renderCustomFields();
+    it("lists each field with its user-facing type, opting into archived fields", async () => {
+        fakeSettingsScreens();
+        const customFieldsApi = fakeCustomFields();
+        await renderAdminApp("/settings", {boot: customFieldsBoot()});
+
+        // Browse hides archived by default; Settings asks for both statuses.
+        await expect.poll(() => customFieldsApi.lastRequest?.url).toContain("filter=status%3A%5Bactive%2Carchived%5D");
 
         const row = settingsScreen.customFields().getByTestId("custom-field-list-item");
         await expect(row).toHaveCount(1);
@@ -134,16 +145,144 @@ describe("Custom fields", () => {
     it("archives a field only after destructive confirmation", async () => {
         fakeSettingsScreens();
         fakeCustomFields();
-        const deleteApi = fakeAdminEndpoint("DELETE", "/members/custom_fields/company/", {});
+        const editApi = fakeAdminEndpoint("PUT", "/members/custom_fields/company/", {
+            members_custom_fields: [{...companyField, status: "archived"}],
+        });
         await renderAdminApp("/settings", {boot: customFieldsBoot()});
 
         await settingsScreen.customFields().getByTestId("custom-field-list-item").click();
         await settingsScreen.customFieldModal().getByRole("button", {name: "Archive"}).click();
         const confirmation = settingsScreen.confirmationModal();
-        await expect.element(confirmation).toHaveTextContent("Its key stays reserved so it can’t be reused");
+        await expect.element(confirmation).toHaveTextContent("will no longer show up on your members, collect new information, or appear in filters");
+        await expect.element(confirmation).toHaveTextContent("Values already collected for this field will remain unchanged");
         await confirmation.getByRole("button", {name: "Archive"}).click();
 
         await expect.element(settingsScreen.successToast()).toHaveTextContent("Custom field archived");
+        // Archiving is a status edit, not a DELETE — DELETE is permanent removal.
+        expect(editApi.lastRequest?.body).toEqual({members_custom_fields: [{status: "archived"}]});
+    });
+
+    it("splits fields into Active and Archived tabs", async () => {
+        fakeSettingsScreens();
+        fakeCustomFields([companyField, archivedField]);
+        await renderAdminApp("/settings", {boot: customFieldsBoot()});
+
+        // Active tab is the default and shows only active fields.
+        const rows = settingsScreen.customFields().getByTestId("custom-field-list-item");
+        await expect(rows).toHaveCount(1);
+        await expect.element(rows).toHaveTextContent("Company");
+
+        await settingsScreen.customFields().getByRole("tab", {name: "Archived"}).click();
+        await expect(rows).toHaveCount(1);
+        await expect.element(rows).toHaveTextContent("Old hobby");
+    });
+
+    it("collapses long lists behind Show all, five at a time like recommendations", async () => {
+        fakeSettingsScreens();
+        const manyFields = Array.from({length: 7}, (_, index) => ({
+            ...companyField,
+            key: `field-${index}`,
+            name: `Field ${index}`,
+        }));
+        fakeCustomFields(manyFields);
+        await renderAdminApp("/settings", {boot: customFieldsBoot()});
+
+        const rows = settingsScreen.customFields().getByTestId("custom-field-list-item");
+        await expect(rows).toHaveCount(5);
+
+        await settingsScreen.customFields().getByRole("button", {name: "Show all"}).click();
+        await expect(rows).toHaveCount(7);
+        await expect(settingsScreen.customFields().getByRole("button", {name: "Show all"})).toHaveCount(0);
+
+        // The reveal survives tab switches — TabView unmounts hidden tabs, so
+        // this pins the state living above them.
+        await settingsScreen.customFields().getByRole("tab", {name: "Archived"}).click();
+        await settingsScreen.customFields().getByRole("tab", {name: "Active"}).click();
+        await expect(rows).toHaveCount(7);
+    });
+
+    it("reveals a just-created field even when the list is collapsed", async () => {
+        fakeSettingsScreens();
+        let currentFields = Array.from({length: 6}, (_, index) => ({
+            ...companyField,
+            key: `field-${index}`,
+            name: `Field ${index}`,
+        }));
+        fakeAdminEndpoint("GET", new RegExp("^/members/custom_fields/\\?"), () => ({members_custom_fields: currentFields}));
+        fakeAdminEndpoint("POST", "/members/custom_fields/", () => {
+            const created = {...companyField, key: "newest", name: "Newest"};
+            currentFields = [...currentFields, created];
+            return {members_custom_fields: [created]};
+        });
+        await renderAdminApp("/settings", {boot: customFieldsBoot()});
+
+        const rows = settingsScreen.customFields().getByTestId("custom-field-list-item");
+        await expect(rows).toHaveCount(5);
+
+        // New fields append at the END of the list — exactly the collapsed
+        // slot — so creating one must expand the list rather than swallow it.
+        await settingsScreen.customFields().getByRole("button", {name: "Add custom field"}).click();
+        const modal = settingsScreen.customFieldModal();
+        await modal.getByLabelText("Name").fill("Newest");
+        await modal.getByRole("button", {name: "Save"}).click();
+
+        await expect(rows).toHaveCount(7);
+        await expect.element(rows.last()).toHaveTextContent("Newest");
+
+        // Wait for the modal to finish closing (Save holds it open ~500ms for
+        // its saving state). Ending the test earlier leaves that removal
+        // pending, and it would fire into the NEXT test's freshly-opened
+        // modal — NiceModal keys modals by component and dispatches globally.
+        await expect(modal).toHaveCount(0);
+    });
+
+    it("permanently deletes an archived field from the header menu, after a heavy warning", async () => {
+        fakeSettingsScreens();
+        fakeCustomFields([companyField, archivedField]);
+        const deleteApi = fakeAdminEndpoint("DELETE", "/members/custom_fields/old-hobby/", {});
+        await renderAdminApp("/settings", {boot: customFieldsBoot()});
+
+        await settingsScreen.customFields().getByRole("tab", {name: "Archived"}).click();
+        await settingsScreen.customFields().getByTestId("custom-field-list-item").click();
+
+        // Deletion hides behind the modal's header menu — never a visible button.
+        const modal = settingsScreen.customFieldModal();
+        await modal.getByRole("button", {name: "Menu"}).click();
+        await modal.getByRole("button", {name: "Delete custom field"}).click();
+
+        const confirmation = settingsScreen.confirmationModal();
+        await expect.element(confirmation).toHaveTextContent("Old hobby and every value collected from your members will be permanently deleted from the database. This can’t be undone.");
+        await confirmation.getByRole("button", {name: "Delete"}).click();
+
+        await expect.element(settingsScreen.successToast()).toHaveTextContent("Custom field deleted");
         expect(deleteApi.requests).toHaveLength(1);
+    });
+
+    it("shows no tabs at all while no fields exist", async () => {
+        fakeSettingsScreens();
+        fakeCustomFields([]);
+        await renderAdminApp("/settings", {boot: customFieldsBoot()});
+
+        await expect.element(settingsScreen.customFields()).toBeVisible();
+        await expect(settingsScreen.customFields().getByRole("tab")).toHaveCount(0);
+    });
+
+    it("reactivates an archived field after confirmation, as a status edit", async () => {
+        fakeSettingsScreens();
+        fakeCustomFields([companyField, archivedField]);
+        const editApi = fakeAdminEndpoint("PUT", "/members/custom_fields/old-hobby/", {
+            members_custom_fields: [{...archivedField, status: "active"}],
+        });
+        await renderAdminApp("/settings", {boot: customFieldsBoot()});
+
+        await settingsScreen.customFields().getByRole("tab", {name: "Archived"}).click();
+        await settingsScreen.customFields().getByTestId("custom-field-list-item").click();
+        await settingsScreen.customFieldModal().getByRole("button", {name: "Reactivate"}).click();
+        const confirmation = settingsScreen.confirmationModal();
+        await expect.element(confirmation).toHaveTextContent("Values already collected for this field will remain unchanged");
+        await confirmation.getByRole("button", {name: "Reactivate"}).click();
+
+        await expect.element(settingsScreen.successToast()).toHaveTextContent("Custom field reactivated");
+        expect(editApi.lastRequest?.body).toEqual({members_custom_fields: [{status: "active"}]});
     });
 });

--- a/e2e/helpers/pages/admin/settings/sections/custom-fields-section.ts
+++ b/e2e/helpers/pages/admin/settings/sections/custom-fields-section.ts
@@ -23,6 +23,14 @@ export class CustomFieldsSection extends BasePage {
         return this.section.getByTestId('custom-field-list-item').filter({hasText: name});
     }
 
+    tab(name: 'Active' | 'Archived'): Locator {
+        return this.section.getByRole('tab', {name});
+    }
+
+    async openTab(name: 'Active' | 'Archived'): Promise<void> {
+        await this.tab(name).click();
+    }
+
     /**
      * Create a field of the default (short text) type. That keeps the member
      * detail editor a plain text input, which is all the cross-surface flow
@@ -34,5 +42,54 @@ export class CustomFieldsSection extends BasePage {
         await this.modal.getByLabel('Name').fill(name);
         await this.modal.getByRole('button', {name: 'Save'}).click();
         await this.listItem(name).waitFor();
+    }
+
+    /** Open a field's edit modal from whichever tab it lives in. */
+    async openField(name: string): Promise<void> {
+        await this.listItem(name).click();
+        await this.modal.waitFor();
+    }
+
+    /** Rename a field in place; the modal closes on success. */
+    async renameField(name: string, newName: string): Promise<void> {
+        await this.openField(name);
+        await this.modal.getByLabel('Name').fill(newName);
+        await this.modal.getByRole('button', {name: 'Save'}).click();
+        await this.listItem(newName).waitFor();
+    }
+
+    /**
+     * Archive an active field. Both the edit modal and the confirmation dialog
+     * carry an "Archive" button; the edit modal closes as the confirmation
+     * opens, so the second click lands on the confirmation.
+     */
+    async archiveField(name: string): Promise<void> {
+        await this.openField(name);
+        await this.modal.getByRole('button', {name: 'Archive'}).click();
+        // The edit modal removes itself as the confirmation opens; wait for it to
+        // go so the confirmation's "Archive" button is the only match.
+        await this.modal.waitFor({state: 'detached'});
+        await this.page.getByRole('button', {name: 'Archive'}).click();
+    }
+
+    /** Reactivate an archived field (open it from the Archived tab first). */
+    async reactivateField(name: string): Promise<void> {
+        await this.openField(name);
+        await this.modal.getByRole('button', {name: 'Reactivate'}).click();
+        await this.modal.waitFor({state: 'detached'});
+        await this.page.getByRole('button', {name: 'Reactivate'}).click();
+    }
+
+    /**
+     * Permanently delete an archived field. Deletion lives behind the modal's
+     * header menu, then a destructive confirmation — the API only allows it on
+     * an already-archived field.
+     */
+    async deleteField(name: string): Promise<void> {
+        await this.openField(name);
+        await this.modal.getByRole('button', {name: 'Menu'}).click();
+        await this.modal.getByRole('button', {name: 'Delete custom field'}).click();
+        await this.modal.waitFor({state: 'detached'});
+        await this.page.getByRole('button', {name: 'Delete', exact: true}).click();
     }
 }

--- a/e2e/tests/admin/settings/custom-fields-lifecycle.test.ts
+++ b/e2e/tests/admin/settings/custom-fields-lifecycle.test.ts
@@ -1,0 +1,56 @@
+import {SettingsPage} from '@/admin-pages';
+import {expect, test} from '@/helpers/playwright';
+import {usePerTestIsolation} from '@/helpers/playwright/isolation';
+
+/**
+ * The full definition lifecycle of a custom field, driven entirely through
+ * Settings against a real backend: define -> rename -> archive -> reactivate ->
+ * archive -> permanently delete. The acceptance tests cover each step against a
+ * fake API; this pins the whole journey end to end, including the tab a field
+ * moves between and its disappearance once deleted.
+ *
+ * The whole section is behind the membersCustomFields flag.
+ */
+usePerTestIsolation();
+
+test.describe('Ghost Admin - Custom field lifecycle', () => {
+    test.use({labs: {membersCustomFields: true}});
+
+    test('a field can be defined, renamed, archived, reactivated and permanently deleted', async ({page}) => {
+        const original = `Delivery address ${Date.now()}`;
+        const renamed = `Shipping address ${Date.now()}`;
+
+        const settingsPage = new SettingsPage(page);
+        const customFields = settingsPage.customFieldsSection;
+
+        await settingsPage.goto();
+
+        // Define
+        await customFields.createShortTextField(original);
+        await expect(customFields.listItem(original)).toBeVisible();
+
+        // Rename
+        await customFields.renameField(original, renamed);
+        await expect(customFields.listItem(renamed)).toBeVisible();
+
+        // Archive: leaves the Active tab, appears under Archived
+        await customFields.archiveField(renamed);
+        await expect(customFields.listItem(renamed)).toHaveCount(0);
+        await customFields.openTab('Archived');
+        await expect(customFields.listItem(renamed)).toBeVisible();
+
+        // Reactivate: leaves Archived, back under Active
+        await customFields.reactivateField(renamed);
+        await expect(customFields.listItem(renamed)).toHaveCount(0);
+        await customFields.openTab('Active');
+        await expect(customFields.listItem(renamed)).toBeVisible();
+
+        // Archive again, then permanently delete from the Archived tab
+        await customFields.archiveField(renamed);
+        await customFields.openTab('Archived');
+        await expect(customFields.listItem(renamed)).toBeVisible();
+
+        await customFields.deleteField(renamed);
+        await expect(customFields.listItem(renamed)).toHaveCount(0);
+    });
+});


### PR DESCRIPTION
## Describe the problem you are solving

Archiving a custom field used to be a dead end: archived fields disappeared from Settings entirely, and since field names are globally unique, an archived field silently blocked its name with no way to reach it. This PR makes archived fields visible and manageable — and adds a way to permanently remove one.

- The Custom fields group now splits into **Active** and **Archived** tabs (the newsletters pattern). Archived fields can be found, renamed, and reactivated.
- Archiving and reactivating are status edits over the existing PUT, both behind confirmation dialogs that spell out what changes (and that collected values are preserved).
- Permanent deletion follows the API's own two-step: only an archived field can be deleted, and the UI keeps the same distance — a `…` menu on the archived field's edit modal reveals "Delete custom field", which opens a heavy confirmation (the field and every collected value are permanently deleted from the database).

Ref https://linear.app/ghost/issue/BER-3802/view-and-manage-archived-custom-fields-in-settings

## Changelog for devs

* Added Active/Archived tabs to Settings → Membership → Custom fields; Settings opts into archived fields via `filter=status:[active,archived]` (browse hides them by default, so other consumers like member details are untouched)
* Added archive/reactivate confirmation flows as `status` edits over the existing PUT
* Added permanent delete for archived fields behind a header `…` menu, calling the DELETE endpoint (cascades collected values; API rejects it for active fields)
* Added an optional `icon` to the design system `Menu` items (this modal is currently its only consumer)
* Added browser-mode acceptance tests for the tab split, filter opt-in, archive/reactivate/delete flows, empty states, and the Show all collapse (13 total)
* Fixed a cross-test flake: a test ending before its modal finished closing let the pending removal fire into the next test's freshly-opened modal (NiceModal keys modals by component and dispatches globally)

## Changelog for customers

* Nothing yet — everything ships behind the `membersCustomFields` flag

## Notes

* Consumes the BER-3803 API contract from #29393 (`status` on the wire, browse hiding archived by default, PUT status edits, DELETE gated on archived). Draft until that lands.
* Manually tested against the real API on a local integration branch (this branch + #29393); the API test suite passes there.

## Technical debt

* None introduced

## PR Scope (mark all that apply)

- [x] Improves the user experience
- [ ] Enhances the readability of our code
- [ ] Simplifies the maintenance of our software
- [ ] Fixes a bug
- [ ] Provide a core layer to allow one of the points above

## Checklist before requesting a review (mark all that apply)

- [x] I have performed a self-review of my code
- [x] It's simple enough
- [x] The PR is not extensive
- [ ] It includes documentation
- [x] I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
