### PR TITLE
Added `track_clicks` and `clicked_at` columns to `automated_email_recipients` table

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.54/2026-07-22-10-41-08-add-click-tracking-to-automated-email-recipients.js
+++ b/ghost/core/core/server/data/migrations/versions/6.54/2026-07-22-10-41-08-add-click-tracking-to-automated-email-recipients.js
@@ -1,0 +1,13 @@
+const {combineNonTransactionalMigrations, createAddColumnMigration} = require('../../utils');
+
+module.exports = combineNonTransactionalMigrations(
+    createAddColumnMigration('automated_email_recipients', 'track_clicks', {
+        type: 'boolean',
+        nullable: false,
+        defaultTo: false
+    }, {algorithm: 'auto'}),
+    createAddColumnMigration('automated_email_recipients', 'clicked_at', {
+        type: 'dateTime',
+        nullable: true
+    }, {algorithm: 'auto'})
+);

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1340,7 +1340,9 @@ module.exports = {
         mailgun_message_id: {type: 'string', maxlength: 1000, nullable: true},
         delivered_at: {type: 'dateTime', nullable: true},
         opened_at: {type: 'dateTime', nullable: true},
+        clicked_at: {type: 'dateTime', nullable: true},
         track_opens: {type: 'boolean', nullable: false, defaultTo: false},
+        track_clicks: {type: 'boolean', nullable: false, defaultTo: false},
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: true}
     },

--- a/ghost/core/core/server/services/automations/database-automations-repository.ts
+++ b/ghost/core/core/server/services/automations/database-automations-repository.ts
@@ -242,6 +242,8 @@ export function createDatabaseAutomationsRepository({
                     automation_action_revision_id: options.automationActionRevisionId,
                     ...(options.mailgunMessageId ? {mailgun_message_id: options.mailgunMessageId} : {}),
                     track_opens: options.trackOpens,
+                    // TODO(NY-1491) Snapshot the email_track_clicks setting when creating recipients.
+                    track_clicks: false,
                     created_at: now,
                     updated_at: now
                 });

--- a/ghost/core/core/server/services/automations/welcome-email-automation-poll.js
+++ b/ghost/core/core/server/services/automations/welcome-email-automation-poll.js
@@ -235,7 +235,8 @@ async function processRun({
                 member_uuid: member.get('uuid'),
                 member_email: member.get('email'),
                 member_name: member.get('name'),
-                track_opens: false
+                track_opens: false,
+                track_clicks: false
             }, {transacting});
 
             await markExited(run.id, 'finished', transacting);

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'eec8860c75b34885e8698f996367a936';
+    const currentSchemaHash = '2f3efab004dbe06fa13f9902af24aa56';
     const currentFixturesHash = '065b413e1d1f4f95fa7cb7734c5e7934';
     const currentSettingsHash = '397be8628c753b1959b8954d5610f83f';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';

--- a/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
+++ b/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
@@ -131,7 +131,9 @@ const createDatabase = async (): Promise<Knex> => {
         table.text('mailgun_message_id');
         table.datetime('delivered_at');
         table.datetime('opened_at');
+        table.datetime('clicked_at');
         table.boolean('track_opens').notNullable().defaultTo(false);
+        table.boolean('track_clicks').notNullable().defaultTo(false);
         table.datetime('created_at');
         table.datetime('updated_at');
     });
@@ -1879,7 +1881,9 @@ describe('automations repository', function () {
                 mailgun_message_id: 'mailgun-message-id',
                 delivered_at: null,
                 opened_at: null,
+                clicked_at: null,
                 track_opens: 1,
+                track_clicks: 0,
                 created_at: recipient.created_at,
                 updated_at: recipient.updated_at
             });
@@ -1911,6 +1915,7 @@ describe('automations repository', function () {
             assert.equal(recipient.mailgun_message_id, null);
             assert.equal(recipient.member_name, null);
             assert.equal(recipient.track_opens, 0);
+            assert.equal(recipient.track_clicks, 0);
         });
     });
 


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1487/

## Summary

- Added track_clicks and clicked_at columns to automated email recipients
- Updated the current schema definition and integrity hash