### PR TITLE
🎨 Further improved automation polling performance

### DIFF
--- a/ghost/core/core/server/services/automations/database-automations-repository.ts
+++ b/ghost/core/core/server/services/automations/database-automations-repository.ts
@@ -566,6 +566,7 @@ async function fetchAndLockSteps(trx: Knex.Transaction, limit: number): Promise<
         .innerJoin('automations as automation', 'automation.id', 'run.automation_id')
         .innerJoin('automation_action_revisions as revision', 'revision.id', 'step.automation_action_revision_id')
         .innerJoin('automation_actions as action', 'action.id', 'revision.action_id')
+        .whereIn('step.id', candidateIds)
         .where('step.locked_by', lockId)
         .orderBy([
             'step.ready_at',


### PR DESCRIPTION
no ref

When fetching automation steps to run, we try to lock up to 100 rows, then select any rows we've locked.

This improves the performance of that query by limiting it to our candidate rows. That means we'll only check 100 rows instead of the full database.

See also: https://github.com/TryGhost/Ghost/pull/29476
