### PR TITLE
Filter and segment members by their custom fields

### DIFF
--- a/apps/admin/src/members/components/members-filters.tsx
+++ b/apps/admin/src/members/components/members-filters.tsx
@@ -13,6 +13,8 @@ import {getSettingValue, useBrowseSettings} from '@tryghost/admin-x-framework/ap
 import {getSiteTimezone} from '@tryghost/admin-x-framework/utils/get-site-timezone';
 import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
 import {useBrowseOffers} from '@tryghost/admin-x-framework/api/offers';
+import {useFeatureFlag} from '@tryghost/admin-x-framework/hooks';
+import {useBrowseMemberCustomFields} from '@tryghost/admin-x-framework/api/member-custom-fields';
 import {useEmailPostValueSource, useLabelValueSource, usePostResourceValueSource, useTierValueSource} from '@/shared/filter-sources';
 import type {MemberView} from '@/members/hooks/use-member-views';
 
@@ -93,6 +95,9 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
     const emailValueSource = useEmailPostValueSource();
     const labelValueSource = useLabelValueSource();
     const {valueSource: tierValueSource, hasMultipleTiers} = useTierValueSource();
+    const customFieldsEnabled = useFeatureFlag('membersCustomFields');
+    const {data: customFieldsData} = useBrowseMemberCustomFields({enabled: customFieldsEnabled});
+    const customFields = customFieldsData?.members_custom_fields ?? [];
 
     const filterFields = useMemberFilterFields({
         newsletters,
@@ -109,7 +114,9 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
         membersTrackSources,
         emailTrackOpens,
         emailTrackClicks,
-        siteTimezone
+        siteTimezone,
+        customFieldsEnabled,
+        customFields
     });
 
     const hasFilters = filters.length > 0;

--- a/apps/admin/src/members/components/members-filters.tsx
+++ b/apps/admin/src/members/components/members-filters.tsx
@@ -14,7 +14,8 @@ import {getSiteTimezone} from '@tryghost/admin-x-framework/utils/get-site-timezo
 import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
 import {useBrowseOffers} from '@tryghost/admin-x-framework/api/offers';
 import {useFeatureFlag} from '@tryghost/admin-x-framework/hooks';
-import {useBrowseMemberCustomFields} from '@tryghost/admin-x-framework/api/member-custom-fields';
+import {useBrowseMemberCustomFields, useBrowseMemberCustomFieldsIncludingArchived} from '@tryghost/admin-x-framework/api/member-custom-fields';
+import type {MemberCustomField} from '@tryghost/admin-x-framework/api/member-custom-fields';
 import {useEmailPostValueSource, useLabelValueSource, usePostResourceValueSource, useTierValueSource} from '@/shared/filter-sources';
 import type {MemberView} from '@/members/hooks/use-member-views';
 
@@ -29,6 +30,7 @@ interface MembersFiltersProps {
 }
 
 const EMPTY_OFFERS: typeof buildOfferOptions extends (offers: infer T) => unknown ? T : never = [];
+const EMPTY_CUSTOM_FIELDS: MemberCustomField[] = [];
 
 function mapOfferRedemptionFilters(
     filters: Filter[],
@@ -96,8 +98,25 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
     const labelValueSource = useLabelValueSource();
     const {valueSource: tierValueSource, hasMultipleTiers} = useTierValueSource();
     const customFieldsEnabled = useFeatureFlag('membersCustomFields');
+    // The picker lists active fields — the endpoint the members page has always used.
     const {data: customFieldsData} = useBrowseMemberCustomFields({enabled: customFieldsEnabled});
-    const customFields = customFieldsData?.members_custom_fields ?? [];
+    const customFields = customFieldsData?.members_custom_fields ?? EMPTY_CUSTOM_FIELDS;
+    const referencedCustomFieldKeys = useMemo(() => new Set(
+        filters
+            .map(filter => filter.field)
+            .filter(field => field.startsWith('custom_field.'))
+            .map(field => field.slice('custom_field.'.length))
+            .filter(Boolean)
+    ), [filters]);
+    // Only when the current filter references a custom field do we also pull the archived
+    // ones, so a saved segment on a since-archived field still renders its read-only pill.
+    // Skipped otherwise, so the common members view makes no extra request.
+    const {data: archivedCustomFieldsData} = useBrowseMemberCustomFieldsIncludingArchived({
+        enabled: customFieldsEnabled && referencedCustomFieldKeys.size > 0
+    });
+    const archivedCustomFields = useMemo(() => (archivedCustomFieldsData?.members_custom_fields ?? EMPTY_CUSTOM_FIELDS)
+        .filter(field => field.status === 'archived' && referencedCustomFieldKeys.has(field.key))
+        .map(field => ({key: field.key, name: field.name})), [archivedCustomFieldsData, referencedCustomFieldKeys]);
 
     const filterFields = useMemberFilterFields({
         newsletters,
@@ -116,7 +135,8 @@ const MembersFilters: React.FC<MembersFiltersProps> = ({
         emailTrackClicks,
         siteTimezone,
         customFieldsEnabled,
-        customFields
+        customFields,
+        archivedCustomFields
     });
 
     const hasFilters = filters.length > 0;

--- a/apps/admin/src/members/custom-field-filter-renderer.tsx
+++ b/apps/admin/src/members/custom-field-filter-renderer.tsx
@@ -1,0 +1,88 @@
+import React, {useEffect} from 'react';
+import {CUSTOM_FIELD_OPERATORS, CUSTOM_FIELD_SET_OPERATORS} from './member-fields';
+import {FilterSegmentInput, FilterSegmentSelect} from '@tryghost/shade/patterns';
+import {createOperatorOptions} from '@/shared/filters';
+import {memberCustomFieldParts, useBrowseMemberCustomFields} from '@tryghost/admin-x-framework/api/member-custom-fields';
+import type {CustomRendererProps} from '@tryghost/shade/patterns';
+
+// The dropdown entry has already chosen the field (its key is in `field.key` as
+// `custom_field.<key>`), so this renders only what's left in the pill: for a
+// composite field a part selector (with "Any" for the whole field), then the
+// operator, then the value. The predicate carries [subfield, value]; subfield is ''
+// for a scalar field or the "Any" whole-field set/unset case. The operator lives here
+// because its valid set depends on the part chosen here.
+
+const KEY_PREFIX = 'custom_field.';
+
+const CustomFieldFilterRenderer: React.FC<CustomRendererProps<string>> = ({field, values, onChange, operator, onOperatorChange}) => {
+    const {data} = useBrowseMemberCustomFields();
+    const definitions = data?.members_custom_fields ?? [];
+
+    const fieldKey = (field.key ?? '').slice(KEY_PREFIX.length);
+    const definition = definitions.find(candidate => candidate.key === fieldKey);
+    // The shared catalog decides which parts a type has and what they are called; a scalar
+    // field has none. Its keys are the ones the predicate carries.
+    const parts = definition
+        ? (memberCustomFieldParts(definition.type) ?? []).map(({key, label}) => ({value: key, label}))
+        : [];
+    const isComposite = parts.length > 0;
+
+    const [subfield = '', value = ''] = values;
+    const isWholeField = subfield === '';
+
+    // A composite's "Any" (whole field) only supports set / not-set — "Any contains X"
+    // is meaningless. A specific part, and a scalar field, support the value operators
+    // and set / not-set. Only "Any" restricts the set, so only it needs the operator
+    // coerced when the part selection changes — done in an effect rather than the change
+    // handler, because the framework's filter update reads a stale list within a tick, so
+    // a value change and an operator change can't both land in the same one.
+    const operators = isComposite && isWholeField
+        ? CUSTOM_FIELD_SET_OPERATORS
+        : CUSTOM_FIELD_OPERATORS;
+
+    useEffect(() => {
+        if (!onOperatorChange || operators.includes(operator)) {
+            return;
+        }
+        onOperatorChange('is-set');
+    }, [operator, operators, onOperatorChange]);
+
+    const needsValue = !CUSTOM_FIELD_SET_OPERATORS.includes(operator);
+    const partOptions = [{value: '', label: 'Any'}, ...parts];
+
+    return (
+        <>
+            {isComposite && (
+                <FilterSegmentSelect
+                    ariaLabel="Field part"
+                    options={partOptions}
+                    testId="custom-field-filter-subfield"
+                    value={subfield}
+                    onChange={nextSubfield => onChange([nextSubfield, value])}
+                />
+            )}
+
+            {onOperatorChange && (
+                <FilterSegmentSelect
+                    ariaLabel="Operator"
+                    options={createOperatorOptions(operators)}
+                    testId="custom-field-filter-operator"
+                    value={operator}
+                    onChange={onOperatorChange}
+                />
+            )}
+
+            {needsValue && (
+                <FilterSegmentInput
+                    ariaLabel="Value"
+                    placeholder="Enter value..."
+                    testId="custom-field-filter-value"
+                    value={value}
+                    onChange={nextValue => onChange([subfield, nextValue])}
+                />
+            )}
+        </>
+    );
+};
+
+export default CustomFieldFilterRenderer;

--- a/apps/admin/src/members/custom-field-filter-renderer.tsx
+++ b/apps/admin/src/members/custom-field-filter-renderer.tsx
@@ -25,6 +25,9 @@ const CustomFieldFilterRenderer: React.FC<CustomRendererProps<string>> = ({field
     const parts = definition
         ? (memberCustomFieldParts(definition.type) ?? []).map(({key, label}) => ({value: key, label}))
         : [];
+    // Name the field in each segment's aria-label so two custom-field pills on one row
+    // are distinguishable to a screen reader rather than all reading "Operator"/"Value".
+    const fieldLabel = field.label ?? definition?.name ?? 'Custom field';
     const isComposite = parts.length > 0;
 
     const [subfield = '', value = ''] = values;
@@ -54,7 +57,7 @@ const CustomFieldFilterRenderer: React.FC<CustomRendererProps<string>> = ({field
         <>
             {isComposite && (
                 <FilterSegmentSelect
-                    ariaLabel="Field part"
+                    ariaLabel={`${fieldLabel} part`}
                     options={partOptions}
                     testId="custom-field-filter-subfield"
                     value={subfield}
@@ -64,7 +67,7 @@ const CustomFieldFilterRenderer: React.FC<CustomRendererProps<string>> = ({field
 
             {onOperatorChange && (
                 <FilterSegmentSelect
-                    ariaLabel="Operator"
+                    ariaLabel={`${fieldLabel} operator`}
                     options={createOperatorOptions(operators)}
                     testId="custom-field-filter-operator"
                     value={operator}
@@ -74,7 +77,7 @@ const CustomFieldFilterRenderer: React.FC<CustomRendererProps<string>> = ({field
 
             {needsValue && (
                 <FilterSegmentInput
-                    ariaLabel="Value"
+                    ariaLabel={`${fieldLabel} value`}
                     placeholder="Enter value..."
                     testId="custom-field-filter-value"
                     value={value}

--- a/apps/admin/src/members/custom-field-filter-renderer.tsx
+++ b/apps/admin/src/members/custom-field-filter-renderer.tsx
@@ -2,7 +2,7 @@ import React, {useEffect} from 'react';
 import {CUSTOM_FIELD_OPERATORS, CUSTOM_FIELD_SET_OPERATORS} from './member-fields';
 import {FilterSegmentInput, FilterSegmentSelect} from '@tryghost/shade/patterns';
 import {createOperatorOptions} from '@/shared/filters';
-import {memberCustomFieldParts, useBrowseMemberCustomFields} from '@tryghost/admin-x-framework/api/member-custom-fields';
+import {memberCustomFieldParts, useBrowseMemberCustomFieldsIncludingArchived} from '@tryghost/admin-x-framework/api/member-custom-fields';
 import type {CustomRendererProps} from '@tryghost/shade/patterns';
 
 // The dropdown entry has already chosen the field (its key is in `field.key` as
@@ -14,8 +14,10 @@ import type {CustomRendererProps} from '@tryghost/shade/patterns';
 
 const KEY_PREFIX = 'custom_field.';
 
-const CustomFieldFilterRenderer: React.FC<CustomRendererProps<string>> = ({field, values, onChange, operator, onOperatorChange}) => {
-    const {data} = useBrowseMemberCustomFields();
+const CustomFieldFilterRenderer: React.FC<CustomRendererProps<string>> = ({field, values, onChange, operator, onOperatorChange, readOnly}) => {
+    // Include-archived so an archived composite field's pill can still resolve its parts
+    // and show which one the saved segment filters on.
+    const {data} = useBrowseMemberCustomFieldsIncludingArchived();
     const definitions = data?.members_custom_fields ?? [];
 
     const fieldKey = (field.key ?? '').slice(KEY_PREFIX.length);
@@ -44,11 +46,12 @@ const CustomFieldFilterRenderer: React.FC<CustomRendererProps<string>> = ({field
         : CUSTOM_FIELD_OPERATORS;
 
     useEffect(() => {
-        if (!onOperatorChange || operators.includes(operator)) {
+        // A read-only pill never rewrites its own operator; it just displays what's set.
+        if (readOnly || !onOperatorChange || operators.includes(operator)) {
             return;
         }
         onOperatorChange('is-set');
-    }, [operator, operators, onOperatorChange]);
+    }, [readOnly, operator, operators, onOperatorChange]);
 
     const needsValue = !CUSTOM_FIELD_SET_OPERATORS.includes(operator);
     const partOptions = [{value: '', label: 'Any'}, ...parts];
@@ -59,6 +62,7 @@ const CustomFieldFilterRenderer: React.FC<CustomRendererProps<string>> = ({field
                 <FilterSegmentSelect
                     ariaLabel={`${fieldLabel} part`}
                     options={partOptions}
+                    readOnly={readOnly}
                     testId="custom-field-filter-subfield"
                     value={subfield}
                     onChange={nextSubfield => onChange([nextSubfield, value])}
@@ -69,6 +73,7 @@ const CustomFieldFilterRenderer: React.FC<CustomRendererProps<string>> = ({field
                 <FilterSegmentSelect
                     ariaLabel={`${fieldLabel} operator`}
                     options={createOperatorOptions(operators)}
+                    readOnly={readOnly}
                     testId="custom-field-filter-operator"
                     value={operator}
                     onChange={onOperatorChange}
@@ -79,6 +84,7 @@ const CustomFieldFilterRenderer: React.FC<CustomRendererProps<string>> = ({field
                 <FilterSegmentInput
                     ariaLabel={`${fieldLabel} value`}
                     placeholder="Enter value..."
+                    readOnly={readOnly}
                     testId="custom-field-filter-value"
                     value={value}
                     onChange={nextValue => onChange([subfield, nextValue])}

--- a/apps/admin/src/members/member-fields.test.ts
+++ b/apps/admin/src/members/member-fields.test.ts
@@ -42,7 +42,8 @@ describe('memberFields', () => {
             'clicked_links.post_id',
             'newsletter_feedback',
             'offer_redemptions',
-            'count.active_stripe_customers'
+            'count.active_stripe_customers',
+            'custom_field.:key'
         ]);
     });
 

--- a/apps/admin/src/members/member-fields.ts
+++ b/apps/admin/src/members/member-fields.ts
@@ -133,6 +133,80 @@ const multipleActiveSubscriptionsCodec: FilterCodec = {
     }
 };
 
+// Presence operators: the extra an optional, per-member field has that a table column does
+// not — a column is always set, so no built-in field offers these.
+export const CUSTOM_FIELD_SET_OPERATORS: readonly string[] = ['is-set', 'is-not-set'];
+
+// A custom text field's operators, composed from the shared groups so the members filter
+// keeps one vocabulary: the equality pair (is / is-not) the scalar fields use, then the
+// text matching operators (contains, starts-with, …) with their duplicate `is` dropped,
+// then presence. Labels come from the shared createOperatorOptions default (dash to space),
+// which reads every one of these correctly, so no label map is needed.
+export const CUSTOM_FIELD_OPERATORS: readonly string[] = [
+    ...SCALAR_OPERATORS,
+    ...TEXT_OPERATORS.filter(op => !(SCALAR_OPERATORS as readonly string[]).includes(op)),
+    ...CUSTOM_FIELD_SET_OPERATORS
+];
+
+// NQL operator symbol for each value operator. The field is named in the value
+// position (`custom_fields.key:'…'`) so its key can carry hyphens; the value is
+// matched on `custom_fields.value` (scalar) or `custom_fields.value.<subfield>`
+// (address), which the members filter relation maps onto the real columns.
+const CUSTOM_FIELD_VALUE_SYMBOLS: Record<string, string> = {
+    is: '',
+    'is-not': '-',
+    contains: '~',
+    'does-not-contain': '-~',
+    'starts-with': '~^',
+    'ends-with': '~$'
+};
+
+const customFieldsCodec: FilterCodec = {
+    // Parsing a grouped custom-field expression back to a predicate is bespoke —
+    // its field and part are spread across a `(key + value)` pair — so it's handled
+    // by a compound matcher in member-filter-query.ts, not here.
+    parse() {
+        return null;
+    },
+    // The field's stable key comes from the dropdown entry (`custom_field.<key>`,
+    // resolved into `ctx.params.key`); the predicate carries only [subfield, value],
+    // with subfield '' for a scalar field or the "Any" (whole-field set/unset) case.
+    serialize(predicate, ctx) {
+        const fieldKey = ctx.params.key;
+        const [subfield, value] = predicate.values as [string, string];
+
+        if (!fieldKey) {
+            return null;
+        }
+
+        const keyClause = `custom_fields.key:${escapeNqlString(fieldKey)}`;
+
+        // set / not-set target a part's presence when a part is chosen (`path`), or the
+        // whole field otherwise (the bare key / its negation).
+        if (predicate.operator === 'is-set') {
+            return subfield
+                ? [`(${keyClause}+custom_fields.path:${escapeNqlString(subfield)})`]
+                : [keyClause];
+        }
+
+        if (predicate.operator === 'is-not-set') {
+            return subfield
+                ? [`(${keyClause}+custom_fields.path:-${escapeNqlString(subfield)})`]
+                : [`custom_fields.key:-${escapeNqlString(fieldKey)}`];
+        }
+
+        const symbol = CUSTOM_FIELD_VALUE_SYMBOLS[predicate.operator];
+
+        if (symbol === undefined || value === undefined || value === null || value === '') {
+            return null;
+        }
+
+        const valueKey = subfield ? `custom_fields.value.${subfield}` : 'custom_fields.value';
+
+        return [`(${keyClause}+${valueKey}:${symbol}${escapeNqlString(String(value))})`];
+    }
+};
+
 const baseMemberFields = defineFields({
     name: {
         operators: TEXT_OPERATORS,
@@ -453,6 +527,18 @@ const baseMemberFields = defineFields({
             {value: 'false', label: 'No'}
         ],
         codec: multipleActiveSubscriptionsCodec
+    },
+    // Each defined custom field is its own filter, named directly in the dropdown
+    // (`custom_field.<key>`), so this template supplies the shared operators and codec;
+    // use-member-filter-fields builds one entry per field from the definitions.
+    'custom_field.:key': {
+        operators: CUSTOM_FIELD_OPERATORS,
+        ui: {
+            label: 'Custom field',
+            type: 'custom',
+            component: 'custom-field'
+        },
+        codec: customFieldsCodec
     }
 });
 

--- a/apps/admin/src/members/member-filter-query.test.ts
+++ b/apps/admin/src/members/member-filter-query.test.ts
@@ -311,3 +311,53 @@ describe('isPredicateEnabled', () => {
         )).toBe(false);
     });
 });
+
+describe('member-filter-query - custom fields', () => {
+    // Serialize each operator to NQL, then parse it back, and confirm the predicate
+    // survives the round trip a saved segment relies on. Each field is its own
+    // predicate keyed `custom_field.<key>`; `values` is [subfield, value].
+    const cases: Array<{field: string; operator: string; values: [string, string]; nql: string}> = [
+        {field: 'custom_field.company', operator: 'is', values: ['', 'Ghost'], nql: "(custom_fields.key:'company'+custom_fields.value:'Ghost')"},
+        {field: 'custom_field.company', operator: 'is-not', values: ['', 'Ghost'], nql: "(custom_fields.key:'company'+custom_fields.value:-'Ghost')"},
+        {field: 'custom_field.company', operator: 'contains', values: ['', 'host'], nql: "(custom_fields.key:'company'+custom_fields.value:~'host')"},
+        {field: 'custom_field.company', operator: 'does-not-contain', values: ['', 'host'], nql: "(custom_fields.key:'company'+custom_fields.value:-~'host')"},
+        {field: 'custom_field.company', operator: 'starts-with', values: ['', 'Gh'], nql: "(custom_fields.key:'company'+custom_fields.value:~^'Gh')"},
+        {field: 'custom_field.company', operator: 'ends-with', values: ['', 'st'], nql: "(custom_fields.key:'company'+custom_fields.value:~$'st')"},
+        // A value that ends with a literal `$` must survive as contains, not be
+        // misread as ends-with when the regex source (`5\$`) is parsed back.
+        {field: 'custom_field.company', operator: 'contains', values: ['', '5$'], nql: "(custom_fields.key:'company'+custom_fields.value:~'5$')"},
+        {field: 'custom_field.shipping-address', operator: 'is', values: ['country', 'GB'], nql: "(custom_fields.key:'shipping-address'+custom_fields.value.country:'GB')"},
+        {field: 'custom_field.shipping-address', operator: 'is-not', values: ['country', 'GB'], nql: "(custom_fields.key:'shipping-address'+custom_fields.value.country:-'GB')"},
+        {field: 'custom_field.phone', operator: 'is-set', values: ['', ''], nql: "custom_fields.key:'phone'"},
+        {field: 'custom_field.phone', operator: 'is-not-set', values: ['', ''], nql: "custom_fields.key:-'phone'"},
+        // A part's set / not-set targets its presence via `path`, not the whole field.
+        {field: 'custom_field.shipping-address', operator: 'is-set', values: ['country', ''], nql: "(custom_fields.key:'shipping-address'+custom_fields.path:'country')"},
+        {field: 'custom_field.shipping-address', operator: 'is-not-set', values: ['country', ''], nql: "(custom_fields.key:'shipping-address'+custom_fields.path:-'country')"}
+    ];
+
+    it.each(cases)('serializes $field $operator to the expected NQL', ({field, operator, values, nql}) => {
+        const serialized = serializeMemberFilters([{id: 'x', field, operator, values}], 'UTC');
+        expect(serialized).toBe(nql);
+    });
+
+    it.each(cases)('parses $field $operator back into the same predicate', ({field, operator, values, nql}) => {
+        expect(stripIds(parseMemberFilter(nql, 'UTC'))).toEqual([
+            {field, operator, values}
+        ]);
+    });
+
+    it.each(cases)('round-trips $field $operator (predicate -> nql -> predicate)', ({field, operator, values}) => {
+        const predicate: FilterPredicate = {id: 'x', field, operator, values};
+        const nql = serializeMemberFilters([predicate], 'UTC');
+        expect(stripIds(parseMemberFilter(nql, 'UTC'))).toEqual([
+            {field, operator, values}
+        ]);
+    });
+
+    it('is enabled for every operator the custom field advertises', () => {
+        const fields = getMemberFields();
+        for (const {field, operator, values} of cases) {
+            expect(isPredicateEnabled({field, operator, values}, fields)).toBe(true);
+        }
+    });
+});

--- a/apps/admin/src/members/member-filter-query.ts
+++ b/apps/admin/src/members/member-filter-query.ts
@@ -180,10 +180,164 @@ function matchFeedbackGroupedNode(node: AstNode): ParsedPredicate | null {
     };
 }
 
+// A trailing `$` is an end anchor only when it isn't escaped: a value containing
+// a literal `$` (contains `5$`) reaches here as the source `5\$`, which must not
+// be read as ends-with. An odd run of backslashes before the `$` escapes it.
+function endsWithAnchor(source: string): boolean {
+    if (!source.endsWith('$')) {
+        return false;
+    }
+    let backslashes = 0;
+    for (let i = source.length - 2; i >= 0 && source[i] === '\\'; i -= 1) {
+        backslashes += 1;
+    }
+    return backslashes % 2 === 0;
+}
+
+// A regex value read back into a text operator by its anchors, mirroring the
+// serialize symbols in member-fields.ts (`~` contains, `~^` starts, `~$` ends).
+// A literal `^` in a value is escaped to `\^` so it never leads, but a literal
+// `$` escapes to `\$` and still ends the source, hence the anchor check above.
+// `$not` is only ever emitted by `does-not-contain` (an unanchored regex), so a
+// negated pattern always maps back to that operator.
+function regexToOperator(pattern: RegExp, negated: boolean): {operator: string; value: string} {
+    const source = pattern.source;
+    const startsWith = source.startsWith('^');
+    const endsWith = endsWithAnchor(source);
+
+    let base: string;
+    let body: string;
+    if (startsWith && !endsWith) {
+        base = 'starts-with';
+        body = source.slice(1);
+    } else if (endsWith && !startsWith) {
+        base = 'ends-with';
+        body = source.slice(0, -1);
+    } else {
+        base = 'contains';
+        body = source;
+    }
+
+    const value = body.replace(/\\([\\.^$|?*+()[\]{}/-])/g, '$1');
+    return {operator: negated ? 'does-not-contain' : base, value};
+}
+
+// The value NQL a custom-field predicate carries, read back into a (operator,
+// value) pair. nql represents `:~x` as {$regex: /x/} and its negation as
+// {$not: /x/}; a bare string is `is` and {$ne} is `is-not`. Returns null for a
+// shape we don't emit.
+function interpretCustomFieldValue(raw: unknown): {operator: string; value: string} | null {
+    if (typeof raw === 'string') {
+        return {operator: 'is', value: raw};
+    }
+
+    if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+        const object = raw as Record<string, unknown>;
+
+        if (typeof object.$ne === 'string') {
+            return {operator: 'is-not', value: object.$ne};
+        }
+
+        if (object.$regex instanceof RegExp) {
+            return regexToOperator(object.$regex, false);
+        }
+
+        if (object.$not instanceof RegExp) {
+            return regexToOperator(object.$not, true);
+        }
+    }
+
+    return null;
+}
+
+// A custom-field filter is `(custom_fields.key:'<key>'+custom_fields.value[.sub]:<v>)`,
+// or the flat `custom_fields.key:'<key>'` / `:-'<key>'` for set / not set. Each field
+// is its own predicate keyed `custom_field.<key>`, so the field's stable key becomes
+// part of the predicate field and the remaining `values` are [subfield, value]
+// (subfield '' for a scalar field or the whole-field set/unset case). This can't ride
+// the generic parser because the key lives in the value of the key clause, not the key.
+function matchCustomFieldNode(node: AstNode): ParsedPredicate | null {
+    const compound = getCompoundChildren(node);
+
+    if (!compound) {
+        const keyValue = node['custom_fields.key'];
+
+        if (typeof keyValue === 'string') {
+            return {field: `custom_field.${keyValue}`, operator: 'is-set', values: ['', '']};
+        }
+
+        if (keyValue && typeof keyValue === 'object' && !Array.isArray(keyValue) && typeof (keyValue as Record<string, unknown>).$ne === 'string') {
+            return {field: `custom_field.${(keyValue as Record<string, string>).$ne}`, operator: 'is-not-set', values: ['', '']};
+        }
+
+        return null;
+    }
+
+    if (compound.operator !== '$and' || compound.children.length !== 2) {
+        return null;
+    }
+
+    let fieldKey: string | undefined;
+    let valueEntry: {subfield: string; raw: unknown} | undefined;
+    let pathEntry: {subfield: string; negated: boolean} | undefined;
+
+    for (const child of compound.children) {
+        if (typeof child['custom_fields.key'] === 'string') {
+            fieldKey = child['custom_fields.key'];
+        }
+
+        for (const childKey of Object.keys(child)) {
+            if (childKey === 'custom_fields.value') {
+                valueEntry = {subfield: '', raw: child[childKey]};
+            } else if (childKey.startsWith('custom_fields.value.')) {
+                valueEntry = {subfield: childKey.slice('custom_fields.value.'.length), raw: child[childKey]};
+            } else if (childKey === 'custom_fields.path') {
+                const raw = child[childKey];
+
+                if (typeof raw === 'string') {
+                    pathEntry = {subfield: raw, negated: false};
+                } else if (raw && typeof raw === 'object' && !Array.isArray(raw) && typeof (raw as Record<string, unknown>).$ne === 'string') {
+                    pathEntry = {subfield: (raw as Record<string, string>).$ne, negated: true};
+                }
+            }
+        }
+    }
+
+    if (!fieldKey) {
+        return null;
+    }
+
+    // A `path` clause is a part's set / not-set: its presence, carrying no value.
+    if (pathEntry) {
+        return {
+            field: `custom_field.${fieldKey}`,
+            operator: pathEntry.negated ? 'is-not-set' : 'is-set',
+            values: [pathEntry.subfield, '']
+        };
+    }
+
+    if (!valueEntry) {
+        return null;
+    }
+
+    const interpreted = interpretCustomFieldValue(valueEntry.raw);
+
+    if (!interpreted) {
+        return null;
+    }
+
+    return {
+        field: `custom_field.${fieldKey}`,
+        operator: interpreted.operator,
+        values: [valueEntry.subfield, interpreted.value]
+    };
+}
+
 const MEMBER_COMPOUND_MATCHERS: CompoundMatcher[] = [
     matchSubscribedNode,
     matchNewsletterGroupedNode,
-    matchFeedbackGroupedNode
+    matchFeedbackGroupedNode,
+    matchCustomFieldNode
 ];
 
 function parseMemberNode(node: AstNode, timezone: string): ParsedPredicate[] {

--- a/apps/admin/src/members/use-member-filter-fields.test.ts
+++ b/apps/admin/src/members/use-member-filter-fields.test.ts
@@ -225,6 +225,44 @@ describe('useMemberFilterFields', () => {
         expect(subscriptionFields.map(field => field.key)).not.toContain('count.active_stripe_customers');
     });
 
+    it('gives each defined custom field its own named entry', () => {
+        const {result} = renderHook(() => useMemberFilterFields({
+            customFieldsEnabled: true,
+            customFields: [
+                {key: 'shipping_address', name: 'Shipping address', type: 'address'},
+                {key: 'job_title', name: 'Job title', type: 'short_text'}
+            ],
+            siteTimezone: 'UTC'
+        }));
+
+        const customFields = result.current.find(group => group.group === 'Custom fields')?.fields ?? [];
+
+        expect(customFields.map(field => ({key: field.key, label: field.label}))).toEqual([
+            {key: 'custom_field.shipping_address', label: 'Shipping address'},
+            {key: 'custom_field.job_title', label: 'Job title'}
+        ]);
+    });
+
+    it('omits the custom fields group when no fields are defined', () => {
+        const {result} = renderHook(() => useMemberFilterFields({
+            customFieldsEnabled: true,
+            customFields: [],
+            siteTimezone: 'UTC'
+        }));
+
+        expect(result.current.map(group => group.group)).not.toContain('Custom fields');
+    });
+
+    it('omits the custom fields group when the flag is off', () => {
+        const {result} = renderHook(() => useMemberFilterFields({
+            customFieldsEnabled: false,
+            customFields: [{key: 'job_title', name: 'Job title', type: 'short_text'}],
+            siteTimezone: 'UTC'
+        }));
+
+        expect(result.current.map(group => group.group)).not.toContain('Custom fields');
+    });
+
     it('hydrates grouped retention offers on the offer field', () => {
         const {result} = renderHook(() => useMemberFilterFields({
             paidMembersEnabled: true,

--- a/apps/admin/src/members/use-member-filter-fields.ts
+++ b/apps/admin/src/members/use-member-filter-fields.ts
@@ -27,6 +27,10 @@ interface UseMemberFilterFieldsOptions {
     emailTrackClicks?: boolean;
     customFieldsEnabled?: boolean;
     customFields?: Array<{key: string; name: string; type: MemberCustomField['type']}>;
+    // Archived fields still referenced by the current filter. Rendered as disabled,
+    // removable-only pills so a saved segment stays visible and undoable even though
+    // the field is no longer offered in the picker.
+    archivedCustomFields?: Array<{key: string; name: string}>;
     siteTimezone?: string;
 }
 
@@ -92,8 +96,6 @@ function getFieldIcon(key: string) {
         return React.createElement(LucideIcon.MousePointerClick, {className: 'size-4'});
     case 'newsletter_feedback':
         return React.createElement(LucideIcon.MessageSquare, {className: 'size-4'});
-    case 'custom_field':
-        return React.createElement(LucideIcon.SlidersHorizontal, {className: 'size-4'});
     case 'offer_redemptions':
         return React.createElement(LucideIcon.Ticket, {className: 'size-4'});
     case MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FIELD:
@@ -101,10 +103,6 @@ function getFieldIcon(key: string) {
     default:
         if (key.startsWith('newsletters.')) {
             return React.createElement(LucideIcon.Newspaper, {className: 'size-4'});
-        }
-
-        if (key.startsWith('custom_field.')) {
-            return React.createElement(LucideIcon.SlidersHorizontal, {className: 'size-4'});
         }
 
         return undefined;
@@ -272,6 +270,7 @@ export function useMemberFilterFields({
     emailTrackClicks = false,
     customFieldsEnabled = false,
     customFields = [],
+    archivedCustomFields = [],
     siteTimezone = 'UTC'
 }: UseMemberFilterFieldsOptions): FilterFieldGroup[] {
     return useMemo(() => {
@@ -371,19 +370,43 @@ export function useMemberFilterFields({
         // for "Shipping address" directly rather than reaching it through a generic
         // "Custom field" door. A simple field filters on its value; a composite field's
         // renderer opens its parts (plus "Any") in the pill.
-        if (customFieldsEnabled && customFields.length > 0) {
+        if (customFieldsEnabled) {
             const customFieldFields = customFields.map(field => createFieldConfig(`custom_field.${field.key}`, {
                 label: field.name,
                 // The dropdown entry and the added filter show the field type's own icon
                 // rather than a generic custom-field mark.
                 icon: React.createElement(CustomFieldIcon, {type: field.type, className: 'size-4'}),
+                // Text fields default to "contains" to match native Name/Email; a
+                // composite defaults to whole-field "is set" (the renderer coerces it).
+                defaultOperator: 'contains',
                 // The field's type decides its parts and operators, so the operator
                 // control lives in the renderer, after any part is chosen.
                 renderOperatorInValue: true,
                 customRenderer: props => React.createElement(CustomFieldFilterRenderer, props as React.ComponentProps<typeof CustomFieldFilterRenderer>)
             }));
 
-            groups.push({group: 'Custom fields', fields: customFieldFields, previewLimit: CUSTOM_FIELDS_PREVIEW_LIMIT});
+            // An archived field the current filter still references: a disabled,
+            // removable-only pill with an archive icon. Its key is already in the filter,
+            // so the picker's own de-dup keeps it out of the add-list — it only ever
+            // renders as an existing pill.
+            const archivedFieldFields = archivedCustomFields.map(field => createFieldConfig(`custom_field.${field.key}`, {
+                label: field.name,
+                icon: React.createElement(LucideIcon.Archive, {className: 'size-4'}),
+                // Read-only: the operator and value stay visible so the segment reads
+                // clearly, but the field is gone from the picker, so the pill can only
+                // be removed, never re-edited.
+                readOnly: true,
+                renderOperatorInValue: true,
+                customRenderer: props => React.createElement(CustomFieldFilterRenderer, props as React.ComponentProps<typeof CustomFieldFilterRenderer>)
+            }));
+
+            const allCustomFieldFields = [...customFieldFields, ...archivedFieldFields];
+
+            // Nothing defined yet means nothing to filter on, so the group stays out of
+            // the picker entirely rather than showing a section that can't be used.
+            if (allCustomFieldFields.length > 0) {
+                groups.push({group: 'Custom fields', fields: allCustomFieldFields, previewLimit: CUSTOM_FIELDS_PREVIEW_LIMIT});
+            }
         }
 
         if (activeNewsletters.length > 1) {
@@ -495,6 +518,7 @@ export function useMemberFilterFields({
         emailValueSource,
         customFieldsEnabled,
         customFields,
+        archivedCustomFields,
         emailTrackClicks,
         emailTrackOpens,
         hasMultipleTiers,

--- a/apps/admin/src/members/use-member-filter-fields.ts
+++ b/apps/admin/src/members/use-member-filter-fields.ts
@@ -33,6 +33,10 @@ interface UseMemberFilterFieldsOptions {
 type OfferOption = FilterOption<string>;
 type SearchableFieldOverrides = Pick<FilterFieldConfig, 'options' | 'valueSource'>;
 
+// How many custom fields the picker shows before "Show more" — the same preview
+// size the settings list uses. The rest stay searchable and resolvable.
+const CUSTOM_FIELDS_PREVIEW_LIMIT = 5;
+
 const MEMBER_OPERATOR_LABELS: Record<string, string> = {
     'is-any': 'is any of',
     'is-not-any': 'is none of',
@@ -379,7 +383,7 @@ export function useMemberFilterFields({
                 customRenderer: props => React.createElement(CustomFieldFilterRenderer, props as React.ComponentProps<typeof CustomFieldFilterRenderer>)
             }));
 
-            groups.push({group: 'Custom fields', fields: customFieldFields});
+            groups.push({group: 'Custom fields', fields: customFieldFields, previewLimit: CUSTOM_FIELDS_PREVIEW_LIMIT});
         }
 
         if (activeNewsletters.length > 1) {

--- a/apps/admin/src/members/use-member-filter-fields.ts
+++ b/apps/admin/src/members/use-member-filter-fields.ts
@@ -1,10 +1,13 @@
 import React, {useMemo} from 'react';
 import {DATE_OPERATOR_LABELS, RELATIVE_DATE_OPERATOR_LABELS, createOperatorOptions, createRelativeDateRenderer, fieldHasRelativeOperator, getTodayInTimezone} from '@/shared/filters';
 import {type FilterFieldConfig, type FilterFieldGroup, type FilterOption, type ValueSource} from '@tryghost/shade/patterns';
+import CustomFieldFilterRenderer from './custom-field-filter-renderer';
+import CustomFieldIcon from '@/shared/member-custom-fields/custom-field-icon';
 import {LabelFilterRenderer} from '@/members/label-picker';
 import {LucideIcon} from '@tryghost/shade/utils';
 import {MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FIELD} from './multiple-active-subscriptions';
 import {getMemberFields} from './member-fields';
+import type {MemberCustomField} from '@tryghost/admin-x-framework/api/member-custom-fields';
 import type {Offer} from '@tryghost/admin-x-framework/api/offers';
 
 interface UseMemberFilterFieldsOptions {
@@ -22,6 +25,8 @@ interface UseMemberFilterFieldsOptions {
     membersTrackSources?: boolean;
     emailTrackOpens?: boolean;
     emailTrackClicks?: boolean;
+    customFieldsEnabled?: boolean;
+    customFields?: Array<{key: string; name: string; type: MemberCustomField['type']}>;
     siteTimezone?: string;
 }
 
@@ -83,6 +88,8 @@ function getFieldIcon(key: string) {
         return React.createElement(LucideIcon.MousePointerClick, {className: 'size-4'});
     case 'newsletter_feedback':
         return React.createElement(LucideIcon.MessageSquare, {className: 'size-4'});
+    case 'custom_field':
+        return React.createElement(LucideIcon.SlidersHorizontal, {className: 'size-4'});
     case 'offer_redemptions':
         return React.createElement(LucideIcon.Ticket, {className: 'size-4'});
     case MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FIELD:
@@ -90,6 +97,10 @@ function getFieldIcon(key: string) {
     default:
         if (key.startsWith('newsletters.')) {
             return React.createElement(LucideIcon.Newspaper, {className: 'size-4'});
+        }
+
+        if (key.startsWith('custom_field.')) {
+            return React.createElement(LucideIcon.SlidersHorizontal, {className: 'size-4'});
         }
 
         return undefined;
@@ -255,6 +266,8 @@ export function useMemberFilterFields({
     membersTrackSources = false,
     emailTrackOpens = false,
     emailTrackClicks = false,
+    customFieldsEnabled = false,
+    customFields = [],
     siteTimezone = 'UTC'
 }: UseMemberFilterFieldsOptions): FilterFieldGroup[] {
     return useMemo(() => {
@@ -266,9 +279,14 @@ export function useMemberFilterFields({
             overrides: Partial<FilterFieldConfig> = {},
             operatorLabels: Record<string, string> = MEMBER_OPERATOR_LABELS
         ): FilterFieldConfig {
-            const field = key.startsWith('newsletters.')
-                ? fields['newsletters.:slug']
-                : fields[key as MemberFieldKey];
+            let field;
+            if (key.startsWith('newsletters.')) {
+                field = fields['newsletters.:slug'];
+            } else if (key.startsWith('custom_field.')) {
+                field = fields['custom_field.:key'];
+            } else {
+                field = fields[key as MemberFieldKey];
+            }
 
             return {
                 key,
@@ -344,6 +362,25 @@ export function useMemberFilterFields({
         }
 
         groups.push({group: 'Basic', fields: basicFields});
+
+        // Each defined custom field is its own named entry, so a publisher can search
+        // for "Shipping address" directly rather than reaching it through a generic
+        // "Custom field" door. A simple field filters on its value; a composite field's
+        // renderer opens its parts (plus "Any") in the pill.
+        if (customFieldsEnabled && customFields.length > 0) {
+            const customFieldFields = customFields.map(field => createFieldConfig(`custom_field.${field.key}`, {
+                label: field.name,
+                // The dropdown entry and the added filter show the field type's own icon
+                // rather than a generic custom-field mark.
+                icon: React.createElement(CustomFieldIcon, {type: field.type, className: 'size-4'}),
+                // The field's type decides its parts and operators, so the operator
+                // control lives in the renderer, after any part is chosen.
+                renderOperatorInValue: true,
+                customRenderer: props => React.createElement(CustomFieldFilterRenderer, props as React.ComponentProps<typeof CustomFieldFilterRenderer>)
+            }));
+
+            groups.push({group: 'Custom fields', fields: customFieldFields});
+        }
 
         if (activeNewsletters.length > 1) {
             const newsletterFields: FilterFieldConfig[] = [
@@ -452,6 +489,8 @@ export function useMemberFilterFields({
     }, [
         emailFiltersEnabled,
         emailValueSource,
+        customFieldsEnabled,
+        customFields,
         emailTrackClicks,
         emailTrackOpens,
         hasMultipleTiers,

--- a/apps/shade/src/components/patterns/filters.stories.tsx
+++ b/apps/shade/src/components/patterns/filters.stories.tsx
@@ -1,6 +1,6 @@
 import type {Meta, StoryObj} from '@storybook/react-vite';
 import {useState} from 'react';
-import {Filters, type Filter, type FilterFieldConfig, createFilter} from './filters';
+import {Filters, FilterSegmentSelect, FilterSegmentInput, type CustomRendererProps, type Filter, type FilterFieldConfig, createFilter} from './filters';
 import {
     User,
     Mail,
@@ -15,7 +15,9 @@ import {
     CheckCircle,
     XCircle,
     Circle,
-    X
+    X,
+    Archive,
+    SlidersHorizontal
 } from 'lucide-react';
 
 const meta = {
@@ -826,3 +828,117 @@ export const ClearButtonCustomHandler: Story = {
         }
     }
 };
+
+// A customRenderer composing FilterSegmentSelect + FilterSegmentInput into a cascade
+// (part -> operator -> value) that reads as native filter segments.
+const CascadeRenderer = ({values, onChange, operator, onOperatorChange, readOnly}: CustomRendererProps<string>) => {
+    const [part = '', value = ''] = values;
+
+    return (
+        <>
+            <FilterSegmentSelect
+                ariaLabel="Part"
+                options={[{value: '', label: 'Any'}, {value: 'city', label: 'City'}, {value: 'country', label: 'Country'}]}
+                readOnly={readOnly}
+                value={part}
+                onChange={next => onChange([next, value])}
+            />
+            {onOperatorChange && (
+                <FilterSegmentSelect
+                    ariaLabel="Operator"
+                    options={[{value: 'contains', label: 'contains'}, {value: 'is', label: 'is'}]}
+                    readOnly={readOnly}
+                    value={operator}
+                    onChange={onOperatorChange}
+                />
+            )}
+            <FilterSegmentInput
+                ariaLabel="Value"
+                placeholder="Enter value..."
+                readOnly={readOnly}
+                value={value}
+                onChange={next => onChange([part, next])}
+            />
+        </>
+    );
+};
+
+const segmentFields: FilterFieldConfig[] = [
+    {
+        key: 'address',
+        label: 'Address',
+        type: 'custom',
+        icon: <SlidersHorizontal className="size-4" />,
+        renderOperatorInValue: true,
+        operators: [{value: 'contains', label: 'contains'}, {value: 'is', label: 'is'}],
+        customRenderer: props => <CascadeRenderer {...(props as CustomRendererProps<string>)} />
+    }
+];
+
+export const ComposedSegments: Story = {
+    render: () => <FilterDemo fields={segmentFields} initialFilters={[createFilter('address', 'contains', ['city', 'York'])]} />,
+    parameters: {
+        docs: {
+            description: {
+                story: 'FilterSegmentSelect and FilterSegmentInput composed by a customRenderer (with `renderOperatorInValue`) into a cascade that reads as native filter segments rather than standalone selects.'
+            }
+        }
+    }
+};
+
+const readOnlyFields: FilterFieldConfig[] = [
+    {
+        key: 'archived_field',
+        label: 'Archived field',
+        type: 'text',
+        icon: <Archive className="size-4" />,
+        readOnly: true,
+        operators: [{value: 'is', label: 'is'}]
+    },
+    {
+        key: 'name',
+        label: 'Name',
+        type: 'text',
+        icon: <User className="size-4" />
+    }
+];
+
+export const ReadOnlyFilter: Story = {
+    render: () => <FilterDemo fields={readOnlyFields} initialFilters={[createFilter('archived_field', 'is', ['London'])]} />,
+    parameters: {
+        docs: {
+            description: {
+                story: 'A read-only filter keeps its operator and value visible as static text and can only be removed — for a filter on a source no longer offered, such as an archived field.'
+            }
+        }
+    }
+};
+
+const previewLimitFields: FilterFieldConfig[] = [
+    {
+        group: 'Basic',
+        fields: [{key: 'name', label: 'Name', type: 'text', icon: <User className="size-4" />}]
+    },
+    {
+        group: 'Custom fields',
+        previewLimit: 3,
+        fields: Array.from({length: 8}, (_, index): FilterFieldConfig => ({
+            key: `custom_field.field_${index + 1}`,
+            label: `Field ${index + 1}`,
+            type: 'text',
+            icon: <SlidersHorizontal className="size-4" />
+        }))
+    }
+];
+
+export const GroupPreviewLimit: Story = {
+    render: () => <FilterDemo fields={previewLimitFields} />,
+    parameters: {
+        docs: {
+            description: {
+                story: 'A group can preview a subset of its fields with `previewLimit`, revealing the rest behind "Show more". Every field stays resolvable and findable by search.'
+            }
+        }
+    }
+};
+

--- a/apps/shade/src/components/patterns/filters.tsx
+++ b/apps/shade/src/components/patterns/filters.tsx
@@ -35,6 +35,7 @@ export interface FilterI18nConfig {
     noResultsFound: string;
     loading: string;
     loadMore: string;
+    showMore: (count: number) => string;
     select: string;
     true: string;
     false: string;
@@ -112,6 +113,7 @@ export const DEFAULT_I18N: FilterI18nConfig = {
     noResultsFound: 'No results found.',
     loading: 'Loading...',
     loadMore: 'Load more',
+    showMore: count => `Show ${count} more`,
     select: 'Select...',
     true: 'True',
     false: 'False',
@@ -346,12 +348,19 @@ const filterOperatorVariants = cva(
             cursorPointer: {
                 true: 'cursor-pointer',
                 false: ''
+            },
+            // A read-only segment keeps its chrome but reads as static: muted, no
+            // hover, no pointer. Used for an applied-but-not-editable filter.
+            readOnly: {
+                true: 'pointer-events-none text-muted-foreground hover:text-muted-foreground',
+                false: ''
             }
         },
         defaultVariants: {
             variant: 'outline',
             size: 'md',
-            cursorPointer: true
+            cursorPointer: true,
+            readOnly: false
         }
     }
 );
@@ -414,12 +423,19 @@ const filterFieldValueVariants = cva(
             cursorPointer: {
                 true: 'cursor-pointer has-[[data-slot=switch]]:cursor-default has-[>[data-slot=filters-input-wrapper]]:cursor-text',
                 false: ''
+            },
+            // A read-only value keeps its chrome but reads as static: muted, no hover,
+            // no pointer. Mirrors the operator segment's read-only treatment.
+            readOnly: {
+                true: 'pointer-events-none text-muted-foreground hover:bg-background',
+                false: ''
             }
         },
         defaultVariants: {
             variant: 'outline',
             size: 'md',
-            cursorPointer: true
+            cursorPointer: true,
+            readOnly: false
         }
     }
 );
@@ -920,6 +936,10 @@ export interface CustomRendererProps<T = unknown> {
     // depends on a choice made in the value area (e.g. a custom field whose type
     // is picked here) can own the operator control itself.
     onOperatorChange?: (operator: string) => void;
+    // Render the composed segments as static, non-editable text (an applied filter
+    // that can't be changed, e.g. one on an archived source). The renderer should
+    // pass this through to its FilterSegment* children.
+    readOnly?: boolean;
 }
 
 // Grouped field configuration interface
@@ -980,6 +1000,10 @@ export interface FilterFieldConfig<T = unknown> {
     group?: string;
     fields?: FilterFieldConfig<T>[];
     previewLimit?: number;
+    // Renders an existing pill as read-only: its operator and value stay visible but
+    // static, and it can only be removed — for a filter on a source no longer offered
+    // in the picker (e.g. an archived field).
+    readOnly?: boolean;
     // Field-specific options
     options?: FilterOption<T>[];
     isLoading?: boolean;
@@ -1212,64 +1236,40 @@ interface FilterOperatorDropdownProps<T = unknown> {
     onChange: (operator: string) => void;
 }
 
-function FilterOperatorDropdown<T = unknown>({field, operator, values, onChange}: FilterOperatorDropdownProps<T>) {
+// The operator-style dropdown chrome, shared by the built-in operator control and the
+// composable FilterSegmentSelect: a trigger styled with `filterOperatorVariants` over a
+// checked option list. `readOnly` renders the trigger as static text with no menu, so an
+// applied-but-not-editable filter still shows its value.
+function SegmentDropdown({
+    trigger,
+    options,
+    value,
+    onChange,
+    readOnly,
+    ariaLabel,
+    testId
+}: {
+    trigger: React.ReactNode;
+    options: FilterSegmentOption[];
+    value: string;
+    onChange: (value: string) => void;
+    readOnly?: boolean;
+    ariaLabel?: string;
+    testId?: string;
+}) {
     const context = useFilterContext();
-    const operators = getOperatorsForField(field, values, context.i18n);
 
-    // Find the operator label, with fallback to formatted operator name
-    const operatorLabel =
-    operators.find(op => op.value === operator)?.label || context.i18n.helpers.formatOperator(operator);
-
-    // If hideOperatorSelect is true, just render the operator as plain text
-    if (field.hideOperatorSelect) {
+    if (readOnly) {
         return (
-            <div className="flex items-center self-stretch border border-r-0 px-2.5 whitespace-nowrap text-muted-foreground">
-                {operatorLabel}
+            <div
+                aria-label={ariaLabel}
+                className={filterOperatorVariants({variant: context.variant, size: context.size, readOnly: true})}
+                data-testid={testId}
+            >
+                {trigger}
             </div>
         );
     }
-
-    return (
-        <DropdownMenu>
-            <DropdownMenuTrigger className={filterOperatorVariants({variant: context.variant, size: context.size})}>
-                {operatorLabel}
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" className="w-fit min-w-fit">
-                {operators.map(op => (
-                    <DropdownMenuItem
-                        key={op.value}
-                        className="flex items-center justify-between"
-                        onClick={() => onChange(op.value)}
-                    >
-                        <span>{op.label}</span>
-                        <Check className={`ms-auto text-primary ${op.value === operator ? 'opacity-100' : 'opacity-0'}`} />
-                    </DropdownMenuItem>
-                ))}
-            </DropdownMenuContent>
-        </DropdownMenu>
-    );
-}
-
-export interface FilterSegmentOption {
-    value: string;
-    label: string;
-}
-
-export interface FilterSegmentSelectProps {
-    value: string;
-    options: FilterSegmentOption[];
-    onChange: (value: string) => void;
-    placeholder?: string;
-    ariaLabel?: string;
-    testId?: string;
-}
-
-// A dropdown segment styled like the built-in operator control, so a custom
-// renderer can compose its own choices (e.g. a custom field's field / sub-field /
-// operator) that read as native filter segments rather than standalone selects.
-export function FilterSegmentSelect({value, options, onChange, placeholder, ariaLabel, testId}: FilterSegmentSelectProps) {
-    const context = useFilterContext();
-    const selected = options.find(option => option.value === value);
 
     return (
         <DropdownMenu>
@@ -1278,9 +1278,7 @@ export function FilterSegmentSelect({value, options, onChange, placeholder, aria
                 className={filterOperatorVariants({variant: context.variant, size: context.size})}
                 data-testid={testId}
             >
-                <span className={selected ? undefined : 'text-muted-foreground'}>
-                    {selected ? selected.label : placeholder}
-                </span>
+                {trigger}
             </DropdownMenuTrigger>
             <DropdownMenuContent align="start" className="w-fit min-w-fit">
                 {options.map(option => (
@@ -1298,6 +1296,68 @@ export function FilterSegmentSelect({value, options, onChange, placeholder, aria
     );
 }
 
+function FilterOperatorDropdown<T = unknown>({field, operator, values, onChange}: FilterOperatorDropdownProps<T>) {
+    const context = useFilterContext();
+    const operators = getOperatorsForField(field, values, context.i18n);
+
+    // Find the operator label, with fallback to formatted operator name
+    const operatorLabel =
+    operators.find(op => op.value === operator)?.label || context.i18n.helpers.formatOperator(operator);
+
+    // Both `hideOperatorSelect` and a read-only field render the operator as static
+    // text through the shared chrome, rather than a live menu.
+    return (
+        <SegmentDropdown
+            options={operators}
+            readOnly={field.readOnly || field.hideOperatorSelect}
+            trigger={operatorLabel}
+            value={operator}
+            onChange={onChange}
+        />
+    );
+}
+
+export interface FilterSegmentOption {
+    value: string;
+    label: string;
+}
+
+export interface FilterSegmentSelectProps {
+    value: string;
+    options: FilterSegmentOption[];
+    onChange: (value: string) => void;
+    placeholder?: string;
+    ariaLabel?: string;
+    className?: string;
+    testId?: string;
+    // Render the selection as static text (no menu) — for an applied filter that
+    // should stay legible but not editable.
+    readOnly?: boolean;
+}
+
+// A dropdown segment styled like the built-in operator control, so a custom
+// renderer can compose its own choices (e.g. a custom field's field / sub-field /
+// operator) that read as native filter segments rather than standalone selects.
+export function FilterSegmentSelect({value, options, onChange, placeholder, ariaLabel, className, testId, readOnly}: FilterSegmentSelectProps) {
+    const selected = options.find(option => option.value === value);
+
+    return (
+        <SegmentDropdown
+            ariaLabel={ariaLabel}
+            options={options}
+            readOnly={readOnly}
+            testId={testId}
+            trigger={
+                <span className={cn(selected ? undefined : 'text-muted-foreground', className)}>
+                    {selected ? selected.label : placeholder}
+                </span>
+            }
+            value={value}
+            onChange={onChange}
+        />
+    );
+}
+
 export interface FilterSegmentInputProps {
     value: string;
     onChange: (value: string) => void;
@@ -1305,11 +1365,14 @@ export interface FilterSegmentInputProps {
     ariaLabel?: string;
     className?: string;
     testId?: string;
+    // Render the value as static text (no input) — for an applied filter that should
+    // stay legible but not editable.
+    readOnly?: boolean;
 }
 
 // A text-input segment styled like the built-in value input, for the value part
 // of a custom renderer composed from segments.
-export function FilterSegmentInput({value, onChange, placeholder, ariaLabel, className, testId}: FilterSegmentInputProps) {
+export function FilterSegmentInput({value, onChange, placeholder, ariaLabel, className, testId, readOnly}: FilterSegmentInputProps) {
     const context = useFilterContext();
 
     return (
@@ -1317,16 +1380,27 @@ export function FilterSegmentInput({value, onChange, placeholder, ariaLabel, cla
             className={cn('w-36', filterInputVariants({variant: context.variant, size: context.size}), className)}
             data-slot="filters-input-wrapper"
         >
-            <input
-                aria-label={ariaLabel}
-                autoComplete="off"
-                className="w-full bg-transparent outline-hidden dark:!bg-transparent"
-                data-slot="filters-input"
-                data-testid={testId}
-                placeholder={placeholder}
-                value={value}
-                onChange={event => onChange(event.target.value)}
-            />
+            {readOnly ? (
+                <span
+                    aria-label={ariaLabel}
+                    className="block w-full truncate text-muted-foreground"
+                    data-slot="filters-input"
+                    data-testid={testId}
+                >
+                    {value || placeholder}
+                </span>
+            ) : (
+                <input
+                    aria-label={ariaLabel}
+                    autoComplete="off"
+                    className="w-full bg-transparent outline-hidden"
+                    data-slot="filters-input"
+                    data-testid={testId}
+                    placeholder={placeholder}
+                    value={value}
+                    onChange={event => onChange(event.target.value)}
+                />
+            )}
         </div>
     );
 }
@@ -1337,6 +1411,7 @@ interface FilterValueSelectorProps<T = unknown> {
     onChange: (values: T[]) => void;
     operator: string;
     onOperatorChange?: (operator: string) => void;
+    readOnly?: boolean;
 }
 
 interface SelectOptionsPopoverProps<T = unknown> {
@@ -1848,7 +1923,7 @@ function SelectOptionsPopover<T = unknown>({
     );
 }
 
-function FilterValueSelector<T = unknown>({field, values, onChange, operator, onOperatorChange}: FilterValueSelectorProps<T>) {
+function FilterValueSelector<T = unknown>({field, values, onChange, operator, onOperatorChange, readOnly}: FilterValueSelectorProps<T>) {
     const [open, setOpen] = useState(false);
     const [searchInput, setSearchInput] = useState('');
     const context = useFilterContext();
@@ -1877,7 +1952,7 @@ function FilterValueSelector<T = unknown>({field, values, onChange, operator, on
         // it sits directly in the filter item rather than inside a single value box
         // — otherwise its segments would nest inside one bordered value pill.
         if (field.renderOperatorInValue) {
-            return <>{field.customRenderer({field, values, onChange, operator, onOperatorChange})}</>;
+            return <>{field.customRenderer({field, values, onChange, operator, onOperatorChange, readOnly})}</>;
         }
 
         return (
@@ -1885,10 +1960,37 @@ function FilterValueSelector<T = unknown>({field, values, onChange, operator, on
                 className={filterFieldValueVariants({
                     variant: context.variant,
                     size: context.size,
-                    cursorPointer: context.cursorPointer
+                    cursorPointer: context.cursorPointer,
+                    readOnly
                 })}
             >
-                {field.customRenderer({field, values, onChange, operator, onOperatorChange})}
+                {field.customRenderer({field, values, onChange, operator, onOperatorChange, readOnly})}
+            </div>
+        );
+    }
+
+    // A read-only field with no custom renderer shows its value as static text.
+    if (readOnly) {
+        return (
+            <div
+                className={filterFieldValueVariants({
+                    variant: context.variant,
+                    size: context.size,
+                    cursorPointer: context.cursorPointer,
+                    readOnly: true
+                })}
+            >
+                {field.customValueRenderer
+                    ? field.customValueRenderer(values, field.options ?? [])
+                    : values
+                        .map((currentValue) => {
+                            // Through the options, as the editable path does: a field that
+                            // reads "Gold" while editable must not read "t1" once frozen.
+                            const option = field.options?.find(candidate => candidate.value === currentValue);
+                            return option ? option.label : String(currentValue);
+                        })
+                        .filter(Boolean)
+                        .join(', ')}
             </div>
         );
     }
@@ -2368,6 +2470,7 @@ export const FiltersContent = <T = unknown,>({filters, fields, onChange}: Filter
                         <FilterValueSelector<T>
                             field={field}
                             operator={filter.operator}
+                            readOnly={field.readOnly}
                             values={filter.values}
                             onChange={values => updateFilter(filter.id, {values})}
                             onOperatorChange={operator => updateFilter(filter.id, {operator})}
@@ -2610,6 +2713,19 @@ export function Filters<T = unknown>({
         [closeFilterPopover, filters, onChange]
     );
 
+    // A read-only field is never offered: it exists so a filter already applied against it
+    // stays readable and removable. Checked before allowMultiple, which otherwise lets a
+    // field be picked again while it is applied — minting a second, uneditable, empty one.
+    const isOfferable = useCallback((field: FilterFieldConfig<T>) => {
+        if (field.readOnly) {
+            return false;
+        }
+        if (allowMultiple) {
+            return true;
+        }
+        return !filters.some(filter => filter.field === field.key);
+    }, [allowMultiple, filters]);
+
     const selectableFields = useMemo(() => {
         const flatFields = flattenFields(fields);
         return flatFields.filter((field) => {
@@ -2617,14 +2733,9 @@ export function Filters<T = unknown>({
             if (!field.key || field.type === 'separator') {
                 return false;
             }
-            // If allowMultiple is true, don't filter out fields that already have filters
-            if (allowMultiple) {
-                return true;
-            }
-            // Filter out fields that already have filters (default behavior)
-            return !filters.some(filter => filter.field === field.key);
+            return isOfferable(field);
         });
-    }, [fields, filters, allowMultiple]);
+    }, [fields, isOfferable]);
 
     // A group can preview a subset in the picker (previewLimit) while every field
     // stays resolvable — getFieldsMap flattens all of them, so named pills and saved
@@ -2637,6 +2748,8 @@ export function Filters<T = unknown>({
         groupFields: FilterFieldConfig<T>[],
         previewLimit?: number
     ) => {
+        // A group with nothing left to add collapses away rather than showing an empty
+        // heading.
         if (groupFields.length === 0) {
             return null;
         }
@@ -2677,7 +2790,7 @@ export function Filters<T = unknown>({
                             return next;
                         })}
                     >
-                        <span className="truncate">Show {hiddenCount} more</span>
+                        <span className="truncate">{mergedI18n.showMore(hiddenCount)}</span>
                     </CommandItem>
                 )}
             </CommandGroup>
@@ -2733,10 +2846,14 @@ export function Filters<T = unknown>({
                                 />
                             )}
 
-                            {/* Value Selector */}
+                            {/* Value Selector. A read-only field (e.g. an archived
+                                source) still renders its operator and value, but as
+                                static segments, so the filter stays legible while only
+                                the remove control acts. */}
                             <FilterValueSelector<T>
                                 field={field}
                                 operator={filter.operator}
+                                readOnly={field.readOnly}
                                 values={filter.values}
                                 onChange={values => updateFilter(filter.id, {values})}
                                 onOperatorChange={operator => updateFilter(filter.id, {operator})}
@@ -2822,12 +2939,7 @@ export function Filters<T = unknown>({
                                                     if (field.type === 'separator') {
                                                         return true;
                                                     }
-                                                    // If allowMultiple is true, don't filter out fields that already have filters
-                                                    if (allowMultiple) {
-                                                        return true;
-                                                    }
-                                                    // Filter out fields that already have filters (default behavior)
-                                                    return !filters.some(filter => filter.field === field.key);
+                                                    return isOfferable(field);
                                                 });
 
                                                 return renderPickerGroup(item.group || `group-${index}`, item.group || 'Fields', groupFields, item.previewLimit);
@@ -2840,12 +2952,7 @@ export function Filters<T = unknown>({
                                                     if (field.type === 'separator') {
                                                         return true;
                                                     }
-                                                    // If allowMultiple is true, don't filter out fields that already have filters
-                                                    if (allowMultiple) {
-                                                        return true;
-                                                    }
-                                                    // Filter out fields that already have filters (default behavior)
-                                                    return !filters.some(filter => filter.field === field.key);
+                                                    return isOfferable(field);
                                                 });
 
                                                 return renderPickerGroup(item.group || `group-${index}`, item.group || 'Fields', groupFields, item.previewLimit);
@@ -2860,8 +2967,7 @@ export function Filters<T = unknown>({
                                                 return <CommandSeparator key={sepKey} />;
                                             }
 
-                                            // If allowMultiple is false, filter out fields that already have filters
-                                            if (!allowMultiple && filters.some(filter => filter.field === field.key)) {
+                                            if (!isOfferable(field)) {
                                                 return null;
                                             }
 

--- a/apps/shade/src/components/patterns/filters.tsx
+++ b/apps/shade/src/components/patterns/filters.tsx
@@ -915,6 +915,11 @@ export interface CustomRendererProps<T = unknown> {
     values: T[];
     onChange: (values: T[]) => void;
     operator: string;
+    // Set the predicate's operator from inside the renderer. Provided when the
+    // field opts into `renderOperatorInValue`, so a renderer whose operator set
+    // depends on a choice made in the value area (e.g. a custom field whose type
+    // is picked here) can own the operator control itself.
+    onOperatorChange?: (operator: string) => void;
 }
 
 // Grouped field configuration interface
@@ -1006,6 +1011,12 @@ export interface FilterFieldConfig<T = unknown> {
     defaultValue?: T;
     // Hide the operator dropdown and only show the operator as text
     hideOperatorSelect?: boolean;
+    // Suppress the framework's operator control entirely and let a customRenderer
+    // render its own, positioned after the value area's own selections. Used when
+    // the valid operator set depends on a choice made inside the renderer (e.g. a
+    // custom field whose type is picked there). The renderer receives
+    // `onOperatorChange` to drive the predicate operator.
+    renderOperatorInValue?: boolean;
     // Controlled values support for this field
     value?: T[];
     onValueChange?: (values: T[]) => void;
@@ -1234,11 +1245,93 @@ function FilterOperatorDropdown<T = unknown>({field, operator, values, onChange}
     );
 }
 
+export interface FilterSegmentOption {
+    value: string;
+    label: string;
+}
+
+export interface FilterSegmentSelectProps {
+    value: string;
+    options: FilterSegmentOption[];
+    onChange: (value: string) => void;
+    placeholder?: string;
+    ariaLabel?: string;
+    testId?: string;
+}
+
+// A dropdown segment styled like the built-in operator control, so a custom
+// renderer can compose its own choices (e.g. a custom field's field / sub-field /
+// operator) that read as native filter segments rather than standalone selects.
+export function FilterSegmentSelect({value, options, onChange, placeholder, ariaLabel, testId}: FilterSegmentSelectProps) {
+    const context = useFilterContext();
+    const selected = options.find(option => option.value === value);
+
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger
+                aria-label={ariaLabel}
+                className={filterOperatorVariants({variant: context.variant, size: context.size})}
+                data-testid={testId}
+            >
+                <span className={selected ? undefined : 'text-muted-foreground'}>
+                    {selected ? selected.label : placeholder}
+                </span>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="w-fit min-w-fit">
+                {options.map(option => (
+                    <DropdownMenuItem
+                        key={option.value}
+                        className="flex items-center justify-between"
+                        onClick={() => onChange(option.value)}
+                    >
+                        <span>{option.label}</span>
+                        <Check className={`ms-auto text-primary ${option.value === value ? 'opacity-100' : 'opacity-0'}`} />
+                    </DropdownMenuItem>
+                ))}
+            </DropdownMenuContent>
+        </DropdownMenu>
+    );
+}
+
+export interface FilterSegmentInputProps {
+    value: string;
+    onChange: (value: string) => void;
+    placeholder?: string;
+    ariaLabel?: string;
+    className?: string;
+    testId?: string;
+}
+
+// A text-input segment styled like the built-in value input, for the value part
+// of a custom renderer composed from segments.
+export function FilterSegmentInput({value, onChange, placeholder, ariaLabel, className, testId}: FilterSegmentInputProps) {
+    const context = useFilterContext();
+
+    return (
+        <div
+            className={cn('w-36', filterInputVariants({variant: context.variant, size: context.size}), className)}
+            data-slot="filters-input-wrapper"
+        >
+            <input
+                aria-label={ariaLabel}
+                autoComplete="off"
+                className="w-full bg-transparent outline-hidden dark:!bg-transparent"
+                data-slot="filters-input"
+                data-testid={testId}
+                placeholder={placeholder}
+                value={value}
+                onChange={event => onChange(event.target.value)}
+            />
+        </div>
+    );
+}
+
 interface FilterValueSelectorProps<T = unknown> {
     field: FilterFieldConfig<T>;
     values: T[];
     onChange: (values: T[]) => void;
     operator: string;
+    onOperatorChange?: (operator: string) => void;
 }
 
 interface SelectOptionsPopoverProps<T = unknown> {
@@ -1750,7 +1843,7 @@ function SelectOptionsPopover<T = unknown>({
     );
 }
 
-function FilterValueSelector<T = unknown>({field, values, onChange, operator}: FilterValueSelectorProps<T>) {
+function FilterValueSelector<T = unknown>({field, values, onChange, operator, onOperatorChange}: FilterValueSelectorProps<T>) {
     const [open, setOpen] = useState(false);
     const [searchInput, setSearchInput] = useState('');
     const context = useFilterContext();
@@ -1775,6 +1868,13 @@ function FilterValueSelector<T = unknown>({field, values, onChange, operator}: F
 
     // Use custom renderer if provided
     if (field.customRenderer) {
+        // A field that renders its own operator also composes its own segments, so
+        // it sits directly in the filter item rather than inside a single value box
+        // — otherwise its segments would nest inside one bordered value pill.
+        if (field.renderOperatorInValue) {
+            return <>{field.customRenderer({field, values, onChange, operator, onOperatorChange})}</>;
+        }
+
         return (
             <div
                 className={filterFieldValueVariants({
@@ -1783,7 +1883,7 @@ function FilterValueSelector<T = unknown>({field, values, onChange, operator}: F
                     cursorPointer: context.cursorPointer
                 })}
             >
-                {field.customRenderer({field, values, onChange, operator})}
+                {field.customRenderer({field, values, onChange, operator, onOperatorChange})}
             </div>
         );
     }
@@ -2250,12 +2350,14 @@ export const FiltersContent = <T = unknown,>({filters, fields, onChange}: Filter
                         </div>
 
                         {/* Operator Dropdown */}
-                        <FilterOperatorDropdown<T>
-                            field={field}
-                            operator={filter.operator}
-                            values={filter.values}
-                            onChange={operator => updateFilter(filter.id, {operator})}
-                        />
+                        {!field.renderOperatorInValue && (
+                            <FilterOperatorDropdown<T>
+                                field={field}
+                                operator={filter.operator}
+                                values={filter.values}
+                                onChange={operator => updateFilter(filter.id, {operator})}
+                            />
+                        )}
 
                         {/* Value Selector */}
                         <FilterValueSelector<T>
@@ -2263,6 +2365,7 @@ export const FiltersContent = <T = unknown,>({filters, fields, onChange}: Filter
                             operator={filter.operator}
                             values={filter.values}
                             onChange={values => updateFilter(filter.id, {values})}
+                            onOperatorChange={operator => updateFilter(filter.id, {operator})}
                         />
 
                         {/* Remove Button */}
@@ -2551,12 +2654,14 @@ export function Filters<T = unknown>({
                             </div>
 
                             {/* Operator Dropdown */}
-                            <FilterOperatorDropdown<T>
-                                field={field}
-                                operator={filter.operator}
-                                values={filter.values}
-                                onChange={operator => updateFilter(filter.id, {operator})}
-                            />
+                            {!field.renderOperatorInValue && (
+                                <FilterOperatorDropdown<T>
+                                    field={field}
+                                    operator={filter.operator}
+                                    values={filter.values}
+                                    onChange={operator => updateFilter(filter.id, {operator})}
+                                />
+                            )}
 
                             {/* Value Selector */}
                             <FilterValueSelector<T>
@@ -2564,6 +2669,7 @@ export function Filters<T = unknown>({
                                 operator={filter.operator}
                                 values={filter.values}
                                 onChange={values => updateFilter(filter.id, {values})}
+                                onOperatorChange={operator => updateFilter(filter.id, {operator})}
                             />
 
                             {/* Remove Button */}

--- a/apps/shade/src/components/patterns/filters.tsx
+++ b/apps/shade/src/components/patterns/filters.tsx
@@ -926,6 +926,10 @@ export interface CustomRendererProps<T = unknown> {
 export interface FilterFieldGroup<T = unknown> {
     group?: string;
     fields: FilterFieldConfig<T>[];
+    // Show only the first `previewLimit` fields in the picker, with a "Show more"
+    // to reveal the rest. Every field stays resolvable regardless — this caps
+    // presentation, not the config map. Absent = show all.
+    previewLimit?: number;
 }
 
 // Union type for both flat and grouped field configurations
@@ -975,6 +979,7 @@ export interface FilterFieldConfig<T = unknown> {
     // Group-level configuration
     group?: string;
     fields?: FilterFieldConfig<T>[];
+    previewLimit?: number;
     // Field-specific options
     options?: FilterOption<T>[];
     isLoading?: boolean;
@@ -2439,6 +2444,11 @@ export function Filters<T = unknown>({
     const [addFilterOpen, setAddFilterOpen] = useState(false);
     const [selectedFieldKeyForOptions, setSelectedFieldKeyForOptions] = useState<string | null>(null);
     const [tempSelectedValues, setTempSelectedValues] = useState<unknown[]>([]);
+    // The field-picker search, controlled so a `previewLimit` group can uncap while
+    // the user is searching. `expandedGroups` holds the groups whose "Show more" was
+    // clicked. Both reset when the picker closes.
+    const [fieldSearch, setFieldSearch] = useState('');
+    const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
 
     // Notify parent when active field changes
     useEffect(() => {
@@ -2542,6 +2552,8 @@ export function Filters<T = unknown>({
         setAddFilterOpen(false);
         setSelectedFieldKeyForOptions(null);
         setTempSelectedValues([]);
+        setFieldSearch('');
+        setExpandedGroups(new Set());
     }, []);
 
     const addFilter = useCallback(
@@ -2613,6 +2625,64 @@ export function Filters<T = unknown>({
             return !filters.some(filter => filter.field === field.key);
         });
     }, [fields, filters, allowMultiple]);
+
+    // A group can preview a subset in the picker (previewLimit) while every field
+    // stays resolvable — getFieldsMap flattens all of them, so named pills and saved
+    // segments never depend on a field being listed here. "Show more" reveals the
+    // rest; an active search reveals the whole group so a capped-out field is still
+    // findable by name.
+    const renderPickerGroup = (
+        groupKey: string,
+        heading: string,
+        groupFields: FilterFieldConfig<T>[],
+        previewLimit?: number
+    ) => {
+        if (groupFields.length === 0) {
+            return null;
+        }
+
+        const searching = fieldSearch.trim().length > 0;
+        const capped = previewLimit !== undefined
+            && !searching
+            && !expandedGroups.has(groupKey)
+            && groupFields.length > previewLimit;
+        const visibleFields = capped ? groupFields.slice(0, previewLimit) : groupFields;
+        const hiddenCount = groupFields.length - visibleFields.length;
+
+        return (
+            <CommandGroup key={groupKey} heading={heading}>
+                {visibleFields.map((field, fieldIndex) => {
+                    if (field.type === 'separator') {
+                        return <CommandSeparator key={field.key ?? `${groupKey}-separator-${fieldIndex}`} />;
+                    }
+
+                    return (
+                        <CommandItem
+                            key={field.key ?? `${groupKey}-field-${fieldIndex}`}
+                            className="min-w-0"
+                            onSelect={() => field.key && addFilter(field.key)}
+                        >
+                            {field.icon}
+                            <span className="truncate">{field.label}</span>
+                        </CommandItem>
+                    );
+                })}
+                {capped && (
+                    <CommandItem
+                        className="min-w-0 text-muted-foreground"
+                        value={`${groupKey}-show-more`}
+                        onSelect={() => setExpandedGroups((prev) => {
+                            const next = new Set(prev);
+                            next.add(groupKey);
+                            return next;
+                        })}
+                    >
+                        <span className="truncate">Show {hiddenCount} more</span>
+                    </CommandItem>
+                )}
+            </CommandGroup>
+        );
+    };
 
     return (
         <FilterContext.Provider
@@ -2686,6 +2756,8 @@ export function Filters<T = unknown>({
                             if (!open) {
                                 setSelectedFieldKeyForOptions(null);
                                 setTempSelectedValues([]);
+                                setFieldSearch('');
+                                setExpandedGroups(new Set());
                             }
                         }}
                     >
@@ -2739,7 +2811,7 @@ export function Filters<T = unknown>({
                             ) : (
                                 // Show field selection - needs Command wrapper for search/list
                                 <Command className='outline-hidden' tabIndex={showSearchInput ? undefined : 0}>
-                                    {showSearchInput && <CommandInput className="h-(--control-height)" placeholder={mergedI18n.searchFields} />}
+                                    {showSearchInput && <CommandInput className="h-(--control-height)" placeholder={mergedI18n.searchFields} value={fieldSearch} onValueChange={setFieldSearch} />}
                                     <CommandList className="outline-hidden">
                                         <CommandEmpty>{mergedI18n.noFieldsFound}</CommandEmpty>
                                         {fields.map((item, index) => {
@@ -2758,33 +2830,7 @@ export function Filters<T = unknown>({
                                                     return !filters.some(filter => filter.field === field.key);
                                                 });
 
-                                                if (groupFields.length === 0) {
-                                                    return null;
-                                                }
-
-                                                return (
-                                                    <CommandGroup key={item.group || `group-${index}`} heading={item.group || 'Fields'}>
-                                                        {groupFields.map((field, fieldIndex) => {
-                                                            // Handle separator - use field.key if available, or generate stable key
-                                                            if (field.type === 'separator') {
-                                                                const sepKey = field.key ?? `${item.group ?? `group-${index}`}-separator-${fieldIndex}`;
-                                                                return <CommandSeparator key={sepKey} />;
-                                                            }
-
-                                                            // Regular field
-                                                            return (
-                                                                <CommandItem
-                                                                    key={field.key ?? `${item.group ?? `group-${index}`}-field-${fieldIndex}`}
-                                                                    className="min-w-0"
-                                                                    onSelect={() => field.key && addFilter(field.key)}
-                                                                >
-                                                                    {field.icon}
-                                                                    <span className="truncate">{field.label}</span>
-                                                                </CommandItem>
-                                                            );
-                                                        })}
-                                                    </CommandGroup>
-                                                );
+                                                return renderPickerGroup(item.group || `group-${index}`, item.group || 'Fields', groupFields, item.previewLimit);
                                             }
 
                                             // Handle group-level fields (new FilterFieldConfig structure with group property)
@@ -2802,29 +2848,7 @@ export function Filters<T = unknown>({
                                                     return !filters.some(filter => filter.field === field.key);
                                                 });
 
-                                                if (groupFields.length === 0) {
-                                                    return null;
-                                                }
-
-                                                return (
-                                                    <CommandGroup key={item.group || `group-${index}`} heading={item.group || 'Fields'}>
-                                                        {groupFields.map((field) => {
-                                                            // Handle separator - use field.key if available, or generate stable key
-                                                            if (field.type === 'separator') {
-                                                                const sepKey = field.key || `${item.group || `group-${index}`}-separator-${field.label || Math.random()}`;
-                                                                return <CommandSeparator key={sepKey} />;
-                                                            }
-
-                                                            // Regular field
-                                                            return (
-                                                                <CommandItem key={field.key} className="min-w-0" onSelect={() => field.key && addFilter(field.key)}>
-                                                                    {field.icon}
-                                                                    <span className="truncate">{field.label}</span>
-                                                                </CommandItem>
-                                                            );
-                                                        })}
-                                                    </CommandGroup>
-                                                );
+                                                return renderPickerGroup(item.group || `group-${index}`, item.group || 'Fields', groupFields, item.previewLimit);
                                             }
 
                                             // Handle flat field configuration (backward compatibility)

--- a/apps/shade/test/unit/components/patterns/filters.test.tsx
+++ b/apps/shade/test/unit/components/patterns/filters.test.tsx
@@ -436,4 +436,89 @@ describe('Filters', () => {
             expect(screen.queryByRole('option', {name: 'Gold'})).toBeNull();
         });
     });
+
+    describe('group previewLimit', () => {
+        beforeAll(() => {
+            global.ResizeObserver = class {
+                observe() {
+                    return undefined;
+                }
+
+                unobserve() {
+                    return undefined;
+                }
+
+                disconnect() {
+                    return undefined;
+                }
+            } as unknown as typeof ResizeObserver;
+            HTMLElement.prototype.scrollIntoView = vi.fn();
+        });
+
+        function PreviewLimitFilters({previewLimit}: Readonly<{previewLimit?: number}>) {
+            const [filters, setFilters] = useState<Filter<string>[]>([]);
+            const fields = useMemo(() => ([
+                {
+                    group: 'Custom fields',
+                    previewLimit,
+                    fields: Array.from({length: 8}, (_, index) => ({
+                        key: `custom_field.field_${index + 1}`,
+                        label: `Field ${index + 1}`,
+                        type: 'text' as const,
+                        operators: [{value: 'is', label: 'is'}]
+                    }))
+                }
+            ]), [previewLimit]);
+
+            return (
+                <Filters
+                    addButtonText="Add filter"
+                    allowMultiple={true}
+                    fields={fields}
+                    filters={filters}
+                    showSearchInput={true}
+                    onChange={setFilters}
+                />
+            );
+        }
+
+        it('previews only the first previewLimit fields behind a "Show more"', async () => {
+            render(<PreviewLimitFilters previewLimit={5} />);
+            fireEvent.click(screen.getByRole('button', {name: 'Add filter'}));
+
+            expect(await screen.findByRole('option', {name: 'Field 5'})).toBeDefined();
+            expect(screen.queryByRole('option', {name: 'Field 6'})).toBeNull();
+            expect(screen.getByRole('option', {name: 'Show 3 more'})).toBeDefined();
+        });
+
+        it('reveals the rest of the group when "Show more" is clicked', async () => {
+            render(<PreviewLimitFilters previewLimit={5} />);
+            fireEvent.click(screen.getByRole('button', {name: 'Add filter'}));
+
+            fireEvent.click(await screen.findByRole('option', {name: 'Show 3 more'}));
+
+            expect(await screen.findByRole('option', {name: 'Field 8'})).toBeDefined();
+            expect(screen.queryByRole('option', {name: /Show \d+ more/})).toBeNull();
+        });
+
+        it('uncaps the group while searching so a capped-out field is findable by name', async () => {
+            render(<PreviewLimitFilters previewLimit={5} />);
+            fireEvent.click(screen.getByRole('button', {name: 'Add filter'}));
+
+            const search = await screen.findByPlaceholderText('Search fields...');
+            fireEvent.change(search, {target: {value: 'Field 8'}});
+
+            expect(await screen.findByRole('option', {name: 'Field 8'})).toBeDefined();
+            // "Show more" is a capping affordance, never part of a search result.
+            expect(screen.queryByRole('option', {name: /Show \d+ more/})).toBeNull();
+        });
+
+        it('shows every field when no previewLimit is set', async () => {
+            render(<PreviewLimitFilters />);
+            fireEvent.click(screen.getByRole('button', {name: 'Add filter'}));
+
+            expect(await screen.findByRole('option', {name: 'Field 8'})).toBeDefined();
+            expect(screen.queryByRole('option', {name: /Show \d+ more/})).toBeNull();
+        });
+    });
 });

--- a/apps/shade/test/unit/components/patterns/filters.test.tsx
+++ b/apps/shade/test/unit/components/patterns/filters.test.tsx
@@ -1,6 +1,6 @@
 import {useMemo, useState} from 'react';
 import {act, fireEvent, render, screen, waitFor} from '../../utils/test-utils';
-import {afterEach, beforeAll, describe, expect, it, vi} from 'vitest';
+import {afterAll, afterEach, beforeAll, describe, expect, it, vi} from 'vitest';
 import {createFilter, Filter, FilterFieldConfig, Filters, ValueSource} from '../../../../src/components/patterns/filters';
 
 vi.mock('@/components/ui/calendar', () => ({
@@ -438,6 +438,9 @@ describe('Filters', () => {
     });
 
     describe('group previewLimit', () => {
+        const originalResizeObserver = global.ResizeObserver;
+        const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+
         beforeAll(() => {
             global.ResizeObserver = class {
                 observe() {
@@ -453,6 +456,11 @@ describe('Filters', () => {
                 }
             } as unknown as typeof ResizeObserver;
             HTMLElement.prototype.scrollIntoView = vi.fn();
+        });
+
+        afterAll(() => {
+            global.ResizeObserver = originalResizeObserver;
+            HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
         });
 
         function PreviewLimitFilters({previewLimit}: Readonly<{previewLimit?: number}>) {
@@ -520,5 +528,124 @@ describe('Filters', () => {
             expect(await screen.findByRole('option', {name: 'Field 8'})).toBeDefined();
             expect(screen.queryByRole('option', {name: /Show \d+ more/})).toBeNull();
         });
+    });
+
+    describe('disabled fields and group empty state', () => {
+        const originalResizeObserver = global.ResizeObserver;
+        const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+
+        beforeAll(() => {
+            global.ResizeObserver = class {
+                observe() {
+                    return undefined;
+                }
+
+                unobserve() {
+                    return undefined;
+                }
+
+                disconnect() {
+                    return undefined;
+                }
+            } as unknown as typeof ResizeObserver;
+            HTMLElement.prototype.scrollIntoView = vi.fn();
+        });
+
+        afterAll(() => {
+            global.ResizeObserver = originalResizeObserver;
+            HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+        });
+
+        function ReadOnlyFieldFilters() {
+            const [filters, setFilters] = useState<Filter<string>[]>([createFilter('custom_field.archived', 'is', ['London'])]);
+            const fields = useMemo(() => ([
+                {
+                    group: 'Custom fields',
+                    fields: [{
+                        key: 'custom_field.archived',
+                        label: 'Archived field',
+                        type: 'text' as const,
+                        readOnly: true,
+                        operators: [{value: 'is', label: 'is'}]
+                    }]
+                }
+            ]), []);
+
+            return <Filters fields={fields} filters={filters} showSearchInput={true} onChange={setFilters} />;
+        }
+
+        function ReadOnlyPickerFilters() {
+            const [filters, setFilters] = useState<Filter<string>[]>([createFilter('custom_field.archived', 'is', ['London'])]);
+            const fields = useMemo(() => ([
+                {
+                    group: 'Custom fields',
+                    fields: [
+                        {
+                            key: 'custom_field.archived',
+                            label: 'Archived field',
+                            type: 'text' as const,
+                            readOnly: true,
+                            operators: [{value: 'is', label: 'is'}]
+                        },
+                        {
+                            key: 'custom_field.active',
+                            label: 'Active field',
+                            type: 'text' as const,
+                            operators: [{value: 'is', label: 'is'}]
+                        }
+                    ]
+                }
+            ]), []);
+
+            // allowMultiple is what a caller passes to let one field carry several filters.
+            // It skips the applied-field de-dup, so it is the case where a read-only field
+            // would otherwise reappear in the picker while its own pill is on screen.
+            return <Filters addButtonText="Add filter" allowMultiple={true} fields={fields} filters={filters} showSearchInput={true} onChange={setFilters} />;
+        }
+
+        it('never offers a read-only field in the picker, even where a field may repeat', () => {
+            render(<ReadOnlyPickerFilters />);
+            fireEvent.click(screen.getByRole('button', {name: 'Add filter'}));
+
+            // The one that can be filtered on is offered...
+            expect(screen.getByRole('option', {name: 'Active field'})).toBeDefined();
+            // ...the read-only one is not: picking it would mint a second filter that could
+            // never be edited. Its existing pill is still on screen.
+            expect(screen.queryByRole('option', {name: 'Archived field'})).toBeNull();
+        });
+
+        function ReadOnlyOptionLabelFilters() {
+            const [filters, setFilters] = useState<Filter<string>[]>([createFilter('tier', 'is', ['t1'])]);
+            const fields = useMemo(() => ([{
+                key: 'tier',
+                label: 'Tier',
+                type: 'select' as const,
+                readOnly: true,
+                operators: [{value: 'is', label: 'is'}],
+                options: [{value: 't1', label: 'Gold'}]
+            }]), []);
+
+            return <Filters fields={fields} filters={filters} onChange={setFilters} />;
+        }
+
+        it('reads a read-only value through its option label, as the editable one does', () => {
+            render(<ReadOnlyOptionLabelFilters />);
+
+            expect(screen.getByText('Gold')).toBeDefined();
+            expect(screen.queryByText('t1')).toBeNull();
+        });
+
+        it('renders a read-only field showing its operator and value as static, non-editable text', () => {
+            render(<ReadOnlyFieldFilters />);
+
+            expect(screen.getByText('Archived field')).toBeDefined();
+            // Operator and value stay visible so the filter reads clearly...
+            expect(screen.getByText('is')).toBeDefined();
+            expect(screen.getByText('London')).toBeDefined();
+            // ...but there is nothing to edit: no input and no operator menu button.
+            expect(screen.queryByRole('textbox')).toBeNull();
+            expect(screen.queryByRole('button', {name: 'is'})).toBeNull();
+        });
+
     });
 });

--- a/e2e/helpers/pages/admin/members/members-list-page.ts
+++ b/e2e/helpers/pages/admin/members/members-list-page.ts
@@ -69,6 +69,35 @@ export class MembersListPage extends AdminPage {
         await this.addSearchableFilter('Label', labelName, labelName);
     }
 
+    // Custom fields are named directly in the filter dropdown (their own group), so a
+    // field is chosen by its name. For a composite field, pass a part; the rest of the
+    // cascade (part, then operator, then value) lives in the filter pill. Operator
+    // defaults to "is"; pass one to change it.
+    async addCustomFieldFilter({field, value, subfield, operator}: {field: string; value?: string; subfield?: string; operator?: string}): Promise<void> {
+        await this.filterButton.click();
+        await this.page.getByRole('option', {name: field, exact: true}).click();
+
+        if (subfield) {
+            // The cascade segments are dropdown menus, so their choices are menuitems.
+            await this.page.getByTestId('custom-field-filter-subfield').click();
+            await this.page.getByRole('menuitem', {name: subfield, exact: true}).click();
+        }
+
+        if (operator) {
+            // The operator lives in the pill after any part; its options carry the
+            // display labels, e.g. "is set".
+            await this.page.getByTestId('custom-field-filter-operator').click();
+            await this.page.getByRole('menuitem', {name: operator, exact: true}).click();
+        }
+
+        if (value !== undefined) {
+            await this.page.getByTestId('custom-field-filter-value').fill(value);
+        }
+
+        // Close the add-filter popover so the list re-queries.
+        await this.page.keyboard.press('Escape');
+    }
+
     async getVisibleMemberCount(): Promise<number> {
         return await this.memberRows.count();
     }

--- a/e2e/tests/admin/members/custom-field-filter-round-trip.test.ts
+++ b/e2e/tests/admin/members/custom-field-filter-round-trip.test.ts
@@ -1,0 +1,99 @@
+import {MemberDetailsPage, MembersListPage, SettingsPage, SidebarPage} from '@/admin-pages';
+import {createMemberFactory} from '@/data-factory';
+import {expect, test} from '@/helpers/playwright';
+import {usePerTestIsolation} from '@/helpers/playwright/isolation';
+
+/**
+ * The full custom-fields filtering journey across every surface it touches:
+ * define a field in Settings, give one member a value on the React detail screen,
+ * filter the members list by that field, save the filter as a segment, and reopen
+ * the segment to confirm the filter round-trips. The last step is the point of the
+ * test — a saved segment is only its NQL string, so reopening it and seeing the
+ * filter restored (and the same members matched) proves the compound grammar
+ * parses back to exactly what produced it.
+ *
+ * React member detail (the value editor is React-only) plus the membersCustomFields
+ * flag that gates the whole feature.
+ */
+usePerTestIsolation();
+
+test.describe('Ghost Admin - Filter members by custom fields', () => {
+    test.use({labs: {membersCustomFields: true, memberDetailsReact: true}});
+
+    test('a custom field filter can be built, saved as a segment, and reopened intact', async ({page}) => {
+        test.slow();
+
+        const stamp = Date.now();
+        const fieldName = `Company ${stamp}`;
+        const viewName = `Ghost staff ${stamp}`;
+        const memberFactory = createMemberFactory(page.request);
+
+        const matchingMember = await memberFactory.create({name: `Ghost Employee ${stamp}`, email: `ghost-${stamp}@example.com`});
+        await memberFactory.create({name: `Acme Employee ${stamp}`, email: `acme-${stamp}@example.com`});
+
+        const settingsPage = new SettingsPage(page);
+        const memberDetailsPage = new MemberDetailsPage(page);
+        const membersPage = new MembersListPage(page);
+        const sidebar = new SidebarPage(page);
+
+        // Define the field
+        await settingsPage.goto();
+        await settingsPage.customFieldsSection.createShortTextField(fieldName);
+
+        // Give one member a value for it
+        await page.goto(`/ghost/#/members/${matchingMember.id}`);
+        await memberDetailsPage.setCustomFieldValue(fieldName, 'Ghost');
+
+        // Filter the members list by the field
+        await page.goto('/ghost/#/members');
+        await membersPage.addCustomFieldFilter({field: fieldName, value: 'Ghost'});
+
+        await expect(membersPage.getMemberByName(`Ghost Employee ${stamp}`)).toBeVisible();
+        await expect(membersPage.getMemberByName(`Acme Employee ${stamp}`)).toHaveCount(0);
+
+        // Save it as a segment; the saved view becomes active
+        await membersPage.saveCurrentView(viewName);
+        await expect(sidebar.getNavLink(viewName)).toHaveAttribute('aria-current', 'page');
+
+        // Leave the segment
+        await sidebar.getNavLink('Members').click();
+        await expect(sidebar.getNavLink(viewName)).not.toHaveAttribute('aria-current', 'page');
+
+        // Reopen it: the filter round-trips (the view goes active again only if the
+        // reopened NQL re-serialises to the exact saved string), the custom-field
+        // filter is present, and the same member is matched.
+        await sidebar.getNavLink(viewName).click();
+
+        await expect(sidebar.getNavLink(viewName)).toHaveAttribute('aria-current', 'page');
+        await expect(membersPage.getFilterItem(fieldName)).toContainText(fieldName);
+        await expect(membersPage.getMemberByName(`Ghost Employee ${stamp}`)).toBeVisible();
+        await expect(membersPage.getMemberByName(`Acme Employee ${stamp}`)).toHaveCount(0);
+    });
+
+    test('an is-set custom field filter matches members that have a value', async ({page}) => {
+        test.slow();
+
+        const stamp = Date.now();
+        const fieldName = `Phone ${stamp}`;
+        const memberFactory = createMemberFactory(page.request);
+
+        const withValue = await memberFactory.create({name: `Reachable ${stamp}`, email: `reachable-${stamp}@example.com`});
+        await memberFactory.create({name: `Unreachable ${stamp}`, email: `unreachable-${stamp}@example.com`});
+
+        const settingsPage = new SettingsPage(page);
+        const memberDetailsPage = new MemberDetailsPage(page);
+        const membersPage = new MembersListPage(page);
+
+        await settingsPage.goto();
+        await settingsPage.customFieldsSection.createShortTextField(fieldName);
+
+        await page.goto(`/ghost/#/members/${withValue.id}`);
+        await memberDetailsPage.setCustomFieldValue(fieldName, '+44 20 7946 0000');
+
+        await page.goto('/ghost/#/members');
+        await membersPage.addCustomFieldFilter({field: fieldName, operator: 'is set'});
+
+        await expect(membersPage.getMemberByName(`Reachable ${stamp}`)).toBeVisible();
+        await expect(membersPage.getMemberByName(`Unreachable ${stamp}`)).toHaveCount(0);
+    });
+});

--- a/ghost/core/core/server/models/member.js
+++ b/ghost/core/core/server/models/member.js
@@ -1,8 +1,11 @@
 const ghostBookshelf = require('./base');
 const crypto = require('crypto');
 const _ = require('lodash');
+const {chainTransformers} = require('@tryghost/mongo-utils');
 const config = require('../../shared/config');
+const labs = require('../../shared/labs');
 const {MemberCommentingCodec} = require('../services/members/commenting');
+const {CUSTOM_FIELDS_RELATION, createCustomFieldsFilterTransformer} = require('../services/members-custom-fields/filter');
 
 const DEEP_OFFSET_THRESHOLD = 1000;
 
@@ -166,8 +169,29 @@ const Member = ghostBookshelf.Model.extend({
         }];
     },
 
+    // Chain the custom-field filter transformer at this single choke point — the method
+    // every members query routes its filter through (list, CSV export, bulk edit/destroy,
+    // count, email send all reach it via findPage or getFilteredCollectionQuery) — so a
+    // saved `custom_fields.*` segment works the same everywhere without each call site
+    // wiring it. Runs only behind the flag and only when the filter names the relation; the
+    // transformer maps the public `key`/`value` grammar onto the leaf-row columns.
+    applyDefaultAndCustomFilters(options) {
+        if (labs.isSet('membersCustomFields') && options.filter && options.filter.includes(`${CUSTOM_FIELDS_RELATION.tableNameAs}.`)) {
+            const transformer = createCustomFieldsFilterTransformer();
+            options.mongoTransformer = options.mongoTransformer
+                ? chainTransformers(options.mongoTransformer, transformer)
+                : transformer;
+        }
+        return ghostBookshelf.Model.prototype.applyDefaultAndCustomFilters.call(this, options);
+    },
+
     filterRelations() {
         return {
+            // Custom field values are filterable only behind the feature flag. Gating the
+            // relation here (rather than the whole model) means a `custom_fields.*` filter
+            // is simply an unknown relation when the flag is off, and the filter is
+            // rejected — nothing to special-case downstream.
+            ...(labs.isSet('membersCustomFields') ? {custom_fields: CUSTOM_FIELDS_RELATION} : {}),
             labels: {
                 tableName: 'labels',
                 type: 'manyToMany',

--- a/ghost/core/core/server/services/members-custom-fields/filter.ts
+++ b/ghost/core/core/server/services/members-custom-fields/filter.ts
@@ -101,24 +101,49 @@ export function createCustomFieldsFilterTransformer() {
     // is-not-set — no such leaf — which negates the whole match.
     function toElemMatch(clauses: QueryNode[]): QueryNode {
         let fieldKey = '';
+        let hasKey = false;
+        let hasLeaf = false;
         const conditions: QueryNode = {};
         let negate = false;
+
+        const oneLeafOnly = () => {
+            if (hasLeaf) {
+                throw new errors.BadRequestError({
+                    message: 'A custom field filter takes one value or path clause.'
+                });
+            }
+            hasLeaf = true;
+        };
 
         for (const clause of clauses) {
             const [attribute, value] = Object.entries(clause)[0];
 
             if (attribute === KEY_ATTRIBUTE) {
+                if (hasKey) {
+                    throw new errors.BadRequestError({
+                        message: `A custom field filter takes one "${KEY_ATTRIBUTE}" clause.`
+                    });
+                }
+                hasKey = true;
                 fieldKey = keyOf(value);
             } else if (attribute === PATH_ATTRIBUTE) {
+                oneLeafOnly();
                 const negatedPath = negatedString(value);
                 conditions.path = negatedPath ?? value;
                 negate = negatedPath !== null;
             } else {
                 const path = pathForValueAttribute(attribute);
-                if (path !== null) {
-                    conditions.path = path;
-                    conditions.value_text = value;
+                if (path === null) {
+                    // Not the key, a value/value.<part>, or a path: it names no leaf
+                    // column, so dropping it would silently widen the match to the key
+                    // alone. Fail closed instead.
+                    throw new errors.BadRequestError({
+                        message: `Unsupported custom field filter clause "${attribute}".`
+                    });
                 }
+                oneLeafOnly();
+                conditions.path = path;
+                conditions.value_text = value;
             }
         }
 

--- a/ghost/core/core/server/services/members-custom-fields/filter.ts
+++ b/ghost/core/core/server/services/members-custom-fields/filter.ts
@@ -1,0 +1,184 @@
+// The members filter reaches custom field values through a `custom_fields` relation
+// on the Member model (the values table joined on member_id). A field is named by its
+// `key` — the stable public slug — and matched on its `value`; a composite field's
+// part is named as `value.<part>`, and a part's presence as `path.<part>`:
+//
+//   (custom_fields.key:'company'+custom_fields.value:'Ghost')               // value
+//   (custom_fields.key:'shipping_address'+custom_fields.value.country:'GB')
+//   custom_fields.key:'phone'  /  custom_fields.key:-'phone'                // field set / not set
+//   (custom_fields.key:'shipping_address'+custom_fields.path:'country')     // part set
+//   (custom_fields.key:'shipping_address'+custom_fields.path:-'country')    // part not set
+//
+// The values table stores one row per leaf: `custom_field_key` (the field's stable key),
+// `path` (empty for a scalar, the part's key for a composite), and `value_text`. A scalar
+// field is just a leaf at path ''; "the field", "a part", and "the whole field" are the
+// same thing — a set of leaf rows pinned by (custom_field_key, [path], [value]). So every
+// filter is one `$elemMatch` over those columns: positive asserts a matching leaf exists,
+// `$not` asserts none does. The public grammar is the storage vocabulary here — the key
+// sits on the row — so the transformer emits it straight, with no id lookup and no field
+// catalog read. That is what lets the Member model chain it inline on every members query,
+// rather than each call site remembering to wire it. A key that names no current field
+// matches no leaf; the admin never offers an archived or deleted field in the filter UI,
+// though the API leaves them queryable.
+import errors from '@tryghost/errors';
+
+const RELATION = 'custom_fields';
+const PREFIX = `${RELATION}.`;
+const KEY_ATTRIBUTE = `${PREFIX}key`;
+const VALUE_ATTRIBUTE = `${PREFIX}value`;
+const PATH_ATTRIBUTE = `${PREFIX}path`;
+const ROOT_PATH = '';
+
+type QueryNode = Record<string, unknown>;
+
+// Only recurse into plain objects/arrays; a RegExp, Date, etc. is a leaf value that
+// must pass through by reference (recursing would strip a regex to `{}`).
+function isPlainObject(value: unknown): value is QueryNode {
+    return typeof value === 'object'
+        && value !== null
+        && !Array.isArray(value)
+        && (Object.getPrototypeOf(value) === Object.prototype || Object.getPrototypeOf(value) === null);
+}
+
+// A single-clause object whose one key targets the custom_fields relation.
+function isCustomFieldClause(node: unknown): node is QueryNode {
+    if (!isPlainObject(node)) {
+        return false;
+    }
+    const keys = Object.keys(node);
+    return keys.length === 1 && keys[0].startsWith(PREFIX);
+}
+
+// A grouped compound: an $and whose clauses all target the relation and name exactly one
+// `key`. Its clauses describe one leaf row.
+//
+// Exactly one, not at least one: two whole-field filters ANDed together arrive as a flat
+// `key:'a'+key:'b'`, since a bare key clause needs no group of its own. That is two
+// filters — a member with a value for both — not one leaf that is somehow both fields, so
+// it has to fall through and be transformed a clause at a time.
+function isCustomFieldCompound(clauses: unknown): clauses is QueryNode[] {
+    if (!Array.isArray(clauses) || clauses.length < 2 || !clauses.every(isCustomFieldClause)) {
+        return false;
+    }
+    return clauses.filter(clause => Object.keys(clause)[0] === KEY_ATTRIBUTE).length === 1;
+}
+
+// `custom_fields.value` addresses the scalar (root) leaf; `custom_fields.value.<part>`
+// a composite's part. Returns the row `path` the attribute selects, or null if the
+// attribute isn't a value clause.
+function pathForValueAttribute(attribute: string): string | null {
+    if (attribute === VALUE_ATTRIBUTE) {
+        return ROOT_PATH;
+    }
+    if (attribute.startsWith(`${VALUE_ATTRIBUTE}.`)) {
+        return attribute.slice(`${VALUE_ATTRIBUTE}.`.length);
+    }
+    return null;
+}
+
+// The single `{$ne}` shape all negations arrive as (is-not-set on a key or part).
+function negatedString(value: unknown): string | null {
+    return isPlainObject(value) && typeof value.$ne === 'string' ? value.$ne : null;
+}
+
+export function createCustomFieldsFilterTransformer() {
+    // The grammar carries the field key in the clause value; take it as a string,
+    // defaulting to one no field can hold so a malformed clause matches nothing.
+    const keyOf = (value: unknown): string => (typeof value === 'string' ? value : '');
+
+    // One (maybe-negated) $elemMatch over the leaf columns: positive is "a leaf pinned
+    // by these matches", `$not` is "no leaf does".
+    function buildElemMatch(fieldKey: string, conditions: QueryNode, negate: boolean): QueryNode {
+        const match = {custom_field_key: fieldKey, ...conditions};
+        if (negate) {
+            return {[RELATION]: {$not: {$elemMatch: match}}};
+        }
+        return {[RELATION]: {$elemMatch: match}};
+    }
+
+    // A `(key + value[.part] | path)` compound. A `value` clause pins the part and its
+    // value; a `path` clause pins the part's presence (no value), and a negated path is
+    // is-not-set — no such leaf — which negates the whole match.
+    function toElemMatch(clauses: QueryNode[]): QueryNode {
+        let fieldKey = '';
+        const conditions: QueryNode = {};
+        let negate = false;
+
+        for (const clause of clauses) {
+            const [attribute, value] = Object.entries(clause)[0];
+
+            if (attribute === KEY_ATTRIBUTE) {
+                fieldKey = keyOf(value);
+            } else if (attribute === PATH_ATTRIBUTE) {
+                const negatedPath = negatedString(value);
+                conditions.path = negatedPath ?? value;
+                negate = negatedPath !== null;
+            } else {
+                const path = pathForValueAttribute(attribute);
+                if (path !== null) {
+                    conditions.path = path;
+                    conditions.value_text = value;
+                }
+            }
+        }
+
+        return buildElemMatch(fieldKey, conditions, negate);
+    }
+
+    // A standalone `key` clause is whole-field is-set / is-not-set: a leaf for this
+    // field exists (any part), or none does.
+    function fromKeyClause(value: unknown): QueryNode {
+        const negatedKey = negatedString(value);
+        if (negatedKey !== null) {
+            return buildElemMatch(keyOf(negatedKey), {}, true);
+        }
+        return buildElemMatch(keyOf(value), {}, false);
+    }
+
+    function transform(node: unknown): unknown {
+        if (Array.isArray(node)) {
+            return node.map(transform);
+        }
+        if (!isPlainObject(node)) {
+            return node;
+        }
+
+        if (isCustomFieldCompound(node.$and)) {
+            return toElemMatch(node.$and);
+        }
+
+        const out: QueryNode = {};
+        for (const [key, value] of Object.entries(node)) {
+            if (key === KEY_ATTRIBUTE) {
+                Object.assign(out, fromKeyClause(value));
+            } else if (key.startsWith(PREFIX)) {
+                // A value or path clause only means something paired with its key in one
+                // leaf, which arrives as the compound handled above. A `custom_fields.*`
+                // clause reaching here is unpaired (or its pair was not grouped), so fail
+                // closed rather than pass it to mongo-knex as a column that does not exist.
+                throw new errors.BadRequestError({
+                    message: `A "${key}" filter must be grouped with its "${KEY_ATTRIBUTE}" clause, for example (${KEY_ATTRIBUTE}:'a_field'+${VALUE_ATTRIBUTE}:'a value').`
+                });
+            } else {
+                out[key] = transform(value);
+            }
+        }
+        return out;
+    }
+
+    return (query: object): object => transform(query) as object;
+}
+
+/**
+ * The Member filter relation that exposes custom field values. A member has many leaf
+ * rows (one per field, or per part of a composite field), and a predicate asks whether
+ * one of them matches, so this joins the values table on member_id and mongo-knex emits
+ * it as a correlated `members.id IN (…)` subquery — composing with every other member
+ * filter. Registered only behind the `membersCustomFields` flag.
+ */
+export const CUSTOM_FIELDS_RELATION = {
+    tableName: 'members_custom_field_values',
+    tableNameAs: RELATION,
+    type: 'oneToOne',
+    joinFrom: 'member_id'
+} as const;

--- a/ghost/core/test/e2e-api/admin/members-filter-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/members-filter-custom-fields.test.ts
@@ -268,6 +268,15 @@ describe('Members filtering by custom fields', function () {
                 .get(`members/?filter=${encodeURIComponent("custom_fields.path:'country'")}`)
                 .expectStatus(400);
         });
+
+        // A recognised (key + …) compound that also carries a clause naming no leaf
+        // column is rejected rather than silently dropped, which would leave a wider
+        // match on the key alone.
+        it('rejects an unsupported clause inside a field compound', async function () {
+            await agent
+                .get(`members/?filter=${encodeURIComponent("(custom_fields.key:'company'+custom_fields.invalid:'x')")}`)
+                .expectStatus(400);
+        });
     });
 
     describe('composition with other filters', function () {

--- a/ghost/core/test/e2e-api/admin/members-filter-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/members-filter-custom-fields.test.ts
@@ -1,0 +1,355 @@
+import assert from 'node:assert/strict';
+
+const {agentProvider, fixtureManager, mockManager} = require('../../utils/e2e-framework');
+const models = require('../../../core/server/models');
+
+// Filtering members by their custom field values. Values live in a separate table as
+// one leaf row per field (a composite address stores one row per part), reached
+// through the model's `custom_fields` relation. A filter names the field by its stable
+// key and matches on value; both halves of a `(key + value)` pair must match the same
+// leaf:
+//   (custom_fields.key:'company'+custom_fields.value:'Ghost')
+//   (custom_fields.key:'shipping_address'+custom_fields.value.country:'GB')
+// These tests pin the behaviour end to end over the real browse endpoint.
+describe('Members filtering by custom fields', function () {
+    let agent: {
+        get: (_url: string) => any;
+        put: (_url: string) => any;
+        post: (_url: string) => any;
+        loginAsOwner: () => Promise<void>;
+    };
+
+    async function createField(field: {name: string, type?: string}) {
+        const {body} = await agent
+            .post('members/custom_fields/')
+            .body({members_custom_fields: [{type: 'short_text', ...field}]})
+            .expectStatus(201);
+        return body.members_custom_fields[0];
+    }
+
+    let memberCounter = 0;
+    async function createMember(customFields?: Record<string, unknown>, labels?: string[]): Promise<{id: string, email: string}> {
+        memberCounter += 1;
+        const email = `cf-filter-${memberCounter}@example.com`;
+        const member: Record<string, unknown> = {email};
+        if (labels) {
+            member.labels = labels.map(name => ({name}));
+        }
+        const {body} = await agent
+            .post('members/')
+            .body({members: [member]})
+            .expectStatus(201);
+        const id = body.members[0].id;
+        if (customFields) {
+            await agent
+                .put(`members/${id}/`)
+                .body({members: [{custom_fields: customFields}]})
+                .expectStatus(200);
+        }
+        return {id, email};
+    }
+
+    async function browse(filter: string): Promise<string[]> {
+        const {body} = await agent
+            .get(`members/?filter=${encodeURIComponent(filter)}`)
+            .expectStatus(200);
+        return body.members.map((m: {email: string}) => m.email);
+    }
+
+    beforeAll(async function () {
+        agent = await agentProvider.getAdminAPIAgent();
+        await fixtureManager.init('users');
+        await agent.loginAsOwner();
+    });
+
+    beforeEach(function () {
+        mockManager.mockLabsEnabled('membersCustomFields');
+    });
+
+    afterEach(async function () {
+        mockManager.restore();
+        await models.Base.knex('members_custom_field_values').del();
+        await models.Base.knex('members_custom_fields').del();
+        await models.Base.knex('members_labels').del();
+        await models.Base.knex('members').del();
+    });
+
+    describe('text fields', function () {
+        it('filters by equality on a short text value', async function () {
+            await createField({name: 'Company'});
+            const ghost = await createMember({company: 'Ghost'});
+            await createMember({company: 'Acme'});
+            await createMember();
+
+            const matched = await browse("(custom_fields.key:'company'+custom_fields.value:'Ghost')");
+            assert.deepEqual(matched, [ghost.email]);
+        });
+
+        it('filters by a contains match on a short text value', async function () {
+            await createField({name: 'Company'});
+            const a = await createMember({company: 'Ghost Foundation'});
+            const b = await createMember({company: 'Ghosting Inc'});
+            await createMember({company: 'Acme'});
+
+            const matched = await browse("(custom_fields.key:'company'+custom_fields.value:~'Ghost')");
+            assert.deepEqual(matched.sort(), [a.email, b.email].sort());
+        });
+
+        it('finds members with no value for a field (is empty)', async function () {
+            await createField({name: 'Company'});
+            await createMember({company: 'Ghost'});
+            const noCompanyA = await createMember({}, ['prospect']);
+            const noCompanyB = await createMember();
+
+            const matched = await browse("custom_fields.key:-'company'");
+            assert.deepEqual(matched.sort(), [noCompanyA.email, noCompanyB.email].sort());
+        });
+
+        it('finds members that have any value for a field (is set)', async function () {
+            await createField({name: 'Company'});
+            const ghost = await createMember({company: 'Ghost'});
+            const acme = await createMember({company: 'Acme'});
+            await createMember();
+
+            const matched = await browse("custom_fields.key:'company'");
+            assert.deepEqual(matched.sort(), [ghost.email, acme.email].sort());
+        });
+
+        // Archiving hides a field from the admin dropdown but leaves it filterable through
+        // the API: its rows stay, so is-not-set still means "no value for this field", not
+        // match-nobody.
+        it('keeps an archived field filterable: is-not-set matches members with no value', async function () {
+            const field = await createField({name: 'Company'});
+            await createMember({company: 'Ghost'});
+            const noCompany = await createMember();
+            await agent
+                .put(`members/custom_fields/${field.key}/`)
+                .body({members_custom_fields: [{status: 'archived'}]})
+                .expectStatus(200);
+
+            const matched = await browse("custom_fields.key:-'company'");
+            assert.deepEqual(matched, [noCompany.email]);
+        });
+    });
+
+    describe('address fields', function () {
+        it('filters by a subfield inside the address (country)', async function () {
+            await createField({name: 'Shipping address', type: 'address'});
+            const uk = await createMember({
+                'shipping_address': {line1: '1 King St', city: 'London', postal_code: 'EC1', country: 'GB'}
+            });
+            await createMember({
+                'shipping_address': {line1: '5 Main St', city: 'Boston', postal_code: '02101', country: 'US'}
+            });
+            await createMember();
+
+            const matched = await browse("(custom_fields.key:'shipping_address'+custom_fields.value.country:'GB')");
+            assert.deepEqual(matched, [uk.email]);
+        });
+
+        it('finds members with no address set', async function () {
+            await createField({name: 'Shipping address', type: 'address'});
+            await createMember({
+                'shipping_address': {line1: '1 King St', city: 'London', postal_code: 'EC1', country: 'GB'}
+            });
+            const noAddress = await createMember();
+
+            const matched = await browse("custom_fields.key:-'shipping_address'");
+            assert.deepEqual(matched, [noAddress.email]);
+        });
+
+        it('finds members who have a value for a subfield (part is set)', async function () {
+            await createField({name: 'Shipping address', type: 'address'});
+            const withCountry = await createMember({'shipping_address': {city: 'London', country: 'GB'}});
+            await createMember({'shipping_address': {city: 'Boston'}});
+            await createMember();
+
+            const matched = await browse("(custom_fields.key:'shipping_address'+custom_fields.path:'country')");
+            assert.deepEqual(matched, [withCountry.email]);
+        });
+
+        it('finds members missing a subfield (part is not set), including those with no address', async function () {
+            await createField({name: 'Shipping address', type: 'address'});
+            await createMember({'shipping_address': {city: 'London', country: 'GB'}});
+            const cityOnly = await createMember({'shipping_address': {city: 'Boston'}});
+            const noAddress = await createMember();
+
+            const matched = await browse("(custom_fields.key:'shipping_address'+custom_fields.path:-'country')");
+            assert.deepEqual(matched.sort(), [cityOnly.email, noAddress.email].sort());
+        });
+
+        it('matches a subfield case-insensitively (contains)', async function () {
+            await createField({name: 'Shipping address', type: 'address'});
+            const london = await createMember({
+                'shipping_address': {line1: '1 King St', city: 'London', postal_code: 'EC1', country: 'GB'}
+            });
+            await createMember({
+                'shipping_address': {line1: '5 Main St', city: 'Boston', postal_code: '02101', country: 'US'}
+            });
+
+            const matched = await browse("(custom_fields.key:'shipping_address'+custom_fields.value.city:~'LONDON')");
+            assert.deepEqual(matched, [london.email]);
+        });
+    });
+
+    describe('negation', function () {
+        // A negated value clause must stay on the same joined row as the key
+        // clause: "company is-not Ghost" means the member's *company* row isn't
+        // Ghost, not that the member has no row valued Ghost anywhere. The Acme
+        // member here also carries a team valued Ghost, which a split query would
+        // wrongly use to exclude them.
+        it('excludes a value on the same field row (is-not)', async function () {
+            await createField({name: 'Company'});
+            await createField({name: 'Team'});
+            const acmeGhostTeam = await createMember({company: 'Acme', team: 'Ghost'});
+            const acme = await createMember({company: 'Acme'});
+            await createMember({company: 'Ghost'});
+            await createMember();
+
+            const matched = await browse("(custom_fields.key:'company'+custom_fields.value:-'Ghost')");
+            assert.deepEqual(matched.sort(), [acmeGhostTeam.email, acme.email].sort());
+        });
+
+        it('excludes a substring on the same field row (does-not-contain)', async function () {
+            await createField({name: 'Company'});
+            const acme = await createMember({company: 'Acme'});
+            await createMember({company: 'Ghost Foundation'});
+            await createMember();
+
+            const matched = await browse("(custom_fields.key:'company'+custom_fields.value:-~'Ghost')");
+            assert.deepEqual(matched, [acme.email]);
+        });
+
+        // "country is not GB" asks for members who HAVE an address whose country
+        // isn't GB. A member with the GB address is excluded, and so is a member with
+        // no address at all — the key discriminator requires the field to be present.
+        it('excludes an address subfield value (is-not) and members with no address', async function () {
+            await createField({name: 'Shipping address', type: 'address'});
+            const us = await createMember({
+                'shipping_address': {line1: '5 Main St', city: 'Boston', postal_code: '02101', country: 'US'}
+            });
+            await createMember({
+                'shipping_address': {line1: '1 King St', city: 'London', postal_code: 'EC1', country: 'GB'}
+            });
+            await createMember();
+
+            const matched = await browse("(custom_fields.key:'shipping_address'+custom_fields.value.country:-'GB')");
+            assert.deepEqual(matched, [us.email]);
+        });
+    });
+
+    describe('behind the flag', function () {
+        it('rejects a custom field filter when the flag is off', async function () {
+            await createField({name: 'Company'});
+            await createMember({company: 'Ghost'});
+            mockManager.mockLabsDisabled('membersCustomFields');
+
+            // With the feature off the relation is not registered, so the filter
+            // references an unknown relation and the request is rejected rather than
+            // quietly returning custom-field-filtered results.
+            await agent
+                .get(`members/?filter=${encodeURIComponent("(custom_fields.key:'company'+custom_fields.value:'Ghost')")}`)
+                .expectStatus(400);
+        });
+    });
+
+    describe('invalid grammar', function () {
+        // A value or path clause names no field on its own — it means something only paired
+        // with a key in the same leaf, which arrives as a group. An unpaired one is rejected
+        // rather than passed through to a storage column that does not exist.
+        it('rejects a value clause with no field key', async function () {
+            await agent
+                .get(`members/?filter=${encodeURIComponent("custom_fields.value:'Ghost'")}`)
+                .expectStatus(400);
+        });
+
+        it('rejects a part-presence clause with no field key', async function () {
+            await agent
+                .get(`members/?filter=${encodeURIComponent("custom_fields.path:'country'")}`)
+                .expectStatus(400);
+        });
+    });
+
+    describe('composition with other filters', function () {
+        it('combines a custom field with a label relation filter', async function () {
+            await createField({name: 'Company'});
+            const target = await createMember({company: 'Ghost'}, ['vip']);
+            await createMember({company: 'Ghost'}, ['prospect']);
+            await createMember({company: 'Acme'}, ['vip']);
+
+            const matched = await browse("label:'vip'+(custom_fields.key:'company'+custom_fields.value:'Ghost')");
+            assert.deepEqual(matched, [target.email]);
+        });
+
+        it('combines two custom fields using OR', async function () {
+            await createField({name: 'Company'});
+            await createField({name: 'Industry'});
+            const ghost = await createMember({company: 'Ghost'});
+            const tech = await createMember({industry: 'Tech'});
+            await createMember({company: 'Acme', industry: 'Retail'});
+
+            const matched = await browse("(custom_fields.key:'company'+custom_fields.value:'Ghost'),(custom_fields.key:'industry'+custom_fields.value:'Tech')");
+            assert.deepEqual(matched.sort(), [ghost.email, tech.email].sort());
+        });
+
+        // Two whole-field is-set filters carry no value, so neither needs a group of its
+        // own and they arrive as one flat conjunction of key clauses. That reads as a
+        // compound describing a single leaf unless the transformer counts the keys.
+        it('combines two whole-field is-set filters using AND', async function () {
+            await createField({name: 'Company'});
+            await createField({name: 'Industry'});
+            const both = await createMember({company: 'Ghost', industry: 'Tech'});
+            await createMember({company: 'Acme'});
+            await createMember({industry: 'Retail'});
+
+            const matched = await browse("custom_fields.key:'company'+custom_fields.key:'industry'");
+            assert.deepEqual(matched, [both.email]);
+        });
+
+        it('combines a whole-field is-set filter with a value filter on another field', async function () {
+            await createField({name: 'Company'});
+            await createField({name: 'Industry'});
+            const target = await createMember({company: 'Ghost', industry: 'Tech'});
+            await createMember({company: 'Acme', industry: 'Tech'});
+            await createMember({company: 'Ghost'});
+
+            const matched = await browse("custom_fields.key:'industry'+(custom_fields.key:'company'+custom_fields.value:'Ghost')");
+            assert.deepEqual(matched, [target.email]);
+        });
+    });
+
+    // A saved segment is only useful if it works everywhere the members list feeds a
+    // filter, not just the list view. Export and bulk actions run the same NQL, so the
+    // custom_fields relation has to be served on those paths too.
+    describe('in export and bulk actions', function () {
+        it('exports only members a custom-field filter matches', async function () {
+            await createField({name: 'Company'});
+            const ghost = await createMember({company: 'Ghost'});
+            const acme = await createMember({company: 'Acme'});
+
+            const filter = encodeURIComponent("(custom_fields.key:'company'+custom_fields.value:'Ghost')");
+            const {text} = await agent.get(`members/upload/?limit=all&filter=${filter}`).expectStatus(200);
+
+            assert.ok(text.includes(ghost.email), 'exports the matching member');
+            assert.ok(!text.includes(acme.email), 'excludes a non-matching member');
+        });
+
+        it('bulk-acts on only members a custom-field filter matches', async function () {
+            await createField({name: 'Company'});
+            const ghost = await createMember({company: 'Ghost'});
+            await createMember({company: 'Acme'});
+            const label = await models.Label.add({name: 'cf-bulk-target'});
+
+            const filter = encodeURIComponent("(custom_fields.key:'company'+custom_fields.value:'Ghost')");
+            const {body} = await agent
+                .put(`members/bulk/?filter=${filter}`)
+                .body({bulk: {action: 'addLabel', meta: {label: {id: label.id, name: 'cf-bulk-target'}}}})
+                .expectStatus(200);
+
+            assert.equal(body.bulk.meta.stats.successful, 1);
+
+            const labelled = await browse("label:'cf-bulk-target'");
+            assert.deepEqual(labelled, [ghost.email]);
+        });
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,8 +178,8 @@ catalogs:
       specifier: 3.4.2
       version: 3.4.2
     '@tryghost/mongo-knex':
-      specifier: 0.11.1
-      version: 0.11.1
+      specifier: 0.11.2
+      version: 0.11.2
     '@tryghost/request':
       specifier: 4.0.1
       version: 4.0.1
@@ -499,7 +499,7 @@ overrides:
   knex-migrator>knex: 2.4.2
   '@tryghost/errors': 3.3.8
   '@tryghost/logging': 5.3.4
-  '@tryghost/nql': 0.13.3
+  '@tryghost/nql': 0.13.4
   '@tryghost/nql-lang': 0.7.0
   jackspeak: 4.2.3
   moment: 2.30.1
@@ -775,8 +775,8 @@ importers:
         specifier: 'catalog:'
         version: 1.5.6
       '@tryghost/nql':
-        specifier: 0.13.3
-        version: 0.13.3(supports-color@10.2.2)
+        specifier: 0.13.4
+        version: 0.13.4(supports-color@10.2.2)
       '@tryghost/nql-lang':
         specifier: 0.7.0
         version: 0.7.0
@@ -1176,8 +1176,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/i18n
       '@tryghost/nql':
-        specifier: 0.13.3
-        version: 0.13.3(supports-color@10.2.2)
+        specifier: 0.13.4
+        version: 0.13.4(supports-color@10.2.2)
       '@types/react':
         specifier: catalog:react17
         version: 17.0.93
@@ -1324,8 +1324,8 @@ importers:
         specifier: 'catalog:'
         version: 1.5.6
       '@tryghost/nql':
-        specifier: 0.13.3
-        version: 0.13.3(supports-color@10.2.2)
+        specifier: 0.13.4
+        version: 0.13.4(supports-color@10.2.2)
       '@tryghost/nql-string':
         specifier: workspace:*
         version: link:../../packages/nql-string
@@ -2303,7 +2303,7 @@ importers:
         version: 3.4.2(supports-color@10.2.2)
       '@tryghost/mongo-knex':
         specifier: 'catalog:'
-        version: 0.11.1(supports-color@10.2.2)
+        version: 0.11.2(supports-color@10.2.2)
       '@tryghost/mongo-utils':
         specifier: 0.6.5
         version: 0.6.5
@@ -2317,8 +2317,8 @@ importers:
         specifier: 2.3.1
         version: 2.3.1(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)
       '@tryghost/nql':
-        specifier: 0.13.3
-        version: 0.13.3(supports-color@10.2.2)
+        specifier: 0.13.4
+        version: 0.13.4(supports-color@10.2.2)
       '@tryghost/nql-lang':
         specifier: 0.7.0
         version: 0.7.0
@@ -4019,8 +4019,8 @@ importers:
         specifier: workspace:*
         version: link:../../configs/vitest
       '@tryghost/nql':
-        specifier: 0.13.3
-        version: 0.13.3(supports-color@10.2.2)
+        specifier: 0.13.4
+        version: 0.13.4(supports-color@10.2.2)
       '@types/node':
         specifier: 'catalog:'
         version: 22.20.1
@@ -9185,8 +9185,8 @@ packages:
   '@tryghost/metrics@3.4.2':
     resolution: {integrity: sha512-20ldmzt6yHK7835yuU/PJDfZXaHlLl9Y3QfKM2tHUXJH0t6VdTEx1CSEnMjdSgxKG2z5+5uK84FoFD67toUVrQ==}
 
-  '@tryghost/mongo-knex@0.11.1':
-    resolution: {integrity: sha512-W5m2aU4WW14fMQoyj5oY6vvHTGzMfz1WEVGK8YTY0zWszJ/kUPo5qHXY9ivoxQthmFoBUpSbNuP0qRAfE6UrNQ==}
+  '@tryghost/mongo-knex@0.11.2':
+    resolution: {integrity: sha512-0l7L/J609p+12+rA15Muya1JoIeSfBxIUZRB2FfROtJ2U+FTEOzZ/c0HgxB8eAArJMW2VXECmLCAbNUwygRzfg==}
 
   '@tryghost/mongo-utils@0.6.5':
     resolution: {integrity: sha512-fMEfdlVaVkr7SJwVxBxVDfUQ+x4DVF4PMet698PLzabqSnGsaWcruBaQlOuNvtf8ITNXKFUAqZMdmSUTIAHU+Q==}
@@ -9206,8 +9206,8 @@ packages:
   '@tryghost/nql-lang@0.7.0':
     resolution: {integrity: sha512-S3P66JRL7kiKhYR7VnYC5S5xnkKqS+A5aW60nCGi/lraAhk/G5+xmPisztQiJWbHxM1odIagt2GpDMbKCDXT2w==}
 
-  '@tryghost/nql@0.13.3':
-    resolution: {integrity: sha512-nnX7l8tr6GuPoQML1wDn86JYQpdZ9kFLhJ75JVfF1iTYEWB/WQpJ2tCGRBxXr160jM5L/hMe2dfnZr9EZRMksg==}
+  '@tryghost/nql@0.13.4':
+    resolution: {integrity: sha512-XE3lEpkqZM3ueOyKz5suwb2W4muWAM/YfYYpXHrnu0H7r46Xuo7FZm1s6Ga2Cut/STtuax5E6NfZ1AFv017X4w==}
 
   '@tryghost/pretty-cli@3.3.1':
     resolution: {integrity: sha512-P7/GffeBG0grjmFxMWEeVFONL6HGt1mWUZvI5G36mhlxC/AXSWCSS6+qiQU91ZfenTwBrP6LZRC9Pyt0gqfzLg==}
@@ -28416,7 +28416,7 @@ snapshots:
     dependencies:
       '@tryghost/debug': 2.3.7(supports-color@10.2.2)
       '@tryghost/errors': 3.3.8
-      '@tryghost/nql': 0.13.3(supports-color@10.2.2)
+      '@tryghost/nql': 0.13.4(supports-color@10.2.2)
       '@tryghost/tpl': 2.3.7
     transitivePeerDependencies:
       - supports-color
@@ -28666,7 +28666,7 @@ snapshots:
       - '@75lb/nature'
       - supports-color
 
-  '@tryghost/mongo-knex@0.11.1(supports-color@10.2.2)':
+  '@tryghost/mongo-knex@0.11.2(supports-color@10.2.2)':
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       lodash: 4.18.1
@@ -28710,9 +28710,9 @@ snapshots:
     dependencies:
       luxon: 3.7.2
 
-  '@tryghost/nql@0.13.3(supports-color@10.2.2)':
+  '@tryghost/nql@0.13.4(supports-color@10.2.2)':
     dependencies:
-      '@tryghost/mongo-knex': 0.11.1(supports-color@10.2.2)
+      '@tryghost/mongo-knex': 0.11.2(supports-color@10.2.2)
       '@tryghost/mongo-utils': 0.6.6
       '@tryghost/nql-lang': 0.7.0
       lodash: 4.18.1
@@ -37468,7 +37468,7 @@ snapshots:
       '@tryghost/debug': 2.3.1(supports-color@10.2.2)
       '@tryghost/errors': 3.3.8
       '@tryghost/logging': 5.3.4(supports-color@10.2.2)
-      '@tryghost/nql': 0.13.3(supports-color@10.2.2)
+      '@tryghost/nql': 0.13.4(supports-color@10.2.2)
       '@tryghost/pretty-cli': 3.3.1
       '@tryghost/server': 3.1.1(supports-color@10.2.2)
       '@tryghost/zip': 3.5.0(supports-color@10.2.2)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -90,8 +90,8 @@ catalog:
   '@tryghost/limit-service': 1.5.6
   '@tryghost/logging': 5.3.4
   '@tryghost/metrics': 3.4.2
-  '@tryghost/mongo-knex': 0.11.1
-  '@tryghost/nql': 0.13.3
+  '@tryghost/mongo-knex': 0.11.2
+  '@tryghost/nql': 0.13.4
   '@tryghost/nql-lang': 0.7.0
   '@tryghost/request': 4.0.1
   '@tryghost/string': 0.3.5


### PR DESCRIPTION
## Problem

Custom fields let publishers collect data about their members, but that data can't be queried yet. A publisher can't find everyone still missing an address, build a "print subscribers" view, or reach exactly the members who match. Collected data that can't be filtered is a data graveyard, and it's the groundwork the collection forms depend on: asking "everyone who hasn't answered yet" is itself a filter over the values.

## Solution

Members can now be filtered and segmented by their custom field values. Each defined field appears as its own entry in a named, searchable "Custom fields" group in the members filter, the way newsletters do, so a publisher looks for "Shipping address" directly rather than through a generic entry. A field can be matched by equality or a contains search, and checked for whether the field (or an individual part of a composite field like an address) is set or not set.

The filter applies everywhere a members query runs, so the same saved segment behaves identically in the members list, CSV export, bulk actions, member counts, and email audiences. Archived fields stay out of the filter dropdown but remain queryable through the API. Saved segments round-trip: reopening one restores the filter and the members it matches.

Behind the `membersCustomFields` flag. BER-3792.
