### PR TITLE
Added top clicked links to automation sidebar

### DIFF
--- a/apps/admin/src/automations/components/canvas/email-performance-section.tsx
+++ b/apps/admin/src/automations/components/canvas/email-performance-section.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import {useEmailTrackingSettings} from '@/automations/hooks/use-email-tracking-settings';
-import {ChartContainer, HoverCard, HoverCardContent, HoverCardTrigger, Separator} from '@tryghost/shade/components';
+import {ChartContainer, DataList, DataListBar, DataListBody, DataListItemContent, DataListItemValue, DataListItemValueAbs, DataListItemValuePerc, DataListRow, HoverCard, HoverCardContent, HoverCardTrigger, LoadingIndicator, Separator, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@tryghost/shade/components';
 import type {ChartConfig} from '@tryghost/shade/components';
-import type {AutomationEmailStats} from '@tryghost/admin-x-framework/api/automations';
-import {Recharts, cn, formatNumber} from '@tryghost/shade/utils';
+import {Inline, Stack, Text} from '@tryghost/shade/primitives';
+import type {AutomationActionLink, AutomationEmailStats} from '@tryghost/admin-x-framework/api/automations';
+import {useBrowseAutomationActionLinks} from '@tryghost/admin-x-framework/api/automations';
+import {LucideIcon, Recharts, cn, formatNumber, formatPercentage} from '@tryghost/shade/utils';
 import {formatRate} from './format-stats';
 import {OffValue, TRACKING_OFF_MESSAGE} from './off-value';
 
@@ -142,7 +144,99 @@ const Kpi: React.FC<{
     );
 };
 
-export const EmailPerformanceSection: React.FC<{stats: AutomationEmailStats}> = ({stats}) => {
+const displayUrl = (url: string) => url.replace(/^https?:\/\//i, '');
+
+const TopClickedLinksContent: React.FC<{
+    clickedCount: number;
+    isError: boolean;
+    isLoading: boolean;
+    links: AutomationActionLink[];
+    sentCount: number;
+}> = ({clickedCount, isError, isLoading, links, sentCount}) => {
+    if (sentCount === 0) {
+        return <Text className='py-6 text-center' size='sm' tone='secondary'>No emails sent yet.</Text>;
+    }
+
+    if (isLoading) {
+        return <Inline className='py-6' data-testid='automation-action-links-loading' justify='center'><LoadingIndicator size='sm' /></Inline>;
+    }
+
+    if (isError) {
+        return <Text className='py-6 text-center text-destructive' role='alert' size='sm'>Couldn&apos;t load clicked links.</Text>;
+    }
+
+    if (links.length === 0) {
+        return <Text className='py-6 text-center' size='sm' tone='secondary'>No click data yet.</Text>;
+    }
+
+    return (
+        <TooltipProvider delayDuration={150}>
+            <DataList className='group/datalist'>
+                <DataListBody>
+                    {links.map((link) => {
+                        const percentage = clickedCount > 0 ? Math.min(link.clicked_count / clickedCount, 1) : 0;
+                        return (
+                            <DataListRow key={link.url}>
+                                <DataListBar style={{width: `${Math.round(percentage * 100)}%`}} />
+                                <DataListItemContent>
+                                    <Tooltip>
+                                        <TooltipTrigger asChild>
+                                            <a className='block min-w-0 hover:underline' href={link.url} rel='noreferrer' target='_blank'>
+                                                <Inline as='span' className='min-w-0' gap='sm'>
+                                                    <LucideIcon.Link className='shrink-0 text-muted-foreground' size={16} strokeWidth={1.5} />
+                                                    <Text as='span' className='font-medium' truncate>{displayUrl(link.url)}</Text>
+                                                </Inline>
+                                            </a>
+                                        </TooltipTrigger>
+                                        <TooltipContent className='max-w-[28rem] break-all'>{link.url}</TooltipContent>
+                                    </Tooltip>
+                                </DataListItemContent>
+                                <DataListItemValue>
+                                    <DataListItemValueAbs>{formatNumber(link.clicked_count)}</DataListItemValueAbs>
+                                    <DataListItemValuePerc>{formatPercentage(percentage)}</DataListItemValuePerc>
+                                </DataListItemValue>
+                            </DataListRow>
+                        );
+                    })}
+                </DataListBody>
+            </DataList>
+        </TooltipProvider>
+    );
+};
+
+const TopClickedLinks: React.FC<{
+    actionId: string;
+    automationId: string;
+    clickedCount: number;
+    sentCount: number;
+}> = ({actionId, automationId, clickedCount, sentCount}) => {
+    const {data, isError, isLoading} = useBrowseAutomationActionLinks(automationId, actionId, {
+        defaultErrorHandler: false,
+        enabled: sentCount > 0
+    });
+    const links = data?.automation_action_links.slice(0, 10) ?? [];
+
+    return (
+        <>
+            <Separator />
+            <Stack gap='md'>
+                <Inline justify='between'>
+                    <Text size='sm' tone='secondary' weight='medium'>Top clicked links</Text>
+                    <Text size='sm' tone='tertiary' weight='medium'>Members</Text>
+                </Inline>
+                <TopClickedLinksContent
+                    clickedCount={clickedCount}
+                    isError={isError}
+                    isLoading={isLoading}
+                    links={links}
+                    sentCount={sentCount}
+                />
+            </Stack>
+        </>
+    );
+};
+
+export const EmailPerformanceSection: React.FC<{actionId: string; automationId: string; stats: AutomationEmailStats}> = ({actionId, automationId, stats}) => {
     const {emailTrackOpens, emailTrackClicks} = useEmailTrackingSettings();
 
     return (
@@ -180,17 +274,14 @@ export const EmailPerformanceSection: React.FC<{stats: AutomationEmailStats}> = 
                     opensTracked={emailTrackOpens}
                 />
             </div>
-            {/* @TODO: NY-1457 — hidden entirely when click tracking is off; the
-                off-state is already conveyed by the Clicked KPI and ring above. */}
-            {/* {emailTrackClicks && (
-                <>
-                    <Separator />
-                    <div className='flex items-center justify-between'>
-                        <span className='text-sm font-medium text-text-secondary'>Top clicked links</span>
-                        <span className='text-sm font-medium text-muted-foreground'>Members</span>
-                    </div>
-                </>
-            )} */}
+            {emailTrackClicks && (
+                <TopClickedLinks
+                    actionId={actionId}
+                    automationId={automationId}
+                    clickedCount={stats.email_clicked_count}
+                    sentCount={stats.email_sent_count}
+                />
+            )}
         </div>
     );
 };

--- a/apps/admin/src/automations/components/canvas/email-performance-section.tsx
+++ b/apps/admin/src/automations/components/canvas/email-performance-section.tsx
@@ -166,7 +166,7 @@ const TopClickedLinksContent: React.FC<{
     }
 
     if (links.length === 0) {
-        return <Text className='py-6 text-center' size='sm' tone='secondary'>No click data yet.</Text>;
+        return <Text className='py-6 text-center' size='sm' tone='secondary'>No link data to show.</Text>;
     }
 
     return (

--- a/apps/admin/src/automations/components/canvas/step-sidebar.tsx
+++ b/apps/admin/src/automations/components/canvas/step-sidebar.tsx
@@ -175,11 +175,12 @@ const WaitSidebarBody: React.FC<{
 };
 
 const SendEmailSidebarBody: React.FC<{
+  automationId: string;
   action: AutomationSendEmailAction;
   onUpdateSubject: (subject: string) => void;
   onEditEmail: () => void;
   onDelete: () => void;
-}> = ({action, onUpdateSubject, onEditEmail, onDelete}) => {
+}> = ({automationId, action, onUpdateSubject, onEditEmail, onDelete}) => {
     const subjectInputRef = useRef<HTMLInputElement>(null);
     const automationAnalyticsEnabled = useFeatureFlag('automationAnalytics');
 
@@ -206,7 +207,7 @@ const SendEmailSidebarBody: React.FC<{
                 <LucideIcon.Pencil className='size-4' />
               Edit email
             </Button>
-            {automationAnalyticsEnabled && action.stats && <EmailPerformanceSection stats={action.stats} />}
+            {automationAnalyticsEnabled && action.stats && <EmailPerformanceSection actionId={action.id} automationId={automationId} stats={action.stats} />}
             <div className='mt-auto pt-6'>
                 <DeleteStepButton onClick={onDelete} />
             </div>
@@ -221,7 +222,7 @@ const StepSidebarBody: React.FC<{detail: StepSidebarDetail}> = ({detail}) => {
     case 'wait':
         return <WaitSidebarBody key={detail.action.id} action={detail.action} onDelete={detail.onDelete} onUpdate={detail.onUpdate} />;
     case 'send_email':
-        return <SendEmailSidebarBody key={detail.action.id} action={detail.action} onDelete={detail.onDelete} onEditEmail={detail.onEditEmail} onUpdateSubject={detail.onUpdateSubject} />;
+        return <SendEmailSidebarBody key={detail.action.id} action={detail.action} automationId={detail.automationId} onDelete={detail.onDelete} onEditEmail={detail.onEditEmail} onUpdateSubject={detail.onUpdateSubject} />;
     default: {
         const _exhaustive: never = detail;
         throw new Error(`Unknown sidebar type: ${String(_exhaustive)}`);
@@ -300,6 +301,7 @@ const getStepSidebarDetail = ({automation, stepId, onDelete, onUpdateWait, onUpd
     }
     case 'send_email':
         return {
+            automationId: automation.id,
             icon: LucideIcon.Mail,
             label: 'Send email',
             isPlaceholderTitle: !action.data.email_subject,

--- a/apps/admin/src/automations/components/types.ts
+++ b/apps/admin/src/automations/components/types.ts
@@ -25,6 +25,7 @@ type WaitStepSidebarDetail = ActionStepSidebarDetail<AutomationWaitAction, 'Wait
 };
 
 type SendEmailStepSidebarDetail = ActionStepSidebarDetail<AutomationSendEmailAction, 'Send email'> & {
+  automationId: string;
   onUpdateSubject: (subject: string) => void;
   onEditEmail: () => void;
 };

--- a/apps/admin/src/automations/editor.test.tsx
+++ b/apps/admin/src/automations/editor.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {AppProvider} from '@tryghost/admin-x-framework';
 import type {AppSettings} from '@tryghost/admin-x-framework';
 import {MAX_AUTOMATION_ACTIONS} from '@tryghost/admin-x-framework/api/automations';
-import type {AutomationDetail, AutomationDetailResponseType, AutomationEmailStats, EditAutomationPayload} from '@tryghost/admin-x-framework/api/automations';
+import type {AutomationActionLinksResponseType, AutomationDetail, AutomationDetailResponseType, AutomationEmailStats, EditAutomationPayload} from '@tryghost/admin-x-framework/api/automations';
 import {RouterProvider, createMemoryRouter} from 'react-router';
 import {act, fireEvent, render, screen, waitFor, within} from '@testing-library/react';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
@@ -115,6 +115,7 @@ type MockEditMutationOptions = {
     onError?: (error?: unknown) => void;
 };
 const mockUseReadAutomation = vi.fn<(...args: unknown[]) => {data?: AutomationDetailResponseType; isLoading?: boolean; isError?: boolean}>();
+const mockUseBrowseAutomationActionLinks = vi.fn<(...args: unknown[]) => {data?: AutomationActionLinksResponseType; isLoading: boolean; isError: boolean}>();
 const mockEditMutation = {
     mutate: vi.fn<(payload: EditAutomationPayload, options: MockEditMutationOptions) => void>(),
     isLoading: false,
@@ -135,6 +136,7 @@ vi.mock('@tryghost/admin-x-framework/api/automations', async () => {
     return {
         ...actual,
         useReadAutomation: (...args: unknown[]) => mockUseReadAutomation(...args),
+        useBrowseAutomationActionLinks: (...args: unknown[]) => mockUseBrowseAutomationActionLinks(...args),
         useEditAutomation: () => mockEditMutation
     };
 });
@@ -331,6 +333,12 @@ const mockAutomationWithEmailStats = (statsOverrides: Partial<AutomationEmailSta
 describe('AutomationEditor', () => {
     beforeEach(() => {
         mockUseReadAutomation.mockReset();
+        mockUseBrowseAutomationActionLinks.mockReset();
+        mockUseBrowseAutomationActionLinks.mockReturnValue({
+            data: {automation_action_links: []},
+            isLoading: false,
+            isError: false
+        });
         mockEditMutation.mutate.mockReset();
         mockReactFlow.fitView.mockReset();
         mockReactFlow.zoomIn.mockReset();
@@ -561,6 +569,119 @@ describe('AutomationEditor', () => {
         const clickedKpi = within(sidebar).getByText('Clicked').parentElement;
         expect(within(clickedKpi!).getByText('0%')).toBeInTheDocument();
         expect(within(clickedKpi!).getByText('0')).toBeInTheDocument();
+    });
+
+    it('renders up to ten top clicked links with counts, clamped percentages, and full destinations', async () => {
+        mockLabs.current = {automationAnalytics: true};
+        mockAutomationWithEmailStats({
+            email_clicked_count: 5,
+            email_sent_count: 10,
+            email_opened_count: 7,
+            opened_rate: 70,
+            clicked_rate: 50
+        });
+        mockUseBrowseAutomationActionLinks.mockReturnValue({
+            data: {
+                automation_action_links: Array.from({length: 12}, (_, index) => ({
+                    url: `https://example.com/link-${index + 1}`,
+                    clicked_count: index === 0 ? 6 : index === 2 ? 0 : 5 - Math.min(index, 4)
+                }))
+            },
+            isLoading: false,
+            isError: false
+        });
+
+        renderEditor();
+        expect(mockUseBrowseAutomationActionLinks).not.toHaveBeenCalled();
+        fireEvent.click(screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'}));
+
+        const sidebar = screen.getByRole('complementary', {name: 'Step details'});
+        expect(mockUseBrowseAutomationActionLinks).toHaveBeenCalledWith('automation-id-1', 'action-email', {defaultErrorHandler: false, enabled: true});
+        expect(within(sidebar).getAllByRole('link')).toHaveLength(10);
+
+        const firstLink = within(sidebar).getByRole('link', {name: 'example.com/link-1'});
+        expect(firstLink).toHaveAttribute('href', 'https://example.com/link-1');
+        expect(firstLink.querySelector('svg')).toBeInTheDocument();
+        const firstRow = firstLink.parentElement?.parentElement;
+        expect(firstRow).not.toBeNull();
+        expect(within(firstRow!).getByText('6')).toBeInTheDocument();
+        expect(within(firstRow!).getByText('100%')).toBeInTheDocument();
+        expect(firstRow?.querySelector('[style="width: 100%;"]')).toBeInTheDocument();
+        const zeroClickRow = within(sidebar).getByRole('link', {name: 'example.com/link-3'}).parentElement?.parentElement;
+        expect(within(zeroClickRow!).getByText('0')).toBeInTheDocument();
+        expect(within(zeroClickRow!).getByText('0%')).toBeInTheDocument();
+        expect(within(sidebar).queryByRole('link', {name: 'example.com/link-11'})).not.toBeInTheDocument();
+
+        fireEvent.focus(firstLink);
+        expect(await screen.findByRole('tooltip')).toHaveTextContent('https://example.com/link-1');
+    });
+
+    it('renders top clicked link loading, error, and empty states', () => {
+        mockLabs.current = {automationAnalytics: true};
+        mockAutomationWithEmailStats({
+            email_clicked_count: 2,
+            email_sent_count: 10,
+            email_opened_count: 5,
+            opened_rate: 50,
+            clicked_rate: 20
+        });
+
+        mockUseBrowseAutomationActionLinks.mockReturnValue({data: undefined, isLoading: true, isError: false});
+        const {unmount} = renderEditor();
+        fireEvent.click(screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'}));
+        expect(screen.getByTestId('automation-action-links-loading')).toBeInTheDocument();
+        unmount();
+
+        mockUseBrowseAutomationActionLinks.mockReturnValue({data: undefined, isLoading: false, isError: true});
+        const secondRender = renderEditor();
+        fireEvent.click(screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'}));
+        expect(screen.getByRole('alert')).toHaveTextContent('Couldn\'t load clicked links.');
+        secondRender.unmount();
+
+        mockUseBrowseAutomationActionLinks.mockReturnValue({data: {automation_action_links: []}, isLoading: false, isError: false});
+        renderEditor();
+        fireEvent.click(screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'}));
+        expect(screen.getByText('No click data yet.')).toBeInTheDocument();
+    });
+
+    it('disables the links request and shows a no-sends state when no emails were sent', () => {
+        mockLabs.current = {automationAnalytics: true};
+        mockAutomationWithEmailStats({
+            email_clicked_count: 0,
+            email_sent_count: 0,
+            email_opened_count: 0,
+            opened_rate: null,
+            clicked_rate: null
+        });
+
+        renderEditor();
+        fireEvent.click(screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'}));
+
+        expect(screen.getByText('No emails sent yet.')).toBeInTheDocument();
+        expect(mockUseBrowseAutomationActionLinks).toHaveBeenCalledWith('automation-id-1', 'action-email', {defaultErrorHandler: false, enabled: false});
+    });
+
+    it('hides clicked links and skips the request when click tracking is off', () => {
+        mockLabs.current = {automationAnalytics: true};
+        mockAppSettings = createAppSettings({emailTrackClicks: false});
+        mockAutomationWithEmailStats();
+
+        renderEditor();
+        fireEvent.click(screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'}));
+
+        const sidebar = screen.getByRole('complementary', {name: 'Step details'});
+        expect(within(sidebar).queryByText('Top clicked links')).not.toBeInTheDocument();
+        expect(mockUseBrowseAutomationActionLinks).not.toHaveBeenCalled();
+    });
+
+    it('does not request clicked links for a closed or non-email sidebar', () => {
+        mockLabs.current = {automationAnalytics: true};
+        mockAutomationWithEmailStats();
+
+        renderEditor();
+        expect(mockUseBrowseAutomationActionLinks).not.toHaveBeenCalled();
+        fireEvent.click(screen.getByRole('button', {name: 'Wait: 1 day'}));
+        expect(mockUseBrowseAutomationActionLinks).not.toHaveBeenCalled();
     });
 
     it('renders styled canvas zoom controls without the interaction toggle', () => {

--- a/apps/admin/src/automations/editor.test.tsx
+++ b/apps/admin/src/automations/editor.test.tsx
@@ -641,7 +641,7 @@ describe('AutomationEditor', () => {
         mockUseBrowseAutomationActionLinks.mockReturnValue({data: {automation_action_links: []}, isLoading: false, isError: false});
         renderEditor();
         fireEvent.click(screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'}));
-        expect(screen.getByText('No click data yet.')).toBeInTheDocument();
+        expect(screen.getByText('No link data to show.')).toBeInTheDocument();
     });
 
     it('disables the links request and shows a no-sends state when no emails were sent', () => {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1485

Automation owners could see aggregate email clicks but not which destinations drove them. Showing link-level results in the selected email sidebar keeps that detail alongside the existing performance metrics, while lazy loading avoids adding work to the canvas or closed sidebars.

This builds on the automation action links endpoint from NY-1486.

Behavior:
- shows the ten most-clicked destinations with unique member counts and percentages
- opens destinations in a new tab and exposes each full URL in a tooltip
- handles no-sends, loading, error, and no-click-data states explicitly
- skips the request until an email sidebar is open, and disables the feature when click tracking is off

Review guide:
1. Start with TopClickedLinks in email-performance-section.tsx for rendering and query gates.
2. Check step-sidebar.tsx and types.ts for automation and action ID plumbing.
3. Review editor.test.tsx for list limits, percentages, destinations, states, and request suppression.

Depends on https://github.com/TryGhost/Ghost/pull/29637