### PR TITLE
🐛 Fixed three data-loss bugs in the members CSV importer

### DIFF
--- a/ghost/core/core/server/services/members/csv/unparse.ts
+++ b/ghost/core/core/server/services/members/csv/unparse.ts
@@ -16,7 +16,15 @@ const DEFAULT_COLUMNS = [
     'gift_id'
 ];
 
-export default function unparse(rows: MemberCsvRow[], columns: string[] = DEFAULT_COLUMNS): string {
+interface UnparseOptions {
+    // Prefixes a leading =, +, -, @ or tab with an apostrophe so a spreadsheet does
+    // not read the value as a formula. On by default: it belongs on any CSV a person
+    // opens. The importer's own intermediate file is not one, and turns it off, so a
+    // member named "-5" is not read back as "'-5".
+    escapeFormulae?: boolean;
+}
+
+export default function unparse(rows: MemberCsvRow[], columns: string[] = DEFAULT_COLUMNS, {escapeFormulae = true}: UnparseOptions = {}): string {
     const outputColumns = columns.map((column) => {
         if (column === 'subscribed') {
             return 'subscribed_to_emails';
@@ -65,7 +73,7 @@ export default function unparse(rows: MemberCsvRow[], columns: string[] = DEFAUL
     });
 
     return papaparse.unparse(mappedRows, {
-        escapeFormulae: true,
+        escapeFormulae,
         columns: outputColumns
     });
 }

--- a/ghost/core/core/server/services/members/importer/members-csv-importer.js
+++ b/ghost/core/core/server/services/members/importer/members-csv-importer.js
@@ -115,7 +115,9 @@ module.exports = class MembersCSVImporter {
         // no rows has no columns, and serialising nothing has nothing to say.
         const columns = [...new Set(rows.flatMap(row => Object.keys(row)))];
         const numberOfBatches = Math.ceil(rows.length / batchSize);
-        const mappedCSV = columns.length ? membersCSV.unparse(rows, columns) : '';
+        // No formula escaping: this file is only ever read back by the import, not
+        // opened by a person, and escaping would be stored on the member verbatim.
+        const mappedCSV = columns.length ? membersCSV.unparse(rows, columns, {escapeFormulae: false}) : '';
 
         const hasStripeData = !!(rows.find(function rowHasStripeData(row) {
             return !!row.stripe_customer_id;

--- a/ghost/core/core/server/services/members/importer/members-csv-importer.js
+++ b/ghost/core/core/server/services/members/importer/members-csv-importer.js
@@ -87,11 +87,10 @@ module.exports = class MembersCSVImporter {
      *
      * @param {string} inputFilePath - The path to the CSV to prepare
      * @param {Object.<string, string>} [headerMapping] - An object whose keys are headers in the input CSV and values are the header to replace it with
-     * @param {Array<string>} [defaultLabels] - A list of labels to apply to every member
      *
      * @returns {Promise<{filePath: string, batches: number, metadata: Object.<string, any>}>} - A promise resolving to the data including filePath of "prepared" CSV
      */
-    async prepare(inputFilePath, headerMapping, defaultLabels) {
+    async prepare(inputFilePath, headerMapping) {
         headerMapping = headerMapping || DEFAULT_CSV_HEADER_MAPPING;
         // @NOTE: investigate why is it "1" and do we even need this concept anymore?
         const batchSize = 1;
@@ -108,7 +107,7 @@ module.exports = class MembersCSVImporter {
         }
 
         // completely rely on explicit user input for header mappings
-        const rows = await membersCSV.parse(inputFilePath, headerMapping, defaultLabels);
+        const rows = await membersCSV.parse(inputFilePath, headerMapping);
         // Columns come from every row, not the first. A row with fewer fields than
         // the header parses to fewer keys, so reading the schema off one row drops
         // the columns it happened to omit for the whole file. A file of headers and
@@ -139,8 +138,17 @@ module.exports = class MembersCSVImporter {
      *
      * @param {string} filePath - the path to a "prepared" CSV file
      */
-    async perform(filePath) {
+    async perform(filePath, globalLabels = []) {
         const performStart = Date.now();
+        // Copied per row, not shared: the member model stamps ids and trims names onto
+        // label objects in place, one of these is the caller's import label that
+        // process() looks up again once the import finishes, and each row runs in its
+        // own transaction that can roll back.
+        const cloneGlobalLabels = () => (globalLabels || [])
+            .map(label => (typeof label === 'string' ? {name: label} : {...label}))
+            // A caller can hand in a nameless label; the model would drop it, but the
+            // round-trip this replaced dropped it before the model ever saw it.
+            .filter(label => label.name);
         const rows = await membersCSV.parse(filePath, DEFAULT_CSV_HEADER_MAPPING);
 
         const defaultTier = await this._getDefaultTier();
@@ -188,7 +196,10 @@ module.exports = class MembersCSVImporter {
                     note: row.note,
                     subscribed: row.subscribed,
                     created_at: createdAt,
-                    labels: row.labels
+                    // Form labels are applied here rather than folded into the parsed
+                    // rows, so a name that contains a comma does not go through the
+                    // prepared file's comma-separated labels column and split in two.
+                    labels: [...row.labels, ...cloneGlobalLabels()]
                 };
                 const existingMember = await membersRepository.get({email: memberValues.email}, {
                     ...options,
@@ -425,12 +436,12 @@ module.exports = class MembersCSVImporter {
      */
     async process({pathToCSV, headerMapping, globalLabels, importLabel, user, LabelModel, forceInline, verificationTrigger}) {
         const meta = {};
-        const job = await this.prepare(pathToCSV, headerMapping, globalLabels);
+        const job = await this.prepare(pathToCSV, headerMapping);
 
         meta.originalImportSize = job.batches;
 
         if ((job.batches <= 500 && !job.metadata.hasStripeData) || forceInline) {
-            const result = await this.perform(job.filePath);
+            const result = await this.perform(job.filePath, globalLabels);
             const importLabelModel = result.imported ? await LabelModel.findOne(importLabel) : null;
             await verificationTrigger.testImportThreshold();
 
@@ -448,7 +459,7 @@ module.exports = class MembersCSVImporter {
             this._addJob({
                 job: async () => {
                     try {
-                        const result = await this.perform(job.filePath);
+                        const result = await this.perform(job.filePath, globalLabels);
                         const importLabelModel = result.imported ? await LabelModel.findOne(importLabel) : null;
                         const emailContent = this.generateCompletionEmail(result, {
                             emailRecipient,

--- a/ghost/core/core/server/services/members/importer/members-csv-importer.js
+++ b/ghost/core/core/server/services/members/importer/members-csv-importer.js
@@ -109,9 +109,13 @@ module.exports = class MembersCSVImporter {
 
         // completely rely on explicit user input for header mappings
         const rows = await membersCSV.parse(inputFilePath, headerMapping, defaultLabels);
-        const columns = Object.keys(rows[0]);
+        // Columns come from every row, not the first. A row with fewer fields than
+        // the header parses to fewer keys, so reading the schema off one row drops
+        // the columns it happened to omit for the whole file. A file of headers and
+        // no rows has no columns, and serialising nothing has nothing to say.
+        const columns = [...new Set(rows.flatMap(row => Object.keys(row)))];
         const numberOfBatches = Math.ceil(rows.length / batchSize);
-        const mappedCSV = membersCSV.unparse(rows, columns);
+        const mappedCSV = columns.length ? membersCSV.unparse(rows, columns) : '';
 
         const hasStripeData = !!(rows.find(function rowHasStripeData(row) {
             return !!row.stripe_customer_id;

--- a/ghost/core/test/e2e-api/admin/members-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/members-importer.test.js
@@ -376,6 +376,25 @@ describe('Members Importer API', function () {
         assert.equal(symbols.note, '@handle');
     });
 
+    it('Keeps a form label that contains a comma as one label', async function () {
+        await request
+            .post(localUtils.API.getApiQuery(`members/upload/`))
+            .field('labels', ['Bristol, UK'])
+            .attach('membersfile', path.join(__dirname, '/../../utils/fixtures/csv/valid-members-labels.csv'))
+            .set('Origin', config.get('url'))
+            .expect(201);
+
+        const res = await request
+            .get(localUtils.API.getApiQuery("members/?filter=label:'bristol-uk'"))
+            .set('Origin', config.get('url'))
+            .expect(200);
+
+        assert.equal(res.body.meta.pagination.total, 2, 'both members should carry the whole label');
+        const labels = res.body.members[0].labels.map(l => l.name);
+        assert.ok(labels.includes('Bristol, UK'), `expected "Bristol, UK", got ${JSON.stringify(labels)}`);
+        assert.equal(labels.includes('Bristol'), false, 'the label must not have been split');
+    });
+
     it('Can handle empty body', async function () {
         const res = await request
             .post(localUtils.API.getApiQuery(`members/upload/`))

--- a/ghost/core/test/e2e-api/admin/members-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/members-importer.test.js
@@ -353,6 +353,29 @@ describe('Members Importer API', function () {
         assert.equal(member.note, 'a note');
     });
 
+    it('Stores values that look like formulas exactly as given', async function () {
+        await request
+            .post(localUtils.API.getApiQuery(`members/upload/`))
+            .attach('membersfile', path.join(__dirname, '/../../utils/fixtures/csv/members-formula-like-values.csv'))
+            .set('Origin', config.get('url'))
+            .expect(201);
+
+        const res = await request
+            .get(localUtils.API.getApiQuery('members/?search=formula'))
+            .set('Origin', config.get('url'))
+            .expect(200);
+
+        const dash = res.body.members.find(m => m.email === 'formula@example.com');
+        assertExists(dash);
+        assert.equal(dash.name, '-5');
+        assert.equal(dash.note, '+44 123');
+
+        const symbols = res.body.members.find(m => m.email === 'formula2@example.com');
+        assertExists(symbols);
+        assert.equal(symbols.name, '=SUM(A1)');
+        assert.equal(symbols.note, '@handle');
+    });
+
     it('Can handle empty body', async function () {
         const res = await request
             .post(localUtils.API.getApiQuery(`members/upload/`))

--- a/ghost/core/test/e2e-api/admin/members-importer.test.js
+++ b/ghost/core/test/e2e-api/admin/members-importer.test.js
@@ -11,6 +11,14 @@ const models = require('../../../core/server/models');
 
 let request;
 
+async function countMembers(agent) {
+    const res = await agent
+        .get(localUtils.API.getApiQuery('members/?limit=1'))
+        .set('Origin', config.get('url'))
+        .expect(200);
+    return res.body.meta.pagination.total;
+}
+
 async function getNewsletters() {
     return (await models.Newsletter.findAll({filter: 'status:active'})).models;
 }
@@ -312,6 +320,37 @@ describe('Members Importer API', function () {
             .expect(200);
 
         assert.equal(postLabelRemoveBrowseResponse.body.members.length, 0);
+    });
+
+    it('Imports a CSV of headers with no rows without failing', async function () {
+        const before = await countMembers(request);
+
+        const res = await request
+            .post(localUtils.API.getApiQuery(`members/upload/`))
+            .attach('membersfile', path.join(__dirname, '/../../utils/fixtures/csv/members-headers-only.csv'))
+            .set('Origin', config.get('url'))
+            .expect(201);
+
+        assert.equal(res.body.meta.stats.imported, 0);
+        assert.equal(await countMembers(request), before, 'nobody should have been created');
+    });
+
+    it('Keeps every column when the first row has fewer fields than the header', async function () {
+        await request
+            .post(localUtils.API.getApiQuery(`members/upload/`))
+            .attach('membersfile', path.join(__dirname, '/../../utils/fixtures/csv/members-ragged-row.csv'))
+            .set('Origin', config.get('url'))
+            .expect(201);
+
+        const res = await request
+            .get(localUtils.API.getApiQuery('members/?search=ragged-full'))
+            .set('Origin', config.get('url'))
+            .expect(200);
+
+        const member = res.body.members.find(m => m.email === 'ragged-full@example.com');
+        assertExists(member);
+        assert.equal(member.name, 'Bob');
+        assert.equal(member.note, 'a note');
     });
 
     it('Can handle empty body', async function () {

--- a/ghost/core/test/legacy/api/admin/members-importer.test.js
+++ b/ghost/core/test/legacy/api/admin/members-importer.test.js
@@ -341,6 +341,21 @@ describe('Members Importer API', function () {
             });
 
             assert.equal(receivedWebhookRequests.length, 1, 'Expected to receive webhook requests');
+
+            // The global label is applied to each member by the background job, which
+            // runs after the response. Earlier tests in this file reuse the same label,
+            // so this asserts a member from this batch specifically carries it rather
+            // than a shared count.
+            const imported = await request
+                .get(localUtils.API.getApiQuery(`members/?search=test1%40example.com&include=labels`))
+                .set('Origin', config.get('url'))
+                .expect(200);
+            const member = imported.body.members.find(m => m.email === 'test1@example.com');
+            assertExists(member);
+            assert.ok(
+                member.labels.some(label => label.name === 'new-global-label'),
+                `a queued member should carry the form label, got ${JSON.stringify(member.labels.map(l => l.name))}`
+            );
         } finally {
             await restoreEmailVerificationUtils();
         }

--- a/ghost/core/test/unit/server/services/members/csv/unparse.test.ts
+++ b/ghost/core/test/unit/server/services/members/csv/unparse.test.ts
@@ -161,6 +161,19 @@ third-member-email@email.com,"banana, avocado"`;
         assert.equal(result, expected);
     });
 
+    it('leaves CSV injection characters unescaped when escapeFormulae is off', async function () {
+        const json = [{
+            email: 'email@example.com',
+            name: '=1+2',
+            note: '-5'
+        }];
+
+        const result = unparse(json, undefined, {escapeFormulae: false});
+
+        const expected = `id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_id\r\n,email@example.com,=1+2,-5,,,,,,,,`;
+        assert.equal(result, expected);
+    });
+
     it('escapes fields with CSV injection characters and quotes', async function () {
         const json = [{
             email: 'email@example.com',

--- a/ghost/core/test/unit/server/services/members/importer/members-csv-importer.test.js
+++ b/ghost/core/test/unit/server/services/members/importer/members-csv-importer.test.js
@@ -438,6 +438,20 @@ describe('MembersCSVImporter', function () {
         });
     });
 
+    describe('generateErrorCSV', function () {
+        // The intermediate import file turns formula escaping off. This is the CSV a
+        // human is emailed, so it must keep escaping regardless.
+        it('escapes a value a spreadsheet would read as a formula', function () {
+            const importer = buildMockImporterInstance();
+
+            const csv = importer.generateErrorCSV({
+                errors: [{email: 'a@example.com', name: '=1+2', error: 'some error'}]
+            });
+
+            assert.ok(csv.includes(`"'=1+2"`), csv);
+        });
+    });
+
     describe('sendErrorEmail', function () {
         it('should send email with errors for invalid CSV file', async function () {
             const importer = buildMockImporterInstance();

--- a/ghost/core/test/utils/fixtures/csv/members-formula-like-values.csv
+++ b/ghost/core/test/utils/fixtures/csv/members-formula-like-values.csv
@@ -1,0 +1,3 @@
+email,name,note
+formula@example.com,-5,+44 123
+formula2@example.com,=SUM(A1),@handle

--- a/ghost/core/test/utils/fixtures/csv/members-headers-only.csv
+++ b/ghost/core/test/utils/fixtures/csv/members-headers-only.csv
@@ -1,0 +1,1 @@
+email,name

--- a/ghost/core/test/utils/fixtures/csv/members-ragged-row.csv
+++ b/ghost/core/test/utils/fixtures/csv/members-ragged-row.csv
@@ -1,0 +1,3 @@
+email,name,note
+ragged-first@example.com
+ragged-full@example.com,Bob,a note


### PR DESCRIPTION
## Problem

Importing members loses data in three ways, all in the step that writes and re-reads the importer's intermediate CSV. Each is its own commit with its own integration test.

**A file with an uneven first row silently dropped columns.** The intermediate file took its columns from the first parsed row, so a first row missing trailing fields decided the schema for the whole file. Every column that row omitted was dropped from every row after it, with no error:

```
email,name,note
short@example.com          ← fewer fields than the header
full@example.com,Bob,a note

→ 201, imported: 2
→ Bob's name and note: silently gone
```

Reversing two rows changed what got imported. The same line also 500'd on a file of headers with no rows at all.

**Values that look like formulas were corrupted.** The serialiser escapes anything starting with `=`, `+`, `-`, `@` or a tab so a spreadsheet will not run it, and nothing stripped that on the way back in. A member named `-5` was stored as `'-5`, a note of `+44 123` as `'+44 123`.

**A form label containing a comma was split in two.** Labels typed into the import form apply to every member and are one name each, but they went through the intermediate file's comma-separated labels column. `Bristol, UK` came back as `Bristol` and ` UK`.

## Solution

Three fixes, each with a test that fails without it. Two are fixed at the source now that `@tryghost/members-csv` lives in the repo.

| Fix | Where |
|---|---|
| Columns come from every row, and a file with no rows writes nothing | Importer |
| `unparse` gains an `escapeFormulae` option; the internal file is written without it | The vendored CSV serialiser |
| Form labels are applied when the member is built, not folded through the CSV | Importer |

Nothing a publisher opens changes: `escapeFormulae` still defaults to on, so the member export and the import's error CSV still escape.

One thing worth naming: form labels are now copied rather than passed by reference, because the member model stamps ids and trims names onto label objects in place, and one of those objects is the import label the importer looks up again once the import has finished.

## The shared root

Two of these three — the formula escaping and the comma-split label — are symptoms of the same design fact: the importer writes the parsed rows back to a CSV file and immediately re-reads it. Each is fixed at its own layer here, which is bugfix-appropriate, but the round-trip is the common cause. Removing it (passing the parsed rows to the import in memory) is the real fix, and is out of scope for these bug fixes.

One behaviour change worth naming: a failed row in the emailed error CSV no longer carries the form/import labels, because those are now applied to the member rather than folded into the intermediate file. The publisher re-supplies them via the form on re-upload, so this is a simplification rather than a loss.

Supersedes #29486, which fixed the same bugs against the CSV code before it was vendored into the repo.
