### PR TITLE
Fixed E2E route teardown races

### DIFF
--- a/e2e/helpers/playwright/fixture.ts
+++ b/e2e/helpers/playwright/fixture.ts
@@ -718,6 +718,7 @@ export const test = base.extend<GhostInstanceFixture & InternalFixtures, WorkerF
     }
 
     await use(page);
+    await page.unrouteAll({ behavior: 'wait' });
 
     if (EGRESS_MONITOR_ENABLED) {
       page.off('request', onRequest);

--- a/e2e/helpers/playwright/fixture.ts
+++ b/e2e/helpers/playwright/fixture.ts
@@ -596,6 +596,7 @@ export const test = base.extend<GhostInstanceFixture & InternalFixtures, WorkerF
         }
 
         await use(page);
+        await page.unrouteAll({behavior: 'wait'});
 
         if (EGRESS_MONITOR_ENABLED) {
             page.off('request', onRequest);


### PR DESCRIPTION
## What changed

- Wait for active Playwright page route handlers to finish before fixture teardown closes the browser context.

## Why

A `page.route()` handler can still be reading a fetched response after the test body returns. Closing the context at that point disposes the response and surfaces an unhandled `apiResponse.json: Response has been disposed` error, as seen in [this flaky CI run](https://github.com/TryGhost/Ghost/actions/runs/30280645853/attempts/1?pr=29621).

Using Playwright's `wait` teardown behavior drains active handlers without swallowing genuine handler errors.