### PR TITLE
Removed the unused routes_hash mechanism

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -304,11 +304,6 @@ async function initDynamicRouting() {
         urlService: urlService.facade
     });
 
-    const getRoutesHash = () => routeSettingsModule.service.getCurrentHash();
-
-    const settings = require('./server/services/settings/settings-service');
-    await settings.syncRoutesHash(getRoutesHash);
-
     debug('End: Dynamic Routing');
 }
 

--- a/ghost/core/core/server/api/endpoints/settings.js
+++ b/ghost/core/core/server/api/endpoints/settings.js
@@ -174,8 +174,6 @@ const controller = {
         async query(frame) {
             const content = await fs.readFile(frame.file.path, 'utf8');
             await routeSettings.api.upload(content);
-            const getRoutesHash = () => routeSettings.api.getCurrentHash();
-            await settingsService.syncRoutesHash(getRoutesHash);
         }
     },
 

--- a/ghost/core/core/server/data/migrations/versions/6.55/2026-07-28-12-08-00-remove-routes-hash-from-settings.js
+++ b/ghost/core/core/server/data/migrations/versions/6.55/2026-07-28-12-08-00-remove-routes-hash-from-settings.js
@@ -1,0 +1,5 @@
+const {combineTransactionalMigrations, removeSetting} = require('../../utils');
+
+module.exports = combineTransactionalMigrations(
+    removeSetting('routes_hash')
+);

--- a/ghost/core/core/server/data/schema/default-settings/default-settings.json
+++ b/ghost/core/core/server/data/schema/default-settings/default-settings.json
@@ -8,10 +8,6 @@
             "defaultValue": null,
             "type": "string"
         },
-        "routes_hash": {
-            "defaultValue": null,
-            "type": "string"
-        },
         "next_update_check": {
             "defaultValue": null,
             "type": "number"

--- a/ghost/core/core/server/services/route-settings/dynamic-routing-service.js
+++ b/ghost/core/core/server/services/route-settings/dynamic-routing-service.js
@@ -1,4 +1,3 @@
-const crypto = require('crypto');
 const debug = require('@tryghost/debug')('services:route-settings:service');
 const logging = require('@tryghost/logging');
 const errors = require('@tryghost/errors');
@@ -7,12 +6,6 @@ const tpl = require('@tryghost/tpl');
 const messages = {
     loadError: 'Could not load routes.yaml file.'
 };
-
-/**
- * md5 of the expanded default route settings — the routes_hash value for a
- * site that has never customised its routes.
- */
-const DEFAULT_ROUTES_SETTING_HASH = '3d180d52c663d173a6be791ef411ed01';
 
 function isStoredContentError(err) {
     return err.errorType === 'ValidationError' || err.errorType === 'IncorrectUsageError';
@@ -31,9 +24,9 @@ class DynamicRoutingService {
     }
 
     /**
-     * Wire the storage-layer dependency so the API surface (upload, download,
-     * getCurrentHash) works immediately after boot — even when the frontend is
-     * disabled and `start()` is never called.
+     * Wire the storage-layer dependency so the API surface (upload, download)
+     * works immediately after boot — even when the frontend is disabled and
+     * `start()` is never called.
      *
      * @param {object} deps
      * @param {RouteSettingsStore} deps.store - adapter-manager provided store
@@ -82,18 +75,6 @@ class DynamicRoutingService {
 
             throw err;
         }
-    }
-
-    getDefaultHash() {
-        return DEFAULT_ROUTES_SETTING_HASH;
-    }
-
-    async getCurrentHash() {
-        const expanded = await this.loadRouteSettings();
-
-        return crypto.createHash('md5')
-            .update(JSON.stringify(expanded), 'binary')
-            .digest('hex');
     }
 
     async download() {

--- a/ghost/core/core/server/services/route-settings/dynamic-routing-service.js
+++ b/ghost/core/core/server/services/route-settings/dynamic-routing-service.js
@@ -62,8 +62,8 @@ class DynamicRoutingService {
             // A stored-content error means the site's routes.yaml is invalid —
             // either it fails validation or it isn't parseable YAML. Log a
             // targeted error so the failure is easy to spot in the logs, then
-            // rethrow so the caller (boot, or the routes-hash sync) surfaces the
-            // genuine error rather than silently degrading.
+            // rethrow so the caller surfaces the genuine error rather than
+            // silently degrading.
             if (isStoredContentError(err)) {
                 logging.error(new errors.InternalServerError({
                     message: 'Route settings could not be loaded because the routes.yaml file is invalid. Please fix the file.',

--- a/ghost/core/core/server/services/route-settings/index.js
+++ b/ghost/core/core/server/services/route-settings/index.js
@@ -19,10 +19,6 @@ module.exports = {
         return service.loadRouteSettings.bind(service);
     },
 
-    get getDefaultHash() {
-        return service.getDefaultHash.bind(service);
-    },
-
     /**
      * Methods backing the Admin API settings endpoint — delegate to the
      * service instance so the endpoint stays decoupled from service wiring.
@@ -33,9 +29,6 @@ module.exports = {
         },
         get download() {
             return service.download.bind(service);
-        },
-        get getCurrentHash() {
-            return service.getCurrentHash.bind(service);
         }
     }
 };

--- a/ghost/core/core/server/services/settings/settings-service.js
+++ b/ghost/core/core/server/services/settings/settings-service.js
@@ -184,24 +184,6 @@ module.exports = {
     },
 
     /**
-     * Handles synchronization of routes.yaml hash loaded in the frontend with
-     * the value stored in the settings table.
-     * getRoutesHash is a function to allow keeping "frontend" decoupled from settings
-     *
-     * @param {function} getRoutesHash function fetching currently loaded routes file hash
-     */
-    async syncRoutesHash(getRoutesHash) {
-        const currentRoutesHash = await getRoutesHash();
-
-        if (SettingsCache.get('routes_hash') !== currentRoutesHash) {
-            return await models.Settings.edit([{
-                key: 'routes_hash',
-                value: currentRoutesHash
-            }], {context: {internal: true}});
-        }
-    },
-
-    /**
      * Handles email setting synchronization when email has been verified per instance
      *
      * @param {boolean} configValue current email verification value from local config

--- a/ghost/core/test/integration/services/route-settings/dynamic-routing-service.test.ts
+++ b/ghost/core/test/integration/services/route-settings/dynamic-routing-service.test.ts
@@ -119,11 +119,4 @@ describe('Integration: DynamicRoutingService over a real FileStore', function ()
             return true;
         });
     });
-
-    it('getCurrentHash over the bundled defaults matches the known default hash', async function () {
-        const defaultYaml = await fs.readFile(path.join(DEFAULT_SETTINGS_BASE_PATH, 'default-routes.yaml'), 'utf8');
-        await writeRoutes(defaultYaml);
-
-        assert.equal(await service.getCurrentHash(), service.getDefaultHash());
-    });
 });

--- a/ghost/core/test/integration/settings/settings.test.js
+++ b/ghost/core/test/integration/settings/settings.test.js
@@ -18,7 +18,6 @@ describe('Settings', function () {
     const coreSettingKeys = [
         'last_mentions_report_email_timestamp',
         'db_hash',
-        'routes_hash',
         'next_update_check',
         'notifications',
         'version_notifications',

--- a/ghost/core/test/legacy/models/model-settings.test.js
+++ b/ghost/core/test/legacy/models/model-settings.test.js
@@ -5,12 +5,12 @@ const db = require('../../../core/server/data/db');
 // Stuff we are testing
 const models = require('../../../core/server/models');
 
-const SETTINGS_LENGTH = 112;
+const SETTINGS_LENGTH = 111;
 
 describe('Settings Model', function () {
     // Create the schema once, then empty every table before each test — these
     // assert populateDefaults() starting from an empty settings table (setup()
-    // itself populates the 112 defaults, hence the teardown). Under the old
+    // itself populates the 111 defaults, hence the teardown). Under the old
     // serial model this free-rode on an earlier file's init + truncated state;
     // per-file isolation means each file does its own.
     beforeAll(testUtils.setup());

--- a/ghost/core/test/unit/server/data/exporter/index.test.js
+++ b/ghost/core/test/unit/server/data/exporter/index.test.js
@@ -211,7 +211,7 @@ describe('Exporter', function () {
 
             // NOTE: if default settings changed either modify the settings keys blocklist or increase allowedKeysLength
             //       This is a reminder to think about the importer/exporter scenarios ;)
-            const allowedKeysLength = 108;
+            const allowedKeysLength = 107;
             assert.equal(totalKeysLength, SETTING_KEYS_BLOCKLIST.length + allowedKeysLength);
         });
     });

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -69,6 +69,5 @@ describe('DB version integrity', function () {
         assert.equal(fixturesHash, currentFixturesHash, 'Fixtures have changed, please ensure a proper migration has been created if necessary and update the hash in this test.');
         assert.equal(settingsHash, currentSettingsHash, 'Default settings have changed, please ensure a proper migration has been created if necessary and update the hash in this test.');
         assert.equal(routesHash, currentRoutesHash, 'Default routes have changed, please ensure a proper migration has been created if necessary and update the hash in this test.');
-        assert.equal(routesHash, routeSettings.getDefaultHash());
     });
 });

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -38,7 +38,7 @@ describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = 'c0fe7246714201a82b75f80308d5e300';
     const currentFixturesHash = '065b413e1d1f4f95fa7cb7734c5e7934';
-    const currentSettingsHash = '397be8628c753b1959b8954d5610f83f';
+    const currentSettingsHash = '8650db85b9a61afe4797ad6333066c62';
     const currentRoutesHash = '3d180d52c663d173a6be791ef411ed01';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,

--- a/ghost/core/test/unit/server/services/route-settings/activation-bridge.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/activation-bridge.test.ts
@@ -32,7 +32,7 @@ describe('activation-bridge', function () {
         // Characterisation tests for the full expanded output. The expected
         // values are the canonical expansions the legacy validate.js produced
         // before it was retired — parsing + the bridge must keep matching them
-        // so routes_hash and router wiring stay byte-for-byte stable.
+        // so the expanded output and router wiring stay byte-for-byte stable.
         describe('produces the expected expanded output', function () {
             const cases: Array<{name: string; raw: unknown; expected: object}> = [
                 {
@@ -398,9 +398,10 @@ describe('activation-bridge', function () {
     });
 
     describe('hash continuity', function () {
-        // routes_hash is md5(JSON.stringify(...)) over the expanded settings —
-        // parsing + the bridge must keep producing the known default hash so a
-        // site that never customised its routes keeps the same stored value.
+        // This md5 over the expanded settings is a structural fingerprint of
+        // the default routes — parsing + the bridge must keep producing the
+        // known default hash so a site that never customised its routes keeps
+        // the same expanded output.
         const DEFAULT_ROUTES_HASH = '3d180d52c663d173a6be791ef411ed01';
 
         const defaultRoutesYaml = fs.readFileSync(

--- a/ghost/core/test/unit/server/services/route-settings/dynamic-routing-service.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/dynamic-routing-service.test.ts
@@ -1,7 +1,4 @@
 import assert from 'node:assert/strict';
-import crypto from 'node:crypto';
-import fs from 'fs-extra';
-import path from 'node:path';
 import sinon from 'sinon';
 import {afterEach, beforeEach, describe, it} from 'vitest';
 
@@ -57,26 +54,6 @@ describe('UNIT: DynamicRoutingService (store-backed)', function () {
         assert.deepEqual(expanded.routes['/about/'], {templates: ['about']});
         assert.equal(expanded.collections['/'].permalink, '/:slug/');
         assert.equal(expanded.taxonomies.tag, '/tag/:slug/');
-    });
-
-    it('getCurrentHash over the bundled defaults matches the known default hash', async function () {
-        const defaultYaml = await fs.readFile(
-            path.join(__dirname, '../../../../../core/server/services/route-settings/default-routes.yaml'),
-            'utf8'
-        );
-        await store.replace(fromYaml(defaultYaml));
-
-        assert.equal(await service.getCurrentHash(), service.getDefaultHash());
-    });
-
-    it('getCurrentHash matches md5 of the stringified expansion', async function () {
-        await store.replace(fromYaml(CUSTOM_YAML));
-
-        const expected = crypto.createHash('md5')
-            .update(JSON.stringify(await service.loadRouteSettings()), 'binary')
-            .digest('hex');
-
-        assert.equal(await service.getCurrentHash(), expected);
     });
 
     describe('loadRouteSettings validation failure', function () {

--- a/ghost/core/test/utils/fixtures/default-settings.json
+++ b/ghost/core/test/utils/fixtures/default-settings.json
@@ -8,10 +8,6 @@
             "defaultValue": null,
             "type": "string"
         },
-        "routes_hash": {
-            "defaultValue": null,
-            "type": "string"
-        },
         "next_update_check": {
             "defaultValue": null,
             "type": "number"


### PR DESCRIPTION
## Summary

Removes the `routes_hash` mechanism, which was dead, write-only state.

`routes_hash` was an md5 of the expanded `routes.yaml` that Ghost wrote into the `settings` table on boot and after every `routes.yaml` upload. **Nothing ever read the stored value back.** It was introduced in 2020 (#12171) to detect a changed `routes.yaml` "since last restart", but the code that once consumed it is long gone — today the routing/URL service works directly from the loaded routes, never from the stored hash.

## Why it's safe to remove

Verified there is no behavioral consumer of the stored value:

- The only read is the write-dedup check inside `syncRoutesHash` itself — it just avoids a redundant DB write and nothing branches on it downstream.
- It is a `core`-group setting, so it is filtered out of the settings API (`settings-bread-service` only returns core settings for internal context) — never exposed to Admin, Portal, themes, or the Content/Admin API.
- No event listener on `settings.routes_hash.edited`; no frontend / url-service / theme / webhook / Ghost(Pro) code references it.
- The data importer strips all `core` settings before import, so old exports that carry `routes_hash` are unaffected.

Contrast with its sibling `db_hash`, which **is** genuinely used (invite secret, password reset) and is left untouched.

## Changes

**Commit 1 — remove the write path + dead accessors**
- Removed `syncRoutesHash()` and its two callers (`boot.js` `initDynamicRouting`, and the settings API `routes.yaml` upload endpoint).
- Removed the now-unused `getCurrentHash()` / `getDefaultHash()` accessors and the `DEFAULT_ROUTES_SETTING_HASH` constant that existed only to feed the write path, plus their re-exports and the unit tests that exercised them.

**Commit 2 — remove the setting itself**
- Removed the `routes_hash` definition from `default-settings.json` (and the test fixture copy).
- Added a migration (`removeSetting('routes_hash')`) to drop the stored row on existing installs. It is idempotent — a fresh install where the row was never created skips with a warning.
- Updated the guard tests: `integrity.test.js` settings-hash constant, the exporter default-settings key count (108 → 107), and the core-settings allowlist in the settings integration test.

Default-routes drift is still guarded by `integrity.test.js` and the activation-bridge hash-continuity test, which fingerprint the expansion independently of the removed accessors.

## Out of scope

The legacy `route-settings.js` `RouteSettings` class still has its own `getDefaultHash`/`getCurrentHash` — that whole class is dead code used only by its own unit test, and its removal is a separate cleanup. The historical export fixtures (`v4_export.json`, `v5_export.json`) intentionally keep `routes_hash` as realistic sample data.
