### PR TITLE
Moved devcontainer build cache to GHCR

### DIFF
--- a/.github/workflows/devcontainer-build.yml
+++ b/.github/workflows/devcontainer-build.yml
@@ -66,5 +66,5 @@ jobs:
           tags: |
             ghcr.io/tryghost/ghost-devcontainer:latest
             ghcr.io/tryghost/ghost-devcontainer:${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=ghcr.io/tryghost/ghost-devcontainer:buildcache
+          cache-to: type=registry,ref=ghcr.io/tryghost/ghost-devcontainer:buildcache,mode=max


### PR DESCRIPTION
## What changed

- Replaced the devcontainer workflow's experimental GitHub Actions cache backend with a GHCR registry cache at `ghost-devcontainer:buildcache`.
- Kept cache export failures fatal; no errors are ignored.
- Matched the registry-cache pattern already used by Ghost's main image workflows.

## Root cause

The [failed devcontainer run](https://github.com/TryGhost/Ghost/actions/runs/29871460295/job/88772304409) successfully built and pushed both multi-platform image tags. It then failed while finalizing the separate `type=gha` BuildKit cache with `error writing layer blob: not_found`.

The settings commit changed `pnpm-lock.yaml`, which invalidated the large dependency-install layer and forced a fresh cache upload. GitHub's cache API contains the exact failed blob (`sha256:34e4edf45c4780fbec35e29083ca893629222ff5c6b625592e9ff7e4508ad82d`, 389,545,787 bytes) created at the failure timestamp, but no new cache index was finalized. Relevant BuildKit cache entries total roughly 3.1 GB, so this was not quota exhaustion. The commit exposed a GHA cache finalization failure; it did not break the image build.

Moving the cache to GHCR avoids the experimental GHA cache finalization path while preserving `mode=max` caching and treating cache integrity as part of a successful workflow.

## Validation

- Parsed `.github/workflows/devcontainer-build.yml` successfully as YAML.
- Ran `git diff --check`.
- Confirmed the configuration matches the registry-cache pattern in `.github/workflows/ci.yml`.
- Re-reviewed by an independent subagent with no findings.