### PR TITLE
Auto-format with Oxfmt on commit

### DIFF
--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -1,8 +1,10 @@
 const path = require('path');
 const fs = require('fs');
 const {quote: shellQuote} = require('shell-quote');
+const pm = require('picomatch');
 
 const ROOT = process.cwd();
+const ESLINT_FILES = new Set(['.js', '.ts', '.tsx', '.jsx', '.cjs']);
 
 function normalize(p) {
     return p.split(path.sep).join('/');
@@ -97,21 +99,50 @@ function buildEmberTemplateLintCommand(files) {
     return `pnpm --dir ${shellQuote(workspace)} exec ember-template-lint ${relativeFiles}`;
 }
 
-module.exports = {
-    '*.{js,ts,tsx,jsx,cjs}': files => {
-        const groups = new Map();
-        for (const file of files) {
+/**
+ * @param {string[]} files
+ * @returns {string[]}
+ */
+module.exports = files => {
+    /** @type {Map<null | string, Set<string>>} */ const workspaceFiles = new Map();
+    /** @type {Set<string>} */ const boundaries = new Set();
+    /** @type {Set<string>} */ const emberAdminTemplates = new Set();
+
+    for (const file of files) {
+        const extension = path.extname(file);
+        if (ESLINT_FILES.has(extension)) {
             const workspace = findWorkspace(file);
-            const key = workspace ?? '';
-            if (!groups.has(key)) {
-                groups.set(key, []);
-            }
-            groups.get(key).push(file);
+            const filesForWorkspace = workspaceFiles.get(workspace) ?? new Set();
+            filesForWorkspace.add(file);
+            workspaceFiles.set(workspace, filesForWorkspace);
         }
-        return [...groups.entries()].map(([workspace, wsFiles]) => buildEslintCommand(workspace || null, wsFiles));
-    },
-    'ghost/core/core/{server,shared,frontend}/**/*.{js,ts}': files => buildBoundaryCommand(files),
-    'apps/ember-admin/**/*.hbs': files => buildEmberTemplateLintCommand(files),
-    'apps/{shade,admin-x-framework,activitypub,admin-x-settings,portal,comments-ui,signup-form,sodo-search,announcement-bar,admin-toolbar}/src/**/*.{js,ts,tsx,jsx}':
-        files => buildBoundaryCommand(files)
+        const isBoundary = pm.isMatch(file, [
+            'ghost/core/core/{server,shared,frontend}/**/*.{js,ts}',
+            'apps/{shade,admin-x-framework,activitypub,admin-x-settings,portal,comments-ui,signup-form,sodo-search,announcement-bar,admin-toolbar}/src/**/*.{js,ts,tsx,jsx}'
+        ]);
+        if (isBoundary) {
+            boundaries.add(file);
+        }
+
+        const isEmberAdminTemplate = pm.isMatch(file, 'apps/ember-admin/**/*.hbs');
+        if (isEmberAdminTemplate) {
+            emberAdminTemplates.add(file);
+        }
+    }
+
+    /** @type {string[]} */ const result = [];
+
+    for (const [workspace, filesForWorkspace] of workspaceFiles.entries()) {
+        result.push(buildEslintCommand(workspace, Array.from(filesForWorkspace)));
+    }
+
+    if (boundaries.size > 0) {
+        result.push(buildBoundaryCommand(Array.from(boundaries)));
+    }
+
+    if (emberAdminTemplates.size > 0) {
+        result.push(buildEmberTemplateLintCommand(Array.from(emberAdminTemplates)));
+    }
+
+    return result;
 };

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -91,6 +91,16 @@ function buildBoundaryCommand(files) {
     return `pnpm exec depcruise --config .dependency-cruiser.cjs -- ${shellQuote(relativeFiles)}`;
 }
 
+function buildEmberTemplateLintCommand(files) {
+    const workspace = 'apps/ember-admin';
+    const base = path.join(ROOT, workspace);
+    const relativeFiles = files
+        .map(file => normalize(path.relative(base, file)))
+        .map(shellQuote)
+        .join(' ');
+    return `pnpm --dir ${shellQuote(workspace)} exec ember-template-lint ${relativeFiles}`;
+}
+
 module.exports = {
     '*.{js,ts,tsx,jsx,cjs}': (files) => {
         const groups = new Map();
@@ -108,6 +118,8 @@ module.exports = {
     },
     'ghost/core/core/{server,shared,frontend}/**/*.{js,ts}': (files) =>
         buildBoundaryCommand(files),
+    'apps/ember-admin/**/*.hbs': (files) =>
+        buildEmberTemplateLintCommand(files),
     'apps/{shade,admin-x-framework,activitypub,admin-x-settings,portal,comments-ui,signup-form,sodo-search,announcement-bar,admin-toolbar}/src/**/*.{js,ts,tsx,jsx}': (files) =>
         buildBoundaryCommand(files)
 };

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -61,9 +61,7 @@ function expandPattern(pattern) {
     return candidates;
 }
 
-const WORKSPACES = new Set(
-    loadWorkspacePatterns().flatMap(expandPattern)
-);
+const WORKSPACES = new Set(loadWorkspacePatterns().flatMap(expandPattern));
 
 function findWorkspace(file) {
     let dir = path.dirname(path.resolve(file));
@@ -79,15 +77,13 @@ function findWorkspace(file) {
 
 function buildCommand(workspace, files) {
     const base = workspace ? path.join(ROOT, workspace) : ROOT;
-    const relativeFiles = files
-        .map(file => normalize(path.relative(base, file)));
+    const relativeFiles = files.map(file => normalize(path.relative(base, file)));
     const dirArg = workspace ? `--dir ${shellQuote([workspace])} ` : '';
     return `pnpm ${dirArg}exec eslint --cache -- ${shellQuote(relativeFiles)}`;
 }
 
 function buildBoundaryCommand(files) {
-    const relativeFiles = files
-        .map(file => normalize(path.relative(ROOT, file)));
+    const relativeFiles = files.map(file => normalize(path.relative(ROOT, file)));
     return `pnpm exec depcruise --config .dependency-cruiser.cjs -- ${shellQuote(relativeFiles)}`;
 }
 
@@ -102,7 +98,7 @@ function buildEmberTemplateLintCommand(files) {
 }
 
 module.exports = {
-    '*.{js,ts,tsx,jsx,cjs}': (files) => {
+    '*.{js,ts,tsx,jsx,cjs}': files => {
         const groups = new Map();
         for (const file of files) {
             const workspace = findWorkspace(file);
@@ -112,14 +108,10 @@ module.exports = {
             }
             groups.get(key).push(file);
         }
-        return [...groups.entries()].map(([workspace, wsFiles]) =>
-            buildCommand(workspace || null, wsFiles)
-        );
+        return [...groups.entries()].map(([workspace, wsFiles]) => buildCommand(workspace || null, wsFiles));
     },
-    'ghost/core/core/{server,shared,frontend}/**/*.{js,ts}': (files) =>
-        buildBoundaryCommand(files),
-    'apps/ember-admin/**/*.hbs': (files) =>
-        buildEmberTemplateLintCommand(files),
-    'apps/{shade,admin-x-framework,activitypub,admin-x-settings,portal,comments-ui,signup-form,sodo-search,announcement-bar,admin-toolbar}/src/**/*.{js,ts,tsx,jsx}': (files) =>
-        buildBoundaryCommand(files)
+    'ghost/core/core/{server,shared,frontend}/**/*.{js,ts}': files => buildBoundaryCommand(files),
+    'apps/ember-admin/**/*.hbs': files => buildEmberTemplateLintCommand(files),
+    'apps/{shade,admin-x-framework,activitypub,admin-x-settings,portal,comments-ui,signup-form,sodo-search,announcement-bar,admin-toolbar}/src/**/*.{js,ts,tsx,jsx}':
+        files => buildBoundaryCommand(files)
 };

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -75,7 +75,7 @@ function findWorkspace(file) {
     return null;
 }
 
-function buildCommand(workspace, files) {
+function buildEslintCommand(workspace, files) {
     const base = workspace ? path.join(ROOT, workspace) : ROOT;
     const relativeFiles = files.map(file => normalize(path.relative(base, file)));
     const dirArg = workspace ? `--dir ${shellQuote([workspace])} ` : '';
@@ -108,7 +108,7 @@ module.exports = {
             }
             groups.get(key).push(file);
         }
-        return [...groups.entries()].map(([workspace, wsFiles]) => buildCommand(workspace || null, wsFiles));
+        return [...groups.entries()].map(([workspace, wsFiles]) => buildEslintCommand(workspace || null, wsFiles));
     },
     'ghost/core/core/{server,shared,frontend}/**/*.{js,ts}': files => buildBoundaryCommand(files),
     'apps/ember-admin/**/*.hbs': files => buildEmberTemplateLintCommand(files),

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -101,11 +101,8 @@ function buildBoundaryCommand(files) {
 function buildEmberTemplateLintCommand(files) {
     const workspace = 'apps/ember-admin';
     const base = path.join(ROOT, workspace);
-    const relativeFiles = files
-        .map(file => normalize(path.relative(base, file)))
-        .map(shellQuote)
-        .join(' ');
-    return `pnpm --dir ${shellQuote(workspace)} exec ember-template-lint ${relativeFiles}`;
+    const relativeFiles = files.map(file => normalize(path.relative(base, file)));
+    return `pnpm --dir ${shellQuote([workspace])} exec ember-template-lint ${shellQuote(relativeFiles)}`;
 }
 
 /**

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -77,6 +77,15 @@ function findWorkspace(file) {
     return null;
 }
 
+/**
+ * @param {ReadonlyArray<string>} files
+ * @returns {string}
+ */
+function buildOxfmtCommand(files) {
+    const relativeFiles = files.map(file => normalize(path.relative(ROOT, file)));
+    return `pnpm exec oxfmt --no-error-on-unmatched-pattern -- ${shellQuote(relativeFiles)}`;
+}
+
 function buildEslintCommand(workspace, files) {
     const base = workspace ? path.join(ROOT, workspace) : ROOT;
     const relativeFiles = files.map(file => normalize(path.relative(base, file)));
@@ -131,6 +140,10 @@ module.exports = files => {
     }
 
     /** @type {string[]} */ const result = [];
+
+    if (files.length) {
+        result.push(buildOxfmtCommand(files));
+    }
 
     for (const [workspace, filesForWorkspace] of workspaceFiles.entries()) {
         result.push(buildEslintCommand(workspace, Array.from(filesForWorkspace)));

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,29 @@
+{
+    "$schema": "./node_modules/oxfmt/configuration_schema.json",
+    "arrowParens": "avoid",
+    "bracketSpacing": false,
+    "ignorePatterns": [
+        "**/build/**",
+        "**/built/**",
+        "**/coverage/**",
+        "**/dist/**",
+        "**/*.min.*",
+        "**/*.hbs",
+        "package.json",
+        "skills-lock.json",
+        "koenig/kg-default-nodes/**",
+        "koenig/kg-lexical-html-renderer/**",
+        "koenig/kg-simplemde/debug/**",
+        "koenig/koenig-lexical/**"
+    ],
+    "jsdoc": {
+        "addDefaultToDescription": false,
+        "bracketSpacing": false
+    },
+    "jsxSingleQuote": true,
+    "printWidth": 120,
+    "singleQuote": true,
+    "sortPackageJson": false,
+    "tabWidth": 4,
+    "trailingComma": "none"
+}

--- a/apps/ember-admin/package.json
+++ b/apps/ember-admin/package.json
@@ -167,10 +167,6 @@
     "ember": {
         "edition": "octane"
     },
-    "lint-staged": {
-        "*.hbs": "ember-template-lint",
-        "*.js": "eslint"
-    },
     "dependencies": {
         "dompurify": "catalog:",
         "lodash": "catalog:",

--- a/ghost/core/test/utils/fixtures/settings/.oxfmtrc.json
+++ b/ghost/core/test/utils/fixtures/settings/.oxfmtrc.json
@@ -1,0 +1,3 @@
+{
+    "ignorePatterns": ["badroutes.yaml"]
+}

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "lint-staged": "17.0.8",
     "nx": "23.0.1",
     "oxfmt": "catalog:",
+    "picomatch": "catalog:",
     "rimraf": "6.1.3",
     "secretlint": "13.0.2",
     "shell-quote": "catalog:",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "knip": "6.24.0",
     "lint-staged": "17.0.8",
     "nx": "23.0.1",
+    "oxfmt": "catalog:",
     "rimraf": "6.1.3",
     "secretlint": "13.0.2",
     "shell-quote": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -330,6 +330,9 @@ catalogs:
     oxfmt:
       specifier: 0.60.0
       version: 0.60.0
+    picomatch:
+      specifier: 4.0.5
+      version: 4.0.5
     postcss:
       specifier: 8.5.16
       version: 8.5.16
@@ -526,6 +529,9 @@ importers:
       oxfmt:
         specifier: 'catalog:'
         version: 0.60.0
+      picomatch:
+        specifier: 'catalog:'
+        version: 4.0.5
       rimraf:
         specifier: 6.1.3
         version: 6.1.3
@@ -4087,7 +4093,7 @@ importers:
         specifier: 'catalog:'
         version: 4.3.0
       picomatch:
-        specifier: 4.0.5
+        specifier: 'catalog:'
         version: 4.0.5
       semver:
         specifier: 'catalog:'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,6 +327,9 @@ catalogs:
     node-html-markdown:
       specifier: 2.0.0
       version: 2.0.0
+    oxfmt:
+      specifier: 0.60.0
+      version: 0.60.0
     postcss:
       specifier: 8.5.16
       version: 8.5.16
@@ -520,6 +523,9 @@ importers:
       nx:
         specifier: 23.0.1
         version: 23.0.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(debug@4.4.3(supports-color@10.2.2))
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.60.0
       rimraf:
         specifier: 6.1.3
         version: 6.1.3
@@ -7054,6 +7060,128 @@ packages:
 
   '@oxc-resolver/binding-win32-x64-msvc@11.21.3':
     resolution: {integrity: sha512-H7BCt/VnS9hnmMp42eGhZ99izSCRvlnWwy/N71K1/J8QoExwY4262Z8QiEkMDtduRJrztayDxETTckmUuAVL9Q==}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxfmt/binding-android-arm-eabi@0.60.0':
+    resolution: {integrity: sha512-1q4q4Jc8FlOMVojEisyFAVyl8h1yawNv6phjgmhGVEDeyeOdsSnSr9x0+D4mOnEKvpO5L4mxKZ/DP9X6U3A/Mw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxfmt/binding-android-arm64@0.60.0':
+    resolution: {integrity: sha512-tD41I6nCt9k8SQXft0CSjjU9jg6SwG7uMu7PxodSEHXl+GDW0868oy6tTtoJkyUze8YKFgTpz/k5LuPUnFiGLw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxfmt/binding-darwin-arm64@0.60.0':
+    resolution: {integrity: sha512-TTpzPug96Zxdyb46KvTyIUQDdsqbumXh2TKG9C23PCT0kF7JkW56Z/quPuG9rqOFKQIi1gpRNZ7DX18LwxXPnw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxfmt/binding-darwin-x64@0.60.0':
+    resolution: {integrity: sha512-CnOoWgQ7L+JL/YQaRJ+NyATciSfcftncm7y3kqyte1cGtFEGnStaCd1TAyrinkfQ7nRBfHrTs1/vTwUJr3WF2Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxfmt/binding-freebsd-x64@0.60.0':
+    resolution: {integrity: sha512-ychJo7S3hZxdO6eDZ9zM6F2lM9fpJS3EKS5CAUSWyprdLYxTu4gbaUKV/VBPTcMJwQa2Bpo+643y3OJ537pihA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.60.0':
+    resolution: {integrity: sha512-36IH5o55T2Fx7E0feDttt+mifxN6yk9pWv4KfhAIsP0dFnUq27331OwbpOsZdoXF9soOLWm7mQUz5+UUmyec4g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.60.0':
+    resolution: {integrity: sha512-G1Ve7lAa6sFBolVI2LWHfEAqy0YKh4vnioH8uYO9kAEdgM7mR40IksIx9/Zk4+vbYew/sGa4J9Q4tZ3n9gXDHA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-gnu@0.60.0':
+    resolution: {integrity: sha512-LTQdRBf6uzj/h7Xk6lKzbGD2hrF/fK4YI9LIN1c0509tPUn8wRa3mCmrFQpEWJPLYGFrLFFMTYW1Ljj6VqW2Hw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-arm64-musl@0.60.0':
+    resolution: {integrity: sha512-2JMo3XPxMPx3hiqddSZYyaH+fKJm6cz0u8n1naYjP/CdOQOZW34i8lKBUfmbWiuFvd6KoYXLmhAyBuvojsYS7Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.60.0':
+    resolution: {integrity: sha512-L3C+nBD13lr306tr/PjM3RMll+BVqgFrIgUyoeHuai5oueJrRLgO3j+GO5/Cbhtkf5PSlHYTI1JY7iqBd1qa6A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.60.0':
+    resolution: {integrity: sha512-M4MsmvqlxFiPtSRGyBYQSZxchEf463AOyd+Dh4/9xDpjWBsRtDUTDMFN5EdHinjVK1/eDJQ8MLpcYjpYayaCnA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-musl@0.60.0':
+    resolution: {integrity: sha512-OH+9UskYuxRB+GxqdGkVN8f5UpwhqG8YscNo1wl8+KJ62cd7wZdGga6iGLJIf8kibF1WBwvlfDUx3cez/VXwFg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-s390x-gnu@0.60.0':
+    resolution: {integrity: sha512-y7AAFutt9wFWBFOAn6+BHaV39usZmcr3YYH2385f+NHgPNpIF9HpqKp0jgUxPaUOCyG3oaX5VhJduL1Nw164rw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-gnu@0.60.0':
+    resolution: {integrity: sha512-yKZ9+CXAI+1RO5nH/4Z/9M6DAsfOzd5bw/gtWk81KB4mpalMaRRSXfouc5/tHxazDmBek55HNPepNYBgaCew0Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-musl@0.60.0':
+    resolution: {integrity: sha512-bCUGaF6hJOYnQzLJdHLZbvGsOd5oSvGAyJhPAKum2uyLYUuXmP8vqg690DWi2hqcnIoYpqSqCrjzE5aiUAgwQg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-openharmony-arm64@0.60.0':
+    resolution: {integrity: sha512-GrUeZOvzP30ExxfCuQiyofuUGI+OmvAgFwOO5w5p9mGPlxcyuqI+6Sy9fAKFFfLQrqKYWFgc5sYA2Unj/29nPg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxfmt/binding-win32-arm64-msvc@0.60.0':
+    resolution: {integrity: sha512-WD4Q954kUl2TDJV/6q7UnE2rlKk047kXLJsr4bJ2mXRaAqNXcmV3nwKUsGCc3mz/jYDBnXtJEaBErJEybK8iQQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxfmt/binding-win32-ia32-msvc@0.60.0':
+    resolution: {integrity: sha512-HqDekjr8JXzVDUP1YthDZ1Y3CBEcuZT4WX3B+1kaxj8CvZA8Y2YhcEsXqoSop3tVsgjACxjnFQFDkBo0r/jq1Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxfmt/binding-win32-x64-msvc@0.60.0':
+    resolution: {integrity: sha512-tz78yhmGPKboTMHCHSaUqXK8JrmoSejgDcWeqAtg2s07ZGKQ3rH5Jn8NuXPGNG33CDbY2e9NoQWXIVEmKO21Rw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
@@ -18341,6 +18469,19 @@ packages:
   oxc-resolver@11.21.3:
     resolution: {integrity: sha512-2Mx3fKQz7+xgrBONjsxOgCGtMHOn38/HxMzW1I5efwXB5a4lRN0Vp40gYUJFBWJslcrvwoofTrqoTnLbwTd3pA==}
 
+  oxfmt@0.60.0:
+    resolution: {integrity: sha512-fViX6i+gJuZWY+jI/fnR6WRbRj70GZ9RlCd30MygJrHTUNc4DxvKHWw8vBjMjffv3PgU5qWDR0AzmojQByqaZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      svelte: ^5.0.0
+      vite-plus: '*'
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+      vite-plus:
+        optional: true
+
   p-cancelable@2.1.1:
     resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
     engines: {node: '>=8'}
@@ -21347,6 +21488,10 @@ packages:
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@2.1.0:
+    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
@@ -26197,6 +26342,63 @@ snapshots:
     optional: true
 
   '@oxc-resolver/binding-win32-x64-msvc@11.21.3':
+    optional: true
+
+  '@oxfmt/binding-android-arm-eabi@0.60.0':
+    optional: true
+
+  '@oxfmt/binding-android-arm64@0.60.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-arm64@0.60.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-x64@0.60.0':
+    optional: true
+
+  '@oxfmt/binding-freebsd-x64@0.60.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.60.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.60.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-gnu@0.60.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-musl@0.60.0':
+    optional: true
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.60.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.60.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-musl@0.60.0':
+    optional: true
+
+  '@oxfmt/binding-linux-s390x-gnu@0.60.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-gnu@0.60.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-musl@0.60.0':
+    optional: true
+
+  '@oxfmt/binding-openharmony-arm64@0.60.0':
+    optional: true
+
+  '@oxfmt/binding-win32-arm64-msvc@0.60.0':
+    optional: true
+
+  '@oxfmt/binding-win32-ia32-msvc@0.60.0':
+    optional: true
+
+  '@oxfmt/binding-win32-x64-msvc@0.60.0':
     optional: true
 
   '@paralleldrive/cuid2@2.3.1':
@@ -41883,6 +42085,30 @@ snapshots:
       '@oxc-resolver/binding-win32-arm64-msvc': 11.21.3
       '@oxc-resolver/binding-win32-x64-msvc': 11.21.3
 
+  oxfmt@0.60.0:
+    dependencies:
+      tinypool: 2.1.0
+    optionalDependencies:
+      '@oxfmt/binding-android-arm-eabi': 0.60.0
+      '@oxfmt/binding-android-arm64': 0.60.0
+      '@oxfmt/binding-darwin-arm64': 0.60.0
+      '@oxfmt/binding-darwin-x64': 0.60.0
+      '@oxfmt/binding-freebsd-x64': 0.60.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.60.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.60.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.60.0
+      '@oxfmt/binding-linux-arm64-musl': 0.60.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.60.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.60.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.60.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.60.0
+      '@oxfmt/binding-linux-x64-gnu': 0.60.0
+      '@oxfmt/binding-linux-x64-musl': 0.60.0
+      '@oxfmt/binding-openharmony-arm64': 0.60.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.60.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.60.0
+      '@oxfmt/binding-win32-x64-msvc': 0.60.0
+
   p-cancelable@2.1.1: {}
 
   p-cancelable@3.0.0: {}
@@ -45544,6 +45770,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
+
+  tinypool@2.1.0: {}
 
   tinyrainbow@2.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -144,6 +144,7 @@ catalog:
   moment-timezone: 0.5.45
   msw: 2.14.6
   node-html-markdown: 2.0.0
+  oxfmt: 0.60.0
   postcss: 8.5.16
   preact: ^10.29.2
   react: 18.3.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -145,6 +145,7 @@ catalog:
   msw: 2.14.6
   node-html-markdown: 2.0.0
   oxfmt: 0.60.0
+  picomatch: 4.0.5
   postcss: 8.5.16
   preact: ^10.29.2
   react: 18.3.1

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -16,7 +16,7 @@
     "camelcase-keys": "10.0.2",
     "execa": "9.6.1",
     "js-yaml": "catalog:",
-    "picomatch": "4.0.5",
+    "picomatch": "catalog:",
     "semver": "catalog:"
   },
   "devDependencies": {


### PR DESCRIPTION
towards https://linear.app/ghost/issue/PLA-137

*I recommend [reviewing this one commit at a time](https://github.com/TryGhost/Ghost/pull/29638/commits).*

What
----

This formats changed code with [Oxfmt] using our existing [lint-staged] setup. Developers don't need to do anything differently; Oxfmt will automatically pick up changes. No violations are reported (e.g., `pnpm lint` doesn't check this).

Why
---

We want to introduce auto-formatting. If we introduced it all at once, this could be disruptive to existing branches. This approach lets us adopt it more gradually and transparently.

This is also probably something we'll want anyway.

This PR also lays most of the groundwork required for Oxfmt.

[Oxfmt]: https://oxc.rs/docs/guide/usage/formatter.html
[lint-staged]: https://github.com/lint-staged/lint-staged
