### PR TITLE
Fix pages mis-typed as posts (webmentions + email) and log the endpoint on compare divergences

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/url.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/url.js
@@ -24,7 +24,17 @@ const forPost = (id, attrs, frame, type = 'posts') => {
         return attrs;
     }
 
-    attrs.url = urlService.facade.getUrlForResource({...attrs, id, type}, {absolute: true});
+    // Diagnostic only: hand the compare-mode URL service the producing api
+    // endpoint. The parity/thin-resource logs capture a caller stack, but it
+    // truncates at the async api-framework boundary and never names the
+    // endpoint; the api-framework Frame carries it, so pass it through. Omitted
+    // for non-api callers (mentions, email) whose frame has no endpoint fields.
+    const options = {absolute: true};
+    if (frame && (frame.docName || frame.method)) {
+        options.serializerContext = {apiType: frame.apiType, docName: frame.docName, method: frame.method};
+    }
+
+    attrs.url = urlService.facade.getUrlForResource({...attrs, id, type}, options);
 
     /**
      * CASE: admin api should serve preview urls

--- a/ghost/core/core/server/services/email-service/email-service-wrapper.js
+++ b/ghost/core/core/server/services/email-service/email-service-wrapper.js
@@ -6,7 +6,12 @@ const events = require('../../lib/common/events');
 class EmailServiceWrapper {
     getPostUrl(post) {
         const jsonModel = post.toJSON();
-        url.forPost(post.id, jsonModel, {options: {}});
+        // The URL service routes by resource type. Pages and posts share the
+        // Post model, so the page's own type must reach forPost — otherwise it
+        // defaults to 'posts', matches no post collection, and 404s under the
+        // lazy service.
+        const type = jsonModel.type === 'page' ? 'pages' : 'posts';
+        url.forPost(post.id, jsonModel, {options: {}}, type);
         return jsonModel.url;
     }
 

--- a/ghost/core/core/server/services/mentions/service.js
+++ b/ghost/core/core/server/services/mentions/service.js
@@ -29,7 +29,11 @@ async function getPostData(post) {
 
 function getPostUrl(id, postData) {
     const jsonModel = {...postData};
-    outputSerializerUrlUtil.forPost(id, jsonModel, {options: {}});
+    // The URL service routes by resource type. Pages and posts share the Post
+    // model, so the page's own type must reach forPost — otherwise it defaults
+    // to 'posts', matches no post collection, and 404s under the lazy service.
+    const type = postData.type === 'page' ? 'pages' : 'posts';
+    outputSerializerUrlUtil.forPost(id, jsonModel, {options: {}}, type);
     return jsonModel.url;
 }
 

--- a/ghost/core/core/server/services/url/url-service-facade.ts
+++ b/ghost/core/core/server/services/url/url-service-facade.ts
@@ -43,6 +43,12 @@ export interface UrlOptions {
     // rows per rebuild would only capture stacks and recompute for nothing.
     // Dies with compare mode.
     skipComparison?: boolean;
+    // Diagnostic only: the producing api endpoint (docName/method/apiType),
+    // threaded from the output serializer so a compare mismatch or thin-resource
+    // throw names its producer in the logs. The compare-log caller stack
+    // truncates at the async api-framework boundary, so the stack alone can't.
+    // Ignored by both backends; only read into the compare context.
+    serializerContext?: {apiType?: string; docName?: string; method?: string};
 }
 
 /**
@@ -138,7 +144,8 @@ export class UrlServiceFacade {
         }
         const url = this.urlService.getUrlByResourceId(resource.id, options);
         if (this.isComparing() && !options?.skipComparison) {
-            const context = this._compareContext(resource);
+            const context = this._compareContext(resource,
+                options?.serializerContext ? {serializer: options.serializerContext} : {});
             // Snapshot: callers mutate the resource's nested objects in place
             // after this returns, but the comparison runs later via setImmediate.
             const snapshot = _.cloneDeep(resource);

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/utils/url.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/utils/url.test.js
@@ -44,6 +44,18 @@ describe('Unit: endpoints/utils/serializers/output/utils/url', function () {
             assert.deepEqual(options, {absolute: true});
         });
 
+        it('passes the api endpoint identity (serializerContext) for compare diagnostics', function () {
+            // The compare-log caller stack truncates at the async api-framework
+            // boundary, so the api-framework Frame's endpoint identity is
+            // threaded to the URL service to pin producers in production.
+            const post = pageModel(testUtils.DataGenerator.forKnex.createPost({id: 'id1', mobiledoc: '{}', html: 'html'}));
+
+            urlUtil.forPost(post.id, post, {options: {}, apiType: 'admin', docName: 'posts', method: 'read'});
+
+            const [, options] = getUrlForResourceStub.firstCall.args;
+            assert.deepEqual(options.serializerContext, {apiType: 'admin', docName: 'posts', method: 'read'});
+        });
+
         it('still passes id when attrs has been stripped (e.g. fields=url)', function () {
             // Content API request like `?fields=url` runs jsonModel through a
             // serializer that strips every attribute except `url`. The mapper

--- a/ghost/core/test/unit/server/services/email-service/email-service-wrapper.test.js
+++ b/ghost/core/test/unit/server/services/email-service/email-service-wrapper.test.js
@@ -1,0 +1,35 @@
+const assert = require('node:assert/strict');
+const sinon = require('sinon');
+const url = require('../../../../../core/server/api/endpoints/utils/serializers/output/utils/url');
+const EmailServiceWrapper = require('../../../../../core/server/services/email-service/email-service-wrapper');
+
+describe('EmailServiceWrapper getPostUrl', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    function fakePost(type) {
+        return {
+            id: 'resource-id',
+            toJSON: () => ({id: 'resource-id', slug: 'a-slug', status: 'published', type})
+        };
+    }
+
+    it('routes a page as a page, not a post', function () {
+        // The URL service routes by resource type; a page mis-typed as a post
+        // matches no post collection and 404s under the lazy service.
+        const forPost = sinon.stub(url, 'forPost');
+
+        new EmailServiceWrapper().getPostUrl(fakePost('page'));
+
+        assert.equal(forPost.getCall(0).args[3], 'pages');
+    });
+
+    it('routes a post as a post', function () {
+        const forPost = sinon.stub(url, 'forPost');
+
+        new EmailServiceWrapper().getPostUrl(fakePost('post'));
+
+        assert.equal(forPost.getCall(0).args[3], 'posts');
+    });
+});

--- a/ghost/core/test/unit/server/services/mentions/service.test.js
+++ b/ghost/core/test/unit/server/services/mentions/service.test.js
@@ -40,6 +40,25 @@ describe('Mentions service post url helpers', function () {
         assert.equal(forPost.getCall(0).args[1].status, 'published');
     });
 
+    it('routes a page as a page, not a post', function () {
+        // The URL service routes by resource type. A page mis-typed as a post
+        // matches no post collection and 404s under the lazy service, so the
+        // page's own type must reach forPost.
+        const forPost = sinon.stub(outputSerializerUrlUtil, 'forPost');
+
+        getPostUrl('page-id', {slug: 'about', status: 'published', type: 'page'});
+
+        assert.equal(forPost.getCall(0).args[3], 'pages');
+    });
+
+    it('routes a post as a post', function () {
+        const forPost = sinon.stub(outputSerializerUrlUtil, 'forPost');
+
+        getPostUrl('post-id', {slug: 'hello', status: 'published', type: 'post'});
+
+        assert.equal(forPost.getCall(0).args[3], 'posts');
+    });
+
     it('does not reload relations that are already loaded', async function () {
         sinon.stub(urlService.facade, 'getRequiredRelations').returns(['tags', 'authors']);
         const post = fakePost({tags: {}, authors: {}});

--- a/ghost/core/test/unit/server/services/url/url-service-facade.test.js
+++ b/ghost/core/test/unit/server/services/url/url-service-facade.test.js
@@ -367,6 +367,35 @@ describe('UrlServiceFacade', function () {
             assert.equal(logging.error.firstCall.args[0].code, 'LAZY_URL_PARITY_MISMATCH');
         });
 
+        it('includes the serializer context (api endpoint) in a forward parity mismatch', async function () {
+            // Diagnostic: the compare-log caller stack truncates at the async
+            // api-framework boundary, so the producing endpoint is threaded in
+            // explicitly to pin thin-resource / mismatch producers in production.
+            compareFacade.getUrlForResource(
+                {type: 'posts', id: 'a'},
+                {serializerContext: {apiType: 'admin', docName: 'posts', method: 'read'}}
+            );
+            await flush();
+
+            sinon.assert.calledOnce(logging.error);
+            const reported = logging.error.firstCall.args[0];
+            assert.equal(reported.code, 'LAZY_URL_PARITY_MISMATCH');
+            assert.deepEqual(reported.errorDetails.serializer, {apiType: 'admin', docName: 'posts', method: 'read'});
+        });
+
+        it('includes the serializer context when the lazy backend throws (thin resource)', async function () {
+            lazyUrlService.getUrlForResource.throws(new Error('thin resource'));
+            compareFacade.getUrlForResource(
+                {type: 'posts', id: 'a'},
+                {serializerContext: {apiType: 'admin', docName: 'posts', method: 'read'}}
+            );
+            await flush();
+
+            const reported = logging.error.firstCall.args[0];
+            assert.equal(reported.code, 'LAZY_URL_COMPARE_ERROR');
+            assert.equal(reported.errorDetails.serializer.method, 'read');
+        });
+
         it('does not report when the lazy forward URL matches', async function () {
             lazyUrlService.getUrlForResource.returns('/hello-world/');
             compareFacade.getUrlForResource({type: 'posts', id: 'a'});


### PR DESCRIPTION
Part of the eager → lazy URL service migration (compare mode). This is the non-`sort_order` slice of the remaining parity divergences: pages the lazy service wrongly 404s, plus a diagnostic to pin the last thin-resource producers.

## Pages served as posts

Two helpers computed a resource's URL through the shared `forPost` serializer helper without passing the resource type, so it defaulted to `'posts'`. For a **page**, the lazy URL service then routes it through the post collections, matches none, and returns `/404/` where the eager service (id lookup) serves the real URL — a live page URL that would break once lazy is authoritative.

- **Webmention sending service** — the confirmed live producer, pinned from the compare-log caller stack.
- **Email service** `getPostUrl` — the same latent mis-typing (not a live producer today, since emails aren't sent for pages and its pipeline pre-loads relations, but fixed for correctness).

Both now pass the resource's own type (`page` → `'pages'`).

## Log the endpoint on compare divergences

A handful of thin-resource throws (`LAZY_URL_COMPARE_ERROR`) remain. The compare log captures a caller stack, but it truncates at the async api-framework boundary and never names the producing endpoint, so these can't be traced to the request that made them. The api-framework `Frame` already carries its `apiType`/`docName`/`method`; the output url serializer now threads them to the URL service as a diagnostic-only `serializerContext`, which the compare reporter includes in `errorDetails`. Non-api callers (webmentions, email) whose frame has no endpoint fields are unaffected.

One production deploy then names the exact endpoint behind the residual thin-resource errors, so the actual force-load fix can be written against a known target instead of a guess.
