### PR TITLE
Fixed Renovate dropping pnpmfileChecksum from lockfiles

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -135,3 +135,11 @@ jobs:
           RENOVATE_REPOSITORIES: TryGhost/Ghost
           # Ghost is already onboarded via Mend; don't open an onboarding PR.
           RENOVATE_ONBOARDING: 'false'
+          # pnpm ≥ 11.13 records a pnpmfileChecksum in pnpm-lock.yaml whenever a
+          # .pnpmfile is present. With allowScripts=false (the default) Renovate
+          # regenerates lockfiles with `pnpm install --ignore-pnpmfile`, which
+          # drops the checksum, and CI's frozen install then rejects the lockfile
+          # (ERR_PNPM_LOCKFILE_CONFIG_MISMATCH). allowScripts=true makes Renovate
+          # honour the pnpmfile; dependency install scripts stay blocked because
+          # the repo-level `ignoreScripts` default (true) keeps --ignore-scripts.
+          RENOVATE_ALLOW_SCRIPTS: 'true'


### PR DESCRIPTION
Since the repo gained a `.pnpmfile.mjs` (#29426), pnpm 11.13.1 records a `pnpmfileChecksum` in `pnpm-lock.yaml`. Every Renovate PR that touches the lockfile now fails the Setup job with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` — currently 7 of the 10 open Renovate PRs (#29084, #29092, #29099, #29119, #29125, #29339, #29415), and any new npm-dependency PR is born broken.

**Root cause** (from the self-hosted runner's debug logs): Renovate installs the correct pnpm from the `packageManager` field, but because the global `allowScripts` setting defaults to `false` it regenerates lockfiles with:

```
pnpm install --lockfile-only --recursive --ignore-scripts --ignore-pnpmfile
```

With the pnpmfile ignored, pnpm writes the lockfile without the checksum; CI's frozen install (pnpmfile active) then rejects it.

**Fix**: set `RENOVATE_ALLOW_SCRIPTS: 'true'` on the Renovate step. Per renovatebot/renovate#37750, this makes Renovate honour the pnpmfile while still passing `--ignore-scripts` — the repo-level `ignoreScripts` option defaults to `true`, so dependency install scripts remain blocked. Bumping the `renovatebot/github-action` pin would not help: the pnpm version was never the problem, the flags were.

Once this merges, the next Renovate runs should regenerate the 7 broken branches with valid lockfiles.
