### PR TITLE
Removed unused base adapter shims

### DIFF
--- a/ghost/core/core/server/adapters/scheduling/scheduling-base.js
+++ b/ghost/core/core/server/adapters/scheduling/scheduling-base.js
@@ -1,5 +1,0 @@
-const {SchedulingBase} = require('@tryghost/adapter-base-scheduling');
-
-// NOTE: this is a temporary shim to ensure that Moya requires continue to work
-// until @tryghost/adapter-base-scheduling is published to NPM and Moya depends on it directly
-module.exports = SchedulingBase;

--- a/ghost/core/core/server/adapters/sso/SSOBase.js
+++ b/ghost/core/core/server/adapters/sso/SSOBase.js
@@ -1,5 +1,0 @@
-const {SSOBase} = require('@tryghost/adapter-base-sso');
-
-// NOTE: this is a temporary shim to ensure that Moya requires continue to work
-// until @tryghost/adapter-base-sso is published to NPM and Moya depends on it directly.
-module.exports = SSOBase;


### PR DESCRIPTION
no ref
- now that Moya has no more core requires, these shims are unused and can be cleaned up