### PR TITLE
Added `email_clicked_count` column to `automation_action_revisions` table

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.54/2026-07-22-15-10-30-add-email-clicked-count-to-automation-action-revisions.js
+++ b/ghost/core/core/server/data/migrations/versions/6.54/2026-07-22-15-10-30-add-email-clicked-count-to-automation-action-revisions.js
@@ -1,0 +1,7 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('automation_action_revisions', 'email_clicked_count', {
+    type: 'integer',
+    nullable: true,
+    unsigned: true
+}, {algorithm: 'auto'});

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1266,6 +1266,7 @@ module.exports = {
         email_design_setting_id: {type: 'string', maxlength: 24, nullable: true, references: 'email_design_settings.id', setNullDelete: true},
         email_sent_count: {type: 'integer', nullable: true, unsigned: true},
         email_opened_count: {type: 'integer', nullable: true, unsigned: true},
+        email_clicked_count: {type: 'integer', nullable: true, unsigned: true},
         '@@UNIQUE_CONSTRAINTS@@': [
             ['created_at', 'action_id']
         ]

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '2f3efab004dbe06fa13f9902af24aa56';
+    const currentSchemaHash = '2657a1cc3db66153bd743251a0430401';
     const currentFixturesHash = '065b413e1d1f4f95fa7cb7734c5e7934';
     const currentSettingsHash = '397be8628c753b1959b8954d5610f83f';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1488/add-nullable-email-clicked-count-to-automation-action-revisions

## Summary

- Adds a nullable unsigned email_clicked_count column to automation_action_revisions
- This column is dormant for now, but will be populated soon