### PR TITLE
Fixed Koenig ESLint TypeScript config roots

### DIFF
--- a/.changeset/soft-lamps-sniff.md
+++ b/.changeset/soft-lamps-sniff.md
@@ -1,0 +1,16 @@
+---
+"@tryghost/kg-card-factory": none
+"@tryghost/kg-clean-basic-html": none
+"@tryghost/kg-converters": none
+"@tryghost/kg-default-cards": none
+"@tryghost/kg-default-nodes": none
+"@tryghost/kg-default-transforms": none
+"@tryghost/kg-html-to-lexical": none
+"@tryghost/kg-lexical-html-renderer": none
+"@tryghost/kg-markdown-html-renderer": none
+"@tryghost/kg-unsplash-selector": none
+"@tryghost/kg-utils": none
+"@tryghost/koenig-lexical": none
+---
+
+Fixed editor linting across Koenig workspaces by configuring explicit TypeScript ESLint roots

--- a/koenig/kg-card-factory/eslint.config.mjs
+++ b/koenig/kg-card-factory/eslint.config.mjs
@@ -12,7 +12,7 @@ export default defineConfig([
             tseslint.configs.recommended
         ],
         languageOptions: {
-            parserOptions: {ecmaVersion: 2022, sourceType: 'module'}
+            parserOptions: {ecmaVersion: 2022, sourceType: 'module', tsconfigRootDir: import.meta.dirname}
         },
         plugins: {ghost: ghostPlugin},
         rules: {

--- a/koenig/kg-clean-basic-html/eslint.config.mjs
+++ b/koenig/kg-clean-basic-html/eslint.config.mjs
@@ -12,7 +12,7 @@ export default defineConfig([
       tseslint.configs.recommended,
     ],
     languageOptions: {
-      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module', tsconfigRootDir: import.meta.dirname },
     },
     plugins: { ghost: ghostPlugin },
     rules: {

--- a/koenig/kg-converters/eslint.config.mjs
+++ b/koenig/kg-converters/eslint.config.mjs
@@ -12,7 +12,7 @@ export default defineConfig([
       tseslint.configs.recommended,
     ],
     languageOptions: {
-      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module', tsconfigRootDir: import.meta.dirname },
     },
     plugins: { ghost: ghostPlugin },
     rules: {

--- a/koenig/kg-default-cards/eslint.config.mjs
+++ b/koenig/kg-default-cards/eslint.config.mjs
@@ -12,7 +12,7 @@ export default defineConfig([
             tseslint.configs.recommended
         ],
         languageOptions: {
-            parserOptions: {ecmaVersion: 2022, sourceType: 'module'}
+            parserOptions: {ecmaVersion: 2022, sourceType: 'module', tsconfigRootDir: import.meta.dirname}
         },
         plugins: {ghost: ghostPlugin},
         rules: {

--- a/koenig/kg-default-nodes/eslint.config.mjs
+++ b/koenig/kg-default-nodes/eslint.config.mjs
@@ -12,7 +12,7 @@ export default defineConfig([
       tseslint.configs.recommended,
     ],
     languageOptions: {
-      parserOptions: { ecmaVersion: 2022, sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2022, sourceType: 'module', tsconfigRootDir: import.meta.dirname },
     },
     plugins: { ghost: ghostPlugin },
     rules: {

--- a/koenig/kg-default-transforms/eslint.config.mjs
+++ b/koenig/kg-default-transforms/eslint.config.mjs
@@ -12,7 +12,7 @@ export default defineConfig([
             tseslint.configs.recommended
         ],
         languageOptions: {
-            parserOptions: {ecmaVersion: 2022, sourceType: 'module'}
+            parserOptions: {ecmaVersion: 2022, sourceType: 'module', tsconfigRootDir: import.meta.dirname}
         },
         plugins: {ghost: ghostPlugin},
         rules: {

--- a/koenig/kg-html-to-lexical/eslint.config.mjs
+++ b/koenig/kg-html-to-lexical/eslint.config.mjs
@@ -12,7 +12,7 @@ export default defineConfig([
             tseslint.configs.recommended
         ],
         languageOptions: {
-            parserOptions: {ecmaVersion: 2022, sourceType: 'module'}
+            parserOptions: {ecmaVersion: 2022, sourceType: 'module', tsconfigRootDir: import.meta.dirname}
         },
         plugins: {ghost: ghostPlugin},
         rules: {

--- a/koenig/kg-lexical-html-renderer/eslint.config.mjs
+++ b/koenig/kg-lexical-html-renderer/eslint.config.mjs
@@ -12,7 +12,7 @@ export default defineConfig([
             tseslint.configs.recommended
         ],
         languageOptions: {
-            parserOptions: {ecmaVersion: 2022, sourceType: 'module'}
+            parserOptions: {ecmaVersion: 2022, sourceType: 'module', tsconfigRootDir: import.meta.dirname}
         },
         plugins: {ghost: ghostPlugin},
         rules: {

--- a/koenig/kg-markdown-html-renderer/eslint.config.mjs
+++ b/koenig/kg-markdown-html-renderer/eslint.config.mjs
@@ -12,7 +12,7 @@ export default defineConfig([
             tseslint.configs.recommended
         ],
         languageOptions: {
-            parserOptions: {ecmaVersion: 2022, sourceType: 'module'}
+            parserOptions: {ecmaVersion: 2022, sourceType: 'module', tsconfigRootDir: import.meta.dirname}
         },
         plugins: {ghost: ghostPlugin},
         rules: {

--- a/koenig/kg-unsplash-selector/eslint.config.js
+++ b/koenig/kg-unsplash-selector/eslint.config.js
@@ -22,7 +22,8 @@ export default defineConfig([
             parserOptions: {
                 ecmaVersion: 'latest',
                 sourceType: 'module',
-                ecmaFeatures: {jsx: true}
+                ecmaFeatures: {jsx: true},
+                tsconfigRootDir: import.meta.dirname
             }
         },
         plugins: {

--- a/koenig/kg-utils/eslint.config.mjs
+++ b/koenig/kg-utils/eslint.config.mjs
@@ -12,7 +12,7 @@ export default defineConfig([
             tseslint.configs.recommended
         ],
         languageOptions: {
-            parserOptions: {ecmaVersion: 2022, sourceType: 'module'}
+            parserOptions: {ecmaVersion: 2022, sourceType: 'module', tsconfigRootDir: import.meta.dirname}
         },
         plugins: {ghost: ghostPlugin},
         rules: {

--- a/koenig/koenig-lexical/eslint.config.mjs
+++ b/koenig/koenig-lexical/eslint.config.mjs
@@ -37,7 +37,8 @@ export default [
                 ...globals.node
             },
             parserOptions: {
-                ecmaFeatures: {jsx: true}
+                ecmaFeatures: {jsx: true},
+                tsconfigRootDir: import.meta.dirname
             }
         },
         rules: {


### PR DESCRIPTION
## What changed

- Set `tsconfigRootDir` explicitly in every Koenig TypeScript ESLint config.
- Added a no-release changeset because this is an internal tooling change.

## Why

Zed was showing an error at the beginning of any Koenig files:

```
Parsing error: No tsconfigRootDir was set, and multiple candidate TSConfigRootDirs are present:
 - /Users/kevin/code/Ghost/apps/shade
 - /Users/kevin/code/Ghost/ghost/core
 - /Users/kevin/code/Ghost/koenig/kg-clean-basic-html
You'll need to explicitly set tsconfigRootDir in your parser options.
See: https://tseslint.com/parser-tsconfigrootdir (eslint)
```