### PR TITLE
Fixed ordering of adapter resolution

### DIFF
--- a/ghost/core/core/server/services/adapter-manager/index.ts
+++ b/ghost/core/core/server/services/adapter-manager/index.ts
@@ -10,13 +10,17 @@ import config from '../../../shared/config';
 
 const adapterPaths = new Set<string>([
     '', // A blank path will cause us to check node_modules for the adapter
-    config.getContentPath('adapters'),
     config.get('paths').internalAdaptersPath,
 
     // custom docker builds may install adapters in a separate path from content,
     // since the content dir is often bind-mounted into the container. Offering
     // an escape hatch here to allow for this
     config.get('paths').installedAdaptersPath ?? '',
+
+    // load adapters from content last, so that they don't override any other
+    // internal or platform-installed adapters
+    // TODO: potentially deprecate/remove as part of Ghost 7.0
+    config.getContentPath('adapters'),
 ]);
 
 // A singleton adapter manager, preconfigured with the base classes for every


### PR DESCRIPTION
no ref
- ensure adapters installed in content/adapters are loaded last, so they don't accidentally shadow any internal or platform-installed adapters
