### PR TITLE
Required the custom fields services on their members consumers

### DIFF
--- a/ghost/core/core/server/services/members-custom-fields/values-service.ts
+++ b/ghost/core/core/server/services/members-custom-fields/values-service.ts
@@ -146,13 +146,18 @@ export class CustomFieldValuesService {
     }
 
     /**
-     * Whether input names any values. Throws if it isn't a values object at all,
-     * with the same error resolving it would have raised.
+     * Whether input names any values. An absent key names none; anything present
+     * that isn't a values object throws, with the same error resolving it would
+     * have raised.
      *
      * Answers the shape question alone, with no catalog lookup, so it can be asked
      * before a write is known to be permitted.
      */
     namesValues(input: unknown): boolean {
+        if (input === undefined) {
+            return false;
+        }
+
         return Object.keys(this.parseValues(input)).length > 0;
     }
 

--- a/ghost/core/core/server/services/members/api.js
+++ b/ghost/core/core/server/services/members/api.js
@@ -261,7 +261,11 @@ function createApiInstance(config) {
         commentsService,
         emailAddressService: emailAddressService.service,
         giftService,
-        customFieldsService
+        // Resolved here rather than passed as the module: the members service needs
+        // the values service itself, and reading it at construction is what ties the
+        // two together in boot order. Custom fields is initialised in initCore, the
+        // members API is built in initServices, so this is always the live instance.
+        customFieldValues: customFieldsService.values
     });
 
     return membersApiInstance;

--- a/ghost/core/core/server/services/members/exporter/query.js
+++ b/ghost/core/core/server/services/members/exporter/query.js
@@ -4,7 +4,6 @@ const moment = require('moment');
 const logging = require('@tryghost/logging');
 const {Transform} = require('stream');
 const labs = require('../../../../shared/labs');
-const customFields = require('../../members-custom-fields');
 const {csvCellsForFields} = require('@tryghost/custom-field-types/csv');
 
 /**
@@ -60,7 +59,7 @@ function processMembersData(members, tiersMap, labelsMap, stripeCustomerMap, sub
  * @param {Object} options - Export options
  * @returns {Promise<Object>} A readable stream of processed members
  */
-async function createExportStream(options) {
+async function createExportStream(options, {definitions, values}) {
     const hasFilter = options.limit !== 'all' || options.filter || options.search;
     const start = Date.now();
     
@@ -99,12 +98,8 @@ async function createExportStream(options) {
     // field mid-export can't leave the header ragged. It can still leave that
     // field's cells empty from the batch after the archive onwards, because the
     // per-batch value read applies its own active filter.
-    const customFieldsEnabled = labs.isSet('membersCustomFields');
-    if (customFieldsEnabled && !customFields.definitions) {
-        logging.warn('[MembersExporter] Custom fields service is not initialised, exporting without custom field columns');
-    }
-    const activeCustomFields = customFieldsEnabled && customFields.definitions
-        ? await customFields.definitions.browse()
+    const activeCustomFields = labs.isSet('membersCustomFields')
+        ? await definitions.browse()
         : [];
 
     // Create a transform stream that will process the members as they come in
@@ -142,7 +137,7 @@ async function createExportStream(options) {
                         .whereIn('redeemer_member_id', memberIds),
 
                     activeCustomFields.length > 0
-                        ? customFields.values.getValuesForMembers(memberIds)
+                        ? values.getValuesForMembers(memberIds)
                         : new Map()
                 ]);
 
@@ -231,6 +226,8 @@ async function createExportStream(options) {
  * @param {Object} options - Export options
  * @returns {Promise<Array|Object>} Array of members or stream of members
  */
-module.exports = async function (options = {}) {
-    return createExportStream(options);
+module.exports = function createExporter({definitions, values}) {
+    return async function (options = {}) {
+        return createExportStream(options, {definitions, values});
+    };
 };

--- a/ghost/core/core/server/services/members/members-api/members-api.js
+++ b/ghost/core/core/server/services/members/members-api/members-api.js
@@ -85,7 +85,7 @@ module.exports = function MembersAPI({
     commentsService,
     emailAddressService,
     giftService,
-    customFieldsService
+    customFieldValues
 }) {
     const tokenService = new TokenService({
         privateKey,
@@ -169,7 +169,7 @@ module.exports = function MembersAPI({
         nextPaymentCalculator,
         commentsService,
         giftService,
-        customFieldsService
+        customFieldValues
     });
 
     const geolocationService = new GeolocationService();

--- a/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/member-bread-service.js
@@ -37,16 +37,6 @@ const CUSTOM_FIELDS_EDITED_ACTION = 'custom_fields_edited';
  * @prop {{getActiveByMembers: (memberIds: string[]) => Promise<Map<string, {cadence: 'month' | 'year', currency: string, amount: number}>>}} service
  */
 
-/**
- * @typedef {object} ICustomFieldsServiceWrapper
- * @prop {{
- *   getValuesForMembers: (memberIds: string[]) => Promise<Map<string, Record<string, unknown>>>,
- *   namesValues: (values: unknown) => boolean,
- *   planWrite: (values: unknown) => Promise<object[]>,
- *   applyWrite: (memberId: string, writes: object[]) => Promise<void>
- * }} values
- */
-
 module.exports = class MemberBREADService {
     /**
      * @param {object} deps
@@ -60,9 +50,9 @@ module.exports = class MemberBREADService {
      * @param {import('../../../settings-helpers/settings-helpers')} deps.settingsHelpers
      * @param {import('./next-payment-calculator')} deps.nextPaymentCalculator
      * @param {IGiftServiceWrapper} deps.giftService
-     * @param {ICustomFieldsServiceWrapper} deps.customFieldsService
+     * @param {import('../../../members-custom-fields/values-service').CustomFieldValuesService} deps.customFieldValues Required: boot builds it before the members service
      */
-    constructor({memberRepository, labsService, emailService, stripeService, offersAPI, memberAttributionService, emailSuppressionList, settingsHelpers, nextPaymentCalculator, commentsService, giftService, customFieldsService}) {
+    constructor({memberRepository, labsService, emailService, stripeService, offersAPI, memberAttributionService, emailSuppressionList, settingsHelpers, nextPaymentCalculator, commentsService, giftService, customFieldValues}) {
         this.offersAPI = offersAPI;
         /** @private */
         this.memberRepository = memberRepository;
@@ -85,7 +75,7 @@ module.exports = class MemberBREADService {
         /** @private */
         this.giftService = giftService;
         /** @private */
-        this.customFieldsService = customFieldsService;
+        this.customFieldValues = customFieldValues;
     }
 
     /**
@@ -114,7 +104,7 @@ module.exports = class MemberBREADService {
             return null;
         }
 
-        return this.customFieldsService.values.getValuesForMembers(memberIds);
+        return this.customFieldValues.getValuesForMembers(memberIds);
     }
 
     /**
@@ -463,10 +453,9 @@ module.exports = class MemberBREADService {
         this.dropCustomFieldsWhenDisabled(data);
 
         // Values cannot be set on create, only on a subsequent edit. `namesValues`
-        // both judges the body and rejects a malformed one, so create and edit agree
-        // on what a write is. Reached only when the key is present, so a create
-        // without custom fields does not depend on the values service.
-        if (data.custom_fields !== undefined && this.customFieldsService.values.namesValues(data.custom_fields)) {
+        // both judges the body and rejects a malformed one, so a body refused here is
+        // refused on edit for the same reason.
+        if (this.customFieldValues.namesValues(data.custom_fields)) {
             throw new errors.ValidationError({
                 message: tpl(messages.customFieldsOnAdd),
                 property: 'custom_fields'
@@ -574,7 +563,7 @@ module.exports = class MemberBREADService {
         // plan to apply once below, so the values aren't resolved and validated
         // twice.
         const plannedCustomFields = writeCustomFields
-            ? await this.customFieldsService.values.planWrite(customFields)
+            ? await this.customFieldValues.planWrite(customFields)
             : null;
 
         let model;
@@ -623,7 +612,7 @@ module.exports = class MemberBREADService {
         }
 
         if (plannedCustomFields) {
-            await this.customFieldsService.values.applyWrite(model.id, plannedCustomFields);
+            await this.customFieldValues.applyWrite(model.id, plannedCustomFields);
 
             // Custom fields aren't a member column or relation, so an edit touching
             // only them leaves `model._changed` empty and the save fires nothing.

--- a/ghost/core/core/server/services/members/service.js
+++ b/ghost/core/core/server/services/members/service.js
@@ -151,6 +151,14 @@ module.exports = {
         module.exports.verificationTrigger = verificationTrigger;
 
         const membersCSVImporter = initMembersCSVImporter({stripeAPIService: stripeService.api});
+        // Constructed here rather than required statically: the exporter needs the
+        // custom fields services, which boot builds before this one.
+        const customFields = require('../members-custom-fields');
+        module.exports.export = require('./exporter/query')({
+            definitions: customFields.definitions,
+            values: customFields.values
+        });
+
         module.exports.processImport = async (options) => {
             return await membersCSVImporter.process({...options, verificationTrigger});
         };
@@ -196,7 +204,8 @@ module.exports = {
     processImport: null,
 
     stats: membersStats,
-    export: require('./exporter/query')
+
+    export: null
 };
 
 module.exports.middleware = require('./middleware');

--- a/ghost/core/test/unit/server/services/members-custom-fields/values-service.test.ts
+++ b/ghost/core/test/unit/server/services/members-custom-fields/values-service.test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import {describe, it} from 'vitest';
+import {CustomFieldValuesService} from '../../../../../core/server/services/members-custom-fields/values-service';
+
+// `namesValues` answers from the input alone, so it needs neither a database nor a
+// real ceiling to be exercised.
+const service = () => new CustomFieldValuesService({
+    knex: {} as never,
+    getMaxDefinitions: () => 100
+});
+
+describe('CustomFieldValuesService', function () {
+    describe('namesValues', function () {
+        it('answers no for a body that carries no values', function () {
+            // An absent key is not a malformed one: a request that says nothing about
+            // custom fields is asking for nothing, not asking for something invalid.
+            assert.equal(service().namesValues(undefined), false);
+            assert.equal(service().namesValues({}), false);
+        });
+
+        it('answers yes for a body that names a value', function () {
+            assert.equal(service().namesValues({'favourite-topic': 'Ghosts'}), true);
+        });
+
+        it('rejects a body that is present but is not a values object', function () {
+            for (const malformed of [null, 'not-an-object', 42, true, [], ['a']]) {
+                assert.throws(
+                    () => service().namesValues(malformed),
+                    (error: {errorType?: string, property?: string}) => {
+                        assert.equal(error.errorType, 'ValidationError');
+                        assert.equal(error.property, 'custom_fields');
+                        return true;
+                    },
+                    `expected ${JSON.stringify(malformed)} to be rejected`
+                );
+            }
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/members/members-api/members-api.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/members-api.test.js
@@ -88,6 +88,12 @@ describe('MembersAPI', function () {
                 service: {
                     redeem: giftRedeem
                 }
+            },
+            customFieldValues: {
+                getValuesForMembers: sinon.stub().resolves(new Map()),
+                namesValues: sinon.stub().returns(false),
+                planWrite: sinon.stub().resolves([]),
+                applyWrite: sinon.stub().resolves()
             }
         });
     };

--- a/ghost/core/test/unit/server/services/members/members-api/services/members-bread-service.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/members-bread-service.test.js
@@ -4,6 +4,17 @@ const MemberBreadService = require('../../../../../../../core/server/services/me
 const NextPaymentCalculator = require('../../../../../../../core/server/services/members/members-api/services/next-payment-calculator');
 const moment = require('moment');
 
+// The custom fields service is a required dependency: boot constructs it before
+// the members service, so the members service is never without one. Fixtures build
+// it the same way, otherwise a test fails on a dependency the code is entitled to
+// assume rather than on the behaviour it is checking.
+const createCustomFieldValuesStub = () => ({
+    getValuesForMembers: sinon.stub().resolves(new Map()),
+    namesValues: sinon.stub().returns(false),
+    planWrite: sinon.stub().resolves([]),
+    applyWrite: sinon.stub().resolves()
+});
+
 describe('MemberBreadService', function () {
     afterEach(function () {
         sinon.restore();
@@ -40,7 +51,7 @@ describe('MemberBreadService', function () {
         }
 
         // Helper to create a properly mocked service
-        function createService(memberRepositoryOverrides = {}) {
+        function createService(memberRepositoryOverrides = {}, customFieldValues = createCustomFieldValuesStub()) {
             const mockMemberModel = createMockMemberModel();
 
             const linkStripeCustomerStub = sinon.stub().resolves();
@@ -62,7 +73,8 @@ describe('MemberBreadService', function () {
                 newslettersService: {browse: sinon.stub().resolves([])},
                 settingsCache: {get: sinon.stub()},
                 emailSuppressionList: {getSuppressionData: getSuppressionDataStub},
-                settingsHelpers: {createUnsubscribeUrl: sinon.stub().returns('http://example.com/unsubscribe')}
+                settingsHelpers: {createUnsubscribeUrl: sinon.stub().returns('http://example.com/unsubscribe')},
+                customFieldValues
             });
 
             // Stub the read method to avoid having to mock all its dependencies
@@ -73,8 +85,40 @@ describe('MemberBreadService', function () {
                 status: 'free'
             });
 
-            return {service, memberRepository, linkStripeCustomerStub, createStub, getSuppressionDataStub};
+            return {service, memberRepository, linkStripeCustomerStub, createStub, getSuppressionDataStub, customFieldValues};
         }
+
+        it('refuses a create whose body names custom field values', async function () {
+            // Values can only be set on a later edit. The values service decides what
+            // counts as naming them, so drive it directly rather than through a body
+            // shape, which is the values service's own contract to test.
+            const customFieldValues = createCustomFieldValuesStub();
+            customFieldValues.namesValues.returns(true);
+            const {service, createStub} = createService({}, customFieldValues);
+
+            await assert.rejects(
+                () => service.add({email: 'test@example.com', custom_fields: {'favourite-topic': 'Ghosts'}}, {}),
+                (error) => {
+                    assert.equal(error.errorType, 'ValidationError');
+                    assert.equal(error.property, 'custom_fields');
+                    return true;
+                }
+            );
+
+            assert.equal(createStub.called, false, 'the member must not be created');
+        });
+
+        it('creates a member when the body names no custom field values', async function () {
+            const {service, createStub, customFieldValues} = createService();
+
+            await service.add({email: 'test@example.com'}, {});
+
+            assert.equal(createStub.calledOnce, true);
+            // Asked unconditionally: the member data is handed over whether or not it
+            // carries the key, and an absent one is the values service's to judge.
+            assert.equal(customFieldValues.namesValues.calledOnce, true);
+            assert.equal(customFieldValues.namesValues.firstCall.args[0], undefined);
+        });
 
         it('passes context to linkStripeCustomer when stripe_customer_id is provided', async function () {
             // This test verifies that when a member is created via Admin API with a stripe_customer_id,
@@ -236,7 +280,8 @@ describe('MemberBreadService', function () {
                 newslettersService: {browse: sinon.stub().resolves([])},
                 settingsCache: {get: sinon.stub()},
                 emailSuppressionList: {getSuppressionData: getSuppressionDataStub},
-                settingsHelpers: {createUnsubscribeUrl: sinon.stub().returns('http://example.com/unsubscribe')}
+                settingsHelpers: {createUnsubscribeUrl: sinon.stub().returns('http://example.com/unsubscribe')},
+                customFieldValues: createCustomFieldValuesStub()
             });
 
             sinon.stub(service, 'read').resolves({id: 'member_123'});
@@ -376,13 +421,7 @@ describe('MemberBreadService', function () {
             }
         };
 
-        const defaultCustomFieldsService = {
-            values: {
-                getValuesForMembers: sinon.stub().resolves(new Map()),
-                planWrite: sinon.stub().resolves([]),
-                applyWrite: sinon.stub().resolves()
-            }
-        };
+        const defaultCustomFieldValues = createCustomFieldValuesStub();
 
         const getService = (options = {}) => {
             return new MemberBreadService({
@@ -396,7 +435,7 @@ describe('MemberBreadService', function () {
                 offersAPI: options.offersAPI || defaultOffersAPI,
                 labsService: options.labsService || {isSet: sinon.stub().returns(false)},
                 giftService: options.giftService || defaultGiftService,
-                customFieldsService: options.customFieldsService || defaultCustomFieldsService
+                customFieldValues: options.customFieldValues || defaultCustomFieldValues
             });
         };
 


### PR DESCRIPTION
## Problem

The custom fields services are exported as module-level bindings that are undefined until `init()` runs. Their consumers in the members service each invented a way to cope with that: the member create path checked whether the request body carried values before asking the service anything, and the CSV exporter warned and exported without custom field columns when the definitions service was absent.

Neither state can occur. Boot builds the custom fields services before the members service, so by the time either consumer exists the dependency is resolved. Both were guarding against something the dependency graph already rules out, and the guards obscured that.

## Solution

Both consumers now receive the services they need rather than reaching for the module and hoping. The members service is handed the values service at construction, where boot order is expressed; the exporter is a factory built during the members service's init, alongside the other members that are resolved there rather than required statically. With the dependency genuinely present, the guards go, and the labs flag is left as the only thing deciding whether custom fields participate.

Fixtures now build these services the way boot does. One of them was constructing a members service that could not exist in a running Ghost, which is what made the guard look necessary in the first place. The hand-written type describing the values service is replaced by the real exported type, which cannot drift from it.

The Admin API endpoint still unwraps the definitions service with a non-null assertion. Endpoint modules are constructed at import time and cannot take an injected instance without a much larger change, so that one is left as a known case.

No request or export changes behaviour.