### PR TITLE
Declared custom fields in the Admin API member schema

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/validators/input/members.js
+++ b/ghost/core/core/server/api/endpoints/utils/validators/input/members.js
@@ -1,56 +1,6 @@
-const errors = require('@tryghost/errors');
 const jsonSchema = require('../utils/json-schema');
-const labs = require('../../../../../../shared/labs');
-
-// The members JSON schemas live in @tryghost/admin-api-schema and set
-// `additionalProperties: false`, so ajv strips `custom_fields` out of the body
-// before it reaches the service — silently, with no error to explain where the
-// values went. Stash the key across validation and restore it afterwards, so
-// values can ride the member body while the rest of it stays schema-validated.
-//
-// Gated on the flag: with the flag off, the key is stripped exactly as it is
-// today. The lasting fix is declaring `custom_fields` in the schema package
-// upstream, which is a separate release; this holds the seam until then.
-function preserveCustomFields(validate) {
-    return async function validateWithCustomFields(apiConfig, frame) {
-        if (!labs.isSet('membersCustomFields') || !Array.isArray(frame.data.members)) {
-            return validate(apiConfig, frame);
-        }
-
-        const stashed = frame.data.members.map(member => member && member.custom_fields);
-
-        await validate(apiConfig, frame);
-
-        frame.data.members.forEach((member, index) => {
-            if (member && stashed[index] !== undefined) {
-                member.custom_fields = stashed[index];
-            }
-        });
-    };
-}
-
-// Setting values while *creating* a member is a later vertical, not this one. On
-// add, ajv would silently strip `custom_fields` (a value that appears to vanish),
-// so reject it explicitly instead — the gap is then legible rather than a mystery.
-// Flag-gated, so with the flag off the key is stripped exactly as before.
-function rejectCustomFieldsOnAdd(validate) {
-    return function validateWithoutCustomFields(apiConfig, frame) {
-        const hasCustomFields = labs.isSet('membersCustomFields')
-            && Array.isArray(frame.data.members)
-            && frame.data.members.some(member => member && member.custom_fields !== undefined);
-
-        if (hasCustomFields) {
-            throw new errors.ValidationError({
-                message: 'Custom field values cannot be set while creating a member. Create the member, then set values with an edit.',
-                property: 'custom_fields'
-            });
-        }
-
-        return validate(apiConfig, frame);
-    };
-}
 
 module.exports = {
-    add: rejectCustomFieldsOnAdd(jsonSchema.validate),
-    edit: preserveCustomFields(jsonSchema.validate)
+    add: jsonSchema.validate,
+    edit: jsonSchema.validate
 };

--- a/ghost/core/core/server/services/members-custom-fields/index.ts
+++ b/ghost/core/core/server/services/members-custom-fields/index.ts
@@ -42,6 +42,11 @@ export function init(): void {
         getMaxDefinitions: () => resolveMaxDefinitions(config.get('members:customFields:maxDefinitions'))
     });
     // The values service reads the field definitions straight from the table, so
-    // it needs only knex — no handle on the definitions service.
-    values = new CustomFieldValuesService({knex});
+    // it needs knex and the same ceiling — no handle on the definitions service.
+    // A write can't name more keys than the site is allowed definitions, so the
+    // two share one number rather than the value path inventing its own.
+    values = new CustomFieldValuesService({
+        knex,
+        getMaxDefinitions: () => resolveMaxDefinitions(config.get('members:customFields:maxDefinitions'))
+    });
 }

--- a/ghost/core/core/server/services/members-custom-fields/values-service.ts
+++ b/ghost/core/core/server/services/members-custom-fields/values-service.ts
@@ -11,10 +11,16 @@ import {storageCodecFor, storageColumnsFor} from './storage';
 const FIELDS_TABLE = 'members_custom_fields';
 const VALUES_TABLE = 'members_custom_field_values';
 
-// Values arrive keyed by field key. The values themselves stay `unknown` here —
+// Matches the `members_custom_fields.key` column (schema.js), so no key a site
+// could actually have minted is ever refused by it.
+const MAX_KEY_LENGTH = 191;
+
+// Values arrive keyed by field key. Keys are bounded by the column they are
+// minted into, so anything longer cannot name a field that exists and is refused
+// as input rather than looked up. The values themselves stay `unknown` here —
 // each one is validated by its own field type's schema, which isn't known until
 // the key is resolved to a definition.
-const ValuesInput = z.record(z.string(), z.unknown());
+const ValuesInput = z.record(z.string().max(MAX_KEY_LENGTH), z.unknown());
 
 // The field facts the value path needs: the id to write the FK, the key to match
 // input against, the name for error messages, and the type to pick the validator
@@ -47,9 +53,17 @@ interface PlannedWrite {
  */
 export class CustomFieldValuesService {
     private knex: Knex;
+    /**
+     * @private
+     * A getter, not a number: the ceiling is an operator setting that can change
+     * between requests, and reading config belongs to the module that builds this,
+     * not here.
+     */
+    private getMaxDefinitions: () => number;
 
-    constructor({knex}: {knex: Knex}) {
+    constructor({knex, getMaxDefinitions}: {knex: Knex, getMaxDefinitions: () => number}) {
         this.knex = knex;
+        this.getMaxDefinitions = getMaxDefinitions;
     }
 
     /**
@@ -131,7 +145,22 @@ export class CustomFieldValuesService {
             throw new errors.ValidationError({message: 'Custom field values must be an object keyed by field key.', property: 'custom_fields'});
         }
 
-        const byKey = await this.activeFieldsByKey(Object.keys(parsed.data));
+        const keys = Object.keys(parsed.data);
+
+        // A write can't name more fields than the site is allowed to define, so the
+        // ceiling is the same operator setting that bounds definitions rather than a
+        // number invented here. It also keeps the resolving query's bound parameters
+        // in proportion: one per key, against a driver limit that an unbounded object
+        // would otherwise blow past as a 500 carrying the generated SQL.
+        const maxKeys = this.getMaxDefinitions();
+        if (keys.length > maxKeys) {
+            throw new errors.ValidationError({
+                message: `Custom field values are limited to ${maxKeys} fields per request.`,
+                property: 'custom_fields'
+            });
+        }
+
+        const byKey = await this.activeFieldsByKey(keys);
         const writes: PlannedWrite[] = [];
 
         for (const [key, raw] of Object.entries(parsed.data)) {

--- a/ghost/core/core/server/services/members-custom-fields/values-service.ts
+++ b/ghost/core/core/server/services/members-custom-fields/values-service.ts
@@ -134,18 +134,42 @@ export class CustomFieldValuesService {
     }
 
     /**
+     * @private
+     * Input as the values object it claims to be, rejecting anything that isn't
+     * one. The single place that decision is made, so every caller asking about
+     * the same body gets the same answer and the same error.
+     */
+    private parseValues(input: unknown): Record<string, unknown> {
+        const parsed = ValuesInput.safeParse(input);
+        if (!parsed.success) {
+            throw new errors.ValidationError({message: 'Custom field values must be an object keyed by field key.', property: 'custom_fields'});
+        }
+
+        return parsed.data;
+    }
+
+    /**
+     * Whether input names any values at all, rejecting a body that isn't a values
+     * object in the first place.
+     *
+     * The shape question on its own, with no catalog lookup, so a caller can ask
+     * before deciding whether a write is even permitted — and get the same verdict,
+     * and the same rejection, that resolving it would have produced. An object
+     * carrying nothing but a `__proto__` key names nothing once parsed.
+     */
+    namesValues(input: unknown): boolean {
+        return Object.keys(this.parseValues(input)).length > 0;
+    }
+
+    /**
      * Resolve input into the writes it implies, rejecting anything invalid, and
      * writing nothing. Returned so a caller can validate before it commits to a
      * change it would have to unwind (the member edit validates up front), then
      * apply the same plan without re-resolving or re-validating.
      */
     async planWrite(input: unknown): Promise<PlannedWrite[]> {
-        const parsed = ValuesInput.safeParse(input);
-        if (!parsed.success) {
-            throw new errors.ValidationError({message: 'Custom field values must be an object keyed by field key.', property: 'custom_fields'});
-        }
-
-        const keys = Object.keys(parsed.data);
+        const values = this.parseValues(input);
+        const keys = Object.keys(values);
 
         // A write can't name more fields than the site is allowed to define, so the
         // ceiling is the same operator setting that bounds definitions rather than a
@@ -163,7 +187,7 @@ export class CustomFieldValuesService {
         const byKey = await this.activeFieldsByKey(keys);
         const writes: PlannedWrite[] = [];
 
-        for (const [key, raw] of Object.entries(parsed.data)) {
+        for (const [key, raw] of Object.entries(values)) {
             const field = byKey.get(key);
             if (!field) {
                 // Unknown (or archived) key. Rejected rather than ignored: a typo

--- a/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
@@ -6,7 +6,8 @@ const moment = require('moment');
 const messages = {
     stripeNotConnected: 'Missing Stripe connection.',
     memberAlreadyExists: 'Member already exists.',
-    memberNotFound: 'Member not found.'
+    memberNotFound: 'Member not found.',
+    customFieldsOnAdd: 'Custom field values cannot be set while creating a member. Create the member, then set values with an edit.'
 };
 
 // Stored in the action's `context.action_name`; Admin maps it to a display label.
@@ -40,6 +41,7 @@ const CUSTOM_FIELDS_EDITED_ACTION = 'custom_fields_edited';
  * @typedef {object} ICustomFieldsServiceWrapper
  * @prop {{
  *   getValuesForMembers: (memberIds: string[]) => Promise<Map<string, Record<string, unknown>>>,
+ *   namesValues: (values: unknown) => boolean,
  *   planWrite: (values: unknown) => Promise<object[]>,
  *   applyWrite: (memberId: string, writes: object[]) => Promise<void>
  * }} values
@@ -444,7 +446,44 @@ module.exports = class MemberBREADService {
         return member;
     }
 
+    /**
+     * @private
+     * The write-side flag gate, mirroring the read side in `fetchCustomFieldValues`:
+     * with the feature off the key is dropped, so a flag-off site stays byte-identical
+     * to a Ghost that predates the feature. The schema declares `custom_fields`
+     * unconditionally — it describes the endpoint, not any one site — which is what
+     * makes the flag, rather than ajv, the thing deciding whether values are written.
+     * @param {object} data
+     */
+    dropCustomFieldsWhenDisabled(data) {
+        if (!this.labsService.isSet('membersCustomFields')) {
+            delete data.custom_fields;
+        }
+    }
+
     async add(data, options) {
+        this.dropCustomFieldsWhenDisabled(data);
+
+        // Setting values while *creating* a member is a later vertical, not this
+        // one. Refuse rather than accept-and-drop, so the gap is legible.
+        //
+        // What counts as "naming a value" belongs to the values service, which
+        // answers it exactly as resolving an edit would — so a body malformed enough
+        // to be refused on edit is refused here too, rather than being accepted and
+        // dropped. Guarded on the key being present at all, so a create that never
+        // mentions custom fields — the overwhelming majority, and every create on a
+        // site without the feature — does not reach for the collaborator at all.
+        if (data.custom_fields !== undefined && this.customFieldsService.values.namesValues(data.custom_fields)) {
+            throw new errors.ValidationError({
+                message: tpl(messages.customFieldsOnAdd),
+                property: 'custom_fields'
+            });
+        }
+
+        // `custom_fields` is not a member column, so it comes off before the
+        // repository sees it, exactly as on edit. Only `{}` can reach here.
+        delete data.custom_fields;
+
         if (!this.stripeService.configured && (data.comped || data.stripe_customer_id)) {
             const property = data.comped ? 'comped' : 'stripe_customer_id';
             throw new errors.ValidationError({
@@ -527,10 +566,12 @@ module.exports = class MemberBREADService {
     async edit(data, options) {
         delete data.last_seen_at;
 
+        this.dropCustomFieldsWhenDisabled(data);
+
         // Values live in their own table, so they come off the member data before
-        // the repository sees it — `custom_fields` is not a member column. It only
-        // reaches here at all when the flag is on (the input validator strips it
-        // otherwise), so its presence is the signal to write.
+        // the repository sees it — `custom_fields` is not a member column. The gate
+        // above has already dropped it when the feature is off, so by this point its
+        // presence is the signal to write.
         const customFields = data.custom_fields;
         const writeCustomFields = customFields !== undefined;
         delete data.custom_fields;

--- a/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
@@ -839,6 +839,40 @@ describe('Member Custom Fields Admin API', function () {
                 .expectStatus(422);
         });
 
+        it('rejects a key too long to name a field, without echoing it back', async function () {
+            // Keys are minted into a bounded column, so a longer one cannot name a
+            // field that exists. Refused as input rather than looked up, which also
+            // means the response never carries the key back — the unknown-key error
+            // names the key it was given, so an enormous one would otherwise answer
+            // a request with a multiple of its own size.
+            const memberId = await createMember();
+            const hugeKey = 'k'.repeat(200000);
+
+            const body = await setValues(memberId, {[hugeKey]: 'v'}, 422);
+            assert.equal(body.errors[0].property, 'custom_fields');
+            assert.ok(body.errors[0].context.length < 1000, 'the key must not be echoed back');
+        });
+
+        it('rejects a write naming more fields than the site may define', async function () {
+            // A write can't name more fields than the site is allowed definitions, so
+            // the ceiling is the operator's configured one. Without it, each key binds
+            // a query parameter and a big enough object exceeds the driver's limit,
+            // surfacing as a 500 with the generated SQL in the error.
+            configUtils.set('members:customFields:maxDefinitions', 3);
+            const memberId = await createMember();
+
+            const atCeiling = Object.fromEntries(Array.from({length: 3}, (_, i) => [`k${i}`, 'v']));
+            // At the ceiling it gets as far as resolving the keys, which is where an
+            // undefined field is the thing rejected — not the ceiling.
+            const allowed = await setValues(memberId, atCeiling, 422);
+            assert.match(allowed.errors[0].context ?? allowed.errors[0].message, /Unknown custom field/);
+
+            const overCeiling = Object.fromEntries(Array.from({length: 4}, (_, i) => [`k${i}`, 'v']));
+            const refused = await setValues(memberId, overCeiling, 422);
+            assert.equal(refused.errors[0].property, 'custom_fields');
+            assert.match(refused.errors[0].context ?? refused.errors[0].message, /limited to 3 fields/);
+        });
+
         it('clearing a value that was never set is a no-op', async function () {
             const field = await createField({name: 'Favourite topic'});
             const memberId = await createMember();

--- a/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
@@ -873,6 +873,55 @@ describe('Member Custom Fields Admin API', function () {
             assert.match(refused.errors[0].context ?? refused.errors[0].message, /limited to 3 fields/);
         });
 
+        it('refuses a malformed custom_fields identically on create and on edit', async function () {
+            // The schema lets every shape through on purpose, so the service is the
+            // only thing judging it — and both verbs must judge it the same way. A
+            // body too malformed to be a write is refused, not accepted and dropped,
+            // which is the whole reason create refuses rather than ignoring.
+            const memberId = await createMember();
+
+            for (const [index, malformed] of [null, 'not-an-object', 42, true, [], ['a']].entries()) {
+                const created = await agent
+                    .post('members/')
+                    .body({members: [{email: `create-malformed-${index}@example.com`, custom_fields: malformed}]})
+                    .expectStatus(422);
+                assert.equal(created.body.errors[0].property, 'custom_fields');
+
+                const edited = await setValues(memberId, malformed as unknown as Record<string, unknown>, 422);
+                assert.equal(edited.errors[0].property, 'custom_fields');
+            }
+        });
+
+        it('treats a create and an edit the same on what counts as setting values', async function () {
+            // An object carrying only a `__proto__` key names no value once parsed,
+            // so neither path should see it as a write. Create and edit resolve that
+            // question with the same schema, so they cannot drift on it.
+            const payload = JSON.parse('{"__proto__": {"polluted": true}}');
+
+            await agent
+                .post('members/')
+                .body({members: [{email: 'create-proto@example.com', custom_fields: payload}]})
+                .expectStatus(201);
+
+            const memberId = await createMember();
+            await agent
+                .put(`members/${memberId}/`)
+                .body({members: [{custom_fields: payload}]})
+                .expectStatus(200);
+
+            assert.deepEqual(await readValues(memberId), {});
+            assert.equal(({} as Record<string, unknown>).polluted, undefined, 'the prototype must not be polluted');
+        });
+
+        it('accepts an empty custom_fields when creating a member', async function () {
+            // `{}` asks for nothing, and an edit treats it as a no-op, so a client
+            // whose serializer always emits the key can still create members.
+            await agent
+                .post('members/')
+                .body({members: [{email: 'create-empty-values@example.com', custom_fields: {}}]})
+                .expectStatus(201);
+        });
+
         it('clearing a value that was never set is a no-op', async function () {
             const field = await createField({name: 'Favourite topic'});
             const memberId = await createMember();
@@ -1147,6 +1196,11 @@ describe('Member Custom Fields Admin API', function () {
         });
 
         it('ignores custom_fields on a member edit and never returns them', async function () {
+            // The schema declares `custom_fields` on every site, so with the feature
+            // off the key reaches the service and is dropped there. A flag-off site
+            // stays byte-identical to a Ghost that predates the feature: the edit
+            // succeeds, the rest of it applies, and the values are ignored.
+            //
             // The field and value are set up with the flag on, then the flag goes
             // off for the request under test.
             mockManager.restore();
@@ -1170,6 +1224,38 @@ describe('Member Custom Fields Admin API', function () {
             mockManager.restore();
             mockManager.mockLabsEnabled('membersCustomFields');
             assert.deepEqual(await readValues(memberId), {[field.key]: 'Ghosts'});
+        });
+
+        it('ignores custom_fields on a member create', async function () {
+            // The not-yet-supported refusal that create gets with the flag on must
+            // not leak to a site without the feature: there, the key is simply
+            // dropped, exactly as a pre-feature Ghost would have.
+            const {body} = await agent
+                .post('members/')
+                .body({members: [{email: 'create-flag-off@example.com', custom_fields: {'favourite-topic': 'Ghosts'}}]})
+                .expectStatus(201);
+
+            assert.equal(body.members[0].custom_fields, undefined);
+        });
+
+        it('ignores a malformed custom_fields rather than rejecting it', async function () {
+            // The schema declares `custom_fields` on every site, so a shape it might
+            // have judged would be judged everywhere — including sites without the
+            // feature, which accepted anything under this key before it existed.
+            // Leaving the schema permissive is what keeps those callers working.
+            const memberId = await createMember();
+
+            for (const malformed of [null, 'not-an-object', 42, []]) {
+                await agent
+                    .put(`members/${memberId}/`)
+                    .body({members: [{custom_fields: malformed}]})
+                    .expectStatus(200);
+            }
+
+            await agent
+                .post('members/')
+                .body({members: [{email: 'create-malformed@example.com', custom_fields: 'not-an-object'}]})
+                .expectStatus(201);
         });
     });
 

--- a/packages/admin-api-schema/src/schemas/members-edit.json
+++ b/packages/admin-api-schema/src/schemas/members-edit.json
@@ -54,6 +54,9 @@
           "can_comment": {
             "type": "boolean"
           },
+          "custom_fields": {
+            "description": "Declared so it is not stripped as an unknown property. Deliberately unconstrained: only the site's field-type catalog knows what a given key accepts, so the shape is validated there rather than split across two layers that could disagree."
+          },
           "comment_ban": {
             "oneOf": [
               {

--- a/packages/admin-api-schema/src/schemas/members.json
+++ b/packages/admin-api-schema/src/schemas/members.json
@@ -51,6 +51,9 @@
         "can_comment": {
           "type": "boolean"
         },
+        "custom_fields": {
+          "description": "Declared so it is not stripped as an unknown property. Deliberately unconstrained: only the site's field-type catalog knows what a given key accepts, so the shape is validated there rather than split across two layers that could disagree."
+        },
         "comment_ban": {
           "oneOf": [
             {

--- a/packages/admin-api-schema/test/api.test.ts
+++ b/packages/admin-api-schema/test/api.test.ts
@@ -172,6 +172,42 @@ describe('Exposes a correct API', function () {
             await apiSchema.validate({data, schema: 'webhooks-edit', definition: 'webhooks'});
         });
 
+        it('Keeps custom_fields on a member body instead of stripping it', async function () {
+            // `additionalProperties: false` + ajv's `removeAdditional` means an
+            // undeclared property is silently dropped rather than rejected, so this
+            // asserts survival, not acceptance — dropping it is the failure mode
+            // the declaration exists to prevent.
+            const edit = {members: [{custom_fields: {'favourite-topic': 'Ghosts'}}]};
+            await apiSchema.validate({data: edit, schema: 'members-edit', definition: 'members'});
+            assert.deepEqual(edit.members[0]?.custom_fields, {'favourite-topic': 'Ghosts'});
+
+            const add = {members: [{email: 'test@example.com', custom_fields: {'favourite-topic': 'Ghosts'}}]};
+            await apiSchema.validate({data: add, schema: 'members-add', definition: 'members'});
+            assert.deepEqual(add.members[0]?.custom_fields, {'favourite-topic': 'Ghosts'});
+        });
+
+        it('Judges no part of custom_fields, whatever shape it arrives in', async function () {
+            // The declaration exists to stop the key being stripped, not to validate
+            // it: only the site's field-type catalog knows what a given key accepts.
+            // Constraining the shape here would also change behaviour for every
+            // existing caller, since the key reaches this schema on every site
+            // regardless of whether the feature is switched on.
+            for (const anyShape of [null, [], 'x', 5, true, {}, {a: 'b'}]) {
+                const data = {members: [{custom_fields: anyShape}]};
+                await apiSchema.validate({data, schema: 'members-edit', definition: 'members'});
+                assert.deepEqual(data.members[0]?.custom_fields, anyShape, `expected ${JSON.stringify(anyShape)} to survive untouched`);
+            }
+        });
+
+        it('Leaves the values inside custom_fields untouched', async function () {
+            // `removeAdditional` must not recurse into the object: composite values
+            // (an address, say) are validated by the field-type catalog downstream,
+            // so anything stripped here would vanish before it got there.
+            const data = {members: [{custom_fields: {home: {line1: '1 Main St', city: 'Dublin'}}}]};
+            await apiSchema.validate({data, schema: 'members-edit', definition: 'members'});
+            assert.deepEqual(data.members[0]?.custom_fields, {home: {line1: '1 Main St', city: 'Dublin'}});
+        });
+
         it('Uses schema $id for error key when dataPath is empty', async function () {
             const data = {};
 


### PR DESCRIPTION
Refs BER-3801

## Problem

The member schemas in the Admin API schema package reject unknown properties, and the validator is configured to strip them rather than error. Custom field values sent on a member body were therefore removed before they ever reached the service — silently, with nothing in the response to explain where they went. The previous workaround stashed the values across validation and restored them afterwards, which kept the feature working but left the API describing itself inaccurately: the endpoint accepted something its own schema said did not exist.

## Solution

Custom fields are now declared on the member schemas directly, so the key survives validation on its own terms and the stash-and-restore workaround is gone. The declaration is deliberately permissive and constrains nothing about the value. Only the site's own field-type catalog knows what any given key accepts, and splitting that judgement across two layers invites them to disagree; validating in one place keeps the rules honest. It also matters because the schema describes the endpoint rather than any one site, so a shape it judged would be judged everywhere, including on sites that have never turned the feature on and that accepted anything under this key before it existed.

Because the schema no longer decides whether values get through, the feature flag does. The service drops the key when the feature is off, on both create and edit, so a flag-off site behaves exactly as a Ghost that predates the feature: the write succeeds, everything else applies, and the values are ignored rather than rejected. With the flag on, setting values while creating a member is still refused outright, since that vertical has not been built yet and refusing is more legible than accepting and quietly discarding. An empty object is allowed through on create so clients whose serializer always emits the key can still create members.

There is also a ceiling on the number of keys accepted in a single write. Resolving keys binds one query parameter each, so a large enough object exceeded the database driver's parameter limit and surfaced as a server error carrying the generated SQL. The limit sits far above any workable number of field definitions and well below the lowest driver limit, so its only job is to turn an absurd payload into a clean rejection.