### PR TITLE
Updated offers table to use Shade primitives

### DIFF
--- a/apps/admin-x-settings/src/components/settings/growth/offers/offers-index.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/offers-index.tsx
@@ -5,11 +5,11 @@ import {Icon} from '@tryghost/admin-x-design-system';
 import {Inline, Stack} from '@tryghost/shade/primitives';
 import {LucideIcon, formatNumber} from '@tryghost/shade/utils';
 import {Modal} from '@tryghost/admin-x-design-system';
+import {type Offer, useBrowseOffers} from '@tryghost/admin-x-framework/api/offers';
 import {type RetentionOffer, getRetentionOffers} from './offers-retention';
 import {type Tier, getPaidActiveTiers, useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
 import {createOfferRedemptionFilterUrl, createOfferRedemptionsFilterUrl} from './offer-helpers';
 import {currencyToDecimal, getSymbol} from '../../../../utils/currency';
-import {useBrowseOffers} from '@tryghost/admin-x-framework/api/offers';
 import {useModal} from '@ebay/nice-modal-react';
 import {useOffersShowArchived, useSortingState} from '../../../providers/settings-app-provider';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
@@ -165,6 +165,99 @@ const RetentionOfferRow: React.FC<{
     );
 };
 
+const SignupOfferRow: React.FC<{
+    archived: boolean;
+    offer: Offer;
+    tier: Tier;
+    onClick: () => void;
+}> = ({archived, offer, tier, onClick}) => {
+    const {discountOffer, originalPriceWithCurrency, updatedPriceWithCurrency} = getOfferDiscount(offer.type, offer.amount, offer.cadence, offer.currency || 'USD', tier);
+
+    return (
+        <TableRow className={archived ? 'opacity-60' : undefined} data-testid='offer-item'>
+            <TableCell className='sticky left-0 z-10 bg-background p-0'>
+                <button className='block w-full cursor-pointer p-5 pl-0 text-left' type='button' onClick={onClick}>
+                    <Stack gap='none'>
+                        <span className='font-semibold'>{offer.name}</span>
+                        <span className='text-muted-foreground'>{tier.name} {getOfferCadence(offer.cadence)}</span>
+                    </Stack>
+                </button>
+            </TableCell>
+            <TableCell className='p-0 whitespace-nowrap'>
+                <button className='block w-full cursor-pointer p-5 text-left' type='button' onClick={onClick}>
+                    <Stack gap='none'>
+                        <span className='text-sm font-medium uppercase'>{discountOffer}</span>
+                        <span className='text-muted-foreground'>{offer.type !== 'trial' ? getOfferDuration(offer.duration) : 'Trial period'}</span>
+                    </Stack>
+                </button>
+            </TableCell>
+            <TableCell className='p-0 whitespace-nowrap'>
+                <button className='block w-full cursor-pointer p-5 text-left' type='button' onClick={onClick}>
+                    <span className='font-medium'>{updatedPriceWithCurrency}</span> {offer.type !== 'trial' ? <span className='relative text-sm text-muted-foreground before:absolute before:-inset-x-0.5 before:top-1/2 before:rotate-[-20deg] before:border-t before:content-[""]'>{originalPriceWithCurrency}</span> : null}
+                </button>
+            </TableCell>
+            <TableCell className='p-0 whitespace-nowrap'>
+                {offer.redemption_count > 0 && offer.id ? (
+                    <a className='block cursor-pointer p-5 hover:underline' href={createOfferRedemptionFilterUrl(offer.id)}>{formatNumber(offer.redemption_count)}</a>
+                ) : (
+                    <button className='block w-full cursor-pointer p-5 text-left' type='button' onClick={onClick}>{formatNumber(offer.redemption_count)}</button>
+                )}
+            </TableCell>
+            <TableCell className='p-0 whitespace-nowrap'>
+                <button className='block w-full cursor-pointer p-5 text-left' type='button' onClick={onClick}>
+                    {archived ? (
+                        <Badge className='rounded-full uppercase' variant='secondary'>Archived</Badge>
+                    ) : (
+                        <Badge className='rounded-full uppercase' variant='success'>Active</Badge>
+                    )}
+                </button>
+            </TableCell>
+        </TableRow>
+    );
+};
+
+type OfferListItem =
+    | {kind: 'retention'; offer: RetentionOffer}
+    | {kind: 'signup'; offer: Offer};
+
+const getOfferListItemName = (item: OfferListItem): string => item.offer.name;
+const getOfferListItemRedemptions = (item: OfferListItem): number => item.kind === 'retention' ? item.offer.redemptions : item.offer.redemption_count;
+const getOfferListItemCreatedAt = (item: OfferListItem): string | null => item.kind === 'retention' ? item.offer.createdAt : item.offer.created_at || null;
+
+const sortOfferListItems = (items: OfferListItem[], sortOption: string, sortDirection: string): OfferListItem[] => {
+    const multiplier = sortDirection === 'desc' ? -1 : 1;
+
+    return [...items].sort((item1, item2) => {
+        let result: number;
+
+        switch (sortOption) {
+        case 'name':
+            result = getOfferListItemName(item1).localeCompare(getOfferListItemName(item2));
+            break;
+        case 'redemptions':
+            result = getOfferListItemRedemptions(item1) - getOfferListItemRedemptions(item2);
+            break;
+        default: {
+            const date1 = getOfferListItemCreatedAt(item1);
+            const date2 = getOfferListItemCreatedAt(item2);
+
+            if (!date1 && !date2) {
+                result = 0;
+            } else if (!date1) {
+                return 1;
+            } else if (!date2) {
+                return -1;
+            } else {
+                result = new Date(date1).getTime() - new Date(date2).getTime();
+            }
+            break;
+        }
+        }
+
+        return (result || getOfferListItemName(item1).localeCompare(getOfferListItemName(item2))) * multiplier;
+    });
+};
+
 export const OffersIndexModal: React.FC = () => {
     const modal = useModal();
     const {updateRoute} = useRouting();
@@ -191,22 +284,9 @@ export const OffersIndexModal: React.FC = () => {
         updateRoute(`offers/edit/retention/${id}`);
     };
 
-    const sortedOffers = signupOffers
-        .sort((offer1, offer2) => {
-            const multiplier = sortDirection === 'desc' ? -1 : 1;
-            switch (sortOption) {
-            case 'name':
-                return multiplier * offer1.name.localeCompare(offer2.name);
-            case 'redemptions':
-                return multiplier * (offer1.redemption_count - offer2.redemption_count);
-            default:
-                return multiplier * ((offer1.created_at ? new Date(offer1.created_at).getTime() : 0) - (offer2.created_at ? new Date(offer2.created_at).getTime() : 0));
-            }
-        });
-
     const paidActiveTiers = getPaidActiveTiers(allTiers || []);
 
-    const filteredSignupOffers = sortedOffers.filter((offer) => {
+    const filteredSignupOffers = signupOffers.filter((offer) => {
         const offerTier = allTiers?.find(tier => tier.id === offer?.tier?.id);
         const isActive = offer.status === 'active' && offerTier && offerTier.active === true;
         const isArchived = offer.status === 'archived' || (offerTier && offerTier.active === false);
@@ -219,6 +299,11 @@ export const OffersIndexModal: React.FC = () => {
         }
         return false;
     });
+
+    const sortedOfferListItems = sortOfferListItems([
+        ...retentionOffers.map(offer => ({kind: 'retention' as const, offer})),
+        ...filteredSignupOffers.map(offer => ({kind: 'signup' as const, offer}))
+    ], sortOption, sortDirection);
 
     const handleSortChange = (selectedOption: string) => {
         setSortingState?.([{
@@ -239,7 +324,7 @@ export const OffersIndexModal: React.FC = () => {
 
     const isOfferArchived = (offer: typeof signupOffers[0]) => {
         const offerTier = allTiers?.find(tier => tier.id === offer?.tier?.id);
-        return offer.status === 'archived' || (offerTier && offerTier.active === false);
+        return offer.status === 'archived' || offerTier?.active === false;
     };
 
     const buttons: ButtonProps[] = [
@@ -299,15 +384,19 @@ export const OffersIndexModal: React.FC = () => {
                     </TableHead>
                 </TableRow>
             </TableHeader>
-            <TableBody>
-                {retentionOffers.map(offer => (
-                    <RetentionOfferRow
-                        key={offer.id}
-                        offer={offer}
-                        onClick={() => handleRetentionOfferEdit(offer.id)}
-                    />
-                ))}
-                {filteredSignupOffers.map((offer) => {
+            <TableBody data-testid='offers-table-body'>
+                {sortedOfferListItems.map((item) => {
+                    if (item.kind === 'retention') {
+                        return (
+                            <RetentionOfferRow
+                                key={`retention-${item.offer.id}`}
+                                offer={item.offer}
+                                onClick={() => handleRetentionOfferEdit(item.offer.id)}
+                            />
+                        );
+                    }
+
+                    const offer = item.offer;
                     const offerTier = allTiers?.find(tier => tier.id === offer?.tier?.id);
 
                     if (!offerTier) {
@@ -316,48 +405,14 @@ export const OffersIndexModal: React.FC = () => {
 
                     const archived = isOfferArchived(offer);
 
-                    const {discountOffer, originalPriceWithCurrency, updatedPriceWithCurrency} = getOfferDiscount(offer.type, offer.amount, offer.cadence, offer.currency || 'USD', offerTier);
-
                     return (
-                        <TableRow key={offer.id} className={archived ? 'opacity-60' : undefined} data-testid='offer-item'>
-                            <TableCell className='sticky left-0 z-10 bg-background p-0'>
-                                <button className='block w-full cursor-pointer p-5 pl-0 text-left' type='button' onClick={() => handleOfferEdit(offer.id)}>
-                                    <Stack gap='none'>
-                                        <span className='font-semibold'>{offer.name}</span>
-                                        <span className='text-muted-foreground'>{offerTier.name} {getOfferCadence(offer.cadence)}</span>
-                                    </Stack>
-                                </button>
-                            </TableCell>
-                            <TableCell className='p-0 whitespace-nowrap'>
-                                <button className='block w-full cursor-pointer p-5 text-left' type='button' onClick={() => handleOfferEdit(offer.id)}>
-                                    <Stack gap='none'>
-                                        <span className='text-sm font-medium uppercase'>{discountOffer}</span>
-                                        <span className='text-muted-foreground'>{offer.type !== 'trial' ? getOfferDuration(offer.duration) : 'Trial period'}</span>
-                                    </Stack>
-                                </button>
-                            </TableCell>
-                            <TableCell className='p-0 whitespace-nowrap'>
-                                <button className='block w-full cursor-pointer p-5 text-left' type='button' onClick={() => handleOfferEdit(offer.id)}>
-                                    <span className='font-medium'>{updatedPriceWithCurrency}</span> {offer.type !== 'trial' ? <span className='relative text-sm text-muted-foreground before:absolute before:-inset-x-0.5 before:top-1/2 before:rotate-[-20deg] before:border-t before:content-[""]'>{originalPriceWithCurrency}</span> : null}
-                                </button>
-                            </TableCell>
-                            <TableCell className='p-0 whitespace-nowrap'>
-                                {offer.redemption_count > 0 && offer.id ? (
-                                    <a className='block cursor-pointer p-5 hover:underline' href={createOfferRedemptionFilterUrl(offer.id)}>{formatNumber(offer.redemption_count)}</a>
-                                ) : (
-                                    <button className='block w-full cursor-pointer p-5 text-left' type='button' onClick={() => handleOfferEdit(offer.id)}>{formatNumber(offer.redemption_count)}</button>
-                                )}
-                            </TableCell>
-                            <TableCell className='p-0 whitespace-nowrap'>
-                                <button className='block w-full cursor-pointer p-5 text-left' type='button' onClick={() => handleOfferEdit(offer.id)}>
-                                    {archived ? (
-                                        <Badge className='rounded-full uppercase' variant='secondary'>Archived</Badge>
-                                    ) : (
-                                        <Badge className='rounded-full uppercase' variant='success'>Active</Badge>
-                                    )}
-                                </button>
-                            </TableCell>
-                        </TableRow>
+                        <SignupOfferRow
+                            key={`signup-${offer.id}`}
+                            archived={archived}
+                            offer={offer}
+                            tier={offerTier}
+                            onClick={() => handleOfferEdit(offer.id)}
+                        />
                     );
                 })}
             </TableBody>

--- a/apps/admin-x-settings/src/components/settings/growth/offers/offers-index.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/offers-index.tsx
@@ -1,14 +1,14 @@
+import {Badge, DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuRadioGroup, DropdownMenuRadioItem, DropdownMenuSeparator, DropdownMenuTrigger, Table, TableBody, TableCell, TableHead, TableHeader, TableRow} from '@tryghost/shade/components';
 import {Button, type ButtonProps, showToast} from '@tryghost/admin-x-design-system';
 import {ButtonGroup} from '@tryghost/admin-x-design-system';
-import {DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuRadioGroup, DropdownMenuRadioItem, DropdownMenuSeparator, DropdownMenuTrigger} from '@tryghost/shade/components';
 import {Icon} from '@tryghost/admin-x-design-system';
+import {Inline, Stack} from '@tryghost/shade/primitives';
 import {LucideIcon, formatNumber} from '@tryghost/shade/utils';
 import {Modal} from '@tryghost/admin-x-design-system';
 import {type RetentionOffer, getRetentionOffers} from './offers-retention';
 import {type Tier, getPaidActiveTiers, useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
 import {createOfferRedemptionFilterUrl, createOfferRedemptionsFilterUrl} from './offer-helpers';
 import {currencyToDecimal, getSymbol} from '../../../../utils/currency';
-import {numberWithCommas} from '../../../../utils/helpers';
 import {useBrowseOffers} from '@tryghost/admin-x-framework/api/offers';
 import {useModal} from '@ebay/nice-modal-react';
 import {useOffersShowArchived, useSortingState} from '../../../providers/settings-app-provider';
@@ -24,29 +24,26 @@ export const getOfferDuration = (duration: string): string => {
     return (duration === 'once' ? 'First payment' : duration === 'repeating' ? 'Repeating' : 'Forever');
 };
 
-export const getOfferDiscount = (type: string, amount: number, cadence: string, currency: string, tier: Tier | undefined): {discountColor: string, discountOffer: string, originalPriceWithCurrency: string, updatedPriceWithCurrency: string} => {
-    let discountColor = '';
+export const getOfferDiscount = (type: string, amount: number, cadence: string, currency: string, tier: Tier | undefined): {discountOffer: string, originalPriceWithCurrency: string, updatedPriceWithCurrency: string} => {
     let discountOffer = '';
     const originalPrice = cadence === 'month' ? tier?.monthly_price ?? 0 : tier?.yearly_price ?? 0;
     let updatedPrice = originalPrice;
 
     const formatToTwoDecimals = (num: number): number => parseFloat(num.toFixed(2));
+    const formatPrice = (num: number): string => formatNumber(formatToTwoDecimals(currencyToDecimal(num)), {maximumFractionDigits: 2});
 
-    let originalPriceWithCurrency = getSymbol(currency) + numberWithCommas(formatToTwoDecimals(currencyToDecimal(originalPrice)));
+    let originalPriceWithCurrency = getSymbol(currency) + formatPrice(originalPrice);
 
     switch (type) {
     case 'percent':
-        discountColor = 'text-green';
         discountOffer = `${formatNumber(amount)}% off`;
         updatedPrice = originalPrice - ((originalPrice * amount) / 100);
         break;
     case 'fixed':
-        discountColor = 'text-blue';
-        discountOffer = numberWithCommas(formatToTwoDecimals(currencyToDecimal(amount))) + ' ' + currency + ' off';
+        discountOffer = `${formatPrice(amount)} ${currency} off`;
         updatedPrice = originalPrice - amount;
         break;
     case 'trial':
-        discountColor = 'text-pink';
         discountOffer = `${formatNumber(amount)} days free`;
         originalPriceWithCurrency = '';
         break;
@@ -58,10 +55,9 @@ export const getOfferDiscount = (type: string, amount: number, cadence: string, 
         updatedPrice = 0;
     }
 
-    const updatedPriceWithCurrency = getSymbol(currency) + numberWithCommas(formatToTwoDecimals(currencyToDecimal(updatedPrice)));
+    const updatedPriceWithCurrency = getSymbol(currency) + formatPrice(updatedPrice);
 
     return {
-        discountColor,
         discountOffer,
         originalPriceWithCurrency,
         updatedPriceWithCurrency
@@ -110,31 +106,33 @@ const RetentionOfferRow: React.FC<{
         : undefined;
 
     return (
-        <tr className='group relative border-b border-b-grey-200 dark:border-grey-800' data-testid='retention-offer-item'>
-            <td className='sticky left-0 z-10 bg-white p-0 dark:bg-black'>
-                <button className='block w-full cursor-pointer p-5 pl-0 text-left' type="button" onClick={onClick}>
-                    <span className='font-semibold'>{offer.name}</span><br />
-                    <span className='text-grey-700'>{offer.description}</span>
+        <TableRow data-testid='retention-offer-item'>
+            <TableCell className='sticky left-0 z-10 bg-background p-0'>
+                <button className='block w-full cursor-pointer p-5 pl-0 text-left' type='button' onClick={onClick}>
+                    <Stack gap='none'>
+                        <span className='font-semibold'>{offer.name}</span>
+                        <span className='text-muted-foreground'>{offer.description}</span>
+                    </Stack>
                 </button>
-            </td>
-            <td className='p-0 whitespace-nowrap'>
-                <button className='block w-full cursor-pointer p-5 text-left' type="button" onClick={onClick}>
+            </TableCell>
+            <TableCell className='p-0 whitespace-nowrap'>
+                <button className='block w-full cursor-pointer p-5 text-left' type='button' onClick={onClick}>
                     {offer.terms ? (
-                        <>
-                            <span className='text-[1.3rem] font-medium uppercase'>{offer.terms}</span><br />
-                            <span className='text-grey-700'>{offer.termsDetail}</span>
-                        </>
+                        <Stack gap='none'>
+                            <span className='text-sm font-medium uppercase'>{offer.terms}</span>
+                            <span className='text-muted-foreground'>{offer.termsDetail}</span>
+                        </Stack>
                     ) : (
-                        <span className='text-grey-700'>&ndash;</span>
+                        <span className='text-muted-foreground'>&ndash;</span>
                     )}
                 </button>
-            </td>
-            <td className='p-0 whitespace-nowrap'>
-                <button className='block w-full cursor-pointer p-5 text-left' type="button" onClick={onClick}>
-                    <span className='text-grey-700'>&ndash;</span>
+            </TableCell>
+            <TableCell className='p-0 whitespace-nowrap'>
+                <button className='block w-full cursor-pointer p-5 text-left' type='button' onClick={onClick}>
+                    <span className='text-muted-foreground'>&ndash;</span>
                 </button>
-            </td>
-            <td className='p-0 whitespace-nowrap'>
+            </TableCell>
+            <TableCell className='p-0 whitespace-nowrap'>
                 {redemptionFilterUrl ? (
                     <a
                         className='block cursor-pointer p-5 hover:underline'
@@ -153,17 +151,17 @@ const RetentionOfferRow: React.FC<{
                         {formatNumber(offer.redemptions)}
                     </button>
                 )}
-            </td>
-            <td className='p-0 whitespace-nowrap'>
-                <button className='block w-full cursor-pointer p-5 text-left' type="button" onClick={onClick}>
+            </TableCell>
+            <TableCell className='p-0 whitespace-nowrap'>
+                <button className='block w-full cursor-pointer p-5 text-left' type='button' onClick={onClick}>
                     {offer.status === 'active' ? (
-                        <span className='inline-flex items-center rounded-full bg-[rgba(48,207,67,0.15)] px-2 py-0.5 text-xs font-semibold tracking-wide text-green uppercase'>Active</span>
+                        <Badge className='rounded-full uppercase' variant='success'>Active</Badge>
                     ) : (
-                        <span className='inline-flex items-center rounded-full bg-grey-200 px-2 py-0.5 text-xs font-semibold tracking-wide text-grey-700 uppercase dark:bg-grey-900 dark:text-grey-500'>Inactive</span>
+                        <Badge className='rounded-full uppercase' variant='secondary'>Inactive</Badge>
                     )}
                 </button>
-            </td>
-        </tr>
+            </TableCell>
+        </TableRow>
     );
 };
 
@@ -272,7 +270,7 @@ export const OffersIndexModal: React.FC = () => {
     ];
 
     const listLayoutOutput = <div className='overflow-x-auto'>
-        <table className='m-0 min-w-[900px]'>
+        <Table className='m-0 min-w-[900px]'>
             <colgroup>
                 <col className='w-[25%]' />
                 <col className='w-[200px]' />
@@ -280,14 +278,14 @@ export const OffersIndexModal: React.FC = () => {
                 <col className='w-[200px]' />
                 <col className='w-[220px]' />
             </colgroup>
-            <thead>
-                <tr className='border-b border-b-grey-200 dark:border-grey-800'>
-                    <th className='sticky left-0 z-10 bg-white p-0 pb-2.5 text-left text-sm font-medium tracking-wide text-grey-700 uppercase dark:bg-black'>Name</th>
-                    <th className='p-0 pb-2.5 pl-5 text-left text-sm font-medium tracking-wide text-grey-700 uppercase'>Terms</th>
-                    <th className='p-0 pb-2.5 pl-5 text-left text-sm font-medium tracking-wide text-grey-700 uppercase'>Price</th>
-                    <th className='p-0 pb-2.5 pl-5 text-left text-sm font-medium tracking-wide text-grey-700 uppercase'>Redemptions</th>
-                    <th className='p-0 pb-2.5 pl-5 text-left text-sm font-medium tracking-wide text-grey-700 uppercase'>
-                        <span className='flex items-center justify-between'>
+            <TableHeader>
+                <TableRow>
+                    <TableHead className='sticky left-0 z-10 h-auto bg-background p-0 pb-2.5 uppercase'>Name</TableHead>
+                    <TableHead className='h-auto p-0 pb-2.5 pl-5 uppercase'>Terms</TableHead>
+                    <TableHead className='h-auto p-0 pb-2.5 pl-5 uppercase'>Price</TableHead>
+                    <TableHead className='h-auto p-0 pb-2.5 pl-5 uppercase'>Redemptions</TableHead>
+                    <TableHead className='h-auto p-0 pb-2.5 pl-5 uppercase'>
+                        <Inline align='center' justify='between'>
                             Status
                             <OffersFilterMenu
                                 setShowArchived={setShowArchived}
@@ -297,11 +295,11 @@ export const OffersIndexModal: React.FC = () => {
                                 onDirectionChange={handleDirectionChange}
                                 onSortChange={handleSortChange}
                             />
-                        </span>
-                    </th>
-                </tr>
-            </thead>
-            <tbody>
+                        </Inline>
+                    </TableHead>
+                </TableRow>
+            </TableHeader>
+            <TableBody>
                 {retentionOffers.map(offer => (
                     <RetentionOfferRow
                         key={offer.id}
@@ -321,25 +319,49 @@ export const OffersIndexModal: React.FC = () => {
                     const {discountOffer, originalPriceWithCurrency, updatedPriceWithCurrency} = getOfferDiscount(offer.type, offer.amount, offer.cadence, offer.currency || 'USD', offerTier);
 
                     return (
-                        <tr key={offer.id} className={`group relative border-b border-b-grey-200 dark:border-grey-800 ${archived ? 'opacity-60' : ''}`} data-testid="offer-item">
-                            <td className='sticky left-0 z-10 bg-white p-0 dark:bg-black'><a className='block cursor-pointer p-5 pl-0' onClick={() => handleOfferEdit(offer.id)}><span className='font-semibold'>{offer?.name}</span><br /><span className='text-grey-700'>{offerTier.name} {getOfferCadence(offer.cadence)}</span></a></td>
-                            <td className='p-0 whitespace-nowrap'><a className='block cursor-pointer p-5' onClick={() => handleOfferEdit(offer.id)}><span className='text-[1.3rem] font-medium uppercase'>{discountOffer}</span><br /><span className='text-grey-700'>{offer.type !== 'trial' ? getOfferDuration(offer.duration) : 'Trial period'}</span></a></td>
-                            <td className='p-0 whitespace-nowrap'><a className='block cursor-pointer p-5' onClick={() => handleOfferEdit(offer.id)}><span className='font-medium'>{updatedPriceWithCurrency}</span> {offer.type !== 'trial' ? <span className='relative text-sm text-grey-700 before:absolute before:-inset-x-0.5 before:top-1/2 before:rotate-[-20deg] before:border-t before:content-[""]'>{originalPriceWithCurrency}</span> : null}</a></td>
-                            <td className='p-0 whitespace-nowrap'><a className={`block cursor-pointer p-5 ${offer.redemption_count === 0 ? '' : 'hover:underline'}`} href={offer.redemption_count > 0 && offer.id ? createOfferRedemptionFilterUrl(offer.id) : undefined} onClick={offer.redemption_count === 0 && offer.id ? () => handleOfferEdit(offer.id) : undefined}>{formatNumber(offer.redemption_count)}</a></td>
-                            <td className='p-0 whitespace-nowrap'>
-                                <a className='block cursor-pointer p-5' onClick={() => handleOfferEdit(offer.id)}>
+                        <TableRow key={offer.id} className={archived ? 'opacity-60' : undefined} data-testid='offer-item'>
+                            <TableCell className='sticky left-0 z-10 bg-background p-0'>
+                                <button className='block w-full cursor-pointer p-5 pl-0 text-left' type='button' onClick={() => handleOfferEdit(offer.id)}>
+                                    <Stack gap='none'>
+                                        <span className='font-semibold'>{offer.name}</span>
+                                        <span className='text-muted-foreground'>{offerTier.name} {getOfferCadence(offer.cadence)}</span>
+                                    </Stack>
+                                </button>
+                            </TableCell>
+                            <TableCell className='p-0 whitespace-nowrap'>
+                                <button className='block w-full cursor-pointer p-5 text-left' type='button' onClick={() => handleOfferEdit(offer.id)}>
+                                    <Stack gap='none'>
+                                        <span className='text-sm font-medium uppercase'>{discountOffer}</span>
+                                        <span className='text-muted-foreground'>{offer.type !== 'trial' ? getOfferDuration(offer.duration) : 'Trial period'}</span>
+                                    </Stack>
+                                </button>
+                            </TableCell>
+                            <TableCell className='p-0 whitespace-nowrap'>
+                                <button className='block w-full cursor-pointer p-5 text-left' type='button' onClick={() => handleOfferEdit(offer.id)}>
+                                    <span className='font-medium'>{updatedPriceWithCurrency}</span> {offer.type !== 'trial' ? <span className='relative text-sm text-muted-foreground before:absolute before:-inset-x-0.5 before:top-1/2 before:rotate-[-20deg] before:border-t before:content-[""]'>{originalPriceWithCurrency}</span> : null}
+                                </button>
+                            </TableCell>
+                            <TableCell className='p-0 whitespace-nowrap'>
+                                {offer.redemption_count > 0 && offer.id ? (
+                                    <a className='block cursor-pointer p-5 hover:underline' href={createOfferRedemptionFilterUrl(offer.id)}>{formatNumber(offer.redemption_count)}</a>
+                                ) : (
+                                    <button className='block w-full cursor-pointer p-5 text-left' type='button' onClick={() => handleOfferEdit(offer.id)}>{formatNumber(offer.redemption_count)}</button>
+                                )}
+                            </TableCell>
+                            <TableCell className='p-0 whitespace-nowrap'>
+                                <button className='block w-full cursor-pointer p-5 text-left' type='button' onClick={() => handleOfferEdit(offer.id)}>
                                     {archived ? (
-                                        <span className='inline-flex items-center rounded-full bg-grey-200 px-2 py-0.5 text-xs font-semibold tracking-wide text-grey-700 uppercase dark:bg-grey-900 dark:text-grey-500'>Archived</span>
+                                        <Badge className='rounded-full uppercase' variant='secondary'>Archived</Badge>
                                     ) : (
-                                        <span className='inline-flex items-center rounded-full bg-[rgba(48,207,67,0.15)] px-2 py-0.5 text-xs font-semibold tracking-wide text-green uppercase'>Active</span>
+                                        <Badge className='rounded-full uppercase' variant='success'>Active</Badge>
                                     )}
-                                </a>
-                            </td>
-                        </tr>
+                                </button>
+                            </TableCell>
+                        </TableRow>
                     );
                 })}
-            </tbody>
-        </table>
+            </TableBody>
+        </Table>
     </div>;
 
     return <Modal
@@ -357,8 +379,8 @@ export const OffersIndexModal: React.FC = () => {
         topRightContent={<ButtonGroup buttons={buttons} />}
         width={1140}
     >
-        <div className='flex h-full flex-col pt-8'>
+        <Stack className='h-full pt-8'>
             {listLayoutOutput}
-        </div>
+        </Stack>
     </Modal>;
 };

--- a/apps/admin-x-settings/src/components/settings/growth/offers/offers-retention.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/offers/offers-retention.tsx
@@ -1,4 +1,5 @@
 import {type Offer} from '@tryghost/admin-x-framework/api/offers';
+import {formatNumber} from '@tryghost/shade/utils';
 
 type RetentionCadence = 'month' | 'year';
 
@@ -11,6 +12,7 @@ export type RetentionOffer = {
     redemptionOfferIds: string[];
     redemptions: number;
     status: 'active' | 'inactive';
+    createdAt: string | null;
 };
 
 const getActiveRetentionOfferByCadence = (offers: Offer[], cadence: RetentionCadence): Offer | null => {
@@ -39,6 +41,19 @@ const getRetentionOfferIdsByCadence = (offers: Offer[], cadence: RetentionCadenc
         .map(offer => offer.id);
 };
 
+const getLatestRetentionOfferDateByCadence = (offers: Offer[], cadence: RetentionCadence): string | null => {
+    const timestamps = offers
+        .filter(offer => offer.redemption_type === 'retention' && offer.cadence === cadence && offer.created_at)
+        .map(offer => new Date(offer.created_at!).getTime())
+        .filter(timestamp => !Number.isNaN(timestamp));
+
+    if (timestamps.length === 0) {
+        return null;
+    }
+
+    return new Date(Math.max(...timestamps)).toISOString();
+};
+
 const isFreeMonthsOffer = (offer: Offer): boolean => {
     return offer.type === 'percent' && offer.amount === 100 && offer.duration === 'repeating';
 };
@@ -51,11 +66,11 @@ const getRetentionTerms = (offer: Offer | null): string | null => {
     if (isFreeMonthsOffer(offer)) {
         const months = offer.duration_in_months || 0;
         const monthLabel = months === 1 ? 'month' : 'months';
-        return `${months} ${monthLabel} free`;
+        return `${formatNumber(months)} ${monthLabel} free`;
     }
 
     if (offer.type === 'percent') {
-        return `${offer.amount}% OFF`;
+        return `${formatNumber(offer.amount)}% OFF`;
     }
 
     return null;
@@ -76,7 +91,7 @@ const getRetentionTermsDetail = (offer: Offer | null): string | null => {
 
     if (offer.duration === 'repeating' && offer.duration_in_months) {
         const monthLabel = offer.duration_in_months === 1 ? 'month' : 'months';
-        return `For ${offer.duration_in_months} ${monthLabel}`;
+        return `For ${formatNumber(offer.duration_in_months)} ${monthLabel}`;
     }
 
     if (offer.duration === 'forever') {
@@ -103,7 +118,8 @@ export const getRetentionOffers = (offers: Offer[]): RetentionOffer[] => {
             termsDetail: getRetentionTermsDetail(monthlyOffer),
             redemptionOfferIds: monthlyOfferIds,
             redemptions: monthlyRedemptions,
-            status: monthlyOffer ? 'active' : 'inactive'
+            status: monthlyOffer ? 'active' : 'inactive',
+            createdAt: getLatestRetentionOfferDateByCadence(offers, 'month')
         },
         {
             id: 'yearly',
@@ -113,7 +129,8 @@ export const getRetentionOffers = (offers: Offer[]): RetentionOffer[] => {
             termsDetail: getRetentionTermsDetail(yearlyOffer),
             redemptionOfferIds: yearlyOfferIds,
             redemptions: yearlyRedemptions,
-            status: yearlyOffer ? 'active' : 'inactive'
+            status: yearlyOffer ? 'active' : 'inactive',
+            createdAt: getLatestRetentionOfferDateByCadence(offers, 'year')
         }
     ];
 };

--- a/apps/admin/src/settings/offers.acceptance.test.tsx
+++ b/apps/admin/src/settings/offers.acceptance.test.tsx
@@ -194,6 +194,46 @@ describe("Offers", () => {
         await expect.element(offersScreen.listModal()).toHaveTextContent("Third offer");
     });
 
+    it("sorts signup and retention offers by date, name and redemptions", async () => {
+        fakeSettingsScreens();
+        const supporter = supporterTier();
+        const tierRef = { id: supporter.id, name: supporter.name };
+        fakeTiers([supporter]);
+        fakeOffers([
+            offer({ name: "Alpha signup", created_at: "2026-01-04T12:00:00.000Z", redemption_count: 5, tier: tierRef }),
+            offer({ name: "Zulu signup", created_at: "2026-01-01T12:00:00.000Z", redemption_count: 1, tier: tierRef }),
+            retentionOffer({ name: "Monthly retention offer", created_at: "2026-01-03T12:00:00.000Z", redemption_count: 7 }),
+            retentionOffer({ name: "Yearly retention offer", cadence: "year", created_at: "2026-01-02T12:00:00.000Z", redemption_count: 3 }),
+        ]);
+        await renderAdminApp("/settings/offers/edit", withStripe());
+
+        const rows = offersScreen.tableRows();
+        await expect(rows).toHaveCount(4);
+
+        const expectOrder = async (names: string[]) => {
+            for (const [index, name] of names.entries()) {
+                await expect.element(rows.nth(index)).toHaveTextContent(name);
+            }
+        };
+
+        await expectOrder(["Alpha signup", "Monthly retention", "Yearly retention", "Zulu signup"]);
+
+        await offersScreen.sortOffersBy("Name");
+        await expectOrder(["Zulu signup", "Yearly retention", "Monthly retention", "Alpha signup"]);
+
+        await offersScreen.toggleSortDirection("Descending");
+        await expectOrder(["Alpha signup", "Monthly retention", "Yearly retention", "Zulu signup"]);
+
+        await offersScreen.sortOffersBy("Redemptions");
+        await expectOrder(["Zulu signup", "Yearly retention", "Alpha signup", "Monthly retention"]);
+
+        await offersScreen.toggleSortDirection("Ascending");
+        await expectOrder(["Monthly retention", "Alpha signup", "Yearly retention", "Zulu signup"]);
+
+        await offersScreen.sortOffersBy("Date added");
+        await expectOrder(["Alpha signup", "Monthly retention", "Yearly retention", "Zulu signup"]);
+    });
+
     it("supports updating an offer", async () => {
         fakeSettingsScreens();
         const supporter = supporterTier();
@@ -275,7 +315,7 @@ describe("Offers", () => {
             const rows = offersScreen.retentionRows();
             await expect(rows).toHaveCount(2);
 
-            const monthlyRow = rows.nth(0);
+            const monthlyRow = rows.filter({ hasText: "Monthly retention" });
             await expect.element(monthlyRow).toHaveTextContent("Monthly retention");
             await expect.element(monthlyRow).toHaveTextContent("25% OFF");
             await expect.element(monthlyRow).toHaveTextContent("First payment");
@@ -285,7 +325,7 @@ describe("Offers", () => {
                 .element(offersScreen.retentionRedemptionsLink("monthly"))
                 .toHaveAttribute("href", "/ghost/#/members?filter=offer_redemptions%3A%5Bretention-month-active%2Cretention-month-archived%5D");
 
-            const yearlyRow = rows.nth(1);
+            const yearlyRow = rows.filter({ hasText: "Yearly retention" });
             await expect.element(yearlyRow).toHaveTextContent("Yearly retention");
             await expect.element(yearlyRow).toHaveTextContent("Inactive");
             await expect.element(yearlyRow).toHaveTextContent("9");

--- a/apps/admin/src/settings/offers.screen.ts
+++ b/apps/admin/src/settings/offers.screen.ts
@@ -10,6 +10,7 @@ export const offersScreen = {
 
     listModal: () => page.getByTestId(testIds.listModal),
     listRows: () => page.getByTestId(testIds.listRow),
+    tableRows: () => page.getByTestId(testIds.tableBody).getByRole("row"),
     retentionRows: () => page.getByTestId(testIds.retentionRow),
     retentionRedemptionsLink: (cadence: "monthly" | "yearly") => page.getByTestId(testIds.retentionRedemptionsLink(cadence)),
     newOfferButton: () => page.getByTestId(testIds.listModal).getByRole("button", { name: names.newOfferButton }),
@@ -37,5 +38,15 @@ export const offersScreen = {
     async showArchivedOffers(): Promise<void> {
         await offersScreen.listModal().getByRole("button", { name: names.filterOptionsButton }).click();
         await page.getByRole("menuitemcheckbox", { name: names.showArchivedToggle }).click();
+    },
+
+    async sortOffersBy(option: "Date added" | "Name" | "Redemptions"): Promise<void> {
+        await offersScreen.listModal().getByRole("button", { name: names.filterOptionsButton }).click();
+        await page.getByRole("menuitemradio", { name: option }).click();
+    },
+
+    async toggleSortDirection(direction: "Ascending" | "Descending"): Promise<void> {
+        await offersScreen.listModal().getByRole("button", { name: names.filterOptionsButton }).click();
+        await page.getByRole("menuitem").filter({ hasText: direction }).click();
     },
 };

--- a/packages/testing/test-data/src/selectors/offers.ts
+++ b/packages/testing/test-data/src/selectors/offers.ts
@@ -6,6 +6,7 @@ export const offersSelectors = {
     testIds: {
         section: "offers",
         listModal: "offers-modal",
+        tableBody: "offers-table-body",
         listRow: "offer-item",
         retentionRow: "retention-offer-item",
         retentionRedemptionsLink: (cadence: "monthly" | "yearly") => `retention-redemptions-link-${cadence}`,


### PR DESCRIPTION
## What changed

- replaced the raw offers table markup with Shade `Table` primitives
- replaced bespoke active, inactive and archived pills with Shade `Badge`
- moved table surfaces, borders and secondary text onto semantic Shade tokens
- changed click-only anchors into buttons while keeping redemption destinations as links
- fixed sorting so Date added, Name, Redemptions and direction apply to every visible signup and retention row
- derived retention-row dates from the latest underlying retention offer
- added acceptance coverage for every sorting option and both directions

## Why

The settings rip-out plan identified Offers as the dense table minefield in the lists/tables group. Splitting it into a focused PR keeps its interaction and visual review separate from the broader legacy `List`/`Table` component deletion that follows.

The existing sort implementation only sorted signup offers. Retention rows were permanently pinned, so on sites with one signup offer—such as the local fixture—every sorting option appeared to do nothing.

## Impact

Signup and retention offers now form one sortable visible list. Archived filtering, editor navigation and redemption links are preserved. Retention rows use their aggregated redemption count and latest underlying creation date when sorting.

## Validation

- `pnpm --filter @tryghost/admin-x-settings lint`
- `pnpm --filter @tryghost/admin-x-settings test:unit` — 206 tests
- targeted offers acceptance suite — 19 tests
- full Admin acceptance suite — 371 tests before the sorting follow-up
- `pnpm --filter @tryghost/admin build`
- local rendered verification of Name sorting and direction reversal with no browser console errors

## Manual testing

1. Open **Settings → Growth → Offers → Manage offers**.
2. Check signup and retention row alignment.
3. Select **Name** and confirm every visible row reorders; reverse the direction and confirm the order reverses.
4. Repeat with **Redemptions** and **Date added**.
5. Toggle **Show archived** and confirm archived signup offers join the same sorted list.
6. Click ordinary cells in signup and retention rows and confirm the correct edit view opens.
7. For an offer with redemptions, click the count and confirm Members opens with the offer filter.
8. Check badges and sticky Name cells in light/dark mode and with horizontal scrolling.