### PR TITLE
Moved the last frontend services off direct server requires

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -67,7 +67,6 @@ module.exports = {
                     '^ghost/core/core/frontend/apps/private-blogging/lib/router\\.js$',
 
                     // Leaks that bypass the proxy (fix first).
-                    '^ghost/core/core/frontend/services/routing/router-manager\\.js$', // server/lib/common/events bus
                     '^ghost/core/core/frontend/services/sitemap/site-map-manager\\.js$' // server/lib/common/events bus
                 ]
             },

--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -67,7 +67,6 @@ module.exports = {
                     '^ghost/core/core/frontend/apps/private-blogging/lib/router\\.js$',
 
                     // Leaks that bypass the proxy (fix first).
-                    '^ghost/core/core/frontend/services/routing/controllers/unsubscribe\\.js$', // services/members + settings-helpers
                     '^ghost/core/core/frontend/services/routing/router-manager\\.js$', // server/lib/common/events bus
                     '^ghost/core/core/frontend/services/sitemap/site-map-manager\\.js$' // server/lib/common/events bus
                 ]

--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -64,10 +64,7 @@ module.exports = {
                     '^ghost/core/core/frontend/web/middleware/frontend-caching\\.js$',
                     '^ghost/core/core/frontend/web/middleware/handle-image-sizes\\.js$',
                     '^ghost/core/core/frontend/web/routers/link-redirects\\.js$',
-                    '^ghost/core/core/frontend/apps/private-blogging/lib/router\\.js$',
-
-                    // Leaks that bypass the proxy (fix first).
-                    '^ghost/core/core/frontend/services/sitemap/site-map-manager\\.js$' // server/lib/common/events bus
+                    '^ghost/core/core/frontend/apps/private-blogging/lib/router\\.js$'
                 ]
             },
             to: {path: '^ghost/core/core/server/'}

--- a/ghost/core/core/frontend/services/proxy.js
+++ b/ghost/core/core/frontend/services/proxy.js
@@ -4,7 +4,14 @@ const config = require('../../shared/config');
 const settingsHelpers = require('../../server/services/settings-helpers');
 const storageUtils = require('../../server/adapters/storage/utils');
 const internalKeys = require('../../server/services/internal-keys').default;
+const serverEventBus = require('../../server/lib/common/events');
+const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
+
+// The only server events the frontend may subscribe to. A narrow surface on
+// purpose: the shared bus's own header discourages widening cross-layer
+// coupling, so new event names here need the same scrutiny as new exports.
+const FRONTEND_SUBSCRIBABLE_EVENTS = ['site.changed', 'url.added', 'url.removed'];
 
 // Require from the handlebars framework
 const {SafeString} = require('./handlebars');
@@ -76,6 +83,19 @@ module.exports = {
 
     // TODO: Expose less of the API to make this safe
     api: require('../../server/api').endpoints,
+
+    // Narrow subscription surface for server events the frontend reacts to
+    serverEvents: {
+        on(eventName, listener) {
+            if (!FRONTEND_SUBSCRIBABLE_EVENTS.includes(eventName)) {
+                throw new errors.IncorrectUsageError({
+                    message: `The frontend may not subscribe to the server event "${eventName}"`,
+                    context: `Allowed events: ${FRONTEND_SUBSCRIBABLE_EVENTS.join(', ')}`
+                });
+            }
+            serverEventBus.on(eventName, listener);
+        }
+    },
 
     // Labs utils for enabling/disabling helpers
     labs: require('../../shared/labs'),

--- a/ghost/core/core/frontend/services/proxy.js
+++ b/ghost/core/core/frontend/services/proxy.js
@@ -62,7 +62,16 @@ module.exports = {
 
     // Settings helpers for calculated settings
     settingsHelpers: {
-        isWebAnalyticsEnabled: settingsHelpers.isWebAnalyticsEnabled.bind(settingsHelpers)
+        isWebAnalyticsEnabled: settingsHelpers.isWebAnalyticsEnabled.bind(settingsHelpers),
+        // Delegates at call time (not bound at load) so tests that stub the
+        // method on the settings-helpers service are still seen through here.
+        getMembersValidationKey: (...args) => settingsHelpers.getMembersValidationKey(...args)
+    },
+
+    // Member actions needed by the frontend's unsubscribe route. Lazy so that
+    // loading the proxy does not pull the members service in ahead of boot.
+    get members() {
+        return require('../../server/services/members');
     },
 
     // TODO: Expose less of the API to make this safe

--- a/ghost/core/core/frontend/services/routing/controllers/unsubscribe.js
+++ b/ghost/core/core/frontend/services/routing/controllers/unsubscribe.js
@@ -1,12 +1,17 @@
 const debug = require('@tryghost/debug')('services:routing:controllers:unsubscribe');
 const url = require('url');
-const {members, settingsHelpers} = require('../../proxy');
+const proxy = require('../../proxy');
+const {settingsHelpers} = proxy;
 const urlUtils = require('../../../../shared/url-utils');
 const logging = require('@tryghost/logging');
 const crypto = require('crypto');
 
 module.exports = async function unsubscribeController(req, res) {
     debug('unsubscribeController');
+
+    // Resolved per-request so requiring this controller never triggers the
+    // proxy's lazy members getter ahead of boot
+    const {members} = proxy;
 
     const {query} = url.parse(req.url, true);
 

--- a/ghost/core/core/frontend/services/routing/controllers/unsubscribe.js
+++ b/ghost/core/core/frontend/services/routing/controllers/unsubscribe.js
@@ -1,9 +1,8 @@
 const debug = require('@tryghost/debug')('services:routing:controllers:unsubscribe');
 const url = require('url');
-const members = require('../../../../server/services/members');
+const {members, settingsHelpers} = require('../../proxy');
 const urlUtils = require('../../../../shared/url-utils');
 const logging = require('@tryghost/logging');
-const settingsHelpers = require('../../../../server/services/settings-helpers');
 const crypto = require('crypto');
 
 module.exports = async function unsubscribeController(req, res) {

--- a/ghost/core/core/frontend/services/routing/events.js
+++ b/ghost/core/core/frontend/services/routing/events.js
@@ -1,0 +1,12 @@
+const EventEmitter = require('events').EventEmitter;
+
+/**
+ * Frontend-internal routing events.
+ *
+ * Carries `router.created` and `routers.reset`, which are emitted by the
+ * router manager and consumed only inside the frontend (the sitemap keeps
+ * its route entries in sync from them). They used to ride the server's
+ * shared event bus purely for historical reasons — nothing server-side
+ * listens to them.
+ */
+module.exports = new EventEmitter();

--- a/ghost/core/core/frontend/services/routing/router-manager.js
+++ b/ghost/core/core/frontend/services/routing/router-manager.js
@@ -9,8 +9,8 @@ const ParentRouter = require('./parent-router');
 const EmailRouter = require('./email-router');
 const UnsubscribeRouter = require('./unsubscribe-router');
 
-// This emits its own routing events
-const events = require('../../../server/lib/common/events');
+// Frontend-internal routing events (router.created / routers.reset)
+const routingEvents = require('./events');
 
 class RouterManager {
     constructor({registry}) {
@@ -31,9 +31,7 @@ class RouterManager {
     }
 
     routerCreated(router) {
-        // NOTE: this event should be become an "internal frontend even"
-        //       and should not be consumed by the modules outside the frontend
-        events.emit('router.created', router);
+        routingEvents.emit('router.created', router);
 
         // CASE: there are router types which do not generate resource urls
         //       e.g. static route router, in this case we don't want ot notify the URL service
@@ -68,9 +66,7 @@ class RouterManager {
         this.registry.resetAllRouters();
         this.registry.resetAllRoutes();
 
-        // NOTE: this event could become an "internal frontend" in the future, it's used has been kept to prevent
-        //       from tying up this module with sitemaps
-        events.emit('routers.reset');
+        routingEvents.emit('routers.reset');
 
         this.siteRouter = new ParentRouter('SiteRouter');
         this.registry.setRouter('siteRouter', this.siteRouter);

--- a/ghost/core/core/frontend/services/sitemap/site-map-manager.js
+++ b/ghost/core/core/frontend/services/sitemap/site-map-manager.js
@@ -10,8 +10,6 @@ const TagsMapGenerator = require('./tags-map-generator');
 
 // Frontend-internal routing events (router.created / routers.reset)
 const routingEvents = require('../routing/events');
-// Server events: url.added / url.removed from the URL service, site.changed
-const events = require('../../../server/lib/common/events');
 
 // What the sitemap XML reads off each resource, beyond the columns URL
 // computation needs: lastmod dates, image nodes, and the canonical_url skip
@@ -43,6 +41,12 @@ class SiteMapManager {
         // url service loads at require time and loading it when this module
         // loads would change boot order.
         this._urlService = options.urlService || null;
+
+        // Server events arrive through the proxy's narrow subscription
+        // surface (site.changed, url.added, url.removed). Injectable for
+        // tests; resolved at construction (not module load) for the same
+        // boot-order reason as the url service above.
+        this._serverEvents = options.serverEvents || require('../proxy').serverEvents;
 
         // Index state for the build path. _indexEpoch increments on every
         // invalidation signal; a build compares the epoch it started with so
@@ -78,7 +82,7 @@ class SiteMapManager {
         // current after the initial build, exactly as before this change —
         // deploying is a no-op until the lazy flip. Pure lazy fires no
         // events, so there the index empties and the next read rebuilds.
-        events.on('site.changed', () => {
+        this._serverEvents.on('site.changed', () => {
             if (this._getUrlService().isLazy()) {
                 this._invalidateIndex();
             }
@@ -90,11 +94,11 @@ class SiteMapManager {
             this[event.data.resourceType].updateURL(event.data);
         });
 
-        events.on('url.added', (obj) => {
+        this._serverEvents.on('url.added', (obj) => {
             this[obj.resource.config.type].addUrl(obj.url.absolute, obj.resource.data);
         });
 
-        events.on('url.removed', (obj) => {
+        this._serverEvents.on('url.removed', (obj) => {
             this[obj.resource.config.type].removeUrl(obj.url.absolute, obj.resource.data);
         });
 

--- a/ghost/core/core/frontend/services/sitemap/site-map-manager.js
+++ b/ghost/core/core/frontend/services/sitemap/site-map-manager.js
@@ -8,7 +8,9 @@ const PostsMapGenerator = require('./post-map-generator');
 const UsersMapGenerator = require('./user-map-generator');
 const TagsMapGenerator = require('./tags-map-generator');
 
-// This uses events from the routing service and the URL service
+// Frontend-internal routing events (router.created / routers.reset)
+const routingEvents = require('../routing/events');
+// Server events: url.added / url.removed from the URL service, site.changed
 const events = require('../../../server/lib/common/events');
 
 // What the sitemap XML reads off each resource, beyond the columns URL
@@ -53,7 +55,7 @@ class SiteMapManager {
         // every rebuild can replay them after resetting the generators.
         this._routerEntries = [];
 
-        events.on('router.created', (router) => {
+        routingEvents.on('router.created', (router) => {
             if (router.name !== 'StaticRoutesRouter' && router.name !== 'CollectionRouter') {
                 return;
             }
@@ -96,7 +98,7 @@ class SiteMapManager {
             this[obj.resource.config.type].removeUrl(obj.url.absolute, obj.resource.data);
         });
 
-        events.on('routers.reset', () => {
+        routingEvents.on('routers.reset', () => {
             this.pages && this.pages.reset();
             this.posts && this.posts.reset();
             this.users && this.users.reset();

--- a/ghost/core/test/unit/frontend/services/proxy.test.js
+++ b/ghost/core/test/unit/frontend/services/proxy.test.js
@@ -1,0 +1,35 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+
+const proxy = require('../../../../core/frontend/services/proxy');
+const serverEventBus = require('../../../../core/server/lib/common/events');
+
+describe('Proxy: serverEvents', function () {
+    let busOnStub;
+
+    beforeEach(function () {
+        busOnStub = sinon.stub(serverEventBus, 'on');
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    ['site.changed', 'url.added', 'url.removed'].forEach(function (eventName) {
+        it(`subscribes a listener to the permitted "${eventName}" event`, function () {
+            const listener = () => {};
+
+            proxy.serverEvents.on(eventName, listener);
+
+            sinon.assert.calledOnceWithExactly(busOnStub, eventName, listener);
+        });
+    });
+
+    it('throws an IncorrectUsageError for any other event and registers nothing', function () {
+        assert.throws(() => {
+            proxy.serverEvents.on('settings.edited', () => {});
+        }, {errorType: 'IncorrectUsageError'});
+
+        sinon.assert.notCalled(busOnStub);
+    });
+});

--- a/ghost/core/test/unit/frontend/services/sitemap/manager.test.js
+++ b/ghost/core/test/unit/frontend/services/sitemap/manager.test.js
@@ -6,7 +6,6 @@ const {assertExists} = require('../../../../utils/assertions');
 const DomainEvents = require('@tryghost/domain-events');
 const {URLResourceUpdatedEvent} = require('../../../../../core/shared/events');
 
-const events = require('../../../../../core/server/lib/common/events');
 const routingEvents = require('../../../../../core/frontend/services/routing/events');
 const urlUtils = require('../../../../../core/shared/url-utils');
 
@@ -42,6 +41,13 @@ describe('Unit: sitemap/manager', function () {
                 isLazy: () => false,
                 getRoutableResources: async () => [],
                 getUrlForResource: () => '/x/'
+            },
+            // Server events come through the proxy's narrow surface in
+            // production; injected here like the url service
+            serverEvents: {
+                on: (eventName, callback) => {
+                    eventsToRemember[eventName] = callback;
+                }
             }
         });
     };
@@ -51,9 +57,6 @@ describe('Unit: sitemap/manager', function () {
 
         // @NOTE: the pattern of faking event call is not great, we should be
         //        ideally tasting on real events instead of faking them
-        sinon.stub(events, 'on').callsFake(function (eventName, callback) {
-            eventsToRemember[eventName] = callback;
-        });
         // router.created / routers.reset are frontend-internal routing events
         sinon.stub(routingEvents, 'on').callsFake(function (eventName, callback) {
             eventsToRemember[eventName] = callback;
@@ -145,7 +148,12 @@ describe('Unit: sitemap/manager', function () {
                     pages: new PageGenerator(),
                     tags: new TagGenerator(),
                     authors: new UserGenerator(),
-                    urlService
+                    urlService,
+                    serverEvents: {
+                        on: (eventName, callback) => {
+                            eventsToRemember[eventName] = callback;
+                        }
+                    }
                 });
             }
 

--- a/ghost/core/test/unit/frontend/services/sitemap/manager.test.js
+++ b/ghost/core/test/unit/frontend/services/sitemap/manager.test.js
@@ -7,6 +7,7 @@ const DomainEvents = require('@tryghost/domain-events');
 const {URLResourceUpdatedEvent} = require('../../../../../core/shared/events');
 
 const events = require('../../../../../core/server/lib/common/events');
+const routingEvents = require('../../../../../core/frontend/services/routing/events');
 const urlUtils = require('../../../../../core/shared/url-utils');
 
 const SiteMapManager = require('../../../../../core/frontend/services/sitemap/site-map-manager');
@@ -51,6 +52,10 @@ describe('Unit: sitemap/manager', function () {
         // @NOTE: the pattern of faking event call is not great, we should be
         //        ideally tasting on real events instead of faking them
         sinon.stub(events, 'on').callsFake(function (eventName, callback) {
+            eventsToRemember[eventName] = callback;
+        });
+        // router.created / routers.reset are frontend-internal routing events
+        sinon.stub(routingEvents, 'on').callsFake(function (eventName, callback) {
             eventsToRemember[eventName] = callback;
         });
 


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/28420

The frontend/server boundary rule (`pnpm lint:boundaries`) allows frontend code to reach `core/server` only via the proxy. Three services-layer files still bypassed it and sat on the dep-cruiser allowlist: the unsubscribe controller, the router manager, and the sitemap manager. This PR takes all three off the allowlist — one commit each — leaving only the web-layer mount files (`site.js` and friends) as allowlisted crossings.

- the unsubscribe controller now gets `members` and `settingsHelpers` from the proxy
- `router.created` / `routers.reset` move to a frontend-local emitter (`services/routing/events.js`) — they are emitted and consumed only inside the frontend, as the in-code NOTEs have suggested for years
- the sitemap subscribes to `site.changed` / `url.added` / `url.removed` through a deliberately narrow `serverEvents` surface on the proxy that permits only those three events and throws on anything else

This is transitional, not the end state. The proxy grows here on purpose: consolidating every crossing into the one seam is the setup for inverting that seam into injected dependencies (the direction agreed in #28420), at which point the lazy `members` getter and the call-time delegation shims disappear with it. No behavior changes — no new events, routes or settings, and boot order is unchanged.

For anyone on the routes.yaml / lazy-routing work: the router-manager change only swaps which emitter carries two frontend-internal events. Route settings handling, router construction order and the URL service interaction are untouched, so this should not collide with anything in flight there.