### PR TITLE
Moved the Slack ping service into a folder as slack-ping

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -337,7 +337,7 @@ async function initServices({ghostServer} = {}) {
     const tiers = require('./server/services/tiers');
     const permissions = require('./server/services/permissions');
     const indexnow = require('./server/services/indexnow-ping');
-    const slack = require('./server/services/slack');
+    const slack = require('./server/services/slack-ping');
     const webhooks = require('./server/services/webhooks');
     const postScheduling = require('./server/services/post-scheduling').default;
     const comments = require('./server/services/comments');
@@ -386,7 +386,7 @@ async function initServices({ghostServer} = {}) {
         membersEvents.init(),
         permissions.init(),
         indexnow.init(),
-        slack.listen(),
+        slack.init(),
         audienceFeedback.init(),
         emailService.init({ghostServer}),
         emailAnalytics.init(),

--- a/ghost/core/core/server/services/slack-ping/index.js
+++ b/ghost/core/core/server/services/slack-ping/index.js
@@ -2,14 +2,14 @@ const errors = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
 const logging = require('@tryghost/logging');
 const request = require('@tryghost/request');
-const {blogIcon} = require('../lib/image');
-const urlUtils = require('../../shared/url-utils');
-const urlService = require('./url');
-const settingsCache = require('../../shared/settings-cache');
+const {blogIcon} = require('../../lib/image');
+const urlUtils = require('../../../shared/url-utils');
+const urlService = require('../url');
+const settingsCache = require('../../../shared/settings-cache');
 const moment = require('moment');
 
 // Used to receive post.published model event, but also the slack.test event from the API which iirc this was done to avoid circular deps a long time ago
-const events = require('../lib/common/events');
+const events = require('../../lib/common/events');
 
 const messages = {
     requestFailedError: 'The {service} service was unable to send a ping request, your site will continue to function.',
@@ -193,7 +193,7 @@ function slackTestPing() {
     });
 }
 
-function listen() {
+function init() {
     if (!events.hasRegisteredListener('post.published', 'slackListener')) {
         events.on('post.published', slackListener);
     }
@@ -205,5 +205,5 @@ function listen() {
 
 // Public API
 module.exports = {
-    listen: listen
+    init: init
 };

--- a/ghost/core/test/unit/server/services/slack-ping/index.test.js
+++ b/ghost/core/test/unit/server/services/slack-ping/index.test.js
@@ -2,17 +2,17 @@ const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const _ = require('lodash');
 const nock = require('nock');
-const testUtils = require('../../../utils');
-const configUtils = require('../../../utils/config-utils');
+const testUtils = require('../../../../utils');
+const configUtils = require('../../../../utils/config-utils');
 
 // Stuff we test
-const slack = require('../../../../core/server/services/slack');
+const slack = require('../../../../../core/server/services/slack-ping');
 
-const events = require('../../../../core/server/lib/common/events');
+const events = require('../../../../../core/server/lib/common/events');
 const logging = require('@tryghost/logging');
-const imageLib = require('../../../../core/server/lib/image');
-const urlService = require('../../../../core/server/services/url');
-const settingsCache = require('../../../../core/shared/settings-cache');
+const imageLib = require('../../../../../core/server/lib/image');
+const urlService = require('../../../../../core/server/services/url');
+const settingsCache = require('../../../../../core/shared/settings-cache');
 
 // Test data
 const slackURL = 'https://hooks.slack.com/services/a-b-c-d';
@@ -45,7 +45,7 @@ describe('Slack', function () {
     });
 
     function getListeners() {
-        slack.listen();
+        slack.init();
 
         return {
             slackListener: eventStub.firstCall.args[1],
@@ -91,8 +91,8 @@ describe('Slack', function () {
         };
     }
 
-    it('listen() should initialise event correctly', function () {
-        slack.listen();
+    it('init() should initialise event correctly', function () {
+        slack.init();
         sinon.assert.calledTwice(eventStub);
         sinon.assert.calledWith(eventStub.firstCall, 'post.published', sinon.match.func);
         sinon.assert.calledWith(eventStub.secondCall, 'slack.test', sinon.match.func);


### PR DESCRIPTION
Relocates the flat single-file `services/slack.js` to `services/slack-ping/index.js`, matching the `explore-ping`/`indexnow-ping` naming for outbound ping services, and renames `listen()` to `init()` to match the boot lifecycle convention.

Naming note: `slack-ping` (this service) sends the post-published / test-notification pings configured in Slack settings; the adjacent `slack-notifications` service is a different feature (milestone webhooks for hosting). The folder move makes that distinction visible.

Pure move — no behaviour or logic changes:
- relative require paths bumped one level
- `boot.js` require path + call updated
- test moved to `test/unit/server/services/slack-ping/` with the same path bumps
- the `slack.test` event name and Slack settings keys are unchanged (event/settings names, not folder names)

Sibling of #29418 (indexnow-ping).