### PR TITLE
Changed Koenig editor to preserve component identity

### DIFF
--- a/apps/ember-admin/app/components/koenig-lexical-editor.js
+++ b/apps/ember-admin/app/components/koenig-lexical-editor.js
@@ -131,6 +131,40 @@ const TKCountPlugin = ({editorResource, ...props}) => {
     return <_TKCountPlugin {...props} />;
 };
 
+const FILE_UPLOADER = {
+    useFileUpload: useKoenigFileUpload,
+    fileTypes: koenigFileUploadTypes
+};
+
+const NOOP = () => {};
+
+const KGEditorComponent = ({cardConfig, darkMode, editorArgs, editorResource, isInitInstance, onError}) => {
+    return (
+        <div data-secondary-instance={isInitInstance ? true : false} style={isInitInstance ? {display: 'none'} : {}}>
+            <KoenigComposer
+                editorResource={editorResource}
+                cardConfig={cardConfig}
+                fileUploader={FILE_UPLOADER}
+                initialEditorState={editorArgs.lexical}
+                onError={onError}
+                darkMode={darkMode}
+                isTKEnabled={true}
+            >
+                <KoenigEditor
+                    editorResource={editorResource}
+                    cursorDidExitAtTop={isInitInstance ? null : editorArgs.cursorDidExitAtTop}
+                    placeholderText={isInitInstance ? null : editorArgs.placeholderText}
+                    darkMode={isInitInstance ? null : darkMode}
+                    onChange={isInitInstance ? editorArgs.updateSecondaryInstanceModel : editorArgs.onChange}
+                    registerAPI={isInitInstance ? editorArgs.registerSecondaryAPI : editorArgs.registerAPI}
+                />
+                <WordCountPlugin editorResource={editorResource} onChange={isInitInstance ? NOOP : editorArgs.updateWordCount} />
+                <TKCountPlugin editorResource={editorResource} onChange={isInitInstance ? NOOP : editorArgs.updatePostTkCount} />
+            </KoenigComposer>
+        </div>
+    );
+};
+
 export default class KoenigLexicalEditor extends Component {
     @service ajax;
     @service feature;
@@ -450,40 +484,20 @@ export default class KoenigLexicalEditor extends Component {
             visibilitySettings: getCardVisibilitySettings(props.cardConfig)
         };
         const cardConfig = Object.assign({}, defaultCardConfig, props.cardConfig, {pinturaConfig: this.pinturaConfig, visibilitySettings: defaultCardConfig.visibilitySettings});
-
-        const KGEditorComponent = ({isInitInstance}) => {
-            return (
-                <div data-secondary-instance={isInitInstance ? true : false} style={isInitInstance ? {display: 'none'} : {}}>
-                    <KoenigComposer
-                        editorResource={this.editorResource}
-                        cardConfig={cardConfig}
-                        fileUploader={{useFileUpload: useKoenigFileUpload, fileTypes: koenigFileUploadTypes}}
-                        initialEditorState={this.args.lexical}
-                        onError={this.onError}
-                        darkMode={this.feature.nightShift}
-                        isTKEnabled={true}
-                    >
-                        <KoenigEditor
-                            editorResource={this.editorResource}
-                            cursorDidExitAtTop={isInitInstance ? null : this.args.cursorDidExitAtTop}
-                            placeholderText={isInitInstance ? null : this.args.placeholderText}
-                            darkMode={isInitInstance ? null : this.feature.nightShift}
-                            onChange={isInitInstance ? this.args.updateSecondaryInstanceModel : this.args.onChange}
-                            registerAPI={isInitInstance ? this.args.registerSecondaryAPI : this.args.registerAPI}
-                        />
-                        <WordCountPlugin editorResource={this.editorResource} onChange={isInitInstance ? () => {} : this.args.updateWordCount} />
-                        <TKCountPlugin editorResource={this.editorResource} onChange={isInitInstance ? () => {} : this.args.updatePostTkCount} />
-                    </KoenigComposer>
-                </div>
-            );
+        const kgEditorProps = {
+            cardConfig,
+            darkMode: this.feature.nightShift,
+            editorArgs: this.args,
+            editorResource: this.editorResource,
+            onError: this.onError
         };
 
         return (
             <div className={['koenig-react-editor', 'koenig-lexical', this.args.className].filter(Boolean).join(' ')}>
                 <ErrorHandler config={this.config}>
                     <Suspense fallback={<p className="koenig-react-editor-loading">Loading editor...</p>}>
-                        <KGEditorComponent />
-                        <KGEditorComponent isInitInstance={true} />
+                        <KGEditorComponent {...kgEditorProps} />
+                        <KGEditorComponent {...kgEditorProps} isInitInstance={true} />
                     </Suspense>
                 </ErrorHandler>
             </div>

--- a/apps/ember-admin/tests/integration/components/koenig-lexical-editor-test.js
+++ b/apps/ember-admin/tests/integration/components/koenig-lexical-editor-test.js
@@ -1,0 +1,112 @@
+import React from 'react';
+import Service from '@ember/service';
+import hbs from 'htmlbars-inline-precompile';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {fillIn, find, render, waitFor, waitUntil} from '@ember/test-helpers';
+import {setupRenderingTest} from 'ember-mocha';
+
+const MockKoenigComposer = ({cardConfig, children}) => {
+    return React.createElement(
+        React.Fragment,
+        null,
+        React.createElement('span', {'data-test-visibility-settings': ''}, cardConfig.visibilitySettings),
+        children
+    );
+};
+
+const MockKoenigEditor = () => {
+    return React.createElement('input', {'data-test-editor-state': ''});
+};
+
+const MockPlugin = () => null;
+
+const EDITOR_RESOURCE = {
+    read() {
+        return {
+            KoenigComposer: MockKoenigComposer,
+            KoenigEditor: MockKoenigEditor,
+            TKCountPlugin: MockPlugin,
+            WordCountPlugin: MockPlugin
+        };
+    }
+};
+
+const SESSION_USER = {
+    isContributor: false
+};
+
+class FeatureService extends Service {
+    get nightShift() {
+        return false;
+    }
+}
+
+class KoenigService extends Service {
+    get resource() {
+        return EDITOR_RESOURCE;
+    }
+}
+
+class SessionService extends Service {
+    get user() {
+        return SESSION_USER;
+    }
+}
+
+class SettingsService extends Service {
+    get membersSignupAccess() {
+        return 'all';
+    }
+
+    get title() {
+        return 'Test site';
+    }
+}
+
+describe('Integration: Component: koenig-lexical-editor', function () {
+    setupRenderingTest();
+
+    beforeEach(function () {
+        this.owner.register('config:main', {
+            getSiteUrl(path) {
+                return `https://example.com${path}`;
+            },
+            site_uuid: 'test-site-uuid',
+            stripeDirect: false
+        }, {instantiate: false});
+
+        this.owner.register('service:feature', FeatureService);
+        this.owner.register('service:koenig', KoenigService);
+        this.owner.register('service:session', SessionService);
+        this.owner.register('service:settings', SettingsService);
+
+        this.set('cardConfig', {
+            post: {
+                displayName: 'post'
+            }
+        });
+    });
+
+    it('preserves editor state when updated card config re-renders the React root', async function () {
+        await render(hbs`<KoenigLexicalEditor @cardConfig={{this.cardConfig}} />`);
+        await waitFor('[data-secondary-instance="false"] [data-test-editor-state]');
+
+        const editorSelector = '[data-secondary-instance="false"] [data-test-editor-state]';
+        const visibilitySelector = '[data-secondary-instance="false"] [data-test-visibility-settings]';
+
+        expect(find(visibilitySelector)).to.have.text('web and email');
+
+        await fillIn(editorSelector, 'Unsaved editor state');
+
+        this.set('cardConfig', {
+            post: {
+                displayName: 'page'
+            }
+        });
+
+        await waitUntil(() => find(visibilitySelector)?.textContent === 'web only');
+
+        expect(find(editorSelector)).to.have.value('Unsaved editor state');
+    });
+});


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3821

`KGEditorComponent` was defined inside the Ember-to-React bridge render function, creating a new component type on every bridge re-render. React consequently unmounted and remounted the Koenig composer, discarding selection, focus, and in-progress card UI state.

Adding live post data (e.g. post access setting) to the card config prop makes re-renders more likely, so the editor subtree needs a stable component identity.

- hoisted `KGEditorComponent` to module scope and passed render-dependent values through props
- reused stable file-uploader and no-op references
- added regression coverage for retaining editor-owned state across bridge re-renders
