### PR TITLE
Removed unnecessary lint-staged for Ember admin

### DIFF
--- a/apps/ember-admin/package.json
+++ b/apps/ember-admin/package.json
@@ -168,8 +168,7 @@
         "edition": "octane"
     },
     "lint-staged": {
-        "*.hbs": "ember-template-lint",
-        "*.js": "eslint"
+        "*.hbs": "ember-template-lint"
     },
     "dependencies": {
         "lodash": "catalog:",


### PR DESCRIPTION
towards https://linear.app/ghost/issue/PLA-137

This change should have no impact to anyone.

We had an unnecessary "run ESLint on changed `.js` files in ember-admin". This was already picked up by our parent `lint-staged` config, so we can remove it.

Manually tested this by trying to commit a bogus `.js` file, and verified that lint still failed.

I think this is useful on its own, but will also make it easier to add Oxfmt.