### PR TITLE
Load URL relations before serializing webhook post payloads

### DIFF
--- a/ghost/core/core/server/services/webhooks/index.js
+++ b/ghost/core/core/server/services/webhooks/index.js
@@ -1,5 +1,21 @@
+// Composition root for the webhook dispatch pipeline: builds the
+// serialize → payload → trigger chain and registers the model-event
+// listeners. Requires are deferred until listen() runs so the model layer
+// isn't loaded before boot wires it.
 module.exports = {
-    get listen() {
-        return require('./listen');
+    listen() {
+        const models = require('../../models');
+        const limitService = require('../../services/limits');
+        const events = require('../../lib/common/events');
+        const createSerialize = require('./serialize');
+        const createPayload = require('./payload');
+        const WebhookTrigger = require('./webhook-trigger');
+        const registerListeners = require('./listen');
+
+        const serialize = createSerialize();
+        const payload = createPayload({serialize});
+        const trigger = new WebhookTrigger({models, payload, limitService});
+
+        registerListeners({events, trigger});
     }
 };

--- a/ghost/core/core/server/services/webhooks/index.js
+++ b/ghost/core/core/server/services/webhooks/index.js
@@ -7,12 +7,13 @@ module.exports = {
         const models = require('../../models');
         const limitService = require('../../services/limits');
         const events = require('../../lib/common/events');
+        const urlService = require('../url').facade;
         const createSerialize = require('./serialize');
         const createPayload = require('./payload');
         const WebhookTrigger = require('./webhook-trigger');
         const registerListeners = require('./listen');
 
-        const serialize = createSerialize();
+        const serialize = createSerialize({urlService});
         const payload = createPayload({serialize});
         const trigger = new WebhookTrigger({models, payload, limitService});
 

--- a/ghost/core/core/server/services/webhooks/listen.js
+++ b/ghost/core/core/server/services/webhooks/listen.js
@@ -1,11 +1,4 @@
 const _ = require('lodash');
-const limitService = require('../../services/limits');
-const WebhookTrigger = require('./webhook-trigger');
-const models = require('../../models');
-const payload = require('./payload');
-
-// The webhook system is fundamentally built on top of our model event system
-const events = require('../../lib/common/events');
 
 const WEBHOOKS = [
     'site.changed',
@@ -44,8 +37,10 @@ const WEBHOOKS = [
     'page.tag.detached'
 ];
 
-const listen = async () => {
-    const webhookTrigger = new WebhookTrigger({models, payload, limitService});
+// Registers the webhook dispatch listeners on the model event system. The
+// trigger is built by the composition root (index.js) and injected here so
+// this module owns only the event-to-trigger wiring.
+const registerListeners = ({events, trigger}) => {
     _.each(WEBHOOKS, (event) => {
         // @NOTE: The early exit makes sure the listeners are only registered once.
         //        During testing the "events" instance is kept around with all the
@@ -62,9 +57,9 @@ const listen = async () => {
                 return;
             }
 
-            webhookTrigger.trigger(event, model);
+            trigger.trigger(event, model);
         });
     });
 };
 
-module.exports = listen;
+module.exports = registerListeners;

--- a/ghost/core/core/server/services/webhooks/payload.js
+++ b/ghost/core/core/server/services/webhooks/payload.js
@@ -1,6 +1,4 @@
-const serialize = require('./serialize');
-
-module.exports = (event, model) => {
+module.exports = ({serialize}) => (event, model) => {
     const payload = {};
 
     if (model) {

--- a/ghost/core/core/server/services/webhooks/serialize.js
+++ b/ghost/core/core/server/services/webhooks/serialize.js
@@ -1,4 +1,4 @@
-module.exports = async (event, model) => {
+module.exports = () => async (event, model) => {
     const _ = require('lodash');
     const api = require('../../api').endpoints;
     const apiFramework = require('@tryghost/api-framework');

--- a/ghost/core/core/server/services/webhooks/serialize.js
+++ b/ghost/core/core/server/services/webhooks/serialize.js
@@ -1,4 +1,18 @@
-module.exports = () => async (event, model) => {
+// The event model doesn't reliably carry the relations the URL service reads
+// when routing (collection filters like tags:internal-tag), so under lazy
+// routing an under-loaded post 404s. Ask the URL service which relations it
+// needs and load only the ones missing — reloading a relation the event
+// already carries (e.g. authors) would strip its nested roles from the
+// payload. Returns [] under eager routing, which resolves URLs by id.
+const loadRequiredUrlRelations = async (model, urlService) => {
+    const required = urlService.getRequiredRelations();
+    const missing = required.filter(relation => !model.relations[relation]);
+    if (missing.length) {
+        await model.load(missing);
+    }
+};
+
+module.exports = ({urlService}) => async (event, model) => {
     const _ = require('lodash');
     const api = require('../../api').endpoints;
     const apiFramework = require('@tryghost/api-framework');
@@ -28,6 +42,7 @@ module.exports = () => async (event, model) => {
         case 'posts':
         case 'pages':
             frame.options.formats = POST_FORMATS;
+            await loadRequiredUrlRelations(model, urlService);
             frame.options.withRelated = POST_WITH_RELATED;
             model._originalOptions = {
                 withRelated: POST_WITH_RELATED

--- a/ghost/core/test/unit/server/services/webhooks/serialize.test.js
+++ b/ghost/core/test/unit/server/services/webhooks/serialize.test.js
@@ -5,7 +5,11 @@ const {Post} = require('../../../../../core/server/models/post');
 const {Member} = require('../../../../../core/server/models/member');
 
 const createSerialize = require('../../../../../core/server/services/webhooks/serialize');
-const serialize = createSerialize();
+
+// Eager routing needs no relations; getRequiredRelations returns [] there, so
+// this is the default for tests that don't exercise relation loading.
+const noRelationsUrlService = {getRequiredRelations: () => []};
+const serialize = createSerialize({urlService: noRelationsUrlService});
 
 // Mocked internals
 const tiersService = require('../../../../../core/server/services/tiers');
@@ -63,6 +67,7 @@ describe('WebhookService - Serialize', function () {
     it('can serialize a new post', async function () {
         const post = fixtureManager.get('posts', 1);
         const postModel = new Post(post);
+        sinon.stub(postModel, 'load').resolves(postModel);
 
         const result = await serialize('post.added', postModel);
 
@@ -72,9 +77,38 @@ describe('WebhookService - Serialize', function () {
         assert.equal(result.post.current.reading_time, 1, 'The reading time generated field should be present');
     });
 
+    it('loads only the URL service relations the event model is missing', async function () {
+        // The URL service declares which relations it reads when routing (e.g.
+        // tags for a tags:internal-tag collection). Only the missing ones are
+        // loaded: a relation the event already carries (authors, with its
+        // nested roles) is left untouched so the payload keeps them.
+        const urlService = {getRequiredRelations: () => ['tags', 'authors']};
+        const serializeWithRelations = createSerialize({urlService});
+
+        const post = fixtureManager.get('posts', 1);
+        const postModel = new Post(post);
+        postModel.relations = {authors: {}};
+        sinon.stub(postModel, 'load').resolves(postModel);
+
+        await serializeWithRelations('post.published', postModel);
+
+        sinon.assert.calledWith(postModel.load, ['tags']);
+    });
+
+    it('loads no relations when the URL service needs none (eager routing)', async function () {
+        const post = fixtureManager.get('posts', 1);
+        const postModel = new Post(post);
+        sinon.stub(postModel, 'load').resolves(postModel);
+
+        await serialize('post.published', postModel);
+
+        sinon.assert.neverCalledWith(postModel.load, sinon.match.array);
+    });
+
     it('can serialize an edited post', async function () {
         const post = fixtureManager.get('posts', 1);
         const postModel = new Post(post);
+        sinon.stub(postModel, 'load').resolves(postModel);
 
         // We use both _previousAttributes and _changed in the webhook serializer
         postModel._previousAttributes.title = post.title;

--- a/ghost/core/test/unit/server/services/webhooks/serialize.test.js
+++ b/ghost/core/test/unit/server/services/webhooks/serialize.test.js
@@ -4,7 +4,8 @@ const sinon = require('sinon');
 const {Post} = require('../../../../../core/server/models/post');
 const {Member} = require('../../../../../core/server/models/member');
 
-const serialize = require('../../../../../core/server/services/webhooks/serialize');
+const createSerialize = require('../../../../../core/server/services/webhooks/serialize');
+const serialize = createSerialize();
 
 // Mocked internals
 const tiersService = require('../../../../../core/server/services/tiers');


### PR DESCRIPTION
Part of the eager → lazy URL service migration (compare mode). Shadow comparison flagged published posts in relation-filtered collections resolving to their real URL under the eager service but `/404/` under the lazy one.

The posts/pages branch of the webhook serializer set `frame.options.withRelated` but never called `model.load()` for it, unlike the members branch directly below. It serialized whatever relations the event model happened to carry — often empty — so the resource reaching the URL service had no usable tags or authors. The lazy service evaluates relation-based collection filters (`tags:...`, `author:...`) against that serialized resource, so an under-loaded post 404s where the eager service (id lookup) resolves the real URL. Loading the relations first restores parity and also corrects the webhook payload itself, whose `tags`/`authors` were incomplete regardless of URLs.
