### PR TITLE
🐛 Fixed settings preview interaction regressions

### DIFF
--- a/apps/admin-x-settings/src/components/color-picker-field.tsx
+++ b/apps/admin-x-settings/src/components/color-picker-field.tsx
@@ -173,7 +173,7 @@ const ColorPickerField = ({
                     onTouchStartCapture={() => allowPickerChanges.current = true}
                 >
                     <ColorPicker
-                        value={normalizedValue}
+                        defaultValue={normalizedValue}
                         onChange={(hex) => {
                             if (!suppressPickerChanges.current && allowPickerChanges.current) {
                                 handleChange(hex.toLowerCase());

--- a/apps/admin-x-settings/src/components/settings/growth/embed-signup/embed-signup-preview.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/embed-signup/embed-signup-preview.tsx
@@ -1,5 +1,5 @@
 import IframeBuffering from '../../../../utils/iframe-buffering';
-import React from 'react';
+import React, {useCallback, useRef} from 'react';
 
 type EmbedSignupPreviewProps = {
     backgroundColor: string;
@@ -8,32 +8,88 @@ type EmbedSignupPreviewProps = {
 };
 
 const EmbedSignupPreview: React.FC<EmbedSignupPreviewProps> = ({backgroundColor, html, style}) => {
-    const generateContentForEmbed = (iframe: HTMLIFrameElement) => {
+    const backgroundColorRef = useRef(backgroundColor);
+    const htmlRef = useRef(html);
+    const hasContent = Boolean(html);
+    backgroundColorRef.current = backgroundColor;
+    htmlRef.current = html;
+
+    const generateContentForEmbed = useCallback((iframe: HTMLIFrameElement) => {
         const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
         if (!iframeDoc) {
             return;
         }
 
+        iframe.dataset.previewLayout = style;
+
         const docString = `
             <html>
                 <head>
-                    <style>body, html {height: 100%; padding: 0; margin: 0; overflow: hidden; background: ${backgroundColor};}</style>
+                    <style>body, html {height: 100%; padding: 0; margin: 0; overflow: hidden; background: ${backgroundColorRef.current}; transition: background-color 200ms ease;}</style>
                     <style>${style}</style>
                 </head>
-                <body>${html}</body>
+                <body>${htmlRef.current}</body>
             </html>
         `;
 
         iframeDoc.open();
         iframeDoc.write(docString);
         iframeDoc.close();
-    };
+    // The preview code arrives after the modal first renders. Treat that first
+    // document as structural content so it is generated through the buffer;
+    // subsequent option changes can safely update the mounted form in place.
+    }, [hasContent, style]);
+
+    const updateContentForEmbed = useCallback((iframe: HTMLIFrameElement) => {
+        // Structural layout changes are handled by the buffered generator. Do
+        // not apply their attributes to the still-visible previous layout.
+        if (iframe.dataset.previewLayout !== style) {
+            return;
+        }
+
+        const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+        if (!iframeDoc) {
+            return;
+        }
+
+        [iframeDoc.documentElement, iframeDoc.body].forEach((element) => {
+            element.style.backgroundColor = backgroundColor;
+            element.style.transition = 'background-color 200ms ease';
+        });
+
+        const sourceDoc = new DOMParser().parseFromString(html, 'text/html');
+        const sourceScript = sourceDoc.querySelector('script');
+        const targetScript = iframeDoc.querySelector('script');
+        if (!sourceScript || !targetScript) {
+            return;
+        }
+
+        // Signup form observes data attribute mutations, so preview options can
+        // update without remounting the form or fading the entire iframe.
+        const nextAttributes = new Map(
+            Array.from(sourceScript.attributes)
+                .filter(attribute => attribute.name.startsWith('data-'))
+                .map(attribute => [attribute.name, attribute.value])
+        );
+
+        Array.from(targetScript.attributes)
+            .filter(attribute => attribute.name.startsWith('data-') && !nextAttributes.has(attribute.name))
+            .forEach(attribute => targetScript.removeAttribute(attribute.name));
+
+        nextAttributes.forEach((value, name) => {
+            if (targetScript.getAttribute(name) !== value) {
+                targetScript.setAttribute(name, value);
+            }
+        });
+    }, [backgroundColor, html, style]);
+
     return (
         <IframeBuffering
             className="absolute size-full overflow-hidden transition-opacity duration-500"
             generateContent={generateContentForEmbed}
             height="100%"
             parentClassName="relative h-full min-h-[400px] w-full"
+            updateContent={updateContentForEmbed}
             width="100%"
         />
     );

--- a/apps/admin-x-settings/src/components/settings/growth/embed-signup/embed-signup-sidebar.tsx
+++ b/apps/admin-x-settings/src/components/settings/growth/embed-signup/embed-signup-sidebar.tsx
@@ -109,6 +109,7 @@ const EmbedSignupSidebar: React.FC<SidebarProps> = ({selectedLayout,
                     {
                         selectedLayout === 'all-in-one' &&
                         <ColorPickerField
+                            debounceMs={200}
                             direction='rtl'
                             eyedropper={true}
                             swatches={[

--- a/apps/admin-x-settings/src/components/settings/membership/portal/look-and-feel.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/portal/look-and-feel.tsx
@@ -114,12 +114,12 @@ const LookAndFeel: React.FC<{
                             </ToggleGroup>
                             <ImageUpload className={`size-[46px] overflow-visible border ${currentIcon === uploadedIcon ? 'border-primary' : 'border-transparent'}`}>
                                 {uploadedIcon ? (
-                                    <ImageUploadPreview>
-                                        <ImageUploadImage src={uploadedIcon} />
+                                    <ImageUploadPreview className='overflow-visible'>
+                                        <ImageUploadImage className='rounded-md' src={uploadedIcon} />
                                         <Button
                                             aria-label='Use uploaded Portal icon'
                                             aria-pressed={currentIcon === uploadedIcon}
-                                            className='absolute inset-0 z-10 size-full rounded-none bg-transparent'
+                                            className='absolute inset-0 z-10 size-full rounded-md bg-transparent hover:bg-transparent'
                                             size='icon'
                                             type='button'
                                             variant='ghost'

--- a/apps/admin-x-settings/src/components/settings/membership/portal/portal-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/portal/portal-modal.tsx
@@ -12,6 +12,7 @@ import {type Setting, type SettingValue, getSettingValues, useEditSettings} from
 import {Tabs, TabsContent, TabsList, TabsTrigger} from '@tryghost/shade/components';
 import {type Tier, useBrowseTiers, useEditTier} from '@tryghost/admin-x-framework/api/tiers';
 import {fullEmailAddress} from '@tryghost/admin-x-framework/api/site';
+import {useFocusContext} from '@tryghost/shade/app';
 import {useGlobalData} from '../../../providers/global-data-provider';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
 import {verifyEmailToken} from '@tryghost/admin-x-framework/api/email-verification';
@@ -64,6 +65,7 @@ const Sidebar: React.FC<{
 
 const PortalModal: React.FC = () => {
     const {updateRoute} = useRouting();
+    const {darkMode} = useFocusContext();
 
     const [selectedPreviewTab, setSelectedPreviewTab] = useState<PreviewTab>('signup');
     const [selectedSidebarTab, setSelectedSidebarTab] = useState<SidebarTab>('signupOptions');
@@ -216,6 +218,7 @@ const PortalModal: React.FC = () => {
         onTabChange={onSidebarTabChange}
     />;
     const preview = <PortalPreview
+        darkMode={darkMode}
         localSettings={formState.settings}
         localTiers={formState.tiers}
         selectedTab={selectedPreviewTab}

--- a/apps/admin-x-settings/src/components/settings/membership/portal/portal-preview.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/portal/portal-preview.tsx
@@ -7,12 +7,14 @@ import {getPortalPreviewUrl} from '../../../../utils/get-portal-preview-url';
 import {useGlobalData} from '../../../providers/global-data-provider';
 
 interface PortalPreviewProps {
+    darkMode: boolean;
     selectedTab: string;
     localSettings: Setting[];
     localTiers: Tier[];
 }
 
 const PortalPreview: React.FC<PortalPreviewProps> = ({
+    darkMode,
     selectedTab = 'signup',
     localSettings,
     localTiers
@@ -26,6 +28,7 @@ const PortalPreview: React.FC<PortalPreviewProps> = ({
         settings: localSettings,
         tiers: localTiers,
         selectedTab,
+        previewTheme: darkMode ? 'dark' : 'light',
         siteData,
         config
     });

--- a/apps/admin-x-settings/src/utils/get-portal-preview-url.ts
+++ b/apps/admin-x-settings/src/utils/get-portal-preview-url.ts
@@ -9,9 +9,10 @@ export type portalPreviewUrlTypes = {
     tiers: Tier[];
     siteData: SiteData | null;
     selectedTab: string;
+    previewTheme: 'light' | 'dark';
 };
 
-export const getPortalPreviewUrl = ({settings, config, tiers, siteData, selectedTab} : portalPreviewUrlTypes): string | null => {
+export const getPortalPreviewUrl = ({settings, config, tiers, siteData, selectedTab, previewTheme} : portalPreviewUrlTypes): string | null => {
     if (!siteData?.url) {
         return null;
     }
@@ -31,6 +32,7 @@ export const getPortalPreviewUrl = ({settings, config, tiers, siteData, selected
     settingsParam.append('isMonthly', checkStripeEnabled(settings, config) && portalPlans.includes('monthly') ? 'true' : 'false');
     settingsParam.append('isYearly', checkStripeEnabled(settings, config) && portalPlans.includes('yearly') ? 'true' : 'false');
     settingsParam.append('page', selectedTab === 'account' ? 'accountHome' : 'signup');
+    settingsParam.append('previewTheme', previewTheme);
     settingsParam.append('buttonIcon', encodeURIComponent(getSettingValue(settings, 'portal_button_icon') || 'icon-1'));
     settingsParam.append('signupButtonText', encodeURIComponent(getSettingValue(settings, 'portal_button_signup_text') || ''));
     settingsParam.append('membersSignupAccess', getSettingValue(settings, 'members_signup_access') || 'all');

--- a/apps/admin-x-settings/src/utils/iframe-buffering.tsx
+++ b/apps/admin-x-settings/src/utils/iframe-buffering.tsx
@@ -3,6 +3,8 @@ import React, {useEffect, useRef, useState} from 'react';
 
 type IframeBufferingProps = {
   generateContent: (iframe: HTMLIFrameElement) => void;
+  // Apply lightweight changes without rebuilding or fading the iframe contents.
+  updateContent?: (iframe: HTMLIFrameElement) => void;
   className?: string;
   parentClassName?: string;
   height?: string;
@@ -24,7 +26,7 @@ function debounce(func: any, wait: number) { // eslint-disable-line
     };
 }
 
-const IframeBuffering: React.FC<IframeBufferingProps> = ({generateContent, className, height, width, parentClassName, testId, addDelay = false}) => {
+const IframeBuffering: React.FC<IframeBufferingProps> = ({generateContent, updateContent, className, height, width, parentClassName, testId, addDelay = false}) => {
     const [visibleIframeIndex, setVisibleIframeIndex] = useState(0);
     const iframes = [useRef<HTMLIFrameElement>(null), useRef<HTMLIFrameElement>(null)];  
     const [scrollPosition, setScrollPosition] = useState(0);
@@ -87,6 +89,18 @@ const IframeBuffering: React.FC<IframeBufferingProps> = ({generateContent, class
             }
         }
     }, [scrollPosition, visibleIframeIndex, iframes]);
+
+    useEffect(() => {
+        if (!updateContent) {
+            return;
+        }
+
+        iframes.forEach(({current}) => {
+            if (current) {
+                updateContent(current);
+            }
+        });
+    }, [updateContent]);
 
     return (
         <div className={parentClassName} data-testid={testId}>

--- a/apps/admin-x-settings/test/unit/growth/embed-signup-preview.test.tsx
+++ b/apps/admin-x-settings/test/unit/growth/embed-signup-preview.test.tsx
@@ -1,0 +1,23 @@
+import EmbedSignupPreview from '@src/components/settings/growth/embed-signup/embed-signup-preview';
+import {render, waitFor} from '@testing-library/react';
+
+describe('EmbedSignupPreview', () => {
+    it('generates the preview when its asynchronously loaded content arrives', async () => {
+        const {container, rerender} = render(
+            <EmbedSignupPreview backgroundColor="#08090c" html="" style="all-in-one" />
+        );
+
+        rerender(
+            <EmbedSignupPreview
+                backgroundColor="#08090c"
+                html={'<div><script data-background-color="#08090c" src="/signup-form.js"></script></div>'}
+                style="all-in-one"
+            />
+        );
+
+        await waitFor(() => {
+            const frames = Array.from(container.querySelectorAll('iframe'));
+            expect(frames.some(frame => frame.contentDocument?.querySelector('script[src="/signup-form.js"]'))).toBe(true);
+        });
+    });
+});

--- a/apps/admin-x-settings/test/unit/utils/iframe-buffering.test.tsx
+++ b/apps/admin-x-settings/test/unit/utils/iframe-buffering.test.tsx
@@ -1,0 +1,27 @@
+import IframeBuffering from '@src/utils/iframe-buffering';
+import {render, waitFor} from '@testing-library/react';
+
+describe('IframeBuffering', () => {
+    it('applies lightweight updates without regenerating the iframe contents', async () => {
+        const generateContent = vi.fn();
+        const initialUpdate = vi.fn();
+        const nextUpdate = vi.fn();
+        const {rerender} = render(
+            <IframeBuffering generateContent={generateContent} updateContent={initialUpdate} />
+        );
+
+        await waitFor(() => {
+            expect(generateContent).toHaveBeenCalledOnce();
+            expect(initialUpdate).toHaveBeenCalledTimes(2);
+        });
+
+        rerender(
+            <IframeBuffering generateContent={generateContent} updateContent={nextUpdate} />
+        );
+
+        await waitFor(() => {
+            expect(nextUpdate).toHaveBeenCalledTimes(2);
+        });
+        expect(generateContent).toHaveBeenCalledOnce();
+    });
+});

--- a/apps/portal/src/app.jsx
+++ b/apps/portal/src/app.jsx
@@ -488,6 +488,8 @@ export default class App extends React.Component {
                 currency = currencyValue;
             } else if (key === 'disableBackground') {
                 data.site.disableBackground = JSON.parse(value);
+            } else if (key === 'previewTheme') {
+                data.site.preview_theme = value;
             } else if (key === 'membersSignupAccess' && value) {
                 data.site.members_signup_access = value;
             } else if (key === 'portalDefaultPlan' && value) {

--- a/apps/portal/src/components/frame.styles.js
+++ b/apps/portal/src/components/frame.styles.js
@@ -326,6 +326,10 @@ html[dir="rtl"] .gh-portal-btn-site-title-back span {
     pointer-events: none;
 }
 
+.gh-portal-popup-background.preview.preview-dark {
+    background: linear-gradient(45deg, var(--grey0) 0%, var(--black) 100%);
+}
+
 @keyframes fadein {
     0% { opacity: 0; }
     100%{ opacity: 1.0; }

--- a/apps/portal/src/components/popup-modal.jsx
+++ b/apps/portal/src/components/popup-modal.jsx
@@ -320,6 +320,9 @@ export default class PopupModal extends React.Component {
 
         if (hasMode(['preview'], {customSiteUrl}) && !site.disableBackground) {
             className += ' preview';
+            if (site.preview_theme === 'dark') {
+                className += ' preview-dark';
+            }
         }
 
         if (hasMode(['dev'])) {

--- a/apps/portal/src/index.css
+++ b/apps/portal/src/index.css
@@ -1,0 +1,5 @@
+html[data-portal-preview-theme='dark'],
+html[data-portal-preview-theme='dark'] body,
+html[data-portal-preview-theme='dark'] #ghost-portal-root {
+    background: #1d1d1d;
+}

--- a/apps/portal/src/index.jsx
+++ b/apps/portal/src/index.jsx
@@ -36,11 +36,21 @@ function handleTokenUrl() {
     }
 }
 
+function setPreviewTheme() {
+    const [, queryString] = window.location.hash.substring(1).split('?');
+    const previewTheme = new URLSearchParams(queryString).get('previewTheme');
+
+    if (previewTheme === 'dark') {
+        document.documentElement.dataset.portalPreviewTheme = 'dark';
+    }
+}
+
 function init() {
     // const customSiteUrl = getSiteUrl();
     const {siteUrl: customSiteUrl, apiKey, apiUrl, siteI18nEnabled, locale} = getSiteData();
     const siteUrl = customSiteUrl || window.location.origin;
 
+    setPreviewTheme();
     addRootDiv();
     handleTokenUrl();
 

--- a/apps/portal/test/app.test.jsx
+++ b/apps/portal/test/app.test.jsx
@@ -381,7 +381,7 @@ describe('App', function () {
     });
 
     test('parses a valid preview hash', () => {
-        window.location.hash = '#/portal/preview?button=true&isFree=true&isMonthly=true&isYearly=false&signupCheckboxRequired=false';
+        window.location.hash = '#/portal/preview?button=true&isFree=true&isMonthly=true&isYearly=false&signupCheckboxRequired=false&previewTheme=dark';
 
         const app = new App({siteUrl: 'http://example.com'});
         const data = app.fetchPreviewData();
@@ -392,5 +392,6 @@ describe('App', function () {
         expect(data.site.portal_plans).toContain('monthly');
         expect(data.site.portal_plans).not.toContain('yearly');
         expect(data.site.portal_signup_checkbox_required).toBe(false);
+        expect(data.site.preview_theme).toBe('dark');
     });
 });

--- a/apps/shade/src/components/patterns/color-picker.tsx
+++ b/apps/shade/src/components/patterns/color-picker.tsx
@@ -210,7 +210,7 @@ export type ColorPickerSelectionProps = HTMLAttributes<HTMLDivElement>;
 export const ColorPickerSelection = memo(
     ({className, ...props}: ColorPickerSelectionProps) => {
         const containerRef = useRef<HTMLDivElement>(null);
-        const [isDragging, setIsDragging] = useState(false);
+        const activePointerId = useRef<number | null>(null);
         const [positionX, setPositionX] = useState(0);
         const [positionY, setPositionY] = useState(0);
         const {hue, saturation, lightness, setSaturation, setLightness} =
@@ -257,30 +257,6 @@ export const ColorPickerSelection = memo(
             [setSaturation, setLightness]
         );
 
-        const handlePointerMove = useCallback(
-            (event: PointerEvent) => {
-                if (!isDragging) {
-                    return;
-                }
-                updateColorFromPointer(event);
-            },
-            [isDragging, updateColorFromPointer]
-        );
-
-        useEffect(() => {
-            const handlePointerUp = () => setIsDragging(false);
-
-            if (isDragging) {
-                window.addEventListener('pointermove', handlePointerMove);
-                window.addEventListener('pointerup', handlePointerUp);
-            }
-
-            return () => {
-                window.removeEventListener('pointermove', handlePointerMove);
-                window.removeEventListener('pointerup', handlePointerUp);
-            };
-        }, [isDragging, handlePointerMove]);
-
         return (
             <div
                 ref={containerRef}
@@ -291,10 +267,27 @@ export const ColorPickerSelection = memo(
                 style={{
                     background: backgroundGradient
                 }}
+                onPointerCancel={(e) => {
+                    if (activePointerId.current === e.pointerId) {
+                        activePointerId.current = null;
+                    }
+                }}
                 onPointerDown={(e) => {
                     e.preventDefault();
-                    setIsDragging(true);
+                    activePointerId.current = e.pointerId;
+                    e.currentTarget.setPointerCapture?.(e.pointerId);
                     updateColorFromPointer(e.nativeEvent);
+                }}
+                onPointerMove={(e) => {
+                    if (activePointerId.current === e.pointerId) {
+                        updateColorFromPointer(e.nativeEvent);
+                    }
+                }}
+                onPointerUp={(e) => {
+                    if (activePointerId.current === e.pointerId) {
+                        activePointerId.current = null;
+                        e.currentTarget.releasePointerCapture?.(e.pointerId);
+                    }
                 }}
                 {...props}
             >

--- a/apps/shade/test/unit/components/patterns/color-picker.test.tsx
+++ b/apps/shade/test/unit/components/patterns/color-picker.test.tsx
@@ -91,6 +91,21 @@ describe('ColorPicker Component', () => {
             const lastCall = handleChange.mock.calls[handleChange.mock.calls.length - 1];
             assert.equal(lastCall[0].toUpperCase(), '#000000');
         });
+
+        it('tracks one pointer throughout a drag and stops after release', () => {
+            const {gradient, handleChange} = renderGradient();
+
+            fireEvent.pointerDown(gradient, {clientX: 20, clientY: 20, pointerId: 1});
+            fireEvent.pointerMove(gradient, {clientX: 160, clientY: 120, pointerId: 1});
+            const dragCall = handleChange.mock.calls[handleChange.mock.calls.length - 1];
+
+            fireEvent.pointerMove(gradient, {clientX: 40, clientY: 180, pointerId: 2});
+            assert.deepEqual(handleChange.mock.calls[handleChange.mock.calls.length - 1], dragCall);
+
+            fireEvent.pointerUp(gradient, {pointerId: 1});
+            fireEvent.pointerMove(gradient, {clientX: 100, clientY: 100, pointerId: 1});
+            assert.deepEqual(handleChange.mock.calls[handleChange.mock.calls.length - 1], dragCall);
+        });
     });
 
     describe('hex input', () => {

--- a/apps/signup-form/src/components/pages/form-view.tsx
+++ b/apps/signup-form/src/components/pages/form-view.tsx
@@ -23,7 +23,7 @@ export const FormView: React.FC<FormProps & {
 
     return (
         <div
-            className='flex h-[100vh] flex-col items-center justify-center px-4 sm:px-6 md:px-10'
+            className='flex h-[100vh] flex-col items-center justify-center px-4 transition-colors duration-200 sm:px-6 md:px-10'
             data-testid="wrapper"
             style={{backgroundColor, color: textColor}}
         >


### PR DESCRIPTION
## What changed

- Stabilized Shade color-picker dragging with pointer capture so the selection does not flicker between competing pointer states.
- Updated the embed signup-form preview in place during color changes instead of rebuilding and fading its iframe.
- Debounced embed background-color changes to match the Design picker behavior.
- Fixed the custom Portal icon hover/delete layering and removed the empty gray hover state.
- Made the Portal preview canvas follow Admin dark mode while keeping Portal itself white.
- Added focused coverage for iframe updates, delayed preview content, color-picker pointer handling, and Portal preview-theme parsing.

## Why

The Shade cleanup exposed several preview-specific interaction regressions. Color dragging could feed controlled values back into the picker while the pointer was still moving, iframe previews were unnecessarily regenerated for lightweight option changes, and Portal preview chrome had no knowledge of the active Admin theme.

The attempted Safari-only signup-form first-paint workaround was reverted because it did not eliminate WebKit's white flash and added complexity without improving behavior.

## Validation

- Admin Settings: 26 test files, 219 tests; lint
- Shade: 25 test files, 235 tests; lint and typecheck
- Portal: 46 test files, 583 tests; lint, typecheck, and production build
- Signup form: lint, typecheck, and production build
- git diff --check