### PR TITLE
🐛 Fixed members being removed from all newsletters when unsubscribing from one

### DIFF
--- a/ghost/core/core/server/services/email-service/newsletter-email-event-storage.js
+++ b/ghost/core/core/server/services/email-service/newsletter-email-event-storage.js
@@ -179,7 +179,9 @@ class NewsletterEmailEventStorage {
         try {
             // Unsubscribe member from the specific newsletter
             const newsletters = await this.findNewslettersToKeep(event);
-            await this.#membersRepository.update({newsletters}, {id: event.memberId});
+            if (newsletters) {
+                await this.#membersRepository.update({newsletters}, {id: event.memberId});
+            }
 
             // Remove member from Mailgun's suppression list
             await this.#emailSuppressionList.removeUnsubscribe(event.email);
@@ -207,9 +209,14 @@ class NewsletterEmailEventStorage {
 
     async findNewslettersToKeep(event) {
         try {
-            const member = await this.#membersRepository.get({email: event.email}, {
+            const member = await this.#membersRepository.get({id: event.memberId}, {
                 withRelated: ['newsletters']
             });
+
+            if (!member) {
+                return undefined;
+            }
+
             const existingNewsletters = member.related('newsletters');
 
             const email = await this.#models.Email.findOne({id: event.emailId});
@@ -220,7 +227,7 @@ class NewsletterEmailEventStorage {
             });
         } catch (err) {
             logging.error(err);
-            return [];
+            return undefined;
         }
     }
 

--- a/ghost/core/core/server/services/email-service/newsletter-email-event-storage.js
+++ b/ghost/core/core/server/services/email-service/newsletter-email-event-storage.js
@@ -1,4 +1,5 @@
 const moment = require('moment-timezone');
+const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
 const config = require('../../../shared/config');
 
@@ -186,7 +187,6 @@ class NewsletterEmailEventStorage {
             }
 
             if (result.status === 'ok') {
-                // Unsubscribe member from the specific newsletter
                 await this.#membersRepository.update({newsletters: result.newsletters}, {id: event.memberId});
             }
 
@@ -247,7 +247,10 @@ class NewsletterEmailEventStorage {
                 })
             };
         } catch (err) {
-            logging.error(err);
+            logging.error(new errors.InternalServerError({
+                message: `Could not resolve newsletters to keep for unsubscribe event (member ${event.memberId}, email ${event.emailId})`,
+                err
+            }));
             return {status: 'failed'};
         }
     }

--- a/ghost/core/core/server/services/email-service/newsletter-email-event-storage.js
+++ b/ghost/core/core/server/services/email-service/newsletter-email-event-storage.js
@@ -177,13 +177,21 @@ class NewsletterEmailEventStorage {
 
     async handleUnsubscribed(event) {
         try {
-            // Unsubscribe member from the specific newsletter
-            const newsletters = await this.findNewslettersToKeep(event);
-            if (newsletters) {
-                await this.#membersRepository.update({newsletters}, {id: event.memberId});
+            const result = await this.findNewslettersToKeep(event);
+
+            if (result.status === 'failed') {
+                // Leave Mailgun's suppression in place: these events are fetched
+                // once and never retried, so it is the only remaining protection.
+                return;
             }
 
-            // Remove member from Mailgun's suppression list
+            if (result.status === 'ok') {
+                // Unsubscribe member from the specific newsletter
+                await this.#membersRepository.update({newsletters: result.newsletters}, {id: event.memberId});
+            }
+
+            // Remove member from Mailgun's suppression list, only once the local
+            // record reflects the unsubscribe or there is no member left to protect
             await this.#emailSuppressionList.removeUnsubscribe(event.email);
         } catch (err) {
             logging.error(err);
@@ -207,6 +215,16 @@ class NewsletterEmailEventStorage {
         }
     }
 
+    /**
+     * @typedef {{status: 'ok', newsletters: {id: string}[]}
+     *     | {status: 'no-member'}
+     *     | {status: 'failed'}} FindNewslettersToKeepResult
+     */
+
+    /**
+     * @param {import('./events/email-unsubscribed-event')} event
+     * @returns {Promise<FindNewslettersToKeepResult>}
+     */
     async findNewslettersToKeep(event) {
         try {
             const member = await this.#membersRepository.get({id: event.memberId}, {
@@ -214,7 +232,7 @@ class NewsletterEmailEventStorage {
             });
 
             if (!member) {
-                return undefined;
+                return {status: 'no-member'};
             }
 
             const existingNewsletters = member.related('newsletters');
@@ -222,12 +240,15 @@ class NewsletterEmailEventStorage {
             const email = await this.#models.Email.findOne({id: event.emailId});
             const newsletterToRemove = email.get('newsletter_id');
 
-            return existingNewsletters.models.filter(newsletter => newsletter.id !== newsletterToRemove).map((n) => {
-                return {id: n.id};
-            });
+            return {
+                status: 'ok',
+                newsletters: existingNewsletters.models.filter(newsletter => newsletter.id !== newsletterToRemove).map((n) => {
+                    return {id: n.id};
+                })
+            };
         } catch (err) {
             logging.error(err);
-            return undefined;
+            return {status: 'failed'};
         }
     }
 

--- a/ghost/core/test/integration/services/email-service/newsletter-email-event-storage.test.js
+++ b/ghost/core/test/integration/services/email-service/newsletter-email-event-storage.test.js
@@ -1107,6 +1107,59 @@ processingModes.forEach(({name, batchProcessing}) => {
             assert(member.related('newsletters').models.some(newsletter => newsletter.id === newsletterToKeep));
         });
 
+        it('Keeps other newsletters when the member changed their email after the send', async function () {
+            const newsletterToRemove = fixtureManager.get('newsletters', 0).id;
+            const newsletterToKeep = fixtureManager.get('newsletters', 1).id;
+
+            const email = fixtureManager.get('emails', 0);
+            await models.Email.edit({newsletter_id: newsletterToRemove}, {id: email.id});
+
+            const emailBatch = fixtureManager.get('email_batches', 0);
+            const emailRecipient = fixtureManager.get('email_recipients', 0);
+            const memberId = emailRecipient.member_id;
+            const providerId = emailBatch.provider_id;
+            const timestamp = new Date(2000, 0, 1);
+
+            // Member subscribed to 2 newsletters
+            await membersService.api.members.update({newsletters: [
+                {id: newsletterToRemove},
+                {id: newsletterToKeep}
+            ]}, {id: memberId});
+
+            const memberInitial = await membersService.api.members.get({id: memberId}, {withRelated: ['newsletters']});
+            assert.equal(memberInitial.related('newsletters').length, 2, 'precondition: subscribed to 2 newsletters');
+
+            await membersService.api.members.update({email: 'changed-address@example.com'}, {id: memberId});
+
+            events = [{
+                event: 'unsubscribed',
+                recipient: emailRecipient.member_email, // the old, send-time address
+                'user-variables': {
+                    'email-id': email.id
+                },
+                message: {
+                    headers: {
+                        'message-id': providerId
+                    }
+                },
+                timestamp: Math.round(timestamp.getTime() / 1000)
+            }];
+
+            const result = await emailAnalytics.newsletters.fetchLatestOpenedEvents();
+            assert.equal(result, 1);
+            await DomainEvents.allSettled();
+
+            const member = await membersService.api.members.get({id: memberId}, {withRelated: ['newsletters']});
+
+            // The member clicked unsubscribe on one newsletter and is a healthy member
+            // reachable by their new email — they must keep the other newsletter.
+            assert.equal(
+                member.related('newsletters').length, 1,
+                `member should still have 1 newsletter but has ${member.related('newsletters').length}`
+            );
+            assert(member.related('newsletters').models.some(newsletter => newsletter.id === newsletterToKeep));
+        });
+
         it('Can handle unknown events', async function () {
             const emailBatch = fixtureManager.get('email_batches', 0);
             const emailId = emailBatch.email_id;

--- a/ghost/core/test/integration/services/email-service/newsletter-email-event-storage.test.js
+++ b/ghost/core/test/integration/services/email-service/newsletter-email-event-storage.test.js
@@ -1151,8 +1151,6 @@ processingModes.forEach(({name, batchProcessing}) => {
 
             const member = await membersService.api.members.get({id: memberId}, {withRelated: ['newsletters']});
 
-            // The member clicked unsubscribe on one newsletter and is a healthy member
-            // reachable by their new email — they must keep the other newsletter.
             assert.equal(
                 member.related('newsletters').length, 1,
                 `member should still have 1 newsletter but has ${member.related('newsletters').length}`

--- a/ghost/core/test/unit/server/services/email-service/newsletter-email-event-storage.test.js
+++ b/ghost/core/test/unit/server/services/email-service/newsletter-email-event-storage.test.js
@@ -521,17 +521,18 @@ describe('Email Event Storage', function () {
         });
         await eventHandler.handleUnsubscribed(event);
 
-        // The member is looked up by id, not by the (possibly stale) send-time email
         sinon.assert.calledWithMatch(get, {id: '123'});
 
-        // The member keeps newsletter_2 and is unsubscribed only from newsletter_1
         sinon.assert.calledOnce(update);
         assert(update.firstCall.args[0].newsletters.length === 1);
         assert(update.firstCall.args[0].newsletters[0].id === 'newsletter_2');
         sinon.assert.calledOnce(emailSuppressionList.removeUnsubscribe);
+
+        // Suppression may only be lifted once the local record is written
+        sinon.assert.callOrder(update, emailSuppressionList.removeUnsubscribe);
     });
 
-    it('Does not touch newsletters when the member cannot be resolved', async function () {
+    it('Unsubscribes a member subscribed to a single newsletter', async function () {
         const event = EmailUnsubscribedEvent.create({
             email: 'example@example.com',
             memberId: '123',
@@ -539,10 +540,52 @@ describe('Email Event Storage', function () {
             timestamp: new Date(0)
         });
 
-        // Member not found by id (e.g. deleted) — must not wipe their newsletters
+        const update = sinon.stub().resolves();
+        const get = sinon.stub().resolves({
+            related: sinon.stub().returns({
+                models: [{id: 'newsletter_1'}]
+            })
+        });
+
+        const emailSuppressionList = {
+            removeUnsubscribe: sinon.stub().resolves()
+        };
+
+        const Email = {
+            findOne: sinon.stub().resolves({
+                get: sinon.stub().returns('newsletter_1')
+            })
+        };
+
+        const eventHandler = new NewsletterEmailEventStorage({
+            membersRepository: {
+                get,
+                update
+            },
+            models: {
+                Email
+            },
+            emailSuppressionList
+        });
+        await eventHandler.handleUnsubscribed(event);
+
+        sinon.assert.calledOnce(update);
+        assert.deepEqual(update.firstCall.args[0].newsletters, []);
+        sinon.assert.calledOnce(emailSuppressionList.removeUnsubscribe);
+        sinon.assert.calledWith(emailSuppressionList.removeUnsubscribe, 'example@example.com');
+        sinon.assert.callOrder(update, emailSuppressionList.removeUnsubscribe);
+    });
+
+    it('Lifts Mailgun suppression when the member cannot be resolved', async function () {
+        const event = EmailUnsubscribedEvent.create({
+            email: 'example@example.com',
+            memberId: '123',
+            emailId: '456',
+            timestamp: new Date(0)
+        });
+
         const get = sinon.stub().resolves(null);
         const update = sinon.stub().resolves();
-
         const emailSuppressionList = {
             removeUnsubscribe: sinon.stub().resolves()
         };
@@ -556,11 +599,12 @@ describe('Email Event Storage', function () {
         });
         await eventHandler.handleUnsubscribed(event);
 
-        // Update is not called with an empty newsletter list
         sinon.assert.notCalled(update);
+        sinon.assert.calledOnce(emailSuppressionList.removeUnsubscribe);
+        sinon.assert.calledWith(emailSuppressionList.removeUnsubscribe, 'example@example.com');
     });
 
-    it('Does not touch newsletters when the lookup throws (transient error)', async function () {
+    it('Keeps Mailgun suppression when the lookup fails', async function () {
         const event = EmailUnsubscribedEvent.create({
             email: 'example@example.com',
             memberId: '123',
@@ -568,7 +612,6 @@ describe('Email Event Storage', function () {
             timestamp: new Date(0)
         });
 
-        // The member resolves, but a later step throws (e.g. a transient DB error)
         const get = sinon.stub().resolves({
             related: sinon.stub().returns({
                 models: [{id: 'newsletter_1'}, {id: 'newsletter_2'}]
@@ -594,8 +637,46 @@ describe('Email Event Storage', function () {
         });
         await eventHandler.handleUnsubscribed(event);
 
-        // A transient error must not be interpreted as "unsubscribe from all"
         sinon.assert.notCalled(update);
+        sinon.assert.notCalled(emailSuppressionList.removeUnsubscribe);
+        sinon.assert.calledOnce(logError);
+    });
+
+    it('Keeps Mailgun suppression when the email record is missing', async function () {
+        const event = EmailUnsubscribedEvent.create({
+            email: 'example@example.com',
+            memberId: '123',
+            emailId: '456',
+            timestamp: new Date(0)
+        });
+
+        const get = sinon.stub().resolves({
+            related: sinon.stub().returns({
+                models: [{id: 'newsletter_1'}, {id: 'newsletter_2'}]
+            })
+        });
+        const update = sinon.stub().resolves();
+        const Email = {
+            findOne: sinon.stub().resolves(null)
+        };
+        const emailSuppressionList = {
+            removeUnsubscribe: sinon.stub().resolves()
+        };
+
+        const eventHandler = new NewsletterEmailEventStorage({
+            membersRepository: {
+                get,
+                update
+            },
+            models: {
+                Email
+            },
+            emailSuppressionList
+        });
+        await eventHandler.handleUnsubscribed(event);
+
+        sinon.assert.notCalled(update);
+        sinon.assert.notCalled(emailSuppressionList.removeUnsubscribe);
         sinon.assert.calledOnce(logError);
     });
 
@@ -633,8 +714,8 @@ describe('Email Event Storage', function () {
 
         const result = await eventHandler.findNewslettersToKeep(event);
 
-        assert(result.length === 1);
-        assert(result[0].id === 'newsletter_2');
+        assert.equal(result.status, 'ok');
+        assert.deepEqual(result.newsletters, [{id: 'newsletter_2'}]);
     });
 
     it('Handles complaints', async function () {

--- a/ghost/core/test/unit/server/services/email-service/newsletter-email-event-storage.test.js
+++ b/ghost/core/test/unit/server/services/email-service/newsletter-email-event-storage.test.js
@@ -488,24 +488,50 @@ describe('Email Event Storage', function () {
         });
 
         const update = sinon.stub().resolves();
+        // The member is resolved by id and is subscribed to two newsletters
+        const get = sinon.stub().resolves({
+            related: sinon.stub().returns({
+                models: [
+                    {id: 'newsletter_1'},
+                    {id: 'newsletter_2'}
+                ]
+            })
+        });
 
         const emailSuppressionList = {
             removeUnsubscribe: sinon.stub().resolves()
         };
 
+        const Email = {
+            // The email being unsubscribed from belongs to newsletter_1
+            findOne: sinon.stub().resolves({
+                get: sinon.stub().returns('newsletter_1')
+            })
+        };
+
         const eventHandler = new NewsletterEmailEventStorage({
             membersRepository: {
+                get,
                 update
+            },
+            models: {
+                Email
             },
             emailSuppressionList
         });
         await eventHandler.handleUnsubscribed(event);
+
+        // The member is looked up by id, not by the (possibly stale) send-time email
+        sinon.assert.calledWithMatch(get, {id: '123'});
+
+        // The member keeps newsletter_2 and is unsubscribed only from newsletter_1
         sinon.assert.calledOnce(update);
-        assert(update.firstCall.args[0].newsletters.length === 0);
+        assert(update.firstCall.args[0].newsletters.length === 1);
+        assert(update.firstCall.args[0].newsletters[0].id === 'newsletter_2');
         sinon.assert.calledOnce(emailSuppressionList.removeUnsubscribe);
     });
 
-    it('Handles unsubscribe with a non-existent member', async function () {
+    it('Does not touch newsletters when the member cannot be resolved', async function () {
         const event = EmailUnsubscribedEvent.create({
             email: 'example@example.com',
             memberId: '123',
@@ -513,17 +539,64 @@ describe('Email Event Storage', function () {
             timestamp: new Date(0)
         });
 
-        const error = new Error('Member not found');
-        const update = sinon.stub().throws(error);
+        // Member not found by id (e.g. deleted) — must not wipe their newsletters
+        const get = sinon.stub().resolves(null);
+        const update = sinon.stub().resolves();
+
+        const emailSuppressionList = {
+            removeUnsubscribe: sinon.stub().resolves()
+        };
 
         const eventHandler = new NewsletterEmailEventStorage({
             membersRepository: {
+                get,
                 update
-            }
+            },
+            emailSuppressionList
         });
         await eventHandler.handleUnsubscribed(event);
-        sinon.assert.calledOnce(update);
-        assert(update.firstCall.args[0].newsletters.length === 0);
+
+        // Update is not called with an empty newsletter list
+        sinon.assert.notCalled(update);
+    });
+
+    it('Does not touch newsletters when the lookup throws (transient error)', async function () {
+        const event = EmailUnsubscribedEvent.create({
+            email: 'example@example.com',
+            memberId: '123',
+            emailId: '456',
+            timestamp: new Date(0)
+        });
+
+        // The member resolves, but a later step throws (e.g. a transient DB error)
+        const get = sinon.stub().resolves({
+            related: sinon.stub().returns({
+                models: [{id: 'newsletter_1'}, {id: 'newsletter_2'}]
+            })
+        });
+        const update = sinon.stub().resolves();
+        const Email = {
+            findOne: sinon.stub().rejects(new Error('transient DB error'))
+        };
+        const emailSuppressionList = {
+            removeUnsubscribe: sinon.stub().resolves()
+        };
+
+        const eventHandler = new NewsletterEmailEventStorage({
+            membersRepository: {
+                get,
+                update
+            },
+            models: {
+                Email
+            },
+            emailSuppressionList
+        });
+        await eventHandler.handleUnsubscribed(event);
+
+        // A transient error must not be interpreted as "unsubscribe from all"
+        sinon.assert.notCalled(update);
+        sinon.assert.calledOnce(logError);
     });
 
     it('Finds newsletters to keep during an unsubscribe', async function () {


### PR DESCRIPTION
## Cause

The Mailgun `unsubscribed`-event sync (`NewsletterEmailEventStorage.findNewslettersToKeep`) looked the member up by the **send-time `event.email`** and returned `[]` on any failure. The caller passes that result to `membersRepository.update({newsletters})`, where `[]` means **"keep no newsletters"** (i.e. remove the member from all of them).

## Circumstances

The lookup fails (so the member gets wiped) when:
- the member **changed their email** after the send (`event.email` no longer matches the `members` table), or
- **any transient error** occurs during the lookup (e.g. a DB error).

Note: `event.memberId` is already present and correct on the event (it's used for the `update`); only the redundant email-based re-lookup fails.

## Outcome

A member who unsubscribes from **one** newsletter is silently removed from **every** newsletter.

**Fix:**
- Resolve the member by `event.memberId` (stable, always present) instead of `event.email`.
- Return `undefined` (not `[]`) when the member can't be resolved or the lookup throws, so the caller skips the update and leaves subscriptions untouched.

`[]` is preserved as a legitimate result (member was only subscribed to the one newsletter they unsubscribed from).

## Testing

Added regression coverage: an integration test for the email-change case, and unit tests for the member-not-found and transient-error paths. All pass; each fails against the unpatched code.

---

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works
