### PR TITLE
Fixed lazy URL primary_tag on tied tag sort_order

### DIFF
--- a/ghost/core/core/server/models/post.js
+++ b/ghost/core/core/server/models/post.js
@@ -950,15 +950,29 @@ Post = ghostBookshelf.Model.extend({
     },
 
     authors: function authors() {
+        // posts_authors.id breaks sort_order ties deterministically (by attach
+        // order); without it MySQL can order tied rows differently per query,
+        // which changes the computed primary_author. See tags() below.
+        // `id` is pivoted in so it is in the SELECT list — the query uses
+        // DISTINCT, which requires ORDER BY columns to be selected.
         return this.belongsToMany('User', 'posts_authors', 'post_id', 'author_id')
-            .withPivot('sort_order')
-            .query('orderBy', 'sort_order', 'ASC');
+            .withPivot(['sort_order', 'id'])
+            .query('orderBy', 'sort_order', 'ASC')
+            .query('orderBy', 'posts_authors.id', 'ASC');
     },
 
     tags: function tags() {
+        // posts_tags.id breaks sort_order ties deterministically (by attach
+        // order). primary_tag is tags[0]-if-public, so a non-deterministic tie
+        // order (which MySQL produces for tags sharing a sort_order) makes the
+        // primary tag — and the post's URL under a {primary_tag} permalink —
+        // depend on the query shape.
+        // `id` is pivoted in so it is in the SELECT list — the query uses
+        // DISTINCT, which requires ORDER BY columns to be selected.
         return this.belongsToMany('Tag', 'posts_tags', 'post_id', 'tag_id')
-            .withPivot('sort_order')
-            .query('orderBy', 'sort_order', 'ASC');
+            .withPivot(['sort_order', 'id'])
+            .query('orderBy', 'sort_order', 'ASC')
+            .query('orderBy', 'posts_tags.id', 'ASC');
     },
 
     mobiledoc_revisions() {

--- a/ghost/core/test/integration/url-serializer-parity.test.js
+++ b/ghost/core/test/integration/url-serializer-parity.test.js
@@ -11,6 +11,7 @@ const {createFindResource} = require('../../core/server/services/url/lazy-find-r
 const inputSerializer = require('../../core/server/api/endpoints/utils/serializers/input/posts');
 const postsMapper = require('../../core/server/api/endpoints/utils/serializers/output/mappers/posts');
 const memberAttribution = require('../../core/server/services/member-attribution');
+const db = require('../../core/server/data/db');
 
 // Drives the real Content API serializer pipeline (input serializer → model
 // fetch → output mapper → facade) against a lazy backend and compares URLs
@@ -255,6 +256,41 @@ describe('Integration: Content API serializer → lazy URL parity (primary_tag p
                     );
                 }
             });
+        });
+    });
+
+    // Regression for the production divergence where a post's tags share a
+    // sort_order (left behind by bulk/import ops). primary_tag is the first
+    // tag if public, so without a tie-break the lazy path's tag load could
+    // order the tied tags differently per query on MySQL, changing the post's
+    // URL under a {primary_tag} permalink (seen as /disaster-preparedness/ vs
+    // /claremont-elmwood/). The posts_tags.id tie-break pins the lazy path to
+    // the first-attached public tag — the tag eager already serves. Only
+    // diverges on MySQL; on sqlite this pins the expected ordering.
+    describe('tied tag sort_order', function () {
+        beforeAll(async function () {
+            // Two public tags with an internal one between them, all sharing
+            // sort_order 0.
+            const tiedPost = await models.Post.add({
+                title: 'Tied Tags', slug: 'tied-tags', status: 'published', lexical: EMPTY_LEXICAL,
+                tags: [
+                    {name: 'First Public', slug: 'first-public'},
+                    {name: '#internal', slug: 'hash-tied-internal'},
+                    {name: 'Second Public', slug: 'second-public'}
+                ]
+            }, {context: {internal: true}, withRelated: ['tags']});
+            await db.knex('posts_tags').where('post_id', tiedPost.id).update({sort_order: 0});
+        });
+
+        it('resolves the lazy tie to the first-attached public tag', async function () {
+            // The suite's facade routes getUrlForResource through the lazy
+            // backend, so this is the lazy path's primary_tag.
+            const mapped = await browsePipeline({slug: 'tied-tags'});
+            assert.match(
+                mapped.url,
+                /\/first-public\//,
+                `expected the first attached public tag as primary_tag, got ${mapped.url}`
+            );
         });
     });
 });


### PR DESCRIPTION
## Why

Under a `{primary_tag}` or `{primary_author}` permalink, a post's URL is built from its primary tag — the post's first tag, if that tag is public. So the URL depends on the order the tags relation returns.

The lazy URL path and the eager service load a post's tags through different queries, and both order by `sort_order` with no tie-breaker. When several of a post's tags share a `sort_order` — the state bulk edits and imports leave behind — MySQL is free to return them in a different order for each query. So the lazy path and eager pick a different primary tag and build a different URL for the same post. In production this surfaced as eager serving `/disaster-preparedness/…` while the lazy comparison produced `/claremont-elmwood/…` for the same post.

Eager is authoritative and is being removed, so rather than touch its query this pins only the lazy path. The model's `tags()` and `authors()` relations now order by the pivot id (`posts_tags.id` / `posts_authors.id`) after `sort_order`. That's attach order, which is the tag eager already serves, so the lazy path now matches it without eager changing.

The pivot id is pulled into the relation's `withPivot` because the query uses `DISTINCT`, which requires ORDER BY columns to be in the SELECT list.

The divergence only happens on MySQL — sqlite resolves the tie consistently — so the added regression test pins the deterministic ordering rather than reproducing the divergence.
