### PR TITLE
Fixed member custom field actions breaking history

### DIFF
--- a/ghost/core/core/server/models/action.js
+++ b/ghost/core/core/server/models/action.js
@@ -1,5 +1,12 @@
 const ghostBookshelf = require('./base');
 
+// Member custom fields are owned by a raw-knex service rather than the Bookshelf
+// registry. Actions still need a read model for `include=resource` to recognise
+// their polymorphic resource type and load the current field definition.
+const MemberCustomFieldResource = ghostBookshelf.Model.extend({
+    tableName: 'members_custom_fields'
+});
+
 const Action = ghostBookshelf.Model.extend({
     tableName: 'actions',
 
@@ -17,6 +24,8 @@ const Action = ghostBookshelf.Model.extend({
         if (User) {
             candidates.push([User, 'security_action']);
         }
+
+        candidates.push([MemberCustomFieldResource, 'member_custom_field']);
 
         return candidates;
     },

--- a/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
@@ -1324,7 +1324,7 @@ describe('Member Custom Fields Admin API', function () {
         let actorId: string;
 
         const customFieldActions = async () => {
-            const {body} = await agent.get('actions/?filter=resource_type:member_custom_field').expectStatus(200);
+            const {body} = await agent.get('actions/?filter=resource_type:member_custom_field&include=actor,resource').expectStatus(200);
             return body.actions;
         };
 
@@ -1347,6 +1347,7 @@ describe('Member Custom Fields Admin API', function () {
             assert.equal(contextOf(actions[0]).key, field.key);
             assert.equal(actions[0].actor_type, 'user');
             assert.equal(actions[0].actor_id, actorId);
+            assert.equal(actions[0].resource.name, field.name);
         });
 
         // `resource_id` holds 24 characters and a key derived from a publisher-chosen
@@ -1428,6 +1429,7 @@ describe('Member Custom Fields Admin API', function () {
             assert.ok(deleted, 'a deleted action should be recorded');
             assert.equal(contextOf(deleted).key, field.key);
             assert.equal(deleted.actor_id, actorId);
+            assert.deepEqual(deleted.resource, {});
         });
 
         it('records the whole lifecycle as an ordered, attributed, named timeline', async function () {
@@ -1461,6 +1463,7 @@ describe('Member Custom Fields Admin API', function () {
             for (const a of timeline) {
                 assert.equal(a.actor_id, actorId, `the ${a.event} action is attributed`);
                 assert.ok(contextOf(a)?.primary_name, `the ${a.event} action names the field`);
+                assert.deepEqual(a.resource, {}, `the ${a.event} action tolerates its deleted resource`);
             }
 
             // Names track the field at each point; the rename also records what it was.


### PR DESCRIPTION
## What changed

- Added a lightweight read model for `member_custom_field` resources to the Action polymorphic resource candidates.
- Updated the existing member custom-field lifecycle coverage to request `include=actor,resource`, matching the History UI request.
- Covered both live definitions and actions whose definition has been permanently deleted.

## Why

Member custom-field definitions are managed through raw Knex rather than Ghost's Bookshelf model registry. Their actions use `resource_type=member_custom_field`, but that type was missing from `Action.resourceCandidates()`. Eager-loading `resource` therefore rejected the polymorphic type and returned a 500 for the whole History request.

The new read-only candidate points at the canonical `members_custom_fields` table. Existing action context remains the fallback for deleted definitions.

## Validation

- `member-custom-fields.test.ts`: 118/118 passed
- Focused custom-field action lifecycle: 9/9 passed
- `actions.test.js`: 2/2 passed
- Targeted ESLint and dependency-cruiser checks passed
- `pnpm exec tsc --noEmit` passed