### PR TITLE
Added logic to show/hide automation email opens/clicks

### DIFF
--- a/apps/admin/src/automations/components/canvas/email-performance-section.tsx
+++ b/apps/admin/src/automations/components/canvas/email-performance-section.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import {ChartContainer, Separator} from '@tryghost/shade/components';
+import {useEmailTrackingSettings} from '@/automations/hooks/use-email-tracking-settings';
+import {ChartContainer, HoverCard, HoverCardContent, HoverCardTrigger, Separator} from '@tryghost/shade/components';
 import type {ChartConfig} from '@tryghost/shade/components';
 import type {AutomationEmailStats} from '@tryghost/admin-x-framework/api/automations';
-import {Recharts, formatNumber} from '@tryghost/shade/utils';
+import {Recharts, cn, formatNumber} from '@tryghost/shade/utils';
 import {formatRate} from './format-stats';
+import {OffValue, TRACKING_OFF_MESSAGE} from './off-value';
 
 const EMAIL_PERFORMANCE_CHART_CONFIG = {
     value: {label: 'Rate'}
@@ -15,13 +17,19 @@ const EmailPerformanceRing: React.FC<{
     color: 'purple' | 'blue' | 'teal';
     innerRadius: number;
     outerRadius: number;
-}> = ({datatype, value, color, innerRadius, outerRadius}) => {
+    tracked?: boolean;
+}> = ({datatype, value, color, innerRadius, outerRadius, tracked = true}) => {
     const gradientId = `emailRing-${color}`;
     const colorVar = `var(--chart-${color})`;
     return (
-        <ChartContainer className='absolute inset-0 aspect-square' config={EMAIL_PERFORMANCE_CHART_CONFIG}>
+        <ChartContainer
+            className={cn('absolute inset-0 aspect-square', !tracked && 'opacity-30')}
+            config={EMAIL_PERFORMANCE_CHART_CONFIG}
+            data-testid={`email-performance-${datatype.toLowerCase()}-ring`}
+            data-tracked={tracked}
+        >
             <Recharts.RadialBarChart
-                data={[{datatype, value}]}
+                data={[{datatype, value: tracked ? value : 0}]}
                 endAngle={-270}
                 innerRadius={innerRadius}
                 outerRadius={outerRadius}
@@ -63,7 +71,12 @@ const EMAIL_CHART_RINGS = {
     clicked: {innerRadius: 38, outerRadius: 60}
 };
 
-const EmailPerformanceChart: React.FC<{openRate: number}> = ({openRate}) => (
+const EmailPerformanceChart: React.FC<{
+    clickRate: number;
+    openRate: number;
+    clicksTracked: boolean;
+    opensTracked: boolean;
+}> = ({clickRate, openRate, clicksTracked, opensTracked}) => (
     <div className='relative mx-auto aspect-square size-[240px]'>
         <EmailPerformanceRing
             color='purple'
@@ -77,62 +90,104 @@ const EmailPerformanceChart: React.FC<{openRate: number}> = ({openRate}) => (
             datatype='Opened'
             innerRadius={EMAIL_CHART_RINGS.opened.innerRadius}
             outerRadius={EMAIL_CHART_RINGS.opened.outerRadius}
+            tracked={opensTracked}
             value={openRate}
         />
-        {/* @TODO: NY-1457 */}
-        {/* <EmailPerformanceRing
+        <EmailPerformanceRing
             color='teal'
             datatype='Clicked'
             innerRadius={EMAIL_CHART_RINGS.clicked.innerRadius}
             outerRadius={EMAIL_CHART_RINGS.clicked.outerRadius}
+            tracked={clicksTracked}
             value={clickRate}
-        /> */}
+        />
     </div>
 );
 
-const KPI_CLASS_NAME = 'group/kpi -mx-2 -my-1 flex flex-col gap-0.5 rounded-md px-2 py-1 transition-colors hover:bg-muted';
+const KPI_CLASS_NAME = 'group/kpi -mx-2 -my-1 flex flex-col gap-0.5 rounded-md px-2 py-1 transition-colors hover:bg-muted focus-visible:bg-muted focus-visible:outline-none';
 
-export const EmailPerformanceSection: React.FC<{stats: AutomationEmailStats}> = ({stats}) => (
-    <div className='flex flex-col gap-5'>
-        <Separator />
-        <div className='flex flex-col gap-5'>
-            <h3 className='text-sm font-medium tracking-normal text-text-secondary'>
-                Email performance
-            </h3>
-            <div className='grid grid-cols-3 gap-4'>
-                <div className={KPI_CLASS_NAME}>
-                    <span className='flex items-center gap-1.5 text-sm text-text-secondary'>
-                        <span aria-hidden='true' className='size-2 rounded-full' style={{backgroundColor: 'var(--chart-purple)'}} />
-                        Sent
-                    </span>
-                    <span className='text-xl font-semibold tracking-tight tabular-nums'>{formatNumber(stats.email_sent_count)}</span>
-                </div>
-                <div className={KPI_CLASS_NAME}>
-                    <span className='flex items-center gap-1.5 text-sm text-text-secondary'>
-                        <span aria-hidden='true' className='size-2 rounded-full' style={{backgroundColor: 'var(--chart-blue)'}} />
-                        Opened
-                    </span>
+const Kpi: React.FC<{
+    label: string;
+    color: string;
+    tracked?: boolean;
+    value: string;
+    hoverValue?: string;
+}> = ({label, color, tracked = true, value, hoverValue}) => {
+    const tile = (
+        <div className={KPI_CLASS_NAME} tabIndex={tracked ? undefined : 0}>
+            <span className='flex items-center gap-1.5 text-sm text-text-secondary'>
+                <span aria-hidden='true' className='size-2 rounded-full' style={{backgroundColor: tracked ? color : 'var(--muted-foreground)'}} />
+                {label}
+            </span>
+            {tracked
+                ? (
                     <span className='text-xl font-semibold tracking-tight tabular-nums'>
-                        <span className='group-hover/kpi:hidden'>{formatRate(stats.opened_rate)}</span>
-                        <span className='hidden group-hover/kpi:inline'>{stats.email_sent_count > 0 ? formatNumber(stats.email_opened_count) : '--'}</span>
+                        <span className='group-hover/kpi:hidden'>{value}</span>
+                        <span className='hidden group-hover/kpi:inline'>{hoverValue ?? value}</span>
                     </span>
-                </div>
-                {/* @TODO: NY-1457 */}
-                {/* <div className={KPI_CLASS_NAME}>
-                    <span className='flex items-center gap-1.5 text-sm text-text-secondary'>
-                        <span aria-hidden='true' className='size-2 rounded-full' style={{backgroundColor: 'var(--chart-teal)'}} />
-                        Clicked
-                    </span>
-                    <span className='text-xl font-semibold tracking-tight tabular-nums'>{formatRate(stats.clicked_rate)}</span>
-                </div> */}
-            </div>
-            <EmailPerformanceChart openRate={(stats.opened_rate ?? 0) / 100} />
+                )
+                : <OffValue className='text-xl' />}
         </div>
-        {/* @TODO: NY-1457 */}
-        {/* <Separator />
-        <div className='flex items-center justify-between'>
-            <span className='text-sm font-medium text-text-secondary'>Top clicked links</span>
-            <span className='text-sm font-medium text-muted-foreground'>Members</span>
-        </div> */}
-    </div>
-);
+    );
+    if (tracked) {
+        return tile;
+    }
+    return (
+        <HoverCard>
+            <HoverCardTrigger asChild>{tile}</HoverCardTrigger>
+            <HoverCardContent>{TRACKING_OFF_MESSAGE}</HoverCardContent>
+        </HoverCard>
+    );
+};
+
+export const EmailPerformanceSection: React.FC<{stats: AutomationEmailStats}> = ({stats}) => {
+    const {emailTrackOpens, emailTrackClicks} = useEmailTrackingSettings();
+
+    return (
+        <div className='flex flex-col gap-5'>
+            <Separator />
+            <div className='flex flex-col gap-5'>
+                <h3 className='text-sm font-medium tracking-normal text-text-secondary'>
+                    Email performance
+                </h3>
+                <div className='grid grid-cols-3 gap-4'>
+                    <Kpi
+                        color='var(--chart-purple)'
+                        label='Sent'
+                        value={formatNumber(stats.email_sent_count)}
+                    />
+                    <Kpi
+                        color='var(--chart-blue)'
+                        hoverValue={stats.email_sent_count > 0 ? formatNumber(stats.email_opened_count) : '--'}
+                        label='Opened'
+                        tracked={emailTrackOpens}
+                        value={formatRate(stats.opened_rate)}
+                    />
+                    <Kpi
+                        color='var(--chart-teal)'
+                        label='Clicked'
+                        tracked={emailTrackClicks}
+                        value={formatRate(stats.clicked_rate)}
+                    />
+                </div>
+                <EmailPerformanceChart
+                    clickRate={(stats.clicked_rate ?? 0) / 100}
+                    clicksTracked={emailTrackClicks}
+                    openRate={(stats.opened_rate ?? 0) / 100}
+                    opensTracked={emailTrackOpens}
+                />
+            </div>
+            {/* @TODO: NY-1457 — hidden entirely when click tracking is off; the
+                off-state is already conveyed by the Clicked KPI and ring above. */}
+            {/* {emailTrackClicks && (
+                <>
+                    <Separator />
+                    <div className='flex items-center justify-between'>
+                        <span className='text-sm font-medium text-text-secondary'>Top clicked links</span>
+                        <span className='text-sm font-medium text-muted-foreground'>Members</span>
+                    </div>
+                </>
+            )} */}
+        </div>
+    );
+};

--- a/apps/admin/src/automations/components/canvas/nodes.tsx
+++ b/apps/admin/src/automations/components/canvas/nodes.tsx
@@ -1,12 +1,14 @@
 import '@xyflow/react/dist/style.css';
 import React, {useRef, useState} from 'react';
 import StepPicker, {type StepPickerType} from './step-picker';
+import {useEmailTrackingSettings} from '@/automations/hooks/use-email-tracking-settings';
 import {ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuSeparator, ContextMenuTrigger, Popover, PopoverContent, PopoverTrigger} from '@tryghost/shade/components';
 import {Handle, Position} from '@xyflow/react';
 import type {Node, NodeProps} from '@xyflow/react';
 import type {AutomationEmailStats} from '@tryghost/admin-x-framework/api/automations';
 import {LucideIcon, cn, formatNumber} from '@tryghost/shade/utils';
 import {formatRate} from './format-stats';
+import {OffValue} from './off-value';
 
 // React Flow node IDs for the trigger and tail nodes. The canvas builds the visual graph using
 // these; they are not action IDs and never reach the API.
@@ -167,23 +169,26 @@ const StepNodeContent: React.FC<{data: StepNodeData}> = ({data}) => {
     );
 };
 
-const EmailStepStatsFooter: React.FC<{stats: AutomationEmailStats}> = ({stats}) => (
-    <div className='mt-3 grid w-full grid-cols-3 gap-3 border-t border-border-default pt-3'>
-        <div className='flex flex-col text-left'>
-            <span className='text-xs text-text-secondary'>Sent</span>
-            <span className='text-base font-medium'>{formatNumber(stats.email_sent_count)}</span>
-        </div>
-        <div className='flex flex-col text-left'>
-            <span className='text-xs text-text-secondary'>Opened</span>
-            <span className='text-base font-medium'>{formatRate(stats.opened_rate)}</span>
-        </div>
-        {/* @TODO: NY-1457 */}
-        {/* <div className='flex flex-col text-left'>
-            <span className='text-xs text-text-secondary'>Clicked</span>
-            <span className='text-base font-medium'>{formatRate(stats?.clicked_rate)}</span>
-        </div> */}
+const FooterMetric: React.FC<{label: string; tracked?: boolean; children: React.ReactNode}> = ({label, tracked = true, children}) => (
+    <div className='flex flex-col text-left'>
+        <span className={cn('text-xs', tracked ? 'text-text-secondary' : 'text-muted-foreground')}>{label}</span>
+        {tracked
+            ? <span className='text-base font-medium'>{children}</span>
+            : <OffValue className='text-base' />}
     </div>
 );
+
+const EmailStepStatsFooter: React.FC<{stats: AutomationEmailStats}> = ({stats}) => {
+    const {emailTrackOpens, emailTrackClicks} = useEmailTrackingSettings();
+
+    return (
+        <div className='mt-3 grid w-full grid-cols-3 gap-3 border-t border-border-default pt-3'>
+            <FooterMetric label='Sent'>{formatNumber(stats.email_sent_count)}</FooterMetric>
+            <FooterMetric label='Opened' tracked={emailTrackOpens}>{formatRate(stats.opened_rate)}</FooterMetric>
+            <FooterMetric label='Clicked' tracked={emailTrackClicks}>{formatRate(stats.clicked_rate)}</FooterMetric>
+        </div>
+    );
+};
 
 const TriggerNode = React.memo<NodeProps<StepFlowNode>>(({data}) => (
     <NodeShell data={data}>

--- a/apps/admin/src/automations/components/canvas/off-value.tsx
+++ b/apps/admin/src/automations/components/canvas/off-value.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import {cn} from '@tryghost/shade/utils';
+
+export const TRACKING_OFF_MESSAGE = 'Tracking is off in Analytics settings.';
+
+export const OffValue: React.FC<{
+    className?: string;
+}> = ({className}) => (
+    <span className={cn('text-muted-foreground', className)}>
+        <span aria-hidden='true'>Off</span>
+        <span className='sr-only'>{TRACKING_OFF_MESSAGE}</span>
+    </span>
+);

--- a/apps/admin/src/automations/editor.test.tsx
+++ b/apps/admin/src/automations/editor.test.tsx
@@ -1,5 +1,7 @@
 import AutomationEditor from './editor';
 import React from 'react';
+import {AppProvider} from '@tryghost/admin-x-framework';
+import type {AppSettings} from '@tryghost/admin-x-framework';
 import {MAX_AUTOMATION_ACTIONS} from '@tryghost/admin-x-framework/api/automations';
 import type {AutomationDetail, AutomationDetailResponseType, EditAutomationPayload} from '@tryghost/admin-x-framework/api/automations';
 import {RouterProvider, createMemoryRouter} from 'react-router';
@@ -13,6 +15,21 @@ const {mockToastError} = vi.hoisted(() => ({
 }));
 
 const NON_EMPTY_EMAIL_LEXICAL = '{"root":{"children":[{"type":"paragraph","children":[{"type":"text","text":"Welcome email body"}]}]}}';
+
+const createAppSettings = (analyticsOverrides: Partial<AppSettings['analytics']> = {}): AppSettings => ({
+    paidMembersEnabled: true,
+    newslettersEnabled: true,
+    analytics: {
+        emailTrackClicks: true,
+        emailTrackOpens: true,
+        membersTrackSources: true,
+        outboundLinkTagging: true,
+        webAnalytics: true,
+        ...analyticsOverrides
+    }
+});
+
+let mockAppSettings: AppSettings | undefined;
 
 vi.mock('sonner', () => ({
     toast: {
@@ -263,7 +280,11 @@ const renderEditor = (initialEntries = ['/automations/automation-id-1']) => {
 
     return {
         router,
-        ...render(<RouterProvider router={router} />)
+        ...render(
+            <AppProvider appSettings={mockAppSettings}>
+                <RouterProvider router={router} />
+            </AppProvider>
+        )
     };
 };
 
@@ -282,6 +303,29 @@ const withEmptyEmailBodies = (fixture: AutomationDetail): AutomationDetail => ({
     ))
 });
 
+const mockAutomationWithEmailStats = () => {
+    mockUseReadAutomation.mockReturnValue({
+        data: {
+            automations: [{
+                ...automationDetail,
+                actions: automationDetail.actions.map(action => (action.type === 'send_email'
+                    ? {
+                        ...action,
+                        stats: {
+                            email_sent_count: 1247,
+                            email_opened_count: 780,
+                            opened_rate: 65,
+                            clicked_rate: 24
+                        }
+                    }
+                    : action))
+            }]
+        },
+        isLoading: false,
+        isError: false
+    });
+};
+
 describe('AutomationEditor', () => {
     beforeEach(() => {
         mockUseReadAutomation.mockReset();
@@ -295,6 +339,7 @@ describe('AutomationEditor', () => {
         mockEditMutation.variables = undefined;
         mockToastError.mockReset();
         mockLabs.current = {};
+        mockAppSettings = createAppSettings();
     });
 
     it('renders the loading state while the automation is fetching', () => {
@@ -383,26 +428,7 @@ describe('AutomationEditor', () => {
     });
 
     it('renders send-email node stats only when the automationAnalytics labs flag is enabled', () => {
-        mockUseReadAutomation.mockReturnValue({
-            data: {
-                automations: [{
-                    ...automationDetail,
-                    actions: automationDetail.actions.map(action => (action.type === 'send_email'
-                        ? {
-                            ...action,
-                            stats: {
-                                email_sent_count: 1247,
-                                email_opened_count: 780,
-                                opened_rate: 65,
-                                clicked_rate: null
-                            }
-                        }
-                        : action))
-                }]
-            },
-            isLoading: false,
-            isError: false
-        });
+        mockAutomationWithEmailStats();
 
         const {unmount} = renderEditor();
         expect(screen.queryByText('Sent')).not.toBeInTheDocument();
@@ -414,8 +440,52 @@ describe('AutomationEditor', () => {
         const emailStep = screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'});
         expect(within(emailStep).getByText('Sent').nextElementSibling).toHaveTextContent('1,247');
         expect(within(emailStep).getByText('Opened').nextElementSibling).toHaveTextContent('65%');
-        // @TODO: NY-1457 — Clicked is deferred until click data is available
-        expect(within(emailStep).queryByText('Clicked')).not.toBeInTheDocument();
+        expect(within(emailStep).getByText('Clicked').nextElementSibling).toHaveTextContent('24%');
+    });
+
+    it.each([
+        {emailTrackOpens: true, emailTrackClicks: true},
+        {emailTrackOpens: true, emailTrackClicks: false},
+        {emailTrackOpens: false, emailTrackClicks: true},
+        {emailTrackOpens: false, emailTrackClicks: false}
+    ])('shows a muted Off for untracked email metrics when opens=$emailTrackOpens and clicks=$emailTrackClicks', ({emailTrackOpens, emailTrackClicks}) => {
+        mockLabs.current = {automationAnalytics: true};
+        mockAppSettings = createAppSettings({emailTrackOpens, emailTrackClicks});
+        mockAutomationWithEmailStats();
+
+        renderEditor();
+
+        const emailStep = screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'});
+        expect(within(emailStep).getByText('Sent').nextElementSibling).toHaveTextContent('1,247');
+        expect(within(emailStep).getByText('Opened').nextElementSibling).toHaveTextContent(emailTrackOpens ? '65%' : 'Off');
+        expect(within(emailStep).getByText('Clicked').nextElementSibling).toHaveTextContent(emailTrackClicks ? '24%' : 'Off');
+
+        fireEvent.click(emailStep);
+        const sidebar = screen.getByRole('complementary', {name: 'Step details'});
+        expect(within(sidebar).queryAllByText('65%').length > 0).toBe(emailTrackOpens);
+        expect(within(sidebar).queryAllByText('24%').length > 0).toBe(emailTrackClicks);
+        expect(within(sidebar).queryAllByText('Off')).toHaveLength(Number(!emailTrackOpens) + Number(!emailTrackClicks));
+        expect(within(sidebar).getByTestId('email-performance-sent-ring')).toHaveAttribute('data-tracked', 'true');
+        expect(within(sidebar).getByTestId('email-performance-opened-ring')).toHaveAttribute('data-tracked', String(emailTrackOpens));
+        expect(within(sidebar).getByTestId('email-performance-clicked-ring')).toHaveAttribute('data-tracked', String(emailTrackClicks));
+    });
+
+    it('treats unresolved app settings as untracked', () => {
+        mockLabs.current = {automationAnalytics: true};
+        mockAppSettings = undefined;
+        mockAutomationWithEmailStats();
+
+        renderEditor();
+
+        const emailStep = screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'});
+        expect(within(emailStep).getByText('Opened').nextElementSibling).toHaveTextContent('Off');
+        expect(within(emailStep).getByText('Clicked').nextElementSibling).toHaveTextContent('Off');
+
+        fireEvent.click(emailStep);
+        const sidebar = screen.getByRole('complementary', {name: 'Step details'});
+        expect(within(sidebar).queryAllByText('Off')).toHaveLength(2);
+        expect(within(sidebar).getByTestId('email-performance-opened-ring')).toHaveAttribute('data-tracked', 'false');
+        expect(within(sidebar).getByTestId('email-performance-clicked-ring')).toHaveAttribute('data-tracked', 'false');
     });
 
     it('does not render send-email node stats when the action has no stats', () => {

--- a/apps/admin/src/automations/hooks/use-email-tracking-settings.ts
+++ b/apps/admin/src/automations/hooks/use-email-tracking-settings.ts
@@ -1,0 +1,8 @@
+import {useAppContext} from '@tryghost/admin-x-framework';
+
+export const useEmailTrackingSettings = () => {
+    const {appSettings} = useAppContext();
+    const {emailTrackOpens = false, emailTrackClicks = false} = appSettings?.analytics ?? {};
+
+    return {emailTrackOpens, emailTrackClicks};
+};


### PR DESCRIPTION
closes [NY-1466](https://linear.app/ghost/issue/NY-1466)

When "Email opens" or "Email clicks" is disabled in Settings → Analytics, automation email metrics show a muted "Off" instead of a number — on the canvas step footer and in the step sidebar's Email performance panel.

Metrics stay in place rather than hiding, and "Off" is distinct from "--" (tracking on, no data yet). Untracked sidebar tiles get a hover card explaining why, their chart rings fade to an empty track, and the status is exposed to screen readers. Display-only — re-enabling tracking restores the numbers immediately.

Gated behind the `automationAnalytics` labs flag. To test: open an automation with a Send email step and toggle the two settings.

Note that there's no actual click data yet, so you'll only see "Off" or "--".

demo:

https://github.com/user-attachments/assets/d9b39db9-2401-49fe-b418-ffbca01b1be1