### PR TITLE
🐛 Fixed custom routes with :param paths being rejected on upload

### DIFF
--- a/ghost/core/core/server/services/route-settings/route-settings-parser.ts
+++ b/ghost/core/core/server/services/route-settings/route-settings-parser.ts
@@ -37,9 +37,15 @@ const SHORTFORM_HELP = 'e.g. data: tag.recipes';
 
 /**
  * Shorthand data definitions look like `tag.recipes` — resource, dot, slug.
+ *
+ * `%s` stands in for the slug: on channel routes and collections, fetch-data
+ * substitutes it with the request's `slug` param at query time, which is how a
+ * wildcard route such as `/author/:slug/` serves a different author per request.
+ * There is no static slug that could replace it, so rejecting it would break
+ * those routes.
  */
 function validateDataShortForm(value: string, path: PathSegment[]): void {
-    if (!/^[a-zA-Z0-9_]+\.[a-zA-Z0-9_-]+$/.test(value)) {
+    if (!/^[a-zA-Z0-9_]+\.(?:%s|[a-zA-Z0-9_-]+)$/.test(value)) {
         throw validationError(
             formatLocation(path),
             `"${value}" is not a valid data shorthand. Please use resource.slug, e.g. tag.recipes.`,
@@ -270,8 +276,15 @@ const RouteSettingsSchema = z.object({
 /**
  * Every path in routes.yaml — route paths, collection paths, permalinks and
  * taxonomy permalinks — follows the same rules, so they share one message set.
+ *
+ * `allowParamNotation` is set for route and collection keys, which are mounted on
+ * Express verbatim: nothing rewrites `{param}` to `:param` for them the way it
+ * does for permalinks and taxonomies. So `/author/:slug/` is a working wildcard
+ * route on live sites and `/author/{slug}/` would be a dead literal path —
+ * rejecting :param there would break the former, and the suggested rewrite would
+ * silently produce the latter.
  */
-function validatePath(value: string, path: PathSegment[], example: string): void {
+function validatePath(value: string, path: PathSegment[], example: string, {allowParamNotation = false}: {allowParamNotation?: boolean} = {}): void {
     const at = formatLocation(path);
 
     if (!value.startsWith('/')) {
@@ -280,7 +293,7 @@ function validatePath(value: string, path: PathSegment[], example: string): void
     if (!value.endsWith('/')) {
         throw validationError(at, `"${value}" is missing a trailing slash. Please use e.g. ${example}.`);
     }
-    if (/\/:\w+/.test(value)) {
+    if (!allowParamNotation && /\/:\w+/.test(value)) {
         // Suggest the same path in the notation Ghost expects, rather than a
         // generic example the author then has to translate.
         throw validationError(at, `"${value}" uses the :param notation. Please use "${value.replace(/\/:(\w+)/g, '/{$1}')}".`);
@@ -301,7 +314,7 @@ export function parseRouteSettings(raw: unknown, yamlSource: string): RouteSetti
     if (rawRoutes) {
         for (const [path, value] of Object.entries(rawRoutes)) {
             const routeLocation: PathSegment[] = ['routes', path];
-            validatePath(path, routeLocation, '/about/');
+            validatePath(path, routeLocation, '/about/', {allowParamNotation: true});
 
             if (value === null || value === undefined) {
                 throw validationError(formatLocation(routeLocation), 'Please define a template, e.g. /about/: about.');
@@ -330,7 +343,7 @@ export function parseRouteSettings(raw: unknown, yamlSource: string): RouteSetti
     if (rawCollections) {
         for (const [path, value] of Object.entries(rawCollections)) {
             const collectionLocation: PathSegment[] = ['collections', path];
-            validatePath(path, collectionLocation, '/blog/');
+            validatePath(path, collectionLocation, '/blog/', {allowParamNotation: true});
 
             const collectionResult = collectionValueSchema(collectionLocation).safeParse(value);
             if (!collectionResult.success) {

--- a/ghost/core/test/unit/server/services/route-settings/route-settings-parser.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/route-settings-parser.test.ts
@@ -514,11 +514,15 @@ describe('UNIT: services/route-settings/route-settings-parser', function () {
             const original = buildRouteSettings({
                 routes: [
                     {type: 'template', path: '/about/', templates: ['about']},
-                    {type: 'channel', path: '/featured/', templates: ['featured'], filter: 'featured:true', rss: true, data: 'tag.featured'}
+                    {type: 'channel', path: '/featured/', templates: ['featured'], filter: 'featured:true', rss: true, data: 'tag.featured'},
+                    // A :param key becomes a YAML mapping key containing a colon,
+                    // which only became expressible once keys accepted :param.
+                    {type: 'channel', path: '/author/:slug/', templates: ['author'], data: 'author.%s'}
                 ],
                 collections: [
                     {path: '/', permalink: '/{slug}/', templates: ['index']},
-                    {path: '/podcast/', permalink: '/podcast/{slug}/', templates: ['podcast'], filter: 'tag:podcast'}
+                    {path: '/podcast/', permalink: '/podcast/{slug}/', templates: ['podcast'], filter: 'tag:podcast'},
+                    {path: '/locations/:location/', permalink: '/locations/{slug}/', templates: ['tag']}
                 ],
                 taxonomies: {tag: '/tag/{slug}/', author: '/author/{slug}/'}
             });

--- a/ghost/core/test/unit/server/services/route-settings/validate-route-settings.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/validate-route-settings.test.ts
@@ -83,10 +83,12 @@ describe('UNIT: services/route-settings/validation (via parseRouteSettings)', fu
             }));
         });
 
-        it('throws on route path with :slug notation', function () {
-            throwsValidation(() => parse({
+        it('accepts route path with :slug notation', function () {
+            const settings = parse({
                 routes: {'/foo/:slug/': 'post'}
-            }));
+            });
+
+            assert.equal(settings.routes[0].path, '/foo/:slug/');
         });
     });
 
@@ -115,10 +117,18 @@ describe('UNIT: services/route-settings/validation (via parseRouteSettings)', fu
             }), 'Please define a permalink route');
         });
 
-        it('throws on collection path with :slug notation', function () {
-            throwsValidation(() => parse({
+        it('accepts collection path with :slug notation', function () {
+            const settings = parse({
                 collections: {'/blog/:slug/': {permalink: '/{slug}/'}}
-            }));
+            });
+
+            assert.equal(settings.collections[0].path, '/blog/:slug/');
+        });
+
+        it('throws on permalink using :slug notation even when the path does', function () {
+            throwsValidation(() => parse({
+                collections: {'/blog/:slug/': {permalink: '/:slug/'}}
+            }), 'uses the :param notation');
         });
 
         it('throws on permalink without leading slash', function () {
@@ -194,6 +204,22 @@ describe('UNIT: services/route-settings/validation (via parseRouteSettings)', fu
         it('accepts valid shortform data', function () {
             assert.doesNotThrow(() => parse({
                 routes: {'/food/': {template: 'food', data: 'tag.food'}}
+            }));
+        });
+
+        it('accepts %s as the shortform slug', function () {
+            const settings = parse({
+                routes: {'/food/': {template: 'food', data: 'tag.%s'}}
+            });
+
+            assert.equal(settings.routes[0].data, 'tag.%s');
+        });
+
+        it('throws on shortform data with %s embedded in the slug', function () {
+            // %s is only meaningful as the whole slug — fetch-data swaps it for the
+            // request's slug param, and nothing in the fleet uses a partial form.
+            throwsValidation(() => parse({
+                routes: {'/food/': {template: 'food', data: 'tag.recipes-%s'}}
             }));
         });
 
@@ -482,7 +508,6 @@ describe('UNIT: services/route-settings/validation (via parseRouteSettings)', fu
             const cases: [string, unknown, string][] = [
                 ['route missing a leading slash', {routes: {'about/': 'about'}}, 'The following definition "routes[\'about/\']" is invalid: "about/" is missing a leading slash. Please use e.g. /about/.'],
                 ['route missing a trailing slash', {routes: {'/about': 'about'}}, 'The following definition "routes[\'/about\']" is invalid: "/about" is missing a trailing slash. Please use e.g. /about/.'],
-                ['route using :param', {routes: {'/foo/:slug/': 'post'}}, 'The following definition "routes[\'/foo/:slug/\']" is invalid: "/foo/:slug/" uses the :param notation. Please use "/foo/{slug}/".'],
                 ['collection missing a leading slash', {collections: {'blog/': {permalink: '/{slug}/'}}}, 'The following definition "collections[\'blog/\']" is invalid: "blog/" is missing a leading slash. Please use e.g. /blog/.'],
                 ['collection missing a trailing slash', {collections: {'/blog': {permalink: '/{slug}/'}}}, 'The following definition "collections[\'/blog\']" is invalid: "/blog" is missing a trailing slash. Please use e.g. /blog/.'],
                 ['permalink missing a leading slash', {collections: {'/blog/': {permalink: '{slug}/'}}}, 'The following definition "collections[\'/blog/\'].permalink" is invalid: "{slug}/" is missing a leading slash. Please use e.g. /{slug}/.'],


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1940/

## Problem

The new route-settings validator rejects `:param` notation in **every** path. That's correct for collection permalinks and taxonomy values — but wrong for route and collection **keys**.

Keys are mounted on Express verbatim. Nothing ever rewrites `{param}` → `:param` for them, the way `activation-bridge` does for permalinks and taxonomies. So:

| key | today |
|---|---|
| `/author/:slug/` | real Express param — matches `/author/anything/`, **works** |
| `/author/{slug}/` | matches the literal `/author/%7Bslug%7D/` — **dead route** |

The error even suggested the rewrite that breaks it:

```
"/author/:slug/" uses the :param notation. Please use "/author/{slug}/".
```

Following that advice would silently kill a working route. On one affected site the `:param` route mounts before taxonomies and *shadows Ghost's built-in author router*, so any edit there changes every author page.

Legacy `validate.js` only ever checked `/:\w+` on collection permalinks (`:316`) and taxonomy values (`:390`) — never on keys. These files have always been valid; only the new validator rejects them.

## Change

- `validatePath` takes `allowParamNotation`, set for route and collection keys only. Permalinks and taxonomies still reject `:param`, matching legacy.
- The data shorthand accepts `%s` as the slug. `fetch-data` substitutes it with the request's `slug` param on channel routes and collections, which is what makes a wildcard route serve a different resource per request — there is no static slug that could replace it. Exactly one file in the fleet uses it, for per-language author/tag pages.

Both are relaxations of a gate that is stricter than the validator it replaced, so no configuration that validates today stops validating.

## Why not fix `{}` to work instead?

Considered and rejected. Making `{param}` behave as a wildcard in keys would bring **45 currently-dead routes across 31 live sites** to life at once — 22 of which pass validation today. One has `/tag/{slug}/` alongside a `tag` taxonomy (the route would start shadowing it); another has a collection at `/{primary_tag}/` that would become a root-level wildcard swallowing the site's entire URL space. Those owners wrote `{slug}`, got an inert route, and built around the result. Not something to change silently under them.

## Impact

- 10 `routes.yaml` files in the Pro fleet validate without any edit. Fleet failures: 51 → 41.
- Uploads accept these forms again, as they did before the migration.
- No runtime change: the path string is passed through untouched, so routes mount exactly as before. Verified by expanding the affected files through the legacy validator and through the new gate and diffing — identical output.

## Testing

- 211 route-settings unit tests pass.
- Two tests flipped from `throws` to `accepts`; new coverage for `%s`, for `%s` rejected when embedded mid-slug, for `:param` still rejected in a permalink *even when the collection key uses it*, and a serialize round-trip with a `:param` key (a YAML mapping key containing a colon, only expressible since this change).