### PR TITLE
Fix toggle card screen reader accessibility

### DIFF
--- a/ghost/core/core/frontend/src/cards/js/toggle.js
+++ b/ghost/core/core/frontend/src/cards/js/toggle.js
@@ -1,18 +1,62 @@
 (function() {
-    const toggleHeadingElements = document.getElementsByClassName("kg-toggle-heading");
+    const toggleCardElements = document.getElementsByClassName("kg-toggle-card");
+
+    const getToggleControl = function(headingElement) {
+        if (headingElement.tagName === 'BUTTON') {
+            return headingElement;
+        }
+
+        return headingElement.querySelector('button');
+    };
+
+    const setToggleState = function(parentElement, isOpen) {
+        const headingElement = parentElement.querySelector('.kg-toggle-heading');
+        const toggleElement = headingElement && getToggleControl(headingElement);
+        const headingTextElement = headingElement && headingElement.querySelector('.kg-toggle-heading-text');
+        const contentElement = parentElement.querySelector('.kg-toggle-content');
+
+        parentElement.setAttribute('data-kg-toggle-state', isOpen ? 'open' : 'close');
+
+        if (toggleElement) {
+            if (!toggleElement.getAttribute('aria-label') && !toggleElement.getAttribute('aria-labelledby') && headingTextElement) {
+                toggleElement.setAttribute('aria-label', headingTextElement.textContent.trim());
+            }
+
+            toggleElement.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        }
+
+        if (contentElement) {
+            contentElement.hidden = !isOpen;
+            contentElement.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
+        }
+    };
 
     const toggleFn = function(event) {
         const targetElement = event.target;
         const parentElement = targetElement.closest('.kg-toggle-card');
-        var toggleState = parentElement.getAttribute("data-kg-toggle-state");
-        if (toggleState === 'close') {
-            parentElement.setAttribute('data-kg-toggle-state', 'open');
-        } else {
-            parentElement.setAttribute('data-kg-toggle-state', 'close');
+        const headingElement = parentElement.querySelector('.kg-toggle-heading');
+        const toggleElement = headingElement && getToggleControl(headingElement);
+        const interactiveElement = targetElement.closest('a, button, input, select, textarea, label, summary, [role="button"], [role="link"]');
+
+        if (interactiveElement && (!toggleElement || (interactiveElement !== toggleElement && !toggleElement.contains(interactiveElement)))) {
+            return;
         }
+
+        const isOpening = parentElement.getAttribute("data-kg-toggle-state") === 'close';
+
+        setToggleState(parentElement, isOpening);
     };
 
-    for (let i = 0; i < toggleHeadingElements.length; i++) {
-        toggleHeadingElements[i].addEventListener('click', toggleFn, false);
+    for (let i = 0; i < toggleCardElements.length; i++) {
+        const toggleCardElement = toggleCardElements[i];
+        const toggleHeadingElement = toggleCardElement.querySelector('.kg-toggle-heading');
+        const toggleState = toggleCardElement.getAttribute("data-kg-toggle-state");
+
+        if (!toggleHeadingElement) {
+            continue;
+        }
+
+        setToggleState(toggleCardElement, toggleState !== 'close');
+        toggleHeadingElement.addEventListener('click', toggleFn, false);
     }
 })();

--- a/ghost/core/test/unit/frontend/src/cards-toggle.test.js
+++ b/ghost/core/test/unit/frontend/src/cards-toggle.test.js
@@ -1,0 +1,157 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const {createBrowserEnvironment, loadScript} = require('../../../utils/browser-test-utils');
+
+describe('Toggle card script', function () {
+    let env;
+
+    afterEach(function () {
+        env?.dom.window.close();
+    });
+
+    function loadToggleScript(html) {
+        env = createBrowserEnvironment({
+            html
+        });
+
+        const scriptPath = path.join(__dirname, '../../../../core/frontend/src/cards/js/toggle.js');
+        loadScript(env, fs.readFileSync(scriptPath, 'utf8'));
+    }
+
+    function assertToggleState({toggleCard, toggleControl, toggleContent, state}) {
+        const isOpen = state === 'open';
+
+        assert.equal(toggleCard.getAttribute('data-kg-toggle-state'), state);
+        assert.equal(toggleControl.getAttribute('aria-expanded'), isOpen ? 'true' : 'false');
+        assert.equal(toggleContent.getAttribute('aria-hidden'), isOpen ? 'false' : 'true');
+        assert.equal(toggleContent.hidden, !isOpen);
+    }
+
+    it('keeps disclosure state and hidden content in sync when toggling current markup', function () {
+        loadToggleScript(`
+            <!DOCTYPE html>
+            <html>
+                <body>
+                    <div class="kg-card kg-toggle-card" data-kg-toggle-state="close">
+                        <div class="kg-toggle-heading">
+                            <h4 class="kg-toggle-heading-text">Spoilers below</h4>
+                            <button class="kg-toggle-card-icon" type="button" aria-expanded="false"></button>
+                        </div>
+                        <div class="kg-toggle-content" aria-hidden="true" hidden>Hidden spoiler content</div>
+                    </div>
+                </body>
+            </html>
+        `);
+
+        const toggleCard = env.document.querySelector('.kg-toggle-card');
+        const toggleHeading = env.document.querySelector('.kg-toggle-heading');
+        const toggleControl = env.document.querySelector('.kg-toggle-card-icon');
+        const toggleContent = env.document.querySelector('.kg-toggle-content');
+
+        assertToggleState({
+            toggleCard,
+            toggleControl,
+            toggleContent,
+            state: 'close'
+        });
+        assert.equal(toggleControl.getAttribute('aria-label'), 'Spoilers below');
+
+        toggleHeading.click();
+
+        assertToggleState({
+            toggleCard,
+            toggleControl,
+            toggleContent,
+            state: 'open'
+        });
+
+        toggleHeading.click();
+
+        assertToggleState({
+            toggleCard,
+            toggleControl,
+            toggleContent,
+            state: 'close'
+        });
+    });
+
+    it('adds disclosure state and hides content when toggling old stored markup', function () {
+        loadToggleScript(`
+            <!DOCTYPE html>
+            <html>
+                <body>
+                    <div class="kg-card kg-toggle-card" data-kg-toggle-state="close">
+                        <div class="kg-toggle-heading">
+                            <h4 class="kg-toggle-heading-text">Spoilers below</h4>
+                            <button class="kg-toggle-card-icon"></button>
+                        </div>
+                        <div class="kg-toggle-content">Hidden spoiler content</div>
+                    </div>
+                </body>
+            </html>
+        `);
+
+        const toggleCard = env.document.querySelector('.kg-toggle-card');
+        const toggleHeading = env.document.querySelector('.kg-toggle-heading');
+        const toggleControl = env.document.querySelector('.kg-toggle-card-icon');
+        const toggleContent = env.document.querySelector('.kg-toggle-content');
+
+        assertToggleState({
+            toggleCard,
+            toggleControl,
+            toggleContent,
+            state: 'close'
+        });
+        assert.equal(toggleControl.getAttribute('aria-label'), 'Spoilers below');
+
+        toggleHeading.click();
+
+        assertToggleState({
+            toggleCard,
+            toggleControl,
+            toggleContent,
+            state: 'open'
+        });
+
+        toggleHeading.click();
+
+        assertToggleState({
+            toggleCard,
+            toggleControl,
+            toggleContent,
+            state: 'close'
+        });
+    });
+
+    it('does not toggle when clicking an interactive heading link', function () {
+        loadToggleScript(`
+            <!DOCTYPE html>
+            <html>
+                <body>
+                    <div class="kg-card kg-toggle-card" data-kg-toggle-state="close">
+                        <div class="kg-toggle-heading">
+                            <h4 class="kg-toggle-heading-text"><a href="https://example.com">Linked heading</a></h4>
+                            <button class="kg-toggle-card-icon" type="button" aria-expanded="false"></button>
+                        </div>
+                        <div class="kg-toggle-content" aria-hidden="true" hidden>Hidden spoiler content</div>
+                    </div>
+                </body>
+            </html>
+        `);
+
+        const toggleCard = env.document.querySelector('.kg-toggle-card');
+        const toggleControl = env.document.querySelector('.kg-toggle-card-icon');
+        const toggleContent = env.document.querySelector('.kg-toggle-content');
+        const headingLink = env.document.querySelector('.kg-toggle-heading-text a');
+
+        headingLink.click();
+
+        assertToggleState({
+            toggleCard,
+            toggleControl,
+            toggleContent,
+            state: 'close'
+        });
+    });
+});

--- a/ghost/core/test/unit/frontend/src/cards-toggle.test.js
+++ b/ghost/core/test/unit/frontend/src/cards-toggle.test.js
@@ -93,7 +93,6 @@ describe('Toggle card script', function () {
         `);
 
         const toggleCard = env.document.querySelector('.kg-toggle-card');
-        const toggleHeading = env.document.querySelector('.kg-toggle-heading');
         const toggleControl = env.document.querySelector('.kg-toggle-card-icon');
         const toggleContent = env.document.querySelector('.kg-toggle-content');
 
@@ -105,7 +104,7 @@ describe('Toggle card script', function () {
         });
         assert.equal(toggleControl.getAttribute('aria-label'), 'Spoilers below');
 
-        toggleHeading.click();
+        toggleControl.click();
 
         assertToggleState({
             toggleCard,
@@ -114,7 +113,7 @@ describe('Toggle card script', function () {
             state: 'open'
         });
 
-        toggleHeading.click();
+        toggleControl.click();
 
         assertToggleState({
             toggleCard,

--- a/koenig/kg-default-cards/src/cards/toggle.ts
+++ b/koenig/kg-default-cards/src/cards/toggle.ts
@@ -19,11 +19,11 @@ const toggleCard: Card = {
             <div class="kg-card kg-toggle-card" data-kg-toggle-state="close">
                 <div class="kg-toggle-heading">
                     <h4 class="kg-toggle-heading-text">{{{heading}}}</h4>
-                    <button class="kg-toggle-card-icon">
+                    <button class="kg-toggle-card-icon" type="button" aria-expanded="false">
                         <svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"/></svg>
                     </button>
                 </div>
-                <div class="kg-toggle-content">{{{content}}}</div>
+                <div class="kg-toggle-content" aria-hidden="true" hidden>{{{content}}}</div>
             </div>
         `;
 

--- a/koenig/kg-default-cards/test/cards/toggle.test.ts
+++ b/koenig/kg-default-cards/test/cards/toggle.test.ts
@@ -1,6 +1,27 @@
 import card from '../../src/cards/toggle.js';
 import {Document as SimpleDomDocument, HTMLSerializer, voidMap} from 'simple-dom';
+import {JSDOM} from 'jsdom';
 const serializer = new HTMLSerializer(voidMap);
+
+function assertCollapsedToggleIsAccessible(renderedHtml: string) {
+    const {document} = new JSDOM(renderedHtml).window;
+    const toggle = document.querySelector('.kg-toggle-card');
+    const details = toggle?.matches('details') ? toggle : toggle?.querySelector('details');
+
+    if (details) {
+        expect(details.hasAttribute('open')).toBe(false);
+        expect(details.querySelector('summary')).not.toBeNull();
+        return;
+    }
+
+    const button = toggle?.querySelector('button');
+    const content = toggle?.querySelector('.kg-toggle-content');
+
+    expect(button?.getAttribute('aria-expanded')).toBe('false');
+    expect(
+        content?.hasAttribute('hidden') || content?.getAttribute('aria-hidden') === 'true'
+    ).toBe(true);
+}
 
 describe('Toggle card', function () {
     describe('front-end render', function () {
@@ -13,7 +34,35 @@ describe('Toggle card', function () {
                 }
             };
 
-            expect(serializer.serialize(card.render(opts))).toBe('<div class="kg-card kg-toggle-card" data-kg-toggle-state="close"><div class="kg-toggle-heading"><h4 class="kg-toggle-heading-text">This is toggle heading</h4><button class="kg-toggle-card-icon"><svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"/></svg></button></div><div class="kg-toggle-content">This is toggle content</div></div>');
+            expect(serializer.serialize(card.render(opts))).toBe('<div class="kg-card kg-toggle-card" data-kg-toggle-state="close"><div class="kg-toggle-heading"><h4 class="kg-toggle-heading-text">This is toggle heading</h4><button class="kg-toggle-card-icon" type="button" aria-expanded="false"><svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"/></svg></button></div><div class="kg-toggle-content" aria-hidden="true" hidden>This is toggle content</div></div>');
+        });
+
+        it('renders a collapsed toggle that exposes state and hides content from assistive technology', function () {
+            const opts = {
+                env: {dom: new SimpleDomDocument()},
+                payload: {
+                    heading: 'Spoilers below',
+                    content: 'Hidden spoiler content'
+                }
+            };
+
+            assertCollapsedToggleIsAccessible(serializer.serialize(card.render(opts)));
+        });
+
+        it('keeps heading links outside the toggle button', function () {
+            const opts = {
+                env: {dom: new SimpleDomDocument()},
+                payload: {
+                    heading: '<a href="https://example.com">Linked heading</a>',
+                    content: 'Hidden spoiler content'
+                }
+            };
+
+            const renderedHtml = serializer.serialize(card.render(opts));
+            const {document} = new JSDOM(renderedHtml).window;
+
+            expect(document.querySelector('.kg-toggle-heading-text a')?.textContent).toBe('Linked heading');
+            expect(!!document.querySelector('button .kg-toggle-heading-text a')).toBe(false);
         });
     });
 

--- a/koenig/kg-default-nodes/src/nodes/toggle/toggle-renderer.ts
+++ b/koenig/kg-default-nodes/src/nodes/toggle/toggle-renderer.ts
@@ -16,13 +16,13 @@ function cardTemplate({node}: {node: ToggleNodeData}) {
         <div class="kg-card kg-toggle-card" data-kg-toggle-state="close">
             <div class="kg-toggle-heading">
                 <h4 class="kg-toggle-heading-text">${node.heading}</h4>
-                <button class="kg-toggle-card-icon" aria-label="Expand toggle to read content">
+                <button class="kg-toggle-card-icon" type="button" aria-expanded="false">
                     <svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                         <path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"></path>
                     </svg>
                 </button>
             </div>
-            <div class="kg-toggle-content">${node.content}</div>
+            <div class="kg-toggle-content" aria-hidden="true" hidden>${node.content}</div>
         </div>
         `
     );

--- a/koenig/kg-default-nodes/test/nodes/toggle.test.ts
+++ b/koenig/kg-default-nodes/test/nodes/toggle.test.ts
@@ -174,15 +174,28 @@ describe('ToggleNode', function () {
             <div class="kg-card kg-toggle-card" data-kg-toggle-state="close">
                 <div class="kg-toggle-heading">
                     <h4 class="kg-toggle-heading-text">Heading</h4>
-                    <button class="kg-toggle-card-icon" aria-label="Expand toggle to read content">
+                    <button class="kg-toggle-card-icon" type="button" aria-expanded="false">
                         <svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                             <path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"></path>
                         </svg>
                     </button>
                 </div>
-                <div class="kg-toggle-content">Content</div>
+                <div class="kg-toggle-content" aria-hidden="true" hidden="">Content</div>
             </div>
             `);
+        }));
+
+        it('keeps heading links outside the toggle button', editorTest(function () {
+            const payload = {
+                heading: '<a href="https://example.com">Linked heading</a>',
+                content: 'Content'
+            };
+            const toggleNode = $createToggleNode(payload);
+            const result = toggleNode.exportDOM(editor, exportOptions);
+            const element = result.element as HTMLElement;
+
+            expect(element.querySelector('.kg-toggle-heading-text a')?.textContent).toBe('Linked heading');
+            expect(!!element.querySelector('button .kg-toggle-heading-text a')).toBe(false);
         }));
 
         it('renders for email target', editorTest(function () {

--- a/koenig/kg-default-nodes/test/renderers/toggle-renderer.test.ts
+++ b/koenig/kg-default-nodes/test/renderers/toggle-renderer.test.ts
@@ -1,5 +1,27 @@
 import assert from 'node:assert/strict';
+import {JSDOM} from 'jsdom';
 import {assertPrettifiesTo, callRenderer, html} from '../test-utils/index.js';
+
+function assertCollapsedToggleIsAccessible(renderedHtml: string) {
+    const {document} = new JSDOM(renderedHtml).window;
+    const toggle = document.querySelector('.kg-toggle-card');
+    const details = toggle?.matches('details') ? toggle : toggle?.querySelector('details');
+
+    if (details) {
+        assert.equal(details.hasAttribute('open'), false);
+        assert.ok(details.querySelector('summary'));
+        return;
+    }
+
+    const button = toggle?.querySelector('button');
+    const content = toggle?.querySelector('.kg-toggle-content');
+
+    assert.equal(button?.getAttribute('aria-expanded'), 'false');
+    assert.equal(
+        content?.hasAttribute('hidden') || content?.getAttribute('aria-hidden') === 'true',
+        true
+    );
+}
 
 describe('renderers/toggle-renderer', function () {
     function getTestData(overrides = {}) {
@@ -28,9 +50,7 @@ describe('renderers/toggle-renderer', function () {
                 <div class="kg-card kg-toggle-card" data-kg-toggle-state="close">
                     <div class="kg-toggle-heading">
                         <h4 class="kg-toggle-heading-text">Toggle Heading</h4>
-                        <button
-                            class="kg-toggle-card-icon"
-                            aria-label="Expand toggle to read content">
+                        <button class="kg-toggle-card-icon" type="button" aria-expanded="false">
                             <svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                                 <path
                                     class="cls-1"
@@ -38,9 +58,19 @@ describe('renderers/toggle-renderer', function () {
                             </svg>
                         </button>
                     </div>
-                    <div class="kg-toggle-content">Collapsible content</div>
+                    <div class="kg-toggle-content" aria-hidden="true" hidden="">Collapsible content</div>
                 </div>
             `);
+        });
+
+        it('renders a collapsed toggle that exposes state and hides content from assistive technology', function () {
+            const result = renderForWeb({
+                heading: 'Spoilers below',
+                content: 'Hidden spoiler content'
+            });
+
+            assert.ok(result.html);
+            assertCollapsedToggleIsAccessible(result.html);
         });
     });
 


### PR DESCRIPTION
## Why I am making it

Fixes #27462.

Toggle cards are visually collapsed, but the current markup and frontend behavior can still expose collapsed content to screen readers. VoiceOver can also reach the toggle control as an unlabeled button separate from the visible heading text.

## What it does

This keeps the existing toggle card markup shape, but makes the existing icon button work as an accessible disclosure control:

- the generated toggle button now has `type="button"` and an initial `aria-expanded="false"`
- the frontend script copies the visible heading text onto the button's accessible name
- the script keeps `aria-expanded` in sync when toggling
- collapsed content is hidden with `hidden` and `aria-hidden`
- the heading row remains clickable, but clicks on interactive heading content such as links are left alone

Existing posts do not need to be re-saved or migrated. Saved and newly rendered toggle cards keep the same markup structure; the frontend script applies the accessible name, disclosure state, and hidden-content behavior at runtime.

Implementation note: this intentionally keeps the visible heading outside the button. A previous version made the whole heading a native button, but toggle headings can contain rich inline HTML such as links. Keeping the existing heading-plus-icon-button structure preserves that content and avoids nesting interactive links inside a button.

## Demo (turn audio on)

https://github.com/user-attachments/assets/447d498a-e576-48a2-bcff-6c2d13e78266

The demo shows VoiceOver navigating the post end to end. The toggle heading is announced as a heading, the icon button is announced as "My collapsible header, collapsed, button", activating it changes the state to "expanded", and the collapsed content is only reached after expansion.

Notes:

- audio starts around 0:50
- I am not familiar with VoiceOver, so there are a few back-and-forth navigation steps before finding the right place

## Testing

- `rtk /bin/zsh -lc 'cd /Users/pedroalmeida/Documents/GitHub/open-source/Ghost/Ghost && PATH=/Users/pedroalmeida/.nvm/versions/node/v22.18.0/bin:$PATH pnpm --dir ghost/core test:single test/unit/frontend/src/cards-toggle.test.js'`
- `rtk /bin/zsh -lc 'cd /Users/pedroalmeida/Documents/GitHub/open-source/Ghost/Ghost && PATH=/Users/pedroalmeida/.nvm/versions/node/v22.18.0/bin:$PATH pnpm --dir koenig/kg-default-nodes exec vitest run test/nodes/toggle.test.ts test/renderers/toggle-renderer.test.ts'`
- `rtk /bin/zsh -lc 'cd /Users/pedroalmeida/Documents/GitHub/open-source/Ghost/Ghost && PATH=/Users/pedroalmeida/.nvm/versions/node/v22.18.0/bin:$PATH pnpm --dir koenig/kg-default-cards exec vitest run test/cards/toggle.test.ts'`
- `rtk /bin/zsh -lc 'cd /Users/pedroalmeida/Documents/GitHub/open-source/Ghost/Ghost && PATH=/Users/pedroalmeida/.nvm/versions/node/v22.18.0/bin:$PATH pnpm --dir koenig/kg-default-nodes test:types'`
- `rtk /bin/zsh -lc 'cd /Users/pedroalmeida/Documents/GitHub/open-source/Ghost/Ghost && PATH=/Users/pedroalmeida/.nvm/versions/node/v22.18.0/bin:$PATH pnpm --dir koenig/kg-default-cards test:types'`

## Checklist

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works
