### PR TITLE
Fixed comment post URLs typing pages as posts under lazy routing

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/comments.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/comments.js
@@ -120,7 +120,10 @@ const commentMapper = (model, frame) => {
 
     if (jsonModel.post) {
         // We could use the post mapper here, but we need less field + don't need all the async behavior support
-        url.forPost(jsonModel.post.id, jsonModel.post, frame);
+        // Comments live on pages as well as posts; the URL service routes by
+        // the passed type, so a page typed 'posts' resolves to /404/.
+        const routerType = jsonModel.post.type === 'page' ? 'pages' : 'posts';
+        url.forPost(jsonModel.post.id, jsonModel.post, frame, routerType);
         response.post = _.pick(jsonModel.post, postFields);
 
         // Compute excerpt from custom_excerpt or plaintext (same logic as post serializer)

--- a/ghost/core/core/server/services/comments/comments-service-emails.js
+++ b/ghost/core/core/server/services/comments/comments-service-emails.js
@@ -26,7 +26,10 @@ class CommentsServiceEmails {
      */
     getPostUrl(post, commentId) {
         const postData = toPlain(post);
-        const baseUrl = this.urlService.facade.getUrlForResource({...postData, type: 'posts'}, {absolute: true});
+        // Comments live on pages as well as posts; the URL service routes by
+        // the passed type, so a page typed 'posts' resolves to /404/.
+        const routerType = postData.type === 'page' ? 'pages' : 'posts';
+        const baseUrl = this.urlService.facade.getUrlForResource({...postData, type: routerType}, {absolute: true});
         return `${baseUrl}#ghost-comments-${commentId}`;
     }
 

--- a/ghost/core/test/e2e-api/members-comments/comments-lazy-url-parity.test.js
+++ b/ghost/core/test/e2e-api/members-comments/comments-lazy-url-parity.test.js
@@ -1,0 +1,150 @@
+const assert = require('node:assert/strict');
+const path = require('path');
+const fs = require('fs');
+const FormData = require('form-data');
+const sinon = require('sinon');
+const logging = require('@tryghost/logging');
+const {agentProvider, fixtureManager, configUtils} = require('../../utils/e2e-framework');
+const models = require('../../../core/server/models');
+const settingsCache = require('../../../core/shared/settings-cache');
+const urlService = require('../../../core/server/services/url');
+const LazyUrlService = require('../../../core/server/services/url/lazy-url-service');
+const {createFindResource} = require('../../../core/server/services/url/lazy-find-resource');
+const {UrlServiceFacade} = require('../../../core/server/services/url/url-service-facade');
+const urlServiceUtils = require('../../utils/url-service-utils');
+
+// The page must not match the collection filter: the production bug only
+// surfaces on sites whose collections are tag-filtered, because a page
+// mis-typed 'posts' falls through every filtered collection to /404/.
+// On an unfiltered (catch-all) collection the wrong type still lands on
+// the same /:slug/ URL and the divergence is invisible.
+const TAG_FILTERED_ROUTES = [
+    'routes:',
+    '',
+    'collections:',
+    '  /blog/:',
+    '    permalink: /blog/{slug}/',
+    '    filter: tag:hash-blog',
+    '',
+    'taxonomies:',
+    '  tag: /tag/{slug}/',
+    '  author: /author/{slug}/',
+    ''
+].join('\n');
+
+async function uploadRoutes(adminAgent, routesYaml) {
+    const formData = new FormData();
+    formData.append('routes', routesYaml, {
+        filename: 'routes.yaml',
+        contentType: 'application/yaml'
+    });
+    await adminAgent.post('settings/routes/yaml/')
+        .body(formData)
+        .expectStatus(200);
+    await urlServiceUtils.isFinished();
+}
+
+describe('Comments API lazy URL parity', function () {
+    let membersAgent;
+    let adminAgent;
+    let page;
+    let originalFacade;
+    let loggingErrorSpy;
+
+    beforeAll(async function () {
+        const agents = await agentProvider.getAgentsForMembers();
+        membersAgent = agents.membersAgent;
+        adminAgent = agents.adminAgent;
+
+        await fixtureManager.init('posts', 'members');
+        await adminAgent.loginAsOwner();
+
+        // Tee every read through a lazy backend in compare mode, the same
+        // shape production runs behind the lazyRouting flag. Swapped before
+        // the routes upload so the frontend reload registers the new routers
+        // on both backends (bridge reads urlService.facade at reload time).
+        originalFacade = urlService.facade;
+        urlService.facade = new UrlServiceFacade({
+            urlService,
+            lazyUrlService: new LazyUrlService({findResource: createFindResource(models)}),
+            compare: true
+        });
+
+        await uploadRoutes(adminAgent, TAG_FILTERED_ROUTES);
+
+        page = await models.Post.add({
+            title: 'Commented Page',
+            slug: 'commented-page',
+            type: 'page',
+            status: 'published'
+        }, {context: {internal: true}});
+
+        await models.Comment.add({
+            post_id: page.id,
+            member_id: fixtureManager.get('members', 0).id,
+            html: '<p>A comment on a page</p>',
+            status: 'published'
+        });
+    });
+
+    afterAll(async function () {
+        // The DB suites share one process: put back the eager-only facade and
+        // the default routes so later suites see the stock configuration.
+        const defaultRoutes = fs.readFileSync(
+            path.join(configUtils.config.get('paths:appRoot'), 'test/utils/fixtures/settings/routes.yaml'),
+            'utf8'
+        );
+        urlService.facade = originalFacade;
+        await uploadRoutes(adminAgent, defaultRoutes);
+    });
+
+    beforeEach(function () {
+        const getStub = sinon.stub(settingsCache, 'get');
+        getStub.callsFake((key, options) => {
+            if (key === 'comments_enabled') {
+                return 'all';
+            }
+            return getStub.wrappedMethod.call(settingsCache, key, options);
+        });
+        loggingErrorSpy = sinon.spy(logging, 'error');
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it('boots with the shadow comparison active', function () {
+        // Guards the facade wiring: without it the no-mismatch assertion
+        // below is vacuous.
+        assert.equal(urlService.facade.isComparing(), true);
+    });
+
+    it('serializes a page comment URL without a lazy parity mismatch', async function () {
+        const {body} = await membersAgent
+            .get(`/api/comments/post/${page.id}/?include=post`)
+            .expectStatus(200);
+
+        assert.equal(body.comments.length, 1);
+        const url = body.comments[0].post.url;
+        assert.match(url, /\/commented-page\/$/, `expected the page URL, got ${url}`);
+        assert.doesNotMatch(url, /\/404\//);
+
+        // The lazy shadow answer is compared on setImmediate; flush before
+        // asserting nothing was reported.
+        await new Promise((resolve) => {
+            setImmediate(resolve);
+        });
+        await new Promise((resolve) => {
+            setImmediate(resolve);
+        });
+
+        const parityReports = loggingErrorSpy.getCalls()
+            .map(call => call.args[0])
+            .filter(err => err && (err.code === 'LAZY_URL_PARITY_MISMATCH' || err.code === 'LAZY_URL_COMPARE_ERROR'));
+        assert.deepEqual(
+            parityReports.map(err => err.errorDetails),
+            [],
+            'lazy URL service diverged from eager while serializing a page comment'
+        );
+    });
+});

--- a/ghost/core/test/unit/server/api/endpoints/utils/serializers/output/mappers/comments.test.js
+++ b/ghost/core/test/unit/server/api/endpoints/utils/serializers/output/mappers/comments.test.js
@@ -1,0 +1,80 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const urlService = require('../../../../../../../../../core/server/services/url');
+const commentMapper = require('../../../../../../../../../core/server/api/endpoints/utils/serializers/output/mappers/comments');
+
+describe('Unit: endpoints/utils/serializers/output/mappers/comments', function () {
+    let getUrlForResourceStub;
+
+    beforeEach(function () {
+        getUrlForResourceStub = sinon.stub(urlService.facade, 'getUrlForResource').returns('https://example.com/resolved/');
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    function makeFrame() {
+        return {
+            apiType: 'members',
+            options: {},
+            original: {}
+        };
+    }
+
+    function makeComment(post) {
+        return {
+            id: 'comment-id',
+            html: '<p>comment</p>',
+            status: 'published',
+            post
+        };
+    }
+
+    it('resolves a comment on a post with the posts router type', function () {
+        commentMapper(makeComment({
+            id: 'post-id',
+            uuid: 'post-uuid',
+            title: 'A post',
+            slug: 'a-post',
+            type: 'post',
+            status: 'published'
+        }), makeFrame());
+
+        sinon.assert.calledOnce(getUrlForResourceStub);
+        const [resource] = getUrlForResourceStub.firstCall.args;
+        assert.equal(resource.type, 'posts');
+    });
+
+    it('resolves a comment on a page with the pages router type', function () {
+        // Comments are enabled on pages too. The lazy URL service routes by
+        // the passed type: a page typed 'posts' is matched against the post
+        // collections' filters, matches none, and resolves to /404/.
+        commentMapper(makeComment({
+            id: 'page-id',
+            uuid: 'page-uuid',
+            title: 'A page',
+            slug: 'a-page',
+            type: 'page',
+            status: 'published'
+        }), makeFrame());
+
+        sinon.assert.calledOnce(getUrlForResourceStub);
+        const [resource] = getUrlForResourceStub.firstCall.args;
+        assert.equal(resource.type, 'pages');
+    });
+
+    it('defaults to the posts router type when the post relation carries no type', function () {
+        commentMapper(makeComment({
+            id: 'post-id',
+            uuid: 'post-uuid',
+            title: 'A post',
+            slug: 'a-post',
+            status: 'published'
+        }), makeFrame());
+
+        sinon.assert.calledOnce(getUrlForResourceStub);
+        const [resource] = getUrlForResourceStub.firstCall.args;
+        assert.equal(resource.type, 'posts');
+    });
+});

--- a/ghost/core/test/unit/server/services/comments/comments-service-emails.test.js
+++ b/ghost/core/test/unit/server/services/comments/comments-service-emails.test.js
@@ -49,6 +49,25 @@ describe('Comments Service: CommentsServiceEmails', function () {
             );
         });
 
+        it('passes a pages resource to the facade for a comment on a page', function () {
+            // Comments are enabled on pages too. The lazy URL service routes
+            // by the passed type: a page typed 'posts' matches none of the
+            // post collections' filters and resolves to /404/, so the
+            // notification email links to the 404 page.
+            const {instance, urlService} = createClassInstance({});
+            const fakeBookshelfModel = {
+                toJSON: () => ({id: '123', slug: 'my-page', type: 'page'})
+            };
+
+            instance.getPostUrl(fakeBookshelfModel, '456');
+
+            sinon.assert.calledWith(
+                urlService.facade.getUrlForResource,
+                sinon.match({id: '123', slug: 'my-page', type: 'pages'}),
+                {absolute: true}
+            );
+        });
+
         it('serialises Bookshelf-model input so spread does not lose the id', function () {
             // Real callers (notify*Authors / notifyParentCommentAuthor / notifyReport)
             // pass a Bookshelf model from Post.findOne. Spreading one with

--- a/ghost/core/test/unit/server/services/email-service/email-controller.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-controller.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const sinon = require('sinon');
 const EmailController = require('../../../../../core/server/services/email-service/email-controller');
 const {createModel, createModelClass} = require('./utils');
 
@@ -23,6 +24,33 @@ describe('Email Controller', function () {
             });
             assert.equal(post.id, 'options-id');
             assert.equal(newsletter.get('slug'), 'post-newsletter');
+        });
+
+        it('loads the URL service relations the lazy backend needs', async function () {
+            // On sites whose routes.yaml filters collections by tag/author the
+            // lazy URL service refuses a post without those relations as thin,
+            // which would turn email previews into a 500 in pure-lazy mode.
+            const Post = createModelClass({
+                findOne: {
+                    title: 'Post title',
+                    newsletter: createModel({slug: 'post-newsletter'})
+                }
+            });
+            const findOneSpy = sinon.spy(Post, 'findOne');
+            const controller = new EmailController({}, {
+                models: {Post},
+                getRequiredUrlRelations: () => ['tags', 'authors']
+            });
+
+            await controller._getFrameData({
+                options: {id: 'options-id'},
+                data: {}
+            });
+
+            sinon.assert.calledOnce(findOneSpy);
+            const {withRelated} = findOneSpy.firstCall.args[1];
+            assert.ok(withRelated.includes('tags'));
+            assert.ok(withRelated.includes('authors'));
         });
 
         it('throws if post is not found', async function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1822

Two callers in the comments domain passed every comment post to the URL service typed `posts`. The eager URL service looks resources up by id and is unaffected, but the lazy service routes by the passed type: a page typed `posts` is matched against the post collections' filters, matches none of them, and resolves to `/404/`. On sites with tag-filtered collections this produced a parity mismatch on every comments request for a page — the largest remaining "lazy is wrong" class in the shadow-comparison logs.

- **Comments mapper** (`output/mappers/comments.js`): derive the router type from the loaded post relation, the same way the posts mapper does. This also covers comment events in the activity feed, which delegate to this mapper.
- **Comment notification emails** (`comments-service-emails.js`): `getPostUrl` hardcoded `type: 'posts'`, so notification emails for comments on pages linked to the 404 page. Same fix shape.
- **Email controller pinning test**: the email preview flow already loads the relations the lazy URL service needs (`getRequiredUrlRelations` → `withRelated`), but no test pinned it — a refactor could drop the relations and only fail in production, where a thin post turns email previews into a 500 in pure-lazy mode.

All other hardcoded `type: 'posts'` call sites were audited and are provably post-only by event source (indexnow and slack-ping listen to `post.published`, RSS renders collections, audience-feedback covers newsletters, the email-post controller serves sent posts).

Both fixes were written test-first; the new tests reproduce the mis-typing before the fix.