### PR TITLE
🐛 Fixed settings routes not hiding the outer admin sidebar

### DIFF
--- a/apps/admin/src/layout/sidebar.acceptance.test.tsx
+++ b/apps/admin/src/layout/sidebar.acceptance.test.tsx
@@ -99,6 +99,17 @@ describe("Sidebar navigation", () => {
 
         await expect.poll(currentRoute).toMatch(/^\/settings/);
     });
+
+    it("hides the outer admin sidebar on settings routes", async () => {
+        // Settings is full-screen; leaving the shell sidebar mounted made it
+        // look clickable while clicks were swallowed (see #26607).
+        allowUnhandledRequests();
+        await renderAdminApp("/settings/staff");
+
+        await expect.poll(currentRoute).toMatch(/^\/settings/);
+        await expect.element(sidebarScreen.navLink("Settings")).not.toBeInTheDocument();
+        await expect.element(sidebarScreen.navLink("Posts")).not.toBeInTheDocument();
+    });
 });
 
 describe("Sidebar user menu", () => {

--- a/apps/admin/src/layout/sidebar.acceptance.test.tsx
+++ b/apps/admin/src/layout/sidebar.acceptance.test.tsx
@@ -101,14 +101,14 @@ describe("Sidebar navigation", () => {
     });
 
     it("hides the outer admin sidebar on settings routes", async () => {
-        // Settings is full-screen; leaving the shell sidebar mounted made it
-        // look clickable while clicks were swallowed (see #26607).
         allowUnhandledRequests();
-        await renderAdminApp("/settings/staff");
+        await renderAdminApp("/");
+
+        await expect.element(sidebarScreen.navLink("Settings")).toBeVisible();
+        await sidebarScreen.navLink("Settings").click();
 
         await expect.poll(currentRoute).toMatch(/^\/settings/);
-        await expect.element(sidebarScreen.navLink("Settings")).not.toBeInTheDocument();
-        await expect.element(sidebarScreen.navLink("Posts")).not.toBeInTheDocument();
+        await expect.poll(sidebarScreen.isMounted).toBe(false);
     });
 });
 

--- a/apps/admin/src/layout/sidebar.screen.ts
+++ b/apps/admin/src/layout/sidebar.screen.ts
@@ -22,6 +22,8 @@ const appearanceOptions = {
 /** Admin sidebar locators and gestures for acceptance specs; no assertions. */
 export const sidebarScreen = {
     navLink: (name: string) => page.getByRole("navigation").getByRole("link", { name, exact: true }),
+    /** Settings renders its own nav, so role queries can't tell the two apart. */
+    isMounted: () => document.querySelector('[data-sidebar="sidebar"]') !== null,
     postsToggle: () => page.getByRole("button", { name: postsToggle }),
     networkBadge: () => page.getByTestId(networkNotificationBadge),
     userMenuTrigger: () => page.getByRole("button", { name: userMenuTrigger }),

--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -173,9 +173,8 @@ export const routes: RouteObject[] = [
                 children: activityPubRoutes,
             },
             {
-                // Settings is a full-screen surface — hide the outer admin
-                // sidebar so Editors/Authors don't see a visible-but-dead nav
-                // (and so sidebar hooks like member-count don't keep firing).
+                // Settings hides the admin sidebar for a focused, full-screen
+                // surface.
                 path: `settings/*`,
                 lazy: lazyComponent(() => import("./settings/settings")),
                 handle: {

--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -173,9 +173,15 @@ export const routes: RouteObject[] = [
                 children: activityPubRoutes,
             },
             {
+                // Settings is a full-screen surface — hide the outer admin
+                // sidebar so Editors/Authors don't see a visible-but-dead nav
+                // (and so sidebar hooks like member-count don't keep firing).
                 path: `settings/*`,
                 lazy: lazyComponent(() => import("./settings/settings")),
-                handle: { allowInForceUpgrade: true } satisfies RouteHandle,
+                handle: {
+                    allowInForceUpgrade: true,
+                    hideAdminSidebar: true
+                } satisfies AdminRouteHandle,
             },
             {path: "/posts", Component: EmberListWithGiftLinks, handle: emberFallbackHandle},
             {path: "/pages", Component: EmberListWithGiftLinks, handle: emberFallbackHandle},


### PR DESCRIPTION
## Summary
- Settings is rendered as a full-screen surface, but `settings/*` did not set `hideAdminSidebar: true`, so the outer admin shell sidebar stayed mounted underneath.
- That matches the Editor experience in #26607: sidebar looked present but clicks/nav were dead, and sidebar hooks (including member-count) kept running under the settings portal.
- `useMemberCount` is already permission-gated on `main`; this PR fixes the remaining settings-route sidebar visibility hole.

fixes https://github.com/TryGhost/Ghost/issues/26607

## Test plan
- [x] `pnpm exec vitest run src/layout/sidebar-visibility.test.tsx` (3 passed)
- [x] `pnpm test:acceptance src/layout/sidebar.acceptance.test.tsx` (17 passed, including new settings-route assertion)
- [ ] Log in as Editor → open `#/settings/staff` → confirm outer admin sidebar is hidden and no “browse members” toast from the shell nav