### PR TITLE
Fixed exclusion of private packages from pnpm changesets

### DIFF
--- a/.pnpmfile.mjs
+++ b/.pnpmfile.mjs
@@ -1,3 +1,5 @@
+import {glob, readFile} from 'node:fs/promises';
+
 // Global pnpm hooks for the Ghost monorepo.
 //
 // Only `beforePacking` is defined. It runs during `pnpm pack` / `pnpm publish`
@@ -63,4 +65,44 @@ function beforePacking(pkg) {
     return pkg;
 }
 
-export const hooks = {beforePacking};
+/**
+ * Dynamic config update function to automatically exclude "private" packages
+ * from pnpm's changelog detection. We can't remove the version fields
+ * because that would break workspace resolution, but we can dynamically add them
+ * to the versioning.ignore list so that they don't trigger changelog generation.
+ */
+async function updateConfig(config) {
+    const {packages, versioning = {}} = config;
+    const ignoredPackages = new Set(versioning.ignore ?? []);
+
+    // step 1: enumerate all workspace packages with glob
+    const ignore = packages
+        .filter(p => p.startsWith('!'))
+        .map(p => p.slice(1));
+    const patterns = packages
+        .filter(p => !p.startsWith('!'))
+        .map(p => `${p}/package.json`);
+
+    const files = await Array.fromAsync(glob(patterns, {ignore}));
+
+    // step 2: read each package.json and check for "private", if so add to
+    // the ignore set
+    await Promise.all(
+        files.map(async (file) => {
+            const pkg = JSON.parse(await readFile(file, 'utf-8'));
+            if (pkg.private) {
+                ignoredPackages.add(pkg.name);
+            }
+        })
+    );
+
+    // step 3: update the config with the new ignore list
+    config.versioning = {
+        ...versioning,
+        ignore: Array.from(ignoredPackages),
+    };
+
+    return config;
+}
+
+export const hooks = {beforePacking, updateConfig};

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0-private",
   "description": "The professional publishing platform",
   "private": true,
-  "packageManager": "pnpm@11.13.0+sha512.88d94724d8f2e6c186744a5584c6e59ecac869ec7ba15e9cb4cd628e8dc7066820b2481d8ee3b51ea8da323a7378068aa58c556a3720d32b7c20a051d088363a",
+  "packageManager": "pnpm@11.13.1+sha512.b2fc7683b8a6525414e7d13e1ba28caaddde96bf66ec540bfaeb7e702b81f3e0be4d1f295edf7f9fe0396740a8dce4509c582ddf79891f4543fea32d37645f25",
   "engines": {
     "node": "^22.23.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -462,7 +462,7 @@ overrides:
 
 packageExtensionsChecksum: sha256-gFsvptlcVXY90ntXWh9ANUP1/LYyeqXjWoDGw6BCfOY=
 
-pnpmfileChecksum: sha256-HFDJRDXPJung3QA+SJGLFvCaWudv3AAtCmD3O4SpXLY=
+pnpmfileChecksum: sha256-B3i6YArI7D1jT8BbG4lawJAjCjpu7xMSRW7OjAIK0Uw=
 
 importers:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -249,16 +249,32 @@ packageExtensions:
       '@babel/runtime': ^7.26.10
 minimumReleaseAgeExclude:
   # Our own packages are published by us, so the release-age delay doesn't apply
-  - "@tryghost/*"
+  - '@tryghost/*'
   # TryGhost-published packages that live outside the @tryghost/ npm scope.
   # Deliberately NOT listed: sqlite3 — TryGhost stewards it, but legacy
   # (Mapbox-era) npm maintainer accounts can still publish, so the soak
   # retains value there.
-  - "bookshelf-relations"
-  - "eslint-plugin-ghost"
-  - "express-hbs"
-  - "ghost-storage-base"
-  - "gscan"
-  - "knex-migrator"
+  - 'bookshelf-relations'
+  - 'eslint-plugin-ghost'
+  - 'express-hbs'
+  - 'ghost-storage-base'
+  - 'gscan'
+  - 'knex-migrator'
   # Renovate security update: file-type@21.3.1 || 21.3.2
   - file-type@21.3.1 || 21.3.2
+
+# configuration for pnpm's changeset functionality
+versioning:
+  ignore:
+    # ignore root ghost-monorepo package
+    - ghost-monorepo
+    # ignore ghost/ghost-admin since they're manually versioned by release scripts
+    - ghost
+    - ghost-admin
+    # ignore public apps since they're deployed outside pnpm's changelog versioning
+    - '@tryghost/announcement-bar'
+    - '@tryghost/admin-toolbar'
+    - '@tryghost/comments-ui'
+    - '@tryghost/portal'
+    - '@tryghost/signup-form'
+    - '@tryghost/sodo-search'


### PR DESCRIPTION
no ref
Adds a dynamic hook to pnpmfile to automatically exclude private packages from pnpm's change detection. The 'built-in' way to exclude a package is to remove the version field, but that breaks workspace resolution in several places (see #29376, #29424, #29425), so to avoid having to maintain by hand an exclusion list, we automatically populate it with all private packages