### PR TITLE
Added automation redirect target uniqueness

### DIFF
--- a/apps/ember-admin/package.json
+++ b/apps/ember-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost-admin",
-  "version": "6.54.0-rc.0",
+  "version": "6.55.0-rc.0",
   "description": "Ember.js admin client for Ghost",
   "author": "Ghost Foundation",
   "homepage": "http://ghost.org",

--- a/ghost/core/core/server/data/migrations/versions/6.55/2026-07-23-18-48-54-add-generated-to-hash-to-redirects.js
+++ b/ghost/core/core/server/data/migrations/versions/6.55/2026-07-23-18-48-54-add-generated-to-hash-to-redirects.js
@@ -1,0 +1,33 @@
+const DatabaseInfo = require('@tryghost/database-info');
+const {combineNonTransactionalMigrations, createAddColumnMigration, createNonTransactionalMigration} = require('../../utils');
+const {addIndex, addUnique, dropUnique} = require('../../../schema/commands');
+
+const uniqueColumns = ['automation_action_revision_id', 'to_hash'];
+const columnDefinition = {
+    type: 'string',
+    maxlength: 32,
+    nullable: true,
+    generated: {
+        dialect: 'mysql',
+        expression: 'MD5(`to`)',
+        storage: 'virtual'
+    }
+};
+
+module.exports = combineNonTransactionalMigrations(
+    createAddColumnMigration('redirects', 'to_hash', columnDefinition, {algorithm: 'auto'}),
+    createNonTransactionalMigration(
+        async function up(knex) {
+            await addUnique('redirects', uniqueColumns, knex);
+        },
+        async function down(knex) {
+            // InnoDB removes its automatic single-column foreign-key index when
+            // the composite index replaces it, so restore one before dropping
+            // the composite index.
+            if (DatabaseInfo.isMySQL(knex)) {
+                await addIndex('redirects', ['automation_action_revision_id'], knex);
+            }
+            await dropUnique('redirects', uniqueColumns, knex);
+        }
+    )
+);

--- a/ghost/core/core/server/data/schema/commands.js
+++ b/ghost/core/core/server/data/schema/commands.js
@@ -18,12 +18,21 @@ const messages = {
  * @param {import('knex').knex.TableBuilder} tableBuilder
  * @param {string} columnName
  * @param {object} [columnSpec]
+ * @param {import('knex').Knex} [transaction]
  */
-function addTableColumn(tableName, tableBuilder, columnName, columnSpec = schema[tableName][columnName]) {
+function addTableColumn(tableName, tableBuilder, columnName, columnSpec = schema[tableName][columnName], transaction = db.knex) {
     let column;
+    const isMySQLGeneratedColumn = columnSpec.generated?.dialect === 'mysql' && DatabaseInfo.isMySQL(transaction);
 
     // creation distinguishes between text with fieldtype, string with maxlength and all others
-    if (columnSpec.type === 'text' && Object.prototype.hasOwnProperty.call(columnSpec, 'fieldtype')) {
+    if (isMySQLGeneratedColumn) {
+        const maxlength = columnSpec.maxlength || 191;
+        const storage = columnSpec.generated.storage.toUpperCase();
+        column = tableBuilder.specificType(
+            columnName,
+            `varchar(${maxlength}) GENERATED ALWAYS AS (${columnSpec.generated.expression}) ${storage}`
+        );
+    } else if (columnSpec.type === 'text' && Object.prototype.hasOwnProperty.call(columnSpec, 'fieldtype')) {
         column = tableBuilder[columnSpec.type](columnName, columnSpec.fieldtype);
     } else if (columnSpec.type === 'string') {
         if (Object.prototype.hasOwnProperty.call(columnSpec, 'maxlength')) {
@@ -35,10 +44,12 @@ function addTableColumn(tableName, tableBuilder, columnName, columnSpec = schema
         column = tableBuilder[columnSpec.type](columnName);
     }
 
-    if (Object.prototype.hasOwnProperty.call(columnSpec, 'nullable') && columnSpec.nullable === true) {
-        column.nullable();
-    } else {
-        column.nullable(false);
+    if (!isMySQLGeneratedColumn) {
+        if (Object.prototype.hasOwnProperty.call(columnSpec, 'nullable') && columnSpec.nullable === true) {
+            column.nullable();
+        } else {
+            column.nullable(false);
+        }
     }
     if (Object.prototype.hasOwnProperty.call(columnSpec, 'primary') && columnSpec.primary === true) {
         column.primary();
@@ -104,7 +115,7 @@ function dropNullable(tableName, column, transaction = db.knex) {
  */
 async function addColumn(tableName, column, transaction = db.knex, columnSpec, options = {}) {
     const addColumnBuilder = transaction.schema.table(tableName, function (table) {
-        addTableColumn(tableName, table, column, columnSpec);
+        addTableColumn(tableName, table, column, columnSpec, transaction);
     });
 
     // Use the default flow for SQLite because .toSQL() is tricky with SQLite when
@@ -517,7 +528,7 @@ function createTable(table, transaction = db.knex, tableSpec = schema[table]) {
     return transaction.schema.createTable(table, function (t) {
         Object.keys(tableSpec)
             .filter(column => !(column.startsWith('@@')))
-            .forEach(column => addTableColumn(table, t, column, tableSpec[column]));
+            .forEach(column => addTableColumn(table, t, column, tableSpec[column], transaction));
 
         if (tableSpec['@@INDEXES@@']) {
             tableSpec['@@INDEXES@@'].forEach((index) => {

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1263,8 +1263,21 @@ module.exports = {
         to: {type: 'string', maxlength: 2000, nullable: false},
         post_id: {type: 'string', maxlength: 24, nullable: true, unique: false, references: 'posts.id', setNullDelete: true},
         automation_action_revision_id: {type: 'string', maxlength: 24, nullable: true, references: 'automation_action_revisions.id', setNullDelete: true},
+        to_hash: {
+            type: 'string',
+            maxlength: 32,
+            nullable: true,
+            generated: {
+                dialect: 'mysql',
+                expression: 'MD5(`to`)',
+                storage: 'virtual'
+            }
+        },
         created_at: {type: 'dateTime', nullable: false},
-        updated_at: {type: 'dateTime', nullable: true}
+        updated_at: {type: 'dateTime', nullable: true},
+        '@@UNIQUE_CONSTRAINTS@@': [
+            ['automation_action_revision_id', 'to_hash']
+        ]
     },
     members_click_events: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost",
-  "version": "6.54.0-rc.0",
+  "version": "6.55.0-rc.0",
   "description": "The professional publishing platform",
   "author": "Ghost Foundation",
   "homepage": "https://ghost.org",

--- a/ghost/core/test/unit/server/data/schema/commands.test.js
+++ b/ghost/core/test/unit/server/data/schema/commands.test.js
@@ -4,6 +4,43 @@ const errors = require('@tryghost/errors');
 const commands = require('../../../../../core/server/data/schema/commands');
 
 describe('schema commands', function () {
+    describe('generated columns', function () {
+        const generatedTableSpec = {
+            to: {type: 'string', maxlength: 2000, nullable: false},
+            to_hash: {
+                type: 'string',
+                maxlength: 32,
+                nullable: true,
+                generated: {
+                    dialect: 'mysql',
+                    expression: 'MD5(`to`)',
+                    storage: 'virtual'
+                }
+            }
+        };
+
+        it('creates a virtual generated column on MySQL', async function () {
+            const Knex = require('knex');
+            const knex = Knex({client: 'mysql2'});
+
+            const sql = commands.createTable('generated_test', knex, generatedTableSpec).toSQL()[0].sql;
+
+            assert.match(sql, /`to_hash` varchar\(32\) GENERATED ALWAYS AS \(MD5\(`to`\)\) VIRTUAL/);
+            await knex.destroy();
+        });
+
+        it('creates a regular nullable column on SQLite', async function () {
+            const Knex = require('knex');
+            const knex = Knex({client: 'better-sqlite3', useNullAsDefault: true});
+
+            const sql = commands.createTable('generated_test', knex, generatedTableSpec).toSQL()[0].sql;
+
+            assert.match(sql, /`to_hash` varchar\(32\) null/);
+            assert.doesNotMatch(sql, /GENERATED ALWAYS/);
+            await knex.destroy();
+        });
+    });
+
     it('_hasForeignSQLite throws when knex is nox configured to use sqlite3', async function () {
         const Knex = require('knex');
         const knex = Knex({

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '34a2e4ccd25c04dc9c4eb90abed13494';
+    const currentSchemaHash = 'd2c5c4cb8d54bb40dbfcf92c1a044b9d';
     const currentFixturesHash = '065b413e1d1f4f95fa7cb7734c5e7934';
     const currentSettingsHash = '397be8628c753b1959b8954d5610f83f';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';

--- a/ghost/core/test/unit/server/data/schema/schema.test.js
+++ b/ghost/core/test/unit/server/data/schema/schema.test.js
@@ -34,7 +34,8 @@ const VALID_KEYS = {
         'cascadeDelete',
         'restrictDelete',
         'setNullDelete',
-        'index'
+        'index',
+        'generated'
     ],
     text: [
         'fieldtype',
@@ -69,6 +70,13 @@ describe('schema validations', function () {
                         'Column index option, if present, should be valid'
                     );
                 };
+
+                if ('generated' in column) {
+                    assert.deepEqual(Object.keys(column.generated).sort(), ['dialect', 'expression', 'storage']);
+                    assert.equal(column.generated.dialect, 'mysql');
+                    assert.equal(typeof column.generated.expression, 'string');
+                    assert(['stored', 'virtual'].includes(column.generated.storage));
+                }
             });
         });
     });


### PR DESCRIPTION
## Summary

- add MySQL virtual generated-column support to the schema commands
- generate a compact MD5 hash for redirect targets
- enforce one redirect per automation action revision and target pair
- cover generated SQL and schema validation behavior with unit tests