### PR TITLE
Added route-settings validation error codes and registry class

### DIFF
--- a/ghost/core/core/frontend/services/routing/registry.js
+++ b/ghost/core/core/frontend/services/routing/registry.js
@@ -1,36 +1,46 @@
 const _ = require('lodash');
-let routes = [];
-let routers = {};
 
 /**
- * @description The router registry is helpful for debugging purposes and let's you search existing routes and routers.
+ * @description The router registry is helpful for debugging purposes and lets you search existing routes and routers.
+ *
+ * Exported as a single shared instance so that every consumer
+ * (`routing/index.js`, `parent-router.js`) operates on the same registry, the
+ * same way the previous module-level state did — just held on an instance
+ * rather than in module-scoped `let` variables.
  */
-module.exports = {
+class Registry {
+    constructor() {
+        /** @type {Array<{route: string, from: string}>} */
+        this.routes = [];
+        /** @type {Object<string, import('express').Router>} */
+        this.routers = {};
+    }
+
     /**
-     * @description Get's called if you register a url pattern in express.
+     * @description Gets called if you register a url pattern in express.
      * @param {string} routerName
      * @param {string} route
      */
     setRoute(routerName, route) {
-        routes.push({route: route, from: routerName});
-    },
+        this.routes.push({route: route, from: routerName});
+    }
 
     /**
-     * @description Get's called if you register a router in express.
+     * @description Gets called if you register a router in express.
      * @param {string} name
      * @param {import('express').Router} router
      */
     setRouter(name, router) {
-        routers[name] = router;
-    },
+        this.routers[name] = router;
+    }
 
     /**
      * @description Get all registered routes.
-     * @returns {Array}
+     * @returns {Array<{route: string, from: string}>}
      */
     getAllRoutes() {
-        return _.cloneDeep(routes);
-    },
+        return _.cloneDeep(this.routes);
+    }
 
     /**
      * @description Get router by name.
@@ -38,8 +48,8 @@ module.exports = {
      * @returns {import('express').Router}
      */
     getRouter(name) {
-        return routers[name];
-    },
+        return this.routers[name];
+    }
 
     /**
      * Gets a router by it's internal router name
@@ -47,12 +57,12 @@ module.exports = {
      * @returns {import('express').Router}
      */
     getRouterByName(name) {
-        for (let routerKey in routers) {
-            if (routers[routerKey].name === name) {
-                return routers[routerKey];
+        for (let routerKey in this.routers) {
+            if (this.routers[routerKey].name === name) {
+                return this.routers[routerKey];
             }
         }
-    },
+    }
 
     /**
      *
@@ -77,7 +87,7 @@ module.exports = {
     getRssUrl(options) {
         let rssUrl = null;
 
-        const collectionIndexRouter = _.find(routers, {name: 'CollectionRouter', routerName: 'index'});
+        const collectionIndexRouter = _.find(this.routers, {name: 'CollectionRouter', routerName: 'index'});
 
         if (collectionIndexRouter) {
             rssUrl = collectionIndexRouter.getRssUrl(options);
@@ -88,7 +98,7 @@ module.exports = {
             }
         }
 
-        const collectionRouters = _.filter(routers, {name: 'CollectionRouter'});
+        const collectionRouters = _.filter(this.routers, {name: 'CollectionRouter'});
 
         if (collectionRouters && collectionRouters.length === 1) {
             rssUrl = collectionRouters[0].getRssUrl(options);
@@ -108,32 +118,34 @@ module.exports = {
         }
 
         return rssUrl;
-    },
+    }
 
     /**
      * @description Reset all routes.
      */
     resetAllRoutes() {
-        routes = [];
-    },
+        this.routes = [];
+    }
 
     /**
      * @description Reset all routers.
      */
     resetAllRouters() {
-        _.each(routers, (value) => {
+        _.each(this.routers, (value) => {
             if (value && typeof value.reset === 'function') {
                 value.reset();
             }
         });
 
-        routers = {};
-    },
+        this.routers = {};
+    }
 
     /**
      * @description Clear all routers (for testing).
      */
     clearAllRouters() {
-        routers = {};
+        this.routers = {};
     }
-};
+}
+
+module.exports = new Registry();

--- a/ghost/core/core/frontend/services/routing/registry.js
+++ b/ghost/core/core/frontend/services/routing/registry.js
@@ -1,58 +1,82 @@
 const _ = require('lodash');
-let routes = [];
-let routers = {};
 
 /**
- * @description The router registry is helpful for debugging purposes and let's you search existing routes and routers.
+ * Every registered router is a Ghost router — `ParentRouter` itself (the site
+ * and apps routers) or one of its subclasses (Collection, StaticRoutes,
+ * Taxonomy, StaticPages, Preview, Email, Unsubscribe). They wrap an Express
+ * router, reachable via `.router()`, but are not one themselves: the registry's
+ * own lookups read Ghost-side members (`.name`, `.routerName`, `.reset()`,
+ * `.getRssUrl()`) that an Express router does not have.
+ *
+ * Type-only import — no runtime require, so this does not close a cycle with
+ * `parent-router.js`, which requires this module.
+ *
+ * @typedef {import('./parent-router')} ParentRouter
  */
-module.exports = {
+
+/**
+ * @description The router registry is helpful for debugging purposes and lets you search existing routes and routers.
+ *
+ * Exported as a single shared instance so that every consumer
+ * (`routing/index.js`, `parent-router.js`) operates on the same registry, the
+ * same way the previous module-level state did — just held on an instance
+ * rather than in module-scoped `let` variables.
+ */
+class Registry {
+    constructor() {
+        /** @type {Array<{route: string, from: string}>} */
+        this.routes = [];
+        /** @type {Object<string, ParentRouter>} */
+        this.routers = {};
+    }
+
     /**
-     * @description Get's called if you register a url pattern in express.
+     * @description Gets called if you register a url pattern in express.
      * @param {string} routerName
      * @param {string} route
      */
     setRoute(routerName, route) {
-        routes.push({route: route, from: routerName});
-    },
+        this.routes.push({route: route, from: routerName});
+    }
 
     /**
-     * @description Get's called if you register a router in express.
+     * @description Gets called if you register a router in express.
      * @param {string} name
-     * @param {import('express').Router} router
+     * @param {ParentRouter} router
      */
     setRouter(name, router) {
-        routers[name] = router;
-    },
+        this.routers[name] = router;
+    }
 
     /**
      * @description Get all registered routes.
-     * @returns {Array}
+     * @returns {Array<{route: string, from: string}>}
      */
     getAllRoutes() {
-        return _.cloneDeep(routes);
-    },
+        return _.cloneDeep(this.routes);
+    }
 
     /**
      * @description Get router by name.
      * @param {string} name
-     * @returns {import('express').Router}
+     * @returns {ParentRouter|undefined}
      */
     getRouter(name) {
-        return routers[name];
-    },
+        return this.routers[name];
+    }
 
     /**
-     * Gets a router by it's internal router name
+     * Gets a router by its internal router name
      * @param {string} name internal router name
-     * @returns {import('express').Router}
+     * @returns {ParentRouter|undefined}
      */
     getRouterByName(name) {
-        for (let routerKey in routers) {
-            if (routers[routerKey].name === name) {
-                return routers[routerKey];
+        for (let routerKey in this.routers) {
+            if (this.routers[routerKey].name === name) {
+                return this.routers[routerKey];
             }
         }
-    },
+    }
 
     /**
      *
@@ -77,7 +101,7 @@ module.exports = {
     getRssUrl(options) {
         let rssUrl = null;
 
-        const collectionIndexRouter = _.find(routers, {name: 'CollectionRouter', routerName: 'index'});
+        const collectionIndexRouter = _.find(this.routers, {name: 'CollectionRouter', routerName: 'index'});
 
         if (collectionIndexRouter) {
             rssUrl = collectionIndexRouter.getRssUrl(options);
@@ -88,7 +112,7 @@ module.exports = {
             }
         }
 
-        const collectionRouters = _.filter(routers, {name: 'CollectionRouter'});
+        const collectionRouters = _.filter(this.routers, {name: 'CollectionRouter'});
 
         if (collectionRouters && collectionRouters.length === 1) {
             rssUrl = collectionRouters[0].getRssUrl(options);
@@ -108,32 +132,34 @@ module.exports = {
         }
 
         return rssUrl;
-    },
+    }
 
     /**
      * @description Reset all routes.
      */
     resetAllRoutes() {
-        routes = [];
-    },
+        this.routes = [];
+    }
 
     /**
      * @description Reset all routers.
      */
     resetAllRouters() {
-        _.each(routers, (value) => {
+        _.each(this.routers, (value) => {
             if (value && typeof value.reset === 'function') {
                 value.reset();
             }
         });
 
-        routers = {};
-    },
+        this.routers = {};
+    }
 
     /**
      * @description Clear all routers (for testing).
      */
     clearAllRouters() {
-        routers = {};
+        this.routers = {};
     }
-};
+}
+
+module.exports = new Registry();

--- a/ghost/core/core/server/services/route-settings/route-settings-parser.ts
+++ b/ghost/core/core/server/services/route-settings/route-settings-parser.ts
@@ -12,8 +12,8 @@ import type {
 } from '@tryghost/adapter-base-route-settings';
 import {z} from 'zod';
 import tpl from '@tryghost/tpl';
-import type {PathSegment} from './validation-errors';
-import {describeValue, formatLocation, humanList, toValidationError, validationError} from './validation-errors';
+import type {PathSegment, RouteSettingsErrorCode} from './validation-errors';
+import {describeValue, formatLocation, humanList, ROUTE_SETTINGS_ERROR_CODES, toValidationError, validationError} from './validation-errors';
 
 const messages = {
     badDataError: '"{key}" is a reserved key. Please wrap the data definition into a custom name.',
@@ -49,7 +49,7 @@ function validateDataShortForm(value: string, path: PathSegment[]): void {
         throw validationError(
             formatLocation(path),
             `"${value}" is not a valid data shorthand. Please use resource.slug, e.g. tag.recipes.`,
-            SHORTFORM_HELP
+            {help: SHORTFORM_HELP, code: ROUTE_SETTINGS_ERROR_CODES.INVALID_DATA}
         );
     }
 
@@ -58,7 +58,7 @@ function validateDataShortForm(value: string, path: PathSegment[]): void {
         throw validationError(
             formatLocation(path),
             `resource "${resource}" is not supported. Please use ${humanList(VALID_SHORTFORM_RESOURCES)}.`,
-            SHORTFORM_HELP
+            {help: SHORTFORM_HELP, code: ROUTE_SETTINGS_ERROR_CODES.INVALID_RESOURCE}
         );
     }
 }
@@ -108,20 +108,20 @@ function parseDataEntry(value: unknown, path: PathSegment[]): DataEntry {
             // is free to change.
             if (issue.code === 'invalid_union' && issue.path[0] === 'type') {
                 if (record.type === undefined) {
-                    throw validationError(at, 'type is required. Please use read or browse.', DATA_ENTRY_HELP);
+                    throw validationError(at, 'type is required. Please use read or browse.', {help: DATA_ENTRY_HELP, code: ROUTE_SETTINGS_ERROR_CODES.INVALID_DATA});
                 }
-                throw validationError(at, `type "${record.type}" is not supported. Please use read or browse.`, DATA_ENTRY_HELP);
+                throw validationError(at, `type "${record.type}" is not supported. Please use read or browse.`, {help: DATA_ENTRY_HELP, code: ROUTE_SETTINGS_ERROR_CODES.INVALID_DATA});
             }
             if (issue.path.includes('resource')) {
                 if (record.resource === undefined) {
-                    throw validationError(at, `resource is required. Please use ${humanList(VALID_LONGFORM_RESOURCES)}.`, DATA_ENTRY_HELP);
+                    throw validationError(at, `resource is required. Please use ${humanList(VALID_LONGFORM_RESOURCES)}.`, {help: DATA_ENTRY_HELP, code: ROUTE_SETTINGS_ERROR_CODES.INVALID_RESOURCE});
                 }
-                throw validationError(at, `resource "${record.resource}" is not supported. Please use ${humanList(VALID_LONGFORM_RESOURCES)}.`, DATA_ENTRY_HELP);
+                throw validationError(at, `resource "${record.resource}" is not supported. Please use ${humanList(VALID_LONGFORM_RESOURCES)}.`, {help: DATA_ENTRY_HELP, code: ROUTE_SETTINGS_ERROR_CODES.INVALID_RESOURCE});
             }
             if (issue.path.includes('slug') && !record.slug) {
-                throw validationError(at, 'slug is required for read data entries.', DATA_ENTRY_HELP);
+                throw validationError(at, 'slug is required for read data entries.', {help: DATA_ENTRY_HELP, code: ROUTE_SETTINGS_ERROR_CODES.INVALID_DATA});
             }
-            throw toValidationError(result.error, path, value);
+            throw toValidationError(result.error, path, value, ROUTE_SETTINGS_ERROR_CODES.INVALID_DATA);
         }
         // Fields set to an explicitly empty value parse to undefined — drop the
         // keys so "unset" means absent in the domain model and serialized output.
@@ -137,7 +137,7 @@ function parseDataEntry(value: unknown, path: PathSegment[]): DataEntry {
     throw validationError(
         formatLocation(path),
         `a data entry must be a shorthand like tag.recipes, or a map with type and resource, but ${describeValue(value)} was provided.`,
-        DATA_ENTRY_HELP
+        {help: DATA_ENTRY_HELP, code: ROUTE_SETTINGS_ERROR_CODES.INVALID_DATA}
     );
 }
 
@@ -151,7 +151,7 @@ function parseRouteData(data: unknown, path: PathSegment[]): RouteData {
         throw validationError(
             formatLocation(path),
             `data must be a shorthand like tag.recipes, or a map of named data entries, but ${describeValue(data)} was provided.`,
-            DATA_ENTRY_HELP
+            {help: DATA_ENTRY_HELP, code: ROUTE_SETTINGS_ERROR_CODES.INVALID_DATA}
         );
     }
 
@@ -159,10 +159,10 @@ function parseRouteData(data: unknown, path: PathSegment[]): RouteData {
 
     for (const key of Object.keys(record)) {
         if (RESERVED_DATA_KEYS.includes(key)) {
-            throw validationError(formatLocation([...path, key]), tpl(messages.badDataError, {key}), messages.badDataHelp);
+            throw validationError(formatLocation([...path, key]), tpl(messages.badDataError, {key}), {help: messages.badDataHelp, code: ROUTE_SETTINGS_ERROR_CODES.INVALID_DATA});
         }
         if (key === 'author') {
-            throw validationError(formatLocation([...path, key]), messages.authorDeprecatedError);
+            throw validationError(formatLocation([...path, key]), messages.authorDeprecatedError, {code: ROUTE_SETTINGS_ERROR_CODES.INVALID_DATA});
         }
     }
 
@@ -284,19 +284,19 @@ const RouteSettingsSchema = z.object({
  * rejecting :param there would break the former, and the suggested rewrite would
  * silently produce the latter.
  */
-function validatePath(value: string, path: PathSegment[], example: string, {allowParamNotation = false}: {allowParamNotation?: boolean} = {}): void {
+function validatePath(value: string, path: PathSegment[], example: string, {allowParamNotation = false, code = ROUTE_SETTINGS_ERROR_CODES.INVALID_PATH}: {allowParamNotation?: boolean, code?: RouteSettingsErrorCode} = {}): void {
     const at = formatLocation(path);
 
     if (!value.startsWith('/')) {
-        throw validationError(at, `"${value}" is missing a leading slash. Please use e.g. ${example}.`);
+        throw validationError(at, `"${value}" is missing a leading slash. Please use e.g. ${example}.`, {code});
     }
     if (!value.endsWith('/')) {
-        throw validationError(at, `"${value}" is missing a trailing slash. Please use e.g. ${example}.`);
+        throw validationError(at, `"${value}" is missing a trailing slash. Please use e.g. ${example}.`, {code});
     }
     if (!allowParamNotation && /\/:\w+/.test(value)) {
         // Suggest the same path in the notation Ghost expects, rather than a
         // generic example the author then has to translate.
-        throw validationError(at, `"${value}" uses the :param notation. Please use "${value.replace(/\/:(\w+)/g, '/{$1}')}".`);
+        throw validationError(at, `"${value}" uses the :param notation. Please use "${value.replace(/\/:(\w+)/g, '/{$1}')}".`, {code});
     }
 }
 
@@ -317,7 +317,7 @@ export function parseRouteSettings(raw: unknown, yamlSource: string): RouteSetti
             validatePath(path, routeLocation, '/about/', {allowParamNotation: true});
 
             if (value === null || value === undefined) {
-                throw validationError(formatLocation(routeLocation), 'Please define a template, e.g. /about/: about.');
+                throw validationError(formatLocation(routeLocation), 'Please define a template, e.g. /about/: about.', {code: ROUTE_SETTINGS_ERROR_CODES.INVALID_TEMPLATE});
             }
 
             if (typeof value === 'string') {
@@ -332,7 +332,7 @@ export function parseRouteSettings(raw: unknown, yamlSource: string): RouteSetti
 
             const route = routeResult.data;
             if (route.type === 'template' && (!route.templates || route.templates.length === 0) && !route.data && !(route as Omit<TemplateRoute, 'path'>).contentType) {
-                throw validationError(formatLocation(routeLocation), 'Please define a template, e.g. /about/: about.');
+                throw validationError(formatLocation(routeLocation), 'Please define a template, e.g. /about/: about.', {code: ROUTE_SETTINGS_ERROR_CODES.INVALID_TEMPLATE});
             }
 
             routes.push({...route, path} as Route);
@@ -352,9 +352,9 @@ export function parseRouteSettings(raw: unknown, yamlSource: string): RouteSetti
 
             const collection = collectionResult.data;
             if (!collection.permalink) {
-                throw validationError(formatLocation(collectionLocation), 'Please define a permalink route, e.g. permalink: /{slug}/.');
+                throw validationError(formatLocation(collectionLocation), 'Please define a permalink route, e.g. permalink: /{slug}/.', {code: ROUTE_SETTINGS_ERROR_CODES.INVALID_PERMALINK});
             }
-            validatePath(collection.permalink, [...collectionLocation, 'permalink'], '/{slug}/');
+            validatePath(collection.permalink, [...collectionLocation, 'permalink'], '/{slug}/', {code: ROUTE_SETTINGS_ERROR_CODES.INVALID_PERMALINK});
 
             collections.push({...collection, path});
         }
@@ -365,12 +365,12 @@ export function parseRouteSettings(raw: unknown, yamlSource: string): RouteSetti
         for (const [key, value] of Object.entries(rawTaxonomies)) {
             const taxonomyLocation: PathSegment[] = ['taxonomies', key];
             if (!['tag', 'author'].includes(key)) {
-                throw validationError(formatLocation(taxonomyLocation), 'Unknown taxonomy. Please use tag or author.');
+                throw validationError(formatLocation(taxonomyLocation), 'Unknown taxonomy. Please use tag or author.', {code: ROUTE_SETTINGS_ERROR_CODES.INVALID_TAXONOMY});
             }
             if (!value) {
-                throw validationError(formatLocation(taxonomyLocation), `Please define a taxonomy permalink route, e.g. ${key}: /${key}/{slug}/.`);
+                throw validationError(formatLocation(taxonomyLocation), `Please define a taxonomy permalink route, e.g. ${key}: /${key}/{slug}/.`, {code: ROUTE_SETTINGS_ERROR_CODES.INVALID_PERMALINK});
             }
-            validatePath(value, taxonomyLocation, `/${key}/{slug}/`);
+            validatePath(value, taxonomyLocation, `/${key}/{slug}/`, {code: ROUTE_SETTINGS_ERROR_CODES.INVALID_PERMALINK});
             if (key === 'tag') {
                 taxonomies.tag = value;
             }

--- a/ghost/core/core/server/services/route-settings/validation-errors.ts
+++ b/ghost/core/core/server/services/route-settings/validation-errors.ts
@@ -12,6 +12,40 @@ const MAX_SHOWN_LENGTH = 40;
 export type PathSegment = string | number;
 
 /**
+ * Stable, machine-readable codes describing the class of a routes.yaml failure.
+ *
+ * The human-readable message is authored for the person editing the file and is
+ * free to change; the code is the contract a caller can branch on. Every
+ * validation error carries one — the default is the generic
+ * `INVALID_ROUTE_SETTINGS`.
+ *
+ * Codes name the *kind* of thing that is wrong, independent of which section it
+ * was found in, so a caller can branch on the failure class without also
+ * knowing whether it came from a route, a collection or a taxonomy:
+ *
+ * - `INVALID_ROUTE_SETTINGS` — the overall document/section shape is wrong (the
+ *   schema rejected it); also the default for anything not otherwise classified.
+ * - `INVALID_PATH` — a mount path key (a `routes:`/`collections:` key) is malformed.
+ * - `INVALID_PERMALINK` — a permalink value is missing or malformed, wherever it
+ *   appears (a collection `permalink` or a taxonomy permalink).
+ * - `INVALID_TAXONOMY` — the taxonomy itself is not one Ghost supports (not tag/author).
+ * - `INVALID_TEMPLATE` — a route/collection has no template, data or content type.
+ * - `INVALID_RESOURCE` — a data entry names an unsupported resource.
+ * - `INVALID_DATA` — a data definition's shape is otherwise invalid.
+ */
+export const ROUTE_SETTINGS_ERROR_CODES = {
+    INVALID_ROUTE_SETTINGS: 'INVALID_ROUTE_SETTINGS',
+    INVALID_PATH: 'INVALID_PATH',
+    INVALID_PERMALINK: 'INVALID_PERMALINK',
+    INVALID_TAXONOMY: 'INVALID_TAXONOMY',
+    INVALID_TEMPLATE: 'INVALID_TEMPLATE',
+    INVALID_RESOURCE: 'INVALID_RESOURCE',
+    INVALID_DATA: 'INVALID_DATA'
+} as const;
+
+export type RouteSettingsErrorCode = typeof ROUTE_SETTINGS_ERROR_CODES[keyof typeof ROUTE_SETTINGS_ERROR_CODES];
+
+/**
  * Renders the path to the offending value the way an author would find it in
  * their file, e.g. `routes['/about/'].template[1]`.
  */
@@ -162,9 +196,14 @@ function valueAtPath(value: unknown, path: readonly PathSegment[]): unknown {
     }, value);
 }
 
-export function validationError(at: string, reason: string, help?: string): errors.ValidationError {
+export function validationError(
+    at: string,
+    reason: string,
+    {help, code = ROUTE_SETTINGS_ERROR_CODES.INVALID_ROUTE_SETTINGS}: {help?: string, code?: RouteSettingsErrorCode} = {}
+): errors.ValidationError {
     return new errors.ValidationError({
         message: tpl(messages.validationError, {at, reason}),
+        code,
         ...(help ? {help} : {})
     });
 }
@@ -178,19 +217,19 @@ export function validationError(at: string, reason: string, help?: string): erro
  * @param basePath path of the value that was handed to the schema
  * @param value  that same value, used to describe what the author wrote
  */
-export function toValidationError(error: z.ZodError, basePath: readonly PathSegment[] = [], value?: unknown): errors.ValidationError {
+export function toValidationError(error: z.ZodError, basePath: readonly PathSegment[] = [], value?: unknown, code: RouteSettingsErrorCode = ROUTE_SETTINGS_ERROR_CODES.INVALID_ROUTE_SETTINGS): errors.ValidationError {
     const issue = error.issues[0];
     const issuePath = issue.path as PathSegment[];
     const path = [...basePath, ...issuePath];
 
     const expectation = describeExpectation(path);
     if (!expectation) {
-        return validationError(formatLocation(path), issue.message, DOCS_URL);
+        return validationError(formatLocation(path), issue.message, {help: DOCS_URL, code});
     }
 
     const provided = valueAtPath(value, issuePath);
     const listProblem = Array.isArray(provided) ? lookup(LIST_ENTRY_PROBLEMS, fieldKey(path)) : undefined;
     const found = listProblem ?? `${describeValue(provided)} was provided`;
 
-    return validationError(formatLocation(path), `${expectation.subject} must be ${expectation.expectation}, but ${found}.`, DOCS_URL);
+    return validationError(formatLocation(path), `${expectation.subject} must be ${expectation.expectation}, but ${found}.`, {help: DOCS_URL, code});
 }

--- a/ghost/core/core/server/services/route-settings/validation-errors.ts
+++ b/ghost/core/core/server/services/route-settings/validation-errors.ts
@@ -12,6 +12,40 @@ const MAX_SHOWN_LENGTH = 40;
 export type PathSegment = string | number;
 
 /**
+ * Stable, machine-readable codes describing the class of a routes.yaml failure.
+ *
+ * The human-readable message is authored for the person editing the file and is
+ * free to change; the code is the contract a caller can branch on. Every
+ * validation error carries one — the default is the generic
+ * `INVALID_ROUTE_SETTINGS`.
+ *
+ * Codes name the *kind* of thing that is wrong, independent of which section it
+ * was found in, so a caller can branch on the failure class without also
+ * knowing whether it came from a route, a collection or a taxonomy:
+ *
+ * - `INVALID_ROUTE_SETTINGS` — the overall document/section shape is wrong (the
+ *   schema rejected it); also the default for anything not otherwise classified.
+ * - `INVALID_PATH` — a mount path key (a `routes:`/`collections:` key) is malformed.
+ * - `INVALID_PERMALINK` — a permalink value is missing or malformed, wherever it
+ *   appears (a collection `permalink` or a taxonomy permalink).
+ * - `INVALID_TAXONOMY` — the taxonomy itself is not one Ghost supports (not tag/author).
+ * - `INVALID_TEMPLATE` — a route/collection has no template, data or content type.
+ * - `INVALID_RESOURCE` — a data entry names an unsupported resource.
+ * - `INVALID_DATA` — a data definition's shape is otherwise invalid.
+ */
+export const ROUTE_SETTINGS_ERROR_CODES = {
+    INVALID_ROUTE_SETTINGS: 'INVALID_ROUTE_SETTINGS',
+    INVALID_PATH: 'INVALID_PATH',
+    INVALID_PERMALINK: 'INVALID_PERMALINK',
+    INVALID_TAXONOMY: 'INVALID_TAXONOMY',
+    INVALID_TEMPLATE: 'INVALID_TEMPLATE',
+    INVALID_RESOURCE: 'INVALID_RESOURCE',
+    INVALID_DATA: 'INVALID_DATA'
+} as const;
+
+export type RouteSettingsErrorCode = typeof ROUTE_SETTINGS_ERROR_CODES[keyof typeof ROUTE_SETTINGS_ERROR_CODES];
+
+/**
  * Renders the path to the offending value the way an author would find it in
  * their file, e.g. `routes['/about/'].template[1]`.
  */
@@ -153,6 +187,37 @@ function describeExpectation(path: readonly PathSegment[]): {subject: string, ex
     return expectation ? {subject: String(fieldKey(path)), expectation} : null;
 }
 
+/**
+ * Codes that follow from the key a schema failure landed on, so a failure the
+ * schema catches is classified the same as the equivalent one caught by hand.
+ *
+ * Without this, which code an author gets depends on how they happened to write
+ * the mistake: `permalink: ""` is caught by an explicit check and coded
+ * `INVALID_PERMALINK`, while `permalink:` (empty in YAML, so `null`) and
+ * `permalink: 42` are rejected by the schema one step earlier and would fall
+ * back to the generic code. The empty form is the common one, so the most
+ * frequent permalink mistake would be the one carrying the least useful code.
+ */
+const FIELD_CODES: Record<string, RouteSettingsErrorCode> = {
+    permalink: ROUTE_SETTINGS_ERROR_CODES.INVALID_PERMALINK
+};
+
+/**
+ * The code implied by `path`, or undefined when the key implies nothing more
+ * specific than "the schema rejected it".
+ */
+function codeForPath(path: readonly PathSegment[]): RouteSettingsErrorCode | undefined {
+    // A taxonomy's value *is* its permalink, so the key is the taxonomy name
+    // (`taxonomies.tag`) rather than a `permalink` field.
+    if (path.length === 2 && path[0] === 'taxonomies') {
+        return ROUTE_SETTINGS_ERROR_CODES.INVALID_PERMALINK;
+    }
+
+    const key = fieldKey(path);
+
+    return typeof key === 'string' && Object.prototype.hasOwnProperty.call(FIELD_CODES, key) ? FIELD_CODES[key] : undefined;
+}
+
 function valueAtPath(value: unknown, path: readonly PathSegment[]): unknown {
     return path.reduce<unknown>((current, segment) => {
         if (current === null || typeof current !== 'object') {
@@ -162,9 +227,14 @@ function valueAtPath(value: unknown, path: readonly PathSegment[]): unknown {
     }, value);
 }
 
-export function validationError(at: string, reason: string, help?: string): errors.ValidationError {
+export function validationError(
+    at: string,
+    reason: string,
+    {help, code = ROUTE_SETTINGS_ERROR_CODES.INVALID_ROUTE_SETTINGS}: {help?: string, code?: RouteSettingsErrorCode} = {}
+): errors.ValidationError {
     return new errors.ValidationError({
         message: tpl(messages.validationError, {at, reason}),
+        code,
         ...(help ? {help} : {})
     });
 }
@@ -177,20 +247,25 @@ export function validationError(at: string, reason: string, help?: string): erro
  * @param error  the schema failure
  * @param basePath path of the value that was handed to the schema
  * @param value  that same value, used to describe what the author wrote
+ * @param code   forces the code; omit to infer it from the failing key, which
+ *               is what callers covering a whole section (a route, a
+ *               collection) want — the failure could be about any field in it.
  */
-export function toValidationError(error: z.ZodError, basePath: readonly PathSegment[] = [], value?: unknown): errors.ValidationError {
+export function toValidationError(error: z.ZodError, basePath: readonly PathSegment[] = [], value?: unknown, code?: RouteSettingsErrorCode): errors.ValidationError {
     const issue = error.issues[0];
     const issuePath = issue.path as PathSegment[];
     const path = [...basePath, ...issuePath];
 
+    const resolvedCode = code ?? codeForPath(path) ?? ROUTE_SETTINGS_ERROR_CODES.INVALID_ROUTE_SETTINGS;
+
     const expectation = describeExpectation(path);
     if (!expectation) {
-        return validationError(formatLocation(path), issue.message, DOCS_URL);
+        return validationError(formatLocation(path), issue.message, {help: DOCS_URL, code: resolvedCode});
     }
 
     const provided = valueAtPath(value, issuePath);
     const listProblem = Array.isArray(provided) ? lookup(LIST_ENTRY_PROBLEMS, fieldKey(path)) : undefined;
     const found = listProblem ?? `${describeValue(provided)} was provided`;
 
-    return validationError(formatLocation(path), `${expectation.subject} must be ${expectation.expectation}, but ${found}.`, DOCS_URL);
+    return validationError(formatLocation(path), `${expectation.subject} must be ${expectation.expectation}, but ${found}.`, {help: DOCS_URL, code: resolvedCode});
 }

--- a/ghost/core/test/unit/frontend/services/routing/registry.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/registry.test.js
@@ -103,4 +103,86 @@ describe('UNIT: services/routing/registry', function () {
             assert.equal(registry.getRssUrl(), null);
         });
     });
+
+    describe('class shape', function () {
+        it('is exported as a Registry class instance, not a bare object literal', function () {
+            assert.equal(registry.constructor.name, 'Registry');
+        });
+
+        it('is a singleton — repeated requires share one instance', function () {
+            const again = require('../../../../../core/frontend/services/routing/registry');
+            assert.equal(again, registry);
+        });
+    });
+
+    describe('fn: routes', function () {
+        it('records routes with their originating router name', function () {
+            registry.setRoute('CollectionRouter', '/');
+            registry.setRoute('StaticRoutesRouter', '/about/');
+
+            assert.deepEqual(registry.getAllRoutes(), [
+                {route: '/', from: 'CollectionRouter'},
+                {route: '/about/', from: 'StaticRoutesRouter'}
+            ]);
+        });
+
+        it('getAllRoutes returns a defensive copy', function () {
+            registry.setRoute('CollectionRouter', '/');
+
+            const first = registry.getAllRoutes();
+            first.push({route: '/injected/', from: 'x'});
+
+            assert.equal(registry.getAllRoutes().length, 1);
+        });
+
+        it('resetAllRoutes empties the routes', function () {
+            registry.setRoute('CollectionRouter', '/');
+            registry.resetAllRoutes();
+
+            assert.deepEqual(registry.getAllRoutes(), []);
+        });
+    });
+
+    describe('fn: routers', function () {
+        it('sets and gets a router by key', function () {
+            const router = {name: 'CollectionRouter'};
+            registry.setRouter('collectionRouter', router);
+
+            assert.equal(registry.getRouter('collectionRouter'), router);
+        });
+
+        it('getRouterByName finds a router by its internal name', function () {
+            const router = {name: 'CollectionRouter'};
+            registry.setRouter('collectionRouter', router);
+
+            assert.equal(registry.getRouterByName('CollectionRouter'), router);
+        });
+
+        it('getRouterByName returns undefined when no router matches', function () {
+            assert.equal(registry.getRouterByName('Nope'), undefined);
+        });
+
+        it('resetAllRouters calls reset() on routers that support it and clears them', function () {
+            const resettable = {name: 'A', reset: sinon.stub()};
+            const plain = {name: 'B'};
+            registry.setRouter('a', resettable);
+            registry.setRouter('b', plain);
+
+            registry.resetAllRouters();
+
+            assert.equal(resettable.reset.calledOnce, true);
+            assert.equal(registry.getRouter('a'), undefined);
+            assert.equal(registry.getRouter('b'), undefined);
+        });
+
+        it('clearAllRouters drops all routers without calling reset()', function () {
+            const resettable = {name: 'A', reset: sinon.stub()};
+            registry.setRouter('a', resettable);
+
+            registry.clearAllRouters();
+
+            assert.equal(resettable.reset.called, false);
+            assert.equal(registry.getRouter('a'), undefined);
+        });
+    });
 });

--- a/ghost/core/test/unit/server/services/route-settings/validate-route-settings.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/validate-route-settings.test.ts
@@ -530,4 +530,41 @@ describe('UNIT: services/route-settings/validation (via parseRouteSettings)', fu
             assert.match(helpFor({routes: {'/x/': {template: 'x', data: {e: {resource: 'posts'}}}}}) ?? '', /^e\.g\.\n data:/);
         });
     });
+
+    describe('domain error codes', function () {
+        function codeFor(raw: unknown): string | undefined {
+            try {
+                parse(raw);
+            } catch (err) {
+                assert.ok(err instanceof errors.ValidationError, `expected a ValidationError, got ${err}`);
+                return (err as {code?: string}).code;
+            }
+            return assert.fail('expected parsing to throw');
+        }
+
+        // Each invalid file should carry a stable, machine-readable code so
+        // callers can react to the failure class without matching on message
+        // text (which is authored for humans and free to change).
+        const cases: Array<[string, unknown, string]> = [
+            ['route path missing a slash', {routes: {'about/': 'about'}}, 'INVALID_PATH'],
+            ['collection path missing a slash', {collections: {'blog/': {permalink: '/{slug}/'}}}, 'INVALID_PATH'],
+            ['collection permalink using :param', {collections: {'/blog/': {permalink: '/:slug/'}}}, 'INVALID_PERMALINK'],
+            ['collection missing a permalink', {collections: {'/blog/': {template: 'index'}}}, 'INVALID_PERMALINK'],
+            ['route with no template, data or content_type', {routes: {'/about/': {}}}, 'INVALID_TEMPLATE'],
+            ['unknown taxonomy key', {taxonomies: {category: '/category/{slug}/'}}, 'INVALID_TAXONOMY'],
+            ['missing taxonomy permalink', {taxonomies: {tag: ''}}, 'INVALID_PERMALINK'],
+            ['taxonomy permalink using :param', {taxonomies: {tag: '/tag/:slug/'}}, 'INVALID_PERMALINK'],
+            ['unsupported longform data resource', {routes: {'/x/': {template: 'x', data: {thing: {type: 'read', resource: 'widgets', slug: 'a'}}}}}, 'INVALID_RESOURCE'],
+            ['unsupported shorthand data resource', {routes: {'/x/': {template: 'x', data: 'widget.foo'}}}, 'INVALID_RESOURCE'],
+            ['reserved data key', {routes: {'/x/': {template: 'x', data: {slug: 'tag.recipes'}}}}, 'INVALID_DATA'],
+            ['data provided as a list', {routes: {'/x/': {template: 'x', data: ['a', 'b']}}}, 'INVALID_DATA'],
+            ['top-level section not a map', {routes: 'hello'}, 'INVALID_ROUTE_SETTINGS']
+        ];
+
+        cases.forEach(([name, raw, expected]) => {
+            it(`${name} → ${expected}`, function () {
+                assert.equal(codeFor(raw), expected);
+            });
+        });
+    });
 });

--- a/ghost/core/test/unit/server/services/route-settings/validate-route-settings.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/validate-route-settings.test.ts
@@ -530,4 +530,49 @@ describe('UNIT: services/route-settings/validation (via parseRouteSettings)', fu
             assert.match(helpFor({routes: {'/x/': {template: 'x', data: {e: {resource: 'posts'}}}}}) ?? '', /^e\.g\.\n data:/);
         });
     });
+
+    describe('domain error codes', function () {
+        function codeFor(raw: unknown): string | undefined {
+            try {
+                parse(raw);
+            } catch (err) {
+                assert.ok(err instanceof errors.ValidationError, `expected a ValidationError, got ${err}`);
+                return (err as {code?: string}).code;
+            }
+            return assert.fail('expected parsing to throw');
+        }
+
+        // Each invalid file should carry a stable, machine-readable code so
+        // callers can react to the failure class without matching on message
+        // text (which is authored for humans and free to change).
+        const cases: Array<[string, unknown, string]> = [
+            ['route path missing a slash', {routes: {'about/': 'about'}}, 'INVALID_PATH'],
+            ['collection path missing a slash', {collections: {'blog/': {permalink: '/{slug}/'}}}, 'INVALID_PATH'],
+            ['collection permalink using :param', {collections: {'/blog/': {permalink: '/:slug/'}}}, 'INVALID_PERMALINK'],
+            ['collection missing a permalink', {collections: {'/blog/': {template: 'index'}}}, 'INVALID_PERMALINK'],
+            ['route with no template, data or content_type', {routes: {'/about/': {}}}, 'INVALID_TEMPLATE'],
+            ['unknown taxonomy key', {taxonomies: {category: '/category/{slug}/'}}, 'INVALID_TAXONOMY'],
+            ['missing taxonomy permalink', {taxonomies: {tag: ''}}, 'INVALID_PERMALINK'],
+            ['taxonomy permalink using :param', {taxonomies: {tag: '/tag/:slug/'}}, 'INVALID_PERMALINK'],
+            // The schema rejects these one step before the hand-written checks
+            // above, so they only carry the permalink code if the code is also
+            // inferred from the failing key. `permalink:`/`tag:` left empty in
+            // YAML parses to null, which is the common way to write it.
+            ['collection permalink left empty', {collections: {'/blog/': {permalink: null}}}, 'INVALID_PERMALINK'],
+            ['collection permalink of the wrong type', {collections: {'/blog/': {permalink: 42}}}, 'INVALID_PERMALINK'],
+            ['taxonomy permalink left empty', {taxonomies: {tag: null}}, 'INVALID_PERMALINK'],
+            ['taxonomy permalink of the wrong type', {taxonomies: {tag: 42}}, 'INVALID_PERMALINK'],
+            ['unsupported longform data resource', {routes: {'/x/': {template: 'x', data: {thing: {type: 'read', resource: 'widgets', slug: 'a'}}}}}, 'INVALID_RESOURCE'],
+            ['unsupported shorthand data resource', {routes: {'/x/': {template: 'x', data: 'widget.foo'}}}, 'INVALID_RESOURCE'],
+            ['reserved data key', {routes: {'/x/': {template: 'x', data: {slug: 'tag.recipes'}}}}, 'INVALID_DATA'],
+            ['data provided as a list', {routes: {'/x/': {template: 'x', data: ['a', 'b']}}}, 'INVALID_DATA'],
+            ['top-level section not a map', {routes: 'hello'}, 'INVALID_ROUTE_SETTINGS']
+        ];
+
+        cases.forEach(([name, raw, expected]) => {
+            it(`${name} → ${expected}`, function () {
+                assert.equal(codeFor(raw), expected);
+            });
+        });
+    });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1831

## Summary

The final two independent DDD-cleanup steps for `route-settings` (design steps 3.9 + 3.11). No behavioural change beyond an additive error `code`.

### 1. Domain error codes on validation failures

Route-settings validation errors now carry a stable, machine-readable `code` so callers can branch on the *class* of failure instead of matching human-authored message text:

- `INVALID_ROUTE_SETTINGS` (default / schema-shape), `INVALID_PATH`, `INVALID_PERMALINK`, `INVALID_TAXONOMY`, `INVALID_TEMPLATE`, `INVALID_RESOURCE`, `INVALID_DATA`.
- Codes name the **kind** of failure independent of which section it came from — a malformed permalink is `INVALID_PERMALINK` whether it is a collection permalink or a taxonomy permalink; `INVALID_TAXONOMY` is reserved for an unsupported taxonomy key.
- Threaded through a small `{help, code}` options object on `validationError()` (removing the previous positional `help`/`undefined` noise).

### 2. Routing registry as a class

`frontend/services/routing/registry.js` moves from module-level `let routes/routers` state to `class Registry`, exported as a single shared instance (`module.exports = new Registry()`). The two consumers (`routing/index.js`, `parent-router.js`) keep sharing one registry exactly as before — behaviour is identical, state just lives on the instance.

## Safety

- **Messages and `help` are byte-for-byte unchanged.** The only observable effect is that a failed `routes.yaml` upload now returns a domain `code` in the 4xx error body where it was previously `null`. Nothing branches on `err.code` for these errors today (the read-path fallback keys on `errorType === 'ValidationError'`).
- Registry conversion is behaviour-preserving: no consumer destructures methods off the export, so the object to class `this` shift is invisible; it was already a module singleton and remains one.
- Built test-first. Reviewed locally by three independent agents (production-safety, clean-code, test-quality) across two rounds; all confirmed no behavioural change and merge-readiness.

## Testing

- `test/unit/frontend/services/routing/registry.test.js` — singleton identity, defensive copy in `getAllRoutes`, `resetAllRouters` (calls `reset()`) vs `clearAllRouters`, `getRouterByName` miss.
- `test/unit/server/services/route-settings/validate-route-settings.test.ts` — a `domain error codes` table asserting the code for each failure class (all 7 codes exercised).
- Full route-settings + routing unit suites green (322 tests); ESLint + `tsc --noEmit` clean; schema `integrity` (default routes hash) unaffected.
