### PR TITLE
Fixed thin-resource errors from webmention URL building

### DIFF
--- a/ghost/core/core/server/services/mentions/mention-sending-service.js
+++ b/ghost/core/core/server/services/mentions/mention-sending-service.js
@@ -68,7 +68,7 @@ module.exports = class MentionSendingService {
             if (html || previousHtml) {
                 await this.#jobService.addJob('sendWebmentions', async () => {
                     await this.sendForHTMLResource({
-                        url: new URL(this.#getPostUrl(post)),
+                        url: new URL(await this.#getPostUrl(post)),
                         html: html,
                         previousHtml: previousHtml
                     });

--- a/ghost/core/core/server/services/mentions/service.js
+++ b/ghost/core/core/server/services/mentions/service.js
@@ -16,7 +16,13 @@ const settingsCache = require('../../../shared/settings-cache');
 const DomainEvents = require('@tryghost/domain-events');
 const jobsService = require('../mentions-jobs');
 
-function getPostUrl(post) {
+async function getPostUrl(post) {
+    // the lazy URL service needs the post's relations to evaluate collection
+    // filters; event-emitted models don't reliably carry them
+    const missing = urlService.facade.getRequiredRelations().filter(relation => !post.relations[relation]);
+    if (missing.length) {
+        await post.load(missing);
+    }
     const jsonModel = post.toJSON();
     outputSerializerUrlUtil.forPost(post.id, jsonModel, {options: {}});
     return jsonModel.url;
@@ -116,3 +122,6 @@ module.exports = {
         this.sendingService = sendingService;
     }
 };
+
+// exposed for testing
+module.exports.getPostUrl = getPostUrl;

--- a/ghost/core/test/unit/server/services/mentions/service.test.js
+++ b/ghost/core/test/unit/server/services/mentions/service.test.js
@@ -1,0 +1,60 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const urlService = require('../../../../../core/server/services/url');
+const outputSerializerUrlUtil = require('../../../../../core/server/api/endpoints/utils/serializers/output/utils/url');
+const {getPostUrl} = require('../../../../../core/server/services/mentions/service');
+
+describe('Mentions service getPostUrl', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    function fakePost(relations = {}) {
+        return {
+            id: 'post-id',
+            relations,
+            load: sinon.stub().resolves(),
+            toJSON: sinon.stub().returns({id: 'post-id', title: 'Post'})
+        };
+    }
+
+    it('loads the URL service required relations before building the url', async function () {
+        sinon.stub(urlService.facade, 'getRequiredRelations').returns(['tags', 'authors']);
+        sinon.stub(outputSerializerUrlUtil, 'forPost').callsFake((id, attrs) => {
+            attrs.url = 'https://site.com/post/';
+            return attrs;
+        });
+        const post = fakePost();
+
+        const url = await getPostUrl(post);
+
+        sinon.assert.calledOnceWithExactly(post.load, ['tags', 'authors']);
+        assert.equal(url, 'https://site.com/post/');
+    });
+
+    it('does not reload relations that are already loaded', async function () {
+        sinon.stub(urlService.facade, 'getRequiredRelations').returns(['tags', 'authors']);
+        sinon.stub(outputSerializerUrlUtil, 'forPost').callsFake((id, attrs) => {
+            attrs.url = 'https://site.com/post/';
+            return attrs;
+        });
+        const post = fakePost({tags: {}, authors: {}});
+
+        await getPostUrl(post);
+
+        sinon.assert.notCalled(post.load);
+    });
+
+    it('loads nothing under the eager service', async function () {
+        sinon.stub(urlService.facade, 'getRequiredRelations').returns([]);
+        sinon.stub(outputSerializerUrlUtil, 'forPost').callsFake((id, attrs) => {
+            attrs.url = 'https://site.com/post/';
+            return attrs;
+        });
+        const post = fakePost();
+
+        await getPostUrl(post);
+
+        sinon.assert.notCalled(post.load);
+    });
+});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1822

Caller-frame stacks attributed another thin-resource producer:

```
at Object.forPost (serializers/output/utils/url.js:27)
at getPostUrl (services/mentions/service.js:21)
at MentionSendingService.getPostUrl
```

The mention sending service builds the post URL from the event-emitted model (`post.toJSON()` + `forPost` with an empty frame). Event models don't reliably carry the tags/authors relations the lazy URL service needs to evaluate collection filters, so the URL computation rejects the post as thin on filtered-collection sites.

`getPostUrl` is now async and `post.load()`s whichever of `getRequiredRelations()` aren't already on the model before serializing. No-op under the eager service (no required relations) and when the event model already carries them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)