### PR TITLE
✨ Added config to specify custom adapter install location

### DIFF
--- a/ghost/core/core/server/services/adapter-manager/index.ts
+++ b/ghost/core/core/server/services/adapter-manager/index.ts
@@ -8,17 +8,24 @@ import {RouteSettingsStoreBase} from '@tryghost/adapter-base-route-settings';
 import {AdapterManager} from './adapter-manager';
 import config from '../../../shared/config';
 
+const adapterPaths = new Set<string>([
+    '', // A blank path will cause us to check node_modules for the adapter
+    config.getContentPath('adapters'),
+    config.get('paths').internalAdaptersPath,
+
+    // custom docker builds may install adapters in a separate path from content,
+    // since the content dir is often bind-mounted into the container. Offering
+    // an escape hatch here to allow for this
+    config.get('paths').installedAdaptersPath ?? '',
+]);
+
 // A singleton adapter manager, preconfigured with the base classes for every
 // known adapter type. `getAdapter` resolves the active adapter and its options
 // from config on each call, so runtime config changes are always reflected.
 const adapterManager = new AdapterManager({
     loadAdapterFromPath: require,
     config,
-    pathsToAdapters: [
-        '', // A blank path will cause us to check node_modules for the adapter
-        config.getContentPath('adapters'),
-        config.get('paths').internalAdaptersPath
-    ],
+    pathsToAdapters: Array.from(adapterPaths),
     baseClasses: {
         storage: GhostStorageBase,
         scheduling: SchedulingBase,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLA-249
- in custom Ghost docker builds, adapters installed in the default `content` dir are potentially susceptible to shadowing if the `content` dir is bind-mounted into the container
- adding a separate 'installedAdaptersPath' config option allows specifying a directory inside the container build where adapters can be installed

Long-term it may make sense to deprecate the `content/adapters` path (esp in Docker installs) but for now this unblocks custom adapter installs.