### PR TITLE
Added custom field changes to the member history log

### DIFF
--- a/apps/admin-x-framework/src/api/actions.ts
+++ b/apps/admin-x-framework/src/api/actions.ts
@@ -221,6 +221,8 @@ export const getActionTitle = (action: Action) => {
 
     if (actionName === 'reset_authentication') {
         actionName = 'reset authentication';
+    } else if (actionName === 'custom_fields_edited') {
+        actionName = 'custom fields edited';
     }
 
     if (action.context?.count && (action.context?.count as number) > 1) {

--- a/apps/admin-x-framework/test/unit/api/actions.test.ts
+++ b/apps/admin-x-framework/test/unit/api/actions.test.ts
@@ -53,5 +53,19 @@ describe('actions api helpers', () => {
             expect(title('restored')).toBe('Custom field restored');
             expect(title('deleted')).toBe('Custom field deleted');
         });
+
+        it('formats a member custom field value change', () => {
+            expect(getActionTitle(baseAction({
+                resource_type: 'member',
+                context: {action_name: 'custom_fields_edited', primary_name: 'Jamie Larson'}
+            }))).toBe('Member custom fields edited');
+        });
+
+        it('formats a member edit that did not touch custom fields', () => {
+            expect(getActionTitle(baseAction({
+                resource_type: 'member',
+                context: {primary_name: 'Jamie Larson'}
+            }))).toBe('Member edited');
+        });
     });
 });

--- a/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
@@ -9,6 +9,9 @@ const messages = {
     memberNotFound: 'Member not found.'
 };
 
+// Stored in the action's `context.action_name`; Admin maps it to a display label.
+const CUSTOM_FIELDS_EDITED_ACTION = 'custom_fields_edited';
+
 /**
  * @typedef {object} ILabsService
  * @prop {(key: string) => boolean} isSet
@@ -605,7 +608,17 @@ module.exports = class MemberBREADService {
             const memberUnchanged = !model._changed || Object.keys(model._changed).length === 0;
             if (memberUnchanged && plannedCustomFields.length > 0) {
                 model._changed = {custom_fields: true};
-                const eventOptions = {context: options.context, transacting: options.transacting};
+                // `actionName` is what the history log reads to title an `edited`
+                // action as something more specific than "Member edited" — the same
+                // hinge `commenting_disabled` uses. Only the values-only edit can
+                // claim it: an edit that changed the member too already fired its
+                // action from the save above, and labelling that one would hide the
+                // member change behind the custom-field one.
+                const eventOptions = {
+                    context: options.context,
+                    transacting: options.transacting,
+                    actionName: CUSTOM_FIELDS_EDITED_ACTION
+                };
                 await model.triggerThen('updated', model, eventOptions);
             }
         }

--- a/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
@@ -608,12 +608,9 @@ module.exports = class MemberBREADService {
             const memberUnchanged = !model._changed || Object.keys(model._changed).length === 0;
             if (memberUnchanged && plannedCustomFields.length > 0) {
                 model._changed = {custom_fields: true};
-                // `actionName` is what the history log reads to title an `edited`
-                // action as something more specific than "Member edited" — the same
-                // hinge `commenting_disabled` uses. Only the values-only edit can
-                // claim it: an edit that changed the member too already fired its
-                // action from the save above, and labelling that one would hide the
-                // member change behind the custom-field one.
+                // A mixed edit keeps the generic label on purpose: relabelling the
+                // one action a member change already fired would bury that change
+                // behind this one.
                 const eventOptions = {
                     context: options.context,
                     transacting: options.transacting,

--- a/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
@@ -930,9 +930,9 @@ describe('Member Custom Fields Admin API', function () {
         // Admin parses it before reading `action_name`, and so does this.
         const parseContext = (action: {context: string | null}) => (typeof action.context === 'string' ? JSON.parse(action.context) : action.context);
 
-        // The member's edit history as the history log asks for it: the same
-        // endpoint, filter and include the Admin history modal uses.
-        const memberEditedActions = async (memberId: string) => {
+        // Read back over the API the history log is served from, not the table,
+        // so what Admin receives is what's asserted — `context` included.
+        const memberEditedActionsViaApi = async (memberId: string) => {
             const {body} = await agent
                 .get(`actions/?filter=resource_id:'${memberId}'%2Bresource_type:member&include=actor`)
                 .expectStatus(200);
@@ -947,7 +947,7 @@ describe('Member Custom Fields Admin API', function () {
 
             await setValues(memberId, {[field.key]: 'Ghosts'});
 
-            const actions = await memberEditedActions(memberId);
+            const actions = await memberEditedActionsViaApi(memberId);
             assert.equal(actions.length, 1);
             assert.equal(parseContext(actions[0]).action_name, 'custom_fields_edited');
             assert.equal(actions[0].resource_id, memberId);
@@ -965,7 +965,7 @@ describe('Member Custom Fields Admin API', function () {
                 .body({members: [{name: 'Renamed'}]})
                 .expectStatus(200);
 
-            const actions = await memberEditedActions(memberId);
+            const actions = await memberEditedActionsViaApi(memberId);
             assert.equal(actions.length, 1);
             assert.equal(parseContext(actions[0]).action_name, undefined);
         });
@@ -983,7 +983,7 @@ describe('Member Custom Fields Admin API', function () {
                 .body({members: [{name: 'Renamed', custom_fields: {[field.key]: 'Ghosts'}}]})
                 .expectStatus(200);
 
-            const actions = await memberEditedActions(memberId);
+            const actions = await memberEditedActionsViaApi(memberId);
             assert.equal(actions.length, 1);
             assert.equal(parseContext(actions[0]).action_name, undefined);
         });
@@ -1001,7 +1001,7 @@ describe('Member Custom Fields Admin API', function () {
                 .body({members: [{email, custom_fields: {[field.key]: 'Ghosts'}}]})
                 .expectStatus(200);
 
-            const actions = await memberEditedActions(memberId);
+            const actions = await memberEditedActionsViaApi(memberId);
             assert.equal(actions.length, 1);
             assert.equal(parseContext(actions[0]).action_name, 'custom_fields_edited');
         });

--- a/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
@@ -925,6 +925,88 @@ describe('Member Custom Fields Admin API', function () {
         });
     });
 
+    describe('records member custom field value changes in the history (via the actions API)', function () {
+        // `context` is a text column, so the API hands it back as a JSON string —
+        // Admin parses it before reading `action_name`, and so does this.
+        const parseContext = (action: {context: string | null}) => (typeof action.context === 'string' ? JSON.parse(action.context) : action.context);
+
+        // The member's edit history as the history log asks for it: the same
+        // endpoint, filter and include the Admin history modal uses.
+        const memberEditedActions = async (memberId: string) => {
+            const {body} = await agent
+                .get(`actions/?filter=resource_id:'${memberId}'%2Bresource_type:member&include=actor`)
+                .expectStatus(200);
+            return body.actions.filter((action: {event: string}) => action.event === 'edited');
+        };
+
+        it('marks a values-only edit as a custom-field change', async function () {
+            // The payload that makes the whole feature auditable: without
+            // action_name the log can't tell this from a name change.
+            const field = await createField({name: 'Favourite topic'});
+            const memberId = await createMember();
+
+            await setValues(memberId, {[field.key]: 'Ghosts'});
+
+            const actions = await memberEditedActions(memberId);
+            assert.equal(actions.length, 1);
+            assert.equal(parseContext(actions[0]).action_name, 'custom_fields_edited');
+            assert.equal(actions[0].resource_id, memberId);
+            // The row still has to say who the member is and who changed them —
+            // action_name titles the entry, it doesn't replace the rest of it.
+            assert.ok(parseContext(actions[0]).primary_name, 'the action should name the member');
+            assert.equal(actions[0].actor_type, 'user');
+        });
+
+        it('leaves a plain member edit unmarked', async function () {
+            const memberId = await createMember();
+
+            await agent
+                .put(`members/${memberId}/`)
+                .body({members: [{name: 'Renamed'}]})
+                .expectStatus(200);
+
+            const actions = await memberEditedActions(memberId);
+            assert.equal(actions.length, 1);
+            assert.equal(parseContext(actions[0]).action_name, undefined);
+        });
+
+        it('leaves an edit that changes the member too unmarked', async function () {
+            // The member's own save already fired the one action for this edit, and
+            // it covers a change to the member itself — marking it as a custom-field
+            // change would hide the rename behind the wrong label. The generic
+            // "Member edited" is the honest title for a mixed edit.
+            const field = await createField({name: 'Favourite topic'});
+            const memberId = await createMember();
+
+            await agent
+                .put(`members/${memberId}/`)
+                .body({members: [{name: 'Renamed', custom_fields: {[field.key]: 'Ghosts'}}]})
+                .expectStatus(200);
+
+            const actions = await memberEditedActions(memberId);
+            assert.equal(actions.length, 1);
+            assert.equal(parseContext(actions[0]).action_name, undefined);
+        });
+
+        it('marks a full PUT that only really changes a custom field', async function () {
+            // The Admin member editor resends the whole member, so the save is a
+            // no-op and only the custom field actually changed.
+            const field = await createField({name: 'Favourite topic'});
+            const memberId = await createMember();
+            const {body} = await agent.get(`members/${memberId}/`).expectStatus(200);
+            const {email} = body.members[0];
+
+            await agent
+                .put(`members/${memberId}/`)
+                .body({members: [{email, custom_fields: {[field.key]: 'Ghosts'}}]})
+                .expectStatus(200);
+
+            const actions = await memberEditedActions(memberId);
+            assert.equal(actions.length, 1);
+            assert.equal(parseContext(actions[0]).action_name, 'custom_fields_edited');
+        });
+    });
+
     describe('Authorization', function () {
         // The full role matrix is pinned in migration.test.js; here we only prove
         // the endpoint enforces the permission — a role without it is rejected.


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3809

## Problem

Every member `edited` action in the Settings history log reads "Member edited: <name>" regardless of what actually changed, so there's no way to tell a custom-field change from a name change.

## Solution

An edit that only changes custom field values now records an action name marking it as a custom-field change, and Admin renders it as "Member custom fields edited". An edit that also changes the member itself keeps the generic title, since its single action already covers the member change and relabelling it would hide that change behind the custom-field one.

## Notes for reviewers

The log says a custom field changed but not which one. That's deferred, matching the issue's "not doing" scope on value diffs.

BER-3803 (#29393) is still open and touches the same action title helper in a different statement, so expect a small conflict there whenever either one merges.