### PR TITLE
Adds posts CSV import endpoint

### DIFF
--- a/ghost/core/core/server/api/endpoints/posts.js
+++ b/ghost/core/core/server/api/endpoints/posts.js
@@ -113,6 +113,22 @@ const controller = {
         }
     },
 
+    importCSV: {
+        statusCode: 202,
+        headers: {
+            cacheInvalidate: false
+        },
+        permissions: {
+            docName: 'content_imports',
+            method: 'importContent'
+        },
+        async query() {
+            // CSV processing lands in a later milestone — for now the endpoint
+            // only accepts the upload (gated by the csvContentImporter flag)
+            return {};
+        }
+    },
+
     read: {
         headers: {
             cacheInvalidate: false

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/posts.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/posts.js
@@ -71,6 +71,10 @@ module.exports = {
         });
     },
 
+    importCSV(result, apiConfig, frame) {
+        frame.response = result;
+    },
+
     bulkEdit(bulkActionResult, _apiConfig, frame) {
         frame.response = {
             bulk: {

--- a/ghost/core/core/server/data/migrations/versions/6.54/2026-07-19-16-59-00-add-content-import-permission.js
+++ b/ghost/core/core/server/data/migrations/versions/6.54/2026-07-19-16-59-00-add-content-import-permission.js
@@ -1,0 +1,10 @@
+const {addPermissionWithRoles} = require('../../utils');
+
+// Content import (the CSV posts importer) is restricted to Administrators
+// (the Owner bypasses permission checks) and the self-serve migrator's
+// integration, mirroring the existing db importContent permissions.
+module.exports = addPermissionWithRoles({
+    name: 'Import content',
+    action: 'importContent',
+    object: 'content_import'
+}, ['Administrator', 'Self-Serve Migration Integration']);

--- a/ghost/core/core/server/data/schema/fixtures/fixtures.json
+++ b/ghost/core/core/server/data/schema/fixtures/fixtures.json
@@ -145,6 +145,11 @@
                     "object_type": "db"
                 },
                 {
+                    "name": "Import content",
+                    "action_type": "importContent",
+                    "object_type": "content_import"
+                },
+                {
                     "name": "Send mail",
                     "action_type": "send",
                     "object_type": "mail"
@@ -966,6 +971,7 @@
             "entries": {
                 "Administrator": {
                     "db": "all",
+                    "content_import": "all",
                     "mail": "all",
                     "notification": "all",
                     "post": "all",
@@ -1020,6 +1026,7 @@
                 },
                 "Self-Serve Migration Integration": {
                     "db": "importContent",
+                    "content_import": "importContent",
                     "member": "add",
                     "tag": "read"
                 },

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -33,6 +33,7 @@ module.exports = function apiRoutes() {
     router.post('/posts', mw.authAdminApi, http(api.posts.add));
     router.delete('/posts', mw.authAdminApi, http(api.posts.bulkDestroy));
     router.put('/posts/bulk', mw.authAdminApi, http(api.posts.bulkEdit));
+    router.post('/posts/upload', mw.authAdminApi, labs.enabledMiddleware('csvContentImporter'), apiMw.upload.single('postsfile'), apiMw.upload.validation({type: 'posts'}), http(api.posts.importCSV));
     router.get('/posts/:id', mw.authAdminApi, http(api.posts.read));
     router.get('/posts/slug/:slug', mw.authAdminApi, http(api.posts.read));
     router.put('/posts/:id', mw.authAdminApi, http(api.posts.edit));

--- a/ghost/core/core/server/web/api/middleware/upload.js
+++ b/ghost/core/core/server/web/api/middleware/upload.js
@@ -34,6 +34,10 @@ const messages = {
         missingFile: 'Please select a members CSV file.',
         invalidFile: 'Please select a valid CSV file.'
     },
+    posts: {
+        missingFile: 'Please select a posts CSV file.',
+        invalidFile: 'Please select a valid CSV file.'
+    },
     images: {
         missingFile: 'Please select an image.',
         invalidFile: 'Please select a valid image.'

--- a/ghost/core/core/shared/config/overrides.json
+++ b/ghost/core/core/shared/config/overrides.json
@@ -22,6 +22,10 @@
             "extensions": [".csv"],
             "contentTypes": ["text/csv", "application/csv", "application/octet-stream", "application/vnd.ms-excel"]
         },
+        "posts": {
+            "extensions": [".csv"],
+            "contentTypes": ["text/csv", "application/csv", "application/octet-stream", "application/vnd.ms-excel"]
+        },
         "images": {
             "extensions": [".jpg", ".jpeg", ".gif", ".png", ".svg", ".svgz", ".ico", ".webp"],
             "contentTypes": ["image/jpeg", "image/png", "image/gif", "image/svg+xml", "image/x-icon", "image/vnd.microsoft.icon", "image/webp"]

--- a/ghost/core/test/e2e-api/admin/posts-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/posts-importer.test.js
@@ -1,0 +1,117 @@
+const {agentProvider, fixtureManager, assertions, mockManager, resetRateLimits} = require('../../utils/e2e-framework');
+const {cacheInvalidateHeaderNotSet} = assertions;
+const path = require('path');
+
+const csvPath = path.join(__dirname, '../../utils/fixtures/csv/valid-posts-import.csv');
+
+describe('Posts Importer API', function () {
+    let agent;
+
+    beforeAll(async function () {
+        agent = await agentProvider.getAdminAPIAgent();
+        await fixtureManager.init('users');
+    });
+
+    beforeEach(async function () {
+        // Each test logs in as a different role — reset the login rate limiter
+        // so the repeated logins don't trip spam prevention
+        await resetRateLimits();
+    });
+
+    afterEach(function () {
+        mockManager.restore();
+    });
+
+    it('Can upload a posts CSV as Owner', async function () {
+        await agent.loginAsOwner();
+
+        await agent
+            .post('posts/upload/')
+            .attach('postsfile', csvPath)
+            .expectStatus(202)
+            .expect(cacheInvalidateHeaderNotSet());
+    });
+
+    it('Can upload a posts CSV as Administrator', async function () {
+        await agent.loginAsAdmin();
+
+        await agent
+            .post('posts/upload/')
+            .attach('postsfile', csvPath)
+            .expectStatus(202)
+            .expect(cacheInvalidateHeaderNotSet());
+    });
+
+    it('Cannot upload a posts CSV as Editor', async function () {
+        await agent.loginAsEditor();
+
+        await agent
+            .post('posts/upload/')
+            .attach('postsfile', csvPath)
+            .expectStatus(403);
+    });
+
+    it('Cannot upload a posts CSV as Author', async function () {
+        await agent.loginAsAuthor();
+
+        await agent
+            .post('posts/upload/')
+            .attach('postsfile', csvPath)
+            .expectStatus(403);
+    });
+
+    it('Can upload a posts CSV as the Self-Serve Migration Integration', async function () {
+        await agent.useSelfServeMigrationAdminAPIKey();
+
+        await agent
+            .post('posts/upload/')
+            .attach('postsfile', csvPath)
+            .expectStatus(202)
+            .expect(cacheInvalidateHeaderNotSet());
+    });
+
+    it('Cannot upload a posts CSV as a regular Admin Integration', async function () {
+        await agent.useZapierAdminAPIKey();
+
+        await agent
+            .post('posts/upload/')
+            .attach('postsfile', csvPath)
+            .expectStatus(403);
+    });
+
+    it('Cannot upload a posts CSV as Contributor', async function () {
+        await agent.loginAsContributor();
+
+        await agent
+            .post('posts/upload/')
+            .attach('postsfile', csvPath)
+            .expectStatus(403);
+    });
+
+    it('Cannot upload a posts CSV when the csvContentImporter flag is disabled', async function () {
+        mockManager.mockLabsDisabled('csvContentImporter');
+        await agent.loginAsOwner();
+
+        await agent
+            .post('posts/upload/')
+            .attach('postsfile', csvPath)
+            .expectStatus(404);
+    });
+
+    it('Cannot upload a file that is not a CSV', async function () {
+        await agent.loginAsOwner();
+
+        await agent
+            .post('posts/upload/')
+            .attach('postsfile', path.join(__dirname, '../../utils/fixtures/data/redirects.json'))
+            .expectStatus(415);
+    });
+
+    it('Cannot upload without a file', async function () {
+        await agent.loginAsOwner();
+
+        await agent
+            .post('posts/upload/')
+            .expectStatus(422);
+    });
+});

--- a/ghost/core/test/integration/migrations/migration.test.js
+++ b/ghost/core/test/integration/migrations/migration.test.js
@@ -91,11 +91,12 @@ describe('Migrations', function () {
         // Custom assertion to wrap all permissions
         function assertCompletePermissions(permissions) {
             // If you have to change this number, please add the relevant `assertHavePermission` checks below
-            assert.equal(permissions.length, 142);
+            assert.equal(permissions.length, 143);
 
             assertHavePermission(permissions, 'Export database', ['Administrator', 'DB Backup Integration']);
             assertHavePermission(permissions, 'Import database', ['Administrator', 'Self-Serve Migration Integration', 'DB Backup Integration']);
             assertHavePermission(permissions, 'Delete all content', ['Administrator', 'DB Backup Integration']);
+            assertHavePermission(permissions, 'Import content', ['Administrator', 'Self-Serve Migration Integration']);
             assertHavePermission(permissions, 'Backup database', ['Administrator', 'DB Backup Integration']);
 
             assertHavePermission(permissions, 'Send mail', ['Administrator', 'Admin Integration']);

--- a/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
+++ b/ghost/core/test/unit/server/data/schema/fixtures/fixture-manager.test.js
@@ -398,7 +398,7 @@ describe('Migration Fixture Utils', function () {
             const rolesAllStub = sinon.stub(models.Role, 'findAll').returns(Promise.resolve(dataMethodStub));
 
             const result = await fixtureManager.addFixturesForRelation(fixtures.relations[0]);
-            const FIXTURE_COUNT = 150;
+            const FIXTURE_COUNT = 152;
             assertExists(result);
             assert(_.isPlainObject(result));
             assert.equal(result.expected, FIXTURE_COUNT);

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -36,7 +36,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '7465c11135be88e9d2d48c5f2f1811bb';
-    const currentFixturesHash = '80c53cf0838e1fe32749db92c30cb6b9';
+    const currentFixturesHash = '065b413e1d1f4f95fa7cb7734c5e7934';
     const currentSettingsHash = '397be8628c753b1959b8954d5610f83f';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 

--- a/ghost/core/test/utils/agents/admin-api-test-agent.js
+++ b/ghost/core/test/utils/agents/admin-api-test-agent.js
@@ -170,6 +170,11 @@ class AdminAPITestAgent extends TestAgent {
         const {apiKeyId ,apiKeySecret} = await findIntegrationKey('zapier');
         return this.useToken(apiKeyId, apiKeySecret);
     }
+
+    async useSelfServeMigrationAdminAPIKey() {
+        const {apiKeyId ,apiKeySecret} = await findIntegrationKey('self-serve-migration');
+        return this.useToken(apiKeyId, apiKeySecret);
+    }
 }
 
 module.exports = AdminAPITestAgent;

--- a/ghost/core/test/utils/fixtures/csv/valid-posts-import.csv
+++ b/ghost/core/test/utils/fixtures/csv/valid-posts-import.csv
@@ -1,0 +1,3 @@
+title,html,published_at
+Imported post one,<p>Hello world</p>,2025-01-01T00:00:00.000Z
+Imported post two,<p>Second post</p>,2025-01-02T12:30:00.000Z

--- a/ghost/core/test/utils/fixtures/fixtures.json
+++ b/ghost/core/test/utils/fixtures/fixtures.json
@@ -146,6 +146,11 @@
                     "object_type": "db"
                 },
                 {
+                    "name": "Import content",
+                    "action_type": "importContent",
+                    "object_type": "content_import"
+                },
+                {
                     "name": "Send mail",
                     "action_type": "send",
                     "object_type": "mail"
@@ -1120,6 +1125,7 @@
             "entries": {
                 "Administrator": {
                     "db": "all",
+                    "content_import": "all",
                     "mail": "all",
                     "notification": "all",
                     "post": "all",
@@ -1174,6 +1180,7 @@
                 },
                 "Self-Serve Migration Integration": {
                     "db": "importContent",
+                    "content_import": "importContent",
                     "member": "add",
                     "tag": "read"
                 },


### PR DESCRIPTION
ref https://linear.app/ghost/issue/MIG-1479/

This PR adds a new POST `/posts/upload/` endpoint, gated for `Administrator` and `Self-Serve Migration Integration` roles. It does not currently process the CSV, that will come in a later PR.

- Adds `/posts/upload/` API endpoint which accepts a CSV file, currently behind the `csvContentImporter` labs flag
- Adds DB migration to the `Administrator` and `Self-Serve Migration Integration` permissions to access this endpoint
- New tests to check different roles can and cannot upload

This does not affect the existing JSON import to the `/db/` endpoint or add any new UI