### PR TITLE
🐛 Fixed missing newsletter title heading

### DIFF
--- a/ghost/core/core/server/services/email-rendering/partials/email-wrapper.hbs
+++ b/ghost/core/core/server/services/email-rendering/partials/email-wrapper.hbs
@@ -84,7 +84,9 @@
                                                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                                                         <tr>
                                                             <td>
-                                                                <a href="{{post.url}}" class="{{classes.titleLink}}">{{post.title}}</a>
+                                                                <h1 style="margin: 0; font-family: inherit; font-size: inherit; font-weight: inherit; line-height: inherit;">
+                                                                    <a href="{{post.url}}" class="{{classes.titleLink}}">{{post.title}}</a>
+                                                                </h1>
                                                             </td>
                                                         </tr>
                                                     </table>

--- a/ghost/core/core/server/services/email-rendering/partials/email-wrapper.hbs
+++ b/ghost/core/core/server/services/email-rendering/partials/email-wrapper.hbs
@@ -84,7 +84,7 @@
                                                     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                                                         <tr>
                                                             <td>
-                                                                <h1 style="margin: 0; font-family: inherit; font-size: inherit; font-weight: inherit; line-height: inherit;">
+                                                                <h1 class="post-title-heading">
                                                                     <a href="{{post.url}}" class="{{classes.titleLink}}">{{post.title}}</a>
                                                                 </h1>
                                                             </td>

--- a/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
+++ b/ghost/core/core/server/services/email-service/email-templates/partials/styles.hbs
@@ -161,6 +161,14 @@ img.is-dark-background {
     color: {{postTitleColor}};
 }
 
+/* Outlook's Word engine ignores `inherit`, so repeat the `.post-title > table td` values */
+.post-title-heading {
+    margin: 0;
+    font-size: 36px;
+    line-height: 1.1;
+    font-weight: {{titleWeight}};
+}
+
 .post-title a {
     color: {{postTitleColor}} !important;
 }

--- a/ghost/core/test/e2e-api/admin/__snapshots__/email-previews.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/email-previews.test.js.snap
@@ -698,7 +698,9 @@ table.body h2 span {
                                                     <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                         <tr>
                                                             <td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; font-size: 36px; line-height: 1.1; font-weight: 700; text-align: center; color: #000000;\\" valign=\\"top\\" align=\\"center\\">
-                                                                <a href=\\"http://127.0.0.1:2369/p/d52c42ae-2755-455c-80ec-70b2ec55c904/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">Post with email-only card</a>
+                                                                <h1 class=\\"post-title-heading\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; text-rendering: optimizeLegibility; margin: 0; font-size: 36px; line-height: 1.1; font-weight: 700;\\">
+                                                                    <a href=\\"http://127.0.0.1:2369/p/d52c42ae-2755-455c-80ec-70b2ec55c904/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">Post with email-only card</a>
+                                                                </h1>
                                                             </td>
                                                         </tr>
                                                     </table>
@@ -883,7 +885,12 @@ Default Newsletter [http://127.0.0.1:2369/]
 
 
 
+
+
+
+
 Post with email-only card [http://127.0.0.1:2369/p/d52c42ae-2755-455c-80ec-70b2ec55c904/]
+
 
 
 
@@ -1020,7 +1027,7 @@ exports[`Email Preview API Read can read post email preview with email card and 
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "36587",
+  "content-length": "36982",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -1632,7 +1639,9 @@ table.body h2 span {
                                                     <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                         <tr>
                                                             <td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; font-size: 36px; line-height: 1.1; font-weight: 700; text-align: center; color: #000000;\\" valign=\\"top\\" align=\\"center\\">
-                                                                <a href=\\"http://127.0.0.1:2369/html-ipsum/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">HTML Ipsum</a>
+                                                                <h1 class=\\"post-title-heading\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; text-rendering: optimizeLegibility; margin: 0; font-size: 36px; line-height: 1.1; font-weight: 700;\\">
+                                                                    <a href=\\"http://127.0.0.1:2369/html-ipsum/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">HTML Ipsum</a>
+                                                                </h1>
                                                             </td>
                                                         </tr>
                                                     </table>
@@ -1822,7 +1831,12 @@ Default Newsletter [http://127.0.0.1:2369/]
 
 
 
+
+
+
+
 HTML Ipsum [http://127.0.0.1:2369/html-ipsum/]
+
 
 
 
@@ -1976,7 +1990,7 @@ exports[`Email Preview API Read can read post email preview with fields 4: [head
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "40907",
+  "content-length": "41302",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -2619,7 +2633,9 @@ table.body h2 span {
                                                     <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                         <tr>
                                                             <td style=\\"font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; vertical-align: top; font-size: 36px; line-height: 1.1; font-weight: 700; text-align: center; color: #000000;\\" valign=\\"top\\" align=\\"center\\">
-                                                                <a href=\\"http://127.0.0.1:2369/p/d52c42ae-2755-455c-80ec-70b2ec55c904/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">Post with email-only card</a>
+                                                                <h1 class=\\"post-title-heading\\" style=\\"margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif; text-rendering: optimizeLegibility; margin: 0; font-size: 36px; line-height: 1.1; font-weight: 700;\\">
+                                                                    <a href=\\"http://127.0.0.1:2369/p/d52c42ae-2755-455c-80ec-70b2ec55c904/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">Post with email-only card</a>
+                                                                </h1>
                                                             </td>
                                                         </tr>
                                                     </table>
@@ -2804,7 +2820,12 @@ Default Newsletter [http://127.0.0.1:2369/]
 
 
 
+
+
+
+
 Post with email-only card [http://127.0.0.1:2369/p/d52c42ae-2755-455c-80ec-70b2ec55c904/]
+
 
 
 
@@ -2948,7 +2969,7 @@ exports[`Email Preview API Read has custom content transformations for email com
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "36299",
+  "content-length": "36694",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -3927,7 +3948,9 @@ table.body h2 span {
                                                     <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                         <tr>
                                                             <td style=\\"vertical-align: top; font-family: Georgia, serif; letter-spacing: -0.01em; font-size: 36px; line-height: 1.1; font-weight: 700; text-align: center; color: #000000;\\" valign=\\"top\\" align=\\"center\\">
-                                                                <a href=\\"http://127.0.0.1:2369/p/d52c42ae-2755-455c-80ec-70b2ec55c904/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">Post with email-only card</a>
+                                                                <h1 class=\\"post-title-heading\\" style=\\"margin-top: 0; text-rendering: optimizeLegibility; margin: 0; font-size: 36px; line-height: 1.1; font-weight: 700; font-family: Georgia, serif; letter-spacing: -0.01em;\\">
+                                                                    <a href=\\"http://127.0.0.1:2369/p/d52c42ae-2755-455c-80ec-70b2ec55c904/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">Post with email-only card</a>
+                                                                </h1>
                                                             </td>
                                                         </tr>
                                                     </table>
@@ -4119,7 +4142,12 @@ Daily newsletter [http://127.0.0.1:2369/]
 
 
 
+
+
+
+
 Post with email-only card [http://127.0.0.1:2369/p/d52c42ae-2755-455c-80ec-70b2ec55c904/]
+
 
 
 
@@ -4263,7 +4291,7 @@ exports[`Email Preview API Read uses the newsletter provided through ?newsletter
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "37176",
+  "content-length": "37539",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,
@@ -5268,7 +5296,9 @@ table.body h2 span {
                                                     <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                         <tr>
                                                             <td style=\\"vertical-align: top; font-family: Georgia, serif; letter-spacing: -0.01em; font-size: 36px; line-height: 1.1; font-weight: 700; text-align: center; color: #000000;\\" valign=\\"top\\" align=\\"center\\">
-                                                                <a href=\\"http://127.0.0.1:2369/p/d52c42ae-2755-455c-80ec-70b2ec55c904/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">Post with email-only card</a>
+                                                                <h1 class=\\"post-title-heading\\" style=\\"margin-top: 0; text-rendering: optimizeLegibility; margin: 0; font-size: 36px; line-height: 1.1; font-weight: 700; font-family: Georgia, serif; letter-spacing: -0.01em;\\">
+                                                                    <a href=\\"http://127.0.0.1:2369/p/d52c42ae-2755-455c-80ec-70b2ec55c904/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">Post with email-only card</a>
+                                                                </h1>
                                                             </td>
                                                         </tr>
                                                     </table>
@@ -5460,7 +5490,12 @@ Daily newsletter [http://127.0.0.1:2369/]
 
 
 
+
+
+
+
 Post with email-only card [http://127.0.0.1:2369/p/d52c42ae-2755-455c-80ec-70b2ec55c904/]
+
 
 
 
@@ -5604,7 +5639,7 @@ exports[`Email Preview API Read uses the posts newsletter by default 4: [headers
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "37176",
+  "content-length": "37539",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/integration/services/email-service/__snapshots__/batch-sending.test.js.snap
+++ b/ghost/core/test/integration/services/email-service/__snapshots__/batch-sending.test.js.snap
@@ -598,7 +598,9 @@ table.body h2 span {
                                                     <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                         <tr>
                                                             <td style=\\"vertical-align: top; font-family: Georgia, serif; letter-spacing: -0.01em; font-size: 36px; line-height: 1.1; font-weight: 700; text-align: center; color: #000000;\\" valign=\\"top\\" align=\\"center\\">
-                                                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">A random test post</a>
+                                                                <h1 class=\\"post-title-heading\\" style=\\"margin-top: 0; text-rendering: optimizeLegibility; margin: 0; font-size: 36px; line-height: 1.1; font-weight: 700; font-family: Georgia, serif; letter-spacing: -0.01em;\\">
+                                                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">A random test post</a>
+                                                                </h1>
                                                             </td>
                                                         </tr>
                                                     </table>
@@ -785,7 +787,12 @@ Daily newsletter [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
 
 
 
+
+
+
+
 A random test post [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+
 
 
 
@@ -1521,7 +1528,9 @@ table.body h2 span {
                                                     <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                         <tr>
                                                             <td style=\\"vertical-align: top; font-family: Georgia, serif; letter-spacing: -0.01em; font-size: 36px; line-height: 1.1; font-weight: 700; text-align: center; color: #000000;\\" valign=\\"top\\" align=\\"center\\">
-                                                                <a href=\\"http://127.0.0.1:2369/email/post-uuid/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">This is a test post title</a>
+                                                                <h1 class=\\"post-title-heading\\" style=\\"margin-top: 0; text-rendering: optimizeLegibility; margin: 0; font-size: 36px; line-height: 1.1; font-weight: 700; font-family: Georgia, serif; letter-spacing: -0.01em;\\">
+                                                                    <a href=\\"http://127.0.0.1:2369/email/post-uuid/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">This is a test post title</a>
+                                                                </h1>
                                                             </td>
                                                         </tr>
                                                     </table>
@@ -1681,7 +1690,12 @@ Daily newsletter [http://127.0.0.1:2369/]
 
 
 
+
+
+
+
 This is a test post title [http://127.0.0.1:2369/email/post-uuid/]
+
 
 
 
@@ -2386,7 +2400,9 @@ table.body h2 span {
                                                     <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                         <tr>
                                                             <td style=\\"vertical-align: top; font-family: Georgia, serif; letter-spacing: -0.01em; font-size: 36px; line-height: 1.1; font-weight: 700; text-align: center; color: #000000;\\" valign=\\"top\\" align=\\"center\\">
-                                                                <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-6/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">This is a test post title</a>
+                                                                <h1 class=\\"post-title-heading\\" style=\\"margin-top: 0; text-rendering: optimizeLegibility; margin: 0; font-size: 36px; line-height: 1.1; font-weight: 700; font-family: Georgia, serif; letter-spacing: -0.01em;\\">
+                                                                    <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-6/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">This is a test post title</a>
+                                                                </h1>
                                                             </td>
                                                         </tr>
                                                     </table>
@@ -2546,7 +2562,12 @@ Daily newsletter [http://127.0.0.1:2369/]
 
 
 
+
+
+
+
 This is a test post title [http://127.0.0.1:2369/this-is-a-test-post-title-6/]
+
 
 
 
@@ -3251,7 +3272,9 @@ table.body h2 span {
                                                     <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                         <tr>
                                                             <td style=\\"vertical-align: top; font-family: Georgia, serif; letter-spacing: -0.01em; font-size: 36px; line-height: 1.1; font-weight: 700; text-align: center; color: #000000;\\" valign=\\"top\\" align=\\"center\\">
-                                                                <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-7/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">This is a test post title</a>
+                                                                <h1 class=\\"post-title-heading\\" style=\\"margin-top: 0; text-rendering: optimizeLegibility; margin: 0; font-size: 36px; line-height: 1.1; font-weight: 700; font-family: Georgia, serif; letter-spacing: -0.01em;\\">
+                                                                    <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-7/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">This is a test post title</a>
+                                                                </h1>
                                                             </td>
                                                         </tr>
                                                     </table>
@@ -3411,7 +3434,12 @@ Daily newsletter [http://127.0.0.1:2369/]
 
 
 
+
+
+
+
 This is a test post title [http://127.0.0.1:2369/this-is-a-test-post-title-7/]
+
 
 
 
@@ -4951,7 +4979,9 @@ table.body h2 span {
                                                     <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                         <tr>
                                                             <td style=\\"vertical-align: top; font-family: Georgia, serif; letter-spacing: -0.01em; font-size: 36px; line-height: 1.1; font-weight: 700; text-align: center; color: #000000;\\" valign=\\"top\\" align=\\"center\\">
-                                                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">This is a test post title</a>
+                                                                <h1 class=\\"post-title-heading\\" style=\\"margin-top: 0; text-rendering: optimizeLegibility; margin: 0; font-size: 36px; line-height: 1.1; font-weight: 700; font-family: Georgia, serif; letter-spacing: -0.01em;\\">
+                                                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">This is a test post title</a>
+                                                                </h1>
                                                             </td>
                                                         </tr>
                                                     </table>
@@ -5125,7 +5155,12 @@ Daily newsletter [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
 
 
 
+
+
+
+
 This is a test post title [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+
 
 
 
@@ -5850,7 +5885,9 @@ table.body h2 span {
                                                     <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                         <tr>
                                                             <td style=\\"vertical-align: top; font-family: Georgia, serif; letter-spacing: -0.01em; font-size: 36px; line-height: 1.1; font-weight: 700; text-align: center; color: #000000;\\" valign=\\"top\\" align=\\"center\\">
-                                                                <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-4/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">This is a test post title</a>
+                                                                <h1 class=\\"post-title-heading\\" style=\\"margin-top: 0; text-rendering: optimizeLegibility; margin: 0; font-size: 36px; line-height: 1.1; font-weight: 700; font-family: Georgia, serif; letter-spacing: -0.01em;\\">
+                                                                    <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-4/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">This is a test post title</a>
+                                                                </h1>
                                                             </td>
                                                         </tr>
                                                     </table>
@@ -6036,7 +6073,12 @@ Daily newsletter [http://127.0.0.1:2369/]
 
 
 
+
+
+
+
 This is a test post title [http://127.0.0.1:2369/this-is-a-test-post-title-4/]
+
 
 
 
@@ -6781,7 +6823,9 @@ table.body h2 span {
                                                     <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                         <tr>
                                                             <td style=\\"vertical-align: top; font-family: Georgia, serif; letter-spacing: -0.01em; font-size: 36px; line-height: 1.1; font-weight: 700; text-align: center; color: #000000;\\" valign=\\"top\\" align=\\"center\\">
-                                                                <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-3/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">This is a test post title</a>
+                                                                <h1 class=\\"post-title-heading\\" style=\\"margin-top: 0; text-rendering: optimizeLegibility; margin: 0; font-size: 36px; line-height: 1.1; font-weight: 700; font-family: Georgia, serif; letter-spacing: -0.01em;\\">
+                                                                    <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-3/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">This is a test post title</a>
+                                                                </h1>
                                                             </td>
                                                         </tr>
                                                     </table>
@@ -6955,7 +6999,12 @@ Daily newsletter [http://127.0.0.1:2369/]
 
 
 
+
+
+
+
 This is a test post title [http://127.0.0.1:2369/this-is-a-test-post-title-3/]
+
 
 
 
@@ -9044,7 +9093,9 @@ table.body h2 span {
                                                     <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                         <tr>
                                                             <td style=\\"vertical-align: top; font-family: Georgia, serif; letter-spacing: -0.01em; font-size: 36px; line-height: 1.1; font-weight: 700; text-align: center; color: #000000;\\" valign=\\"top\\" align=\\"center\\">
-                                                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">This is the main post title</a>
+                                                                <h1 class=\\"post-title-heading\\" style=\\"margin-top: 0; text-rendering: optimizeLegibility; margin: 0; font-size: 36px; line-height: 1.1; font-weight: 700; font-family: Georgia, serif; letter-spacing: -0.01em;\\">
+                                                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">This is the main post title</a>
+                                                                </h1>
                                                             </td>
                                                         </tr>
                                                     </table>
@@ -9277,7 +9328,12 @@ Daily newsletter [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
 
 
 
+
+
+
+
 This is the main post title [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+
 
 
 
@@ -10088,7 +10144,9 @@ table.body h2 span {
                                                     <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                         <tr>
                                                             <td style=\\"vertical-align: top; font-family: Georgia, serif; letter-spacing: -0.01em; font-size: 36px; line-height: 1.1; font-weight: 700; text-align: center; color: #000000;\\" valign=\\"top\\" align=\\"center\\">
-                                                                <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-14/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">This is a test post title</a>
+                                                                <h1 class=\\"post-title-heading\\" style=\\"margin-top: 0; text-rendering: optimizeLegibility; margin: 0; font-size: 36px; line-height: 1.1; font-weight: 700; font-family: Georgia, serif; letter-spacing: -0.01em;\\">
+                                                                    <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-14/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">This is a test post title</a>
+                                                                </h1>
                                                             </td>
                                                         </tr>
                                                     </table>
@@ -10282,7 +10340,12 @@ Daily newsletter [http://127.0.0.1:2369/]
 
 
 
+
+
+
+
 This is a test post title [http://127.0.0.1:2369/this-is-a-test-post-title-14/]
+
 
 
 
@@ -11042,7 +11105,9 @@ table.body h2 span {
                                                     <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                         <tr>
                                                             <td style=\\"vertical-align: top; font-family: Georgia, serif; letter-spacing: -0.01em; font-size: 36px; line-height: 1.1; font-weight: 700; text-align: center; color: #000000;\\" valign=\\"top\\" align=\\"center\\">
-                                                                <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-11/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">This is a test post title</a>
+                                                                <h1 class=\\"post-title-heading\\" style=\\"margin-top: 0; text-rendering: optimizeLegibility; margin: 0; font-size: 36px; line-height: 1.1; font-weight: 700; font-family: Georgia, serif; letter-spacing: -0.01em;\\">
+                                                                    <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-11/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">This is a test post title</a>
+                                                                </h1>
                                                             </td>
                                                         </tr>
                                                     </table>
@@ -11236,7 +11301,12 @@ Daily newsletter [http://127.0.0.1:2369/]
 
 
 
+
+
+
+
 This is a test post title [http://127.0.0.1:2369/this-is-a-test-post-title-11/]
+
 
 
 
@@ -11996,7 +12066,9 @@ table.body h2 span {
                                                     <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                         <tr>
                                                             <td style=\\"vertical-align: top; font-family: Georgia, serif; letter-spacing: -0.01em; font-size: 36px; line-height: 1.1; font-weight: 700; text-align: center; color: #000000;\\" valign=\\"top\\" align=\\"center\\">
-                                                                <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-10/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">This is a test post title</a>
+                                                                <h1 class=\\"post-title-heading\\" style=\\"margin-top: 0; text-rendering: optimizeLegibility; margin: 0; font-size: 36px; line-height: 1.1; font-weight: 700; font-family: Georgia, serif; letter-spacing: -0.01em;\\">
+                                                                    <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-10/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">This is a test post title</a>
+                                                                </h1>
                                                             </td>
                                                         </tr>
                                                     </table>
@@ -12190,7 +12262,12 @@ Daily newsletter [http://127.0.0.1:2369/]
 
 
 
+
+
+
+
 This is a test post title [http://127.0.0.1:2369/this-is-a-test-post-title-10/]
+
 
 
 
@@ -12950,7 +13027,9 @@ table.body h2 span {
                                                     <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                         <tr>
                                                             <td style=\\"vertical-align: top; font-family: Georgia, serif; letter-spacing: -0.01em; font-size: 36px; line-height: 1.1; font-weight: 700; text-align: center; color: #000000;\\" valign=\\"top\\" align=\\"center\\">
-                                                                <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-13/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">This is a test post title</a>
+                                                                <h1 class=\\"post-title-heading\\" style=\\"margin-top: 0; text-rendering: optimizeLegibility; margin: 0; font-size: 36px; line-height: 1.1; font-weight: 700; font-family: Georgia, serif; letter-spacing: -0.01em;\\">
+                                                                    <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-13/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">This is a test post title</a>
+                                                                </h1>
                                                             </td>
                                                         </tr>
                                                     </table>
@@ -13144,7 +13223,12 @@ Daily newsletter [http://127.0.0.1:2369/]
 
 
 
+
+
+
+
 This is a test post title [http://127.0.0.1:2369/this-is-a-test-post-title-13/]
+
 
 
 
@@ -13904,7 +13988,9 @@ table.body h2 span {
                                                     <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                         <tr>
                                                             <td style=\\"vertical-align: top; font-family: Georgia, serif; letter-spacing: -0.01em; font-size: 36px; line-height: 1.1; font-weight: 700; text-align: center; color: #000000;\\" valign=\\"top\\" align=\\"center\\">
-                                                                <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-12/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">This is a test post title</a>
+                                                                <h1 class=\\"post-title-heading\\" style=\\"margin-top: 0; text-rendering: optimizeLegibility; margin: 0; font-size: 36px; line-height: 1.1; font-weight: 700; font-family: Georgia, serif; letter-spacing: -0.01em;\\">
+                                                                    <a href=\\"http://127.0.0.1:2369/this-is-a-test-post-title-12/\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">This is a test post title</a>
+                                                                </h1>
                                                             </td>
                                                         </tr>
                                                     </table>
@@ -14098,7 +14184,12 @@ Daily newsletter [http://127.0.0.1:2369/]
 
 
 
+
+
+
+
 This is a test post title [http://127.0.0.1:2369/this-is-a-test-post-title-12/]
+
 
 
 
@@ -14858,7 +14949,9 @@ table.body h2 span {
                                                     <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                         <tr>
                                                             <td style=\\"vertical-align: top; font-family: Georgia, serif; letter-spacing: -0.01em; font-size: 36px; line-height: 1.1; font-weight: 700; text-align: center; color: #000000;\\" valign=\\"top\\" align=\\"center\\">
-                                                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">A random test post</a>
+                                                                <h1 class=\\"post-title-heading\\" style=\\"margin-top: 0; text-rendering: optimizeLegibility; margin: 0; font-size: 36px; line-height: 1.1; font-weight: 700; font-family: Georgia, serif; letter-spacing: -0.01em;\\">
+                                                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">A random test post</a>
+                                                                </h1>
                                                             </td>
                                                         </tr>
                                                     </table>
@@ -15032,7 +15125,12 @@ Daily newsletter [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
 
 
 
+
+
+
+
 A random test post [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+
 
 
 
@@ -15759,7 +15857,9 @@ table.body h2 span {
                                                     <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                         <tr>
                                                             <td style=\\"vertical-align: top; font-family: Georgia, serif; letter-spacing: -0.01em; font-size: 36px; line-height: 1.1; font-weight: 700; text-align: center; color: #000000;\\" valign=\\"top\\" align=\\"center\\">
-                                                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">A random test post</a>
+                                                                <h1 class=\\"post-title-heading\\" style=\\"margin-top: 0; text-rendering: optimizeLegibility; margin: 0; font-size: 36px; line-height: 1.1; font-weight: 700; font-family: Georgia, serif; letter-spacing: -0.01em;\\">
+                                                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">A random test post</a>
+                                                                </h1>
                                                             </td>
                                                         </tr>
                                                     </table>
@@ -15933,7 +16033,12 @@ Daily newsletter [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
 
 
 
+
+
+
+
 A random test post [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+
 
 
 

--- a/ghost/core/test/integration/services/email-service/__snapshots__/cards.test.js.snap
+++ b/ghost/core/test/integration/services/email-service/__snapshots__/cards.test.js.snap
@@ -598,7 +598,9 @@ table.body h2 span {
                                                     <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                         <tr>
                                                             <td style=\\"vertical-align: top; font-family: Georgia, serif; letter-spacing: -0.01em; font-size: 36px; line-height: 1.1; font-weight: 700; text-align: center; color: #000000;\\" valign=\\"top\\" align=\\"center\\">
-                                                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">A random test post</a>
+                                                                <h1 class=\\"post-title-heading\\" style=\\"margin-top: 0; text-rendering: optimizeLegibility; margin: 0; font-size: 36px; line-height: 1.1; font-weight: 700; font-family: Georgia, serif; letter-spacing: -0.01em;\\">
+                                                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">A random test post</a>
+                                                                </h1>
                                                             </td>
                                                         </tr>
                                                     </table>
@@ -772,7 +774,12 @@ Daily newsletter [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
 
 
 
+
+
+
+
 A random test post [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+
 
 
 
@@ -1497,7 +1504,9 @@ table.body h2 span {
                                                     <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                         <tr>
                                                             <td style=\\"vertical-align: top; font-family: Georgia, serif; letter-spacing: -0.01em; font-size: 36px; line-height: 1.1; font-weight: 700; text-align: center; color: #000000;\\" valign=\\"top\\" align=\\"center\\">
-                                                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">A random test post</a>
+                                                                <h1 class=\\"post-title-heading\\" style=\\"margin-top: 0; text-rendering: optimizeLegibility; margin: 0; font-size: 36px; line-height: 1.1; font-weight: 700; font-family: Georgia, serif; letter-spacing: -0.01em;\\">
+                                                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">A random test post</a>
+                                                                </h1>
                                                             </td>
                                                         </tr>
                                                     </table>
@@ -1671,7 +1680,12 @@ Daily newsletter [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
 
 
 
+
+
+
+
 A random test post [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+
 
 
 
@@ -8220,7 +8234,9 @@ Ghost: Independent technology for modern publishingBeautiful, modern publishing 
                                                     <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                         <tr>
                                                             <td style=\\"vertical-align: top; font-family: Georgia, serif; letter-spacing: -0.01em; font-size: 36px; line-height: 1.1; font-weight: 700; text-align: center; color: #000000;\\" valign=\\"top\\" align=\\"center\\">
-                                                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">A random test post</a>
+                                                                <h1 class=\\"post-title-heading\\" style=\\"margin-top: 0; text-rendering: optimizeLegibility; margin: 0; font-size: 36px; line-height: 1.1; font-weight: 700; font-family: Georgia, serif; letter-spacing: -0.01em;\\">
+                                                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">A random test post</a>
+                                                                </h1>
                                                             </td>
                                                         </tr>
                                                     </table>
@@ -8687,7 +8703,12 @@ Daily newsletter [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
 
 
 
+
+
+
+
 A random test post [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+
 
 
 
@@ -9799,7 +9820,9 @@ Beautiful, modern publishing with newsletters and premium subscriptions built-in
                                                     <table role=\\"presentation\\" border=\\"0\\" cellpadding=\\"0\\" cellspacing=\\"0\\" style=\\"border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;\\" width=\\"100%\\">
                                                         <tr>
                                                             <td style=\\"vertical-align: top; font-family: Georgia, serif; letter-spacing: -0.01em; font-size: 36px; line-height: 1.1; font-weight: 700; text-align: center; color: #000000;\\" valign=\\"top\\" align=\\"center\\">
-                                                                <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">A random test post</a>
+                                                                <h1 class=\\"post-title-heading\\" style=\\"margin-top: 0; text-rendering: optimizeLegibility; margin: 0; font-size: 36px; line-height: 1.1; font-weight: 700; font-family: Georgia, serif; letter-spacing: -0.01em;\\">
+                                                                    <a href=\\"http://127.0.0.1:2369/r/xxxxxx?m=member-uuid\\" class=\\"post-title-link\\" style=\\"text-decoration: none; display: block; margin-top: 32px; text-align: center; line-height: 1.1; overflow-wrap: anywhere; color: #000000;\\" target=\\"_blank\\">A random test post</a>
+                                                                </h1>
                                                             </td>
                                                         </tr>
                                                     </table>
@@ -10266,7 +10289,12 @@ Daily newsletter [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
 
 
 
+
+
+
+
 A random test post [http://127.0.0.1:2369/r/xxxxxx?m=member-uuid]
+
 
 
 

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -1574,6 +1574,10 @@ describe('Email renderer', function () {
 
             assert.equal(heading.length, 1);
             assert.equal(heading.find('a.post-title-link').text(), 'Test Post');
+
+            // Outlook's Word engine ignores `inherit`, so the heading needs concrete values
+            assert.match(heading.attr('style'), /font-size: 36px/);
+            assert.doesNotMatch(heading.attr('style'), /inherit/);
         });
 
         it('Converts a mobiledoc-only post to lexical before rendering', async function () {

--- a/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-renderer.test.js
@@ -1562,6 +1562,20 @@ describe('Email renderer', function () {
             );
         });
 
+        it('renders the post title as the top-level heading', async function () {
+            const post = createModel(basePost);
+            const newsletter = createModel(baseNewsletter);
+
+            const response = await emailRenderer.renderBody(post, newsletter, null, {});
+            await validateHtml(response.html);
+
+            const $ = cheerio.load(response.html);
+            const heading = $('.post-title > table td > h1');
+
+            assert.equal(heading.length, 1);
+            assert.equal(heading.find('a.post-title-link').text(), 'Test Post');
+        });
+
         it('Converts a mobiledoc-only post to lexical before rendering', async function () {
             // Legacy posts can still be stored as mobiledoc with no lexical (mobiledoc is only
             // converted on save, not on read). The email renderer must convert the mobiledoc to


### PR DESCRIPTION
## Problem

Newsletter post titles are styled visually as headings, but the rendered email marks them up as a regular link. This hides the top-level document structure from assistive technology and fails WCAG 1.3.1.

## Solution

Wrap the post title link in an `h1` while resetting the heading's default typography so the existing email-table layout and title styling remain unchanged. Add a focused rendering test that validates the output HTML and semantic title structure.

Fixes #29612

## Test plan

- [x] `pnpm exec vitest run test/unit/server/services/email-service/email-renderer.test.js -t 'renders the post title as the top-level heading'`
- [x] `pnpm exec eslint test/unit/server/services/email-service/email-renderer.test.js --no-cache`
- [x] `git diff --check`

Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works
