### PR TITLE
Improved newsletter publishing by avoiding duplicate recipient counts

### DIFF
--- a/ghost/core/core/server/services/email-service/email-service.js
+++ b/ghost/core/core/server/services/email-service/email-service.js
@@ -122,9 +122,11 @@ class EmailService {
      *
      * @param {object} newsletter - The newsletter model to send to
      * @param {string} emailRecipientFilter - The recipient filter for the email
+     * @param {object} [options]
+     * @param {number} [options.emailCount] - A previously counted audience to revalidate without recounting
      * @returns {Promise<{emailCount: number}>} The email count if checks pass, throws if email cannot be sent
      */
-    async checkCanSendEmail(newsletter, emailRecipientFilter) {
+    async checkCanSendEmail(newsletter, emailRecipientFilter, {emailCount: knownEmailCount} = {}) {
         if (!newsletter) {
             throw new errors.EmailError({
                 message: tpl(messages.missingNewsletterError)
@@ -139,7 +141,9 @@ class EmailService {
             });
         }
 
-        const emailCount = await this.#emailSegmenter.getMembersCount(newsletter, emailRecipientFilter);
+        const emailCount = knownEmailCount === undefined
+            ? await this.#emailSegmenter.getMembersCount(newsletter, emailRecipientFilter)
+            : knownEmailCount;
         await this.checkLimits(emailCount);
 
         return {emailCount};
@@ -148,13 +152,20 @@ class EmailService {
     /**
      *
      * @param {Post} post
+     * @param {object} [options]
+     * @param {object} [options.preflight]
      * @returns {Promise<Email>}
      */
-    async createEmail(post) {
+    async createEmail(post, {preflight} = {}) {
         const newsletter = await post.getLazyRelation('newsletter');
         const emailRecipientFilter = post.get('email_recipient_filter');
 
-        const {emailCount} = await this.checkCanSendEmail(newsletter, emailRecipientFilter);
+        const preflightMatches = preflight?.newsletter?.id
+            && preflight.newsletter.id === newsletter?.id
+            && preflight.emailRecipientFilter === emailRecipientFilter;
+        const {emailCount} = preflightMatches
+            ? await this.checkCanSendEmail(newsletter, emailRecipientFilter, {emailCount: preflight.emailCount})
+            : await this.checkCanSendEmail(newsletter, emailRecipientFilter);
 
         const csdEmailCount = this.#domainWarmingService.isEnabled()
             ? await this.#domainWarmingService.getWarmupLimit(emailCount)

--- a/ghost/core/core/server/services/email-service/email-service.js
+++ b/ghost/core/core/server/services/email-service/email-service.js
@@ -6,6 +6,11 @@
  * @typedef {object} LimitService
  * @typedef {{checkVerificationRequired(): Promise<boolean>}} VerificationTrigger
  * @typedef {import ('./domain-warming-service').DomainWarmingService} DomainWarmingService
+ *
+ * @typedef {object} EmailPreflight - Validation result from a pre-save checkCanSendEmail call
+ * @property {object} newsletter
+ * @property {string} emailRecipientFilter
+ * @property {number} emailCount
  */
 
 const BatchSendingService = require('./batch-sending-service');
@@ -153,7 +158,7 @@ class EmailService {
      *
      * @param {Post} post
      * @param {object} [options]
-     * @param {object} [options.preflight]
+     * @param {EmailPreflight} [options.preflight] - The emailCount is reused if the newsletter and filter still match the saved post
      * @returns {Promise<Email>}
      */
     async createEmail(post, {preflight} = {}) {

--- a/ghost/core/core/server/services/posts/post-email-handler.js
+++ b/ghost/core/core/server/services/posts/post-email-handler.js
@@ -100,7 +100,10 @@ class PostEmailHandler {
      *
      * @param {Object} model - The post model
      * @param {Object} [options]
-     * @param {Object} [options.preflight]
+     * @param {Object} [options.preflight] - Validation result from validateBeforeSave, passed through to createEmail
+     * @param {Object} [options.preflight.newsletter]
+     * @param {string} [options.preflight.emailRecipientFilter]
+     * @param {number} [options.preflight.emailCount]
      * @returns {Promise<void>}
      */
     async createOrRetryEmail(model, {preflight} = {}) {

--- a/ghost/core/core/server/services/posts/post-email-handler.js
+++ b/ghost/core/core/server/services/posts/post-email-handler.js
@@ -22,13 +22,13 @@ class PostEmailHandler {
      * Validates email can be sent before saving the post (if an email will be sent)
      *
      * @param {import('@tryghost/api-framework').Frame} frame
-     * @returns {Promise<void>}
+     * @returns {Promise<{newsletter: Object, emailRecipientFilter: string, emailCount: number}|null>}
      */
     async validateBeforeSave(frame) {
         const newStatus = frame.data.posts[0].status;
 
         if (!EMAIL_SENDING_STATUSES.includes(newStatus)) {
-            return;
+            return null;
         }
 
         const existingPost = await this.models.Post.findOne(
@@ -41,7 +41,7 @@ class PostEmailHandler {
         const sendingEmail = hasNewsletter && this.shouldSendEmail(newStatus, previousStatus);
 
         if (!sendingEmail) {
-            return;
+            return null;
         }
 
         const emailRecipientFilter = frame.options.email_segment || existingPost?.get('email_recipient_filter') || 'all';
@@ -50,7 +50,9 @@ class PostEmailHandler {
 
         const newsletter = await this.getNewsletter(frame, existingPost);
 
-        await this.emailService.checkCanSendEmail(newsletter, emailRecipientFilter);
+        const {emailCount} = await this.emailService.checkCanSendEmail(newsletter, emailRecipientFilter);
+
+        return {newsletter, emailRecipientFilter, emailCount};
     }
 
     /**
@@ -97,9 +99,11 @@ class PostEmailHandler {
      * Handles creating or retrying the newsletter email after post is saved
      *
      * @param {Object} model - The post model
+     * @param {Object} [options]
+     * @param {Object} [options.preflight]
      * @returns {Promise<void>}
      */
-    async createOrRetryEmail(model) {
+    async createOrRetryEmail(model, {preflight} = {}) {
         if (!model.get('newsletter_id')) {
             return;
         }
@@ -114,7 +118,7 @@ class PostEmailHandler {
         let email;
 
         if (!postEmail) {
-            email = await this.emailService.createEmail(model);
+            email = await this.emailService.createEmail(model, {preflight});
         } else if (postEmail.get('status') === 'failed') {
             email = await this.emailService.retryEmail(postEmail);
         }

--- a/ghost/core/core/server/services/posts/posts-service.js
+++ b/ghost/core/core/server/services/posts/posts-service.js
@@ -61,11 +61,11 @@ class PostsService {
      * @returns
      */
     async editPost(frame, options) {
-        await this.postEmailHandler.validateBeforeSave(frame);
+        const preflight = await this.postEmailHandler.validateBeforeSave(frame);
 
         const model = await this.models.Post.edit(frame.data.posts[0], frame.options);
 
-        await this.postEmailHandler.createOrRetryEmail(model);
+        await this.postEmailHandler.createOrRetryEmail(model, {preflight});
 
         const dto = model.toJSON(frame.options);
 

--- a/ghost/core/test/integration/services/email-service/recipient-count.test.js
+++ b/ghost/core/test/integration/services/email-service/recipient-count.test.js
@@ -1,0 +1,60 @@
+const sinon = require('sinon');
+
+const {agentProvider, fixtureManager, mockManager} = require('../../../utils/e2e-framework');
+const jobManager = require('../../../../core/server/services/jobs/job-service');
+const EmailSegmenter = require('../../../../core/server/services/email-service/email-segmenter');
+
+describe('Email recipient count', function () {
+    let agent;
+    let ghostServer;
+
+    beforeAll(async function () {
+        const agents = await agentProvider.getAgentsWithFrontend();
+        agent = agents.adminAgent;
+        ghostServer = agents.ghostServer;
+
+        await fixtureManager.init('newsletters', 'members:newsletters');
+        await agent.loginAsOwner();
+    });
+
+    beforeEach(function () {
+        mockManager.mockMail();
+        mockManager.mockStripe();
+        sinon.stub(jobManager, 'addJob');
+    });
+
+    afterEach(function () {
+        sinon.restore();
+        mockManager.restore();
+    });
+
+    afterAll(async function () {
+        mockManager.restore();
+        await ghostServer.stop();
+    });
+
+    it('counts recipients once when publishing a newsletter post', async function () {
+        const {body} = await agent.post('posts/')
+            .body({
+                posts: [{
+                    title: `Recipient count test ${Date.now()}`,
+                    status: 'draft'
+                }]
+            })
+            .expectStatus(201);
+        const post = body.posts[0];
+        const newsletterSlug = fixtureManager.get('newsletters', 0).slug;
+        const getMembersCount = sinon.spy(EmailSegmenter.prototype, 'getMembersCount');
+
+        await agent.put(`posts/${post.id}/?newsletter=${newsletterSlug}`)
+            .body({
+                posts: [{
+                    status: 'published',
+                    updated_at: post.updated_at
+                }]
+            })
+            .expectStatus(200);
+
+        sinon.assert.calledOnce(getMembersCount);
+    });
+});

--- a/ghost/core/test/unit/server/services/email-service/email-service.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-service.test.js
@@ -13,6 +13,7 @@ describe('Email Service', function () {
     let sendingService;
     let scheduleRecurringNewslettersJob;
     let domainWarmingService;
+    let getMembersCount;
 
     beforeEach(function () {
         memberCount = 123;
@@ -72,12 +73,11 @@ describe('Email Service', function () {
             isEnabled: sinon.stub().returns(false),
             getWarmupLimit: sinon.stub()
         };
+        getMembersCount = sinon.stub().callsFake(() => Promise.resolve(memberCount));
 
         service = new EmailService({
             emailSegmenter: {
-                getMembersCount: () => {
-                    return Promise.resolve(memberCount);
-                }
+                getMembersCount
             },
             limitService: {
                 isLimited: (type) => {
@@ -253,6 +253,20 @@ describe('Email Service', function () {
             });
             await assert.doesNotReject(service.checkCanSendEmail(newsletter, 'all'));
         });
+
+        it('Revalidates limits without recounting when an email count is supplied', async function () {
+            limited.emails = true;
+            const newsletter = createModel({
+                status: 'active'
+            });
+
+            await assert.rejects(
+                service.checkCanSendEmail(newsletter, 'all', {emailCount: 42}),
+                /Would go over limit/
+            );
+
+            sinon.assert.notCalled(getMembersCount);
+        });
     });
 
     describe('createEmail', function () {
@@ -294,6 +308,78 @@ describe('Email Service', function () {
             assert.equal(email.get('source'), post.get('mobiledoc'));
             assert.equal(email.get('source_type'), 'mobiledoc');
             sinon.assert.calledOnce(scheduleRecurringNewslettersJob);
+        });
+
+        it('Reuses the recipient count when preflight data matches the saved post', async function () {
+            const newsletter = createModel({
+                id: 'newsletter-123',
+                status: 'active',
+                feedback_enabled: true
+            });
+            const post = createModel({
+                id: 'post-123',
+                newsletter,
+                email_recipient_filter: 'status:paid',
+                mobiledoc: 'Mobiledoc'
+            });
+
+            const email = await service.createEmail(post, {
+                preflight: {
+                    newsletter,
+                    emailRecipientFilter: 'status:paid',
+                    emailCount: 42
+                }
+            });
+
+            sinon.assert.notCalled(getMembersCount);
+            assert.equal(email.get('email_count'), 42);
+        });
+
+        it('Recounts recipients when preflight data does not match the saved post', async function () {
+            const newsletter = createModel({
+                id: 'newsletter-123',
+                status: 'active',
+                feedback_enabled: true
+            });
+            const post = createModel({
+                id: 'post-123',
+                newsletter,
+                email_recipient_filter: 'status:paid',
+                mobiledoc: 'Mobiledoc'
+            });
+
+            const email = await service.createEmail(post, {
+                preflight: {
+                    newsletter,
+                    emailRecipientFilter: 'status:free',
+                    emailCount: 42
+                }
+            });
+
+            sinon.assert.calledOnceWithExactly(getMembersCount, newsletter, 'status:paid');
+            assert.equal(email.get('email_count'), memberCount);
+        });
+
+        it('Revalidates newsletter status without recounting when preflight data matches', async function () {
+            const newsletter = createModel({
+                id: 'newsletter-123',
+                status: 'archived'
+            });
+            const post = createModel({
+                id: 'post-123',
+                newsletter,
+                email_recipient_filter: 'all'
+            });
+
+            await assert.rejects(service.createEmail(post, {
+                preflight: {
+                    newsletter,
+                    emailRecipientFilter: 'all',
+                    emailCount: 42
+                }
+            }), /Cannot send email to archived newsletters/);
+
+            sinon.assert.notCalled(getMembersCount);
         });
 
         describe('Domain warming', function () {

--- a/ghost/core/test/unit/server/services/posts/post-email-handler.test.js
+++ b/ghost/core/test/unit/server/services/posts/post-email-handler.test.js
@@ -21,7 +21,7 @@ describe('PostEmailHandler', function () {
         };
 
         mockEmailService = {
-            checkCanSendEmail: sinon.stub().resolves(),
+            checkCanSendEmail: sinon.stub().resolves({emailCount: 42}),
             createEmail: sinon.stub(),
             retryEmail: sinon.stub()
         };
@@ -133,7 +133,7 @@ describe('PostEmailHandler', function () {
             setupExistingPost();
             const newsletter = setupNewsletter();
 
-            await postEmailHandler.validateBeforeSave(createFrame('published', {newsletter: 'default-newsletter'}));
+            const result = await postEmailHandler.validateBeforeSave(createFrame('published', {newsletter: 'default-newsletter'}));
 
             sinon.assert.calledOnceWithExactly(
                 mockModels.Post.findOne,
@@ -141,6 +141,11 @@ describe('PostEmailHandler', function () {
                 {columns: ['id', 'status', 'newsletter_id', 'email_recipient_filter']}
             );
             sinon.assert.calledOnceWithExactly(mockEmailService.checkCanSendEmail, newsletter, 'all');
+            assert.deepEqual(result, {
+                newsletter,
+                emailRecipientFilter: 'all',
+                emailCount: 42
+            });
         });
 
         it('validates when publishing post with existing newsletter_id', async function () {
@@ -382,11 +387,12 @@ describe('PostEmailHandler', function () {
         it('creates email when publishing fresh post', async function () {
             const model = createMockModel();
             const createdEmail = {id: 'email-123'};
+            const preflight = {emailCount: 42};
             mockEmailService.createEmail.resolves(createdEmail);
 
-            await postEmailHandler.createOrRetryEmail(model);
+            await postEmailHandler.createOrRetryEmail(model, {preflight});
 
-            sinon.assert.calledOnceWithExactly(mockEmailService.createEmail, model);
+            sinon.assert.calledOnceWithExactly(mockEmailService.createEmail, model, {preflight});
             sinon.assert.notCalled(mockEmailService.retryEmail);
             sinon.assert.calledOnceWithExactly(model.set, 'email', createdEmail);
         });
@@ -422,7 +428,7 @@ describe('PostEmailHandler', function () {
 
             await postEmailHandler.createOrRetryEmail(model);
 
-            sinon.assert.calledOnceWithExactly(mockEmailService.createEmail, model);
+            sinon.assert.calledOnceWithExactly(mockEmailService.createEmail, model, {preflight: undefined});
             sinon.assert.calledOnceWithExactly(model.set, 'email', createdEmail);
         });
 
@@ -432,7 +438,7 @@ describe('PostEmailHandler', function () {
 
             await postEmailHandler.createOrRetryEmail(model);
 
-            sinon.assert.calledOnceWithExactly(mockEmailService.createEmail, model);
+            sinon.assert.calledOnceWithExactly(mockEmailService.createEmail, model, {preflight: undefined});
             sinon.assert.notCalled(model.set);
         });
     });

--- a/ghost/core/test/unit/server/services/posts/posts-service.test.js
+++ b/ghost/core/test/unit/server/services/posts/posts-service.test.js
@@ -344,7 +344,9 @@ describe('Posts Service', function () {
             const model = {
                 toJSON: sinon.stub().returns({id: 'post-123'})
             };
+            const preflight = {emailCount: 42};
             mockModels.Post.edit.resolves(model);
+            postEmailHandlerStub.validateBeforeSave.resolves(preflight);
 
             const frame = {
                 data: {posts: [{status: 'published'}]},
@@ -353,7 +355,7 @@ describe('Posts Service', function () {
 
             await postsService.editPost(frame);
 
-            sinon.assert.calledOnceWithExactly(postEmailHandlerStub.createOrRetryEmail, model);
+            sinon.assert.calledOnceWithExactly(postEmailHandlerStub.createOrRetryEmail, model, {preflight});
         });
 
         it('returns post JSON and calls eventHandler', async function () {


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/NY-1499

Publishing a newsletter counted recipients during preflight and repeated the same expensive count while creating the email record.

The preflight count is now reused when the saved newsletter and recipient filter still match. Newsletter status and sending limits are revalidated, while mismatches fall back to recounting.

Local MySQL benchmarks reduced median publish time from 494ms to 260ms with 100k recipients and from 8.41s to 4.21s with 1m recipients, an improvement of about 50%.
