### PR TITLE
Removed internal Admin API schema from Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -359,7 +359,6 @@
             "groupName": "TryGhost runtime packages",
             "matchPackageNames": [
                 "@tryghost/adapter-base-cache",
-                "@tryghost/admin-api-schema",
                 "@tryghost/api-framework",
                 "@tryghost/bookshelf-plugins",
                 "@tryghost/database-info",


### PR DESCRIPTION
## Summary

- Remove the now-private `@tryghost/admin-api-schema` workspace package from Renovate's published TryGhost runtime package group.
- Keep Renovate from proposing npm updates for a dependency that Ghost Core now resolves via `workspace:*`.

## Testing

- [x] `git diff --check`
- [x] Verified the change only removes the obsolete package entry.
