### PR TITLE
Made the members import inline threshold configurable

### DIFF
--- a/ghost/core/core/server/services/members/importer/config.ts
+++ b/ghost/core/core/server/services/members/importer/config.ts
@@ -1,0 +1,39 @@
+import {z} from 'zod';
+
+/**
+ * Resolving Ghost's config into the values the importer runs on.
+ *
+ * Config arrives untyped: defaults.json supplies the shipped value, and any
+ * higher layer — an operator's config file, an environment variable, argv — can
+ * replace it with anything at all. Turning that into something usable is a
+ * config concern, so it happens here, at the boundary. The importer is handed an
+ * answer and never learns where it came from.
+ */
+
+// The row count at or below which an import is performed while the request is
+// still open. Zero is allowed and means every import is deferred. A numeric
+// string is accepted because a value supplied through an environment variable
+// can arrive as one.
+const Threshold = z
+    .union([z.number(), z.string().trim().min(1)])
+    .transform(Number)
+    .pipe(z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER));
+
+// defaults.json is the single source of the shipped threshold: it is the lowest
+// config layer and the file an operator actually reads and edits, so it is read
+// rather than restated. Parsed eagerly because a missing or malformed value
+// there is our bug rather than an operator's, and should fail loudly at boot
+// instead of quietly becoming the fallback for everything below.
+const shippedThreshold: number = Threshold.parse(
+    require('../../../../shared/config/defaults.json').members.importer.inlineThreshold
+);
+
+// A higher layer can override the shipped value with anything. Something
+// unreadable falls back to the shipped threshold rather than throwing, because
+// an operator can correct this live and a bad value must not take member import
+// down with it.
+const InlineThreshold = Threshold.catch(shippedThreshold);
+
+export function resolveInlineThreshold(configured: unknown): number {
+    return InlineThreshold.parse(configured);
+}

--- a/ghost/core/core/server/services/members/importer/members-csv-importer.js
+++ b/ghost/core/core/server/services/members/importer/members-csv-importer.js
@@ -61,9 +61,10 @@ module.exports = class MembersCSVImporter {
     /**
      * @param {MembersCSVImporterOptions} options
      */
-    constructor({storagePath, getTimezone, getMembersRepository, getDefaultTier, getTierByName, getGiftService, sendEmail, isSet, addJob, knex, urlFor, context, stripeUtils}) {
+    constructor({storagePath, getTimezone, getInlineThreshold, getMembersRepository, getDefaultTier, getTierByName, getGiftService, sendEmail, isSet, addJob, knex, urlFor, context, stripeUtils}) {
         this._storagePath = storagePath;
         this._getTimezone = getTimezone;
+        this._getInlineThreshold = getInlineThreshold;
         this._getMembersRepository = getMembersRepository;
         this._getDefaultTier = getDefaultTier;
         this._getTierByName = getTierByName;
@@ -440,7 +441,7 @@ module.exports = class MembersCSVImporter {
 
         meta.originalImportSize = job.batches;
 
-        if ((job.batches <= 500 && !job.metadata.hasStripeData) || forceInline) {
+        if ((job.batches <= this._getInlineThreshold() && !job.metadata.hasStripeData) || forceInline) {
             const result = await this.perform(job.filePath, globalLabels);
             const importLabelModel = result.imported ? await LabelModel.findOne(importLabel) : null;
             await verificationTrigger.testImportThreshold();

--- a/ghost/core/core/server/services/members/service.js
+++ b/ghost/core/core/server/services/members/service.js
@@ -5,6 +5,7 @@ const MembersSSR = require('./members-ssr');
 const db = require('../../data/db');
 const MembersConfigProvider = require('./members-config-provider');
 const makeMembersCSVImporter = require('./importer');
+const {resolveInlineThreshold} = require('./importer/config');
 const MembersStats = require('./stats/members-stats');
 const memberJobs = require('./jobs');
 const logging = require('@tryghost/logging');
@@ -50,6 +51,9 @@ const initMembersCSVImporter = ({stripeAPIService}) => {
     return makeMembersCSVImporter({
         storagePath: config.getContentPath('data'),
         getTimezone: () => settingsCache.get('timezone'),
+        // A getter rather than a value because the threshold is an operator
+        // setting that can change between requests
+        getInlineThreshold: () => resolveInlineThreshold(config.get('members:importer:inlineThreshold')),
         getMembersRepository: async () => {
             const api = await module.exports.api;
             return api.members;

--- a/ghost/core/core/shared/config/defaults.json
+++ b/ghost/core/core/shared/config/defaults.json
@@ -74,6 +74,9 @@
         "customFields": {
             "maxDefinitions": 100
         },
+        "importer": {
+            "inlineThreshold": 500
+        },
         "emailTemplate": {
             "showSiteHeader": true,
             "showPoweredBy": true

--- a/ghost/core/test/e2e-api/admin/members-import-path-selection.test.js
+++ b/ghost/core/test/e2e-api/admin/members-import-path-selection.test.js
@@ -1,0 +1,92 @@
+const path = require('path');
+const assert = require('node:assert/strict');
+const supertest = require('supertest');
+const testUtils = require('../../utils');
+const localUtils = require('./utils');
+const configUtils = require('../../utils/config-utils');
+const config = require('../../../core/shared/config');
+const jobsService = require('../../../core/server/services/jobs');
+const {mockManager} = require('../../utils/e2e-framework');
+
+// An import is performed while the request is open, or handed to a background
+// job. Which one it takes is decided by the row count against a configurable
+// threshold, by whether the file carries Stripe data, and by whether the caller
+// forced it. The threshold is set per test so the same small fixture can stand
+// on either side of it, rather than the boundary needing a fixture large enough
+// to cross the shipped default.
+const fixture = name => path.join(__dirname, '/../../utils/fixtures/csv/', name);
+
+describe('Members import path selection', function () {
+    let request;
+
+    beforeAll(async function () {
+        await localUtils.startGhost();
+        request = supertest.agent(config.get('url'));
+        await localUtils.doAuth(request, 'newsletters', 'members:newsletters');
+    });
+
+    beforeEach(function () {
+        mockManager.mockMail();
+    });
+
+    afterEach(async function () {
+        mockManager.restore();
+        await configUtils.restore();
+    });
+
+    const upload = file => request
+        .post(localUtils.API.getApiQuery('members/upload/'))
+        .attach('membersfile', fixture(file))
+        .set('Origin', config.get('url'))
+        .expect('Content-Type', /json/)
+        .expect('Cache-Control', testUtils.cacheRules.private);
+
+    describe('within the threshold', function () {
+        it('imports while the request is open and reports what it did', async function () {
+            configUtils.set('members:importer:inlineThreshold', 5);
+
+            const res = await upload('valid-members-import.csv');
+
+            assert.equal(res.status, 201);
+            assert.equal(res.body.meta.originalImportSize, 2);
+            assert.equal(res.body.meta.stats.imported, 2);
+        });
+
+        it('still defers a file carrying Stripe data, which is slow to import', async function () {
+            configUtils.set('members:importer:inlineThreshold', 5);
+
+            const res = await upload('members-with-stripe-ids.csv');
+
+            assert.equal(res.status, 202);
+            assert.equal(res.body.meta.stats, undefined);
+
+            // the deferred job reports by email, so it has to finish inside the
+            // test: the mail mock is torn down before the framework settles jobs
+            await jobsService.allSettled();
+            mockManager.assert.sentEmailCount(1);
+        });
+    });
+
+    describe('over the threshold', function () {
+        it('defers to a background job and reports no stats yet', async function () {
+            configUtils.set('members:importer:inlineThreshold', 1);
+
+            const res = await upload('valid-members-import.csv');
+
+            assert.equal(res.status, 202);
+            assert.equal(res.body.meta.stats, undefined);
+
+            await jobsService.allSettled();
+            mockManager.assert.sentEmailCount(1);
+        });
+
+        it('treats the threshold as inclusive', async function () {
+            configUtils.set('members:importer:inlineThreshold', 2);
+
+            const res = await upload('valid-members-import.csv');
+
+            assert.equal(res.status, 201);
+            assert.equal(res.body.meta.stats.imported, 2);
+        });
+    });
+});

--- a/ghost/core/test/unit/server/services/members/importer/config.test.ts
+++ b/ghost/core/test/unit/server/services/members/importer/config.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import {resolveInlineThreshold} from '../../../../../../core/server/services/members/importer/config';
+
+// The value shipped in defaults.json. Read rather than restated so this suite
+// follows the shipped threshold if it is ever changed.
+const shipped: number = require('../../../../../../core/shared/config/defaults.json')
+    .members.importer.inlineThreshold;
+
+describe('resolveInlineThreshold', function () {
+    it('uses the shipped threshold when nothing is configured', function () {
+        assert.equal(resolveInlineThreshold(undefined), shipped);
+    });
+
+    it('takes a configured number', function () {
+        assert.equal(resolveInlineThreshold(250), 250);
+    });
+
+    it('takes a number supplied as a string, as an environment variable would', function () {
+        assert.equal(resolveInlineThreshold('250'), 250);
+    });
+
+    it('takes zero, which defers every import', function () {
+        assert.equal(resolveInlineThreshold(0), 0);
+    });
+
+    // An operator can correct a bad value live, so an unusable one falls back to
+    // the shipped threshold rather than throwing and taking member import down
+    // with it, and rather than being read as "no threshold".
+    for (const unusable of [-1, 1.5, 'five hundred', '', null, true, NaN, Infinity, [], {}]) {
+        it(`falls back to the shipped threshold for ${JSON.stringify(unusable) ?? String(unusable)}`, function () {
+            assert.equal(resolveInlineThreshold(unusable), shipped);
+        });
+    }
+});

--- a/ghost/core/test/unit/server/services/members/importer/members-csv-importer.test.js
+++ b/ghost/core/test/unit/server/services/members/importer/members-csv-importer.test.js
@@ -78,6 +78,7 @@ describe('MembersCSVImporter', function () {
         return new MembersCSVImporter({
             storagePath: csvPath,
             getTimezone: sinon.stub().returns('UTC'),
+            getInlineThreshold: sinon.stub().returns(500),
             getMembersRepository: () => {
                 return membersRepositoryStub;
             },


### PR DESCRIPTION
## Problem

The row count above which a members import stops running inline and is handed to a background job was a fixed number written into the middle of the import logic. How long a request can be held open before an import has to go async is not the same for every deployment, but there was no way to change it without editing the code.

## Solution

The cutoff is now a configuration setting, defaulting to the same number it replaced, so existing behaviour is unchanged. Because it is configuration rather than a constant, the tests can drive both the inline path and the deferred path with one small fixture by setting the threshold on either side of it, rather than needing a file large enough to cross the shipped default.

The importer does not read configuration itself. It is handed the value through the same wiring it already uses for the other settings it depends on, and a small resolver at the boundary turns whatever configuration supplies into a usable number, falling back to the shipped default when a value cannot be used so that a bad override is correctable rather than taking member import down.

## Notes

This branch previously also fixed a crash on importing an empty file, but that was fixed independently on main first, so only the configurable threshold remains here.
