### PR TITLE
Moved IndexNow into a service folder as indexnow-ping

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -336,7 +336,7 @@ async function initServices({ghostServer} = {}) {
     const members = require('./server/services/members');
     const tiers = require('./server/services/tiers');
     const permissions = require('./server/services/permissions');
-    const indexnow = require('./server/services/indexnow');
+    const indexnow = require('./server/services/indexnow-ping');
     const slack = require('./server/services/slack');
     const webhooks = require('./server/services/webhooks');
     const postScheduling = require('./server/services/post-scheduling').default;
@@ -385,7 +385,7 @@ async function initServices({ghostServer} = {}) {
         postsPublic.init(),
         membersEvents.init(),
         permissions.init(),
-        indexnow.listen(),
+        indexnow.init(),
         slack.listen(),
         audienceFeedback.init(),
         emailService.init({ghostServer}),

--- a/ghost/core/core/frontend/web/middleware/serve-indexnow-key.js
+++ b/ghost/core/core/frontend/web/middleware/serve-indexnow-key.js
@@ -19,7 +19,7 @@
  * theme .txt files with matching names (which is the intended behavior
  * for system-generated verification files).
  *
- * @see ghost/core/core/server/services/indexnow.js - Main IndexNow service
+ * @see ghost/core/core/server/services/indexnow-ping - Main IndexNow service
  */
 
 const settingsCache = require('../../../shared/settings-cache');

--- a/ghost/core/core/server/services/indexnow-ping/index.js
+++ b/ghost/core/core/server/services/indexnow-ping/index.js
@@ -20,16 +20,16 @@
  * ghost/core/core/frontend/web/middleware/serve-indexnow-key.js
  */
 
-const urlService = require('./url');
-const urlUtils = require('../../shared/url-utils');
+const urlService = require('../url');
+const urlUtils = require('../../../shared/url-utils');
 const errors = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
 const logging = require('@tryghost/logging');
 const request = require('@tryghost/request');
-const settingsCache = require('../../shared/settings-cache');
-const config = require('../../shared/config');
-const labs = require('../../shared/labs');
-const events = require('../lib/common/events');
+const settingsCache = require('../../../shared/settings-cache');
+const config = require('../../../shared/config');
+const labs = require('../../../shared/labs');
+const events = require('../../lib/common/events');
 
 const messages = {
     requestFailedError: 'The {service} service was unable to send a ping request, your site will continue to function.',
@@ -238,7 +238,7 @@ function indexnowListener(model, options) {
 /**
  * Register event listeners for IndexNow
  */
-function listen() {
+function init() {
     // Listen for new posts being published
     events
         .removeListener('post.published', indexnowListener)
@@ -251,7 +251,7 @@ function listen() {
 }
 
 module.exports = {
-    listen: listen,
+    init: init,
     ping: ping,
     getApiKey: getApiKey
 };

--- a/ghost/core/test/unit/server/services/indexnow-ping/index.test.js
+++ b/ghost/core/test/unit/server/services/indexnow-ping/index.test.js
@@ -2,14 +2,14 @@ const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const _ = require('lodash');
 const nock = require('nock');
-const testUtils = require('../../../utils');
-const indexnow = require('../../../../core/server/services/indexnow');
-const events = require('../../../../core/server/lib/common/events');
-const settingsCache = require('../../../../core/shared/settings-cache');
-const config = require('../../../../core/shared/config');
-const labs = require('../../../../core/shared/labs');
+const testUtils = require('../../../../utils');
+const indexnow = require('../../../../../core/server/services/indexnow-ping');
+const events = require('../../../../../core/server/lib/common/events');
+const settingsCache = require('../../../../../core/shared/settings-cache');
+const config = require('../../../../../core/shared/config');
+const labs = require('../../../../../core/shared/labs');
 const logging = require('@tryghost/logging');
-const urlService = require('../../../../core/server/services/url');
+const urlService = require('../../../../../core/server/services/url');
 
 describe('IndexNow', function () {
     let eventStub;
@@ -36,9 +36,9 @@ describe('IndexNow', function () {
         nock.cleanAll();
     });
 
-    describe('listen()', function () {
+    describe('init()', function () {
         it('should initialise events correctly', function () {
-            indexnow.listen();
+            indexnow.init();
             sinon.assert.calledTwice(eventStub);
             sinon.assert.calledWith(eventStub, 'post.published');
             sinon.assert.calledWith(eventStub, 'post.published.edited');
@@ -54,7 +54,7 @@ describe('IndexNow', function () {
             settingsCacheStub.withArgs('indexnow_api_key').returns(null);
             loggingStub = sinon.stub(logging, 'warn');
 
-            indexnow.listen();
+            indexnow.init();
             listener = eventStub.firstCall.args[1];
         });
 


### PR DESCRIPTION
Relocates the flat single-file IndexNow service to `services/indexnow-ping/index.js`, matching the `explore-ping` naming for outbound ping services, and renames `listen()` to `init()` to match the boot lifecycle convention used by the other services in the boot `Promise.all`.

Pure move — no behaviour or logic changes:
- relative require paths bumped one level
- `boot.js` require path + call updated
- test moved to `test/unit/server/services/indexnow-ping/` with the same path bumps
- stale `@see` path in `serve-indexnow-key.js` middleware updated

The `indexnow` labs flag, `indexnow_api_key` setting, and `indexnow.*` log event names are protocol/flag names, not folder names, and are intentionally unchanged.

First of a short series bringing the ping-style services onto a consistent shape; a sibling PR will do the same move for `slack.js`.