### PR TITLE
Added paywallImprovements feature flag

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -83,6 +83,10 @@ const features: Feature[] = [{
     title: 'Preview by tier',
     description: 'Preview posts and emails as a member of a specific tier',
     flag: 'previewByTier'
+}, {
+    title: 'Paywall improvements',
+    description: 'Enables paywall usability, discoverability and email customization improvements',
+    flag: 'paywallImprovements'
 }];
 
 const AlphaFeatures: React.FC = () => {

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -64,7 +64,8 @@ const PRIVATE_FEATURES = [
     'getHelperDeduplication',
     'memberDetailsReact',
     'membersCustomFields',
-    'previewByTier'
+    'previewByTier',
+    'paywallImprovements'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -35,6 +35,7 @@ Object {
       "memberDetailsReact": true,
       "members": true,
       "membersCustomFields": true,
+      "paywallImprovements": true,
       "pictureImageFormats": true,
       "previewByTier": true,
       "smarterCounts": true,


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3822/add-paywallimprovements-feature-flag

The paywall usability, discoverability & email customization project ships every user-visible slice behind a flag, so the flag needs to exist before the first feature lands — otherwise each subsequent PR has to bundle the flag plumbing with its own behaviour change.

Registers `paywallImprovements` as a private (developer experiments) feature flag: backend registration in `labs.js` plus the Labs settings toggle. Private rather than public beta because nothing here is ready to be exposed to users yet.

There is no user-facing behaviour beyond the toggle appearing under developer experiments.