### PR TITLE
Switched sso/scheduling base adapters to public

### DIFF
--- a/packages/adapters/scheduling-base/package.json
+++ b/packages/adapters/scheduling-base/package.json
@@ -1,8 +1,7 @@
 {
   "name": "@tryghost/adapter-base-scheduling",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "The adapter-base-scheduling package for Ghost.",
-  "private": true,
   "type": "module",
   "repository": {
     "type": "git",

--- a/packages/adapters/sso-base/package.json
+++ b/packages/adapters/sso-base/package.json
@@ -1,8 +1,7 @@
 {
   "name": "@tryghost/adapter-base-sso",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "The adapter-base-sso package for Ghost.",
-  "private": true,
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLA-233/create-public-npm-package-for-sso-adapter-base, https://linear.app/ghost/issue/PLA-232/create-public-npm-package-for-scheduling-adapter
- marks both sso and scheduling adapters public, bumps version to 0.1.0

merging this before I publish these to npm initially
