### PR TITLE
Split indexnow-ping into a wrapper, service class and constants

### DIFF
--- a/ghost/core/core/server/services/indexnow-ping/constants.js
+++ b/ghost/core/core/server/services/indexnow-ping/constants.js
@@ -1,0 +1,39 @@
+const messages = {
+    requestFailedError: 'The {service} service was unable to send a ping request, your site will continue to function.',
+    requestFailedHelp: 'If you get this error repeatedly, please seek help on {url}.'
+};
+
+const INDEXNOW_LOG_KEY = '[indexnow]';
+
+// IndexNow endpoint - this routes to all participating search engines
+const INDEXNOW_ENDPOINT = 'https://api.indexnow.org/indexnow';
+
+const defaultPostSlugs = [
+    'welcome',
+    'the-editor',
+    'using-tags',
+    'managing-users',
+    'private-sites',
+    'advanced-markdown',
+    'themes',
+    'coming-soon'
+];
+
+// Fields that affect how the post appears in search engine results
+const seoFields = [
+    'html', // Post content
+    'title', // Post title (appears in SERP)
+    'slug', // URL path
+    'meta_title', // Custom meta title
+    'meta_description', // Meta description (appears in SERP)
+    'canonical_url', // Canonical URL
+    'status' // Published status change
+];
+
+module.exports = {
+    messages,
+    INDEXNOW_LOG_KEY,
+    INDEXNOW_ENDPOINT,
+    defaultPostSlugs,
+    seoFields
+};

--- a/ghost/core/core/server/services/indexnow-ping/index.js
+++ b/ghost/core/core/server/services/indexnow-ping/index.js
@@ -1,257 +1,35 @@
-/**
- * IndexNow Integration Service
- *
- * IndexNow is a protocol that allows websites to notify search engines about
- * content changes for faster indexing. Instead of waiting for crawlers to
- * discover updates, we proactively ping the IndexNow API when posts are
- * published or updated.
- *
- * Protocol: https://www.indexnow.org/documentation
- *
- * How it works:
- * 1. Ghost generates a unique API key (32-char hex string)
- * 2. The key is stored in settings and served at /{key}.txt for verification
- * 3. When a post is published/updated, we send a GET request to IndexNow:
- *    GET https://api.indexnow.org/indexnow?url={post-url}&key={key}&keyLocation={key-file-url}
- * 4. IndexNow distributes the notification to participating search engines
- *    (Bing, Yandex, Seznam.cz, Naver, and others)
- *
- * The API key file is served by the middleware in:
- * ghost/core/core/frontend/web/middleware/serve-indexnow-key.js
- */
+const IndexNowPingService = require('./indexnow-ping-service');
 
-const urlService = require('../url');
-const urlUtils = require('../../../shared/url-utils');
-const errors = require('@tryghost/errors');
-const tpl = require('@tryghost/tpl');
-const logging = require('@tryghost/logging');
-const request = require('@tryghost/request');
-const settingsCache = require('../../../shared/settings-cache');
-const config = require('../../../shared/config');
-const labs = require('../../../shared/labs');
-const events = require('../../lib/common/events');
-
-const messages = {
-    requestFailedError: 'The {service} service was unable to send a ping request, your site will continue to function.',
-    requestFailedHelp: 'If you get this error repeatedly, please seek help on {url}.'
-};
-
-const INDEXNOW_LOG_KEY = '[indexnow]';
-
-const defaultPostSlugs = [
-    'welcome',
-    'the-editor',
-    'using-tags',
-    'managing-users',
-    'private-sites',
-    'advanced-markdown',
-    'themes',
-    'coming-soon'
-];
-
-// IndexNow endpoint - this routes to all participating search engines
-const INDEXNOW_ENDPOINT = 'https://api.indexnow.org/indexnow';
-
-/**
- * Get existing API key from settings
- * The key is auto-generated on boot by the settings service
- * @returns {string|null} The API key or null if not set
- */
-function getApiKey() {
-    return settingsCache.get('indexnow_api_key') || null;
-}
-
-/**
- * Ping IndexNow with a URL
- * @param {Object} post - The post object
- */
-async function ping(post) {
-    // Skip pages - only ping for posts
-    if (post.type === 'page') {
-        return;
-    }
-
-    // Skip if site is private
-    if (settingsCache.get('is_private')) {
-        return;
-    }
-
-    // Skip if IndexNow pings are disabled via privacy config
-    if (config.isPrivacyDisabled('useIndexNow')) {
-        return;
-    }
-
-    // Skip if IndexNow is not enabled in labs
-    if (!labs.isSet('indexnow')) {
-        return;
-    }
-
-    // Don't ping for the default posts
-    if (defaultPostSlugs.indexOf(post.slug) > -1) {
-        return;
-    }
-
-    let url = null;
-    try {
-        url = urlService.facade.getUrlForResource({...post, type: 'posts'}, {absolute: true});
-
-        if (!url || url.endsWith('/404/')) {
-            logging.warn({
-                event: {name: 'indexnow.unresolved_url'},
-                post: {id: post.id, slug: post.slug, url}
-            }, `${INDEXNOW_LOG_KEY} Skipped ping - post has no resolvable URL`);
+class IndexNowPingServiceWrapper {
+    init() {
+        if (this.service) {
+            // Already done
             return;
         }
 
-        // Get the API key (auto-generated on boot by settings service)
-        const key = getApiKey();
-        if (!key) {
-            logging.warn({
-                event: {name: 'indexnow.api_key_missing'},
-                post: {id: post.id, slug: post.slug}
-            }, `${INDEXNOW_LOG_KEY} API key not available`);
-            return;
-        }
+        // Wire up all the dependencies
+        const settingsCache = require('../../../shared/settings-cache');
+        const config = require('../../../shared/config');
+        const labs = require('../../../shared/labs');
+        const urlService = require('../url');
+        const urlUtils = require('../../../shared/url-utils');
+        const request = require('@tryghost/request');
+        const logging = require('@tryghost/logging');
+        const events = require('../../lib/common/events');
 
-        // Get the site URL for the keyLocation parameter
-        const siteUrl = urlUtils.urlFor('home', true);
+        this.service = new IndexNowPingService({
+            settingsCache,
+            config,
+            labs,
+            urlService,
+            urlUtils,
+            request,
+            logging,
+            events
+        });
 
-        // Build the IndexNow request URL
-        const indexNowUrl = new URL(INDEXNOW_ENDPOINT);
-        indexNowUrl.searchParams.set('url', url);
-        indexNowUrl.searchParams.set('key', key);
-        indexNowUrl.searchParams.set('keyLocation', urlUtils.urlJoin(siteUrl, `${key}.txt`));
-
-        const options = {
-            timeout: {
-                request: 5 * 1000 // 5 second timeout
-            }
-        };
-
-        const response = await request(indexNowUrl.toString(), options);
-
-        if (response.statusCode !== 200 && response.statusCode !== 202) {
-            throw new errors.InternalServerError({
-                message: `IndexNow returned unexpected status: ${response.statusCode}`,
-                statusCode: response.statusCode
-            });
-        }
-
-        logging.info({
-            event: {name: 'indexnow.pinged'},
-            post: {id: post.id, slug: post.slug, url},
-            http: {response: {status_code: response.statusCode}}
-        }, `${INDEXNOW_LOG_KEY} Successfully pinged ${url}`);
-    } catch (err) {
-        // Log errors but don't throw - IndexNow failures shouldn't disrupt publishing
-        const statusCode = err.statusCode ?? err.response?.statusCode ?? null;
-
-        let eventName;
-        let error;
-        if (statusCode === 429) {
-            // Rate limited by IndexNow - we have no retry/backoff, so the ping is dropped
-            eventName = 'indexnow.rate_limited';
-            error = new errors.TooManyRequestsError({
-                err,
-                message: err.message,
-                context: tpl(messages.requestFailedError, {service: 'IndexNow'}),
-                help: tpl(messages.requestFailedHelp, {url: 'https://ghost.org/docs/'})
-            });
-        } else if (statusCode === 422 || statusCode === 403) {
-            eventName = 'indexnow.key_validation_failed';
-            error = new errors.ValidationError({
-                err,
-                message: 'IndexNow key validation failed',
-                context: tpl(messages.requestFailedError, {service: 'IndexNow'}),
-                help: 'Ensure your IndexNow API key file is accessible at the correct URL'
-            });
-        } else {
-            eventName = 'indexnow.ping_failed';
-            error = new errors.InternalServerError({
-                err: err,
-                message: err.message,
-                context: tpl(messages.requestFailedError, {service: 'IndexNow'}),
-                help: tpl(messages.requestFailedHelp, {url: 'https://ghost.org/docs/'})
-            });
-        }
-
-        logging.warn({
-            event: {name: eventName},
-            post: {id: post.id, slug: post.slug, url},
-            http: {response: {status_code: statusCode}},
-            err: error
-        }, `${INDEXNOW_LOG_KEY} ${error.message}`);
+        this.service.subscribeEvents();
     }
 }
 
-/**
- * Check if any SEO-relevant fields have changed
- * These are fields that affect how the post appears in search results
- * @param {Object} model - The model instance
- * @returns {boolean} True if SEO-relevant content has changed
- */
-function hasSeoRelevantChanges(model) {
-    // Fields that affect how the post appears in search engine results
-    const seoFields = [
-        'html', // Post content
-        'title', // Post title (appears in SERP)
-        'slug', // URL path
-        'meta_title', // Custom meta title
-        'meta_description', // Meta description (appears in SERP)
-        'canonical_url', // Canonical URL
-        'status' // Published status change
-    ];
-
-    return seoFields.some(field => model.get(field) !== model.previous(field));
-}
-
-/**
- * Event listener for post.published events
- * @param {Object} model - The model instance
- * @param {Object} options - Event options
- */
-function indexnowListener(model, options) {
-    // CASE: do not ping if we import a database
-    if (options && options.importing) {
-        return;
-    }
-
-    // Content-based deduplication: skip if no SEO-relevant fields changed
-    // This avoids spamming IndexNow when minor non-content edits are made
-    if (!hasSeoRelevantChanges(model)) {
-        return;
-    }
-
-    ping({
-        ...model.toJSON(),
-        // tags and authors are needed so the lazy URL service can evaluate
-        // collection filters (e.g. `tag:foo`) when resolving the post URL;
-        // without them a tag/author-filtered post resolves to /404/
-        authors: model.related('authors').toJSON(),
-        tags: model.related('tags').toJSON()
-    }).catch(() => {
-        // Errors are already logged inside ping()
-        // This catch is just to prevent unhandled rejection warnings
-    });
-}
-
-/**
- * Register event listeners for IndexNow
- */
-function init() {
-    // Listen for new posts being published
-    events
-        .removeListener('post.published', indexnowListener)
-        .on('post.published', indexnowListener);
-
-    // Also listen for published posts being edited
-    events
-        .removeListener('post.published.edited', indexnowListener)
-        .on('post.published.edited', indexnowListener);
-}
-
-module.exports = {
-    init: init,
-    ping: ping,
-    getApiKey: getApiKey
-};
+module.exports = new IndexNowPingServiceWrapper();

--- a/ghost/core/core/server/services/indexnow-ping/indexnow-ping-service.js
+++ b/ghost/core/core/server/services/indexnow-ping/indexnow-ping-service.js
@@ -1,0 +1,267 @@
+/**
+ * IndexNow Integration Service
+ *
+ * IndexNow is a protocol that allows websites to notify search engines about
+ * content changes for faster indexing. Instead of waiting for crawlers to
+ * discover updates, we proactively ping the IndexNow API when posts are
+ * published or updated.
+ *
+ * Protocol: https://www.indexnow.org/documentation
+ *
+ * How it works:
+ * 1. Ghost generates a unique API key (32-char hex string)
+ * 2. The key is stored in settings and served at /{key}.txt for verification
+ * 3. When a post is published/updated, we send a GET request to IndexNow:
+ *    GET https://api.indexnow.org/indexnow?url={post-url}&key={key}&keyLocation={key-file-url}
+ * 4. IndexNow distributes the notification to participating search engines
+ *    (Bing, Yandex, Seznam.cz, Naver, and others)
+ *
+ * The API key file is served by the middleware in:
+ * ghost/core/core/frontend/web/middleware/serve-indexnow-key.js
+ */
+
+const errors = require('@tryghost/errors');
+const tpl = require('@tryghost/tpl');
+
+const {
+    messages,
+    INDEXNOW_LOG_KEY,
+    INDEXNOW_ENDPOINT,
+    defaultPostSlugs,
+    seoFields
+} = require('./constants');
+
+class IndexNowPingService {
+    /**
+     * @param {object} deps
+     * @param {{get: (key: string) => any}} deps.settingsCache
+     * @param {{isPrivacyDisabled: (key: string) => boolean}} deps.config
+     * @param {{isSet: (flag: string) => boolean}} deps.labs
+     * @param {{facade: {getUrlForResource: (resource: object, options: object) => string}}} deps.urlService
+     * @param {{urlFor: Function, urlJoin: Function}} deps.urlUtils
+     * @param {Function} deps.request
+     * @param {object} deps.logging
+     * @param {{removeListener: Function, on: Function}} deps.events
+     */
+    constructor({settingsCache, config, labs, urlService, urlUtils, request, logging, events}) {
+        this.settingsCache = settingsCache;
+        this.config = config;
+        this.labs = labs;
+        this.urlService = urlService;
+        this.urlUtils = urlUtils;
+        this.request = request;
+        this.logging = logging;
+        this.events = events;
+
+        // Stable reference so removeListener() can de-register it across reboots.
+        this.listener = this.handlePostEvent.bind(this);
+    }
+
+    /**
+     * Get existing API key from settings.
+     * The key is auto-generated on boot by the settings service.
+     * @returns {string|null} The API key or null if not set
+     */
+    getApiKey() {
+        return this.settingsCache.get('indexnow_api_key') || null;
+    }
+
+    /**
+     * Check if any SEO-relevant fields have changed.
+     * These are fields that affect how the post appears in search results.
+     * @param {object} model - The model instance
+     * @returns {boolean} True if SEO-relevant content has changed
+     */
+    hasSeoRelevantChanges(model) {
+        return seoFields.some(field => model.get(field) !== model.previous(field));
+    }
+
+    /**
+     * Ping IndexNow with a URL.
+     * @param {object} post - The post object
+     */
+    async ping(post) {
+        // Skip pages - only ping for posts
+        if (post.type === 'page') {
+            return;
+        }
+
+        // Skip if site is private
+        if (this.settingsCache.get('is_private')) {
+            return;
+        }
+
+        // Skip if IndexNow pings are disabled via privacy config
+        if (this.config.isPrivacyDisabled('useIndexNow')) {
+            return;
+        }
+
+        // Skip if IndexNow is not enabled in labs
+        if (!this.labs.isSet('indexnow')) {
+            return;
+        }
+
+        // Don't ping for the default posts
+        if (defaultPostSlugs.indexOf(post.slug) > -1) {
+            return;
+        }
+
+        // Everything from URL resolution onwards sits inside the swallow-and-log
+        // envelope: the lazy URL service evaluates collection filters during
+        // resolution and can throw, and IndexNow failures must never disrupt
+        // publishing.
+        let url = null;
+        try {
+            url = this.urlService.facade.getUrlForResource({...post, type: 'posts'}, {absolute: true});
+
+            if (!url || url.endsWith('/404/')) {
+                this.logging.warn({
+                    event: {name: 'indexnow.unresolved_url'},
+                    post: {id: post.id, slug: post.slug, url}
+                }, `${INDEXNOW_LOG_KEY} Skipped ping - post has no resolvable URL`);
+                return;
+            }
+
+            // Get the API key (auto-generated on boot by settings service)
+            const key = this.getApiKey();
+            if (!key) {
+                this.logging.warn({
+                    event: {name: 'indexnow.api_key_missing'},
+                    post: {id: post.id, slug: post.slug}
+                }, `${INDEXNOW_LOG_KEY} API key not available`);
+                return;
+            }
+
+            // Get the site URL for the keyLocation parameter
+            const siteUrl = this.urlUtils.urlFor('home', true);
+
+            // Build the IndexNow request URL
+            const indexNowUrl = new URL(INDEXNOW_ENDPOINT);
+            indexNowUrl.searchParams.set('url', url);
+            indexNowUrl.searchParams.set('key', key);
+            indexNowUrl.searchParams.set('keyLocation', this.urlUtils.urlJoin(siteUrl, `${key}.txt`));
+
+            const response = await this.request(indexNowUrl.toString(), {
+                timeout: {
+                    request: 5 * 1000 // 5 second timeout
+                }
+            });
+
+            if (response.statusCode !== 200 && response.statusCode !== 202) {
+                throw new errors.InternalServerError({
+                    message: `IndexNow returned unexpected status: ${response.statusCode}`,
+                    statusCode: response.statusCode
+                });
+            }
+
+            this.logging.info({
+                event: {name: 'indexnow.pinged'},
+                post: {id: post.id, slug: post.slug, url},
+                http: {response: {status_code: response.statusCode}}
+            }, `${INDEXNOW_LOG_KEY} Successfully pinged ${url}`);
+        } catch (err) {
+            // Log errors but don't throw - IndexNow failures shouldn't disrupt publishing
+            const statusCode = err.statusCode ?? err.response?.statusCode ?? null;
+            const {eventName, error} = this.#classifyError(statusCode, err);
+
+            this.logging.warn({
+                event: {name: eventName},
+                post: {id: post.id, slug: post.slug, url},
+                http: {response: {status_code: statusCode}},
+                err: error
+            }, `${INDEXNOW_LOG_KEY} ${error.message}`);
+        }
+    }
+
+    /**
+     * Map an IndexNow response status to a log event name and a structured error.
+     * IndexNow-protocol-specific interpretation; when this logic is lifted into a
+     * shared ping primitive, this becomes the injected `interpret(status)` hook.
+     * @param {number|null} statusCode
+     * @param {Error} err
+     * @returns {{eventName: string, error: Error}}
+     */
+    #classifyError(statusCode, err) {
+        if (statusCode === 429) {
+            // Rate limited by IndexNow - we have no retry/backoff, so the ping is dropped
+            return {
+                eventName: 'indexnow.rate_limited',
+                error: new errors.TooManyRequestsError({
+                    err,
+                    message: err.message,
+                    context: tpl(messages.requestFailedError, {service: 'IndexNow'}),
+                    help: tpl(messages.requestFailedHelp, {url: 'https://ghost.org/docs/'})
+                })
+            };
+        }
+
+        if (statusCode === 422 || statusCode === 403) {
+            return {
+                eventName: 'indexnow.key_validation_failed',
+                error: new errors.ValidationError({
+                    err,
+                    message: 'IndexNow key validation failed',
+                    context: tpl(messages.requestFailedError, {service: 'IndexNow'}),
+                    help: 'Ensure your IndexNow API key file is accessible at the correct URL'
+                })
+            };
+        }
+
+        return {
+            eventName: 'indexnow.ping_failed',
+            error: new errors.InternalServerError({
+                err,
+                message: err.message,
+                context: tpl(messages.requestFailedError, {service: 'IndexNow'}),
+                help: tpl(messages.requestFailedHelp, {url: 'https://ghost.org/docs/'})
+            })
+        };
+    }
+
+    /**
+     * Event listener for post.published / post.published.edited.
+     * @param {object} model - The model instance
+     * @param {object} options - Event options
+     */
+    handlePostEvent(model, options) {
+        // CASE: do not ping if we import a database
+        if (options && options.importing) {
+            return;
+        }
+
+        // Content-based deduplication: skip if no SEO-relevant fields changed
+        // This avoids spamming IndexNow when minor non-content edits are made
+        if (!this.hasSeoRelevantChanges(model)) {
+            return;
+        }
+
+        this.ping({
+            ...model.toJSON(),
+            // tags and authors are needed so the lazy URL service can evaluate
+            // collection filters (e.g. `tag:foo`) when resolving the post URL;
+            // without them a tag/author-filtered post resolves to /404/
+            authors: model.related('authors').toJSON(),
+            tags: model.related('tags').toJSON()
+        }).catch(() => {
+            // Errors are already logged inside ping()
+            // This catch is just to prevent unhandled rejection warnings
+        });
+    }
+
+    /**
+     * Register event listeners for IndexNow.
+     */
+    subscribeEvents() {
+        // Listen for new posts being published
+        this.events
+            .removeListener('post.published', this.listener)
+            .on('post.published', this.listener);
+
+        // Also listen for published posts being edited
+        this.events
+            .removeListener('post.published.edited', this.listener)
+            .on('post.published.edited', this.listener);
+    }
+}
+
+module.exports = IndexNowPingService;

--- a/ghost/core/test/unit/server/services/indexnow-ping/indexnow-ping-service.test.js
+++ b/ghost/core/test/unit/server/services/indexnow-ping/indexnow-ping-service.test.js
@@ -3,62 +3,70 @@ const sinon = require('sinon');
 const _ = require('lodash');
 const nock = require('nock');
 const testUtils = require('../../../../utils');
-const indexnow = require('../../../../../core/server/services/indexnow-ping');
-const events = require('../../../../../core/server/lib/common/events');
-const settingsCache = require('../../../../../core/shared/settings-cache');
-const config = require('../../../../../core/shared/config');
-const labs = require('../../../../../core/shared/labs');
-const logging = require('@tryghost/logging');
-const urlService = require('../../../../../core/server/services/url');
+const request = require('@tryghost/request');
+const IndexNowPingService = require('../../../../../core/server/services/indexnow-ping/indexnow-ping-service');
+
+const VALID_API_KEY = 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4';
+
+// Build an IndexNowPingService with fully injected fakes. The real @tryghost/request
+// is injected so nock continues to intercept at the HTTP layer, exactly as
+// before - only the stateful/config singletons become injected fakes.
+function createService() {
+    const settingsCache = {get: sinon.stub()};
+    settingsCache.get.withArgs('is_private').returns(false);
+    settingsCache.get.withArgs('indexnow_api_key').returns(VALID_API_KEY);
+
+    const config = {isPrivacyDisabled: sinon.stub()};
+    config.isPrivacyDisabled.withArgs('useIndexNow').returns(false);
+
+    const labs = {isSet: sinon.stub()};
+    labs.isSet.withArgs('indexnow').returns(true);
+
+    const urlService = {
+        facade: {
+            getUrlForResource: sinon.stub().returns('https://example.com/my-post/')
+        }
+    };
+
+    const urlUtils = {
+        urlFor: sinon.stub().returns('https://example.com'),
+        urlJoin: (...args) => args.join('/')
+    };
+
+    const logging = {info: sinon.stub(), warn: sinon.stub(), error: sinon.stub()};
+
+    // Chainable so `events.removeListener(...).on(...)` works.
+    const events = {removeListener: sinon.stub().returnsThis(), on: sinon.stub().returnsThis()};
+
+    const deps = {settingsCache, config, labs, urlService, urlUtils, request, logging, events};
+    const service = new IndexNowPingService(deps);
+
+    return {service, deps};
+}
 
 describe('IndexNow', function () {
-    let eventStub;
-    let loggingStub;
-    let settingsCacheStub;
-    let labsStub;
-    let privacyDisabledStub;
-
-    beforeEach(function () {
-        eventStub = sinon.stub(events, 'on');
-        settingsCacheStub = sinon.stub(settingsCache, 'get');
-        labsStub = sinon.stub(labs, 'isSet');
-        privacyDisabledStub = sinon.stub(config, 'isPrivacyDisabled');
-
-        // Default: IndexNow enabled, site not private, API key set, privacy not disabled
-        labsStub.withArgs('indexnow').returns(true);
-        settingsCacheStub.withArgs('is_private').returns(false);
-        settingsCacheStub.withArgs('indexnow_api_key').returns('a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4');
-        privacyDisabledStub.withArgs('useIndexNow').returns(false);
-    });
-
     afterEach(function () {
         sinon.restore();
         nock.cleanAll();
     });
 
-    describe('init()', function () {
-        it('should initialise events correctly', function () {
-            indexnow.init();
-            sinon.assert.calledTwice(eventStub);
-            sinon.assert.calledWith(eventStub, 'post.published');
-            sinon.assert.calledWith(eventStub, 'post.published.edited');
+    describe('subscribeEvents()', function () {
+        it('registers listeners for post.published and post.published.edited', function () {
+            const {service, deps} = createService();
+
+            service.subscribeEvents();
+
+            sinon.assert.calledTwice(deps.events.on);
+            sinon.assert.calledWith(deps.events.on, 'post.published');
+            sinon.assert.calledWith(deps.events.on, 'post.published.edited');
         });
     });
 
-    describe('listener()', function () {
-        let listener;
-        let urlStub;
-
-        beforeEach(function () {
-            urlStub = sinon.stub(urlService.facade, 'getUrlForResource').returns('https://example.com/my-post/');
-            settingsCacheStub.withArgs('indexnow_api_key').returns(null);
-            loggingStub = sinon.stub(logging, 'warn');
-
-            indexnow.init();
-            listener = eventStub.firstCall.args[1];
-        });
-
+    describe('handlePostEvent()', function () {
         it('calls ping() with toJSONified model including tags and authors when content changed', function () {
+            const {service} = createService();
+            const pingStub = sinon.stub(service, 'ping').resolves();
+
             const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
             const testAuthor = _.clone(testUtils.DataGenerator.Content.users[0]);
             const testTag = _.clone(testUtils.DataGenerator.Content.tags[0]);
@@ -100,21 +108,23 @@ describe('IndexNow', function () {
                 }
             };
 
-            listener(testModel);
+            service.handlePostEvent(testModel);
 
-            sinon.assert.calledOnce(urlStub);
-            // tags and authors must reach the URL service so the lazy backend
-            // can evaluate collection filters (e.g. `tag:foo`) when building the URL
+            sinon.assert.calledOnce(pingStub);
+            // tags and authors must reach ping() (and onward the URL service) so
+            // the lazy backend can evaluate collection filters (e.g. `tag:foo`)
+            // when building the URL
             sinon.assert.calledWith(
-                urlStub,
-                sinon.match({...testPost, type: 'posts', authors: [testAuthor], tags: [testTag]}),
-                {absolute: true}
+                pingStub,
+                sinon.match({...testPost, authors: [testAuthor], tags: [testTag]})
             );
         });
 
         it('does not call ping() when importing', function () {
-            const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
+            const {service} = createService();
+            const pingStub = sinon.stub(service, 'ping').resolves();
 
+            const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
             const testModel = {
                 toJSON: function () {
                     return testPost;
@@ -127,54 +137,47 @@ describe('IndexNow', function () {
                 }
             };
 
-            listener(testModel, {importing: true});
+            service.handlePostEvent(testModel, {importing: true});
 
-            sinon.assert.notCalled(urlStub);
+            sinon.assert.notCalled(pingStub);
         });
 
         it('does not call ping() when no SEO-relevant fields have changed', function () {
-            const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
+            const {service} = createService();
+            const pingStub = sinon.stub(service, 'ping').resolves();
 
+            const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
+            const values = {
+                status: 'published',
+                html: '<p>same content</p>',
+                title: 'Same Title',
+                slug: 'same-slug',
+                meta_title: 'Same Meta Title',
+                meta_description: 'Same meta description',
+                canonical_url: null
+            };
             const testModel = {
                 toJSON: function () {
                     return testPost;
                 },
                 get: function (key) {
-                    // Return same values for all SEO-relevant fields
-                    const values = {
-                        status: 'published',
-                        html: '<p>same content</p>',
-                        title: 'Same Title',
-                        slug: 'same-slug',
-                        meta_title: 'Same Meta Title',
-                        meta_description: 'Same meta description',
-                        canonical_url: null
-                    };
                     return values[key];
                 },
                 previous: function (key) {
-                    // Return same values as get() - no changes
-                    const values = {
-                        status: 'published',
-                        html: '<p>same content</p>',
-                        title: 'Same Title',
-                        slug: 'same-slug',
-                        meta_title: 'Same Meta Title',
-                        meta_description: 'Same meta description',
-                        canonical_url: null
-                    };
                     return values[key];
                 }
             };
 
-            listener(testModel);
+            service.handlePostEvent(testModel);
 
-            sinon.assert.notCalled(urlStub);
+            sinon.assert.notCalled(pingStub);
         });
 
         it('calls ping() when title changes', function () {
-            const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
+            const {service} = createService();
+            const pingStub = sinon.stub(service, 'ping').resolves();
 
+            const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
             const testModel = {
                 toJSON: function () {
                     return testPost;
@@ -196,14 +199,16 @@ describe('IndexNow', function () {
                 }
             };
 
-            listener(testModel);
+            service.handlePostEvent(testModel);
 
-            sinon.assert.calledOnce(urlStub);
+            sinon.assert.calledOnce(pingStub);
         });
 
         it('calls ping() when slug changes', function () {
-            const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
+            const {service} = createService();
+            const pingStub = sinon.stub(service, 'ping').resolves();
 
+            const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
             const testModel = {
                 toJSON: function () {
                     return testPost;
@@ -225,14 +230,16 @@ describe('IndexNow', function () {
                 }
             };
 
-            listener(testModel);
+            service.handlePostEvent(testModel);
 
-            sinon.assert.calledOnce(urlStub);
+            sinon.assert.calledOnce(pingStub);
         });
 
         it('calls ping() when meta_description changes', function () {
-            const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
+            const {service} = createService();
+            const pingStub = sinon.stub(service, 'ping').resolves();
 
+            const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
             const testModel = {
                 toJSON: function () {
                     return testPost;
@@ -254,46 +261,40 @@ describe('IndexNow', function () {
                 }
             };
 
-            listener(testModel);
+            service.handlePostEvent(testModel);
 
-            sinon.assert.calledOnce(urlStub);
+            sinon.assert.calledOnce(pingStub);
         });
     });
 
     describe('ping()', function () {
-        let urlStub;
-
-        beforeEach(function () {
-            urlStub = sinon.stub(urlService.facade, 'getUrlForResource').returns('https://example.com/my-post/');
-        });
-
         it('with a post should execute ping', async function () {
-            loggingStub = sinon.stub(logging, 'info');
+            const {service, deps} = createService();
             nock('https://api.indexnow.org')
                 .get(/\/indexnow/)
                 .reply(200);
             const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
 
-            await indexnow.ping(testPost);
+            await service.ping(testPost);
 
-            sinon.assert.calledOnce(loggingStub);
-            assert.equal(loggingStub.args[0][0].event.name, 'indexnow.pinged');
-            assert.equal(loggingStub.args[0][0].http.response.status_code, 200);
+            sinon.assert.calledOnce(deps.logging.info);
+            assert.equal(deps.logging.info.args[0][0].event.name, 'indexnow.pinged');
+            assert.equal(deps.logging.info.args[0][0].http.response.status_code, 200);
         });
 
         it('does not ping when the post has no resolvable URL (/404/)', async function () {
-            urlStub.returns('https://example.com/404/');
-            loggingStub = sinon.stub(logging, 'warn');
+            const {service, deps} = createService();
+            deps.urlService.facade.getUrlForResource.returns('https://example.com/404/');
             const pingRequest = nock('https://api.indexnow.org')
                 .get(/\/indexnow/)
                 .reply(200);
             const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
 
-            await indexnow.ping(testPost);
+            await service.ping(testPost);
 
             assert.equal(pingRequest.isDone(), false);
-            sinon.assert.calledOnce(loggingStub);
-            const logged = loggingStub.args[0][0];
+            sinon.assert.calledOnce(deps.logging.warn);
+            const logged = deps.logging.warn.args[0][0];
             assert.equal(logged.event.name, 'indexnow.unresolved_url');
             assert.equal(logged.post.url, 'https://example.com/404/');
             assert.equal(logged.post.id, testPost.id);
@@ -301,6 +302,7 @@ describe('IndexNow', function () {
         });
 
         it('with default post should not execute ping', async function () {
+            const {service} = createService();
             const pingRequest = nock('https://api.indexnow.org')
                 .get(/\/indexnow/)
                 .reply(200);
@@ -308,142 +310,146 @@ describe('IndexNow', function () {
 
             testPost.slug = 'welcome';
 
-            await indexnow.ping(testPost);
+            await service.ping(testPost);
 
             assert.equal(pingRequest.isDone(), false);
         });
 
         it('with a page should not execute ping', async function () {
+            const {service} = createService();
             const pingRequest = nock('https://api.indexnow.org')
                 .get(/\/indexnow/)
                 .reply(200);
             const testPage = _.clone(testUtils.DataGenerator.Content.posts[5]);
 
-            await indexnow.ping(testPage);
+            await service.ping(testPage);
 
             assert.equal(pingRequest.isDone(), false);
         });
 
         it('when labs.indexnow is false should not execute ping', async function () {
-            labsStub.withArgs('indexnow').returns(false);
+            const {service, deps} = createService();
+            deps.labs.isSet.withArgs('indexnow').returns(false);
 
             const pingRequest = nock('https://api.indexnow.org')
                 .get(/\/indexnow/)
                 .reply(200);
             const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
 
-            await indexnow.ping(testPost);
+            await service.ping(testPost);
 
             assert.equal(pingRequest.isDone(), false);
         });
 
         it('when privacy.useIndexNow is disabled should not execute ping', async function () {
-            privacyDisabledStub.withArgs('useIndexNow').returns(true);
+            const {service, deps} = createService();
+            deps.config.isPrivacyDisabled.withArgs('useIndexNow').returns(true);
 
             const pingRequest = nock('https://api.indexnow.org')
                 .get(/\/indexnow/)
                 .reply(200);
             const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
 
-            await indexnow.ping(testPost);
+            await service.ping(testPost);
 
             assert.equal(pingRequest.isDone(), false);
         });
 
         it('when site is private should not execute ping', async function () {
-            settingsCacheStub.withArgs('is_private').returns(true);
+            const {service, deps} = createService();
+            deps.settingsCache.get.withArgs('is_private').returns(true);
 
             const pingRequest = nock('https://api.indexnow.org')
                 .get(/\/indexnow/)
                 .reply(200);
             const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
 
-            await indexnow.ping(testPost);
+            await service.ping(testPost);
 
             assert.equal(pingRequest.isDone(), false);
         });
 
         it('when no API key is set should not execute ping and log warning', async function () {
-            settingsCacheStub.withArgs('indexnow_api_key').returns(null);
-            loggingStub = sinon.stub(logging, 'warn');
+            const {service, deps} = createService();
+            deps.settingsCache.get.withArgs('indexnow_api_key').returns(null);
 
             const pingRequest = nock('https://api.indexnow.org')
                 .get(/\/indexnow/)
                 .reply(200);
             const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
 
-            await indexnow.ping(testPost);
+            await service.ping(testPost);
 
             // Should NOT have made the ping request
             assert.equal(pingRequest.isDone(), false);
             // Should have logged a warning with a structured event
-            sinon.assert.calledOnce(loggingStub);
-            assert.equal(loggingStub.args[0][0].event.name, 'indexnow.api_key_missing');
-            assert(loggingStub.args[0][1].includes('API key not available'));
+            sinon.assert.calledOnce(deps.logging.warn);
+            assert.equal(deps.logging.warn.args[0][0].event.name, 'indexnow.api_key_missing');
+            assert(deps.logging.warn.args[0][1].includes('API key not available'));
         });
 
         it('should handle 202 response as success', async function () {
-            loggingStub = sinon.stub(logging, 'info');
+            const {service, deps} = createService();
             const pingRequest = nock('https://api.indexnow.org')
                 .get(/\/indexnow/)
                 .reply(202);
             const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
 
-            await indexnow.ping(testPost);
+            await service.ping(testPost);
 
             assert.equal(pingRequest.isDone(), true);
-            sinon.assert.calledOnce(loggingStub);
-            assert.equal(loggingStub.args[0][0].event.name, 'indexnow.pinged');
-            assert.equal(loggingStub.args[0][0].http.response.status_code, 202);
+            sinon.assert.calledOnce(deps.logging.info);
+            assert.equal(deps.logging.info.args[0][0].event.name, 'indexnow.pinged');
+            assert.equal(deps.logging.info.args[0][0].http.response.status_code, 202);
         });
 
         it('captures && logs errors from 400 requests', async function () {
-            loggingStub = sinon.stub(logging, 'warn');
+            const {service, deps} = createService();
             const pingRequest = nock('https://api.indexnow.org')
                 .get(/\/indexnow/)
                 .reply(400);
             const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
 
-            await indexnow.ping(testPost);
+            await service.ping(testPost);
 
             assert.equal(pingRequest.isDone(), true);
-            sinon.assert.calledOnce(loggingStub);
-            assert.equal(loggingStub.args[0][0].event.name, 'indexnow.ping_failed');
-            assert.equal(loggingStub.args[0][0].http.response.status_code, 400);
+            sinon.assert.calledOnce(deps.logging.warn);
+            assert.equal(deps.logging.warn.args[0][0].event.name, 'indexnow.ping_failed');
+            assert.equal(deps.logging.warn.args[0][0].http.response.status_code, 400);
         });
 
         it('captures && logs validation errors from 422 requests', async function () {
-            loggingStub = sinon.stub(logging, 'warn');
+            const {service, deps} = createService();
             const pingRequest = nock('https://api.indexnow.org')
                 .get(/\/indexnow/)
                 .reply(422);
             const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
 
-            await indexnow.ping(testPost);
+            await service.ping(testPost);
 
             assert.equal(pingRequest.isDone(), true);
-            sinon.assert.calledOnce(loggingStub);
-            assert.equal(loggingStub.args[0][0].event.name, 'indexnow.key_validation_failed');
-            assert.equal(loggingStub.args[0][0].http.response.status_code, 422);
+            sinon.assert.calledOnce(deps.logging.warn);
+            assert.equal(deps.logging.warn.args[0][0].event.name, 'indexnow.key_validation_failed');
+            assert.equal(deps.logging.warn.args[0][0].http.response.status_code, 422);
         });
 
         it('should behave correctly when getting a 429', async function () {
-            loggingStub = sinon.stub(logging, 'warn');
+            const {service, deps} = createService();
             const pingRequest = nock('https://api.indexnow.org')
                 .get(/\/indexnow/)
                 .reply(429);
             const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
 
-            await indexnow.ping(testPost);
+            await service.ping(testPost);
 
             assert.equal(pingRequest.isDone(), true);
-            sinon.assert.calledOnce(loggingStub);
-            assert.equal(loggingStub.args[0][0].event.name, 'indexnow.rate_limited');
-            assert.equal(loggingStub.args[0][0].http.response.status_code, 429);
+            sinon.assert.calledOnce(deps.logging.warn);
+            assert.equal(deps.logging.warn.args[0][0].event.name, 'indexnow.rate_limited');
+            assert.equal(deps.logging.warn.args[0][0].http.response.status_code, 429);
         });
 
         it('logs the real status code for an unexpected 2xx response', async function () {
-            loggingStub = sinon.stub(logging, 'warn');
+            const {service, deps} = createService();
             // 204 is a 2xx that request() does not throw on, so it hits the
             // manual unexpected-status check rather than an HTTP error
             const pingRequest = nock('https://api.indexnow.org')
@@ -451,115 +457,122 @@ describe('IndexNow', function () {
                 .reply(204);
             const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
 
-            await indexnow.ping(testPost);
+            await service.ping(testPost);
 
             assert.equal(pingRequest.isDone(), true);
-            sinon.assert.calledOnce(loggingStub);
-            assert.equal(loggingStub.args[0][0].event.name, 'indexnow.ping_failed');
-            assert.equal(loggingStub.args[0][0].http.response.status_code, 204);
+            sinon.assert.calledOnce(deps.logging.warn);
+            assert.equal(deps.logging.warn.args[0][0].event.name, 'indexnow.ping_failed');
+            assert.equal(deps.logging.warn.args[0][0].http.response.status_code, 204);
         });
     });
 
     describe('ping() error classification (got HTTPError shape)', function () {
-        beforeEach(function () {
-            sinon.stub(urlService.facade, 'getUrlForResource').returns('https://example.com/my-post/');
-            loggingStub = sinon.stub(logging, 'warn');
-        });
-
-        async function pingWithHttpError(statusCode) {
+        async function pingWithHttpError(service, statusCode) {
             nock('https://api.indexnow.org')
                 .get(/\/indexnow/)
                 .reply(statusCode);
             const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
-            await indexnow.ping(testPost);
+            await service.ping(testPost);
         }
 
         it('classifies a 429 (status on err.response.statusCode) as rate_limited', async function () {
-            await pingWithHttpError(429);
+            const {service, deps} = createService();
+            await pingWithHttpError(service, 429);
 
-            sinon.assert.calledOnce(loggingStub);
-            assert.equal(loggingStub.args[0][0].event.name, 'indexnow.rate_limited');
-            assert.equal(loggingStub.args[0][0].http.response.status_code, 429);
+            sinon.assert.calledOnce(deps.logging.warn);
+            assert.equal(deps.logging.warn.args[0][0].event.name, 'indexnow.rate_limited');
+            assert.equal(deps.logging.warn.args[0][0].http.response.status_code, 429);
         });
 
         it('classifies a 422 (status on err.response.statusCode) as key_validation_failed', async function () {
-            await pingWithHttpError(422);
+            const {service, deps} = createService();
+            await pingWithHttpError(service, 422);
 
-            sinon.assert.calledOnce(loggingStub);
-            assert.equal(loggingStub.args[0][0].event.name, 'indexnow.key_validation_failed');
-            assert.equal(loggingStub.args[0][0].http.response.status_code, 422);
+            sinon.assert.calledOnce(deps.logging.warn);
+            assert.equal(deps.logging.warn.args[0][0].event.name, 'indexnow.key_validation_failed');
+            assert.equal(deps.logging.warn.args[0][0].http.response.status_code, 422);
         });
 
         it('classifies a 403 (key not valid) as key_validation_failed', async function () {
-            await pingWithHttpError(403);
+            const {service, deps} = createService();
+            await pingWithHttpError(service, 403);
 
-            sinon.assert.calledOnce(loggingStub);
-            assert.equal(loggingStub.args[0][0].event.name, 'indexnow.key_validation_failed');
-            assert.equal(loggingStub.args[0][0].http.response.status_code, 403);
+            sinon.assert.calledOnce(deps.logging.warn);
+            assert.equal(deps.logging.warn.args[0][0].event.name, 'indexnow.key_validation_failed');
+            assert.equal(deps.logging.warn.args[0][0].http.response.status_code, 403);
         });
 
         it('classifies other 5xx errors (status on err.response.statusCode) as ping_failed', async function () {
-            await pingWithHttpError(503);
+            const {service, deps} = createService();
+            await pingWithHttpError(service, 503);
 
-            sinon.assert.calledOnce(loggingStub);
-            assert.equal(loggingStub.args[0][0].event.name, 'indexnow.ping_failed');
-            assert.equal(loggingStub.args[0][0].http.response.status_code, 503);
+            sinon.assert.calledOnce(deps.logging.warn);
+            assert.equal(deps.logging.warn.args[0][0].event.name, 'indexnow.ping_failed');
+            assert.equal(deps.logging.warn.args[0][0].http.response.status_code, 503);
+        });
+
+        // URL resolution runs real filter evaluation in the lazy URL service and
+        // can throw; a throw must be swallowed and logged, never rejected out of
+        // ping() (the event listener's catch is silent, so a rejection here
+        // would vanish without a trace).
+        it('logs and swallows a throw from URL resolution as ping_failed', async function () {
+            const {service, deps} = createService();
+            deps.urlService.facade.getUrlForResource.throws(new Error('filter evaluation failed'));
+            const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
+
+            await service.ping(testPost);
+
+            sinon.assert.calledOnce(deps.logging.warn);
+            assert.equal(deps.logging.warn.args[0][0].event.name, 'indexnow.ping_failed');
+            assert.equal(deps.logging.warn.args[0][0].post.url, null);
         });
     });
 
     describe('getApiKey()', function () {
         it('should return the API key from settings', function () {
+            const {service, deps} = createService();
             const expectedKey = 'test-api-key-12345';
-            settingsCacheStub.withArgs('indexnow_api_key').returns(expectedKey);
+            deps.settingsCache.get.withArgs('indexnow_api_key').returns(expectedKey);
 
-            const key = indexnow.getApiKey();
-            assert.equal(key, expectedKey);
+            assert.equal(service.getApiKey(), expectedKey);
         });
 
         it('should return null when no key is set', function () {
-            settingsCacheStub.withArgs('indexnow_api_key').returns(null);
+            const {service, deps} = createService();
+            deps.settingsCache.get.withArgs('indexnow_api_key').returns(null);
 
-            const key = indexnow.getApiKey();
-            assert.equal((key === null), true);
+            assert.equal(service.getApiKey(), null);
         });
     });
 
-    // Pin which URL ping() actually sends. The earlier `ping()` block above
-    // uses nock to intercept the HTTP request but never inspects the
-    // `?url=...` query parameter; that's the exact value a future change to
-    // the url-service call shape (e.g. swapping the legacy id-based method
-    // for a resource-based facade method) could regress without anyone
-    // noticing.
+    // Pin which URL ping() actually sends. The ping() block above uses nock to
+    // intercept the HTTP request but never inspects the `?url=...` query
+    // parameter; that's the exact value a future change to the url-service call
+    // shape (e.g. swapping the legacy id-based method for a resource-based facade
+    // method) could regress without anyone noticing.
     describe('ping() URL output', function () {
         const POST_URL = 'https://my-blog.example/some-post/';
-        let getUrlForResourceStub;
-        let pingRequest;
 
-        beforeEach(function () {
+        it('passes the post URL into the IndexNow request', async function () {
+            const {service, deps} = createService();
+
             // Bind the stub to the exact resource shape production passes
-            // (`{...post, type: 'posts'}`) so a regression that drops the
-            // type override or the spread surfaces here.
-            getUrlForResourceStub = sinon.stub(urlService.facade, 'getUrlForResource');
-            getUrlForResourceStub
+            // (`{...post, type: 'posts'}`) so a regression that drops the type
+            // override or the spread surfaces here.
+            deps.urlService.facade.getUrlForResource
                 .withArgs(sinon.match({id: 'abc', type: 'posts'}), {absolute: true})
                 .returns(POST_URL);
 
-            pingRequest = nock('https://api.indexnow.org')
+            const pingRequest = nock('https://api.indexnow.org')
                 .get('/indexnow')
-                .query((query) => {
-                    return query.url === POST_URL;
-                })
+                .query(query => query.url === POST_URL)
                 .reply(200);
 
-            settingsCacheStub.withArgs('indexnow_api_key').returns('a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4');
-        });
-
-        it('passes the post URL into the IndexNow request', async function () {
             const post = {id: 'abc', slug: 'some-post', type: 'post'};
 
-            await indexnow.ping(post);
+            await service.ping(post);
 
-            sinon.assert.calledOnce(getUrlForResourceStub);
+            sinon.assert.calledOnce(deps.urlService.facade.getUrlForResource);
             assert.equal(pingRequest.isDone(), true);
         });
     });


### PR DESCRIPTION
Step 2 of the ping-services cleanup (after #29418/#29420 moved the flat files into folders).

Splits `services/indexnow-ping/index.js` (257-line single file) into the established service shape, following the most common wrapper convention (as used by comments, audience-feedback, donations):

- `index.js` — `IndexNowPingServiceWrapper`: wires dependencies inside `init()` (lazy requires), constructs the service, subscribes events. Idempotent.
- `indexnow-ping-service.js` — `IndexNowPingService`: all logic, every stateful dependency injected through the constructor; requires only pure modules (`@tryghost/errors`, `tpl`, its constants).
- `constants.js` — endpoint, default-slug skip list, SEO-relevant fields, log messages.

The payoff is the test: previously it stubbed **18 module-level globals** (`settingsCache`, `labs`, `config`, `events`, `urlService.facade`, `logging`, …) and the module exported `ping`/`getApiKey` solely so the test could reach them. The test now constructs the class with injected fakes (`nock` still intercepts real HTTP), nothing test-only is exported, and coverage grows by one case: a throw from URL resolution is logged-and-swallowed rather than escaping the listener (URL resolution can throw when the lazy URL service evaluates collection filters).

No behaviour changes: gating order, slug/page skips, 429/422/403 error mapping, structured log events and swallow-and-log semantics all move verbatim. `boot.js` is untouched — it already calls `init()`.
