### PR TITLE
Changed RouterManager and routers to consume RouteSettings arrays

### DIFF
--- a/ghost/core/core/frontend/services/routing/router-manager.js
+++ b/ghost/core/core/frontend/services/routing/router-manager.js
@@ -1,5 +1,4 @@
 const debug = require('@tryghost/debug')('frontend:routing');
-const _ = require('lodash');
 const StaticRoutesRouter = require('./static-routes-router');
 const StaticPagesRouter = require('./static-pages-router');
 const CollectionRouter = require('./collection-router');
@@ -111,30 +110,30 @@ class RouterManager {
         this.siteRouter.mountRouter(previewRouter.router());
         this.registry.setRouter('previewRouter', previewRouter);
 
-        _.each(routerSettings.routes, (value, key) => {
-            const staticRoutesRouter = new StaticRoutesRouter(key, value, this.routerCreated.bind(this));
+        for (const route of routerSettings.routes) {
+            const staticRoutesRouter = new StaticRoutesRouter(route.path, route, this.routerCreated.bind(this));
             this.siteRouter.mountRouter(staticRoutesRouter.router());
 
             this.registry.setRouter(staticRoutesRouter.identifier, staticRoutesRouter);
-        });
+        }
 
-        _.each(routerSettings.collections, (value, key) => {
-            const collectionRouter = new CollectionRouter(key, value, RESOURCE_CONFIG, this.routerCreated.bind(this));
+        for (const collection of routerSettings.collections) {
+            const collectionRouter = new CollectionRouter(collection.path, collection, RESOURCE_CONFIG, this.routerCreated.bind(this));
             this.siteRouter.mountRouter(collectionRouter.router());
             this.registry.setRouter(collectionRouter.identifier, collectionRouter);
-        });
+        }
 
         const staticPagesRouter = new StaticPagesRouter(RESOURCE_CONFIG, this.routerCreated.bind(this));
         this.siteRouter.mountRouter(staticPagesRouter.router());
 
         this.registry.setRouter('staticPagesRouter', staticPagesRouter);
 
-        _.each(routerSettings.taxonomies, (value, key) => {
-            const taxonomyRouter = new TaxonomyRouter(key, value, RESOURCE_CONFIG, this.routerCreated.bind(this));
+        for (const taxonomy of routerSettings.taxonomies) {
+            const taxonomyRouter = new TaxonomyRouter(taxonomy.key, taxonomy.permalink, RESOURCE_CONFIG, this.routerCreated.bind(this));
             this.siteRouter.mountRouter(taxonomyRouter.router());
 
             this.registry.setRouter(taxonomyRouter.identifier, taxonomyRouter);
-        });
+        }
 
         const appRouter = new ParentRouter('AppsRouter');
         this.siteRouter.mountRouter(appRouter.router());
@@ -187,9 +186,9 @@ module.exports = RouterManager;
 
 /**
  * @typedef {Object} RouteSettings
- * @property {Object} routes
- * @property {Object} collections
- * @property {Object} taxonomies
+ * @property {Array} routes - route entries, each carrying its own `path`
+ * @property {Array} collections - collection entries, each carrying its own `path`
+ * @property {Array} taxonomies - `{key, permalink}` entries
  */
 
 /**

--- a/ghost/core/core/frontend/services/routing/router-manager.js
+++ b/ghost/core/core/frontend/services/routing/router-manager.js
@@ -185,10 +185,11 @@ module.exports = RouterManager;
  */
 
 /**
- * @typedef {Object} RouteSettings
- * @property {Array} routes - route entries, each carrying its own `path`
- * @property {Array} collections - collection entries, each carrying its own `path`
- * @property {Array} taxonomies - `{key, permalink}` entries
+ * The shape RouterManager consumes — produced by the activation bridge. This is
+ * a temporary reference into server code; when the bridge is removed (HKG-1898)
+ * it becomes the domain `RouteSettings` from @tryghost/adapter-base-route-settings.
+ *
+ * @typedef {import('../../../server/services/route-settings/activation-bridge').RouterSettings} RouteSettings
  */
 
 /**

--- a/ghost/core/core/frontend/services/routing/static-routes-router.js
+++ b/ghost/core/core/frontend/services/routing/static-routes-router.js
@@ -30,12 +30,12 @@ class StaticRoutesRouter extends ParentRouter {
             this.limit = object.limit;
             this.order = object.order;
 
-            this.controller = object.controller;
+            this.type = object.type;
 
             debug(this.route.value, this.templates, this.filter, this.data);
             this._registerChannelRoutes();
         } else {
-            this.contentType = object.content_type;
+            this.contentType = object.contentType;
             debug(this.route.value, this.templates);
             this._registerStaticRoute();
         }
@@ -56,11 +56,11 @@ class StaticRoutesRouter extends ParentRouter {
         }
 
         // REGISTER: channel route
-        this.mountRoute(this.route.value, controllers[this.controller]);
+        this.mountRoute(this.route.value, controllers[this.type]);
 
         // REGISTER: pagination
         this.router().param('page', middleware.pageParam);
-        this.mountRoute(urlUtils.urlJoin(this.route.value, 'page', ':page(\\d+)'), controllers[this.controller]);
+        this.mountRoute(urlUtils.urlJoin(this.route.value, 'page', ':page(\\d+)'), controllers[this.type]);
 
         this.routerCreated(this);
     }
@@ -74,7 +74,7 @@ class StaticRoutesRouter extends ParentRouter {
      */
     _prepareChannelContext(req, res, next) {
         res.routerOptions = {
-            type: this.controller,
+            type: this.type,
             name: this.routerName,
             context: [this.routerName],
             filter: this.filter,
@@ -131,11 +131,9 @@ class StaticRoutesRouter extends ParentRouter {
      * @returns {boolean}
      */
     isChannel(object) {
-        if (object && object.controller && object.controller === 'channel') {
-            return true;
-        }
-
-        return this.controller === 'channel';
+        // buildRouterSettings always sets `type` ('channel' | 'template') on
+        // every route, so a channel is simply `type === 'channel'`.
+        return object?.type === 'channel';
     }
 }
 

--- a/ghost/core/core/server/services/route-settings/activation-bridge.ts
+++ b/ghost/core/core/server/services/route-settings/activation-bridge.ts
@@ -121,90 +121,128 @@ function convertSlugsToColons(value: string): string {
     return value.replace(/{(\w+)}/g, ':$1');
 }
 
-function expandRoute(route: Route): Record<string, any> {
-    const expanded: Record<string, any> = {};
+/**
+ * Router-facing shapes. These mirror the domain model (arrays, `type`,
+ * `contentType`, `{slug}`→`:slug` permalinks) but still carry the legacy
+ * `data` expansion (`{query, router}`) and `:slug` notation that the routers,
+ * controllers and URL service consume today. Later cleanup PRs peel those two
+ * conversions off into the permalink/API adapters (HKG-1896/HKG-1897).
+ */
+interface RouterRoute {
+    path: string;
+    type: 'channel' | 'template';
+    templates: string[];
+    data?: ExpandedData;
+    contentType?: string;
+    filter?: string;
+    order?: string;
+    limit?: number | 'all';
+    rss?: boolean;
+}
 
-    expanded.templates = route.templates || [];
+interface RouterCollection {
+    path: string;
+    permalink: string;
+    templates: string[];
+    data?: ExpandedData;
+    filter?: string;
+    order?: string;
+    limit?: number | 'all';
+    rss?: boolean;
+}
+
+interface RouterTaxonomy {
+    key: string;
+    permalink: string;
+}
+
+interface RouterSettings {
+    routes: RouterRoute[];
+    collections: RouterCollection[];
+    taxonomies: RouterTaxonomy[];
+}
+
+function buildRouterRoute(route: Route): RouterRoute {
+    const result: RouterRoute = {
+        path: route.path,
+        type: route.type,
+        templates: route.templates || []
+    };
 
     if (route.data !== undefined) {
-        expanded.data = expandRouteData(route.data);
+        result.data = expandRouteData(route.data);
     }
 
     if (route.type === 'channel') {
         const channel = route as ChannelRoute;
-        expanded.controller = 'channel';
         if (channel.filter !== undefined) {
-            expanded.filter = channel.filter;
+            result.filter = channel.filter;
         }
         if (channel.order !== undefined) {
-            expanded.order = channel.order;
+            result.order = channel.order;
         }
         if (channel.limit !== undefined) {
-            expanded.limit = channel.limit;
+            result.limit = channel.limit;
         }
         if (channel.rss !== undefined) {
-            expanded.rss = channel.rss;
+            result.rss = channel.rss;
         }
     } else {
         const template = route as TemplateRoute;
         if (template.contentType !== undefined) {
-            expanded.content_type = template.contentType;
+            result.contentType = template.contentType;
         }
     }
 
-    return expanded;
+    return result;
 }
 
-function expandCollection(collection: CollectionConfig): Record<string, any> {
-    const expanded: Record<string, any> = {};
-
-    expanded.permalink = convertSlugsToColons(collection.permalink);
-    expanded.templates = collection.templates || [];
+function buildRouterCollection(collection: CollectionConfig): RouterCollection {
+    const result: RouterCollection = {
+        path: collection.path,
+        permalink: convertSlugsToColons(collection.permalink),
+        templates: collection.templates || []
+    };
 
     if (collection.data !== undefined) {
-        expanded.data = expandRouteData(collection.data);
+        result.data = expandRouteData(collection.data);
     }
-
     if (collection.filter !== undefined) {
-        expanded.filter = collection.filter;
+        result.filter = collection.filter;
     }
     if (collection.order !== undefined) {
-        expanded.order = collection.order;
+        result.order = collection.order;
     }
     if (collection.limit !== undefined) {
-        expanded.limit = collection.limit;
+        result.limit = collection.limit;
     }
     if (collection.rss !== undefined) {
-        expanded.rss = collection.rss;
+        result.rss = collection.rss;
     }
 
-    return expanded;
+    return result;
 }
 
 /**
- * Converts a RouteSettings domain model into the legacy expanded format
- * that routerManager.start() expects.
+ * Converts a RouteSettings domain model into the array shape that
+ * RouterManager.start() iterates. Each route/collection carries its own `path`,
+ * and taxonomies become `{key, permalink}` entries, so the routing layer no
+ * longer reads paths from map keys.
  *
- * This is a temporary adapter — it gets removed once RouterManager is
- * refactored to consume the domain model directly (HKG-1895/HKG-1898).
+ * Temporary adapter: removed in HKG-1898 once the routers consume the domain
+ * model directly.
  */
-export function expandRouteSettings(settings: RouteSettings): {routes: Record<string, any>; collections: Record<string, any>; taxonomies: Record<string, string>} {
-    const routes: Record<string, any> = {};
-    for (const route of settings.routes) {
-        routes[route.path] = expandRoute(route);
-    }
-
-    const collections: Record<string, any> = {};
-    for (const collection of settings.collections) {
-        collections[collection.path] = expandCollection(collection);
-    }
-
-    const taxonomies: Record<string, string> = {};
+export function buildRouterSettings(settings: RouteSettings): RouterSettings {
+    const taxonomies: RouterTaxonomy[] = [];
     for (const [key, value] of Object.entries(settings.taxonomies)) {
         if (value) {
-            taxonomies[key] = convertSlugsToColons(value);
+            taxonomies.push({key, permalink: convertSlugsToColons(value)});
         }
     }
 
-    return {routes, collections, taxonomies};
+    return {
+        routes: settings.routes.map(buildRouterRoute),
+        collections: settings.collections.map(buildRouterCollection),
+        taxonomies
+    };
 }

--- a/ghost/core/core/server/services/route-settings/activation-bridge.ts
+++ b/ghost/core/core/server/services/route-settings/activation-bridge.ts
@@ -4,6 +4,8 @@ import {QUERY} from '../../../frontend/services/routing/config';
 import type {
     RouteSettings,
     Route,
+    ChannelRoute,
+    TemplateRoute,
     CollectionConfig,
     RouteData,
     DataShortForm,
@@ -120,35 +122,29 @@ function convertSlugsToColons(value: string): string {
 }
 
 /**
- * Router-facing shapes. These mirror the domain model (arrays, `type`,
- * `contentType`, `{slug}`→`:slug` permalinks) but still carry the legacy
- * `data` expansion (`{query, router}`) and `:slug` notation that the routers,
- * controllers and URL service consume today. Later cleanup PRs peel those two
- * conversions off into the permalink/API adapters (HKG-1896/HKG-1897).
+ * Router-facing shapes. RouterManager consumes the domain model after the two
+ * conversions the bridge still applies: `data` expanded to `{query, router}`,
+ * and collection/taxonomy permalinks rewritten to `:slug`.
+ *
+ * Routes and collections are written as their domain counterpart with just
+ * `data` overridden to the expanded shape — `Omit<…, 'data'> & {data?}` rather
+ * than `extends`, because the override changes `data`'s type (interface
+ * extension can only add fields, not retype them). That keeps the delta from
+ * the domain model explicit: `data` is the only structural difference. When the
+ * bridge is removed (HKG-1898) the override falls away and these collapse back
+ * to `Route` / `CollectionConfig`.
  */
-interface RouterRoute {
-    path: string;
-    type: 'channel' | 'template';
-    templates: string[];
-    data?: ExpandedData;
-    contentType?: string;
-    filter?: string;
-    order?: string;
-    limit?: number | 'all';
-    rss?: boolean;
-}
+type RouterChannelRoute = Omit<ChannelRoute, 'data'> & {data?: ExpandedData};
+type RouterTemplateRoute = Omit<TemplateRoute, 'data'> & {data?: ExpandedData};
+type RouterRoute = RouterChannelRoute | RouterTemplateRoute;
 
-interface RouterCollection {
-    path: string;
-    permalink: string;
-    templates: string[];
-    data?: ExpandedData;
-    filter?: string;
-    order?: string;
-    limit?: number | 'all';
-    rss?: boolean;
-}
+type RouterCollection = Omit<CollectionConfig, 'data'> & {data?: ExpandedData};
 
+// Taxonomies and RouteSettings have no direct domain counterpart to derive from:
+// the domain stores taxonomies as a `{tag, author}` map, which the bridge
+// flattens into these `{key, permalink}` entries, and RouterSettings drops
+// `yamlSource` and swaps all three array element types (routes, collections,
+// taxonomies) — so they stay standalone.
 interface RouterTaxonomy {
     key: string;
     permalink: string;
@@ -161,18 +157,19 @@ export interface RouterSettings {
 }
 
 function buildRouterRoute(route: Route): RouterRoute {
-    const result: RouterRoute = {
-        path: route.path,
-        type: route.type,
-        templates: route.templates || []
-    };
+    const data = route.data !== undefined ? expandRouteData(route.data) : undefined;
 
-    if (route.data !== undefined) {
-        result.data = expandRouteData(route.data);
-    }
-
+    // Build per branch: RouterRoute is a discriminated union, so each member is
+    // constructed as its concrete type. `route` is narrowed by the check.
     if (route.type === 'channel') {
-        // `route` is narrowed to ChannelRoute here by the discriminant check.
+        const result: RouterChannelRoute = {
+            path: route.path,
+            type: 'channel',
+            templates: route.templates || []
+        };
+        if (data !== undefined) {
+            result.data = data;
+        }
         if (route.filter !== undefined) {
             result.filter = route.filter;
         }
@@ -185,10 +182,20 @@ function buildRouterRoute(route: Route): RouterRoute {
         if (route.rss !== undefined) {
             result.rss = route.rss;
         }
-    } else if (route.contentType !== undefined) {
-        result.contentType = route.contentType;
+        return result;
     }
 
+    const result: RouterTemplateRoute = {
+        path: route.path,
+        type: 'template',
+        templates: route.templates || []
+    };
+    if (data !== undefined) {
+        result.data = data;
+    }
+    if (route.contentType !== undefined) {
+        result.contentType = route.contentType;
+    }
     return result;
 }
 

--- a/ghost/core/core/server/services/route-settings/activation-bridge.ts
+++ b/ghost/core/core/server/services/route-settings/activation-bridge.ts
@@ -4,8 +4,6 @@ import {QUERY} from '../../../frontend/services/routing/config';
 import type {
     RouteSettings,
     Route,
-    ChannelRoute,
-    TemplateRoute,
     CollectionConfig,
     RouteData,
     DataShortForm,
@@ -156,7 +154,7 @@ interface RouterTaxonomy {
     permalink: string;
 }
 
-interface RouterSettings {
+export interface RouterSettings {
     routes: RouterRoute[];
     collections: RouterCollection[];
     taxonomies: RouterTaxonomy[];
@@ -174,24 +172,21 @@ function buildRouterRoute(route: Route): RouterRoute {
     }
 
     if (route.type === 'channel') {
-        const channel = route as ChannelRoute;
-        if (channel.filter !== undefined) {
-            result.filter = channel.filter;
+        // `route` is narrowed to ChannelRoute here by the discriminant check.
+        if (route.filter !== undefined) {
+            result.filter = route.filter;
         }
-        if (channel.order !== undefined) {
-            result.order = channel.order;
+        if (route.order !== undefined) {
+            result.order = route.order;
         }
-        if (channel.limit !== undefined) {
-            result.limit = channel.limit;
+        if (route.limit !== undefined) {
+            result.limit = route.limit;
         }
-        if (channel.rss !== undefined) {
-            result.rss = channel.rss;
+        if (route.rss !== undefined) {
+            result.rss = route.rss;
         }
-    } else {
-        const template = route as TemplateRoute;
-        if (template.contentType !== undefined) {
-            result.contentType = template.contentType;
-        }
+    } else if (route.contentType !== undefined) {
+        result.contentType = route.contentType;
     }
 
     return result;

--- a/ghost/core/core/server/services/route-settings/dynamic-routing-service.js
+++ b/ghost/core/core/server/services/route-settings/dynamic-routing-service.js
@@ -54,10 +54,10 @@ class DynamicRoutingService {
     }
 
     async loadRouteSettings() {
-        const {expandRouteSettings} = require('./activation-bridge');
+        const {buildRouterSettings} = require('./activation-bridge');
 
         try {
-            return expandRouteSettings(await this.store.get());
+            return buildRouterSettings(await this.store.get());
         } catch (err) {
             // A stored-content error means the site's routes.yaml is invalid —
             // either it fails validation or it isn't parseable YAML. Log a

--- a/ghost/core/test/integration/services/route-settings/dynamic-routing-service.test.ts
+++ b/ghost/core/test/integration/services/route-settings/dynamic-routing-service.test.ts
@@ -69,14 +69,14 @@ describe('Integration: DynamicRoutingService over a real FileStore', function ()
 
     const writeRoutes = (yaml: string) => fs.writeFile(path.join(contentDir, 'routes.yaml'), yaml, 'utf8');
 
-    it('loadRouteSettings expands a valid stored file into the router format', async function () {
+    it('loadRouteSettings expands a valid stored file into the router array format', async function () {
         await writeRoutes(VALID_YAML);
 
         const expanded = await service.loadRouteSettings();
 
-        assert.deepEqual(expanded.routes['/about/'], {templates: ['about']});
-        assert.equal(expanded.collections['/'].permalink, '/:slug/');
-        assert.equal(expanded.taxonomies.tag, '/tag/:slug/');
+        assert.deepEqual(expanded.routes, [{path: '/about/', type: 'template', templates: ['about']}]);
+        assert.deepEqual(expanded.collections, [{path: '/', permalink: '/:slug/', templates: ['index']}]);
+        assert.deepEqual(expanded.taxonomies, [{key: 'tag', permalink: '/tag/:slug/'}]);
     });
 
     it('loadRouteSettings logs ROUTE_SETTINGS_VALIDATION_ERROR and rethrows when the file fails validation', async function () {

--- a/ghost/core/test/legacy/mock-express-style/api-vs-frontend.test.js
+++ b/ghost/core/test/legacy/mock-express-style/api-vs-frontend.test.js
@@ -10,6 +10,28 @@ const urlUtils = require('../../utils/url-utils');
 const routeSettingsService = require('../../../core/server/services/route-settings');
 const themeEngine = require('../../../core/frontend/services/theme-engine');
 
+// `loadRouteSettings` returns the router-facing array shape: each route and
+// collection carries its own `path`, and taxonomies are `{key, permalink}`
+// entries. These fixtures are authored as the legacy path-keyed maps, so reshape
+// them in one place rather than rewriting every stub. The shape mirrors what
+// buildRouterSettings() really emits — routes always carry `type` (defaulting to
+// `template`) and a `templates` array, and a string value is the shorthand form.
+function asRouterSettings({routes = {}, collections = {}, taxonomies = {}}) {
+    const toRoute = ([path, value]) => {
+        if (typeof value === 'string') {
+            return {path, type: 'template', templates: [value]};
+        }
+        return {type: 'template', templates: [], ...value, path};
+    };
+    const toCollection = ([path, value]) => ({templates: [], ...value, path});
+
+    return {
+        routes: Object.entries(routes).map(toRoute),
+        collections: Object.entries(collections).map(toCollection),
+        taxonomies: Object.entries(taxonomies).map(([key, permalink]) => ({key, permalink}))
+    };
+}
+
 describe('Frontend behavior tests', function () {
     let app;
 
@@ -329,7 +351,7 @@ describe('Frontend behavior tests', function () {
     describe('extended routes.yaml: collections', function () {
         describe('2 collections', function () {
             beforeAll(async function () {
-                sinon.stub(routeSettingsService.service, 'loadRouteSettings').resolves({
+                sinon.stub(routeSettingsService.service, 'loadRouteSettings').resolves(asRouterSettings({
                     routes: {
                         '/': {templates: ['home']}
                     },
@@ -350,7 +372,7 @@ describe('Frontend behavior tests', function () {
                         tag: '/categories/:slug/',
                         author: '/authors/:slug/'
                     }
-                });
+                }));
 
                 localUtils.urlService.resetGenerators();
                 localUtils.defaultMocks(sinon, {theme: 'test-theme'});
@@ -447,7 +469,7 @@ describe('Frontend behavior tests', function () {
 
         describe('no collections', function () {
             beforeAll(async function () {
-                sinon.stub(routeSettingsService.service, 'loadRouteSettings').resolves({
+                sinon.stub(routeSettingsService.service, 'loadRouteSettings').resolves(asRouterSettings({
                     routes: {
                         '/something/': {
                             templates: ['something']
@@ -455,7 +477,7 @@ describe('Frontend behavior tests', function () {
                     },
                     collections: {},
                     taxonomies: {}
-                });
+                }));
 
                 localUtils.urlService.resetGenerators();
                 localUtils.defaultMocks(sinon, {theme: 'test-theme'});
@@ -493,7 +515,7 @@ describe('Frontend behavior tests', function () {
 
         describe('static permalink route', function () {
             beforeAll(async function () {
-                sinon.stub(routeSettingsService.service, 'loadRouteSettings').resolves({
+                sinon.stub(routeSettingsService.service, 'loadRouteSettings').resolves(asRouterSettings({
                     routes: {},
 
                     collections: {
@@ -508,7 +530,7 @@ describe('Frontend behavior tests', function () {
                     },
 
                     taxonomies: {}
-                });
+                }));
 
                 localUtils.urlService.resetGenerators();
                 localUtils.defaultMocks(sinon);
@@ -590,7 +612,7 @@ describe('Frontend behavior tests', function () {
 
         describe('primary author permalink', function () {
             beforeAll(async function () {
-                sinon.stub(routeSettingsService.service, 'loadRouteSettings').resolves({
+                sinon.stub(routeSettingsService.service, 'loadRouteSettings').resolves(asRouterSettings({
                     routes: {},
 
                     collections: {
@@ -600,7 +622,7 @@ describe('Frontend behavior tests', function () {
                     },
 
                     taxonomies: {}
-                });
+                }));
 
                 localUtils.urlService.resetGenerators();
                 localUtils.defaultMocks(sinon);
@@ -666,7 +688,7 @@ describe('Frontend behavior tests', function () {
 
         describe('primary tag permalink', function () {
             beforeAll(async function () {
-                sinon.stub(routeSettingsService.service, 'loadRouteSettings').resolves({
+                sinon.stub(routeSettingsService.service, 'loadRouteSettings').resolves(asRouterSettings({
                     routes: {},
 
                     collections: {
@@ -676,7 +698,7 @@ describe('Frontend behavior tests', function () {
                     },
 
                     taxonomies: {}
-                });
+                }));
 
                 localUtils.urlService.resetGenerators();
                 localUtils.defaultMocks(sinon);
@@ -756,7 +778,7 @@ describe('Frontend behavior tests', function () {
 
         describe('collection/routes with data key', function () {
             beforeAll(async function () {
-                sinon.stub(routeSettingsService.service, 'loadRouteSettings').resolves({
+                sinon.stub(routeSettingsService.service, 'loadRouteSettings').resolves(asRouterSettings({
                     routes: {
                         '/my-page/': {
                             data: {
@@ -823,7 +845,7 @@ describe('Frontend behavior tests', function () {
                         tag: '/categories/:slug/',
                         author: '/authors/:slug/'
                     }
-                });
+                }));
 
                 localUtils.urlService.resetGenerators();
                 localUtils.defaultMocks(sinon);
@@ -916,7 +938,7 @@ describe('Frontend behavior tests', function () {
     describe('extended routes.yaml: templates', function () {
         describe('default template, no template', function () {
             beforeAll(async function () {
-                sinon.stub(routeSettingsService.service, 'loadRouteSettings').resolves({
+                sinon.stub(routeSettingsService.service, 'loadRouteSettings').resolves(asRouterSettings({
                     routes: {},
 
                     collections: {
@@ -928,7 +950,7 @@ describe('Frontend behavior tests', function () {
                             permalink: '/magic/:slug/'
                         }
                     }
-                });
+                }));
 
                 localUtils.urlService.resetGenerators();
                 localUtils.defaultMocks(sinon);
@@ -977,7 +999,7 @@ describe('Frontend behavior tests', function () {
 
         describe('two templates', function () {
             beforeAll(async function () {
-                sinon.stub(routeSettingsService.service, 'loadRouteSettings').resolves({
+                sinon.stub(routeSettingsService.service, 'loadRouteSettings').resolves(asRouterSettings({
                     routes: {},
 
                     collections: {
@@ -986,7 +1008,7 @@ describe('Frontend behavior tests', function () {
                             templates: ['something', 'default']
                         }
                     }
-                });
+                }));
 
                 localUtils.urlService.resetGenerators();
                 localUtils.defaultMocks(sinon);
@@ -1024,7 +1046,7 @@ describe('Frontend behavior tests', function () {
 
         describe('home.hbs priority', function () {
             beforeAll(async function () {
-                sinon.stub(routeSettingsService.service, 'loadRouteSettings').resolves({
+                sinon.stub(routeSettingsService.service, 'loadRouteSettings').resolves(asRouterSettings({
                     routes: {},
 
                     collections: {
@@ -1037,7 +1059,7 @@ describe('Frontend behavior tests', function () {
                             templates: ['something', 'default']
                         }
                     }
-                });
+                }));
 
                 localUtils.urlService.resetGenerators();
                 localUtils.defaultMocks(sinon, {theme: 'test-theme'});
@@ -1094,10 +1116,10 @@ describe('Frontend behavior tests', function () {
             beforeAll(async function () {
                 localUtils.defaultMocks(sinon, {theme: 'test-theme-channels'});
 
-                sinon.stub(routeSettingsService.service, 'loadRouteSettings').resolves({
+                sinon.stub(routeSettingsService.service, 'loadRouteSettings').resolves(asRouterSettings({
                     routes: {
                         '/channel1/': {
-                            controller: 'channel',
+                            type: 'channel',
                             filter: 'tag:kitchen-sink',
                             data: {
                                 query: {
@@ -1117,7 +1139,7 @@ describe('Frontend behavior tests', function () {
                         },
 
                         '/channel2/': {
-                            controller: 'channel',
+                            type: 'channel',
                             filter: 'tag:bacon',
                             data: {
                                 query: {
@@ -1138,7 +1160,7 @@ describe('Frontend behavior tests', function () {
                         },
 
                         '/channel3/': {
-                            controller: 'channel',
+                            type: 'channel',
                             filter: 'author:joe-bloggs',
                             data: {
                                 query: {
@@ -1159,12 +1181,12 @@ describe('Frontend behavior tests', function () {
                         },
 
                         '/channel4/': {
-                            controller: 'channel',
+                            type: 'channel',
                             filter: 'author:joe-bloggs'
                         },
 
                         '/channel5/': {
-                            controller: 'channel',
+                            type: 'channel',
                             data: {
                                 query: {
                                     tag: {
@@ -1184,7 +1206,7 @@ describe('Frontend behavior tests', function () {
                         },
 
                         '/channel6/': {
-                            controller: 'channel',
+                            type: 'channel',
                             data: {
                                 query: {
                                     post: {
@@ -1214,7 +1236,7 @@ describe('Frontend behavior tests', function () {
                         tag: '/tag/:slug/',
                         author: '/author/:slug/'
                     }
-                });
+                }));
 
                 app = await localUtils.initGhost();
                 sinon.stub(themeEngine.getActive(), 'config').withArgs('posts_per_page').returns(10);
@@ -1411,18 +1433,18 @@ describe('Frontend behavior tests', function () {
 
     describe('extended routes.yaml (5): rss override', function () {
         beforeAll(async function () {
-            sinon.stub(routeSettingsService.service, 'loadRouteSettings').resolves({
+            sinon.stub(routeSettingsService.service, 'loadRouteSettings').resolves(asRouterSettings({
                 routes: {
                     '/podcast/rss/': {
                         templates: ['podcast/rss'],
-                        content_type: 'application/rss+xml'
+                        contentType: 'application/rss+xml'
                     },
                     '/cooking/': {
-                        controller: 'channel',
+                        type: 'channel',
                         rss: false
                     },
                     '/flat/': {
-                        controller: 'channel'
+                        type: 'channel'
                     }
                 },
 
@@ -1443,7 +1465,7 @@ describe('Frontend behavior tests', function () {
                 },
 
                 taxonomies: {}
-            });
+            }));
 
             localUtils.urlService.resetGenerators();
             localUtils.defaultMocks(sinon, {theme: 'test-theme'});

--- a/ghost/core/test/unit/frontend/services/routing/static-routes-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/static-routes-router.test.js
@@ -111,7 +111,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
         describe('initialize', function () {
             it('initialize with controller+data+filter', function () {
                 const staticRoutesRouter = new StaticRoutesRouter('/channel/', {
-                    controller: 'channel',
+                    type: 'channel',
                     data: {query: {}, router: {}},
                     filter: 'tag:test'
                 }, routerCreatedSpy);
@@ -139,7 +139,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
 
             it('initialize with controller+filter', function () {
                 const staticRoutesRouter = new StaticRoutesRouter('/channel/', {
-                    controller: 'channel',
+                    type: 'channel',
                     filter: 'tag:test'
                 }, routerCreatedSpy);
 
@@ -166,7 +166,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
 
             it('initialize with controller+data', function () {
                 const staticRoutesRouter = new StaticRoutesRouter('/channel/', {
-                    controller: 'channel',
+                    type: 'channel',
                     data: {query: {}, router: {}}
                 }, routerCreatedSpy);
 
@@ -177,7 +177,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
                 configUtils.set('url', 'http://localhost:2366/blog/');
 
                 new StaticRoutesRouter('/channel/', {
-                    controller: 'channel',
+                    type: 'channel',
                     data: {query: {}, router: {}},
                     filter: 'author:michi'
                 }, routerCreatedSpy);
@@ -197,7 +197,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
         describe('fn: _prepareChannelContext', function () {
             it('with data+filter', function () {
                 const staticRoutesRouter = new StaticRoutesRouter('/channel/', {
-                    controller: 'channel',
+                    type: 'channel',
                     data: {query: {}, router: {}},
                     filter: 'tag:test'
                 }, routerCreatedSpy);
@@ -218,7 +218,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
 
             it('with data', function () {
                 const staticRoutesRouter = new StaticRoutesRouter('/nothingcomparestoyou/', {
-                    controller: 'channel',
+                    type: 'channel',
                     data: {query: {type: 'read'}, router: {}}
                 }, routerCreatedSpy);
 
@@ -238,7 +238,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
 
             it('with filter', function () {
                 const staticRoutesRouter = new StaticRoutesRouter('/channel/', {
-                    controller: 'channel',
+                    type: 'channel',
                     filter: 'tag:test'
                 }, routerCreatedSpy);
 
@@ -258,7 +258,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
 
             it('with order+limit', function () {
                 const staticRoutesRouter = new StaticRoutesRouter('/channel/', {
-                    controller: 'channel',
+                    type: 'channel',
                     filter: 'tag:test',
                     limit: 2,
                     order: 'published_at asc'

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -11,7 +11,7 @@ const defaultSettings = require('../../../../../core/server/data/schema/default-
 // Routes are yaml so we can require the file directly
 const routeSettings = require('../../../../../core/server/services/route-settings');
 routeSettings.init();
-const {expandRouteSettings} = require('../../../../../core/server/services/route-settings/activation-bridge');
+const {buildRouterSettings} = require('../../../../../core/server/services/route-settings/activation-bridge');
 const {parseRouteSettings} = require('../../../../../core/server/services/route-settings/route-settings-parser');
 const parseYaml = require('../../../../../core/server/services/route-settings/yaml-parser');
 
@@ -39,14 +39,14 @@ describe('DB version integrity', function () {
     const currentSchemaHash = 'c0fe7246714201a82b75f80308d5e300';
     const currentFixturesHash = '065b413e1d1f4f95fa7cb7734c5e7934';
     const currentSettingsHash = '8650db85b9a61afe4797ad6333066c62';
-    const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
+    const currentRoutesHash = '96a7d0955083bae3f79522b23a1d698d';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,
     // and the values above will need updating as confirmation
     it('should not change without fixing this test', function () {
         const routesPath = path.join(config.get('paths').defaultRouteSettings, 'default-routes.yaml');
         const defaultRoutesSource = fs.readFileSync(routesPath, 'utf-8');
-        const defaultRoutes = expandRouteSettings(parseRouteSettings(parseYaml(defaultRoutesSource), defaultRoutesSource));
+        const defaultRoutes = buildRouterSettings(parseRouteSettings(parseYaml(defaultRoutesSource), defaultRoutesSource));
 
         const tablesNoValidation = _.cloneDeep(schema);
         let schemaHash;

--- a/ghost/core/test/unit/server/services/route-settings/activation-bridge.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/activation-bridge.test.ts
@@ -1,13 +1,9 @@
 import assert from 'node:assert/strict';
-import crypto from 'node:crypto';
-import fs from 'node:fs';
-import path from 'node:path';
 import {describe, it} from 'vitest';
-import {expandRouteSettings} from '../../../../../core/server/services/route-settings/activation-bridge';
+import type {RouteSettings} from '@tryghost/adapter-base-route-settings';
+import {buildRouterSettings} from '../../../../../core/server/services/route-settings/activation-bridge';
 import {parseRouteSettings} from '../../../../../core/server/services/route-settings/route-settings-parser';
 import {buildRouteSettings} from './route-settings-fixture';
-
-const parseYaml = require('../../../../../core/server/services/route-settings/yaml-parser');
 
 // The bridge only reads structural fields — raw objects built inline have no
 // YAML text behind them, so an empty source is attached.
@@ -18,449 +14,163 @@ function empty() {
 }
 
 describe('activation-bridge', function () {
-    describe('expandRouteSettings', function () {
-        it('returns empty maps for empty settings', function () {
-            const result = expandRouteSettings(empty());
-
-            assert.deepEqual(result, {
-                routes: {},
-                collections: {},
-                taxonomies: {}
+    describe('buildRouterSettings', function () {
+        it('returns empty arrays for empty settings', function () {
+            assert.deepEqual(buildRouterSettings(empty()), {
+                routes: [],
+                collections: [],
+                taxonomies: []
             });
         });
 
-        // Characterisation tests for the full expanded output. The expected
-        // values are the canonical expansions the legacy validate.js produced
-        // before it was retired — parsing + the bridge must keep matching them
-        // so the expanded output and router wiring stay byte-for-byte stable.
-        describe('produces the expected expanded output', function () {
+        // Characterisation tests for the router-facing array output. Each item
+        // carries its own `path`; routes use the domain `type`/`contentType`
+        // names; permalinks are already in `:slug` notation and `data` is still
+        // expanded to `{query, router}` (peeled off in later cleanup PRs).
+        describe('produces the expected array output', function () {
             const cases: Array<{name: string; raw: unknown; expected: object}> = [
                 {
                     name: 'bare string template route',
                     raw: {routes: {'/about/': 'about'}, collections: {}, taxonomies: {}},
-                    expected: {routes: {'/about/': {templates: ['about']}}, collections: {}, taxonomies: {}}
+                    expected: {routes: [{path: '/about/', type: 'template', templates: ['about']}], collections: [], taxonomies: []}
                 },
                 {
-                    name: 'template route with content_type',
+                    name: 'template route with content_type maps to contentType',
                     raw: {routes: {'/api/': {template: 'api', content_type: 'application/json'}}, collections: {}, taxonomies: {}},
-                    expected: {routes: {'/api/': {content_type: 'application/json', templates: ['api']}}, collections: {}, taxonomies: {}}
+                    expected: {routes: [{path: '/api/', type: 'template', templates: ['api'], contentType: 'application/json'}], collections: [], taxonomies: []}
                 },
                 {
-                    name: 'channel route',
+                    name: 'channel route keeps type: channel',
                     raw: {routes: {'/featured/': {controller: 'channel', filter: 'featured:true', template: 'featured'}}, collections: {}, taxonomies: {}},
-                    expected: {routes: {'/featured/': {controller: 'channel', filter: 'featured:true', templates: ['featured']}}, collections: {}, taxonomies: {}}
+                    expected: {routes: [{path: '/featured/', type: 'channel', templates: ['featured'], filter: 'featured:true'}], collections: [], taxonomies: []}
                 },
                 {
                     name: 'channel route with rss disabled',
                     raw: {routes: {'/featured/': {controller: 'channel', filter: 'featured:true', rss: false}}, collections: {}, taxonomies: {}},
-                    expected: {routes: {'/featured/': {controller: 'channel', filter: 'featured:true', rss: false, templates: []}}, collections: {}, taxonomies: {}}
+                    expected: {routes: [{path: '/featured/', type: 'channel', templates: [], filter: 'featured:true', rss: false}], collections: [], taxonomies: []}
                 },
                 {
-                    name: 'route with shortform data',
+                    name: 'route with shortform data expands to {query, router}',
                     raw: {routes: {'/food/': {template: 'food', data: 'tag.food'}}, collections: {}, taxonomies: {}},
                     expected: {
-                        routes: {'/food/': {
+                        routes: [{
+                            path: '/food/',
+                            type: 'template',
+                            templates: ['food'],
                             data: {
                                 query: {tag: {controller: 'tagsPublic', type: 'read', resource: 'tags', options: {slug: 'food', visibility: 'public'}}},
                                 router: {tags: [{slug: 'food', redirect: true}]}
-                            },
-                            templates: ['food']
-                        }},
-                        collections: {},
-                        taxonomies: {}
+                            }
+                        }],
+                        collections: [],
+                        taxonomies: []
                     }
                 },
                 {
-                    name: 'route with named shortform data',
-                    raw: {routes: {'/food/': {template: 'food', data: {recipe: 'tag.recipes', post: 'post.my-post'}}}, collections: {}, taxonomies: {}},
-                    expected: {
-                        routes: {'/food/': {
-                            data: {
-                                query: {
-                                    recipe: {controller: 'tagsPublic', type: 'read', resource: 'tags', options: {slug: 'recipes', visibility: 'public'}},
-                                    post: {controller: 'postsPublic', type: 'read', resource: 'posts', options: {slug: 'my-post'}}
-                                },
-                                router: {
-                                    tags: [{slug: 'recipes', redirect: true}],
-                                    posts: [{slug: 'my-post', redirect: true}]
-                                }
-                            },
-                            templates: ['food']
-                        }},
-                        collections: {},
-                        taxonomies: {}
-                    }
-                },
-                {
-                    name: 'route with longform read data',
-                    raw: {routes: {'/food/': {template: 'food', data: {people: {resource: 'authors', type: 'read', slug: 'joe'}}}}, collections: {}, taxonomies: {}},
-                    expected: {
-                        routes: {'/food/': {
-                            data: {
-                                query: {people: {options: {slug: 'joe'}, type: 'read', resource: 'authors', controller: 'authorsPublic'}},
-                                router: {authors: [{slug: 'joe', redirect: true}]}
-                            },
-                            templates: ['food']
-                        }},
-                        collections: {},
-                        taxonomies: {}
-                    }
-                },
-                {
-                    name: 'route with longform browse data',
-                    raw: {routes: {'/food/': {template: 'food', data: {featured: {resource: 'posts', type: 'browse', filter: 'featured:true', limit: 3}}}}, collections: {}, taxonomies: {}},
-                    expected: {
-                        routes: {'/food/': {
-                            data: {
-                                query: {featured: {options: {limit: 3, filter: 'featured:true'}, type: 'browse', resource: 'posts', controller: 'postsPublic'}},
-                                router: {posts: [{redirect: true}]}
-                            },
-                            templates: ['food']
-                        }},
-                        collections: {},
-                        taxonomies: {}
-                    }
-                },
-                {
-                    name: 'collection with permalink',
+                    name: 'collection with permalink converts {slug} to :slug',
                     raw: {routes: {}, collections: {'/': {permalink: '/{slug}/', template: 'index'}}, taxonomies: {}},
-                    expected: {routes: {}, collections: {'/': {permalink: '/:slug/', templates: ['index']}}, taxonomies: {}}
+                    expected: {routes: [], collections: [{path: '/', permalink: '/:slug/', templates: ['index']}], taxonomies: []}
                 },
                 {
                     name: 'collection with filter and data',
                     raw: {routes: {}, collections: {'/podcast/': {permalink: '/podcast/{slug}/', filter: 'tag:podcast', template: 'podcast', data: 'tag.podcast'}}, taxonomies: {}},
                     expected: {
-                        routes: {},
-                        collections: {'/podcast/': {
+                        routes: [],
+                        collections: [{
+                            path: '/podcast/',
                             permalink: '/podcast/:slug/',
-                            filter: 'tag:podcast',
+                            templates: ['podcast'],
                             data: {
                                 query: {tag: {controller: 'tagsPublic', type: 'read', resource: 'tags', options: {slug: 'podcast', visibility: 'public'}}},
                                 router: {tags: [{slug: 'podcast', redirect: true}]}
                             },
-                            templates: ['podcast']
-                        }},
-                        taxonomies: {}
+                            filter: 'tag:podcast'
+                        }],
+                        taxonomies: []
                     }
                 },
                 {
-                    name: 'taxonomies',
+                    name: 'taxonomies become {key, permalink} entries in :slug notation',
                     raw: {routes: {}, collections: {}, taxonomies: {tag: '/tag/{slug}/', author: '/author/{slug}/'}},
-                    expected: {routes: {}, collections: {}, taxonomies: {tag: '/tag/:slug/', author: '/author/:slug/'}}
+                    expected: {routes: [], collections: [], taxonomies: [{key: 'tag', permalink: '/tag/:slug/'}, {key: 'author', permalink: '/author/:slug/'}]}
                 },
                 {
-                    name: 'a full routes.yaml',
-                    raw: {
-                        routes: {
-                            '/about/': 'about',
-                            '/food/': {template: 'food', data: 'tag.food'},
-                            '/featured/': {controller: 'channel', filter: 'featured:true', template: 'featured'}
-                        },
-                        collections: {
-                            '/podcast/': {permalink: '/podcast/{slug}/', filter: 'tag:podcast', template: 'podcast', data: 'tag.podcast'},
-                            '/': {permalink: '/{slug}/', template: 'index'}
-                        },
-                        taxonomies: {tag: '/tag/{slug}/', author: '/author/{slug}/'}
-                    },
-                    expected: {
-                        routes: {
-                            '/about/': {templates: ['about']},
-                            '/food/': {
-                                data: {
-                                    query: {tag: {controller: 'tagsPublic', type: 'read', resource: 'tags', options: {slug: 'food', visibility: 'public'}}},
-                                    router: {tags: [{slug: 'food', redirect: true}]}
-                                },
-                                templates: ['food']
-                            },
-                            '/featured/': {controller: 'channel', filter: 'featured:true', templates: ['featured']}
-                        },
-                        collections: {
-                            '/podcast/': {
-                                permalink: '/podcast/:slug/',
-                                filter: 'tag:podcast',
-                                data: {
-                                    query: {tag: {controller: 'tagsPublic', type: 'read', resource: 'tags', options: {slug: 'podcast', visibility: 'public'}}},
-                                    router: {tags: [{slug: 'podcast', redirect: true}]}
-                                },
-                                templates: ['podcast']
-                            },
-                            '/': {permalink: '/:slug/', templates: ['index']}
-                        },
-                        taxonomies: {tag: '/tag/:slug/', author: '/author/:slug/'}
-                    }
+                    name: 'channel route copies order and limit',
+                    raw: {routes: {'/featured/': {controller: 'channel', filter: 'featured:true', order: 'published_at desc', limit: 3}}, collections: {}, taxonomies: {}},
+                    expected: {routes: [{path: '/featured/', type: 'channel', templates: [], filter: 'featured:true', order: 'published_at desc', limit: 3}], collections: [], taxonomies: []}
                 },
                 {
-                    name: 'channel route with explicit rss: true',
-                    raw: {routes: {'/featured/': {controller: 'channel', filter: 'featured:true', rss: true}}, collections: {}, taxonomies: {}},
-                    expected: {routes: {'/featured/': {controller: 'channel', filter: 'featured:true', rss: true, templates: []}}, collections: {}, taxonomies: {}}
-                },
-                {
-                    name: 'channel route with rss omitted',
-                    raw: {routes: {'/featured/': {controller: 'channel', filter: 'featured:true'}}, collections: {}, taxonomies: {}},
-                    expected: {routes: {'/featured/': {controller: 'channel', filter: 'featured:true', templates: []}}, collections: {}, taxonomies: {}}
-                },
-                {
-                    name: 'template route with array templates',
-                    raw: {routes: {'/about/': {template: ['about', 'default']}}, collections: {}, taxonomies: {}},
-                    expected: {routes: {'/about/': {templates: ['about', 'default']}}, collections: {}, taxonomies: {}}
-                },
-                {
-                    name: 'longform read data with redirect: false',
-                    raw: {routes: {'/food/': {template: 'food', data: {people: {resource: 'authors', type: 'read', slug: 'joe', redirect: false}}}}, collections: {}, taxonomies: {}},
-                    expected: {
-                        routes: {'/food/': {
-                            data: {
-                                query: {people: {options: {slug: 'joe'}, type: 'read', resource: 'authors', controller: 'authorsPublic'}},
-                                router: {authors: [{redirect: false, slug: 'joe'}]}
-                            },
-                            templates: ['food']
-                        }},
-                        collections: {},
-                        taxonomies: {}
-                    }
-                },
-                {
-                    name: 'longform browse data with limit: all',
-                    raw: {routes: {'/food/': {template: 'food', data: {featured: {resource: 'posts', type: 'browse', limit: 'all'}}}}, collections: {}, taxonomies: {}},
-                    expected: {
-                        routes: {'/food/': {
-                            data: {
-                                query: {featured: {options: {limit: 'all'}, type: 'browse', resource: 'posts', controller: 'postsPublic'}},
-                                router: {posts: [{redirect: true}]}
-                            },
-                            templates: ['food']
-                        }},
-                        collections: {},
-                        taxonomies: {}
-                    }
-                },
-                {
-                    name: 'two data entries resolve to the same router key',
-                    raw: {routes: {'/food/': {template: 'food', data: {one: 'post.first', two: 'post.second'}}}, collections: {}, taxonomies: {}},
-                    expected: {
-                        routes: {'/food/': {
-                            data: {
-                                query: {
-                                    one: {controller: 'postsPublic', type: 'read', resource: 'posts', options: {slug: 'first'}},
-                                    two: {controller: 'postsPublic', type: 'read', resource: 'posts', options: {slug: 'second'}}
-                                },
-                                router: {posts: [{slug: 'first', redirect: true}, {slug: 'second', redirect: true}]}
-                            },
-                            templates: ['food']
-                        }},
-                        collections: {},
-                        taxonomies: {}
-                    }
-                },
-                {
-                    name: 'collection with rss: false',
-                    raw: {routes: {}, collections: {'/': {permalink: '/{slug}/', template: 'index', rss: false}}, taxonomies: {}},
-                    expected: {routes: {}, collections: {'/': {permalink: '/:slug/', rss: false, templates: ['index']}}, taxonomies: {}}
+                    name: 'collection copies order, limit and rss',
+                    raw: {routes: {}, collections: {'/': {permalink: '/{slug}/', template: 'index', order: 'published_at asc', limit: 10, rss: false}}, taxonomies: {}},
+                    expected: {routes: [], collections: [{path: '/', permalink: '/:slug/', templates: ['index'], order: 'published_at asc', limit: 10, rss: false}], taxonomies: []}
                 }
             ];
 
             cases.forEach(({name, raw, expected}) => {
                 it(name, function () {
-                    assert.deepEqual(expandRouteSettings(parse(raw)), expected);
+                    assert.deepEqual(buildRouterSettings(parse(raw)), expected);
                 });
             });
         });
 
-        describe('slug conversion', function () {
-            it('converts {slug} to :slug in collection permalinks', function () {
-                const settings = buildRouteSettings({
-                    routes: [],
-                    collections: [{path: '/', permalink: '/{slug}/', templates: []}],
-                    taxonomies: {}
-                });
-
-                const result = expandRouteSettings(settings);
-                assert.equal(result.collections['/'].permalink, '/:slug/');
+        it('omits data when no data specified', function () {
+            const settings = buildRouteSettings({
+                routes: [{type: 'template', path: '/about/', templates: ['about']}],
+                collections: [],
+                taxonomies: {}
             });
 
-            it('converts {primary_author} to :primary_author in permalinks', function () {
-                const settings = buildRouteSettings({
-                    routes: [],
-                    collections: [{path: '/', permalink: '/{primary_author}/{slug}/', templates: []}],
-                    taxonomies: {}
-                });
-
-                const result = expandRouteSettings(settings);
-                assert.equal(result.collections['/'].permalink, '/:primary_author/:slug/');
-            });
-
-            it('converts {slug} to :slug in taxonomy paths', function () {
-                const settings = buildRouteSettings({
-                    routes: [],
-                    collections: [],
-                    taxonomies: {tag: '/tag/{slug}/'}
-                });
-
-                const result = expandRouteSettings(settings);
-                assert.equal(result.taxonomies.tag, '/tag/:slug/');
-            });
+            assert.equal(buildRouterSettings(settings).routes[0].data, undefined);
         });
 
-        describe('route expansion', function () {
-            it('sets controller to channel for channel routes', function () {
-                const settings = buildRouteSettings({
-                    routes: [{type: 'channel', path: '/featured/', templates: [], filter: 'featured:true', rss: true}],
-                    collections: [],
-                    taxonomies: {}
-                });
+        it('drops taxonomies with an empty permalink', function () {
+            const settings: RouteSettings = {routes: [], collections: [], taxonomies: {tag: ''}, yamlSource: ''};
 
-                const result = expandRouteSettings(settings);
-                assert.equal(result.routes['/featured/'].controller, 'channel');
-            });
-
-            it('maps contentType back to content_type', function () {
-                const settings = buildRouteSettings({
-                    routes: [{type: 'template', path: '/api/', templates: ['api'], contentType: 'application/json'}],
-                    collections: [],
-                    taxonomies: {}
-                });
-
-                const result = expandRouteSettings(settings);
-                assert.equal(result.routes['/api/'].content_type, 'application/json');
-                assert.equal(result.routes['/api/'].contentType, undefined);
-            });
-
-            it('omits data when no data specified', function () {
-                const settings = buildRouteSettings({
-                    routes: [{type: 'template', path: '/about/', templates: ['about']}],
-                    collections: [],
-                    taxonomies: {}
-                });
-
-                const result = expandRouteSettings(settings);
-                assert.equal(result.routes['/about/'].data, undefined);
-            });
-        });
-
-        describe('data expansion', function () {
-            it('expands shortform data with redirect enabled by default', function () {
-                const settings = buildRouteSettings({
-                    routes: [{type: 'template', path: '/food/', templates: ['food'], data: 'tag.food'}],
-                    collections: [],
-                    taxonomies: {}
-                });
-
-                const result = expandRouteSettings(settings);
-                const data = result.routes['/food/'].data;
-
-                assert.equal(data.router.tags[0].redirect, true);
-                assert.equal(data.router.tags[0].slug, 'food');
-                assert.equal(data.query.tag.options.slug, 'food');
-            });
-
-            it('expands longform read data with default options', function () {
-                const settings = buildRouteSettings({
-                    routes: [{
-                        type: 'template', path: '/food/', templates: ['food'],
-                        data: {
-                            people: {resource: 'authors', type: 'read', slug: 'joe'}
-                        }
-                    }],
-                    collections: [],
-                    taxonomies: {}
-                });
-
-                const result = expandRouteSettings(settings);
-                const data = result.routes['/food/'].data;
-
-                assert.equal(data.query.people.type, 'read');
-                assert.equal(data.query.people.resource, 'authors');
-                assert.equal(data.query.people.options.slug, 'joe');
-                assert.equal(data.router.authors[0].redirect, true);
-            });
-
-            it('expands longform browse data without default slug option', function () {
-                const settings = buildRouteSettings({
-                    routes: [{
-                        type: 'template', path: '/food/', templates: ['food'],
-                        data: {
-                            featured: {resource: 'posts', type: 'browse', filter: 'featured:true', limit: 3}
-                        }
-                    }],
-                    collections: [],
-                    taxonomies: {}
-                });
-
-                const result = expandRouteSettings(settings);
-                const data = result.routes['/food/'].data;
-
-                assert.equal(data.query.featured.type, 'browse');
-                assert.equal(data.query.featured.options.filter, 'featured:true');
-                assert.equal(data.query.featured.options.limit, 3);
-                assert.equal(data.query.featured.options.slug, undefined);
-            });
+            assert.deepEqual(buildRouterSettings(settings).taxonomies, []);
         });
     });
 
-    describe('hash continuity', function () {
-        // This md5 over the expanded settings is a structural fingerprint of
-        // the default routes — parsing + the bridge must keep producing the
-        // known default hash so a site that never customised its routes keeps
-        // the same expanded output.
-        const DEFAULT_ROUTES_HASH = '3d180d52c663d173a6be791ef411ed01';
+    describe('determinism', function () {
+        // buildRouterSettings feeds the schema integrity canary, which md5s its
+        // output, so the same config must always serialize identically —
+        // regardless of the order the operator wrote the properties in.
+        const complexConfig = {
+            routes: {
+                '/about/': 'about',
+                '/api/': {template: 'api', content_type: 'application/json'},
+                '/featured/': {controller: 'channel', filter: 'featured:true', template: 'featured', rss: true, data: 'tag.featured'},
+                '/reader/': {template: 'reader', data: {entry: {type: 'read', resource: 'posts', slug: 'welcome', redirect: false}}}
+            },
+            collections: {
+                '/': {permalink: '/{primary_author}/{slug}/', template: 'index'},
+                '/podcast/': {permalink: '/podcast/{slug}/', template: 'podcast', filter: 'tag:podcast', rss: false}
+            },
+            taxonomies: {tag: '/tag/{slug}/', author: '/author/{slug}/'}
+        };
 
-        const defaultRoutesYaml = fs.readFileSync(
-            path.join(__dirname, '../../../../../core/server/services/route-settings/default-routes.yaml'),
-            'utf8'
-        );
+        it('serializes identically across repeated parses of the same config', function () {
+            const first = buildRouterSettings(parse(structuredClone(complexConfig)));
+            const second = buildRouterSettings(parse(structuredClone(complexConfig)));
 
-        function hash(expanded: object): string {
-            return crypto.createHash('md5')
-                .update(JSON.stringify(expanded), 'binary')
-                .digest('hex');
-        }
-
-        it('bridge output serializes to the known default routes hash', function () {
-            const domain = parseRouteSettings(parseYaml(defaultRoutesYaml), defaultRoutesYaml);
-            const expanded = expandRouteSettings(domain);
-
-            assert.equal(hash(expanded), DEFAULT_ROUTES_HASH);
+            assert.equal(JSON.stringify(first), JSON.stringify(second));
         });
 
-        describe('stringify determinism', function () {
-            const complexConfig = {
-                routes: {
-                    '/about/': 'about',
-                    '/api/': {template: 'api', content_type: 'application/json'},
-                    '/featured/': {controller: 'channel', filter: 'featured:true', template: 'featured', rss: true, data: 'tag.featured'},
-                    '/reader/': {template: 'reader', data: {entry: {type: 'read', resource: 'posts', slug: 'welcome', redirect: false}}}
-                },
-                collections: {
-                    '/': {permalink: '/{primary_author}/{slug}/', template: 'index'},
-                    '/podcast/': {permalink: '/podcast/{slug}/', template: 'podcast', filter: 'tag:podcast', rss: false}
-                },
-                taxonomies: {tag: '/tag/{slug}/', author: '/author/{slug}/'}
+        it('serializes identically when the operator orders route properties differently', function () {
+            const orderedOneWay = {
+                routes: {'/featured/': {controller: 'channel', filter: 'featured:true', template: 'featured', rss: true, data: 'tag.featured'}},
+                collections: {'/': {permalink: '/{slug}/', template: 'index'}},
+                taxonomies: {}
+            };
+            const orderedAnotherWay = {
+                routes: {'/featured/': {data: 'tag.featured', rss: true, template: 'featured', filter: 'featured:true', controller: 'channel'}},
+                collections: {'/': {template: 'index', permalink: '/{slug}/'}},
+                taxonomies: {}
             };
 
-            it('serializes identically across repeated parses of the same config', function () {
-                const first = expandRouteSettings(parse(structuredClone(complexConfig)));
-                const second = expandRouteSettings(parse(structuredClone(complexConfig)));
+            const first = buildRouterSettings(parse(orderedOneWay));
+            const second = buildRouterSettings(parse(orderedAnotherWay));
 
-                assert.equal(JSON.stringify(first), JSON.stringify(second));
-            });
-
-            it('serializes identically when the operator orders route properties differently', function () {
-                const orderedOneWay = {
-                    routes: {'/featured/': {controller: 'channel', filter: 'featured:true', template: 'featured', rss: true, data: 'tag.featured'}},
-                    collections: {'/': {permalink: '/{slug}/', template: 'index'}},
-                    taxonomies: {}
-                };
-                const orderedAnotherWay = {
-                    routes: {'/featured/': {data: 'tag.featured', rss: true, template: 'featured', filter: 'featured:true', controller: 'channel'}},
-                    collections: {'/': {template: 'index', permalink: '/{slug}/'}},
-                    taxonomies: {}
-                };
-
-                const first = expandRouteSettings(parse(orderedOneWay));
-                const second = expandRouteSettings(parse(orderedAnotherWay));
-
-                assert.equal(JSON.stringify(first), JSON.stringify(second));
-            });
+            assert.equal(JSON.stringify(first), JSON.stringify(second));
         });
     });
 });

--- a/ghost/core/test/unit/server/services/route-settings/dynamic-routing-service.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/dynamic-routing-service.test.ts
@@ -46,14 +46,14 @@ describe('UNIT: DynamicRoutingService (store-backed)', function () {
         assert.equal(await service.download(), CUSTOM_YAML);
     });
 
-    it('loadRouteSettings expands the domain model into the router format', async function () {
+    it('loadRouteSettings expands the domain model into the router array format', async function () {
         await store.replace(fromYaml(CUSTOM_YAML));
 
         const expanded = await service.loadRouteSettings();
 
-        assert.deepEqual(expanded.routes['/about/'], {templates: ['about']});
-        assert.equal(expanded.collections['/'].permalink, '/:slug/');
-        assert.equal(expanded.taxonomies.tag, '/tag/:slug/');
+        assert.deepEqual(expanded.routes, [{path: '/about/', type: 'template', templates: ['about']}]);
+        assert.deepEqual(expanded.collections, [{path: '/', permalink: '/:slug/', templates: ['index']}]);
+        assert.deepEqual(expanded.taxonomies, [{key: 'tag', permalink: '/tag/:slug/'}]);
     });
 
     describe('loadRouteSettings validation failure', function () {
@@ -103,7 +103,7 @@ describe('UNIT: DynamicRoutingService (store-backed)', function () {
 
             const settings = await service.loadRouteSettings();
 
-            assert.deepEqual(settings.routes['/about/'], {templates: ['about']});
+            assert.deepEqual(settings.routes, [{path: '/about/', type: 'template', templates: ['about']}]);
             assert.equal(errorStub.called, false);
         });
     });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1895

Second PR in the route-settings DDD cleanup. Rebased onto `main` after #29643 (routes_hash removal) landed.

## Summary

The activation bridge handed `RouterManager` **path-keyed maps** with legacy property names (`controller`, `content_type`), and `RouterManager` iterated them with `_.each`, reading each path from the map key. This moves the routing layer onto the **domain array shape** (design steps 3.1 + 3.2) while keeping the bridge in place — routing behaviour is byte-identical.

## What changed

- **`activation-bridge.ts`** — replaced `expandRouteSettings` with **`buildRouterSettings()`**, which emits **arrays**: each route/collection carries its own `path`, taxonomies become `{key, permalink}` entries, and routes use the domain names `type`/`contentType`. The bridge still performs the other three conversions (`{slug}`→`:slug`, `resource`→controller, `data`→`{query, router}`) — those come off in later PRs (HKG-1896/1897).
- **`router-manager.js`** — `start()` iterates with `for..of` over the arrays, reading `.path`; dropped the now-unused `lodash` import.
- **`static-routes-router.js`** — reads the domain names (`object.type`, `object.contentType`); `isChannel` checks `.type === 'channel'`. `controllers[this.type]` resolves identically to the old `controllers[this.controller]` (both `'channel'`).
- **`dynamic-routing-service.js`** — `loadRouteSettings()` now returns the router arrays (one-line swap to `buildRouterSettings`).

## expandRouteSettings deleted

With #29643 removing the unused `routes_hash` mechanism, the legacy path-keyed `expandRouteSettings` (and its `expandRoute`/`expandCollection` helpers) had **no remaining consumer** once the routers move to `buildRouterSettings` — so they're deleted. `buildRouterSettings` is now the sole bridge output. The schema-integrity routes canary is repointed onto `buildRouterSettings` and its checksum updated (the default `routes.yaml` is unchanged; only the canary's normalised representation moved from map to array).

## Testing

- `route-settings` + frontend `routing` unit suites + schema `integrity`: **245 passing**.
- `dynamic-routing-service` integration (real FileStore): passing.
- The `api-vs-frontend` behavioural suite (11 `loadRouteSettings` fixtures reshaped to arrays via a small `asRouterSettings` map→array helper): **60 passing** — proves routing output is byte-identical.
- `pnpm lint` (incl. `tsc --noEmit`) + dependency-cruiser clean.

Net **−231 lines**.