### PR TITLE
Removed superagent and superagent-throttle from ghost/core

### DIFF
--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -234,8 +234,6 @@
     "simple-dom": "1.4.0",
     "stoppable": "1.1.0",
     "stripe": "8.222.0",
-    "superagent": "5.3.1",
-    "superagent-throttle": "1.0.1",
     "terser": "5.48.0",
     "tiny-glob": "0.2.9",
     "tldts": "catalog:",

--- a/knip.json
+++ b/knip.json
@@ -28,8 +28,6 @@
         "ghost/core": {
             "ignoreDependencies": [
                 "@slack/webhook",
-                "superagent",
-                "superagent-throttle",
                 "bookshelf-relations",
                 "mysql",
                 "cssnano"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2778,12 +2778,6 @@ importers:
       stripe:
         specifier: 8.222.0
         version: 8.222.0
-      superagent:
-        specifier: 5.3.1
-        version: 5.3.1(supports-color@5.5.0)
-      superagent-throttle:
-        specifier: 1.0.1
-        version: 1.0.1
       terser:
         specifier: 5.48.0
         version: 5.48.0
@@ -14844,10 +14838,6 @@ packages:
     engines: {node: '>=18.3.0'}
     hasBin: true
 
-  formidable@1.2.6:
-    resolution: {integrity: sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ==}
-    deprecated: 'Please upgrade to latest, formidable@v2 or formidable@v3! Check these notes: https://bit.ly/2ZEqIau'
-
   formidable@3.5.4:
     resolution: {integrity: sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==}
     engines: {node: '>=14.0.0'}
@@ -21221,17 +21211,9 @@ packages:
   sum-up@1.0.3:
     resolution: {integrity: sha512-zw5P8gnhiqokJUWRdR6F4kIIIke0+ubQSGyYUY506GCbJWtV7F6Xuy0j6S125eSX2oF+a8KdivsZ8PlVEH0Mcw==}
 
-  superagent-throttle@1.0.1:
-    resolution: {integrity: sha512-m5Ngf0S5QoA84zgwVqVnVA34u9uvo8uM+QEF9B7eNI5FDaSoSoUwQsx7V1GmLXgYLkolhIiucFDVJXF9z49hgQ==}
-
   superagent@10.3.0:
     resolution: {integrity: sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==}
     engines: {node: '>=14.18.0'}
-
-  superagent@5.3.1:
-    resolution: {integrity: sha512-wjJ/MoTid2/RuGCOFtlacyGNxN9QLMgcpYLDQlWFIhhdJ93kNscFonGvrpAHSCVjRVj++DGCglocF7Aej1KHvQ==}
-    engines: {node: '>= 7.0.0'}
-    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
 
   supertest@7.2.2:
     resolution: {integrity: sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==}
@@ -38378,8 +38360,6 @@ snapshots:
     dependencies:
       fd-package-json: 2.0.0
 
-  formidable@1.2.6: {}
-
   formidable@3.5.4:
     dependencies:
       '@paralleldrive/cuid2': 2.3.1
@@ -46941,8 +46921,6 @@ snapshots:
     dependencies:
       chalk: 1.1.3
 
-  superagent-throttle@1.0.1: {}
-
   superagent@10.3.0(supports-color@5.5.0):
     dependencies:
       component-emitter: 1.3.1
@@ -46954,22 +46932,6 @@ snapshots:
       methods: 1.1.2
       mime: 2.6.0
       qs: 6.15.3
-    transitivePeerDependencies:
-      - supports-color
-
-  superagent@5.3.1(supports-color@5.5.0):
-    dependencies:
-      component-emitter: 1.3.1
-      cookiejar: 2.1.4
-      debug: 4.4.3(supports-color@5.5.0)
-      fast-safe-stringify: 2.1.1
-      form-data: 3.0.5
-      formidable: 1.2.6
-      methods: 1.1.2
-      mime: 2.6.0
-      qs: 6.15.3
-      readable-stream: 3.6.2
-      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
### Why

Reviewing #29496, acburdine noted that `superagent`/`superagent-throttle` can come out of knip's `ignoreDependencies` list since Moya (Ghost(Pro)'s private scheduling adapter) no longer needs them. They were originally pinned there because that adapter used to depend on both packages (see #28498 / #27753 history) — a case knip can't see since it's private code outside this repo.

### What

- Removed `superagent` and `superagent-throttle` from `ghost/core/package.json`.
- Removed the corresponding `ignoreDependencies` entries in `knip.json` — no longer needed since the packages are actually gone now, not just hidden from knip.

### Verification

- Confirmed no real code in `ghost/core` references either package — the only two hits for `superagent` are unrelated comments (an illustrative example string in `adapter-manager`'s error-parsing logic, and a test comment describing supertest/superagent cookie behavior), not actual imports.
- `pnpm knip` is clean — no unused or unlisted dependency findings for either package.
- ghost/core's full test suite passes: 581/581 test files, 7520/7520 tests.