### PR TITLE
Removed progress=quiet from docker builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "reset:data:empty": "docker exec ghost-dev bash -c 'cd /home/ghost/ghost/core && node index.js generate-data --clear-database --quantities members:0,posts:0 --seed 123'",
     "reset:data:xxl": "docker exec ghost-dev bash -c 'cd /home/ghost/ghost/core && node index.js generate-data --clear-database --quantities members:2000000,posts:0,emails:0,members_stripe_customers:0,members_login_events:0,members_status_events:0 --seed 123'",
     "seed:multi-sub-scenarios": "docker exec ghost-dev bash -c 'cd /home/ghost/ghost/core && node scripts/seed-multi-sub-scenarios.js'",
-    "docker:build": "docker compose --progress=quiet -f compose.dev.yaml ${DEV_COMPOSE_FILES} build",
+    "docker:build": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} build",
     "docker:build:verbose": "docker compose --progress=plain -f compose.dev.yaml ${DEV_COMPOSE_FILES} build",
     "docker:clean": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} --profile all down -v --remove-orphans --rmi local",
     "docker:down": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} down",
@@ -135,7 +135,7 @@
       "docker:build": {
         "executor": "nx:run-commands",
         "options": {
-          "command": "docker compose --progress=quiet -f compose.dev.yaml ${DEV_COMPOSE_FILES} build"
+          "command": "docker compose -f compose.dev.yaml ${DEV_COMPOSE_FILES} build"
         }
       },
       "docker:dev": {


### PR DESCRIPTION
no ref

I initially removed this to clean up the logs for agents but it's been problematic when troubleshooting docker builds.