### PR TITLE
🐛 Fixed broken internal links in automation emails

### DIFF
--- a/ghost/core/core/server/services/automations/database-automations-repository.ts
+++ b/ghost/core/core/server/services/automations/database-automations-repository.ts
@@ -5,6 +5,9 @@ import ObjectId from 'bson-objectid';
 import {dequal} from 'dequal';
 import {type Knex} from 'knex';
 import moment from 'moment';
+// @ts-expect-error This module currently lacks type definitions.
+import lexicalLib from '../../lib/lexical';
+import urlUtils from '../../../shared/url-utils';
 import {DEFAULT_EMAIL_DESIGN_SETTING_SLUG, MEMBER_WELCOME_EMAIL_SLUGS} from '../member-welcome-emails/constants';
 import type {
     AutomatedEmailEvents,
@@ -921,7 +924,7 @@ async function updateAutomation(trx: Knex.Transaction, automation: AutomationRow
 async function replaceAutomationGraph(trx: Knex.Transaction, automationId: string, submittedActions: AutomationAction[], edges: AutomationEdge[]): Promise<void> {
     const existingActions = await loadAutomationActionRows(trx, automationId);
     const existingActionById = new Map(existingActions.map(action => [action.id, action]));
-    const actions = await resolveEmailDesignSettingIds(trx, submittedActions);
+    const actions = (await resolveEmailDesignSettingIds(trx, submittedActions)).map(formatActionOnWrite);
     const submittedActionIds = new Set(actions.map(action => action.id));
     const actionIdsWithOwners = await loadActionIdsWithOwners(trx, [...submittedActionIds]);
     const latestRevisionByActionId = new Map((await loadLatestActionRevisions(trx, [...submittedActionIds])).map(revision => [revision.action_id, revision]));
@@ -980,6 +983,23 @@ async function replaceAutomationGraph(trx: Knex.Transaction, automationId: strin
     await deleteAutomationEdges(trx, automationId);
 
     await insertActionEdges(trx, edges);
+}
+
+function formatActionOnWrite(action: AutomationAction): AutomationAction {
+    if (action.type !== 'send_email') {
+        return action;
+    }
+
+    return {
+        ...action,
+        data: {
+            ...action.data,
+            email_lexical: urlUtils.lexicalToTransformReady(action.data.email_lexical, {
+                nodes: lexicalLib.nodes,
+                transformMap: lexicalLib.urlTransformMap
+            })
+        }
+    };
 }
 
 async function resolveEmailDesignSettingIds(trx: Knex.Transaction, actions: ReadonlyArray<AutomationAction>): Promise<AutomationAction[]> {
@@ -1312,7 +1332,7 @@ function buildActionPayload(row: ActionRow, stats: AutomationEmailStats | null):
             type: 'send_email',
             data: {
                 email_subject: requireValue(row, 'email_subject'),
-                email_lexical: requireValue(row, 'email_lexical'),
+                email_lexical: urlUtils.transformReadyToAbsolute(requireValue(row, 'email_lexical')),
                 email_design_setting_id: requireValue(row, 'email_design_setting_id')
             },
             stats: stats ?? EMPTY_EMAIL_STATS

--- a/ghost/core/core/server/services/member-welcome-emails/member-welcome-email-renderer.js
+++ b/ghost/core/core/server/services/member-welcome-emails/member-welcome-email-renderer.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const lexicalLib = require('../../lib/lexical');
 const labs = require('../../../shared/labs');
+const urlUtils = require('../../../shared/url-utils').default;
 const {finalize} = require('../email-rendering/finalize');
 const errors = require('@tryghost/errors');
 const {MESSAGES} = require('./constants');
@@ -138,7 +139,8 @@ class MemberWelcomeEmailRenderer {
 
         let content;
         try {
-            content = await lexicalLib.render(lexical, {target: 'email', design});
+            const absoluteLexical = urlUtils.transformReadyToAbsolute(lexical);
+            content = await lexicalLib.render(absoluteLexical, {target: 'email', design});
         } catch (err) {
             throw new errors.IncorrectUsageError({
                 message: MESSAGES.INVALID_LEXICAL_STRUCTURE,

--- a/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
+++ b/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
@@ -4,6 +4,7 @@ import ObjectId from 'bson-objectid';
 import createKnex, {type Knex} from 'knex';
 import moment from 'moment';
 import {NON_EMPTY_EMAIL_LEXICAL} from '../../../../utils/automations-fixtures';
+import ghostConfig from '../../../../../core/shared/config';
 import {createDatabaseAutomationsRepository} from '../../../../../core/server/services/automations/database-automations-repository';
 import type {AutomatedEmailEvents, AutomationAction, AutomationsRepository, AutomationStepToRun} from '../../../../../core/server/services/automations/automations-repository';
 
@@ -13,6 +14,17 @@ const DATABASE_DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss';
 
 const toDatabaseDate = (date: Date | string): string => moment(date).format(DATABASE_DATE_FORMAT);
 const toRepositoryDateISOString = (date: Date | string): string => new Date(toDatabaseDate(date)).toISOString();
+const linkLexical = (url: string): string => JSON.stringify({
+    root: {
+        children: [{
+            type: 'paragraph',
+            children: [{
+                type: 'link',
+                url
+            }]
+        }]
+    }
+});
 
 const addHours = (dateCol: unknown, hours: number): Date => {
     assert(typeof dateCol === 'string', 'Expected date column to be a string');
@@ -416,6 +428,7 @@ describe('automations repository', function () {
                 'automation_actions.type as action_type',
                 'automation_action_revisions.id as revision_id',
                 'automation_action_revisions.wait_hours as wait_hours',
+                'automation_action_revisions.email_lexical as email_lexical',
                 'automation_action_revisions.email_design_setting_id as email_design_setting_id'
             )
             .innerJoin('automation_action_revisions', 'automation_action_revisions.action_id', 'automation_actions.id')
@@ -675,6 +688,70 @@ describe('automations repository', function () {
                 .first();
 
             assert.equal(Number(totalActions?.count), 2);
+        });
+    });
+
+    describe('URL serialization', function () {
+        it('returns stored transform-ready email URLs as absolute URLs', async function () {
+            const automation = await getAutomationBySlug('member-welcome-email-free');
+            const emailAction = automation.actions.find(action => action.type === 'send_email');
+            assert(emailAction);
+
+            await knex('automation_action_revisions')
+                .where('action_id', emailAction.id)
+                .update({
+                    email_lexical: linkLexical('__GHOST_URL__/archive/')
+                });
+
+            const result = await repo.getById(automation.id);
+            assert(result);
+            const returnedEmailAction = result.actions.find(action => action.id === emailAction.id);
+            assert(returnedEmailAction?.type === 'send_email');
+            assert(returnedEmailAction.data.email_lexical.includes(`${ghostConfig.get('url')}/archive/`));
+            assert(!returnedEmailAction.data.email_lexical.includes('__GHOST_URL__'));
+        });
+
+        it('stores internal URLs as transform-ready without creating a revision on an unchanged save', async function () {
+            const automation = await getAutomationBySlug('member-welcome-email-free');
+            const emailAction = automation.actions.find(action => action.type === 'send_email');
+            assert(emailAction?.type === 'send_email');
+
+            const absoluteLexical = linkLexical(`${ghostConfig.get('url')}/archive/`);
+            const updatedActions = automation.actions.map(action => (
+                action.id === emailAction.id
+                    ? {
+                        ...emailAction,
+                        data: {
+                            ...emailAction.data,
+                            email_lexical: absoluteLexical
+                        }
+                    }
+                    : action
+            ));
+
+            const result = await repo.edit(automation.id, {
+                status: automation.status,
+                actions: updatedActions,
+                edges: automation.edges
+            });
+
+            assert(result);
+            const returnedEmailAction = result.actions.find(action => action.id === emailAction.id);
+            assert(returnedEmailAction?.type === 'send_email');
+            assert(returnedEmailAction.data.email_lexical.includes(`${ghostConfig.get('url')}/archive/`));
+            assert(!returnedEmailAction.data.email_lexical.includes('__GHOST_URL__'));
+
+            const storedRevision = await getLatestActionRevisionByActionId(emailAction.id);
+            assert.equal(storedRevision.email_lexical, linkLexical('__GHOST_URL__/archive/'));
+            const initialRevisionCount = await getRevisionCount(emailAction.id);
+
+            await repo.edit(automation.id, {
+                status: result.status,
+                actions: result.actions,
+                edges: result.edges
+            });
+
+            assert.equal(await getRevisionCount(emailAction.id), initialRevisionCount);
         });
     });
 

--- a/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
@@ -3,6 +3,7 @@ const cheerio = require('cheerio');
 const sinon = require('sinon');
 const errors = require('@tryghost/errors');
 const lexicalLib = require('../../../../../core/server/lib/lexical');
+const config = require('../../../../../core/shared/config');
 const emailDesign = require('../../../../../core/server/services/email-rendering/email-design');
 const MemberWelcomeEmailRenderer = require('../../../../../core/server/services/member-welcome-emails/member-welcome-email-renderer');
 
@@ -326,6 +327,63 @@ describe('MemberWelcomeEmailRenderer', function () {
             const $link = $('a[href="https://example.com/#/portal/support"]');
             assert($link.length, 'Expected a link to the absolute portal support URL');
             assert.equal($link.text(), 'Support us');
+        });
+
+        it('resolves transform-ready URLs before rendering Lexical content', async function () {
+            lexicalRenderStub.restore();
+            const renderer = createRenderer();
+            const siteUrl = config.get('url');
+            const lexical = JSON.stringify({
+                root: {
+                    children: [{
+                        children: [{
+                            children: [{
+                                detail: 0,
+                                format: 0,
+                                mode: 'normal',
+                                style: '',
+                                text: 'Open the archive',
+                                type: 'extended-text',
+                                version: 1
+                            }],
+                            direction: 'ltr',
+                            format: '',
+                            indent: 0,
+                            rel: 'noreferrer',
+                            target: null,
+                            title: null,
+                            type: 'link',
+                            url: '__GHOST_URL__/archive/',
+                            version: 1
+                        }],
+                        direction: 'ltr',
+                        format: '',
+                        indent: 0,
+                        type: 'paragraph',
+                        version: 1
+                    }],
+                    direction: 'ltr',
+                    format: '',
+                    indent: 0,
+                    type: 'root',
+                    version: 1
+                }
+            });
+
+            const result = await renderer.render({
+                lexical,
+                subject: 'Welcome!',
+                member: {name: 'John', email: 'john@example.com'},
+                siteSettings: {
+                    ...defaultSiteSettings,
+                    url: siteUrl
+                }
+            });
+
+            const $ = cheerio.load(result.html);
+            const $link = $(`a[href="${siteUrl}/archive/"]`);
+            assert($link.length, 'Expected a transform-ready URL to resolve against the site URL');
+            assert(!result.html.includes('__GHOST_URL__'));
         });
 
         it('generates plain text from HTML', async function () {


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/NY-1503

Problem

Legacy welcome emails store internal Lexical URLs using __GHOST_URL__. When Automations initialized the default free and paid flows, it copied that data directly into action revisions with Knex, bypassing the legacy model parser.

The editor and poller then read the raw revision. This exposed the placeholder in the editor and produced links such as https://site.example/__GHOST_URL__/archive/ in rendered emails.

Reproduction

1. Before enabling Automations, add an internal link such as /archive/ to a free or paid welcome email.
2. Enable the Automations labs flag and visit Automations to initialize the default flow.
3. Open the first email action. Its link URL displays as __GHOST_URL__/archive/.
4. Send a preview and inspect its link. The href contains /__GHOST_URL__/archive/ and 404s.

Fix

- Expand transform-ready URLs when returning automation data so the editor receives the current absolute URL.
- Convert internal URLs back to transform-ready form before comparing and storing revisions. This matches posts and legacy welcome emails, preserves domain portability, and avoids revisions for unchanged saves.
- Expand URLs again immediately before rendering because the poller reads immutable revisions directly, bypassing the editor serializer.
- Avoid a migration: existing revisions are corrected at read and render time, while future writes use the established storage format.

Verification

Reopen the action and confirm the link popover shows the absolute site URL. Send a preview and confirm its href points directly to /archive/ with no __GHOST_URL__ token. Saving without changes should not create another action revision.

Impact

This specifically affects only the legacy welcome email copied into each default free or paid automation when Automations is initialized. It may no longer be the first step if waits were inserted before it, but later email actions authored in Automations are unaffected. Sites that have not switched to Automations are unaffected.