### PR TITLE
Added `automation_action_revision_id` foreign key to `redirects` table

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.54/2026-07-23-10-24-18-add-automation-action-revision-to-redirects.js
+++ b/ghost/core/core/server/data/migrations/versions/6.54/2026-07-23-10-24-18-add-automation-action-revision-to-redirects.js
@@ -1,0 +1,9 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('redirects', 'automation_action_revision_id', {
+    type: 'string',
+    maxlength: 24,
+    nullable: true,
+    references: 'automation_action_revisions.id',
+    setNullDelete: true
+}, {algorithm: 'auto'});

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1076,20 +1076,6 @@ module.exports = {
         metadata: {type: 'string', maxlength: 2000, nullable: true},
         queue_entry: {type: 'integer', nullable: true, unsigned: true}
     },
-    redirects: {
-        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
-        from: {type: 'string', maxlength: 191, nullable: false, index: true},
-        to: {type: 'string', maxlength: 2000, nullable: false},
-        post_id: {type: 'string', maxlength: 24, nullable: true, unique: false, references: 'posts.id', setNullDelete: true},
-        created_at: {type: 'dateTime', nullable: false},
-        updated_at: {type: 'dateTime', nullable: true}
-    },
-    members_click_events: {
-        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
-        member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
-        redirect_id: {type: 'string', maxlength: 24, nullable: false, references: 'redirects.id', cascadeDelete: true},
-        created_at: {type: 'dateTime', nullable: false}
-    },
     members_feedback: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         score: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0},
@@ -1270,6 +1256,21 @@ module.exports = {
         '@@UNIQUE_CONSTRAINTS@@': [
             ['created_at', 'action_id']
         ]
+    },
+    redirects: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        from: {type: 'string', maxlength: 191, nullable: false, index: true},
+        to: {type: 'string', maxlength: 2000, nullable: false},
+        post_id: {type: 'string', maxlength: 24, nullable: true, unique: false, references: 'posts.id', setNullDelete: true},
+        automation_action_revision_id: {type: 'string', maxlength: 24, nullable: true, references: 'automation_action_revisions.id', setNullDelete: true},
+        created_at: {type: 'dateTime', nullable: false},
+        updated_at: {type: 'dateTime', nullable: true}
+    },
+    members_click_events: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
+        redirect_id: {type: 'string', maxlength: 24, nullable: false, references: 'redirects.id', cascadeDelete: true},
+        created_at: {type: 'dateTime', nullable: false}
     },
     automation_action_edges: {
         source_action_id: {type: 'string', maxlength: 24, nullable: false, references: 'automation_actions.id', restrictDelete: true},

--- a/ghost/core/core/server/data/seeders/data-generator.js
+++ b/ghost/core/core/server/data/seeders/data-generator.js
@@ -59,8 +59,10 @@ class DataGenerator {
             table.dependencies = Object.entries(this.schemaTables[table.name]).reduce((acc, [_col, data]) => {
                 if (data.references) {
                     const referencedTable = data.references.split('.')[0];
-                    // The ghost_subscriptions_id property has a foreign key to the subscriptions table, but we don't use that table yet atm, so don't add it as a dependency
-                    if (!acc.includes(referencedTable) && referencedTable !== 'subscriptions') {
+                    // Some nullable relationships point to tables the generator does not populate.
+                    // Generated redirects belong to posts, so automation revisions are not a seed dependency.
+                    const isUnsupportedOptionalDependency = referencedTable === 'subscriptions' || (referencedTable === 'automation_action_revisions' && data.nullable);
+                    if (!acc.includes(referencedTable) && !isUnsupportedOptionalDependency) {
                         acc.push(referencedTable);
                     }
                 }

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'c9971ddc1b9d88d7078db1d421cdb6b4';
+    const currentSchemaHash = '34a2e4ccd25c04dc9c4eb90abed13494';
     const currentFixturesHash = '065b413e1d1f4f95fa7cb7734c5e7934';
     const currentSettingsHash = '397be8628c753b1959b8954d5610f83f';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1489/add-nullable-automation-action-revision-id-column-to-redirects

_This should have no user impact; this column is currently dormant in the codebase, but we'll be using it soon._

## Summary

- Adds a nullable automation revision foreign key to redirects with ON DELETE SET NULL
- Orders schema tables so fresh MySQL databases create referenced tables before their dependents
- Keeps nullable automation revisions out of generated redirect seed dependencies