### PR TITLE
Fixed Tinybird tests not being required for relevant pull requests

### DIFF
--- a/.github/workflows/tinybird.yml
+++ b/.github/workflows/tinybird.yml
@@ -3,11 +3,6 @@ name: Tinybird
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - '.github/workflows/tinybird.yml'
-      - 'compose.dev.analytics.yaml'
-      - 'ghost/core/core/server/data/tinybird/**'
-      - '!ghost/core/core/server/data/tinybird/**/*.md'
   push:
     # Run on pushes to main, release branches, and previous/future major version branches.
     branches:
@@ -26,9 +21,38 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect Tinybird changes
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      tinybird: ${{ steps.changed.outputs.tinybird }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      # Pushes remain filtered at the workflow level, so change detection is
+      # only needed to decide whether the tests should run for a pull request.
+      - name: Determine whether Tinybird files changed
+        id: changed
+        if: github.event_name == 'pull_request'
+        uses: AurorNZ/paths-filter@c9dd42e99db87803313ff6f4b1150cc9f6c836af # v5.0.0
+        with:
+          filters: |
+            tinybird:
+              - '.github/workflows/tinybird.yml'
+              - 'compose.dev.analytics.yaml'
+              - 'ghost/core/core/server/data/tinybird/**'
+              - '!ghost/core/core/server/data/tinybird/**/*.md'
+
   tests:
     name: Tinybird Tests
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.tinybird == 'true'
     defaults:
       run:
         working-directory: ghost/core/core/server/data/tinybird
@@ -78,6 +102,17 @@ jobs:
               "caller_run_id": "${{ github.run_id }}",
               "run_local_tests": false
             }
+
+  required:
+    name: Tinybird required tests passed or skipped
+    needs: [changes, tests]
+    if: always() && github.event_name == 'pull_request'
+    runs-on: ubuntu-slim
+    steps:
+      - name: Check if any required jobs failed or were cancelled
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "Tinybird change detection or tests failed or were cancelled." && exit 1
 
   deploy:
     name: Deploy Tinybird


### PR DESCRIPTION
no ref

The path-filtered workflow did not produce a check that could be safely required without also blocking unrelated pull requests. An always-reported rollup check now gates Tinybird changes while allowing other changes to skip the tests.