### PR TITLE
Added fallback console.log for boot errors

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -639,6 +639,8 @@ async function bootGhost({backend = true, frontend = true, server = true} = {}) 
         }
 
         logging.error(serverStartError);
+        // fallback in case logger fails to flush before exit
+        console.error(serverStartError); // eslint-disable-line no-console
 
         // If ghost was started and something else went wrong, we shut it down
         if (ghostServer) {


### PR DESCRIPTION
no ref
- ensure that boot errors are logged to the console on exit, on the off chance that the logger fails to flush before container exit
