### PR TITLE
Wired the members export streams with pipeline so failures propagate

### DIFF
--- a/ghost/core/core/server/services/members/import-export/export/exporter.ts
+++ b/ghost/core/core/server/services/members/import-export/export/exporter.ts
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import {Transform, type Readable} from 'node:stream';
+import {Transform, pipeline, type Readable} from 'node:stream';
 import type {Knex} from 'knex';
 
 const logging = require('@tryghost/logging');
@@ -164,15 +164,18 @@ export default class MembersCSVExporter {
         }
 
         logging.info('[MembersExporter] Starting streaming export of members');
-        const stream = membersQuery.stream()
-            .pipe(this.createBatchingTransform())
-            .pipe(this.createProcessingTransform(reference));
+        const batchingTransform = this.createBatchingTransform();
+        const processingTransform = this.createProcessingTransform(reference);
 
-        stream.on('end', () => {
-            logging.info('[MembersExporter] Total time taken for member export: ' + (Date.now() - start) / 1000 + 's');
+        pipeline(membersQuery.stream(), batchingTransform, processingTransform, (err) => {
+            if (err) {
+                logging.error({event: {name: 'members-export.stream.error'}, err}, 'Members export stream failed');
+            } else {
+                logging.info('[MembersExporter] Total time taken for member export: ' + (Date.now() - start) / 1000 + 's');
+            }
         });
 
-        return stream;
+        return processingTransform;
     }
 
     // products and labels are small, stable tables, read once up front as id->name


### PR DESCRIPTION
## Problem

The members export assembled its streaming chain with plain `.pipe()` calls, which do not forward source errors. A failure in the database stream would not reach the response, so the export could hang or the error could go unhandled rather than tearing the chain down.

## Solution

Wired the internal export stream chain with `pipeline`, matching how the response layer already consumes it. A database stream failure now tears down every stream and surfaces on the returned stream, which the response pipeline forwards to the framework's error handler. The happy path is unchanged and covered by the existing export tests.
