### PR TITLE
Fixed subscribe event newsletter database migration drift

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.54/2026-07-20-19-58-38-make-members-subscribe-events-newsletter-id-nullable.js
+++ b/ghost/core/core/server/data/migrations/versions/6.54/2026-07-20-19-58-38-make-members-subscribe-events-newsletter-id-nullable.js
@@ -1,0 +1,3 @@
+const {createSetNullableMigration} = require('../../utils');
+
+module.exports = createSetNullableMigration('members_subscribe_events', 'newsletter_id', {disableForeignKeyChecks: true});

--- a/ghost/core/core/server/data/migrations/versions/6.54/2026-07-20-19-58-38-make-members-subscribe-events-newsletter-id-nullable.js
+++ b/ghost/core/core/server/data/migrations/versions/6.54/2026-07-20-19-58-38-make-members-subscribe-events-newsletter-id-nullable.js
@@ -1,3 +1,0 @@
-const {createSetNullableMigration} = require('../../utils');
-
-module.exports = createSetNullableMigration('members_subscribe_events', 'newsletter_id', {disableForeignKeyChecks: true});

--- a/ghost/core/core/server/data/migrations/versions/6.60/2026-08-18-21-21-13-make-members-subscribe-events-newsletter-id-not-null.js
+++ b/ghost/core/core/server/data/migrations/versions/6.60/2026-08-18-21-21-13-make-members-subscribe-events-newsletter-id-not-null.js
@@ -1,0 +1,18 @@
+const logging = require('@tryghost/logging');
+const {createDropNullableMigration} = require('../../utils');
+
+const dropNullableMigration = createDropNullableMigration('members_subscribe_events', 'newsletter_id', {
+    disableForeignKeyChecks: true
+});
+
+module.exports = {
+    ...dropNullableMigration,
+    async up(config) {
+        const knex = config.transacting || config.connection;
+
+        const deletedEvents = await knex('members_subscribe_events').whereNull('newsletter_id').del();
+        logging.info(`Deleted ${deletedEvents} members_subscribe_events with a null newsletter_id`);
+
+        await dropNullableMigration.up(config);
+    }
+};

--- a/ghost/core/core/server/data/migrations/versions/6.60/2026-08-18-21-21-13-make-members-subscribe-events-newsletter-id-not-null.js
+++ b/ghost/core/core/server/data/migrations/versions/6.60/2026-08-18-21-21-13-make-members-subscribe-events-newsletter-id-not-null.js
@@ -1,18 +1,22 @@
 const logging = require('@tryghost/logging');
-const {createDropNullableMigration} = require('../../utils');
+const { createDropNullableMigration } = require('../../utils');
 
-const dropNullableMigration = createDropNullableMigration('members_subscribe_events', 'newsletter_id', {
-    disableForeignKeyChecks: true
-});
+const dropNullableMigration = createDropNullableMigration(
+  'members_subscribe_events',
+  'newsletter_id',
+  {
+    disableForeignKeyChecks: true,
+  },
+);
 
 module.exports = {
-    ...dropNullableMigration,
-    async up(config) {
-        const knex = config.transacting || config.connection;
+  ...dropNullableMigration,
+  async up(config) {
+    const knex = config.transacting || config.connection;
 
-        const deletedEvents = await knex('members_subscribe_events').whereNull('newsletter_id').del();
-        logging.info(`Deleted ${deletedEvents} members_subscribe_events with a null newsletter_id`);
+    const deletedEvents = await knex('members_subscribe_events').whereNull('newsletter_id').del();
+    logging.info(`Deleted ${deletedEvents} members_subscribe_events with a null newsletter_id`);
 
-        await dropNullableMigration.up(config);
-    }
+    await dropNullableMigration.up(config);
+  },
 };

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1358,7 +1358,7 @@ module.exports = {
     newsletter_id: {
       type: 'string',
       maxlength: 24,
-      nullable: true,
+      nullable: false,
       references: 'newsletters.id',
       cascadeDelete: false,
     },

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -37,7 +37,7 @@ const parseYaml = require('../../../../../core/server/services/route-settings/ya
  */
 describe('DB version integrity', function () {
   // Only these variables should need updating
-  const currentSchemaHash = '091d0105868c689120d75dcc553282e7';
+  const currentSchemaHash = '505157ea7743d1266acd9e940d3f8250';
   const currentFixturesHash = '84c2ea9677201ec4e59ca893f3a9f2c1';
   const currentSettingsHash = 'f57245b22af55ea5fc1e5e20913de9bb';
   const currentRoutesHash = 'd8c25fa01bf6d22a2bcb05ba0de70dc1';


### PR DESCRIPTION
closes [NY-1483](https://linear.app/ghost/issue/NY-1483)

In the schema snapshot, `members_subscribe_events.newsletter_id` is nullable.

But if you run all migrations from scratch, the column is required. See `2022-05-03-09-39-drop-nullable-subscribe-event-newsletter-id.js`.

This fixes that drift by making the column nullable.

I think this is a useful fix on its own, but will also make an upcoming change possible.