### PR TITLE
🐛 Fixed settings sidebar flash for editors/contributors

### DIFF
--- a/apps/admin/src/layout/app-sidebar/app-sidebar.tsx
+++ b/apps/admin/src/layout/app-sidebar/app-sidebar.tsx
@@ -8,7 +8,7 @@ import AppSidebarContent from "./app-sidebar-content";
 
 function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
     return (
-        <Sidebar {...props}>
+        <Sidebar data-testid="admin-sidebar" {...props}>
             <AppSidebarHeader className="px-5 pt-5 pb-0" />
             <AppSidebarContent />
             <AppSidebarFooter className="gap-0 p-3" />

--- a/apps/admin/src/layout/sidebar.acceptance.test.tsx
+++ b/apps/admin/src/layout/sidebar.acceptance.test.tsx
@@ -90,14 +90,28 @@ describe("Sidebar navigation", () => {
         await expect.poll(currentRoute).toBe("/posts?type=scheduled");
     });
 
-    it("navigates to settings from the sidebar footer", async () => {
+    it("navigates to settings from the sidebar footer and hides the shell nav", async () => {
         // The settings app owns its request graph; this spec asserts only the shell navigation.
         allowUnhandledRequests();
         await renderAdminApp("/");
 
+        await expect.element(sidebarScreen.shellNav()).toBeVisible();
         await sidebarScreen.navLink("Settings").click();
 
         await expect.poll(currentRoute).toMatch(/^\/settings/);
+        await expect.element(sidebarScreen.shellNav()).not.toBeInTheDocument();
+    });
+
+    it("hides the shell nav when a settings route is loaded directly", async () => {
+        // The settings app owns its request graph; this spec asserts only the shell navigation.
+        allowUnhandledRequests();
+        await renderAdminApp("/settings/staff");
+
+        await expect.poll(currentRoute).toMatch(/^\/settings\/staff/);
+        // The shell mounts only once the current user resolves — wait for it, or a
+        // sidebar that appears on that later paint slips past the assertion.
+        await expect.element(sidebarScreen.shellMain()).toBeInTheDocument();
+        await expect.element(sidebarScreen.shellNav()).not.toBeInTheDocument();
     });
 });
 

--- a/apps/admin/src/layout/sidebar.screen.ts
+++ b/apps/admin/src/layout/sidebar.screen.ts
@@ -1,5 +1,6 @@
 import { page } from "vitest/browser";
 import {
+    adminSidebar,
     appearanceMenuItem,
     darkAppearanceOption,
     lightAppearanceOption,
@@ -21,6 +22,10 @@ const appearanceOptions = {
 
 /** Admin sidebar locators and gestures for acceptance specs; no assertions. */
 export const sidebarScreen = {
+    // The settings app renders its own nav, so the shell sidebar needs its own hook.
+    shellNav: () => page.getByTestId(adminSidebar),
+    /** The shell's content area, rendered by AdminLayout alongside the sidebar. */
+    shellMain: () => page.getByRole("main").first(),
     navLink: (name: string) => page.getByRole("navigation").getByRole("link", { name, exact: true }),
     postsToggle: () => page.getByRole("button", { name: postsToggle }),
     networkBadge: () => page.getByTestId(networkNotificationBadge),

--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -172,9 +172,15 @@ const appRoutes: RouteObject[] = [
         children: activityPubRoutes,
     },
     {
+        // hideAdminSidebar lives on the handle, not the lazy module, so the shell
+        // hides at first paint instead of waiting on the settings chunk.
         path: `settings/*`,
         lazy: lazyComponent(() => import("./settings/settings")),
-        handle: { allowInForceUpgrade: true, requiresAccess: canAccessSettingsRoute } satisfies RouteHandle & AccessRouteHandle,
+        handle: {
+            allowInForceUpgrade: true,
+            hideAdminSidebar: true,
+            requiresAccess: canAccessSettingsRoute
+        } satisfies RouteHandle & AdminRouteHandle & AccessRouteHandle,
     },
     {path: "/posts", Component: EmberListWithGiftLinks, handle: emberFallbackHandle},
     {path: "/pages", Component: EmberListWithGiftLinks, handle: emberFallbackHandle},

--- a/packages/testing/test-data/src/selectors/sidebar.ts
+++ b/packages/testing/test-data/src/selectors/sidebar.ts
@@ -4,6 +4,7 @@
  */
 
 // testids
+export const adminSidebar = "admin-sidebar";
 export const networkNotificationBadge = "network-notification-badge";
 
 // accessible names


### PR DESCRIPTION
Loading a settings URL directly — `/ghost/#/settings/staff?tab=editors` — painted the admin sidebar for a frame before hiding it.

`settings/*` relied on the Ember bridge to report that the sidebar should be hidden, and the bridge only reports after the React shell has mounted. Declaring `hideAdminSidebar` on the route handle instead means `useAdminSidebarVisibility` reads it from `useMatches` on the first paint, before the lazy settings chunk resolves.

ref https://github.com/TryGhost/Ghost/issues/26607

## Test plan
- [ ] `pnpm test:acceptance src/layout/sidebar.acceptance.test.tsx` (from `apps/admin`) — covers both entry points; both new assertions fail without the handle change
- [ ] Open `#/settings/staff?tab=editors` in a fresh tab — no sidebar frame before settings renders
- [ ] Navigate Posts → Settings → back to Posts — sidebar hides and returns