### PR TITLE
Added support for idempotency key in scheduling adapter interface

### DIFF
--- a/.changeset/fifty-maps-sing.md
+++ b/.changeset/fifty-maps-sing.md
@@ -1,0 +1,5 @@
+---
+"@tryghost/adapter-base-scheduling": minor
+---
+
+Added support for idempotency key in scheduling adapter interface

--- a/packages/adapters/scheduling-base/src/base.ts
+++ b/packages/adapters/scheduling-base/src/base.ts
@@ -11,6 +11,7 @@ export interface SchedulerJob {
     url: string;
     extra: {
         httpMethod: string;
+        idempotencyKey?: string;
         oldTime?: number | null;
     };
 }


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1396

This is a types-only change.

Soon, we'll start sending an idempotency key to the scheduler. This adds support for that.
