### PR TITLE
🐛 Fixed async logging streams failing to flush before exit

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -575,6 +575,13 @@ async function bootGhost({backend = true, frontend = true, server = true} = {}) 
     }
 
     try {
+        // TEMP: force a fatal boot error to validate the Elasticsearch log flush
+        // path in Pro. Remove before merging. Only fires where PRO_ENV is set.
+        if (process.env.PRO_ENV) {
+            // eslint-disable-next-line ghost/ghost-custom/no-native-error
+            throw new Error('TEMP forced boot error to validate logging flush');
+        }
+
         // Step 1 - require more fundamental components
 
         // Sentry must be initialized early, but requires config

--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -51,6 +51,44 @@ class BootLogger {
 }
 
 /**
+ * Flush buffered logs before the process exits.
+ *
+ * `logging.flush` drains any batching transport (e.g. ElasticSearch) and is
+ * itself best-effort — it swallows transport errors. The transport's own client
+ * bounds each request (the ES client defaults to a 30s request timeout), so
+ * `flush` always settles on its own; a healthy ship completes in milliseconds.
+ *
+ * The timeout here is only a last-resort guard against a genuinely wedged
+ * transport that never settles, so it must sit comfortably above any realistic
+ * ship — a tight bound would abandon a slow-but-working request (cold TLS +
+ * product check + cross-region RTT to a remote cluster) and drop the very log
+ * we're trying to ship, exactly the boot-error loss this flush exists to fix.
+ * @param {{flush: () => Promise<void>}} logging
+ * @param {number} [timeoutMs]
+ * @returns {Promise<void>}
+ */
+async function flushLogging(logging, timeoutMs = 10000) {
+    const {setTimeout: sleep} = require('node:timers/promises');
+
+    // Runs in the fatal-error path immediately before `process.exit`, so it must
+    // never throw — a rejection here would skip the exit. `logging.flush` is
+    // already best-effort, but a synchronous throw or rejection is swallowed too.
+    const abortController = new AbortController();
+    try {
+        await Promise.race([
+            logging.flush(),
+            sleep(timeoutMs, undefined, {signal: abortController.signal})
+        ]);
+    } catch {
+        // A broken flush must not block shutdown.
+    } finally {
+        // Cancel the timer as soon as the race settles so it can't keep the
+        // event loop alive past the flush.
+        abortController.abort();
+    }
+}
+
+/**
  * Helper function to handle sending server ready notifications
  * @param {string} [error]
  */
@@ -640,15 +678,19 @@ async function bootGhost({backend = true, frontend = true, server = true} = {}) 
 
         logging.error(serverStartError);
 
+        // `logging.error` may buffer on an async transport (e.g. the
+        // ElasticSearch transport batches writes and only ships on a ~30s
+        // interval). We exit moments later, so without an explicit flush the
+        // crash reason is never shipped anywhere but stdout. Force the buffers
+        // out before exiting.
+        await flushLogging(logging);
+
         // If ghost was started and something else went wrong, we shut it down
         if (ghostServer) {
             notifyServerReady(serverStartError);
             ghostServer.shutdown(2);
         } else {
-            // Ghost server failed to start, set a timeout to give logging a chance to flush
-            setTimeout(() => {
-                process.exit(2);
-            }, 100);
+            process.exit(2);
         }
     }
 }

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -116,7 +116,7 @@
     "@tryghost/kg-lexical-html-renderer": "workspace:*",
     "@tryghost/limit-service": "catalog:",
     "@tryghost/logging": "catalog:",
-    "@tryghost/metrics": "1.0.43",
+    "@tryghost/metrics": "3.3.4",
     "@tryghost/mongo-knex": "catalog:",
     "@tryghost/mongo-utils": "0.6.5",
     "@tryghost/mw-error-handler": "1.0.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2420,8 +2420,8 @@ importers:
         specifier: 5.2.1
         version: 5.2.1(supports-color@10.2.2)
       '@tryghost/metrics':
-        specifier: 1.0.43
-        version: 1.0.43(supports-color@10.2.2)
+        specifier: 3.3.4
+        version: 3.3.4(supports-color@10.2.2)
       '@tryghost/mongo-knex':
         specifier: 'catalog:'
         version: 0.10.1(supports-color@10.2.2)
@@ -5312,10 +5312,6 @@ packages:
       react: '>16.8.0'
       react-dom: '>16.8.0'
 
-  '@elastic/elasticsearch@8.13.1':
-    resolution: {integrity: sha512-2G4Vu6OHw4+XTrp7AGIcOEezpPEoVrWg2JTK1v/exEKSLYquZkUdd+m4yOL3/UZ6bTj7hmXwrmYzW76BnLCkJQ==}
-    engines: {node: '>=18'}
-
   '@elastic/elasticsearch@8.19.2':
     resolution: {integrity: sha512-LMJCju/+AZkDlJArd/MYABWTDrHi4U7j3qGTKi1hYC7+67SaiYmYFItiueACQVrj2j3ECPMcguZ+7WrZeB+Z5g==}
     engines: {node: '>=20'}
@@ -5323,10 +5319,6 @@ packages:
   '@elastic/transport@8.10.1':
     resolution: {integrity: sha512-xo2lPBAJEt81fQRAKa9T/gUq1SPGBHpSnVUXhoSpL996fPZRAfQwFA4BZtEUQL1p8Dezodd3ZN8Wwno+mYyKuw==}
     engines: {node: '>=18'}
-
-  '@elastic/transport@8.4.1':
-    resolution: {integrity: sha512-/SXVuVnuU5b4dq8OFY4izG+dmGla185PcoqgK6+AJMpmOeY1QYVNbWtCwvSvoAANN5D/wV+EBU8+x7Vf9EphbA==}
-    engines: {node: '>=16'}
 
   '@ember-data/adapter@3.24.0':
     resolution: {integrity: sha512-vdDvvHF2QyAfLLvJPeREAVUr3M5LsjaZDJJ6Ernf8gJDZBwYvTcYGQEk39GeCzd1Qhw8F7tUTz1DGZXQQRDCrw==}
@@ -9152,9 +9144,6 @@ packages:
   '@tryghost/domain-events@3.3.4':
     resolution: {integrity: sha512-fLLk5UuoUA/70LolcRhOBPlIMNvQ29ZvVc7yrd9ZKknTmeIf6+lVKAIFASaVZUJXGK1mwht6CCOxA2ydqAj2/A==}
 
-  '@tryghost/elasticsearch@3.0.29':
-    resolution: {integrity: sha512-WGfoGbPXzX7SYPKeD7naYyoF8Lc7KruQPixFSJGLciRQ3wkrZQANQIguD4nA71upp0dhsT4D4aWP296VfJxuPw==}
-
   '@tryghost/elasticsearch@5.4.1':
     resolution: {integrity: sha512-63SFapiBA/HPAJrNbZ8KpOOxH6FaUZxU7Cff3LCFbGGM/522dBus73JBwbVo1NYwEtNPJkLKfajplSCO8QPn6A==}
 
@@ -9200,8 +9189,8 @@ packages:
   '@tryghost/logging@5.2.1':
     resolution: {integrity: sha512-AAPopZkmPiWNCpQXkBjTw3NFGtS+sYXqypYLkpFViDBbU3e7ivK4dEbpnLUa/OJhnYSu276jZ4U5cuPtoUWINw==}
 
-  '@tryghost/metrics@1.0.43':
-    resolution: {integrity: sha512-zTpO/VWhhsDgT/NPeXTa2UNO6KRoMVroo5oHpvKCB29eSE2td6uSarxZCzoxZ9c6rgA2TW0tiGuNu7sB3bMY7g==}
+  '@tryghost/metrics@3.3.4':
+    resolution: {integrity: sha512-MfyTFcif86MzhEXYs5OaxsAMGvqyRIrP6BsGJ2eN4Yi5d6ZoDRAVxIhEb9H7LQsc75qBmmukRJF0uDNJvlBmKg==}
 
   '@tryghost/mongo-knex@0.10.1':
     resolution: {integrity: sha512-6LRA4zVpNvCrVrA9hOhs8N4iylAiafGssiKuD8yML/13xg2PvKw6dzOZj6hg0CKQwG7tVp8TA+7Nw3iDOzy/jQ==}
@@ -9229,9 +9218,6 @@ packages:
 
   '@tryghost/pretty-cli@3.3.2':
     resolution: {integrity: sha512-JOWoEwrdF+flxZBWq+ikww5BRvU95jfUzUnx25pkrSNJEdTYWzJj3bsTGt7LravWCN41M9y4+XvYwEp6cfawpg==}
-
-  '@tryghost/pretty-stream@0.2.5':
-    resolution: {integrity: sha512-2bc5mk+7BAOt/mrcbjTsmUQhTKqysbIDOUUThSemPVbnij6487DhaRbnYWZW2IGKfAucrEO3h6TTm3kfioKJSw==}
 
   '@tryghost/pretty-stream@2.3.4':
     resolution: {integrity: sha512-GYv3pQwscj5jhWheWpBY6BD0L25sqfL0GIp2gzIrYbF7tiTJbiJCeQaAsH0obq0JXRNXhNRwjqZG6VxuyEL7Ig==}
@@ -20551,9 +20537,6 @@ packages:
     resolution: {integrity: sha512-cZFz5XcvYzdHUCOwwrrSFPA9KZdukGENO7ukOgxpcScZaM8zRMIyR6LRySdgoX0nD7NH+XY85F1pQ7n89CZliw==}
     hasBin: true
 
-  secure-json-parse@2.7.0:
-    resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
-
   secure-json-parse@3.0.2:
     resolution: {integrity: sha512-H6nS2o8bWfpFEV6U38sOSjS7bTbdgbCGU9wEM6W14P5H0QOsz94KCusifV44GpHDTu2nqZbuDNhTzu+mjDSw1w==}
 
@@ -24225,13 +24208,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@elastic/elasticsearch@8.13.1(supports-color@10.2.2)':
-    dependencies:
-      '@elastic/transport': 8.4.1(supports-color@10.2.2)
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@elastic/elasticsearch@8.19.2(supports-color@10.2.2)':
     dependencies:
       '@elastic/transport': 8.10.1(supports-color@10.2.2)
@@ -24249,17 +24225,6 @@ snapshots:
       hpagent: 1.2.0
       ms: 2.1.3
       secure-json-parse: 3.0.2
-      tslib: 2.8.1
-      undici: 6.27.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@elastic/transport@8.4.1(supports-color@10.2.2)':
-    dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
-      hpagent: 1.2.0
-      ms: 2.1.3
-      secure-json-parse: 2.7.0
       tslib: 2.8.1
       undici: 6.27.0
     transitivePeerDependencies:
@@ -28534,14 +28499,6 @@ snapshots:
       - '@75lb/nature'
       - supports-color
 
-  '@tryghost/elasticsearch@3.0.29(supports-color@10.2.2)':
-    dependencies:
-      '@elastic/elasticsearch': 8.13.1(supports-color@10.2.2)
-      '@tryghost/debug': 0.1.40(supports-color@10.2.2)
-      split2: 4.2.0
-    transitivePeerDependencies:
-      - supports-color
-
   '@tryghost/elasticsearch@5.4.1(supports-color@10.2.2)':
     dependencies:
       '@elastic/elasticsearch': 8.19.2(supports-color@10.2.2)
@@ -28656,13 +28613,14 @@ snapshots:
       - '@75lb/nature'
       - supports-color
 
-  '@tryghost/metrics@1.0.43(supports-color@10.2.2)':
+  '@tryghost/metrics@3.3.4(supports-color@10.2.2)':
     dependencies:
-      '@tryghost/elasticsearch': 3.0.29(supports-color@10.2.2)
-      '@tryghost/pretty-stream': 0.2.5
-      '@tryghost/root-utils': 0.3.38
+      '@tryghost/elasticsearch': 5.4.1(supports-color@10.2.2)
+      '@tryghost/pretty-stream': 2.3.4
+      '@tryghost/root-utils': 2.3.4
       json-stringify-safe: 5.0.1
     transitivePeerDependencies:
+      - '@75lb/nature'
       - supports-color
 
   '@tryghost/mongo-knex@0.10.1(supports-color@10.2.2)':
@@ -28777,12 +28735,6 @@ snapshots:
     dependencies:
       chalk: 5.6.2
       sywac: 1.3.0
-
-  '@tryghost/pretty-stream@0.2.5':
-    dependencies:
-      date-format: 4.0.14
-      lodash: 4.18.1
-      prettyjson: 1.2.5
 
   '@tryghost/pretty-stream@2.3.4':
     dependencies:
@@ -44303,8 +44255,6 @@ snapshots:
       ee-log: 1.1.0
       ee-types: 2.2.1
       glob: 7.2.3
-
-  secure-json-parse@2.7.0: {}
 
   secure-json-parse@3.0.2: {}
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLA-254/fatal-boot-errors-are-lost-from-elasticsearch-no-logging-flush-before
- the setTimeout approach before wouldn't work with certain logging transports (i.e. Elasticsearch) and startup error logs would be silently dropped
- wires in the new logging.flush helper to ensure logs are flushed before exit, with a timeout race to ensure exiting doesn't hang