### PR TITLE
Send csvContentImporter flag to migration app

### DIFF
--- a/apps/ember-admin/app/services/feature.js
+++ b/apps/ember-admin/app/services/feature.js
@@ -87,6 +87,7 @@ export default class FeatureService extends Service {
     @feature('memberDetailsReact') memberDetailsReact;
     @feature('previewByTier') previewByTier;
     @feature('automations') automations;
+    @feature('csvContentImporter') csvContentImporter;
     _user = null;
 
     @computed('settings.labs')

--- a/apps/ember-admin/app/services/migrate.js
+++ b/apps/ember-admin/app/services/migrate.js
@@ -5,6 +5,7 @@ import {tracked} from '@glimmer/tracking';
 export default class MigrateService extends Service {
     @service ajax;
     @service billing;
+    @service feature;
     @service router;
     @service ghostPaths;
     @service settings;
@@ -48,6 +49,7 @@ export default class MigrateService extends Service {
             apiUrl: this.apiUrl,
             apiKey: theKey,
             stripe: this.isStripeConnected,
+            csvContentImporter: this.isCsvContentImporterEnabled,
             ghostVersion: this.ghostVersion,
             ownerEmail: theOwner.email
         };
@@ -57,6 +59,10 @@ export default class MigrateService extends Service {
 
     get isStripeConnected() {
         return (this.settings.stripeConnectAccountId && this.settings.stripeConnectPublishableKey && this.settings.stripeConnectLivemode) ? true : false;
+    }
+
+    get isCsvContentImporterEnabled() {
+        return this.feature.csvContentImporter ? true : false;
     }
 
     get ghostVersion() {

--- a/apps/ember-admin/tests/unit/services/migrate-test.js
+++ b/apps/ember-admin/tests/unit/services/migrate-test.js
@@ -36,14 +36,39 @@ describe('Unit: Service: migrate', function () {
             }
         }));
 
+        this.owner.register('service:feature', Service.extend({
+            csvContentImporter: false
+        }));
+
         let payload = await migrateService.postMessagePayload();
 
-        expect(payload).to.be.an('object').that.has.all.keys('apiUrl', 'apiKey', 'stripe', 'ghostVersion', 'ownerEmail');
+        expect(payload).to.be.an('object').that.has.all.keys('apiUrl', 'apiKey', 'stripe', 'csvContentImporter', 'ghostVersion', 'ownerEmail');
         expect(isValidUrl(payload.apiUrl)).to.be.true;
         expect(payload.apiUrl.endsWith('/ghost')).to.be.true;
         expect(payload.apiKey).to.equal('abcd:1234');
         expect(payload.stripe).to.be.false;
+        expect(payload.csvContentImporter).to.be.false;
         expect(payload.ghostVersion).to.be.string;
         expect(payload.ownerEmail).to.equal('name@example.com');
+    });
+
+    it('reports csvContentImporter as enabled when the labs flag is on', async function () {
+        sinon.stub(migrateService, 'apiKey').resolves('abcd:1234');
+
+        this.owner.register('service:billing', Service.extend({
+            getOwnerUser: () => {
+                return {
+                    email: 'name@example.com'
+                };
+            }
+        }));
+
+        this.owner.register('service:feature', Service.extend({
+            csvContentImporter: true
+        }));
+
+        let payload = await migrateService.postMessagePayload();
+
+        expect(payload.csvContentImporter).to.be.true;
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/MIG-1436/

Exposes the `csvContentImporter` flag to the Ember feature service, and adds it to the postMessage payload so that the migrate app can conditionally use the upcoming CSV post import feature