### PR TITLE
🐛 Fixed theme toggle crossfade in the standalone React admin

### DIFF
--- a/apps/admin/src/hooks/use-theme.test.tsx
+++ b/apps/admin/src/hooks/use-theme.test.tsx
@@ -18,7 +18,7 @@ const themeTest = baseTest.extend<{
     server: SetupServer;
     queryClient: QueryClient;
     wrapper: TestWrapperComponent;
-    animationFrames: FrameRequestCallback[];
+    animationFrames: Map<number, FrameRequestCallback>;
 }>({
     ...serverFixture,
     ...queryClientFixtures,
@@ -26,21 +26,34 @@ const themeTest = baseTest.extend<{
     // `theme-switching` suppression window and release it deterministically.
     animationFrames: async ({ task }, provide) => {
         void task;
-        const callbacks: FrameRequestCallback[] = [];
-        const spy = vi
+        const callbacks = new Map<number, FrameRequestCallback>();
+        let nextFrameId = 1;
+        const requestAnimationFrameSpy = vi
             .spyOn(window, "requestAnimationFrame")
             .mockImplementation((callback) => {
-                callbacks.push(callback);
-                return callbacks.length;
+                const frameId = nextFrameId;
+                nextFrameId += 1;
+                callbacks.set(frameId, callback);
+                return frameId;
+            });
+        const cancelAnimationFrameSpy = vi
+            .spyOn(window, "cancelAnimationFrame")
+            .mockImplementation((frameId) => {
+                callbacks.delete(frameId);
             });
         await provide(callbacks);
-        spy.mockRestore();
+        requestAnimationFrameSpy.mockRestore();
+        cancelAnimationFrameSpy.mockRestore();
     },
 });
 
-function flushAnimationFrames(callbacks: FrameRequestCallback[]) {
-    while (callbacks.length > 0) {
-        callbacks.shift()?.(0);
+function flushAnimationFrames(callbacks: Map<number, FrameRequestCallback>) {
+    while (callbacks.size > 0) {
+        const [frameId, callback] = callbacks.entries().next().value ?? [];
+        if (frameId !== undefined && callback) {
+            callbacks.delete(frameId);
+            callback(0);
+        }
     }
 }
 
@@ -90,6 +103,9 @@ describe("useTheme (standalone)", () => {
         const html = document.documentElement;
         expect(html.classList.contains("dark")).toBe(true);
         expect(html.classList.contains("theme-switching")).toBe(true);
+        // Loading preferences reapplies the theme before the initial suppression
+        // window closes, leaving only the latest release callback scheduled.
+        expect(animationFrames.size).toBe(1);
 
         flushAnimationFrames(animationFrames);
 

--- a/apps/admin/src/hooks/use-theme.test.tsx
+++ b/apps/admin/src/hooks/use-theme.test.tsx
@@ -1,0 +1,130 @@
+import { test as baseTest, afterEach, describe, expect, vi } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import type { QueryClient } from "@tanstack/react-query";
+import { useTheme } from "./use-theme";
+import { useUserPreferences } from "./user-preferences";
+import { HttpResponse, http } from "msw";
+import { mockUser } from "@test-utils/factories";
+import { serverFixture } from "@test-utils/fixtures/msw";
+import { queryClientFixtures, type TestWrapperComponent } from "@test-utils/fixtures/query-client";
+import type { UpdateUserRequestBody, UsersResponseType } from "@tryghost/admin-x-framework/api/users";
+import type { SetupServer } from "msw/node";
+
+// Constants
+const USERS_API_URL = "/ghost/api/admin/users/me/";
+const USER_UPDATE_API_URL = "/ghost/api/admin/users/:id/";
+
+const themeTest = baseTest.extend<{
+    server: SetupServer;
+    queryClient: QueryClient;
+    wrapper: TestWrapperComponent;
+    animationFrames: FrameRequestCallback[];
+}>({
+    ...serverFixture,
+    ...queryClientFixtures,
+    // Captures requestAnimationFrame callbacks so tests can observe the
+    // `theme-switching` suppression window and release it deterministically.
+    animationFrames: async ({ task }, provide) => {
+        void task;
+        const callbacks: FrameRequestCallback[] = [];
+        const spy = vi
+            .spyOn(window, "requestAnimationFrame")
+            .mockImplementation((callback) => {
+                callbacks.push(callback);
+                return callbacks.length;
+            });
+        await provide(callbacks);
+        spy.mockRestore();
+    },
+});
+
+function flushAnimationFrames(callbacks: FrameRequestCallback[]) {
+    while (callbacks.length > 0) {
+        callbacks.shift()?.(0);
+    }
+}
+
+function mockPreferences(server: SetupServer, nightShift: string) {
+    server.use(
+        http.get(USERS_API_URL, () => {
+            return HttpResponse.json({
+                users: [
+                    {
+                        ...mockUser,
+                        accessibility: JSON.stringify({ nightShift }),
+                    },
+                ],
+            });
+        }),
+        http.put<{ id: string }, UpdateUserRequestBody, UsersResponseType>(
+            USER_UPDATE_API_URL,
+            async ({ request }) => {
+                const body = await request.json();
+                return HttpResponse.json({
+                    users: [
+                        {
+                            ...mockUser,
+                            accessibility: body.users[0]?.accessibility ?? "",
+                        },
+                    ],
+                });
+            }
+        )
+    );
+}
+
+afterEach(() => {
+    document.documentElement.classList.remove("dark", "theme-switching");
+});
+
+describe("useTheme (standalone)", () => {
+    themeTest("applies the persisted theme with transition suppression", async ({ server, wrapper, animationFrames }) => {
+        mockPreferences(server, "dark");
+
+        const { result } = renderHook(() => useTheme(), { wrapper });
+
+        await waitFor(() => {
+            expect(result.current.resolvedTheme).toBe("dark");
+        });
+
+        const html = document.documentElement;
+        expect(html.classList.contains("dark")).toBe(true);
+        expect(html.classList.contains("theme-switching")).toBe(true);
+
+        flushAnimationFrames(animationFrames);
+
+        expect(html.classList.contains("dark")).toBe(true);
+        expect(html.classList.contains("theme-switching")).toBe(false);
+    });
+
+    themeTest("suppresses transitions while switching theme, then releases", async ({ server, wrapper, animationFrames }) => {
+        mockPreferences(server, "light");
+
+        const { result } = renderHook(() => ({
+            theme: useTheme(),
+            preferences: useUserPreferences(),
+        }), { wrapper });
+
+        // Wait for preferences to load so setTheme can persist the change
+        await waitFor(() => {
+            expect(result.current.preferences.data).toBeDefined();
+        });
+        flushAnimationFrames(animationFrames);
+
+        const html = document.documentElement;
+        expect(html.classList.contains("dark")).toBe(false);
+        expect(html.classList.contains("theme-switching")).toBe(false);
+
+        await act(async () => {
+            await result.current.theme.setTheme("dark");
+        });
+
+        expect(html.classList.contains("dark")).toBe(true);
+        expect(html.classList.contains("theme-switching")).toBe(true);
+
+        flushAnimationFrames(animationFrames);
+
+        expect(html.classList.contains("dark")).toBe(true);
+        expect(html.classList.contains("theme-switching")).toBe(false);
+    });
+});

--- a/apps/admin/src/hooks/use-theme.ts
+++ b/apps/admin/src/hooks/use-theme.ts
@@ -12,15 +12,25 @@ function getSystemTheme(): ResolvedThemeMode {
     return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 }
 
+let themeSwitchingFrame: number | undefined;
+
 function applyThemeClass(resolvedTheme: ResolvedThemeMode) {
     const html = document.documentElement;
     // `theme-switching` suppresses transitions (rule in shade/styles.css) so the
     // swap lands in one paint; double-rAF release mirrors Ember's feature.js.
     html.classList.add('theme-switching');
     html.classList.toggle('dark', resolvedTheme === 'dark');
-    requestAnimationFrame(() => requestAnimationFrame(() => {
-        html.classList.remove('theme-switching');
-    }));
+
+    if (themeSwitchingFrame !== undefined) {
+        cancelAnimationFrame(themeSwitchingFrame);
+    }
+
+    themeSwitchingFrame = requestAnimationFrame(() => {
+        themeSwitchingFrame = requestAnimationFrame(() => {
+            html.classList.remove('theme-switching');
+            themeSwitchingFrame = undefined;
+        });
+    });
 }
 
 // In the embedded admin, Ember owns the DOM theme: it manages both the `dark`

--- a/apps/admin/src/hooks/use-theme.ts
+++ b/apps/admin/src/hooks/use-theme.ts
@@ -13,7 +13,14 @@ function getSystemTheme(): ResolvedThemeMode {
 }
 
 function applyThemeClass(resolvedTheme: ResolvedThemeMode) {
-    document.documentElement.classList.toggle('dark', resolvedTheme === 'dark');
+    const html = document.documentElement;
+    // `theme-switching` suppresses transitions (rule in shade/styles.css) so the
+    // swap lands in one paint; double-rAF release mirrors Ember's feature.js.
+    html.classList.add('theme-switching');
+    html.classList.toggle('dark', resolvedTheme === 'dark');
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+        html.classList.remove('theme-switching');
+    }));
 }
 
 // In the embedded admin, Ember owns the DOM theme: it manages both the `dark`

--- a/apps/shade/styles.css
+++ b/apps/shade/styles.css
@@ -87,6 +87,17 @@
     filter: invert(100%);
 }
 
+/* Suppress transitions/animations during a light/dark mode swap so the
+   whole UI flips in a single paint instead of crossfading per element. */
+html.theme-switching,
+html.theme-switching *,
+html.theme-switching *::before,
+html.theme-switching *::after {
+    transition: none !important;
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+}
+
 .shade .no-scrollbar::-webkit-scrollbar {
     display: none; /* Chrome */
 }


### PR DESCRIPTION
## Problem

The embedded admin suppresses all transitions during a light/dark swap: `feature.js` puts a `theme-switching` class on `<html>` (released after a double `requestAnimationFrame`), and a matching rule in `app.css` disables transitions and animations under it, so the whole UI flips in a single paint.

The standalone React admin toggled the `dark` class with no such suppression. Components that carry `transition-colors` for hover states incidentally crossfaded during the theme swap while everything else snapped, producing an inconsistent, partially animated toggle.

## Solution

Ports the same single-paint pattern to the React path:

- `apps/admin/src/hooks/use-theme.ts` — `applyThemeClass` (the single standalone-path DOM writer) now wraps the `dark` toggle in the `theme-switching` window with the same double-rAF release. Reapplying the theme cancels the pending release frame so only the latest swap can end suppression. The embedded delegation path is untouched.
- `apps/shade/styles.css` — hosts the suppressor rule so it loads in both standalone and embedded admin (standalone does not load the Ember stylesheet). In embedded mode it duplicates the identical existing rule, which is harmless.

## Verification

- Colocated tests in `use-theme.test.tsx` assert the class is present during the swap and released after the double rAF, for both initial load and explicit toggles.
- The animation-frame fixture tracks cancellation by frame ID and verifies overlapping theme applications leave only the latest release sequence scheduled.
- `pnpm nx run @tryghost/admin:build`
- `pnpm nx run @tryghost/admin:test:unit` — 1060/1060 passed.
- Focused ESLint checks passed for the changed hook and test.