### PR TITLE
🐛 Fixed storage failures reporting "Maximum call stack size exceeded"

### DIFF
--- a/ghost/core/core/server/adapters/redirects/S3RedirectsStore.ts
+++ b/ghost/core/core/server/adapters/redirects/S3RedirectsStore.ts
@@ -22,7 +22,8 @@ const messages = {
     missingBucket: 'S3RedirectsStore requires a bucket name',
     missingStaticFileURLPrefix: 'S3RedirectsStore requires a staticFileURLPrefix',
     partialCredentials: 'S3RedirectsStore requires both accessKeyId and secretAccessKey when either is provided',
-    missingResponseBody: 'S3 GetObject returned no body'
+    missingResponseBody: 'S3 GetObject returned no body',
+    requestFailed: 'Redirects storage request failed: {operation} returned {code}.'
 };
 
 const stripLeadingAndTrailingSlashes = (value = '') => value.replace(/^\/+|\/+$/g, '');
@@ -114,7 +115,11 @@ export default class S3RedirectsStore extends RedirectsStoreBase {
                 sessionToken: options.sessionToken
             };
         }
-        this.client = new S3Client(clientConfig);
+        // `s3Client` is a test-only injection seam — it never comes from config
+        // (nconf holds static values), so it's read from the raw input rather
+        // than the validated schema output.
+        const injectedClient = (config as {s3Client?: S3Client} | null | undefined)?.s3Client;
+        this.client = injectedClient || new S3Client(clientConfig);
     }
 
     async getAll(): Promise<RedirectConfig[]> {
@@ -134,7 +139,7 @@ export default class S3RedirectsStore extends RedirectsStoreBase {
             if (this._isNotFound(err)) {
                 return [];
             }
-            throw err;
+            throw this.toStoreError(err, 'GetObject', this.buildKey());
         }
 
         return parseJson(body);
@@ -144,19 +149,28 @@ export default class S3RedirectsStore extends RedirectsStoreBase {
         const key = this.buildKey();
 
         if (await this._canonicalExists()) {
-            await this.client.send(new CopyObjectCommand({
-                Bucket: this.bucket,
-                Key: getBackupRedirectsFilePath(key),
-                CopySource: `${this.bucket}/${key}`
-            }));
+            const backupKey = getBackupRedirectsFilePath(key);
+            try {
+                await this.client.send(new CopyObjectCommand({
+                    Bucket: this.bucket,
+                    Key: backupKey,
+                    CopySource: `${this.bucket}/${key}`
+                }));
+            } catch (err) {
+                throw this.toStoreError(err, 'CopyObject', backupKey);
+            }
         }
 
-        await this.client.send(new PutObjectCommand({
-            Bucket: this.bucket,
-            Key: key,
-            Body: JSON.stringify(redirects),
-            ContentType: 'application/json'
-        }));
+        try {
+            await this.client.send(new PutObjectCommand({
+                Bucket: this.bucket,
+                Key: key,
+                Body: JSON.stringify(redirects),
+                ContentType: 'application/json'
+            }));
+        } catch (err) {
+            throw this.toStoreError(err, 'PutObject', key);
+        }
     }
 
     private buildKey(): string {
@@ -165,21 +179,54 @@ export default class S3RedirectsStore extends RedirectsStoreBase {
     }
 
     private async _canonicalExists(): Promise<boolean> {
+        const key = this.buildKey();
         try {
             await this.client.send(new HeadObjectCommand({
                 Bucket: this.bucket,
-                Key: this.buildKey()
+                Key: key
             }));
             return true;
         } catch (err) {
             if (this._isNotFound(err)) {
                 return false;
             }
-            throw err;
+            throw this.toStoreError(err, 'HeadObject', key);
         }
     }
 
     private _isNotFound(err: unknown): boolean {
         return err instanceof NotFound || err instanceof NoSuchKey;
+    }
+
+    /**
+     * Convert an S3 failure into a Ghost error naming the operation, key and
+     * S3 error code.
+     *
+     * The SDK's exceptions are deliberately *not* attached: they hold a
+     * reference to the HTTP response, and the API error handler deep-clones
+     * whatever it is given, so a raw SDK error makes the request die with
+     * "Maximum call stack size exceeded" and the real cause never reaches the
+     * operator. Everything useful is copied out by value instead.
+     */
+    private toStoreError(err: unknown, operation: string, key: string): Error {
+        if (err instanceof Error && errors.utils.isGhostError(err)) {
+            return err;
+        }
+
+        const s3Error = err as {name?: string; message?: string; $metadata?: {httpStatusCode?: number}};
+        const code = s3Error.name || 'UnknownError';
+
+        return new errors.InternalServerError({
+            message: tpl(messages.requestFailed, {operation, code}),
+            context: s3Error.message,
+            code: 'REDIRECTS_STORAGE_REQUEST_FAILED',
+            errorDetails: {
+                operation,
+                bucket: this.bucket,
+                key,
+                s3ErrorCode: code,
+                statusCode: s3Error.$metadata?.httpStatusCode
+            }
+        });
     }
 }

--- a/ghost/core/core/server/adapters/redirects/S3RedirectsStore.ts
+++ b/ghost/core/core/server/adapters/redirects/S3RedirectsStore.ts
@@ -123,24 +123,30 @@ export default class S3RedirectsStore extends RedirectsStoreBase {
     }
 
     async getAll(): Promise<RedirectConfig[]> {
-        let body: string;
+        const key = this.buildKey();
+
+        // Only the S3 call is wrapped, so `toStoreError` only ever sees an SDK
+        // failure and never has to decide whether an error is already ours.
+        let response;
         try {
-            const response = await this.client.send(new GetObjectCommand({
+            response = await this.client.send(new GetObjectCommand({
                 Bucket: this.bucket,
-                Key: this.buildKey()
+                Key: key
             }));
-            if (!response.Body) {
-                throw new errors.InternalServerError({
-                    message: tpl(messages.missingResponseBody)
-                });
-            }
-            body = await response.Body.transformToString('utf-8');
         } catch (err) {
             if (this._isNotFound(err)) {
                 return [];
             }
-            throw this.toStoreError(err, 'GetObject', this.buildKey());
+            throw this.toStoreError(err, 'GetObject', key);
         }
+
+        if (!response.Body) {
+            throw new errors.InternalServerError({
+                message: tpl(messages.missingResponseBody)
+            });
+        }
+
+        const body = await response.Body.transformToString('utf-8');
 
         return parseJson(body);
     }
@@ -209,10 +215,6 @@ export default class S3RedirectsStore extends RedirectsStoreBase {
      * operator. Everything useful is copied out by value instead.
      */
     private toStoreError(err: unknown, operation: string, key: string): Error {
-        if (err instanceof Error && errors.utils.isGhostError(err)) {
-            return err;
-        }
-
         const s3Error = err as {name?: string; message?: string; $metadata?: {httpStatusCode?: number}};
         const code = s3Error.name || 'UnknownError';
 

--- a/ghost/core/core/server/adapters/redirects/S3RedirectsStore.ts
+++ b/ghost/core/core/server/adapters/redirects/S3RedirectsStore.ts
@@ -184,16 +184,6 @@ export default class S3RedirectsStore extends RedirectsStoreBase {
         }
     }
 
-    /**
-     * An AWS SDK exception holds `$response`, a reference to its own live HTTP
-     * response — a circular object graph. Ghost's API error handler deep-clones
-     * the error it renders, with no cycle detection, so letting one escape made
-     * that clone recurse until the stack blew and the caller was told "Maximum
-     * call stack size exceeded". Nothing is taken off the SDK exception by
-     * reference, which is what makes the replacement safe to serialise; the
-     * origin frames are carried across as a string so the real failure is still
-     * diagnosable from the logs.
-     */
     private _requestError(err: unknown): Error {
         // The only Ghost errors reaching here are this store's own, which are
         // already safe to render — re-wrapping them would hide the reason.

--- a/ghost/core/core/server/adapters/redirects/S3RedirectsStore.ts
+++ b/ghost/core/core/server/adapters/redirects/S3RedirectsStore.ts
@@ -22,7 +22,8 @@ const messages = {
     missingBucket: 'S3RedirectsStore requires a bucket name',
     missingStaticFileURLPrefix: 'S3RedirectsStore requires a staticFileURLPrefix',
     partialCredentials: 'S3RedirectsStore requires both accessKeyId and secretAccessKey when either is provided',
-    missingResponseBody: 'S3 GetObject returned no body'
+    missingResponseBody: 'S3 GetObject returned no body',
+    requestFailed: 'Something went wrong, please try again.'
 };
 
 const stripLeadingAndTrailingSlashes = (value = '') => value.replace(/^\/+|\/+$/g, '');
@@ -134,7 +135,7 @@ export default class S3RedirectsStore extends RedirectsStoreBase {
             if (this._isNotFound(err)) {
                 return [];
             }
-            throw err;
+            throw this._requestError(err);
         }
 
         return parseJson(body);
@@ -143,20 +144,24 @@ export default class S3RedirectsStore extends RedirectsStoreBase {
     async replaceAll(redirects: RedirectConfig[]): Promise<void> {
         const key = this.buildKey();
 
-        if (await this._canonicalExists()) {
-            await this.client.send(new CopyObjectCommand({
-                Bucket: this.bucket,
-                Key: getBackupRedirectsFilePath(key),
-                CopySource: `${this.bucket}/${key}`
-            }));
-        }
+        try {
+            if (await this._canonicalExists()) {
+                await this.client.send(new CopyObjectCommand({
+                    Bucket: this.bucket,
+                    Key: getBackupRedirectsFilePath(key),
+                    CopySource: `${this.bucket}/${key}`
+                }));
+            }
 
-        await this.client.send(new PutObjectCommand({
-            Bucket: this.bucket,
-            Key: key,
-            Body: JSON.stringify(redirects),
-            ContentType: 'application/json'
-        }));
+            await this.client.send(new PutObjectCommand({
+                Bucket: this.bucket,
+                Key: key,
+                Body: JSON.stringify(redirects),
+                ContentType: 'application/json'
+            }));
+        } catch (err) {
+            throw this._requestError(err);
+        }
     }
 
     private buildKey(): string {
@@ -175,8 +180,36 @@ export default class S3RedirectsStore extends RedirectsStoreBase {
             if (this._isNotFound(err)) {
                 return false;
             }
-            throw err;
+            throw this._requestError(err);
         }
+    }
+
+    /**
+     * An AWS SDK exception holds `$response`, a reference to its own live HTTP
+     * response — a circular object graph. Ghost's API error handler deep-clones
+     * the error it renders, with no cycle detection, so letting one escape made
+     * that clone recurse until the stack blew and the caller was told "Maximum
+     * call stack size exceeded". Nothing is taken off the SDK exception by
+     * reference, which is what makes the replacement safe to serialise; the
+     * origin frames are carried across as a string so the real failure is still
+     * diagnosable from the logs.
+     */
+    private _requestError(err: unknown): Error {
+        // The only Ghost errors reaching here are this store's own, which are
+        // already safe to render — re-wrapping them would hide the reason.
+        if (err instanceof errors.InternalServerError) {
+            return err;
+        }
+
+        const requestError = new errors.InternalServerError({
+            message: tpl(messages.requestFailed)
+        });
+
+        if (typeof (err as {stack?: string})?.stack === 'string') {
+            requestError.stack = `${requestError.stack}\n\nCaused by: ${(err as {stack: string}).stack}`;
+        }
+
+        return requestError;
     }
 
     private _isNotFound(err: unknown): boolean {

--- a/ghost/core/core/server/adapters/route-settings/S3RouteSettingsStore.ts
+++ b/ghost/core/core/server/adapters/route-settings/S3RouteSettingsStore.ts
@@ -30,7 +30,8 @@ const messages = {
     missingDefaultSettingsBasePath: 'S3RouteSettingsStore requires a defaultSettingsBasePath',
     partialCredentials: 'S3RouteSettingsStore requires both accessKeyId and secretAccessKey when either is provided',
     missingResponseBody: 'S3 GetObject returned no body',
-    ensureDefaults: 'Error trying to access the default settings file in {path}.'
+    ensureDefaults: 'Error trying to access the default settings file in {path}.',
+    requestFailed: 'Route settings storage request failed: {operation} returned {code}.'
 };
 
 const stripLeadingAndTrailingSlashes = (value = '') => value.replace(/^\/+|\/+$/g, '');
@@ -135,7 +136,7 @@ export default class S3RouteSettingsStore extends RouteSettingsStoreBase {
                 const defaultContent = await this.readDefaultSettings();
                 return parseRouteSettings(parseYaml(defaultContent), defaultContent);
             }
-            throw err;
+            throw this.toStoreError(err, 'GetObject', this.buildKey());
         }
 
         return parseRouteSettings(parseYaml(body), body);
@@ -145,19 +146,28 @@ export default class S3RouteSettingsStore extends RouteSettingsStoreBase {
         const key = this.buildKey();
 
         if (await this._canonicalExists()) {
-            await this.client.send(new CopyObjectCommand({
-                Bucket: this.bucket,
-                Key: getBackupRouteSettingsFilePath(key),
-                CopySource: `${this.bucket}/${key}`
-            }));
+            const backupKey = getBackupRouteSettingsFilePath(key);
+            try {
+                await this.client.send(new CopyObjectCommand({
+                    Bucket: this.bucket,
+                    Key: backupKey,
+                    CopySource: `${this.bucket}/${key}`
+                }));
+            } catch (err) {
+                throw this.toStoreError(err, 'CopyObject', backupKey);
+            }
         }
 
-        await this.client.send(new PutObjectCommand({
-            Bucket: this.bucket,
-            Key: key,
-            Body: settings.yamlSource,
-            ContentType: CONTENT_TYPE
-        }));
+        try {
+            await this.client.send(new PutObjectCommand({
+                Bucket: this.bucket,
+                Key: key,
+                Body: settings.yamlSource,
+                ContentType: CONTENT_TYPE
+            }));
+        } catch (err) {
+            throw this.toStoreError(err, 'PutObject', key);
+        }
     }
 
     private buildKey(): string {
@@ -166,17 +176,18 @@ export default class S3RouteSettingsStore extends RouteSettingsStoreBase {
     }
 
     private async _canonicalExists(): Promise<boolean> {
+        const key = this.buildKey();
         try {
             await this.client.send(new HeadObjectCommand({
                 Bucket: this.bucket,
-                Key: this.buildKey()
+                Key: key
             }));
             return true;
         } catch (err) {
             if (this._isNotFound(err)) {
                 return false;
             }
-            throw err;
+            throw this.toStoreError(err, 'HeadObject', key);
         }
     }
 
@@ -195,5 +206,37 @@ export default class S3RouteSettingsStore extends RouteSettingsStoreBase {
 
     private _isNotFound(err: unknown): boolean {
         return err instanceof NotFound || err instanceof NoSuchKey;
+    }
+
+    /**
+     * Convert an S3 failure into a Ghost error naming the operation, key and
+     * S3 error code.
+     *
+     * The SDK's exceptions are deliberately *not* attached: they hold a
+     * reference to the HTTP response, and the API error handler deep-clones
+     * whatever it is given, so a raw SDK error makes the request die with
+     * "Maximum call stack size exceeded" and the real cause never reaches the
+     * operator. Everything useful is copied out by value instead.
+     */
+    private toStoreError(err: unknown, operation: string, key: string): Error {
+        if (err instanceof Error && errors.utils.isGhostError(err)) {
+            return err;
+        }
+
+        const s3Error = err as {name?: string; message?: string; $metadata?: {httpStatusCode?: number}};
+        const code = s3Error.name || 'UnknownError';
+
+        return new errors.InternalServerError({
+            message: tpl(messages.requestFailed, {operation, code}),
+            context: s3Error.message,
+            code: 'ROUTE_SETTINGS_STORAGE_REQUEST_FAILED',
+            errorDetails: {
+                operation,
+                bucket: this.bucket,
+                key,
+                s3ErrorCode: code,
+                statusCode: s3Error.$metadata?.httpStatusCode
+            }
+        });
     }
 }

--- a/ghost/core/core/server/adapters/route-settings/S3RouteSettingsStore.ts
+++ b/ghost/core/core/server/adapters/route-settings/S3RouteSettingsStore.ts
@@ -119,25 +119,31 @@ export default class S3RouteSettingsStore extends RouteSettingsStoreBase {
     }
 
     async get(): Promise<RouteSettings> {
-        let body: string;
+        const key = this.buildKey();
+
+        // Only the S3 call is wrapped, so `toStoreError` only ever sees an SDK
+        // failure and never has to decide whether an error is already ours.
+        let response;
         try {
-            const response = await this.client.send(new GetObjectCommand({
+            response = await this.client.send(new GetObjectCommand({
                 Bucket: this.bucket,
-                Key: this.buildKey()
+                Key: key
             }));
-            if (!response.Body) {
-                throw new errors.InternalServerError({
-                    message: tpl(messages.missingResponseBody)
-                });
-            }
-            body = await response.Body.transformToString('utf-8');
         } catch (err) {
             if (this._isNotFound(err)) {
                 const defaultContent = await this.readDefaultSettings();
                 return parseRouteSettings(parseYaml(defaultContent), defaultContent);
             }
-            throw this.toStoreError(err, 'GetObject', this.buildKey());
+            throw this.toStoreError(err, 'GetObject', key);
         }
+
+        if (!response.Body) {
+            throw new errors.InternalServerError({
+                message: tpl(messages.missingResponseBody)
+            });
+        }
+
+        const body = await response.Body.transformToString('utf-8');
 
         return parseRouteSettings(parseYaml(body), body);
     }
@@ -219,10 +225,6 @@ export default class S3RouteSettingsStore extends RouteSettingsStoreBase {
      * operator. Everything useful is copied out by value instead.
      */
     private toStoreError(err: unknown, operation: string, key: string): Error {
-        if (err instanceof Error && errors.utils.isGhostError(err)) {
-            return err;
-        }
-
         const s3Error = err as {name?: string; message?: string; $metadata?: {httpStatusCode?: number}};
         const code = s3Error.name || 'UnknownError';
 

--- a/ghost/core/core/server/adapters/route-settings/S3RouteSettingsStore.ts
+++ b/ghost/core/core/server/adapters/route-settings/S3RouteSettingsStore.ts
@@ -30,7 +30,8 @@ const messages = {
     missingDefaultSettingsBasePath: 'S3RouteSettingsStore requires a defaultSettingsBasePath',
     partialCredentials: 'S3RouteSettingsStore requires both accessKeyId and secretAccessKey when either is provided',
     missingResponseBody: 'S3 GetObject returned no body',
-    ensureDefaults: 'Error trying to access the default settings file in {path}.'
+    ensureDefaults: 'Error trying to access the default settings file in {path}.',
+    requestFailed: 'Something went wrong, please try again.'
 };
 
 const stripLeadingAndTrailingSlashes = (value = '') => value.replace(/^\/+|\/+$/g, '');
@@ -135,7 +136,7 @@ export default class S3RouteSettingsStore extends RouteSettingsStoreBase {
                 const defaultContent = await this.readDefaultSettings();
                 return parseRouteSettings(parseYaml(defaultContent), defaultContent);
             }
-            throw err;
+            throw this._requestError(err);
         }
 
         return parseRouteSettings(parseYaml(body), body);
@@ -144,20 +145,24 @@ export default class S3RouteSettingsStore extends RouteSettingsStoreBase {
     async replace(settings: RouteSettings): Promise<void> {
         const key = this.buildKey();
 
-        if (await this._canonicalExists()) {
-            await this.client.send(new CopyObjectCommand({
-                Bucket: this.bucket,
-                Key: getBackupRouteSettingsFilePath(key),
-                CopySource: `${this.bucket}/${key}`
-            }));
-        }
+        try {
+            if (await this._canonicalExists()) {
+                await this.client.send(new CopyObjectCommand({
+                    Bucket: this.bucket,
+                    Key: getBackupRouteSettingsFilePath(key),
+                    CopySource: `${this.bucket}/${key}`
+                }));
+            }
 
-        await this.client.send(new PutObjectCommand({
-            Bucket: this.bucket,
-            Key: key,
-            Body: settings.yamlSource,
-            ContentType: CONTENT_TYPE
-        }));
+            await this.client.send(new PutObjectCommand({
+                Bucket: this.bucket,
+                Key: key,
+                Body: settings.yamlSource,
+                ContentType: CONTENT_TYPE
+            }));
+        } catch (err) {
+            throw this._requestError(err);
+        }
     }
 
     private buildKey(): string {
@@ -176,8 +181,36 @@ export default class S3RouteSettingsStore extends RouteSettingsStoreBase {
             if (this._isNotFound(err)) {
                 return false;
             }
-            throw err;
+            throw this._requestError(err);
         }
+    }
+
+    /**
+     * An AWS SDK exception holds `$response`, a reference to its own live HTTP
+     * response — a circular object graph. Ghost's API error handler deep-clones
+     * the error it renders, with no cycle detection, so letting one escape made
+     * that clone recurse until the stack blew and the caller was told "Maximum
+     * call stack size exceeded". Nothing is taken off the SDK exception by
+     * reference, which is what makes the replacement safe to serialise; the
+     * origin frames are carried across as a string so the real failure is still
+     * diagnosable from the logs.
+     */
+    private _requestError(err: unknown): Error {
+        // The only Ghost errors reaching here are this store's own, which are
+        // already safe to render — re-wrapping them would hide the reason.
+        if (err instanceof errors.InternalServerError) {
+            return err;
+        }
+
+        const requestError = new errors.InternalServerError({
+            message: tpl(messages.requestFailed)
+        });
+
+        if (typeof (err as {stack?: string})?.stack === 'string') {
+            requestError.stack = `${requestError.stack}\n\nCaused by: ${(err as {stack: string}).stack}`;
+        }
+
+        return requestError;
     }
 
     private async readDefaultSettings(): Promise<string> {

--- a/ghost/core/core/server/adapters/route-settings/S3RouteSettingsStore.ts
+++ b/ghost/core/core/server/adapters/route-settings/S3RouteSettingsStore.ts
@@ -185,16 +185,6 @@ export default class S3RouteSettingsStore extends RouteSettingsStoreBase {
         }
     }
 
-    /**
-     * An AWS SDK exception holds `$response`, a reference to its own live HTTP
-     * response — a circular object graph. Ghost's API error handler deep-clones
-     * the error it renders, with no cycle detection, so letting one escape made
-     * that clone recurse until the stack blew and the caller was told "Maximum
-     * call stack size exceeded". Nothing is taken off the SDK exception by
-     * reference, which is what makes the replacement safe to serialise; the
-     * origin frames are carried across as a string so the real failure is still
-     * diagnosable from the logs.
-     */
     private _requestError(err: unknown): Error {
         // The only Ghost errors reaching here are this store's own, which are
         // already safe to render — re-wrapping them would hide the reason.

--- a/ghost/core/test/integration/adapters/route-settings/s3-route-settings-store.test.ts
+++ b/ghost/core/test/integration/adapters/route-settings/s3-route-settings-store.test.ts
@@ -43,6 +43,12 @@ taxonomies:
   author: /author/{slug}/
 `;
 
+interface StoreErrorShape {
+    errorType?: string;
+    context?: string;
+    errorDetails?: {operation?: string; key?: string; s3ErrorCode?: string};
+}
+
 const canonicalKey = (tenantPrefix = ''): string => [tenantPrefix, STATIC_PREFIX, CANONICAL_FILENAME].filter(Boolean).join('/');
 
 const fromYaml = (yaml: string) => parseRouteSettings(parseYaml(yaml), yaml);
@@ -292,25 +298,36 @@ describe('Integration: S3RouteSettingsStore without a live bucket', function () 
         });
     });
 
-    it('propagates a non-NotFound error raised while reading', async function () {
+    it('reports a non-NotFound error raised while reading', async function () {
         const store = faultyStore(async (command) => {
             if (command instanceof GetObjectCommand) {
-                throw new Error('connection reset');
+                throw Object.assign(new Error('connection reset'), {name: 'NetworkingError'});
             }
             return {};
         });
 
-        await assert.rejects(store.get(), /connection reset/);
+        await assert.rejects(store.get(), (err: StoreErrorShape) => {
+            assert.equal(err.errorType, 'InternalServerError');
+            assert.equal(err.errorDetails?.operation, 'GetObject');
+            assert.equal(err.errorDetails?.s3ErrorCode, 'NetworkingError');
+            assert.equal(err.context, 'connection reset');
+            return true;
+        });
     });
 
-    it('propagates a non-NotFound error raised by the existence check on replace', async function () {
+    it('reports a non-NotFound error raised by the existence check on replace', async function () {
         const store = faultyStore(async (command) => {
             if (command instanceof HeadObjectCommand) {
-                throw new Error('access denied');
+                throw Object.assign(new Error('Access denied.'), {name: 'AccessDenied'});
             }
             return {};
         });
 
-        await assert.rejects(store.replace(fromYaml(SAMPLE_YAML)), /access denied/);
+        await assert.rejects(store.replace(fromYaml(SAMPLE_YAML)), (err: StoreErrorShape) => {
+            assert.equal(err.errorType, 'InternalServerError');
+            assert.equal(err.errorDetails?.operation, 'HeadObject');
+            assert.equal(err.errorDetails?.s3ErrorCode, 'AccessDenied');
+            return true;
+        });
     });
 });

--- a/ghost/core/test/integration/adapters/route-settings/s3-route-settings-store.test.ts
+++ b/ghost/core/test/integration/adapters/route-settings/s3-route-settings-store.test.ts
@@ -292,7 +292,7 @@ describe('Integration: S3RouteSettingsStore without a live bucket', function () 
         });
     });
 
-    it('propagates a non-NotFound error raised while reading', async function () {
+    it('reports a non-NotFound error raised while reading', async function () {
         const store = faultyStore(async (command) => {
             if (command instanceof GetObjectCommand) {
                 throw new Error('connection reset');
@@ -300,10 +300,10 @@ describe('Integration: S3RouteSettingsStore without a live bucket', function () 
             return {};
         });
 
-        await assert.rejects(store.get(), /connection reset/);
+        await assert.rejects(store.get(), /Something went wrong, please try again\./);
     });
 
-    it('propagates a non-NotFound error raised by the existence check on replace', async function () {
+    it('reports a non-NotFound error raised by the existence check on replace', async function () {
         const store = faultyStore(async (command) => {
             if (command instanceof HeadObjectCommand) {
                 throw new Error('access denied');
@@ -311,6 +311,6 @@ describe('Integration: S3RouteSettingsStore without a live bucket', function () 
             return {};
         });
 
-        await assert.rejects(store.replace(fromYaml(SAMPLE_YAML)), /access denied/);
+        await assert.rejects(store.replace(fromYaml(SAMPLE_YAML)), /Something went wrong, please try again\./);
     });
 });

--- a/ghost/core/test/unit/server/adapters/redirects/s3-redirects-store.test.ts
+++ b/ghost/core/test/unit/server/adapters/redirects/s3-redirects-store.test.ts
@@ -1,6 +1,42 @@
 import assert from 'node:assert/strict';
+import sinon from 'sinon';
+import {CopyObjectCommand, HeadObjectCommand, PutObjectCommand, type S3Client} from '@aws-sdk/client-s3';
 
 import S3RedirectsStore from '../../../../../core/server/adapters/redirects/S3RedirectsStore';
+
+const CANONICAL_KEY = 'content/data/redirects.json';
+
+interface GhostErrorShape {
+    errorType?: string;
+    code?: string;
+    context?: string;
+    errorDetails?: {
+        operation?: string;
+        key?: string;
+        s3ErrorCode?: string;
+        statusCode?: number;
+    };
+}
+
+// Mimics an AWS SDK exception, including the circular reference back to its own
+// HTTP response that made the API error handler recurse until the stack blew.
+const s3Failure = (): Error => {
+    const err = Object.assign(new Error('Access denied.'), {
+        name: 'AccessDenied',
+        $metadata: {httpStatusCode: 403}
+    }) as Error & {$response?: unknown};
+    err.$response = {error: err};
+    return err;
+};
+
+const storeWithClient = (send: (command: unknown) => Promise<unknown>) => {
+    const client: Pick<S3Client, 'send'> = {send: sinon.stub().callsFake(send)};
+    return new S3RedirectsStore({
+        bucket: 'a-bucket',
+        staticFileURLPrefix: 'content/data',
+        s3Client: client as S3Client
+    });
+};
 
 describe('UNIT: S3RedirectsStore', function () {
     describe('constructor validation', function () {
@@ -41,6 +77,78 @@ describe('UNIT: S3RedirectsStore', function () {
 
         it('accepts a tenantPrefix without throwing', function () {
             assert.doesNotThrow(() => new S3RedirectsStore({bucket: 'x', staticFileURLPrefix: 'content/data', tenantPrefix: 'tenant-abc'}));
+        });
+    });
+
+    // The API error handler deep-clones whatever it is handed. A raw SDK
+    // exception carries a circular reference to its HTTP response, so it used to
+    // surface as "Maximum call stack size exceeded" and the real S3 failure
+    // never reached the operator.
+    describe('S3 failure reporting', function () {
+        afterEach(function () {
+            sinon.restore();
+        });
+
+        it('reports the S3 error code, operation and key rather than the raw SDK error', async function () {
+            const store = storeWithClient(async () => {
+                throw s3Failure();
+            });
+
+            await assert.rejects(store.getAll(), (err: GhostErrorShape) => {
+                assert.equal(err.errorType, 'InternalServerError');
+                assert.equal(err.code, 'REDIRECTS_STORAGE_REQUEST_FAILED');
+                assert.equal(err.context, 'Access denied.');
+                assert.equal(err.errorDetails?.s3ErrorCode, 'AccessDenied');
+                assert.equal(err.errorDetails?.statusCode, 403);
+                assert.equal(err.errorDetails?.operation, 'GetObject');
+                assert.equal(err.errorDetails?.key, CANONICAL_KEY);
+                assert.doesNotThrow(() => JSON.stringify(err.errorDetails));
+                return true;
+            });
+        });
+
+        it('names CopyObject and the backup key when the backup fails', async function () {
+            const store = storeWithClient(async (command) => {
+                if (command instanceof CopyObjectCommand) {
+                    throw s3Failure();
+                }
+                return {};
+            });
+
+            await assert.rejects(store.replaceAll([]), (err: GhostErrorShape) => {
+                assert.equal(err.errorDetails?.operation, 'CopyObject');
+                assert.match(String(err.errorDetails?.key), /^content\/data\/redirects-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}\.json$/);
+                return true;
+            });
+        });
+
+        it('names PutObject and the canonical key when the write fails', async function () {
+            const store = storeWithClient(async (command) => {
+                if (command instanceof PutObjectCommand) {
+                    throw s3Failure();
+                }
+                return {};
+            });
+
+            await assert.rejects(store.replaceAll([]), (err: GhostErrorShape) => {
+                assert.equal(err.errorDetails?.operation, 'PutObject');
+                assert.equal(err.errorDetails?.key, CANONICAL_KEY);
+                return true;
+            });
+        });
+
+        it('names HeadObject when the existence check fails', async function () {
+            const store = storeWithClient(async (command) => {
+                if (command instanceof HeadObjectCommand) {
+                    throw s3Failure();
+                }
+                return {};
+            });
+
+            await assert.rejects(store.replaceAll([]), (err: GhostErrorShape) => {
+                assert.equal(err.errorDetails?.operation, 'HeadObject');
+                return true;
+            });
         });
     });
 });

--- a/ghost/core/test/unit/server/adapters/route-settings/s3-route-settings-store.test.ts
+++ b/ghost/core/test/unit/server/adapters/route-settings/s3-route-settings-store.test.ts
@@ -41,6 +41,30 @@ const fromYaml = (yaml: string) => parseRouteSettings(parseYaml(yaml), yaml);
 type StubbedClient = Pick<S3Client, 'send'>;
 type S3Command = GetObjectCommand | HeadObjectCommand | CopyObjectCommand | PutObjectCommand;
 
+interface GhostErrorShape {
+    errorType?: string;
+    code?: string;
+    context?: string;
+    errorDetails?: {
+        operation?: string;
+        bucket?: string;
+        key?: string;
+        s3ErrorCode?: string;
+        statusCode?: number;
+    };
+}
+
+// Mimics an AWS SDK exception, including the circular reference back to its own
+// HTTP response that made the API error handler recurse until the stack blew.
+const s3Failure = (): Error => {
+    const err = Object.assign(new Error('Access denied.'), {
+        name: 'AccessDenied',
+        $metadata: {httpStatusCode: 403}
+    }) as Error & {$response?: unknown};
+    err.$response = {error: err};
+    return err;
+};
+
 const createNotFound = () => new NotFound({$metadata: {httpStatusCode: 404}, message: 'Not Found'});
 const createNoSuchKey = () => new NoSuchKey({$metadata: {httpStatusCode: 404}, message: 'The specified key does not exist.'});
 
@@ -227,12 +251,15 @@ describe('UNIT: S3RouteSettingsStore', function () {
                 const client = stubbedClient(async (command) => {
                     sent.push(command);
                     if (command instanceof HeadObjectCommand) {
-                        throw new Error('access denied');
+                        throw s3Failure();
                     }
                     return {};
                 });
 
-                await assert.rejects(createStore(client).replace(fromYaml(SAMPLE_YAML)), /access denied/);
+                await assert.rejects(createStore(client).replace(fromYaml(SAMPLE_YAML)), (err: GhostErrorShape) => {
+                    assert.equal(err.errorDetails?.s3ErrorCode, 'AccessDenied');
+                    return true;
+                });
                 assert.equal(putCommands(sent).length, 0);
             });
         });
@@ -285,10 +312,94 @@ describe('UNIT: S3RouteSettingsStore', function () {
 
             it('propagates non-NotFound S3 errors instead of falling back to defaults', async function () {
                 const client = stubbedClient(async () => {
-                    throw new Error('AccessDenied');
+                    throw s3Failure();
                 });
 
-                await assert.rejects(createStore(client).get(), /AccessDenied/);
+                await assert.rejects(createStore(client).get(), (err: GhostErrorShape) => {
+                    assert.equal(err.errorType, 'InternalServerError');
+                    assert.equal(err.errorDetails?.operation, 'GetObject');
+                    return true;
+                });
+            });
+        });
+
+        // The API error handler deep-clones whatever it is handed. A raw SDK
+        // exception carries a circular reference to its HTTP response, so it
+        // used to surface as "Maximum call stack size exceeded" and the real S3
+        // failure never reached the operator.
+        describe('S3 failure reporting', function () {
+            it('reports the S3 error code, operation and key rather than the raw SDK error', async function () {
+                const client = stubbedClient(async () => {
+                    throw s3Failure();
+                });
+
+                await assert.rejects(createStore(client).get(), (err: GhostErrorShape) => {
+                    assert.equal(err.errorType, 'InternalServerError');
+                    assert.equal(err.code, 'ROUTE_SETTINGS_STORAGE_REQUEST_FAILED');
+                    assert.equal(err.context, 'Access denied.');
+                    assert.equal(err.errorDetails?.s3ErrorCode, 'AccessDenied');
+                    assert.equal(err.errorDetails?.statusCode, 403);
+                    assert.equal(err.errorDetails?.operation, 'GetObject');
+                    assert.equal(err.errorDetails?.key, CANONICAL_KEY);
+                    // The details must survive serialisation — that is the bug.
+                    assert.doesNotThrow(() => JSON.stringify(err.errorDetails));
+                    return true;
+                });
+            });
+
+            it('names CopyObject and the backup key when the backup fails', async function () {
+                const client = stubbedClient(async (command) => {
+                    if (command instanceof CopyObjectCommand) {
+                        throw s3Failure();
+                    }
+                    return command instanceof HeadObjectCommand ? {} : {};
+                });
+
+                await assert.rejects(createStore(client).replace(fromYaml(SAMPLE_YAML)), (err: GhostErrorShape) => {
+                    assert.equal(err.errorDetails?.operation, 'CopyObject');
+                    assert.match(String(err.errorDetails?.key), /^content\/settings\/routes-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}\.yaml$/);
+                    return true;
+                });
+            });
+
+            it('names PutObject and the canonical key when the write fails', async function () {
+                const fake = createFakeS3();
+                const client = stubbedClient(async (command) => {
+                    if (command instanceof PutObjectCommand) {
+                        throw s3Failure();
+                    }
+                    return fake.client.send(command as never);
+                });
+
+                await assert.rejects(createStore(client).replace(fromYaml(SAMPLE_YAML)), (err: GhostErrorShape) => {
+                    assert.equal(err.errorDetails?.operation, 'PutObject');
+                    assert.equal(err.errorDetails?.key, CANONICAL_KEY);
+                    return true;
+                });
+            });
+
+            it('names HeadObject when the existence check fails', async function () {
+                const client = stubbedClient(async (command) => {
+                    if (command instanceof HeadObjectCommand) {
+                        throw s3Failure();
+                    }
+                    return {};
+                });
+
+                await assert.rejects(createStore(client).replace(fromYaml(SAMPLE_YAML)), (err: GhostErrorShape) => {
+                    assert.equal(err.errorDetails?.operation, 'HeadObject');
+                    return true;
+                });
+            });
+
+            it('passes Ghost errors through untouched', async function () {
+                const client = stubbedClient(async () => ({Body: undefined}));
+
+                await assert.rejects(createStore(client).get(), (err: GhostErrorShape) => {
+                    assert.equal(err.errorType, 'InternalServerError');
+                    assert.notEqual(err.code, 'ROUTE_SETTINGS_STORAGE_REQUEST_FAILED');
+                    return true;
+                });
             });
         });
     });

--- a/ghost/core/test/unit/server/adapters/route-settings/s3-route-settings-store.test.ts
+++ b/ghost/core/test/unit/server/adapters/route-settings/s3-route-settings-store.test.ts
@@ -12,6 +12,7 @@ import {
     type S3Client
 } from '@aws-sdk/client-s3';
 
+import {utils as errorUtils} from '@tryghost/errors';
 import {RouteSettingsStoreBase} from '@tryghost/adapter-base-route-settings';
 
 import S3RouteSettingsStore from '../../../../../core/server/adapters/route-settings/S3RouteSettingsStore';
@@ -222,7 +223,7 @@ describe('UNIT: S3RouteSettingsStore', function () {
                 assert.equal(copyCommands(fake.sent).length, 0);
             });
 
-            it('propagates a non-NotFound existence-check error and does not overwrite', async function () {
+            it('reports a non-NotFound existence-check error and does not overwrite', async function () {
                 const sent: S3Command[] = [];
                 const client = stubbedClient(async (command) => {
                     sent.push(command);
@@ -232,7 +233,7 @@ describe('UNIT: S3RouteSettingsStore', function () {
                     return {};
                 });
 
-                await assert.rejects(createStore(client).replace(fromYaml(SAMPLE_YAML)), /access denied/);
+                await assert.rejects(createStore(client).replace(fromYaml(SAMPLE_YAML)), /Something went wrong, please try again\./);
                 assert.equal(putCommands(sent).length, 0);
             });
         });
@@ -283,12 +284,37 @@ describe('UNIT: S3RouteSettingsStore', function () {
                 });
             });
 
-            it('propagates non-NotFound S3 errors instead of falling back to defaults', async function () {
+            it('reports non-NotFound S3 errors instead of falling back to defaults', async function () {
                 const client = stubbedClient(async () => {
                     throw new Error('AccessDenied');
                 });
 
-                await assert.rejects(createStore(client).get(), /AccessDenied/);
+                await assert.rejects(createStore(client).get(), /Something went wrong, please try again\./);
+            });
+
+            // The bug this replacement exists for: an AWS SDK exception holds a
+            // circular reference to its own HTTP response, and the API error
+            // handler deep-clones the error before rendering it. That clone used
+            // to recurse until the stack blew, so the caller was told "Maximum
+            // call stack size exceeded" instead of anything about S3.
+            it('reports an error the API error handler can clone', async function () {
+                const sdkException = Object.assign(new Error('Access Denied'), {name: 'AccessDenied'}) as Error & {$response?: unknown};
+                sdkException.$response = {error: sdkException};
+                const client = stubbedClient(async () => {
+                    throw sdkException;
+                });
+
+                // Guards the guard: if this stops throwing, the hazard is gone
+                // upstream and this whole approach can be revisited.
+                assert.throws(() => errorUtils.prepareStackForUser(sdkException), RangeError);
+
+                await assert.rejects(createStore(client).get(), (err: {message?: string; stack?: string}) => {
+                    assert.equal(err.message, 'Something went wrong, please try again.');
+                    assert.doesNotThrow(() => errorUtils.prepareStackForUser(err as Error));
+                    // The S3 failure is still diagnosable from the logs.
+                    assert.match(String(err.stack), /Caused by: AccessDenied: Access Denied/);
+                    return true;
+                });
             });
         });
     });

--- a/ghost/core/test/unit/server/adapters/route-settings/s3-route-settings-store.test.ts
+++ b/ghost/core/test/unit/server/adapters/route-settings/s3-route-settings-store.test.ts
@@ -292,11 +292,6 @@ describe('UNIT: S3RouteSettingsStore', function () {
                 await assert.rejects(createStore(client).get(), /Something went wrong, please try again\./);
             });
 
-            // The bug this replacement exists for: an AWS SDK exception holds a
-            // circular reference to its own HTTP response, and the API error
-            // handler deep-clones the error before rendering it. That clone used
-            // to recurse until the stack blew, so the caller was told "Maximum
-            // call stack size exceeded" instead of anything about S3.
             it('reports an error the API error handler can clone', async function () {
                 const sdkException = Object.assign(new Error('Access Denied'), {name: 'AccessDenied'}) as Error & {$response?: unknown};
                 sdkException.$response = {error: sdkException};


### PR DESCRIPTION
no ref

Uploading a `routes.yaml` to a GCS-backed site came back with this:

```json
{"errors":[{"message":"Maximum call stack size exceeded"}]}
```

The actual failure was an S3 `AccessDenied`. Working that out took hours, because every attempt destroyed the evidence.

## The fix

Store now turn a non-`NotFound` S3 failure into a plain Ghost error. Nothing is taken off the SDK exception by reference, which is what makes the result safe to clone.

The message stays generic on purpose. A storage failure is Ghost's problem, not the customer's, and an S3 error code isn't something they can do anything with.
