### PR TITLE
Ordered automation revision locks consistently to prevent deadlocks

### DIFF
--- a/ghost/core/core/server/services/automations/database-automations-repository.ts
+++ b/ghost/core/core/server/services/automations/database-automations-repository.ts
@@ -290,7 +290,11 @@ export function createDatabaseAutomationsRepository({
                     }
                 }
 
-                for (const [id, opens] of newOpensPerRevision) {
+                // Keep lock acquisition order consistent across concurrent transactions to avoid deadlocks.
+                const revisions = [...newOpensPerRevision.entries()]
+                    .sort(([left], [right]) => left.localeCompare(right));
+
+                for (const [id, opens] of revisions) {
                     await trx('automation_action_revisions')
                         .where({id})
                         .update({


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/29462

Found [another][0] spot in automations where we might have deadlocks.

When we track an automation email's delivered & opened, we increment the `email_opened_count` for several revisions. Imagine the following scenario:

1. Call A wants to update revisions X and Y.
2. Call B wants to update revisions Y and X.
3. Call A starts updating revision X, so it gets a lock on the row.
4. Call B starts updating revision Y, so it gets a lock on the row.
5. Call A wants to update revision Y, so it requests a lock on the row, but can't get it because Call B hasn't released its lock.
6. Call B wants to update revision X, so it requests a lock on the row, but can't get it because Call A hasn't released its lock.

That's a deadlock!

The fix is pretty boring: sort the revisions by some deterministic order. That avoids the deadlock, because one call wouldn't wait for another.

[0]: https://linear.app/ghost/issue/NY-1481
