### PR TITLE
Fixed custom field keys colliding with Object.prototype names

### DIFF
--- a/ghost/core/core/server/services/members-custom-fields/actions.ts
+++ b/ghost/core/core/server/services/members-custom-fields/actions.ts
@@ -29,8 +29,9 @@ export type CustomFieldVerb = keyof typeof COMMANDS;
 // `details` is stored in the action's `context` column (Ghost's slot for "diffs,
 // meta"). We always pass the field's `primary_name` so the log reads as a human
 // label, not a bare key — this is what keeps the timeline legible after a hard
-// delete, when the row itself is gone.
-export type CustomFieldActionDetails = {primary_name: string; previous_name?: string};
+// delete, when the row itself is gone. `key` rides alongside it because the key is
+// how a field is addressed publicly — its id never leaves the API.
+export type CustomFieldActionDetails = {primary_name: string; key: string; previous_name?: string};
 
 export type RecordCustomFieldAction =
     (input: {context: RequestContext; verb: CustomFieldVerb; subject: string; details: CustomFieldActionDetails}) => Promise<void>;
@@ -47,6 +48,9 @@ export async function recordCustomFieldAction(
         await Action.add({
             event: COMMANDS[verb],
             resource_type: 'member_custom_field',
+            // The field's id: this column holds 24 characters, and a key minted from
+            // a publisher-chosen name is bounded by the far wider key column, so only
+            // the id fits every field.
             resource_id: subject,
             actor_type: context.actor.type,
             actor_id: context.actor.id,

--- a/ghost/core/core/server/services/members-custom-fields/definitions-service.ts
+++ b/ghost/core/core/server/services/members-custom-fields/definitions-service.ts
@@ -183,7 +183,7 @@ export class CustomFieldDefinitionsService {
         // outside this transaction, so recording inside it would leave orphaned
         // "added" entries for fields a rollback never created.
         for (const field of created) {
-            await this.recordAction({context, verb: 'create', subject: field.key, details: {primary_name: field.name}});
+            await this.recordAction({context, verb: 'create', subject: field.id, details: {primary_name: field.name, key: field.key}});
         }
         return created;
     }
@@ -318,7 +318,7 @@ export class CustomFieldDefinitionsService {
                 }
                 throw err;
             }
-            await this.recordAction({context, verb: 'rename', subject: key, details: {primary_name: patch.name, previous_name: existing.name}});
+            await this.recordAction({context, verb: 'rename', subject: existing.id, details: {primary_name: patch.name, key, previous_name: existing.name}});
         }
 
         // A status change is the archive/restore transition. Only write (and log)
@@ -328,7 +328,7 @@ export class CustomFieldDefinitionsService {
                 .where('key', key)
                 .update({status: patch.status, updated_at: new Date()});
             const verb = patch.status === FIELD_STATUS.archived ? 'archive' : 'restore';
-            await this.recordAction({context, verb, subject: key, details: {primary_name: patch.name ?? existing.name}});
+            await this.recordAction({context, verb, subject: existing.id, details: {primary_name: patch.name ?? existing.name, key}});
         }
 
         return this.read(key);
@@ -350,7 +350,7 @@ export class CustomFieldDefinitionsService {
             throw new errors.ValidationError({message: 'Only archived custom fields can be deleted. Archive the field first.'});
         }
         await this.knex(TABLE).where('key', key).del();
-        await this.recordAction({context, verb: 'delete', subject: key, details: {primary_name: field.name}});
+        await this.recordAction({context, verb: 'delete', subject: field.id, details: {primary_name: field.name, key}});
     }
 }
 

--- a/ghost/core/core/server/services/members-custom-fields/definitions-service.ts
+++ b/ghost/core/core/server/services/members-custom-fields/definitions-service.ts
@@ -32,6 +32,19 @@ const MAX_SLUG_ITERATIONS = 1000;
 // Reserve room for a `-<n>` suffix (n up to MAX_SLUG_ITERATIONS).
 const MAX_KEY_BASE_LENGTH = MAX_KEY_LENGTH - (String(MAX_SLUG_ITERATIONS).length + 1);
 
+// A key becomes a property name on the plain objects that carry a member's values —
+// on both sides of the wire, since `custom_fields` is JSON and a client gets a plain
+// object from JSON.parse. A key naming a member of Object.prototype reads back as
+// inherited rather than absent wherever one of those objects is indexed, and
+// `__proto__` holds no value at all: the values schema drops it during parse, and
+// assigning it sets a prototype rather than a property.
+//
+// Derived rather than listed, because the set is a consequence of how keys are
+// minted: slugifying lowercases, so only an already-lowercase prototype name can
+// survive to become a key. Currently `constructor` and `__proto__`.
+const RESERVED_KEYS = Object.getOwnPropertyNames(Object.prototype)
+    .filter(name => slugify(name) === name);
+
 const FieldName = z.string().trim().min(1, {message: 'Custom field name is required.'}).max(MAX_NAME_LENGTH, {message: 'Custom field name is too long.'});
 
 // The backend mints the key from the name, so create takes just a name and type.
@@ -233,9 +246,10 @@ export class CustomFieldDefinitionsService {
      */
     private async mintKey(db: Knex, base: string): Promise<string> {
         const safeBase = base.slice(0, MAX_KEY_BASE_LENGTH);
-        const taken = new Set(
-            await db(TABLE).where('key', 'like', `${safeBase}%`).pluck('key')
-        );
+        const taken = new Set([
+            ...RESERVED_KEYS,
+            ...await db(TABLE).where('key', 'like', `${safeBase}%`).pluck('key')
+        ]);
         if (!taken.has(safeBase)) {
             return safeBase;
         }

--- a/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
@@ -720,10 +720,15 @@ describe('Member Custom Fields Admin API', function () {
             await createField({name: 'Company'});
             await createFieldExpecting('Role', 403);
 
+            // The key identifies the field publicly; it rides in the action's context
+            // because resource_id holds the row id.
             const actions = await models.Base.knex('actions')
                 .where('resource_type', 'member_custom_field')
-                .select('resource_id');
-            assert.deepEqual(actions.map((action: {resource_id: string}) => action.resource_id), ['company']);
+                .select('context');
+            assert.deepEqual(
+                actions.map((action: {context: string | null}) => JSON.parse(action.context ?? '{}').key),
+                ['company']
+            );
         });
     });
 
@@ -1211,6 +1216,12 @@ describe('Member Custom Fields Admin API', function () {
             return body.actions;
         };
 
+        // A field is addressed publicly by its key, and the key rides in the action's
+        // context rather than in resource_id, which holds the row id.
+        const contextOf = (a: {context: unknown}) =>
+            (typeof a.context === 'string' ? JSON.parse(a.context) : a.context) as
+                {primary_name?: string; key?: string; previous_name?: string};
+
         beforeAll(async function () {
             actorId = (await agent.get('users/me/').expectStatus(200)).body.users[0].id;
         });
@@ -1221,9 +1232,24 @@ describe('Member Custom Fields Admin API', function () {
             const actions = await customFieldActions();
             assert.equal(actions.length, 1);
             assert.equal(actions[0].event, 'added');
-            assert.equal(actions[0].resource_id, field.key);
+            assert.equal(contextOf(actions[0]).key, field.key);
             assert.equal(actions[0].actor_type, 'user');
             assert.equal(actions[0].actor_id, actorId);
+        });
+
+        // `resource_id` holds 24 characters and a key derived from a publisher-chosen
+        // name can be far longer, so only the row id fits every field. The action
+        // write is best-effort, so a row that does not fit is dropped without error.
+        it('records an action for a field whose key is longer than resource_id allows', async function () {
+            const field = await createField({name: 'Favourite ice cream flavour'});
+            assert.ok(field.key.length > 24, 'the key needs to be longer than resource_id to be a regression test');
+
+            const actions = await customFieldActions();
+            assert.equal(actions.length, 1);
+            assert.equal(contextOf(actions[0]).key, field.key);
+
+            const row = await models.Base.knex('members_custom_fields').where('key', field.key).first();
+            assert.equal(actions[0].resource_id, row.id);
         });
 
         it('records an "edited" action when a field is renamed', async function () {
@@ -1235,7 +1261,7 @@ describe('Member Custom Fields Admin API', function () {
 
             const edited = (await customFieldActions()).find((a: {event: string}) => a.event === 'edited');
             assert.ok(edited, 'an edited action should be recorded');
-            assert.equal(edited.resource_id, field.key);
+            assert.equal(contextOf(edited).key, field.key);
             assert.equal(edited.actor_id, actorId);
         });
 
@@ -1256,7 +1282,7 @@ describe('Member Custom Fields Admin API', function () {
 
             const archived = (await customFieldActions()).find((a: {event: string}) => a.event === 'archived');
             assert.ok(archived, 'an archived action should be recorded');
-            assert.equal(archived.resource_id, field.key);
+            assert.equal(contextOf(archived).key, field.key);
             assert.equal(archived.actor_id, actorId);
         });
 
@@ -1267,7 +1293,7 @@ describe('Member Custom Fields Admin API', function () {
 
             const restored = (await customFieldActions()).find((a: {event: string}) => a.event === 'restored');
             assert.ok(restored, 'a restored action should be recorded');
-            assert.equal(restored.resource_id, field.key);
+            assert.equal(contextOf(restored).key, field.key);
             assert.equal(restored.actor_id, actorId);
         });
 
@@ -1288,7 +1314,7 @@ describe('Member Custom Fields Admin API', function () {
 
             const deleted = (await customFieldActions()).find((a: {event: string}) => a.event === 'deleted');
             assert.ok(deleted, 'a deleted action should be recorded');
-            assert.equal(deleted.resource_id, field.key);
+            assert.equal(contextOf(deleted).key, field.key);
             assert.equal(deleted.actor_id, actorId);
         });
 
@@ -1309,11 +1335,8 @@ describe('Member Custom Fields Admin API', function () {
             // creation order even for events that land in the same second (which
             // created_at ordering can't disambiguate).
             const timeline = (await customFieldActions())
-                .filter((a: {resource_id: string}) => a.resource_id === field.key)
+                .filter((a: {context: unknown}) => contextOf(a).key === field.key)
                 .sort((a: {id: string}, b: {id: string}) => (a.id < b.id ? -1 : 1));
-
-            const parseContext = (a: {context: unknown}) =>
-                (typeof a.context === 'string' ? JSON.parse(a.context) : a.context) as {primary_name?: string; previous_name?: string};
 
             // The full ordered story, including the repeated archive.
             assert.deepEqual(
@@ -1325,14 +1348,14 @@ describe('Member Custom Fields Admin API', function () {
             // logs, and the delete still says what the field was after its row is gone.
             for (const a of timeline) {
                 assert.equal(a.actor_id, actorId, `the ${a.event} action is attributed`);
-                assert.ok(parseContext(a)?.primary_name, `the ${a.event} action names the field`);
+                assert.ok(contextOf(a)?.primary_name, `the ${a.event} action names the field`);
             }
 
             // Names track the field at each point; the rename also records what it was.
-            assert.equal(parseContext(timeline[0]).primary_name, 'Delivery address');
-            assert.equal(parseContext(timeline[1]).primary_name, 'Shipping address');
-            assert.equal(parseContext(timeline[1]).previous_name, 'Delivery address');
-            assert.equal(parseContext(timeline[5]).primary_name, 'Shipping address');
+            assert.equal(contextOf(timeline[0]).primary_name, 'Delivery address');
+            assert.equal(contextOf(timeline[1]).primary_name, 'Shipping address');
+            assert.equal(contextOf(timeline[1]).previous_name, 'Delivery address');
+            assert.equal(contextOf(timeline[5]).primary_name, 'Shipping address');
         });
     });
 

--- a/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
@@ -125,6 +125,70 @@ describe('Member Custom Fields Admin API', function () {
                 .expectStatus(422);
         });
 
+        // A key names a property on the plain objects carrying a member's values, so
+        // one naming a member of Object.prototype reads back as inherited rather than
+        // absent wherever it is indexed. Those keys are already taken, so the
+        // publisher keeps the name and the key takes a suffix. The match is on the
+        // slug rather than the name, which is what catches every spelling that
+        // collapses onto it.
+        const reservedSpellings = [
+            {name: 'Constructor', key: 'constructor-2'},
+            {name: 'constructor', key: 'constructor-2'},
+            {name: '__proto__', key: '__proto__-2'},
+            {name: '__PROTO__', key: '__proto__-2'},
+            {name: '＿＿ｐｒｏｔｏ＿＿', key: '__proto__-2'}
+        ];
+        for (const {name, key} of reservedSpellings) {
+            it(`mints ${key} for the name ${name}, and the value round-trips`, async function () {
+                const field = await createField({name});
+                assert.equal(field.key, key);
+
+                const memberId = await createMember();
+                await setValues(memberId, {[key]: 'Bex'});
+
+                assert.deepEqual(await readValues(memberId), {[key]: 'Bex'});
+            });
+        }
+
+        // A reserved key is claimed by whichever field takes the suffix first, so the
+        // next one along has to keep counting rather than collide with it.
+        it('keeps counting past a reserved key already claimed by another field', async function () {
+            const first = await createField({name: 'Constructor'});
+            const second = await createField({name: 'Constructor!'});
+
+            assert.equal(first.key, 'constructor-2');
+            assert.equal(second.key, 'constructor-3');
+        });
+
+        // The batch runs in one transaction, so mintKey sees the rows minted earlier
+        // in the same request — reserving a key must hold within a batch too, not
+        // just across separate requests.
+        it('mints distinct keys when two definitions in one batch both slug onto a reserved key', async function () {
+            const {body} = await agent
+                .post('members/custom_fields/')
+                .body({members_custom_fields: [
+                    {name: 'Constructor', type: 'short_text'},
+                    {name: 'Constructor!', type: 'short_text'}
+                ]})
+                .expectStatus(201);
+
+            assert.deepEqual(
+                body.members_custom_fields.map((f: {key: string}) => f.key),
+                ['constructor-2', 'constructor-3']
+            );
+        });
+
+        // A reserved slug must not take a whole prefix with it — only the exact key.
+        it('leaves a name that merely starts with a reserved word unsuffixed', async function () {
+            const field = await createField({name: 'Constructor role'});
+            assert.equal(field.key, 'constructor-role');
+
+            const memberId = await createMember();
+            await setValues(memberId, {[field.key]: 'Foreman'});
+
+            assert.deepEqual(await readValues(memberId), {'constructor-role': 'Foreman'});
+        });
+
         it('rejects a name that exceeds the maximum length', async function () {
             await agent
                 .post('members/custom_fields/')


### PR DESCRIPTION
## Problem

A custom field key is minted by slugifying a name the publisher chose, and that key becomes a property name on the plain objects that carry a member's values — on both sides of the wire, since `custom_fields` is JSON and a client gets a plain object from `JSON.parse` whatever the server built.

Slugifying lowercases, which leaves exactly two of `Object.prototype`'s names intact: `constructor` and `__proto__`. A field keyed either way reads back as inherited rather than absent everywhere one of those objects is indexed, so the CSV export carried a function body where a publisher's data belonged, for every member in the file rather than only those holding a value. `__proto__` is worse still — the values schema drops it during parse and assigning it sets a prototype rather than a property, so a write returned 200 and stored nothing.

Separately, the activity log recorded a field's key in `actions.resource_id`. That column holds 24 characters and a key is bounded only by the much wider key column, so a field named something ordinary like "Favourite ice cream flavour" overflowed it and failed the insert. Action writes are best-effort, so the row was dropped silently and the field never appeared in the timeline at all.

## Solution

Reserve both names at the single point keys are minted, by seeding the already-taken set that the collision path already consults. A name slugging onto one takes a numeric suffix exactly as it would for a genuine clash, so the publisher keeps the name they chose — "Constructor" is a reasonable thing to call a field — and the key is safe by construction. Matching on the slug rather than the name is what catches every spelling that collapses onto it, including non-ASCII forms.

Fixing the key at its source means no downstream container has to be careful, so this needs no guards at the read sites. The feature is behind the `membersCustomFields` flag and unreleased, so there is no existing data holding such a key.

The action log now records the field's row id, which fits the column by construction, and carries the key in the action's context so the log still identifies the field the way the API addresses it.

Ref BER-3815
