### PR TITLE
Fixed Docker build context traversal

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,6 @@
+# Avoid negated patterns. They prevent BuildKit from pruning ignored directories
+# during wildcard COPY context discovery, causing severe build slowdowns.
+
 node_modules
 
 .nxcache
@@ -24,9 +27,10 @@ Dockerfile
 .editorconfig
 compose.yml
 
-docker
-!docker/**/*.entrypoint.sh
-!docker/**/*entrypoint.sh
+.agents
+.claude
+.codex
+.cursor
 
 # NOTE: core/built/admin is intentionally NOT ignored — the production image's
 # `full` stage COPYs it from the build context, where CI injects the admin build


### PR DESCRIPTION
## What changed
- ignored repository-local agent/tooling directories (`.agents`, `.claude`, `.codex`, and `.cursor`) from Docker build contexts
- removed the `docker` exclusion and its entrypoint negations, leaving the small `docker/` directory available directly
- documented why negated patterns should not be added to `.dockerignore`

These ignore rules affect only the Docker build context. The configuration in those directories remains tracked by Git, and builds launched from a Git worktree still work because the patterns are evaluated relative to that worktree's build context.

## Why
The development Dockerfile uses wildcard `COPY` sources for workspace manifests. BuildKit performs filesystem discovery for those sources. The wildcard manifest copying was introduced in [#29256](https://github.com/TryGhost/Ghost/pull/29256).

Negated `.dockerignore` patterns prevent BuildKit from pruning ignored directories during that discovery. Repository-local agent directories can contain generated caches or nested worktrees with hundreds of thousands of files, causing context loading to take several minutes while BuildKit repeatedly stats them. CI does not reproduce this because it builds from a clean checkout without those local artifacts.

Keeping the approximately 60 KB `docker/` directory in the context avoids the negation set while preserving access to the entrypoint files.

## Validation
- `pnpm docker:build`
- development image context loaded in 0.4 seconds
- `git diff --check`