### PR TITLE
Changed Admin acceptance test concurrency in CI

### DIFF
--- a/apps/admin/vitest.acceptance.config.ts
+++ b/apps/admin/vitest.acceptance.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
     test: {
         name: "acceptance",
         include: ["src/**/*.acceptance.test.tsx"],
+        maxWorkers: process.env.CI ? 2 : undefined,
         setupFiles: ["./test-utils/acceptance/setup.ts"],
         expect: {
             // Full-app renders are slower than unit renders; the harness's


### PR DESCRIPTION
## What changed

- Caps the Admin Vitest browser acceptance suite at two workers in CI.
- Leaves local worker selection unchanged.
- Keeps the affected integration test on the standard 15-second timeout.
- Does not shard the GitHub Actions job.

## Why

The [original failing job](https://github.com/TryGhost/Ghost/actions/runs/29785795398/job/88497129785) took 15.33 seconds for the affected test, but the same test takes 3.7 seconds in isolation. The complete integrations file was similarly about three times slower in CI than locally, indicating full-app browser files were competing for runner resources rather than the test having an inherently slow interaction.

## CI benchmark

The [two-worker PR job](https://github.com/TryGhost/Ghost/actions/runs/29792585731/job/88517528684) passed all 51 files and 366 tests on the standard timeout.

| Measurement | Original CI | Two workers | Change |
| --- | ---: | ---: | ---: |
| Target test | 15.33s | 6.06s | 60% faster |
| Integrations file | 58.14s | 36.78s | 37% faster |
| Vitest suite | 355.77s | 347.04s | 9s faster |
| Playwright step | 6m 06s | 5m 54s | 12s faster |

## Local benchmark

| Workers | Wall time | Target test | Result |
| ---: | ---: | ---: | --- |
| Default (14 locally) | 114.9s | 5.54s | Failed with concurrency/import errors |
| 4 | 80.7s | 5.33s | 363 passed |
| 3 | 95.1s | 4.76s | 363 passed |
| 2 | 131.2s | 2.99s | 363 passed |
| 1 | 243.7s | 3.29s | 363 passed |

## Validation

- Full local suite with two workers: 51 files and 363 tests passed.
- Focused test with the CI configuration passed in 3.59 seconds.
- Full PR CI suite: 51 files and 366 tests passed.