### PR TITLE
Removed a dead complimentary_plan field from the members export row

### DIFF
--- a/ghost/core/core/server/services/members/import-export/export/exporter.ts
+++ b/ghost/core/core/server/services/members/import-export/export/exporter.ts
@@ -81,7 +81,6 @@ interface MemberExportRow extends MemberDbRow {
     labels: Array<{name: string}>;
     subscribed: boolean;
     comped: boolean;
-    complimentary_plan: boolean;
     gift_id: string | null;
     stripe_customer_id: string | null;
     custom_field_cells: Record<string, unknown>;
@@ -307,7 +306,6 @@ export default class MembersCSVExporter {
                 ...row,
                 subscribed: subscribedSet.has(row.id),
                 comped: row.status === 'comped',
-                complimentary_plan: row.status === 'complimentary',
                 gift_id: giftIdMap.get(row.id) || null,
                 stripe_customer_id: stripeCustomerMap.get(row.id) || null,
                 created_at: moment(row.created_at).toISOString(),


### PR DESCRIPTION
## Problem

The members export row carried a `complimentary_plan` field derived from a member status value that never occurs, so it was always false. Nothing read it, so it was dead code that also encoded an incorrect check, and it risked a future change wiring the export off it by mistake.

## Solution

Removed the unused field. The exported `complimentary_plan` column is unchanged; it is still derived from the member's comped status. Behaviour is identical and covered by the existing export tests.
