### PR TITLE
Revert "Cleaned up private package versions"

### DIFF
--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,7 +1,8 @@
 {
     "name": "@tryghost/activitypub",
     "type": "module",
-    "version": "3.1.55",
+    "version": "0.0.0",
+    "private": true,
     "license": "MIT",
     "repository": {
         "type": "git",
@@ -22,7 +23,6 @@
         },
         "./api": "./src/index.tsx"
     },
-    "private": false,
     "scripts": {
         "dev": "vite build --watch",
         "dev:start": "vite",

--- a/apps/activitypub/package.json
+++ b/apps/activitypub/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@tryghost/activitypub",
     "type": "module",
-    "private": true,
+    "version": "3.1.55",
     "license": "MIT",
     "repository": {
         "type": "git",
@@ -22,6 +22,7 @@
         },
         "./api": "./src/index.tsx"
     },
+    "private": false,
     "scripts": {
         "dev": "vite build --watch",
         "dev:start": "vite",

--- a/apps/admin-x-design-system/package.json
+++ b/apps/admin-x-design-system/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@tryghost/admin-x-design-system",
     "type": "module",
+    "version": "0.0.0",
     "repository": "https://github.com/TryGhost/Ghost/tree/main/packages/admin-x-design-system",
     "author": "Ghost Foundation",
     "private": true,

--- a/apps/admin-x-framework/package.json
+++ b/apps/admin-x-framework/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@tryghost/admin-x-framework",
     "type": "module",
+    "version": "0.0.0",
     "repository": "https://github.com/TryGhost/Ghost/tree/main/apps/admin-x-framework",
     "author": "Ghost Foundation",
     "private": true,

--- a/apps/admin-x-settings/package.json
+++ b/apps/admin-x-settings/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@tryghost/admin-x-settings",
     "type": "module",
+    "version": "0.0.0",
     "license": "MIT",
     "repository": {
         "type": "git",

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@tryghost/admin",
     "private": true,
+    "version": "0.0.0",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/configs/eslint-react/package.json
+++ b/configs/eslint-react/package.json
@@ -1,5 +1,6 @@
 {
     "name": "@internal/cfg-eslint-react",
+    "version": "0.0.0",
     "description": "Shared ESLint config for internal Ghost React apps",
     "private": true,
     "type": "module",

--- a/configs/eslint/package.json
+++ b/configs/eslint/package.json
@@ -1,5 +1,6 @@
 {
     "name": "@internal/cfg-eslint",
+    "version": "0.0.0",
     "description": "Shared ESLint atoms + Node-library config for internal Ghost packages",
     "private": true,
     "type": "module",

--- a/configs/typescript/package.json
+++ b/configs/typescript/package.json
@@ -1,5 +1,6 @@
 {
     "name": "@internal/cfg-typescript",
+    "version": "0.0.0",
     "description": "Shared TypeScript config for internal ESM-only Ghost packages",
     "private": true,
     "license": "MIT",

--- a/configs/vitest/package.json
+++ b/configs/vitest/package.json
@@ -1,5 +1,6 @@
 {
     "name": "@internal/cfg-vitest",
+    "version": "0.0.0",
     "description": "Shared Vitest config for internal Ghost packages",
     "private": true,
     "type": "module",

--- a/ghost/core/scripts/pack.mjs
+++ b/ghost/core/scripts/pack.mjs
@@ -35,11 +35,6 @@ const CORE_DIR = path.resolve(import.meta.dirname, '..');
 const ROOT_DIR = path.resolve(CORE_DIR, '../..');
 const BUILD_DIR = path.join(CORE_DIR, 'package');
 const COMPONENTS_DIR = path.join(BUILD_DIR, 'components');
-const BUILD_PKG_PATH = path.join(BUILD_DIR, 'package.json');
-
-// Placeholder stamped onto versionless workspace packages for the duration of
-// the pack — see stampMissingVersions.
-const STAMPED_VERSION = '0.0.0';
 
 const readJson = async file => JSON.parse(await fs.readFile(file, 'utf8'));
 const writeJson = (file, data) => fs.writeFile(file, JSON.stringify(data, null, 2) + '\n');
@@ -79,47 +74,6 @@ function parsePackJson(output) {
     }
 }
 
-/**
- * Stamp STAMPED_VERSION onto every workspace package that doesn't declare a
- * version, and return a function that restores the manifests byte-for-byte.
- *
- * Private packages declare no version: nothing reads it, since every workspace
- * dep resolves through `workspace:`. `pnpm pack` is the exception — it resolves
- * the workspace protocol against each package's on-disk manifest, and a
- * versionless target fails the pack with
- * ERR_PNPM_CANNOT_RESOLVE_WORKSPACE_PROTOCOL. Neither pnpmfile hook can supply
- * the version: that resolution runs before `beforePacking`, and `readPackage`
- * doesn't feed it either.
- *
- * This covers every versionless workspace package, not just ghost's prod
- * closure, because the closure's devDependencies (`@internal/cfg-*`) get
- * resolved too — `beforePacking` strips them, but only after they've resolved.
- *
- * The value never reaches a consumer: it only names the component tarballs,
- * which are wired up by exact filename (the `components` map below, and the
- * file:components/*.tgz overrides written in step 3).
- *
- * @returns {Promise<() => Promise<void>>} restores the stamped manifests
- */
-async function stampMissingVersions() {
-    const {stdout} = await pnpm(['list', '--recursive', '--depth', '-1', '--json']);
-    const stamped = await Promise.all(JSON.parse(stdout).map(async ({path: dir}) => {
-        const file = path.join(dir, 'package.json');
-        const raw = await fs.readFile(file, 'utf8');
-        const manifest = JSON.parse(raw);
-        if (manifest.version) {
-            return null;
-        }
-        await writeJson(file, {...manifest, version: STAMPED_VERSION});
-        return {file, raw};
-    }));
-    const originals = stamped.filter(Boolean);
-    console.log(`Stamping version ${STAMPED_VERSION} onto ${originals.length} versionless workspace package(s)`);
-    return async () => {
-        await Promise.all(originals.map(({file, raw}) => fs.writeFile(file, raw)));
-    };
-}
-
 // Read the root manifest + workspace config up front (independent of the build).
 // packageManager is required by corepack and verified by CI release checks.
 const [rootPkg, rootWorkspace] = await Promise.all([
@@ -134,70 +88,64 @@ if (!rootPkg.packageManager) {
 await fs.rm(BUILD_DIR, {recursive: true, force: true});
 await fs.mkdir(COMPONENTS_DIR, {recursive: true});
 
-// Both pack steps resolve `workspace:` specs against the on-disk manifests, so
-// the versionless packages need a version for as long as they run.
+// 1. Pack the production workspace dependency closure as component tarballs.
+// `--filter-prod "ghost^..."` selects exactly the prod (not dev) workspace deps
+// of ghost, transitively — the kg-* editor packages (which depend on each other),
+// @tryghost/i18n, parse-email-address, and the adapter-base-* packages. These
+// are the versions this Ghost build was tested against; ghost-cli must install
+// them from these bundled tarballs, never from the registry.
+console.log('Packing workspace components (pnpm pack, prod closure)...');
+const {stdout: packJson} = await pnpm([
+    '--filter-prod', 'ghost^...',
+    'pack',
+    '--pack-destination', COMPONENTS_DIR,
+    '--json'
+]);
+
+// `pnpm pack --json` emits one JSON object per packed package.
 const components = new Map(); // package name → tarball filename
-const restoreVersions = await stampMissingVersions();
-try {
-    // 1. Pack the production workspace dependency closure as component tarballs.
-    // `--filter-prod "ghost^..."` selects exactly the prod (not dev) workspace deps
-    // of ghost, transitively — the kg-* editor packages (which depend on each other),
-    // @tryghost/i18n, parse-email-address, and the adapter-base-* packages. These
-    // are the versions this Ghost build was tested against; ghost-cli must install
-    // them from these bundled tarballs, never from the registry.
-    console.log('\nPacking workspace components (pnpm pack, prod closure)...');
-    const {stdout: packJson} = await pnpm([
-        '--filter-prod', 'ghost^...',
-        'pack',
-        '--pack-destination', COMPONENTS_DIR,
-        '--json'
-    ]);
-
-    // `pnpm pack --json` emits one JSON object per packed package.
-    for (const obj of parsePackJson(packJson)) {
-        const name = obj.name;
-        const file = path.basename(obj.filename || obj.path || '');
-        if (!name || !file) {
-            continue;
-        }
-        components.set(name, file);
-        console.log(`  ${name} → components/${file}`);
+for (const obj of parsePackJson(packJson)) {
+    const name = obj.name;
+    const file = path.basename(obj.filename || obj.path || '');
+    if (!name || !file) {
+        continue;
     }
-    if (components.size === 0) {
-        throw new Error('pnpm pack produced no component tarballs');
-    }
-    await Promise.all([...components].map(async ([name, file]) => {
-        if (!await exists(path.join(COMPONENTS_DIR, file))) {
-            throw new Error(`Component tarball missing after pack: ${file} (for ${name})`);
-        }
-    }));
-
-    // 2. Pack `ghost` itself. The root .pnpmfile.mjs beforePacking hook reads
-    // GHOST_COMPONENTS to rewrite ghost's workspace deps to file:components/*.tgz,
-    // and strips devDependencies/nx/scripts from the packed manifest. Extract the
-    // resulting tarball into package/ (npm layout: a top-level package/ dir).
-    console.log('\nPacking ghost (pnpm pack)...');
-    const ghostPackDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ghost-pack-'));
-    await pnpm(
-        ['--filter', 'ghost', 'pack', '--pack-destination', ghostPackDir],
-        {env: {...process.env, GHOST_COMPONENTS: JSON.stringify(Object.fromEntries(components))}}
-    );
-    const ghostTgz = (await fs.readdir(ghostPackDir)).find(f => f.endsWith('.tgz'));
-    if (!ghostTgz) {
-        throw new Error('pnpm pack did not produce a ghost tarball');
-    }
-    // Extract into CORE_DIR; the tarball's top-level package/ dir becomes BUILD_DIR,
-    // merging alongside the components/ dir packed in step 1.
-    await execFileAsync('tar', ['xzf', path.join(ghostPackDir, ghostTgz), '-C', CORE_DIR]);
-    await fs.rm(ghostPackDir, {recursive: true, force: true});
-} finally {
-    await restoreVersions();
+    components.set(name, file);
+    console.log(`  ${name} → components/${file}`);
 }
+if (components.size === 0) {
+    throw new Error('pnpm pack produced no component tarballs');
+}
+await Promise.all([...components].map(async ([name, file]) => {
+    if (!await exists(path.join(COMPONENTS_DIR, file))) {
+        throw new Error(`Component tarball missing after pack: ${file} (for ${name})`);
+    }
+}));
+
+// 2. Pack `ghost` itself. The root .pnpmfile.mjs beforePacking hook reads
+// GHOST_COMPONENTS to rewrite ghost's workspace deps to file:components/*.tgz,
+// and strips devDependencies/nx/scripts from the packed manifest. Extract the
+// resulting tarball into package/ (npm layout: a top-level package/ dir).
+console.log('\nPacking ghost (pnpm pack)...');
+const ghostPackDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ghost-pack-'));
+await pnpm(
+    ['--filter', 'ghost', 'pack', '--pack-destination', ghostPackDir],
+    {env: {...process.env, GHOST_COMPONENTS: JSON.stringify(Object.fromEntries(components))}}
+);
+const ghostTgz = (await fs.readdir(ghostPackDir)).find(f => f.endsWith('.tgz'));
+if (!ghostTgz) {
+    throw new Error('pnpm pack did not produce a ghost tarball');
+}
+// Extract into CORE_DIR; the tarball's top-level package/ dir becomes BUILD_DIR,
+// merging alongside the components/ dir packed in step 1.
+await execFileAsync('tar', ['xzf', path.join(ghostPackDir, ghostTgz), '-C', CORE_DIR]);
+await fs.rm(ghostPackDir, {recursive: true, force: true});
 
 // Carry the root packageManager over — ghost/core's own manifest doesn't declare one.
-const pkg = await readJson(BUILD_PKG_PATH);
+const pkgPath = path.join(BUILD_DIR, 'package.json');
+const pkg = await readJson(pkgPath);
 pkg.packageManager = rootPkg.packageManager;
-await writeJson(BUILD_PKG_PATH, pkg);
+await writeJson(pkgPath, pkg);
 console.log(`  Set packageManager: ${rootPkg.packageManager.split('+')[0]}`);
 
 // 3. Write a trimmed pnpm-workspace.yaml. We keep:
@@ -246,7 +194,7 @@ await pnpm(
 console.log('\nValidating build output...');
 const requiredFiles = ['pnpm-workspace.yaml', 'pnpm-lock.yaml', 'package.json'];
 const [packagedPkg, packagedWorkspace, missingFiles, componentTgzCount] = await Promise.all([
-    readJson(BUILD_PKG_PATH),
+    readJson(pkgPath),
     readYaml(path.join(BUILD_DIR, 'pnpm-workspace.yaml')),
     Promise.all(requiredFiles.map(async rel => (await exists(path.join(BUILD_DIR, rel)) ? null : rel))),
     fs.readdir(COMPONENTS_DIR).then(files => files.filter(f => f.endsWith('.tgz')).length)

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "ghost-monorepo",
+  "version": "0.0.0-private",
   "description": "The professional publishing platform",
   "private": true,
   "packageManager": "pnpm@11.13.0+sha512.88d94724d8f2e6c186744a5584c6e59ecac869ec7ba15e9cb4cd628e8dc7066820b2481d8ee3b51ea8da323a7378068aa58c556a3720d32b7c20a051d088363a",

--- a/packages/_template/package.json
+++ b/packages/_template/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@tryghost/{{NAME}}",
+  "version": "0.0.0",
   "description": "{{DESCRIPTION}}",
   "private": true,
   "type": "module",

--- a/packages/adapters/redirects-base/package.json
+++ b/packages/adapters/redirects-base/package.json
@@ -2,6 +2,7 @@
   "name": "@tryghost/adapter-base-redirects",
   "version": "0.0.0",
   "description": "The adapter-base-redirects package for Ghost.",
+  "private": true,
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/adapters/route-settings-base/package.json
+++ b/packages/adapters/route-settings-base/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@tryghost/adapter-base-route-settings",
+  "version": "0.0.0",
   "description": "The adapter-base-route-settings package for Ghost.",
   "private": true,
   "type": "module",

--- a/packages/adapters/scheduling-base/package.json
+++ b/packages/adapters/scheduling-base/package.json
@@ -2,6 +2,7 @@
   "name": "@tryghost/adapter-base-scheduling",
   "version": "0.0.0",
   "description": "The adapter-base-scheduling package for Ghost.",
+  "private": true,
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/adapters/sso-base/package.json
+++ b/packages/adapters/sso-base/package.json
@@ -2,6 +2,7 @@
   "name": "@tryghost/adapter-base-sso",
   "version": "0.0.0",
   "description": "The adapter-base-sso package for Ghost.",
+  "private": true,
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/custom-field-types/package.json
+++ b/packages/custom-field-types/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@tryghost/custom-field-types",
+  "version": "0.0.0",
   "description": "Shared catalog of member custom field types: storage routing and value validation, consumed by Ghost core and admin",
   "private": true,
   "type": "module",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@tryghost/i18n",
+  "version": "0.0.0",
   "repository": "https://github.com/TryGhost/Ghost/tree/main/packages/i18n",
   "author": "Ghost Foundation",
   "private": true,

--- a/packages/parse-email-address/package.json
+++ b/packages/parse-email-address/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@tryghost/parse-email-address",
+  "version": "0.0.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/testing/test-data/package.json
+++ b/packages/testing/test-data/package.json
@@ -1,5 +1,6 @@
 {
     "name": "@tryghost/test-data",
+    "version": "0.0.0",
     "private": true,
     "type": "module",
     "repository": "https://github.com/TryGhost/Ghost/tree/main/testing/test-data",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@internal/scripts",
+  "version": "0.0.0",
   "description": "Repo automation scripts, invoked from CI workflows and local pnpm aliases",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
This reverts commit 140a323913006047bf07ac01b2f439565ed9f245.

`pnpm publish` uses `pnpm pack` internally, so any publishing would fail due to the same issue. Instead, i'll explore a different way to handle changelog ignores