### PR TITLE
Improved settings design system migration cleanup

### DIFF
--- a/apps/admin-x-settings/src/components/color-picker-field.tsx
+++ b/apps/admin-x-settings/src/components/color-picker-field.tsx
@@ -1,5 +1,6 @@
 import {ColorPicker, ColorPickerTrigger, type ColorSwatchOption, ColorSwatchRow} from '@tryghost/shade/patterns';
 import {FieldDescription, Popover, PopoverContent, PopoverTrigger} from '@tryghost/shade/components';
+import {Inline} from '@tryghost/shade/primitives';
 import {type ReactNode, useCallback, useEffect, useId, useMemo, useRef, useState} from 'react';
 import {debounce} from '../utils/debounce';
 
@@ -132,9 +133,12 @@ const ColorPickerField = ({
                 setOpen(nextOpen);
             }}
         >
-            <div
-                className={`flex w-full items-start justify-between gap-2 ${direction === 'ltr' ? 'flex-row-reverse' : ''}`}
+            <Inline
+                align={hint ? 'start' : 'center'}
+                className={`w-full ${direction === 'ltr' ? 'flex-row-reverse' : ''}`}
                 data-testid={testId}
+                gap='sm'
+                justify='between'
             >
                     {title && (
                         <label className="min-w-0 flex-1 cursor-pointer text-left" htmlFor={triggerId}>
@@ -159,7 +163,7 @@ const ColorPickerField = ({
                             <ColorPickerTrigger id={triggerId} value={normalizedValue} />
                         </PopoverTrigger>
                     </div>
-            </div>
+            </Inline>
             <PopoverContent
                 align={direction === 'rtl' ? 'end' : 'start'}
                 className="w-auto p-4"

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/newsletter-detail-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/newsletter-detail-modal.tsx
@@ -265,7 +265,7 @@ const Sidebar: React.FC<{
             title: 'General',
             contents:
             <>
-                <FieldSet className='mt-10 gap-5'>
+                <FieldSet className='mt-8 gap-4'>
                     <FieldLegend className='mb-0 text-md! leading-supertight font-bold md:text-lg!'>Name and description</FieldLegend>
                     <FieldGroup className='gap-6 [&_:where(input)]:h-[var(--control-height)] [&_:where(input)]:border-transparent [&_:where(input)]:bg-muted'>
                     <Field data-invalid={Boolean(errors.name) || undefined}>
@@ -279,7 +279,7 @@ const Sidebar: React.FC<{
                     </Field>
                     </FieldGroup>
                 </FieldSet>
-                <FieldSet className='mt-10 gap-5'>
+                <FieldSet className='mt-8 gap-4'>
                     <FieldLegend className='mb-0 text-md! leading-supertight font-bold md:text-lg!'>Email info</FieldLegend>
                     <FieldGroup className='gap-6 [&_:where(input)]:h-[var(--control-height)] [&_:where(input)]:border-transparent [&_:where(input)]:bg-muted'>
                     <Field>
@@ -290,7 +290,7 @@ const Sidebar: React.FC<{
                     <ReplyToEmailField clearError={clearError} errors={errors} newsletter={newsletter} updateNewsletter={updateNewsletter} validate={validate} />
                     </FieldGroup>
                 </FieldSet>
-                <FieldSet className='mt-10 gap-5'>
+                <FieldSet className='mt-8 gap-4'>
                     <FieldLegend className='mb-0 text-md! leading-supertight font-bold md:text-lg!'>Member settings</FieldLegend>
                     <FieldGroup className='gap-6'>
                     <Field orientation='horizontal'>
@@ -309,7 +309,7 @@ const Sidebar: React.FC<{
             title: 'Content',
             contents:
             <>
-                <FieldSet className='mt-10 gap-5'>
+                <FieldSet className='mt-8 gap-4'>
                     <FieldLegend className='mb-0 text-md! leading-supertight font-bold md:text-lg!'>Header</FieldLegend>
                     <FieldGroup className='gap-6'>
                     <div>
@@ -360,9 +360,9 @@ const Sidebar: React.FC<{
                     </FieldGroup>
                 </FieldSet>
 
-                <FieldSet className='mt-10 gap-5'>
+                <FieldSet className='mt-8 gap-4'>
                     <FieldLegend className='mb-0 text-md! leading-supertight font-bold md:text-lg!'>Title section</FieldLegend>
-                    <FieldGroup className='gap-5'>
+                    <FieldGroup className='gap-4'>
                     <Field orientation='horizontal'>
                         <FieldLabel htmlFor='newsletter-show-post-title'>Post title</FieldLabel>
                         <Switch checked={Boolean(newsletter.show_post_title_section)} id='newsletter-show-post-title' onCheckedChange={checked => updateNewsletter({show_post_title_section: checked})} />
@@ -380,7 +380,7 @@ const Sidebar: React.FC<{
                     </FieldGroup>
                 </FieldSet>
 
-                <FieldSet className='mt-10 gap-5'>
+                <FieldSet className='mt-8 gap-4'>
                     <FieldLegend className='mb-0 text-md! leading-supertight font-bold md:text-lg!'>Footer</FieldLegend>
                     <FieldGroup className='gap-6'>
                     <Stack gap='lg'>
@@ -415,7 +415,7 @@ const Sidebar: React.FC<{
                     />
                     </FieldGroup>
                 </FieldSet>
-                <Separator className='mt-10' />
+                <Separator className='mt-8' />
                 <div className='my-5 flex w-full items-start'>
                     <span>
                         <LucideIcon.Heart className='mt-[-1px] mr-2 size-5 text-red'/>
@@ -437,7 +437,7 @@ const Sidebar: React.FC<{
             title: 'Design',
             contents:
             <>
-                <FieldSet className='mt-10 gap-5'>
+                <FieldSet className='mt-8 gap-4'>
                     <FieldLegend className='mb-0 text-md! leading-supertight font-bold md:text-lg!'>Global</FieldLegend>
                     <FieldGroup className='gap-5'>
                     <div className='mb-1'>
@@ -494,7 +494,7 @@ const Sidebar: React.FC<{
                     </div>
                     </FieldGroup>
                 </FieldSet>
-                <FieldSet className='mt-10 gap-5'>
+                <FieldSet className='mt-8 gap-4'>
                     <FieldLegend className='mb-0 text-md! leading-supertight font-bold md:text-lg!'>Header</FieldLegend>
                     <FieldGroup className='gap-5'>
                     <div className='mb-1'>
@@ -549,7 +549,7 @@ const Sidebar: React.FC<{
                     </FieldGroup>
                 </FieldSet>
 
-                <FieldSet className='mt-10 gap-5'>
+                <FieldSet className='mt-8 gap-4'>
                     <FieldLegend className='mb-0 text-md! leading-supertight font-bold md:text-lg!'>Body</FieldLegend>
                     <FieldGroup className='gap-5'>
                     <div className='mb-1'>

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/newsletter-detail-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/newsletter-detail-modal.tsx
@@ -265,9 +265,9 @@ const Sidebar: React.FC<{
             title: 'General',
             contents:
             <>
-                <FieldSet className='mt-6 gap-0'>
-                    <FieldLegend className='mb-4 text-md! leading-supertight font-bold md:text-lg!'>Name and description</FieldLegend>
-                    <FieldGroup className='mb-12 gap-6 [&_:where(input)]:h-[var(--control-height)] [&_:where(input)]:border-transparent [&_:where(input)]:bg-muted'>
+                <FieldSet className='mt-8 gap-4'>
+                    <FieldLegend className='mb-0 text-md! leading-supertight font-bold md:text-lg!'>Name and description</FieldLegend>
+                    <FieldGroup className='gap-6 [&_:where(input)]:h-[var(--control-height)] [&_:where(input)]:border-transparent [&_:where(input)]:bg-muted'>
                     <Field data-invalid={Boolean(errors.name) || undefined}>
                         <FieldLabel htmlFor='newsletter-detail-name'>Name</FieldLabel>
                         <Input aria-invalid={Boolean(errors.name) || undefined} id='newsletter-detail-name' maxLength={191} placeholder='Weekly Roundup' value={newsletter.name || ''} onChange={e => updateNewsletter({name: e.target.value})} onKeyDown={() => clearError('name')} />
@@ -279,9 +279,9 @@ const Sidebar: React.FC<{
                     </Field>
                     </FieldGroup>
                 </FieldSet>
-                <FieldSet className='mt-6 gap-0'>
-                    <FieldLegend className='mb-4 text-md! leading-supertight font-bold md:text-lg!'>Email info</FieldLegend>
-                    <FieldGroup className='mb-12 gap-6 [&_:where(input)]:h-[var(--control-height)] [&_:where(input)]:border-transparent [&_:where(input)]:bg-muted'>
+                <FieldSet className='mt-8 gap-4'>
+                    <FieldLegend className='mb-0 text-md! leading-supertight font-bold md:text-lg!'>Email info</FieldLegend>
+                    <FieldGroup className='gap-6 [&_:where(input)]:h-[var(--control-height)] [&_:where(input)]:border-transparent [&_:where(input)]:bg-muted'>
                     <Field>
                         <FieldLabel htmlFor='newsletter-sender-name'>Sender name</FieldLabel>
                         <Input id='newsletter-sender-name' maxLength={191} placeholder={siteTitle} value={newsletter.sender_name || ''} onChange={e => updateNewsletter({sender_name: e.target.value})} />
@@ -290,9 +290,9 @@ const Sidebar: React.FC<{
                     <ReplyToEmailField clearError={clearError} errors={errors} newsletter={newsletter} updateNewsletter={updateNewsletter} validate={validate} />
                     </FieldGroup>
                 </FieldSet>
-                <FieldSet className='mt-6 gap-0'>
-                    <FieldLegend className='mb-4 text-md! leading-supertight font-bold md:text-lg!'>Member settings</FieldLegend>
-                    <FieldGroup className='mb-12 gap-6'>
+                <FieldSet className='mt-8 gap-4'>
+                    <FieldLegend className='mb-0 text-md! leading-supertight font-bold md:text-lg!'>Member settings</FieldLegend>
+                    <FieldGroup className='gap-6'>
                     <Field orientation='horizontal'>
                         <FieldLabel htmlFor='newsletter-subscribe-on-signup'>Subscribe new members on signup</FieldLabel>
                         <Switch checked={Boolean(newsletter.subscribe_on_signup)} id='newsletter-subscribe-on-signup' onCheckedChange={checked => updateNewsletter({subscribe_on_signup: checked})} />
@@ -309,9 +309,9 @@ const Sidebar: React.FC<{
             title: 'Content',
             contents:
             <>
-                <FieldSet className='mt-6 gap-0'>
-                    <FieldLegend className='mb-4 text-md! leading-supertight font-bold md:text-lg!'>Header</FieldLegend>
-                    <FieldGroup className='mb-12 gap-6'>
+                <FieldSet className='mt-8 gap-4'>
+                    <FieldLegend className='mb-0 text-md! leading-supertight font-bold md:text-lg!'>Header</FieldLegend>
+                    <FieldGroup className='gap-6'>
                     <div>
                         <div>
                             <Text as='h6' className="mb-2 text-base" weight='semibold'>Header image</Text>
@@ -336,7 +336,7 @@ const Sidebar: React.FC<{
                                             handleError(e);
                                         }
                                     }}>
-                                        <LucideIcon.Image className='size-5 text-grey-700 dark:text-grey-300' />
+                                        <LucideIcon.Image className='size-5 text-muted-foreground' />
                                     </ImageUploadDropzone>
                                 )}
                             </ImageUpload>
@@ -360,9 +360,9 @@ const Sidebar: React.FC<{
                     </FieldGroup>
                 </FieldSet>
 
-                <FieldSet className='mt-6 gap-0'>
-                    <FieldLegend className='mb-4 text-md! leading-supertight font-bold md:text-lg!'>Title section</FieldLegend>
-                    <FieldGroup className='mb-12 gap-4'>
+                <FieldSet className='mt-8 gap-4'>
+                    <FieldLegend className='mb-0 text-md! leading-supertight font-bold md:text-lg!'>Title section</FieldLegend>
+                    <FieldGroup className='gap-4'>
                     <Field orientation='horizontal'>
                         <FieldLabel htmlFor='newsletter-show-post-title'>Post title</FieldLabel>
                         <Switch checked={Boolean(newsletter.show_post_title_section)} id='newsletter-show-post-title' onCheckedChange={checked => updateNewsletter({show_post_title_section: checked})} />
@@ -380,9 +380,9 @@ const Sidebar: React.FC<{
                     </FieldGroup>
                 </FieldSet>
 
-                <FieldSet className='mt-6 gap-0'>
-                    <FieldLegend className='mb-4 text-md! leading-supertight font-bold md:text-lg!'>Footer</FieldLegend>
-                    <FieldGroup className='mb-12 gap-6'>
+                <FieldSet className='mt-8 gap-4'>
+                    <FieldLegend className='mb-0 text-md! leading-supertight font-bold md:text-lg!'>Footer</FieldLegend>
+                    <FieldGroup className='gap-6'>
                     <Stack gap='lg'>
                         <Field orientation='horizontal'>
                             <FieldLabel htmlFor='newsletter-feedback-enabled'>Ask your readers for feedback</FieldLabel>
@@ -415,7 +415,7 @@ const Sidebar: React.FC<{
                     />
                     </FieldGroup>
                 </FieldSet>
-                <Separator />
+                <Separator className='mt-8' />
                 <div className='my-5 flex w-full items-start'>
                     <span>
                         <LucideIcon.Heart className='mt-[-1px] mr-2 size-5 text-red'/>
@@ -437,9 +437,9 @@ const Sidebar: React.FC<{
             title: 'Design',
             contents:
             <>
-                <FieldSet className='mt-6 gap-0'>
-                    <FieldLegend className='mb-4 text-md! leading-supertight font-bold md:text-lg!'>Global</FieldLegend>
-                    <FieldGroup className='mb-12 gap-4'>
+                <FieldSet className='mt-8 gap-4'>
+                    <FieldLegend className='mb-0 text-md! leading-supertight font-bold md:text-lg!'>Global</FieldLegend>
+                    <FieldGroup className='gap-4'>
                     <div className='mb-1'>
                         <ColorPickerField
                             direction='rtl'
@@ -494,9 +494,9 @@ const Sidebar: React.FC<{
                     </div>
                     </FieldGroup>
                 </FieldSet>
-                <FieldSet className='mt-6 gap-0'>
-                    <FieldLegend className='mb-4 text-md! leading-supertight font-bold md:text-lg!'>Header</FieldLegend>
-                    <FieldGroup className='mb-12 gap-4'>
+                <FieldSet className='mt-8 gap-4'>
+                    <FieldLegend className='mb-0 text-md! leading-supertight font-bold md:text-lg!'>Header</FieldLegend>
+                    <FieldGroup className='gap-4'>
                     <div className='mb-1'>
                         <ColorPickerField
                             direction='rtl'
@@ -549,9 +549,9 @@ const Sidebar: React.FC<{
                     </FieldGroup>
                 </FieldSet>
 
-                <FieldSet className='mt-6 gap-0'>
-                    <FieldLegend className='mb-4 text-md! leading-supertight font-bold md:text-lg!'>Body</FieldLegend>
-                    <FieldGroup className='mb-12 gap-4'>
+                <FieldSet className='mt-8 gap-4'>
+                    <FieldLegend className='mb-0 text-md! leading-supertight font-bold md:text-lg!'>Body</FieldLegend>
+                    <FieldGroup className='gap-4'>
                     <div className='mb-1'>
                         <ColorPickerField
                             direction='rtl'

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/newsletter-detail-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/newsletter-detail-modal.tsx
@@ -265,7 +265,7 @@ const Sidebar: React.FC<{
             title: 'General',
             contents:
             <>
-                <FieldSet className='mt-8 gap-4'>
+                <FieldSet className='mt-10 gap-5'>
                     <FieldLegend className='mb-0 text-md! leading-supertight font-bold md:text-lg!'>Name and description</FieldLegend>
                     <FieldGroup className='gap-6 [&_:where(input)]:h-[var(--control-height)] [&_:where(input)]:border-transparent [&_:where(input)]:bg-muted'>
                     <Field data-invalid={Boolean(errors.name) || undefined}>
@@ -279,7 +279,7 @@ const Sidebar: React.FC<{
                     </Field>
                     </FieldGroup>
                 </FieldSet>
-                <FieldSet className='mt-8 gap-4'>
+                <FieldSet className='mt-10 gap-5'>
                     <FieldLegend className='mb-0 text-md! leading-supertight font-bold md:text-lg!'>Email info</FieldLegend>
                     <FieldGroup className='gap-6 [&_:where(input)]:h-[var(--control-height)] [&_:where(input)]:border-transparent [&_:where(input)]:bg-muted'>
                     <Field>
@@ -290,7 +290,7 @@ const Sidebar: React.FC<{
                     <ReplyToEmailField clearError={clearError} errors={errors} newsletter={newsletter} updateNewsletter={updateNewsletter} validate={validate} />
                     </FieldGroup>
                 </FieldSet>
-                <FieldSet className='mt-8 gap-4'>
+                <FieldSet className='mt-10 gap-5'>
                     <FieldLegend className='mb-0 text-md! leading-supertight font-bold md:text-lg!'>Member settings</FieldLegend>
                     <FieldGroup className='gap-6'>
                     <Field orientation='horizontal'>
@@ -309,7 +309,7 @@ const Sidebar: React.FC<{
             title: 'Content',
             contents:
             <>
-                <FieldSet className='mt-8 gap-4'>
+                <FieldSet className='mt-10 gap-5'>
                     <FieldLegend className='mb-0 text-md! leading-supertight font-bold md:text-lg!'>Header</FieldLegend>
                     <FieldGroup className='gap-6'>
                     <div>
@@ -360,9 +360,9 @@ const Sidebar: React.FC<{
                     </FieldGroup>
                 </FieldSet>
 
-                <FieldSet className='mt-8 gap-4'>
+                <FieldSet className='mt-10 gap-5'>
                     <FieldLegend className='mb-0 text-md! leading-supertight font-bold md:text-lg!'>Title section</FieldLegend>
-                    <FieldGroup className='gap-4'>
+                    <FieldGroup className='gap-5'>
                     <Field orientation='horizontal'>
                         <FieldLabel htmlFor='newsletter-show-post-title'>Post title</FieldLabel>
                         <Switch checked={Boolean(newsletter.show_post_title_section)} id='newsletter-show-post-title' onCheckedChange={checked => updateNewsletter({show_post_title_section: checked})} />
@@ -380,7 +380,7 @@ const Sidebar: React.FC<{
                     </FieldGroup>
                 </FieldSet>
 
-                <FieldSet className='mt-8 gap-4'>
+                <FieldSet className='mt-10 gap-5'>
                     <FieldLegend className='mb-0 text-md! leading-supertight font-bold md:text-lg!'>Footer</FieldLegend>
                     <FieldGroup className='gap-6'>
                     <Stack gap='lg'>
@@ -415,7 +415,7 @@ const Sidebar: React.FC<{
                     />
                     </FieldGroup>
                 </FieldSet>
-                <Separator className='mt-8' />
+                <Separator className='mt-10' />
                 <div className='my-5 flex w-full items-start'>
                     <span>
                         <LucideIcon.Heart className='mt-[-1px] mr-2 size-5 text-red'/>
@@ -437,9 +437,9 @@ const Sidebar: React.FC<{
             title: 'Design',
             contents:
             <>
-                <FieldSet className='mt-8 gap-4'>
+                <FieldSet className='mt-10 gap-5'>
                     <FieldLegend className='mb-0 text-md! leading-supertight font-bold md:text-lg!'>Global</FieldLegend>
-                    <FieldGroup className='gap-4'>
+                    <FieldGroup className='gap-5'>
                     <div className='mb-1'>
                         <ColorPickerField
                             direction='rtl'
@@ -494,9 +494,9 @@ const Sidebar: React.FC<{
                     </div>
                     </FieldGroup>
                 </FieldSet>
-                <FieldSet className='mt-8 gap-4'>
+                <FieldSet className='mt-10 gap-5'>
                     <FieldLegend className='mb-0 text-md! leading-supertight font-bold md:text-lg!'>Header</FieldLegend>
-                    <FieldGroup className='gap-4'>
+                    <FieldGroup className='gap-5'>
                     <div className='mb-1'>
                         <ColorPickerField
                             direction='rtl'
@@ -549,9 +549,9 @@ const Sidebar: React.FC<{
                     </FieldGroup>
                 </FieldSet>
 
-                <FieldSet className='mt-8 gap-4'>
+                <FieldSet className='mt-10 gap-5'>
                     <FieldLegend className='mb-0 text-md! leading-supertight font-bold md:text-lg!'>Body</FieldLegend>
-                    <FieldGroup className='gap-4'>
+                    <FieldGroup className='gap-5'>
                     <div className='mb-1'>
                         <ColorPickerField
                             direction='rtl'

--- a/apps/admin-x-settings/src/components/settings/email/newsletters/newsletter-detail-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/email/newsletters/newsletter-detail-modal.tsx
@@ -12,11 +12,11 @@ import {Button, Field, FieldContent, FieldDescription, FieldError, FieldGroup, F
 import {type ErrorMessages, useForm, useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {HostLimitError, useLimiter} from '../../../../hooks/use-limiter';
 import {ImageUpload, ImageUploadAction, ImageUploadActions, ImageUploadDropzone, ImageUploadImage, ImageUploadPreview} from '@tryghost/shade/patterns';
+import {Inline, Stack, Text} from '@tryghost/shade/primitives';
 import {LucideIcon, formatNumber} from '@tryghost/shade/utils';
 import {type Newsletter, useBrowseNewsletters, useEditNewsletter} from '@tryghost/admin-x-framework/api/newsletters';
 import {PreviewModalContent} from '../../preview-modal';
 import {type RoutingModalProps, useRouting} from '@tryghost/admin-x-framework/routing';
-import {Stack, Text} from '@tryghost/shade/primitives';
 import {Trash2} from 'lucide-react';
 import {getImageUrl, useUploadImage} from '@tryghost/admin-x-framework/api/images';
 import {getSettingValue, getSettingValues} from '@tryghost/admin-x-framework/api/settings';
@@ -438,7 +438,7 @@ const Sidebar: React.FC<{
             contents:
             <>
                 <FieldSet className='mt-8 gap-4'>
-                    <FieldLegend className='mb-0 text-md! leading-supertight font-bold md:text-lg!'>Global</FieldLegend>
+                    <FieldLegend className='mb-0 pb-2 text-md! leading-supertight font-bold md:text-lg!'>Global</FieldLegend>
                     <FieldGroup className='gap-5'>
                     <div className='mb-1'>
                         <ColorPickerField
@@ -456,7 +456,7 @@ const Sidebar: React.FC<{
                             onChange={color => updateNewsletter({background_color: color!})}
                         />
                     </div>
-                    <div className='flex w-full items-center justify-between gap-2'>
+                    <Inline className='w-full' gap='sm' justify='between'>
                         <div className='shrink-0'>Heading font</div>
                         <Field className='max-w-[200px]'>
                             <FieldLabel className='sr-only'>Heading font</FieldLabel>
@@ -467,8 +467,8 @@ const Sidebar: React.FC<{
                                 </SelectContent>
                             </Select>
                         </Field>
-                    </div>
-                    <div className='flex w-full items-center justify-between gap-2'>
+                    </Inline>
+                    <Inline className='w-full' gap='sm' justify='between'>
                         <div className='shrink-0'>Heading weight</div>
                         <Field className='max-w-[200px]'>
                             <FieldLabel className='sr-only'>Heading weight</FieldLabel>
@@ -479,8 +479,8 @@ const Sidebar: React.FC<{
                                 </SelectContent>
                             </Select>
                         </Field>
-                    </div>
-                    <div className='flex w-full items-center justify-between gap-2'>
+                    </Inline>
+                    <Inline className='w-full' gap='sm' justify='between'>
                         <div className='shrink-0'>Body font</div>
                         <Field className='max-w-[200px]'>
                             <FieldLabel className='sr-only'>Body font</FieldLabel>
@@ -491,11 +491,11 @@ const Sidebar: React.FC<{
                                 </SelectContent>
                             </Select>
                         </Field>
-                    </div>
+                    </Inline>
                     </FieldGroup>
                 </FieldSet>
                 <FieldSet className='mt-8 gap-4'>
-                    <FieldLegend className='mb-0 text-md! leading-supertight font-bold md:text-lg!'>Header</FieldLegend>
+                    <FieldLegend className='mb-0 pb-2 text-md! leading-supertight font-bold md:text-lg!'>Header</FieldLegend>
                     <FieldGroup className='gap-5'>
                     <div className='mb-1'>
                         <ColorPickerField
@@ -534,7 +534,7 @@ const Sidebar: React.FC<{
                             onChange={color => updateNewsletter({post_title_color: color})}
                         />
                     </div>
-                    <div className='flex w-full justify-between'>
+                    <Inline className='w-full' gap='sm' justify='between'>
                         <div>Title alignment</div>
                         <IconToggleGroup
                             label='Title alignment'
@@ -545,12 +545,12 @@ const Sidebar: React.FC<{
                             value={newsletter.title_alignment}
                             onValueChange={titleAlignment => updateNewsletter({title_alignment: titleAlignment})}
                         />
-                    </div>
+                    </Inline>
                     </FieldGroup>
                 </FieldSet>
 
                 <FieldSet className='mt-8 gap-4'>
-                    <FieldLegend className='mb-0 text-md! leading-supertight font-bold md:text-lg!'>Body</FieldLegend>
+                    <FieldLegend className='mb-0 pb-2 text-md! leading-supertight font-bold md:text-lg!'>Body</FieldLegend>
                     <FieldGroup className='gap-5'>
                     <div className='mb-1'>
                         <ColorPickerField
@@ -594,7 +594,7 @@ const Sidebar: React.FC<{
                             onChange={color => updateNewsletter({button_color: color})}
                         />
                     </div>
-                    <div className='flex w-full justify-between'>
+                    <Inline className='w-full' gap='sm' justify='between'>
                         <div>Button style</div>
                         <IconToggleGroup
                             label='Button style'
@@ -605,8 +605,8 @@ const Sidebar: React.FC<{
                             value={newsletter.button_style || 'fill'}
                             onValueChange={buttonStyle => updateNewsletter({button_style: buttonStyle})}
                         />
-                    </div>
-                    <div className='flex w-full justify-between'>
+                    </Inline>
+                    <Inline className='w-full' gap='sm' justify='between'>
                         <div>Button corners</div>
                         <IconToggleGroup
                             label='Button corners'
@@ -618,7 +618,7 @@ const Sidebar: React.FC<{
                             value={newsletter.button_corners || 'rounded'}
                             onValueChange={buttonCorners => updateNewsletter({button_corners: buttonCorners})}
                         />
-                    </div>
+                    </Inline>
                     <div className='mb-1'>
                         <ColorPickerField
                             direction='rtl'
@@ -640,7 +640,7 @@ const Sidebar: React.FC<{
                             onChange={color => updateNewsletter({link_color: color})}
                         />
                     </div>
-                    <div className='flex w-full justify-between'>
+                    <Inline className='w-full' gap='sm' justify='between'>
                         <div>Link style</div>
                         <IconToggleGroup
                             label='Link style'
@@ -652,8 +652,8 @@ const Sidebar: React.FC<{
                             value={newsletter.link_style || 'underline'}
                             onValueChange={linkStyle => updateNewsletter({link_style: linkStyle})}
                         />
-                    </div>
-                    <div className='flex w-full justify-between'>
+                    </Inline>
+                    <Inline className='w-full' gap='sm' justify='between'>
                         <div>Image corners</div>
                         <IconToggleGroup
                             label='Image corners'
@@ -664,7 +664,7 @@ const Sidebar: React.FC<{
                             value={newsletter.image_corners || 'square'}
                             onValueChange={imageCorners => updateNewsletter({image_corners: imageCorners})}
                         />
-                    </div>
+                    </Inline>
                     <div className='mb-1'>
                         <ColorPickerField
                             direction='rtl'

--- a/apps/admin-x-settings/src/components/settings/general/invite-user-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/invite-user-modal.tsx
@@ -9,7 +9,7 @@ import {toast} from 'sonner';
 import {useAddInvite, useBrowseInvites} from '@tryghost/admin-x-framework/api/invites';
 import {useBrowseRoles} from '@tryghost/admin-x-framework/api/roles';
 import {useBrowseUsers} from '@tryghost/admin-x-framework/api/users';
-import {useEffect, useRef, useState} from 'react';
+import {useEffect, useState} from 'react';
 import {useGlobalData} from '../../providers/global-data-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useRouting} from '@tryghost/admin-x-framework/routing';
@@ -30,7 +30,6 @@ const InviteUserModal = NiceModal.create(() => {
     const {updateRoute} = useRouting();
     const {config} = useGlobalData();
     const editorBeta = config.labs.superEditors;
-    const focusRef = useRef<HTMLInputElement>(null);
     const [email, setEmail] = useState<string>('');
     const [saveState, setSaveState] = useState<'saving' | 'saved' | 'error' | ''>('');
     const [role, setRole] = useState<RoleType>('contributor');
@@ -43,12 +42,6 @@ const InviteUserModal = NiceModal.create(() => {
     const {data: {invites} = {}} = useBrowseInvites();
     const {mutateAsync: addInvite} = useAddInvite();
     const handleError = useHandleError();
-
-    useEffect(() => {
-        if (focusRef.current) {
-            focusRef.current.focus();
-        }
-    }, []);
 
     useEffect(() => {
         if (saveState === 'saved') {
@@ -227,11 +220,11 @@ const InviteUserModal = NiceModal.create(() => {
                 <Field data-invalid={Boolean(errors.email) || undefined}>
                     <FieldLabel htmlFor='invite-email'>Email address</FieldLabel>
                     <Input
-                        ref={focusRef}
                         aria-invalid={Boolean(errors.email) || undefined}
                         id='invite-email'
                         placeholder='jamie@example.com'
                         value={email}
+                        autoFocus
                         onChange={event => setEmail(event.target.value)}
                         onKeyDown={() => setErrors(e => ({...e, email: undefined}))}
                     />

--- a/apps/admin-x-settings/src/components/settings/general/invite-user-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/invite-user-modal.tsx
@@ -1,9 +1,10 @@
 import NiceModal from '@ebay/nice-modal-react';
 import validator from 'validator';
 import {APIError, ValidationError} from '@tryghost/admin-x-framework/errors';
-import {Field, FieldContent, FieldDescription, FieldError, FieldLabel, FieldLegend, FieldSeparator, FieldSet, Input, RadioGroup, RadioGroupItem} from '@tryghost/shade/components';
+import {Field, FieldContent, FieldDescription, FieldError, FieldLabel, FieldLegend, FieldSet, Input, RadioGroup, RadioGroupItem} from '@tryghost/shade/components';
 import {HostLimitError, useLimiter} from '../../../hooks/use-limiter';
 import {SettingsModal} from '@tryghost/shade/patterns';
+import {Stack} from '@tryghost/shade/primitives';
 import {toast} from 'sonner';
 import {useAddInvite, useBrowseInvites} from '@tryghost/admin-x-framework/api/invites';
 import {useBrowseRoles} from '@tryghost/admin-x-framework/api/roles';
@@ -211,7 +212,7 @@ const InviteUserModal = NiceModal.create(() => {
             afterClose={() => {
                 updateRoute('staff');
             }}
-            cancelLabel=''
+            cancelLabel='Close'
             okLabel={okLabel}
             okVariant={saveState === 'error' || !!errors.email ? 'destructive' : 'default'}
             testId='invite-user-modal'
@@ -219,7 +220,7 @@ const InviteUserModal = NiceModal.create(() => {
             width={540}
             onOk={handleSendInvitation}
         >
-            <div className='flex flex-col gap-6 py-4 [&_:where(input)]:h-[var(--control-height)] [&_:where(input)]:border-transparent [&_:where(input)]:bg-muted'>
+            <Stack className='py-4 [&_:where(input)]:h-[var(--control-height)] [&_:where(input)]:border-transparent [&_:where(input)]:bg-muted' gap='xl'>
                 <p>
                     Send an invitation for a new person to create a staff account on your site, and select a role that matches what you’d like them to be able to do.
                 </p>
@@ -260,9 +261,8 @@ const InviteUserModal = NiceModal.create(() => {
                         })}
                     </RadioGroup>
                     <FieldError id='invite-role-error'>{errors.role}</FieldError>
-                    <FieldSeparator />
                 </FieldSet>
-            </div>
+            </Stack>
         </SettingsModal>
     );
 });

--- a/apps/admin-x-settings/src/components/settings/general/invite-user-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/invite-user-modal.tsx
@@ -213,7 +213,7 @@ const InviteUserModal = NiceModal.create(() => {
             width={540}
             onOk={handleSendInvitation}
         >
-            <Stack className='py-4 [&_:where(input)]:h-[var(--control-height)] [&_:where(input)]:border-transparent [&_:where(input)]:bg-muted' gap='xl'>
+            <Stack className='py-4' gap='xl'>
                 <p>
                     Send an invitation for a new person to create a staff account on your site, and select a role that matches what you’d like them to be able to do.
                 </p>
@@ -221,10 +221,12 @@ const InviteUserModal = NiceModal.create(() => {
                     <FieldLabel htmlFor='invite-email'>Email address</FieldLabel>
                     <Input
                         aria-invalid={Boolean(errors.email) || undefined}
+                        autoComplete='off'
+                        className='h-[var(--control-height)] border-transparent bg-muted'
                         id='invite-email'
                         placeholder='jamie@example.com'
                         value={email}
-                        autoFocus
+                        data-1p-ignore
                         onChange={event => setEmail(event.target.value)}
                         onKeyDown={() => setErrors(e => ({...e, email: undefined}))}
                     />

--- a/apps/admin-x-settings/src/components/settings/membership/portal/transistor-settings.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/portal/transistor-settings.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import {Box, Text} from '@tryghost/shade/primitives';
-import {Field, FieldContent, FieldDescription, FieldLabel, Input, Separator, Switch} from '@tryghost/shade/components';
+import {Field, FieldContent, FieldDescription, FieldGroup, FieldLabel, Input, Separator, Switch} from '@tryghost/shade/components';
 import {type Setting, type SettingValue, getSettingValues} from '@tryghost/admin-x-framework/api/settings';
+import {Stack, Text} from '@tryghost/shade/primitives';
 
 const TransistorSettings: React.FC<{
     localSettings: Setting[]
@@ -36,25 +36,27 @@ const TransistorSettings: React.FC<{
     const urlTemplate = transistorPortalUrlTemplate as string;
 
     return (
-        <Box className='[&_:where(input)]:h-[var(--control-height)] [&_:where(input)]:border-transparent [&_:where(input)]:bg-muted'>
+        <Stack className='[&_:where(input)]:h-[var(--control-height)] [&_:where(input)]:border-transparent [&_:where(input)]:bg-muted' gap='xl'>
             <Separator />
-            <Text as='h5' className='md:text-lg' leading='supertight' weight='bold'>Transistor</Text>
-            <Field orientation='horizontal'>
-                <FieldContent>
-                    <FieldLabel htmlFor='transistor-portal-enabled'>Enable Transistor integration</FieldLabel>
-                    <FieldDescription>Show a section on the account page for members to access private podcasts</FieldDescription>
-                </FieldContent>
-                <Switch checked={enabled} id='transistor-portal-enabled' onCheckedChange={checked => updateSetting('transistor_portal_enabled', checked)} />
-            </Field>
+            <Stack gap='md'>
+                <Text as='h5' className='md:text-lg' leading='supertight' weight='bold'>Transistor</Text>
+                <Field orientation='horizontal'>
+                    <FieldContent>
+                        <FieldLabel htmlFor='transistor-portal-enabled'>Enable Transistor integration</FieldLabel>
+                        <FieldDescription>Show a section on the account page for members to access private podcasts</FieldDescription>
+                    </FieldContent>
+                    <Switch checked={enabled} id='transistor-portal-enabled' onCheckedChange={checked => updateSetting('transistor_portal_enabled', checked)} />
+                </Field>
+            </Stack>
             {enabled && (
-                <>
+                <FieldGroup className='gap-6'>
                     <Field><FieldLabel htmlFor='transistor-heading'>Heading</FieldLabel><Input id='transistor-heading' placeholder='Podcasts' value={heading} onChange={e => updateSetting('transistor_portal_heading', e.target.value)} /><FieldDescription>The heading displayed above the Transistor section</FieldDescription></Field>
                     <Field><FieldLabel htmlFor='transistor-description'>Description</FieldLabel><Input id='transistor-description' placeholder='Access your RSS feeds' value={description} onChange={e => updateSetting('transistor_portal_description', e.target.value)} /><FieldDescription>A short description of what members can do</FieldDescription></Field>
                     <Field><FieldLabel htmlFor='transistor-button-text'>Button text</FieldLabel><Input id='transistor-button-text' placeholder='Manage' value={buttonText} onChange={e => updateSetting('transistor_portal_button_text', e.target.value)} /><FieldDescription>The text displayed on the button</FieldDescription></Field>
                     <Field><FieldLabel htmlFor='transistor-url-template'>URL template</FieldLabel><Input id='transistor-url-template' placeholder='https://partner.transistor.fm/ghost/{memberUuid}' value={urlTemplate} onChange={e => updateSetting('transistor_portal_url_template', e.target.value)} /><FieldDescription>Use {'{memberUuid}'} as a placeholder for the member ID</FieldDescription></Field>
-                </>
+                </FieldGroup>
             )}
-        </Box>
+        </Stack>
     );
 };
 

--- a/apps/admin-x-settings/src/components/settings/membership/tiers/tier-detail-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/membership/tiers/tier-detail-modal.tsx
@@ -8,10 +8,10 @@ import useSortableIndexedList from '../../../../hooks/use-sortable-indexed-list'
 import useUrlInput from '../../../../hooks/use-url-input';
 import {Button, Combobox, ComboboxContent, ComboboxTrigger, ComboboxValue, Field, FieldDescription, FieldError, FieldGroup, FieldLabel, FieldLegend, FieldSet, Input, InputGroup, InputGroupAddon, InputGroupInput, InputGroupText, MultiSelectCombobox, SortableList, Switch} from '@tryghost/shade/components';
 import {type ErrorMessages, useForm, useHandleError} from '@tryghost/admin-x-framework/hooks';
+import {Inline, Text} from '@tryghost/shade/primitives';
 import {LucideIcon} from '@tryghost/shade/utils';
 import {type RoutingModalProps, useRouting} from '@tryghost/admin-x-framework/routing';
 import {SettingsModal} from '@tryghost/shade/patterns';
-import {Text} from '@tryghost/shade/primitives';
 import {type Tier, useAddTier, useBrowseTiers, useEditTier} from '@tryghost/admin-x-framework/api/tiers';
 import {currencies, currencySelectGroups, validateCurrencyAmount} from '../../../../utils/currency';
 import {getSettingValues, useEditSettings} from '@tryghost/admin-x-framework/api/settings';
@@ -333,48 +333,46 @@ const TierDetailModalContent: React.FC<{tier?: Tier}> = ({tier}) => {
                 <FieldSet className='gap-0'>
                     <FieldLegend className='mb-3 text-md! leading-supertight font-bold md:text-lg!'>Benefits</FieldLegend>
                     <FieldGroup className='mb-10 gap-0 rounded-sm border border-border-default p-4 md:p-7 [&_:where(input)]:h-[var(--control-height)] [&_:where(input)]:border-transparent [&_:where(input)]:bg-muted'>
-                        <div className='-mt-3'>
                         <SortableList
                             getDragHandleLabel={({item}) => `Reorder benefit${item ? `: ${item}` : ''}`}
                             items={benefits.items}
                             itemSeparator={false}
-                            renderItem={({id, item}) => <div className='relative flex w-full items-center gap-5'>
-                                <div className='absolute top-1/2 left-[-32px] flex size-6 -translate-y-1/2 items-center justify-center bg-background group-hover:hidden'><LucideIcon.Check className='size-4' /></div>
+                            renderItem={({id, item}) => <Inline align='center' className='relative w-full' gap='lg'>
+                                <Inline align='center' className='absolute top-1/2 left-[-32px] size-6 -translate-y-1/2 bg-background group-hover:hidden' justify='center'><LucideIcon.Check className='size-4' /></Inline>
                                 <Input aria-label='Benefit' className='grow' maxLength={191} value={item} onChange={e => benefits.updateItem(id, e.target.value)} />
                                 <Button aria-label='Delete benefit' className='absolute top-1/2 right-1 z-10 size-5! -translate-y-1/2 p-0! opacity-0 group-hover:opacity-100' size='icon' type='button' variant='secondary' onClick={() => benefits.removeItem(id)}>
                                     <LucideIcon.Trash2 />
                                 </Button>
-                            </div>}
+                            </Inline>}
                             onMove={benefits.moveItem}
                         />
-                    </div>
-                    <div className="relative mt-1 flex items-center gap-3">
-                        <LucideIcon.Check className='size-4' />
-                        <Field className='w-100'>
-                            <FieldLabel className='sr-only' htmlFor='new-tier-benefit'>New benefit</FieldLabel>
-                            <Input
-                            className='grow'
-                            id='new-tier-benefit'
-                            maxLength={191}
-                            placeholder='Expert analysis'
-                            value={benefits.newItem}
-                            onChange={e => benefits.setNewItem(e.target.value)}
-                            onKeyDown={(e) => {
-                                if (e.key === 'Enter') {
-                                    benefits.addItem();
-                                }
-                            }} />
-                        </Field>
-                        <Button
-                            aria-label='Add benefit'
-                            className='absolute top-1/2 right-1 z-10 size-[22px]! -translate-y-1/2 p-0!'
-                            size='icon'
-                            type='button'
-                            onClick={() => benefits.addItem()}
-                        >
-                            <LucideIcon.Plus />
-                        </Button>
-                        </div>
+                        <Inline align='center' className='relative mt-1' gap='md'>
+                            <LucideIcon.Check className='size-4' />
+                            <Field className='w-100'>
+                                <FieldLabel className='sr-only' htmlFor='new-tier-benefit'>New benefit</FieldLabel>
+                                <Input
+                                    className='grow'
+                                    id='new-tier-benefit'
+                                    maxLength={191}
+                                    placeholder='Expert analysis'
+                                    value={benefits.newItem}
+                                    onChange={e => benefits.setNewItem(e.target.value)}
+                                    onKeyDown={(e) => {
+                                        if (e.key === 'Enter') {
+                                            benefits.addItem();
+                                        }
+                                    }} />
+                            </Field>
+                            <Button
+                                aria-label='Add benefit'
+                                className='absolute top-1/2 right-1 z-10 size-[22px]! -translate-y-1/2 p-0!'
+                                size='icon'
+                                type='button'
+                                onClick={() => benefits.addItem()}
+                            >
+                                <LucideIcon.Plus />
+                            </Button>
+                        </Inline>
                     </FieldGroup>
                 </FieldSet>
             </div>

--- a/apps/shade/src/components/ui/input-group.stories.tsx
+++ b/apps/shade/src/components/ui/input-group.stories.tsx
@@ -123,6 +123,26 @@ export const Text: Story = {
     }
 };
 
+export const FocusSurface: Story = {
+    render: () => (
+        <div className="w-full max-w-sm">
+            <InputGroup>
+                <InputGroupInput aria-label="Monthly price" defaultValue="50" />
+                <InputGroupAddon align="inline-end">
+                    <InputGroupText>USD/month</InputGroupText>
+                </InputGroupAddon>
+            </InputGroup>
+        </div>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Focusing the control applies one focus ring around the complete grouped field.'
+            }
+        }
+    }
+};
+
 export const Button: Story = {
     render: () => (
         <div className="grid w-full max-w-sm gap-6">

--- a/apps/shade/src/components/ui/input-group.tsx
+++ b/apps/shade/src/components/ui/input-group.tsx
@@ -14,7 +14,7 @@ function InputGroup({className, ...props}: React.ComponentProps<'div'>) {
                 inputSurfaceClasses.invalidWithin,
 
                 // Wrapper layout + group context (input-group specific).
-                'group/input-group relative flex w-full items-center outline-hidden',
+                'group/input-group relative flex w-full items-center outline-hidden [&>[data-slot=input-group-control]]:bg-transparent',
                 'h-9 has-[>textarea]:h-auto',
 
                 // Variants based on alignment.

--- a/apps/shade/src/components/ui/input-group.tsx
+++ b/apps/shade/src/components/ui/input-group.tsx
@@ -3,9 +3,7 @@ import {cva, type VariantProps} from 'class-variance-authority';
 
 import {cn} from '@/lib/utils';
 import {Button} from '@/components/ui/button';
-import {Input} from '@/components/ui/input';
 import {inputSurfaceClasses} from '@/components/ui/input-surface';
-import {Textarea} from '@/components/ui/textarea';
 
 function InputGroup({className, ...props}: React.ComponentProps<'div'>) {
     return (
@@ -126,10 +124,10 @@ function InputGroupText({className, ...props}: React.ComponentProps<'span'>) {
 }
 
 const InputGroupInput = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(({className, ...props}, ref) => (
-    <Input
+    <input
         ref={ref}
         className={cn(
-            'flex-1 rounded-none border-0 bg-transparent shadow-none focus-visible:border-0! focus-visible:shadow-none! focus-visible:ring-0! focus-visible:outline-hidden!',
+            'flex h-9 w-full flex-1 border-0 bg-transparent px-3 py-1 text-control outline-hidden file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50',
             className
         )}
         data-slot="input-group-control"
@@ -139,10 +137,10 @@ const InputGroupInput = React.forwardRef<HTMLInputElement, React.ComponentProps<
 InputGroupInput.displayName = 'InputGroupInput';
 
 const InputGroupTextarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<'textarea'>>(({className, ...props}, ref) => (
-    <Textarea
+    <textarea
         ref={ref}
         className={cn(
-            'flex-1 resize-none rounded-none border-0 bg-transparent py-3 shadow-none focus-visible:border-0! focus-visible:shadow-none! focus-visible:ring-0! focus-visible:outline-hidden!',
+            'min-h-[80px] w-full flex-1 resize-none border-0 bg-transparent p-3 text-base outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50',
             className
         )}
         data-slot="input-group-control"

--- a/apps/shade/src/components/ui/input-group.tsx
+++ b/apps/shade/src/components/ui/input-group.tsx
@@ -129,7 +129,7 @@ const InputGroupInput = React.forwardRef<HTMLInputElement, React.ComponentProps<
     <Input
         ref={ref}
         className={cn(
-            'flex-1 rounded-none border-0 bg-transparent shadow-none focus-visible:shadow-none focus-visible:ring-0 focus-visible:outline-hidden',
+            'flex-1 rounded-none border-0 bg-transparent shadow-none focus-visible:border-0! focus-visible:shadow-none! focus-visible:ring-0! focus-visible:outline-hidden!',
             className
         )}
         data-slot="input-group-control"
@@ -142,7 +142,7 @@ const InputGroupTextarea = React.forwardRef<HTMLTextAreaElement, React.Component
     <Textarea
         ref={ref}
         className={cn(
-            'flex-1 resize-none rounded-none border-0 bg-transparent py-3 shadow-none focus-visible:shadow-none focus-visible:ring-0 focus-visible:outline-hidden',
+            'flex-1 resize-none rounded-none border-0 bg-transparent py-3 shadow-none focus-visible:border-0! focus-visible:shadow-none! focus-visible:ring-0! focus-visible:outline-hidden!',
             className
         )}
         data-slot="input-group-control"

--- a/apps/shade/src/components/ui/tabs.stories.tsx
+++ b/apps/shade/src/components/ui/tabs.stories.tsx
@@ -52,6 +52,39 @@ export const Default: Story = {
     }
 };
 
+export const StableSelectionWidth: Story = {
+    args: {
+        defaultValue: 'signup',
+        variant: 'button',
+        children: [
+            <TabsList key="list">
+                <TabsTrigger value="signup">Signup options</TabsTrigger>
+                <TabsTrigger value="appearance">Look &amp; feel</TabsTrigger>
+                <TabsTrigger value="account">Account page</TabsTrigger>
+            </TabsList>,
+
+            <TabsContent key="signup" value="signup">
+                Signup options
+            </TabsContent>,
+
+            <TabsContent key="appearance" value="appearance">
+                Appearance options
+            </TabsContent>,
+
+            <TabsContent key="account" value="account">
+                Account page options
+            </TabsContent>
+        ]
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: 'Button tabs keep the same font weight and width when the active tab changes.'
+            }
+        }
+    }
+};
+
 export const Segmented: Story = {
     args: {
         defaultValue: 'overview',

--- a/apps/shade/src/components/ui/tabs.tsx
+++ b/apps/shade/src/components/ui/tabs.tsx
@@ -89,11 +89,11 @@ const tabsTriggerVariants = cva(
             variant: {
                 segmented: 'h-7 rounded-md text-control font-medium data-[state=active]:shadow-md',
                 'segmented-sm': 'h-[26px] rounded-md text-sm font-medium data-[state=active]:shadow-md',
-                button: 'h-(--control-height) gap-1.5 rounded-md py-2 text-control font-normal hover:bg-muted data-[state=active]:bg-muted-foreground/10 data-[state=active]:font-medium dark:hover:bg-tab-hover dark:data-[state=active]:bg-tab-active dark:data-[state=active]:hover:bg-tab-active',
-                'button-sm': 'h-6 gap-1.5 rounded-md p-2 text-sm font-normal text-text-secondary hover:bg-muted data-[state=active]:bg-muted-foreground/10 data-[state=active]:font-medium data-[state=active]:text-foreground dark:hover:bg-tab-hover dark:data-[state=active]:bg-tab-active dark:data-[state=active]:hover:bg-tab-active',
+                button: 'h-(--control-height) gap-1.5 rounded-md py-2 text-control font-medium hover:bg-tab-hover data-[state=active]:bg-tab-active data-[state=active]:hover:bg-tab-active',
+                'button-sm': 'h-6 gap-1.5 rounded-md p-2 text-sm font-medium text-text-secondary hover:bg-tab-hover data-[state=active]:bg-tab-active data-[state=active]:text-foreground data-[state=active]:hover:bg-tab-active',
                 underline: 'relative h-9 px-0 text-control font-semibold text-text-secondary after:absolute after:inset-x-0 after:-bottom-px after:h-0.5 after:bg-foreground after:opacity-0 after:content-[""] hover:after:opacity-10 data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:after:opacity-100!',
                 navbar: 'relative h-[52px] px-px text-control font-semibold text-muted-foreground after:absolute after:inset-x-0 after:-bottom-px after:h-0.5 after:bg-foreground after:opacity-0 after:content-[""] hover:text-foreground data-[state=active]:bg-transparent data-[state=active]:text-foreground data-[state=active]:after:opacity-100!',
-                pill: 'relative h-[30px] rounded-md px-3 text-control font-medium text-text-secondary hover:text-foreground data-[state=active]:bg-muted-foreground/10 data-[state=active]:font-semibold data-[state=active]:text-foreground dark:hover:bg-tab-hover dark:data-[state=active]:bg-tab-active dark:data-[state=active]:hover:bg-tab-active',
+                pill: 'relative h-[30px] rounded-md px-3 text-control font-medium text-text-secondary hover:bg-tab-hover hover:text-foreground data-[state=active]:bg-tab-active data-[state=active]:text-foreground data-[state=active]:hover:bg-tab-active',
                 kpis: 'relative h-full! items-start! rounded-none border-border bg-transparent px-6 py-5 text-foreground ring-0 transition-all after:absolute after:inset-x-0 after:-bottom-px after:h-0.5 after:bg-foreground after:opacity-0 after:content-[""] first:rounded-tl-md last:rounded-tr-md hover:bg-interactive-hover data-[state=active]:bg-transparent data-[state=active]:after:opacity-100 [&:not(:last-child)]:border-r [&[data-state=active]_[data-type="value"]]:text-foreground'
             }
         },
@@ -184,7 +184,7 @@ const TabsDropdownTrigger = React.forwardRef<HTMLButtonElement, TabsDropdownTrig
 }, ref) => {
     const variant = React.useContext(TabsVariantContext);
     return (
-        <div className="relative rounded-md hover:bg-muted">
+        <div className="relative rounded-md hover:bg-tab-hover">
             <TabsPrimitive.Trigger
                 ref={ref}
                 className={cn(tabsTriggerVariants({variant, className}))}


### PR DESCRIPTION
## What changed

- restored the Close action and removed the trailing separator in the staff invite modal
- made Shade button and pill tabs use a stable font weight so selection does not shift layouts
- applied grouped-input focus styling to the full tier price/free-trial control
- normalised newsletter General, Content, and Design section spacing
- restored consistent spacing around Portal's Transistor account-page settings

## Why

This follows up the settings design-system migration with the visual and interaction cleanup tracked in [DES-1428](https://linear.app/ghost/issue/DES-1428/settings-design-system-migration-cleanup).

## Testing

- `pnpm --filter @tryghost/admin-x-settings lint`
- `pnpm --filter @tryghost/admin-x-settings test:unit`
- `pnpm --filter @tryghost/shade lint`
- `pnpm --filter @tryghost/shade test:unit`
- `pnpm --filter @tryghost/shade build`