### PR TITLE
Only schedule automation email analytics job if we know we need to

### DIFF
--- a/ghost/core/core/server/services/automations/poll.ts
+++ b/ghost/core/core/server/services/automations/poll.ts
@@ -221,17 +221,19 @@ const processStep = async ({
                     }
                 }, `[AUTOMATIONS] Failed to record automated email recipient for step ${step.id}`);
             }
-            try {
-                await scheduleAutomationEmailAnalyticsJob();
-            } catch (err) {
-                logging.error({
-                    err,
-                    system: {
-                        event: 'automations.poll.analytics_scheduling_failed',
-                        member_id: step.member_id,
-                        step_id: step.id
-                    }
-                }, `[AUTOMATIONS] Failed to schedule email analytics job for step ${step.id}`);
+            if (mailgunMessageId) {
+                try {
+                    await scheduleAutomationEmailAnalyticsJob();
+                } catch (err) {
+                    logging.error({
+                        err,
+                        system: {
+                            event: 'automations.poll.analytics_scheduling_failed',
+                            member_id: step.member_id,
+                            step_id: step.id
+                        }
+                    }, `[AUTOMATIONS] Failed to schedule email analytics job for step ${step.id}`);
+                }
             }
             break;
         }

--- a/ghost/core/test/unit/server/services/automations/poll.test.ts
+++ b/ghost/core/test/unit/server/services/automations/poll.test.ts
@@ -410,6 +410,19 @@ describe('automations poll', function () {
         }));
     });
 
+    it('does not schedule email analytics when the send has no Mailgun message ID', async function () {
+        const step = buildEmailStep();
+        automationsApi.fetchAndLockSteps.resolves({steps: [step], nextStepReadyAt: null});
+        memberWelcomeEmailService.api.sendAutomationEmail.resolves({
+            messageId: '<smtp-message-id>',
+            response: '250 Message accepted'
+        });
+
+        await poll(options);
+
+        sinon.assert.notCalled(scheduleAutomationEmailAnalyticsJob);
+    });
+
     it('records the automated email recipient without a Mailgun message ID after an SMTP send', async function () {
         const step = buildEmailStep({
             automation_action_revision_id: 'revision-id'
@@ -458,6 +471,7 @@ describe('automations poll', function () {
     it('does not retry the email send when scheduling email analytics fails', async function () {
         const step = buildEmailStep();
         automationsApi.fetchAndLockSteps.resolves({steps: [step], nextStepReadyAt: null});
+        memberWelcomeEmailService.api.sendAutomationEmail.resolves({id: '<mailgun-message-id>'});
         scheduleAutomationEmailAnalyticsJob.rejects(new Error('email analytics scheduling failed'));
 
         await poll(options);


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/29456

_I recommend [reviewing this with whitespace changes disabled](https://github.com/TryGhost/Ghost/pull/29492/changes?w=1)._

We schedule the recurring automation analytics job in two places:

1. At startup. It won't run if there are no relevant `automated_email_recipients` rows.
2. When sending an automation email. After all, we now know there's a relevant row!

This tightens that second assumption. There might not be a relevant row if Mailgun isn't used, so don't schedule the job in that case.

This change shouldn't affect correctness, but prevents us from running an unnecessary, useless job.
