### PR TITLE
Imported member custom field values from CSV

### DIFF
--- a/apps/admin-x-framework/src/api/member-custom-fields.ts
+++ b/apps/admin-x-framework/src/api/member-custom-fields.ts
@@ -1,5 +1,10 @@
 import {FIELD_TYPE_IDS, type FieldType} from '@tryghost/custom-field-types';
+import {csvColumnsForField} from '@tryghost/custom-field-types/csv';
 import {Meta, createMutation, createQuery, createQueryWithId} from '../utils/api/hooks';
+
+// Re-exported so the import mapping can recognise a custom_fields.* column (same reason
+// as the re-exports below).
+export {isCustomFieldColumn} from '@tryghost/custom-field-types/csv';
 
 // Re-exported so admin apps can type address values and validate against the
 // same schemas the server enforces, without a direct dependency on the shared
@@ -35,6 +40,9 @@ export type MemberCustomFieldUserType = {
     label: string;
     // Which control collects/edits a value of this type
     input: 'text' | 'textarea' | 'address';
+    // Composite types only: label per sub-field, keyed by the sub-field key the shared
+    // value schema defines. Kept with the type's other presentation, not a parallel map.
+    subFields?: Record<string, string>;
 };
 
 // Presentation for every field type in the shared catalog. The explicit
@@ -43,7 +51,18 @@ export type MemberCustomFieldUserType = {
 const fieldTypePresentation: Record<FieldType, Omit<MemberCustomFieldUserType, 'id'>> = {
     short_text: {label: 'Short text', input: 'text'},
     long_text: {label: 'Long text', input: 'textarea'},
-    address: {label: 'Address', input: 'address'}
+    address: {
+        label: 'Address',
+        input: 'address',
+        subFields: {
+            line1: 'Address line 1',
+            line2: 'Address line 2',
+            city: 'City',
+            state: 'State',
+            postal_code: 'Postal code',
+            country: 'Country'
+        }
+    }
 };
 
 // The catalog in the shared catalog's declared order, so every admin surface
@@ -51,10 +70,37 @@ const fieldTypePresentation: Record<FieldType, Omit<MemberCustomFieldUserType, '
 export const memberCustomFieldUserTypes: MemberCustomFieldUserType[] =
     FIELD_TYPE_IDS.map(id => ({id, ...fieldTypePresentation[id]}));
 
-// Resolve the user type for a field loaded from the API. Falls back to the
-// first entry so an unknown future type degrades to a rendered row, not a crash.
-export const userTypeForField = (field: MemberCustomField): MemberCustomFieldUserType => {
-    return memberCustomFieldUserTypes.find(userType => userType.id === field.type) || memberCustomFieldUserTypes[0];
+// Resolve the presentation for a field type. Falls back to the first entry so an unknown
+// future type degrades to a rendered row, not a crash.
+export const userTypeForFieldType = (type: FieldType): MemberCustomFieldUserType => {
+    return memberCustomFieldUserTypes.find(userType => userType.id === type) || memberCustomFieldUserTypes[0];
+};
+
+// As above, for a field loaded from the API.
+export const userTypeForField = (field: MemberCustomField): MemberCustomFieldUserType => userTypeForFieldType(field.type);
+
+// A custom field CSV column offered as an import mapping target: the column name the
+// backend reads (`value`) and a human label for the picker.
+export type MemberCustomFieldCsvColumn = {label: string; value: string};
+
+/**
+ * The CSV import mapping targets for a set of custom fields: one per column the export
+ * writes, labelled for the field (and sub-field, for a composite). Column names come from
+ * the shared codec the exporter writes and the importer reads, so a target is exactly a
+ * round-tripping column rather than one hand-kept in sync.
+ */
+export const memberCustomFieldCsvColumns = (fields: MemberCustomField[]): MemberCustomFieldCsvColumn[] => {
+    return fields.flatMap((field) => {
+        const columns = csvColumnsForField({key: field.key, type: field.type});
+        return columns.map((column) => {
+            if (columns.length === 1) {
+                return {label: field.name, value: column};
+            }
+            const sub = column.slice(column.lastIndexOf('.') + 1);
+            const subLabel = userTypeForFieldType(field.type).subFields?.[sub] ?? sub;
+            return {label: `${field.name} (${subLabel})`, value: column};
+        });
+    });
 };
 
 export interface MemberCustomFieldsResponseType {

--- a/apps/admin-x-framework/test/unit/api/member-custom-fields.test.ts
+++ b/apps/admin-x-framework/test/unit/api/member-custom-fields.test.ts
@@ -1,0 +1,38 @@
+import {type MemberCustomField, memberCustomFieldCsvColumns} from '../../../src/api/member-custom-fields';
+
+const field = (overrides: Partial<MemberCustomField>): MemberCustomField => ({
+    key: 'nickname',
+    name: 'Nickname',
+    type: 'short_text',
+    status: 'active',
+    created_at: '2026-07-01T00:00:00.000Z',
+    updated_at: null,
+    ...overrides
+});
+
+describe('member custom fields api helpers', () => {
+    describe('memberCustomFieldCsvColumns', () => {
+        it('gives a scalar field one target labelled by its name', () => {
+            expect(memberCustomFieldCsvColumns([field({key: 'nickname', name: 'Nickname'})])).toEqual([
+                {label: 'Nickname', value: 'custom_fields.nickname'}
+            ]);
+        });
+
+        it('expands a composite field into one target per sub-field', () => {
+            const columns = memberCustomFieldCsvColumns([field({key: 'shipping_address', name: 'Shipping Address', type: 'address'})]);
+
+            expect(columns).toEqual([
+                {label: 'Shipping Address (Address line 1)', value: 'custom_fields.shipping_address.line1'},
+                {label: 'Shipping Address (Address line 2)', value: 'custom_fields.shipping_address.line2'},
+                {label: 'Shipping Address (City)', value: 'custom_fields.shipping_address.city'},
+                {label: 'Shipping Address (State)', value: 'custom_fields.shipping_address.state'},
+                {label: 'Shipping Address (Postal code)', value: 'custom_fields.shipping_address.postal_code'},
+                {label: 'Shipping Address (Country)', value: 'custom_fields.shipping_address.country'}
+            ]);
+        });
+
+        it('returns no targets for an empty field set', () => {
+            expect(memberCustomFieldCsvColumns([])).toEqual([]);
+        });
+    });
+});

--- a/apps/admin/src/members/components/bulk-action-modals/import-members-modal.tsx
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members-modal.tsx
@@ -7,9 +7,11 @@ import {buildImportResponse} from './import-members/upload';
 import {cn} from '@tryghost/shade/utils';
 import {createInitialImportState, importReducer} from './import-members/reducer';
 import {isImportMembersCompleteResponse, useImportMembers} from '@tryghost/admin-x-framework/api/members';
+import {memberCustomFieldCsvColumns, useBrowseMemberCustomFields} from '@tryghost/admin-x-framework/api/member-custom-fields';
 import {parseCSV} from './import-members/csv';
 import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
 import {useCallback, useEffect, useMemo, useReducer, useRef} from 'react';
+import {useFeatureFlag} from '@/hooks/use-feature-flag';
 import {useLabelPicker} from '@/members/hooks/use-label-picker';
 
 interface ImportMembersModalProps {
@@ -30,7 +32,29 @@ export function ImportMembersModal({
     const {data: configData} = useBrowseConfig();
     const {mutateAsync: importMembers} = useImportMembers();
     const importMemberTier = configData?.config?.labs?.importMemberTier === true;
-    const fieldMappings = useMemo(() => getFieldMappings({importMemberTier}), [importMemberTier]);
+
+    // Defined custom fields become mapping targets. Fetched only when the feature is on;
+    // browse returns active fields only, which are the ones the importer writes to.
+    const customFieldsEnabled = useFeatureFlag('membersCustomFields');
+    const {data: customFieldsData} = useBrowseMemberCustomFields({enabled: customFieldsEnabled});
+    const customFieldColumns = useMemo(
+        () => memberCustomFieldCsvColumns(customFieldsData?.members_custom_fields ?? []),
+        [customFieldsData]
+    );
+    // The file-reader effect waits for this before its first parse: with the feature on,
+    // the custom field definitions must be loaded or auto-detection would miss
+    // custom_fields.* columns on a fast upload. It flips false -> true once and stays true
+    // (a refetch keeps data defined), so readiness never re-triggers the read.
+    const customFieldsReady = !customFieldsEnabled || customFieldsData !== undefined;
+    // Detection options are read inside the effect through this ref rather than as deps, so
+    // a later refetch of the options can't re-run the read and overwrite a mapping the user
+    // has begun editing.
+    const detectOptionsRef = useRef({importMemberTier, customFieldColumns});
+    detectOptionsRef.current = {importMemberTier, customFieldColumns};
+    const fieldMappings = useMemo(
+        () => getFieldMappings({importMemberTier, customFieldColumns}),
+        [importMemberTier, customFieldColumns]
+    );
 
     const labelPicker = useLabelPicker({
         selectedSlugs: state.selectedLabelSlugs,
@@ -70,7 +94,7 @@ export function ImportMembersModal({
     }, [onClose, onOpenChange, reset, state.importResponse, state.status]);
 
     useEffect(() => {
-        if (!state.file) {
+        if (!state.file || !customFieldsReady) {
             return;
         }
 
@@ -85,7 +109,7 @@ export function ImportMembersModal({
                 const data = parseCSV(text);
 
                 if (data.length > 0) {
-                    const detectedMapping = detectFieldTypes(data, {importMemberTier});
+                    const detectedMapping = detectFieldTypes(data, detectOptionsRef.current);
                     const fieldMapping = new MembersFieldMapping(detectedMapping);
 
                     dispatch({
@@ -137,7 +161,7 @@ export function ImportMembersModal({
                 reader.abort();
             }
         };
-    }, [importMemberTier, state.file]);
+    }, [state.file, customFieldsReady]);
 
     const validateFile = useCallback((file: File): boolean => {
         const match = /(?:\.([^.]+))?$/.exec(file.name);

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/mapping.test.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/mapping.test.ts
@@ -88,4 +88,56 @@ describe('mapping helpers', () => {
 
         expect(mapping.gift_id).toBe('gift_id');
     });
+
+    const customFieldColumns = [
+        {label: 'Nickname', value: 'custom_fields.nickname'},
+        {label: 'Shipping Address (Line 1)', value: 'custom_fields.shipping_address.line1'},
+        {label: 'Shipping Address (First name)', value: 'custom_fields.shipping_address.first_name'}
+    ];
+
+    it('offers the custom field columns as mapping targets', () => {
+        const mappings = getFieldMappings({customFieldColumns});
+
+        expect(mappings).toContainEqual({label: 'Nickname', value: 'custom_fields.nickname'});
+        expect(mappings).toContainEqual({label: 'Shipping Address (Line 1)', value: 'custom_fields.shipping_address.line1'});
+    });
+
+    it('auto-detects a custom field column by its namespaced header', () => {
+        const mapping = detectFieldTypes([
+            {email: 'user@example.com', 'custom_fields.nickname': 'Bex'}
+        ], {customFieldColumns});
+
+        expect(mapping['custom_fields.nickname']).toBe('custom_fields.nickname');
+    });
+
+    // The /name/i heuristic must not claim a custom field column containing "name".
+    it('does not map a name-like custom field column to the member name', () => {
+        const mapping = detectFieldTypes([
+            {email: 'user@example.com', 'custom_fields.shipping_address.first_name': 'Bex'}
+        ], {customFieldColumns});
+
+        expect(mapping.name).toBeUndefined();
+        expect(mapping['custom_fields.shipping_address.first_name']).toBe('custom_fields.shipping_address.first_name');
+    });
+
+    // Even a namespaced column with no offered target (its field archived after export,
+    // or a hand-built file) must not be claimed as the member name.
+    it('does not map a name-like namespaced column that has no offered target', () => {
+        const mapping = detectFieldTypes([
+            {email: 'user@example.com', 'custom_fields.former_field.last_name': 'Bex'}
+        ]);
+
+        expect(mapping.name).toBeUndefined();
+    });
+
+    // An email-typed custom field must not be bound to the member email (and thereby
+    // dropped) just because its values look like email addresses.
+    it('does not bind an email-valued custom field column to the member email', () => {
+        const mapping = detectFieldTypes([
+            {'custom_fields.contact_email': 'contact@example.com', email: 'member@example.com'}
+        ], {customFieldColumns: [{label: 'Contact email', value: 'custom_fields.contact_email'}]});
+
+        expect(mapping.email).toBe('email');
+        expect(mapping['custom_fields.contact_email']).toBe('custom_fields.contact_email');
+    });
 });

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/mapping.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/mapping.ts
@@ -1,5 +1,12 @@
+import {isCustomFieldColumn} from '@tryghost/admin-x-framework/api/member-custom-fields';
+
+type CustomFieldColumn = {label: string; value: string};
+
 type FieldMappingOptions = {
     importMemberTier?: boolean;
+    // Custom field CSV columns offered as mapping targets (see memberCustomFieldCsvColumns);
+    // empty when the feature is off.
+    customFieldColumns?: CustomFieldColumn[];
 };
 
 export const FIELD_MAPPINGS = [
@@ -28,17 +35,19 @@ const SUPPORTED_TYPES = [
     'gift_id'
 ];
 
-function getSupportedTypes({importMemberTier = false}: FieldMappingOptions = {}): string[] {
+function getSupportedTypes({importMemberTier = false, customFieldColumns = []}: FieldMappingOptions = {}): string[] {
     return [
         ...SUPPORTED_TYPES,
-        ...(importMemberTier ? [IMPORT_TIER_FIELD_MAPPING.value] : [])
+        ...(importMemberTier ? [IMPORT_TIER_FIELD_MAPPING.value] : []),
+        ...customFieldColumns.map(column => column.value)
     ];
 }
 
-export function getFieldMappings({importMemberTier = false}: FieldMappingOptions = {}) {
+export function getFieldMappings({importMemberTier = false, customFieldColumns = []}: FieldMappingOptions = {}) {
     return [
         ...FIELD_MAPPINGS,
-        ...(importMemberTier ? [IMPORT_TIER_FIELD_MAPPING] : [])
+        ...(importMemberTier ? [IMPORT_TIER_FIELD_MAPPING] : []),
+        ...customFieldColumns
     ];
 }
 
@@ -147,10 +156,11 @@ export function detectFieldTypes(data: Record<string, string>[], options: FieldM
     // Match column headers against supported types using all headers from the
     // original data. sampleData only keeps keys with non-empty values, so
     // entirely-empty columns (e.g. an empty "note" column) would be missed if
-    // we only checked sampled entries.
+    // we only checked sampled entries. A custom field column auto-maps to itself here;
+    // isCustomFieldColumn holds it apart from the fuzzy core-field heuristics below.
     if (data.length > 0) {
         for (const key of Object.keys(data[0])) {
-            if (!mapping.name && /name/i.test(key)) {
+            if (!mapping.name && /name/i.test(key) && !isCustomFieldColumn(key)) {
                 mapping.name = key;
                 continue;
             }
@@ -161,7 +171,7 @@ export function detectFieldTypes(data: Record<string, string>[], options: FieldM
         }
     }
 
-    // Detect value-based types (email) from sampled data
+    // Detect value-based types (email) from sampled data.
     let i = 0;
     while (i <= sampledData.length - 1) {
         if (mapping.email) {
@@ -170,7 +180,7 @@ export function detectFieldTypes(data: Record<string, string>[], options: FieldM
 
         const entry = sampledData[i];
         for (const [key, value] of Object.entries(entry)) {
-            if (!mapping.email && value && EMAIL_REGEX.test(value)) {
+            if (!mapping.email && value && EMAIL_REGEX.test(value) && !isCustomFieldColumn(key)) {
                 mapping.email = key;
             }
         }

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/modal.test.tsx
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/modal.test.tsx
@@ -34,6 +34,19 @@ vi.mock('@tryghost/admin-x-framework/api/members', async () => {
     };
 });
 
+// The modal offers defined custom fields as mapping targets. Stub the browse hook
+// (which needs a QueryClient this test does not mount) while keeping the real
+// column-deriving helper, so a mapping built from fields still exercises production logic.
+vi.mock('@tryghost/admin-x-framework/api/member-custom-fields', async () => {
+    const actual = await vi.importActual<typeof import('@tryghost/admin-x-framework/api/member-custom-fields')>(
+        '@tryghost/admin-x-framework/api/member-custom-fields'
+    );
+    return {
+        ...actual,
+        useBrowseMemberCustomFields: () => ({data: undefined})
+    };
+});
+
 vi.mock('@/members/hooks/use-label-picker', () => ({
     useLabelPicker: () => ({
         labels: [],

--- a/apps/admin/src/members/detail/member-custom-fields-field.tsx
+++ b/apps/admin/src/members/detail/member-custom-fields-field.tsx
@@ -5,7 +5,7 @@ import {dequal} from 'dequal';
 import {ADDRESS_SUBFIELD_KEYS, buildCustomFieldSavePayload, getCustomFieldValidationErrors, getEditableCustomFieldValues, parseCustomFieldServerErrors} from './member-detail-edit';
 import {formatAddressValue} from './member-detail-format';
 import {toast} from 'sonner';
-import {useBrowseMemberCustomFields, userTypeForField} from '@tryghost/admin-x-framework/api/member-custom-fields';
+import {useBrowseMemberCustomFields, userTypeForField, userTypeForFieldType} from '@tryghost/admin-x-framework/api/member-custom-fields';
 import {useEditMember} from '@tryghost/admin-x-framework/api/members';
 import type {EditableAddressValue, EditableCustomFieldValue} from './member-detail-edit';
 import type {MemberCustomField} from '@tryghost/admin-x-framework/api/member-custom-fields';
@@ -19,14 +19,8 @@ interface MemberCustomFieldsFieldProps {
     disabled?: boolean;
 }
 
-const ADDRESS_SUBFIELD_LABELS: Record<typeof ADDRESS_SUBFIELD_KEYS[number], string> = {
-    line1: 'Address line 1',
-    line2: 'Address line 2',
-    city: 'City',
-    state: 'State',
-    postal_code: 'Postal code',
-    country: 'Country'
-};
+// Shared with the CSV import mapping so a sub-field reads the same on every surface.
+const ADDRESS_SUBFIELD_LABELS = userTypeForFieldType('address').subFields ?? {};
 
 // role='alert': after a save-attempt these render while focus stays on the Save
 // button, so an assertive live region is the only way a screen reader hears the
@@ -54,7 +48,7 @@ const AddressInput: React.FC<{
                 const error = errors?.[subfield];
                 return (
                     <div key={subfield} className='flex flex-col gap-1.5'>
-                        <Label htmlFor={subfieldId}>{ADDRESS_SUBFIELD_LABELS[subfield]}</Label>
+                        <Label htmlFor={subfieldId}>{ADDRESS_SUBFIELD_LABELS[subfield] ?? subfield}</Label>
                         <Input
                             aria-invalid={error ? true : undefined}
                             disabled={disabled}

--- a/e2e/helpers/pages/admin/members/members-import-modal.ts
+++ b/e2e/helpers/pages/admin/members/members-import-modal.ts
@@ -27,4 +27,11 @@ export class MembersImportModal {
     getMappingValue(fieldName: string): Locator {
         return this.getMappingRow(fieldName).getByRole('combobox');
     }
+
+    // Point a CSV column at a target field: open its "Import as" select and pick an option
+    // (a core field or a defined custom field, by its label).
+    async setMappingTarget(csvColumn: string, targetLabel: string): Promise<void> {
+        await this.getMappingValue(csvColumn).click();
+        await this.page.getByRole('option', {name: targetLabel, exact: true}).click();
+    }
 }

--- a/e2e/helpers/pages/admin/members/members-list-page.ts
+++ b/e2e/helpers/pages/admin/members/members-list-page.ts
@@ -58,6 +58,13 @@ export class MembersListPage extends AdminPage {
         await this.actionsButton.click();
     }
 
+    // Open the import modal from the Actions menu. The empty-state importCsvLink only
+    // exists before the list has any members; once it does, import lives here.
+    async openImport(): Promise<void> {
+        await this.openActionsMenu();
+        await this.getMenuItem(/Import members/).click();
+    }
+
     async applyLabelFilter(labelName: string): Promise<void> {
         await this.addSearchableFilter('Label', labelName, labelName);
     }

--- a/e2e/tests/admin/members/import-custom-fields.test.ts
+++ b/e2e/tests/admin/members/import-custom-fields.test.ts
@@ -1,0 +1,121 @@
+import {join} from 'node:path';
+import {tmpdir} from 'node:os';
+import {writeFileSync} from 'node:fs';
+
+import {MemberDetailsPage, MembersImportModal, MembersListPage, SettingsPage} from '@/admin-pages';
+import {createMemberFactory} from '@/data-factory';
+import {expect, test} from '@/helpers/playwright';
+import {usePerTestIsolation} from '@/helpers/playwright/isolation';
+
+/**
+ * The custom-fields CSV round trip through the real admin UI: a value defined on a member,
+ * exported, and imported back. The HTTP API tests cover the server behaviour; this pins the
+ * two things only the browser exercises -- the export -> import loop end to end, and the
+ * mapping step both auto-detecting an exported column and taking a hand-picked target.
+ *
+ * Behind membersCustomFields (the whole feature) and memberDetailsReact (the member detail
+ * screen that renders a field's value).
+ */
+usePerTestIsolation();
+
+test.describe('Ghost Admin - Members import with custom fields', () => {
+    test.use({labs: {membersCustomFields: true, memberDetailsReact: true}});
+
+    test('an exported custom field value round-trips back through import, auto-mapped', async ({page}) => {
+        const ts = Date.now();
+        const fieldName = `Loyalty tier ${ts}`;
+        const sourceEmail = `rt-src-${ts}@ghost.org`;
+        const sourceName = `RoundTrip Source ${ts}`;
+        const freshEmail = `rt-fresh-${ts}@ghost.org`;
+        const freshName = `RoundTrip Fresh ${ts}`;
+
+        const memberFactory = createMemberFactory(page.request);
+        const member = await memberFactory.create({name: sourceName, email: sourceEmail});
+
+        const settingsPage = new SettingsPage(page);
+        const memberDetailsPage = new MemberDetailsPage(page);
+        const membersPage = new MembersListPage(page);
+        const importModal = new MembersImportModal(page);
+
+        await settingsPage.goto();
+        await settingsPage.customFieldsSection.createShortTextField(fieldName);
+
+        await page.goto(`/ghost/#/members/${member.id}`);
+        await memberDetailsPage.setCustomFieldValue(fieldName, 'Gold');
+        await expect(memberDetailsPage.customFieldsCard.getByText('Gold')).toBeVisible();
+
+        await membersPage.goto();
+        await membersPage.openActionsMenu();
+        const {content} = await membersPage.exportMembers();
+
+        const customColumn = content.match(/custom_fields\.[a-z0-9_-]+/)?.[0];
+        expect(customColumn, 'export carries a custom field column').toBeTruthy();
+        expect(content).toContain('Gold');
+
+        // Re-import under a fresh identity, so the member is created from the CSV and the
+        // value can only come from the import, not the setup above.
+        const csvPath = join(tmpdir(), `members-rt-${ts}.csv`);
+        writeFileSync(csvPath, content.replace(sourceEmail, freshEmail).replace(sourceName, freshName));
+
+        // The list now has a member, so import lives in the Actions menu (not the
+        // empty-state link).
+        await membersPage.goto();
+        await membersPage.openImport();
+        await importModal.fileInput.setInputFiles(csvPath);
+
+        await expect(importModal.importButton).toBeVisible();
+        // Default mapping: the exported column auto-detects to its field, no manual step.
+        await expect(importModal.getMappingValue(customColumn as string)).toHaveText(fieldName);
+
+        await importModal.importButton.click();
+        await expect(importModal.importHeading).toBeVisible({timeout: 15000});
+        await importModal.closeButton.click();
+
+        await membersPage.goto();
+        await membersPage.searchInput.fill(freshEmail);
+        await expect(membersPage.getMemberByName(freshName)).toBeVisible({timeout: 30000});
+        await membersPage.openMemberByName(freshName);
+
+        await expect(memberDetailsPage.customFieldsCard.getByText('Gold')).toBeVisible();
+    });
+
+    test('a column is mapped to a custom field by hand and its value is imported', async ({page}) => {
+        const ts = Date.now();
+        const fieldName = `Occupation ${ts}`;
+        const email = `cm-${ts}@ghost.org`;
+        const name = `Custom Mapping ${ts}`;
+
+        const settingsPage = new SettingsPage(page);
+        const memberDetailsPage = new MemberDetailsPage(page);
+        const membersPage = new MembersListPage(page);
+        const importModal = new MembersImportModal(page);
+
+        await settingsPage.goto();
+        await settingsPage.customFieldsSection.createShortTextField(fieldName);
+
+        // A header the importer will not auto-detect, so the mapping is done by hand.
+        const csv = ['email,name,Their Job', `${email},${name},Engineer`].join('\n');
+        const csvPath = join(tmpdir(), `members-cm-${ts}.csv`);
+        writeFileSync(csvPath, csv);
+
+        await membersPage.goto();
+        await membersPage.importCsvLink.click();
+        await importModal.fileInput.setInputFiles(csvPath);
+        await expect(importModal.importButton).toBeVisible();
+
+        await expect(importModal.getMappingValue('Their Job')).toHaveText('Not imported');
+        await importModal.setMappingTarget('Their Job', fieldName);
+        await expect(importModal.getMappingValue('Their Job')).toHaveText(fieldName);
+
+        await importModal.importButton.click();
+        await expect(importModal.importHeading).toBeVisible({timeout: 15000});
+        await importModal.closeButton.click();
+
+        await membersPage.goto();
+        await membersPage.searchInput.fill(email);
+        await expect(membersPage.getMemberByName(name)).toBeVisible({timeout: 30000});
+        await membersPage.openMemberByName(name);
+
+        await expect(memberDetailsPage.customFieldsCard.getByText('Engineer')).toBeVisible();
+    });
+});

--- a/ghost/core/core/server/services/members-custom-fields/values-service.ts
+++ b/ghost/core/core/server/services/members-custom-fields/values-service.ts
@@ -164,8 +164,9 @@ export class CustomFieldValuesService {
     /**
      * Resolve input into the writes it implies, rejecting anything invalid, and
      * writing nothing. Returned so a caller can validate before it commits to a
-     * change it would have to unwind (the member edit validates up front), then
-     * apply the same plan without re-resolving or re-validating.
+     * change it would have to unwind (the member edit and the importer both validate
+     * up front, before opening a transaction), then apply the same plan without
+     * re-resolving or re-validating.
      */
     async planWrite(input: unknown): Promise<PlannedWrite[]> {
         const values = this.parseValues(input);
@@ -225,15 +226,18 @@ export class CustomFieldValuesService {
      * Apply a plan from `planWrite`.
      *
      * Merge, not replace: only the fields in the plan are touched, so a caller
-     * that doesn't know about a field can't erase it. The whole plan is applied in
-     * one transaction, so a mid-batch failure rolls the batch back.
+     * that doesn't know about a field can't erase it.
+     *
+     * Always transactional, so a mid-batch failure rolls the batch back. Passed an
+     * executor it joins that transaction -- the importer passes its per-member one, so a
+     * failed value write takes the member with it; passed nothing it opens its own.
      */
-    async applyWrite(memberId: string, writes: PlannedWrite[]): Promise<void> {
+    async applyWrite(memberId: string, writes: PlannedWrite[], executor: Knex = this.knex): Promise<void> {
         if (writes.length === 0) {
             return;
         }
 
-        await this.knex.transaction(async (trx) => {
+        const apply = async (trx: Knex) => {
             for (const {field, value} of writes) {
                 const target = {member_id: memberId, custom_field_id: field.id};
 
@@ -250,6 +254,14 @@ export class CustomFieldValuesService {
                     .onConflict(['member_id', 'custom_field_id'])
                     .merge({...valueColumns, updated_at: new Date()});
             }
-        });
+        };
+
+        // isTransaction is knex's marker for a transactor: join an existing transaction
+        // rather than nesting a savepoint under it, otherwise open one.
+        if (executor.isTransaction) {
+            await apply(executor);
+        } else {
+            await executor.transaction(apply);
+        }
     }
 }

--- a/ghost/core/core/server/services/members/import-export/csv/formula.ts
+++ b/ghost/core/core/server/services/members/import-export/csv/formula.ts
@@ -1,0 +1,14 @@
+// The export writes with papaparse's escapeFormulae on (see serialize), which prefixes a
+// cell starting with one of these with an apostrophe so a spreadsheet won't read it as a
+// formula: `=SUM(A1)` is written as `'=SUM(A1)`.
+const FORMULA_TRIGGERS = ['=', '+', '-', '@', '\t', '\r'];
+
+// Strip that guard back off, so a re-imported value doesn't gain an apostrophe on every
+// round trip. Only a lone apostrophe before a trigger is the guard; one before anything
+// else is a character the value actually starts with, and is left alone.
+export function stripFormulaGuard(cell: string): string {
+    if (cell.charAt(0) === '\'' && FORMULA_TRIGGERS.includes(cell.charAt(1))) {
+        return cell.slice(1);
+    }
+    return cell;
+}

--- a/ghost/core/core/server/services/members/import-export/csv/index.ts
+++ b/ghost/core/core/server/services/members/import-export/csv/index.ts
@@ -1,2 +1,3 @@
 export {default as parse, type Row} from './parse';
 export {default as serialize} from './serialize';
+export {stripFormulaGuard} from './formula';

--- a/ghost/core/core/server/services/members/import-export/import/completion-email.ts
+++ b/ghost/core/core/server/services/members/import-export/import/completion-email.ts
@@ -1,4 +1,5 @@
 import {serialize} from '../csv';
+import {isCustomFieldColumn} from '@tryghost/custom-field-types/csv';
 import type {MemberImportRow, ImportErrorRow, ImportLabel, Label} from './row';
 
 const emailTemplate = require('./email-template');
@@ -43,10 +44,12 @@ function humaniseError(message: string): string {
         .replace(/No such customer:[^,]*/, 'Could not find Stripe customer');
 }
 
-// One row of the attached error report, in emit order. papaparse takes the columns from
-// these keys, so the report cannot drift from the shaper -- a new column must be added
-// here or the shaper stops compiling. tiers and deleted_at are export-vocabulary columns
-// an import never fills; kept always-empty so the report matches the members export CSV.
+// One row of the fixed, member-vocabulary part of the error report, in emit order.
+// papaparse takes the fixed columns from these keys, so the report cannot drift from the
+// shaper -- a new member column must be added here or the shaper stops compiling. tiers
+// and deleted_at are export-vocabulary columns an import never fills; kept always-empty
+// so the report matches the members export CSV. Any custom_fields.* columns a submitted
+// row carried are dynamic, so they are threaded in separately by buildErrorReport.
 type ErrorReportRow = {
     id: MemberImportRow['id'];
     email: MemberImportRow['email'];
@@ -67,6 +70,15 @@ function stringifyLabels(labels: Array<string | Label>): string {
     return labels.map(label => (typeof label === 'string' ? label : label.name)).join(',');
 }
 
+// The custom_fields.* cells a submitted row carried, echoed untouched so a manager can
+// fix a failed row and re-upload the values they mapped.
+function customFieldCells(row: ImportErrorRow): Record<string, unknown> {
+    return Object.fromEntries(Object.entries(row).filter(([column]) => isCustomFieldColumn(column)));
+}
+
+// Shape a failed import row into its fixed error-report cells, with the raw ORM message
+// rewritten into copy the member manager can act on. Custom field cells are merged on by
+// buildErrorReport, which owns the dynamic column set.
 function toErrorReportRow(row: ImportErrorRow): ErrorReportRow {
     return {
         id: row.id,
@@ -85,10 +97,20 @@ function toErrorReportRow(row: ImportErrorRow): ErrorReportRow {
     };
 }
 
-// The error report attached to the completion email: the failed rows as CSV. No column
-// list is passed -- the typed ErrorReportRow defines the columns.
+// The error report attached to the completion email: the failed rows as CSV. It shares
+// the serialiser with the export but not the shaping -- the export writes db members,
+// this echoes submitted rows. Member columns come from the shaper's keys (so the type
+// stays the single source); the custom_fields.* columns across the rows are threaded in
+// before the last error column, and each row's custom cells merged on.
 function buildErrorReport(errors: ImportErrorRow[]): string {
-    return serialize(errors.map(toErrorReportRow));
+    if (errors.length === 0) {
+        return serialize([]);
+    }
+    const memberColumns = Object.keys(toErrorReportRow(errors[0])).filter(column => column !== 'error');
+    const customColumns = [...new Set(errors.flatMap(row => Object.keys(customFieldCells(row))))];
+    const columns = [...memberColumns, ...customColumns, 'error'];
+    const rows = errors.map(row => ({...toErrorReportRow(row), ...customFieldCells(row)}));
+    return serialize(rows, {columns});
 }
 
 // Compose the completion email for a finished import: the summary and its links,

--- a/ghost/core/core/server/services/members/import-export/import/importer.ts
+++ b/ghost/core/core/server/services/members/import-export/import/importer.ts
@@ -1,5 +1,7 @@
 import moment from 'moment-timezone';
 import buildCompletionEmail from './completion-email';
+import {stripFormulaGuard} from '../csv';
+import {fieldValuesFromCsvRow, type CsvField} from '@tryghost/custom-field-types/csv';
 import type {Knex} from 'knex';
 import type {MemberImportRow, ImportErrorRow, ImportLabel, Label} from './row';
 import type {RowSpool, SpooledRows} from './spool';
@@ -91,6 +93,19 @@ export interface EmailNotifications {
     urlFor(type: string, data: unknown, absolute: boolean): string;
 }
 
+// Opaque to the import: planWrite produces it, applyWrite consumes it.
+type CustomFieldPlan = unknown;
+
+// The custom fields collaborator as the import needs it. activeFields is the field set a
+// custom_fields.* column is read against, empty when the feature is off; planWrite
+// validates a row's values (throwing so the row fails whole) and applyWrite persists
+// them, both on the row's transaction.
+export interface CustomFieldsImport {
+    activeFields(): Promise<CsvField[]>;
+    planWrite(values: Record<string, unknown>): Promise<CustomFieldPlan[]>;
+    applyWrite(memberId: string, plan: CustomFieldPlan[], executor: Knex): Promise<void>;
+}
+
 // The collaborators the import depends on, one per concern.
 interface ImporterDeps {
     knex: Knex;
@@ -100,6 +115,7 @@ interface ImporterDeps {
     tiers: TiersRepository;
     stripe: StripeSubscriptions;
     gifts: GiftService;
+    customFields: CustomFieldsImport;
     email: EmailNotifications;
     addJob: (job: {job: () => Promise<void>; offloaded: boolean; name: string}) => void;
     getTimezone: () => string;
@@ -183,12 +199,13 @@ class MembersCSVImporter {
     private _tiers: TiersRepository;
     private _stripe: StripeSubscriptions;
     private _gifts: GiftService;
+    private _customFields: CustomFieldsImport;
     private _email: EmailNotifications;
     private _addJob: (job: {job: () => Promise<void>; offloaded: boolean; name: string}) => void;
     private _getTimezone: () => string;
     private _getInlineThreshold: () => number;
 
-    constructor({knex, readRows, spool, members, tiers, stripe, gifts, email, addJob, getTimezone, getInlineThreshold}: ImporterDeps) {
+    constructor({knex, readRows, spool, members, tiers, stripe, gifts, customFields, email, addJob, getTimezone, getInlineThreshold}: ImporterDeps) {
         this._knex = knex;
         this._readRows = readRows;
         this._spool = spool;
@@ -196,6 +213,7 @@ class MembersCSVImporter {
         this._tiers = tiers;
         this._stripe = stripe;
         this._gifts = gifts;
+        this._customFields = customFields;
         this._email = email;
         this._addJob = addJob;
         this._getTimezone = getTimezone;
@@ -283,6 +301,9 @@ class MembersCSVImporter {
         const globalLabels: Label[] = [importLabel, ...extraLabels];
         const performStart = Date.now();
         const defaultTier = await this._tiers.getDefault();
+        // The field set a custom_fields.* column is read against; empty when the feature
+        // is off, so a carried-through column is dropped and the write boundary stays shut.
+        const activeCustomFields = await this._customFields.activeFields();
         const tierIdCache = new Map();
         const archivableStripePriceIds: string[] = [];
         // Copied per row: the member model stamps ids and trims names onto these in
@@ -295,8 +316,7 @@ class MembersCSVImporter {
         let imported = 0;
         const importErrors: ImportErrorRow[] = [];
         for (const row of rows) {
-            const trx = await this._knex.transaction(undefined, {doNotRejectOnRollback: false});
-            const options = {transacting: trx, context: IMPORT_CONTEXT};
+            let trx: Knex.Transaction | undefined;
             try {
                 if (row.gift_id) {
                     if (row.import_tier) {
@@ -306,6 +326,17 @@ class MembersCSVImporter {
                         throw wrapGiftError(new errors.DataImportError({message: tpl(messages.giftCannotCombineWithComplimentary)}));
                     }
                 }
+
+                // Validate the row's custom field values before the transaction opens.
+                // planWrite only reads, and it throws on an invalid value to fail the row
+                // before any member write -- so there is no reason to hold a transaction
+                // across it, and doing so would deadlock the single-connection SQLite pool.
+                const customFieldPlan = activeCustomFields.length > 0
+                    ? await this._customFields.planWrite(fieldValuesFromCsvRow(activeCustomFields, row, stripFormulaGuard))
+                    : [];
+
+                trx = await this._knex.transaction(undefined, {doNotRejectOnRollback: false});
+                const options = {transacting: trx, context: IMPORT_CONTEXT};
 
                 const createdAt = (row.created_at && moment(row.created_at).isAfter(moment())) ? moment().toDate() : row.created_at;
                 const memberValues: MemberImportValues = {
@@ -394,6 +425,9 @@ class MembersCSVImporter {
                     }
                 }
 
+                // On the row's transaction, so the values commit or roll back with the member.
+                await this._customFields.applyWrite(member.id, customFieldPlan, trx);
+
                 await trx.commit();
                 imported += 1;
             } catch (error) {
@@ -401,7 +435,11 @@ class MembersCSVImporter {
                 const errorMessage = errorList
                     .map(e => (typeof e === 'object' && e !== null && 'message' in e ? e.message : undefined))
                     .join(', ');
-                await trx.rollback();
+                // trx is unset if the row failed before the transaction opened (a bad
+                // custom field value or gift combination).
+                if (trx) {
+                    await trx.rollback();
+                }
                 importErrors.push({...row, error: errorMessage});
             }
         }

--- a/ghost/core/core/server/services/members/import-export/index.ts
+++ b/ghost/core/core/server/services/members/import-export/index.ts
@@ -1,5 +1,6 @@
 import type {Knex} from 'knex';
-import MembersCSVImporter, {type MembersRepository, type GiftService, type EmailNotifications, type Tier} from './import/importer';
+import type {CsvField} from '@tryghost/custom-field-types/csv';
+import MembersCSVImporter, {type MembersRepository, type GiftService, type EmailNotifications, type Tier, type CustomFieldsImport} from './import/importer';
 import readMemberRows from './import/reader';
 import {createRowSpool} from './import/spool';
 import MembersCSVExporter, {type ExportOptions, type CustomFieldDefinition} from './export/exporter';
@@ -25,6 +26,14 @@ interface ImporterServices {
     getInlineThreshold(): number;
     stripeAPIService: unknown;
     productRepository: unknown;
+    // The custom fields services the members service hands the import composition root.
+    customFields: {
+        definitions: {browse(): Promise<CsvField[]>};
+        values: {
+            planWrite(values: Record<string, unknown>): Promise<unknown[]>;
+            applyWrite(memberId: string, plan: unknown[], executor: Knex): Promise<void>;
+        };
+    };
 }
 
 // The custom fields services the members service hands the export composition root.
@@ -66,6 +75,15 @@ export function makeImporter(deps: ImporterServices) {
         reassignRedeemer: (giftId, memberId, options) => deps.getGiftService().reassignRedeemer(giftId, memberId, options)
     };
 
+    // Gated by the same labs flag as the export, so the two halves round-trip or stay
+    // silent together: off, activeFields resolves empty and every custom_fields.* column
+    // is dropped.
+    const customFields: CustomFieldsImport = {
+        activeFields: async () => (labs.isSet('membersCustomFields') ? deps.customFields.definitions.browse() : []),
+        planWrite: values => deps.customFields.values.planWrite(values),
+        applyWrite: (memberId, plan, executor) => deps.customFields.values.applyWrite(memberId, plan, executor)
+    };
+
     return new MembersCSVImporter({
         knex: deps.knex,
         readRows: readMemberRows,
@@ -80,6 +98,7 @@ export function makeImporter(deps: ImporterServices) {
             productRepository: deps.productRepository
         }),
         gifts,
+        customFields,
         email,
         addJob: deps.addJob,
         getTimezone: deps.getTimezone,

--- a/ghost/core/core/server/services/members/service.js
+++ b/ghost/core/core/server/services/members/service.js
@@ -47,6 +47,9 @@ let membersApi;
 let verificationTrigger;
 
 const buildImporterDeps = ({stripeAPIService}) => {
+    // Required here, not statically: boot builds the custom fields services before this
+    // one (the exporter below relies on the same).
+    const customFields = require('../members-custom-fields');
     return {
         getTimezone: () => settingsCache.get('timezone'),
         // A getter rather than a value because the threshold is an operator
@@ -81,7 +84,11 @@ const buildImporterDeps = ({stripeAPIService}) => {
         knex: db.knex,
         urlFor: urlUtils.urlFor.bind(urlUtils),
         stripeAPIService,
-        productRepository: membersApi.productRepository
+        productRepository: membersApi.productRepository,
+        customFields: {
+            definitions: customFields.definitions,
+            values: customFields.values
+        }
     };
 };
 

--- a/ghost/core/test/e2e-api/admin/members-export-import.test.js
+++ b/ghost/core/test/e2e-api/admin/members-export-import.test.js
@@ -155,11 +155,11 @@ describe('Members export -> import round-trip', function () {
         await assertSurvivesWithCoreFields(emails);
     });
 
-    // With the flag on, the export gains a custom_fields.* column. Custom fields are
-    // export-only today: the import does not consume that column. Re-importing under a
-    // fresh email creates the member from the CSV, so we can see the core fields
-    // reconstruct while the custom field does not -- pinning the gap until it closes.
-    it('exports a custom field but does not import it (export-only)', async function () {
+    // With the flag on, the export gains a custom_fields.* column and the import now
+    // consumes it. Re-importing under a fresh email creates the member from the CSV, so
+    // the core fields and the custom field value both reconstruct -- closing the round
+    // trip the base issue describes.
+    it('exports a custom field and re-imports its value onto a fresh member', async function () {
         mockManager.mockLabsEnabled('membersCustomFields');
 
         const fieldRes = await request
@@ -174,18 +174,22 @@ describe('Members export -> import round-trip', function () {
             email_disabled: false, email: srcEmail, name: 'CF Member', note: 'cf note',
             newsletters: [{id: newsletter.id}], labels: [{name: customLabel.get('name')}]
         });
+        // A formula-shaped value, so the export's escapeFormulae guard and the import's
+        // strip are exercised together: if either drifts, the round-trip below breaks.
+        const formulaValue = '=SUM(A1:A9)';
         const src = await findMember(srcEmail);
         await request
             .put(localUtils.API.getApiQuery(`members/${src.id}/`))
             .set('Origin', config.get('url'))
-            .send({members: [{custom_fields: {[customFieldKey]: 'kept value'}}]})
+            .send({members: [{custom_fields: {[customFieldKey]: formulaValue}}]})
             .expect(200);
 
         const csv = await exportSet(customLabel.get('slug'));
 
-        // The export produces the custom field column carrying the value.
+        // The export produces the custom field column, guarding the leading = with an
+        // apostrophe so a spreadsheet won't read it as a formula.
         assert.ok(csv.includes(`custom_fields.${customFieldKey}`), 'export includes the custom field column');
-        assert.equal(Papa.parse(csv, {header: true}).data.find(r => r.email === srcEmail)[`custom_fields.${customFieldKey}`], 'kept value');
+        assert.equal(Papa.parse(csv, {header: true}).data.find(r => r.email === srcEmail)[`custom_fields.${customFieldKey}`], `'${formulaValue}`);
 
         // Sanity: the read path surfaces custom fields for a member that has them, so
         // the "fresh member has none" assertion below is a real gap, not a blind read.
@@ -193,7 +197,7 @@ describe('Members export -> import round-trip', function () {
             .get(localUtils.API.getApiQuery(`members/?search=${encodeURIComponent(srcEmail)}&include=custom_fields`))
             .set('Origin', config.get('url'))
             .expect(200);
-        assert.equal(srcRead.body.members.find(m => m.email === srcEmail).custom_fields?.[customFieldKey], 'kept value');
+        assert.equal(srcRead.body.members.find(m => m.email === srcEmail).custom_fields?.[customFieldKey], formulaValue);
 
         // Re-import under a fresh email so the member is created from the CSV. No
         // Stripe column, so this imports inline.
@@ -225,9 +229,74 @@ describe('Members export -> import round-trip', function () {
         assert.equal(fresh.subscribed, true);
         assert.ok(fresh.labels.map(l => l.name).includes('Round-Trip Custom'), 'labels reconstruct');
 
-        // ...but the custom field does not: the import ignores the column today. This
-        // assertion flips to 'kept value' when custom-field import lands.
-        assert.equal(fresh.custom_fields?.[customFieldKey], undefined, 'custom fields are export-only until import supports them');
+        // ...and so does the custom field value, with the formula guard stripped back off
+        // so it does not accrete an apostrophe on the round trip.
+        assert.equal(fresh.custom_fields?.[customFieldKey], formulaValue, 'custom field value round-trips');
+    });
+
+    // The Stripe column defers this import, so it also checks the JSON spool carries
+    // custom_fields.* columns through. A value-less member exports all-blank address cells,
+    // which re-import as untouched rather than failing the row.
+    it('round-trips an address custom field and leaves a value-less member untouched', async function () {
+        mockManager.mockLabsEnabled('membersCustomFields');
+
+        await models.Label.add({name: 'Round-Trip Address'});
+        const addressLabel = (await models.Label.findAll()).models.find(l => l.get('name') === 'Round-Trip Address');
+
+        const fieldRes = await request
+            .post(localUtils.API.getApiQuery('members/custom_fields/'))
+            .set('Origin', config.get('url'))
+            .send({members_custom_fields: [{name: 'Shipping Address', type: 'address'}]})
+            .expect(201);
+        const addressKey = fieldRes.body.members_custom_fields[0].key;
+
+        const emails = await seedMembers('rtaddr', addressLabel.get('name'));
+        // A plain member with no address, so a fresh re-import proves an all-blank address
+        // writes nothing. (The seeded gift member can't serve this: its gift_id column fails
+        // to re-import under a new email.)
+        const plainEmail = 'rtaddr-plain@example.com';
+        await models.Member.add({
+            email_disabled: false, email: plainEmail, name: 'Plain Member',
+            newsletters: [{id: newsletter.id}], labels: [{name: addressLabel.get('name')}]
+        });
+        // Give one seeded member a full address; the rest hold none, so their exported
+        // address cells are all blank.
+        const withAddress = await findMember(emails.core);
+        await request
+            .put(localUtils.API.getApiQuery(`members/${withAddress.id}/`))
+            .set('Origin', config.get('url'))
+            .send({members: [{custom_fields: {[addressKey]: {line1: '1 High Street', city: 'London', postal_code: 'E1 6AN', country: 'GB'}}}]})
+            .expect(200);
+
+        const csv = await exportSet(addressLabel.get('slug'));
+        assert.ok(csv.includes(`custom_fields.${addressKey}.line1`), 'export expands the address into sub-columns');
+
+        // Re-import the addressed and plain members under fresh emails so they are created
+        // from the CSV -- the address must come from the import, not the setup PUT above.
+        // The other seeded members keep their emails (the Stripe column still defers, so the
+        // JSON spool carrying the columns is exercised too).
+        const freshCore = 'rtaddr-fresh-core@example.com';
+        const freshPlain = 'rtaddr-fresh-plain@example.com';
+        await reimport(csv.replace(emails.core, freshCore).replace(plainEmail, freshPlain));
+
+        const reCore = await request
+            .get(localUtils.API.getApiQuery(`members/?search=${encodeURIComponent(freshCore)}&include=custom_fields`))
+            .set('Origin', config.get('url'))
+            .expect(200);
+        const core = reCore.body.members.find(m => m.email === freshCore);
+        assertExists(core, 'addressed member created from the CSV');
+        assert.deepEqual(core.custom_fields?.[addressKey], {
+            line1: '1 High Street', city: 'London', postal_code: 'E1 6AN', country: 'GB'
+        }, 'the address is written from the import, through the spool');
+
+        // A member whose address cells are all blank gets no address written.
+        const rePlain = await request
+            .get(localUtils.API.getApiQuery(`members/?search=${encodeURIComponent(freshPlain)}&include=custom_fields`))
+            .set('Origin', config.get('url'))
+            .expect(200);
+        const plain = rePlain.body.members.find(m => m.email === freshPlain);
+        assertExists(plain, 'value-less member created from the CSV');
+        assert.equal(plain.custom_fields?.[addressKey], undefined, 'no address written for a value-less member');
     });
 });
 

--- a/ghost/core/test/e2e-api/admin/members-import-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/members-import-custom-fields.test.ts
@@ -1,0 +1,203 @@
+import path from 'node:path';
+import os from 'node:os';
+import fs from 'node:fs';
+import assert from 'node:assert/strict';
+
+const supertest = require('supertest');
+const localUtils = require('./utils');
+const config = require('../../../core/shared/config');
+const models = require('../../../core/server/models');
+const {mockManager} = require('../../utils/e2e-framework');
+
+// The importer reading custom field values back out of a members CSV, exercised at the
+// API boundary. Its sibling members-exporter-custom-fields covers the write direction;
+// together they are the round trip. The mapping (a column named for a field, or mapped
+// onto one) and the validation (a value failing its field type fails its row) are the
+// two behaviours proven here; the end-to-end export -> import loop lives in
+// members-export-import.
+describe('Members import — custom fields', function () {
+    let request: {post: (_url: string) => any; get: (_url: string) => any};
+
+    // The key is minted server-side from the name, so callers read it off the result.
+    async function createField(name: string, type: string): Promise<string> {
+        const res = await (request.post(localUtils.API.getApiQuery('members/custom_fields/')) as any)
+            .set('Origin', config.get('url'))
+            .send({members_custom_fields: [{name, type}]})
+            .expect(201);
+        return res.body.members_custom_fields[0].key;
+    }
+
+    // Upload a CSV built inline. `mapping` is the header -> target map the mapping step
+    // sends; omitted, the importer reads each column under its own name (which is how an
+    // exported file, whose headers already are the field targets, re-imports untouched).
+    async function importCSV(csv: string, mapping?: Record<string, string>): Promise<any> {
+        const csvPath = path.join(os.tmpdir(), `members-import-cf-${Date.now()}-${Math.random().toString(16).slice(2)}.csv`);
+        fs.writeFileSync(csvPath, csv);
+        try {
+            let req = (request.post(localUtils.API.getApiQuery('members/upload/')) as any)
+                .set('Origin', config.get('url'));
+            for (const [header, target] of Object.entries(mapping ?? {})) {
+                req = req.field(`mapping[${header}]`, target);
+            }
+            return await req.attach('membersfile', csvPath).expect('Content-Type', /json/);
+        } finally {
+            fs.unlinkSync(csvPath);
+        }
+    }
+
+    const findMember = async (email: string): Promise<any> => {
+        const res = await (request.get(localUtils.API.getApiQuery(`members/?search=${encodeURIComponent(email)}&include=custom_fields`)) as any)
+            .set('Origin', config.get('url'))
+            .expect(200);
+        return res.body.members.find((m: {email: string}) => m.email === email);
+    };
+
+    beforeAll(async function () {
+        await localUtils.startGhost();
+        request = supertest.agent(config.get('url'));
+        await localUtils.doAuth(request, 'newsletters', 'members:newsletters');
+    });
+
+    beforeEach(function () {
+        mockManager.mockMail();
+        mockManager.mockLabsEnabled('membersCustomFields');
+    });
+
+    afterEach(async function () {
+        mockManager.restore();
+        await models.Base.knex('members_custom_field_values').del();
+        await models.Base.knex('members_custom_fields').del();
+        await models.Base.knex('actions').whereIn('resource_type', ['member', 'member_custom_field']).del();
+    });
+
+    // An exported file re-imports with no mapping: its header is already the field target.
+    it('reads a namespaced column onto a member with no mapping', async function () {
+        const key = await createField('Nickname', 'short_text');
+        const email = 'cf-auto@example.com';
+
+        const res = await importCSV(`email,custom_fields.${key}\n${email},Bex\n`);
+        assert.equal(res.status, 201);
+        assert.equal(res.body.meta.stats.imported, 1);
+
+        const member = await findMember(email);
+        assert.equal(member.custom_fields?.[key], 'Bex');
+    });
+
+    // A blank cell must not wipe an existing value: it means "no data for this row", the
+    // same way a blank name or note column leaves the member's field untouched.
+    it('leaves an existing value untouched when its column is blank on re-import', async function () {
+        const key = await createField('Nickname', 'short_text');
+        const email = 'cf-blank-keeps@example.com';
+
+        await importCSV(`email,custom_fields.${key}\n${email},Bex\n`);
+        assert.equal((await findMember(email)).custom_fields?.[key], 'Bex');
+
+        const res = await importCSV(`email,custom_fields.${key}\n${email},\n`);
+        assert.equal(res.status, 201);
+        assert.equal(res.body.meta.stats.imported, 1);
+
+        assert.equal((await findMember(email)).custom_fields?.[key], 'Bex', 'the blank cell did not clear the value');
+    });
+
+    it('maps an arbitrary header onto a custom field', async function () {
+        const key = await createField('Nickname', 'short_text');
+        const email = 'cf-mapped@example.com';
+
+        const res = await importCSV(`Email Address,Preferred Name\n${email},Bex\n`, {'Email Address': 'email', 'Preferred Name': `custom_fields.${key}`});
+        assert.equal(res.status, 201);
+        assert.equal(res.body.meta.stats.imported, 1);
+
+        const member = await findMember(email);
+        assert.equal(member.custom_fields?.[key], 'Bex');
+    });
+
+    it('reads an address from its sub-field columns', async function () {
+        const key = await createField('Shipping Address', 'address');
+        const email = 'cf-address@example.com';
+
+        const csv = [
+            `email,custom_fields.${key}.line1,custom_fields.${key}.city,custom_fields.${key}.postal_code,custom_fields.${key}.country`,
+            `${email},1 High Street,London,E1 6AN,GB`,
+            ''
+        ].join('\n');
+
+        const res = await importCSV(csv);
+        assert.equal(res.status, 201);
+        assert.equal(res.body.meta.stats.imported, 1);
+
+        const member = await findMember(email);
+        assert.deepEqual(member.custom_fields?.[key], {line1: '1 High Street', city: 'London', postal_code: 'E1 6AN', country: 'GB'});
+    });
+
+    // A partial composite is an invalid value, so the whole row fails like any other.
+    it('fails a row whose address is missing a required sub-field', async function () {
+        const key = await createField('Shipping Address', 'address');
+        const email = 'cf-partial-address@example.com';
+
+        // city alone, no line1/postal_code/country.
+        const res = await importCSV(`email,custom_fields.${key}.city\n${email},London\n`);
+        assert.equal(res.status, 201);
+        assert.equal(res.body.meta.stats.imported, 0);
+        assert.equal(res.body.meta.stats.invalid.length, 1);
+        assert.match(res.body.meta.stats.invalid[0].error, /Shipping Address/);
+
+        assert.equal(await findMember(email), undefined, 'the failed row created no member');
+    });
+
+    it('fails a row whose value is too long for its field type', async function () {
+        const key = await createField('Nickname', 'short_text');
+        const email = 'cf-too-long@example.com';
+
+        const res = await importCSV(`email,custom_fields.${key}\n${email},${'x'.repeat(256)}\n`);
+        assert.equal(res.status, 201);
+        assert.equal(res.body.meta.stats.imported, 0);
+        assert.equal(res.body.meta.stats.invalid.length, 1);
+        assert.match(res.body.meta.stats.invalid[0].error, /Nickname/);
+
+        assert.equal(await findMember(email), undefined);
+    });
+
+    // An unrecognised column is dropped, not an error, so the member still imports.
+    it('drops a namespaced column that names no active field', async function () {
+        await createField('Nickname', 'short_text');
+        const email = 'cf-unknown-col@example.com';
+
+        const res = await importCSV(`email,custom_fields.does_not_exist\n${email},anything\n`);
+        assert.equal(res.status, 201);
+        assert.equal(res.body.meta.stats.imported, 1);
+        assert.equal(res.body.meta.stats.invalid.length, 0);
+
+        assert.notEqual(await findMember(email), undefined);
+    });
+
+    // Off, no field is active, so even a column for a defined field is dropped like any
+    // unknown one -- the value is never written.
+    it('ignores custom field columns when the feature is disabled', async function () {
+        const key = await createField('Nickname', 'short_text');
+        mockManager.mockLabsDisabled('membersCustomFields');
+        const email = 'cf-flag-off@example.com';
+
+        const res = await importCSV(`email,custom_fields.${key}\n${email},Bex\n`);
+        assert.equal(res.status, 201);
+        assert.equal(res.body.meta.stats.imported, 1);
+        assert.equal(res.body.meta.stats.invalid.length, 0);
+
+        const member = await findMember(email);
+        const values = await models.Base.knex('members_custom_field_values').where('member_id', member.id);
+        assert.equal(values.length, 0, 'no value written for a defined field while the feature was off');
+    });
+
+    // The export guards a leading =/+/-/@ with an apostrophe; the import strips it, so the
+    // value doesn't gain an apostrophe each round trip.
+    it('strips the export formula guard from a value', async function () {
+        const key = await createField('Nickname', 'short_text');
+        const email = 'cf-formula@example.com';
+
+        const res = await importCSV(`email,custom_fields.${key}\n${email},'=SUM(A1:A9)\n`);
+        assert.equal(res.status, 201);
+        assert.equal(res.body.meta.stats.imported, 1);
+
+        const member = await findMember(email);
+        assert.equal(member.custom_fields?.[key], '=SUM(A1:A9)');
+    });
+});

--- a/ghost/core/test/e2e-api/admin/members-import-error-report.test.js
+++ b/ghost/core/test/e2e-api/admin/members-import-error-report.test.js
@@ -8,12 +8,11 @@ const config = require('../../../core/shared/config');
 const jobsService = require('../../../core/server/services/jobs');
 const {mockManager} = require('../../utils/e2e-framework');
 
-// The error report a failed import emails back to the manager. Pinned against
-// origin/main's behaviour so the refactored importer keeps emitting the same CSV:
-// one importable row (so the run reports as a completion), then rows failing for
-// the distinct reasons a manager sees. The header row carries a formula-shaped
-// name and an unknown column, to hold the line on escaping and on which columns
-// the report echoes.
+// The error report a failed import emails back to the manager: one importable row (so
+// the run reports as a completion), then rows failing for the distinct reasons a manager
+// sees. The header row carries a formula-shaped name (to hold the line on escaping), an
+// import-only column that is not echoed (import_tier), and a custom field column that is
+// echoed so a manager can fix and re-upload the values they mapped (custom_fields.color).
 const CSV = [
     'email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,labels,import_tier,gift_id,custom_fields.color',
     'valid+ok@example.com,Good Member,,false,,,,,,,',
@@ -22,9 +21,13 @@ const CSV = [
     'bad-tier@example.com,Tier Person,,true,,,,,Nonexistent Tier,,'
 ].join('\n');
 
+// The fixed member vocabulary, then the submitted custom field columns, then the error
+// column last. custom_fields.* columns are threaded in before error so a re-upload of the
+// fixed rows carries their values back; import_tier and other input columns are not.
 const EXPECTED_COLUMNS = [
     'id', 'email', 'name', 'note', 'subscribed_to_emails', 'complimentary_plan',
-    'stripe_customer_id', 'created_at', 'deleted_at', 'labels', 'tiers', 'gift_id', 'error'
+    'stripe_customer_id', 'created_at', 'deleted_at', 'labels', 'tiers', 'gift_id',
+    'custom_fields.color', 'error'
 ];
 
 describe('Members import error report', function () {
@@ -71,15 +74,17 @@ describe('Members import error report', function () {
 
     const rowFor = email => rows.find(row => row.email === email);
 
-    it('emits the fixed member-vocabulary columns', function () {
+    it('emits the member-vocabulary columns and the submitted custom field columns', function () {
         assert.deepEqual(columns, EXPECTED_COLUMNS);
     });
 
-    it('does not carry import-only or unknown columns', function () {
-        // The report echoes the member vocabulary, not the raw submitted columns:
-        // import_tier and any unmapped column (custom_fields.*) are not emitted.
+    it('carries submitted custom field columns but not other input columns', function () {
+        // The report echoes the member vocabulary and the custom field columns a row
+        // carried, so a manager can fix the failed rows and re-upload their values.
+        // import_tier is an input the report resolves rather than echoes, so it is not.
         assert.ok(!columns.includes('import_tier'), 'no import_tier column');
-        assert.ok(!columns.includes('custom_fields.color'), 'no unmapped custom column');
+        assert.ok(columns.includes('custom_fields.color'), 'the submitted custom field column is echoed');
+        assert.equal(rowFor('not-a-valid-email')['custom_fields.color'], 'blue', 'its value is echoed on the failed row');
     });
 
     it('keeps the tiers column present but empty', function () {

--- a/ghost/core/test/unit/server/services/members/import-export/csv/formula.test.ts
+++ b/ghost/core/test/unit/server/services/members/import-export/csv/formula.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import {stripFormulaGuard} from '../../../../../../../core/server/services/members/import-export/csv';
+
+// The inverse of the export's papaparse escapeFormulae guard. Behaviour end-to-end is
+// proven in the members import HTTP API tests; the trigger set is pinned here.
+describe('stripFormulaGuard', function () {
+    it('strips a lone apostrophe before a formula trigger', function () {
+        for (const trigger of ['=', '+', '-', '@', '\t', '\r']) {
+            assert.equal(stripFormulaGuard(`'${trigger}SUM(A1)`), `${trigger}SUM(A1)`);
+        }
+    });
+
+    it('leaves an apostrophe before a non-trigger character alone', function () {
+        assert.equal(stripFormulaGuard('\'tis'), '\'tis');
+        assert.equal(stripFormulaGuard('\'\''), '\'\'');
+    });
+
+    it('leaves a value that is not guarded alone', function () {
+        assert.equal(stripFormulaGuard('=SUM(A1)'), '=SUM(A1)');
+        assert.equal(stripFormulaGuard('plain'), 'plain');
+        assert.equal(stripFormulaGuard(''), '');
+    });
+});

--- a/packages/custom-field-types/src/csv.ts
+++ b/packages/custom-field-types/src/csv.ts
@@ -43,6 +43,18 @@ function toCell(value: unknown): string {
     return value === undefined || value === null ? '' : String(value);
 }
 
+// Shares csvCellsForFields' column derivation, so a field is written, read, and offered
+// as a mapping target under one set of column names.
+export function csvColumnsForField(field: CsvField): string[] {
+    const column = `${NAMESPACE}${SEPARATOR}${field.key}`;
+    const subFields = subFieldsOf(field.type);
+    return subFields ? subFields.map(sub => `${column}${SEPARATOR}${sub}`) : [column];
+}
+
+export function isCustomFieldColumn(column: string): boolean {
+    return column === NAMESPACE || column.startsWith(`${NAMESPACE}${SEPARATOR}`);
+}
+
 /**
  * The CSV cells for one member's custom field values, keyed by column name.
  *
@@ -70,4 +82,66 @@ export function csvCellsForFields(fields: readonly CsvField[], values: Record<st
     }
 
     return cells;
+}
+
+/**
+ * The inverse of `csvCellsForFields`: read a row's custom field cells into the values a
+ * member write takes. Only the passed fields are read, so a column naming no active field
+ * is dropped rather than erroring.
+ *
+ * `decodeCell` turns a raw cell into its value; it defaults to identity. The caller owns
+ * any de-serialization the specific file needs — the members importer passes one that
+ * strips the export's formula guard — so this stays pure vocabulary and holds no knowledge
+ * of how any particular CSV escapes its cells.
+ *
+ * A field is written only from a non-blank cell; a blank or absent cell leaves the
+ * existing value untouched, not cleared — matching how the importer keeps a blank name or
+ * note, so re-importing a partly-filled export can't wipe values a publisher didn't
+ * touch. A composite whose every cell is blank is omitted too, because the export writes
+ * "no address" and an all-blank address identically; one with any filled cell is read
+ * from its non-blank cells and validated whole (a missing required sub-field fails).
+ */
+export function fieldValuesFromCsvRow(
+    fields: readonly CsvField[],
+    row: Record<string, unknown>,
+    decodeCell: (cell: string) => string = cell => cell
+): Record<string, unknown> {
+    const values: Record<string, unknown> = {};
+
+    // The parser only ever sets a string cell for these columns, so a non-string is an
+    // absent column, read as untouched.
+    for (const field of fields) {
+        const column = `${NAMESPACE}${SEPARATOR}${field.key}`;
+        const subFields = subFieldsOf(field.type);
+
+        if (!subFields) {
+            const cell = row[column];
+            if (typeof cell === 'string') {
+                const decoded = decodeCell(cell);
+                if (decoded !== '') {
+                    values[field.key] = decoded;
+                }
+            }
+            continue;
+        }
+
+        let anyColumnPresent = false;
+        const composite: Record<string, string> = {};
+        for (const sub of subFields) {
+            const cell = row[`${column}${SEPARATOR}${sub}`];
+            if (typeof cell === 'string') {
+                anyColumnPresent = true;
+                const decoded = decodeCell(cell);
+                if (decoded !== '') {
+                    composite[sub] = decoded;
+                }
+            }
+        }
+
+        if (anyColumnPresent && Object.keys(composite).length > 0) {
+            values[field.key] = composite;
+        }
+    }
+
+    return values;
 }

--- a/packages/custom-field-types/test/csv.test.ts
+++ b/packages/custom-field-types/test/csv.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import {describe, it} from 'vitest';
-import {csvCellsForFields} from '../src/csv.ts';
+import {csvCellsForFields, csvColumnsForField, fieldValuesFromCsvRow, isCustomFieldColumn} from '../src/csv.ts';
 
 // The behavioural outcomes — an export carrying the right columns, an exported
 // file re-importing without remapping — are proven end-to-end through the member
@@ -74,5 +74,98 @@ describe('custom field CSV cells', function () {
 
     it('treats an explicit null as no value', function () {
         assert.deepEqual(csvCellsForFields([nickname], {nickname: null}), {'custom_fields.nickname': ''});
+    });
+});
+
+// The column names are the vocabulary the admin offers as import mapping targets and
+// the error report echoes, so they are derived from the same primitives the cells are.
+describe('custom field CSV columns', function () {
+    it('gives a scalar field one namespaced column', function () {
+        assert.deepEqual(csvColumnsForField({key: 'nickname', type: 'short_text'}), ['custom_fields.nickname']);
+    });
+
+    it('gives a composite field one column per sub-field', function () {
+        assert.deepEqual(csvColumnsForField({key: 'shipping_address', type: 'address'}), [
+            'custom_fields.shipping_address.line1',
+            'custom_fields.shipping_address.line2',
+            'custom_fields.shipping_address.city',
+            'custom_fields.shipping_address.state',
+            'custom_fields.shipping_address.postal_code',
+            'custom_fields.shipping_address.country'
+        ]);
+    });
+
+    it('recognises a custom field column by its namespace', function () {
+        assert.equal(isCustomFieldColumn('custom_fields.nickname'), true);
+        assert.equal(isCustomFieldColumn('custom_fields.shipping_address.city'), true);
+        assert.equal(isCustomFieldColumn('email'), false);
+        // A core column that merely starts with the word is not namespaced by it.
+        assert.equal(isCustomFieldColumn('custom_fields_note'), false);
+    });
+});
+
+// End-to-end round-tripping is proven in the member import HTTP API tests; the row-level
+// reading rules are pinned here.
+describe('reading custom field values from a CSV row', function () {
+    const nickname = {key: 'nickname', type: 'short_text'} as const;
+    const address = {key: 'shipping_address', type: 'address'} as const;
+
+    it('reads a scalar column into its value', function () {
+        assert.deepEqual(fieldValuesFromCsvRow([nickname], {'custom_fields.nickname': 'Bex'}), {nickname: 'Bex'});
+    });
+
+    it('leaves a field untouched when its column is absent from the row', function () {
+        assert.deepEqual(fieldValuesFromCsvRow([nickname], {email: 'a@b.com'}), {});
+    });
+
+    // Blank means untouched, not cleared, so re-importing a partly-edited export can't wipe values.
+    it('leaves a field untouched when its scalar column is present but blank', function () {
+        assert.deepEqual(fieldValuesFromCsvRow([nickname], {'custom_fields.nickname': ''}), {});
+    });
+
+    it('reads only active fields, dropping a column that names no passed field', function () {
+        assert.deepEqual(fieldValuesFromCsvRow([nickname], {
+            'custom_fields.nickname': 'Bex',
+            'custom_fields.unknown': 'ignored'
+        }), {nickname: 'Bex'});
+    });
+
+    // The export writes "no address" and an all-blank address identically, so all-blank is read as absent.
+    it('omits a composite whose every sub-cell is blank', function () {
+        assert.deepEqual(fieldValuesFromCsvRow([address], {
+            'custom_fields.shipping_address.line1': '',
+            'custom_fields.shipping_address.line2': '',
+            'custom_fields.shipping_address.city': '',
+            'custom_fields.shipping_address.state': '',
+            'custom_fields.shipping_address.postal_code': '',
+            'custom_fields.shipping_address.country': ''
+        }), {});
+    });
+
+    it('reads a composite from its non-blank sub-cells, omitting the blank ones', function () {
+        assert.deepEqual(fieldValuesFromCsvRow([address], {
+            'custom_fields.shipping_address.line1': '1 High Street',
+            'custom_fields.shipping_address.line2': '',
+            'custom_fields.shipping_address.city': 'London',
+            'custom_fields.shipping_address.state': '',
+            'custom_fields.shipping_address.postal_code': 'E1 6AN',
+            'custom_fields.shipping_address.country': 'GB'
+        }), {shipping_address: {line1: '1 High Street', city: 'London', postal_code: 'E1 6AN', country: 'GB'}});
+    });
+
+    // A partial composite is read as a value (validation, run by the caller, is what
+    // rejects it) rather than silently dropped like an all-blank one.
+    it('reads a partial composite so its validation can fail the row', function () {
+        assert.deepEqual(fieldValuesFromCsvRow([address], {
+            'custom_fields.shipping_address.city': 'London'
+        }), {shipping_address: {city: 'London'}});
+    });
+
+    // The caller decodes each cell (the members importer strips the export's formula
+    // guard); the vocabulary itself holds no escaping knowledge. Blank-after-decode still
+    // reads as untouched, so a decoder can't accidentally write an emptied field.
+    it('decodes each cell through the caller-supplied decoder', function () {
+        assert.deepEqual(fieldValuesFromCsvRow([nickname], {'custom_fields.nickname': ' Bex '}, cell => cell.trim()), {nickname: 'Bex'});
+        assert.deepEqual(fieldValuesFromCsvRow([nickname], {'custom_fields.nickname': '   '}, cell => cell.trim()), {});
     });
 });


### PR DESCRIPTION
## Problem

Members could export their custom field values to CSV but not bring them back. A re-imported file carried the custom field columns untouched, yet the importer only ever wrote core member fields, so those values were silently dropped. Publishers migrating from a spreadsheet or a CRM had no way to land the data they already held, which is the whole point of the feature.

## Solution

The member importer now reads each row's custom field columns and writes their values onto the matching member, behind the membersCustomFields flag. Columns are read against the active field definitions using the same shared vocabulary the export writes from, so an exported file re-imports with no manual remapping and the two halves cannot drift.

Each value is validated up front and written on the member's own transaction, so an invalid value fails the whole row and a value commits or rolls back together with its member rather than being left orphaned. The import mapping step offers the defined fields as targets, an address one sub-field per column. A blank cell leaves an existing value untouched, and a column that names no active field is dropped as it always was. With the flag off, every custom field column is dropped exactly as before.
