### PR TITLE
Added member custom field values to the members CSV export

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/members.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/members.js
@@ -25,22 +25,6 @@ module.exports = {
     activityFeed: createSerializer('activityFeed', activityFeed)
 };
 
-// Columns to export in CSV
-const CSV_HEADERS = [
-    'id',
-    'email',
-    'name',
-    'note',
-    'subscribed_to_emails',
-    'complimentary_plan',
-    'stripe_customer_id',
-    'created_at',
-    'deleted_at',
-    'labels',
-    'tiers',
-    'gift_id'
-];
-
 /**
  * Formats a single member for CSV export
  * @param {Object} member - Member object
@@ -84,7 +68,10 @@ function formatMemberForCSV(member) {
         deleted_at: member.deleted_at || null,
         labels: labels,
         tiers: tiers,
-        gift_id: giftId
+        gift_id: giftId,
+        // The exporter flattens custom field values into their CSV columns, since
+        // which columns exist is a per-site question only the database can answer.
+        ...member.custom_field_cells
     };
 }
 
@@ -429,38 +416,41 @@ function serializeNewsletters(newsletters) {
  * @returns {Transform} Transform stream that converts objects to CSV
  */
 function createCSVTransform() {
-    let isFirstChunk = true;
-    
+    // Locked in from the first row rather than declared up front: custom fields
+    // add a column per site, so the column set isn't known until a row arrives.
+    // Every row carries the same keys, so the first is representative.
+    let fields = null;
+
     return new Transform({
         objectMode: true,
         transform(member, encoding, callback) {
             try {
                 // Format the member data for CSV
                 const formattedMember = formatMemberForCSV(member);
-                
+
                 // For first chunk, include the headers
-                if (isFirstChunk) {
+                if (fields === null) {
+                    fields = Object.keys(formattedMember);
                     const csv = papaparse.unparse({
-                        fields: CSV_HEADERS,
+                        fields,
                         data: [formattedMember]
                     }, {
                         header: true,
                         escapeFormulae: true,
                         newline: '\r\n' // Explicitly set Windows-style line endings for compatibility
                     });
-                    isFirstChunk = false;
                     callback(null, csv);
                 } else {
                     // For subsequent chunks, don't include headers, just the data
                     const csv = papaparse.unparse({
-                        fields: CSV_HEADERS,
+                        fields,
                         data: [formattedMember]
                     }, {
                         header: false,
                         escapeFormulae: true,
                         newline: '\r\n' // Explicitly set Windows-style line endings for compatibility
                     });
-                    
+
                     // Make sure each row starts with a newline to ensure separation between rows
                     // Ensure consistent line endings by using explicit CR+LF sequence
                     callback(null, '\r\n' + csv.replace(/^\r?\n+/, ''));

--- a/ghost/core/core/server/services/members/exporter/query.js
+++ b/ghost/core/core/server/services/members/exporter/query.js
@@ -3,6 +3,9 @@ const {knex} = require('../../../data/db');
 const moment = require('moment');
 const logging = require('@tryghost/logging');
 const {Transform} = require('stream');
+const labs = require('../../../../shared/labs');
+const customFields = require('../../members-custom-fields');
+const {csvCellsForFields} = require('@tryghost/custom-field-types/csv');
 
 /**
  * Process a batch of members with all their related data
@@ -14,9 +17,11 @@ const {Transform} = require('stream');
  * @param {Map} giftIdMap - Map of member_id to gift id (for gift members only)
  * @param {Object} allProducts - Map of product IDs to product names
  * @param {Object} allLabels - Map of label IDs to label names
+ * @param {Array} activeCustomFields - Active custom field definitions
+ * @param {Map} customFieldValuesMap - Map of member_id to their custom field values
  * @returns {Array} Processed member records
  */
-function processMembersData(members, tiersMap, labelsMap, stripeCustomerMap, subscribedSet, giftIdMap, allProducts, allLabels) {
+function processMembersData(members, tiersMap, labelsMap, stripeCustomerMap, subscribedSet, giftIdMap, allProducts, allLabels, activeCustomFields, customFieldValuesMap) {
     for (const row of members) {
         const tierIds = tiersMap.get(row.id) ? tiersMap.get(row.id).split(',') : [];
         const tierDetails = tierIds.map((id) => {
@@ -40,6 +45,12 @@ function processMembersData(members, tiersMap, labelsMap, stripeCustomerMap, sub
         row.gift_id = giftIdMap.get(row.id) || null;
         row.stripe_customer_id = stripeCustomerMap.get(row.id) || null;
         row.created_at = moment(row.created_at).toISOString();
+
+        // Flattened here rather than in the serializer because the column set is
+        // only knowable from the database. Every member carries a cell for every
+        // active field's column, so a member with no values still contributes the
+        // full set — the CSV header is taken from whichever row streams first.
+        row.custom_field_cells = csvCellsForFields(activeCustomFields, customFieldValuesMap.get(row.id) || {});
     }
     return members;
 }
@@ -83,6 +94,19 @@ async function createExportStream(options) {
 
     logging.info('[MembersExporter] Fetched products and labels in ' + (Date.now() - startFetchingProducts) + 'ms');
 
+    // Definitions are a small, stable table, so they're read once rather than per
+    // batch. Reading once also fixes the column set for the whole file: archiving a
+    // field mid-export can't leave the header ragged. It can still leave that
+    // field's cells empty from the batch after the archive onwards, because the
+    // per-batch value read applies its own active filter.
+    const customFieldsEnabled = labs.isSet('membersCustomFields');
+    if (customFieldsEnabled && !customFields.definitions) {
+        logging.warn('[MembersExporter] Custom fields service is not initialised, exporting without custom field columns');
+    }
+    const activeCustomFields = customFieldsEnabled && customFields.definitions
+        ? await customFields.definitions.browse()
+        : [];
+
     // Create a transform stream that will process the members as they come in
     const processMembersTransform = new Transform({
         objectMode: true,
@@ -92,7 +116,7 @@ async function createExportStream(options) {
                 const memberIds = batch.map(member => member.id);
                 
                 // Fetch related data for this batch
-                const [tiers, labels, stripeCustomers, subscriptions, gifts] = await Promise.all([
+                const [tiers, labels, stripeCustomers, subscriptions, gifts, customFieldValuesMap] = await Promise.all([
                     knex('members_products')
                         .select('member_id', knex.raw('GROUP_CONCAT(product_id) as tiers'))
                         .whereIn('member_id', memberIds)
@@ -115,7 +139,11 @@ async function createExportStream(options) {
                     knex('gifts')
                         .select('id', 'redeemer_member_id')
                         .where('status', 'redeemed')
-                        .whereIn('redeemer_member_id', memberIds)
+                        .whereIn('redeemer_member_id', memberIds),
+
+                    activeCustomFields.length > 0
+                        ? customFields.values.getValuesForMembers(memberIds)
+                        : new Map()
                 ]);
 
                 // Create maps for quick lookups
@@ -133,8 +161,10 @@ async function createExportStream(options) {
                     stripeCustomerMap, 
                     subscribedSet, 
                     giftIdMap,
-                    allProducts, 
-                    allLabels
+                    allProducts,
+                    allLabels,
+                    activeCustomFields,
+                    customFieldValuesMap
                 );
 
                 // Push each member individually to avoid large arrays in memory

--- a/ghost/core/test/e2e-api/admin/members-exporter-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/members-exporter-custom-fields.test.ts
@@ -1,0 +1,305 @@
+import assert from 'node:assert/strict';
+
+const Papa = require('papaparse');
+const {agentProvider, fixtureManager, mockManager} = require('../../utils/e2e-framework');
+const models = require('../../../core/server/models');
+
+const CORE_COLUMNS = [
+    'id',
+    'email',
+    'name',
+    'note',
+    'subscribed_to_emails',
+    'complimentary_plan',
+    'stripe_customer_id',
+    'created_at',
+    'deleted_at',
+    'labels',
+    'tiers',
+    'gift_id'
+];
+
+const ADDRESS_SUB_FIELDS = ['line1', 'line2', 'city', 'state', 'postal_code', 'country'];
+
+/** Custom field columns are namespaced so a minted key can never take a core column. */
+function columnFor(key: string, subField?: string) {
+    return subField ? `custom_fields.${key}.${subField}` : `custom_fields.${key}`;
+}
+
+function addressColumnsFor(key: string) {
+    return ADDRESS_SUB_FIELDS.map(sub => columnFor(key, sub));
+}
+
+const FULL_ADDRESS = {
+    line1: '1 High Street',
+    line2: 'Flat 2',
+    city: 'London',
+    state: 'Greater London',
+    postal_code: 'E1 6AN',
+    country: 'GB'
+};
+
+// Only the sub-fields the type requires; line2 and state are optional.
+const MINIMAL_ADDRESS = {
+    line1: '9 Long Lane',
+    city: 'Bristol',
+    postal_code: 'BS1 4DJ',
+    country: 'GB'
+};
+
+describe('Members API — exportCSV with custom fields', function () {
+    let agent: {
+        get: (_url: string) => any;
+        put: (_url: string) => any;
+        post: (_url: string) => any;
+        loginAsOwner: () => Promise<void>;
+    };
+
+    // The key is minted server-side from the name, so callers read it off the result.
+    async function createField(name: string, type: string) {
+        const {body} = await agent
+            .post('members/custom_fields/')
+            .body({members_custom_fields: [{name, type}]})
+            .expectStatus(201);
+        return body.members_custom_fields[0];
+    }
+
+    async function archiveField(key: string) {
+        await agent
+            .put(`members/custom_fields/${key}/`)
+            .body({members_custom_fields: [{status: 'archived'}]})
+            .expectStatus(200);
+    }
+
+    let memberCounter = 0;
+    async function createMember(customFields?: Record<string, unknown>) {
+        memberCounter += 1;
+        const email = `export-custom-fields-${memberCounter}@example.com`;
+        const {body} = await agent
+            .post('members/')
+            .body({members: [{email}]})
+            .expectStatus(201);
+        const id = body.members[0].id;
+
+        if (customFields) {
+            await agent
+                .put(`members/${id}/`)
+                .body({members: [{custom_fields: customFields}]})
+                .expectStatus(200);
+        }
+
+        return {id, email};
+    }
+
+    async function exportCSV() {
+        const res = await agent.get('/members/upload/?limit=all').expectStatus(200);
+        const parsed = Papa.parse(res.text.trim(), {header: true});
+        return {
+            columns: parsed.meta.fields as string[],
+            rowFor: (id: string) => parsed.data.find((row: {id: string}) => row.id === id)
+        };
+    }
+
+    beforeAll(async function () {
+        agent = await agentProvider.getAdminAPIAgent();
+        await fixtureManager.init('users');
+        await agent.loginAsOwner();
+    });
+
+    beforeEach(function () {
+        mockManager.mockLabsEnabled('membersCustomFields');
+    });
+
+    afterEach(async function () {
+        mockManager.restore();
+        await models.Base.knex('members_custom_field_values').del();
+        await models.Base.knex('members_custom_fields').del();
+        await models.Base.knex('members').del();
+        await models.Base.knex('actions').whereIn('resource_type', ['member', 'member_custom_field']).del();
+    });
+
+    it('adds a column per active field, expanding an address into its sub-fields', async function () {
+        const nickname = await createField('Nickname', 'short_text');
+        const bio = await createField('Bio', 'long_text');
+        const address = await createField('Shipping Address', 'address');
+
+        await createMember();
+
+        const {columns} = await exportCSV();
+
+        assert.deepEqual(columns, [
+            ...CORE_COLUMNS,
+            columnFor(nickname.key),
+            columnFor(bio.key),
+            ...addressColumnsFor(address.key)
+        ]);
+    });
+
+    it('exports the values a member has set', async function () {
+        const nickname = await createField('Nickname', 'short_text');
+        const bio = await createField('Bio', 'long_text');
+        const address = await createField('Shipping Address', 'address');
+
+        const member = await createMember({
+            [nickname.key]: 'Bex',
+            [bio.key]: 'Writes about trains.',
+            [address.key]: FULL_ADDRESS
+        });
+
+        const {rowFor} = await exportCSV();
+        const row = rowFor(member.id);
+
+        assert.equal(row[columnFor(nickname.key)], 'Bex');
+        assert.equal(row[columnFor(bio.key)], 'Writes about trains.');
+        for (const sub of ADDRESS_SUB_FIELDS) {
+            assert.equal(row[columnFor(address.key, sub)], FULL_ADDRESS[sub as keyof typeof FULL_ADDRESS]);
+        }
+    });
+
+    it('leaves cells empty for fields a member has not filled in', async function () {
+        const nickname = await createField('Nickname', 'short_text');
+        const bio = await createField('Bio', 'long_text');
+        const address = await createField('Shipping Address', 'address');
+
+        const partial = await createMember({[nickname.key]: 'Sam'});
+        const empty = await createMember();
+
+        const {rowFor} = await exportCSV();
+
+        const partialRow = rowFor(partial.id);
+        assert.equal(partialRow[columnFor(nickname.key)], 'Sam');
+        assert.equal(partialRow[columnFor(bio.key)], '');
+        assert.equal(partialRow[columnFor(address.key, 'line1')], '');
+
+        const emptyRow = rowFor(empty.id);
+        assert.equal(emptyRow[columnFor(nickname.key)], '');
+        assert.equal(emptyRow[columnFor(bio.key)], '');
+        for (const sub of ADDRESS_SUB_FIELDS) {
+            assert.equal(emptyRow[columnFor(address.key, sub)], '');
+        }
+    });
+
+    it('leaves optional address sub-fields empty when the address omits them', async function () {
+        const address = await createField('Shipping Address', 'address');
+
+        const member = await createMember({[address.key]: MINIMAL_ADDRESS});
+
+        const {rowFor} = await exportCSV();
+        const row = rowFor(member.id);
+
+        assert.equal(row[columnFor(address.key, 'line1')], MINIMAL_ADDRESS.line1);
+        assert.equal(row[columnFor(address.key, 'city')], MINIMAL_ADDRESS.city);
+        assert.equal(row[columnFor(address.key, 'postal_code')], MINIMAL_ADDRESS.postal_code);
+        assert.equal(row[columnFor(address.key, 'country')], MINIMAL_ADDRESS.country);
+        assert.equal(row[columnFor(address.key, 'line2')], '');
+        assert.equal(row[columnFor(address.key, 'state')], '');
+    });
+
+    // The header is derived from the first row, so a field with no values anywhere
+    // still has to reach the column list.
+    it('includes the columns when no member has a value', async function () {
+        const nickname = await createField('Nickname', 'short_text');
+
+        await createMember();
+
+        const {columns} = await exportCSV();
+
+        assert.deepEqual(columns, [...CORE_COLUMNS, columnFor(nickname.key)]);
+    });
+
+    // JavaScript orders integer-like object keys before every other key, and the
+    // header comes from the first row's key order. An unnamespaced numeric key
+    // would jump the whole column list; the namespace is what keeps it in place.
+    it('keeps a numeric key in insertion order rather than first', async function () {
+        const numeric = await createField('2024', 'short_text');
+
+        await createMember({[numeric.key]: 'a value'});
+
+        const {columns} = await exportCSV();
+
+        assert.deepEqual(columns, [...CORE_COLUMNS, columnFor(numeric.key)]);
+    });
+
+    it('escapes values that would otherwise break the CSV', async function () {
+        const notes = await createField('Notes', 'short_text');
+
+        const value = 'Smith, "Bex"\r\nsecond line';
+        const member = await createMember({[notes.key]: value});
+
+        const {rowFor} = await exportCSV();
+
+        assert.equal(rowFor(member.id)[columnFor(notes.key)], value);
+    });
+
+    // papaparse's escapeFormulae guard, which the export has always applied to
+    // every column. It prefixes the cell, so a formula-like value is deliberately
+    // not byte-identical on the way out.
+    it('defuses a value that a spreadsheet would read as a formula', async function () {
+        const notes = await createField('Notes', 'short_text');
+
+        const member = await createMember({[notes.key]: '=SUM(A1:A9)'});
+
+        const {rowFor} = await exportCSV();
+
+        assert.equal(rowFor(member.id)[columnFor(notes.key)], "'=SUM(A1:A9)");
+    });
+
+    // Pre-existing behaviour, pinned here because deleting the static header list
+    // means nothing else describes what an empty export looks like.
+    it('writes nothing at all when there are no members', async function () {
+        await createField('Nickname', 'short_text');
+
+        const res = await agent.get('/members/upload/?limit=all').expectStatus(200);
+
+        assert.equal(res.text, '');
+    });
+
+    // Whether a name like this is reservable is the definitions layer's business,
+    // not the export's — the namespace holds either way. The property itself is
+    // pinned in the custom-field-types unit tests, where the colliding key is
+    // constructed directly rather than minted.
+    it('keeps a field named after a core column out of that column', async function () {
+        const field = await createField('Email', 'short_text');
+
+        const member = await createMember({[field.key]: 'not an email address'});
+
+        const {columns, rowFor} = await exportCSV();
+        const row = rowFor(member.id);
+
+        assert.deepEqual(columns, [...CORE_COLUMNS, columnFor(field.key)]);
+        assert.equal(row.email, member.email);
+        assert.equal(row[columnFor(field.key)], 'not an email address');
+    });
+
+    it('excludes archived fields', async function () {
+        const kept = await createField('Nickname', 'short_text');
+        const archived = await createField('Old Field', 'short_text');
+
+        const member = await createMember({
+            [kept.key]: 'Bex',
+            [archived.key]: 'stale value'
+        });
+
+        await archiveField(archived.key);
+
+        const {columns, rowFor} = await exportCSV();
+
+        assert.deepEqual(columns, [...CORE_COLUMNS, columnFor(kept.key)]);
+        assert.equal(rowFor(member.id)[columnFor(kept.key)], 'Bex');
+    });
+
+    // Fields can only be created while the flag is on, so this is the site that
+    // defined fields and then had the flag turned back off.
+    it('omits custom field columns when the flag is disabled', async function () {
+        const nickname = await createField('Nickname', 'short_text');
+
+        const member = await createMember({[nickname.key]: 'Bex'});
+
+        mockManager.mockLabsDisabled('membersCustomFields');
+
+        const {columns, rowFor} = await exportCSV();
+
+        assert.deepEqual(columns, CORE_COLUMNS);
+        assert.equal(rowFor(member.id)[columnFor(nickname.key)], undefined);
+    });
+});

--- a/packages/custom-field-types/package.json
+++ b/packages/custom-field-types/package.json
@@ -16,6 +16,11 @@
       "source": "./src/index.ts",
       "types": "./build/index.d.ts",
       "default": "./build/index.js"
+    },
+    "./csv": {
+      "source": "./src/csv.ts",
+      "types": "./build/csv.d.ts",
+      "default": "./build/csv.js"
     }
   },
   "main": "build/index.js",

--- a/packages/custom-field-types/src/csv.ts
+++ b/packages/custom-field-types/src/csv.ts
@@ -1,0 +1,73 @@
+import {z} from 'zod';
+import {FIELD_TYPES, type FieldType} from './index.ts';
+
+/**
+ * How a field's value maps onto CSV columns.
+ *
+ * CSV is flat and a value need not be, so a composite occupies one column per
+ * sub-field. That shape is derived from the type's own value schema rather than
+ * declared alongside it: the two cannot drift, and it stays correct as sub-fields
+ * are added, removed, or made optional — an optional sub-field is still a column,
+ * it just holds an empty cell more often.
+ *
+ * The same column names are the vocabulary the importer maps onto, so an exported
+ * file re-imports without the publisher remapping anything by hand.
+ */
+
+const SEPARATOR = '.';
+
+/**
+ * Custom field columns are namespaced. A field's key is minted from a name the
+ * publisher chose, so nothing stops it landing on a column the export already
+ * has — a field named "Email" mints the key `email`. Unnamespaced, that column
+ * would quietly take the place of the member's address. The namespace also keeps
+ * a core column added in future from colliding with a key minted years earlier.
+ *
+ * `custom_fields` is the same path the Admin API already uses to address these
+ * values, so a column reads like the field it came from.
+ */
+const NAMESPACE = 'custom_fields';
+
+/** A field definition reduced to what CSV needs to know about it. */
+export interface CsvField {
+    key: string;
+    type: FieldType;
+}
+
+function subFieldsOf(type: FieldType): string[] | null {
+    const {value} = FIELD_TYPES[type];
+    return value instanceof z.ZodObject ? Object.keys(value.shape) : null;
+}
+
+function toCell(value: unknown): string {
+    return value === undefined || value === null ? '' : String(value);
+}
+
+/**
+ * The CSV cells for one member's custom field values, keyed by column name.
+ *
+ * Every column of every field passed in is present in the result, whether or not
+ * the member holds a value for it. Callers derive the CSV header from a single
+ * row, so a key omitted here is a column dropped from the whole export.
+ */
+export function csvCellsForFields(fields: readonly CsvField[], values: Record<string, unknown>): Record<string, string> {
+    const cells: Record<string, string> = {};
+
+    for (const field of fields) {
+        const value = values[field.key];
+        const subFields = subFieldsOf(field.type);
+        const column = `${NAMESPACE}${SEPARATOR}${field.key}`;
+
+        if (!subFields) {
+            cells[column] = toCell(value);
+            continue;
+        }
+
+        const composite = (value ?? {}) as Record<string, unknown>;
+        for (const sub of subFields) {
+            cells[`${column}${SEPARATOR}${sub}`] = toCell(composite[sub]);
+        }
+    }
+
+    return cells;
+}

--- a/packages/custom-field-types/src/index.ts
+++ b/packages/custom-field-types/src/index.ts
@@ -8,12 +8,19 @@ import {z} from 'zod';
  * imports it to *enforce* validation (and to route storage); admin imports the
  * same schemas for instant form feedback. Neither drifts.
  *
- * It is deliberately pure data: no presentation (labels, icons, input controls
- * stay in the frontend), no storage codecs (columns and serialize/deserialize
- * stay in the backend), and no lookup helpers (consumers index `FIELD_TYPES`
- * directly). Keeping it pure keeps the backend's dependency surface clean and
- * means its behaviour is proven where it matters — the members custom-fields
- * HTTP API integration tests — rather than in isolated unit tests here.
+ * This module is deliberately pure data: no presentation (labels, icons, input
+ * controls stay in the frontend), no storage codecs (columns and
+ * serialize/deserialize stay in the backend), and no lookup helpers (consumers
+ * index `FIELD_TYPES` directly).
+ *
+ * The package admits one thing beyond data, in `./csv`: how a value maps onto
+ * CSV columns. That belongs here rather than in either tier because both need
+ * the same answer — the backend to write the export and read an import, admin to
+ * offer the columns as mapping targets — and a disagreement between them is a
+ * file that silently stops round-tripping.
+ *
+ * Behaviour is proven where it matters, in the members custom-fields and member
+ * export HTTP API integration tests, rather than in isolated unit tests here.
  */
 
 /**

--- a/packages/custom-field-types/test/csv.test.ts
+++ b/packages/custom-field-types/test/csv.test.ts
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import {describe, it} from 'vitest';
+import {csvCellsForFields} from '../src/csv.ts';
+
+// The behavioural outcomes — an export carrying the right columns, an exported
+// file re-importing without remapping — are proven end-to-end through the member
+// export and import HTTP API integration tests. What is asserted here is the one
+// invariant those tests can only observe indirectly: the key set is fixed by the
+// field definitions alone, never by which values a given member happens to hold.
+describe('custom field CSV cells', function () {
+    const nickname = {key: 'nickname', type: 'short_text'} as const;
+    const address = {key: 'shipping_address', type: 'address'} as const;
+
+    const ADDRESS_COLUMNS = [
+        'custom_fields.shipping_address.line1',
+        'custom_fields.shipping_address.line2',
+        'custom_fields.shipping_address.city',
+        'custom_fields.shipping_address.state',
+        'custom_fields.shipping_address.postal_code',
+        'custom_fields.shipping_address.country'
+    ];
+
+    it('gives a scalar field one column', function () {
+        assert.deepEqual(csvCellsForFields([nickname], {nickname: 'Bex'}), {'custom_fields.nickname': 'Bex'});
+    });
+
+    // A key is minted from a publisher-chosen name, so it can land on a column the
+    // export already has. Namespacing is what stops the value taking its place.
+    it('namespaces a key that collides with a core export column', function () {
+        const cells = csvCellsForFields([{key: 'email', type: 'short_text'}], {email: 'a nickname'});
+
+        assert.deepEqual(cells, {'custom_fields.email': 'a nickname'});
+        assert.equal(Object.hasOwn(cells, 'email'), false);
+    });
+
+    it('expands a composite field into a column per sub-field', function () {
+        const cells = csvCellsForFields([address], {
+            shipping_address: {
+                line1: '1 High Street',
+                line2: 'Flat 2',
+                city: 'London',
+                state: 'Greater London',
+                postal_code: 'E1 6AN',
+                country: 'GB'
+            }
+        });
+
+        assert.deepEqual(Object.keys(cells), ADDRESS_COLUMNS);
+        assert.equal(cells['custom_fields.shipping_address.line1'], '1 High Street');
+        assert.equal(cells['custom_fields.shipping_address.country'], 'GB');
+    });
+
+    // The export takes its header from a single row, so a field the member has no
+    // value for must still produce its columns or it vanishes from the whole file.
+    it('produces the same columns whether or not the member holds a value', function () {
+        const withValues = csvCellsForFields([nickname, address], {
+            nickname: 'Bex',
+            shipping_address: {line1: '1 High Street', city: 'London', postal_code: 'E1 6AN', country: 'GB'}
+        });
+        const withNothing = csvCellsForFields([nickname, address], {});
+
+        assert.deepEqual(Object.keys(withNothing), Object.keys(withValues));
+        assert.deepEqual(Object.values(withNothing), new Array(Object.keys(withValues).length).fill(''));
+    });
+
+    it('leaves a cell empty for a sub-field the value omits', function () {
+        const cells = csvCellsForFields([address], {
+            shipping_address: {line1: '9 Long Lane', city: 'Bristol', postal_code: 'BS1 4DJ', country: 'GB'}
+        });
+
+        assert.equal(cells['custom_fields.shipping_address.line2'], '');
+        assert.equal(cells['custom_fields.shipping_address.state'], '');
+    });
+
+    it('treats an explicit null as no value', function () {
+        assert.deepEqual(csvCellsForFields([nickname], {nickname: null}), {'custom_fields.nickname': ''});
+    });
+});


### PR DESCRIPTION
Publishers can define custom fields on their members, but the members CSV export knew nothing about them. The export shipped a fixed set of columns, so any custom field values a site had collected simply fell out of the file. That makes the export a lossy view of the member list, and it means an exported file can never be re-imported without losing data.

This change makes the export carry a column for every active custom field. Because a field's value isn't always a single scalar, the column layout is derived from the field type itself rather than declared separately: a composite type like an address occupies one column per sub-field, and that layout stays correct as sub-fields are added, removed, or made optional. Deriving it means the export and the eventual importer cannot disagree about what a column is called, which is what lets a file round-trip.

The column set is only knowable from the database, since it depends on which fields a particular site has defined. The exporter therefore reads the active definitions once at the start of the export and gives every member a cell for every column, so a member holding no values still contributes the full set and the header taken from the first streamed row is representative. Archived fields are excluded, and with the feature flag off the definition list stays empty so the file is byte-for-byte what it was before.

The import side of the round-trip is follow-up work. Reviewers may want to look closely at the header-from-first-row approach in the CSV transform, which replaces the previous hardcoded header constant.