### PR TITLE
Implemented S3RouteSettingsStore for remote route settings

### DIFF
--- a/ghost/core/core/server/adapters/route-settings/S3RouteSettingsStore.ts
+++ b/ghost/core/core/server/adapters/route-settings/S3RouteSettingsStore.ts
@@ -1,7 +1,9 @@
 import fs from 'fs-extra';
 import path from 'path';
 import {
+    CopyObjectCommand,
     GetObjectCommand,
+    HeadObjectCommand,
     NoSuchKey,
     NotFound,
     PutObjectCommand,
@@ -15,6 +17,7 @@ import {RouteSettingsStoreBase, type RouteSettings} from '@tryghost/adapter-base
 
 import parseYaml from '../../services/route-settings/yaml-parser';
 import {parseRouteSettings} from '../../services/route-settings/route-settings-parser';
+import {getBackupRouteSettingsFilePath} from './utils';
 
 const YAML_FILENAME = 'routes.yaml';
 const DEFAULT_SETTINGS_FILENAME = 'default-routes.yaml';
@@ -155,9 +158,19 @@ export default class S3RouteSettingsStore extends RouteSettingsStoreBase {
     }
 
     async replace(settings: RouteSettings): Promise<void> {
+        const key = this.buildKey();
+
+        if (await this._canonicalExists()) {
+            await this.client.send(new CopyObjectCommand({
+                Bucket: this.bucket,
+                Key: getBackupRouteSettingsFilePath(key),
+                CopySource: `${this.bucket}/${key}`
+            }));
+        }
+
         await this.client.send(new PutObjectCommand({
             Bucket: this.bucket,
-            Key: this.buildKey(),
+            Key: key,
             Body: settings.yamlSource,
             ContentType: CONTENT_TYPE
         }));
@@ -166,6 +179,21 @@ export default class S3RouteSettingsStore extends RouteSettingsStoreBase {
     private buildKey(): string {
         const parts = [this.tenantPrefix, this.staticFileURLPrefix, YAML_FILENAME].filter(Boolean);
         return parts.join('/');
+    }
+
+    private async _canonicalExists(): Promise<boolean> {
+        try {
+            await this.client.send(new HeadObjectCommand({
+                Bucket: this.bucket,
+                Key: this.buildKey()
+            }));
+            return true;
+        } catch (err) {
+            if (this._isNotFound(err)) {
+                return false;
+            }
+            throw err;
+        }
     }
 
     private async readDefaultSettings(): Promise<string> {

--- a/ghost/core/core/server/adapters/route-settings/S3RouteSettingsStore.ts
+++ b/ghost/core/core/server/adapters/route-settings/S3RouteSettingsStore.ts
@@ -22,9 +22,9 @@ import {getBackupRouteSettingsFilePath} from './utils';
 const YAML_FILENAME = 'routes.yaml';
 const DEFAULT_SETTINGS_FILENAME = 'default-routes.yaml';
 
-// The canonical key and content-type are fixed by the routes.yaml → GCS migration
-// contract (HKG-1836): the migration writes this exact object, so the store must
-// match it or a migrated site reads back an object it can't identify.
+// Fixed by the routes.yaml → GCS migration contract (HKG-1836): the migration
+// writes objects with this exact content-type, so the store must match it rather
+// than "tidy" the charset away.
 const CONTENT_TYPE = 'application/yaml; charset=utf-8';
 
 const messages = {
@@ -130,7 +130,12 @@ export default class S3RouteSettingsStore extends RouteSettingsStoreBase {
                 sessionToken: options.sessionToken
             };
         }
-        this.client = new S3Client(clientConfig);
+
+        // `s3Client` is a test-only injection seam — it never comes from config
+        // (nconf holds static values), so it's read from the raw input rather
+        // than the validated schema output.
+        const injectedClient = (config as {s3Client?: S3Client} | null | undefined)?.s3Client;
+        this.client = injectedClient || new S3Client(clientConfig);
     }
 
     async get(): Promise<RouteSettings> {

--- a/ghost/core/core/server/adapters/route-settings/S3RouteSettingsStore.ts
+++ b/ghost/core/core/server/adapters/route-settings/S3RouteSettingsStore.ts
@@ -22,9 +22,6 @@ import {getBackupRouteSettingsFilePath} from './utils';
 const YAML_FILENAME = 'routes.yaml';
 const DEFAULT_SETTINGS_FILENAME = 'default-routes.yaml';
 
-// Fixed by the routes.yaml → GCS migration contract (HKG-1836): the migration
-// writes objects with this exact content-type, so the store must match it rather
-// than "tidy" the charset away.
 const CONTENT_TYPE = 'application/yaml; charset=utf-8';
 
 const messages = {
@@ -38,10 +35,6 @@ const messages = {
 
 const stripLeadingAndTrailingSlashes = (value = '') => value.replace(/^\/+|\/+$/g, '');
 
-// Validates and normalises the config: the slash-trimmed fields
-// (`staticFileURLPrefix`, `tenantPrefix`) are stripped via `transform` so the
-// constructor consumes ready-to-use values, plus the credential-pair rule
-// (accessKeyId and secretAccessKey must be supplied together).
 const configSchema = z.object({
     bucket: z.string({error: tpl(messages.missingBucket)}).min(1, {error: tpl(messages.missingBucket)}),
     staticFileURLPrefix: z.string({error: tpl(messages.missingStaticFileURLPrefix)})
@@ -69,10 +62,7 @@ export type S3RouteSettingsStoreOptions = z.infer<typeof configSchema>;
 /**
  * Remote store for route settings backed by an S3-compatible bucket (MinIO in
  * tests, GCS in production). Reads and writes the operator's original
- * `routes.yaml` verbatim — comments, ordering and formatting survive because
- * `settings.yamlSource` is persisted as-is rather than a re-serialised model.
- * When no object exists the parsed bundled defaults are returned without
- * seeding the bucket, matching FileStore's empty-state semantics.
+ * `routes.yaml` verbatim.
  */
 export default class S3RouteSettingsStore extends RouteSettingsStoreBase {
     private readonly client: S3Client;
@@ -81,11 +71,6 @@ export default class S3RouteSettingsStore extends RouteSettingsStoreBase {
     private readonly tenantPrefix: string;
     private readonly defaultSettingsBasePath: string;
 
-    /**
-     * Parse + normalise the config, throwing an actionable IncorrectUsageError
-     * on the first problem. Shared by `validate` (boot-time check) and the
-     * constructor (which uses the normalised result).
-     */
     private static parseConfig(config: unknown): z.infer<typeof configSchema> {
         const result = configSchema.safeParse(config);
         if (!result.success) {
@@ -96,12 +81,6 @@ export default class S3RouteSettingsStore extends RouteSettingsStoreBase {
         return result.data;
     }
 
-    /**
-     * Validate the options S3RouteSettingsStore would be constructed with,
-     * without instantiating it (no S3 client is created). Called by the adapter
-     * manager at boot so misconfiguration fails early. Narrows `config` to
-     * `S3RouteSettingsStoreOptions`.
-     */
     static validate(config: unknown): asserts config is S3RouteSettingsStoreOptions {
         S3RouteSettingsStore.parseConfig(config);
     }

--- a/ghost/core/core/server/adapters/route-settings/S3RouteSettingsStore.ts
+++ b/ghost/core/core/server/adapters/route-settings/S3RouteSettingsStore.ts
@@ -1,0 +1,187 @@
+import fs from 'fs-extra';
+import path from 'path';
+import {
+    GetObjectCommand,
+    NoSuchKey,
+    NotFound,
+    PutObjectCommand,
+    S3Client,
+    S3ClientConfig
+} from '@aws-sdk/client-s3';
+import {z} from 'zod';
+import tpl from '@tryghost/tpl';
+import * as errors from '@tryghost/errors';
+import {RouteSettingsStoreBase, type RouteSettings} from '@tryghost/adapter-base-route-settings';
+
+import parseYaml from '../../services/route-settings/yaml-parser';
+import {parseRouteSettings} from '../../services/route-settings/route-settings-parser';
+
+const YAML_FILENAME = 'routes.yaml';
+const DEFAULT_SETTINGS_FILENAME = 'default-routes.yaml';
+
+// The canonical key and content-type are fixed by the routes.yaml → GCS migration
+// contract (HKG-1836): the migration writes this exact object, so the store must
+// match it or a migrated site reads back an object it can't identify.
+const CONTENT_TYPE = 'application/yaml; charset=utf-8';
+
+const messages = {
+    missingBucket: 'S3RouteSettingsStore requires a bucket name',
+    missingStaticFileURLPrefix: 'S3RouteSettingsStore requires a staticFileURLPrefix',
+    missingDefaultSettingsBasePath: 'S3RouteSettingsStore requires a defaultSettingsBasePath',
+    partialCredentials: 'S3RouteSettingsStore requires both accessKeyId and secretAccessKey when either is provided',
+    missingResponseBody: 'S3 GetObject returned no body',
+    ensureDefaults: 'Error trying to access the default settings file in {path}.'
+};
+
+const stripLeadingAndTrailingSlashes = (value = '') => value.replace(/^\/+|\/+$/g, '');
+
+// Validates and normalises the config: the slash-trimmed fields
+// (`staticFileURLPrefix`, `tenantPrefix`) are stripped via `transform` so the
+// constructor consumes ready-to-use values, plus the credential-pair rule
+// (accessKeyId and secretAccessKey must be supplied together).
+const configSchema = z.object({
+    bucket: z.string({error: tpl(messages.missingBucket)}).min(1, {error: tpl(messages.missingBucket)}),
+    staticFileURLPrefix: z.string({error: tpl(messages.missingStaticFileURLPrefix)})
+        .transform(stripLeadingAndTrailingSlashes)
+        .refine(value => value.length > 0, {error: tpl(messages.missingStaticFileURLPrefix)}),
+    defaultSettingsBasePath: z.string({error: tpl(messages.missingDefaultSettingsBasePath)})
+        .min(1, {error: tpl(messages.missingDefaultSettingsBasePath)}),
+    tenantPrefix: z.string().transform(stripLeadingAndTrailingSlashes).optional(),
+    region: z.string().optional(),
+    endpoint: z.string().optional(),
+    forcePathStyle: z.boolean().optional(),
+    accessKeyId: z.string().optional(),
+    secretAccessKey: z.string().optional(),
+    sessionToken: z.string().optional()
+}).refine((config) => {
+    const hasAccessKey = Boolean(config.accessKeyId);
+    const hasSecretKey = Boolean(config.secretAccessKey);
+    const hasSessionToken = Boolean(config.sessionToken);
+    const hasCredentialPair = hasAccessKey && hasSecretKey;
+    return !((hasAccessKey || hasSecretKey || hasSessionToken) && !hasCredentialPair);
+}, {error: tpl(messages.partialCredentials)});
+
+export type S3RouteSettingsStoreOptions = z.infer<typeof configSchema>;
+
+/**
+ * Remote store for route settings backed by an S3-compatible bucket (MinIO in
+ * tests, GCS in production). Reads and writes the operator's original
+ * `routes.yaml` verbatim — comments, ordering and formatting survive because
+ * `settings.yamlSource` is persisted as-is rather than a re-serialised model.
+ * When no object exists the parsed bundled defaults are returned without
+ * seeding the bucket, matching FileStore's empty-state semantics.
+ */
+export default class S3RouteSettingsStore extends RouteSettingsStoreBase {
+    private readonly client: S3Client;
+    private readonly bucket: string;
+    private readonly staticFileURLPrefix: string;
+    private readonly tenantPrefix: string;
+    private readonly defaultSettingsBasePath: string;
+
+    /**
+     * Parse + normalise the config, throwing an actionable IncorrectUsageError
+     * on the first problem. Shared by `validate` (boot-time check) and the
+     * constructor (which uses the normalised result).
+     */
+    private static parseConfig(config: unknown): z.infer<typeof configSchema> {
+        const result = configSchema.safeParse(config);
+        if (!result.success) {
+            throw new errors.IncorrectUsageError({
+                message: [...new Set(result.error.issues.map(issue => issue.message))].join('; ')
+            });
+        }
+        return result.data;
+    }
+
+    /**
+     * Validate the options S3RouteSettingsStore would be constructed with,
+     * without instantiating it (no S3 client is created). Called by the adapter
+     * manager at boot so misconfiguration fails early. Narrows `config` to
+     * `S3RouteSettingsStoreOptions`.
+     */
+    static validate(config: unknown): asserts config is S3RouteSettingsStoreOptions {
+        S3RouteSettingsStore.parseConfig(config);
+    }
+
+    constructor(config: unknown) {
+        super();
+
+        const options = S3RouteSettingsStore.parseConfig(config);
+
+        const hasCredentialPair = Boolean(options.accessKeyId) && Boolean(options.secretAccessKey);
+
+        this.bucket = options.bucket;
+        this.staticFileURLPrefix = options.staticFileURLPrefix;
+        this.tenantPrefix = options.tenantPrefix ?? '';
+        this.defaultSettingsBasePath = options.defaultSettingsBasePath;
+
+        const clientConfig: S3ClientConfig = {
+            region: options.region,
+            endpoint: options.endpoint,
+            forcePathStyle: options.forcePathStyle
+        };
+        if (hasCredentialPair) {
+            clientConfig.credentials = {
+                accessKeyId: options.accessKeyId!,
+                secretAccessKey: options.secretAccessKey!,
+                sessionToken: options.sessionToken
+            };
+        }
+        this.client = new S3Client(clientConfig);
+    }
+
+    async get(): Promise<RouteSettings> {
+        let body: string;
+        try {
+            const response = await this.client.send(new GetObjectCommand({
+                Bucket: this.bucket,
+                Key: this.buildKey()
+            }));
+            if (!response.Body) {
+                throw new errors.InternalServerError({
+                    message: tpl(messages.missingResponseBody)
+                });
+            }
+            body = await response.Body.transformToString('utf-8');
+        } catch (err) {
+            if (this._isNotFound(err)) {
+                const defaultContent = await this.readDefaultSettings();
+                return parseRouteSettings(parseYaml(defaultContent), defaultContent);
+            }
+            throw err;
+        }
+
+        return parseRouteSettings(parseYaml(body), body);
+    }
+
+    async replace(settings: RouteSettings): Promise<void> {
+        await this.client.send(new PutObjectCommand({
+            Bucket: this.bucket,
+            Key: this.buildKey(),
+            Body: settings.yamlSource,
+            ContentType: CONTENT_TYPE
+        }));
+    }
+
+    private buildKey(): string {
+        const parts = [this.tenantPrefix, this.staticFileURLPrefix, YAML_FILENAME].filter(Boolean);
+        return parts.join('/');
+    }
+
+    private async readDefaultSettings(): Promise<string> {
+        const defaultFilePath = path.join(this.defaultSettingsBasePath, DEFAULT_SETTINGS_FILENAME);
+        try {
+            return await fs.readFile(defaultFilePath, 'utf8');
+        } catch (err) {
+            throw new errors.InternalServerError({
+                message: tpl(messages.ensureDefaults, {path: this.defaultSettingsBasePath}),
+                err: err as Error,
+                context: (err as NodeJS.ErrnoException).path
+            });
+        }
+    }
+
+    private _isNotFound(err: unknown): boolean {
+        return err instanceof NotFound || err instanceof NoSuchKey;
+    }
+}

--- a/ghost/core/test/integration/adapters/route-settings/s3-route-settings-store.test.ts
+++ b/ghost/core/test/integration/adapters/route-settings/s3-route-settings-store.test.ts
@@ -199,7 +199,9 @@ describe.skipIf(process.env.GHOST_TEST_MINIO_AVAILABLE !== '1')('Integration: S3
         it('writes the canonical key without a backup when the bucket is empty', async function () {
             await createStore().replace(fromYaml(SAMPLE_YAML));
 
-            assert.deepEqual(await listObjectKeys(adminClient, bucket), [canonicalKey()]);
+            const keys = await listObjectKeys(adminClient, bucket);
+            assert.deepEqual(keys, [canonicalKey()]);
+            assert.equal(keys.filter(k => backupKeyPattern().test(k)).length, 0);
         });
 
         it('backs up the prior contents verbatim before overwriting', async function () {

--- a/ghost/core/test/integration/adapters/route-settings/s3-route-settings-store.test.ts
+++ b/ghost/core/test/integration/adapters/route-settings/s3-route-settings-store.test.ts
@@ -1,0 +1,189 @@
+import {describe, it, beforeAll, afterEach, afterAll} from 'vitest';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import fs from 'fs-extra';
+import {HeadObjectCommand, ListObjectsV2Command, S3Client} from '@aws-sdk/client-s3';
+
+import S3RouteSettingsStore from '../../../../core/server/adapters/route-settings/S3RouteSettingsStore';
+import parseYaml from '../../../../core/server/services/route-settings/yaml-parser';
+import {parseRouteSettings} from '../../../../core/server/services/route-settings/route-settings-parser';
+import {
+    createTestS3Client,
+    createTestBucket,
+    emptyTestBucket,
+    deleteTestBucket,
+    getMinioConfig,
+    getObject,
+    putObject
+} from '../../../utils/minio';
+import {runStoreContract} from '../../../unit/server/adapters/route-settings/helpers/store-contract';
+
+const STATIC_PREFIX = 'content/settings';
+const CANONICAL_FILENAME = 'routes.yaml';
+const CONTENT_TYPE = 'application/yaml; charset=utf-8';
+const REAL_DEFAULTS_PATH = path.join(__dirname, '../../../../core/server/services/route-settings');
+
+// A comment-bearing, non-canonical source: its bytes differ from
+// serializeRouteSettings output, so a store that re-serialises the model instead
+// of persisting yamlSource verbatim cannot pass the round-trip assertions below.
+const SAMPLE_YAML = `# Custom routing for the site
+routes:
+  /about/: about
+  /featured/:
+    controller: channel
+    filter: featured:true
+    template: featured
+
+collections:
+  /:
+    permalink: /{slug}/
+    template: index
+
+taxonomies:
+  tag: /tag/{slug}/
+  author: /author/{slug}/
+`;
+
+const canonicalKey = (tenantPrefix = ''): string => [tenantPrefix, STATIC_PREFIX, CANONICAL_FILENAME].filter(Boolean).join('/');
+
+const fromYaml = (yaml: string) => parseRouteSettings(parseYaml(yaml), yaml);
+
+const listObjectKeys = async (s3Client: S3Client, bucketName: string): Promise<string[]> => {
+    const response = await s3Client.send(new ListObjectsV2Command({Bucket: bucketName}));
+    return (response.Contents ?? []).map(o => o.Key ?? '').filter(Boolean);
+};
+
+// Skip when MinIO is unreachable. The flag is set by the integration
+// globalSetup (vitest-globalsetup-services.ts), which probes MinIO once before
+// the forks spawn.
+describe.skipIf(process.env.GHOST_TEST_MINIO_AVAILABLE !== '1')('Integration: S3RouteSettingsStore', function () {
+    let adminClient: S3Client;
+    let bucket: string;
+    const minioConfig = getMinioConfig();
+
+    const createStore = (overrides: Record<string, unknown> = {}) => new S3RouteSettingsStore({
+        ...minioConfig,
+        bucket,
+        staticFileURLPrefix: STATIC_PREFIX,
+        defaultSettingsBasePath: REAL_DEFAULTS_PATH,
+        ...overrides
+    });
+
+    beforeAll(async function () {
+        adminClient = createTestS3Client();
+        bucket = await createTestBucket(adminClient);
+    });
+
+    afterEach(async function () {
+        await emptyTestBucket(adminClient, bucket);
+    });
+
+    afterAll(async function () {
+        await deleteTestBucket(adminClient, bucket);
+    });
+
+    runStoreContract({
+        createStore: () => createStore()
+    });
+
+    describe('get', function () {
+        it('exposes the exact stored yaml, comments and all, as yamlSource', async function () {
+            await putObject(adminClient, bucket, canonicalKey(), SAMPLE_YAML);
+
+            const settings = await createStore().get();
+
+            assert.equal(settings.yamlSource, SAMPLE_YAML);
+            assert.deepEqual(settings.routes, [
+                {type: 'template', path: '/about/', templates: ['about']},
+                {type: 'channel', path: '/featured/', templates: ['featured'], filter: 'featured:true'}
+            ]);
+        });
+
+        it('returns parsed bundled defaults without seeding the bucket when no object exists', async function () {
+            const defaultYaml = await fs.readFile(path.join(REAL_DEFAULTS_PATH, 'default-routes.yaml'), 'utf8');
+
+            const settings = await createStore().get();
+
+            assert.deepEqual(settings, fromYaml(defaultYaml));
+            assert.deepEqual(await listObjectKeys(adminClient, bucket), []);
+        });
+
+        it('throws for corrupt YAML stored in the bucket', async function () {
+            await putObject(adminClient, bucket, canonicalKey(), 'routes:\n\t- broken');
+
+            await assert.rejects(createStore().get(), (err: {code?: string}) => {
+                assert.equal(err.code, 'YAML_PARSER_ERROR');
+                return true;
+            });
+        });
+
+        it('throws ValidationError for structurally invalid settings', async function () {
+            await putObject(adminClient, bucket, canonicalKey(), 'routes:\n  no-slashes: about\n');
+
+            await assert.rejects(createStore().get(), (err: {errorType?: string}) => {
+                assert.equal(err.errorType, 'ValidationError');
+                return true;
+            });
+        });
+
+        it('throws InternalServerError when the bundled default file is missing on the empty state', async function () {
+            const store = createStore({defaultSettingsBasePath: path.join(REAL_DEFAULTS_PATH, 'does-not-exist')});
+
+            await assert.rejects(store.get(), (err: {errorType?: string}) => {
+                assert.equal(err.errorType, 'InternalServerError');
+                return true;
+            });
+        });
+    });
+
+    describe('replace', function () {
+        it('writes the original yaml verbatim to the canonical key', async function () {
+            await createStore().replace(fromYaml(SAMPLE_YAML));
+
+            const stored = await getObject(adminClient, bucket, canonicalKey());
+            assert.equal(stored?.toString('utf-8'), SAMPLE_YAML);
+        });
+
+        it('stores the object under the canonical content/settings key', async function () {
+            await createStore().replace(fromYaml(SAMPLE_YAML));
+
+            assert.deepEqual(await listObjectKeys(adminClient, bucket), [canonicalKey()]);
+        });
+
+        it('sets the migration content-type on the stored object', async function () {
+            await createStore().replace(fromYaml(SAMPLE_YAML));
+
+            const head = await adminClient.send(new HeadObjectCommand({Bucket: bucket, Key: canonicalKey()}));
+            assert.equal(head.ContentType, CONTENT_TYPE);
+        });
+    });
+
+    describe('tenantPrefix scoping', function () {
+        it('writes the canonical key under the tenant prefix', async function () {
+            await createStore({tenantPrefix: 'tenant-abc'}).replace(fromYaml(SAMPLE_YAML));
+
+            assert.deepEqual(await listObjectKeys(adminClient, bucket), [canonicalKey('tenant-abc')]);
+        });
+
+        it('strips leading and trailing slashes from the tenant prefix', async function () {
+            await createStore({tenantPrefix: '/tenant-abc/'}).replace(fromYaml(SAMPLE_YAML));
+
+            assert.deepEqual(await listObjectKeys(adminClient, bucket), [canonicalKey('tenant-abc')]);
+        });
+
+        it('isolates tenants sharing the same bucket', async function () {
+            const storeA = createStore({tenantPrefix: 'tenant-a'});
+            const storeB = createStore({tenantPrefix: 'tenant-b'});
+
+            await storeA.replace(fromYaml(SAMPLE_YAML));
+            await storeB.replace(parseRouteSettings(parseYaml('routes:\n  /b/: b\n'), 'routes:\n  /b/: b\n'));
+
+            assert.equal((await storeA.get()).yamlSource, SAMPLE_YAML);
+            assert.deepEqual((await storeB.get()).routes, [{type: 'template', path: '/b/', templates: ['b']}]);
+            assert.deepEqual(
+                (await listObjectKeys(adminClient, bucket)).sort(),
+                [canonicalKey('tenant-a'), canonicalKey('tenant-b')]
+            );
+        });
+    });
+});

--- a/ghost/core/test/integration/adapters/route-settings/s3-route-settings-store.test.ts
+++ b/ghost/core/test/integration/adapters/route-settings/s3-route-settings-store.test.ts
@@ -1,8 +1,10 @@
 import {describe, it, beforeAll, afterEach, afterAll} from 'vitest';
 import assert from 'node:assert/strict';
 import path from 'node:path';
+import {setTimeout as sleep} from 'node:timers/promises';
 import fs from 'fs-extra';
-import {HeadObjectCommand, ListObjectsV2Command, S3Client} from '@aws-sdk/client-s3';
+import sinon from 'sinon';
+import {GetObjectCommand, HeadObjectCommand, ListObjectsV2Command, S3Client} from '@aws-sdk/client-s3';
 
 import S3RouteSettingsStore from '../../../../core/server/adapters/route-settings/S3RouteSettingsStore';
 import parseYaml from '../../../../core/server/services/route-settings/yaml-parser';
@@ -56,10 +58,6 @@ const listObjectKeys = async (s3Client: S3Client, bucketName: string): Promise<s
 const backupKeyPattern = (tenantPrefix = ''): RegExp => new RegExp(
     `^${tenantPrefix ? `${tenantPrefix}/` : ''}${STATIC_PREFIX}/routes-\\d{4}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{2}\\.yaml$`
 );
-
-const sleep = (ms: number): Promise<void> => new Promise((resolve) => {
-    setTimeout(resolve, ms);
-});
 
 // Skip when MinIO is unreachable. The flag is set by the integration
 // globalSetup (vitest-globalsetup-services.ts), which probes MinIO once before
@@ -184,7 +182,7 @@ describe.skipIf(process.env.GHOST_TEST_MINIO_AVAILABLE !== '1')('Integration: S3
             const storeB = createStore({tenantPrefix: 'tenant-b'});
 
             await storeA.replace(fromYaml(SAMPLE_YAML));
-            await storeB.replace(parseRouteSettings(parseYaml('routes:\n  /b/: b\n'), 'routes:\n  /b/: b\n'));
+            await storeB.replace(fromYaml('routes:\n  /b/: b\n'));
 
             assert.equal((await storeA.get()).yamlSource, SAMPLE_YAML);
             assert.deepEqual((await storeB.get()).routes, [{type: 'template', path: '/b/', templates: ['b']}]);
@@ -249,5 +247,73 @@ describe.skipIf(process.env.GHOST_TEST_MINIO_AVAILABLE !== '1')('Integration: S3
             const backupBody = await getObject(adminClient, bucket, backupKey!);
             assert.equal(backupBody?.toString('utf-8'), SAMPLE_YAML);
         });
+    });
+});
+
+// Config validation and S3 fault branches are exercised without a live bucket:
+// a real GetObject always returns a Body and Head/Get don't surface arbitrary
+// transport errors on demand, so the error paths are driven with an injected
+// failing client. This lives in the integration suite because only that
+// coverage report is uploaded, and it runs regardless of MinIO.
+describe('Integration: S3RouteSettingsStore without a live bucket', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    const faultyStore = (send: (command: unknown) => Promise<unknown>) => {
+        const client: Pick<S3Client, 'send'> = {send: sinon.stub().callsFake(send)};
+        return new S3RouteSettingsStore({
+            bucket: 'a-bucket',
+            staticFileURLPrefix: STATIC_PREFIX,
+            defaultSettingsBasePath: REAL_DEFAULTS_PATH,
+            s3Client: client as S3Client
+        });
+    };
+
+    it('throws IncorrectUsageError when constructed with invalid config', function () {
+        assert.throws(
+            () => new S3RouteSettingsStore({staticFileURLPrefix: STATIC_PREFIX} as never),
+            {errorType: 'IncorrectUsageError'}
+        );
+    });
+
+    it('validate() accepts valid options and rejects invalid ones', function () {
+        assert.doesNotThrow(() => S3RouteSettingsStore.validate({
+            bucket: 'a-bucket',
+            staticFileURLPrefix: STATIC_PREFIX,
+            defaultSettingsBasePath: REAL_DEFAULTS_PATH
+        }));
+        assert.throws(() => S3RouteSettingsStore.validate({} as never), {errorType: 'IncorrectUsageError'});
+    });
+
+    it('throws InternalServerError when GetObject returns no body', async function () {
+        const store = faultyStore(async () => ({}));
+
+        await assert.rejects(store.get(), (err: {errorType?: string}) => {
+            assert.equal(err.errorType, 'InternalServerError');
+            return true;
+        });
+    });
+
+    it('propagates a non-NotFound error raised while reading', async function () {
+        const store = faultyStore(async (command) => {
+            if (command instanceof GetObjectCommand) {
+                throw new Error('connection reset');
+            }
+            return {};
+        });
+
+        await assert.rejects(store.get(), /connection reset/);
+    });
+
+    it('propagates a non-NotFound error raised by the existence check on replace', async function () {
+        const store = faultyStore(async (command) => {
+            if (command instanceof HeadObjectCommand) {
+                throw new Error('access denied');
+            }
+            return {};
+        });
+
+        await assert.rejects(store.replace(fromYaml(SAMPLE_YAML)), /access denied/);
     });
 });

--- a/ghost/core/test/integration/adapters/route-settings/s3-route-settings-store.test.ts
+++ b/ghost/core/test/integration/adapters/route-settings/s3-route-settings-store.test.ts
@@ -53,6 +53,14 @@ const listObjectKeys = async (s3Client: S3Client, bucketName: string): Promise<s
     return (response.Contents ?? []).map(o => o.Key ?? '').filter(Boolean);
 };
 
+const backupKeyPattern = (tenantPrefix = ''): RegExp => new RegExp(
+    `^${tenantPrefix ? `${tenantPrefix}/` : ''}${STATIC_PREFIX}/routes-\\d{4}-\\d{2}-\\d{2}-\\d{2}-\\d{2}-\\d{2}\\.yaml$`
+);
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => {
+    setTimeout(resolve, ms);
+});
+
 // Skip when MinIO is unreachable. The flag is set by the integration
 // globalSetup (vitest-globalsetup-services.ts), which probes MinIO once before
 // the forks spawn.
@@ -184,6 +192,60 @@ describe.skipIf(process.env.GHOST_TEST_MINIO_AVAILABLE !== '1')('Integration: S3
                 (await listObjectKeys(adminClient, bucket)).sort(),
                 [canonicalKey('tenant-a'), canonicalKey('tenant-b')]
             );
+        });
+    });
+
+    describe('replace: timestamped backups', function () {
+        it('writes the canonical key without a backup when the bucket is empty', async function () {
+            await createStore().replace(fromYaml(SAMPLE_YAML));
+
+            assert.deepEqual(await listObjectKeys(adminClient, bucket), [canonicalKey()]);
+        });
+
+        it('backs up the prior contents verbatim before overwriting', async function () {
+            const store = createStore();
+
+            await store.replace(fromYaml(SAMPLE_YAML));
+            await store.replace(fromYaml('routes:\n  /new/: new\n'));
+
+            const keys = await listObjectKeys(adminClient, bucket);
+            const backupKey = keys.find(k => backupKeyPattern().test(k));
+            assert.ok(backupKey, `expected a timestamped backup key, got: ${keys.join(', ')}`);
+
+            const backupBody = await getObject(adminClient, bucket, backupKey!);
+            assert.equal(backupBody?.toString('utf-8'), SAMPLE_YAML);
+            assert.equal((await store.get()).yamlSource, 'routes:\n  /new/: new\n');
+        });
+
+        it('creates a new backup on every overwrite', {timeout: 15000}, async function () {
+            // The backup key generator uses a per-second timestamp, so real waits
+            // between writes are needed to guarantee distinct backup keys.
+            const store = createStore();
+
+            await store.replace(fromYaml('routes:\n  /a/: a\n'));
+            await sleep(1100);
+            await store.replace(fromYaml('routes:\n  /b/: b\n'));
+            await sleep(1100);
+            await store.replace(fromYaml('routes:\n  /c/: c\n'));
+
+            const keys = await listObjectKeys(adminClient, bucket);
+            const backupKeys = keys.filter(k => backupKeyPattern().test(k));
+            assert.equal(backupKeys.length, 2, `expected 2 timestamped backups, got: ${keys.join(', ')}`);
+            assert.ok(keys.includes(canonicalKey()), `expected canonical ${canonicalKey()}, got: ${keys.join(', ')}`);
+        });
+
+        it('writes backups under the tenant prefix on overwrite', async function () {
+            const store = createStore({tenantPrefix: 'tenant-abc'});
+
+            await store.replace(fromYaml(SAMPLE_YAML));
+            await store.replace(fromYaml('routes:\n  /new/: new\n'));
+
+            const keys = await listObjectKeys(adminClient, bucket);
+            const backupKey = keys.find(k => backupKeyPattern('tenant-abc').test(k));
+            assert.ok(backupKey, `expected a tenant-scoped backup key, got: ${keys.join(', ')}`);
+
+            const backupBody = await getObject(adminClient, bucket, backupKey!);
+            assert.equal(backupBody?.toString('utf-8'), SAMPLE_YAML);
         });
     });
 });

--- a/ghost/core/test/integration/adapters/route-settings/s3-route-settings-store.test.ts
+++ b/ghost/core/test/integration/adapters/route-settings/s3-route-settings-store.test.ts
@@ -25,9 +25,6 @@ const CANONICAL_FILENAME = 'routes.yaml';
 const CONTENT_TYPE = 'application/yaml; charset=utf-8';
 const REAL_DEFAULTS_PATH = path.join(__dirname, '../../../../core/server/services/route-settings');
 
-// A comment-bearing, non-canonical source: its bytes differ from
-// serializeRouteSettings output, so a store that re-serialises the model instead
-// of persisting yamlSource verbatim cannot pass the round-trip assertions below.
 const SAMPLE_YAML = `# Custom routing for the site
 routes:
   /about/: about

--- a/ghost/core/test/unit/server/adapters/route-settings/s3-route-settings-store.test.ts
+++ b/ghost/core/test/unit/server/adapters/route-settings/s3-route-settings-store.test.ts
@@ -22,9 +22,6 @@ const REAL_DEFAULTS_PATH = path.join(__dirname, '../../../../../core/server/serv
 const CANONICAL_KEY = 'content/settings/routes.yaml';
 const CONTENT_TYPE = 'application/yaml; charset=utf-8';
 
-// A comment-bearing, non-canonical source: its bytes differ from
-// serializeRouteSettings output, so these tests fail for a store that
-// re-serialises the model instead of persisting yamlSource verbatim.
 const SAMPLE_YAML = `# Custom routing for the site
 routes:
   /about/: about

--- a/ghost/core/test/unit/server/adapters/route-settings/s3-route-settings-store.test.ts
+++ b/ghost/core/test/unit/server/adapters/route-settings/s3-route-settings-store.test.ts
@@ -224,6 +224,20 @@ describe('UNIT: S3RouteSettingsStore', function () {
 
                 assert.equal(copyCommands(fake.sent).length, 0);
             });
+
+            it('propagates a non-NotFound existence-check error and does not overwrite', async function () {
+                const sent: S3Command[] = [];
+                const client = stubbedClient(async (command) => {
+                    sent.push(command);
+                    if (command instanceof HeadObjectCommand) {
+                        throw new Error('access denied');
+                    }
+                    return {};
+                });
+
+                await assert.rejects(createStore(client).replace(fromYaml(SAMPLE_YAML)), /access denied/);
+                assert.equal(putCommands(sent).length, 0);
+            });
         });
 
         describe('get', function () {

--- a/ghost/core/test/unit/server/adapters/route-settings/s3-route-settings-store.test.ts
+++ b/ghost/core/test/unit/server/adapters/route-settings/s3-route-settings-store.test.ts
@@ -1,8 +1,37 @@
 import assert from 'node:assert/strict';
+import path from 'node:path';
+import fs from 'fs-extra';
+import sinon from 'sinon';
+import {
+    CopyObjectCommand,
+    GetObjectCommand,
+    HeadObjectCommand,
+    NoSuchKey,
+    NotFound,
+    PutObjectCommand,
+    type S3Client
+} from '@aws-sdk/client-s3';
 
 import {RouteSettingsStoreBase} from '@tryghost/adapter-base-route-settings';
 
 import S3RouteSettingsStore from '../../../../../core/server/adapters/route-settings/S3RouteSettingsStore';
+import parseYaml from '../../../../../core/server/services/route-settings/yaml-parser';
+import {parseRouteSettings} from '../../../../../core/server/services/route-settings/route-settings-parser';
+
+const REAL_DEFAULTS_PATH = path.join(__dirname, '../../../../../core/server/services/route-settings');
+const CANONICAL_KEY = 'content/settings/routes.yaml';
+const CONTENT_TYPE = 'application/yaml; charset=utf-8';
+
+// A comment-bearing, non-canonical source: its bytes differ from
+// serializeRouteSettings output, so these tests fail for a store that
+// re-serialises the model instead of persisting yamlSource verbatim.
+const SAMPLE_YAML = `# Custom routing for the site
+routes:
+  /about/: about
+
+taxonomies:
+  tag: /tag/{slug}/
+`;
 
 const validConfig = {
     bucket: 'a-bucket',
@@ -10,7 +39,64 @@ const validConfig = {
     defaultSettingsBasePath: '/var/lib/ghost/content/settings'
 };
 
+const fromYaml = (yaml: string) => parseRouteSettings(parseYaml(yaml), yaml);
+
+type StubbedClient = Pick<S3Client, 'send'>;
+type S3Command = GetObjectCommand | HeadObjectCommand | CopyObjectCommand | PutObjectCommand;
+
+const createNotFound = () => new NotFound({$metadata: {httpStatusCode: 404}, message: 'Not Found'});
+const createNoSuchKey = () => new NoSuchKey({$metadata: {httpStatusCode: 404}, message: 'The specified key does not exist.'});
+
+const stubbedClient = (sendImpl: (command: S3Command) => Promise<unknown>): S3Client => {
+    const client: StubbedClient = {send: sinon.stub().callsFake(sendImpl)};
+    return client as S3Client;
+};
+
+// A minimal in-memory S3 double covering the four commands the store issues, so
+// the read/write/backup behaviour runs without a live bucket.
+const createFakeS3 = (seed: Record<string, string> = {}) => {
+    const objects = new Map<string, string>(Object.entries(seed));
+    const sent: S3Command[] = [];
+    const client = stubbedClient(async (command) => {
+        sent.push(command);
+        // Real S3 throws NoSuchKey from GetObject but NotFound from HeadObject on
+        // a missing key; both must be recognised by the store's _isNotFound.
+        if (command instanceof GetObjectCommand) {
+            const key = command.input.Key ?? '';
+            if (!objects.has(key)) {
+                throw createNoSuchKey();
+            }
+            const body = objects.get(key)!;
+            return {Body: {transformToString: async () => body}};
+        }
+        if (command instanceof HeadObjectCommand) {
+            if (!objects.has(command.input.Key ?? '')) {
+                throw createNotFound();
+            }
+            return {};
+        }
+        if (command instanceof CopyObjectCommand) {
+            const source = (command.input.CopySource ?? '').split('/').slice(1).join('/');
+            objects.set(command.input.Key ?? '', objects.get(source) ?? '');
+            return {};
+        }
+        if (command instanceof PutObjectCommand) {
+            objects.set(command.input.Key ?? '', command.input.Body as string);
+            return {};
+        }
+        throw new Error('unexpected command issued to the S3 double');
+    });
+    return {objects, sent, client};
+};
+
+const putCommands = (sent: S3Command[]): PutObjectCommand[] => sent.filter((c): c is PutObjectCommand => c instanceof PutObjectCommand);
+const copyCommands = (sent: S3Command[]): CopyObjectCommand[] => sent.filter((c): c is CopyObjectCommand => c instanceof CopyObjectCommand);
+
 describe('UNIT: S3RouteSettingsStore', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
     describe('adapter contract', function () {
         it('extends RouteSettingsStoreBase and declares get/replace as required', function () {
             const store = new S3RouteSettingsStore(validConfig);
@@ -69,6 +155,130 @@ describe('UNIT: S3RouteSettingsStore', function () {
 
         it('accepts a complete credential pair without throwing', function () {
             assert.doesNotThrow(() => new S3RouteSettingsStore({...validConfig, accessKeyId: 'AKIA', secretAccessKey: 'shh'}));
+        });
+    });
+
+    describe('validate', function () {
+        it('narrows valid options without throwing', function () {
+            assert.doesNotThrow(() => S3RouteSettingsStore.validate(validConfig));
+        });
+
+        it('throws IncorrectUsageError for invalid options', function () {
+            assert.throws(
+                () => S3RouteSettingsStore.validate({staticFileURLPrefix: 'content/settings', defaultSettingsBasePath: '/x'}),
+                {errorType: 'IncorrectUsageError'}
+            );
+        });
+    });
+
+    // Behavioural coverage with an injected in-memory S3 double, so the store's
+    // read/write/backup logic is exercised without a live MinIO bucket (the
+    // integration suite covers the same guarantees end-to-end against MinIO).
+    describe('behaviour (stubbed S3 client)', function () {
+        const createStore = (client: S3Client, overrides: Record<string, unknown> = {}) => new S3RouteSettingsStore({
+            ...validConfig,
+            defaultSettingsBasePath: REAL_DEFAULTS_PATH,
+            s3Client: client,
+            ...overrides
+        });
+
+        describe('replace', function () {
+            it('writes yamlSource verbatim with the migration content-type at the canonical key', async function () {
+                const fake = createFakeS3();
+
+                await createStore(fake.client).replace(fromYaml(SAMPLE_YAML));
+
+                const puts = putCommands(fake.sent);
+                assert.equal(puts.length, 1);
+                assert.equal(puts[0].input.Key, CANONICAL_KEY);
+                assert.equal(puts[0].input.Body, SAMPLE_YAML);
+                assert.equal(puts[0].input.ContentType, CONTENT_TYPE);
+            });
+
+            it('writes under the tenant prefix when configured', async function () {
+                const fake = createFakeS3();
+
+                await createStore(fake.client, {tenantPrefix: 'tenant-abc'}).replace(fromYaml(SAMPLE_YAML));
+
+                assert.equal(putCommands(fake.sent)[0].input.Key, `tenant-abc/${CANONICAL_KEY}`);
+            });
+
+            it('copies the existing object to a backup before overwriting it', async function () {
+                const fake = createFakeS3({[CANONICAL_KEY]: SAMPLE_YAML});
+
+                await createStore(fake.client).replace(fromYaml('routes:\n  /new/: new\n'));
+
+                const copies = copyCommands(fake.sent);
+                assert.equal(copies.length, 1);
+                assert.match(copies[0].input.Key ?? '', /^content\/settings\/routes-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}\.yaml$/);
+                assert.equal(copies[0].input.CopySource, `a-bucket/${CANONICAL_KEY}`);
+                // Backup must precede the overwrite, and must hold the prior bytes.
+                assert.ok(fake.sent.indexOf(copies[0]) < fake.sent.indexOf(putCommands(fake.sent)[0]));
+                assert.equal(fake.objects.get(copies[0].input.Key ?? ''), SAMPLE_YAML);
+            });
+
+            it('does not create a backup when no object exists yet', async function () {
+                const fake = createFakeS3();
+
+                await createStore(fake.client).replace(fromYaml(SAMPLE_YAML));
+
+                assert.equal(copyCommands(fake.sent).length, 0);
+            });
+        });
+
+        describe('get', function () {
+            it('returns the parsed model and verbatim yamlSource from the stored object', async function () {
+                const fake = createFakeS3({[CANONICAL_KEY]: SAMPLE_YAML});
+
+                const settings = await createStore(fake.client).get();
+
+                assert.equal(settings.yamlSource, SAMPLE_YAML);
+                assert.deepEqual(settings.routes, [{type: 'template', path: '/about/', templates: ['about']}]);
+            });
+
+            it('returns parsed bundled defaults when no object exists', async function () {
+                const fake = createFakeS3();
+                const defaultYaml = await fs.readFile(path.join(REAL_DEFAULTS_PATH, 'default-routes.yaml'), 'utf8');
+
+                const settings = await createStore(fake.client).get();
+
+                assert.deepEqual(settings, fromYaml(defaultYaml));
+            });
+
+            it('throws YAML_PARSER_ERROR for corrupt YAML in the object', async function () {
+                const fake = createFakeS3({[CANONICAL_KEY]: 'routes:\n\t- broken'});
+
+                await assert.rejects(createStore(fake.client).get(), (err: {code?: string}) => {
+                    assert.equal(err.code, 'YAML_PARSER_ERROR');
+                    return true;
+                });
+            });
+
+            it('throws ValidationError for structurally invalid settings', async function () {
+                const fake = createFakeS3({[CANONICAL_KEY]: 'routes:\n  no-slashes: about\n'});
+
+                await assert.rejects(createStore(fake.client).get(), (err: {errorType?: string}) => {
+                    assert.equal(err.errorType, 'ValidationError');
+                    return true;
+                });
+            });
+
+            it('throws InternalServerError when the S3 response has no body', async function () {
+                const client = stubbedClient(async () => ({Body: undefined}));
+
+                await assert.rejects(createStore(client).get(), (err: {errorType?: string}) => {
+                    assert.equal(err.errorType, 'InternalServerError');
+                    return true;
+                });
+            });
+
+            it('propagates non-NotFound S3 errors instead of falling back to defaults', async function () {
+                const client = stubbedClient(async () => {
+                    throw new Error('AccessDenied');
+                });
+
+                await assert.rejects(createStore(client).get(), /AccessDenied/);
+            });
         });
     });
 });

--- a/ghost/core/test/unit/server/adapters/route-settings/s3-route-settings-store.test.ts
+++ b/ghost/core/test/unit/server/adapters/route-settings/s3-route-settings-store.test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+
+import {RouteSettingsStoreBase} from '@tryghost/adapter-base-route-settings';
+
+import S3RouteSettingsStore from '../../../../../core/server/adapters/route-settings/S3RouteSettingsStore';
+
+const validConfig = {
+    bucket: 'a-bucket',
+    staticFileURLPrefix: 'content/settings',
+    defaultSettingsBasePath: '/var/lib/ghost/content/settings'
+};
+
+describe('UNIT: S3RouteSettingsStore', function () {
+    describe('adapter contract', function () {
+        it('extends RouteSettingsStoreBase and declares get/replace as required', function () {
+            const store = new S3RouteSettingsStore(validConfig);
+
+            assert.ok(store instanceof RouteSettingsStoreBase);
+            assert.deepEqual([...store.requiredFns], ['get', 'replace']);
+        });
+    });
+
+    describe('constructor validation', function () {
+        it('throws when no bucket is provided', function () {
+            assert.throws(
+                () => new S3RouteSettingsStore({staticFileURLPrefix: 'content/settings', defaultSettingsBasePath: '/x'} as never),
+                {errorType: 'IncorrectUsageError', message: /bucket/}
+            );
+        });
+
+        it('throws when no staticFileURLPrefix is provided', function () {
+            assert.throws(
+                () => new S3RouteSettingsStore({bucket: 'x', defaultSettingsBasePath: '/x'} as never),
+                {errorType: 'IncorrectUsageError', message: /staticFileURLPrefix/}
+            );
+        });
+
+        it('throws when no defaultSettingsBasePath is provided', function () {
+            assert.throws(
+                () => new S3RouteSettingsStore({bucket: 'x', staticFileURLPrefix: 'content/settings'} as never),
+                {errorType: 'IncorrectUsageError', message: /defaultSettingsBasePath/}
+            );
+        });
+
+        it('throws when only accessKeyId is provided', function () {
+            assert.throws(
+                () => new S3RouteSettingsStore({...validConfig, accessKeyId: 'AKIA'}),
+                {errorType: 'IncorrectUsageError', message: /accessKeyId.*secretAccessKey/}
+            );
+        });
+
+        it('throws when only secretAccessKey is provided', function () {
+            assert.throws(
+                () => new S3RouteSettingsStore({...validConfig, secretAccessKey: 'shh'}),
+                {errorType: 'IncorrectUsageError', message: /accessKeyId.*secretAccessKey/}
+            );
+        });
+
+        it('throws when sessionToken is provided without the credential pair', function () {
+            assert.throws(
+                () => new S3RouteSettingsStore({...validConfig, sessionToken: 'session'}),
+                {errorType: 'IncorrectUsageError', message: /accessKeyId.*secretAccessKey/}
+            );
+        });
+
+        it('accepts a tenantPrefix without throwing', function () {
+            assert.doesNotThrow(() => new S3RouteSettingsStore({...validConfig, tenantPrefix: 'tenant-abc'}));
+        });
+
+        it('accepts a complete credential pair without throwing', function () {
+            assert.doesNotThrow(() => new S3RouteSettingsStore({...validConfig, accessKeyId: 'AKIA', secretAccessKey: 'shh'}));
+        });
+    });
+});


### PR DESCRIPTION
ref HKG-1832

## Problem

`RouteSettingsStore` has a local-disk implementation (`FileStore`) but no remote one. Without a non-local store, Ghost(Pro) instances still depend on Gluster for routing config — the problem the project set out to remove.

## What this does

Adds `S3RouteSettingsStore`, an S3-API-backed route-settings store (MinIO in tests, GCS in production), mirroring the shape and credentialling of the existing `S3RedirectsStore`.

- **Reads/writes the operator's original `routes.yaml` bytes verbatim.** `replace()` persists `settings.yamlSource` — never a re-serialised model — so comments, key ordering and formatting survive a round-trip, and the eventual routes.yaml → GCS migration stays a lossless byte copy.
- **Canonical key** `{tenantPrefix}/content/settings/routes.yaml`, **Content-Type** `application/yaml; charset=utf-8`. Both are fixed by the migration contract (HKG-1836), which writes to exactly this key/type.
- **Timestamped server-side backup before every overwrite.** `replace()` `HeadObject`-checks the canonical key and, if present, `CopyObject`s it to a timestamped key before the `PutObject`, so the previous config is never lost and the bytes never round-trip through the app. Skipped on the first write.
- **Empty state returns the parsed bundled defaults.** On `NoSuchKey`/`NotFound` the store parses the bundled `default-routes.yaml` from disk and returns it without seeding the bucket — matching `FileStore`. Without this a fresh tenant prefix would have no routes and 404 everything until the first upload.
- **Typed errors on bad data.** Corrupt YAML surfaces `YAML_PARSER_ERROR`; structurally invalid settings surface `ValidationError`; a broken object never silently falls back to defaults. Same pipeline and error semantics as `FileStore`.
- **Constructor validation** via zod: throws `IncorrectUsageError` on missing `bucket`, missing `staticFileURLPrefix`, missing `defaultSettingsBasePath`, or a partial credential pair.

## Design choices

- **Verbatim YAML in the bucket, not JSON.** Same bytes the operator uploaded; lossless migration and symmetric rollback. This is why `replace()` writes `yamlSource` and `get()` re-parses the stored bytes.
- **`S3-` prefix, not `GCS-`.** The implementation speaks the S3 API and runs against MinIO in tests and GCS in prod; naming it after the protocol keeps the abstraction honest. Same call the redirects store made.
- **`defaultSettingsBasePath` is a required option** (`S3RedirectsStore` has no equivalent). Required because the empty state reads the bundled `default-routes.yaml` from disk, mirroring `FileStore`. The adapter-manager config that selects this store must supply it.
- **Server-side `CopyObject` for backups**, not client-side download-then-upload.

## Reused / mirrored patterns

- `S3RedirectsStore` — overall store shape, zod `parseConfig`/`validate`, S3 client construction, credential-pair rule, `buildKey`, `_isNotFound`, Head→Copy→Put backup flow.
- `FileStore` — verbatim `yamlSource` persistence and empty-state parsed-defaults semantics.
- `getBackupRouteSettingsFilePath` (route-settings adapter util) — reused for backup key naming, not re-implemented.
- `S3Storage`/`FileStore` — the test-only `s3Client` injection seam (read from raw config, never from the validated schema).

## Test coverage

- **Unit** (`test/unit/server/adapters/route-settings/s3-route-settings-store.test.ts`) — no MinIO required: constructor/`validate` validation incl. partial credentials; and, via an injected in-memory S3 double, verbatim `Body`/Content-Type/canonical key, tenant-prefixed key, copy-before-overwrite ordering + backup contents, first-write skips backup, empty-state parsed defaults, corrupt→`YAML_PARSER_ERROR`, invalid→`ValidationError`, missing-body → `InternalServerError`, and non-NotFound error propagation.
- **Integration** (`test/integration/adapters/route-settings/s3-route-settings-store.test.ts`, MinIO-gated) — the HKG-1825 store contract plus verbatim bytes (both directions), exact Content-Type via `HeadObject`, canonical/tenant keys, empty-state defaults with no seeding, corrupt/invalid errors, missing-default-file → `InternalServerError`, and timestamped backups incl. tenant scoping.