### PR TITLE
Fixed stale Ember admin assets being shipped from the Nx remote cache

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -63,6 +63,7 @@
         "eslint-plugin-react-hooks": "catalog:",
         "eslint-plugin-react-refresh": "catalog:",
         "eslint-plugin-tailwindcss": "catalog:",
+        "ghost-admin": "workspace:*",
         "globals": "catalog:",
         "jest-extended": "7.0.0",
         "jsdom": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -759,6 +759,9 @@ importers:
       eslint-plugin-tailwindcss:
         specifier: 'catalog:'
         version: 4.0.4(@typescript/typescript6@6.0.2)(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(tailwindcss@4.2.2)
+      ghost-admin:
+        specifier: workspace:*
+        version: link:../ember-admin
       globals:
         specifier: 'catalog:'
         version: 17.7.0


### PR DESCRIPTION
ref [GVA-868](https://linear.app/ghost/issue/GVA-868/allow-billing-to-navigate-to-approved-ghost-admin-settings)

## Problem

Ember-only changes silently never ship. `@tryghost/admin:build` lists `ghost-admin` in `dependsOn`, which **orders** the Ember build before the React build — but Nx's `^default` input hash is computed from **project-graph dependencies**, and no graph edge existed (`apps/admin` had no package dependency on the Ember app). So an Ember-only source change never invalidated `@tryghost/admin:build`:

```
$ nx show projects --affected --files=apps/ember-admin/app/services/billing.js
["ghost-admin","ghost-monorepo"]        # @tryghost/admin missing
```

## Observed impact

In the main-branch build for `e91932a4037` (GVA-868, #29527):
- `ghost-admin:build` → **Cache Miss**, rebuilt with the new code (1m30s)
- `@tryghost/admin:build` → **Remote Cache Hit (0s)** — restored a stale combined `apps/admin/dist` + `ghost/core/core/built/admin`, discarding the fresh Ember output

The deployed admin assets for that sha serve an Ember bundle (`ghost-660878….js`) **byte-identical** to the pre-merge build (`6c43413`) — the new billing navigation handler is absent from every script on the page. This affects both the Pro CD artifact (`admin-build-cd`) and the packed archive (`admin-build.tar.gz`), i.e. anything built where only Ember sources changed.

## Fix

Declare `ghost-admin` as a `workspace:*` devDependency of `@tryghost/admin`, giving pnpm and Nx the same source of truth:

- **Nx** derives the project-graph edge from the package dependency, so Ember sources join the `^default` build hash:

  ```
  $ nx show projects --affected --files=apps/ember-admin/app/services/billing.js
  ["ghost-admin","@tryghost/admin","ghost-monorepo"]
  ```

- **pnpm** filtered installs follow the same edge: the Playwright acceptance job's `pnpm install --filter @tryghost/admin...` now includes the Ember app, so the `ghost-admin:build` task that legitimately joins its `^build` chain (~1m30s, cacheable) has its toolchain available.

`apps/ember-admin` has no dependency back on `@tryghost/admin`, so no graph cycle is introduced. `dependsOn` is kept for task ordering.

<details>
<summary>Approaches considered and discarded (see comments)</summary>

1. `implicitDependencies: ["ghost-admin"]` — fixed the hash but is invisible to pnpm, so the Playwright job's filtered install lacked the Ember toolchain (`ember: not found`).
2. Per-target input `{projects: ["ghost-admin"], input: "default"}` — fixed the hash with no graph changes, but left the dependency invisible to pnpm; a real workspace dep expresses the relationship once for both tools (suggested by the team).

</details>

After this merges, the next main build produces a fresh combined artifact containing the GVA-868 Ember changes — staging can then be re-bumped to verify the billing navigation round-trip.