### PR TITLE
Removed "new" comment from boot sequence

### DIFF
--- a/ghost/core/ghost.js
+++ b/ghost/core/ghost.js
@@ -20,6 +20,5 @@ case 'generate-data':
     require('./core/cli/command').run(mode);
     break;
 default:
-    // New boot sequence
     require('./core/boot')();
 }


### PR DESCRIPTION
no ref

This has been the "new" boot sequence since 2021. Let's remove the comment.
