### PR TITLE
Fixed flaky welcome email Escape test

### DIFF
--- a/apps/admin/src/settings/membership/member-welcome-emails.acceptance.test.tsx
+++ b/apps/admin/src/settings/membership/member-welcome-emails.acceptance.test.tsx
@@ -158,10 +158,6 @@ function pasteText(content: string) {
     }));
 }
 
-function pressEscape() {
-    document.dispatchEvent(new KeyboardEvent("keydown", {key: "Escape", code: "Escape", bubbles: true, cancelable: true}));
-}
-
 describe("Member welcome emails", () => {
     it("previews the unsaved draft only after Preview is selected", async () => {
         fakeSettingsScreens();
@@ -277,7 +273,7 @@ describe("Member welcome emails", () => {
         const dropdown = page.getByTestId("test-email-dropdown");
         await expect.element(dropdown).toBeVisible();
 
-        pressEscape();
+        await userEvent.keyboard("{Escape}");
         await expect(dropdown).toHaveCount(0);
         await expect.element(modal).toBeVisible();
     });
@@ -285,7 +281,7 @@ describe("Member welcome emails", () => {
     it("only asks for close confirmation after the draft becomes dirty", async () => {
         const modal = await openWelcomeEmailModal();
         (modal.getByRole("button", {name: "Close"}).element() as HTMLElement).focus();
-        pressEscape();
+        await userEvent.keyboard("{Escape}");
         await expect(modal).toHaveCount(0);
         await expect(settingsScreen.confirmationModal()).toHaveCount(0);
 
@@ -308,7 +304,7 @@ describe("Member welcome emails", () => {
         document.body.appendChild(linkInput);
         linkInput.focus();
 
-        pressEscape();
+        await userEvent.keyboard("{Escape}");
 
         await expect.element(modal).toBeVisible();
         expect(window.location.hash).toContain("/settings/memberemails");
@@ -712,7 +708,7 @@ describe("Member welcome emails", () => {
         it("closes a pristine customize modal on Escape without confirmation", async () => {
             const modal = await openCustomizeModal();
 
-            pressEscape();
+            await userEvent.keyboard("{Escape}");
 
             await expect(modal).toHaveCount(0);
             await expect(settingsScreen.welcomeEmailDirtyConfirmModal()).toHaveCount(0);
@@ -723,14 +719,14 @@ describe("Member welcome emails", () => {
             const modal = await openCustomizeModal();
             await modal.getByLabelText("Email footer").fill("Unsaved footer change");
 
-            pressEscape();
+            await userEvent.keyboard("{Escape}");
 
             const confirmation = settingsScreen.welcomeEmailDirtyConfirmModal();
             await expect.element(confirmation).toBeVisible();
             await expect.element(modal).toBeVisible();
             await expect.poll(currentRoute).toBe("/settings/memberemails");
 
-            pressEscape();
+            await userEvent.keyboard("{Escape}");
 
             await expect(confirmation).toHaveCount(0);
             await expect.element(modal).toBeVisible();


### PR DESCRIPTION
## What changed

- replaced the synchronous raw `KeyboardEvent` helper in the welcome-email acceptance tests with awaited `userEvent.keyboard("{Escape}")` interactions
- updated every Escape scenario in the spec to use the synchronized browser interaction

## Why

The failing test raced React and Radix dialog teardown. The raw DOM event returned before the dirty-confirmation modal had necessarily finished closing, so CI could assert that the modal was gone while it was still mounted.

Using the browser test runner's awaited keyboard interaction matches real user behavior and ensures event handling settles before assertions run.

## Impact

Test-only change. This removes timing sensitivity without changing production behavior.

## Validation

- failing focused scenario passed 10/10 repeated runs
- full `member-welcome-emails.acceptance.test.tsx` suite passed: 33/33
- ESLint passed for the edited file
- `git diff --check` passed