### PR TITLE
Moved getBackupRouteSettingsFilePath into a route-settings adapter util

### DIFF
--- a/ghost/core/core/server/adapters/route-settings/FileStore.ts
+++ b/ghost/core/core/server/adapters/route-settings/FileStore.ts
@@ -1,7 +1,6 @@
 import fs from 'fs-extra';
 import path from 'path';
 import {z} from 'zod';
-import {format} from 'date-fns';
 import * as errors from '@tryghost/errors';
 import tpl from '@tryghost/tpl';
 
@@ -9,6 +8,7 @@ import {RouteSettingsStoreBase, type RouteSettings} from '@tryghost/adapter-base
 
 import parseYaml from '../../services/route-settings/yaml-parser';
 import {parseRouteSettings} from '../../services/route-settings/route-settings-parser';
+import {getBackupRouteSettingsFilePath} from './utils';
 
 const YAML_FILENAME = 'routes.yaml';
 const DEFAULT_SETTINGS_FILENAME = 'default-routes.yaml';
@@ -16,11 +16,6 @@ const DEFAULT_SETTINGS_FILENAME = 'default-routes.yaml';
 const messages = {
     missingPaths: 'FileStore requires basePath and defaultSettingsBasePath.',
     ensureSettings: 'Error trying to access settings files in {path}.'
-};
-
-export const getBackupRouteSettingsFilePath = (filePath: string): string => {
-    const {dir, name, ext} = path.parse(filePath);
-    return path.join(dir, `${name}-${format(new Date(), 'yyyy-MM-dd-HH-mm-ss')}${ext}`);
 };
 
 // Validates the required paths sourced from config. Used by `FileStore.validate`.

--- a/ghost/core/core/server/adapters/route-settings/utils.ts
+++ b/ghost/core/core/server/adapters/route-settings/utils.ts
@@ -1,0 +1,7 @@
+import path from 'path';
+import {format} from 'date-fns';
+
+export const getBackupRouteSettingsFilePath = (filePath: string): string => {
+    const {dir, name, ext} = path.parse(filePath);
+    return path.join(dir, `${name}-${format(new Date(), 'yyyy-MM-dd-HH-mm-ss')}${ext}`);
+};

--- a/ghost/core/test/unit/server/adapters/route-settings/file-store.test.ts
+++ b/ghost/core/test/unit/server/adapters/route-settings/file-store.test.ts
@@ -7,7 +7,7 @@ import {afterEach, beforeEach, describe, it} from 'vitest';
 
 import {RouteSettingsStoreBase, type RouteSettings} from '@tryghost/adapter-base-route-settings';
 
-import FileStore, {getBackupRouteSettingsFilePath} from '../../../../../core/server/adapters/route-settings/FileStore';
+import FileStore from '../../../../../core/server/adapters/route-settings/FileStore';
 import parseYaml from '../../../../../core/server/services/route-settings/yaml-parser';
 import {parseRouteSettings} from '../../../../../core/server/services/route-settings/route-settings-parser';
 import {buildRouteSettings} from '../../services/route-settings/route-settings-fixture';
@@ -232,21 +232,6 @@ describe('UNIT: route-settings FileStore', function () {
                 assert.equal(err.errorType, 'InternalServerError');
                 return true;
             });
-        });
-    });
-
-    describe('getBackupRouteSettingsFilePath', function () {
-        // Same naming scheme as the legacy SettingsPathManager.getBackupFilePath:
-        // routes-yyyy-MM-dd-HH-mm-ss.<ext> next to the canonical file.
-        it('produces a timestamped sibling path preserving the extension', function () {
-            assert.match(
-                getBackupRouteSettingsFilePath('/content/settings/routes.json'),
-                /^\/content\/settings\/routes-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}\.json$/
-            );
-            assert.match(
-                getBackupRouteSettingsFilePath('/content/settings/routes.yaml'),
-                /^\/content\/settings\/routes-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}\.yaml$/
-            );
         });
     });
 });

--- a/ghost/core/test/unit/server/adapters/route-settings/utils.test.ts
+++ b/ghost/core/test/unit/server/adapters/route-settings/utils.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import {describe, it} from 'vitest';
+
+import {getBackupRouteSettingsFilePath} from '../../../../../core/server/adapters/route-settings/utils';
+
+describe('UNIT: route-settings adapter utils', function () {
+    describe('getBackupRouteSettingsFilePath', function () {
+        // Same naming scheme as the legacy SettingsPathManager.getBackupFilePath:
+        // routes-yyyy-MM-dd-HH-mm-ss.<ext> next to the canonical file.
+        it('produces a timestamped sibling path preserving the extension', function () {
+            assert.match(
+                getBackupRouteSettingsFilePath('/content/settings/routes.json'),
+                /^\/content\/settings\/routes-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}\.json$/
+            );
+            assert.match(
+                getBackupRouteSettingsFilePath('/content/settings/routes.yaml'),
+                /^\/content\/settings\/routes-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}\.yaml$/
+            );
+        });
+    });
+});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1832/implement-s3routesettingsstore

## What

Moves `getBackupRouteSettingsFilePath` out of `adapters/route-settings/FileStore.ts` into a new `adapters/route-settings/utils.ts`, and moves its test into a matching `utils.test.ts`. Pure refactor — no behaviour change.

## Why

The upcoming `S3RouteSettingsStore` (HKG-1832) needs the same timestamped backup naming for its backup object keys. Extracting the helper first keeps the store PR purely additive and avoids one store importing from a sibling store — the same shape redirects uses, where `getBackupRedirectsFilePath` lives in a shared module consumed by both `FileStore` and `S3RedirectsStore`.

## Verification

- `file-store.test.ts` (16 tests) and the moved `utils.test.ts` pass
- eslint clean on all four touched files
- `tsc --noEmit` error count identical to main (8 pre-existing, unrelated to route-settings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AC849eR4wS3MNRVHbAgV3v