### PR TITLE
Fixed thin-resource errors from member attribution event queries

### DIFF
--- a/ghost/core/core/server/services/members/api.js
+++ b/ghost/core/core/server/services/members/api.js
@@ -12,6 +12,7 @@ const subscribeEmail = require('./emails/subscribe');
 const updateEmail = require('./emails/update-email');
 const SingleUseTokenProvider = require('./single-use-token-provider');
 const urlUtils = require('../../../shared/url-utils');
+const urlService = require('../url');
 const labsService = require('../../../shared/labs');
 const offersService = require('../offers');
 const tiersService = require('../tiers');
@@ -53,6 +54,7 @@ function trimLeadingWhitespace(strings, ...values) {
 
 function createApiInstance(config) {
     const membersApiInstance = MembersApi({
+        urlService: urlService.facade,
         tokenConfig: config.getTokenConfig(),
         auth: {
             getSigninURL: config.getSigninURL.bind(config),

--- a/ghost/core/core/server/services/members/members-api/members-api.js
+++ b/ghost/core/core/server/services/members/members-api/members-api.js
@@ -81,6 +81,7 @@ module.exports = function MembersAPI({
     sentry,
     settingsHelpers,
     urlUtils,
+    urlService,
     commentsService,
     emailAddressService,
     giftService,
@@ -123,6 +124,7 @@ module.exports = function MembersAPI({
     });
 
     const eventRepository = new EventRepository({
+        urlService,
         DonationPaymentEvent,
         EmailRecipient,
         MemberSubscribeEvent,

--- a/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/event-repository.js
@@ -34,6 +34,7 @@ module.exports = class EventRepository {
         Comment,
         labsService,
         memberAttributionService,
+        urlService,
         MemberEmailChangeEvent,
         AutomatedEmailRecipient,
         Gift
@@ -47,6 +48,7 @@ module.exports = class EventRepository {
         this._EmailRecipient = EmailRecipient;
         this._Comment = Comment;
         this._labsService = labsService;
+        this._urlService = urlService;
         this._MemberCreatedEvent = MemberCreatedEvent;
         this._SubscriptionCreatedEvent = SubscriptionCreatedEvent;
         this._MemberLinkClickEvent = MemberLinkClickEvent;
@@ -57,6 +59,12 @@ module.exports = class EventRepository {
         this._AutomatedEmailRecipient = AutomatedEmailRecipient;
         this._Gift = Gift;
         this._knex = db.knex;
+    }
+
+    // the URL service needs the attributed post's relations (e.g. tags for a
+    // tag-filtered collection) to build its URL; prefix them onto the eager-load
+    #attributionPostRelations(prefix) {
+        return this._urlService.getRequiredRelations().map(relation => `${prefix}.${relation}`);
     }
 
     async getEventTimeline(options = {}) {
@@ -213,6 +221,7 @@ module.exports = class EventRepository {
             withRelated: [
                 'member',
                 'subscriptionCreatedEvent.postAttribution',
+                ...this.#attributionPostRelations('subscriptionCreatedEvent.postAttribution'),
                 'subscriptionCreatedEvent.userAttribution',
                 'subscriptionCreatedEvent.tagAttribution',
                 'subscriptionCreatedEvent.memberCreatedEvent',
@@ -343,6 +352,7 @@ module.exports = class EventRepository {
             withRelated: [
                 'member',
                 'postAttribution',
+                ...this.#attributionPostRelations('postAttribution'),
                 'userAttribution',
                 'tagAttribution',
                 'signupStatusEvent'
@@ -402,6 +412,7 @@ module.exports = class EventRepository {
             withRelated: [
                 'member',
                 'postAttribution',
+                ...this.#attributionPostRelations('postAttribution'),
                 'userAttribution',
                 'tagAttribution'
             ],
@@ -591,7 +602,7 @@ module.exports = class EventRepository {
     async getCommentEvents(options = {}, filter) {
         options = {
             ...options,
-            withRelated: ['member', 'post', 'post.tags', 'post.authors', 'parent'],
+            withRelated: ['member', 'post', ...this.#attributionPostRelations('post'), 'parent'],
             filter: 'member_id:-null+custom:true',
             useBasicCount: true,
             mongoTransformer: chainTransformers(
@@ -625,7 +636,7 @@ module.exports = class EventRepository {
     async getClickEvents(options = {}, filter) {
         options = {
             ...options,
-            withRelated: ['member', 'link', 'link.post', 'link.post.tags', 'link.post.authors'],
+            withRelated: ['member', 'link', 'link.post', ...this.#attributionPostRelations('link.post')],
             filter: 'custom:true',
             useBasicCount: true,
             mongoTransformer: chainTransformers(

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/event-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/event-repository.test.js
@@ -227,6 +227,70 @@ describe('EventRepository', function () {
         });
     });
 
+    describe('attribution event queries', function () {
+        // The lazy URL service needs the attributed post's relations to
+        // build its URL; a bare postAttribution row is rejected as thin.
+        function makeRepository(modelName, requiredRelations = ['tags', 'authors']) {
+            const fake = sinon.fake.resolves({data: [], meta: {}});
+            const eventRepository = new EventRepository({
+                EmailRecipient: null,
+                MemberSubscribeEvent: null,
+                MemberPaymentEvent: null,
+                MemberStatusEvent: null,
+                MemberLoginEvent: null,
+                MemberPaidSubscriptionEvent: null,
+                labsService: null,
+                urlService: {getRequiredRelations: () => requiredRelations},
+                [modelName]: {findPage: fake}
+            });
+            return {eventRepository, fake};
+        }
+
+        it('getSignupEvents loads the attributed post relations', async function () {
+            const {eventRepository, fake} = makeRepository('MemberCreatedEvent');
+
+            await eventRepository.getSignupEvents({}, {});
+
+            sinon.assert.calledOnceWithMatch(fake, {
+                withRelated: sinon.match.array.contains(['postAttribution', 'postAttribution.tags', 'postAttribution.authors'])
+            });
+        });
+
+        it('getDonationEvents loads the attributed post relations', async function () {
+            const {eventRepository, fake} = makeRepository('DonationPaymentEvent');
+
+            await eventRepository.getDonationEvents({}, {});
+
+            sinon.assert.calledOnceWithMatch(fake, {
+                withRelated: sinon.match.array.contains(['postAttribution', 'postAttribution.tags', 'postAttribution.authors'])
+            });
+        });
+
+        it('getSubscriptionEvents loads the attributed post relations', async function () {
+            const {eventRepository, fake} = makeRepository('MemberPaidSubscriptionEvent');
+
+            await eventRepository.getSubscriptionEvents({}, {});
+
+            sinon.assert.calledOnceWithMatch(fake, {
+                withRelated: sinon.match.array.contains([
+                    'subscriptionCreatedEvent.postAttribution',
+                    'subscriptionCreatedEvent.postAttribution.tags',
+                    'subscriptionCreatedEvent.postAttribution.authors'
+                ])
+            });
+        });
+
+        it('loads no extra relations when the URL service requires none', async function () {
+            const {eventRepository, fake} = makeRepository('MemberCreatedEvent', []);
+
+            await eventRepository.getSignupEvents({}, {});
+
+            const withRelated = fake.getCall(0).args[0].withRelated;
+            assert.ok(!withRelated.includes('postAttribution.tags'));
+            assert.ok(withRelated.includes('postAttribution'));
+        });
+    });
+
     describe('getEmailFailedEvents', function () {
         let eventRepository;
         let fake;


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1822

Caller-frame stack attributed another producer — the member event timeline:

```
at UrlTranslator.getResourceUrl (member-attribution/url-translator.js:161)
at Attribution.getResource
at EventRepository.getSignupEvents (event-repository.js:376)
```

`errorDetails` showed a post with every own column but no `tags` array: the event queries eager-load `postAttribution` as a bare post row and hand the model straight to the URL translator — bypassing `getResourceById`, whose `withRelated` we'd already covered. On sites whose routes.yaml filters collections by tag, the lazy URL service rejects the row as thin.

The signup, donation and subscription queries now spread `getRequiredRelations()` onto their attribution eager-loads (prefixed, e.g. `postAttribution.tags`) — the same pattern `comments-service.js` uses — so only sites whose routing actually reads those relations pay for the joins; everyone else gets an empty list. The click and comment event queries, which hardcoded `post.tags`/`post.authors` for the same reason, were converted to the shared helper as well.

Cost: at most two extra batched IN-queries per fetch, admin-only surface, and only on filtered-routing sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)