### PR TITLE
Populated `track_clicks` when sending an automated email

### DIFF
--- a/ghost/core/core/server/services/automations/automations-repository.ts
+++ b/ghost/core/core/server/services/automations/automations-repository.ts
@@ -88,6 +88,7 @@ export type RecordEmailSentOptions = Readonly<{
     memberId: string;
     memberName: string | null;
     memberUuid: string;
+    trackClicks: boolean;
     trackOpens: boolean;
 }>;
 

--- a/ghost/core/core/server/services/automations/database-automations-repository.ts
+++ b/ghost/core/core/server/services/automations/database-automations-repository.ts
@@ -241,9 +241,8 @@ export function createDatabaseAutomationsRepository({
                     member_name: options.memberName,
                     automation_action_revision_id: options.automationActionRevisionId,
                     ...(options.mailgunMessageId ? {mailgun_message_id: options.mailgunMessageId} : {}),
+                    track_clicks: options.trackClicks,
                     track_opens: options.trackOpens,
-                    // TODO(NY-1491) Snapshot the email_track_clicks setting when creating recipients.
-                    track_clicks: false,
                     created_at: now,
                     updated_at: now
                 });

--- a/ghost/core/core/server/services/automations/poll.ts
+++ b/ghost/core/core/server/services/automations/poll.ts
@@ -183,6 +183,7 @@ const processStep = async ({
                 break;
             }
             memberWelcomeEmailService.init();
+            const trackClicks = Boolean(settingsCache.get('email_track_clicks'));
             const trackOpens = Boolean(settingsCache.get('email_track_opens'));
             const sendResult = await memberWelcomeEmailService.api.sendAutomationEmail({
                 email: {
@@ -209,6 +210,7 @@ const processStep = async ({
                     memberId: step.member_id,
                     memberName: member.get('name'),
                     memberUuid: member.get('uuid'),
+                    trackClicks,
                     trackOpens: trackOpensForRecipient
                 });
             } catch (err) {

--- a/ghost/core/test/integration/services/email-analytics/automation-email-analytics.test.js
+++ b/ghost/core/test/integration/services/email-analytics/automation-email-analytics.test.js
@@ -133,7 +133,7 @@ describe('Automation email analytics', function () {
         });
     }
 
-    async function recordEmailSent({revision, mailgunMessageId, trackOpens = true}) {
+    async function recordEmailSent({revision, mailgunMessageId, trackClicks = true, trackOpens = true}) {
         const member = await createMember();
         await automationsApi.recordEmailSent({
             automationActionRevisionId: revision.id,
@@ -142,6 +142,7 @@ describe('Automation email analytics', function () {
             memberId: member.id,
             memberName: member.name,
             memberUuid: member.uuid,
+            trackClicks,
             trackOpens
         });
         return await testUtils.knex('automated_email_recipients')

--- a/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
+++ b/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
@@ -1867,6 +1867,7 @@ describe('automations repository', function () {
                 memberId: 'member-id',
                 memberName: 'Test Member',
                 memberUuid: '00000000-0000-4000-8000-000000000001',
+                trackClicks: true,
                 trackOpens: true
             });
 
@@ -1882,8 +1883,8 @@ describe('automations repository', function () {
                 delivered_at: null,
                 opened_at: null,
                 clicked_at: null,
+                track_clicks: 1,
                 track_opens: 1,
-                track_clicks: 0,
                 created_at: recipient.created_at,
                 updated_at: recipient.updated_at
             });
@@ -1908,14 +1909,15 @@ describe('automations repository', function () {
                 memberId: 'member-id',
                 memberName: null,
                 memberUuid: '00000000-0000-4000-8000-000000000001',
+                trackClicks: false,
                 trackOpens: false
             });
 
             const recipient = await knex('automated_email_recipients').first();
             assert.equal(recipient.mailgun_message_id, null);
             assert.equal(recipient.member_name, null);
-            assert.equal(recipient.track_opens, 0);
             assert.equal(recipient.track_clicks, 0);
+            assert.equal(recipient.track_opens, 0);
         });
     });
 

--- a/ghost/core/test/unit/server/services/automations/poll.test.ts
+++ b/ghost/core/test/unit/server/services/automations/poll.test.ts
@@ -154,6 +154,7 @@ describe('automations poll', function () {
         };
 
         settingsCacheGet = sinon.stub(settingsCache, 'get');
+        settingsCacheGet.withArgs('email_track_clicks').returns(false);
         settingsCacheGet.withArgs('email_track_opens').returns(false);
         sinon.stub(Member, 'findOne').resolves(buildMember());
     });
@@ -368,6 +369,7 @@ describe('automations poll', function () {
             memberId: 'member-id',
             memberName: 'Test Member',
             memberUuid: '00000000-0000-4000-8000-000000000001',
+            trackClicks: false,
             trackOpens: false
         });
         sinon.assert.callOrder(
@@ -423,6 +425,30 @@ describe('automations poll', function () {
         sinon.assert.notCalled(scheduleAutomationEmailAnalyticsJob);
     });
 
+    it('snapshots enabled click tracking on the recipient', async function () {
+        const step = buildEmailStep();
+        automationsApi.fetchAndLockSteps.resolves({steps: [step], nextStepReadyAt: null});
+        settingsCacheGet.withArgs('email_track_clicks').returns(true);
+
+        await poll(options);
+
+        sinon.assert.calledOnceWithExactly(automationsApi.recordEmailSent, sinon.match({
+            trackClicks: true
+        }));
+    });
+
+    it('snapshots disabled click tracking on the recipient', async function () {
+        const step = buildEmailStep();
+        automationsApi.fetchAndLockSteps.resolves({steps: [step], nextStepReadyAt: null});
+        settingsCacheGet.withArgs('email_track_clicks').returns(false);
+
+        await poll(options);
+
+        sinon.assert.calledOnceWithExactly(automationsApi.recordEmailSent, sinon.match({
+            trackClicks: false
+        }));
+    });
+
     it('records the automated email recipient without a Mailgun message ID after an SMTP send', async function () {
         const step = buildEmailStep({
             automation_action_revision_id: 'revision-id'
@@ -445,6 +471,7 @@ describe('automations poll', function () {
             memberId: 'member-id',
             memberName: 'Test Member',
             memberUuid: '00000000-0000-4000-8000-000000000001',
+            trackClicks: false,
             trackOpens: false
         });
         sinon.assert.callOrder(


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1491/populate-track-clicks-when-sending-automation-emails

## Summary

- snapshot the `email_track_clicks` setting when sending automation emails and persist it on the `automated_email_recipients` row
- same idea as `track_opens`