### PR TITLE
Added support for Billing app navigation to approved Admin settings

### DIFF
--- a/apps/ember-admin/app/components/gh-billing-iframe.js
+++ b/apps/ember-admin/app/components/gh-billing-iframe.js
@@ -67,6 +67,10 @@ export default class GhBillingIframe extends Component {
             this._handleForceUpgradeRequest();
         }
 
+        if (data?.request === 'navigateToAdmin') {
+            this.billing.navigateToAdminDestination(data.destination);
+        }
+
         if (data?.subscription) {
             await this._handleSubscriptionUpdate(data);
         }

--- a/apps/ember-admin/app/services/billing.js
+++ b/apps/ember-admin/app/services/billing.js
@@ -10,7 +10,24 @@ const BILLING_APP_ATTEMPT_SOURCE_PRELOAD = 'preload';
 const BILLING_APP_ATTEMPT_SOURCE_USER_OPEN = 'user_open';
 const BILLING_APP_ATTEMPT_SOURCE_RETRY = 'retry';
 
+const NEWSLETTERS_DESTINATION = 'newsletters';
+const NEWSLETTERS_ROUTE_WITH_AUTOMATIONS = '/settings/emails';
+const NEWSLETTERS_ROUTE = '/settings/newsletters';
+
+// Approved destinations the Billing app may request Ghost Admin to navigate to,
+// mapped to the Admin route that owns them. Ghost Admin owns this mapping — the
+// Billing app never sends raw URLs or routes. A null-prototype, frozen object is
+// used so untrusted keys like '__proto__' or 'constructor' cannot resolve.
+const ADMIN_DESTINATION_ROUTES = Object.freeze(Object.assign(Object.create(null), {
+    theme: '/settings/design/change-theme',
+    analytics: '/settings/analytics',
+    staff: '/settings/staff',
+    stripe: '/settings/stripe-connect',
+    integrations: '/settings/integrations'
+}));
+
 export default class BillingService extends Service {
+    @service feature;
     @service ghostPaths;
     @service router;
     @service store;
@@ -65,6 +82,32 @@ export default class BillingService extends Service {
                 window.history.replaceState(window.history.state, '', billingRoute);
             }
         }
+    }
+
+    // Navigates Ghost Admin to an approved settings destination requested by the
+    // validated Billing iframe. Unknown, missing, or non-string destinations are
+    // ignored silently. Navigation goes through Ember client-side routing, which
+    // closes the billing overlay via the pro route's willTransition hook.
+    navigateToAdminDestination(destination) {
+        if (typeof destination !== 'string') {
+            return;
+        }
+
+        const route = this._resolveAdminDestinationRoute(destination);
+
+        if (!route) {
+            return;
+        }
+
+        this.router.transitionTo(route);
+    }
+
+    _resolveAdminDestinationRoute(destination) {
+        if (destination === NEWSLETTERS_DESTINATION) {
+            return this.feature.automations ? NEWSLETTERS_ROUTE_WITH_AUTOMATIONS : NEWSLETTERS_ROUTE;
+        }
+
+        return ADMIN_DESTINATION_ROUTES[destination] ?? null;
     }
 
     _isBillingIframeLoaded() {
@@ -485,12 +528,20 @@ export default class BillingService extends Service {
             return;
         }
 
+        // Keyed off the pre-mutation state so a re-entrant open (overlay already
+        // visible, e.g. checkout) is not treated as a hidden→visible transition.
+        const isOpeningTransition = value && !this.billingWindowOpen;
+
         this.sendRouteUpdate();
 
         this.billingWindowOpen = value;
 
         if (value) {
             this.ensureBillingAppReadyForVisibleUse();
+        }
+
+        if (isOpeningTransition) {
+            this.sendUpdateLimits();
         }
     }
 
@@ -514,7 +565,6 @@ export default class BillingService extends Service {
         window.location.hash = childRoute || '/pro';
 
         this.sendRouteUpdate();
-        this.sendUpdateLimits();
 
         this.router.transitionTo(childRoute || '/pro');
     }

--- a/apps/ember-admin/app/services/feature.js
+++ b/apps/ember-admin/app/services/feature.js
@@ -86,6 +86,7 @@ export default class FeatureService extends Service {
     @feature('commentModeration') commentModeration;
     @feature('memberDetailsReact') memberDetailsReact;
     @feature('previewByTier') previewByTier;
+    @feature('automations') automations;
     _user = null;
 
     @computed('settings.labs')

--- a/apps/ember-admin/tests/integration/components/gh-billing-iframe-test.js
+++ b/apps/ember-admin/tests/integration/components/gh-billing-iframe-test.js
@@ -126,4 +126,112 @@ describe('Integration: Component: gh-billing-iframe', function () {
         expect(markBillingAppLoaded.called).to.be.false;
         expect(billing.billingAppLoaded).to.be.false;
     });
+
+    const approvedDestinations = {
+        theme: '/settings/design/change-theme',
+        analytics: '/settings/analytics',
+        staff: '/settings/staff',
+        stripe: '/settings/stripe-connect',
+        integrations: '/settings/integrations'
+    };
+
+    Object.entries(approvedDestinations).forEach(([destination, route]) => {
+        it(`navigates to ${route} for a validated navigateToAdmin '${destination}' message`, async function () {
+            const router = this.owner.lookup('service:router');
+            const transitionTo = sinon.stub(router, 'transitionTo');
+
+            await render(hbs`<GhBillingIframe />`);
+
+            await postBillingMessage({request: 'navigateToAdmin', destination});
+
+            expect(transitionTo.calledOnceWithExactly(route)).to.be.true;
+        });
+    });
+
+    it('navigates newsletters to the emails route when the automations flag is enabled', async function () {
+        const router = this.owner.lookup('service:router');
+        const transitionTo = sinon.stub(router, 'transitionTo');
+        const feature = this.owner.lookup('service:feature');
+        sinon.stub(feature, 'automations').get(() => true);
+
+        await render(hbs`<GhBillingIframe />`);
+
+        await postBillingMessage({request: 'navigateToAdmin', destination: 'newsletters'});
+
+        expect(transitionTo.calledOnceWithExactly('/settings/emails')).to.be.true;
+    });
+
+    it('navigates newsletters to the newsletters route when the automations flag is disabled', async function () {
+        const router = this.owner.lookup('service:router');
+        const transitionTo = sinon.stub(router, 'transitionTo');
+        const feature = this.owner.lookup('service:feature');
+        sinon.stub(feature, 'automations').get(() => false);
+
+        await render(hbs`<GhBillingIframe />`);
+
+        await postBillingMessage({request: 'navigateToAdmin', destination: 'newsletters'});
+
+        expect(transitionTo.calledOnceWithExactly('/settings/newsletters')).to.be.true;
+    });
+
+    it('ignores a navigateToAdmin message with an unknown destination', async function () {
+        const router = this.owner.lookup('service:router');
+        const transitionTo = sinon.stub(router, 'transitionTo');
+
+        await render(hbs`<GhBillingIframe />`);
+
+        await postBillingMessage({request: 'navigateToAdmin', destination: 'dashboard'});
+
+        expect(transitionTo.called).to.be.false;
+    });
+
+    it('ignores a navigateToAdmin message with a missing destination', async function () {
+        const router = this.owner.lookup('service:router');
+        const transitionTo = sinon.stub(router, 'transitionTo');
+
+        await render(hbs`<GhBillingIframe />`);
+
+        await postBillingMessage({request: 'navigateToAdmin'});
+
+        expect(transitionTo.called).to.be.false;
+    });
+
+    it('ignores a navigateToAdmin message with a non-string destination', async function () {
+        const router = this.owner.lookup('service:router');
+        const transitionTo = sinon.stub(router, 'transitionTo');
+
+        await render(hbs`<GhBillingIframe />`);
+
+        await postBillingMessage({request: 'navigateToAdmin', destination: {route: '/settings/staff'}});
+
+        expect(transitionTo.called).to.be.false;
+    });
+
+    it('ignores a navigateToAdmin message from an invalid origin', async function () {
+        const router = this.owner.lookup('service:router');
+        const transitionTo = sinon.stub(router, 'transitionTo');
+
+        await render(hbs`<GhBillingIframe />`);
+
+        await postBillingMessage(
+            {request: 'navigateToAdmin', destination: 'analytics'},
+            {origin: 'https://evil.example.test'}
+        );
+
+        expect(transitionTo.called).to.be.false;
+    });
+
+    it('ignores a navigateToAdmin message from the wrong source window', async function () {
+        const router = this.owner.lookup('service:router');
+        const transitionTo = sinon.stub(router, 'transitionTo');
+
+        await render(hbs`<GhBillingIframe />`);
+
+        await postBillingMessage(
+            {request: 'navigateToAdmin', destination: 'analytics'},
+            {source: window}
+        );
+
+        expect(transitionTo.called).to.be.false;
+    });
 });

--- a/apps/ember-admin/tests/unit/services/billing-test.js
+++ b/apps/ember-admin/tests/unit/services/billing-test.js
@@ -4,8 +4,8 @@ import sinon from 'sinon';
 import {describe, it} from 'mocha';
 import {expect} from 'chai';
 import {getSentryTestConfig} from 'ghost-admin/utils/sentry';
+import {settled, waitUntil} from '@ember/test-helpers';
 import {setupTest} from 'ember-mocha';
-import {waitUntil} from '@ember/test-helpers';
 
 const {sentryTransport, testkit} = sentryTestKit();
 
@@ -341,5 +341,128 @@ describe('Unit: Service: billing', function () {
         service.reportBillingAppLoadFailure();
 
         expect(testkit.reports()).to.have.lengthOf(0);
+    });
+
+    it('navigates newsletters to the emails route when the automations flag is enabled', function () {
+        const service = this.owner.lookup('service:billing');
+        billingService = service;
+        const transitionTo = sinon.stub(service.router, 'transitionTo');
+        sinon.stub(service.feature, 'automations').get(() => true);
+
+        service.navigateToAdminDestination('newsletters');
+
+        expect(transitionTo.calledOnceWithExactly('/settings/emails')).to.be.true;
+    });
+
+    it('navigates newsletters to the newsletters route when the automations flag is disabled', function () {
+        const service = this.owner.lookup('service:billing');
+        billingService = service;
+        const transitionTo = sinon.stub(service.router, 'transitionTo');
+        sinon.stub(service.feature, 'automations').get(() => false);
+
+        service.navigateToAdminDestination('newsletters');
+
+        expect(transitionTo.calledOnceWithExactly('/settings/newsletters')).to.be.true;
+    });
+
+    it('ignores destinations that are not approved keys', function () {
+        const service = this.owner.lookup('service:billing');
+        billingService = service;
+        const transitionTo = sinon.stub(service.router, 'transitionTo');
+
+        service.navigateToAdminDestination('dashboard');
+        service.navigateToAdminDestination('__proto__');
+        service.navigateToAdminDestination('constructor');
+        service.navigateToAdminDestination(undefined);
+        service.navigateToAdminDestination({destination: 'analytics'});
+
+        expect(transitionTo.called).to.be.false;
+    });
+
+    function limitUpdateCalls(postMessage) {
+        return postMessage.getCalls().filter(call => call.args[0]?.query === 'limitUpdate');
+    }
+
+    it('sends limitUpdate when the billing overlay transitions from hidden to visible', function () {
+        const service = this.owner.lookup('service:billing');
+        billingService = service;
+        const postMessage = sinon.spy();
+        sinon.stub(service, 'getBillingIframe').returns({contentWindow: {postMessage}});
+
+        service.toggleProWindow(true);
+
+        const calls = limitUpdateCalls(postMessage);
+        expect(calls).to.have.lengthOf(1);
+        expect(calls[0].args).to.deep.equal([{query: 'limitUpdate'}, '*']);
+    });
+
+    it('does not send limitUpdate when the billing overlay is hidden', function () {
+        const service = this.owner.lookup('service:billing');
+        billingService = service;
+        const postMessage = sinon.spy();
+        sinon.stub(service, 'getBillingIframe').returns({contentWindow: {postMessage}});
+
+        service.toggleProWindow(false);
+
+        expect(limitUpdateCalls(postMessage)).to.have.lengthOf(0);
+    });
+
+    it('does not send limitUpdate when the billing iframe is not loaded', async function () {
+        const service = this.owner.lookup('service:billing');
+        billingService = service;
+        const postMessage = sinon.spy();
+        const getBillingIframe = sinon.stub(service, 'getBillingIframe').returns(null);
+
+        expect(() => service.toggleProWindow(true)).to.not.throw();
+
+        // Restoring the iframe surfaces any send the transition might have
+        // queued or deferred instead of dropping
+        getBillingIframe.returns({contentWindow: {postMessage}});
+        await settled();
+        expect(limitUpdateCalls(postMessage)).to.have.lengthOf(0);
+    });
+
+    it('does not send limitUpdate on a redundant re-open of an already-visible overlay', function () {
+        const service = this.owner.lookup('service:billing');
+        billingService = service;
+        const postMessage = sinon.spy();
+        sinon.stub(service, 'getBillingIframe').returns({contentWindow: {postMessage}});
+        service.billingWindowOpen = true;
+
+        service.toggleProWindow(true);
+
+        expect(limitUpdateCalls(postMessage)).to.have.lengthOf(0);
+    });
+
+    it('does not send limitUpdate on checkout re-entry of an already-visible overlay', function () {
+        const service = this.owner.lookup('service:billing');
+        billingService = service;
+        const postMessage = sinon.spy();
+        sinon.stub(service, 'getBillingIframe').returns({contentWindow: {postMessage}});
+        service.billingWindowOpen = true;
+        service.action = 'checkout';
+
+        service.toggleProWindow(true);
+
+        expect(limitUpdateCalls(postMessage)).to.have.lengthOf(0);
+    });
+
+    it('sends limitUpdate exactly once via the nav-link entry path', function () {
+        const service = this.owner.lookup('service:billing');
+        billingService = service;
+        const postMessage = sinon.spy();
+        sinon.stub(service, 'getBillingIframe').returns({contentWindow: {postMessage}});
+        sinon.stub(service, 'getOwnerUser').resolves(null);
+        // Simulate ProRoute.model() driving the overlay open on transition
+        sinon.stub(service.router, 'transitionTo').callsFake(() => service.toggleProWindow(true));
+
+        const previousHash = window.location.hash;
+        try {
+            service.openBillingWindow('/posts', '/pro');
+        } finally {
+            window.location.hash = previousHash;
+        }
+
+        expect(limitUpdateCalls(postMessage)).to.have.lengthOf(1);
     });
 });


### PR DESCRIPTION
closes [GVA-868](https://linear.app/ghost/issue/GVA-868/allow-billing-to-navigate-to-approved-ghost-admin-settings)

## What

Ghost Admin now accepts a semantic navigation request from the validated Billing iframe:

```
{request: 'navigateToAdmin', destination: '<approved destination>'}
```

Admin owns the destination→route mapping (allowlist only — no raw URLs, no reuse of the existing `route` sync field):

| Destination | Route |
|---|---|
| `theme` | `/settings/design/change-theme` (theme chooser) |
| `analytics` | `/settings/analytics` |
| `staff` | `/settings/staff` |
| `stripe` | `/settings/stripe-connect` |
| `integrations` | `/settings/integrations` |
| `newsletters` | `/settings/emails` with the `automations` labs flag, otherwise `/settings/newsletters` |

## How

- The request is handled in `gh-billing-iframe` only after the existing `isValidBillingIframeMessage` origin + source-window validation, alongside the other request handlers.
- `BillingService.navigateToAdminDestination()` resolves the destination against a frozen, null-prototype allowlist (so keys like `__proto__`/`constructor` cannot resolve) and navigates via `router.transitionTo()`. Unknown, missing, or non-string destinations are ignored silently.
- Leaving `/pro` through client-side routing closes the Billing overlay via the existing `pro` route `willTransition` handling and preserves usable browser history.
- Registered the `automations` labs flag in the Ember `feature` service (it previously only existed in the React admin).

## Testing

- 12 new integration tests at the postMessage boundary (all six destinations incl. both newsletters variants, unknown/missing/malformed destinations, invalid origin, wrong source window).
- 3 new unit tests for the service method incl. prototype-pollution keys.
- Existing billing route-sync tests unchanged and green; `feature` service suite green; lint clean.
- Mutation-checked: changing a route string or inverting the automations condition makes the suite fail.

## Release note

⚠️ This must be shipped and released **before** the Billing App starts emitting `navigateToAdmin` requests (unblocks GVA-869).