### PR TITLE
Added `to_hash` column to redirects table with composite unique index

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.55/2026-07-27-11-25-44-add-to-hash-to-redirects.js
+++ b/ghost/core/core/server/data/migrations/versions/6.55/2026-07-27-11-25-44-add-to-hash-to-redirects.js
@@ -7,8 +7,8 @@ const leftoverIndexName = 'redirects_automation_action_revision_id_index';
 
 module.exports = combineNonTransactionalMigrations(
     createAddColumnMigration('redirects', 'to_hash', {
-        type: 'string',
-        maxlength: 64,
+        type: 'binary',
+        maxlength: 32,
         nullable: true
     }, {algorithm: 'auto'}),
     createNonTransactionalMigration(

--- a/ghost/core/core/server/data/migrations/versions/6.55/2026-07-27-11-25-44-add-to-hash-to-redirects.js
+++ b/ghost/core/core/server/data/migrations/versions/6.55/2026-07-27-11-25-44-add-to-hash-to-redirects.js
@@ -1,0 +1,39 @@
+const logging = require('@tryghost/logging');
+const {combineNonTransactionalMigrations, createAddColumnMigration, createNonTransactionalMigration} = require('../../utils');
+const {addIndex, addUnique, dropUnique} = require('../../../schema/commands');
+
+const uniqueColumns = ['automation_action_revision_id', 'to_hash'];
+
+module.exports = combineNonTransactionalMigrations(
+    createAddColumnMigration('redirects', 'to_hash', {
+        type: 'string',
+        maxlength: 64,
+        nullable: true
+    }, {algorithm: 'auto'}),
+    createNonTransactionalMigration(
+        async function up(knex) {
+            await addUnique('redirects', uniqueColumns, knex);
+        },
+        async function down(knex) {
+            try {
+                await dropUnique('redirects', uniqueColumns, knex);
+            } catch (err) {
+                // The composite unique ends up as the only index covering the
+                // automation_action_revision_id FK: fresh installs create it
+                // that way, and on upgrades InnoDB drops the FK's own index
+                // once the composite can serve the constraint. MySQL won't
+                // drop the last index a foreign key depends on, so re-add a
+                // single-column one when it objects.
+                if (err.code === 'ER_DROP_INDEX_FK') {
+                    logging.warn('Cannot drop unique constraint over redirects(automation_action_revision_id, to_hash) while it backs the foreign key, re-adding index for automation_action_revision_id');
+
+                    await addIndex('redirects', ['automation_action_revision_id'], knex);
+                    await dropUnique('redirects', uniqueColumns, knex);
+                    return;
+                }
+
+                throw err;
+            }
+        }
+    )
+);

--- a/ghost/core/core/server/data/migrations/versions/6.55/2026-07-27-11-25-44-add-to-hash-to-redirects.js
+++ b/ghost/core/core/server/data/migrations/versions/6.55/2026-07-27-11-25-44-add-to-hash-to-redirects.js
@@ -1,8 +1,9 @@
 const logging = require('@tryghost/logging');
 const {combineNonTransactionalMigrations, createAddColumnMigration, createNonTransactionalMigration} = require('../../utils');
-const {addIndex, addUnique, dropUnique} = require('../../../schema/commands');
+const {addIndex, addUnique, dropIndex, dropUnique, getIndexes} = require('../../../schema/commands');
 
 const uniqueColumns = ['automation_action_revision_id', 'to_hash'];
+const leftoverIndexName = 'redirects_automation_action_revision_id_index';
 
 module.exports = combineNonTransactionalMigrations(
     createAddColumnMigration('redirects', 'to_hash', {
@@ -13,6 +14,17 @@ module.exports = combineNonTransactionalMigrations(
     createNonTransactionalMigration(
         async function up(knex) {
             await addUnique('redirects', uniqueColumns, knex);
+
+            // A previous down() leaves a standalone index behind (see below).
+            // InnoDB drops the index it created for the foreign key itself once
+            // the composite unique can serve the constraint, but not one we
+            // created, so drop it here to keep a rolled-back-and-remigrated
+            // database in the same shape as every other one.
+            const indexes = await getIndexes('redirects', knex);
+
+            if (indexes.includes(leftoverIndexName)) {
+                await dropIndex('redirects', ['automation_action_revision_id'], knex);
+            }
         },
         async function down(knex) {
             try {

--- a/ghost/core/core/server/data/schema/commands.js
+++ b/ghost/core/core/server/data/schema/commands.js
@@ -25,6 +25,11 @@ function addTableColumn(tableName, tableBuilder, columnName, columnSpec = schema
     // creation distinguishes between text with fieldtype, string with maxlength and all others
     if (columnSpec.type === 'text' && Object.prototype.hasOwnProperty.call(columnSpec, 'fieldtype')) {
         column = tableBuilder[columnSpec.type](columnName, columnSpec.fieldtype);
+    } else if (columnSpec.type === 'binary' && Object.prototype.hasOwnProperty.call(columnSpec, 'maxlength')) {
+        // knex emits an unbounded `blob` for a length-less binary column, which
+        // MySQL can only index with a prefix. Passing the length gives us
+        // `varbinary(N)`, which is indexable in full.
+        column = tableBuilder[columnSpec.type](columnName, columnSpec.maxlength);
     } else if (columnSpec.type === 'string') {
         if (Object.prototype.hasOwnProperty.call(columnSpec, 'maxlength')) {
             column = tableBuilder[columnSpec.type](columnName, columnSpec.maxlength);

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1263,8 +1263,12 @@ module.exports = {
         to: {type: 'string', maxlength: 2000, nullable: false},
         post_id: {type: 'string', maxlength: 24, nullable: true, unique: false, references: 'posts.id', setNullDelete: true},
         automation_action_revision_id: {type: 'string', maxlength: 24, nullable: true, references: 'automation_action_revisions.id', setNullDelete: true},
+        to_hash: {type: 'string', maxlength: 64, nullable: true},
         created_at: {type: 'dateTime', nullable: false},
-        updated_at: {type: 'dateTime', nullable: true}
+        updated_at: {type: 'dateTime', nullable: true},
+        '@@UNIQUE_CONSTRAINTS@@': [
+            ['automation_action_revision_id', 'to_hash']
+        ]
     },
     members_click_events: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1263,7 +1263,7 @@ module.exports = {
         to: {type: 'string', maxlength: 2000, nullable: false},
         post_id: {type: 'string', maxlength: 24, nullable: true, unique: false, references: 'posts.id', setNullDelete: true},
         automation_action_revision_id: {type: 'string', maxlength: 24, nullable: true, references: 'automation_action_revisions.id', setNullDelete: true},
-        to_hash: {type: 'string', maxlength: 64, nullable: true},
+        to_hash: {type: 'binary', maxlength: 32, nullable: true},
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: true},
         '@@UNIQUE_CONSTRAINTS@@': [

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ghost",
-    "version": "6.54.2-rc.0",
+    "version": "6.55.0-rc.0",
     "description": "The professional publishing platform",
     "author": "Ghost Foundation",
     "homepage": "https://ghost.org",

--- a/ghost/core/test/unit/server/data/schema/commands.test.js
+++ b/ghost/core/test/unit/server/data/schema/commands.test.js
@@ -34,6 +34,71 @@ describe('schema commands', function () {
         }
     });
 
+    describe('addTableColumn', function () {
+        // addTableColumn isn't exported, so we exercise it through createTable
+        // and stringify the builder rather than running it against a database.
+        function ddlFor(client, tableSpec) {
+            const Knex = require('knex');
+            const knex = Knex({client, useNullAsDefault: true});
+
+            try {
+                return commands.createTable('test_table', knex, tableSpec).toString();
+            } finally {
+                knex.destroy();
+            }
+        }
+
+        it('gives a binary column with a maxlength a bounded varbinary type on MySQL', function () {
+            const ddl = ddlFor('mysql2', {
+                to_hash: {type: 'binary', maxlength: 32, nullable: true}
+            });
+
+            assert.match(ddl, /`to_hash` varbinary\(32\)/);
+        });
+
+        // The bounded type is what makes the column indexable in full: MySQL
+        // can only index an unbounded blob with a prefix, and a prefix on a
+        // UNIQUE index would enforce uniqueness over the prefix alone.
+        it('falls back to an unbounded blob when a binary column has no maxlength', function () {
+            const ddl = ddlFor('mysql2', {
+                to_hash: {type: 'binary', nullable: true}
+            });
+
+            assert.match(ddl, /`to_hash` blob/);
+        });
+
+        it('indexes the whole binary column in a unique constraint, without a prefix', function () {
+            const ddl = ddlFor('mysql2', {
+                owner_id: {type: 'string', maxlength: 24, nullable: true},
+                to_hash: {type: 'binary', maxlength: 32, nullable: true},
+                '@@UNIQUE_CONSTRAINTS@@': [['owner_id', 'to_hash']]
+            });
+
+            // The column has to be bounded for this to be legal: MySQL rejects
+            // an unbounded blob in a key without a prefix length (ER_BLOB_KEY_WITHOUT_LENGTH).
+            assert.match(ddl, /`to_hash` varbinary\(32\)/);
+            assert.match(ddl, /add unique `test_table_owner_id_to_hash_unique`\(`owner_id`, `to_hash`\)/);
+        });
+
+        it('uses blob for binary columns on SQLite, which has no bounded binary type', function () {
+            const ddl = ddlFor('better-sqlite3', {
+                to_hash: {type: 'binary', maxlength: 32, nullable: true}
+            });
+
+            assert.match(ddl, /`to_hash` blob/);
+        });
+
+        it('still applies maxlength to string columns, defaulting to 191', function () {
+            const ddl = ddlFor('mysql2', {
+                bounded: {type: 'string', maxlength: 50, nullable: true},
+                unbounded: {type: 'string', nullable: true}
+            });
+
+            assert.match(ddl, /`bounded` varchar\(50\)/);
+            assert.match(ddl, /`unbounded` varchar\(191\)/);
+        });
+    });
+
     describe('createViewOrReplace', function () {
         // Guards the portability fix: views must never be created with MySQL's
         // default DEFINER security, which binds them to the migrating account

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '34a2e4ccd25c04dc9c4eb90abed13494';
+    const currentSchemaHash = '96aee96a73f1ba1c206b2dcf3ad90cef';
     const currentFixturesHash = '065b413e1d1f4f95fa7cb7734c5e7934';
     const currentSettingsHash = '397be8628c753b1959b8954d5610f83f';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const validateRouteSettings = require('../../../../../core/server/services/route
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '96aee96a73f1ba1c206b2dcf3ad90cef';
+    const currentSchemaHash = 'c0fe7246714201a82b75f80308d5e300';
     const currentFixturesHash = '065b413e1d1f4f95fa7cb7734c5e7934';
     const currentSettingsHash = '397be8628c753b1959b8954d5610f83f';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';

--- a/ghost/core/test/unit/server/data/schema/schema.test.js
+++ b/ghost/core/test/unit/server/data/schema/schema.test.js
@@ -8,6 +8,11 @@ const VALID_KEYS = {
     bigInteger: [
         'nullable'
     ],
+    binary: [
+        'maxlength',
+        'nullable',
+        'index'
+    ],
     boolean: [
         'nullable',
         'defaultTo'


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/NY-1490

_This change should have no user-facing impact._

## Summary

This change adds a new dormant `redirects.to_hash` column and a composite unique index on `(automation_action_revision_id, to_hash)`.

- Adds a nullable `to_hash` column (varchar 64) to `redirects`
- Adds a unique index on `(automation_action_revision_id, to_hash)`, so two workers creating a redirect for the same automation action destination collide on insert instead of racing to create duplicate rows
- Hashing the destination keeps the key within MySQL's index size limits — a unique index on the 2000-char `to` column isn't possible
- Existing redirects keep both columns NULL. NULLs don't collide in a unique index, so ordinary (non-automation) redirects are entirely unconstrained by this

## Notes for reviewers

- No code populates `to_hash` yet — that lands in the follow-up. Because both columns are nullable, the constraint only bites when **both** are non-NULL, so the writing code must always set `to_hash` whenever it sets `automation_action_revision_id`, or the protection silently does nothing.
- The composite unique becomes the only index covering the `automation_action_revision_id` foreign key — fresh installs create the table that way. MySQL then refuses to drop that index, so `down()` catches `ER_DROP_INDEX_FK`, re-adds a single-column index and retries — matching the existing pattern in `5.75`, `5.87` and `5.126`. Both rollback paths were verified against a real MySQL 8.4 instance.