### PR TITLE
Updated package publishing flows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1926,14 +1926,12 @@ jobs:
         run: |
           echo "@tryghost:registry=https://registry.npmjs.org/" >> ~/.npmrc
 
-      # TODO: Check we can remove this once we update Node to v24
-      - name: Install v11 of NPM # We need this to install packages via OIDC.
-        run: npm install -g npm@11
-
+      # --provenance is explicit rather than relying on pnpm's auto-detection,
+      # which degrades to a warning if it can't confirm visibility.
       - name: Publish to npm
         working-directory: ${{ matrix.package_path }}
         run: |
-          pnpm publish --access public --no-git-checks
+          pnpm publish --access public --provenance --no-git-checks
 
       - name: Replace version placeholders in cdn-paths
         id: cdn_paths
@@ -2038,8 +2036,12 @@ jobs:
       - name: Verify tarball contents
         run: tar -xOf ghost-*.tgz package/package.json | jq -e '.packageManager' >/dev/null
 
+      # --provenance is explicit so a publish without an attestation fails the
+      # job instead of warning. Safe with no repo checkout: the SLSA statement
+      # is built from the GITHUB_* env vars plus the tarball digest, and the
+      # subject comes from the packed manifest — nothing reads a working tree.
       - name: Publish to npm
-        run: npm publish ghost-*.tgz --access public
+        run: npm publish ghost-*.tgz --access public --provenance
 
   # NOTE: Publishing the other workspace packages (koenig/*, packages/*, ...) is
   # NOT a job here. The release tag triggers publish-packages.yml directly, in

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -80,10 +80,6 @@ jobs:
         run: |
           echo "@tryghost:registry=https://registry.npmjs.org/" >> ~/.npmrc
 
-      # TODO: Check we can remove this once we update Node to v24
-      - name: Install v11 of NPM # We need this to install packages via OIDC.
-        run: npm install -g npm@11
-
       - name: Publish packages
         # Read as env by publish-packages.js — no shell interpolation of the
         # dispatch inputs (untrusted even on a manual workflow).

--- a/scripts/publish-packages.js
+++ b/scripts/publish-packages.js
@@ -81,8 +81,15 @@ if (!dryRun) {
 // aren't necessarily publishable). pnpm skips versions already on npm, rewrites
 // `workspace:` ranges to the committed versions, and publishes in graph order.
 // No --no-git-checks: this runs from a clean tag checkout in CI.
+// --provenance is explicit, not left to pnpm's auto-detection: on a trusted
+// publish pnpm only turns provenance on if it can confirm both the repo and the
+// package are public, and any hiccup there (visibility fetch fails, an id token
+// it can't read) degrades to a warning and a publish with no attestation.
+// Passing the flag makes it a hard requirement instead — it also short-circuits
+// the visibility lookup. Needs `id-token: write` and a CI provider sigstore
+// recognises, so a local non-dry-run publish will fail here by design.
 const publishFilters = names.flatMap(name => ['--filter', name]);
-const publishArgs = ['publish', ...publishFilters, '--access', 'public'];
+const publishArgs = ['publish', ...publishFilters, '--access', 'public', '--provenance'];
 if (dryRun) {
     publishArgs.push('--dry-run');
 }


### PR DESCRIPTION
no ref
- remove unnecessary npm install npm commands where pnpm is used
- add explicit --provenance flags to publish commands
