### PR TITLE
Fixed webmention url building for deleted published posts

### DIFF
--- a/ghost/core/core/server/services/mentions/mention-sending-service.js
+++ b/ghost/core/core/server/services/mentions/mention-sending-service.js
@@ -5,14 +5,16 @@ module.exports = class MentionSendingService {
     #discoveryService;
     #externalRequest;
     #getSiteUrl;
+    #getPostData;
     #getPostUrl;
     #isEnabled;
     #jobService;
 
-    constructor({discoveryService, externalRequest, getSiteUrl, getPostUrl, isEnabled, jobService}) {
+    constructor({discoveryService, externalRequest, getSiteUrl, getPostData, getPostUrl, isEnabled, jobService}) {
         this.#discoveryService = discoveryService;
         this.#externalRequest = externalRequest;
         this.#getSiteUrl = getSiteUrl;
+        this.#getPostData = getPostData;
         this.#getPostUrl = getPostUrl;
         this.#isEnabled = isEnabled;
         this.#jobService = jobService;
@@ -66,9 +68,12 @@ module.exports = class MentionSendingService {
             let html = post.get('status') === 'published' ? post.get('html') : null;
             let previousHtml = post.previous('status') === 'published' ? post.previous('html') : null;
             if (html || previousHtml) {
+                // Capture the source URL now, from the event's data, rather than
+                // deferring the model into the job.
+                const url = new URL(await this.#resolvePostUrl(post));
                 await this.#jobService.addJob('sendWebmentions', async () => {
                     await this.sendForHTMLResource({
-                        url: new URL(await this.#getPostUrl(post)),
+                        url,
                         html: html,
                         previousHtml: previousHtml
                     });
@@ -78,6 +83,21 @@ module.exports = class MentionSendingService {
             logging.error('Error in webmention sending service post update event handler:');
             logging.error(e);
         }
+    }
+
+    // Deleting a published post fires `unpublished` from onDestroyed with the
+    // model already destroyed: its own attributes are cleared, but its previous
+    // state and loaded relations remain. Resolve the URL from that previous
+    // data, the same way we read previous('html') above; live models resolve
+    // straight from the model.
+    async #resolvePostUrl(post) {
+        // A deleted post arrives destroyed: its own attributes are cleared, so
+        // its data lives in the previous attributes (its relations remain).
+        // A live post loads whatever the URL service still needs.
+        if (post.attributes && Object.keys(post.attributes).length === 0) {
+            return this.#getPostUrl(post.previous('id'), {...post.toJSON(), ...post.previousAttributes()});
+        }
+        return this.#getPostUrl(post.id, await this.#getPostData(post));
     }
 
     /**

--- a/ghost/core/core/server/services/mentions/service.js
+++ b/ghost/core/core/server/services/mentions/service.js
@@ -16,15 +16,20 @@ const settingsCache = require('../../../shared/settings-cache');
 const DomainEvents = require('@tryghost/domain-events');
 const jobsService = require('../mentions-jobs');
 
-async function getPostUrl(post) {
-    // the lazy URL service needs the post's relations to evaluate collection
-    // filters; event-emitted models don't reliably carry them
+// Serializes a post model to the data the URL service needs, loading the
+// relations it reads for filtered collections (event-emitted models don't
+// reliably carry them).
+async function getPostData(post) {
     const missing = urlService.facade.getRequiredRelations().filter(relation => !post.relations[relation]);
     if (missing.length) {
         await post.load(missing);
     }
-    const jsonModel = post.toJSON();
-    outputSerializerUrlUtil.forPost(post.id, jsonModel, {options: {}});
+    return post.toJSON();
+}
+
+function getPostUrl(id, postData) {
+    const jsonModel = {...postData};
+    outputSerializerUrlUtil.forPost(id, jsonModel, {options: {}});
     return jsonModel.url;
 }
 
@@ -105,7 +110,8 @@ module.exports = {
             discoveryService,
             externalRequest,
             getSiteUrl: () => urlUtils.urlFor('home', true),
-            getPostUrl: post => getPostUrl(post),
+            getPostData: post => getPostData(post),
+            getPostUrl: (id, data) => getPostUrl(id, data),
             isEnabled: () => !settingsCache.get('is_private'),
             jobService: {
                 async addJob(name, fn) {
@@ -124,4 +130,5 @@ module.exports = {
 };
 
 // exposed for testing
+module.exports.getPostData = getPostData;
 module.exports.getPostUrl = getPostUrl;

--- a/ghost/core/test/e2e-server/services/mentions.test.js
+++ b/ghost/core/test/e2e-server/services/mentions.test.js
@@ -1,8 +1,10 @@
 const {agentProvider, fixtureManager, mockManager} = require('../../utils/e2e-framework');
 const nock = require('nock');
+const sinon = require('sinon');
 const assert = require('node:assert/strict');
 const markdownToLexical = require('../../utils/fixtures/data-generator').markdownToLexical;
 const jobsService = require('../../../core/server/services/mentions-jobs');
+const urlService = require('../../../core/server/services/url');
 
 let agent;
 let mentionUrl = new URL('https://www.otherghostsite.com/');
@@ -60,6 +62,7 @@ describe('Mentions Service', function () {
     });
 
     afterEach(async function () {
+        sinon.restore();
         mockManager.restore();
     });
 
@@ -265,6 +268,48 @@ describe('Mentions Service', function () {
 
                 assert.equal(mentionMockTwo.isDone(), true);
                 assert.equal(endpointMockTwo.isDone(), true);
+            });
+
+            it('Deleted published post sends with a resolvable url, not a thin resource', async function () {
+                // Deleting a published post fires `unpublished` from onDestroyed,
+                // by which point bookshelf has cleared the model's attributes.
+                // The webmention job must still resolve the post's url — regression
+                // for the thin-resource error on that path.
+                const publishedPost = {status: 'published', ...mentionsPost};
+                const res = await agent
+                    .post('posts/')
+                    .body({posts: [publishedPost]})
+                    .expectStatus(201);
+
+                await jobsService.allSettled();
+                await DomainEvents.allSettled();
+                assert.equal(endpointMock.isDone(), true);
+
+                nock.cleanAll();
+                addMentionMocks();
+
+                // Capture the resource the real webmention job hands the URL
+                // service, so we can prove it isn't the attribute-less husk.
+                const slug = res.body.posts[0].slug;
+                const getUrlForResource = sinon.stub(urlService.facade, 'getUrlForResource')
+                    .callsFake(() => `http://127.0.0.1:2369/${slug}/`);
+
+                const postId = res.body.posts[0].id;
+                await agent.delete(`posts/${postId}/`)
+                    .expectStatus(204);
+
+                await jobsService.allSettled();
+                await DomainEvents.allSettled();
+
+                // the webmention for the removed content went out...
+                assert.equal(endpointMock.isDone(), true);
+                // ...and the resource that produced its url carried the post's
+                // own columns (recovered from the destroyed model's previous
+                // state), not a relations-only husk.
+                sinon.assert.called(getUrlForResource);
+                const resource = getUrlForResource.getCall(0).args[0];
+                assert.equal(resource.status, 'published');
+                assert.equal(resource.slug, slug);
             });
 
             it('Newly published page (page.published)', async function () {

--- a/ghost/core/test/unit/server/services/mentions/mention-sending-service.test.js
+++ b/ghost/core/test/unit/server/services/mentions/mention-sending-service.test.js
@@ -132,6 +132,7 @@ describe('MentionSendingService', function () {
         it('Sends on publish', async function () {
             const service = new MentionSendingService({
                 isEnabled: () => true,
+                getPostData: () => ({}),
                 getPostUrl: () => 'https://site.com/post/',
                 jobService: jobService
             });
@@ -154,6 +155,7 @@ describe('MentionSendingService', function () {
         it('Sends on unpublish', async function () {
             const service = new MentionSendingService({
                 isEnabled: () => true,
+                getPostData: () => ({}),
                 getPostUrl: () => 'https://site.com/post/',
                 jobService: jobService
             });
@@ -173,9 +175,43 @@ describe('MentionSendingService', function () {
             assert.equal(firstCall.previousHtml, 'same');
         });
 
+        it('Resolves the url from previous data when the post was destroyed', async function () {
+            // Deleting a published post fires `unpublished` with the model
+            // already destroyed: own attributes cleared, previous state kept.
+            const getPostData = sinon.stub().resolves({});
+            const getPostUrl = sinon.stub().returns('https://site.com/gone/');
+            const service = new MentionSendingService({
+                isEnabled: () => true,
+                getPostData,
+                getPostUrl,
+                jobService: jobService
+            });
+            const stub = sinon.stub(service, 'sendForHTMLResource');
+
+            const previous = {id: 'post-id', status: 'published', html: 'linky', slug: 'gone', type: 'post'};
+            const destroyedPost = {
+                attributes: {},
+                get: () => undefined,
+                previous: prop => previous[prop],
+                previousAttributes: () => previous,
+                toJSON: () => ({tags: [], authors: []})
+            };
+
+            await service.sendForPost(destroyedPost);
+
+            sinon.assert.calledOnce(stub);
+            assert.equal(stub.getCall(0).args[0].url.toString(), 'https://site.com/gone/');
+            // resolved from the destroyed model's previous data, not by loading it
+            sinon.assert.notCalled(getPostData);
+            assert.equal(getPostUrl.getCall(0).args[0], 'post-id');
+            assert.equal(getPostUrl.getCall(0).args[1].status, 'published');
+            assert.equal(getPostUrl.getCall(0).args[1].slug, 'gone');
+        });
+
         it('Sends on html change', async function () {
             const service = new MentionSendingService({
                 isEnabled: () => true,
+                getPostData: () => ({}),
                 getPostUrl: () => 'https://site.com/post/',
                 jobService: jobService
             });
@@ -198,6 +234,7 @@ describe('MentionSendingService', function () {
         it('Catches and logs errors', async function () {
             const service = new MentionSendingService({
                 isEnabled: () => true,
+                getPostData: () => ({}),
                 getPostUrl: () => 'https://site.com/post/'
             });
             sinon.stub(service, 'sendForHTMLResource').rejects(new Error('Internal error test'));
@@ -215,6 +252,7 @@ describe('MentionSendingService', function () {
         it('Sends no mentions for posts without html and previous html', async function () {
             const service = new MentionSendingService({
                 isEnabled: () => true,
+                getPostData: () => ({}),
                 getPostUrl: () => 'https://site.com/post/',
                 jobService: jobService
             });

--- a/ghost/core/test/unit/server/services/mentions/service.test.js
+++ b/ghost/core/test/unit/server/services/mentions/service.test.js
@@ -2,9 +2,9 @@ const assert = require('node:assert/strict');
 const sinon = require('sinon');
 const urlService = require('../../../../../core/server/services/url');
 const outputSerializerUrlUtil = require('../../../../../core/server/api/endpoints/utils/serializers/output/utils/url');
-const {getPostUrl} = require('../../../../../core/server/services/mentions/service');
+const {getPostData, getPostUrl} = require('../../../../../core/server/services/mentions/service');
 
-describe('Mentions service getPostUrl', function () {
+describe('Mentions service post url helpers', function () {
     afterEach(function () {
         sinon.restore();
     });
@@ -18,42 +18,42 @@ describe('Mentions service getPostUrl', function () {
         };
     }
 
-    it('loads the URL service required relations before building the url', async function () {
+    it('loads the URL service required relations before returning the post data', async function () {
         sinon.stub(urlService.facade, 'getRequiredRelations').returns(['tags', 'authors']);
-        sinon.stub(outputSerializerUrlUtil, 'forPost').callsFake((id, attrs) => {
-            attrs.url = 'https://site.com/post/';
-            return attrs;
-        });
         const post = fakePost();
 
-        const url = await getPostUrl(post);
+        await getPostData(post);
 
         sinon.assert.calledOnceWithExactly(post.load, ['tags', 'authors']);
-        assert.equal(url, 'https://site.com/post/');
+    });
+
+    it('getPostUrl resolves a url from a plain resource', function () {
+        const forPost = sinon.stub(outputSerializerUrlUtil, 'forPost').callsFake((id, attrs) => {
+            attrs.url = `https://site.com/${attrs.slug}/`;
+            return attrs;
+        });
+
+        const url = getPostUrl('post-id', {slug: 'gone', status: 'published', type: 'post'});
+
+        assert.equal(url, 'https://site.com/gone/');
+        assert.equal(forPost.getCall(0).args[0], 'post-id');
+        assert.equal(forPost.getCall(0).args[1].status, 'published');
     });
 
     it('does not reload relations that are already loaded', async function () {
         sinon.stub(urlService.facade, 'getRequiredRelations').returns(['tags', 'authors']);
-        sinon.stub(outputSerializerUrlUtil, 'forPost').callsFake((id, attrs) => {
-            attrs.url = 'https://site.com/post/';
-            return attrs;
-        });
         const post = fakePost({tags: {}, authors: {}});
 
-        await getPostUrl(post);
+        await getPostData(post);
 
         sinon.assert.notCalled(post.load);
     });
 
     it('loads nothing under the eager service', async function () {
         sinon.stub(urlService.facade, 'getRequiredRelations').returns([]);
-        sinon.stub(outputSerializerUrlUtil, 'forPost').callsFake((id, attrs) => {
-            attrs.url = 'https://site.com/post/';
-            return attrs;
-        });
         const post = fakePost();
 
-        await getPostUrl(post);
+        await getPostData(post);
 
         sinon.assert.notCalled(post.load);
     });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1822

Follow-up to #29436. A rare `LAZY_URL_COMPARE_ERROR` survived on the webmention path — `errorDetails` showed a post husk: relations present (`authors`, `tags`, `post_revisions`, ...), every own column gone, `missing:["status"]`.

## Root cause

**Deleting a published post.** `onDestroyed` fires the `unpublished` event (`models/post.js`), but bookshelf's destroy has already run `this.clear()` — emptying the model's `attributes` while keeping `_previousAttributes` and the loaded relations. So the model reaching the webmention sender is a husk *synchronously*, and building its URL hands the URL service a resource with no `status`, which the lazy service rejects as thin.

The `unpublished` event always carries a stale model — the `usePreviousAttribute` flag on it only decides whether the event is named `post.` or `page.` (from `previous('type')`); it does not swap the payload. So reading previous state is already the listener's job: `sendForPost` computes `html`/`previousHtml` from `post.previous(...)` for exactly this reason. It just never did the same for the URL.

## Change

- The webmention **source URL is captured up front when the job is created**, rather than deferring the model into the job.
- For a destroyed post the sender resolves the URL from the model's **previous** data — symmetric with how it already reads `previous('html')`. Live models resolve from their current data.
- URL building is a single function `getPostUrl(id, data)` that resolves from a plain resource — the listener assembles the resource for both paths, so there's one url method, not two. The relation loading #29436 added is now `getPostData(post)` (a data step, not a url step); the destroyed path skips it and reuses the relations destroy already loaded, so there's no extra DB read.

## Tests

- **`test/e2e-server/services/mentions.test.js`** — drives the real flow end to end: publishes a post via the Admin API, then `DELETE`s it, letting the actual `unpublished` → `MentionSendingService` → inline job → URL resolution chain run. Asserts the resource the URL service receives carries `status`/`slug`, not the husk. Verified failing without the fix and passing with it, in the full suite (sole discriminator).
- **`mention-sending-service.test.js`** — unit case for the destroyed-model path resolving from previous data.
- **`service.test.js`** — `getPostData` loads the required relations; `getPostUrl` resolves from a plain resource.

(Earlier iterations: resolving the URL earlier on a "bookshelf resets after save" theory — wrong, save's `_reset` only clears `.changed`; then handling the husk inside the generic resolver — moved to the listener where previous-state handling belongs; then two url methods — collapsed to one. Thanks to the reviewer who pushed on each.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)