### PR TITLE
Changed the members CSV importer to only write a file for queued imports

### DIFF
--- a/ghost/core/core/server/services/members/importer/members-csv-importer.js
+++ b/ghost/core/core/server/services/members/importer/members-csv-importer.js
@@ -1,6 +1,8 @@
-const moment = require('moment-timezone');
+const os = require('os');
 const path = require('path');
 const fs = require('fs-extra');
+const crypto = require('crypto');
+const moment = require('moment-timezone');
 const metrics = require('@tryghost/metrics');
 const membersCSV = require('@tryghost/members-csv');
 const errors = require('@tryghost/errors');
@@ -9,7 +11,6 @@ const emailTemplate = require('./email-template');
 const logging = require('@tryghost/logging');
 
 const messages = {
-    filenameCollision: 'Filename already exists, please try again.',
     freeMemberNotAllowedImportTier: 'You cannot import a free member with a specified tier.',
     invalidImportTier: '"{tier}" is not a valid tier.',
     giftServiceUnavailable: 'Gift service is not available.',
@@ -25,8 +26,9 @@ function wrapGiftError(error) {
     });
 }
 
-// The key should correspond to a member model field (unless it's a special purpose field like 'complimentary_plan')
-// the value should represent an allowed field name coming from user input
+// Keys are the column names a publisher sees and maps onto; values are the field
+// names the import itself reads. They differ for `subscribed_to_emails`, which the
+// member model calls `subscribed`.
 const DEFAULT_CSV_HEADER_MAPPING = {
     email: 'email',
     name: 'name',
@@ -42,28 +44,82 @@ const DEFAULT_CSV_HEADER_MAPPING = {
 
 /**
  * @typedef {Object} MembersCSVImporterOptions
- * @property {string} storagePath - The path to store CSV's in before importing
- * @property {Function} getTimezone - function returning currently configured timezone
  * @property {() => Object} getMembersRepository - member model access instance for data access and manipulation
  * @property {() => Promise<import('../../tiers/tier')>} getDefaultTier - async function returning default Member Tier
  * @property {(string) => Promise<import('../../tiers/tier')>} getTierByName - async function returning Member Tier by name
  * @property {() => Promise<import('../../gifts/gift-service').GiftService>} getGiftService - async function returning the GiftService instance
  * @property {Function} sendEmail - function sending an email
  * @property {(string) => boolean} isSet - Method checking if specific feature is enabled
- * @property {({job, offloaded, name}) => void} addJob - Method registering an async job
+ * @property {({job, data, offloaded, name}) => void} addJob - Method registering an async job
  * @property {Object} knex - An instance of the Ghost Database connection
  * @property {Function} urlFor - function generating urls
  * @property {Object} context
  * @property {Object} stripeUtils - An instance of MembersCSVImporterStripeUtils
  */
 
+/**
+ * Resolves a caller's header mapping onto the member model's own field names.
+ *
+ * Has to happen before parsing rather than after: the parser picks a value's type
+ * from the name it lands on, so a blank `subscribed` reads as subscribed while a
+ * blank anything-else reads as null.
+ *
+ * A field the model doesn't know is carried through untouched, which is what lets
+ * columns outside this fixed set reach the import.
+ *
+ * Two columns can name one field: "subscribed_to_emails" and "subscribed" are the
+ * same one. First claim wins. Left alone the parser takes whichever column came
+ * last, so an ambiguous mapping would flip a member's subscription on column order.
+ *
+ * @param {Object.<string, string>} headerMapping
+ * @returns {Object.<string, string>}
+ */
+function composeHeaderMapping(headerMapping) {
+    const modelFieldMapping = {};
+    const claimedFields = new Set();
+
+    for (const [csvHeader, field] of Object.entries(headerMapping)) {
+        // Own-property check, so a field named after something on Object.prototype
+        // resolves to itself rather than to the prototype.
+        const modelField = Object.hasOwn(DEFAULT_CSV_HEADER_MAPPING, field) ? DEFAULT_CSV_HEADER_MAPPING[field] : field;
+
+        if (claimedFields.has(modelField)) {
+            continue;
+        }
+
+        claimedFields.add(modelField);
+        modelFieldMapping[csvHeader] = modelField;
+    }
+
+    return modelFieldMapping;
+}
+
+/**
+ * Turns one parsed CSV row into the row an import applies.
+ *
+ * `__parsed_extra` holds a ragged row's overflow fields: a parser artifact rather
+ * than a column anyone mapped, so it does not travel with the row.
+ *
+ * Labels are copied because the member model stamps ids and trims names onto them
+ * in place, while each row runs in its own transaction that can roll back. Rows
+ * sharing label objects would carry one row's mutations into the next.
+ *
+ * @param {Object} parsedRow
+ * @returns {Object}
+ */
+// eslint-disable-next-line no-unused-vars, camelcase
+function toImportRow({__parsed_extra, ...row}) {
+    return {
+        ...row,
+        labels: row.labels.map(label => (typeof label === 'string' ? {name: label} : {...label}))
+    };
+}
+
 module.exports = class MembersCSVImporter {
     /**
      * @param {MembersCSVImporterOptions} options
      */
-    constructor({storagePath, getTimezone, getMembersRepository, getDefaultTier, getTierByName, getGiftService, sendEmail, isSet, addJob, knex, urlFor, context, stripeUtils}) {
-        this._storagePath = storagePath;
-        this._getTimezone = getTimezone;
+    constructor({getMembersRepository, getDefaultTier, getTierByName, getGiftService, sendEmail, isSet, addJob, knex, urlFor, context, stripeUtils}) {
         this._getMembersRepository = getMembersRepository;
         this._getDefaultTier = getDefaultTier;
         this._getTierByName = getTierByName;
@@ -79,49 +135,31 @@ module.exports = class MembersCSVImporter {
     }
 
     /**
-     * Prepares a CSV file for import
+     * Reads a CSV file into the rows an import will apply
      * - Maps headers based on headerMapping, this allows for a non standard CSV
      *   to be imported, so long as a mapping exists between it and a standard CSV
-     * - Stores the CSV to be imported in the storagePath
-     * - Creates a MemberImport Job and associated MemberImportBatch's
      *
      * @param {string} inputFilePath - The path to the CSV to prepare
      * @param {Object.<string, string>} [headerMapping] - An object whose keys are headers in the input CSV and values are the header to replace it with
-     * @param {Array<string>} [defaultLabels] - A list of labels to apply to every member
+     * @param {Array<string|{name: string}>} [defaultLabels] - A list of labels to apply to every member
      *
-     * @returns {Promise<{filePath: string, batches: number, metadata: Object.<string, any>}>} - A promise resolving to the data including filePath of "prepared" CSV
+     * @returns {Promise<{rows: Array<Object>, metadata: Object.<string, any>}>} - A promise resolving to the parsed rows and what the caller needs to know about them
      */
     async prepare(inputFilePath, headerMapping, defaultLabels) {
-        headerMapping = headerMapping || DEFAULT_CSV_HEADER_MAPPING;
-        // @NOTE: investigate why is it "1" and do we even need this concept anymore?
-        const batchSize = 1;
+        const parsed = await membersCSV.parse(
+            inputFilePath,
+            composeHeaderMapping(headerMapping || DEFAULT_CSV_HEADER_MAPPING),
+            defaultLabels
+        );
 
-        const siteTimezone = this._getTimezone();
-        const currentTime = moment().tz(siteTimezone).format('YYYY-MM-DD HH:mm:ss.SSS');
-        const outputFileName = `Members Import ${currentTime}.csv`;
-        const outputFilePath = path.join(this._storagePath, '/', outputFileName);
-
-        const pathExists = await fs.pathExists(outputFilePath);
-
-        if (pathExists) {
-            throw new errors.DataImportError({message: tpl(messages.filenameCollision)});
-        }
-
-        // completely rely on explicit user input for header mappings
-        const rows = await membersCSV.parse(inputFilePath, headerMapping, defaultLabels);
-        const columns = Object.keys(rows[0]);
-        const numberOfBatches = Math.ceil(rows.length / batchSize);
-        const mappedCSV = membersCSV.unparse(rows, columns);
+        const rows = parsed.map(toImportRow);
 
         const hasStripeData = !!(rows.find(function rowHasStripeData(row) {
             return !!row.stripe_customer_id;
         }));
 
-        await fs.writeFile(outputFilePath, mappedCSV);
-
         return {
-            filePath: outputFilePath,
-            batches: numberOfBatches,
+            rows,
             metadata: {
                 hasStripeData
             }
@@ -129,13 +167,43 @@ module.exports = class MembersCSVImporter {
     }
 
     /**
-     * Performs an import of a CSV file
+     * Writes rows where a queued job can read them back.
      *
-     * @param {string} filePath - the path to a "prepared" CSV file
+     * Only the queued path needs this: an inline import finishes inside the request
+     * that started it, but a queued one outlives the request, and the uploaded CSV it
+     * came from is deleted the moment the response finishes.
+     *
+     * The temp directory is enough: the spool does not need to outlive the queue,
+     * which is in-process. A crash between spooling and running orphans the file,
+     * bounded by whatever reaps the temp directory.
+     *
+     * @param {Array<Object>} rows
+     * @returns {Promise<string>} path to the spooled rows
      */
-    async perform(filePath) {
+    async spoolRows(rows) {
+        const spoolPath = path.join(os.tmpdir(), `members-import-${crypto.randomUUID()}.json`);
+
+        // Member PII, in a directory shared with every other process on the host
+        await fs.writeFile(spoolPath, JSON.stringify(rows), {mode: 0o600});
+
+        return spoolPath;
+    }
+
+    /**
+     * @param {string} spoolPath - a path returned by spoolRows()
+     * @returns {Promise<Array<Object>>}
+     */
+    async readSpooledRows(spoolPath) {
+        return JSON.parse(await fs.readFile(spoolPath, 'utf8'));
+    }
+
+    /**
+     * Performs an import of already-parsed CSV rows
+     *
+     * @param {Array<Object>} rows - the rows returned by prepare()
+     */
+    async perform(rows) {
         const performStart = Date.now();
-        const rows = await membersCSV.parse(filePath, DEFAULT_CSV_HEADER_MAPPING);
 
         const defaultTier = await this._getDefaultTier();
         const membersRepository = await this._getMembersRepository();
@@ -421,10 +489,10 @@ module.exports = class MembersCSVImporter {
         const meta = {};
         const job = await this.prepare(pathToCSV, headerMapping, globalLabels);
 
-        meta.originalImportSize = job.batches;
+        meta.originalImportSize = job.rows.length;
 
-        if ((job.batches <= 500 && !job.metadata.hasStripeData) || forceInline) {
-            const result = await this.perform(job.filePath);
+        if ((job.rows.length <= 500 && !job.metadata.hasStripeData) || forceInline) {
+            const result = await this.perform(job.rows);
             const importLabelModel = result.imported ? await LabelModel.findOne(importLabel) : null;
             await verificationTrigger.testImportThreshold();
 
@@ -438,45 +506,90 @@ module.exports = class MembersCSVImporter {
                 })
             };
         } else {
-            const emailRecipient = user.email;
-            this._addJob({
-                job: async () => {
-                    try {
-                        const result = await this.perform(job.filePath);
-                        const importLabelModel = result.imported ? await LabelModel.findOne(importLabel) : null;
-                        const emailContent = this.generateCompletionEmail(result, {
-                            emailRecipient,
-                            importLabel: importLabelModel ? importLabelModel.toJSON() : null
-                        });
-                        const errorCSV = this.generateErrorCSV(result);
-                        const emailSubject = result.imported > 0 ? 'Your member import is complete' : 'Your member import was unsuccessful';
-                        await this.sendErrorEmail({
-                            emailRecipient,
-                            emailSubject,
-                            emailContent,
-                            errorCSV,
-                            importLabel
-                        });
-                    } catch (e) {
-                        logging.error('Error in members import job');
-                        logging.error(e);
-                    }
+            const spoolPath = await this.spoolRows(job.rows);
+            const data = {spoolPath, emailRecipient: user.email, importLabel};
 
-                    // Still check verification triggers in case of errors (e.g., email sending failed)
-                    try {
-                        await verificationTrigger.testImportThreshold();
-                    } catch (e) {
-                        logging.error('Error in members import job when testing import threshold');
-                        logging.error(e);
-                    }
-                },
-                offloaded: false,
-                name: 'members-import'
-            });
+            try {
+                this._addJob({
+                    // Plain data and live collaborators kept apart, so a queue that
+                    // stores its jobs has a payload it can store. Nothing crosses a
+                    // process boundary yet.
+                    job: jobData => this.runImportJob(jobData, {LabelModel, verificationTrigger}),
+                    data,
+                    offloaded: false,
+                    name: 'members-import'
+                });
+            } catch (err) {
+                // The in-process queue only schedules, so this guards an enqueue that
+                // can fail: nothing owns the spool until a job exists to own it.
+                await fs.remove(spoolPath).catch(() => {});
+                throw err;
+            }
+
+            logging.info({
+                event: {name: 'members.import.queued'},
+                rowCount: job.rows.length,
+                importLabel: importLabel && importLabel.name
+            }, 'Queued a members import');
 
             return {
                 meta
             };
+        }
+    }
+
+    /**
+     * Runs a queued import and emails the result to whoever started it.
+     *
+     * @param {{spoolPath: string, emailRecipient: string, importLabel: Object}} data - plain data, everything a persisted queue would need to store
+     * @param {{LabelModel: Object, verificationTrigger: Object}} deps - live collaborators, resolved by the caller
+     */
+    async runImportJob({spoolPath, emailRecipient, importLabel}, {LabelModel, verificationTrigger}) {
+        try {
+            const rows = await this.readSpooledRows(spoolPath);
+            const result = await this.perform(rows);
+            const importLabelModel = result.imported ? await LabelModel.findOne(importLabel) : null;
+            const emailContent = this.generateCompletionEmail(result, {
+                emailRecipient,
+                importLabel: importLabelModel ? importLabelModel.toJSON() : null
+            });
+            const errorCSV = this.generateErrorCSV(result);
+            const emailSubject = result.imported > 0 ? 'Your member import is complete' : 'Your member import was unsuccessful';
+            await this.sendErrorEmail({
+                emailRecipient,
+                emailSubject,
+                emailContent,
+                errorCSV,
+                importLabel
+            });
+
+            logging.info({
+                event: {name: 'members.import.completed'},
+                imported: result.imported,
+                errors: result.errors.length,
+                importLabel: importLabel && importLabel.name
+            }, 'Completed a members import');
+        } catch (err) {
+            logging.error({
+                event: {name: 'members.import.failed'},
+                emailRecipient,
+                importLabel: importLabel && importLabel.name,
+                err
+            }, 'Members import job failed');
+        } finally {
+            // Including on failure: the publisher still has the file they uploaded,
+            // so keeping their member data here buys nothing.
+            await fs.remove(spoolPath).catch((err) => {
+                logging.error({event: {name: 'members.import.spool_cleanup_failed'}, spoolPath, err}, 'Failed to remove a members import spool');
+            });
+        }
+
+        // Still check verification triggers in case of errors (e.g., email sending failed)
+        try {
+            await verificationTrigger.testImportThreshold();
+        } catch (e) {
+            logging.error('Error in members import job when testing import threshold');
+            logging.error(e);
         }
     }
 

--- a/ghost/core/core/server/services/members/service.js
+++ b/ghost/core/core/server/services/members/service.js
@@ -48,8 +48,6 @@ let verificationTrigger;
 
 const initMembersCSVImporter = ({stripeAPIService}) => {
     return makeMembersCSVImporter({
-        storagePath: config.getContentPath('data'),
-        getTimezone: () => settingsCache.get('timezone'),
         getMembersRepository: async () => {
             const api = await module.exports.api;
             return api.members;

--- a/ghost/core/test/e2e-api/admin/members-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/members-importer.test.js
@@ -324,4 +324,47 @@ describe('Members Importer API', function () {
 
         assert.equal(res.body.errors[0].message, 'Please select a members CSV file.');
     });
+
+    // The admin import UI maps onto the column names a publisher sees, and
+    // "subscribed_to_emails" is not the member model's field name for it. Nothing at
+    // this layer covered a mapping onto it, so a rename lost in the pipeline would
+    // silently unsubscribe every imported member.
+    it('Can import CSV with a column mapped to subscribed_to_emails', async function () {
+        const res = await request
+            .post(localUtils.API.getApiQuery(`members/upload/`))
+            .field('mapping[correo_electronico]', 'email')
+            .field('mapping[boletin]', 'subscribed_to_emails')
+            .attach('membersfile', path.join(__dirname, '/../../utils/fixtures/csv/members-mapped-subscribed.csv'))
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .expect(201);
+
+        assert.equal(res.body.meta.stats.imported, 2);
+
+        const browse = await request
+            .get(localUtils.API.getApiQuery('members/?search=mapped_sub&include=newsletters'))
+            .set('Origin', config.get('url'))
+            .expect(200);
+
+        const subscribed = browse.body.members.find(m => m.email === 'member+mapped_sub_1@example.com');
+        const unsubscribed = browse.body.members.find(m => m.email === 'member+mapped_sub_2@example.com');
+
+        assertExists(subscribed);
+        assertExists(unsubscribed);
+        assert.ok(subscribed.newsletters.length > 0, 'a member mapped to true should be subscribed');
+        assert.equal(unsubscribed.newsletters.length, 0);
+    });
+
+    it('Can handle a CSV with headers but no rows', async function () {
+        const res = await request
+            .post(localUtils.API.getApiQuery(`members/upload/`))
+            .attach('membersfile', path.join(__dirname, '/../../utils/fixtures/csv/members-headers-only.csv'))
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(201);
+
+        assert.equal(res.body.meta.stats.imported, 0);
+        assert.equal(res.body.meta.stats.invalid.length, 0);
+    });
 });

--- a/ghost/core/test/legacy/api/admin/members-importer.test.js
+++ b/ghost/core/test/legacy/api/admin/members-importer.test.js
@@ -345,4 +345,37 @@ describe('Members Importer API', function () {
             await restoreEmailVerificationUtils();
         }
     });
+
+    // A queued import is applied after the response has gone out, so the response says
+    // nothing about whether the members arrived. This waits for the outcome rather than
+    // for the queue, so it stays honest if how the work is deferred ever changes.
+    it('Creates the members when a queued import runs', async function () {
+        const countMembersLabelled = async (label) => {
+            const res = await request
+                .get(localUtils.API.getApiQuery(`members/?filter=label:${label}&limit=1`))
+                .set('Origin', config.get('url'))
+                .expect(200);
+
+            return res.body.meta.pagination.total;
+        };
+
+        await request
+            .post(localUtils.API.getApiQuery(`members/upload/`))
+            .field('labels', ['queued-import-check'])
+            .attach('membersfile', path.join(__dirname, '/../../../utils/fixtures/csv/valid-members-import-large-501.csv'))
+            .set('Origin', config.get('url'))
+            .expect(202);
+
+        const deadline = Date.now() + 30000;
+        let total = await countMembersLabelled('queued-import-check');
+
+        while (total < 501 && Date.now() < deadline) {
+            await new Promise((resolve) => {
+                setTimeout(resolve, 250);
+            });
+            total = await countMembersLabelled('queued-import-check');
+        }
+
+        assert.equal(total, 501, 'every row in the queued import should reach the members table');
+    });
 });

--- a/ghost/core/test/unit/server/services/members/importer/fixtures/duplicate-subscribed-target.csv
+++ b/ghost/core/test/unit/server/services/members/importer/fixtures/duplicate-subscribed-target.csv
@@ -1,0 +1,2 @@
+email,first,second
+jbloggs@example.com,false,true

--- a/ghost/core/test/unit/server/services/members/importer/fixtures/ragged-row.csv
+++ b/ghost/core/test/unit/server/services/members/importer/fixtures/ragged-row.csv
@@ -1,0 +1,2 @@
+email,name
+ragged@example.com,Al,SECRET-EXTRA,MORE

--- a/ghost/core/test/unit/server/services/members/importer/fixtures/unmapped-column.csv
+++ b/ghost/core/test/unit/server/services/members/importer/fixtures/unmapped-column.csv
@@ -1,0 +1,2 @@
+email,favourite_colour
+jbloggs@example.com,blue

--- a/ghost/core/test/unit/server/services/members/importer/members-csv-importer.test.js
+++ b/ghost/core/test/unit/server/services/members/importer/members-csv-importer.test.js
@@ -2,20 +2,22 @@ const Tier = require('../../../../../../core/server/services/tiers/tier');
 const ObjectID = require('bson-objectid').default;
 const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../../utils/assertions');
-const fs = require('fs-extra');
+const os = require('os');
 const path = require('path');
+const crypto = require('crypto');
+const fs = require('fs-extra');
 const sinon = require('sinon');
 const MembersCSVImporter = require('../../../../../../core/server/services/members/importer/members-csv-importer');
 
 const csvPath = path.join(__dirname, '/fixtures/');
 
 describe('MembersCSVImporter', function () {
-    let fsWriteSpy;
     let memberCreateStub;
     let knexStub;
     let sendEmailStub;
     let membersRepositoryStub;
     let stripeUtilsStub;
+    let addJobStub;
     let defaultTierId;
 
     const defaultAllowedFields = {
@@ -30,19 +32,14 @@ describe('MembersCSVImporter', function () {
         import_tier: 'import_tier'
     };
 
-    beforeEach(function () {
-        fsWriteSpy = sinon.spy(fs, 'writeFile');
-    });
-
     afterEach(function () {
-        const writtenFile = fsWriteSpy.args?.[0]?.[0];
-
-        if (writtenFile) {
-            fs.removeSync(writtenFile);
-        }
-
         sinon.restore();
     });
+
+    const rowsFor = async (importer, filename) => {
+        const {rows} = await importer.prepare(`${csvPath}/${filename}`);
+        return rows;
+    };
 
     const buildMockImporterInstance = (deps = {}) => {
         defaultTierId = new ObjectID();
@@ -70,14 +67,13 @@ describe('MembersCSVImporter', function () {
             transaction: sinon.stub().resolves(trxStub)
         };
         sendEmailStub = sinon.stub();
+        addJobStub = sinon.stub();
         stripeUtilsStub = {
             forceStripeSubscriptionToProduct: sinon.stub().resolves({}),
             archivePrice: sinon.stub().resolves()
         };
 
         return new MembersCSVImporter({
-            storagePath: csvPath,
-            getTimezone: sinon.stub().returns('UTC'),
             getMembersRepository: () => {
                 return membersRepositoryStub;
             },
@@ -86,14 +82,311 @@ describe('MembersCSVImporter', function () {
             },
             sendEmail: sendEmailStub,
             isSet: sinon.stub(),
-            addJob: sinon.stub(),
+            addJob: addJobStub,
             knex: knexStub,
-            urlFor: sinon.stub(),
+            // The completion email builds URLs from this, so it has to return one
+            urlFor: sinon.stub().returns('https://example.com/'),
             context: {importer: true},
             stripeUtils: stripeUtilsStub,
             ...deps
         });
     };
+
+    // The queued path is the only one that writes anything to disk: an inline import
+    // finishes inside the request, a queued one outlives it and the uploaded CSV is
+    // gone by then.
+    describe('process (queued)', function () {
+        let testImportThresholdStub;
+
+        const queue = async (importer, overrides = {}) => {
+            const spoolRows = sinon.spy(importer, 'spoolRows');
+            testImportThresholdStub = sinon.stub().resolves();
+
+            const result = await importer.process({
+                pathToCSV: `${csvPath}/member-csv-export.csv`,
+                headerMapping: defaultAllowedFields,
+                importLabel: {name: 'Test Import'},
+                user: {email: 'importer@example.com'},
+                LabelModel: {findOne: sinon.stub().resolves({name: 'Test Import', toJSON: () => ({name: 'Test Import'})})},
+                verificationTrigger: {testImportThreshold: testImportThresholdStub},
+                ...overrides
+            });
+
+            const {job, data} = addJobStub.firstCall.args[0];
+
+            return {
+                result,
+                data,
+                spoolPath: await spoolRows.firstCall.returnValue,
+                runJob: () => job(data)
+            };
+        };
+
+        it('queues a job rather than importing in the request', async function () {
+            const importer = buildMockImporterInstance();
+
+            const {result, spoolPath} = await queue(importer);
+
+            try {
+                sinon.assert.calledOnce(addJobStub);
+                assert.equal(addJobStub.firstCall.args[0].name, 'members-import');
+                assert.equal(result.meta.stats, undefined, 'a queued import has no stats to report yet');
+                assert.equal(result.meta.originalImportSize, 2);
+                sinon.assert.notCalled(membersRepositoryStub.create);
+            } finally {
+                await fs.remove(spoolPath);
+            }
+        });
+
+        // Everything the job needs to run has to be plain data, so that a queue which
+        // stores its jobs has something it can store.
+        it('carries the job everything it needs as plain data', async function () {
+            const importer = buildMockImporterInstance();
+
+            const {data, spoolPath} = await queue(importer);
+
+            try {
+                assert.deepEqual(data, {
+                    spoolPath,
+                    emailRecipient: 'importer@example.com',
+                    importLabel: {name: 'Test Import'}
+                });
+                assert.deepEqual(JSON.parse(JSON.stringify(data)), data, 'the payload must survive serialisation');
+            } finally {
+                await fs.remove(spoolPath);
+            }
+        });
+
+        it('spools the parsed rows for the job to read back', async function () {
+            const importer = buildMockImporterInstance();
+
+            const {spoolPath} = await queue(importer);
+
+            try {
+                assert.equal(await fs.pathExists(spoolPath), true);
+                const spooled = await importer.readSpooledRows(spoolPath);
+                assert.equal(spooled.length, 2);
+                assert.equal(spooled[0].email, 'member_complimentary_test@example.com');
+            } finally {
+                await fs.remove(spoolPath);
+            }
+        });
+
+        it('imports the spooled rows when the job runs, then removes the spool', async function () {
+            const importer = buildMockImporterInstance();
+
+            const {spoolPath, runJob} = await queue(importer);
+            await runJob();
+
+            sinon.assert.calledTwice(membersRepositoryStub.create);
+            assert.equal(await fs.pathExists(spoolPath), false, 'the job owns the spool and cleans it up');
+        });
+
+        it('emails the result to whoever started the import', async function () {
+            const importer = buildMockImporterInstance();
+
+            const {runJob} = await queue(importer);
+            await runJob();
+
+            sinon.assert.calledOnce(sendEmailStub);
+            const email = sendEmailStub.firstCall.args[0];
+            assert.equal(email.to, 'importer@example.com');
+            assert.equal(email.subject, 'Your member import is complete');
+            assert.equal(email.attachments[0].filename, 'Test Import - Errors.csv');
+        });
+
+        it('reports an import that created nobody as unsuccessful', async function () {
+            const importer = buildMockImporterInstance();
+            const {runJob} = await queue(importer);
+
+            sinon.stub(importer, 'perform').resolves({total: 2, imported: 0, errors: []});
+
+            await runJob();
+
+            assert.equal(sendEmailStub.firstCall.args[0].subject, 'Your member import was unsuccessful');
+        });
+
+        // The threshold is the anti-spam control on bulk member creation, and the
+        // queued path is the one where nobody is watching the response.
+        it('checks the import threshold once the job has run', async function () {
+            const importer = buildMockImporterInstance();
+
+            const {runJob} = await queue(importer);
+            await runJob();
+
+            sinon.assert.calledOnce(testImportThresholdStub);
+        });
+
+        it('checks the import threshold even when the import throws', async function () {
+            const importer = buildMockImporterInstance();
+            const {spoolPath, runJob} = await queue(importer);
+
+            sinon.stub(importer, 'perform').rejects(new Error('boom'));
+
+            await runJob();
+
+            sinon.assert.calledOnce(testImportThresholdStub);
+            await fs.remove(spoolPath);
+        });
+
+        it('removes the spool when the import throws', async function () {
+            const importer = buildMockImporterInstance();
+            const {spoolPath, runJob} = await queue(importer);
+
+            sinon.stub(importer, 'perform').rejects(new Error('boom'));
+
+            await runJob();
+
+            assert.equal(await fs.pathExists(spoolPath), false, 'a failed import must not leave member data behind');
+        });
+
+        it('does not leave a spool behind if the job could not be queued', async function () {
+            const importer = buildMockImporterInstance();
+            const spoolRows = sinon.spy(importer, 'spoolRows');
+            addJobStub.throws(new Error('queue is down'));
+
+            await assert.rejects(() => importer.process({
+                pathToCSV: `${csvPath}/member-csv-export.csv`,
+                headerMapping: defaultAllowedFields,
+                importLabel: {name: 'Test Import'},
+                user: {email: 'importer@example.com'},
+                LabelModel: {findOne: sinon.stub()},
+                verificationTrigger: {testImportThreshold: sinon.stub()}
+            }));
+
+            const spoolPath = await spoolRows.firstCall.returnValue;
+            assert.equal(await fs.pathExists(spoolPath), false, 'nothing owns the spool if the job never existed');
+        });
+    });
+
+    // Which side of this an import lands on decides whether the publisher gets their
+    // result in the response or by email, so the boundary is worth pinning.
+    describe('the inline and queued boundary', function () {
+        const csvWithRows = async (count) => {
+            const file = path.join(os.tmpdir(), `members-threshold-${crypto.randomUUID()}.csv`);
+            const emails = Array.from({length: count}, (_, i) => `member${i}@example.com`);
+            await fs.writeFile(file, `email\n${emails.join('\n')}\n`);
+            return file;
+        };
+
+        const importOf = async (importer, rowCount) => {
+            const pathToCSV = await csvWithRows(rowCount);
+
+            try {
+                return await importer.process({
+                    pathToCSV,
+                    headerMapping: {email: 'email'},
+                    importLabel: {name: 'Test Import'},
+                    user: {email: 'importer@example.com'},
+                    LabelModel: {findOne: sinon.stub().resolves(null)},
+                    verificationTrigger: {testImportThreshold: sinon.stub().resolves()}
+                });
+            } finally {
+                await fs.remove(pathToCSV);
+            }
+        };
+
+        it('imports 500 rows inside the request', async function () {
+            const importer = buildMockImporterInstance();
+
+            const result = await importOf(importer, 500);
+
+            sinon.assert.notCalled(addJobStub);
+            assert.equal(result.meta.stats.imported, 500);
+        });
+
+        it('queues 501 rows', async function () {
+            const importer = buildMockImporterInstance();
+            const spoolRows = sinon.spy(importer, 'spoolRows');
+
+            const result = await importOf(importer, 501);
+
+            sinon.assert.calledOnce(addJobStub);
+            assert.equal(result.meta.stats, undefined);
+            assert.equal(result.meta.originalImportSize, 501);
+            await fs.remove(await spoolRows.firstCall.returnValue);
+        });
+    });
+
+    describe('inline and queued imports agree', function () {
+        const runFor = async (importer, overrides) => {
+            await importer.process({
+                pathToCSV: `${csvPath}/member-csv-export.csv`,
+                headerMapping: defaultAllowedFields,
+                importLabel: {name: 'Test Import'},
+                user: {email: 'importer@example.com'},
+                LabelModel: {findOne: sinon.stub().resolves({name: 'Test Import', toJSON: () => ({name: 'Test Import'})})},
+                verificationTrigger: {testImportThreshold: sinon.stub().resolves()},
+                ...overrides
+            });
+        };
+
+        // The spool sits between parsing and importing on one path and not the other,
+        // so the two have to end up creating the same member records.
+        it('creates the same member records either way', async function () {
+            const inlineImporter = buildMockImporterInstance();
+            await runFor(inlineImporter, {forceInline: true});
+            const inlineArgs = membersRepositoryStub.create.args.map(([values]) => values);
+
+            const queuedImporter = buildMockImporterInstance();
+            const spoolRows = sinon.spy(queuedImporter, 'spoolRows');
+            await runFor(queuedImporter);
+            const {job, data} = addJobStub.firstCall.args[0];
+            await job(data);
+            const queuedArgs = membersRepositoryStub.create.args.map(([values]) => values);
+
+            assert.deepEqual(queuedArgs, inlineArgs);
+            await fs.remove(await spoolRows.firstCall.returnValue).catch(() => {});
+        });
+    });
+
+    describe('spooled rows', function () {
+        // JSON rather than re-serialised CSV, so a column the member model knows
+        // nothing about still reaches the import that reads it back.
+        it('round-trips a row carrying a column outside the model set', async function () {
+            const importer = buildMockImporterInstance();
+            const rows = [{email: 'a@b.com', subscribed: false, labels: [{name: 'VIP'}], favourite_colour: 'blue'}];
+
+            const spoolPath = await importer.spoolRows(rows);
+            try {
+                assert.deepEqual(await importer.readSpooledRows(spoolPath), rows);
+            } finally {
+                await fs.remove(spoolPath);
+            }
+        });
+
+        // The spool holds member names, emails and Stripe ids in a directory shared
+        // with every other process on the host.
+        it('is readable only by the user that wrote it', async function () {
+            const importer = buildMockImporterInstance();
+
+            const spoolPath = await importer.spoolRows([{email: 'a@b.com'}]);
+
+            try {
+                const {mode} = await fs.stat(spoolPath);
+                assert.equal((mode & 0o777).toString(8), '600');
+            } finally {
+                await fs.remove(spoolPath);
+            }
+        });
+
+        it('does not collide when two imports are spooled at once', async function () {
+            const importer = buildMockImporterInstance();
+
+            const [a, b] = await Promise.all([
+                importer.spoolRows([{email: 'a@b.com'}]),
+                importer.spoolRows([{email: 'b@b.com'}])
+            ]);
+
+            try {
+                assert.notEqual(a, b);
+                assert.deepEqual(await importer.readSpooledRows(a), [{email: 'a@b.com'}]);
+                assert.deepEqual(await importer.readSpooledRows(b), [{email: 'b@b.com'}]);
+            } finally {
+                await Promise.all([fs.remove(a), fs.remove(b)]);
+            }
+        });
+    });
 
     describe('process', function () {
         it('should import a CSV file', async function () {
@@ -128,8 +421,6 @@ describe('MembersCSVImporter', function () {
 
             assertExists(result.meta.originalImportSize);
             assert.equal(result.meta.originalImportSize, 2);
-
-            sinon.assert.calledOnce(fsWriteSpy);
 
             // Called at least once
             assert.equal(memberCreateStub.notCalled, false);
@@ -177,8 +468,6 @@ describe('MembersCSVImporter', function () {
 
             assertExists(result.meta.originalImportSize);
             assert.equal(result.meta.originalImportSize, 2);
-
-            sinon.assert.calledOnce(fsWriteSpy);
 
             // member records get inserted
             sinon.assert.calledTwice(membersRepositoryStub.create);
@@ -323,8 +612,6 @@ describe('MembersCSVImporter', function () {
 
             assertExists(result.meta.originalImportSize);
             assert.equal(result.meta.originalImportSize, 15);
-
-            sinon.assert.calledOnce(fsWriteSpy);
 
             // member records get inserted
             sinon.assert.callCount(membersRepositoryStub.create, 5);
@@ -473,33 +760,126 @@ describe('MembersCSVImporter', function () {
 
             const result = await membersImporter.prepare(`${csvPath}/single-column-with-header.csv`, defaultAllowedFields);
 
-            assertExists(result.filePath);
-            assert.match(result.filePath, /\/members\/importer\/fixtures\/Members Import/);
-
-            assert.equal(result.batches, 2);
+            assert.equal(result.rows.length, 2);
+            assert.equal(result.rows[0].email, 'jbloggs@example.com');
             assertExists(result.metadata);
             assert.equal(result.metadata.hasStripeData, false);
-            sinon.assert.calledOnce(fsWriteSpy);
         });
 
-        it('Does not include columns not in the original CSV or mapped', async function () {
+        it('Drops columns the caller did not map', async function () {
             const membersImporter = buildMockImporterInstance();
 
-            await membersImporter.prepare(`${csvPath}/single-column-with-header.csv`, defaultAllowedFields);
+            const {rows} = await membersImporter.prepare(`${csvPath}/unmapped-column.csv`, defaultAllowedFields);
 
-            const fileContents = fsWriteSpy.firstCall.args[1];
+            assert.deepEqual(Object.keys(rows[0]), ['email', 'labels']);
+        });
 
-            assert.match(fileContents, /^email,labels\r\n/);
+        // Anything the caller does map now reaches the rows, including a name the
+        // member model knows nothing about. That is deliberate — it is how columns
+        // beyond this fixed set will be imported — so the boundary that keeps such a
+        // name away from the member record is worth pinning explicitly.
+        it('Carries a mapped column the model does not know through to the rows', async function () {
+            const membersImporter = buildMockImporterInstance();
+
+            const {rows} = await membersImporter.prepare(`${csvPath}/unmapped-column.csv`, {
+                email: 'email',
+                favourite_colour: 'favourite_colour'
+            });
+
+            assert.equal(rows[0].favourite_colour, 'blue');
+        });
+
+        it('Does not let an unknown mapped column reach the member record', async function () {
+            const importer = buildMockImporterInstance();
+
+            const {rows} = await importer.prepare(`${csvPath}/unmapped-column.csv`, {
+                email: 'email',
+                favourite_colour: 'favourite_colour'
+            });
+            await importer.perform(rows);
+
+            assert.equal(membersRepositoryStub.create.args[0][0].favourite_colour, undefined);
+        });
+
+        // "subscribed_to_emails" and "subscribed" are one model field, so a mapping
+        // naming both leaves one value to be discarded. Left to the parser the winner
+        // is whichever column comes last, which flips a member's subscription on
+        // column order alone.
+        it('Resolves two columns claiming one model field to the first of them', async function () {
+            const membersImporter = buildMockImporterInstance();
+
+            const {rows} = await membersImporter.prepare(`${csvPath}/duplicate-subscribed-target.csv`, {
+                email: 'email',
+                first: 'subscribed',
+                second: 'subscribed_to_emails'
+            });
+
+            assert.equal(rows[0].subscribed, false);
+        });
+
+        it('Does not resolve a mapped field name through Object.prototype', async function () {
+            const membersImporter = buildMockImporterInstance();
+
+            const {rows} = await membersImporter.prepare(`${csvPath}/unmapped-column.csv`, {
+                email: 'email',
+                favourite_colour: 'toString'
+            });
+
+            assert.equal(rows[0].toString, 'blue');
+        });
+
+        // Papaparse collects a ragged row's overflow fields under `__parsed_extra`.
+        // It is a parser artifact, not a column anyone mapped, and it should not be
+        // spooled to disk or carried into the import alongside real values.
+        it('Drops the parser artifact a ragged row produces', async function () {
+            const membersImporter = buildMockImporterInstance();
+
+            const {rows} = await membersImporter.prepare(`${csvPath}/ragged-row.csv`, {
+                email: 'email',
+                name: 'name'
+            });
+
+            assert.deepEqual(Object.keys(rows[0]), ['email', 'name', 'labels']);
+        });
+
+        it('Normalises label names given as plain strings', async function () {
+            const membersImporter = buildMockImporterInstance();
+
+            const {rows} = await membersImporter.prepare(
+                `${csvPath}/unmapped-column.csv`,
+                {email: 'email'},
+                ['VIP']
+            );
+
+            assert.deepEqual(rows[0].labels, [{name: 'VIP'}]);
+        });
+
+        // The member model stamps ids and trims names onto label objects in place, so
+        // rows sharing them would leak one row's mutations into the next.
+        it('Gives every row its own label objects', async function () {
+            const membersImporter = buildMockImporterInstance();
+
+            const {rows} = await membersImporter.prepare(
+                `${csvPath}/single-column-with-header.csv`,
+                defaultAllowedFields,
+                [{name: 'Import 2026-01-01'}]
+            );
+
+            assert.equal(rows.length, 2);
+            assert.notEqual(rows[0].labels, rows[1].labels, 'rows should not share a labels array');
+            assert.notEqual(rows[0].labels[0], rows[1].labels[0], 'rows should not share label objects');
+
+            rows[0].labels[0].id = 'mutated';
+            assert.equal(rows[1].labels[0].id, undefined);
         });
 
         it('It supports "subscribed_to_emails" column header ouf of the box', async function (){
             const membersImporter = buildMockImporterInstance();
 
-            await membersImporter.prepare(`${csvPath}/subscribed-to-emails-header.csv`, defaultAllowedFields);
+            const {rows} = await membersImporter.prepare(`${csvPath}/subscribed-to-emails-header.csv`, defaultAllowedFields);
 
-            const fileContents = fsWriteSpy.firstCall.args[1];
-
-            assert.match(fileContents, /^email,subscribed_to_emails,labels\r\n/);
+            // Lands on the member model's field name, not the column's
+            assert.deepEqual(Object.keys(rows[0]), ['email', 'subscribed', 'labels']);
         });
 
         it('checks for stripe data in the imported file', async function () {
@@ -516,7 +896,7 @@ describe('MembersCSVImporter', function () {
         it('performs import on a single csv file', async function () {
             const importer = buildMockImporterInstance();
 
-            const result = await importer.perform(`${csvPath}/single-column-with-header.csv`);
+            const result = await importer.perform(await rowsFor(importer, 'single-column-with-header.csv'));
 
             assert.equal(membersRepositoryStub.create.args[0][0].email, 'jbloggs@example.com');
             assert.deepEqual(membersRepositoryStub.create.args[0][0].labels, []);
@@ -532,7 +912,7 @@ describe('MembersCSVImporter', function () {
         it('performs import on a csv file  "subscribed_to_emails" column header', async function () {
             const importer = buildMockImporterInstance();
 
-            const result = await importer.perform(`${csvPath}/subscribed-to-emails-header.csv`);
+            const result = await importer.perform(await rowsFor(importer, 'subscribed-to-emails-header.csv'));
 
             assert.equal(membersRepositoryStub.create.args[0][0].email, 'jbloggs@example.com');
             assert.equal(membersRepositoryStub.create.args[0][0].subscribed, true);
@@ -550,7 +930,7 @@ describe('MembersCSVImporter', function () {
         it('handles various special cases', async function () {
             const importer = buildMockImporterInstance();
 
-            const result = await importer.perform(`${csvPath}/special-cases.csv`);
+            const result = await importer.perform(await rowsFor(importer, 'special-cases.csv'));
 
             // CASE: Member has created_at in the future
             // The member will not appear in the members list in admin
@@ -569,7 +949,7 @@ describe('MembersCSVImporter', function () {
         it('searches for stripe customer ID by email when "auto" is passed', async function () {
             const importer = buildMockImporterInstance();
 
-            const result = await importer.perform(`${csvPath}/auto-stripe-customer-id.csv`);
+            const result = await importer.perform(await rowsFor(importer, 'auto-stripe-customer-id.csv'));
 
             assert.equal(membersRepositoryStub.linkStripeCustomer.args[0][0].customer_id, 'cus_mock_123456');
 
@@ -604,7 +984,7 @@ describe('MembersCSVImporter', function () {
                 .withArgs({email: 'jbloggs@example.com'})
                 .resolves(member);
 
-            await importer.perform(`${csvPath}/subscribed-to-emails-header.csv`);
+            await importer.perform(await rowsFor(importer, 'subscribed-to-emails-header.csv'));
 
             assert.deepEqual(membersRepositoryStub.update.args[0][0].newsletters, newsletters);
         });
@@ -627,7 +1007,7 @@ describe('MembersCSVImporter', function () {
                 .withArgs({email: 'test@example.com'})
                 .resolves(member);
 
-            await importer.perform(`${csvPath}/single-column-with-header.csv`);
+            await importer.perform(await rowsFor(importer, 'single-column-with-header.csv'));
 
             assert.equal(membersRepositoryStub.update.args[0][0].name, 'John Bloggs');
             assert.equal(membersRepositoryStub.update.args[0][0].note, 'A note');
@@ -649,7 +1029,7 @@ describe('MembersCSVImporter', function () {
                 .withArgs({email: 'jbloggs@example.com'})
                 .resolves(member);
 
-            await importer.perform(`${csvPath}/subscribed-to-emails-header.csv`);
+            await importer.perform(await rowsFor(importer, 'subscribed-to-emails-header.csv'));
 
             assert.deepEqual(membersRepositoryStub.update.args[0][0].subscribed, false);
         });
@@ -680,7 +1060,7 @@ describe('MembersCSVImporter', function () {
                 .withArgs({email: 'test@example.com'})
                 .resolves(member);
 
-            await importer.perform(`${csvPath}/subscribed-to-emails-header.csv`);
+            await importer.perform(await rowsFor(importer, 'subscribed-to-emails-header.csv'));
 
             assert.equal(membersRepositoryStub.update.args[0][0].subscribed, false);
             assert.equal(membersRepositoryStub.update.args[0][0].newsletters, undefined);
@@ -701,7 +1081,7 @@ describe('MembersCSVImporter', function () {
                 getTierByName: getTierByNameStub
             });
 
-            const result = await importer.perform(`${csvPath}/free-member-import-tier.csv`);
+            const result = await importer.perform(await rowsFor(importer, 'free-member-import-tier.csv'));
 
             assert.equal(result.total, 1);
             assert.equal(result.imported, 0);
@@ -724,7 +1104,7 @@ describe('MembersCSVImporter', function () {
                 getTierByName: getTierByNameStub
             });
 
-            const result = await importer.perform(`${csvPath}/comped-member-import-tier.csv`);
+            const result = await importer.perform(await rowsFor(importer, 'comped-member-import-tier.csv'));
 
             assert.equal(result.total, 1);
             assert.equal(result.imported, 1);
@@ -751,7 +1131,7 @@ describe('MembersCSVImporter', function () {
                 getTierByName: getTierByNameStub
             });
 
-            const result = await importer.perform(`${csvPath}/comped-member-invalid-import-tier.csv`);
+            const result = await importer.perform(await rowsFor(importer, 'comped-member-invalid-import-tier.csv'));
 
             assert.equal(result.total, 1);
             assert.equal(result.imported, 0);
@@ -767,7 +1147,7 @@ describe('MembersCSVImporter', function () {
                 getGiftService: async () => giftServiceStub
             });
 
-            const result = await importer.perform(`${csvPath}/gift-member-reassign.csv`);
+            const result = await importer.perform(await rowsFor(importer, 'gift-member-reassign.csv'));
 
             assert.equal(result.total, 1);
             assert.equal(result.imported, 1);
@@ -786,7 +1166,7 @@ describe('MembersCSVImporter', function () {
                 getGiftService: async () => giftServiceStub
             });
 
-            const result = await importer.perform(`${csvPath}/gift-member-reassign-with-tier.csv`);
+            const result = await importer.perform(await rowsFor(importer, 'gift-member-reassign-with-tier.csv'));
 
             assert.equal(result.imported, 0);
             assert.equal(result.errors.length, 1);
@@ -802,7 +1182,7 @@ describe('MembersCSVImporter', function () {
                 getGiftService: async () => giftServiceStub
             });
 
-            const result = await importer.perform(`${csvPath}/gift-member-reassign-with-complimentary.csv`);
+            const result = await importer.perform(await rowsFor(importer, 'gift-member-reassign-with-complimentary.csv'));
 
             assert.equal(result.imported, 0);
             assert.equal(result.errors.length, 1);
@@ -824,7 +1204,7 @@ describe('MembersCSVImporter', function () {
                 getGiftService: async () => giftServiceStub
             });
 
-            const result = await importer.perform(`${csvPath}/gift-member-reassign.csv`);
+            const result = await importer.perform(await rowsFor(importer, 'gift-member-reassign.csv'));
 
             assert.equal(result.imported, 0);
             assert.equal(result.errors.length, 1);
@@ -839,7 +1219,7 @@ describe('MembersCSVImporter', function () {
                 getGiftService: async () => giftServiceStub
             });
 
-            const result = await importer.perform(`${csvPath}/gift-member-reassign.csv`);
+            const result = await importer.perform(await rowsFor(importer, 'gift-member-reassign.csv'));
 
             assert.equal(result.imported, 0);
             assert.equal(result.errors.length, 1);
@@ -854,7 +1234,7 @@ describe('MembersCSVImporter', function () {
                 getGiftService: async () => giftServiceStub
             });
 
-            const result = await importer.perform(`${csvPath}/gift-member-reassign.csv`);
+            const result = await importer.perform(await rowsFor(importer, 'gift-member-reassign.csv'));
 
             assert.equal(result.imported, 0);
             assert.equal(result.errors.length, 1);
@@ -869,7 +1249,7 @@ describe('MembersCSVImporter', function () {
                 getGiftService: async () => giftServiceStub
             });
 
-            const result = await importer.perform(`${csvPath}/gift-member-reassign.csv`);
+            const result = await importer.perform(await rowsFor(importer, 'gift-member-reassign.csv'));
 
             assert.equal(result.imported, 0);
             assert.equal(result.errors.length, 1);
@@ -891,7 +1271,7 @@ describe('MembersCSVImporter', function () {
                 getTierByName: getTierByNameStub
             });
 
-            const result = await importer.perform(`${csvPath}/paid-member-import-tier.csv`);
+            const result = await importer.perform(await rowsFor(importer, 'paid-member-import-tier.csv'));
 
             assert.equal(result.total, 1);
             assert.equal(result.imported, 1);
@@ -928,7 +1308,7 @@ describe('MembersCSVImporter', function () {
                 stripePriceId: newStripePriceId
             });
 
-            const result = await importer.perform(`${csvPath}/paid-member-import-tier.csv`);
+            const result = await importer.perform(await rowsFor(importer, 'paid-member-import-tier.csv'));
 
             assert.equal(result.total, 1);
             assert.equal(result.imported, 1);

--- a/ghost/core/test/utils/fixtures/csv/members-headers-only.csv
+++ b/ghost/core/test/utils/fixtures/csv/members-headers-only.csv
@@ -1,0 +1,1 @@
+email,name

--- a/ghost/core/test/utils/fixtures/csv/members-mapped-subscribed.csv
+++ b/ghost/core/test/utils/fixtures/csv/members-mapped-subscribed.csv
@@ -1,0 +1,3 @@
+correo_electronico,boletin
+member+mapped_sub_1@example.com,true
+member+mapped_sub_2@example.com,false


### PR DESCRIPTION
## Problem

Every member import left behind a file that nothing ever deleted.

The importer parsed the uploaded CSV, wrote it back out as a second CSV, then read that file and parsed it again. Nobody cleaned up the second file.

On Ghost(Pro) those files land on a shared, persistent volume with:

* no cleanup, in any repo
* no per-site quota
* disk alerts that only fire at 95% across the whole volume, with no way to tell which site filled it

For imports small enough to run inside the request, the round trip achieved nothing. Same process, same code, a moment apart.

It broke things too:

* Re-serialising to CSV drops any column the member model doesn't know about, so custom field values can't be imported at all
* A CSV with headers but no rows returned a 500
* A label containing a comma got split into two labels
* Values were saved with the spreadsheet formula-escape character still attached, so a member named `-5` was stored as `'-5`

## Solution

Parse once. Write a file only where one is actually needed.

**Small imports** run inside the request and never touch the disk.

**Queued imports** outlive the request, and the uploaded CSV is deleted the moment the response finishes. So their rows are spooled to a temp file, and the job that reads them is responsible for deleting it.

Three deliberate choices about that spool:

| Choice | Why |
| --- | --- |
| One row per line | Neither writing nor reading builds one giant string. That matters on the path built for large imports. |
| JSON, not CSV | CSV drops unknown columns. JSON keeps them, which is what unblocks custom field values. |
| Deleted whether it succeeds or fails | Keeping the rows on failure would mean holding member data indefinitely against a manual replay that has no tooling behind it. The publisher still has the file they uploaded. |

**Fixed along the way:** the empty-CSV 500, the leaked file, the split label.

**Deliberate changes to stored data:** the formula-escape character is no longer saved, and mapped columns the member model doesn't recognise now reach the import instead of being dropped.

**One ordering change worth knowing about:** if a mapping names two columns for the same field (`subscribed` and `subscribed_to_emails` are one field), the first now wins. Previously the column mapped to the literal `subscribed` won regardless of order, and it was last-wins for anything else. Only reachable by hand-built API calls — the import UI can't produce it — but it decides a member's subscription state, so it's a deliberate rule now rather than an accident of column order.

## How this fits #29170

The queued import is shaped for a queue that stores its jobs.

The job body is one method with two arguments:

```
runImportJob(data, deps)
```

* **`data`** is the spool path, recipient, and label. Plain and serialisable. A test asserts it survives `JSON.parse(JSON.stringify(...))`.
* **`deps`** is the label model and verification trigger. Exactly the things that can't be serialised, and the ones #29170 resolves from injected getters at run time.

It's dispatched through the job manager's own `data` parameter rather than captured in a closure.

**So the change on your side is swapping the dispatch for an enqueue.** The job body doesn't move.

Two things worth deciding together rather than separately:

**Where the spool lives.** It's in the temp directory because its durability only has to match the queue's, and today's queue is in-process. A restart loses the job anyway. Once a durable adapter lands, the spool has to become as durable as the queue. It shouldn't go back into the site's content directory, which is how this went unnoticed for five years.

**Why a spool rather than the uploaded CSV.** Carrying the upload and re-parsing it in the job is just as serialisable, and avoids a second on-disk format. But the upload is deleted when the response finishes, and the opt-out for that (`req.disableUploadClear`) is checked in four places and set in none.

