### PR TITLE
Added automation link click statistics endpoint

### DIFF
--- a/apps/admin-x-framework/src/api/automations.ts
+++ b/apps/admin-x-framework/src/api/automations.ts
@@ -79,6 +79,15 @@ export interface AutomationEmailPreviewResponseType {
     automation_email_previews: AutomationEmailPreview[];
 }
 
+export type AutomationActionLink = {
+    url: string;
+    clicked_count: number;
+}
+
+export type AutomationActionLinksResponseType = {
+    automation_action_links: AutomationActionLink[];
+}
+
 const dataType = 'AutomationsResponseType';
 
 export const useBrowseAutomations = createQuery<AutomationsResponseType>({
@@ -90,6 +99,17 @@ export const useReadAutomation = createQueryWithId<AutomationDetailResponseType>
     dataType,
     path: id => `/automations/${id}/`
 });
+
+const useBrowseAutomationActionLinksQuery = createQueryWithId<AutomationActionLinksResponseType>({
+    dataType: 'AutomationActionLinksResponseType',
+    path: id => `/automations/${id}/links/`
+});
+
+export const useBrowseAutomationActionLinks = (
+    automationId: string,
+    actionId: string,
+    options: Parameters<typeof useBrowseAutomationActionLinksQuery>[1] = {}
+) => useBrowseAutomationActionLinksQuery(`${automationId}/actions/${actionId}`, options);
 
 const serializeEditableAction = (action: AutomationAction): AutomationAction => {
     switch (action.type) {

--- a/apps/admin-x-framework/test/unit/api/automations.test.ts
+++ b/apps/admin-x-framework/test/unit/api/automations.test.ts
@@ -1,4 +1,8 @@
 import ObjectId from 'bson-objectid';
+import {waitFor} from '@testing-library/react';
+import {currentUserQueryKey} from '../../../src/api/current-user';
+import {createTestQueryClient, renderHookWithProviders} from '../../../src/test/test-utils';
+import {withMockFetch} from '../../utils/mock-fetch';
 import {
     AutomationAction,
     AutomationDetail,
@@ -8,7 +12,8 @@ import {
     insertWaitAction,
     removeAction,
     updateSendEmailAction,
-    updateWaitAction
+    updateWaitAction,
+    useBrowseAutomationActionLinks
 } from '../../../src/api/automations';
 
 const baseDetail = (actions: AutomationDetail['actions'], edges: AutomationDetail['edges']): AutomationDetail => ({
@@ -34,6 +39,33 @@ const insertionCases: Array<{
     {name: 'insertWaitAction', insert: insertWaitAction, expectedType: 'wait'},
     {name: 'insertSendEmailAction', insert: insertSendEmailAction, expectedType: 'send_email'}
 ];
+
+describe('automations api queries', () => {
+    it('builds the action links endpoint from the automation and action IDs', async () => {
+        const queryClient = createTestQueryClient();
+        queryClient.setQueryDefaults(currentUserQueryKey, {staleTime: Infinity});
+        queryClient.setQueryData(currentUserQueryKey, {
+            users: [{
+                id: 'user-id',
+                name: 'Test User',
+                email: 'test@example.com',
+                roles: []
+            }]
+        });
+
+        await withMockFetch({
+            json: {
+                automation_action_links: []
+            }
+        }, async (mock) => {
+            const {result} = renderHookWithProviders(() => useBrowseAutomationActionLinks('automation-id', 'action-id'), {queryClient});
+
+            await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+            expect(mock.calls[0][0]).toBe('http://localhost:3000/ghost/api/admin/automations/automation-id/actions/action-id/links/');
+        });
+    });
+});
 
 describe('automations api helpers', () => {
     describe('shared insertion behavior', () => {

--- a/ghost/core/core/server/api/endpoints/automation-action-links.ts
+++ b/ghost/core/core/server/api/endpoints/automation-action-links.ts
@@ -1,0 +1,46 @@
+import * as automationsApi from '../../services/automations/automations-api';
+
+type BrowseFrame = {
+    options: {
+        automation_id: string;
+        action_id: string;
+    };
+};
+
+const controller = {
+    docName: 'automation_action_links',
+
+    browse: {
+        headers: {
+            cacheInvalidate: false
+        },
+        options: [
+            'automation_id',
+            'action_id'
+        ],
+        validation: {
+            options: {
+                automation_id: {
+                    required: true
+                },
+                action_id: {
+                    required: true
+                }
+            }
+        },
+        permissions: {
+            docName: 'automations',
+            method: 'read'
+        },
+        async query(frame: BrowseFrame) {
+            return {
+                data: await automationsApi.browseActionLinks(
+                    frame.options.automation_id,
+                    frame.options.action_id
+                )
+            };
+        }
+    }
+};
+
+module.exports = controller;

--- a/ghost/core/core/server/api/endpoints/index.js
+++ b/ghost/core/core/server/api/endpoints/index.js
@@ -11,6 +11,10 @@ module.exports = {
         return apiFramework.pipeline(require('./automations'), localUtils);
     },
 
+    get automationActionLinks() {
+        return apiFramework.pipeline(require('./automation-action-links'), localUtils);
+    },
+
     get automationEmailPreviews() {
         return apiFramework.pipeline(require('./automation-email-previews'), localUtils);
     },

--- a/ghost/core/core/server/services/automations/automations-api.ts
+++ b/ghost/core/core/server/services/automations/automations-api.ts
@@ -20,6 +20,7 @@ const MAX_AUTOMATION_ACTIONS = 20;
 
 const messages = {
     automationNotFound: 'Automation not found.',
+    automationActionNotFound: 'Automation action not found.',
     invalidAutomationPayload: 'Automation edit payload must include status, actions, and edges.',
     invalidAutomationStatus: 'Automation status must be one of: active, inactive.',
     duplicateAutomationActionIdentity: 'Automation action identifiers must be unique.',
@@ -85,6 +86,18 @@ export async function read(automationId: string) {
     }
 
     return automation;
+}
+
+export async function browseActionLinks(automationId: string, actionId: string) {
+    const links = await repository.getAutomationActionLinks(automationId, actionId);
+
+    if (!links) {
+        throw new errors.NotFoundError({
+            message: tpl(messages.automationActionNotFound)
+        });
+    }
+
+    return links;
 }
 
 export async function edit(automationId: string, data: unknown) {

--- a/ghost/core/core/server/services/automations/automations-repository.ts
+++ b/ghost/core/core/server/services/automations/automations-repository.ts
@@ -33,6 +33,11 @@ export interface AutomationEmailStats {
     clicked_rate: number | null;
 }
 
+export interface AutomationActionLink {
+    url: string;
+    clicked_count: number;
+}
+
 export interface SendEmailAction {
     id: string;
     type: 'send_email';
@@ -132,6 +137,7 @@ export type AutomationStepTerminalStatus =
 export interface AutomationsRepository {
     browse(): Promise<Page<AutomationSummary>>;
     getById(id: string): Promise<Automation | null>;
+    getAutomationActionLinks(automationId: string, actionId: string): Promise<AutomationActionLink[] | null>;
     edit(id: string, data: EditAutomationData): Promise<Automation | null>;
     trigger(options: {
         memberEmail: string;

--- a/ghost/core/core/server/services/automations/database-automations-repository.ts
+++ b/ghost/core/core/server/services/automations/database-automations-repository.ts
@@ -196,7 +196,7 @@ export function createDatabaseAutomationsRepository({
                 .orderBy('url', 'asc');
 
             return rows.map(row => ({
-                url: row.url,
+                url: urlUtils.transformReadyToAbsolute(row.url),
                 clicked_count: Number(row.clicked_count)
             }));
         },

--- a/ghost/core/core/server/services/automations/database-automations-repository.ts
+++ b/ghost/core/core/server/services/automations/database-automations-repository.ts
@@ -69,6 +69,11 @@ type ActionStatsRow = {
     email_opened_count: number | null;
 };
 
+type ActionLinkRow = {
+    url: string;
+    clicked_count: string | number;
+};
+
 type ActionRevisionRow = {
     action_id: string;
     created_at: string;
@@ -163,6 +168,37 @@ export function createDatabaseAutomationsRepository({
 
                 return await buildAutomation(trx, automation);
             });
+        },
+
+        async getAutomationActionLinks(automationId, actionId) {
+            const action = await knex('automation_actions')
+                .select('id')
+                .where({
+                    id: actionId,
+                    automation_id: automationId
+                })
+                .whereNull('deleted_at')
+                .first();
+
+            if (!action) {
+                return null;
+            }
+
+            const rows = await knex('redirects as redirects')
+                .countDistinct({clicked_count: 'members_click_events.member_id'})
+                .select<ActionLinkRow[]>(knex.raw('MIN(??) as ??', ['redirects.to', 'url']))
+                .innerJoin('automation_action_revisions as revisions', 'revisions.id', 'redirects.automation_action_revision_id')
+                .leftJoin('members_click_events', 'members_click_events.redirect_id', 'redirects.id')
+                .where('revisions.action_id', actionId)
+                .whereNotNull('redirects.to_hash')
+                .groupBy('redirects.to_hash')
+                .orderBy('clicked_count', 'desc')
+                .orderBy('url', 'asc');
+
+            return rows.map(row => ({
+                url: row.url,
+                clicked_count: Number(row.clicked_count)
+            }));
         },
 
         async edit(id: string, data: EditAutomationData): Promise<Automation | null> {

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -208,6 +208,7 @@ module.exports = function apiRoutes() {
 
     // ## Automations
     router.get('/automations', mw.authAdminApi, http(api.automations.browse));
+    router.get('/automations/:automation_id/actions/:action_id/links', mw.authAdminApi, http(api.automationActionLinks.browse));
     router.get('/automations/:id', mw.authAdminApi, http(api.automations.read));
     router.post('/automations/:id/email_preview', mw.authAdminApi, http(api.automationEmailPreviews.preview));
     router.post('/automations/:id/email_test', shared.middleware.brute.previewEmailLimiter, mw.authAdminApi, http(api.automationEmailPreviews.sendTestEmail));

--- a/ghost/core/test/e2e-api/admin/automations.test.js
+++ b/ghost/core/test/e2e-api/admin/automations.test.js
@@ -1,4 +1,5 @@
 const assert = require('node:assert/strict');
+const {createHash} = require('node:crypto');
 const sinon = require('sinon');
 const domainEvents = require('@tryghost/domain-events');
 const ObjectId = require('bson-objectid').default;
@@ -12,6 +13,7 @@ const StartAutomationsPollEvent = require('../../../core/server/services/automat
 
 const {anyContentVersion, anyEtag, anyErrorId, anyISODateTime, anyObjectId} = matchers;
 const {cacheInvalidateHeaderNotSet} = assertions;
+const hashRedirectDestination = url => createHash('sha256').update(url).digest();
 
 const matchAutomationSummary = () => ({
     id: anyObjectId,
@@ -82,7 +84,7 @@ describe('Automations API', function () {
 
     beforeAll(async function () {
         agent = await agentProvider.getAdminAPIAgent();
-        await fixtureManager.init('users', 'integrations', 'api_keys');
+        await fixtureManager.init('users', 'integrations', 'api_keys', 'members');
         await agent.loginAsOwner();
 
         schedulerKey = await models.Integration.getApiKeyBySlug('ghost-scheduler', 'admin');
@@ -283,6 +285,102 @@ describe('Automations API', function () {
                         clicked_rate: 67
                     });
                 });
+        });
+    });
+
+    describe('action links', function () {
+        it('returns unique member click counts grouped across revisions', async function () {
+            const {body} = await agent.get('automations').expectStatus(200);
+            const automationId = body.automations[0].id;
+            const action = await models.Base.knex('automation_actions')
+                .where({automation_id: automationId, type: 'send_email'})
+                .first();
+            const revision = await models.Base.knex('automation_action_revisions')
+                .where('action_id', action.id)
+                .first();
+            const secondRevisionId = ObjectId().toHexString();
+            await models.Base.knex('automation_action_revisions').insert({
+                id: secondRevisionId,
+                action_id: action.id,
+                created_at: new Date('2026-07-21T12:00:00.000Z'),
+                email_subject: 'Updated email',
+                email_lexical: NON_EMPTY_EMAIL_LEXICAL,
+                email_design_setting_id: TEST_EMAIL_DESIGN_SETTING_ID
+            });
+
+            const redirects = [{
+                id: ObjectId().toHexString(),
+                from: `/r/${ObjectId().toHexString()}`,
+                to: 'https://example.com/alpha',
+                to_hash: hashRedirectDestination('https://example.com/alpha'),
+                automation_action_revision_id: revision.id,
+                created_at: new Date()
+            }, {
+                id: ObjectId().toHexString(),
+                from: `/r/${ObjectId().toHexString()}`,
+                to: 'https://example.com/alpha',
+                to_hash: hashRedirectDestination('https://example.com/alpha'),
+                automation_action_revision_id: secondRevisionId,
+                created_at: new Date()
+            }, {
+                id: ObjectId().toHexString(),
+                from: `/r/${ObjectId().toHexString()}`,
+                to: 'https://example.com/zero',
+                to_hash: hashRedirectDestination('https://example.com/zero'),
+                automation_action_revision_id: secondRevisionId,
+                created_at: new Date()
+            }];
+            await models.Base.knex('redirects').insert(redirects);
+            await models.Base.knex('members_click_events').insert([{
+                id: ObjectId().toHexString(),
+                member_id: fixtureManager.get('members', 0).id,
+                redirect_id: redirects[0].id,
+                created_at: new Date()
+            }, {
+                id: ObjectId().toHexString(),
+                member_id: fixtureManager.get('members', 0).id,
+                redirect_id: redirects[1].id,
+                created_at: new Date()
+            }, {
+                id: ObjectId().toHexString(),
+                member_id: fixtureManager.get('members', 1).id,
+                redirect_id: redirects[1].id,
+                created_at: new Date()
+            }]);
+
+            const {body: linksBody} = await agent
+                .get(`automations/${automationId}/actions/${action.id}/links`)
+                .expectStatus(200)
+                .expect(cacheInvalidateHeaderNotSet());
+            assert.deepEqual(linksBody, {
+                automation_action_links: [{
+                    url: 'https://example.com/alpha',
+                    clicked_count: 2
+                }, {
+                    url: 'https://example.com/zero',
+                    clicked_count: 0
+                }]
+            });
+        });
+
+        it('returns 404 when the action belongs to a different automation', async function () {
+            const {body} = await agent.get('automations').expectStatus(200);
+            const action = await models.Base.knex('automation_actions')
+                .where('automation_id', body.automations[0].id)
+                .first();
+
+            await agent
+                .get(`automations/${body.automations[1].id}/actions/${action.id}/links`)
+                .expectStatus(404)
+                .expect(cacheInvalidateHeaderNotSet());
+        });
+
+        it('requires an authenticated admin', async function () {
+            agent.resetAuthentication();
+            await agent
+                .get(`automations/${ObjectId().toHexString()}/actions/${ObjectId().toHexString()}/links`)
+                .expectStatus(403);
+            await agent.loginAsOwner();
         });
     });
 

--- a/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
+++ b/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import {createHash} from 'node:crypto';
 import errors from '@tryghost/errors';
 import ObjectId from 'bson-objectid';
 import createKnex, {type Knex} from 'knex';
@@ -25,6 +26,7 @@ const linkLexical = (url: string): string => JSON.stringify({
         }]
     }
 });
+const hashRedirectDestination = (url: string): Buffer => createHash('sha256').update(url).digest();
 
 const addHours = (dateCol: unknown, hours: number): Date => {
     assert(typeof dateCol === 'string', 'Expected date column to be a string');
@@ -102,6 +104,21 @@ const createDatabase = async (): Promise<Knex> => {
         table.integer('email_opened_count');
         table.integer('email_clicked_count');
         table.unique(['created_at', 'action_id']);
+    });
+
+    await database.schema.createTable('redirects', (table) => {
+        table.text('id').primary();
+        table.text('automation_action_revision_id').references('id').inTable('automation_action_revisions');
+        table.text('to').notNullable();
+        table.binary('to_hash');
+        table.unique(['automation_action_revision_id', 'to_hash']);
+    });
+
+    await database.schema.createTable('members_click_events', (table) => {
+        table.text('id').primary();
+        table.text('member_id').notNullable();
+        table.text('redirect_id').notNullable().references('id').inTable('redirects');
+        table.text('created_at').notNullable();
     });
 
     await database.schema.createTable('automation_action_edges', (table) => {
@@ -854,6 +871,70 @@ describe('automations repository', function () {
             assert(action?.type === 'send_email');
             assert.equal(action.stats?.email_clicked_count, 3);
             assert.equal(action.stats?.clicked_rate, 38);
+        });
+    });
+
+    describe('getAutomationActionLinks', function () {
+        it('aggregates unique member clicks by destination hash across action revisions', async function () {
+            const automation = await getAutomationBySlug('member-welcome-email-free');
+            const action = automation.actions.find(candidate => candidate.type === 'send_email');
+            assert(action);
+            const existingRevision = await getLatestActionRevisionByActionId(action.id);
+            const secondRevisionId = ObjectId().toHexString();
+            await knex('automation_action_revisions').insert({
+                id: secondRevisionId,
+                action_id: action.id,
+                created_at: '2026-07-22 12:00:00',
+                email_subject: 'A later revision',
+                email_lexical: NON_EMPTY_EMAIL_LEXICAL,
+                email_design_setting_id: existingRevision.email_design_setting_id
+            });
+
+            const redirects = [
+                {id: ObjectId().toHexString(), automation_action_revision_id: existingRevision.revision_id, to: 'https://example.com/alpha', to_hash: hashRedirectDestination('https://example.com/alpha')},
+                {id: ObjectId().toHexString(), automation_action_revision_id: secondRevisionId, to: 'https://example.com/alpha', to_hash: hashRedirectDestination('https://example.com/alpha')},
+                {id: ObjectId().toHexString(), automation_action_revision_id: secondRevisionId, to: 'https://example.com/beta', to_hash: hashRedirectDestination('https://example.com/beta')},
+                {id: ObjectId().toHexString(), automation_action_revision_id: secondRevisionId, to: 'https://example.com/zero', to_hash: hashRedirectDestination('https://example.com/zero')},
+                {id: ObjectId().toHexString(), automation_action_revision_id: secondRevisionId, to: 'https://example.com/aaa-zero', to_hash: hashRedirectDestination('https://example.com/aaa-zero')},
+                {id: ObjectId().toHexString(), automation_action_revision_id: secondRevisionId, to: 'https://example.com/alpha', to_hash: null}
+            ];
+            await knex('redirects').insert(redirects);
+            await knex('members_click_events').insert([
+                {id: ObjectId().toHexString(), member_id: 'member-1', redirect_id: redirects[0].id, created_at: '2026-07-22 13:00:00'},
+                {id: ObjectId().toHexString(), member_id: 'member-1', redirect_id: redirects[1].id, created_at: '2026-07-22 13:01:00'},
+                {id: ObjectId().toHexString(), member_id: 'member-2', redirect_id: redirects[1].id, created_at: '2026-07-22 13:02:00'},
+                {id: ObjectId().toHexString(), member_id: 'member-3', redirect_id: redirects[2].id, created_at: '2026-07-22 13:03:00'},
+                {id: ObjectId().toHexString(), member_id: 'member-4', redirect_id: redirects[5].id, created_at: '2026-07-22 13:04:00'}
+            ]);
+
+            assert.deepEqual(await repo.getAutomationActionLinks(automation.id, action.id), [{
+                url: 'https://example.com/alpha',
+                clicked_count: 2
+            }, {
+                url: 'https://example.com/beta',
+                clicked_count: 1
+            }, {
+                url: 'https://example.com/aaa-zero',
+                clicked_count: 0
+            }, {
+                url: 'https://example.com/zero',
+                clicked_count: 0
+            }]);
+        });
+
+        it('returns an empty list for a valid action without links', async function () {
+            const automation = await getAutomationBySlug('member-welcome-email-free');
+            assert.deepEqual(await repo.getAutomationActionLinks(automation.id, automation.actions[0].id), []);
+        });
+
+        it('returns null when the action does not belong to the automation or is deleted', async function () {
+            const freeAutomation = await getAutomationBySlug('member-welcome-email-free');
+            const paidAutomation = await getAutomationBySlug('member-welcome-email-paid');
+            const actionId = freeAutomation.actions[0].id;
+
+            assert.equal(await repo.getAutomationActionLinks(paidAutomation.id, actionId), null);
+            await knex('automation_actions').where('id', actionId).update({deleted_at: '2026-07-22 14:00:00'});
+            assert.equal(await repo.getAutomationActionLinks(freeAutomation.id, actionId), null);
         });
     });
 

--- a/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
+++ b/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
@@ -875,6 +875,26 @@ describe('automations repository', function () {
     });
 
     describe('getAutomationActionLinks', function () {
+        it('returns stored transform-ready destinations as absolute URLs', async function () {
+            const automation = await getAutomationBySlug('member-welcome-email-free');
+            const action = automation.actions.find(candidate => candidate.type === 'send_email');
+            assert(action);
+            const revision = await getLatestActionRevisionByActionId(action.id);
+            const absoluteUrl = `${ghostConfig.get('url')}/archive/`;
+
+            await knex('redirects').insert({
+                id: ObjectId().toHexString(),
+                automation_action_revision_id: revision.revision_id,
+                to: '__GHOST_URL__/archive/',
+                to_hash: hashRedirectDestination(absoluteUrl)
+            });
+
+            assert.deepEqual(await repo.getAutomationActionLinks(automation.id, action.id), [{
+                url: absoluteUrl,
+                clicked_count: 0
+            }]);
+        });
+
         it('aggregates unique member clicks by destination hash across action revisions', async function () {
             const automation = await getAutomationBySlug('member-welcome-email-free');
             const action = automation.actions.find(candidate => candidate.type === 'send_email');

--- a/ghost/core/test/utils/automations-fixtures.ts
+++ b/ghost/core/test/utils/automations-fixtures.ts
@@ -120,6 +120,17 @@ export async function cleanupAutomationsFixture(): Promise<void> {
             await db.knex('automated_email_recipients')
                 .whereIn('automation_action_revision_id', revisionIds)
                 .del();
+            const redirectIds: string[] = await db.knex('redirects')
+                .whereIn('automation_action_revision_id', revisionIds)
+                .pluck('id');
+            if (redirectIds.length > 0) {
+                await db.knex('members_click_events')
+                    .whereIn('redirect_id', redirectIds)
+                    .del();
+                await db.knex('redirects')
+                    .whereIn('id', redirectIds)
+                    .del();
+            }
         }
 
         await db.knex('automation_action_edges')


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1486

Automation analytics needs per-link unique click counts, but calculating them during normal automation reads would add unnecessary query cost. A dedicated endpoint lets Admin load link details only when requested.

Behavior:
- validates that the action belongs to the requested automation and is not deleted
- groups destinations by URL hash across every revision of the action
- counts distinct members, so repeat clicks and clicks across revisions are deduplicated
- includes zero-click links and orders results by click count, then URL

Review guide:
1. Start with getAutomationActionLinks for the aggregation and ownership boundary.
2. Follow browseActionLinks through the API controller and authenticated route.
3. Check useBrowseAutomationActionLinks for the lazy Admin client integration.
4. See the repository, API, and client tests for the expected contract and edge cases.