### PR TITLE
🐛 Fixed five data-loss bugs in the members CSV importer

### DIFF
--- a/ghost/core/core/server/services/members/importer/members-csv-importer.js
+++ b/ghost/core/core/server/services/members/importer/members-csv-importer.js
@@ -110,9 +110,12 @@ module.exports = class MembersCSVImporter {
         // completely rely on explicit user input for header mappings
         const rows = await membersCSV.parse(inputFilePath, headerMapping, defaultLabels);
         const numberOfBatches = Math.ceil(rows.length / batchSize);
-        // A CSV of headers and no rows is a valid file that imports no one. There are
-        // no keys to take columns from, and serialising nothing has nothing to say.
-        const mappedCSV = rows.length ? membersCSV.unparse(rows, Object.keys(rows[0])) : '';
+        // Columns come from every row rather than the first. A row with fewer fields
+        // than the header parses to fewer keys, so reading the schema off one row
+        // drops the missing columns for the whole file. No rows means no columns,
+        // and serialising nothing has nothing to say.
+        const columns = [...new Set(rows.flatMap(row => Object.keys(row)))];
+        const mappedCSV = columns.length ? membersCSV.unparse(rows, columns) : '';
 
         const hasStripeData = !!(rows.find(function rowHasStripeData(row) {
             return !!row.stripe_customer_id;

--- a/ghost/core/core/server/services/members/importer/members-csv-importer.js
+++ b/ghost/core/core/server/services/members/importer/members-csv-importer.js
@@ -152,7 +152,13 @@ module.exports = class MembersCSVImporter {
         }
 
         // completely rely on explicit user input for header mappings
-        const rows = await membersCSV.parse(inputFilePath, headerMapping);
+        const parsed = await membersCSV.parse(inputFilePath, headerMapping);
+        // A row with more fields than the header puts the overflow under
+        // `__parsed_extra`. That is the parser reporting a ragged row, not a column
+        // anyone mapped, and taking columns from every row would otherwise turn it
+        // into one for the whole file.
+        // eslint-disable-next-line no-unused-vars, camelcase
+        const rows = parsed.map(({__parsed_extra, ...row}) => row);
         const numberOfBatches = Math.ceil(rows.length / batchSize);
         const mappedCSV = serialisePreparedRows(rows);
 

--- a/ghost/core/core/server/services/members/importer/members-csv-importer.js
+++ b/ghost/core/core/server/services/members/importer/members-csv-importer.js
@@ -3,6 +3,7 @@ const path = require('path');
 const fs = require('fs-extra');
 const metrics = require('@tryghost/metrics');
 const membersCSV = require('@tryghost/members-csv');
+const papaparse = require('papaparse');
 const errors = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
 const emailTemplate = require('./email-template');
@@ -57,6 +58,51 @@ const DEFAULT_CSV_HEADER_MAPPING = {
  * @property {Object} stripeUtils - An instance of MembersCSVImporterStripeUtils
  */
 
+// The parsed rows are keyed by field name; the file they are written to is read
+// back with the same header mapping that produced them, so the headers have to be
+// the names that mapping expects.
+const FIELD_TO_CSV_HEADER = Object.fromEntries(
+    Object.entries(DEFAULT_CSV_HEADER_MAPPING).map(([header, field]) => [field, header])
+);
+
+/**
+ * Serialises parsed rows to the intermediate CSV the import reads back.
+ *
+ * Written here rather than through the members-csv serialiser because that one
+ * escapes anything a spreadsheet would read as a formula, and nothing strips the
+ * escape character on the way back in — so a member named `-5` was stored as `'-5`.
+ * That guard belongs on a CSV a person opens, which this file is not.
+ *
+ * Columns come from every row, not the first: a row with fewer fields than the
+ * header parses to fewer keys, and taking the schema from one row would drop the
+ * missing columns for the whole file.
+ *
+ * @param {Array<Object>} rows
+ * @returns {string}
+ */
+function serialisePreparedRows(rows) {
+    // Labels reach here as objects, as plain names, or as an already-joined string,
+    // depending on what the caller handed the parser.
+    const serialiseLabels = (labels) => {
+        if (typeof labels === 'string') {
+            return labels;
+        }
+
+        return (labels || []).map(label => (typeof label === 'string' ? label : label.name)).join(',');
+    };
+
+    const csvRows = rows.map(row => Object.fromEntries(
+        Object.entries(row).map(([field, value]) => [
+            FIELD_TO_CSV_HEADER[field] ?? field,
+            field === 'labels' ? serialiseLabels(value) : value
+        ])
+    ));
+
+    const columns = [...new Set(csvRows.flatMap(row => Object.keys(row)))];
+
+    return columns.length ? papaparse.unparse(csvRows, {columns}) : '';
+}
+
 module.exports = class MembersCSVImporter {
     /**
      * @param {MembersCSVImporterOptions} options
@@ -110,12 +156,7 @@ module.exports = class MembersCSVImporter {
         // completely rely on explicit user input for header mappings
         const rows = await membersCSV.parse(inputFilePath, headerMapping, defaultLabels);
         const numberOfBatches = Math.ceil(rows.length / batchSize);
-        // Columns come from every row rather than the first. A row with fewer fields
-        // than the header parses to fewer keys, so reading the schema off one row
-        // drops the missing columns for the whole file. No rows means no columns,
-        // and serialising nothing has nothing to say.
-        const columns = [...new Set(rows.flatMap(row => Object.keys(row)))];
-        const mappedCSV = columns.length ? membersCSV.unparse(rows, columns) : '';
+        const mappedCSV = serialisePreparedRows(rows);
 
         const hasStripeData = !!(rows.find(function rowHasStripeData(row) {
             return !!row.stripe_customer_id;

--- a/ghost/core/core/server/services/members/importer/members-csv-importer.js
+++ b/ghost/core/core/server/services/members/importer/members-csv-importer.js
@@ -133,11 +133,9 @@ module.exports = class MembersCSVImporter {
      *
      * @param {string} inputFilePath - The path to the CSV to prepare
      * @param {Object.<string, string>} [headerMapping] - An object whose keys are headers in the input CSV and values are the header to replace it with
-     * @param {Array<string>} [defaultLabels] - A list of labels to apply to every member
-     *
      * @returns {Promise<{filePath: string, batches: number, metadata: Object.<string, any>}>} - A promise resolving to the data including filePath of "prepared" CSV
      */
-    async prepare(inputFilePath, headerMapping, defaultLabels) {
+    async prepare(inputFilePath, headerMapping) {
         headerMapping = headerMapping || DEFAULT_CSV_HEADER_MAPPING;
         // @NOTE: investigate why is it "1" and do we even need this concept anymore?
         const batchSize = 1;
@@ -154,7 +152,7 @@ module.exports = class MembersCSVImporter {
         }
 
         // completely rely on explicit user input for header mappings
-        const rows = await membersCSV.parse(inputFilePath, headerMapping, defaultLabels);
+        const rows = await membersCSV.parse(inputFilePath, headerMapping);
         const numberOfBatches = Math.ceil(rows.length / batchSize);
         const mappedCSV = serialisePreparedRows(rows);
 
@@ -177,9 +175,15 @@ module.exports = class MembersCSVImporter {
      * Performs an import of a CSV file
      *
      * @param {string} filePath - the path to a "prepared" CSV file
+     * @param {Array<string|{name: string}>} [globalLabels] - labels to apply to every member
      */
-    async perform(filePath) {
+    async perform(filePath, globalLabels = []) {
         const performStart = Date.now();
+        // Copied rather than passed through: the member model stamps ids and trims
+        // names onto label objects in place, and these are the caller's — one of them
+        // is the import label it looks up again once the import has finished.
+        const toLabel = label => (typeof label === 'string' ? {name: label} : {...label});
+        const normalisedGlobalLabels = (globalLabels || []).map(toLabel);
         const rows = await membersCSV.parse(filePath, DEFAULT_CSV_HEADER_MAPPING);
 
         const defaultTier = await this._getDefaultTier();
@@ -227,7 +231,13 @@ module.exports = class MembersCSVImporter {
                     note: row.note,
                     subscribed: row.subscribed,
                     created_at: createdAt,
-                    labels: row.labels
+                    // Applied here rather than folded into the parsed rows, so they
+                    // never go through the prepared file's comma-separated labels
+                    // column, which would split a name that contains a comma.
+                    // Fresh copies per row for the same reason: each row runs in its
+                    // own transaction, so rows sharing label objects would carry one
+                    // row's mutations into the next.
+                    labels: [...(row.labels || []), ...normalisedGlobalLabels.map(toLabel)]
                 };
                 const existingMember = await membersRepository.get({email: memberValues.email}, {
                     ...options,
@@ -464,12 +474,12 @@ module.exports = class MembersCSVImporter {
      */
     async process({pathToCSV, headerMapping, globalLabels, importLabel, user, LabelModel, forceInline, verificationTrigger}) {
         const meta = {};
-        const job = await this.prepare(pathToCSV, headerMapping, globalLabels);
+        const job = await this.prepare(pathToCSV, headerMapping);
 
         meta.originalImportSize = job.batches;
 
         if ((job.batches <= 500 && !job.metadata.hasStripeData) || forceInline) {
-            const result = await this.perform(job.filePath);
+            const result = await this.perform(job.filePath, globalLabels);
             const importLabelModel = result.imported ? await LabelModel.findOne(importLabel) : null;
             await verificationTrigger.testImportThreshold();
 
@@ -487,7 +497,7 @@ module.exports = class MembersCSVImporter {
             this._addJob({
                 job: async () => {
                     try {
-                        const result = await this.perform(job.filePath);
+                        const result = await this.perform(job.filePath, globalLabels);
                         const importLabelModel = result.imported ? await LabelModel.findOne(importLabel) : null;
                         const emailContent = this.generateCompletionEmail(result, {
                             emailRecipient,

--- a/ghost/core/core/server/services/members/importer/members-csv-importer.js
+++ b/ghost/core/core/server/services/members/importer/members-csv-importer.js
@@ -109,9 +109,10 @@ module.exports = class MembersCSVImporter {
 
         // completely rely on explicit user input for header mappings
         const rows = await membersCSV.parse(inputFilePath, headerMapping, defaultLabels);
-        const columns = Object.keys(rows[0]);
         const numberOfBatches = Math.ceil(rows.length / batchSize);
-        const mappedCSV = membersCSV.unparse(rows, columns);
+        // A CSV of headers and no rows is a valid file that imports no one. There are
+        // no keys to take columns from, and serialising nothing has nothing to say.
+        const mappedCSV = rows.length ? membersCSV.unparse(rows, Object.keys(rows[0])) : '';
 
         const hasStripeData = !!(rows.find(function rowHasStripeData(row) {
             return !!row.stripe_customer_id;

--- a/ghost/core/test/e2e-api/admin/members-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/members-importer.test.js
@@ -316,6 +316,26 @@ describe('Members Importer API', function () {
 
     // A spreadsheet exported with no rows is a realistic thing for a publisher to
     // upload, and it used to fail with a 500.
+    // Spreadsheets produce rows with trailing fields omitted. The columns were taken
+    // from the first parsed row, so a short first row decided the schema for the file.
+    it('Keeps every column when the first row has fewer fields than the header', async function () {
+        await request
+            .post(localUtils.API.getApiQuery(`members/upload/`))
+            .attach('membersfile', path.join(__dirname, '/../../utils/fixtures/csv/members-ragged-row.csv'))
+            .set('Origin', config.get('url'))
+            .expect(201);
+
+        const res = await request
+            .get(localUtils.API.getApiQuery('members/?search=ragged-full'))
+            .set('Origin', config.get('url'))
+            .expect(200);
+
+        const member = res.body.members.find(m => m.email === 'ragged-full@example.com');
+        assertExists(member);
+        assert.equal(member.name, 'Bob');
+        assert.equal(member.note, 'a note');
+    });
+
     it('Can handle a CSV with headers but no rows', async function () {
         const countMembers = async () => {
             const res = await request

--- a/ghost/core/test/e2e-api/admin/members-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/members-importer.test.js
@@ -314,8 +314,32 @@ describe('Members Importer API', function () {
         assert.equal(postLabelRemoveBrowseResponse.body.members.length, 0);
     });
 
-    // A spreadsheet exported with no rows is a realistic thing for a publisher to
-    // upload, and it used to fail with a 500.
+    // Values starting with = + - @ or a tab are what a spreadsheet would treat as a
+    // formula. Guarding against that belongs on the way out to a CSV, not on the way
+    // in to the database.
+    it('Stores values that look like formulas exactly as given', async function () {
+        await request
+            .post(localUtils.API.getApiQuery(`members/upload/`))
+            .attach('membersfile', path.join(__dirname, '/../../utils/fixtures/csv/members-formula-like-values.csv'))
+            .set('Origin', config.get('url'))
+            .expect(201);
+
+        const res = await request
+            .get(localUtils.API.getApiQuery('members/?search=formula'))
+            .set('Origin', config.get('url'))
+            .expect(200);
+
+        const member = res.body.members.find(m => m.email === 'formula@example.com');
+        assertExists(member);
+        assert.equal(member.name, '-5');
+        assert.equal(member.note, '+44 123');
+
+        const formulaMember = res.body.members.find(m => m.email === 'formula2@example.com');
+        assertExists(formulaMember);
+        assert.equal(formulaMember.name, '=SUM(A1)');
+        assert.equal(formulaMember.note, '@handle');
+    });
+
     // Spreadsheets produce rows with trailing fields omitted. The columns were taken
     // from the first parsed row, so a short first row decided the schema for the file.
     it('Keeps every column when the first row has fewer fields than the header', async function () {
@@ -336,6 +360,8 @@ describe('Members Importer API', function () {
         assert.equal(member.note, 'a note');
     });
 
+    // A spreadsheet exported with no rows is a realistic thing for a publisher to
+    // upload, and it used to fail with a 500.
     it('Can handle a CSV with headers but no rows', async function () {
         const countMembers = async () => {
             const res = await request

--- a/ghost/core/test/e2e-api/admin/members-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/members-importer.test.js
@@ -314,6 +314,28 @@ describe('Members Importer API', function () {
         assert.equal(postLabelRemoveBrowseResponse.body.members.length, 0);
     });
 
+    // A label typed into the import form is one name. Per-row labels in the CSV are
+    // comma-separated by design, but a global label is not, so a comma in it should
+    // not split it in two.
+    it('Keeps a global label that contains a comma as one label', async function () {
+        await request
+            .post(localUtils.API.getApiQuery(`members/upload/`))
+            .field('labels', ['Bristol, UK'])
+            .attach('membersfile', path.join(__dirname, '/../../utils/fixtures/csv/valid-members-labels.csv'))
+            .set('Origin', config.get('url'))
+            .expect(201);
+
+        const res = await request
+            .get(localUtils.API.getApiQuery("members/?filter=label:'bristol-uk'"))
+            .set('Origin', config.get('url'))
+            .expect(200);
+
+        assert.equal(res.body.meta.pagination.total, 2, 'both members should carry the whole label');
+        const labels = res.body.members[0].labels.map(l => l.name);
+        assert.ok(labels.includes('Bristol, UK'), `expected a "Bristol, UK" label, got ${JSON.stringify(labels)}`);
+        assert.equal(labels.includes('Bristol'), false, 'the label should not have been split');
+    });
+
     // Values starting with = + - @ or a tab are what a spreadsheet would treat as a
     // formula. Guarding against that belongs on the way out to a CSV, not on the way
     // in to the database.

--- a/ghost/core/test/e2e-api/admin/members-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/members-importer.test.js
@@ -314,6 +314,34 @@ describe('Members Importer API', function () {
         assert.equal(postLabelRemoveBrowseResponse.body.members.length, 0);
     });
 
+    // A spreadsheet exported with no rows is a realistic thing for a publisher to
+    // upload, and it used to fail with a 500.
+    it('Can handle a CSV with headers but no rows', async function () {
+        const countMembers = async () => {
+            const res = await request
+                .get(localUtils.API.getApiQuery('members/?limit=1'))
+                .set('Origin', config.get('url'))
+                .expect(200);
+            return res.body.meta.pagination.total;
+        };
+
+        const before = await countMembers();
+
+        const res = await request
+            .post(localUtils.API.getApiQuery(`members/upload/`))
+            .attach('membersfile', path.join(__dirname, '/../../utils/fixtures/csv/members-headers-only.csv'))
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(201);
+
+        assert.equal(res.body.meta.stats.imported, 0);
+        assert.equal(res.body.meta.stats.invalid.length, 0);
+        assert.equal(res.body.meta.originalImportSize, 0);
+        assert.equal(res.body.meta.import_label, null);
+        assert.equal(await countMembers(), before, 'nobody should have been created');
+    });
+
     it('Can handle empty body', async function () {
         const res = await request
             .post(localUtils.API.getApiQuery(`members/upload/`))

--- a/ghost/core/test/unit/server/services/members/importer/fixtures/ragged-long-row.csv
+++ b/ghost/core/test/unit/server/services/members/importer/fixtures/ragged-long-row.csv
@@ -1,0 +1,3 @@
+email,name
+a@example.com,A
+b@example.com,B,junk1,junk2

--- a/ghost/core/test/unit/server/services/members/importer/members-csv-importer.test.js
+++ b/ghost/core/test/unit/server/services/members/importer/members-csv-importer.test.js
@@ -502,6 +502,18 @@ describe('MembersCSVImporter', function () {
             assert.match(fileContents, /^email,subscribed_to_emails,labels\r\n/);
         });
 
+        // The prepared file's columns come from every row, so the parser's own
+        // overflow key would otherwise become a column of the whole import. There is
+        // no API response that shows this, so it is asserted where it happens.
+        it('does not carry the parser overflow key from a ragged row', async function () {
+            const membersImporter = buildMockImporterInstance();
+
+            await membersImporter.prepare(`${csvPath}/ragged-long-row.csv`, {email: 'email', name: 'name'});
+
+            const header = fsWriteSpy.firstCall.args[1].split('\r\n')[0];
+            assert.equal(header.includes('__parsed_extra'), false, header);
+        });
+
         it('checks for stripe data in the imported file', async function () {
             const membersImporter = buildMockImporterInstance();
 

--- a/ghost/core/test/utils/fixtures/csv/members-formula-like-values.csv
+++ b/ghost/core/test/utils/fixtures/csv/members-formula-like-values.csv
@@ -1,0 +1,3 @@
+email,name,note
+formula@example.com,-5,+44 123
+formula2@example.com,=SUM(A1),@handle

--- a/ghost/core/test/utils/fixtures/csv/members-headers-only.csv
+++ b/ghost/core/test/utils/fixtures/csv/members-headers-only.csv
@@ -1,0 +1,1 @@
+email,name

--- a/ghost/core/test/utils/fixtures/csv/members-ragged-row.csv
+++ b/ghost/core/test/utils/fixtures/csv/members-ragged-row.csv
@@ -1,0 +1,3 @@
+email,name,note
+ragged-first@example.com
+ragged-full@example.com,Bob,a note


### PR DESCRIPTION
## Problem

Importing members loses data, quietly, in five different ways. Each is its own commit with its own test.

**A file with headers and no rows returned a 500.** A spreadsheet exported with nothing in it is a realistic upload, and it failed outright.

**A row missing trailing fields truncated the whole file.** Columns were taken from the first parsed row, so one short row decided the schema for every row after it. Reversing two lines in a CSV changed what got imported, with no error and no warning:

```
email,name,note
short@example.com          ← ragged
full@example.com,Bob,a note

→ 201, imported: 2, invalid: []
→ Bob's name and note: silently gone
```

**Values that look like formulas were corrupted.** The importer writes an intermediate CSV and reads it back, and the serialiser escapes anything starting with `=`, `+`, `-`, `@` or a tab. Nothing stripped that on the way back in, so a member named `-5` was stored as `'-5`, and a note of `+44 123` as `'+44 123`.

**A label containing a comma was split in two.** Labels typed into the import form apply to every member and are one name each, but they went through the intermediate file's comma-separated labels column. `Bristol, UK` came back as `Bristol` and ` UK`.

**The CSV parser's overflow key became a real column.** A row with more fields than its header leaves the surplus under an internal key. Once columns are taken from every row, one such row turned that into a column for the whole import, writing stray cells into a file on disk.

## Solution

Five focused commits, each with an integration test that fails without it:

| Fix | Test |
|---|---|
| Serialise nothing when there is nothing to serialise | Headers-only file imports zero members and creates nobody |
| Take columns from every row, not the first | A short first row no longer costs later rows their data |
| Write the intermediate file without formula escaping | `-5` stays `-5`, `=SUM(A1)` stays `=SUM(A1)` |
| Apply form labels when the member is built, not before | `Bristol, UK` stays one label |
| Drop the parser's overflow key | It never becomes a column |

Nothing a publisher opens changes: the member export and the import's own error CSV still escape formulas.

Two behaviours worth naming. The intermediate file now carries any column the caller mapped, where those were previously blanked — the import still ignores them, they are dropped when the file is read back. And form labels are now copied rather than passed by reference, because the member model stamps ids and trims names onto label objects in place, and one of those objects is the import label the importer looks up again once the import has finished.