### PR TITLE
Reduce URL parity compare-mode log noise

### DIFF
--- a/ghost/core/core/server/services/url/url-service-facade.ts
+++ b/ghost/core/core/server/services/url/url-service-facade.ts
@@ -423,6 +423,17 @@ export class UrlServiceFacade {
             && this._isNotFound(eagerValue) && !this._isNotFound(lazyValue)) {
             return true;
         }
+
+        // A site's owner starts with the default `ghost-user` slug and is
+        // renamed during setup. The rename emits no event the eager cache
+        // consumes, so eager serves /author/ghost-user/ until the next boot
+        // while lazy has the real slug from the database.
+        if (method === 'getUrlForResource'
+            && context.type === 'authors'
+            && typeof eagerValue === 'string' && eagerValue.endsWith('/author/ghost-user/')
+            && !this._isNotFound(lazyValue)) {
+            return true;
+        }
         return false;
     }
 

--- a/ghost/core/core/server/services/url/url-service-facade.ts
+++ b/ghost/core/core/server/services/url/url-service-facade.ts
@@ -272,7 +272,7 @@ export class UrlServiceFacade {
             void this._compareAsync('resolveUrl', eagerSnapshot,
                 () => this.lazyUrlService!.resolveUrl(urlPath),
                 {path: urlPath},
-                (a, b) => _.isEqual(a, b));
+                (a, b) => this._resolvesToSameResource(a, b));
         }
         return eagerResult;
     }
@@ -388,9 +388,24 @@ export class UrlServiceFacade {
         return typeof value === 'string' && value.endsWith('/404/');
     }
 
-    // Divergences where eager is the stale side and lazy is authoritative, so
-    // logging them only buries real regressions. Each branch is a class
-    // confirmed from production compare data.
+    // resolveUrl's contract is which resource a path maps to, not the exact
+    // serialized record. Eager (raw-knex) and lazy (model.toJSON) shape the same
+    // DB row differently — lazy carries a `parent` key eager omits, eager keeps
+    // __GHOST_URL__ placeholders lazy expands, timestamps differ in precision —
+    // so comparing whole records reports the same resolved resource as a
+    // mismatch. Compare resolved identity instead.
+    private _resolvesToSameResource(a: unknown, b: unknown): boolean {
+        if (a === null || b === null) {
+            return a === b;
+        }
+        const ra = a as Resource;
+        const rb = b as Resource;
+        return ra.id === rb.id && ra.type === rb.type;
+    }
+
+    // Divergences that are not lazy regressions, so logging them only buries
+    // the ones that are. Each branch is a class confirmed from production
+    // compare data.
     private _isExpectedDivergence(
         method: string,
         eagerValue: unknown,

--- a/ghost/core/core/server/services/url/url-service-facade.ts
+++ b/ghost/core/core/server/services/url/url-service-facade.ts
@@ -242,6 +242,7 @@ export class UrlServiceFacade {
         return {
             type: resource.type,
             id: resource.id,
+            status: (resource as Record<string, unknown>).status,
             resourceKeys: Object.keys(resource),
             caller: caller.stack,
             ...extra
@@ -432,6 +433,17 @@ export class UrlServiceFacade {
             && context.type === 'authors'
             && typeof eagerValue === 'string' && eagerValue.endsWith('/author/ghost-user/')
             && !this._isNotFound(lazyValue)) {
+            return true;
+        }
+
+        // lazy returns /404/ where eager serves a real URL: eager cached a
+        // resource that is no longer routable (unpublished or deleted since,
+        // with no event to evict it). Suppress only when the resource is
+        // provably not published — a published resource lazy refuses to route
+        // is a real lazy bug, so that keeps logging.
+        if (method === 'getUrlForResource'
+            && this._isNotFound(lazyValue) && !this._isNotFound(eagerValue)
+            && typeof context.status === 'string' && context.status !== 'published') {
             return true;
         }
         return false;

--- a/ghost/core/core/server/services/url/url-service-facade.ts
+++ b/ghost/core/core/server/services/url/url-service-facade.ts
@@ -384,6 +384,33 @@ export class UrlServiceFacade {
         this._reportMismatch(method, eagerValue, lazyValue, context, isEqual);
     }
 
+    private _isNotFound(value: unknown): boolean {
+        return typeof value === 'string' && value.endsWith('/404/');
+    }
+
+    // Divergences where eager is the stale side and lazy is authoritative, so
+    // logging them only buries real regressions. Each branch is a class
+    // confirmed from production compare data.
+    private _isExpectedDivergence(
+        method: string,
+        eagerValue: unknown,
+        lazyValue: unknown,
+        context: Record<string, unknown>
+    ): boolean {
+        // Eager leaves tags/authors with no published posts out of its URL map
+        // (the shouldHavePosts gate) so they resolve to /404/, while lazy has no
+        // cheap way to run that check and returns the real URL. Eager cache
+        // staleness (a tag gaining its first post after boot) looks the same.
+        // Whether to keep lazy's behaviour is still open, but either way it is
+        // not a lazy bug, so exclude it to surface the divergences that are.
+        if (method === 'getUrlForResource'
+            && (context.type === 'tags' || context.type === 'authors')
+            && this._isNotFound(eagerValue) && !this._isNotFound(lazyValue)) {
+            return true;
+        }
+        return false;
+    }
+
     private _reportMismatch(
         method: string,
         eagerValue: unknown,
@@ -392,6 +419,9 @@ export class UrlServiceFacade {
         isEqual: (a: unknown, b: unknown) => boolean
     ): void {
         if (!isEqual(eagerValue, lazyValue)) {
+            if (this._isExpectedDivergence(method, eagerValue, lazyValue, context)) {
+                return;
+            }
             const {caller, ...details} = context;
             const report = new errors.InternalServerError({
                 message: 'URL service parity mismatch',

--- a/ghost/core/test/unit/server/services/url/url-service-facade.test.js
+++ b/ghost/core/test/unit/server/services/url/url-service-facade.test.js
@@ -374,6 +374,26 @@ describe('UrlServiceFacade', function () {
             sinon.assert.notCalled(logging.error);
         });
 
+        it('does not report a tag/author whose eager URL is /404/ but lazy resolves it', async function () {
+            // Eager cache missing a routable tag/author (no model event) — lazy
+            // is authoritative, so this eager staleness is expected noise.
+            urlService.getUrlByResourceId.returns('/404/');
+            lazyUrlService.getUrlForResource.returns('/tag/news/');
+            compareFacade.getUrlForResource({type: 'tags', id: 't1'});
+            compareFacade.getUrlForResource({type: 'authors', id: 'u1'});
+            await flush();
+            sinon.assert.notCalled(logging.error);
+        });
+
+        it('still reports a post whose eager URL is /404/ (not the tag/author class)', async function () {
+            urlService.getUrlByResourceId.returns('/404/');
+            lazyUrlService.getUrlForResource.returns('/hello-world/');
+            compareFacade.getUrlForResource({type: 'posts', id: 'a'});
+            await flush();
+            sinon.assert.calledOnce(logging.error);
+            assert.equal(logging.error.firstCall.args[0].code, 'LAZY_URL_PARITY_MISMATCH');
+        });
+
         it('reports a mismatch when lazy ownership differs', async function () {
             compareFacade.ownsResource('routerA', {type: 'posts', id: 'a'});
             await flush();

--- a/ghost/core/test/unit/server/services/url/url-service-facade.test.js
+++ b/ghost/core/test/unit/server/services/url/url-service-facade.test.js
@@ -402,6 +402,31 @@ describe('UrlServiceFacade', function () {
             sinon.assert.notCalled(logging.error);
         });
 
+        it('does not report a non-published resource that eager still serves but lazy 404s', async function () {
+            urlService.getUrlByResourceId.returns('/hello-world/');
+            lazyUrlService.getUrlForResource.returns('/404/');
+            compareFacade.getUrlForResource({type: 'posts', id: 'a', status: 'draft'});
+            await flush();
+            sinon.assert.notCalled(logging.error);
+        });
+
+        it('still reports a PUBLISHED resource that lazy 404s (a real lazy bug)', async function () {
+            urlService.getUrlByResourceId.returns('/hello-world/');
+            lazyUrlService.getUrlForResource.returns('/404/');
+            compareFacade.getUrlForResource({type: 'posts', id: 'a', status: 'published'});
+            await flush();
+            sinon.assert.calledOnce(logging.error);
+            assert.equal(logging.error.firstCall.args[0].code, 'LAZY_URL_PARITY_MISMATCH');
+        });
+
+        it('still reports a lazy 404 when the resource carries no status', async function () {
+            urlService.getUrlByResourceId.returns('/hello-world/');
+            lazyUrlService.getUrlForResource.returns('/404/');
+            compareFacade.getUrlForResource({type: 'posts', id: 'a'});
+            await flush();
+            sinon.assert.calledOnce(logging.error);
+        });
+
         it('reports a mismatch when lazy ownership differs', async function () {
             compareFacade.ownsResource('routerA', {type: 'posts', id: 'a'});
             await flush();

--- a/ghost/core/test/unit/server/services/url/url-service-facade.test.js
+++ b/ghost/core/test/unit/server/services/url/url-service-facade.test.js
@@ -470,15 +470,43 @@ describe('UrlServiceFacade', function () {
             await flush();
         });
 
-        it('reports a parity mismatch when the lazy resource differs', async function () {
+        it('reports a parity mismatch when lazy resolves a different resource', async function () {
             urlService.getResource.returns({config: {type: 'posts'}, data: {id: 'eager', slug: 's'}});
-            lazyUrlService.resolveUrl.resolves({type: 'posts', id: 'eager', slug: 'different'});
+            lazyUrlService.resolveUrl.resolves({type: 'posts', id: 'different', slug: 's'});
 
             await compareFacade.resolveUrl('/x/');
             await flush();
 
             sinon.assert.calledOnce(logging.error);
             assert.equal(logging.error.firstCall.args[0].code, 'LAZY_URL_PARITY_MISMATCH');
+        });
+
+        it('reports when the URL resolves on one side but not the other', async function () {
+            urlService.getResource.returns({config: {type: 'posts'}, data: {id: 'eager', slug: 's'}});
+            lazyUrlService.resolveUrl.resolves(null);
+
+            await compareFacade.resolveUrl('/x/');
+            await flush();
+
+            sinon.assert.calledOnce(logging.error);
+            assert.equal(logging.error.firstCall.args[0].code, 'LAZY_URL_PARITY_MISMATCH');
+        });
+
+        it('does not report when both sides resolve the same resource with a different record shape', async function () {
+            // Same resolved resource, different serialization: lazy carries a
+            // `parent` key and an expanded image URL, eager keeps the placeholder.
+            urlService.getResource.returns({config: {type: 'tags'}, data: {
+                id: 'eager', slug: 'news', canonical_url: '__GHOST_URL__/tag/news/'
+            }});
+            lazyUrlService.resolveUrl.resolves({
+                type: 'tags', id: 'eager', slug: 'news', parent: null,
+                canonical_url: 'https://example.com/tag/news/'
+            });
+
+            await compareFacade.resolveUrl('/tag/news/');
+            await flush();
+
+            sinon.assert.notCalled(logging.error);
         });
 
         it('does not report when eager and lazy resources are deep equal', async function () {

--- a/ghost/core/test/unit/server/services/url/url-service-facade.test.js
+++ b/ghost/core/test/unit/server/services/url/url-service-facade.test.js
@@ -394,6 +394,14 @@ describe('UrlServiceFacade', function () {
             assert.equal(logging.error.firstCall.args[0].code, 'LAZY_URL_PARITY_MISMATCH');
         });
 
+        it('does not report an author whose eager URL is the stale ghost-user default', async function () {
+            urlService.getUrlByResourceId.returns('https://site.com/author/ghost-user/');
+            lazyUrlService.getUrlForResource.returns('https://site.com/author/nick/');
+            compareFacade.getUrlForResource({type: 'authors', id: 'u1'});
+            await flush();
+            sinon.assert.notCalled(logging.error);
+        });
+
         it('reports a mismatch when lazy ownership differs', async function () {
             compareFacade.ownsResource('routerA', {type: 'posts', id: 'a'});
             await flush();


### PR DESCRIPTION
## Why

Compare mode runs the lazy URL service alongside the authoritative eager one and logs every difference as `LAZY_URL_PARITY_MISMATCH`. The problem is that almost none of the differences are lazy bugs, and at 600k+ logs every 12h they bury the ones that are. We only found the real bugs by digging past this, so cutting the noise makes the next one easier to spot.

- **404s for empty tags and authors — an open behaviour question, not a bug.** Eager leaves tags and authors with no published posts out of its URL map (the `shouldHavePosts` gate), so they resolve to `/404/`. Lazy builds URLs on demand and has no cheap way to check whether a tag has posts, so it returns the real canonical URL. We haven't decided whether to keep lazy's behaviour, but it isn't a regression: the tag still hard-404s on a direct visit, and the only rendered change is one href in tag/author listings that already pointed at a 404 page.
- **resolveUrl — a bug in the comparison itself.** The check compared whole serialized records with `_.isEqual`. But eager builds records with raw knex and lazy through the model, so the same DB row comes out shaped differently: lazy has a `parent` key, eager keeps the `__GHOST_URL__` placeholder lazy expands, timestamps differ in precision. Both sides resolved the same resource; the comparison was just too strict. It now compares the resolved id and type, which is all resolveUrl actually promises.
- **ghost-user author rename — a latent eager bug that lazy fixes.** A new site owner gets renamed during setup, eager never sees the event, so it keeps serving `/author/ghost-user/` while lazy has the real slug. Eager is wrong here; lazy is right.
- **Deleted or unpublished content — a latent eager bug that lazy fixes.** Eager keeps serving a URL for content that's been unpublished or deleted, because that path emits no event eager consumes. In the URL strings alone this is indistinguishable from a real lazy bug dropping a published post, so it's only suppressed when the resource isn't published. If lazy 404s something that IS published, that still logs.

After this, the compare stream should be down to the one issue that's actually open: eager and lazy picking different primary_tag/primary_author.
