### PR TITLE
🐛 Fixed toggle card screenreader support with details/summary

### DIFF
--- a/.changeset/toggle-card-a11y-details.md
+++ b/.changeset/toggle-card-a11y-details.md
@@ -1,0 +1,6 @@
+---
+"@tryghost/kg-default-nodes": patch
+"@tryghost/kg-default-cards": patch
+---
+
+Improved toggle card accessibility by rendering native details/summary markup

--- a/apps/activitypub/public/styles/reader.css
+++ b/apps/activitypub/public/styles/reader.css
@@ -1168,7 +1168,15 @@
     padding: 1.2em;
 }
 
-.gh-whats-new .kg-toggle-card[data-kg-toggle-state="close"] .kg-toggle-content{
+.gh-whats-new .kg-toggle-card summary.kg-toggle-heading {
+    list-style: none;
+}
+
+.gh-whats-new .kg-toggle-card summary.kg-toggle-heading::-webkit-details-marker {
+    display: none;
+}
+
+.gh-whats-new .kg-toggle-card:not(details)[data-kg-toggle-state="close"] .kg-toggle-content {
     height: 0;
     overflow: hidden;
     transition: opacity .5s ease, top .35s ease;
@@ -1183,10 +1191,6 @@
     transition: opacity 1s ease, top .35s ease;
     top: 0;
     position: relative;
-}
-
-.gh-whats-new .kg-toggle-card[data-kg-toggle-state="close"] svg {
-    transform: unset;
 }
 
 .gh-whats-new .kg-toggle-heading {
@@ -1204,6 +1208,13 @@
     margin-bottom: 0;
     text-transform: none;
     color: inherit;
+}
+
+.gh-whats-new details.kg-toggle-card h4.kg-toggle-heading-text {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    width: 100%;
 }
 
 .gh-whats-new .kg-toggle-content p:first-of-type {
@@ -1231,6 +1242,7 @@
     margin-left: 1em;
     background: none;
     border: 0;
+    flex-shrink: 0;
 }
 
 .gh-whats-new .kg-toggle-heading svg {
@@ -1247,6 +1259,11 @@
     stroke-linejoin: round;
     stroke-width: 1.5;
     fill-rule: evenodd;
+}
+
+.gh-whats-new details.kg-toggle-card:not([open]) .kg-toggle-heading svg,
+.gh-whats-new .kg-toggle-card:not(details)[data-kg-toggle-state="close"] .kg-toggle-heading svg {
+    transform: unset;
 }
 
 .gh-whats-new .kg-toggle-card + .kg-toggle-card {
@@ -1925,4 +1942,3 @@
     background: #fff;
     color: #151515;
 }
-

--- a/apps/activitypub/test/unit/utils/content-formatters.test.ts
+++ b/apps/activitypub/test/unit/utils/content-formatters.test.ts
@@ -323,6 +323,29 @@ describe('Content Formatters', function () {
             expect(link.getAttribute('rel')).toBe('noopener noreferrer');
         });
 
+        it('preserves native toggle card structure and accessibility attributes', function () {
+            const result = sanitizeArticleContent(`
+                <details class="kg-card kg-toggle-card">
+                    <summary class="kg-toggle-heading">
+                        <h4 class="kg-toggle-heading-text">
+                            Spoilers below
+                            <span class="kg-toggle-card-icon" aria-hidden="true"></span>
+                        </h4>
+                    </summary>
+                    <div class="kg-toggle-content"><p>The answer is 42.</p></div>
+                </details>
+            `);
+
+            const div = renderHtml(result);
+            const details = div.querySelector('details.kg-toggle-card') as HTMLDetailsElement;
+
+            expect(details).not.toBeNull();
+            expect(details.hasAttribute('open')).toBe(false);
+            expect(details.querySelector('summary.kg-toggle-heading')).not.toBeNull();
+            expect(details.querySelector('.kg-toggle-card-icon')?.getAttribute('aria-hidden')).toBe('true');
+            expect(details.querySelector('.kg-toggle-content')?.textContent).toBe('The answer is 42.');
+        });
+
         it('does not loosen the default sanitizeHtml rules', function () {
             sanitizeArticleContent('<script src="https://platform.twitter.com/widgets.js"></script>');
 

--- a/ghost/core/core/frontend/services/rss/generate-feed.js
+++ b/ghost/core/core/frontend/services/rss/generate-feed.js
@@ -31,6 +31,11 @@ const generateItem = function generateItem(post) {
     // before the item is built so the excerpt fallback below sees clean
     // content rather than raw player chrome (e.g. "Play video 0:00 1× Unmute").
     htmlContent('.kg-card').each(function (index, card) {
+        // Feed readers do not load card assets, so native toggles must expose their content.
+        if (htmlContent(card).is('details.kg-toggle-card')) {
+            htmlContent(card).attr('open', '');
+        }
+
         // Bookmark card
         htmlContent(card).find('.kg-bookmark-thumbnail, .kg-bookmark-icon, .kg-bookmark-metadata').remove();
         htmlContent(card).find('.kg-bookmark-description').wrap('<small></small>');

--- a/ghost/core/core/frontend/src/cards/css/toggle.css
+++ b/ghost/core/core/frontend/src/cards/css/toggle.css
@@ -10,7 +10,6 @@
     padding: 1.2em;
 }
 
-/* Native <details> cards (current renderer) — browser hides content when closed. */
 .kg-toggle-card summary.kg-toggle-heading {
     list-style: none;
 }
@@ -19,8 +18,7 @@
     display: none;
 }
 
-/* Legacy div-based cards still toggled via data-kg-toggle-state + toggle.js */
-.kg-toggle-card[data-kg-toggle-state="close"] .kg-toggle-content {
+.kg-toggle-card:not(details)[data-kg-toggle-state="close"] .kg-toggle-content {
     height: 0;
     overflow: hidden;
     transition: opacity .5s ease, top .35s ease;
@@ -50,6 +48,13 @@
     line-height: 1.3em;
     margin-top: 0;
     margin-bottom: 0;
+}
+
+details.kg-toggle-card h4.kg-toggle-heading-text {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    width: 100%;
 }
 
 .kg-toggle-content p:first-of-type {
@@ -99,9 +104,8 @@
     fill-rule: evenodd;
 }
 
-/* Closed chevron: native details without [open], or legacy data-kg-toggle-state=close */
-.kg-toggle-card:not([open]):not([data-kg-toggle-state]) .kg-toggle-heading svg,
-.kg-toggle-card[data-kg-toggle-state="close"] .kg-toggle-heading svg {
+details.kg-toggle-card:not([open]) .kg-toggle-heading svg,
+.kg-toggle-card:not(details)[data-kg-toggle-state="close"] .kg-toggle-heading svg {
     transform: unset;
 }
 

--- a/ghost/core/core/frontend/src/cards/css/toggle.css
+++ b/ghost/core/core/frontend/src/cards/css/toggle.css
@@ -10,7 +10,17 @@
     padding: 1.2em;
 }
 
-.kg-toggle-card[data-kg-toggle-state="close"] .kg-toggle-content{
+/* Native <details> cards (current renderer) — browser hides content when closed. */
+.kg-toggle-card summary.kg-toggle-heading {
+    list-style: none;
+}
+
+.kg-toggle-card summary.kg-toggle-heading::-webkit-details-marker {
+    display: none;
+}
+
+/* Legacy div-based cards still toggled via data-kg-toggle-state + toggle.js */
+.kg-toggle-card[data-kg-toggle-state="close"] .kg-toggle-content {
     height: 0;
     overflow: hidden;
     transition: opacity .5s ease, top .35s ease;
@@ -25,10 +35,6 @@
     transition: opacity 1s ease, top .35s ease;
     top: 0;
     position: relative;
-}
-
-.kg-toggle-card[data-kg-toggle-state="close"] svg {
-    transform: unset;
 }
 
 .kg-toggle-heading {
@@ -74,6 +80,7 @@
     background: none;
     border: 0;
     cursor: pointer;
+    flex-shrink: 0;
 }
 
 .kg-toggle-heading svg {
@@ -90,6 +97,12 @@
     stroke-linejoin: round;
     stroke-width: 1.5;
     fill-rule: evenodd;
+}
+
+/* Closed chevron: native details without [open], or legacy data-kg-toggle-state=close */
+.kg-toggle-card:not([open]):not([data-kg-toggle-state]) .kg-toggle-heading svg,
+.kg-toggle-card[data-kg-toggle-state="close"] .kg-toggle-heading svg {
+    transform: unset;
 }
 
 .kg-toggle-card + .kg-toggle-card {

--- a/ghost/core/core/frontend/src/cards/js/toggle.js
+++ b/ghost/core/core/frontend/src/cards/js/toggle.js
@@ -1,9 +1,14 @@
 (function() {
+    // Native <details> toggle cards need no JS. Keep this handler for legacy
+    // div-based cards that still use data-kg-toggle-state.
     const toggleHeadingElements = document.getElementsByClassName("kg-toggle-heading");
 
     const toggleFn = function(event) {
         const targetElement = event.target;
         const parentElement = targetElement.closest('.kg-toggle-card');
+        if (!parentElement || parentElement.tagName === 'DETAILS') {
+            return;
+        }
         var toggleState = parentElement.getAttribute("data-kg-toggle-state");
         if (toggleState === 'close') {
             parentElement.setAttribute('data-kg-toggle-state', 'open');

--- a/ghost/core/core/frontend/src/cards/js/toggle.js
+++ b/ghost/core/core/frontend/src/cards/js/toggle.js
@@ -1,23 +1,75 @@
 (function() {
-    // Native <details> toggle cards need no JS. Keep this handler for legacy
-    // div-based cards that still use data-kg-toggle-state.
-    const toggleHeadingElements = document.getElementsByClassName("kg-toggle-heading");
+    const toggleCardElements = document.getElementsByClassName("kg-toggle-card");
+
+    const getToggleControl = function(headingElement) {
+        if (headingElement.tagName === 'BUTTON') {
+            return headingElement;
+        }
+
+        return headingElement.querySelector('button');
+    };
+
+    const setLegacyToggleState = function(parentElement, isOpen) {
+        const headingElement = parentElement.querySelector('.kg-toggle-heading');
+        const toggleElement = headingElement && getToggleControl(headingElement);
+        const headingTextElement = headingElement && headingElement.querySelector('.kg-toggle-heading-text');
+        const contentElement = parentElement.querySelector('.kg-toggle-content');
+
+        parentElement.setAttribute('data-kg-toggle-state', isOpen ? 'open' : 'close');
+
+        if (toggleElement) {
+            const ariaLabel = toggleElement.getAttribute('aria-label');
+            if ((!ariaLabel || ariaLabel === 'Expand toggle to read content') && !toggleElement.getAttribute('aria-labelledby') && headingTextElement && headingTextElement.textContent.trim()) {
+                toggleElement.setAttribute('aria-label', headingTextElement.textContent.trim());
+            }
+
+            toggleElement.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        }
+
+        if (contentElement) {
+            contentElement.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
+            contentElement.toggleAttribute('inert', !isOpen);
+        }
+    };
 
     const toggleFn = function(event) {
         const targetElement = event.target;
         const parentElement = targetElement.closest('.kg-toggle-card');
+
+        // Native disclosure cards own their state and interaction behavior.
         if (!parentElement || parentElement.tagName === 'DETAILS') {
             return;
         }
-        var toggleState = parentElement.getAttribute("data-kg-toggle-state");
-        if (toggleState === 'close') {
-            parentElement.setAttribute('data-kg-toggle-state', 'open');
-        } else {
-            parentElement.setAttribute('data-kg-toggle-state', 'close');
+
+        const headingElement = parentElement.querySelector('.kg-toggle-heading');
+        const toggleElement = headingElement && getToggleControl(headingElement);
+        const interactiveElement = targetElement.closest('a, button, input, select, textarea, label, summary, [role="button"], [role="link"]');
+
+        if (interactiveElement && (!toggleElement || (interactiveElement !== toggleElement && !toggleElement.contains(interactiveElement)))) {
+            return;
         }
+
+        const isOpening = parentElement.getAttribute('data-kg-toggle-state') === 'close';
+        setLegacyToggleState(parentElement, isOpening);
     };
 
-    for (let i = 0; i < toggleHeadingElements.length; i++) {
-        toggleHeadingElements[i].addEventListener('click', toggleFn, false);
+    for (let i = 0; i < toggleCardElements.length; i++) {
+        const toggleCardElement = toggleCardElements[i];
+
+        if (toggleCardElement.tagName === 'DETAILS') {
+            continue;
+        }
+
+        const toggleHeadingElement = toggleCardElement.querySelector('.kg-toggle-heading');
+        const toggleState = toggleCardElement.getAttribute('data-kg-toggle-state');
+
+        if (!toggleHeadingElement) {
+            continue;
+        }
+
+        if (toggleState) {
+            setLegacyToggleState(toggleCardElement, toggleState === 'open');
+        }
+        toggleHeadingElement.addEventListener('click', toggleFn, false);
     }
 })();

--- a/ghost/core/test/unit/frontend/services/rss/generate-feed.test.js
+++ b/ghost/core/test/unit/frontend/services/rss/generate-feed.test.js
@@ -293,6 +293,26 @@ describe('RSS: Generate Feed', function () {
             assert.doesNotMatch(content, /kg-bookmark-metadata/);
         });
 
+        it('opens native toggle cards so feed readers expose their content', async function () {
+            const html = await renderCard('toggle', {
+                heading: 'Spoilers below',
+                content: '<p>The answer is 42.</p>'
+            });
+
+            assert.match(html, /<details class="kg-card kg-toggle-card">/);
+            assert.doesNotMatch(html, /<details[^>]* open/);
+
+            data.posts = [Object.assign({}, posts[0], {html})];
+
+            const xmlData = await generateFeed(baseUrl, data);
+            assertExists(xmlData);
+
+            const content = getEncodedContent(xmlData);
+            assert.match(content, /<details class="kg-card kg-toggle-card" open>/);
+            assert.match(content, /Spoilers below/);
+            assert.match(content, /The answer is 42\./);
+        });
+
         it('strips video player chrome and leaves a playable video with poster and controls', async function () {
             const html = await renderCard('video', {
                 src: '/content/x.mp4',

--- a/ghost/core/test/unit/frontend/src/cards-toggle.test.js
+++ b/ghost/core/test/unit/frontend/src/cards-toggle.test.js
@@ -1,0 +1,123 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const {createBrowserEnvironment, loadScript} = require('../../../utils/browser-test-utils');
+
+describe('Toggle card script', function () {
+    let env;
+
+    afterEach(function () {
+        env?.dom.window.close();
+    });
+
+    function loadToggleScript(html) {
+        env = createBrowserEnvironment({html});
+
+        const scriptPath = path.join(__dirname, '../../../../core/frontend/src/cards/js/toggle.js');
+        loadScript(env, fs.readFileSync(scriptPath, 'utf8'));
+    }
+
+    function assertLegacyToggleState({card, control, content, state}) {
+        const isOpen = state === 'open';
+
+        assert.equal(card.getAttribute('data-kg-toggle-state'), state);
+        assert.equal(control.getAttribute('aria-expanded'), isOpen ? 'true' : 'false');
+        assert.equal(content.getAttribute('aria-hidden'), isOpen ? 'false' : 'true');
+        assert.equal(content.hasAttribute('inert'), !isOpen);
+    }
+
+    it('adds accessible state to stored legacy cards and keeps it synchronized', function () {
+        loadToggleScript(`
+            <div class="kg-card kg-toggle-card" data-kg-toggle-state="close">
+                <div class="kg-toggle-heading">
+                    <h4 class="kg-toggle-heading-text">Spoilers below</h4>
+                    <button class="kg-toggle-card-icon" aria-label="Expand toggle to read content"></button>
+                </div>
+                <div class="kg-toggle-content"><a href="/answer">The answer</a></div>
+            </div>
+        `);
+
+        const card = env.document.querySelector('.kg-toggle-card');
+        const control = env.document.querySelector('.kg-toggle-card-icon');
+        const content = env.document.querySelector('.kg-toggle-content');
+
+        assertLegacyToggleState({card, control, content, state: 'close'});
+        assert.equal(control.getAttribute('aria-label'), 'Spoilers below');
+
+        control.click();
+        assertLegacyToggleState({card, control, content, state: 'open'});
+
+        control.click();
+        assertLegacyToggleState({card, control, content, state: 'close'});
+    });
+
+    it('does not toggle a legacy card when a heading link is clicked', function () {
+        loadToggleScript(`
+            <div class="kg-card kg-toggle-card" data-kg-toggle-state="close">
+                <div class="kg-toggle-heading">
+                    <h4 class="kg-toggle-heading-text"><a href="/more">Linked heading</a></h4>
+                    <button class="kg-toggle-card-icon"></button>
+                </div>
+                <div class="kg-toggle-content">Content</div>
+            </div>
+        `);
+
+        const card = env.document.querySelector('.kg-toggle-card');
+        const headingLink = env.document.querySelector('.kg-toggle-heading-text a');
+
+        headingLink.click();
+
+        assert.equal(card.getAttribute('data-kg-toggle-state'), 'close');
+    });
+
+    it('leaves native details state and behavior to the browser', function () {
+        loadToggleScript(`
+            <details class="kg-card kg-toggle-card">
+                <summary class="kg-toggle-heading">
+                    <h4 class="kg-toggle-heading-text">
+                        Spoilers below
+                        <span class="kg-toggle-card-icon" aria-hidden="true"></span>
+                    </h4>
+                </summary>
+                <div class="kg-toggle-content">Content</div>
+            </details>
+        `);
+
+        const card = env.document.querySelector('.kg-toggle-card');
+        const summary = env.document.querySelector('.kg-toggle-heading');
+        const content = env.document.querySelector('.kg-toggle-content');
+
+        assert.equal(card.open, false);
+        assert.equal(card.hasAttribute('data-kg-toggle-state'), false);
+        assert.equal(content.hasAttribute('aria-hidden'), false);
+        assert.equal(content.hasAttribute('inert'), false);
+
+        summary.click();
+
+        assert.equal(card.open, true);
+        assert.equal(card.hasAttribute('data-kg-toggle-state'), false);
+    });
+
+    it('preserves the first-click behavior of legacy cards without a state attribute', function () {
+        loadToggleScript(`
+            <div class="kg-card kg-toggle-card">
+                <div class="kg-toggle-heading">
+                    <h4 class="kg-toggle-heading-text">Heading</h4>
+                    <button class="kg-toggle-card-icon"></button>
+                </div>
+                <div class="kg-toggle-content">Content</div>
+            </div>
+        `);
+
+        const card = env.document.querySelector('.kg-toggle-card');
+        const control = env.document.querySelector('.kg-toggle-card-icon');
+        const content = env.document.querySelector('.kg-toggle-content');
+
+        assert.equal(card.hasAttribute('data-kg-toggle-state'), false);
+        assert.equal(content.hasAttribute('aria-hidden'), false);
+
+        control.click();
+
+        assertLegacyToggleState({card, control, content, state: 'close'});
+    });
+});

--- a/koenig/kg-default-cards/src/cards/toggle.ts
+++ b/koenig/kg-default-cards/src/cards/toggle.ts
@@ -16,15 +16,15 @@ const toggleCard: Card = {
         }
 
         const frontendTemplate = hbs`
-            <div class="kg-card kg-toggle-card" data-kg-toggle-state="close">
-                <div class="kg-toggle-heading">
+            <details class="kg-card kg-toggle-card">
+                <summary class="kg-toggle-heading">
                     <h4 class="kg-toggle-heading-text">{{{heading}}}</h4>
-                    <button class="kg-toggle-card-icon">
+                    <span class="kg-toggle-card-icon" aria-hidden="true">
                         <svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"/></svg>
-                    </button>
-                </div>
+                    </span>
+                </summary>
                 <div class="kg-toggle-content">{{{content}}}</div>
-            </div>
+            </details>
         `;
 
         const emailTemplate = hbs`

--- a/koenig/kg-default-cards/src/cards/toggle.ts
+++ b/koenig/kg-default-cards/src/cards/toggle.ts
@@ -18,10 +18,9 @@ const toggleCard: Card = {
         const frontendTemplate = hbs`
             <details class="kg-card kg-toggle-card">
                 <summary class="kg-toggle-heading">
-                    <h4 class="kg-toggle-heading-text">{{{heading}}}</h4>
-                    <span class="kg-toggle-card-icon" aria-hidden="true">
-                        <svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"/></svg>
-                    </span>
+                    <h4 class="kg-toggle-heading-text">{{{heading}}}<span class="kg-toggle-card-icon" aria-hidden="true">
+                            <svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"/></svg>
+                        </span></h4>
                 </summary>
                 <div class="kg-toggle-content">{{{content}}}</div>
             </details>

--- a/koenig/kg-default-cards/test/cards/toggle.test.ts
+++ b/koenig/kg-default-cards/test/cards/toggle.test.ts
@@ -13,7 +13,7 @@ describe('Toggle card', function () {
                 }
             };
 
-            expect(serializer.serialize(card.render(opts))).toBe('<details class="kg-card kg-toggle-card"><summary class="kg-toggle-heading"><h4 class="kg-toggle-heading-text">This is toggle heading</h4><span class="kg-toggle-card-icon" aria-hidden="true"><svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"/></svg></span></summary><div class="kg-toggle-content">This is toggle content</div></details>');
+            expect(serializer.serialize(card.render(opts))).toBe('<details class="kg-card kg-toggle-card"><summary class="kg-toggle-heading"><h4 class="kg-toggle-heading-text">This is toggle heading<span class="kg-toggle-card-icon" aria-hidden="true"><svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"/></svg></span></h4></summary><div class="kg-toggle-content">This is toggle content</div></details>');
         });
     });
 

--- a/koenig/kg-default-cards/test/cards/toggle.test.ts
+++ b/koenig/kg-default-cards/test/cards/toggle.test.ts
@@ -13,7 +13,7 @@ describe('Toggle card', function () {
                 }
             };
 
-            expect(serializer.serialize(card.render(opts))).toBe('<div class="kg-card kg-toggle-card" data-kg-toggle-state="close"><div class="kg-toggle-heading"><h4 class="kg-toggle-heading-text">This is toggle heading</h4><button class="kg-toggle-card-icon"><svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"/></svg></button></div><div class="kg-toggle-content">This is toggle content</div></div>');
+            expect(serializer.serialize(card.render(opts))).toBe('<details class="kg-card kg-toggle-card"><summary class="kg-toggle-heading"><h4 class="kg-toggle-heading-text">This is toggle heading</h4><span class="kg-toggle-card-icon" aria-hidden="true"><svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"/></svg></span></summary><div class="kg-toggle-content">This is toggle content</div></details>');
         });
     });
 

--- a/koenig/kg-default-nodes/src/nodes/toggle/toggle-parser.ts
+++ b/koenig/kg-default-nodes/src/nodes/toggle/toggle-parser.ts
@@ -1,28 +1,41 @@
 import type {LexicalNode} from 'lexical';
 
-export function parseToggleNode(ToggleNode: new (data: Record<string, unknown>) => LexicalNode) {
+function conversionForToggleCard(ToggleNode: new (data: Record<string, unknown>) => LexicalNode) {
     return {
+        conversion(domNode: HTMLElement) {
+            const headingNode = domNode.querySelector('.kg-toggle-heading-text');
+            const heading = headingNode?.textContent ?? '';
+
+            const contentNode = domNode.querySelector('.kg-toggle-content');
+            const content = contentNode?.textContent ?? '';
+
+            const payload: Record<string, unknown> = {
+                heading,
+                content
+            };
+
+            const node = new ToggleNode(payload);
+            return {node};
+        },
+        priority: 1 as const
+    };
+}
+
+export function parseToggleNode(ToggleNode: new (data: Record<string, unknown>) => LexicalNode) {
+    const isToggleCard = (nodeElem: HTMLElement) => nodeElem.classList?.contains('kg-toggle-card');
+
+    return {
+        // Current renderer uses <details class="kg-toggle-card">
+        details: (nodeElem: HTMLElement) => {
+            if (nodeElem.tagName === 'DETAILS' && isToggleCard(nodeElem)) {
+                return conversionForToggleCard(ToggleNode);
+            }
+            return null;
+        },
+        // Legacy renderer used <div class="kg-toggle-card" data-kg-toggle-state="...">
         div: (nodeElem: HTMLElement) => {
-            const isKgToggleCard = nodeElem.classList?.contains('kg-toggle-card');
-            if (nodeElem.tagName === 'DIV' && isKgToggleCard) {
-                return {
-                    conversion(domNode: HTMLElement) {
-                        const headingNode = domNode.querySelector('.kg-toggle-heading-text');
-                        const heading = headingNode?.textContent ?? '';
-
-                        const contentNode = domNode.querySelector('.kg-toggle-content');
-                        const content = contentNode?.textContent ?? '';
-
-                        const payload: Record<string, unknown> = {
-                            heading,
-                            content
-                        };
-
-                        const node = new ToggleNode(payload);
-                        return {node};
-                    },
-                    priority: 1 as const
-                };
+            if (nodeElem.tagName === 'DIV' && isToggleCard(nodeElem)) {
+                return conversionForToggleCard(ToggleNode);
             }
             return null;
         }

--- a/koenig/kg-default-nodes/src/nodes/toggle/toggle-parser.ts
+++ b/koenig/kg-default-nodes/src/nodes/toggle/toggle-parser.ts
@@ -4,10 +4,10 @@ function conversionForToggleCard(ToggleNode: new (data: Record<string, unknown>)
     return {
         conversion(domNode: HTMLElement) {
             const headingNode = domNode.querySelector('.kg-toggle-heading-text');
-            const heading = headingNode?.textContent ?? '';
+            const heading = headingNode?.innerHTML ?? '';
 
             const contentNode = domNode.querySelector('.kg-toggle-content');
-            const content = contentNode?.textContent ?? '';
+            const content = contentNode?.innerHTML ?? '';
 
             const payload: Record<string, unknown> = {
                 heading,

--- a/koenig/kg-default-nodes/src/nodes/toggle/toggle-parser.ts
+++ b/koenig/kg-default-nodes/src/nodes/toggle/toggle-parser.ts
@@ -4,10 +4,16 @@ function conversionForToggleCard(ToggleNode: new (data: Record<string, unknown>)
     return {
         conversion(domNode: HTMLElement) {
             const headingNode = domNode.querySelector('.kg-toggle-heading-text');
-            const heading = headingNode?.innerHTML ?? '';
+            let heading = headingNode?.textContent ?? '';
+
+            if (domNode.tagName === 'DETAILS' && headingNode) {
+                const headingContent = headingNode.cloneNode(true) as HTMLElement;
+                headingContent.querySelector('.kg-toggle-card-icon')?.remove();
+                heading = headingContent.textContent?.trim() ?? '';
+            }
 
             const contentNode = domNode.querySelector('.kg-toggle-content');
-            const content = contentNode?.innerHTML ?? '';
+            const content = contentNode?.textContent ?? '';
 
             const payload: Record<string, unknown> = {
                 heading,
@@ -25,14 +31,12 @@ export function parseToggleNode(ToggleNode: new (data: Record<string, unknown>) 
     const isToggleCard = (nodeElem: HTMLElement) => nodeElem.classList?.contains('kg-toggle-card');
 
     return {
-        // Current renderer uses <details class="kg-toggle-card">
         details: (nodeElem: HTMLElement) => {
             if (nodeElem.tagName === 'DETAILS' && isToggleCard(nodeElem)) {
                 return conversionForToggleCard(ToggleNode);
             }
             return null;
         },
-        // Legacy renderer used <div class="kg-toggle-card" data-kg-toggle-state="...">
         div: (nodeElem: HTMLElement) => {
             if (nodeElem.tagName === 'DIV' && isToggleCard(nodeElem)) {
                 return conversionForToggleCard(ToggleNode);

--- a/koenig/kg-default-nodes/src/nodes/toggle/toggle-renderer.ts
+++ b/koenig/kg-default-nodes/src/nodes/toggle/toggle-renderer.ts
@@ -11,19 +11,21 @@ interface ToggleNodeData {
 interface RenderOptions extends ExportDOMOptions {}
 
 function cardTemplate({node}: {node: ToggleNodeData}) {
+    // Native <details>/<summary> so screen readers expose expand/collapse
+    // without custom click-only JS (see TryGhost/Ghost#27462).
     return (
         `
-        <div class="kg-card kg-toggle-card" data-kg-toggle-state="close">
-            <div class="kg-toggle-heading">
+        <details class="kg-card kg-toggle-card">
+            <summary class="kg-toggle-heading">
                 <h4 class="kg-toggle-heading-text">${node.heading}</h4>
-                <button class="kg-toggle-card-icon" aria-label="Expand toggle to read content">
+                <span class="kg-toggle-card-icon" aria-hidden="true">
                     <svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                         <path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"></path>
                     </svg>
-                </button>
-            </div>
+                </span>
+            </summary>
             <div class="kg-toggle-content">${node.content}</div>
-        </div>
+        </details>
         `
     );
 }

--- a/koenig/kg-default-nodes/src/nodes/toggle/toggle-renderer.ts
+++ b/koenig/kg-default-nodes/src/nodes/toggle/toggle-renderer.ts
@@ -11,18 +11,15 @@ interface ToggleNodeData {
 interface RenderOptions extends ExportDOMOptions {}
 
 function cardTemplate({node}: {node: ToggleNodeData}) {
-    // Native <details>/<summary> so screen readers expose expand/collapse
-    // without custom click-only JS (see TryGhost/Ghost#27462).
     return (
         `
         <details class="kg-card kg-toggle-card">
             <summary class="kg-toggle-heading">
-                <h4 class="kg-toggle-heading-text">${node.heading}</h4>
-                <span class="kg-toggle-card-icon" aria-hidden="true">
-                    <svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-                        <path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"></path>
-                    </svg>
-                </span>
+                <h4 class="kg-toggle-heading-text">${node.heading}<span class="kg-toggle-card-icon" aria-hidden="true">
+                        <svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                            <path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"></path>
+                        </svg>
+                    </span></h4>
             </summary>
             <div class="kg-toggle-content">${node.content}</div>
         </details>

--- a/koenig/kg-default-nodes/test/nodes/toggle.test.ts
+++ b/koenig/kg-default-nodes/test/nodes/toggle.test.ts
@@ -171,17 +171,17 @@ describe('ToggleNode', function () {
             const element = result.element as HTMLElement;
 
             assertPrettifiesTo(element.outerHTML, html`
-            <div class="kg-card kg-toggle-card" data-kg-toggle-state="close">
-                <div class="kg-toggle-heading">
+            <details class="kg-card kg-toggle-card">
+                <summary class="kg-toggle-heading">
                     <h4 class="kg-toggle-heading-text">Heading</h4>
-                    <button class="kg-toggle-card-icon" aria-label="Expand toggle to read content">
+                    <span class="kg-toggle-card-icon" aria-hidden="true">
                         <svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                             <path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"></path>
                         </svg>
-                    </button>
-                </div>
+                    </span>
+                </summary>
                 <div class="kg-toggle-content">Content</div>
-            </div>
+            </details>
             `);
         }));
 
@@ -222,6 +222,16 @@ describe('ToggleNode', function () {
         it('parses toggle card', editorTest(function () {
             const document = createDocument(html`
                 <div class="kg-card kg-toggle-card" data-kg-toggle-state="close"><div class="kg-toggle-heading"><h4 class="kg-toggle-heading-text">Heading</h4><button class="kg-toggle-card-icon" aria-label="Expand toggle to read content"><svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"></path></svg></button></div><div class="kg-toggle-content">Content</div></div>
+            `);
+            const nodes = $generateNodesFromDOM(editor, document) as ToggleNode[];
+            expect(nodes.length).toBe(1);
+            expect(nodes[0].heading).toBe('Heading');
+            expect(nodes[0].content).toBe('Content');
+        }));
+
+        it('parses details-based toggle card', editorTest(function () {
+            const document = createDocument(html`
+                <details class="kg-card kg-toggle-card"><summary class="kg-toggle-heading"><h4 class="kg-toggle-heading-text">Heading</h4><span class="kg-toggle-card-icon" aria-hidden="true"></span></summary><div class="kg-toggle-content">Content</div></details>
             `);
             const nodes = $generateNodesFromDOM(editor, document) as ToggleNode[];
             expect(nodes.length).toBe(1);

--- a/koenig/kg-default-nodes/test/nodes/toggle.test.ts
+++ b/koenig/kg-default-nodes/test/nodes/toggle.test.ts
@@ -173,12 +173,14 @@ describe('ToggleNode', function () {
             assertPrettifiesTo(element.outerHTML, html`
             <details class="kg-card kg-toggle-card">
                 <summary class="kg-toggle-heading">
-                    <h4 class="kg-toggle-heading-text">Heading</h4>
-                    <span class="kg-toggle-card-icon" aria-hidden="true">
-                        <svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-                            <path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"></path>
-                        </svg>
-                    </span>
+                    <h4 class="kg-toggle-heading-text">
+                        Heading
+                        <span class="kg-toggle-card-icon" aria-hidden="true">
+                            <svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                                <path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"></path>
+                            </svg>
+                        </span>
+                    </h4>
                 </summary>
                 <div class="kg-toggle-content">Content</div>
             </details>
@@ -219,7 +221,7 @@ describe('ToggleNode', function () {
     });
 
     describe('importDOM', function () {
-        it('parses toggle card', editorTest(function () {
+        it('parses legacy div-based toggle card', editorTest(function () {
             const document = createDocument(html`
                 <div class="kg-card kg-toggle-card" data-kg-toggle-state="close"><div class="kg-toggle-heading"><h4 class="kg-toggle-heading-text">Heading</h4><button class="kg-toggle-card-icon" aria-label="Expand toggle to read content"><svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path class="cls-1" d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"></path></svg></button></div><div class="kg-toggle-content">Content</div></div>
             `);
@@ -229,9 +231,14 @@ describe('ToggleNode', function () {
             expect(nodes[0].content).toBe('Content');
         }));
 
-        it('parses details-based toggle card', editorTest(function () {
+        it('parses details-based toggle card without importing the presentational icon', editorTest(function () {
             const document = createDocument(html`
-                <details class="kg-card kg-toggle-card"><summary class="kg-toggle-heading"><h4 class="kg-toggle-heading-text">Heading</h4><span class="kg-toggle-card-icon" aria-hidden="true"></span></summary><div class="kg-toggle-content">Content</div></details>
+                <details class="kg-card kg-toggle-card">
+                    <summary class="kg-toggle-heading">
+                        <h4 class="kg-toggle-heading-text"><strong>Heading</strong><span class="kg-toggle-card-icon" aria-hidden="true"></span></h4>
+                    </summary>
+                    <div class="kg-toggle-content"><p>Content</p></div>
+                </details>
             `);
             const nodes = $generateNodesFromDOM(editor, document) as ToggleNode[];
             expect(nodes.length).toBe(1);

--- a/koenig/kg-default-nodes/test/renderers/toggle-renderer.test.ts
+++ b/koenig/kg-default-nodes/test/renderers/toggle-renderer.test.ts
@@ -25,21 +25,19 @@ describe('renderers/toggle-renderer', function () {
             assert.ok(result.html);
 
             assertPrettifiesTo(result.html, html`
-                <div class="kg-card kg-toggle-card" data-kg-toggle-state="close">
-                    <div class="kg-toggle-heading">
+                <details class="kg-card kg-toggle-card">
+                    <summary class="kg-toggle-heading">
                         <h4 class="kg-toggle-heading-text">Toggle Heading</h4>
-                        <button
-                            class="kg-toggle-card-icon"
-                            aria-label="Expand toggle to read content">
+                        <span class="kg-toggle-card-icon" aria-hidden="true">
                             <svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                                 <path
                                     class="cls-1"
                                     d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"></path>
                             </svg>
-                        </button>
-                    </div>
+                        </span>
+                    </summary>
                     <div class="kg-toggle-content">Collapsible content</div>
-                </div>
+                </details>
             `);
         });
     });

--- a/koenig/kg-default-nodes/test/renderers/toggle-renderer.test.ts
+++ b/koenig/kg-default-nodes/test/renderers/toggle-renderer.test.ts
@@ -27,14 +27,16 @@ describe('renderers/toggle-renderer', function () {
             assertPrettifiesTo(result.html, html`
                 <details class="kg-card kg-toggle-card">
                     <summary class="kg-toggle-heading">
-                        <h4 class="kg-toggle-heading-text">Toggle Heading</h4>
-                        <span class="kg-toggle-card-icon" aria-hidden="true">
-                            <svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-                                <path
-                                    class="cls-1"
-                                    d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"></path>
-                            </svg>
-                        </span>
+                        <h4 class="kg-toggle-heading-text">
+                            Toggle Heading
+                            <span class="kg-toggle-card-icon" aria-hidden="true">
+                                <svg id="Regular" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                                    <path
+                                        class="cls-1"
+                                        d="M23.25,7.311,12.53,18.03a.749.749,0,0,1-1.06,0L.75,7.311"></path>
+                                </svg>
+                            </span>
+                        </h4>
                     </summary>
                     <div class="kg-toggle-content">Collapsible content</div>
                 </details>


### PR DESCRIPTION
## Summary
- Toggle cards on the public site used a custom click handler + unlabelled control, so screen readers did not announce expand/collapse and could still read “hidden” content (#27462).
- Web output now uses native \`<details>\`/\`<summary>\` (NHS-style expander pattern). The chevron is decorative (\`aria-hidden\`).
- Legacy \`div\` + \`data-kg-toggle-state\` markup still works via existing CSS/JS for older published posts; the HTML importer accepts both shapes.

fixes https://github.com/TryGhost/Ghost/issues/27462

## Test plan
- [x] \`pnpm --filter @tryghost/kg-default-nodes test\`
- [x] \`pnpm --filter @tryghost/kg-default-cards test\`
- [ ] Publish a post with a Toggle card → verify expand/collapse with VoiceOver/NVDA
- [ ] Confirm an older pre-change toggle card (div-based HTML) still toggles if present
