### PR TITLE
🐛 Fixed redirect capture groups ($1) not being substituted inside query strings

### DIFF
--- a/ghost/core/core/server/services/lib/dynamic-redirect-manager.js
+++ b/ghost/core/core/server/services/lib/dynamic-redirect-manager.js
@@ -56,14 +56,23 @@ class DynamicRedirectManager {
 
         this.router.get(fromRegex, (req, res) => {
             const maxAge = permanent ? this.permanentMaxAge : 0;
-            const toURL = parseURL(to);
-            const toURLParams = parseQuerystring(toURL.query);
             const currentURL = parseURL(req.url);
             const currentURLParams = parseQuerystring(currentURL.query);
+
+            const toURL = parseURL(to);
+            toURL.pathname = currentURL.pathname.replace(fromRegex, toURL.pathname);
+
+            // Captures are percent-encoded path segments (Express rejects any it can't decode),
+            // so decode then re-encode for the query — reserved chars stay literal, no double-encoding
+            const captures = currentURL.pathname.match(fromRegex) || [];
+            const substitutedQuery = (toURL.query || '').replace(/\$(\d+)/g, (match, n) => (
+                captures[n] !== undefined ? encodeURIComponent(decodeURIComponent(captures[n])) : match
+            ));
+            const toURLParams = parseQuerystring(substitutedQuery);
+
             const params = Object.assign({}, currentURLParams, toURLParams);
             const search = formatQuerystring(params);
 
-            toURL.pathname = currentURL.pathname.replace(fromRegex, toURL.pathname);
             toURL.search = search !== '' ? `?${search}` : null;
 
             /**

--- a/ghost/core/test/unit/server/services/lib/dynamic-redirect-manager.test.js
+++ b/ghost/core/test/unit/server/services/lib/dynamic-redirect-manager.test.js
@@ -216,6 +216,168 @@ describe('DynamicRedirectManager', function () {
                 assert.equal(status, 302);
                 assert.equal(location, '/?something=good');
             });
+
+            it('Substitutes a capture into a query parameter', function (){
+                const from = '^/profile/([^/]+)/?$';
+                const to = '/profile/?user=$1';
+
+                manager.addRedirect(from, to, {permanent: true});
+
+                req.url = '/profile/alice/';
+
+                manager.handleRequest(req, res, function next() {
+                    assert.fail('next should NOT have been called');
+                });
+
+                assert.equal(headers['Cache-Control'], 'public, max-age=100');
+                assert.equal(status, 301);
+                assert.equal(location, '/profile/?user=alice');
+            });
+
+            it('Substitutes a capture into a query parameter with a locale prefix', function (){
+                const from = '^/es/profile/([^/]+)/?$';
+                const to = '/es/profile/?user=$1';
+
+                manager.addRedirect(from, to, {permanent: true});
+
+                req.url = '/es/profile/alice/';
+
+                manager.handleRequest(req, res, function next() {
+                    assert.fail('next should NOT have been called');
+                });
+
+                assert.equal(status, 301);
+                assert.equal(location, '/es/profile/?user=alice');
+            });
+
+            it('Substitutes a capture from a nested path into a query parameter', function (){
+                const from = '^/festival/([^/]+)/attendees/?$';
+                const to = '/festival-attendees/?festival=$1';
+
+                manager.addRedirect(from, to, {permanent: true});
+
+                req.url = '/festival/my-festival/attendees/';
+
+                manager.handleRequest(req, res, function next() {
+                    assert.fail('next should NOT have been called');
+                });
+
+                assert.equal(status, 301);
+                assert.equal(location, '/festival-attendees/?festival=my-festival');
+            });
+
+            it('Merges incoming query params when substituting a capture into the query', function (){
+                const from = '^/profile/([^/]+)/?$';
+                const to = '/profile/?user=$1';
+
+                manager.addRedirect(from, to, {permanent: true});
+
+                req.url = '/profile/alice/?ref=xyz';
+
+                manager.handleRequest(req, res, function next() {
+                    assert.fail('next should NOT have been called');
+                });
+
+                assert.equal(status, 301);
+                assert.equal(location, '/profile/?ref=xyz&user=alice');
+            });
+
+            it('Encodes a "+" in a captured value so it stays a literal plus', function (){
+                const from = '^/profile/([^/]+)/?$';
+                const to = '/profile/?user=$1';
+
+                manager.addRedirect(from, to, {permanent: true});
+
+                req.url = '/profile/alice+admin/';
+
+                manager.handleRequest(req, res, function next() {
+                    assert.fail('next should NOT have been called');
+                });
+
+                assert.equal(status, 301);
+                assert.equal(location, '/profile/?user=alice%2Badmin');
+            });
+
+            it('Encodes an "&" in a captured value so it does not inject a parameter', function (){
+                const from = '^/profile/([^/]+)/?$';
+                const to = '/profile/?user=$1';
+
+                manager.addRedirect(from, to, {permanent: true});
+
+                req.url = '/profile/alice&admin=true/';
+
+                manager.handleRequest(req, res, function next() {
+                    assert.fail('next should NOT have been called');
+                });
+
+                assert.equal(status, 301);
+                assert.equal(location, '/profile/?user=alice%26admin%3Dtrue');
+            });
+
+            it('Does not double-encode a "%20" already present in the captured value', function (){
+                const from = '^/profile/([^/]+)/?$';
+                const to = '/profile/?user=$1';
+
+                manager.addRedirect(from, to, {permanent: true});
+
+                req.url = '/profile/alice%20smith/';
+
+                manager.handleRequest(req, res, function next() {
+                    assert.fail('next should NOT have been called');
+                });
+
+                assert.equal(status, 301);
+                assert.equal(location, '/profile/?user=alice%20smith');
+            });
+
+            it('Does not double-encode a "%2B" already present in the captured value', function (){
+                const from = '^/profile/([^/]+)/?$';
+                const to = '/profile/?user=$1';
+
+                manager.addRedirect(from, to, {permanent: true});
+
+                req.url = '/profile/alice%2Bsmith/';
+
+                manager.handleRequest(req, res, function next() {
+                    assert.fail('next should NOT have been called');
+                });
+
+                assert.equal(status, 301);
+                assert.equal(location, '/profile/?user=alice%2Bsmith');
+            });
+
+            it('Does not double-encode a "%26" already present in the captured value', function (){
+                const from = '^/profile/([^/]+)/?$';
+                const to = '/profile/?user=$1';
+
+                manager.addRedirect(from, to, {permanent: true});
+
+                req.url = '/profile/alice%26smith/';
+
+                manager.handleRequest(req, res, function next() {
+                    assert.fail('next should NOT have been called');
+                });
+
+                assert.equal(status, 301);
+                assert.equal(location, '/profile/?user=alice%26smith');
+            });
+
+            it('Never reaches the handler when a capture has a malformed percent-escape', function () {
+                const from = '^/profile/([^/]+)/?$';
+                const to = '/profile/?user=$1';
+
+                manager.addRedirect(from, to, {permanent: true});
+
+                req.url = '/profile/%zz/';
+
+                let nextError;
+                manager.handleRequest(req, res, function next(err) {
+                    nextError = err;
+                });
+
+                assert.equal(status, null);
+                assert.equal(nextError.statusCode, 400);
+            });
         });
 
         describe('Case sensitivity', function () {


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/issues/10898

- a redirect like `^/profile/([^/]+)/?$: /profile/?user=$1` returned `Location: /profile/?user=%241`, so the target received the literal `$1` instead of the captured value (e.g. `alice`)
- capture substitution only ran against the destination path; the query string was parsed and re-encoded separately, which percent-encoded the `$1` placeholder to `%241` before it could be replaced
- now substitutes captures into the whole destination (path and query) before parsing, so `$1` resolves in both

Got some code for us? Awesome 🎊!

Please take a minute to explain the change you're making:
- Why are you making it?
- What does it do?
- Why is this something Ghost users or developers need?

Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works

We appreciate your contribution! 🙏
