### PR TITLE
Moved serve-favicon onto the proxy seam

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -64,7 +64,6 @@ module.exports = {
                     '^ghost/core/core/frontend/web/middleware/frontend-caching\\.js$',
                     '^ghost/core/core/frontend/web/middleware/handle-image-sizes\\.js$',
                     '^ghost/core/core/frontend/web/routers/link-redirects\\.js$',
-                    '^ghost/core/core/frontend/web/routers/serve-favicon\\.js$',
                     '^ghost/core/core/frontend/apps/private-blogging/lib/router\\.js$',
 
                     // Leaks that bypass the proxy (fix first).

--- a/ghost/core/core/frontend/web/routers/serve-favicon.js
+++ b/ghost/core/core/frontend/web/routers/serve-favicon.js
@@ -2,7 +2,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const crypto = require('crypto');
 const config = require('../../../shared/config');
-const {blogIcon} = require('../../../server/lib/image');
+const {blogIcon} = require('../../services/proxy');
 const urlUtils = require('../../../shared/url-utils');
 const settingsCache = require('../../../shared/settings-cache');
 


### PR DESCRIPTION
## Summary

- Continues the frontend/server boundary work from #28420: the frontend should cross into `core/server` only via the proxy seam.
- `serve-favicon.js`'s one remaining direct server require (`blogIcon`) is already exported by the proxy — its storage require was removed in #28745 — so it now requires the proxy instead, and its exception is removed from the boundary allowlist in `.dependency-cruiser.cjs`.
- One less file allowed to cross the boundary directly; no behavior change (`blogIcon` is the same object, re-exported).

## Testing

- [x] `pnpm lint:boundaries` — green with the allowlist entry deleted
- [x] `pnpm test:single test/unit/frontend/web/routers/serve-favicon.test.js` (5 tests)
- [x] `vitest run test/unit/frontend` — full frontend unit suite (1937 tests)
