### PR TITLE
Added client-side sanitization to the ActivityPub reader

### DIFF
--- a/apps/activitypub/src/utils/content-formatters.ts
+++ b/apps/activitypub/src/utils/content-formatters.ts
@@ -25,12 +25,11 @@ export function sanitizeHtml(html: string): string {
 }
 
 // Must stay in sync with allowedScriptHostnames in the backend sanitizer
-// (activitypub/src/helpers/html.ts)
+// (https://github.com/TryGhost/ActivityPub/blob/main/src/helpers/html.ts)
 const ALLOWED_SCRIPT_HOSTNAMES = ['platform.twitter.com', 'platform.x.com'];
 
 // Article content needs looser rules than sanitizeHtml (iframes for YouTube
-// embeds, scripts for Twitter embeds), so it gets its own DOMPurify instance —
-// the script hook below must not affect the default instance.
+// embeds, scripts for Twitter embeds), so it gets its own DOMPurify instance
 const articlePurify = DOMPurify(window);
 
 articlePurify.addHook('uponSanitizeElement', (node, data) => {

--- a/apps/activitypub/src/utils/content-formatters.ts
+++ b/apps/activitypub/src/utils/content-formatters.ts
@@ -24,6 +24,52 @@ export function sanitizeHtml(html: string): string {
     return DOMPurify.sanitize(html);
 }
 
+// Must stay in sync with allowedScriptHostnames in the backend sanitizer
+// (activitypub/src/helpers/html.ts)
+const ALLOWED_SCRIPT_HOSTNAMES = ['platform.twitter.com', 'platform.x.com'];
+
+// Article content needs looser rules than sanitizeHtml (iframes for YouTube
+// embeds, scripts for Twitter embeds), so it gets its own DOMPurify instance —
+// the script hook below must not affect the default instance.
+const articlePurify = DOMPurify(window);
+
+articlePurify.addHook('uponSanitizeElement', (node, data) => {
+    if (data.tagName !== 'script') {
+        return;
+    }
+
+    const element = node as Element;
+    const src = element.getAttribute('src') || '';
+
+    let hasAllowedSrc = false;
+    try {
+        // Relative URLs must not pass, so no base URL here
+        const url = new URL(src);
+        hasAllowedSrc = url.protocol === 'https:' && ALLOWED_SCRIPT_HOSTNAMES.includes(url.hostname);
+    } catch {
+        hasAllowedSrc = false;
+    }
+
+    if (!hasAllowedSrc) {
+        element.parentNode?.removeChild(element);
+        return;
+    }
+
+    // Allowed scripts may only load code via src, never run inline code
+    element.textContent = '';
+});
+
+export function sanitizeArticleContent(content: string): string {
+    return articlePurify.sanitize(content, {
+        ADD_TAGS: ['iframe', 'script'],
+        ADD_ATTR: ['target', 'frameborder', 'allowfullscreen', 'async', 'charset'],
+        // Without this the HTML parser hoists leading <script>/<style> tags
+        // into <head>, which DOMPurify then discards — content starting with
+        // an embed script would lose it
+        FORCE_BODY: true
+    });
+}
+
 export function stripHtml(html: string, exclude: string[] = []): string {
     // If no exclusions, use the original logic
     if (exclude.length === 0) {

--- a/apps/activitypub/src/views/inbox/components/reader.tsx
+++ b/apps/activitypub/src/views/inbox/components/reader.tsx
@@ -20,7 +20,7 @@ import articleBodyStyles from '@src/components/article-body-styles';
 import getReadingTime from '../../../utils/get-reading-time';
 import {Activity} from '@src/api/activitypub';
 import {cardsCSS, cardsJS} from '@src/utils/cards-assets';
-import {enforceVideoCardInlinePlayback, escapeHtml, isSafeUrl, openLinksInNewTab} from '@src/utils/content-formatters';
+import {enforceVideoCardInlinePlayback, escapeHtml, isSafeUrl, openLinksInNewTab, sanitizeArticleContent} from '@src/utils/content-formatters';
 import {handleProfileClick} from '@src/utils/handle-profile-click';
 import {isPendingActivity} from '../../../utils/pending-activity';
 import {useDebounce} from 'use-debounce';
@@ -69,9 +69,12 @@ const ArticleBody: React.FC<{
 
     const cssContent = articleBodyStyles();
     const shouldEnforceVideoCardInlinePlayback = typeof window !== 'undefined' && typeof window.matchMedia === 'function' && window.matchMedia('(hover: none) and (pointer: coarse)').matches;
+
     const articleHtml = useMemo(() => {
         const transformedHtml = shouldEnforceVideoCardInlinePlayback ? enforceVideoCardInlinePlayback(html) : html;
-        return openLinksInNewTab(transformedHtml);
+        // Sanitize last so the transformations above can't reintroduce
+        // anything unsafe
+        return sanitizeArticleContent(openLinksInNewTab(transformedHtml));
     }, [html, shouldEnforceVideoCardInlinePlayback]);
 
     const htmlContent = `

--- a/apps/activitypub/test/unit/utils/content-formatters.test.ts
+++ b/apps/activitypub/test/unit/utils/content-formatters.test.ts
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 
-import {enforceVideoCardInlinePlayback, sanitizeHtml, stripHtml} from '../../../src/utils/content-formatters';
+import {enforceVideoCardInlinePlayback, sanitizeArticleContent, sanitizeHtml, stripHtml} from '../../../src/utils/content-formatters';
 
 function sanitizeStrippedHtml(html: string, exclude: string[] = ['a']) {
     return sanitizeHtml(stripHtml(html, exclude));
@@ -160,6 +160,126 @@ describe('Content Formatters', function () {
             expect(div.querySelector('a')).toBeNull();
             expect(div.querySelector('br')).toBeNull();
             expect(div.textContent).toBe('Hello safe link Bold');
+        });
+    });
+
+    describe('sanitizeArticleContent', function () {
+        it('keeps YouTube iframe embeds intact', function () {
+            const result = sanitizeArticleContent(`
+                <figure class="kg-card kg-embed-card">
+                    <iframe src="https://www.youtube.com/embed/abc123" width="560" height="315" frameborder="0" allowfullscreen></iframe>
+                </figure>
+            `);
+
+            const iframe = renderHtml(result).querySelector('iframe') as HTMLIFrameElement;
+
+            expect(iframe).not.toBeNull();
+            expect(iframe.getAttribute('src')).toBe('https://www.youtube.com/embed/abc123');
+            expect(iframe.getAttribute('width')).toBe('560');
+            expect(iframe.getAttribute('height')).toBe('315');
+            expect(iframe.getAttribute('frameborder')).toBe('0');
+            expect(iframe.hasAttribute('allowfullscreen')).toBe(true);
+        });
+
+        it('removes unsafe iframe attributes and protocols', function () {
+            const result = sanitizeArticleContent(`
+                <iframe src="javascript:alert(1)"></iframe>
+                <iframe srcdoc="<script>window.__xss=true</script>" onload="window.__xss=true"></iframe>
+            `);
+
+            const iframes = renderHtml(result).querySelectorAll('iframe');
+
+            iframes.forEach((iframe) => {
+                expect(iframe.getAttribute('src')).toBeNull();
+                expect(iframe.hasAttribute('srcdoc')).toBe(false);
+                expect(iframe.hasAttribute('onload')).toBe(false);
+            });
+        });
+
+        it('keeps Twitter embed scripts from allowed hostnames', function () {
+            const result = sanitizeArticleContent(`
+                <blockquote class="twitter-tweet"><p>A tweet</p></blockquote>
+                <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+                <script async src="https://platform.x.com/widgets.js" charset="utf-8"></script>
+            `);
+
+            const div = renderHtml(result);
+            const scripts = div.querySelectorAll('script');
+
+            expect(div.querySelector('blockquote.twitter-tweet')).not.toBeNull();
+            expect(scripts).toHaveLength(2);
+            expect(scripts[0].getAttribute('src')).toBe('https://platform.twitter.com/widgets.js');
+            expect(scripts[0].hasAttribute('async')).toBe(true);
+            expect(scripts[0].getAttribute('charset')).toBe('utf-8');
+            expect(scripts[1].getAttribute('src')).toBe('https://platform.x.com/widgets.js');
+        });
+
+        it('removes scripts that are not from allowed hostnames', function () {
+            const result = sanitizeArticleContent(`
+                <p>Content</p>
+                <script src="https://evil.com/widgets.js"></script>
+                <script src="https://platform.twitter.com.evil.com/widgets.js"></script>
+                <script src="https://evil.com/platform.twitter.com"></script>
+                <script src="http://platform.twitter.com/widgets.js"></script>
+                <script src="//platform.twitter.com/widgets.js"></script>
+                <script src="/widgets.js"></script>
+                <script>window.__xss=true</script>
+            `);
+
+            const div = renderHtml(result);
+
+            expect(div.querySelectorAll('script')).toHaveLength(0);
+            expect(div.querySelector('p')?.textContent).toBe('Content');
+        });
+
+        it('strips inline code from scripts with an allowed src', function () {
+            const result = sanitizeArticleContent(`
+                <script src="https://platform.twitter.com/widgets.js">window.__xss=true</script>
+            `);
+
+            const script = renderHtml(result).querySelector('script') as HTMLScriptElement;
+
+            expect(script).not.toBeNull();
+            expect(script.textContent).toBe('');
+        });
+
+        it('removes event handler attributes and unsafe href protocols', function () {
+            const result = sanitizeArticleContent(`
+                <img src="https://example.com/image.png" onerror="window.__xss=true">
+                <p onclick="window.__xss=true">Text</p>
+                <a href="javascript:alert(1)">Link</a>
+            `);
+
+            const div = renderHtml(result);
+
+            expect(div.querySelector('img')?.hasAttribute('onerror')).toBe(false);
+            expect(div.querySelector('p')?.hasAttribute('onclick')).toBe(false);
+            expect(div.querySelector('a')?.getAttribute('href')).not.toBe('javascript:alert(1)');
+        });
+
+        it('preserves target and rel attributes added by openLinksInNewTab', function () {
+            const result = sanitizeArticleContent(`
+                <a href="https://example.com" target="_blank" rel="noopener noreferrer">Link</a>
+            `);
+
+            const link = renderHtml(result).querySelector('a') as HTMLAnchorElement;
+
+            expect(link.getAttribute('target')).toBe('_blank');
+            expect(link.getAttribute('rel')).toBe('noopener noreferrer');
+        });
+
+        it('does not loosen the default sanitizeHtml rules', function () {
+            sanitizeArticleContent('<script src="https://platform.twitter.com/widgets.js"></script>');
+
+            const result = sanitizeHtml(`
+                <script src="https://platform.twitter.com/widgets.js"></script>
+                <iframe src="https://www.youtube.com/embed/abc123"></iframe>
+            `);
+
+            const div = renderHtml(result);
+
+            expect(div.querySelector('script')).toBeNull();
+            expect(div.querySelector('iframe')).toBeNull();
         });
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/SC-69

## Problem

The ActivityPub reader relied on the backend sanitisation layer at ingestion, using `sanitize-html` . Every other remote-content surface in the app (feed items, bios, notifications, profile fields) already had a second DOMPurify layer — the reader was the one place where a single server-side sanitizer was the sole XSS control, which is fragile against sanitizer bypasses or legacy unsanitized rows.

## Solution

The new `sanitizeArticleContent` now sanitizes the ActivityPub reader as the last step before articles are injected into the iframe. Rather than recreating the backend `sanitize-html` rules, it uses DOMPurify defaults with targeted overrides mirroring what the backend deliberately allows:

- iframes stay allowed so YouTube-style static embeds keep working (dangerous attributes like `srcdoc` and event handlers remain stripped by DOMPurify defaults)
- scripts are only kept when loaded via https from `platform.twitter.com` / `platform.x.com` — matching the backend's `allowedScriptHostnames` — so Twitter embeds keep working; inline script code is stripped even on allowed scripts

It runs on a dedicated DOMPurify instance so the looser article rules and the script hook can't leak into the default sanitizer used everywhere else, and with `FORCE_BODY` so articles that start with an embed script don't silently lose it to the parser hoisting it into `<head>`. Unit tests cover the embed-preserving and attack-rejecting paths, including lookalike script hostnames and instance isolation.
