### PR TITLE
Fix published-preview redirect 404ing under the lazy URL service

### DIFF
--- a/ghost/core/core/frontend/services/routing/controllers/previews.js
+++ b/ghost/core/core/frontend/services/routing/controllers/previews.js
@@ -52,12 +52,11 @@ module.exports = function previewController(req, res, next) {
 
             // published content should only resolve to /:slug - /p/:uuid is for drafts only in lieu of an actual preview api
             if (post.status === 'published') {
-                // The preview controller serves either posts or pages
-                // depending on the routerOptions; query.resource is the
-                // routing-level type ('posts' / 'pages'). The post object
-                // has its DB `type` column stripped by the serializer, so
-                // we tag the resource explicitly here.
-                const type = res.routerOptions.query.resource;
+                // The URL service routes by resource type, and `previews` (the
+                // preview router's resource) is not a routable type. Tag the
+                // resource with the post's own type — the previews serializer
+                // re-adds `type` (model.get('type')), so it is 'post' or 'page'.
+                const type = post.type;
                 return urlUtils.redirect301(res, routerManager.getUrlForResource({...post, type}, {withSubdirectory: true}));
             }
 

--- a/ghost/core/test/unit/frontend/services/routing/controllers/previews.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/previews.test.js
@@ -1,8 +1,10 @@
 const sinon = require('sinon');
+const assert = require('node:assert/strict');
 const testUtils = require('../../../../../utils');
 const configUtils = require('../../../../../utils/config-utils');
 const api = require('../../../../../../core/frontend/services/proxy').api;
 const controllers = require('../../../../../../core/frontend/services/routing/controllers');
+const {routerManager} = require('../../../../../../core/frontend/services/routing');
 const renderer = require('../../../../../../core/frontend/services/rendering');
 const urlService = require('../../../../../../core/server/services/url');
 const urlUtils = require('../../../../../../core/shared/url-utils');
@@ -78,5 +80,24 @@ describe('Unit - services/routing/controllers/previews', function () {
         await controllers.previews(req, res, next);
         sinon.assert.called(renderStub);
         sinon.assert.notCalled(next);
+    });
+
+    it('redirects a published preview using the real resource type, not "previews"', async function () {
+        // The URL service routes by resource type; `previews` is not a routable
+        // type, so it must resolve to the post's own type ('post'/'page').
+        post.status = 'published';
+        post.type = 'post';
+
+        let capturedType;
+        sinon.stub(routerManager, 'getUrlForResource').callsFake((resource) => {
+            capturedType = resource.type;
+            return 'http://127.0.0.1:2369/the-slug/';
+        });
+
+        const next = sinon.stub();
+        await controllers.previews(req, res, next);
+
+        sinon.assert.calledOnce(urlUtils.redirect301);
+        assert.equal(capturedType, 'post', 'expected the post type, not "previews"');
     });
 });


### PR DESCRIPTION
Ghost is migrating the URL service from the eager (in-memory, id-based) implementation to a lazy (on-demand, type-routed) one, currently running in compare mode. Shadow comparison flagged that a published post hit via `/p/:uuid/` redirects to its real URL under the eager service but `/404/` under the lazy one.

The preview controller 301-redirects a published `/p/:uuid/` request to the post's canonical URL, but tagged the resource with the preview router's resource type (`previews`). The lazy service routes by resource type and has no `previews` router, so it returned `/404/`; the eager service looks up by id and was unaffected. The fix tags the resource with the post's own type — the previews serializer already re-adds `type` (`post`/`page`), which both services route correctly.
