### PR TITLE
🎨 Changed the sidebar trial banner to be configurable via hostSettings

### DIFF
--- a/apps/admin-x-framework/src/api/config.ts
+++ b/apps/admin-x-framework/src/api/config.ts
@@ -80,6 +80,16 @@ export type Config = {
         billing?: {
             enabled?: boolean
             url?: string
+            // Copy and branding for the sidebar trial banner.
+            // Managed hosting providers can override these; each falls back to Ghost's default.
+            upgradeBanner?: {
+                title?: string // Banner heading
+                message?: string // Banner message, {{days}} is replaced with the remaining trial days
+                upgradeUrl?: string // Destination for the banner's upgrade button
+                logo?: string // Logo shown above the heading
+                logoDark?: string // Logo shown in dark mode, falls back to logo
+                logoAlt?: string // Alt text for the logo
+            }
         },
         pintura?: {
             js?: string

--- a/apps/admin/src/layout/app-sidebar/upgrade-banner.test.tsx
+++ b/apps/admin/src/layout/app-sidebar/upgrade-banner.test.tsx
@@ -47,6 +47,17 @@ describe("UpgradeBanner", () => {
         expect(screen.queryByText("Unlock every feature")).not.toBeInTheDocument();
     });
 
+    test("replaces every days placeholder in a configured message", () => {
+        mockUseBrowseConfig.mockReturnValue(withUpgradeBanner({
+            message: "{{days}} left — upgrade before those {{days}} are up."
+        }));
+
+        render(<UpgradeBanner trialDaysRemaining={3} />);
+
+        expect(screen.getByText(/left — upgrade before/))
+            .toHaveTextContent("3 days left — upgrade before those 3 days are up.");
+    });
+
     test("renders a configured message without the days placeholder unchanged", () => {
         mockUseBrowseConfig.mockReturnValue(withUpgradeBanner({message: "Pick a plan to unlock everything."}));
 

--- a/apps/admin/src/layout/app-sidebar/upgrade-banner.test.tsx
+++ b/apps/admin/src/layout/app-sidebar/upgrade-banner.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import UpgradeBanner from "./upgrade-banner";
+
+const {mockUseBrowseConfig} = vi.hoisted(() => ({
+    mockUseBrowseConfig: vi.fn()
+}));
+
+vi.mock("@tryghost/admin-x-framework/api/config", () => ({
+    useBrowseConfig: mockUseBrowseConfig
+}));
+
+const withUpgradeBanner = (upgradeBanner?: Record<string, string>) => ({
+    data: {config: {hostSettings: {billing: {enabled: true, url: "https://billing.example.com", upgradeBanner}}}}
+});
+
+const logoSources = (container: HTMLElement) => Array.from(container.querySelectorAll("img")).map(img => img.getAttribute("src"));
+
+describe("UpgradeBanner", () => {
+    beforeEach(() => {
+        mockUseBrowseConfig.mockReturnValue(withUpgradeBanner());
+    });
+
+    test("renders Ghost's default copy, link and branding", () => {
+        render(<UpgradeBanner trialDaysRemaining={14} />);
+
+        expect(screen.getByText("Unlock every feature")).toBeInTheDocument();
+        expect(screen.getByText(/Choose a plan to access the full power of Ghost/))
+            .toHaveTextContent("you have 14 days free trial remaining.");
+        expect(screen.getByRole("link", {name: "Upgrade now"})).toHaveAttribute("href", "#/pro/billing/plans");
+        expect(screen.getAllByAltText("Ghost Pro")).toHaveLength(2);
+    });
+
+    test("uses the configured title, message and upgrade link", () => {
+        mockUseBrowseConfig.mockReturnValue(withUpgradeBanner({
+            title: "Ready to launch?",
+            message: "You have {{days}} left to try things out.",
+            upgradeUrl: "https://billing.example.com/plans"
+        }));
+
+        render(<UpgradeBanner trialDaysRemaining={7} />);
+
+        expect(screen.getByText("Ready to launch?")).toBeInTheDocument();
+        expect(screen.getByText(/You have/)).toHaveTextContent("You have 7 days left to try things out.");
+        expect(screen.getByRole("link", {name: "Upgrade now"})).toHaveAttribute("href", "https://billing.example.com/plans");
+        expect(screen.queryByText("Unlock every feature")).not.toBeInTheDocument();
+    });
+
+    test("renders a configured message without the days placeholder unchanged", () => {
+        mockUseBrowseConfig.mockReturnValue(withUpgradeBanner({message: "Pick a plan to unlock everything."}));
+
+        render(<UpgradeBanner trialDaysRemaining={7} />);
+
+        expect(screen.getByText("Pick a plan to unlock everything.")).toBeInTheDocument();
+        expect(screen.queryByText(/7 days/)).not.toBeInTheDocument();
+    });
+
+    test("uses the configured logos and alt text", () => {
+        mockUseBrowseConfig.mockReturnValue(withUpgradeBanner({
+            logo: "https://cdn.example.com/logo.png",
+            logoDark: "https://cdn.example.com/logo-dark.png",
+            logoAlt: "Example Hosting"
+        }));
+
+        const {container} = render(<UpgradeBanner trialDaysRemaining={7} />);
+
+        expect(logoSources(container)).toEqual([
+            "https://cdn.example.com/logo.png",
+            "https://cdn.example.com/logo-dark.png"
+        ]);
+        expect(screen.getAllByAltText("Example Hosting")).toHaveLength(2);
+    });
+
+    test("reuses a single configured logo in dark mode and drops the Ghost Pro alt text", () => {
+        mockUseBrowseConfig.mockReturnValue(withUpgradeBanner({logo: "https://cdn.example.com/logo.png"}));
+
+        const {container} = render(<UpgradeBanner trialDaysRemaining={7} />);
+
+        expect(logoSources(container)).toEqual([
+            "https://cdn.example.com/logo.png",
+            "https://cdn.example.com/logo.png"
+        ]);
+        expect(screen.queryByAltText("Ghost Pro")).not.toBeInTheDocument();
+    });
+});

--- a/apps/admin/src/layout/app-sidebar/upgrade-banner.tsx
+++ b/apps/admin/src/layout/app-sidebar/upgrade-banner.tsx
@@ -1,3 +1,4 @@
+import {Fragment} from "react";
 import {Banner, Button} from "@tryghost/shade/components"
 import {useBrowseConfig} from "@tryghost/admin-x-framework/api/config";
 
@@ -15,10 +16,7 @@ function UpgradeBanner({ trialDaysRemaining }: { trialDaysRemaining: number }) {
     const { data: config } = useBrowseConfig();
     const bannerConfig = config?.config.hostSettings?.billing?.upgradeBanner;
 
-    const message = bannerConfig?.message || DEFAULT_MESSAGE;
-    const daysIndex = message.indexOf(DAYS_PLACEHOLDER);
-    const messageBeforeDays = daysIndex === -1 ? message : message.slice(0, daysIndex);
-    const messageAfterDays = daysIndex === -1 ? "" : message.slice(daysIndex + DAYS_PLACEHOLDER.length);
+    const messageParts = (bannerConfig?.message || DEFAULT_MESSAGE).split(DAYS_PLACEHOLDER);
 
     const logo = bannerConfig?.logo || ghostProLogo;
     const logoDark = bannerConfig?.logoDark || bannerConfig?.logo || ghostProLogoDark;
@@ -33,9 +31,12 @@ function UpgradeBanner({ trialDaysRemaining }: { trialDaysRemaining: number }) {
             </div>
             <div className="mt-3 text-base font-semibold">{bannerConfig?.title || DEFAULT_TITLE}</div>
             <div className="mt-2 mb-4 text-sm text-gray-700">
-                {messageBeforeDays}
-                {daysIndex !== -1 && <span className="font-semibold text-foreground">{trialDaysRemaining} days</span>}
-                {messageAfterDays}
+                {messageParts.map((part, index) => (
+                    <Fragment key={index}>
+                        {index > 0 && <span className="font-semibold text-foreground">{trialDaysRemaining} days</span>}
+                        {part}
+                    </Fragment>
+                ))}
             </div>
             <Button asChild><a href={bannerConfig?.upgradeUrl || DEFAULT_UPGRADE_URL}>Upgrade now</a></Button>
         </Banner>

--- a/apps/admin/src/layout/app-sidebar/upgrade-banner.tsx
+++ b/apps/admin/src/layout/app-sidebar/upgrade-banner.tsx
@@ -1,20 +1,43 @@
 import {Banner, Button} from "@tryghost/shade/components"
+import {useBrowseConfig} from "@tryghost/admin-x-framework/api/config";
 
 import ghostProLogo from "@/assets/images/ghost-pro-logo.png";
 import ghostProLogoDark from "@/assets/images/ghost-pro-logo-dark.png";
 
+const DAYS_PLACEHOLDER = "{{days}}";
+
+const DEFAULT_TITLE = "Unlock every feature";
+const DEFAULT_MESSAGE = `Choose a plan to access the full power of Ghost right away, you have ${DAYS_PLACEHOLDER} free trial remaining.`;
+const DEFAULT_UPGRADE_URL = "#/pro/billing/plans";
+const DEFAULT_LOGO_ALT = "Ghost Pro";
+
 function UpgradeBanner({ trialDaysRemaining }: { trialDaysRemaining: number }) {
+    const { data: config } = useBrowseConfig();
+    const bannerConfig = config?.config.hostSettings?.billing?.upgradeBanner;
+
+    const message = bannerConfig?.message || DEFAULT_MESSAGE;
+    const daysIndex = message.indexOf(DAYS_PLACEHOLDER);
+    const messageBeforeDays = daysIndex === -1 ? message : message.slice(0, daysIndex);
+    const messageAfterDays = daysIndex === -1 ? "" : message.slice(daysIndex + DAYS_PLACEHOLDER.length);
+
+    const logo = bannerConfig?.logo || ghostProLogo;
+    const logoDark = bannerConfig?.logoDark || bannerConfig?.logo || ghostProLogoDark;
+    // A host's own logo is not the Ghost(Pro) logo, so fall back to decorative rather than mislabelling it
+    const logoAlt = bannerConfig?.logoAlt ?? ((bannerConfig?.logo || bannerConfig?.logoDark) ? "" : DEFAULT_LOGO_ALT);
+
     return (
         <Banner variant='gradient' size='lg' className="mx-2 flex flex-col items-stretch">
             <div>
-                <img src={ghostProLogo} alt="Ghost Pro" className="max-h-[33px] dark:hidden" />
-                <img src={ghostProLogoDark} alt="Ghost Pro" className="hidden max-h-[33px] dark:block" />
+                <img src={logo} alt={logoAlt} className="max-h-[33px] dark:hidden" />
+                <img src={logoDark} alt={logoAlt} className="hidden max-h-[33px] dark:block" />
             </div>
-            <div className="mt-3 text-base font-semibold">Unlock every feature</div>
+            <div className="mt-3 text-base font-semibold">{bannerConfig?.title || DEFAULT_TITLE}</div>
             <div className="mt-2 mb-4 text-sm text-gray-700">
-                Choose a plan to access the full power of Ghost right away, you have <span className="font-semibold text-foreground">{trialDaysRemaining} days</span> free trial remaining.
+                {messageBeforeDays}
+                {daysIndex !== -1 && <span className="font-semibold text-foreground">{trialDaysRemaining} days</span>}
+                {messageAfterDays}
             </div>
-            <Button asChild><a href="#/pro/billing/plans">Upgrade now</a></Button>
+            <Button asChild><a href={bannerConfig?.upgradeUrl || DEFAULT_UPGRADE_URL}>Upgrade now</a></Button>
         </Banner>
     )
 }


### PR DESCRIPTION
- the sidebar trial banner hardcodes Ghost(Pro) branding, copy and a `#/pro/billing/plans` link, none of which apply to managed hosting providers other than Ghost(Pro)
- it renders purely off the subscription payload the billing app posts into Admin, so any host configuring hostSettings.billing gets it as soon as one of their sites is on trial
- adds optional title, message, upgradeUrl, logo, logoDark and logoAlt fields under hostSettings.billing.upgradeBanner, each falling back to Ghost's current default so behaviour is unchanged unless a host overrides it
- {{days}} in a custom message is replaced with the emphasised trial days remaining, so hosts keep the countdown the default copy has
- a configured logo without alt text renders as decorative instead of inheriting the "Ghost Pro" alt text

Got some code for us? Awesome 🎊!

Please take a minute to explain the change you're making:
- Why are you making it?
- What does it do?
- Why is this something Ghost users or developers need?

Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works

We appreciate your contribution! 🙏
