### PR TITLE
Converted the Explore ping service to TypeScript

### DIFF
--- a/ghost/core/core/server/services/explore-ping/explore-ping-service.ts
+++ b/ghost/core/core/server/services/explore-ping/explore-ping-service.ts
@@ -1,23 +1,91 @@
-module.exports = class ExplorePingService {
-    /**
-     * @param {object} deps
-     * @param {{get: (string) => string}} deps.settingsCache
-     * @param {object} deps.config
-     * @param {object} deps.labs
-     * @param {object} deps.logging
-     * @param {object} deps.ghostVersion
-     * @param {object} deps.request
-     * @param {{stats: {
-     *   getMostRecentlyPublishedPostDate: () => Promise<Date>,
-     *   getFirstPublishedPostDate: () => Promise<Date>,
-     *   getTotalPostsPublished: () => Promise<number>
-     * }}} deps.posts
-     * @param {{stats: {
-     *   getTotalMembers: () => Promise<number>
-     * }}} deps.members
-     * @param {{api: {mrr: {getCurrentMrr: () => Promise<{currency: string, mrr: number}[]>}}}} deps.statsService
-     */
-    constructor({settingsCache, config, labs, logging, ghostVersion, request, posts, members, statsService}) {
+type SettingsCache = {
+    get(key: string): unknown;
+};
+
+type Config = {
+    get(key: string): unknown;
+};
+
+type Labs = {
+    isSet(flag: string): boolean;
+};
+
+type Logging = {
+    info(...args: unknown[]): void;
+    warn(...args: unknown[]): void;
+};
+
+type GhostVersion = {
+    full: string;
+};
+
+type RequestFn = (url: string, options: Record<string, unknown>) => Promise<{statusCode: number; statusMessage?: string}>;
+
+type PostsService = {
+    stats: {
+        getMostRecentlyPublishedPostDate(): Promise<Date | null>;
+        getFirstPublishedPostDate(): Promise<Date | null>;
+        getTotalPostsPublished(): Promise<number | null>;
+    };
+};
+
+type MembersService = {
+    stats: {
+        getTotalMembers(): Promise<number>;
+    };
+};
+
+type MrrByCurrency = {
+    currency: string;
+    mrr: number;
+};
+
+type StatsService = {
+    api?: {
+        mrr?: {
+            getCurrentMrr(): Promise<MrrByCurrency[]>;
+        };
+    };
+} | null;
+
+type ExplorePayload = {
+    ghost: string;
+    site_uuid: unknown;
+    url: unknown;
+    theme: unknown;
+    facebook: unknown;
+    twitter: unknown;
+    posts_total?: number | null;
+    posts_last?: string | null;
+    posts_first?: string | null;
+    members_total?: number | null;
+    mrr?: MrrByCurrency[] | null;
+};
+
+export type ExplorePingServiceDeps = {
+    settingsCache: SettingsCache;
+    config: Config;
+    labs: Labs;
+    logging: Logging;
+    ghostVersion: GhostVersion;
+    request: RequestFn;
+    posts: PostsService;
+    members: MembersService;
+    statsService: StatsService;
+};
+
+export class ExplorePingService {
+    settingsCache: SettingsCache;
+    config: Config;
+    labs: Labs;
+    logging: Logging;
+    ghostVersion: GhostVersion;
+    request: RequestFn;
+    posts: PostsService;
+    members: MembersService;
+    statsService: StatsService;
+
+    constructor({settingsCache, config, labs, logging, ghostVersion, request, posts, members, statsService}: ExplorePingServiceDeps) {
         this.settingsCache = settingsCache;
         this.config = config;
         this.labs = labs;
@@ -29,8 +97,8 @@ module.exports = class ExplorePingService {
         this.statsService = statsService;
     }
 
-    async constructPayload() {
-        const payload = {
+    async constructPayload(): Promise<ExplorePayload> {
+        const payload: ExplorePayload = {
             ghost: this.ghostVersion.full,
             site_uuid: this.settingsCache.get('site_uuid'),
             url: this.config.get('url'),
@@ -51,7 +119,7 @@ module.exports = class ExplorePingService {
             payload.posts_first = firstPublishedAt ? firstPublishedAt.toISOString() : null;
         } catch (err) {
             this.logging.warn('Failed to fetch post statistics', {
-                error: err.message,
+                error: (err as Error).message,
                 context: 'explore-ping-service'
             });
             payload.posts_total = null;
@@ -76,7 +144,7 @@ module.exports = class ExplorePingService {
                 }
             } catch (err) {
                 this.logging.warn('Failed to fetch member statistics', {
-                    error: err.message,
+                    error: (err as Error).message,
                     context: 'explore-ping-service'
                 });
                 payload.members_total = null;
@@ -87,7 +155,7 @@ module.exports = class ExplorePingService {
         return payload;
     }
 
-    async makeRequest(exploreUrl, payload) {
+    async makeRequest(exploreUrl: string, payload: ExplorePayload | Record<string, unknown>): Promise<{statusCode: number; statusMessage?: string} | undefined> {
         const json = JSON.stringify(payload);
         this.logging.info('Pinging Explore with Payload', exploreUrl, json);
 
@@ -104,16 +172,16 @@ module.exports = class ExplorePingService {
 
             return response;
         } catch (err) {
-            this.logging.warn('Explore Error', err.message);
+            this.logging.warn('Explore Error', (err as Error).message);
         }
     }
 
-    async ping() {
+    async ping(): Promise<void> {
         if (!this.labs.isSet('explore')) {
             return;
         }
 
-        const exploreUrl = this.config.get('explore:update_url');
+        const exploreUrl = this.config.get('explore:update_url') as string | undefined;
         if (!exploreUrl) {
             this.logging.warn('Explore URL not set');
             return;
@@ -127,4 +195,4 @@ module.exports = class ExplorePingService {
         const payload = await this.constructPayload();
         await this.makeRequest(exploreUrl, payload);
     }
-};
+}

--- a/ghost/core/core/server/services/explore-ping/index.ts
+++ b/ghost/core/core/server/services/explore-ping/index.ts
@@ -1,4 +1,5 @@
-const ExplorePingService = require('./explore-ping-service');
+import {ExplorePingService} from './explore-ping-service';
+
 const config = require('../../../shared/config');
 const labs = require('../../../shared/labs');
 const logging = require('@tryghost/logging');
@@ -10,7 +11,7 @@ const members = require('../members');
 const statsService = require('../stats');
 
 // Export the creation function for testing
-module.exports.createService = function createService() {
+export function createService(): ExplorePingService {
     return new ExplorePingService({
         settingsCache,
         config,
@@ -22,9 +23,9 @@ module.exports.createService = function createService() {
         members,
         statsService
     });
-};
+}
 
-module.exports.init = async function init() {
+export async function init(): Promise<void> {
     // The explore ping is a background "phone home" request. It should not run
     // in the test environment (cf. the update-check service, which gates on the
     // same environments), where there is no explore URL configured.
@@ -32,10 +33,10 @@ module.exports.init = async function init() {
         return;
     }
 
-    const explorePingService = module.exports.createService();
+    const explorePingService = createService();
 
     // The final intention is to have this run on a schedule
     // For the initial version, we'll just ping when the server starts
     // Without waiting for the response
     explorePingService.ping();
-};
+}

--- a/ghost/core/test/unit/server/services/explore-ping/explore-ping-service.test.js
+++ b/ghost/core/test/unit/server/services/explore-ping/explore-ping-service.test.js
@@ -1,6 +1,6 @@
 const sinon = require('sinon');
 const assert = require('node:assert/strict');
-const ExplorePingService = require('../../../../../core/server/services/explore-ping/explore-ping-service');
+const {ExplorePingService} = require('../../../../../core/server/services/explore-ping/explore-ping-service');
 
 describe('ExplorePingService', function () {
     let explorePingService;


### PR DESCRIPTION
Stacked on #29442 (the diff shows only explore-ping until that merges; it targets the `slack-ping-ts` branch and will retarget automatically as the stack merges).

Ports `explore-ping` to TypeScript, completing the port of all three ping services. Unlike the other two, this is a **pure port with no structural change**: explore-ping already had an index/service split, and its index uses the functional `createService()`/`init()` idiom rather than the wrapper class — that shape is kept as-is (its named exports mean boot.js needs no change at all). Aligning the instantiation idioms is deliberately left for the upcoming service-instantiation proposal rather than smuggled in here.

- `explore-ping-service.ts` — named-export class with a typed `Deps` options object and structurally-typed dependencies (`posts.stats`, `members.stats`, `statsService.api.mrr`, etc.), matching the indexnow/slack ports
- `index.ts` — same top-level requires and functions as before, now with typed signatures

No logic changes. The unit test is byte-identical apart from a one-line destructure; all 16 tests pass unchanged. `tsc --noEmit` reports zero errors in these files.
