### PR TITLE
Fixed thin-resource errors when serializing destroyed posts, pages and tags

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/default.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/default.js
@@ -12,6 +12,13 @@ const mapResponse = (docName, mappable, frame) => {
 };
 
 module.exports = {
+    // 204 No Content — see posts.js destroy
+    destroy(response, apiConfig, frame) {
+        debug('destroy', apiConfig.docName);
+
+        frame.response = {[apiConfig.docName]: []};
+    },
+
     all(response, apiConfig, frame) {
         const {docName, method} = apiConfig;
         debug('serializing', docName, method);

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/pages.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/pages.js
@@ -3,6 +3,13 @@ const mappers = require('./mappers');
 const tiersService = require('../../../../../services/tiers');
 
 module.exports = {
+    // 204 No Content — see posts.js destroy
+    destroy(models, apiConfig, frame) {
+        debug('destroy');
+
+        frame.response = {pages: []};
+    },
+
     async all(models, apiConfig, frame) {
         debug('all');
 

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/posts.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/posts.js
@@ -5,6 +5,15 @@ const {createCSVTransform} = require('./posts-csv-transform');
 const {createCSVStreamResponse} = require('./stream-csv-response');
 
 module.exports = {
+    // 204 No Content — bookshelf clears the destroyed model's attributes
+    // (only relations remain), so there is nothing serializable left and
+    // computing its URL would hand the URL service a relations-only resource.
+    destroy(models, apiConfig, frame) {
+        debug('destroy');
+
+        frame.response = {posts: []};
+    },
+
     async all(models, apiConfig, frame) {
         debug('all');
 

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/default.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/default.test.js
@@ -15,6 +15,18 @@ describe('Unit: endpoints/utils/serializers/output/default', function () {
         sinon.restore();
     });
 
+    it('.destroy() responds without mapping the destroyed model', function () {
+        sinon.stub(mappers, 'tags').returns({});
+        const frame = {options: {context: {}}};
+        const destroyedModel = {toJSON: toJSONStub};
+
+        serializers.output.default.destroy(destroyedModel, {docName: 'tags', method: 'destroy'}, frame);
+
+        assert.deepEqual(frame.response, {tags: []});
+        sinon.assert.notCalled(mappers.tags);
+        sinon.assert.notCalled(toJSONStub);
+    });
+
     it('.all() can map a pojo with one object', function () {
         const response = {
             title: 'foo'

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/pages.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/pages.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const testUtils = require('../../../../../../utils');
 const mappers = require('../../../../../../../core/server/api/endpoints/utils/serializers/output/mappers');
@@ -24,6 +25,16 @@ describe('Unit: endpoints/utils/serializers/output/pages', function () {
     afterEach(function () {
         sinon.restore();
         tiersService.api = null;
+    });
+
+    it('destroy responds without serializing the destroyed model', async function () {
+        const frame = {options: {context: {}}};
+        const destroyedModel = pageModel({});
+
+        await serializers.output.pages.destroy(destroyedModel, {}, frame);
+
+        assert.deepEqual(frame.response, {pages: []});
+        sinon.assert.notCalled(mappers.pages);
     });
 
     it('calls the mapper', async function () {

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/posts.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/posts.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const testUtils = require('../../../../../../utils');
 const mappers = require('../../../../../../../core/server/api/endpoints/utils/serializers/output/mappers');
@@ -24,6 +25,17 @@ describe('Unit: endpoints/utils/serializers/output/posts', function () {
     afterEach(function () {
         sinon.restore();
         tiersService.api = null;
+    });
+
+    it('destroy responds without serializing the destroyed model', async function () {
+        const frame = {options: {context: {}}};
+        // bookshelf clears attributes on destroy; only relations remain
+        const destroyedModel = postModel({});
+
+        await serializers.output.posts.destroy(destroyedModel, {}, frame);
+
+        assert.deepEqual(frame.response, {posts: []});
+        sinon.assert.notCalled(mappers.posts);
     });
 
     it('calls the mapper', async function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1822

Two more thin-resource classes attributed by the caller-frame stacks — post/page delete and tag delete:

```
errorDetails: resourceKeys:["authors","tags","post_revisions","tiers",...], missing:["status"]
errorDetails: resourceKeys:["posts","parent","id","type"], missing:["visibility"]
```

The fingerprint: relations only, zero own columns. Bookshelf clears a destroyed model's attributes but keeps its loaded relations (the Post model force-loads `authors`/`tags`/`post_revisions` for destroy), and the destroy responses still ran the full output serializers — computing a URL for the gutted model.

Destroy responses are `204 No Content` (Express drops the body), so serializing the husk was pure waste. The posts and pages output serializers and the default serializer (tags and other default-serialized resources) now short-circuit `destroy` with an empty response, following the existing `users.js` destroy precedent. Method-specific serializers win over `all` in api-framework's `getBestMatchSerializer`, so this is a clean dispatch, not a conditional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)