### PR TITLE
Updated Renovate config to ignore pinned pnpm override deps

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -168,7 +168,19 @@
         // knex 3.x, gated on publishing a knex-3 knex-migrator
         // (TryGhost/knex-migrator#86, unreleased), bumped in lockstep with core.
         // Ignore until we do that coordinated upgrade.
-        "knex"
+        "knex",
+        // Same PLA-78 pin, but Renovate treats the pnpm override key
+        // `knex-migrator>knex` as its own dependency name, so the plain "knex"
+        // ignore above doesn't match it (see #29092).
+        "knex-migrator>knex",
+
+        // https://github.com/TryGhost/Ghost/pull/29099
+        // The pnpm override `path-to-regexp@<0.1.13` exists only to force
+        // Express 4's transitive path-to-regexp to the ReDoS-patched 0.1.13.
+        // Express 4 pins path-to-regexp 0.1.x; 0.2.x+ changes routing
+        // semantics and breaks route matching, so this override must never
+        // leave the 0.1 line.
+        "path-to-regexp"
     ],
     "ignorePaths": [
         "test",


### PR DESCRIPTION
Two Renovate PRs recently proposed bumps through pnpm overrides that are intentional pins, because `ignoreDeps` matches package names, not override keys:

- `knex-migrator>knex` — the existing `"knex"` ignore (PLA-78 pin to 2.4.2, in lockstep with ghost/core's knex) doesn't match the override key, so Renovate proposed 2.5.1 (#29092), which breaks bootstrap migrations (2.4.2 query builder compiled by a 2.5.1 compiler).
- `path-to-regexp` — the `path-to-regexp@<0.1.13` override exists only to force Express 4's transitive dep to the ReDoS-patched 0.1.13. Express 4 pins path-to-regexp 0.1.x; the proposed `^0.2.0` (#29099) breaks route matching (its own CI showed the click-tracking redirect test failing).

Adds both to `ignoreDeps` so these unactionable bumps stop recurring.

### Verification
- Config-only change; `node -e "require('json5').parse(...)"` parses clean.