### PR TITLE
Added an operational limit on the number of custom field definitions

### DIFF
--- a/ghost/core/core/server/api/endpoints/member-custom-fields.ts
+++ b/ghost/core/core/server/api/endpoints/member-custom-fields.ts
@@ -67,8 +67,11 @@ const controller = {
         permissions(frame: Frame) {
             return canThis(frame).add.member_custom_field();
         },
+        // The whole array is passed through: create is a batch, applied
+        // all-or-nothing. A client sending a single definition (as Admin does)
+        // is just the one-item case and sees no change.
         query(frame: Frame) {
-            return definitions!.add(requestContextFromFrame(frame), frame.data.members_custom_fields[0]);
+            return definitions!.add(requestContextFromFrame(frame), frame.data.members_custom_fields);
         }
     },
 

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/member-custom-fields.ts
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/member-custom-fields.ts
@@ -9,13 +9,17 @@ const serializeOne = (field: CustomField, _apiConfig: unknown, frame: Frame): vo
     frame.response = toCustomFieldsResponse.parse([field]);
 };
 
+const serializeMany = (fields: CustomField[], _apiConfig: unknown, frame: Frame): void => {
+    frame.response = toCustomFieldsResponse.parse(fields);
+};
+
 // module.exports (not export): the API framework loads serializers via require(). The endpoint ->
 // serializer mapping lives here; the response shaping lives with the members-custom-fields service.
 module.exports = {
-    browse(fields: CustomField[], _apiConfig: unknown, frame: Frame): void {
-        frame.response = toCustomFieldsResponse.parse(fields);
-    },
+    browse: serializeMany,
     read: serializeOne,
-    add: serializeOne,
+    // Create is a batch, so it returns every definition it made. The response is
+    // already an array, so a one-item create looks exactly as it did before.
+    add: serializeMany,
     edit: serializeOne
 };

--- a/ghost/core/core/server/services/members-custom-fields/config.ts
+++ b/ghost/core/core/server/services/members-custom-fields/config.ts
@@ -1,0 +1,38 @@
+import {z} from 'zod';
+
+/**
+ * Resolving Ghost's config into the values this service runs on.
+ *
+ * Config arrives untyped: defaults.json supplies the shipped value, and any
+ * higher layer — an operator's config file, an environment variable, argv — can
+ * replace it with anything at all. Turning that into something usable is a
+ * config concern, so it happens here, at the boundary. The service is handed an
+ * answer and never learns where it came from.
+ */
+
+// A ceiling in the form the service needs it. A numeric string is accepted
+// because a value supplied through an environment variable can arrive as one.
+const Ceiling = z
+    .union([z.number(), z.string().trim().min(1)])
+    .transform(Number)
+    .pipe(z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER));
+
+// defaults.json is the single source of the shipped ceiling: it is the lowest
+// config layer and the file an operator actually reads and edits, so it is read
+// rather than restated. Parsed eagerly because a missing or malformed value
+// there is our bug rather than an operator's, and should fail loudly at boot
+// instead of quietly becoming the fallback for everything below.
+const shippedCeiling: number = Ceiling.parse(
+    require('../../../shared/config/defaults.json').members.customFields.maxDefinitions
+);
+
+// A higher layer can override the shipped value with anything. Something
+// unreadable falls back to the shipped ceiling rather than throwing, because an
+// operator can correct this live and a bad value must not take the feature down
+// with it — and rather than meaning "no ceiling", because a typo must not
+// silently remove the safeguard.
+const MaxDefinitions = Ceiling.catch(shippedCeiling);
+
+export function resolveMaxDefinitions(configured: unknown): number {
+    return MaxDefinitions.parse(configured);
+}

--- a/ghost/core/core/server/services/members-custom-fields/definitions-service.ts
+++ b/ghost/core/core/server/services/members-custom-fields/definitions-service.ts
@@ -65,10 +65,17 @@ const EditFieldInput = z.object({
 export class CustomFieldDefinitionsService {
     private knex: Knex;
     private recordAction: RecordCustomFieldAction;
+    private getMaxDefinitions: () => number;
 
-    constructor({knex, recordAction}: {knex: Knex; recordAction: RecordCustomFieldAction}) {
+    constructor({knex, recordAction, getMaxDefinitions}: {knex: Knex; recordAction: RecordCustomFieldAction; getMaxDefinitions: () => number}) {
         this.knex = knex;
         this.recordAction = recordAction;
+        // A getter, not a value: the ceiling can be raised or lowered at any time,
+        // and a Ghost container holds no state across requests, so the limit that
+        // applies is whatever it resolves to when the request lands. Asking on
+        // every create means a change takes effect on the next one, with no
+        // restart. Where the number comes from is the caller's business.
+        this.getMaxDefinitions = getMaxDefinitions;
     }
 
     async browse(options: {filter?: string} = {}): Promise<CustomField[]> {
@@ -138,6 +145,8 @@ export class CustomFieldDefinitionsService {
         let created: CustomField[];
         try {
             created = await this.knex.transaction(async (trx) => {
+                await this.assertWithinLimit(trx, fields.length);
+
                 const keys: string[] = [];
                 for (const [index, field] of fields.entries()) {
                     await this.assertNameAvailable(trx, field.name);
@@ -164,6 +173,50 @@ export class CustomFieldDefinitionsService {
             await this.recordAction({context, verb: 'create', subject: field.key, details: {primary_name: field.name}});
         }
         return created;
+    }
+
+    /**
+     * The operational ceiling on how many definitions a site can hold. This is a
+     * safeguard against the database load unbounded definitions would create, not
+     * a pricing or packaging limit, so it applies wherever the feature is available
+     * and is deliberately not routed through the entitlement-driven limit service.
+     *
+     * Both active and archived definitions count: an archived field still occupies
+     * a row and still carries its members' values, so archiving alone frees no
+     * space. Deleting an archived field is what releases a slot.
+     *
+     * The count is a consistent read, not a locking one, so two creates landing at
+     * the same instant can both pass and take a site one over. That is deliberate:
+     * this is a ceiling on database load, and holding a table lock across every
+     * create to make it exact would cost more than the overshoot it prevents.
+     *
+     */
+    private async assertWithinLimit(db: Knex, addedCount: number): Promise<void> {
+        const max = this.getMaxDefinitions();
+
+        const row = await db(TABLE).count({count: '*'}).first();
+        const total = Number(row?.count ?? 0);
+        if (total + addedCount <= max) {
+            return;
+        }
+
+        // Two different situations reach here and they need different advice. At or
+        // over the ceiling there is nothing to do but free a slot. With slots still
+        // free the request was simply too big, and telling that operator to delete
+        // something is wrong: they have room, just not this much.
+        const remaining = max - total;
+        const advice = remaining > 0
+            ? `You can add ${remaining} more.`
+            : 'Delete a field you no longer need to make room.';
+
+        throw new errors.HostLimitError({
+            message: `Custom fields are limited to ${max} per site. ${advice}`,
+            code: 'CUSTOM_FIELDS_LIMIT_REACHED',
+            // `requested` is carried alongside the limit-service shape so a batch
+            // rejection is self-describing: without it a client sees free slots and
+            // a refusal, and has to re-derive its own payload size to explain why.
+            errorDetails: {limit: max, total, requested: addedCount}
+        });
     }
 
     /** Read back a batch in the order its keys were created, not the table's order. */

--- a/ghost/core/core/server/services/members-custom-fields/definitions-service.ts
+++ b/ghost/core/core/server/services/members-custom-fields/definitions-service.ts
@@ -40,6 +40,19 @@ const AddFieldInput = z.object({
     type: FieldTypeSchema
 });
 
+// A bound on the work one request can ask for, separate from how many definitions
+// a site may hold in total. Every definition in a batch costs several queries
+// inside one open write transaction, so an operator raising the site ceiling must
+// not also mean a single request can ask for an unbounded amount of that work.
+const MAX_FIELDS_PER_REQUEST = 100;
+
+// Create accepts a batch. The framework guarantees a non-empty array by the time a
+// query runs, but the service validates the whole payload up front so a bad item
+// anywhere fails the request before anything is written.
+const AddFieldsInput = z.array(AddFieldInput)
+    .min(1)
+    .max(MAX_FIELDS_PER_REQUEST, {message: `Custom fields can only be created ${MAX_FIELDS_PER_REQUEST} at a time.`});
+
 // Name and status are mutable. `key` and `type` are accepted so the immutability
 // rules can reject a change loudly; they are never persisted.
 const EditFieldInput = z.object({
@@ -84,23 +97,56 @@ export class CustomFieldDefinitionsService {
         return z.decode(customFieldCodec, row);
     }
 
-    async add(context: RequestContext, input: unknown): Promise<CustomField> {
-        const parsed = AddFieldInput.safeParse(input);
+    /**
+     * Create one or more field definitions. All-or-nothing: the batch runs in a
+     * single transaction, so a name clash or the operational cap on the third item
+     * leaves the first two unwritten rather than half-applying the request.
+     *
+     * Running inside the transaction also makes a batch self-consistent for free —
+     * `assertNameAvailable` and `mintKey` see the rows inserted earlier in the same
+     * batch, so two items sharing a name are caught and two items sharing a slug
+     * get distinct keys, exactly as if they had arrived as separate requests.
+     */
+    async add(context: RequestContext, input: unknown): Promise<CustomField[]> {
+        const requestedCount = Array.isArray(input) ? input.length : 0;
+
+        const parsed = AddFieldsInput.safeParse(input);
         if (!parsed.success) {
-            throw new errors.ValidationError({message: parsed.error.issues[0].message, property: parsed.error.issues[0].path[0]?.toString()});
+            const issue = parsed.error.issues[0];
+            throw new errors.ValidationError({
+                message: issue.message,
+                property: propertyOf(issue.path),
+                context: batchContext(issue.path[0], requestedCount)
+            });
         }
+        const fields = parsed.data;
 
-        const base = slugify(parsed.data.name);
-        if (!base) {
-            throw new errors.ValidationError({message: 'Custom field name must contain at least one usable character.', property: 'name'});
-        }
+        // Slugify before opening the transaction: it needs no database access, and
+        // an unusable name is a payload problem worth reporting on its own terms.
+        const bases = fields.map((field, index) => {
+            const base = slugify(field.name);
+            if (!base) {
+                throw new errors.ValidationError({
+                    message: 'Custom field name must contain at least one usable character.',
+                    property: 'name',
+                    context: batchContext(index, requestedCount)
+                });
+            }
+            return base;
+        });
 
-        await this.assertNameAvailable(parsed.data.name);
-
-        const id = new ObjectID().toHexString();
-        const key = await this.mintKey(base);
+        let created: CustomField[];
         try {
-            await this.knex(TABLE).insert({id, key, name: parsed.data.name, type: parsed.data.type, created_at: new Date()});
+            created = await this.knex.transaction(async (trx) => {
+                const keys: string[] = [];
+                for (const [index, field] of fields.entries()) {
+                    await this.assertNameAvailable(trx, field.name);
+                    const key = await this.mintKey(trx, bases[index]);
+                    await trx(TABLE).insert({id: new ObjectID().toHexString(), key, name: field.name, type: field.type, created_at: new Date()});
+                    keys.push(key);
+                }
+                return this.readMany(trx, keys);
+            });
         } catch (err) {
             // mintKey already picked a free key, so a unique violation here only
             // means a concurrent create claimed the same key in between. The index
@@ -110,8 +156,21 @@ export class CustomFieldDefinitionsService {
             }
             throw err;
         }
-        await this.recordAction({context, verb: 'create', subject: key, details: {primary_name: parsed.data.name}});
-        return this.read(key);
+
+        // Logged after the commit: the action log is a separate Bookshelf write
+        // outside this transaction, so recording inside it would leave orphaned
+        // "added" entries for fields a rollback never created.
+        for (const field of created) {
+            await this.recordAction({context, verb: 'create', subject: field.key, details: {primary_name: field.name}});
+        }
+        return created;
+    }
+
+    /** Read back a batch in the order its keys were created, not the table's order. */
+    private async readMany(db: Knex, keys: string[]): Promise<CustomField[]> {
+        const rows = await db(TABLE).whereIn('key', keys).select('*');
+        const byKey = new Map(rows.map(row => [row.key, row]));
+        return keys.map(key => z.decode(customFieldCodec, byKey.get(key)!));
     }
 
     /**
@@ -119,10 +178,10 @@ export class CustomFieldDefinitionsService {
      * Reads the keys already taken by that base — including archived fields, so a
      * slug is never reused once minted. Mirrors how tags/labels generate slugs.
      */
-    private async mintKey(base: string): Promise<string> {
+    private async mintKey(db: Knex, base: string): Promise<string> {
         const safeBase = base.slice(0, MAX_KEY_BASE_LENGTH);
         const taken = new Set(
-            await this.knex(TABLE).where('key', 'like', `${safeBase}%`).pluck('key')
+            await db(TABLE).where('key', 'like', `${safeBase}%`).pluck('key')
         );
         if (!taken.has(safeBase)) {
             return safeBase;
@@ -148,8 +207,8 @@ export class CustomFieldDefinitionsService {
      * allow it in the SQLite test/dev suites. `exceptKey` lets a field keep its
      * own name on an unrelated edit.
      */
-    private async assertNameAvailable(name: string, exceptKey?: string): Promise<void> {
-        const query = this.knex(TABLE).whereRaw('LOWER(name) = ?', [name.toLowerCase()]);
+    private async assertNameAvailable(db: Knex, name: string, exceptKey?: string): Promise<void> {
+        const query = db(TABLE).whereRaw('LOWER(name) = ?', [name.toLowerCase()]);
         if (exceptKey) {
             query.whereNot('key', exceptKey);
         }
@@ -181,7 +240,7 @@ export class CustomFieldDefinitionsService {
         // Only write (and log a rename) when the name actually changes, so
         // re-saving an unchanged field is a no-op rather than a spurious edit.
         if (patch.name !== undefined && patch.name !== existing.name) {
-            await this.assertNameAvailable(patch.name, key);
+            await this.assertNameAvailable(this.knex, patch.name, key);
             try {
                 await this.knex(TABLE)
                     .where('key', key)
@@ -226,6 +285,25 @@ export class CustomFieldDefinitionsService {
         await this.knex(TABLE).where('key', key).del();
         await this.recordAction({context, verb: 'delete', subject: key, details: {primary_name: field.name}});
     }
+}
+
+// The field a zod issue points at. Create validates an array, so an issue's path
+// is prefixed with the item's index (`[0, 'name']`); `property` names the field
+// that is wrong, so the numeric prefix is dropped. Which item it was is reported
+// separately by batchContext, keeping `property` the bare field name a client can
+// map straight onto its form input.
+function propertyOf(path: PropertyKey[]): string | undefined {
+    return path.find(segment => typeof segment === 'string');
+}
+
+// Which definition of a batch an error belongs to. Only set when the request
+// carried more than one: a lone definition needs no pointer, and every client
+// today sends exactly one, so this stays absent on the common path.
+function batchContext(index: PropertyKey | undefined, requestedCount: number): string | undefined {
+    if (requestedCount <= 1 || typeof index !== 'number') {
+        return undefined;
+    }
+    return `Custom field ${index + 1} of ${requestedCount}.`;
 }
 
 function isUniqueConstraintViolation(error: unknown): boolean {

--- a/ghost/core/core/server/services/members-custom-fields/index.ts
+++ b/ghost/core/core/server/services/members-custom-fields/index.ts
@@ -1,6 +1,7 @@
 import {CustomFieldDefinitionsService} from './definitions-service';
 import {CustomFieldValuesService} from './values-service';
 import {recordCustomFieldAction, type RecordCustomFieldAction} from './actions';
+import {resolveMaxDefinitions} from './config';
 
 export type {CustomField} from './models';
 export type {RequestContext} from './actions';
@@ -29,7 +30,17 @@ export function init(): void {
     const recordAction: RecordCustomFieldAction = ({context, verb, subject, details}) =>
         recordCustomFieldAction({Action: models.Action, context, verb, subject, details});
 
-    definitions = new CustomFieldDefinitionsService({knex, recordAction});
+    // Resolved here, not in the service: reading config is this module's job, and
+    // the service is handed a number. A getter rather than a value because the
+    // ceiling is an operator setting that can change between requests, and a Ghost
+    // container holds no state across them.
+    const config = require('../../../shared/config');
+
+    definitions = new CustomFieldDefinitionsService({
+        knex,
+        recordAction,
+        getMaxDefinitions: () => resolveMaxDefinitions(config.get('members:customFields:maxDefinitions'))
+    });
     // The values service reads the field definitions straight from the table, so
     // it needs only knex — no handle on the definitions service.
     values = new CustomFieldValuesService({knex});

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -70,6 +70,9 @@
     "members": {
         "contentApiAccess": [],
         "paymentProcessors": [],
+        "customFields": {
+            "maxDefinitions": 100
+        },
         "emailTemplate": {
             "showSiteHeader": true,
             "showPoweredBy": true

--- a/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 
-const {agentProvider, fixtureManager, mockManager} = require('../../utils/e2e-framework');
+const {agentProvider, fixtureManager, mockManager, configUtils} = require('../../utils/e2e-framework');
 const models = require('../../../core/server/models');
 const events = require('../../../core/server/lib/common/events');
 
@@ -414,6 +414,9 @@ describe('Member Custom Fields Admin API', function () {
         });
 
         it('rejects a batch larger than a single request may create', async function () {
+            // Work per request is bounded independently of the site ceiling: even
+            // with room to spare, one request cannot ask for unbounded work.
+            configUtils.set('members:customFields:maxDefinitions', 100000);
             const oversized = Array.from({length: 101}, (_unused, index) => ({
                 name: `Field ${index}`,
                 type: 'short_text'
@@ -426,6 +429,7 @@ describe('Member Custom Fields Admin API', function () {
 
             const list = (await agent.get('members/custom_fields/').expectStatus(200)).body;
             assert.deepEqual(list.members_custom_fields, []);
+            await configUtils.restore();
         });
 
         it('writes nothing when a definition in the batch clashes with an existing one', async function () {
@@ -441,6 +445,221 @@ describe('Member Custom Fields Admin API', function () {
 
             const list = (await agent.get('members/custom_fields/').expectStatus(200)).body.members_custom_fields;
             assert.deepEqual(list.map((field: {key: string}) => field.key), ['company']);
+        });
+    });
+
+    describe('Operational limit on the number of definitions', function () {
+        // The cap is an operator setting, not a release constant. Ghost containers
+        // are stateless, so it is read from config on every create: these tests set
+        // it directly and the very next request honours it, with no re-boot.
+        afterEach(async function () {
+            await configUtils.restore();
+        });
+
+        async function createFieldExpecting(name: string, status: number) {
+            const {body} = await agent
+                .post('members/custom_fields/')
+                .body({members_custom_fields: [{name, type: 'short_text'}]})
+                .expectStatus(status);
+            return body;
+        }
+
+        it('rejects a create once the site is at the limit', async function () {
+            configUtils.set('members:customFields:maxDefinitions', 2);
+
+            await createField({name: 'Company'});
+            await createField({name: 'Role'});
+
+            const body = await createFieldExpecting('Bio', 403);
+            assert.equal(body.errors[0].code, 'CUSTOM_FIELDS_LIMIT_REACHED');
+            assert.deepEqual(body.errors[0].details, {limit: 2, total: 2, requested: 1});
+            // At the ceiling, freeing a slot is the only way forward.
+            assert.match(body.errors[0].context, /Delete a field you no longer need/);
+
+            // The rejected field was not written.
+            const list = (await agent.get('members/custom_fields/').expectStatus(200)).body;
+            assert.equal(list.members_custom_fields.length, 2);
+        });
+
+        it('applies a limit change to the very next request, with no restart', async function () {
+            // This is the behaviour that makes the cap operable: raising it must take
+            // effect immediately, which is only true if config is read per request.
+            configUtils.set('members:customFields:maxDefinitions', 1);
+            await createField({name: 'Company'});
+            await createFieldExpecting('Role', 403);
+
+            configUtils.set('members:customFields:maxDefinitions', 2);
+            const created = await createField({name: 'Role'});
+            assert.equal(created.key, 'role');
+
+            // ...and lowering it blocks the next create just as immediately.
+            configUtils.set('members:customFields:maxDefinitions', 1);
+            await createFieldExpecting('Bio', 403);
+        });
+
+        it('leaves definitions already over a lowered limit in place', async function () {
+            configUtils.set('members:customFields:maxDefinitions', 3);
+            await createField({name: 'Company'});
+            await createField({name: 'Role'});
+            await createField({name: 'Bio'});
+
+            // Lowering the cap below the current count is a valid operator action.
+            // It stops new definitions; it never removes existing ones.
+            configUtils.set('members:customFields:maxDefinitions', 1);
+
+            const list = (await agent.get('members/custom_fields/').expectStatus(200)).body;
+            assert.equal(list.members_custom_fields.length, 3);
+
+            const body = await createFieldExpecting('Location', 403);
+            assert.deepEqual(body.errors[0].details, {limit: 1, total: 3, requested: 1});
+        });
+
+        it('counts archived definitions towards the limit, and frees a slot only on delete', async function () {
+            configUtils.set('members:customFields:maxDefinitions', 2);
+            await createField({name: 'Company'});
+            const spare = await createField({name: 'Role'});
+
+            // Archiving is reversible and keeps the row (and its members' values),
+            // so it releases nothing.
+            await setStatus(spare.key, 'archived');
+            const body = await createFieldExpecting('Bio', 403);
+            assert.deepEqual(body.errors[0].details, {limit: 2, total: 2, requested: 1});
+
+            // Deleting the archived field is what actually frees the slot.
+            await agent.delete(`members/custom_fields/${spare.key}/`).expectStatus(204);
+            const created = await createField({name: 'Bio'});
+            assert.equal(created.key, 'bio');
+        });
+
+        it('restores an archived definition while at the limit', async function () {
+            // Restoring changes no row count, so the cap has nothing to say about it.
+            configUtils.set('members:customFields:maxDefinitions', 2);
+            await createField({name: 'Company'});
+            const archived = await createField({name: 'Role'});
+            await setStatus(archived.key, 'archived');
+
+            const restored = await setStatus(archived.key, 'active');
+            assert.equal(restored.status, 'active');
+        });
+
+        it('rejects a batch that would cross the limit, writing none of it', async function () {
+            configUtils.set('members:customFields:maxDefinitions', 3);
+            await createField({name: 'Company'});
+
+            // Two slots remain, so a batch of three is refused outright rather than
+            // being applied up to the remaining space.
+            const {body} = await agent
+                .post('members/custom_fields/')
+                .body({members_custom_fields: [
+                    {name: 'Role', type: 'short_text'},
+                    {name: 'Bio', type: 'short_text'},
+                    {name: 'Location', type: 'short_text'}
+                ]})
+                .expectStatus(403);
+            assert.deepEqual(body.errors[0].details, {limit: 3, total: 1, requested: 3});
+
+            // The site still has room, just not for three. Telling this operator to
+            // delete something would be wrong, so the message says how much room
+            // is actually left.
+            assert.match(body.errors[0].context, /You can add 2 more\./);
+
+            const list = (await agent.get('members/custom_fields/').expectStatus(200)).body.members_custom_fields;
+            assert.deepEqual(list.map((field: {key: string}) => field.key), ['company']);
+        });
+
+        it('accepts a batch that exactly fills the remaining space', async function () {
+            configUtils.set('members:customFields:maxDefinitions', 3);
+            await createField({name: 'Company'});
+
+            const {body} = await agent
+                .post('members/custom_fields/')
+                .body({members_custom_fields: [
+                    {name: 'Role', type: 'short_text'},
+                    {name: 'Bio', type: 'short_text'}
+                ]})
+                .expectStatus(201);
+            assert.equal(body.members_custom_fields.length, 2);
+        });
+
+        it('rejects every create when the limit is zero', async function () {
+            configUtils.set('members:customFields:maxDefinitions', 0);
+            const body = await createFieldExpecting('Company', 403);
+            assert.deepEqual(body.errors[0].details, {limit: 0, total: 0, requested: 1});
+        });
+
+        // A setting that can't be read as a ceiling must neither disable the feature
+        // nor remove the safeguard. Several of these coerce to 0 through `Number()`,
+        // which would stop creation site-wide; treating them as "no limit" instead
+        // would mean a typo silently removes the protection. Both are wrong: they
+        // fall back to the default. Only an explicit 0 disables creation.
+        const unreadableSettings: [string, unknown][] = [
+            ['an unreadable string', 'not-a-number'],
+            ['false', false],
+            ['null', null],
+            ['an empty string', ''],
+            ['an array', []],
+            ['a negative number', -5],
+            ['a fraction', 2.5],
+            ['an unsafely large number', 1e21]
+        ];
+
+        unreadableSettings.forEach(([description, value]) => {
+            it(`falls back to the default ceiling when the setting is ${description}`, async function () {
+                configUtils.set('members:customFields:maxDefinitions', value);
+                await createField({name: 'Company'});
+
+                const list = (await agent.get('members/custom_fields/').expectStatus(200)).body;
+                assert.equal(list.members_custom_fields.length, 1);
+            });
+        });
+
+        it('enforces the shipped ceiling, not an absent one, when the setting is unreadable', async function () {
+            // The checks above only prove creation still works. This proves a
+            // ceiling is genuinely still in force: fill the shipped one exactly,
+            // then watch the next create be refused against it.
+            //
+            // The expected ceiling comes from the config provider rather than from
+            // the module that resolves it, so this asserts against what Ghost
+            // actually ships rather than against the implementation's own idea of
+            // it. Read before the override, which is what makes it unreadable.
+            const shipped = configUtils.config.get('members:customFields:maxDefinitions');
+            configUtils.set('members:customFields:maxDefinitions', 'not-a-number');
+
+            // Filled in batches rather than one create at a time: a hundred-odd
+            // sequential authenticated requests trip Ghost's spam prevention and
+            // leave later tests failing on 403s. The chunk sits comfortably under
+            // the per-request cap so this holds if the shipped ceiling moves.
+            const chunk = 50;
+            for (let created = 0; created < shipped; created += chunk) {
+                await agent
+                    .post('members/custom_fields/')
+                    .body({members_custom_fields: Array.from(
+                        {length: Math.min(chunk, shipped - created)},
+                        (_unused, index) => ({name: `Field ${created + index}`, type: 'short_text'})
+                    )})
+                    .expectStatus(201);
+            }
+
+            const body = await createFieldExpecting('One too many', 403);
+            assert.deepEqual(body.errors[0].details, {limit: shipped, total: shipped, requested: 1});
+        });
+
+        it('honours a numeric limit supplied as a string', async function () {
+            // Config set through an environment variable arrives as a string.
+            configUtils.set('members:customFields:maxDefinitions', '1');
+            await createField({name: 'Company'});
+            await createFieldExpecting('Role', 403);
+        });
+
+        it('does not record an activity-log entry for a create the limit rejected', async function () {
+            configUtils.set('members:customFields:maxDefinitions', 1);
+            await createField({name: 'Company'});
+            await createFieldExpecting('Role', 403);
+
+            const actions = await models.Base.knex('actions')
+                .where('resource_type', 'member_custom_field')
+                .select('resource_id');
+            assert.deepEqual(actions.map((action: {resource_id: string}) => action.resource_id), ['company']);
         });
     });
 

--- a/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
@@ -141,7 +141,7 @@ describe('Member Custom Fields Admin API', function () {
 
         it('rejects a create with no root key', async function () {
             // The framework rejects an empty/malformed body before the query runs,
-            // which is the invariant the endpoint's `[0]` access relies on.
+            // so the service always receives a non-empty array to create from.
             await agent.post('members/custom_fields/').body({}).expectStatus(400);
         });
 
@@ -313,6 +313,134 @@ describe('Member Custom Fields Admin API', function () {
             // fresh field with the same name reclaims the original (unsuffixed) key.
             const fresh = await createField({name: 'Favourite topic'});
             assert.equal(fresh.key, 'favourite-topic');
+        });
+    });
+
+    describe('Creating several definitions at once', function () {
+        it('creates every definition in the request, in order', async function () {
+            const {body} = await agent
+                .post('members/custom_fields/')
+                .body({members_custom_fields: [
+                    {name: 'Company', type: 'short_text'},
+                    {name: 'Role', type: 'short_text'},
+                    {name: 'Bio', type: 'long_text'}
+                ]})
+                .expectStatus(201);
+
+            assert.deepEqual(
+                body.members_custom_fields.map((field: {key: string}) => field.key),
+                ['company', 'role', 'bio']
+            );
+            assert.equal(body.members_custom_fields[2].type, 'long_text');
+
+            const list = (await agent.get('members/custom_fields/').expectStatus(200)).body;
+            assert.equal(list.members_custom_fields.length, 3);
+        });
+
+        it('mints distinct keys when two definitions in the batch derive the same slug', async function () {
+            // Within a batch each insert is visible to the next, so slug collision
+            // resolves exactly as it would across two separate requests.
+            const {body} = await agent
+                .post('members/custom_fields/')
+                .body({members_custom_fields: [
+                    {name: 'Favourite topic', type: 'short_text'},
+                    {name: 'Favourite topic!', type: 'short_text'}
+                ]})
+                .expectStatus(201);
+
+            assert.deepEqual(
+                body.members_custom_fields.map((field: {key: string}) => field.key),
+                ['favourite-topic', 'favourite-topic-2']
+            );
+        });
+
+        it('writes nothing when any definition in the batch is invalid', async function () {
+            await agent
+                .post('members/custom_fields/')
+                .body({members_custom_fields: [
+                    {name: 'Company', type: 'short_text'},
+                    {name: 'Role', type: 'boolean'}
+                ]})
+                .expectStatus(422);
+
+            // The valid first item must not survive the rejected request.
+            const list = (await agent.get('members/custom_fields/').expectStatus(200)).body;
+            assert.deepEqual(list.members_custom_fields, []);
+        });
+
+        it('writes nothing when two definitions in the batch share a name', async function () {
+            await agent
+                .post('members/custom_fields/')
+                .body({members_custom_fields: [
+                    {name: 'Company', type: 'short_text'},
+                    {name: 'company', type: 'short_text'}
+                ]})
+                .expectStatus(422);
+
+            const list = (await agent.get('members/custom_fields/').expectStatus(200)).body;
+            assert.deepEqual(list.members_custom_fields, []);
+        });
+
+        it('names the offending field, and which one it was, when a batch item is invalid', async function () {
+            const {body} = await agent
+                .post('members/custom_fields/')
+                .body({members_custom_fields: [
+                    {name: 'Company', type: 'short_text'},
+                    {name: 'Role', type: 'short_text'},
+                    {name: 'Bio', type: 'boolean'}
+                ]})
+                .expectStatus(422);
+
+            // `property` stays the bare field name so a client can map it onto a
+            // form input; the item pointer rides alongside it in context, which is
+            // where the framework relocates the detail of a validation failure.
+            assert.equal(body.errors[0].property, 'type');
+            assert.match(body.errors[0].context, /Custom field 3 of 3\./);
+        });
+
+        it('does not point at an item when only one definition was sent', async function () {
+            const {body} = await agent
+                .post('members/custom_fields/')
+                .body({members_custom_fields: [{name: 'Bio', type: 'boolean'}]})
+                .expectStatus(422);
+
+            assert.equal(body.errors[0].property, 'type');
+            // context still carries the reason the item was rejected, just no
+            // pointer to which one. Asserted as a string first so that if the
+            // framework ever stops populating it this fails as an assertion
+            // rather than throwing inside doesNotMatch.
+            assert.equal(typeof body.errors[0].context, 'string');
+            assert.doesNotMatch(body.errors[0].context, /Custom field \d+ of \d+/);
+        });
+
+        it('rejects a batch larger than a single request may create', async function () {
+            const oversized = Array.from({length: 101}, (_unused, index) => ({
+                name: `Field ${index}`,
+                type: 'short_text'
+            }));
+
+            await agent
+                .post('members/custom_fields/')
+                .body({members_custom_fields: oversized})
+                .expectStatus(422);
+
+            const list = (await agent.get('members/custom_fields/').expectStatus(200)).body;
+            assert.deepEqual(list.members_custom_fields, []);
+        });
+
+        it('writes nothing when a definition in the batch clashes with an existing one', async function () {
+            await createField({name: 'Company'});
+
+            await agent
+                .post('members/custom_fields/')
+                .body({members_custom_fields: [
+                    {name: 'Role', type: 'short_text'},
+                    {name: 'Company', type: 'short_text'}
+                ]})
+                .expectStatus(422);
+
+            const list = (await agent.get('members/custom_fields/').expectStatus(200)).body.members_custom_fields;
+            assert.deepEqual(list.map((field: {key: string}) => field.key), ['company']);
         });
     });
 


### PR DESCRIPTION
## Problem

Custom field definitions are unlimited today. Ghost(Pro) has operational concerns about the database load that unbounded definitions can create, so a site can grow its field set without any ceiling on the work that puts on the database.

## Solution

Definitions are now capped at an operational ceiling, defaulting to 100 per site. The cap is read from config on every create, so an operator can raise or lower it and have the change apply to the very next request without a restart or a redeploy.

Both active and archived definitions count towards the ceiling. Archiving a field keeps its row and its members' values, so archiving alone frees no space; deleting an archived definition is what releases a slot.

Creating is all-or-nothing. The endpoint now accepts a batch of definitions applied in a single transaction, so a request that would cross the ceiling is refused outright rather than being applied up to the remaining space. Existing clients that send a single definition are unaffected, since the response was already an array.

## Notes for review

The cap is deliberately not routed through the entitlement-driven limit service. This is an operational safeguard rather than a pricing or packaging limit, so it should apply wherever the feature is available, not only where an entitlement says so. The limit service also keeps its allowlist of valid limit names inside the npm package, and silently ignores any name it does not recognise, which makes it a poor fit for a limit defined here.

Bulk create was added because all-or-nothing semantics require it: refusing a request that would cross the ceiling only means something if the whole request is one unit of work. Running the batch inside a transaction made it self-consistent for free, so two items sharing a name are caught and two items deriving the same slug get distinct keys, exactly as if they had arrived as separate requests.

The count is a consistent read rather than a locking one, so two creates landing at the same instant can both pass and take a site slightly over the ceiling. That is an accepted trade-off: this is a ceiling on database load, and holding a lock across every create to make it exact would cost more than the small overshoot it prevents.