### PR TITLE
Fixed false mismatches in URL parity comparisons

### DIFF
--- a/ghost/core/core/server/services/url/url-service-facade.ts
+++ b/ghost/core/core/server/services/url/url-service-facade.ts
@@ -139,8 +139,11 @@ export class UrlServiceFacade {
         const url = this.urlService.getUrlByResourceId(resource.id, options);
         if (this.isComparing() && !options?.skipComparison) {
             const context = this._compareContext(resource);
+            // Snapshot: callers mutate the resource's nested objects in place
+            // after this returns, but the comparison runs later via setImmediate.
+            const snapshot = _.cloneDeep(resource);
             setImmediate(() => this._compare('getUrlForResource', url,
-                () => this.lazyUrlService!.getUrlForResource(resource, options),
+                () => this.lazyUrlService!.getUrlForResource(snapshot, options),
                 context));
         }
         return url;
@@ -218,8 +221,10 @@ export class UrlServiceFacade {
         const owns = this.urlService.owns(routerIdentifier, resource.id);
         if (this.isComparing()) {
             const context = this._compareContext(resource, {routerIdentifier});
+            // Snapshot, as in getUrlForResource.
+            const snapshot = _.cloneDeep(resource);
             setImmediate(() => this._compare('ownsResource', owns,
-                () => this.lazyUrlService!.ownsResource(routerIdentifier, resource),
+                () => this.lazyUrlService!.ownsResource(routerIdentifier, snapshot),
                 context));
         }
         return owns;
@@ -262,7 +267,9 @@ export class UrlServiceFacade {
         if (this.isComparing()) {
             // Fire-and-forget: don't await lazy so the reverse lookup adds no
             // latency for its callers; the lazy DB read runs in the background.
-            void this._compareAsync('resolveUrl', eagerResult,
+            // Snapshot the eager result, as in getUrlForResource.
+            const eagerSnapshot = _.cloneDeep(eagerResult);
+            void this._compareAsync('resolveUrl', eagerSnapshot,
                 () => this.lazyUrlService!.resolveUrl(urlPath),
                 {path: urlPath},
                 (a, b) => _.isEqual(a, b));

--- a/ghost/core/test/integration/url-serializer-parity.test.js
+++ b/ghost/core/test/integration/url-serializer-parity.test.js
@@ -1,0 +1,260 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const testUtils = require('../utils');
+const {waitUntilFinished} = require('../utils/url-service-utils');
+const models = require('../../core/server/models');
+const urlServiceSingleton = require('../../core/server/services/url');
+const UrlService = require('../../core/server/services/url/url-service');
+const LazyUrlService = require('../../core/server/services/url/lazy-url-service');
+const {UrlServiceFacade} = require('../../core/server/services/url/url-service-facade');
+const {createFindResource} = require('../../core/server/services/url/lazy-find-resource');
+const inputSerializer = require('../../core/server/api/endpoints/utils/serializers/input/posts');
+const postsMapper = require('../../core/server/api/endpoints/utils/serializers/output/mappers/posts');
+const memberAttribution = require('../../core/server/services/member-attribution');
+
+// Drives the real Content API serializer pipeline (input serializer → model
+// fetch → output mapper → facade) against a lazy backend and compares URLs
+// with the eager service, on the /:primary_tag/:slug/ permalinks that produced
+// /all/ and /undefined/ divergences in production.
+const ROUTES = [
+    {identifier: 'primary-tag-collection', filter: null, resourceType: 'posts', permalink: '/:primary_tag/:slug/'},
+    {identifier: 'tags-router', filter: null, resourceType: 'tags', permalink: '/tag/:slug/'},
+    {identifier: 'authors-router', filter: null, resourceType: 'authors', permalink: '/author/:slug/'}
+];
+
+describe('Integration: Content API serializer → lazy URL parity (primary_tag permalinks)', function () {
+    let eager;
+    let lazy;
+    let originalFacade;
+    const posts = {};
+
+    beforeAll(testUtils.teardownDb);
+    beforeAll(testUtils.setup('users:roles', 'posts'));
+
+    const EMPTY_LEXICAL = testUtils.DataGenerator.markdownToLexical('parity fixture');
+
+    beforeAll(async function () {
+        posts.publicFirst = await models.Post.add({
+            title: 'Public First',
+            slug: 'public-first',
+            status: 'published',
+            lexical: EMPTY_LEXICAL,
+            tags: [{name: 'Business', slug: 'business'}]
+        }, {context: {internal: true}, withRelated: ['tags']});
+
+        posts.internalFirst = await models.Post.add({
+            title: 'Internal First',
+            slug: 'internal-first',
+            status: 'published',
+            lexical: EMPTY_LEXICAL,
+            tags: [
+                {name: '#hidden', slug: 'hash-hidden'},
+                {name: 'Visible', slug: 'visible'}
+            ]
+        }, {context: {internal: true}, withRelated: ['tags']});
+
+        posts.noTags = await models.Post.add({
+            title: 'No Tags',
+            slug: 'no-tags',
+            status: 'published',
+            lexical: EMPTY_LEXICAL
+        }, {context: {internal: true}});
+
+        eager = new UrlService();
+        ROUTES.forEach(r => eager.onRouterAddedType(r.identifier, r.filter, r.resourceType, r.permalink));
+        eager.init();
+        await waitUntilFinished(eager);
+
+        lazy = new LazyUrlService({findResource: createFindResource(models)});
+        ROUTES.forEach(r => lazy.onRouterAddedType(r.identifier, r.filter, r.resourceType, r.permalink));
+
+        // Route the serializers' singleton facade through the lazy backend.
+        originalFacade = urlServiceSingleton.facade;
+        urlServiceSingleton.facade = new UrlServiceFacade({urlService: eager, lazyUrlService: lazy});
+
+        // outboundLinkTagger is only wired at boot; stub a pass-through.
+        if (!memberAttribution.outboundLinkTagger) {
+            memberAttribution.outboundLinkTagger = {addToHtml: async html => html};
+        }
+    });
+
+    afterAll(function () {
+        if (originalFacade) {
+            urlServiceSingleton.facade = originalFacade;
+        }
+        if (eager) {
+            eager.reset();
+        }
+    });
+    afterAll(testUtils.teardownDb);
+
+    // Runs the real Content API browse pipeline for one post slug and returns
+    // the mapped (serialized) post the API would respond with.
+    async function browsePipeline({slug, fields, filter, include}) {
+        const frame = {
+            apiType: 'content',
+            original: {context: {}},
+            options: {
+                context: {public: true},
+                filter: filter || `slug:${slug}`
+            }
+        };
+        if (fields) {
+            frame.options.columns = fields.split(',');
+        }
+        if (include) {
+            frame.options.withRelated = include.split(',');
+        }
+
+        inputSerializer.browse({}, frame);
+
+        const page = await models.Post.findPage({...frame.options, limit: 'all'});
+        assert.equal(page.data.length, 1, `expected exactly one post for slug ${slug}`);
+
+        return await postsMapper(page.data[0], frame, {});
+    }
+
+    // Compare mode defers the lazy call to setImmediate, by which point the
+    // mapper has stripped slug from the shared primary_tag object — so without
+    // a snapshot it reports /undefined/ mismatches the sync path never produces.
+    describe('compare mode with a mutating serializer pipeline', function () {
+        let reports;
+        let reportStub;
+
+        beforeAll(function () {
+            reportStub = sinon.stub(UrlServiceFacade.prototype, '_report').callsFake(function (error) {
+                reports.push(error);
+            });
+        });
+
+        beforeEach(function () {
+            reports = [];
+        });
+
+        afterAll(function () {
+            reportStub.restore();
+        });
+
+        it('does not report a false parity mismatch from post-hoc jsonModel mutation', async function () {
+            const compareFacade = new UrlServiceFacade({urlService: eager, lazyUrlService: lazy, compare: true});
+            const previousFacade = urlServiceSingleton.facade;
+            urlServiceSingleton.facade = compareFacade;
+
+            try {
+                const mapped = await browsePipeline({
+                    slug: 'public-first',
+                    fields: 'title,url,custom_excerpt,html',
+                    include: 'tags'
+                });
+                assert.equal(
+                    mapped.url,
+                    eager.getUrlByResourceId(posts.publicFirst.id, {absolute: true}),
+                    'compare mode must return the eager URL'
+                );
+
+                // Flush the setImmediate queue so deferred comparisons run.
+                await new Promise((resolve) => {
+                    setImmediate(resolve);
+                });
+                await new Promise((resolve) => {
+                    setImmediate(resolve);
+                });
+
+                const mismatches = reports.filter(r => r.code === 'LAZY_URL_PARITY_MISMATCH');
+                assert.deepEqual(
+                    mismatches.map(r => r.errorDetails),
+                    [],
+                    'deferred comparison reported a mismatch for an in-parity request'
+                );
+            } finally {
+                urlServiceSingleton.facade = previousFacade;
+            }
+        });
+    });
+
+    describe('include=tags combined with ?fields (production /undefined/ shape)', function () {
+        ['public-first', 'internal-first', 'no-tags'].forEach(function (slug) {
+            it(`${slug} serializes the same URL lazy/eager`, async function () {
+                const mapped = await browsePipeline({
+                    slug,
+                    fields: 'title,url,custom_excerpt,html',
+                    include: 'tags'
+                });
+                const key = {['public-first']: 'publicFirst', ['internal-first']: 'internalFirst', ['no-tags']: 'noTags'}[slug];
+                assert.equal(
+                    mapped.url,
+                    eager.getUrlByResourceId(posts[key].id, {absolute: true}),
+                    'lazy URL from include=tags+fields pipeline diverges from eager'
+                );
+            });
+        });
+    });
+
+    describe('tag-filtered browse (joins posts_tags)', function () {
+        it('tag-filtered ?fields=url browse serializes the same URL lazy/eager', async function () {
+            const mapped = await browsePipeline({
+                slug: 'internal-first',
+                fields: 'id,slug,url',
+                filter: 'tag:visible+slug:internal-first'
+            });
+            assert.equal(
+                mapped.url,
+                eager.getUrlByResourceId(posts.internalFirst.id, {absolute: true}),
+                'lazy URL from tag-filtered serializer pipeline diverges from eager'
+            );
+        });
+
+        it('tag-filtered full browse serializes the same URL lazy/eager', async function () {
+            const mapped = await browsePipeline({
+                slug: 'public-first',
+                filter: 'tag:business+slug:public-first'
+            });
+            assert.equal(
+                mapped.url,
+                eager.getUrlByResourceId(posts.publicFirst.id, {absolute: true}),
+                'lazy URL from tag-filtered serializer pipeline diverges from eager'
+            );
+        });
+    });
+
+    ['url', 'id,slug,url', 'title,custom_excerpt,html,url', null].forEach(function (fields) {
+        describe(`fields=${fields === null ? '(none — full browse)' : fields}`, function () {
+            it('public-first-tag post serializes the same URL lazy/eager', async function () {
+                const mapped = await browsePipeline({slug: 'public-first', fields});
+                assert.equal(
+                    mapped.url,
+                    eager.getUrlByResourceId(posts.publicFirst.id, {absolute: true}),
+                    'lazy URL from serializer pipeline diverges from eager'
+                );
+            });
+
+            it('internal-first-tag post serializes the same URL lazy/eager', async function () {
+                const mapped = await browsePipeline({slug: 'internal-first', fields});
+                assert.equal(
+                    mapped.url,
+                    eager.getUrlByResourceId(posts.internalFirst.id, {absolute: true}),
+                    'lazy URL from serializer pipeline diverges from eager'
+                );
+            });
+
+            it('untagged post serializes the same URL lazy/eager', async function () {
+                const mapped = await browsePipeline({slug: 'no-tags', fields});
+                assert.equal(
+                    mapped.url,
+                    eager.getUrlByResourceId(posts.noTags.id, {absolute: true}),
+                    'lazy URL from serializer pipeline diverges from eager'
+                );
+            });
+
+            it('never serializes an /all/ or /undefined/ URL segment', async function () {
+                for (const slug of ['public-first', 'internal-first', 'no-tags']) {
+                    const mapped = await browsePipeline({slug, fields});
+                    assert.ok(
+                        !/\/(undefined)\//.test(mapped.url),
+                        `serialized URL contains an unresolved permalink segment: ${mapped.url}`
+                    );
+                }
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Why

While validating the `LAZY_URL_PARITY_MISMATCH` soak logs, one class of `getUrlForResource` mismatch turned out to be a measurement artifact rather than a real divergence between the eager and lazy URL services.

On sites with `{primary_tag}` / `{primary_author}` permalinks, compare mode was logging lazy URLs of `/undefined/:slug/` or `/all/:slug/` where eager produced the correct tag/author slug
The cause is a torn read, not a routing difference:

1. The output mapper calls `facade.getUrlForResource({...attrs, id, type})`. The spread is a **shallow** copy — the nested `tags` / `primary_tag` objects are shared with the live `jsonModel`.
2. In compare mode the facade returns eager's URL synchronously and schedules the lazy comparison with `setImmediate`.
3. The mapper keeps mutating that same resource: `mapTag` deletes the force-loaded url columns — **including `slug`** — from each tag object, and `primary_tag` holds a reference to one of those same objects (the mapper's own comment notes this). `clean` strips more.
4. When the deferred comparison finally runs, `primary_tag.slug` is gone, so `replacePermalink` emits `undefined` (or `all` when `primary_tag` was nulled).

The synchronous, post-flip lazy path computes the URL at step 1 with the resource intact, so it is **never** affected — this only ever produced noise in the compare logs. The same shared-reference hazard exists for `ownsResource` and for the eager result handed to the `resolveUrl` comparison, so all three are snapshotted.

## What

The facade now deep-clones the resource (and the eager `resolveUrl` result) before deferring the comparison, so the lazy call sees the shape the caller actually passed


🤖 Generated with [Claude Code](https://claude.com/claude-code)
