### PR TITLE
🎨 Added configurable search entries for billing

### DIFF
--- a/apps/admin-x-framework/src/api/config.ts
+++ b/apps/admin-x-framework/src/api/config.ts
@@ -90,10 +90,10 @@ export type Config = {
                 logoDark?: string // Logo shown in dark mode, falls back to logo
                 logoAlt?: string // Alt text for the logo
             }
-            // Search palette group for billing actions — opt-in: the group only
-            // appears when this is configured. Hosts can rename the group and
-            // replace its entries; Ghost(Pro)'s defaults fill anything left unset
-            // (so `search: {}` opts in with the defaults).
+            // Search palette group for billing actions, defined entirely by host
+            // config: the group only appears when a groupName and at least one
+            // valid item are provided. Item paths are routes within the host's
+            // own billing app (eg. '/plans').
             search?: {
                 groupName?: string
                 items?: {

--- a/apps/admin-x-framework/src/api/config.ts
+++ b/apps/admin-x-framework/src/api/config.ts
@@ -90,10 +90,7 @@ export type Config = {
                 logoDark?: string // Logo shown in dark mode, falls back to logo
                 logoAlt?: string // Alt text for the logo
             }
-            // Search palette group for billing actions, defined entirely by host
-            // config: the group only appears when a groupName and at least one
-            // valid item are provided. Item paths are routes within the host's
-            // own billing app (eg. '/plans').
+            // Search entries for billing paths, defined in host config (hostSettings.billing.search: {})
             search?: {
                 groupName?: string
                 items?: {

--- a/apps/admin-x-framework/src/api/config.ts
+++ b/apps/admin-x-framework/src/api/config.ts
@@ -90,9 +90,10 @@ export type Config = {
                 logoDark?: string // Logo shown in dark mode, falls back to logo
                 logoAlt?: string // Alt text for the logo
             }
-            // Search palette group for billing actions. Managed hosting providers
-            // can rename the group and replace its entries; Ghost(Pro)'s
-            // defaults are used otherwise, and an empty items list removes the group.
+            // Search palette group for billing actions — opt-in: the group only
+            // appears when this is configured. Hosts can rename the group and
+            // replace its entries; Ghost(Pro)'s defaults fill anything left unset
+            // (so `search: {}` opts in with the defaults).
             search?: {
                 groupName?: string
                 items?: {

--- a/apps/admin-x-framework/src/api/config.ts
+++ b/apps/admin-x-framework/src/api/config.ts
@@ -90,6 +90,18 @@ export type Config = {
                 logoDark?: string // Logo shown in dark mode, falls back to logo
                 logoAlt?: string // Alt text for the logo
             }
+            // Search palette group for billing actions. Managed hosting providers
+            // can rename the group and replace its entries; Ghost(Pro)'s
+            // defaults are used otherwise, and an empty items list removes the group.
+            search?: {
+                groupName?: string
+                items?: {
+                    id?: string
+                    title?: string
+                    path?: string
+                    keywords?: string
+                }[]
+            }
         },
         pintura?: {
             js?: string

--- a/apps/ember-admin/app/components/gh-billing-iframe.js
+++ b/apps/ember-admin/app/components/gh-billing-iframe.js
@@ -77,14 +77,7 @@ export default class GhBillingIframe extends Component {
     }
 
     _postMessageToBillingIframe(message) {
-        const billingIframeWindow = this.billing.getBillingIframe()?.contentWindow;
-        const billingAppOrigin = this.billing.getBillingAppOrigin();
-
-        if (!billingIframeWindow || !billingAppOrigin) {
-            return;
-        }
-
-        billingIframeWindow.postMessage(message, billingAppOrigin);
+        this.billing.postMessageToBillingApp(message);
     }
 
     _handleTokenRequest() {

--- a/apps/ember-admin/app/components/gh-search-input.js
+++ b/apps/ember-admin/app/components/gh-search-input.js
@@ -1,9 +1,11 @@
 import Component from '@glimmer/component';
+import {GHOST_PRO_GROUP_NAME} from 'ghost-admin/utils/search';
 import {action} from '@ember/object';
 import {run} from '@ember/runloop';
 import {inject as service} from '@ember/service';
 
 export default class GhSearchInputComponent extends Component {
+    @service billing;
     @service router;
     @service search;
 
@@ -33,6 +35,14 @@ export default class GhSearchInputComponent extends Component {
         if (selected.groupName === 'Tags') {
             let id = selected.id.replace('tag.', '');
             this.router.transitionTo('tag', id);
+        }
+
+        if (selected.groupName === GHOST_PRO_GROUP_NAME) {
+            // the BMA iframe navigates via postMessage — the transition alone
+            // isn't enough when Ember considers the route unchanged (eg. after
+            // the BMA rewrote the hash itself via history.replaceState)
+            this.billing.navigateToSubRoute(selected.path.replace('/pro', ''));
+            this.router.transitionTo(selected.path);
         }
     }
 

--- a/apps/ember-admin/app/components/gh-search-input.js
+++ b/apps/ember-admin/app/components/gh-search-input.js
@@ -38,11 +38,17 @@ export default class GhSearchInputComponent extends Component {
         }
 
         if (selected.groupName === GHOST_PRO_GROUP_NAME) {
-            // the BMA iframe navigates via postMessage — the transition alone
-            // isn't enough when Ember considers the route unchanged (eg. after
-            // the BMA rewrote the hash itself via history.replaceState)
-            this.billing.navigateToSubRoute(selected.path.replace('/pro', ''));
-            this.router.transitionTo(selected.path);
+            if (this.router.currentURL === selected.path) {
+                // Ember treats the transition as a no-op (eg. after the BMA
+                // rewrote the hash itself via history.replaceState), so the
+                // pro-sub route hook won't run — tell the iframe directly
+                this.billing.navigateToSubRoute(selected.path.replace(/^\/pro/, ''));
+            } else {
+                // the pro-sub route forwards the destination to the BMA iframe
+                // once the transition succeeds, so an aborted transition (eg.
+                // unsaved changes) leaves the billing app untouched
+                this.router.transitionTo(selected.path);
+            }
         }
     }
 

--- a/apps/ember-admin/app/components/gh-search-input.js
+++ b/apps/ember-admin/app/components/gh-search-input.js
@@ -38,16 +38,20 @@ export default class GhSearchInputComponent extends Component {
         }
 
         if (selected.groupKey === BILLING_SEARCH_GROUP_KEY) {
-            if (this.router.currentURL === selected.path) {
+            // billing results carry a route within the billing app — the
+            // billing service maps it onto the Admin route hosting the iframe
+            const adminRoute = this.billing.getAdminRouteForSubRoute(selected.path);
+
+            if (this.router.currentURL === adminRoute) {
                 // Ember treats the transition as a no-op (eg. after the BMA
                 // rewrote the hash itself via history.replaceState), so the
                 // pro-sub route hook won't run — tell the iframe directly
-                this.billing.navigateToSubRoute(selected.path.replace(/^\/pro/, ''));
+                this.billing.navigateToSubRoute(selected.path);
             } else {
                 // the pro-sub route forwards the destination to the BMA iframe
                 // once the transition succeeds, so an aborted transition (eg.
                 // unsaved changes) leaves the billing app untouched
-                this.router.transitionTo(selected.path);
+                this.router.transitionTo(adminRoute);
             }
         }
     }

--- a/apps/ember-admin/app/components/gh-search-input.js
+++ b/apps/ember-admin/app/components/gh-search-input.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import {GHOST_PRO_GROUP_NAME} from 'ghost-admin/utils/search';
+import {BILLING_SEARCH_GROUP_KEY} from 'ghost-admin/utils/search';
 import {action} from '@ember/object';
 import {run} from '@ember/runloop';
 import {inject as service} from '@ember/service';
@@ -37,7 +37,7 @@ export default class GhSearchInputComponent extends Component {
             this.router.transitionTo('tag', id);
         }
 
-        if (selected.groupName === GHOST_PRO_GROUP_NAME) {
+        if (selected.groupKey === BILLING_SEARCH_GROUP_KEY) {
             if (this.router.currentURL === selected.path) {
                 // Ember treats the transition as a no-op (eg. after the BMA
                 // rewrote the hash itself via history.replaceState), so the

--- a/apps/ember-admin/app/components/gh-search-input.js
+++ b/apps/ember-admin/app/components/gh-search-input.js
@@ -17,6 +17,26 @@ export default class GhSearchInputComponent extends Component {
 
         this.args.onSelected?.(selected);
 
+        if (selected.groupKey === BILLING_SEARCH_GROUP_KEY) {
+            const adminRoute = this.billing.getAdminRouteForSubRoute(selected.path);
+
+            if (this.router.currentURL === adminRoute) {
+                // Ember treats the transition as a no-op (eg. after the billing app
+                // rewrote the hash itself via history.replaceState), so the
+                // pro-sub route hook won't run — tell the iframe directly
+                this.billing.navigateToSubRoute(selected.path);
+            } else {
+                // the pro route hooks forward the destination to the billing app
+                // once the transition succeeds, so an aborted transition (eg.
+                // unsaved changes) leaves the billing app untouched
+                this.router.transitionTo(adminRoute);
+            }
+
+            // billing groups are config-named — never fall through to the
+            // groupName-keyed content branches below
+            return;
+        }
+
         if (selected.groupName === 'Posts') {
             let id = selected.id.replace('post.', '');
             this.router.transitionTo('lexical-editor.edit', 'post', id);
@@ -35,22 +55,6 @@ export default class GhSearchInputComponent extends Component {
         if (selected.groupName === 'Tags') {
             let id = selected.id.replace('tag.', '');
             this.router.transitionTo('tag', id);
-        }
-
-        if (selected.groupKey === BILLING_SEARCH_GROUP_KEY) {
-            const adminRoute = this.billing.getAdminRouteForSubRoute(selected.path);
-
-            if (this.router.currentURL === adminRoute) {
-                // Ember treats the transition as a no-op (eg. after the billing app
-                // rewrote the hash itself via history.replaceState), so the
-                // pro-sub route hook won't run — tell the iframe directly
-                this.billing.navigateToSubRoute(selected.path);
-            } else {
-                // the pro-sub route forwards the destination to the billing app
-                // once the transition succeeds, so an aborted transition (eg.
-                // unsaved changes) leaves the billing app untouched
-                this.router.transitionTo(adminRoute);
-            }
         }
     }
 

--- a/apps/ember-admin/app/components/gh-search-input.js
+++ b/apps/ember-admin/app/components/gh-search-input.js
@@ -38,17 +38,15 @@ export default class GhSearchInputComponent extends Component {
         }
 
         if (selected.groupKey === BILLING_SEARCH_GROUP_KEY) {
-            // billing results carry a route within the billing app — the
-            // billing service maps it onto the Admin route hosting the iframe
             const adminRoute = this.billing.getAdminRouteForSubRoute(selected.path);
 
             if (this.router.currentURL === adminRoute) {
-                // Ember treats the transition as a no-op (eg. after the BMA
+                // Ember treats the transition as a no-op (eg. after the billing app
                 // rewrote the hash itself via history.replaceState), so the
                 // pro-sub route hook won't run — tell the iframe directly
                 this.billing.navigateToSubRoute(selected.path);
             } else {
-                // the pro-sub route forwards the destination to the BMA iframe
+                // the pro-sub route forwards the destination to the billing app
                 // once the transition succeeds, so an aborted transition (eg.
                 // unsaved changes) leaves the billing app untouched
                 this.router.transitionTo(adminRoute);

--- a/apps/ember-admin/app/components/koenig-lexical-editor-input.js
+++ b/apps/ember-admin/app/components/koenig-lexical-editor-input.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/ember';
 import Component from '@glimmer/component';
 import React, {Suspense} from 'react';
+import {GHOST_PRO_GROUP_NAME} from 'ghost-admin/utils/search';
 import {action} from '@ember/object';
 import {decoratePostSearchResult} from 'ghost-admin/components/koenig-lexical-editor';
 import {didCancel} from 'ember-concurrency';
@@ -142,6 +143,11 @@ export default class KoenigLexicalEditorInput extends Component {
             const filteredResults = [];
             results.forEach((group) => {
                 let items = group.options;
+
+                // Ghost (Pro) results are admin billing pages, not linkable site content
+                if (group.groupName === GHOST_PRO_GROUP_NAME) {
+                    return;
+                }
 
                 if (group.groupName === 'Posts' || group.groupName === 'Pages') {
                     items = items.filter(i => i.status === 'published');

--- a/apps/ember-admin/app/components/koenig-lexical-editor-input.js
+++ b/apps/ember-admin/app/components/koenig-lexical-editor-input.js
@@ -144,7 +144,7 @@ export default class KoenigLexicalEditorInput extends Component {
             results.forEach((group) => {
                 let items = group.options;
 
-                // Ghost (Pro) results are admin billing pages, not linkable site content
+                // Ghost(Pro) results are admin billing pages, not linkable site content
                 if (group.groupName === GHOST_PRO_GROUP_NAME) {
                     return;
                 }

--- a/apps/ember-admin/app/components/koenig-lexical-editor-input.js
+++ b/apps/ember-admin/app/components/koenig-lexical-editor-input.js
@@ -1,9 +1,8 @@
 import * as Sentry from '@sentry/ember';
 import Component from '@glimmer/component';
 import React, {Suspense} from 'react';
-import {GHOST_PRO_GROUP_NAME} from 'ghost-admin/utils/search';
 import {action} from '@ember/object';
-import {decoratePostSearchResult} from 'ghost-admin/components/koenig-lexical-editor';
+import {decoratePostSearchResult, filterLinkSearchResults} from 'ghost-admin/components/koenig-lexical-editor';
 import {didCancel} from 'ember-concurrency';
 import {inject} from 'ghost-admin/decorators/inject';
 import {inject as service} from '@ember/service';
@@ -139,40 +138,7 @@ export default class KoenigLexicalEditorInput extends Component {
                 return [];
             }
 
-            // only published posts/pages and staff with posts have URLs
-            const filteredResults = [];
-            results.forEach((group) => {
-                let items = group.options;
-
-                // Ghost(Pro) results are admin billing pages, not linkable site content
-                if (group.groupName === GHOST_PRO_GROUP_NAME) {
-                    return;
-                }
-
-                if (group.groupName === 'Posts' || group.groupName === 'Pages') {
-                    items = items.filter(i => i.status === 'published');
-                }
-
-                if (group.groupName === 'Staff') {
-                    items = items.filter(i => !/\/404\//.test(i.url));
-                }
-
-                if (items.length === 0) {
-                    return;
-                }
-
-                // update the group items with metadata
-                if (group.groupName === 'Posts' || group.groupName === 'Pages') {
-                    items.forEach(item => decoratePostSearchResult(item, this.settings));
-                }
-
-                filteredResults.push({
-                    label: group.groupName,
-                    items
-                });
-            });
-
-            return filteredResults;
+            return filterLinkSearchResults(results, this.settings);
         };
 
         const cardConfig = {

--- a/apps/ember-admin/app/components/koenig-lexical-editor.js
+++ b/apps/ember-admin/app/components/koenig-lexical-editor.js
@@ -440,7 +440,7 @@ export default class KoenigLexicalEditor extends Component {
             results.forEach((group) => {
                 let items = group.options;
 
-                // Ghost (Pro) results are admin billing pages, not linkable site content
+                // Ghost(Pro) results are admin billing pages, not linkable site content
                 if (group.groupName === GHOST_PRO_GROUP_NAME) {
                     return;
                 }

--- a/apps/ember-admin/app/components/koenig-lexical-editor.js
+++ b/apps/ember-admin/app/components/koenig-lexical-editor.js
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/ember';
 import Component from '@glimmer/component';
 import React, {Suspense} from 'react';
 import moment from 'moment-timezone';
+import {GHOST_PRO_GROUP_NAME} from 'ghost-admin/utils/search';
 import {action} from '@ember/object';
 import {didCancel, task} from 'ember-concurrency';
 import {inject} from 'ghost-admin/decorators/inject';
@@ -438,6 +439,11 @@ export default class KoenigLexicalEditor extends Component {
             const filteredResults = [];
             results.forEach((group) => {
                 let items = group.options;
+
+                // Ghost (Pro) results are admin billing pages, not linkable site content
+                if (group.groupName === GHOST_PRO_GROUP_NAME) {
+                    return;
+                }
 
                 if (group.groupName === 'Posts' || group.groupName === 'Pages') {
                     items = items.filter(i => i.status === 'published');

--- a/apps/ember-admin/app/components/koenig-lexical-editor.js
+++ b/apps/ember-admin/app/components/koenig-lexical-editor.js
@@ -51,6 +51,46 @@ export function decoratePostSearchResult(item, settings) {
     }
 }
 
+// Filters search results down to linkable site content for the editor's link
+// search: drops admin-only groups, unpublished posts/pages, and staff without
+// URLs, and decorates post/page items with metadata
+export function filterLinkSearchResults(results, settings) {
+    const filteredResults = [];
+
+    results.forEach((group) => {
+        let items = group.options;
+
+        // Ghost(Pro) results are admin billing pages, not linkable site content
+        if (group.groupName === GHOST_PRO_GROUP_NAME) {
+            return;
+        }
+
+        if (group.groupName === 'Posts' || group.groupName === 'Pages') {
+            items = items.filter(i => i.status === 'published');
+        }
+
+        if (group.groupName === 'Staff') {
+            items = items.filter(i => !/\/404\//.test(i.url));
+        }
+
+        if (items.length === 0) {
+            return;
+        }
+
+        // update the group items with metadata
+        if (group.groupName === 'Posts' || group.groupName === 'Pages') {
+            items.forEach(item => decoratePostSearchResult(item, settings));
+        }
+
+        filteredResults.push({
+            label: group.groupName,
+            items
+        });
+    });
+
+    return filteredResults;
+}
+
 export function getCardVisibilitySettings(cardConfig = {}) {
     const post = cardConfig.post;
     const isPage = post?.isPage || post?.displayName === 'page';
@@ -435,40 +475,7 @@ export default class KoenigLexicalEditor extends Component {
                 return;
             }
 
-            // only published posts/pages and staff with posts have URLs
-            const filteredResults = [];
-            results.forEach((group) => {
-                let items = group.options;
-
-                // Ghost(Pro) results are admin billing pages, not linkable site content
-                if (group.groupName === GHOST_PRO_GROUP_NAME) {
-                    return;
-                }
-
-                if (group.groupName === 'Posts' || group.groupName === 'Pages') {
-                    items = items.filter(i => i.status === 'published');
-                }
-
-                if (group.groupName === 'Staff') {
-                    items = items.filter(i => !/\/404\//.test(i.url));
-                }
-
-                if (items.length === 0) {
-                    return;
-                }
-
-                // update the group items with metadata
-                if (group.groupName === 'Posts' || group.groupName === 'Pages') {
-                    items.forEach(item => decoratePostSearchResult(item, this.settings));
-                }
-
-                filteredResults.push({
-                    label: group.groupName,
-                    items
-                });
-            });
-
-            return filteredResults;
+            return filterLinkSearchResults(results, this.settings);
         };
 
         const unsplashConfig = {

--- a/apps/ember-admin/app/components/koenig-lexical-editor.js
+++ b/apps/ember-admin/app/components/koenig-lexical-editor.js
@@ -2,7 +2,6 @@ import * as Sentry from '@sentry/ember';
 import Component from '@glimmer/component';
 import React, {Suspense} from 'react';
 import moment from 'moment-timezone';
-import {BILLING_SEARCH_GROUP_KEY} from 'ghost-admin/utils/search';
 import {action} from '@ember/object';
 import {didCancel, task} from 'ember-concurrency';
 import {inject} from 'ghost-admin/decorators/inject';
@@ -55,12 +54,9 @@ export function filterLinkSearchResults(results, settings) {
     const filteredResults = [];
 
     results.forEach((group) => {
-        let items = group.options;
-
-        // billing results are admin pages, not linkable site content
-        if (group.groupKey === BILLING_SEARCH_GROUP_KEY) {
-            return;
-        }
+        // only content with a public URL is linkable — this also drops
+        // admin-only groups like billing pages, which have a path but no url
+        let items = group.options.filter(i => i.url);
 
         if (group.groupName === 'Posts' || group.groupName === 'Pages') {
             items = items.filter(i => i.status === 'published');

--- a/apps/ember-admin/app/components/koenig-lexical-editor.js
+++ b/apps/ember-admin/app/components/koenig-lexical-editor.js
@@ -51,9 +51,6 @@ export function decoratePostSearchResult(item, settings) {
     }
 }
 
-// Filters search results down to linkable site content for the editor's link
-// search: drops admin-only groups, unpublished posts/pages, and staff without
-// URLs, and decorates post/page items with metadata
 export function filterLinkSearchResults(results, settings) {
     const filteredResults = [];
 

--- a/apps/ember-admin/app/components/koenig-lexical-editor.js
+++ b/apps/ember-admin/app/components/koenig-lexical-editor.js
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/ember';
 import Component from '@glimmer/component';
 import React, {Suspense} from 'react';
 import moment from 'moment-timezone';
-import {GHOST_PRO_GROUP_NAME} from 'ghost-admin/utils/search';
+import {BILLING_SEARCH_GROUP_KEY} from 'ghost-admin/utils/search';
 import {action} from '@ember/object';
 import {didCancel, task} from 'ember-concurrency';
 import {inject} from 'ghost-admin/decorators/inject';
@@ -60,8 +60,8 @@ export function filterLinkSearchResults(results, settings) {
     results.forEach((group) => {
         let items = group.options;
 
-        // Ghost(Pro) results are admin billing pages, not linkable site content
-        if (group.groupName === GHOST_PRO_GROUP_NAME) {
+        // billing results are admin pages, not linkable site content
+        if (group.groupKey === BILLING_SEARCH_GROUP_KEY) {
             return;
         }
 

--- a/apps/ember-admin/app/routes/application.js
+++ b/apps/ember-admin/app/routes/application.js
@@ -216,10 +216,7 @@ export default Route.extend(ShortcutsRoute, {
         }
 
         if (this.config.hostSettings?.forceUpgrade) {
-            // enforce opening the BMA in a force upgrade state, keeping any
-            // /pro child route from the URL (eg. a reloaded /pro/domain);
-            // openBillingWindow falls back to the billing root when the hash
-            // points elsewhere
+            // enforce opening the billing app in a force upgrade state
             this.billing.openBillingWindow(this.router.currentURL, this.billing.getBillingRouteFromHash());
         }
 

--- a/apps/ember-admin/app/routes/application.js
+++ b/apps/ember-admin/app/routes/application.js
@@ -216,8 +216,13 @@ export default Route.extend(ShortcutsRoute, {
         }
 
         if (this.config.hostSettings?.forceUpgrade) {
-            // enforce opening the BMA in a force upgrade state
-            this.billing.openBillingWindow(this.router.currentURL, '/pro');
+            // enforce opening the BMA in a force upgrade state, keeping any
+            // /pro child route from the URL (eg. a reloaded /pro/domain) so
+            // deep links land on the right billing page
+            const requestedRoute = window.location.hash?.replace(/^#/, '');
+            const billingRoute = requestedRoute?.startsWith('/pro') ? requestedRoute : '/pro';
+
+            this.billing.openBillingWindow(this.router.currentURL, billingRoute);
         }
 
         // Notify React of the initial subscription state

--- a/apps/ember-admin/app/routes/application.js
+++ b/apps/ember-admin/app/routes/application.js
@@ -219,7 +219,7 @@ export default Route.extend(ShortcutsRoute, {
             // enforce opening the BMA in a force upgrade state, keeping any
             // /pro child route from the URL (eg. a reloaded /pro/domain)
             const requestedRoute = window.location.hash?.replace(/^#/, '');
-            const billingRoute = requestedRoute?.startsWith('/pro') ? requestedRoute : '/pro';
+            const billingRoute = /^\/pro(?:\/|\?|$)/.test(requestedRoute ?? '') ? requestedRoute : '/pro';
 
             this.billing.openBillingWindow(this.router.currentURL, billingRoute);
         }

--- a/apps/ember-admin/app/routes/application.js
+++ b/apps/ember-admin/app/routes/application.js
@@ -217,11 +217,10 @@ export default Route.extend(ShortcutsRoute, {
 
         if (this.config.hostSettings?.forceUpgrade) {
             // enforce opening the BMA in a force upgrade state, keeping any
-            // /pro child route from the URL (eg. a reloaded /pro/domain)
-            const requestedRoute = window.location.hash?.replace(/^#/, '');
-            const billingRoute = /^\/pro(?:\/|\?|$)/.test(requestedRoute ?? '') ? requestedRoute : '/pro';
-
-            this.billing.openBillingWindow(this.router.currentURL, billingRoute);
+            // /pro child route from the URL (eg. a reloaded /pro/domain);
+            // openBillingWindow falls back to the billing root when the hash
+            // points elsewhere
+            this.billing.openBillingWindow(this.router.currentURL, this.billing.getBillingRouteFromHash());
         }
 
         // Notify React of the initial subscription state

--- a/apps/ember-admin/app/routes/application.js
+++ b/apps/ember-admin/app/routes/application.js
@@ -217,8 +217,7 @@ export default Route.extend(ShortcutsRoute, {
 
         if (this.config.hostSettings?.forceUpgrade) {
             // enforce opening the BMA in a force upgrade state, keeping any
-            // /pro child route from the URL (eg. a reloaded /pro/domain) so
-            // deep links land on the right billing page
+            // /pro child route from the URL (eg. a reloaded /pro/domain)
             const requestedRoute = window.location.hash?.replace(/^#/, '');
             const billingRoute = requestedRoute?.startsWith('/pro') ? requestedRoute : '/pro';
 

--- a/apps/ember-admin/app/routes/pro.js
+++ b/apps/ember-admin/app/routes/pro.js
@@ -1,13 +1,9 @@
 import AuthenticatedRoute from 'ghost-admin/routes/authenticated';
 import {action} from '@ember/object';
-import {inject} from 'ghost-admin/decorators/inject';
 import {inject as service} from '@ember/service';
 
 export default class ProRoute extends AuthenticatedRoute {
     @service billing;
-    @service session;
-
-    @inject config;
 
     queryParams = {
         action: {refreshModel: true}
@@ -16,8 +12,9 @@ export default class ProRoute extends AuthenticatedRoute {
     beforeModel(transition) {
         super.beforeModel(...arguments);
 
-        // allow non-owner users to access the BMA when we're in a force upgrade state
-        if (!this.session.user.isOwnerOnly && !this.config.hostSettings?.forceUpgrade) {
+        // canAccessBilling also admits non-owner users when the site is in a
+        // force upgrade state
+        if (!this.billing.canAccessBilling) {
             return this.transitionTo('index');
         }
 

--- a/apps/ember-admin/app/routes/pro/index.js
+++ b/apps/ember-admin/app/routes/pro/index.js
@@ -1,0 +1,20 @@
+import Route from '@ember/routing/route';
+import {inject as service} from '@ember/service';
+
+export default class ProIndexRoute extends Route {
+    @service billing;
+
+    // entering the billing root must sync the iframe just like pro-sub does
+    // for child routes — eg. browser Back from /pro/domain, or selecting a
+    // billing search result with path '/'; otherwise the iframe keeps showing
+    // the previous sub-page under the /pro URL
+    beforeModel(transition) {
+        if (transition.to?.queryParams?.action) {
+            // action-driven opens (eg. ?action=checkout) already navigate the
+            // billing app via sendRouteUpdate — don't override the destination
+            return;
+        }
+
+        this.billing.navigateToSubRoute('/');
+    }
+}

--- a/apps/ember-admin/app/routes/pro/pro-sub.js
+++ b/apps/ember-admin/app/routes/pro/pro-sub.js
@@ -4,8 +4,8 @@ import {inject as service} from '@ember/service';
 export default class ProSubRoute extends Route {
     @service billing;
 
-    // The BMA iframe is preloaded without any sub route, so deep links to
-    // /pro/* (eg. from search results) need to tell the loaded app to navigate
+    // the billing app can't follow Ember transitions on its own — forward
+    // /pro/* deep links to it (see billing.navigateToSubRoute)
     model(params) {
         if (params.sub) {
             this.billing.navigateToSubRoute(`/${params.sub}`);

--- a/apps/ember-admin/app/routes/pro/pro-sub.js
+++ b/apps/ember-admin/app/routes/pro/pro-sub.js
@@ -1,0 +1,14 @@
+import Route from '@ember/routing/route';
+import {inject as service} from '@ember/service';
+
+export default class ProSubRoute extends Route {
+    @service billing;
+
+    // The BMA iframe is preloaded without any sub route, so deep links to
+    // /pro/* (eg. from search results) need to tell the loaded app to navigate
+    model(params) {
+        if (params.sub) {
+            this.billing.navigateToSubRoute(`/${params.sub}`);
+        }
+    }
+}

--- a/apps/ember-admin/app/routes/pro/pro-sub.js
+++ b/apps/ember-admin/app/routes/pro/pro-sub.js
@@ -7,7 +7,7 @@ export default class ProSubRoute extends Route {
     // the billing app can't follow Ember transitions on its own — forward
     // /pro/* deep links to it (see billing.navigateToSubRoute)
     beforeModel(transition) {
-        const sub = transition.to?.params?.sub;
+        const sub = transition.to?.params?.sub?.replace(/\/$/, '');
 
         if (sub) {
             this.billing.navigateToSubRoute(`/${sub}`);

--- a/apps/ember-admin/app/routes/pro/pro-sub.js
+++ b/apps/ember-admin/app/routes/pro/pro-sub.js
@@ -5,10 +5,14 @@ export default class ProSubRoute extends Route {
     @service billing;
 
     // the billing app can't follow Ember transitions on its own — forward
-    // /pro/* deep links to it (see billing.navigateToSubRoute)
-    model(params) {
-        if (params.sub) {
-            this.billing.navigateToSubRoute(`/${params.sub}`);
+    // /pro/* deep links to it (see billing.navigateToSubRoute). This route
+    // has no model; it exists to relay the requested sub-route, so the
+    // side effect lives in beforeModel
+    beforeModel(transition) {
+        const sub = transition.to?.params?.sub;
+
+        if (sub) {
+            this.billing.navigateToSubRoute(`/${sub}`);
         }
     }
 }

--- a/apps/ember-admin/app/routes/pro/pro-sub.js
+++ b/apps/ember-admin/app/routes/pro/pro-sub.js
@@ -5,9 +5,7 @@ export default class ProSubRoute extends Route {
     @service billing;
 
     // the billing app can't follow Ember transitions on its own — forward
-    // /pro/* deep links to it (see billing.navigateToSubRoute). This route
-    // has no model; it exists to relay the requested sub-route, so the
-    // side effect lives in beforeModel
+    // /pro/* deep links to it (see billing.navigateToSubRoute)
     beforeModel(transition) {
         const sub = transition.to?.params?.sub;
 

--- a/apps/ember-admin/app/services/billing.js
+++ b/apps/ember-admin/app/services/billing.js
@@ -181,8 +181,8 @@ export default class BillingService extends Service {
         this.billingAppIframeSrcSetAt = Date.now();
         this.resetBillingAppLoadDiagnostics();
         iframe.src = this.getIframeURL();
-        // any pending sub route is now part of the iframe URL, so the app
-        // boots directly on it and no post-load route update is needed
+        // the pending sub route is now part of the iframe URL — no post-load
+        // route update needed
         this.pendingSubRoute = null;
     }
 

--- a/apps/ember-admin/app/services/billing.js
+++ b/apps/ember-admin/app/services/billing.js
@@ -30,6 +30,7 @@ export default class BillingService extends Service {
     @service feature;
     @service ghostPaths;
     @service router;
+    @service session;
     @service store;
 
     @inject config;
@@ -70,6 +71,32 @@ export default class BillingService extends Service {
     willDestroy() {
         super.willDestroy(...arguments);
         this.clearBillingAppLoadMonitor();
+    }
+
+    // Whether the current user may open the billing app: billing must be
+    // enabled for the site, and the user must be the owner — or anyone while
+    // the site is in a force-upgrade state. This is the canonical access rule
+    // consumers should share (the `pro` route enforces the user half of it)
+    get canAccessBilling() {
+        const billingEnabled = Boolean(this.config.hostSettings?.billing?.enabled);
+        const userCanAccessBilling = Boolean(this.session.user?.isOwnerOnly) || Boolean(this.config.hostSettings?.forceUpgrade);
+
+        return billingEnabled && userCanAccessBilling;
+    }
+
+    // The billing route in the current URL hash ('/pro', or a child route like
+    // '/pro/domain'), or null when the hash points elsewhere. Anchored so
+    // hashes that merely start with the same characters (eg. '#/products')
+    // don't match
+    getBillingRouteFromHash() {
+        const hash = window.location.hash;
+        const root = this.billingRouteRoot;
+
+        if (hash === root || hash.startsWith(`${root}/`) || hash.startsWith(`${root}?`)) {
+            return hash.replace(/^#/, '');
+        }
+
+        return null;
     }
 
     handleRouteChangeInIframe(destinationRoute) {
@@ -478,8 +505,14 @@ export default class BillingService extends Service {
         // transition to /pro/* the hash still points at the previous route
         let destinationRoute = this.pendingSubRoute;
 
-        if (!destinationRoute && window.location.hash && window.location.hash.includes(this.billingRouteRoot)) {
-            destinationRoute = window.location.hash.replace(this.billingRouteRoot, '');
+        if (!destinationRoute) {
+            const hashRoute = this.getBillingRouteFromHash();
+
+            if (hashRoute) {
+                // keep only the child segment ('/pro/domain' -> '/domain');
+                // billingRouteRoot minus its '#' prefix is the '/pro' root
+                destinationRoute = hashRoute.slice(this.billingRouteRoot.length - 1);
+            }
         }
 
         if (url && destinationRoute) {
@@ -537,20 +570,26 @@ export default class BillingService extends Service {
             }, billingAppOrigin);
         } else {
             this.pendingSubRoute = destinationRoute;
+
+            // when the window is already visible while the app is still
+            // loading, bake the destination into the iframe URL now — a
+            // post-load route update message can lose a race with the app's
+            // own initial redirects
+            if (this.billingWindowOpen && !this.billingAppLoaded) {
+                this.ensureBillingAppReadyForVisibleUse();
+            }
         }
     }
 
-    // Sends a route update to a child route in the BMA, because we can't control
-    // navigating to it otherwise
+    // Sends the checkout deep link (`?action=checkout`) to the BMA. Delivery
+    // goes through navigateToSubRoute so it's origin-pinned and queued until
+    // the app is ready instead of being dropped
     sendRouteUpdate() {
         const action = this.action;
 
         if (action) {
-            if (action === 'checkout' && this._isBillingIframeLoaded()) {
-                this.getBillingIframe().contentWindow.postMessage({
-                    query: 'routeUpdate',
-                    response: this.checkoutRoute
-                }, '*');
+            if (action === 'checkout') {
+                this.navigateToSubRoute(this.checkoutRoute);
             }
 
             this.action = null;
@@ -587,6 +626,10 @@ export default class BillingService extends Service {
 
         if (value) {
             this.ensureBillingAppReadyForVisibleUse();
+        } else {
+            // closing abandons any queued deep link — a stale route must not
+            // hijack a later plain /pro open
+            this.pendingSubRoute = null;
         }
 
         if (isOpeningTransition) {

--- a/apps/ember-admin/app/services/billing.js
+++ b/apps/ember-admin/app/services/billing.js
@@ -63,6 +63,8 @@ export default class BillingService extends Service {
     billingAppIframeSrcSetAt = null;
     billingAppIframeLoadFired = false;
 
+    pendingSubRoute = null;
+
     _loadListenerAttachedTo = null;
 
     willDestroy() {
@@ -179,6 +181,9 @@ export default class BillingService extends Service {
         this.billingAppIframeSrcSetAt = Date.now();
         this.resetBillingAppLoadDiagnostics();
         iframe.src = this.getIframeURL();
+        // any pending sub route is now part of the iframe URL, so the app
+        // boots directly on it and no post-load route update is needed
+        this.pendingSubRoute = null;
     }
 
     reloadBillingIframe(options = {}) {
@@ -198,6 +203,12 @@ export default class BillingService extends Service {
         this.billingAppReadyReceivedAt = Date.now();
         this.billingAppReadyPayload = payload;
         this.clearBillingAppLoadMonitor();
+
+        if (this.pendingSubRoute) {
+            const route = this.pendingSubRoute;
+            this.pendingSubRoute = null;
+            this.navigateToSubRoute(route);
+        }
     }
 
     resetBillingAppLoadDiagnostics() {
@@ -312,10 +323,21 @@ export default class BillingService extends Service {
         this.clearBillingAppLoadMonitor();
         this.billingAppLoadAttempts = 0;
 
-        if (hadPreloadFailure || hadVisibleFailure) {
+        if (hadPreloadFailure || hadVisibleFailure || this.pendingSubRoute) {
+            let reloadReason = 'visible_open_with_destination_route';
+
+            if (hadPreloadFailure) {
+                reloadReason = 'visible_open_after_preload_failure';
+            } else if (hadVisibleFailure) {
+                reloadReason = 'visible_open_after_load_failure';
+            }
+
+            // reloading with a pending sub route boots the billing app directly
+            // on the destination, avoiding a race with the app's own initial
+            // redirects that a post-load route update message can lose
             this.reloadBillingIframe({
                 source: BILLING_APP_ATTEMPT_SOURCE_USER_OPEN,
-                reloadReason: hadPreloadFailure ? 'visible_open_after_preload_failure' : 'visible_open_after_load_failure'
+                reloadReason
             });
         } else {
             this.billingAppLoadAttemptSource = BILLING_APP_ATTEMPT_SOURCE_USER_OPEN;
@@ -451,12 +473,17 @@ export default class BillingService extends Service {
 
         let url = this.config.hostSettings?.billing?.url;
 
-        if (window.location.hash && window.location.hash.includes(this.billingRouteRoot)) {
-            let destinationRoute = window.location.hash.replace(this.billingRouteRoot, '');
+        // a pending sub route takes precedence over the URL hash — Ember model
+        // hooks run before the browser URL updates, so during an in-app
+        // transition to /pro/* the hash still points at the previous route
+        let destinationRoute = this.pendingSubRoute;
 
-            if (destinationRoute) {
-                url += destinationRoute;
-            }
+        if (!destinationRoute && window.location.hash && window.location.hash.includes(this.billingRouteRoot)) {
+            destinationRoute = window.location.hash.replace(this.billingRouteRoot, '');
+        }
+
+        if (url && destinationRoute) {
+            url = url.replace(/\/$/, '') + destinationRoute;
         }
 
         return this.addBillingAppAttemptIdToURL(url);
@@ -489,6 +516,26 @@ export default class BillingService extends Service {
             this.ownerUser = user;
         }
         return this.ownerUser;
+    }
+
+    // Navigates the BMA iframe to a child route (eg. '/domain'). The iframe is
+    // preloaded when Admin boots, so in-app deep links (eg. search results)
+    // can't rely on the initial iframe URL — the loaded app is told to navigate
+    // via postMessage instead. If the app isn't ready yet the route is kept and
+    // sent once it reports ready (see markBillingAppLoaded)
+    navigateToSubRoute(destinationRoute) {
+        if (!destinationRoute) {
+            return;
+        }
+
+        if (this.billingAppLoaded && this._isBillingIframeLoaded()) {
+            this.getBillingIframe().contentWindow.postMessage({
+                query: 'routeUpdate',
+                response: destinationRoute
+            }, '*');
+        } else {
+            this.pendingSubRoute = destinationRoute;
+        }
     }
 
     // Sends a route update to a child route in the BMA, because we can't control

--- a/apps/ember-admin/app/services/billing.js
+++ b/apps/ember-admin/app/services/billing.js
@@ -528,11 +528,13 @@ export default class BillingService extends Service {
             return;
         }
 
-        if (this.billingAppLoaded && this._isBillingIframeLoaded()) {
+        const billingAppOrigin = this.getBillingAppOrigin();
+
+        if (this.billingAppLoaded && this._isBillingIframeLoaded() && billingAppOrigin) {
             this.getBillingIframe().contentWindow.postMessage({
                 query: 'routeUpdate',
                 response: destinationRoute
-            }, '*');
+            }, billingAppOrigin);
         } else {
             this.pendingSubRoute = destinationRoute;
         }

--- a/apps/ember-admin/app/services/billing.js
+++ b/apps/ember-admin/app/services/billing.js
@@ -73,10 +73,9 @@ export default class BillingService extends Service {
         this.clearBillingAppLoadMonitor();
     }
 
-    // Whether the current user may open the billing app: billing must be
-    // enabled for the site, and the user must be the owner — or anyone while
-    // the site is in a force-upgrade state. This is the canonical access rule
-    // consumers should share (the `pro` route enforces the user half of it)
+    // Whether the current user may open the billing app:
+    // - billing must be enabled for the site
+    // - user must be the owner, except when the site is in a force-upgrade state
     get canAccessBilling() {
         const billingEnabled = Boolean(this.config.hostSettings?.billing?.enabled);
         const userCanAccessBilling = Boolean(this.session.user?.isOwnerOnly) || Boolean(this.config.hostSettings?.forceUpgrade);
@@ -215,8 +214,6 @@ export default class BillingService extends Service {
         this.billingAppIframeSrcSetAt = Date.now();
         this.resetBillingAppLoadDiagnostics();
         iframe.src = this.getIframeURL();
-        // the pending sub route is now part of the iframe URL — no post-load
-        // route update needed
         this.pendingSubRoute = null;
     }
 
@@ -366,9 +363,6 @@ export default class BillingService extends Service {
                 reloadReason = 'visible_open_after_load_failure';
             }
 
-            // reloading with a pending sub route boots the billing app directly
-            // on the destination, avoiding a race with the app's own initial
-            // redirects that a post-load route update message can lose
             this.reloadBillingIframe({
                 source: BILLING_APP_ATTEMPT_SOURCE_USER_OPEN,
                 reloadReason
@@ -558,11 +552,6 @@ export default class BillingService extends Service {
         return this.ownerUser;
     }
 
-    // Navigates the BMA iframe to a child route (eg. '/domain'). The iframe is
-    // preloaded when Admin boots, so in-app deep links (eg. search results)
-    // can't rely on the initial iframe URL — the loaded app is told to navigate
-    // via postMessage instead. If the app isn't ready yet the route is kept and
-    // sent once it reports ready (see markBillingAppLoaded)
     navigateToSubRoute(destinationRoute) {
         if (!destinationRoute) {
             return;
@@ -588,9 +577,6 @@ export default class BillingService extends Service {
         }
     }
 
-    // Sends the checkout deep link (`?action=checkout`) to the BMA. Delivery
-    // goes through navigateToSubRoute so it's origin-pinned and queued until
-    // the app is ready instead of being dropped
     sendRouteUpdate() {
         const action = this.action;
 

--- a/apps/ember-admin/app/services/billing.js
+++ b/apps/ember-admin/app/services/billing.js
@@ -63,6 +63,7 @@ export default class BillingService extends Service {
     billingAppLoadAttemptSequence = 0;
     billingAppIframeSrcSetAt = null;
     billingAppIframeLoadFired = false;
+    billingAppIframeSrcSubRoute = null;
 
     pendingSubRoute = null;
 
@@ -74,13 +75,16 @@ export default class BillingService extends Service {
     }
 
     // Whether the current user may open the billing app:
-    // - billing must be enabled for the site
-    // - user must be the owner, except when the site is in a force-upgrade state
+    // - a force-upgrade state always has access — the billing app is the only
+    //   way out of it, for any signed-in user
+    // - otherwise billing must be enabled for the site and the user must be
+    //   the owner
     get canAccessBilling() {
-        const billingEnabled = Boolean(this.config.hostSettings?.billing?.enabled);
-        const userCanAccessBilling = Boolean(this.session.user?.isOwnerOnly) || Boolean(this.config.hostSettings?.forceUpgrade);
+        if (this.config.hostSettings?.forceUpgrade) {
+            return true;
+        }
 
-        return billingEnabled && userCanAccessBilling;
+        return Boolean(this.config.hostSettings?.billing?.enabled) && Boolean(this.session.user?.isOwnerOnly);
     }
 
     // The Admin route that shows the billing app at the given sub-route
@@ -143,10 +147,6 @@ export default class BillingService extends Service {
         }
 
         return ADMIN_DESTINATION_ROUTES[destination] ?? null;
-    }
-
-    _isBillingIframeLoaded() {
-        return this.getBillingIframe() !== null && this.getBillingIframe().contentWindow;
     }
 
     startBillingAppLoadMonitor(options = {}) {
@@ -214,6 +214,7 @@ export default class BillingService extends Service {
         this.billingAppIframeSrcSetAt = Date.now();
         this.resetBillingAppLoadDiagnostics();
         iframe.src = this.getIframeURL();
+        this.billingAppIframeSrcSubRoute = this.getIframeDestinationRoute();
         this.pendingSubRoute = null;
     }
 
@@ -354,7 +355,13 @@ export default class BillingService extends Service {
         this.clearBillingAppLoadMonitor();
         this.billingAppLoadAttempts = 0;
 
-        if (hadPreloadFailure || hadVisibleFailure || this.pendingSubRoute) {
+        // '/' and no destination both load the billing app root
+        const normalizeSubRoute = subRoute => (subRoute === '/' ? null : subRoute);
+
+        const pendingSubRouteNeedsReload = Boolean(this.pendingSubRoute)
+            && normalizeSubRoute(this.pendingSubRoute) !== normalizeSubRoute(this.billingAppIframeSrcSubRoute);
+
+        if (hadPreloadFailure || hadVisibleFailure || pendingSubRouteNeedsReload) {
             let reloadReason = 'visible_open_with_destination_route';
 
             if (hadPreloadFailure) {
@@ -491,19 +498,7 @@ export default class BillingService extends Service {
         });
     }
 
-    getIframeURL(options = {}) {
-        const {fetchOwner = true} = options;
-
-        // initiate getting owner user in the background
-        if (fetchOwner) {
-            this.getOwnerUser();
-        }
-
-        let url = this.config.hostSettings?.billing?.url;
-
-        // a pending sub route takes precedence over the URL hash — Ember model
-        // hooks run before the browser URL updates, so during an in-app
-        // transition to /pro/* the hash still points at the previous route
+    getIframeDestinationRoute() {
         let destinationRoute = this.pendingSubRoute;
 
         if (!destinationRoute) {
@@ -515,6 +510,20 @@ export default class BillingService extends Service {
                 destinationRoute = hashRoute.slice(this.billingRouteRoot.length - 1);
             }
         }
+
+        return destinationRoute || null;
+    }
+
+    getIframeURL(options = {}) {
+        const {fetchOwner = true} = options;
+
+        // initiate getting owner user in the background
+        if (fetchOwner) {
+            this.getOwnerUser();
+        }
+
+        let url = this.config.hostSettings?.billing?.url;
+        const destinationRoute = this.getIframeDestinationRoute();
 
         if (url && destinationRoute) {
             url = url.replace(/\/$/, '') + destinationRoute;
@@ -552,28 +561,35 @@ export default class BillingService extends Service {
         return this.ownerUser;
     }
 
+    postMessageToBillingApp(message) {
+        const billingIframeWindow = this.getBillingIframe()?.contentWindow;
+        const billingAppOrigin = this.getBillingAppOrigin();
+
+        if (!billingIframeWindow || !billingAppOrigin) {
+            return false;
+        }
+
+        billingIframeWindow.postMessage(message, billingAppOrigin);
+        return true;
+    }
+
     navigateToSubRoute(destinationRoute) {
         if (!destinationRoute) {
             return;
         }
 
-        const billingAppOrigin = this.getBillingAppOrigin();
+        if (this.billingAppLoaded && this.postMessageToBillingApp({query: 'routeUpdate', response: destinationRoute})) {
+            return;
+        }
 
-        if (this.billingAppLoaded && this._isBillingIframeLoaded() && billingAppOrigin) {
-            this.getBillingIframe().contentWindow.postMessage({
-                query: 'routeUpdate',
-                response: destinationRoute
-            }, billingAppOrigin);
-        } else {
-            this.pendingSubRoute = destinationRoute;
+        this.pendingSubRoute = destinationRoute;
 
-            // when the window is already visible while the app is still
-            // loading, bake the destination into the iframe URL now — a
-            // post-load route update message can lose a race with the app's
-            // own initial redirects
-            if (this.billingWindowOpen && !this.billingAppLoaded) {
-                this.ensureBillingAppReadyForVisibleUse();
-            }
+        // when the window is already visible while the app is still
+        // loading, bake the destination into the iframe URL now — a
+        // post-load route update message can lose a race with the app's
+        // own initial redirects
+        if (this.billingWindowOpen && !this.billingAppLoaded) {
+            this.ensureBillingAppReadyForVisibleUse();
         }
     }
 
@@ -590,14 +606,8 @@ export default class BillingService extends Service {
     }
 
     sendUpdateLimits() {
-        if (!this._isBillingIframeLoaded()) {
-            return;
-        }
-
         // Send Billing app message to fetch fresh limit usage
-        this.getBillingIframe().contentWindow.postMessage({
-            query: 'limitUpdate'
-        }, '*');
+        this.postMessageToBillingApp({query: 'limitUpdate'});
     }
 
     // Controls billing window modal visibility and sync of the URL visible in browser

--- a/apps/ember-admin/app/services/billing.js
+++ b/apps/ember-admin/app/services/billing.js
@@ -84,6 +84,13 @@ export default class BillingService extends Service {
         return billingEnabled && userCanAccessBilling;
     }
 
+    // The Admin route that shows the billing app at the given sub-route
+    // (eg. '/domain' -> '/pro/domain'). Admin's mounting point for the billing
+    // app is owned here — callers work with billing app sub-routes only
+    getAdminRouteForSubRoute(subRoute) {
+        return this.billingRouteRoot.replace(/^#/, '') + (subRoute === '/' ? '' : subRoute);
+    }
+
     // The billing route in the current URL hash ('/pro', or a child route like
     // '/pro/domain'), or null when the hash points elsewhere. Anchored so
     // hashes that merely start with the same characters (eg. '#/products')

--- a/apps/ember-admin/app/services/search-provider-basic.js
+++ b/apps/ember-admin/app/services/search-provider-basic.js
@@ -1,7 +1,6 @@
 import RSVP from 'rsvp';
 import Service from '@ember/service';
-import {SEARCHABLES, createSearchResult, isSearchableAvailable, sortSearchResultsByStatus} from '../utils/search';
-import {inject} from 'ghost-admin/decorators/inject';
+import {SEARCHABLES, createSearchResult, sortSearchResultsByStatus} from '../utils/search';
 import {isEmpty} from '@ember/utils';
 import {pluralize} from 'ember-inflector';
 import {inject as service} from '@ember/service';
@@ -11,9 +10,6 @@ export default class SearchProviderBasicService extends Service {
     @service ajax;
     @service notifications;
     @service ghostPaths;
-    @service session;
-
-    @inject config;
 
     content = [];
 
@@ -24,10 +20,6 @@ export default class SearchProviderBasicService extends Service {
         const results = [];
 
         SEARCHABLES.forEach((searchable) => {
-            if (!isSearchableAvailable(searchable, this)) {
-                return;
-            }
-
             let matchedContent = this.content.filter((item) => {
                 if (item.groupName !== searchable.name) {
                     return false;

--- a/apps/ember-admin/app/services/search-provider-basic.js
+++ b/apps/ember-admin/app/services/search-provider-basic.js
@@ -1,6 +1,7 @@
 import RSVP from 'rsvp';
 import Service from '@ember/service';
-import {SEARCHABLES, createSearchResult, sortSearchResultsByStatus} from '../utils/search';
+import {SEARCHABLES, createSearchResult, isSearchableAvailable, sortSearchResultsByStatus} from '../utils/search';
+import {inject} from 'ghost-admin/decorators/inject';
 import {isEmpty} from '@ember/utils';
 import {pluralize} from 'ember-inflector';
 import {inject as service} from '@ember/service';
@@ -10,6 +11,9 @@ export default class SearchProviderBasicService extends Service {
     @service ajax;
     @service notifications;
     @service ghostPaths;
+    @service session;
+
+    @inject config;
 
     content = [];
 
@@ -20,11 +24,21 @@ export default class SearchProviderBasicService extends Service {
         const results = [];
 
         SEARCHABLES.forEach((searchable) => {
+            if (!isSearchableAvailable(searchable, this)) {
+                return;
+            }
+
             let matchedContent = this.content.filter((item) => {
+                if (item.groupName !== searchable.name) {
+                    return false;
+                }
+
                 const normalizedTitle = item.title.toString().toLowerCase();
+                const normalizedKeywords = item.keywords ? item.keywords.toString().toLowerCase() : '';
+
                 return (
-                    item.groupName === searchable.name &&
-                    normalizedTitle.indexOf(normalizedTerm) >= 0
+                    normalizedTitle.indexOf(normalizedTerm) >= 0 ||
+                    normalizedKeywords.indexOf(normalizedTerm) >= 0
                 );
             });
 
@@ -57,6 +71,16 @@ export default class SearchProviderBasicService extends Service {
     }
 
     async _loadSearchable(searchable, content) {
+        // static searchables (eg. Ghost (Pro) pages) are indexed client-side
+        if (searchable.staticItems) {
+            const items = searchable.staticItems.map(
+                item => createSearchResult(searchable, item)
+            );
+
+            content.push(...items);
+            return;
+        }
+
         const url = this.ghostPaths.url.api(`search-index/${pluralize(searchable.model)}`);
         const query = {};
 

--- a/apps/ember-admin/app/services/search-provider-basic.js
+++ b/apps/ember-admin/app/services/search-provider-basic.js
@@ -71,7 +71,6 @@ export default class SearchProviderBasicService extends Service {
     }
 
     async _loadSearchable(searchable, content) {
-        // static searchables (eg. Ghost(Pro) pages) are indexed client-side
         if (searchable.staticItems) {
             const items = searchable.staticItems.map(
                 item => createSearchResult(searchable, item)

--- a/apps/ember-admin/app/services/search-provider-basic.js
+++ b/apps/ember-admin/app/services/search-provider-basic.js
@@ -25,6 +25,11 @@ export default class SearchProviderBasicService extends Service {
                     return false;
                 }
 
+                // matches on the result's `title` (mapped from the searchable's
+                // titleField by createSearchResult) plus optional `keywords`.
+                // Unlike the flex provider this ignores `searchable.index`, so a
+                // searchable's index fields must stay within {titleField, keywords}
+                // for both providers to match the same items
                 const normalizedTitle = item.title.toString().toLowerCase();
                 const normalizedKeywords = item.keywords ? item.keywords.toString().toLowerCase() : '';
 

--- a/apps/ember-admin/app/services/search-provider-basic.js
+++ b/apps/ember-admin/app/services/search-provider-basic.js
@@ -71,7 +71,7 @@ export default class SearchProviderBasicService extends Service {
     }
 
     async _loadSearchable(searchable, content) {
-        // static searchables (eg. Ghost (Pro) pages) are indexed client-side
+        // static searchables (eg. Ghost(Pro) pages) are indexed client-side
         if (searchable.staticItems) {
             const items = searchable.staticItems.map(
                 item => createSearchResult(searchable, item)

--- a/apps/ember-admin/app/services/search-provider-basic.js
+++ b/apps/ember-admin/app/services/search-provider-basic.js
@@ -1,6 +1,7 @@
 import RSVP from 'rsvp';
 import Service from '@ember/service';
-import {SEARCHABLES, createSearchResult, sortSearchResultsByStatus} from '../utils/search';
+import {createSearchResult, getSearchables, sortSearchResultsByStatus} from '../utils/search';
+import {inject} from 'ghost-admin/decorators/inject';
 import {isEmpty} from '@ember/utils';
 import {pluralize} from 'ember-inflector';
 import {inject as service} from '@ember/service';
@@ -11,6 +12,8 @@ export default class SearchProviderBasicService extends Service {
     @service notifications;
     @service ghostPaths;
 
+    @inject config;
+
     content = [];
 
     /* eslint-disable require-yield */
@@ -19,7 +22,7 @@ export default class SearchProviderBasicService extends Service {
         const normalizedTerm = term.toString().toLowerCase();
         const results = [];
 
-        SEARCHABLES.forEach((searchable) => {
+        getSearchables(this.config.hostSettings).forEach((searchable) => {
             let matchedContent = this.content.filter((item) => {
                 if (item.groupName !== searchable.name) {
                     return false;
@@ -44,6 +47,7 @@ export default class SearchProviderBasicService extends Service {
             if (!isEmpty(matchedContent)) {
                 results.push({
                     groupName: searchable.name,
+                    groupKey: searchable.key,
                     options: matchedContent
                 });
             }
@@ -56,7 +60,7 @@ export default class SearchProviderBasicService extends Service {
     @task
     *refreshContentTask() {
         const content = [];
-        const promises = SEARCHABLES.map(searchable => this._loadSearchable(searchable, content));
+        const promises = getSearchables(this.config.hostSettings).map(searchable => this._loadSearchable(searchable, content));
 
         try {
             yield RSVP.all(promises);

--- a/apps/ember-admin/app/services/search-provider-basic.js
+++ b/apps/ember-admin/app/services/search-provider-basic.js
@@ -16,20 +16,29 @@ export default class SearchProviderBasicService extends Service {
 
     content = [];
 
+    constructor() {
+        super(...arguments);
+
+        this.searchables = getSearchables(this.config.hostSettings);
+    }
+
     /* eslint-disable require-yield */
     @task
     *searchTask(term) {
         const normalizedTerm = term.toString().toLowerCase();
         const results = [];
 
-        getSearchables(this.config.hostSettings).forEach((searchable) => {
+        this.searchables.forEach((searchable) => {
+            // only match fields the searchable declares in its index
+            const keywordsIndexed = Boolean(searchable.index?.includes('keywords'));
+
             let matchedContent = this.content.filter((item) => {
                 if (item.groupName !== searchable.name) {
                     return false;
                 }
 
                 const normalizedTitle = item.title.toString().toLowerCase();
-                const normalizedKeywords = item.keywords ? item.keywords.toString().toLowerCase() : '';
+                const normalizedKeywords = keywordsIndexed && item.keywords ? item.keywords.toString().toLowerCase() : '';
 
                 return (
                     normalizedTitle.indexOf(normalizedTerm) >= 0 ||
@@ -55,7 +64,7 @@ export default class SearchProviderBasicService extends Service {
     @task
     *refreshContentTask() {
         const content = [];
-        const promises = getSearchables(this.config.hostSettings).map(searchable => this._loadSearchable(searchable, content));
+        const promises = this.searchables.map(searchable => this._loadSearchable(searchable, content));
 
         try {
             yield RSVP.all(promises);

--- a/apps/ember-admin/app/services/search-provider-basic.js
+++ b/apps/ember-admin/app/services/search-provider-basic.js
@@ -28,11 +28,6 @@ export default class SearchProviderBasicService extends Service {
                     return false;
                 }
 
-                // matches on the result's `title` (mapped from the searchable's
-                // titleField by createSearchResult) plus optional `keywords`.
-                // Unlike the flex provider this ignores `searchable.index`, so a
-                // searchable's index fields must stay within {titleField, keywords}
-                // for both providers to match the same items
                 const normalizedTitle = item.title.toString().toLowerCase();
                 const normalizedKeywords = item.keywords ? item.keywords.toString().toLowerCase() : '';
 

--- a/apps/ember-admin/app/services/search-provider-flex.js
+++ b/apps/ember-admin/app/services/search-provider-flex.js
@@ -85,7 +85,6 @@ export default class SearchProviderFlexService extends Service {
     }
 
     async #loadSearchable(searchable) {
-        // static searchables (eg. Ghost(Pro) pages) are indexed client-side
         if (searchable.staticItems) {
             searchable.staticItems.forEach((item) => {
                 this.indexes[searchable.model].add(item);

--- a/apps/ember-admin/app/services/search-provider-flex.js
+++ b/apps/ember-admin/app/services/search-provider-flex.js
@@ -1,7 +1,8 @@
 import RSVP from 'rsvp';
 import Service from '@ember/service';
 import {default as Flexsearch} from 'flexsearch';
-import {SEARCHABLES, createSearchResult, sortSearchResultsByStatus} from '../utils/search';
+import {SEARCHABLES, createSearchResult, isSearchableAvailable, sortSearchResultsByStatus} from '../utils/search';
+import {inject} from 'ghost-admin/decorators/inject';
 import {isEmpty} from '@ember/utils';
 import {pluralize} from 'ember-inflector';
 import {inject as service} from '@ember/service';
@@ -13,6 +14,9 @@ export default class SearchProviderFlexService extends Service {
     @service ajax;
     @service notifications;
     @service ghostPaths;
+    @service session;
+
+    @inject config;
 
     indexes = SEARCHABLES.reduce((indexes, searchable) => {
         indexes[searchable.model] = new Document({
@@ -33,6 +37,10 @@ export default class SearchProviderFlexService extends Service {
         const results = [];
 
         SEARCHABLES.forEach((searchable) => {
+            if (!isSearchableAvailable(searchable, this)) {
+                return;
+            }
+
             const searchResults = this.indexes[searchable.model].search(term, {enrich: true});
             const usedIds = new Set();
             let groupResults = [];
@@ -77,6 +85,14 @@ export default class SearchProviderFlexService extends Service {
     }
 
     async #loadSearchable(searchable) {
+        // static searchables (eg. Ghost (Pro) pages) are indexed client-side
+        if (searchable.staticItems) {
+            searchable.staticItems.forEach((item) => {
+                this.indexes[searchable.model].add(item);
+            });
+            return;
+        }
+
         const url = this.ghostPaths.url.api(`search-index/${pluralize(searchable.model)}`);
         const query = {};
 

--- a/apps/ember-admin/app/services/search-provider-flex.js
+++ b/apps/ember-admin/app/services/search-provider-flex.js
@@ -1,8 +1,7 @@
 import RSVP from 'rsvp';
 import Service from '@ember/service';
 import {default as Flexsearch} from 'flexsearch';
-import {SEARCHABLES, createSearchResult, isSearchableAvailable, sortSearchResultsByStatus} from '../utils/search';
-import {inject} from 'ghost-admin/decorators/inject';
+import {SEARCHABLES, createSearchResult, sortSearchResultsByStatus} from '../utils/search';
 import {isEmpty} from '@ember/utils';
 import {pluralize} from 'ember-inflector';
 import {inject as service} from '@ember/service';
@@ -14,9 +13,6 @@ export default class SearchProviderFlexService extends Service {
     @service ajax;
     @service notifications;
     @service ghostPaths;
-    @service session;
-
-    @inject config;
 
     indexes = SEARCHABLES.reduce((indexes, searchable) => {
         indexes[searchable.model] = new Document({
@@ -37,10 +33,6 @@ export default class SearchProviderFlexService extends Service {
         const results = [];
 
         SEARCHABLES.forEach((searchable) => {
-            if (!isSearchableAvailable(searchable, this)) {
-                return;
-            }
-
             const searchResults = this.indexes[searchable.model].search(term, {enrich: true});
             const usedIds = new Set();
             let groupResults = [];

--- a/apps/ember-admin/app/services/search-provider-flex.js
+++ b/apps/ember-admin/app/services/search-provider-flex.js
@@ -85,7 +85,7 @@ export default class SearchProviderFlexService extends Service {
     }
 
     async #loadSearchable(searchable) {
-        // static searchables (eg. Ghost (Pro) pages) are indexed client-side
+        // static searchables (eg. Ghost(Pro) pages) are indexed client-side
         if (searchable.staticItems) {
             searchable.staticItems.forEach((item) => {
                 this.indexes[searchable.model].add(item);

--- a/apps/ember-admin/app/services/search-provider-flex.js
+++ b/apps/ember-admin/app/services/search-provider-flex.js
@@ -1,7 +1,8 @@
 import RSVP from 'rsvp';
 import Service from '@ember/service';
 import {default as Flexsearch} from 'flexsearch';
-import {SEARCHABLES, createSearchResult, sortSearchResultsByStatus} from '../utils/search';
+import {SEARCHABLES, createSearchResult, getSearchables, sortSearchResultsByStatus} from '../utils/search';
+import {inject} from 'ghost-admin/decorators/inject';
 import {isEmpty} from '@ember/utils';
 import {pluralize} from 'ember-inflector';
 import {inject as service} from '@ember/service';
@@ -14,6 +15,11 @@ export default class SearchProviderFlexService extends Service {
     @service notifications;
     @service ghostPaths;
 
+    @inject config;
+
+    // indexes are keyed by model with static field config, neither of which
+    // hostSettings can change, so the config-resolved searchable list isn't
+    // needed here
     indexes = SEARCHABLES.reduce((indexes, searchable) => {
         indexes[searchable.model] = new Document({
             tokenize: 'forward',
@@ -32,7 +38,7 @@ export default class SearchProviderFlexService extends Service {
     *searchTask(term) {
         const results = [];
 
-        SEARCHABLES.forEach((searchable) => {
+        getSearchables(this.config.hostSettings).forEach((searchable) => {
             const searchResults = this.indexes[searchable.model].search(term, {enrich: true});
             const usedIds = new Set();
             let groupResults = [];
@@ -56,6 +62,7 @@ export default class SearchProviderFlexService extends Service {
             if (!isEmpty(groupResults)) {
                 results.push({
                     groupName: searchable.name,
+                    groupKey: searchable.key,
                     options: groupResults
                 });
             }
@@ -68,7 +75,7 @@ export default class SearchProviderFlexService extends Service {
     @task
     *refreshContentTask() {
         try {
-            const promises = SEARCHABLES.map(searchable => this.#loadSearchable(searchable));
+            const promises = getSearchables(this.config.hostSettings).map(searchable => this.#loadSearchable(searchable));
             yield RSVP.all(promises);
         } catch (error) {
             // eslint-disable-next-line

--- a/apps/ember-admin/app/services/search-provider-flex.js
+++ b/apps/ember-admin/app/services/search-provider-flex.js
@@ -1,7 +1,7 @@
 import RSVP from 'rsvp';
 import Service from '@ember/service';
 import {default as Flexsearch} from 'flexsearch';
-import {SEARCHABLES, createSearchResult, getSearchables, sortSearchResultsByStatus} from '../utils/search';
+import {createSearchResult, getSearchables, sortSearchResultsByStatus} from '../utils/search';
 import {inject} from 'ghost-admin/decorators/inject';
 import {isEmpty} from '@ember/utils';
 import {pluralize} from 'ember-inflector';
@@ -17,25 +17,30 @@ export default class SearchProviderFlexService extends Service {
 
     @inject config;
 
-    indexes = SEARCHABLES.reduce((indexes, searchable) => {
-        indexes[searchable.model] = new Document({
-            tokenize: 'forward',
-            document: {
-                id: 'id',
-                index: searchable.index,
-                store: true
-            }
-        });
+    constructor() {
+        super(...arguments);
 
-        return indexes;
-    }, {});
+        this.searchables = getSearchables(this.config.hostSettings);
+        this.indexes = this.searchables.reduce((indexes, searchable) => {
+            indexes[searchable.model] = new Document({
+                tokenize: 'forward',
+                document: {
+                    id: 'id',
+                    index: searchable.index,
+                    store: true
+                }
+            });
+
+            return indexes;
+        }, {});
+    }
 
     /* eslint-disable require-yield */
     @task
     *searchTask(term) {
         const results = [];
 
-        getSearchables(this.config.hostSettings).forEach((searchable) => {
+        this.searchables.forEach((searchable) => {
             const searchResults = this.indexes[searchable.model].search(term, {enrich: true});
             const usedIds = new Set();
             let groupResults = [];
@@ -72,7 +77,7 @@ export default class SearchProviderFlexService extends Service {
     @task
     *refreshContentTask() {
         try {
-            const promises = getSearchables(this.config.hostSettings).map(searchable => this.#loadSearchable(searchable));
+            const promises = this.searchables.map(searchable => this.#loadSearchable(searchable));
             yield RSVP.all(promises);
         } catch (error) {
             // eslint-disable-next-line

--- a/apps/ember-admin/app/services/search-provider-flex.js
+++ b/apps/ember-admin/app/services/search-provider-flex.js
@@ -17,9 +17,6 @@ export default class SearchProviderFlexService extends Service {
 
     @inject config;
 
-    // indexes are keyed by model with static field config, neither of which
-    // hostSettings can change, so the config-resolved searchable list isn't
-    // needed here
     indexes = SEARCHABLES.reduce((indexes, searchable) => {
         indexes[searchable.model] = new Document({
             tokenize: 'forward',

--- a/apps/ember-admin/app/services/search.js
+++ b/apps/ember-admin/app/services/search.js
@@ -1,5 +1,7 @@
 import Service from '@ember/service';
+import {GHOST_PRO_GROUP_NAME} from '../utils/search';
 import {action} from '@ember/object';
+import {inject} from 'ghost-admin/decorators/inject';
 import {isBlank} from '@ember/utils';
 import {inject as service} from '@ember/service';
 import {task, timeout} from 'ember-concurrency';
@@ -10,14 +12,27 @@ export default class SearchService extends Service {
     @service notifications;
     @service searchProviderBasic;
     @service searchProviderFlex;
+    @service session;
     @service settings;
     @service store;
+
+    @inject config;
 
     isContentStale = true;
 
     get provider() {
         const isEnglish = this.settings.locale?.toLowerCase().startsWith('en') ?? true;
         return isEnglish ? this.searchProviderFlex : this.searchProviderBasic;
+    }
+
+    // Ghost(Pro) results deep-link into the billing app, so they're only shown
+    // when billing is enabled for the site and the current user is allowed to
+    // open it (mirrors the access rules in the `pro` route)
+    get #canAccessBilling() {
+        const billingEnabled = Boolean(this.config.hostSettings?.billing?.enabled);
+        const userCanAccessBilling = Boolean(this.session.user?.isOwnerOnly) || Boolean(this.config.hostSettings?.forceUpgrade);
+
+        return billingEnabled && userCanAccessBilling;
     }
 
     @action
@@ -42,7 +57,13 @@ export default class SearchService extends Service {
             yield this.refreshContentTask.lastRunning;
         }
 
-        return yield this.provider.searchTask.perform(term);
+        const results = yield this.provider.searchTask.perform(term);
+
+        if (!this.#canAccessBilling) {
+            return results.filter(group => group.groupName !== GHOST_PRO_GROUP_NAME);
+        }
+
+        return results;
     }
 
     @task({drop: true})

--- a/apps/ember-admin/app/services/search.js
+++ b/apps/ember-admin/app/services/search.js
@@ -1,38 +1,25 @@
 import Service from '@ember/service';
 import {GHOST_PRO_GROUP_NAME} from '../utils/search';
 import {action} from '@ember/object';
-import {inject} from 'ghost-admin/decorators/inject';
 import {isBlank} from '@ember/utils';
 import {inject as service} from '@ember/service';
 import {task, timeout} from 'ember-concurrency';
 
 export default class SearchService extends Service {
     @service ajax;
+    @service billing;
     @service feature;
     @service notifications;
     @service searchProviderBasic;
     @service searchProviderFlex;
-    @service session;
     @service settings;
     @service store;
-
-    @inject config;
 
     isContentStale = true;
 
     get provider() {
         const isEnglish = this.settings.locale?.toLowerCase().startsWith('en') ?? true;
         return isEnglish ? this.searchProviderFlex : this.searchProviderBasic;
-    }
-
-    // Ghost(Pro) results deep-link into the billing app, so they're only shown
-    // when billing is enabled for the site and the current user is allowed to
-    // open it (mirrors the access rules in the `pro` route)
-    get #canAccessBilling() {
-        const billingEnabled = Boolean(this.config.hostSettings?.billing?.enabled);
-        const userCanAccessBilling = Boolean(this.session.user?.isOwnerOnly) || Boolean(this.config.hostSettings?.forceUpgrade);
-
-        return billingEnabled && userCanAccessBilling;
     }
 
     @action
@@ -59,7 +46,9 @@ export default class SearchService extends Service {
 
         const results = yield this.provider.searchTask.perform(term);
 
-        if (!this.#canAccessBilling) {
+        // Ghost(Pro) results deep-link into the billing app, so they're only
+        // shown to users who may open it (the billing service owns the rule)
+        if (!this.billing.canAccessBilling) {
             return results.filter(group => group.groupName !== GHOST_PRO_GROUP_NAME);
         }
 

--- a/apps/ember-admin/app/services/search.js
+++ b/apps/ember-admin/app/services/search.js
@@ -1,5 +1,5 @@
 import Service from '@ember/service';
-import {GHOST_PRO_GROUP_NAME} from '../utils/search';
+import {BILLING_SEARCH_GROUP_KEY} from '../utils/search';
 import {action} from '@ember/object';
 import {isBlank} from '@ember/utils';
 import {inject as service} from '@ember/service';
@@ -46,10 +46,10 @@ export default class SearchService extends Service {
 
         const results = yield this.provider.searchTask.perform(term);
 
-        // Ghost(Pro) results deep-link into the billing app, so they're only
+        // billing results deep-link into the billing app, so they're only
         // shown to users who may open it (the billing service owns the rule)
         if (!this.billing.canAccessBilling) {
-            return results.filter(group => group.groupName !== GHOST_PRO_GROUP_NAME);
+            return results.filter(group => group.groupKey !== BILLING_SEARCH_GROUP_KEY);
         }
 
         return results;

--- a/apps/ember-admin/app/services/search.js
+++ b/apps/ember-admin/app/services/search.js
@@ -46,8 +46,6 @@ export default class SearchService extends Service {
 
         const results = yield this.provider.searchTask.perform(term);
 
-        // billing results deep-link into the billing app, so they're only
-        // shown to users who may open it (the billing service owns the rule)
         if (!this.billing.canAccessBilling) {
             return results.filter(group => group.groupKey !== BILLING_SEARCH_GROUP_KEY);
         }

--- a/apps/ember-admin/app/utils/route.js
+++ b/apps/ember-admin/app/utils/route.js
@@ -14,8 +14,7 @@ Route.reopen({
                 this.upgradeStatus.requireUpgrade();
                 return false;
             } else if (this.config.hostSettings?.forceUpgrade) {
-                // Do not prevent transitions to the BMA (including its child
-                // routes, eg. /pro/domain), to signout, or to any settings routes
+                // Do not prevent transitions to the BMA, to signout, or to any settings routes
                 if (transition.to?.name?.startsWith('pro.') || transition.to?.name === 'signout' || transition.to?.params?.path?.startsWith('settings')) {
                     return true;
                 }

--- a/apps/ember-admin/app/utils/route.js
+++ b/apps/ember-admin/app/utils/route.js
@@ -14,8 +14,9 @@ Route.reopen({
                 this.upgradeStatus.requireUpgrade();
                 return false;
             } else if (this.config.hostSettings?.forceUpgrade) {
-                // Do not prevent transitions to the BMA, to signout, or to any settings routes
-                if (transition.to?.name === 'pro.index' || transition.to?.name === 'signout' || transition.to?.params?.path?.startsWith('settings')) {
+                // Do not prevent transitions to the BMA (including its child
+                // routes, eg. /pro/domain), to signout, or to any settings routes
+                if (transition.to?.name?.startsWith('pro.') || transition.to?.name === 'signout' || transition.to?.params?.path?.startsWith('settings')) {
                     return true;
                 }
 

--- a/apps/ember-admin/app/utils/route.js
+++ b/apps/ember-admin/app/utils/route.js
@@ -14,7 +14,7 @@ Route.reopen({
                 this.upgradeStatus.requireUpgrade();
                 return false;
             } else if (this.config.hostSettings?.forceUpgrade) {
-                // Do not prevent transitions to the BMA, to signout, or to any settings routes
+                // Do not prevent transitions to the billing app, to signout, or to any settings routes
                 if (transition.to?.name?.startsWith('pro.') || transition.to?.name === 'signout' || transition.to?.params?.path?.startsWith('settings')) {
                     return true;
                 }

--- a/apps/ember-admin/app/utils/search.js
+++ b/apps/ember-admin/app/utils/search.js
@@ -95,8 +95,7 @@ export const SEARCHABLES = [
         idField: 'id',
         titleField: 'title',
         index: ['title', 'keywords'],
-        staticItems: GHOST_PRO_SEARCH_ITEMS,
-        requiresBillingAccess: true
+        staticItems: GHOST_PRO_SEARCH_ITEMS
     },
     {
         name: 'Posts',
@@ -148,18 +147,4 @@ export function createSearchResult(searchable, item) {
         visibility: item.visibility,
         publishedAt: item.published_at
     };
-}
-
-// Searchables that require billing access (Ghost(Pro) pages) are only shown
-// when the billing app is enabled for the site and the current user is allowed
-// to open it (mirrors the access rules in the `pro` route)
-export function isSearchableAvailable(searchable, {config, session}) {
-    if (!searchable.requiresBillingAccess) {
-        return true;
-    }
-
-    const billingEnabled = Boolean(config?.hostSettings?.billing?.enabled);
-    const userCanAccessBilling = Boolean(session?.user?.isOwnerOnly) || Boolean(config?.hostSettings?.forceUpgrade);
-
-    return billingEnabled && userCanAccessBilling;
 }

--- a/apps/ember-admin/app/utils/search.js
+++ b/apps/ember-admin/app/utils/search.js
@@ -1,54 +1,56 @@
-export const GHOST_PRO_GROUP_NAME = 'Ghost (Pro)';
+export const GHOST_PRO_GROUP_NAME = 'Ghost(Pro)';
 
-// Static list of Ghost (Pro) billing pages/actions. These don't come from the
+// Static list of Ghost(Pro) billing pages/actions. These don't come from the
 // search-index API — they're indexed client-side and only shown when the
 // current user can access the billing app (see isSearchableAvailable).
+// Every entry also matches "ghost"/"pro" queries via the shared keywords
+// appended below, so searching the product name lists the whole group.
 export const GHOST_PRO_SEARCH_ITEMS = [
     {
         id: 'start-subscription',
-        title: 'Ghost (Pro) → Start subscription',
+        title: 'Start subscription',
         path: '/pro/plans',
         keywords: 'billing subscription plan upgrade payment pricing price cost trial'
     },
     {
         id: 'change-plan',
-        title: 'Ghost (Pro) → Change plan',
+        title: 'Change plan',
         path: '/pro/plans',
         keywords: 'billing subscription plan upgrade downgrade payment pricing price cost annual yearly monthly discount limit limits renew renewal'
     },
     {
         id: 'cancel-subscription',
-        title: 'Ghost (Pro) → Cancel subscription',
+        title: 'Cancel subscription',
         path: '/pro/plans',
         keywords: 'billing subscription plan cancel close delete account'
     },
     {
         id: 'view-invoices',
-        title: 'Ghost (Pro) → View invoices',
+        title: 'View invoices',
         path: '/pro/billing',
         keywords: 'billing invoice invoices receipt tax vat billing contact'
     },
     {
         id: 'update-payment-method',
-        title: 'Ghost (Pro) → Update payment method',
+        title: 'Update payment method',
         path: '/pro/billing',
         keywords: 'billing payment method credit card expired declined failed'
     },
     {
         id: 'setup-custom-domain',
-        title: 'Ghost (Pro) → Set up a custom domain',
+        title: 'Set up a custom domain',
         path: '/pro/domain',
         keywords: 'domain custom dns cname ssl url address'
     },
     {
         id: 'change-ghost-io-domain',
-        title: 'Ghost (Pro) → Change ghost.io domain',
+        title: 'Change ghost.io domain',
         path: '/pro/domain',
         keywords: 'domain subdomain ghost.io url address'
     },
     {
         id: 'buy-new-domain',
-        title: 'Ghost (Pro) → Buy a new domain',
+        title: 'Buy a new domain',
         path: '/pro/domain',
         keywords: 'domain buy purchase register new'
     },
@@ -56,17 +58,20 @@ export const GHOST_PRO_SEARCH_ITEMS = [
     // colliding with content export (Settings → Import/Export)
     {
         id: 'request-backup',
-        title: 'Ghost (Pro) → Request backup',
+        title: 'Request backup',
         path: '/pro/backups',
         keywords: 'backup request restore data'
     },
     {
         id: 'contact-support',
-        title: 'Ghost (Pro) → Contact support',
+        title: 'Contact support',
         path: '/pro/support',
         keywords: 'support help contact email refund'
     }
-];
+].map(item => ({
+    ...item,
+    keywords: `ghost(pro) ghost pro ${item.keywords}`
+}));
 
 export const SEARCHABLES = [
     {
@@ -147,7 +152,7 @@ export function createSearchResult(searchable, item) {
     };
 }
 
-// Searchables that require billing access (Ghost (Pro) pages) are only shown
+// Searchables that require billing access (Ghost(Pro) pages) are only shown
 // when the billing app is enabled for the site and the current user is allowed
 // to open it (mirrors the access rules in the `pro` route)
 export function isSearchableAvailable(searchable, {config, session}) {

--- a/apps/ember-admin/app/utils/search.js
+++ b/apps/ember-admin/app/utils/search.js
@@ -1,10 +1,8 @@
 export const GHOST_PRO_GROUP_NAME = 'Ghost(Pro)';
 
-// Static list of Ghost(Pro) billing pages/actions. These don't come from the
-// search-index API — they're indexed client-side and only shown when the
-// current user can access the billing app (see isSearchableAvailable).
-// Every entry also matches "ghost"/"pro" queries via the shared keywords
-// appended below, so searching the product name lists the whole group.
+// Static list of Ghost(Pro) billing pages/actions, indexed client-side rather
+// than fetched from the search-index API. Every entry shares the ghost/pro
+// keywords appended below so searching the product name lists the whole group.
 export const GHOST_PRO_SEARCH_ITEMS = [
     {
         id: 'start-subscription',

--- a/apps/ember-admin/app/utils/search.js
+++ b/apps/ember-admin/app/utils/search.js
@@ -1,3 +1,73 @@
+export const GHOST_PRO_GROUP_NAME = 'Ghost (Pro)';
+
+// Static list of Ghost (Pro) billing pages/actions. These don't come from the
+// search-index API — they're indexed client-side and only shown when the
+// current user can access the billing app (see isSearchableAvailable).
+export const GHOST_PRO_SEARCH_ITEMS = [
+    {
+        id: 'start-subscription',
+        title: 'Ghost (Pro) → Start subscription',
+        path: '/pro/plans',
+        keywords: 'billing subscription plan upgrade payment pricing price cost trial'
+    },
+    {
+        id: 'change-plan',
+        title: 'Ghost (Pro) → Change plan',
+        path: '/pro/plans',
+        keywords: 'billing subscription plan upgrade downgrade payment pricing price cost annual yearly monthly discount limit limits renew renewal'
+    },
+    {
+        id: 'cancel-subscription',
+        title: 'Ghost (Pro) → Cancel subscription',
+        path: '/pro/plans',
+        keywords: 'billing subscription plan cancel close delete account'
+    },
+    {
+        id: 'view-invoices',
+        title: 'Ghost (Pro) → View invoices',
+        path: '/pro/billing',
+        keywords: 'billing invoice invoices receipt tax vat billing contact'
+    },
+    {
+        id: 'update-payment-method',
+        title: 'Ghost (Pro) → Update payment method',
+        path: '/pro/billing',
+        keywords: 'billing payment method credit card expired declined failed'
+    },
+    {
+        id: 'setup-custom-domain',
+        title: 'Ghost (Pro) → Set up a custom domain',
+        path: '/pro/domain',
+        keywords: 'domain custom dns cname ssl url address'
+    },
+    {
+        id: 'change-ghost-io-domain',
+        title: 'Ghost (Pro) → Change ghost.io domain',
+        path: '/pro/domain',
+        keywords: 'domain subdomain ghost.io url address'
+    },
+    {
+        id: 'buy-new-domain',
+        title: 'Ghost (Pro) → Buy a new domain',
+        path: '/pro/domain',
+        keywords: 'domain buy purchase register new'
+    },
+    // note: 'export' is deliberately not a keyword for backups to avoid
+    // colliding with content export (Settings → Import/Export)
+    {
+        id: 'request-backup',
+        title: 'Ghost (Pro) → Request backup',
+        path: '/pro/backups',
+        keywords: 'backup request restore data'
+    },
+    {
+        id: 'contact-support',
+        title: 'Ghost (Pro) → Contact support',
+        path: '/pro/support',
+        keywords: 'support help contact email refund'
+    }
+];
+
 export const SEARCHABLES = [
     {
         name: 'Staff',
@@ -14,6 +84,16 @@ export const SEARCHABLES = [
         idField: 'slug',
         titleField: 'name',
         index: ['name']
+    },
+    {
+        name: GHOST_PRO_GROUP_NAME,
+        model: 'pro-page',
+        pathField: 'id',
+        idField: 'id',
+        titleField: 'title',
+        index: ['title', 'keywords'],
+        staticItems: GHOST_PRO_SEARCH_ITEMS,
+        requiresBillingAccess: true
     },
     {
         name: 'Posts',
@@ -57,10 +137,26 @@ export function createSearchResult(searchable, item) {
     return {
         id: `${searchable.model}.${item[idField]}`,
         url: item.url,
+        path: item.path,
         title: item[searchable.titleField],
+        keywords: item.keywords,
         groupName: searchable.name,
         status: item.status,
         visibility: item.visibility,
         publishedAt: item.published_at
     };
+}
+
+// Searchables that require billing access (Ghost (Pro) pages) are only shown
+// when the billing app is enabled for the site and the current user is allowed
+// to open it (mirrors the access rules in the `pro` route)
+export function isSearchableAvailable(searchable, {config, session}) {
+    if (!searchable.requiresBillingAccess) {
+        return true;
+    }
+
+    const billingEnabled = Boolean(config?.hostSettings?.billing?.enabled);
+    const userCanAccessBilling = Boolean(session?.user?.isOwnerOnly) || Boolean(config?.hostSettings?.forceUpgrade);
+
+    return billingEnabled && userCanAccessBilling;
 }

--- a/apps/ember-admin/app/utils/search.js
+++ b/apps/ember-admin/app/utils/search.js
@@ -75,9 +75,6 @@ export const SEARCHABLES = [
     }
 ];
 
-// Resolves the searchable list for a host: entries that declare configure()
-// resolve themselves against hostSettings and are omitted when they resolve
-// to null. Static entries pass through untouched
 export function getSearchables(hostSettings) {
     return SEARCHABLES
         .map(searchable => (searchable.configure ? searchable.configure(hostSettings) : searchable))

--- a/apps/ember-admin/app/utils/search.js
+++ b/apps/ember-admin/app/utils/search.js
@@ -1,6 +1,11 @@
-export const GHOST_PRO_GROUP_NAME = 'Ghost(Pro)';
+// Stable identifier for the billing search group — the display name is
+// host-configurable (see getSearchables), so consumers must dispatch on this
+// key rather than on the group name
+export const BILLING_SEARCH_GROUP_KEY = 'billing';
 
-// Static list of Ghost(Pro) billing pages/actions, indexed client-side rather
+export const DEFAULT_BILLING_GROUP_NAME = 'Ghost(Pro)';
+
+// Default list of Ghost(Pro) billing pages/actions, indexed client-side rather
 // than fetched from the search-index API. Every entry shares the ghost/pro
 // keywords appended below so searching the product name lists the whole group.
 export const GHOST_PRO_SEARCH_ITEMS = [
@@ -87,7 +92,8 @@ export const SEARCHABLES = [
         index: ['name']
     },
     {
-        name: GHOST_PRO_GROUP_NAME,
+        name: DEFAULT_BILLING_GROUP_NAME,
+        key: BILLING_SEARCH_GROUP_KEY,
         model: 'pro-page',
         pathField: 'id',
         idField: 'id',
@@ -112,6 +118,49 @@ export const SEARCHABLES = [
         index: ['title']
     }
 ];
+
+// The billing group's entries are Ghost(Pro)-specific, so managed hosting
+// providers other than Ghost(Pro) can rename the group and replace its actions
+// via hostSettings.billing.search — Ghost(Pro)'s defaults are used otherwise,
+// and an empty items list removes the group. Custom entries need an id, a
+// title, and a path deep-linking into the billing app (/pro/...); anything
+// else is dropped
+export function getSearchables(hostSettings) {
+    const searchConfig = hostSettings?.billing?.search;
+
+    if (!searchConfig) {
+        return SEARCHABLES;
+    }
+
+    return SEARCHABLES.map((searchable) => {
+        if (searchable.key !== BILLING_SEARCH_GROUP_KEY) {
+            return searchable;
+        }
+
+        const customized = {...searchable};
+
+        if (typeof searchConfig.groupName === 'string' && searchConfig.groupName.trim()) {
+            customized.name = searchConfig.groupName.trim();
+        }
+
+        if (Array.isArray(searchConfig.items)) {
+            customized.staticItems = searchConfig.items
+                .filter(item => (
+                    typeof item?.id === 'string' && item.id
+                    && typeof item.title === 'string' && item.title
+                    && typeof item.path === 'string' && /^\/pro(?:\/|$)/.test(item.path)
+                ))
+                .map(item => ({
+                    id: item.id,
+                    title: item.title,
+                    path: item.path,
+                    keywords: typeof item.keywords === 'string' ? item.keywords : ''
+                }));
+        }
+
+        return customized;
+    });
+}
 
 const STATUS_PRIORITY = {
     scheduled: 1,
@@ -141,6 +190,7 @@ export function createSearchResult(searchable, item) {
         title: item[searchable.titleField],
         keywords: item.keywords,
         groupName: searchable.name,
+        groupKey: searchable.key,
         status: item.status,
         visibility: item.visibility,
         publishedAt: item.published_at

--- a/apps/ember-admin/app/utils/search.js
+++ b/apps/ember-admin/app/utils/search.js
@@ -20,14 +20,19 @@ export const SEARCHABLES = [
     {
         key: BILLING_SEARCH_GROUP_KEY,
         model: 'pro-page',
-        pathField: 'id',
         idField: 'id',
         titleField: 'title',
         index: ['title', 'keywords'],
-        // the billing group is defined entirely in config: it only resolves
-        // when hostSettings.billing.search provides a groupName and at least
-        // one valid item — an id, a title, and a path within the host's own
-        // billing app (eg. '/plans'). Anything else is dropped
+        // the billing group is defined entirely in config (hostSettings.billing.search: {})
+        //
+        // Example:
+        // search: {
+        //   "groupName": "Ghost(Pro)",
+        //   "items": [
+        //      {"id": "change-plan", "title": "Change plan", "path": "/plans", "keywords": "billing subscription plan upgrade"},
+        //      {"id": "contact-support", "title": "Contact support", "path": "/support", "keywords": "support help contact"}
+        //   ]
+        // }
         configure(hostSettings) {
             const searchConfig = hostSettings?.billing?.search;
 
@@ -37,7 +42,9 @@ export const SEARCHABLES = [
                     .filter(item => (
                         typeof item?.id === 'string' && item.id
                         && typeof item.title === 'string' && item.title
-                        && typeof item.path === 'string' && item.path.startsWith('/')
+                        && typeof item.path === 'string'
+                        && /^\/[^?#\s]*$/.test(item.path)
+                        && (item.path === '/' || !item.path.endsWith('/'))
                     ))
                     .map(item => ({
                         id: item.id,
@@ -47,7 +54,12 @@ export const SEARCHABLES = [
                     }))
                 : [];
 
-            if (!groupName || staticItems.length === 0) {
+            // a groupName colliding with a built-in group would route
+            // selections into the wrong openSelected branch and cross-match
+            // items between the two same-named groups
+            const groupNameIsReserved = SEARCHABLES.some(builtIn => builtIn.name === groupName);
+
+            if (!groupName || groupNameIsReserved || staticItems.length === 0) {
                 return null;
             }
 

--- a/apps/ember-admin/app/utils/search.js
+++ b/apps/ember-admin/app/utils/search.js
@@ -1,78 +1,4 @@
-// Stable identifier for the billing search group — the display name is
-// host-configurable (see getSearchables), so consumers must dispatch on this
-// key rather than on the group name
 export const BILLING_SEARCH_GROUP_KEY = 'billing';
-
-export const DEFAULT_BILLING_GROUP_NAME = 'Ghost(Pro)';
-
-// Default list of Ghost(Pro) billing pages/actions, indexed client-side rather
-// than fetched from the search-index API. Every entry shares the ghost/pro
-// keywords appended below so searching the product name lists the whole group.
-export const GHOST_PRO_SEARCH_ITEMS = [
-    {
-        id: 'start-subscription',
-        title: 'Start subscription',
-        path: '/pro/plans',
-        keywords: 'billing subscription plan upgrade payment pricing price cost trial'
-    },
-    {
-        id: 'change-plan',
-        title: 'Change plan',
-        path: '/pro/plans',
-        keywords: 'billing subscription plan upgrade downgrade payment pricing price cost annual yearly monthly discount limit renew renewal'
-    },
-    {
-        id: 'cancel-subscription',
-        title: 'Cancel subscription',
-        path: '/pro/plans',
-        keywords: 'billing subscription plan cancel close delete account'
-    },
-    {
-        id: 'view-invoices',
-        title: 'View invoices',
-        path: '/pro/billing',
-        keywords: 'billing invoice receipt tax vat contact'
-    },
-    {
-        id: 'update-payment-method',
-        title: 'Update payment method',
-        path: '/pro/billing',
-        keywords: 'billing payment method credit card expired declined failed'
-    },
-    {
-        id: 'setup-custom-domain',
-        title: 'Set up a custom domain',
-        path: '/pro/domain',
-        keywords: 'domain custom dns cname ssl url address'
-    },
-    {
-        id: 'change-ghost-io-domain',
-        title: 'Change ghost.io domain',
-        path: '/pro/domain',
-        keywords: 'domain subdomain ghost.io url address'
-    },
-    {
-        id: 'buy-new-domain',
-        title: 'Buy a new domain',
-        path: '/pro/domain',
-        keywords: 'domain buy purchase register new'
-    },
-    {
-        id: 'request-backup',
-        title: 'Request backup',
-        path: '/pro/backups',
-        keywords: 'backup request restore data'
-    },
-    {
-        id: 'contact-support',
-        title: 'Contact support',
-        path: '/pro/support',
-        keywords: 'support help contact email refund'
-    }
-].map(item => ({
-    ...item,
-    keywords: `ghost(pro) ghost pro ${item.keywords}`
-}));
 
 export const SEARCHABLES = [
     {
@@ -92,14 +18,44 @@ export const SEARCHABLES = [
         index: ['name']
     },
     {
-        name: DEFAULT_BILLING_GROUP_NAME,
         key: BILLING_SEARCH_GROUP_KEY,
         model: 'pro-page',
         pathField: 'id',
         idField: 'id',
         titleField: 'title',
         index: ['title', 'keywords'],
-        staticItems: GHOST_PRO_SEARCH_ITEMS
+        // the billing group is defined entirely in config: it only resolves
+        // when hostSettings.billing.search provides a groupName and at least
+        // one valid item — an id, a title, and a path within the host's own
+        // billing app (eg. '/plans'). Anything else is dropped
+        configure(hostSettings) {
+            const searchConfig = hostSettings?.billing?.search;
+
+            const groupName = typeof searchConfig?.groupName === 'string' ? searchConfig.groupName.trim() : '';
+            const staticItems = Array.isArray(searchConfig?.items)
+                ? searchConfig.items
+                    .filter(item => (
+                        typeof item?.id === 'string' && item.id
+                        && typeof item.title === 'string' && item.title
+                        && typeof item.path === 'string' && item.path.startsWith('/')
+                    ))
+                    .map(item => ({
+                        id: item.id,
+                        title: item.title,
+                        path: item.path,
+                        keywords: typeof item.keywords === 'string' ? item.keywords : ''
+                    }))
+                : [];
+
+            if (!groupName || staticItems.length === 0) {
+                return null;
+            }
+
+            const searchable = {...this, name: groupName, staticItems};
+            delete searchable.configure;
+
+            return searchable;
+        }
     },
     {
         name: 'Posts',
@@ -119,47 +75,13 @@ export const SEARCHABLES = [
     }
 ];
 
-// The billing group's entries are host-specific, so the group is opt-in: it
-// only appears when hostSettings.billing.search is configured. Hosts can
-// rename the group via groupName and replace its actions via items —
-// Ghost(Pro)'s defaults fill anything left unset, so Ghost(Pro) opts in with
-// an empty object. Custom entries need an id, a title, and a path
-// deep-linking into the billing app (/pro/...); anything else is dropped
+// Resolves the searchable list for a host: entries that declare configure()
+// resolve themselves against hostSettings and are omitted when they resolve
+// to null. Static entries pass through untouched
 export function getSearchables(hostSettings) {
-    const searchConfig = hostSettings?.billing?.search;
-
-    if (!searchConfig) {
-        return SEARCHABLES.filter(searchable => searchable.key !== BILLING_SEARCH_GROUP_KEY);
-    }
-
-    return SEARCHABLES.map((searchable) => {
-        if (searchable.key !== BILLING_SEARCH_GROUP_KEY) {
-            return searchable;
-        }
-
-        const customized = {...searchable};
-
-        if (typeof searchConfig.groupName === 'string' && searchConfig.groupName.trim()) {
-            customized.name = searchConfig.groupName.trim();
-        }
-
-        if (Array.isArray(searchConfig.items)) {
-            customized.staticItems = searchConfig.items
-                .filter(item => (
-                    typeof item?.id === 'string' && item.id
-                    && typeof item.title === 'string' && item.title
-                    && typeof item.path === 'string' && /^\/pro(?:\/|$)/.test(item.path)
-                ))
-                .map(item => ({
-                    id: item.id,
-                    title: item.title,
-                    path: item.path,
-                    keywords: typeof item.keywords === 'string' ? item.keywords : ''
-                }));
-        }
-
-        return customized;
-    });
+    return SEARCHABLES
+        .map(searchable => (searchable.configure ? searchable.configure(hostSettings) : searchable))
+        .filter(Boolean);
 }
 
 const STATUS_PRIORITY = {

--- a/apps/ember-admin/app/utils/search.js
+++ b/apps/ember-admin/app/utils/search.js
@@ -119,17 +119,17 @@ export const SEARCHABLES = [
     }
 ];
 
-// The billing group's entries are Ghost(Pro)-specific, so managed hosting
-// providers other than Ghost(Pro) can rename the group and replace its actions
-// via hostSettings.billing.search — Ghost(Pro)'s defaults are used otherwise,
-// and an empty items list removes the group. Custom entries need an id, a
-// title, and a path deep-linking into the billing app (/pro/...); anything
-// else is dropped
+// The billing group's entries are host-specific, so the group is opt-in: it
+// only appears when hostSettings.billing.search is configured. Hosts can
+// rename the group via groupName and replace its actions via items —
+// Ghost(Pro)'s defaults fill anything left unset, so Ghost(Pro) opts in with
+// an empty object. Custom entries need an id, a title, and a path
+// deep-linking into the billing app (/pro/...); anything else is dropped
 export function getSearchables(hostSettings) {
     const searchConfig = hostSettings?.billing?.search;
 
     if (!searchConfig) {
-        return SEARCHABLES;
+        return SEARCHABLES.filter(searchable => searchable.key !== BILLING_SEARCH_GROUP_KEY);
     }
 
     return SEARCHABLES.map((searchable) => {

--- a/apps/ember-admin/app/utils/search.js
+++ b/apps/ember-admin/app/utils/search.js
@@ -14,7 +14,7 @@ export const GHOST_PRO_SEARCH_ITEMS = [
         id: 'change-plan',
         title: 'Change plan',
         path: '/pro/plans',
-        keywords: 'billing subscription plan upgrade downgrade payment pricing price cost annual yearly monthly discount limit limits renew renewal'
+        keywords: 'billing subscription plan upgrade downgrade payment pricing price cost annual yearly monthly discount limit renew renewal'
     },
     {
         id: 'cancel-subscription',
@@ -26,7 +26,7 @@ export const GHOST_PRO_SEARCH_ITEMS = [
         id: 'view-invoices',
         title: 'View invoices',
         path: '/pro/billing',
-        keywords: 'billing invoice invoices receipt tax vat billing contact'
+        keywords: 'billing invoice receipt tax vat contact'
     },
     {
         id: 'update-payment-method',
@@ -52,8 +52,6 @@ export const GHOST_PRO_SEARCH_ITEMS = [
         path: '/pro/domain',
         keywords: 'domain buy purchase register new'
     },
-    // note: 'export' is deliberately not a keyword for backups to avoid
-    // colliding with content export (Settings → Import/Export)
     {
         id: 'request-backup',
         title: 'Request backup',

--- a/apps/ember-admin/tests/acceptance/search-test.js
+++ b/apps/ember-admin/tests/acceptance/search-test.js
@@ -360,21 +360,28 @@ describe('Acceptance: Search', function () {
             expect(currentURL()).to.equal(`/settings/staff/${testData.user.slug}`);
         });
 
-        describe('Ghost(Pro) results', function () {
+        describe('billing results', function () {
             const enableBilling = (server) => {
                 server.db.configs.update(1, {
                     hostSettings: {
                         billing: {
                             enabled: true,
                             url: 'http://localhost:4200/billing-app',
-                            // opts in to the billing search group with Ghost(Pro)'s defaults
-                            search: {}
+                            // the group is defined entirely by host config — this
+                            // stands in for a host's search group configuration
+                            search: {
+                                groupName: 'Ghost(Pro)',
+                                items: [
+                                    {id: 'request-backup', title: 'Request backup', path: '/backups', keywords: 'backup restore data'},
+                                    {id: 'contact-support', title: 'Contact support', path: '/support', keywords: 'support help contact'}
+                                ]
+                            }
                         }
                     }
                 });
             };
 
-            it('shows Ghost(Pro) results before content results', async function () {
+            it('shows billing results before content results', async function () {
                 enableBilling(this.server);
                 this.server.create('post', {title: 'Backup post', slug: 'backup-post'});
 
@@ -389,7 +396,7 @@ describe('Acceptance: Search', function () {
                 expect(titles).to.include('Request backup');
             });
 
-            it('navigates to the billing page when selecting a Ghost(Pro) result', async function () {
+            it('navigates to the billing page when selecting a billing result', async function () {
                 enableBilling(this.server);
 
                 await visit('/analytics');
@@ -401,7 +408,7 @@ describe('Acceptance: Search', function () {
                 expect(currentURL()).to.equal('/pro/support');
             });
 
-            it('does not show Ghost(Pro) results when billing is not enabled', async function () {
+            it('does not show billing results when billing is not enabled', async function () {
                 await visit('/analytics');
                 await openSearch(this.owner);
                 await searchFor('backup');

--- a/apps/ember-admin/tests/acceptance/search-test.js
+++ b/apps/ember-admin/tests/acceptance/search-test.js
@@ -367,8 +367,6 @@ describe('Acceptance: Search', function () {
                         billing: {
                             enabled: true,
                             url: 'http://localhost:4200/billing-app',
-                            // the group is defined entirely by host config — this
-                            // stands in for a host's search group configuration
                             search: {
                                 groupName: 'Ghost(Pro)',
                                 items: [

--- a/apps/ember-admin/tests/acceptance/search-test.js
+++ b/apps/ember-admin/tests/acceptance/search-test.js
@@ -360,7 +360,7 @@ describe('Acceptance: Search', function () {
             expect(currentURL()).to.equal(`/settings/staff/${testData.user.slug}`);
         });
 
-        describe('Ghost (Pro) results', function () {
+        describe('Ghost(Pro) results', function () {
             const enableBilling = (server) => {
                 server.db.configs.update(1, {
                     hostSettings: {
@@ -372,7 +372,7 @@ describe('Acceptance: Search', function () {
                 });
             };
 
-            it('shows Ghost (Pro) results before content results', async function () {
+            it('shows Ghost(Pro) results before content results', async function () {
                 enableBilling(this.server);
                 this.server.create('post', {title: 'Backup post', slug: 'backup-post'});
 
@@ -380,14 +380,14 @@ describe('Acceptance: Search', function () {
                 await openSearch(this.owner);
                 await searchFor('backup');
 
-                assertSearchGroups(['Ghost (Pro)', 'Posts']);
+                assertSearchGroups(['Ghost(Pro)', 'Posts']);
 
                 const searchOptions = getSearchOptions();
                 const titles = searchOptions.map(option => getTitleText(option));
-                expect(titles).to.include('Ghost (Pro) → Request backup');
+                expect(titles).to.include('Request backup');
             });
 
-            it('navigates to the billing page when selecting a Ghost (Pro) result', async function () {
+            it('navigates to the billing page when selecting a Ghost(Pro) result', async function () {
                 enableBilling(this.server);
 
                 await visit('/analytics');
@@ -399,7 +399,7 @@ describe('Acceptance: Search', function () {
                 expect(currentURL()).to.equal('/pro/support');
             });
 
-            it('does not show Ghost (Pro) results when billing is not enabled', async function () {
+            it('does not show Ghost(Pro) results when billing is not enabled', async function () {
                 await visit('/analytics');
                 await openSearch(this.owner);
                 await searchFor('backup');

--- a/apps/ember-admin/tests/acceptance/search-test.js
+++ b/apps/ember-admin/tests/acceptance/search-test.js
@@ -366,7 +366,9 @@ describe('Acceptance: Search', function () {
                     hostSettings: {
                         billing: {
                             enabled: true,
-                            url: 'http://localhost:4200/billing-app'
+                            url: 'http://localhost:4200/billing-app',
+                            // opts in to the billing search group with Ghost(Pro)'s defaults
+                            search: {}
                         }
                     }
                 });

--- a/apps/ember-admin/tests/acceptance/search-test.js
+++ b/apps/ember-admin/tests/acceptance/search-test.js
@@ -359,6 +359,54 @@ describe('Acceptance: Search', function () {
 
             expect(currentURL()).to.equal(`/settings/staff/${testData.user.slug}`);
         });
+
+        describe('Ghost (Pro) results', function () {
+            const enableBilling = (server) => {
+                server.db.configs.update(1, {
+                    hostSettings: {
+                        billing: {
+                            enabled: true,
+                            url: 'http://localhost:4200/billing-app'
+                        }
+                    }
+                });
+            };
+
+            it('shows Ghost (Pro) results before content results', async function () {
+                enableBilling(this.server);
+                this.server.create('post', {title: 'Backup post', slug: 'backup-post'});
+
+                await visit('/analytics');
+                await openSearch(this.owner);
+                await searchFor('backup');
+
+                assertSearchGroups(['Ghost (Pro)', 'Posts']);
+
+                const searchOptions = getSearchOptions();
+                const titles = searchOptions.map(option => getTitleText(option));
+                expect(titles).to.include('Ghost (Pro) → Request backup');
+            });
+
+            it('navigates to the billing page when selecting a Ghost (Pro) result', async function () {
+                enableBilling(this.server);
+
+                await visit('/analytics');
+                await openSearch(this.owner);
+                await searchFor('contact support');
+
+                await selectWithEnter();
+
+                expect(currentURL()).to.equal('/pro/support');
+            });
+
+            it('does not show Ghost (Pro) results when billing is not enabled', async function () {
+                await visit('/analytics');
+                await openSearch(this.owner);
+                await searchFor('backup');
+
+                assertNoResults();
+            });
+        });
     });
 
     describe('BasicSearch Provider', function () {

--- a/apps/ember-admin/tests/integration/services/search-test.js
+++ b/apps/ember-admin/tests/integration/services/search-test.js
@@ -145,5 +145,96 @@ suites.forEach((suite) => {
 
             expect(provider.refreshContentTask.perform, 'provider refresh starts after cached search').to.have.been.calledOnce;
         });
+
+        describe('Ghost (Pro) results', function () {
+            beforeEach(function () {
+                const config = this.owner.lookup('config:main');
+                config.hostSettings = {billing: {enabled: true}};
+
+                const session = this.owner.lookup('service:session');
+                session.user = {isOwnerOnly: true};
+            });
+
+            it('includes Ghost (Pro) results before content results', async function () {
+                this.server.create('post', {title: 'Backup post', slug: 'backup-post'});
+
+                const results = await search.searchTask.perform('backup');
+
+                expect(results.map(group => group.groupName)).to.deep.equal(['Ghost (Pro)', 'Posts']);
+
+                const titles = results[0].options.map(option => option.title);
+                expect(titles).to.include('Ghost (Pro) → Request backup');
+                expect(results[0].options[0].path).to.equal('/pro/backups');
+            });
+
+            it('lists Ghost (Pro) results in a fixed order', async function () {
+                const results = await search.searchTask.perform('pro');
+
+                expect(results[0].groupName).to.equal('Ghost (Pro)');
+                expect(results[0].options.map(option => option.title)).to.deep.equal([
+                    'Ghost (Pro) → Start subscription',
+                    'Ghost (Pro) → Change plan',
+                    'Ghost (Pro) → Cancel subscription',
+                    'Ghost (Pro) → View invoices',
+                    'Ghost (Pro) → Update payment method',
+                    'Ghost (Pro) → Set up a custom domain',
+                    'Ghost (Pro) → Change ghost.io domain',
+                    'Ghost (Pro) → Buy a new domain',
+                    'Ghost (Pro) → Request backup',
+                    'Ghost (Pro) → Contact support'
+                ]);
+            });
+
+            it('matches Ghost (Pro) results on keywords', async function () {
+                const results = await search.searchTask.perform('dns');
+
+                expect(results).to.have.length(1);
+                expect(results[0].groupName).to.equal('Ghost (Pro)');
+                expect(results[0].options.map(option => option.title)).to.include('Ghost (Pro) → Set up a custom domain');
+
+                const invoiceResults = await search.searchTask.perform('invoice');
+                expect(invoiceResults[0].options.map(option => option.title)).to.include('Ghost (Pro) → View invoices');
+
+                const paymentResults = await search.searchTask.perform('payment method');
+                expect(paymentResults[0].options.map(option => option.title)).to.include('Ghost (Pro) → Update payment method');
+
+                const priceResults = await search.searchTask.perform('price');
+                expect(priceResults[0].options.map(option => option.title)).to.include('Ghost (Pro) → Change plan');
+
+                const buyDomainResults = await search.searchTask.perform('purchase');
+                expect(buyDomainResults[0].options.map(option => option.title)).to.include('Ghost (Pro) → Buy a new domain');
+            });
+
+            it('does not request Ghost (Pro) results from the API', async function () {
+                await search.searchTask.perform('backup');
+
+                expect(searchIndexRequests(this.server), 'search index requests').to.have.length(4);
+            });
+
+            it('excludes Ghost (Pro) results when billing is not enabled', async function () {
+                this.owner.lookup('config:main').hostSettings = {};
+
+                const results = await search.searchTask.perform('backup');
+
+                expect(results.map(group => group.groupName)).to.not.include('Ghost (Pro)');
+            });
+
+            it('excludes Ghost (Pro) results for non-owner users', async function () {
+                this.owner.lookup('service:session').user = {isOwnerOnly: false};
+
+                const results = await search.searchTask.perform('backup');
+
+                expect(results.map(group => group.groupName)).to.not.include('Ghost (Pro)');
+            });
+
+            it('includes Ghost (Pro) results for non-owner users in a force upgrade state', async function () {
+                this.owner.lookup('config:main').hostSettings = {billing: {enabled: true}, forceUpgrade: true};
+                this.owner.lookup('service:session').user = {isOwnerOnly: false};
+
+                const results = await search.searchTask.perform('backup');
+
+                expect(results.map(group => group.groupName)).to.include('Ghost (Pro)');
+            });
+        });
     });
 });

--- a/apps/ember-admin/tests/integration/services/search-test.js
+++ b/apps/ember-admin/tests/integration/services/search-test.js
@@ -146,7 +146,7 @@ suites.forEach((suite) => {
             expect(provider.refreshContentTask.perform, 'provider refresh starts after cached search').to.have.been.calledOnce;
         });
 
-        describe('Ghost (Pro) results', function () {
+        describe('Ghost(Pro) results', function () {
             beforeEach(function () {
                 const config = this.owner.lookup('config:main');
                 config.hostSettings = {billing: {enabled: true}};
@@ -155,85 +155,85 @@ suites.forEach((suite) => {
                 session.user = {isOwnerOnly: true};
             });
 
-            it('includes Ghost (Pro) results before content results', async function () {
+            it('includes Ghost(Pro) results before content results', async function () {
                 this.server.create('post', {title: 'Backup post', slug: 'backup-post'});
 
                 const results = await search.searchTask.perform('backup');
 
-                expect(results.map(group => group.groupName)).to.deep.equal(['Ghost (Pro)', 'Posts']);
+                expect(results.map(group => group.groupName)).to.deep.equal(['Ghost(Pro)', 'Posts']);
 
                 const titles = results[0].options.map(option => option.title);
-                expect(titles).to.include('Ghost (Pro) → Request backup');
+                expect(titles).to.include('Request backup');
                 expect(results[0].options[0].path).to.equal('/pro/backups');
             });
 
-            it('lists Ghost (Pro) results in a fixed order', async function () {
+            it('lists Ghost(Pro) results in a fixed order', async function () {
                 const results = await search.searchTask.perform('pro');
 
-                expect(results[0].groupName).to.equal('Ghost (Pro)');
+                expect(results[0].groupName).to.equal('Ghost(Pro)');
                 expect(results[0].options.map(option => option.title)).to.deep.equal([
-                    'Ghost (Pro) → Start subscription',
-                    'Ghost (Pro) → Change plan',
-                    'Ghost (Pro) → Cancel subscription',
-                    'Ghost (Pro) → View invoices',
-                    'Ghost (Pro) → Update payment method',
-                    'Ghost (Pro) → Set up a custom domain',
-                    'Ghost (Pro) → Change ghost.io domain',
-                    'Ghost (Pro) → Buy a new domain',
-                    'Ghost (Pro) → Request backup',
-                    'Ghost (Pro) → Contact support'
+                    'Start subscription',
+                    'Change plan',
+                    'Cancel subscription',
+                    'View invoices',
+                    'Update payment method',
+                    'Set up a custom domain',
+                    'Change ghost.io domain',
+                    'Buy a new domain',
+                    'Request backup',
+                    'Contact support'
                 ]);
             });
 
-            it('matches Ghost (Pro) results on keywords', async function () {
+            it('matches Ghost(Pro) results on keywords', async function () {
                 const results = await search.searchTask.perform('dns');
 
                 expect(results).to.have.length(1);
-                expect(results[0].groupName).to.equal('Ghost (Pro)');
-                expect(results[0].options.map(option => option.title)).to.include('Ghost (Pro) → Set up a custom domain');
+                expect(results[0].groupName).to.equal('Ghost(Pro)');
+                expect(results[0].options.map(option => option.title)).to.include('Set up a custom domain');
 
                 const invoiceResults = await search.searchTask.perform('invoice');
-                expect(invoiceResults[0].options.map(option => option.title)).to.include('Ghost (Pro) → View invoices');
+                expect(invoiceResults[0].options.map(option => option.title)).to.include('View invoices');
 
                 const paymentResults = await search.searchTask.perform('payment method');
-                expect(paymentResults[0].options.map(option => option.title)).to.include('Ghost (Pro) → Update payment method');
+                expect(paymentResults[0].options.map(option => option.title)).to.include('Update payment method');
 
                 const priceResults = await search.searchTask.perform('price');
-                expect(priceResults[0].options.map(option => option.title)).to.include('Ghost (Pro) → Change plan');
+                expect(priceResults[0].options.map(option => option.title)).to.include('Change plan');
 
                 const buyDomainResults = await search.searchTask.perform('purchase');
-                expect(buyDomainResults[0].options.map(option => option.title)).to.include('Ghost (Pro) → Buy a new domain');
+                expect(buyDomainResults[0].options.map(option => option.title)).to.include('Buy a new domain');
             });
 
-            it('does not request Ghost (Pro) results from the API', async function () {
+            it('does not request Ghost(Pro) results from the API', async function () {
                 await search.searchTask.perform('backup');
 
                 expect(searchIndexRequests(this.server), 'search index requests').to.have.length(4);
             });
 
-            it('excludes Ghost (Pro) results when billing is not enabled', async function () {
+            it('excludes Ghost(Pro) results when billing is not enabled', async function () {
                 this.owner.lookup('config:main').hostSettings = {};
 
                 const results = await search.searchTask.perform('backup');
 
-                expect(results.map(group => group.groupName)).to.not.include('Ghost (Pro)');
+                expect(results.map(group => group.groupName)).to.not.include('Ghost(Pro)');
             });
 
-            it('excludes Ghost (Pro) results for non-owner users', async function () {
+            it('excludes Ghost(Pro) results for non-owner users', async function () {
                 this.owner.lookup('service:session').user = {isOwnerOnly: false};
 
                 const results = await search.searchTask.perform('backup');
 
-                expect(results.map(group => group.groupName)).to.not.include('Ghost (Pro)');
+                expect(results.map(group => group.groupName)).to.not.include('Ghost(Pro)');
             });
 
-            it('includes Ghost (Pro) results for non-owner users in a force upgrade state', async function () {
+            it('includes Ghost(Pro) results for non-owner users in a force upgrade state', async function () {
                 this.owner.lookup('config:main').hostSettings = {billing: {enabled: true}, forceUpgrade: true};
                 this.owner.lookup('service:session').user = {isOwnerOnly: false};
 
                 const results = await search.searchTask.perform('backup');
 
-                expect(results.map(group => group.groupName)).to.include('Ghost (Pro)');
+                expect(results.map(group => group.groupName)).to.include('Ghost(Pro)');
             });
         });
     });

--- a/apps/ember-admin/tests/integration/services/search-test.js
+++ b/apps/ember-admin/tests/integration/services/search-test.js
@@ -235,6 +235,53 @@ suites.forEach((suite) => {
 
                 expect(results.map(group => group.groupName)).to.include('Ghost(Pro)');
             });
+
+            it('renames the billing group when configured via hostSettings', async function () {
+                this.owner.lookup('config:main').hostSettings = {
+                    billing: {enabled: true, search: {groupName: 'Acme Hosting'}}
+                };
+
+                const results = await search.searchTask.perform('backup');
+
+                expect(results[0].groupName).to.equal('Acme Hosting');
+                expect(results[0].options.map(option => option.title)).to.include('Request backup');
+            });
+
+            it('replaces the billing actions when configured via hostSettings', async function () {
+                this.owner.lookup('config:main').hostSettings = {
+                    billing: {
+                        enabled: true,
+                        search: {
+                            groupName: 'Acme Hosting',
+                            items: [
+                                {id: 'manage-subscription', title: 'Manage subscription', path: '/pro/subscription', keywords: 'billing plan'},
+                                {id: 'external-link', title: 'Externally hosted', path: 'https://example.com', keywords: 'billing'}
+                            ]
+                        }
+                    }
+                };
+
+                const results = await search.searchTask.perform('billing');
+
+                expect(results).to.have.length(1);
+                expect(results[0].groupName).to.equal('Acme Hosting');
+                // the item without a /pro path is dropped
+                expect(results[0].options.map(option => option.title)).to.deep.equal(['Manage subscription']);
+                expect(results[0].options[0].path).to.equal('/pro/subscription');
+
+                const defaultItemResults = await search.searchTask.perform('backup');
+                expect(defaultItemResults).to.have.length(0);
+            });
+
+            it('removes the billing group when hostSettings configures no items', async function () {
+                this.owner.lookup('config:main').hostSettings = {
+                    billing: {enabled: true, search: {items: []}}
+                };
+
+                const results = await search.searchTask.perform('backup');
+
+                expect(results).to.have.length(0);
+            });
         });
     });
 });

--- a/apps/ember-admin/tests/integration/services/search-test.js
+++ b/apps/ember-admin/tests/integration/services/search-test.js
@@ -146,123 +146,68 @@ suites.forEach((suite) => {
             expect(provider.refreshContentTask.perform, 'provider refresh starts after cached search').to.have.been.calledOnce;
         });
 
-        describe('Ghost(Pro) results', function () {
+        describe('billing results', function () {
+            // the group is defined entirely by host config — this fixture
+            // stands in for a host's hostSettings.billing.search
+            const billingSearch = {
+                groupName: 'Acme Hosting',
+                items: [
+                    {id: 'change-plan', title: 'Change plan', path: '/plans', keywords: 'billing subscription plan price'},
+                    {id: 'setup-custom-domain', title: 'Set up a custom domain', path: '/domain', keywords: 'billing domain dns cname'},
+                    {id: 'request-backup', title: 'Request backup', path: '/backups', keywords: 'billing backup restore data'}
+                ]
+            };
+
             beforeEach(function () {
                 const config = this.owner.lookup('config:main');
-                config.hostSettings = {billing: {enabled: true, search: {}}};
+                config.hostSettings = {billing: {enabled: true, search: billingSearch}};
 
                 const session = this.owner.lookup('service:session');
                 session.user = {isOwnerOnly: true};
             });
 
-            it('includes Ghost(Pro) results before content results', async function () {
+            it('includes billing results before content results', async function () {
                 this.server.create('post', {title: 'Backup post', slug: 'backup-post'});
 
                 const results = await search.searchTask.perform('backup');
 
-                expect(results.map(group => group.groupName)).to.deep.equal(['Ghost(Pro)', 'Posts']);
+                expect(results.map(group => group.groupName)).to.deep.equal(['Acme Hosting', 'Posts']);
 
                 const titles = results[0].options.map(option => option.title);
                 expect(titles).to.include('Request backup');
-                expect(results[0].options[0].path).to.equal('/pro/backups');
+                expect(results[0].options[0].path).to.equal('/backups');
             });
 
-            it('lists Ghost(Pro) results in a fixed order', async function () {
-                const results = await search.searchTask.perform('pro');
+            it('lists billing results in the configured order', async function () {
+                const results = await search.searchTask.perform('billing');
 
-                expect(results[0].groupName).to.equal('Ghost(Pro)');
+                expect(results[0].groupName).to.equal('Acme Hosting');
                 expect(results[0].options.map(option => option.title)).to.deep.equal([
-                    'Start subscription',
                     'Change plan',
-                    'Cancel subscription',
-                    'View invoices',
-                    'Update payment method',
                     'Set up a custom domain',
-                    'Change ghost.io domain',
-                    'Buy a new domain',
-                    'Request backup',
-                    'Contact support'
+                    'Request backup'
                 ]);
             });
 
-            it('matches Ghost(Pro) results on keywords', async function () {
+            it('matches billing results on keywords', async function () {
                 const results = await search.searchTask.perform('dns');
 
                 expect(results).to.have.length(1);
-                expect(results[0].groupName).to.equal('Ghost(Pro)');
+                expect(results[0].groupName).to.equal('Acme Hosting');
                 expect(results[0].options.map(option => option.title)).to.include('Set up a custom domain');
-
-                const invoiceResults = await search.searchTask.perform('invoice');
-                expect(invoiceResults[0].options.map(option => option.title)).to.include('View invoices');
-
-                const paymentResults = await search.searchTask.perform('payment method');
-                expect(paymentResults[0].options.map(option => option.title)).to.include('Update payment method');
 
                 const priceResults = await search.searchTask.perform('price');
                 expect(priceResults[0].options.map(option => option.title)).to.include('Change plan');
-
-                const buyDomainResults = await search.searchTask.perform('purchase');
-                expect(buyDomainResults[0].options.map(option => option.title)).to.include('Buy a new domain');
             });
 
-            it('does not request Ghost(Pro) results from the API', async function () {
-                await search.searchTask.perform('backup');
-
-                expect(searchIndexRequests(this.server), 'search index requests').to.have.length(4);
-            });
-
-            it('excludes Ghost(Pro) results when billing is not enabled', async function () {
-                this.owner.lookup('config:main').hostSettings = {};
-
-                const results = await search.searchTask.perform('backup');
-
-                expect(results.map(group => group.groupName)).to.not.include('Ghost(Pro)');
-            });
-
-            it('excludes Ghost(Pro) results for non-owner users', async function () {
-                this.owner.lookup('service:session').user = {isOwnerOnly: false};
-
-                const results = await search.searchTask.perform('backup');
-
-                expect(results.map(group => group.groupName)).to.not.include('Ghost(Pro)');
-            });
-
-            it('includes Ghost(Pro) results for non-owner users in a force upgrade state', async function () {
-                this.owner.lookup('config:main').hostSettings = {billing: {enabled: true, search: {}}, forceUpgrade: true};
-                this.owner.lookup('service:session').user = {isOwnerOnly: false};
-
-                const results = await search.searchTask.perform('backup');
-
-                expect(results.map(group => group.groupName)).to.include('Ghost(Pro)');
-            });
-
-            it('excludes the billing group when hostSettings does not configure search', async function () {
-                this.owner.lookup('config:main').hostSettings = {billing: {enabled: true}};
-
-                const results = await search.searchTask.perform('backup');
-
-                expect(results).to.have.length(0);
-            });
-
-            it('renames the billing group when configured via hostSettings', async function () {
-                this.owner.lookup('config:main').hostSettings = {
-                    billing: {enabled: true, search: {groupName: 'Acme Hosting'}}
-                };
-
-                const results = await search.searchTask.perform('backup');
-
-                expect(results[0].groupName).to.equal('Acme Hosting');
-                expect(results[0].options.map(option => option.title)).to.include('Request backup');
-            });
-
-            it('replaces the billing actions when configured via hostSettings', async function () {
+            it('drops configured items whose path is not a billing app route', async function () {
                 this.owner.lookup('config:main').hostSettings = {
                     billing: {
                         enabled: true,
                         search: {
                             groupName: 'Acme Hosting',
                             items: [
-                                {id: 'manage-subscription', title: 'Manage subscription', path: '/pro/subscription', keywords: 'billing plan'},
+                                {id: 'manage-subscription', title: 'Manage subscription', path: '/subscription', keywords: 'billing'},
                                 {id: 'external-link', title: 'Externally hosted', path: 'https://example.com', keywords: 'billing'}
                             ]
                         }
@@ -272,18 +217,52 @@ suites.forEach((suite) => {
                 const results = await search.searchTask.perform('billing');
 
                 expect(results).to.have.length(1);
-                expect(results[0].groupName).to.equal('Acme Hosting');
-                // the item without a /pro path is dropped
                 expect(results[0].options.map(option => option.title)).to.deep.equal(['Manage subscription']);
-                expect(results[0].options[0].path).to.equal('/pro/subscription');
-
-                const defaultItemResults = await search.searchTask.perform('backup');
-                expect(defaultItemResults).to.have.length(0);
+                expect(results[0].options[0].path).to.equal('/subscription');
             });
 
-            it('removes the billing group when hostSettings configures no items', async function () {
+            it('does not request billing results from the API', async function () {
+                await search.searchTask.perform('backup');
+
+                expect(searchIndexRequests(this.server), 'search index requests').to.have.length(4);
+            });
+
+            it('excludes billing results when billing is not enabled', async function () {
+                this.owner.lookup('config:main').hostSettings = {billing: {search: billingSearch}};
+
+                const results = await search.searchTask.perform('backup');
+
+                expect(results.map(group => group.groupName)).to.not.include('Acme Hosting');
+            });
+
+            it('excludes billing results for non-owner users', async function () {
+                this.owner.lookup('service:session').user = {isOwnerOnly: false};
+
+                const results = await search.searchTask.perform('backup');
+
+                expect(results.map(group => group.groupName)).to.not.include('Acme Hosting');
+            });
+
+            it('includes billing results for non-owner users in a force upgrade state', async function () {
+                this.owner.lookup('config:main').hostSettings = {billing: {enabled: true, search: billingSearch}, forceUpgrade: true};
+                this.owner.lookup('service:session').user = {isOwnerOnly: false};
+
+                const results = await search.searchTask.perform('backup');
+
+                expect(results.map(group => group.groupName)).to.include('Acme Hosting');
+            });
+
+            it('excludes billing results when hostSettings does not configure search', async function () {
+                this.owner.lookup('config:main').hostSettings = {billing: {enabled: true}};
+
+                const results = await search.searchTask.perform('backup');
+
+                expect(results).to.have.length(0);
+            });
+
+            it('excludes billing results when no valid items are configured', async function () {
                 this.owner.lookup('config:main').hostSettings = {
-                    billing: {enabled: true, search: {items: []}}
+                    billing: {enabled: true, search: {groupName: 'Acme Hosting', items: []}}
                 };
 
                 const results = await search.searchTask.perform('backup');

--- a/apps/ember-admin/tests/integration/services/search-test.js
+++ b/apps/ember-admin/tests/integration/services/search-test.js
@@ -147,8 +147,6 @@ suites.forEach((suite) => {
         });
 
         describe('billing results', function () {
-            // the group is defined entirely by host config — this fixture
-            // stands in for a host's hostSettings.billing.search
             const billingSearch = {
                 groupName: 'Acme Hosting',
                 items: [

--- a/apps/ember-admin/tests/integration/services/search-test.js
+++ b/apps/ember-admin/tests/integration/services/search-test.js
@@ -149,7 +149,7 @@ suites.forEach((suite) => {
         describe('Ghost(Pro) results', function () {
             beforeEach(function () {
                 const config = this.owner.lookup('config:main');
-                config.hostSettings = {billing: {enabled: true}};
+                config.hostSettings = {billing: {enabled: true, search: {}}};
 
                 const session = this.owner.lookup('service:session');
                 session.user = {isOwnerOnly: true};
@@ -228,12 +228,20 @@ suites.forEach((suite) => {
             });
 
             it('includes Ghost(Pro) results for non-owner users in a force upgrade state', async function () {
-                this.owner.lookup('config:main').hostSettings = {billing: {enabled: true}, forceUpgrade: true};
+                this.owner.lookup('config:main').hostSettings = {billing: {enabled: true, search: {}}, forceUpgrade: true};
                 this.owner.lookup('service:session').user = {isOwnerOnly: false};
 
                 const results = await search.searchTask.perform('backup');
 
                 expect(results.map(group => group.groupName)).to.include('Ghost(Pro)');
+            });
+
+            it('excludes the billing group when hostSettings does not configure search', async function () {
+                this.owner.lookup('config:main').hostSettings = {billing: {enabled: true}};
+
+                const results = await search.searchTask.perform('backup');
+
+                expect(results).to.have.length(0);
             });
 
             it('renames the billing group when configured via hostSettings', async function () {

--- a/apps/ember-admin/tests/integration/services/search-test.js
+++ b/apps/ember-admin/tests/integration/services/search-test.js
@@ -206,7 +206,9 @@ suites.forEach((suite) => {
                             groupName: 'Acme Hosting',
                             items: [
                                 {id: 'manage-subscription', title: 'Manage subscription', path: '/subscription', keywords: 'billing'},
-                                {id: 'external-link', title: 'Externally hosted', path: 'https://example.com', keywords: 'billing'}
+                                {id: 'external-link', title: 'Externally hosted', path: 'https://example.com', keywords: 'billing'},
+                                {id: 'query-string', title: 'Upgrade plan', path: '/plans?intent=upgrade', keywords: 'billing'},
+                                {id: 'trailing-slash', title: 'Support', path: '/support/', keywords: 'billing'}
                             ]
                         }
                     }

--- a/apps/ember-admin/tests/unit/services/billing-test.js
+++ b/apps/ember-admin/tests/unit/services/billing-test.js
@@ -184,6 +184,60 @@ describe('Unit: Service: billing', function () {
         expect(iframe.src).to.match(/^https:\/\/billing\.example\.test\/\?bmaAttemptId=/);
     });
 
+    it('posts a route update for a sub route when the billing app is loaded', function () {
+        const service = this.owner.lookup('service:billing');
+        billingService = service;
+        const postMessage = sinon.stub();
+        const iframe = {src: '', addEventListener: sinon.stub(), contentWindow: {postMessage}};
+        sinon.stub(service, 'getBillingIframe').returns(iframe);
+        service.billingAppLoaded = true;
+
+        service.navigateToSubRoute('/domain');
+
+        expect(postMessage.calledOnceWith({query: 'routeUpdate', response: '/domain'})).to.be.true;
+        expect(service.pendingSubRoute).to.be.null;
+    });
+
+    it('keeps a sub route pending until the billing app reports ready', function () {
+        const service = this.owner.lookup('service:billing');
+        billingService = service;
+        const postMessage = sinon.stub();
+        const iframe = {src: '', addEventListener: sinon.stub(), contentWindow: {postMessage}};
+        sinon.stub(service, 'getBillingIframe').returns(iframe);
+
+        service.navigateToSubRoute('/domain');
+
+        expect(postMessage.called).to.be.false;
+        expect(service.pendingSubRoute).to.equal('/domain');
+
+        service.markBillingAppLoaded();
+
+        expect(postMessage.calledOnceWith({query: 'routeUpdate', response: '/domain'})).to.be.true;
+        expect(service.pendingSubRoute).to.be.null;
+    });
+
+    it('boots the billing iframe directly on a pending sub route when opened', function () {
+        const service = this.owner.lookup('service:billing');
+        billingService = service;
+        const iframe = {src: '', addEventListener: sinon.stub()};
+        sinon.stub(service, 'getBillingIframe').returns(iframe);
+
+        service.navigateToSubRoute('/domain');
+        service.toggleProWindow(true);
+
+        expect(iframe.src).to.match(/^https:\/\/billing\.example\.test\/domain\?bmaAttemptId=/);
+        expect(service.pendingSubRoute).to.be.null;
+        expect(service.billingAppIframeReloadReason).to.equal('visible_open_with_destination_route');
+    });
+
+    it('prefers a pending sub route over the URL hash for the iframe URL', function () {
+        const service = this.owner.lookup('service:billing');
+        billingService = service;
+        service.pendingSubRoute = '/backups';
+
+        expect(service.getIframeURL({fetchOwner: false})).to.equal('https://billing.example.test/backups');
+    });
+
     it('reports to Sentry with diagnostics when the billing app does not become ready', async function () {
         const service = this.owner.lookup('service:billing');
         billingService = service;

--- a/apps/ember-admin/tests/unit/services/billing-test.js
+++ b/apps/ember-admin/tests/unit/services/billing-test.js
@@ -194,8 +194,23 @@ describe('Unit: Service: billing', function () {
 
         service.navigateToSubRoute('/domain');
 
-        expect(postMessage.calledOnceWith({query: 'routeUpdate', response: '/domain'})).to.be.true;
+        expect(postMessage.calledOnceWith({query: 'routeUpdate', response: '/domain'}, 'https://billing.example.test')).to.be.true;
         expect(service.pendingSubRoute).to.be.null;
+    });
+
+    it('keeps a sub route pending when the billing app origin is unknown', function () {
+        const service = this.owner.lookup('service:billing');
+        billingService = service;
+        const postMessage = sinon.stub();
+        const iframe = {src: '', addEventListener: sinon.stub(), contentWindow: {postMessage}};
+        sinon.stub(service, 'getBillingIframe').returns(iframe);
+        service.billingAppLoaded = true;
+        this.owner.lookup('config:main').hostSettings = {};
+
+        service.navigateToSubRoute('/domain');
+
+        expect(postMessage.called).to.be.false;
+        expect(service.pendingSubRoute).to.equal('/domain');
     });
 
     it('keeps a sub route pending until the billing app reports ready', function () {
@@ -212,7 +227,7 @@ describe('Unit: Service: billing', function () {
 
         service.markBillingAppLoaded();
 
-        expect(postMessage.calledOnceWith({query: 'routeUpdate', response: '/domain'})).to.be.true;
+        expect(postMessage.calledOnceWith({query: 'routeUpdate', response: '/domain'}, 'https://billing.example.test')).to.be.true;
         expect(service.pendingSubRoute).to.be.null;
     });
 

--- a/apps/ember-admin/tests/unit/services/billing-test.js
+++ b/apps/ember-admin/tests/unit/services/billing-test.js
@@ -462,7 +462,7 @@ describe('Unit: Service: billing', function () {
 
         const calls = limitUpdateCalls(postMessage);
         expect(calls).to.have.lengthOf(1);
-        expect(calls[0].args).to.deep.equal([{query: 'limitUpdate'}, '*']);
+        expect(calls[0].args).to.deep.equal([{query: 'limitUpdate'}, 'https://billing.example.test']);
     });
 
     it('does not send limitUpdate when the billing overlay is hidden', function () {


### PR DESCRIPTION
ref [GVA-861](https://linear.app/ghost/issue/GVA-861)

Ghost(Pro) publishers had no way togo find billing actions — changing plan, setting up a custom domain, requesting a backup, contacting support — from the cmd+K search; they had to know these lived behind the Ghost(Pro) tab. Search can now surface them as a group shown above content results so they aren't buried under posts.

Following review feedback from @betschki, the group is **defined entirely by host config** rather than hardcoded: Ghost core ships no group name and no action list, so no hosting provider inherits another platform's actions. Any managed host that uses the billing portal — Ghost(Pro) included — opts in via `hostSettings.billing.search`:

```json
"billing": {
    "enabled": true,
    "url": "https://billing.example-host.com/api/{site}",
    "search": {
        "groupName": "Ghost(Pro)",
        "items": [
            {"id": "change-plan", "title": "Change plan", "path": "/plans", "keywords": "billing subscription plan upgrade"},
            {"id": "contact-support", "title": "Contact support", "path": "/support", "keywords": "support help contact"}
        ]
    }
}
```

* `groupName` is the heading shown above the group in search results
* each item's `path` is a route within the host's **own billing app** (eg. `/plans`) — Admin's `/pro` mounting point is not part of the config contract; the billing service owns that mapping
* items appear in the configured order and match on title plus optional `keywords`
* entries missing an id, title, or a valid path are dropped; without a `groupName` and at least one valid item the group doesn't exist

The group only appears when the site has billing enabled (`hostSettings.billing.enabled`) and the current user can access the billing app — the owner, or anyone while the site is in a force-upgrade state — mirroring the access rules of the `/pro` route (the rule lives on the billing service and is shared). Because the group name is host-defined, all behaviour dispatches on a stable `groupKey` carried by search groups and results — selection handling, access gating and the editor link-search exclusion never hang off display copy.

Note for rollout: until Ghost(Pro)'s infra config adds `hostSettings.billing.search`, publishers won't see the group — the Admin change ships dark and is harmless on its own.

## Also fixed: deep links in the billing iframe

Selecting a result navigates to `/pro/<page>`, and that surfaced a pre-existing problem: the billing app iframe is preloaded when Admin boots, so in-app navigation to `/pro/*` left it sitting on its boot route — and the app's own trial redirect to `/plans` raced (and beat) any post-load route message, which is why deep links always landed on the Billing tab. The billing service now:

* boots the iframe directly on the destination route when the window opens (a pending sub-route takes precedence over the URL hash, which hasn't updated yet during a transition), and
* sends a `routeUpdate` postMessage when the app is already loaded, queuing it until the app reports ready otherwise.

The queued route's lifecycle is kept tight so a stale destination can never hijack a later plain `/pro` open: closing the billing window abandons any queued deep link, a route queued while the window is already visible (but the app still loading) reloads the iframe with the destination baked into the URL rather than racing the app's boot redirects, and search selections transition first — the `pro/pro-sub` route forwards the destination once the transition succeeds, so an aborted transition (eg. unsaved changes) leaves the billing app untouched and nothing is sent twice. The pre-existing `?action=checkout` deep link now goes through the same channel, gaining origin pinning and ready-queueing instead of a `'*'`-targeted message that was dropped when the app wasn't ready. Hash→billing-route parsing is anchored in a single billing service helper so unrelated hashes (eg. `#/products`) can't leak into the iframe URL.

A new `pro/pro-sub` route forwards the wildcard segment, so any future in-app deep link to `/pro/*` works, not just search. Billing results are also excluded from the editor's internal link search (via a shared filter helper), since they aren't linkable site content.