### PR TITLE
Moved database date helper to separate, tested file

### DIFF
--- a/ghost/core/core/server/services/automations/database-automations-repository.ts
+++ b/ghost/core/core/server/services/automations/database-automations-repository.ts
@@ -4,7 +4,6 @@ import crypto from 'node:crypto';
 import ObjectId from 'bson-objectid';
 import {dequal} from 'dequal';
 import {type Knex} from 'knex';
-import moment from 'moment';
 // @ts-expect-error This module currently lacks type definitions.
 import lexicalLib from '../../lib/lexical';
 import urlUtils from '../../../shared/url-utils';
@@ -22,11 +21,11 @@ import type {
     EditAutomationData,
     Page
 } from './automations-repository';
+import {toDatabaseDate} from './database-date';
 import {getStaleLockCutoff} from './stale-lock-cutoff';
 import type {ExclusifyUnion, ReadonlyDeep} from 'type-fest';
 
 const HOUR_MS = 60 * 60 * 1000;
-const DATABASE_DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss';
 const DEFAULT_WELCOME_EMAIL_AUTOMATIONS = [{
     name: 'Free member welcome flow',
     slug: MEMBER_WELCOME_EMAIL_SLUGS.free
@@ -53,9 +52,6 @@ interface AutomationRow {
     updated_at: string;
 }
 
-function toDatabaseDate(date: Date | string): string {
-    return moment(date).format(DATABASE_DATE_FORMAT);
-}
 
 interface ActionRow {
     id: string;

--- a/ghost/core/core/server/services/automations/database-date.ts
+++ b/ghost/core/core/server/services/automations/database-date.ts
@@ -1,0 +1,5 @@
+import moment from 'moment';
+
+const DATABASE_DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss';
+
+export const toDatabaseDate = (date: Date | string): string => moment(date).format(DATABASE_DATE_FORMAT);

--- a/ghost/core/test/unit/server/services/automations/database-date.test.ts
+++ b/ghost/core/test/unit/server/services/automations/database-date.test.ts
@@ -1,17 +1,7 @@
 import assert from 'node:assert/strict';
-import moment from 'moment-timezone';
 import {toDatabaseDate} from '../../../../../core/server/services/automations/database-date';
 
 describe('database date utilities', function () {
-    beforeEach(function () {
-        // Mirror the timezone behavior of production.
-        moment.tz.setDefault('UTC');
-    });
-
-    afterEach(function () {
-        moment.tz.setDefault();
-    });
-
     describe('toDatabaseDate', function () {
         it('converts Dates to database date strings', function () {
             const input = new Date('2024-06-01T12:34:56Z');

--- a/ghost/core/test/unit/server/services/automations/database-date.test.ts
+++ b/ghost/core/test/unit/server/services/automations/database-date.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import moment from 'moment-timezone';
+import {toDatabaseDate} from '../../../../../core/server/services/automations/database-date';
+
+describe('database date utilities', function () {
+    beforeEach(function () {
+        // Mirror the timezone behavior of production.
+        moment.tz.setDefault('UTC');
+    });
+
+    afterEach(function () {
+        moment.tz.setDefault();
+    });
+
+    describe('toDatabaseDate', function () {
+        it('converts Dates to database date strings', function () {
+            const input = new Date('2024-06-01T12:34:56Z');
+            const result = toDatabaseDate(input);
+            assert.strictEqual(result, '2024-06-01 12:34:56');
+        });
+
+        it('converts Zulu date strings to database date strings', function () {
+            const input = '2024-06-01T12:34:56Z';
+            const result = toDatabaseDate(input);
+            assert.strictEqual(result, '2024-06-01 12:34:56');
+        });
+
+        it('converts timezoned date strings to database date strings', function () {
+            const input = '2024-06-01T12:34:56-04:00';
+            const result = toDatabaseDate(input);
+            assert.strictEqual(result, '2024-06-01 16:34:56');
+        });
+    });
+});


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1404

This refactor should have no user impact.

`toDatabaseDate` is now in its own file with tests.

I think this is a useful change on its own but will make [an upcoming change][0] easier.

[0]: https://linear.app/ghost/issue/NY-1404
