### PR TITLE
Tidied the member custom fields comments

### DIFF
--- a/ghost/core/core/server/services/members-custom-fields/index.ts
+++ b/ghost/core/core/server/services/members-custom-fields/index.ts
@@ -43,8 +43,6 @@ export function init(): void {
     });
     // The values service reads the field definitions straight from the table, so
     // it needs knex and the same ceiling — no handle on the definitions service.
-    // A write can't name more keys than the site is allowed definitions, so the
-    // two share one number rather than the value path inventing its own.
     values = new CustomFieldValuesService({
         knex,
         getMaxDefinitions: () => resolveMaxDefinitions(config.get('members:customFields:maxDefinitions'))

--- a/ghost/core/core/server/services/members-custom-fields/values-service.ts
+++ b/ghost/core/core/server/services/members-custom-fields/values-service.ts
@@ -15,11 +15,9 @@ const VALUES_TABLE = 'members_custom_field_values';
 // could actually have minted is ever refused by it.
 const MAX_KEY_LENGTH = 191;
 
-// Values arrive keyed by field key. Keys are bounded by the column they are
-// minted into, so anything longer cannot name a field that exists and is refused
-// as input rather than looked up. The values themselves stay `unknown` here —
-// each one is validated by its own field type's schema, which isn't known until
-// the key is resolved to a definition.
+// Values arrive keyed by field key. Each value stays `unknown` here: it is
+// validated by its own field type's schema, which isn't known until the key is
+// resolved to a definition.
 const ValuesInput = z.record(z.string().max(MAX_KEY_LENGTH), z.unknown());
 
 // The field facts the value path needs: the id to write the FK, the key to match
@@ -55,9 +53,8 @@ export class CustomFieldValuesService {
     private knex: Knex;
     /**
      * @private
-     * A getter, not a number: the ceiling is an operator setting that can change
-     * between requests, and reading config belongs to the module that builds this,
-     * not here.
+     * A getter rather than a number: the ceiling is an operator setting that can
+     * change between requests.
      */
     private getMaxDefinitions: () => number;
 
@@ -136,8 +133,8 @@ export class CustomFieldValuesService {
     /**
      * @private
      * Input as the values object it claims to be, rejecting anything that isn't
-     * one. The single place that decision is made, so every caller asking about
-     * the same body gets the same answer and the same error.
+     * one. Shared by every caller so they cannot disagree on what a values object
+     * is, or on the error when it isn't one.
      */
     private parseValues(input: unknown): Record<string, unknown> {
         const parsed = ValuesInput.safeParse(input);
@@ -149,13 +146,11 @@ export class CustomFieldValuesService {
     }
 
     /**
-     * Whether input names any values at all, rejecting a body that isn't a values
-     * object in the first place.
+     * Whether input names any values. Throws if it isn't a values object at all,
+     * with the same error resolving it would have raised.
      *
-     * The shape question on its own, with no catalog lookup, so a caller can ask
-     * before deciding whether a write is even permitted — and get the same verdict,
-     * and the same rejection, that resolving it would have produced. An object
-     * carrying nothing but a `__proto__` key names nothing once parsed.
+     * Answers the shape question alone, with no catalog lookup, so it can be asked
+     * before a write is known to be permitted.
      */
     namesValues(input: unknown): boolean {
         return Object.keys(this.parseValues(input)).length > 0;
@@ -171,11 +166,10 @@ export class CustomFieldValuesService {
         const values = this.parseValues(input);
         const keys = Object.keys(values);
 
-        // A write can't name more fields than the site is allowed to define, so the
-        // ceiling is the same operator setting that bounds definitions rather than a
-        // number invented here. It also keeps the resolving query's bound parameters
-        // in proportion: one per key, against a driver limit that an unbounded object
-        // would otherwise blow past as a 500 carrying the generated SQL.
+        // A write cannot name more fields than the site may define, so the
+        // definitions ceiling bounds it. This also holds the lookup below within the
+        // database driver's bound-parameter limit, which one key per parameter would
+        // otherwise exceed.
         const maxKeys = this.getMaxDefinitions();
         if (keys.length > maxKeys) {
             throw new errors.ValidationError({

--- a/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
@@ -448,11 +448,9 @@ module.exports = class MemberBREADService {
 
     /**
      * @private
-     * The write-side flag gate, mirroring the read side in `fetchCustomFieldValues`:
-     * with the feature off the key is dropped, so a flag-off site stays byte-identical
-     * to a Ghost that predates the feature. The schema declares `custom_fields`
-     * unconditionally — it describes the endpoint, not any one site — which is what
-     * makes the flag, rather than ajv, the thing deciding whether values are written.
+     * The write-side flag gate, paired with `fetchCustomFieldValues` on the read
+     * side. The schema declares `custom_fields` for every site, so the key arrives
+     * whether or not the feature is on and this is what decides it goes no further.
      * @param {object} data
      */
     dropCustomFieldsWhenDisabled(data) {
@@ -464,15 +462,10 @@ module.exports = class MemberBREADService {
     async add(data, options) {
         this.dropCustomFieldsWhenDisabled(data);
 
-        // Setting values while *creating* a member is a later vertical, not this
-        // one. Refuse rather than accept-and-drop, so the gap is legible.
-        //
-        // What counts as "naming a value" belongs to the values service, which
-        // answers it exactly as resolving an edit would — so a body malformed enough
-        // to be refused on edit is refused here too, rather than being accepted and
-        // dropped. Guarded on the key being present at all, so a create that never
-        // mentions custom fields — the overwhelming majority, and every create on a
-        // site without the feature — does not reach for the collaborator at all.
+        // Values cannot be set on create, only on a subsequent edit. `namesValues`
+        // both judges the body and rejects a malformed one, so create and edit agree
+        // on what a write is. Reached only when the key is present, so a create
+        // without custom fields does not depend on the values service.
         if (data.custom_fields !== undefined && this.customFieldsService.values.namesValues(data.custom_fields)) {
             throw new errors.ValidationError({
                 message: tpl(messages.customFieldsOnAdd),
@@ -480,8 +473,8 @@ module.exports = class MemberBREADService {
             });
         }
 
-        // `custom_fields` is not a member column, so it comes off before the
-        // repository sees it, exactly as on edit. Only `{}` can reach here.
+        // Not a member column, so it comes off before the repository sees it. Only
+        // an absent key or one naming no values gets this far.
         delete data.custom_fields;
 
         if (!this.stripeService.configured && (data.comped || data.stripe_customer_id)) {

--- a/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
@@ -910,10 +910,8 @@ describe('Member Custom Fields Admin API', function () {
 
         it('rejects a key too long to name a field, without echoing it back', async function () {
             // Keys are minted into a bounded column, so a longer one cannot name a
-            // field that exists. Refused as input rather than looked up, which also
-            // means the response never carries the key back — the unknown-key error
-            // names the key it was given, so an enormous one would otherwise answer
-            // a request with a multiple of its own size.
+            // field. Refused as input rather than looked up, so the response never
+            // carries it back — the unknown-key error names the key it was given.
             const memberId = await createMember();
             const hugeKey = 'k'.repeat(200000);
 
@@ -923,10 +921,8 @@ describe('Member Custom Fields Admin API', function () {
         });
 
         it('rejects a write naming more fields than the site may define', async function () {
-            // A write can't name more fields than the site is allowed definitions, so
-            // the ceiling is the operator's configured one. Without it, each key binds
-            // a query parameter and a big enough object exceeds the driver's limit,
-            // surfacing as a 500 with the generated SQL in the error.
+            // The ceiling is the operator's configured definitions limit, so it moves
+            // with the setting rather than being fixed in the service.
             configUtils.set('members:customFields:maxDefinitions', 3);
             const memberId = await createMember();
 
@@ -943,10 +939,9 @@ describe('Member Custom Fields Admin API', function () {
         });
 
         it('refuses a malformed custom_fields identically on create and on edit', async function () {
-            // The schema lets every shape through on purpose, so the service is the
-            // only thing judging it — and both verbs must judge it the same way. A
-            // body too malformed to be a write is refused, not accepted and dropped,
-            // which is the whole reason create refuses rather than ignoring.
+            // The schema lets every shape through, so the service is the only thing
+            // judging it, and both verbs judge it the same way. A body too malformed
+            // to be a write is refused rather than accepted and dropped.
             const memberId = await createMember();
 
             for (const [index, malformed] of [null, 'not-an-object', 42, true, [], ['a']].entries()) {
@@ -1266,9 +1261,8 @@ describe('Member Custom Fields Admin API', function () {
 
         it('ignores custom_fields on a member edit and never returns them', async function () {
             // The schema declares `custom_fields` on every site, so with the feature
-            // off the key reaches the service and is dropped there. A flag-off site
-            // stays byte-identical to a Ghost that predates the feature: the edit
-            // succeeds, the rest of it applies, and the values are ignored.
+            // off the key reaches the service and is dropped there: the edit succeeds,
+            // the rest of it applies, and the values are ignored.
             //
             // The field and value are set up with the flag on, then the flag goes
             // off for the request under test.
@@ -1296,9 +1290,8 @@ describe('Member Custom Fields Admin API', function () {
         });
 
         it('ignores custom_fields on a member create', async function () {
-            // The not-yet-supported refusal that create gets with the flag on must
-            // not leak to a site without the feature: there, the key is simply
-            // dropped, exactly as a pre-feature Ghost would have.
+            // The not-supported-on-create refusal is gated behind the feature too:
+            // with it off, the key is dropped and the create succeeds.
             const {body} = await agent
                 .post('members/')
                 .body({members: [{email: 'create-flag-off@example.com', custom_fields: {'favourite-topic': 'Ghosts'}}]})
@@ -1308,10 +1301,9 @@ describe('Member Custom Fields Admin API', function () {
         });
 
         it('ignores a malformed custom_fields rather than rejecting it', async function () {
-            // The schema declares `custom_fields` on every site, so a shape it might
-            // have judged would be judged everywhere — including sites without the
-            // feature, which accepted anything under this key before it existed.
-            // Leaving the schema permissive is what keeps those callers working.
+            // The schema declares `custom_fields` on every site, so any shape it
+            // judged would be judged on sites without the feature too. Leaving it
+            // unconstrained is what keeps the flag the only thing that matters here.
             const memberId = await createMember();
 
             for (const malformed of [null, 'not-an-object', 42, []]) {

--- a/packages/admin-api-schema/src/schemas/members-edit.json
+++ b/packages/admin-api-schema/src/schemas/members-edit.json
@@ -55,7 +55,8 @@
             "type": "boolean"
           },
           "custom_fields": {
-            "description": "Declared so it is not stripped as an unknown property. Deliberately unconstrained: only the site's field-type catalog knows what a given key accepts, so the shape is validated there rather than split across two layers that could disagree."
+            "description": "Custom field values, keyed by field key.",
+            "$comment": "Intentionally unconstrained. Only the site's field definitions know what a given key accepts, so the shape is validated there; constraining it here would split validation across two layers that could disagree. The declaration exists so the property is not stripped as an unknown one."
           },
           "comment_ban": {
             "oneOf": [

--- a/packages/admin-api-schema/src/schemas/members.json
+++ b/packages/admin-api-schema/src/schemas/members.json
@@ -52,7 +52,8 @@
           "type": "boolean"
         },
         "custom_fields": {
-          "description": "Declared so it is not stripped as an unknown property. Deliberately unconstrained: only the site's field-type catalog knows what a given key accepts, so the shape is validated there rather than split across two layers that could disagree."
+          "description": "Custom field values, keyed by field key.",
+          "$comment": "Intentionally unconstrained. Only the site's field definitions know what a given key accepts, so the shape is validated there; constraining it here would split validation across two layers that could disagree. The declaration exists so the property is not stripped as an unknown one."
         },
         "comment_ban": {
           "oneOf": [

--- a/packages/admin-api-schema/test/api.test.ts
+++ b/packages/admin-api-schema/test/api.test.ts
@@ -188,10 +188,8 @@ describe('Exposes a correct API', function () {
 
         it('Judges no part of custom_fields, whatever shape it arrives in', async function () {
             // The declaration exists to stop the key being stripped, not to validate
-            // it: only the site's field-type catalog knows what a given key accepts.
-            // Constraining the shape here would also change behaviour for every
-            // existing caller, since the key reaches this schema on every site
-            // regardless of whether the feature is switched on.
+            // it: only a site's field definitions know what a given key accepts, and
+            // this schema applies to every site whether or not the feature is on.
             for (const anyShape of [null, [], 'x', 5, true, {}, {a: 'b'}]) {
                 const data = {members: [{custom_fields: anyShape}]};
                 await apiSchema.validate({data, schema: 'members-edit', definition: 'members'});


### PR DESCRIPTION
## Problem

The comments added alongside the member custom fields work had drifted into over-explanation. Several of them restated what the code already says, carried reasoning that belonged to a review conversation rather than the file, or repeated the same justification in three or four places. Read together they were longer than the code they annotated, which makes the genuinely non-obvious constraints harder to spot rather than easier.

## Solution

Trimmed the commentary across the values service, the member BREAD service, the end-to-end tests, and the admin API schemas so each comment states the one thing a reader could not work out from the code. Where the same rationale was repeated in multiple places it now appears once, at the place that owns the decision. In the schemas the prose that explained why the property is deliberately unconstrained moved out of the user-facing description and into a separate annotation, leaving the description to say plainly what the field is.

This is comment-only. No behaviour changes, and no test assertions were touched.