### PR TITLE
🎨 Improved routes.yaml validation errors on upload

### DIFF
--- a/ghost/core/core/server/services/route-settings/route-settings-parser.ts
+++ b/ghost/core/core/server/services/route-settings/route-settings-parser.ts
@@ -11,22 +11,15 @@ import type {
     TemplateRoute
 } from '@tryghost/adapter-base-route-settings';
 import {z} from 'zod';
-import errors from '@tryghost/errors';
 import tpl from '@tryghost/tpl';
+import type {PathSegment} from './validation-errors';
+import {describeValue, formatLocation, humanList, toValidationError, validationError} from './validation-errors';
 
 const messages = {
-    validationError: 'The following definition "{at}" is invalid: {reason}',
-    badDataError: 'Please wrap the data definition into a custom name.',
+    badDataError: '"{key}" is a reserved key. Please wrap the data definition into a custom name.',
     badDataHelp: 'Example:\n data:\n  my-tag:\n    resource: tags\n    ...\n',
-    authorDeprecatedError: 'Please choose a different name. We recommend not using author.'
+    authorDeprecatedError: '"author" is reserved. Please choose a different name. We recommend not using author.'
 };
-
-function validationError(at: string, reason: string, help?: string): errors.ValidationError {
-    return new errors.ValidationError({
-        message: tpl(messages.validationError, {at, reason}),
-        ...(help ? {help} : {})
-    });
-}
 
 const VALID_SHORTFORM_RESOURCES = ['tag', 'page', 'post', 'author'] as const;
 const VALID_LONGFORM_RESOURCES = ['tags', 'posts', 'pages', 'authors'] as const;
@@ -40,21 +33,34 @@ const OptionalBooleanField = z.boolean().nullish().transform(v => v ?? undefined
 const LimitField = z.union([z.number(), z.literal('all'), z.string().regex(/^\d+$/).transform(Number)])
     .nullish().transform(v => v ?? undefined);
 
-const DataShortFormSchema = z.string().superRefine((v, ctx) => {
-    if (!/^[a-zA-Z0-9_]+\.[a-zA-Z0-9_-]+$/.test(v)) {
-        ctx.addIssue({code: 'custom', message: tpl(messages.validationError, {at: v, reason: 'Incorrect Format. Please use e.g. tag.recipes'})});
-        return;
+const SHORTFORM_HELP = 'e.g. data: tag.recipes';
+
+/**
+ * Shorthand data definitions look like `tag.recipes` — resource, dot, slug.
+ */
+function validateDataShortForm(value: string, path: PathSegment[]): void {
+    if (!/^[a-zA-Z0-9_]+\.[a-zA-Z0-9_-]+$/.test(value)) {
+        throw validationError(
+            formatLocation(path),
+            `"${value}" is not a valid data shorthand. Please use resource.slug, e.g. tag.recipes.`,
+            SHORTFORM_HELP
+        );
     }
-    const resource = v.split('.')[0];
+
+    const resource = value.split('.')[0];
     if (!(VALID_SHORTFORM_RESOURCES as readonly string[]).includes(resource)) {
-        ctx.addIssue({code: 'custom', message: tpl(messages.validationError, {at: v, reason: `${resource} not supported. Please use ${VALID_SHORTFORM_RESOURCES.join(', ')}.`})});
+        throw validationError(
+            formatLocation(path),
+            `resource "${resource}" is not supported. Please use ${humanList(VALID_SHORTFORM_RESOURCES)}.`,
+            SHORTFORM_HELP
+        );
     }
-});
+}
 
 const DataReadEntrySchema = z.object({
     type: z.literal('read'),
     resource: z.enum(VALID_LONGFORM_RESOURCES),
-    slug: z.string({message: 'slug is required for read data entries.'}).min(1, {message: 'slug is required for read data entries.'}),
+    slug: z.string().min(1),
     redirect: z.boolean().optional(),
     include: z.string().optional(),
     visibility: z.string().optional(),
@@ -76,34 +82,37 @@ const DataBrowseEntrySchema = z.object({
 
 const DataLongFormEntrySchema = z.discriminatedUnion('type', [DataReadEntrySchema, DataBrowseEntrySchema]);
 
-function parseDataEntry(key: string, value: unknown): DataEntry {
+const DATA_ENTRY_HELP = 'e.g.\n data:\n  my-tag:\n    resource: tags\n    type: read\n    slug: recipes\n';
+
+function parseDataEntry(value: unknown, path: PathSegment[]): DataEntry {
     if (typeof value === 'string') {
-        const result = DataShortFormSchema.safeParse(value);
-        if (!result.success) {
-            throw toValidationError(result.error);
-        }
+        validateDataShortForm(value, path);
         return value as DataShortForm;
     }
 
-    if (typeof value === 'object' && value !== null) {
+    if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
         const result = DataLongFormEntrySchema.safeParse(value);
         if (!result.success) {
             const issue = result.error.issues[0];
+            const at = formatLocation(path);
+            const record = value as Record<string, unknown>;
+
             if (issue.message.includes('discriminator')) {
-                const typeVal = (value as Record<string, unknown>).type;
-                if (typeVal === undefined) {
-                    throw validationError(JSON.stringify(value), 'type is required.');
+                if (record.type === undefined) {
+                    throw validationError(at, 'type is required. Please use read or browse.', DATA_ENTRY_HELP);
                 }
-                throw validationError(JSON.stringify(value), `${typeVal} not supported. Please use read, browse.`);
+                throw validationError(at, `type "${record.type}" is not supported. Please use read or browse.`, DATA_ENTRY_HELP);
             }
-            if (issue.path?.includes('resource')) {
-                const resVal = (value as Record<string, unknown>).resource;
-                if (resVal === undefined) {
-                    throw validationError(JSON.stringify(value), 'resource is required.');
+            if (issue.path.includes('resource')) {
+                if (record.resource === undefined) {
+                    throw validationError(at, `resource is required. Please use ${humanList(VALID_LONGFORM_RESOURCES)}.`, DATA_ENTRY_HELP);
                 }
-                throw validationError(JSON.stringify(value), `${resVal} not supported. Please use ${VALID_LONGFORM_RESOURCES.join(', ')}.`);
+                throw validationError(at, `resource "${record.resource}" is not supported. Please use ${humanList(VALID_LONGFORM_RESOURCES)}.`, DATA_ENTRY_HELP);
             }
-            throw toValidationError(result.error);
+            if (issue.path.includes('slug') && !record.slug) {
+                throw validationError(at, 'slug is required for read data entries.', DATA_ENTRY_HELP);
+            }
+            throw toValidationError(result.error, path, value);
         }
         // Fields set to an explicitly empty value parse to undefined — drop the
         // keys so "unset" means absent in the domain model and serialized output.
@@ -116,41 +125,41 @@ function parseDataEntry(key: string, value: unknown): DataEntry {
         return result.data;
     }
 
-    throw validationError(key, 'Incorrect Format. Please use e.g. tag.recipes');
+    throw validationError(
+        formatLocation(path),
+        `a data entry must be a shorthand like tag.recipes, or a map with type and resource, but ${describeValue(value)} was provided.`,
+        DATA_ENTRY_HELP
+    );
 }
 
-function parseRouteData(data: unknown): RouteData {
+function parseRouteData(data: unknown, path: PathSegment[]): RouteData {
     if (typeof data === 'string') {
-        const result = DataShortFormSchema.safeParse(data);
-        if (!result.success) {
-            throw toValidationError(result.error);
-        }
+        validateDataShortForm(data, path);
         return data as DataShortForm;
     }
 
     if (typeof data !== 'object' || data === null) {
-        throw validationError(String(data), 'Incorrect Format. Please use e.g. tag.recipes');
+        throw validationError(
+            formatLocation(path),
+            `data must be a shorthand like tag.recipes, or a map of named data entries, but ${describeValue(data)} was provided.`,
+            DATA_ENTRY_HELP
+        );
     }
 
     const record = data as Record<string, unknown>;
 
     for (const key of Object.keys(record)) {
         if (RESERVED_DATA_KEYS.includes(key)) {
-            throw new errors.ValidationError({
-                message: tpl(messages.badDataError),
-                help: messages.badDataHelp
-            });
+            throw validationError(formatLocation([...path, key]), tpl(messages.badDataError, {key}), messages.badDataHelp);
         }
         if (key === 'author') {
-            throw new errors.ValidationError({
-                message: tpl(messages.authorDeprecatedError)
-            });
+            throw validationError(formatLocation([...path, key]), messages.authorDeprecatedError);
         }
     }
 
     const parsed: Record<string, DataEntry> = {};
     for (const [key, value] of Object.entries(record)) {
-        parsed[key] = parseDataEntry(key, value);
+        parsed[key] = parseDataEntry(value, [...path, key]);
     }
     return parsed;
 }
@@ -163,7 +172,9 @@ const TemplateField = z.union([z.string(), z.array(z.string())]).nullish().defau
         return Array.isArray(v) ? v : [v];
     });
 
-const RouteObjectSchema = z.object({
+// The schemas are built per route/collection so that errors raised while
+// parsing nested `data` can name the exact path they came from.
+const routeObjectSchema = (path: PathSegment[]) => z.object({
     controller: z.literal('channel').optional(),
     template: TemplateField,
     data: z.unknown().optional(),
@@ -174,7 +185,7 @@ const RouteObjectSchema = z.object({
     rss: OptionalBooleanField
 }).transform((val): Omit<Route, 'path'> => {
     const templates = val.template;
-    const data = val.data !== undefined ? parseRouteData(val.data) : undefined;
+    const data = val.data !== undefined ? parseRouteData(val.data, [...path, 'data']) : undefined;
 
     if (val.controller === 'channel') {
         const route: Omit<ChannelRoute, 'path'> = {
@@ -215,8 +226,8 @@ const RouteObjectSchema = z.object({
     return route;
 });
 
-const RawCollectionValueSchema = z.object({
-    permalink: z.string({message: 'Please define a permalink route.'}).optional(),
+const collectionValueSchema = (path: PathSegment[]) => z.object({
+    permalink: z.string().optional(),
     template: TemplateField,
     data: z.unknown().optional(),
     filter: OptionalStringField,
@@ -224,7 +235,7 @@ const RawCollectionValueSchema = z.object({
     limit: LimitField,
     rss: OptionalBooleanField
 }).transform((val): Omit<CollectionConfig, 'path'> => {
-    const data = val.data !== undefined ? parseRouteData(val.data) : undefined;
+    const data = val.data !== undefined ? parseRouteData(val.data, [...path, 'data']) : undefined;
     const collection: Omit<CollectionConfig, 'path'> = {
         permalink: val.permalink ?? '',
         templates: val.template
@@ -249,15 +260,28 @@ const RawCollectionValueSchema = z.object({
 
 const RouteSettingsSchema = z.object({
     routes: z.record(z.string(), z.unknown()).nullable().optional().default({}),
-    collections: z.record(z.string(), RawCollectionValueSchema).nullable().optional().default({}),
+    collections: z.record(z.string(), z.unknown()).nullable().optional().default({}),
     taxonomies: z.record(z.string(), z.string()).nullable().optional().default({})
 });
 
-function toValidationError(error: z.ZodError): errors.ValidationError {
-    const issue = error.issues[0];
-    return new errors.ValidationError({
-        message: issue.message
-    });
+/**
+ * Every path in routes.yaml — route paths, collection paths, permalinks and
+ * taxonomy permalinks — follows the same rules, so they share one message set.
+ */
+function validatePath(value: string, path: PathSegment[], example: string): void {
+    const at = formatLocation(path);
+
+    if (!value.startsWith('/')) {
+        throw validationError(at, `"${value}" is missing a leading slash. Please use e.g. ${example}.`);
+    }
+    if (!value.endsWith('/')) {
+        throw validationError(at, `"${value}" is missing a trailing slash. Please use e.g. ${example}.`);
+    }
+    if (/\/:\w+/.test(value)) {
+        // Suggest the same path in the notation Ghost expects, rather than a
+        // generic example the author then has to translate.
+        throw validationError(at, `"${value}" uses the :param notation. Ghost uses curly braces — please use "${value.replace(/\/:(\w+)/g, '/{$1}')}".`);
+    }
 }
 
 export function parseRouteSettings(raw: unknown, yamlSource: string): RouteSettings {
@@ -265,7 +289,7 @@ export function parseRouteSettings(raw: unknown, yamlSource: string): RouteSetti
 
     const parsed = RouteSettingsSchema.safeParse(obj);
     if (!parsed.success) {
-        throw toValidationError(parsed.error);
+        throw toValidationError(parsed.error, [], obj);
     }
 
     const {routes: rawRoutes, collections: rawCollections, taxonomies: rawTaxonomies} = parsed.data;
@@ -273,18 +297,11 @@ export function parseRouteSettings(raw: unknown, yamlSource: string): RouteSetti
     const routes: Route[] = [];
     if (rawRoutes) {
         for (const [path, value] of Object.entries(rawRoutes)) {
-            if (!path.startsWith('/')) {
-                throw validationError(path, 'A leading slash is required.');
-            }
-            if (!path.endsWith('/')) {
-                throw validationError(path, 'A trailing slash is required.');
-            }
-            if (/\/:\w+/.test(path)) {
-                throw validationError(path, 'Please use the following notation e.g. /{slug}/.');
-            }
+            const routeLocation: PathSegment[] = ['routes', path];
+            validatePath(path, routeLocation, '/about/');
 
             if (value === null || value === undefined) {
-                throw validationError(path, 'Please define a template.', 'e.g. /about/: about');
+                throw validationError(formatLocation(routeLocation), 'Please define a template, e.g. /about/: about.');
             }
 
             if (typeof value === 'string') {
@@ -292,14 +309,14 @@ export function parseRouteSettings(raw: unknown, yamlSource: string): RouteSetti
                 continue;
             }
 
-            const routeResult = RouteObjectSchema.safeParse(value);
+            const routeResult = routeObjectSchema(routeLocation).safeParse(value);
             if (!routeResult.success) {
-                throw toValidationError(routeResult.error);
+                throw toValidationError(routeResult.error, routeLocation, value);
             }
 
             const route = routeResult.data;
             if (route.type === 'template' && (!route.templates || route.templates.length === 0) && !route.data && !(route as Omit<TemplateRoute, 'path'>).contentType) {
-                throw validationError(path, 'Please define a template.', 'e.g. /about/: about');
+                throw validationError(formatLocation(routeLocation), 'Please define a template, e.g. /about/: about.');
             }
 
             routes.push({...route, path} as Route);
@@ -309,49 +326,35 @@ export function parseRouteSettings(raw: unknown, yamlSource: string): RouteSetti
     const collections: CollectionConfig[] = [];
     if (rawCollections) {
         for (const [path, value] of Object.entries(rawCollections)) {
-            if (!path.startsWith('/')) {
-                throw validationError(path, 'A leading slash is required.');
+            const collectionLocation: PathSegment[] = ['collections', path];
+            validatePath(path, collectionLocation, '/blog/');
+
+            const collectionResult = collectionValueSchema(collectionLocation).safeParse(value);
+            if (!collectionResult.success) {
+                throw toValidationError(collectionResult.error, collectionLocation, value);
             }
-            if (!path.endsWith('/')) {
-                throw validationError(path, 'A trailing slash is required.');
+
+            const collection = collectionResult.data;
+            if (!collection.permalink) {
+                throw validationError(formatLocation(collectionLocation), 'Please define a permalink route, e.g. permalink: /{slug}/.');
             }
-            if (/\/:\w+/.test(path)) {
-                throw validationError(path, 'Please use the following notation e.g. /{slug}/.');
-            }
-            if (!value.permalink) {
-                throw validationError(path, 'Please define a permalink route.', 'e.g. permalink: /{slug}/');
-            }
-            if (!value.permalink.startsWith('/')) {
-                throw validationError(value.permalink, 'A leading slash is required.');
-            }
-            if (!value.permalink.endsWith('/')) {
-                throw validationError(value.permalink, 'A trailing slash is required.');
-            }
-            if (/\/:\w+/.test(value.permalink)) {
-                throw validationError(value.permalink, 'Please use the following notation e.g. /{slug}/.');
-            }
-            collections.push({...value, path});
+            validatePath(collection.permalink, [...collectionLocation, 'permalink'], '/{slug}/');
+
+            collections.push({...collection, path});
         }
     }
 
     const taxonomies: TaxonomyConfig = {};
     if (rawTaxonomies) {
         for (const [key, value] of Object.entries(rawTaxonomies)) {
+            const taxonomyLocation: PathSegment[] = ['taxonomies', key];
             if (!['tag', 'author'].includes(key)) {
-                throw validationError(key, 'Unknown taxonomy.');
+                throw validationError(formatLocation(taxonomyLocation), 'Unknown taxonomy. Please use tag or author.');
             }
             if (!value) {
-                throw validationError(key, 'Please define a taxonomy permalink route.', 'e.g. tag: /tag/{slug}/');
+                throw validationError(formatLocation(taxonomyLocation), `Please define a taxonomy permalink route, e.g. ${key}: /${key}/{slug}/.`);
             }
-            if (!value.startsWith('/')) {
-                throw validationError(value, 'A leading slash is required.');
-            }
-            if (!value.endsWith('/')) {
-                throw validationError(value, 'A trailing slash is required.');
-            }
-            if (/\/:\w+/.test(value)) {
-                throw validationError(value, 'Please use the following notation e.g. /{slug}/.');
-            }
+            validatePath(value, taxonomyLocation, `/${key}/{slug}/`);
             if (key === 'tag') {
                 taxonomies.tag = value;
             }

--- a/ghost/core/core/server/services/route-settings/route-settings-parser.ts
+++ b/ghost/core/core/server/services/route-settings/route-settings-parser.ts
@@ -283,7 +283,7 @@ function validatePath(value: string, path: PathSegment[], example: string): void
     if (/\/:\w+/.test(value)) {
         // Suggest the same path in the notation Ghost expects, rather than a
         // generic example the author then has to translate.
-        throw validationError(at, `"${value}" uses the :param notation. Ghost uses curly braces — please use "${value.replace(/\/:(\w+)/g, '/{$1}')}".`);
+        throw validationError(at, `"${value}" uses the :param notation. Please use "${value.replace(/\/:(\w+)/g, '/{$1}')}".`);
     }
 }
 

--- a/ghost/core/core/server/services/route-settings/route-settings-parser.ts
+++ b/ghost/core/core/server/services/route-settings/route-settings-parser.ts
@@ -97,7 +97,10 @@ function parseDataEntry(value: unknown, path: PathSegment[]): DataEntry {
             const at = formatLocation(path);
             const record = value as Record<string, unknown>;
 
-            if (issue.message.includes('discriminator')) {
+            // A failed `type` discriminator surfaces as a union issue on that
+            // key — matched on the code rather than the wording, which zod
+            // is free to change.
+            if (issue.code === 'invalid_union' && issue.path[0] === 'type') {
                 if (record.type === undefined) {
                     throw validationError(at, 'type is required. Please use read or browse.', DATA_ENTRY_HELP);
                 }
@@ -138,7 +141,7 @@ function parseRouteData(data: unknown, path: PathSegment[]): RouteData {
         return data as DataShortForm;
     }
 
-    if (typeof data !== 'object' || data === null) {
+    if (typeof data !== 'object' || data === null || Array.isArray(data)) {
         throw validationError(
             formatLocation(path),
             `data must be a shorthand like tag.recipes, or a map of named data entries, but ${describeValue(data)} was provided.`,

--- a/ghost/core/core/server/services/route-settings/validation-errors.ts
+++ b/ghost/core/core/server/services/route-settings/validation-errors.ts
@@ -1,0 +1,196 @@
+import type {z} from 'zod';
+import errors from '@tryghost/errors';
+import tpl from '@tryghost/tpl';
+
+const messages = {
+    validationError: 'The following definition "{at}" is invalid: {reason}'
+};
+
+const DOCS_URL = 'https://ghost.org/docs/themes/routing/';
+const MAX_SHOWN_LENGTH = 40;
+
+export type PathSegment = string | number;
+
+/**
+ * Renders the path to the offending value the way an author would find it in
+ * their file, e.g. `routes['/about/'].template[1]`.
+ */
+export function formatLocation(path: readonly PathSegment[]): string {
+    if (path.length === 0) {
+        return 'routes.yaml';
+    }
+
+    return path.reduce<string>((out, segment) => {
+        if (typeof segment === 'number') {
+            return `${out}[${segment}]`;
+        }
+        if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(segment)) {
+            return out ? `${out}.${segment}` : segment;
+        }
+        return `${out}['${segment.replace(/'/g, '\\\'')}']`;
+    }, '');
+}
+
+/**
+ * Names what the author actually wrote, so the error can contrast it with what
+ * was expected. Reads as the "but <this> was provided" half of a message.
+ */
+export function describeValue(value: unknown): string {
+    if (value === null || value === undefined) {
+        return 'nothing';
+    }
+    if (Array.isArray(value)) {
+        return 'a list';
+    }
+    if (value instanceof Date) {
+        return 'a date';
+    }
+    if (typeof value === 'object') {
+        return 'a map';
+    }
+    if (typeof value === 'string') {
+        const shown = value.length > MAX_SHOWN_LENGTH ? `${value.slice(0, MAX_SHOWN_LENGTH)}…` : value;
+        return `the text "${shown}"`;
+    }
+    if (typeof value === 'number' || typeof value === 'boolean') {
+        return String(value);
+    }
+    return 'an unsupported value';
+}
+
+/**
+ * Lists options the way a sentence would, e.g. "posts, pages or tags".
+ */
+export function humanList(items: readonly string[]): string {
+    if (items.length < 2) {
+        return items.join('');
+    }
+    return `${items.slice(0, -1).join(', ')} or ${items[items.length - 1]}`;
+}
+
+/**
+ * What each key in routes.yaml accepts, phrased so the message reads
+ * "<key> must be <expectation>".
+ */
+const FIELD_EXPECTATIONS: Record<string, string> = {
+    routes: 'a map of route paths (e.g. /about/: about)',
+    collections: 'a map of collection paths (e.g. /blog/: {permalink: /{slug}/})',
+    taxonomies: 'a map of tag and/or author permalinks (e.g. tag: /tag/{slug}/)',
+    controller: 'channel, the only supported controller',
+    template: 'a template name, or a list of template names (e.g. template: index)',
+    permalink: 'a route with a leading and trailing slash (e.g. permalink: /{slug}/)',
+    content_type: 'a content type (e.g. content_type: text/xml)',
+    filter: 'a filter string (e.g. filter: featured:true)',
+    order: 'an order string (e.g. order: published_at desc)',
+    limit: 'a number or "all" (e.g. limit: 5)',
+    include: 'a comma-separated string (e.g. include: authors,tags)',
+    fields: 'a comma-separated string (e.g. fields: title,slug)',
+    visibility: 'a string (e.g. visibility: public)',
+    status: 'a string (e.g. status: published)',
+    slug: 'a slug (e.g. slug: welcome)',
+    page: 'a number (e.g. page: 2)',
+    rss: 'true or false',
+    redirect: 'true or false'
+};
+
+const CONTAINER_EXPECTATIONS: Record<string, {subject: string, expectation: string}> = {
+    routes: {subject: 'a route', expectation: 'a template name, or a map of route options (e.g. template, controller, data)'},
+    collections: {subject: 'a collection', expectation: 'a map of collection options (e.g. permalink, template, filter)'}
+};
+
+/**
+ * Keys that accept a list: saying "a list was provided" would contradict the
+ * expectation, so the entries are blamed instead.
+ */
+const LIST_ENTRY_PROBLEMS: Record<string, string> = {
+    template: 'one or more of the entries is not a template name'
+};
+
+function lookup(table: Record<string, string>, key: PathSegment | undefined): string | undefined {
+    return typeof key === 'string' && Object.prototype.hasOwnProperty.call(table, key) ? table[key] : undefined;
+}
+
+/**
+ * The key a failure belongs to — for a list entry that is the key holding the
+ * list, not the index.
+ */
+function fieldKey(path: readonly PathSegment[]): PathSegment | undefined {
+    const last = path[path.length - 1];
+
+    return typeof last === 'number' ? path[path.length - 2] : last;
+}
+
+/**
+ * Resolves the "<subject> must be <expectation>" half of a message for the
+ * value at `path`. Returns null when the key is unknown, in which case the
+ * caller falls back to the underlying schema message.
+ */
+function describeExpectation(path: readonly PathSegment[]): {subject: string, expectation: string} | null {
+    if (path.length === 0) {
+        return {subject: 'the file', expectation: 'a map of routes, collections or taxonomies'};
+    }
+
+    const [section] = path;
+
+    // A whole section, e.g. `routes: hello`
+    if (path.length === 1) {
+        const expectation = lookup(FIELD_EXPECTATIONS, section);
+        return expectation ? {subject: String(section), expectation} : null;
+    }
+
+    // A single route or collection, e.g. `routes: {/about/: [a, b]}`
+    if (path.length === 2 && typeof section === 'string' && Object.prototype.hasOwnProperty.call(CONTAINER_EXPECTATIONS, section)) {
+        return CONTAINER_EXPECTATIONS[section];
+    }
+
+    // A taxonomy permalink, e.g. `taxonomies: {tag: 5}`
+    if (path.length === 2 && section === 'taxonomies') {
+        return {subject: `the ${String(path[1])} taxonomy`, expectation: `a permalink route (e.g. ${String(path[1])}: /${String(path[1])}/{slug}/)`};
+    }
+
+    const expectation = lookup(FIELD_EXPECTATIONS, fieldKey(path));
+
+    return expectation ? {subject: String(fieldKey(path)), expectation} : null;
+}
+
+function valueAtPath(value: unknown, path: readonly PathSegment[]): unknown {
+    return path.reduce<unknown>((current, segment) => {
+        if (current === null || typeof current !== 'object') {
+            return undefined;
+        }
+        return (current as Record<PathSegment, unknown>)[segment];
+    }, value);
+}
+
+export function validationError(at: string, reason: string, help?: string): errors.ValidationError {
+    return new errors.ValidationError({
+        message: tpl(messages.validationError, {at, reason}),
+        ...(help ? {help} : {})
+    });
+}
+
+/**
+ * Turns a schema failure into an error that names the exact key in routes.yaml
+ * and says what that key accepts — schema messages on their own only say
+ * things like "Invalid input: expected string, received number".
+ *
+ * @param error  the schema failure
+ * @param basePath path of the value that was handed to the schema
+ * @param value  that same value, used to describe what the author wrote
+ */
+export function toValidationError(error: z.ZodError, basePath: readonly PathSegment[] = [], value?: unknown): errors.ValidationError {
+    const issue = error.issues[0];
+    const issuePath = issue.path as PathSegment[];
+    const path = [...basePath, ...issuePath];
+
+    const expectation = describeExpectation(path);
+    if (!expectation) {
+        return validationError(formatLocation(path), issue.message, DOCS_URL);
+    }
+
+    const provided = valueAtPath(value, issuePath);
+    const listProblem = Array.isArray(provided) ? lookup(LIST_ENTRY_PROBLEMS, fieldKey(path)) : undefined;
+    const found = listProblem ?? `${describeValue(provided)} was provided`;
+
+    return validationError(formatLocation(path), `${expectation.subject} must be ${expectation.expectation}, but ${found}.`, DOCS_URL);
+}

--- a/ghost/core/core/server/services/route-settings/validation-errors.ts
+++ b/ghost/core/core/server/services/route-settings/validation-errors.ts
@@ -27,7 +27,7 @@ export function formatLocation(path: readonly PathSegment[]): string {
         if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(segment)) {
             return out ? `${out}.${segment}` : segment;
         }
-        return `${out}['${segment.replace(/'/g, '\\\'')}']`;
+        return `${out}['${segment.replace(/\\/g, '\\\\').replace(/'/g, '\\\'')}']`;
     }, '');
 }
 

--- a/ghost/core/test/unit/server/services/route-settings/route-settings-parser.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/route-settings-parser.test.ts
@@ -322,7 +322,7 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
             it('still rejects non-numeric string limits', function () {
                 assert.throws(() => {
                     parse({collections: {'/': {permalink: '/{slug}/', limit: 'banana'}}});
-                }, /Invalid input/);
+                }, /The following definition "collections\['\/'\]\.limit" is invalid: limit must be a number or "all" \(e\.g\. limit: 5\), but the text "banana" was provided\./);
             });
 
             it('still accepts the literal "all" limit', function () {

--- a/ghost/core/test/unit/server/services/route-settings/validate-route-settings.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/validate-route-settings.test.ts
@@ -482,14 +482,14 @@ describe('UNIT: services/route-settings/validation (via parseRouteSettings)', fu
             const cases: [string, unknown, string][] = [
                 ['route missing a leading slash', {routes: {'about/': 'about'}}, 'The following definition "routes[\'about/\']" is invalid: "about/" is missing a leading slash. Please use e.g. /about/.'],
                 ['route missing a trailing slash', {routes: {'/about': 'about'}}, 'The following definition "routes[\'/about\']" is invalid: "/about" is missing a trailing slash. Please use e.g. /about/.'],
-                ['route using :param', {routes: {'/foo/:slug/': 'post'}}, 'The following definition "routes[\'/foo/:slug/\']" is invalid: "/foo/:slug/" uses the :param notation. Ghost uses curly braces — please use "/foo/{slug}/".'],
+                ['route using :param', {routes: {'/foo/:slug/': 'post'}}, 'The following definition "routes[\'/foo/:slug/\']" is invalid: "/foo/:slug/" uses the :param notation. Please use "/foo/{slug}/".'],
                 ['collection missing a leading slash', {collections: {'blog/': {permalink: '/{slug}/'}}}, 'The following definition "collections[\'blog/\']" is invalid: "blog/" is missing a leading slash. Please use e.g. /blog/.'],
                 ['collection missing a trailing slash', {collections: {'/blog': {permalink: '/{slug}/'}}}, 'The following definition "collections[\'/blog\']" is invalid: "/blog" is missing a trailing slash. Please use e.g. /blog/.'],
                 ['permalink missing a leading slash', {collections: {'/blog/': {permalink: '{slug}/'}}}, 'The following definition "collections[\'/blog/\'].permalink" is invalid: "{slug}/" is missing a leading slash. Please use e.g. /{slug}/.'],
                 ['permalink missing a trailing slash', {collections: {'/blog/': {permalink: '/{slug}'}}}, 'The following definition "collections[\'/blog/\'].permalink" is invalid: "/{slug}" is missing a trailing slash. Please use e.g. /{slug}/.'],
-                ['permalink using :param', {collections: {'/blog/': {permalink: '/:slug/'}}}, 'The following definition "collections[\'/blog/\'].permalink" is invalid: "/:slug/" uses the :param notation. Ghost uses curly braces — please use "/{slug}/".'],
+                ['permalink using :param', {collections: {'/blog/': {permalink: '/:slug/'}}}, 'The following definition "collections[\'/blog/\'].permalink" is invalid: "/:slug/" uses the :param notation. Please use "/{slug}/".'],
                 ['taxonomy missing a leading slash', {taxonomies: {tag: 'tag/{slug}/'}}, 'The following definition "taxonomies.tag" is invalid: "tag/{slug}/" is missing a leading slash. Please use e.g. /tag/{slug}/.'],
-                ['taxonomy using :param', {taxonomies: {author: '/author/:slug/'}}, 'The following definition "taxonomies.author" is invalid: "/author/:slug/" uses the :param notation. Ghost uses curly braces — please use "/author/{slug}/".']
+                ['taxonomy using :param', {taxonomies: {author: '/author/:slug/'}}, 'The following definition "taxonomies.author" is invalid: "/author/:slug/" uses the :param notation. Please use "/author/{slug}/".']
             ];
 
             cases.forEach(([name, raw, expected]) => {

--- a/ghost/core/test/unit/server/services/route-settings/validate-route-settings.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/validate-route-settings.test.ts
@@ -50,13 +50,13 @@ describe('UNIT: services/route-settings/validation (via parseRouteSettings)', fu
         it('throws on null route value', function () {
             throwsValidation(() => parse({
                 routes: {'/about/': null}
-            }), 'Please define a template.');
+            }), 'Please define a template');
         });
 
         it('throws on template route with no template and no data', function () {
             throwsValidation(() => parse({
                 routes: {'/empty/': {}}
-            }), 'Please define a template.');
+            }), 'Please define a template');
         });
 
         it('accepts template route with data but no template', function () {
@@ -106,13 +106,13 @@ describe('UNIT: services/route-settings/validation (via parseRouteSettings)', fu
         it('throws when permalink is missing', function () {
             throwsValidation(() => parse({
                 collections: {'/': {permalink: ''}}
-            }), 'Please define a permalink route.');
+            }), 'Please define a permalink route');
         });
 
         it('throws when permalink key is absent', function () {
             throwsValidation(() => parse({
                 collections: {'/': {}}
-            }), 'Please define a permalink route.');
+            }), 'Please define a permalink route');
         });
 
         it('throws on collection path with :slug notation', function () {
@@ -272,7 +272,7 @@ describe('UNIT: services/route-settings/validation (via parseRouteSettings)', fu
                     template: 'food',
                     data: {featured: {resource: 'posts', type: 'edit'}}
                 }}
-            }), 'edit not supported.');
+            }), 'type "edit" is not supported.');
         });
 
         it('throws on longform data with invalid resource', function () {
@@ -281,7 +281,7 @@ describe('UNIT: services/route-settings/validation (via parseRouteSettings)', fu
                     template: 'food',
                     data: {featured: {resource: 'subscribers', type: 'browse'}}
                 }}
-            }), 'subscribers not supported.');
+            }), 'resource "subscribers" is not supported.');
         });
 
         it('throws on reserved key name in data', function () {
@@ -321,6 +321,183 @@ describe('UNIT: services/route-settings/validation (via parseRouteSettings)', fu
                     }
                 }}
             }));
+        });
+    });
+
+    describe('error messages', function () {
+        function messageFor(raw: unknown): string {
+            try {
+                parse(raw);
+            } catch (err) {
+                assert.ok(err instanceof errors.ValidationError, `expected a ValidationError, got ${err}`);
+                return err.message;
+            }
+            return assert.fail('expected parsing to throw');
+        }
+
+        function helpFor(raw: unknown): string | undefined {
+            try {
+                parse(raw);
+            } catch (err) {
+                return (err as {help?: string}).help;
+            }
+            return assert.fail('expected parsing to throw');
+        }
+
+        it('names the file when the whole document is not a map', function () {
+            assert.equal(
+                messageFor(['a', 'b']),
+                'The following definition "routes.yaml" is invalid: the file must be a map of routes, collections or taxonomies, but a list was provided.'
+            );
+        });
+
+        it('names the section when it is not a map', function () {
+            assert.equal(
+                messageFor({routes: 'hello'}),
+                'The following definition "routes" is invalid: routes must be a map of route paths (e.g. /about/: about), but the text "hello" was provided.'
+            );
+            assert.equal(
+                messageFor({collections: 'hello'}),
+                'The following definition "collections" is invalid: collections must be a map of collection paths (e.g. /blog/: {permalink: /{slug}/}), but the text "hello" was provided.'
+            );
+            assert.equal(
+                messageFor({taxonomies: 'hello'}),
+                'The following definition "taxonomies" is invalid: taxonomies must be a map of tag and/or author permalinks (e.g. tag: /tag/{slug}/), but the text "hello" was provided.'
+            );
+        });
+
+        it('names the route or collection when its value is the wrong shape', function () {
+            assert.equal(
+                messageFor({routes: {'/x/': ['a', 'b']}}),
+                'The following definition "routes[\'/x/\']" is invalid: a route must be a template name, or a map of route options (e.g. template, controller, data), but a list was provided.'
+            );
+            assert.equal(
+                messageFor({collections: {'/blog/': 'index'}}),
+                'The following definition "collections[\'/blog/\']" is invalid: a collection must be a map of collection options (e.g. permalink, template, filter), but the text "index" was provided.'
+            );
+        });
+
+        it('names the route and the key that failed', function () {
+            assert.equal(
+                messageFor({routes: {'/x/': {controller: 'channel', filter: 42}}}),
+                'The following definition "routes[\'/x/\'].filter" is invalid: filter must be a filter string (e.g. filter: featured:true), but 42 was provided.'
+            );
+        });
+
+        it('explains what limit accepts', function () {
+            assert.equal(
+                messageFor({routes: {'/x/': {controller: 'channel', limit: [1, 2]}}}),
+                'The following definition "routes[\'/x/\'].limit" is invalid: limit must be a number or "all" (e.g. limit: 5), but a list was provided.'
+            );
+        });
+
+        it('blames the entries when a key that accepts a list gets a bad list', function () {
+            assert.equal(
+                messageFor({routes: {'/x/': {template: ['index', 5]}}}),
+                'The following definition "routes[\'/x/\'].template" is invalid: template must be a template name, or a list of template names (e.g. template: index), but one or more of the entries is not a template name.'
+            );
+        });
+
+        it('names the key inside a data entry', function () {
+            assert.equal(
+                messageFor({routes: {'/x/': {template: 'x', data: {episodes: {type: 'browse', resource: 'posts', limit: [1, 2]}}}}}),
+                'The following definition "routes[\'/x/\'].data.episodes.limit" is invalid: limit must be a number or "all" (e.g. limit: 5), but a list was provided.'
+            );
+        });
+
+        it('names data and data entries that are the wrong shape', function () {
+            assert.equal(
+                messageFor({routes: {'/x/': {template: 'x', data: 42}}}),
+                'The following definition "routes[\'/x/\'].data" is invalid: data must be a shorthand like tag.recipes, or a map of named data entries, but 42 was provided.'
+            );
+            assert.equal(
+                messageFor({routes: {'/x/': {template: 'x', data: {episodes: 42}}}}),
+                'The following definition "routes[\'/x/\'].data.episodes" is invalid: a data entry must be a shorthand like tag.recipes, or a map with type and resource, but 42 was provided.'
+            );
+            assert.equal(
+                messageFor({routes: {'/x/': {template: 'x', data: {episodes: ['tag.recipes']}}}}),
+                'The following definition "routes[\'/x/\'].data.episodes" is invalid: a data entry must be a shorthand like tag.recipes, or a map with type and resource, but a list was provided.'
+            );
+        });
+
+        it('names the reserved data key that needs wrapping', function () {
+            assert.equal(
+                messageFor({routes: {'/x/': {template: 'x', data: {resource: 'posts', type: 'browse'}}}}),
+                'The following definition "routes[\'/x/\'].data.resource" is invalid: "resource" is a reserved key. Please wrap the data definition into a custom name.'
+            );
+        });
+
+        it('names the collection key that failed', function () {
+            assert.equal(
+                messageFor({collections: {'/blog/': {permalink: 123}}}),
+                'The following definition "collections[\'/blog/\'].permalink" is invalid: permalink must be a route with a leading and trailing slash (e.g. permalink: /{slug}/), but 123 was provided.'
+            );
+        });
+
+        it('names the taxonomy that failed', function () {
+            assert.equal(
+                messageFor({taxonomies: {tag: 5}}),
+                'The following definition "taxonomies.tag" is invalid: the tag taxonomy must be a permalink route (e.g. tag: /tag/{slug}/), but 5 was provided.'
+            );
+            assert.equal(
+                messageFor({taxonomies: {author: true}}),
+                'The following definition "taxonomies.author" is invalid: the author taxonomy must be a permalink route (e.g. author: /author/{slug}/), but true was provided.'
+            );
+        });
+
+        it('carries the example for the key that is missing', function () {
+            assert.equal(
+                messageFor({routes: {'/x/': {}}}),
+                'The following definition "routes[\'/x/\']" is invalid: Please define a template, e.g. /about/: about.'
+            );
+            assert.equal(
+                messageFor({collections: {'/blog/': {}}}),
+                'The following definition "collections[\'/blog/\']" is invalid: Please define a permalink route, e.g. permalink: /{slug}/.'
+            );
+            assert.equal(
+                messageFor({taxonomies: {author: ''}}),
+                'The following definition "taxonomies.author" is invalid: Please define a taxonomy permalink route, e.g. author: /author/{slug}/.'
+            );
+        });
+
+        it('describes what the author wrote', function () {
+            // rss takes a boolean, so anything else lands in describeValue
+            const found = (value: unknown) => messageFor({routes: {'/x/': {controller: 'channel', rss: value}}})
+                .replace(/^.*but /, '');
+
+            assert.equal(found(42), '42 was provided.');
+            assert.equal(found({a: 1}), 'a map was provided.');
+            assert.equal(found(new Date('2020-01-01')), 'a date was provided.');
+            assert.equal(found('x'.repeat(40)), `the text "${'x'.repeat(40)}" was provided.`);
+            assert.equal(found('x'.repeat(41)), `the text "${'x'.repeat(40)}…" was provided.`);
+            assert.match(messageFor({routes: {'/x/': {controller: 'channel', filter: true}}}), /but true was provided\.$/);
+        });
+
+        describe('paths', function () {
+            const cases: [string, unknown, string][] = [
+                ['route missing a leading slash', {routes: {'about/': 'about'}}, 'The following definition "routes[\'about/\']" is invalid: "about/" is missing a leading slash. Please use e.g. /about/.'],
+                ['route missing a trailing slash', {routes: {'/about': 'about'}}, 'The following definition "routes[\'/about\']" is invalid: "/about" is missing a trailing slash. Please use e.g. /about/.'],
+                ['route using :param', {routes: {'/foo/:slug/': 'post'}}, 'The following definition "routes[\'/foo/:slug/\']" is invalid: "/foo/:slug/" uses the :param notation. Ghost uses curly braces — please use "/foo/{slug}/".'],
+                ['collection missing a leading slash', {collections: {'blog/': {permalink: '/{slug}/'}}}, 'The following definition "collections[\'blog/\']" is invalid: "blog/" is missing a leading slash. Please use e.g. /blog/.'],
+                ['collection missing a trailing slash', {collections: {'/blog': {permalink: '/{slug}/'}}}, 'The following definition "collections[\'/blog\']" is invalid: "/blog" is missing a trailing slash. Please use e.g. /blog/.'],
+                ['permalink missing a leading slash', {collections: {'/blog/': {permalink: '{slug}/'}}}, 'The following definition "collections[\'/blog/\'].permalink" is invalid: "{slug}/" is missing a leading slash. Please use e.g. /{slug}/.'],
+                ['permalink missing a trailing slash', {collections: {'/blog/': {permalink: '/{slug}'}}}, 'The following definition "collections[\'/blog/\'].permalink" is invalid: "/{slug}" is missing a trailing slash. Please use e.g. /{slug}/.'],
+                ['permalink using :param', {collections: {'/blog/': {permalink: '/:slug/'}}}, 'The following definition "collections[\'/blog/\'].permalink" is invalid: "/:slug/" uses the :param notation. Ghost uses curly braces — please use "/{slug}/".'],
+                ['taxonomy missing a leading slash', {taxonomies: {tag: 'tag/{slug}/'}}, 'The following definition "taxonomies.tag" is invalid: "tag/{slug}/" is missing a leading slash. Please use e.g. /tag/{slug}/.'],
+                ['taxonomy using :param', {taxonomies: {author: '/author/:slug/'}}, 'The following definition "taxonomies.author" is invalid: "/author/:slug/" uses the :param notation. Ghost uses curly braces — please use "/author/{slug}/".']
+            ];
+
+            cases.forEach(([name, raw, expected]) => {
+                it(name, function () {
+                    assert.equal(messageFor(raw), expected);
+                });
+            });
+        });
+
+        it('points at the docs for schema failures and at an example for data failures', function () {
+            assert.equal(helpFor({routes: {'/x/': {controller: 'channel', filter: 42}}}), 'https://ghost.org/docs/themes/routing/');
+            assert.equal(helpFor({routes: {'/x/': {template: 'x', data: 'nonsense'}}}), 'e.g. data: tag.recipes');
+            assert.match(helpFor({routes: {'/x/': {template: 'x', data: {e: {resource: 'posts'}}}}}) ?? '', /^e\.g\.\n data:/);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/route-settings/validate-route-settings.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/validate-route-settings.test.ts
@@ -418,6 +418,11 @@ describe('UNIT: services/route-settings/validation (via parseRouteSettings)', fu
                 messageFor({routes: {'/x/': {template: 'x', data: {episodes: ['tag.recipes']}}}}),
                 'The following definition "routes[\'/x/\'].data.episodes" is invalid: a data entry must be a shorthand like tag.recipes, or a map with type and resource, but a list was provided.'
             );
+            // A list of shorthands would otherwise be read as a map keyed "0", "1", …
+            assert.equal(
+                messageFor({routes: {'/x/': {template: 'x', data: ['tag.recipes', 'post.hello']}}}),
+                'The following definition "routes[\'/x/\'].data" is invalid: data must be a shorthand like tag.recipes, or a map of named data entries, but a list was provided.'
+            );
         });
 
         it('names the reserved data key that needs wrapping', function () {

--- a/ghost/core/test/unit/server/services/route-settings/validation-errors.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/validation-errors.test.ts
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import {z} from 'zod';
+import {describeValue, formatLocation, humanList, toValidationError} from '../../../../../core/server/services/route-settings/validation-errors';
+
+const errorFor = (schema: z.ZodType, value: unknown) => schema.safeParse(value).error as z.ZodError;
+
+describe('UNIT: services/route-settings/validation-errors', function () {
+    describe('formatLocation', function () {
+        it('names the file when there is no path', function () {
+            assert.equal(formatLocation([]), 'routes.yaml');
+        });
+
+        it('uses dots for plain keys and brackets for everything else', function () {
+            assert.equal(formatLocation(['taxonomies', 'tag']), 'taxonomies.tag');
+            assert.equal(formatLocation(['routes', '/about/', 'content_type']), 'routes[\'/about/\'].content_type');
+            assert.equal(formatLocation(['routes', '/x/', 'template', 1]), 'routes[\'/x/\'].template[1]');
+        });
+
+        it('escapes quotes in a path', function () {
+            assert.equal(formatLocation(['routes', '/it\'s/']), 'routes[\'/it\\\'s/\']');
+        });
+    });
+
+    describe('describeValue', function () {
+        it('names each kind of value', function () {
+            assert.equal(describeValue(null), 'nothing');
+            assert.equal(describeValue(undefined), 'nothing');
+            assert.equal(describeValue([1]), 'a list');
+            assert.equal(describeValue(new Date()), 'a date');
+            assert.equal(describeValue({}), 'a map');
+            assert.equal(describeValue('hi'), 'the text "hi"');
+            assert.equal(describeValue(5), '5');
+            assert.equal(describeValue(false), 'false');
+            assert.equal(describeValue(Symbol('x')), 'an unsupported value');
+        });
+    });
+
+    describe('humanList', function () {
+        it('reads as a sentence', function () {
+            assert.equal(humanList([]), '');
+            assert.equal(humanList(['posts']), 'posts');
+            assert.equal(humanList(['posts', 'pages']), 'posts or pages');
+            assert.equal(humanList(['posts', 'pages', 'tags']), 'posts, pages or tags');
+        });
+    });
+
+    describe('toValidationError', function () {
+        it('falls back to the schema message for keys it has no advice for', function () {
+            const err = toValidationError(errorFor(z.string(), 5), ['routes', '/x/', 'mystery'], {});
+
+            assert.match(err.message, /^The following definition "routes\['\/x\/'\]\.mystery" is invalid: /);
+            assert.equal(err.help, 'https://ghost.org/docs/themes/routing/');
+        });
+
+        it('does not mistake inherited object properties for known keys', function () {
+            const err = toValidationError(errorFor(z.string(), 5), ['routes', '/x/', 'data', 'toString'], {});
+
+            assert.doesNotMatch(err.message, /native code/);
+        });
+
+        it('names the key when the failure is on a list entry', function () {
+            const err = toValidationError(errorFor(z.string(), 5), ['routes', '/x/', 'template', 0], {});
+
+            assert.match(err.message, /template must be a template name, or a list of template names/);
+        });
+
+        it('describes a missing value when the path runs through a scalar', function () {
+            const error = errorFor(z.object({filter: z.string()}), {filter: 5});
+
+            assert.equal(
+                toValidationError(error, ['routes', '/x/'], 'a string route').message,
+                'The following definition "routes[\'/x/\'].filter" is invalid: filter must be a filter string (e.g. filter: featured:true), but nothing was provided.'
+            );
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/route-settings/validation-errors.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/validation-errors.test.ts
@@ -16,8 +16,10 @@ describe('UNIT: services/route-settings/validation-errors', function () {
             assert.equal(formatLocation(['routes', '/x/', 'template', 1]), 'routes[\'/x/\'].template[1]');
         });
 
-        it('escapes quotes in a path', function () {
+        it('escapes quotes and backslashes in a path', function () {
             assert.equal(formatLocation(['routes', '/it\'s/']), 'routes[\'/it\\\'s/\']');
+            assert.equal(formatLocation(['routes', '/a\\b/']), 'routes[\'/a\\\\b/\']');
+            assert.equal(formatLocation(['routes', '/a\\\'b/']), 'routes[\'/a\\\\\\\'b/\']');
         });
     });
 


### PR DESCRIPTION
Uploading a `routes.yaml` that fails the stricter validation returned messages straight from the schema layer — `Invalid input`, `Invalid input: expected string, received array` — with no indication of which key in the file was at fault. This makes them name the offending key and say what it accepts.

The boot-time fallback to the legacy validator is untouched.

### Before → after

| routes.yaml | before | after |
|---|---|---|
| `limit: [1, 2]` on a channel route | `Invalid input` | `The following definition "routes['/x/'].limit" is invalid: limit must be a number or "all" (e.g. limit: 5), but a list was provided.` |
| `filter: 42` | `Invalid input: expected string, received number` | `… "routes['/x/'].filter" …: filter must be a filter string (e.g. filter: featured:true), but 42 was provided.` |
| `permalink: 123` | `Please define a permalink route.` (it *was* defined) | `… "collections['/blog/'].permalink" …: permalink must be a route with a leading and trailing slash (e.g. permalink: /{slug}/), but 123 was provided.` |
| `routes: hello` | `Invalid input: expected record, received string` | `… "routes" …: routes must be a map of route paths (e.g. /about/: about), but the text "hello" was provided.` |
| a bad `limit` nested in `data` | `Invalid input` | `… "routes['/x/'].data.episodes.limit" …` |
| `tag: /tag/:slug/` | `Please use the following notation e.g. /{slug}/.` | `… "taxonomies.tag" …: "/tag/:slug/" uses the :param notation. Ghost uses curly braces — please use "/tag/{slug}/".` |

### One behaviour change: a list under `data:`

`data: [tag.recipes]` used to be read as a map keyed `"0"`, `"1"`, … and silently accepted. It is now rejected with the same message as any other wrong shape.

This is a **fix for a regression the strict parser introduced**, not a new tightening. The legacy validator turns such a list into a data entry keyed `tag`, because lodash iterates arrays with a *numeric* `0` and `options.resourceKey || resourceKey` (`validate.js:69`) treats that as falsy. The strict parser's `Object.entries` yields the *string* `"0"`, which is truthy in the activation bridge, so it stuck — and a `"0"` key is unreachable from a theme:

| | strict parser today (`"0"`) | legacy, and after this change (`"tag"`) |
|---|---|---|
| template access | `{{data.0}}` | `{{data.tag}}` |
| `@context` | `[]` | `["tag"]` |
| template resolution | not matched — `data.page`/`data.post` are name-keyed | works |
| default query options | none merged | merged |

Affected sites keep booting through the fallback and get their *original* behaviour back. `routes_hash` changes once for them — that is the restoration of correct output, not damage.

**Measured against the Pro corpus (41,346 files): 2 sites, 6 occurrences — 0.005%.** Both already carry inert `"0"`-keyed data, so nothing functional is lost. Fleet-wide fallback count moves 49 → 51.

### Verification

Differentially parsed the pre-PR parser against this one over 105,000 generated inputs (two independent generators) plus the full 41,346-file Pro corpus:

- differences are **one-way** (old accepted → new rejects); nothing is newly accepted
- a **single** rejection class — the `data:`-as-a-list case above
- for all 41,294 corpus files both parsers accept, the domain object *and* the expanded activation-bridge output are byte-identical
- error types unchanged (always `ValidationError`)

### Notes

- Examples live in the `message` rather than `help`, because Admin renders `context || message` and never shows `help`.
- The schemas are built per route/collection so failures inside nested `data` can report their full path.
- New `validation-errors.ts` holds the location formatting and the per-key expectations.
