### PR TITLE
Updated public preview cards to reflect post access

### DIFF
--- a/.changeset/bright-walls-preview.md
+++ b/.changeset/bright-walls-preview.md
@@ -1,0 +1,5 @@
+---
+"@tryghost/koenig-lexical": minor
+---
+
+Added access-aware labels to public preview cards.

--- a/apps/ember-admin/app/components/koenig-lexical-editor.js
+++ b/apps/ember-admin/app/components/koenig-lexical-editor.js
@@ -493,7 +493,8 @@ export default class KoenigLexicalEditor extends Component {
             fetchLabels,
             renderLabels: !this.session.user.isContributor,
             feature: {
-                transistor: this.settings.transistor
+                transistor: this.settings.transistor,
+                paywallImprovements: this.feature.paywallImprovements
             },
             deprecated: { // todo fix typo
                 headerV1: true // if false, shows header v1 in the menu

--- a/apps/ember-admin/app/services/feature.js
+++ b/apps/ember-admin/app/services/feature.js
@@ -86,6 +86,7 @@ export default class FeatureService extends Service {
     @feature('commentModeration') commentModeration;
     @feature('memberDetailsReact') memberDetailsReact;
     @feature('previewByTier') previewByTier;
+    @feature('paywallImprovements') paywallImprovements;
     @feature('automations') automations;
     @feature('csvContentImporter') csvContentImporter;
     _user = null;

--- a/apps/ember-admin/tests/acceptance/editor/visibility-test.js
+++ b/apps/ember-admin/tests/acceptance/editor/visibility-test.js
@@ -1,13 +1,28 @@
 import {authenticateSession} from 'ember-simple-auth/test-support';
 import {cleanupMockAnalyticsApps, mockAnalyticsApps} from '../../helpers/mock-analytics-apps';
-import {click, fillIn, find} from '@ember/test-helpers';
+import {click, fillIn, find, waitFor, waitUntil} from '@ember/test-helpers';
 import {describe, it} from 'mocha';
+import {enableLabsFlag} from '../../helpers/labs-flag';
 import {enableMembers} from '../../helpers/members';
 import {enableStripe} from '../../helpers/stripe';
 import {expect} from 'chai';
 import {setupApplicationTest} from 'ember-mocha';
 import {setupMirage} from 'ember-cli-mirage/test-support';
 import {visit} from '../../helpers/visit';
+
+const PAYWALL_LEXICAL = JSON.stringify({
+    root: {
+        children: [{
+            type: 'paywall',
+            version: 1
+        }],
+        direction: null,
+        format: '',
+        indent: 0,
+        type: 'root',
+        version: 1
+    }
+});
 
 describe('Acceptance: Editor / Visibility', function () {
     let hooks = setupApplicationTest();
@@ -86,5 +101,46 @@ describe('Acceptance: Editor / Visibility', function () {
         let lastPut = putRequests[putRequests.length - 1];
         let requestBody = JSON.parse(lastPut.requestBody);
         expect(requestBody.posts[0].visibility, 'visibility in PUT request').to.equal('paid');
+    });
+
+    it('reflects post access and updates when access changes', async function () {
+        enableLabsFlag(this.server, 'paywallImprovements');
+
+        const post = this.server.create('post', {
+            authors: [author],
+            lexical: PAYWALL_LEXICAL,
+            status: 'draft',
+            visibility: 'public'
+        });
+
+        await visit(`/editor/post/${post.id}`);
+        await waitFor('[data-kg-card="paywall"]');
+
+        const paywallCard = () => find('[data-kg-card="paywall"]');
+        const waitForPaywallLabel = label => waitUntil(() => paywallCard().textContent.includes(label));
+
+        expect(paywallCard()).to.contain.text('Public preview · No effect while post is public');
+
+        await click('[data-test-psm-trigger]');
+
+        await fillIn('[data-test-select="post-visibility"]', 'members');
+        await waitForPaywallLabel('Members only');
+
+        await fillIn('[data-test-select="post-visibility"]', 'paid');
+        await waitForPaywallLabel('Paid members only');
+
+        const tier = this.server.create('tier', {name: 'Premium'});
+        const tierPost = this.server.create('post', {
+            authors: [author],
+            lexical: PAYWALL_LEXICAL,
+            status: 'draft',
+            tiers: [tier],
+            visibility: 'tiers'
+        });
+
+        await visit(`/editor/post/${tierPost.id}`);
+        await waitFor('[data-kg-card="paywall"]');
+
+        expect(find('[data-kg-card="paywall"]')).to.contain.text('Selected tiers only');
     });
 });

--- a/koenig/koenig-lexical/src/components/ui/cards/PaywallCard.stories.tsx
+++ b/koenig/koenig-lexical/src/components/ui/cards/PaywallCard.stories.tsx
@@ -1,3 +1,4 @@
+import KoenigComposerContext, {defaultKoenigComposerContext} from '../../../context/KoenigComposerContext';
 import {CardWrapper} from './../CardWrapper';
 import {PaywallCard} from './PaywallCard';
 
@@ -5,6 +6,8 @@ const displayOptions = {
     Default: {isSelected: false, isEditing: false},
     Selected: {isSelected: true, isEditing: false}
 };
+
+const accessOptions = ['public', 'members', 'paid', 'tiers'];
 
 const story = {
     title: 'Primary cards/Public preview card',
@@ -22,6 +25,10 @@ const story = {
                 },
                 defaultValue: displayOptions.Default
             }
+        },
+        access: {
+            options: accessOptions,
+            control: {type: 'radio'}
         }
     },
     parameters: {
@@ -32,23 +39,36 @@ const story = {
 };
 export default story;
 
-const Template = ({display, ...args}) => (
-    <div className="kg-prose">
-        <div className="mx-auto my-8 min-w-[initial] max-w-[740px] px-3 py-9">
-            <CardWrapper {...display} {...args}>
-                <PaywallCard {...display} />
-            </CardWrapper>
-        </div>
-        <div className="dark mx-auto my-8 min-w-[initial] max-w-[740px] bg-black px-3 py-9">
-            <CardWrapper {...display} {...args}>
-                <PaywallCard {...display} />
-            </CardWrapper>
-        </div>
-    </div>
-);
+const Template = ({access, display, ...args}) => {
+    const cardConfig = {
+        feature: {
+            paywallImprovements: true
+        },
+        post: {
+            visibility: access
+        }
+    };
+
+    return (
+        <KoenigComposerContext.Provider value={{...defaultKoenigComposerContext, cardConfig}}>
+            <div className="kg-prose">
+                <div className="mx-auto my-8 min-w-[initial] max-w-[740px] px-3 py-9">
+                    <CardWrapper {...display} {...args}>
+                        <PaywallCard />
+                    </CardWrapper>
+                </div>
+                <div className="dark mx-auto my-8 min-w-[initial] max-w-[740px] bg-black px-3 py-9">
+                    <CardWrapper {...display} {...args}>
+                        <PaywallCard />
+                    </CardWrapper>
+                </div>
+            </div>
+        </KoenigComposerContext.Provider>
+    );
+};
 
 export const Default = Template.bind({});
 Default.args = {
+    access: 'members',
     display: 'Selected'
 };
-

--- a/koenig/koenig-lexical/src/components/ui/cards/PaywallCard.tsx
+++ b/koenig/koenig-lexical/src/components/ui/cards/PaywallCard.tsx
@@ -1,11 +1,38 @@
+import KoenigComposerContext from '../../../context/KoenigComposerContext';
+import {useContext} from 'react';
+import type {PostVisibility} from '../../../context/KoenigComposerContext';
+
+const RESTRICTED_ACCESS_LABELS: Record<Exclude<PostVisibility, 'public'>, string> = {
+    members: 'Members only',
+    paid: 'Paid members only',
+    tiers: 'Selected tiers only'
+};
+
 export function PaywallCard() {
+    const {cardConfig} = useContext(KoenigComposerContext);
+    const paywallImprovements = cardConfig?.feature?.paywallImprovements;
+    const postVisibility = cardConfig?.post?.visibility;
+
+    if (paywallImprovements && postVisibility === 'public') {
+        return (
+            <div className="flex h-3 items-center whitespace-pre text-center font-sans text-2xs font-semibold uppercase before:mr-2 before:flex-1 before:border-t before:border-yellow before:content-[''] after:ml-2 after:flex-1 after:border-t after:border-yellow after:content-['']">
+                <span className="text-yellow">Public preview · No effect while post is public</span>
+            </div>
+        );
+    }
+
+    // hosts without a post in their config (email editor, demo) keep the generic label
+    const accessLabel = paywallImprovements && postVisibility && postVisibility !== 'public'
+        ? RESTRICTED_ACCESS_LABELS[postVisibility]
+        : 'Only visible to members';
+
     return (
         <div className="flex h-3 items-center whitespace-pre text-center font-sans text-2xs font-semibold uppercase text-grey-500 before:mr-2 before:flex-1 before:border-t before:border-grey-300 before:content-[''] after:ml-2 after:flex-1 after:border-t after:border-grey-300 dark:text-grey-800">
             Free public preview
             <span className="mx-2 text-green">↑</span>
             /
             <span className="mx-2 text-green">↓</span>
-            Only visible to members
+            {accessLabel}
         </div>
     );
 }


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3823

The public preview card always read "Only visible to members" regardless of the post's actual access. On a public post that's simply wrong — nothing is gated below the boundary at all — and on a paid or tiers-only post it understates who is locked out. Authors changing access in the post settings menu got no feedback from the card either way.

The card now reflects the post's live visibility: "Members only", "Paid members only", or "Selected tiers only", updating as access changes rather than only on load. When a public post contains a preview boundary, it switches to a warning treatment stating the boundary has no effect, instead of describing a restriction that isn't there.

`cardConfig.post.visibility` comes from the typed `CardConfig` contract in #29636, so the card reads a declared `PostVisibility` rather than an untyped passthrough — the ember host narrows the post model and resolves visibility against the site default before it crosses into React. Hosts that pass no post at all, like the email editor and the Koenig demo, keep the generic label.

All of it sits behind the `paywallImprovements` flag.
