### PR TITLE
Added permalink adapter anti-corruption layer for routing

### DIFF
--- a/ghost/core/core/frontend/services/routing/collection-router.js
+++ b/ghost/core/core/frontend/services/routing/collection-router.js
@@ -5,6 +5,7 @@ const ParentRouter = require('./parent-router');
 const controllers = require('./controllers');
 const middleware = require('./middleware');
 const RSSRouter = require('./rss-router');
+const {toExpressNotation} = require('./permalink-adapter');
 
 /**
  * @description Collection Router for post resource.
@@ -26,8 +27,9 @@ class CollectionRouter extends ParentRouter {
 
         this.rss = object.rss !== false;
 
+        // convert domain `{slug}` -> Express/URL-service `:slug` at this boundary
         this.permalinks = {
-            value: object.permalink
+            value: toExpressNotation(object.permalink)
         };
 
         // @NOTE: see renderer/templates - we use unshift to prepend the templates

--- a/ghost/core/core/frontend/services/routing/permalink-adapter.js
+++ b/ghost/core/core/frontend/services/routing/permalink-adapter.js
@@ -1,0 +1,49 @@
+/**
+ * @description Permalink Adapter — the anti-corruption layer between the routing
+ * domain model and the Express / URL-service infrastructure.
+ *
+ * The domain model expresses permalinks in `{slug}` notation (the publisher's
+ * language, as written in `routes.yaml`). Express route mounting, `path-match`
+ * and the URL service's `replacePermalink` all require `:slug` notation. This
+ * module is the single, named boundary where that translation happens — routers
+ * call it when mounting routes and registering with the URL service, so the
+ * conversion lives in exactly one place instead of scattered regex replacements.
+ *
+ * Both conversions are idempotent: passing an already-converted permalink back
+ * through returns it unchanged.
+ */
+
+/**
+ * Convert a domain-model permalink into Express / URL-service notation.
+ *
+ * @example toExpressNotation('/{slug}/')              // => '/:slug/'
+ * @example toExpressNotation('/{primary_tag}/{slug}/') // => '/:primary_tag/:slug/'
+ * @example toExpressNotation('/:slug/')               // => '/:slug/' (idempotent)
+ *
+ * @param {string} permalink permalink in `{slug}` (domain) notation
+ * @returns {string} permalink in `:slug` (infrastructure) notation
+ */
+function toExpressNotation(permalink) {
+    return permalink.replace(/{(\w+)}/g, ':$1');
+}
+
+/**
+ * Convert an Express / URL-service permalink back into domain-model notation.
+ * Will be used on the download path when serialising the canonical shape back
+ * to YAML (wired up in HKG-1897) — no production caller yet.
+ *
+ * @example toDomainNotation('/:slug/')               // => '/{slug}/'
+ * @example toDomainNotation('/:primary_tag/:slug/')  // => '/{primary_tag}/{slug}/'
+ * @example toDomainNotation('/{slug}/')              // => '/{slug}/' (idempotent)
+ *
+ * @param {string} permalink permalink in `:slug` (infrastructure) notation
+ * @returns {string} permalink in `{slug}` (domain) notation
+ */
+function toDomainNotation(permalink) {
+    return permalink.replace(/:(\w+)/g, '{$1}');
+}
+
+module.exports = {
+    toExpressNotation,
+    toDomainNotation
+};

--- a/ghost/core/core/frontend/services/routing/permalink-adapter.ts
+++ b/ghost/core/core/frontend/services/routing/permalink-adapter.ts
@@ -1,19 +1,4 @@
 /**
- * @description Permalink Adapter — the anti-corruption layer between the routing
- * domain model and the Express / URL-service infrastructure.
- *
- * The domain model expresses permalinks in `{slug}` notation (the publisher's
- * language, as written in `routes.yaml`). Express route mounting, `path-match`
- * and the URL service's `replacePermalink` all require `:slug` notation. This
- * module is the single, named boundary where that translation happens — routers
- * call it when mounting routes and registering with the URL service, so the
- * conversion lives in exactly one place instead of scattered regex replacements.
- *
- * Both conversions are idempotent: passing an already-converted permalink back
- * through returns it unchanged.
- */
-
-/**
  * Convert a domain-model permalink into Express / URL-service notation.
  *
  * @example toExpressNotation('/{slug}/')               // => '/:slug/'

--- a/ghost/core/core/frontend/services/routing/permalink-adapter.ts
+++ b/ghost/core/core/frontend/services/routing/permalink-adapter.ts
@@ -16,14 +16,11 @@
 /**
  * Convert a domain-model permalink into Express / URL-service notation.
  *
- * @example toExpressNotation('/{slug}/')              // => '/:slug/'
+ * @example toExpressNotation('/{slug}/')               // => '/:slug/'
  * @example toExpressNotation('/{primary_tag}/{slug}/') // => '/:primary_tag/:slug/'
- * @example toExpressNotation('/:slug/')               // => '/:slug/' (idempotent)
- *
- * @param {string} permalink permalink in `{slug}` (domain) notation
- * @returns {string} permalink in `:slug` (infrastructure) notation
+ * @example toExpressNotation('/:slug/')                // => '/:slug/' (idempotent)
  */
-function toExpressNotation(permalink) {
+export function toExpressNotation(permalink: string): string {
     return permalink.replace(/{(\w+)}/g, ':$1');
 }
 
@@ -35,15 +32,7 @@ function toExpressNotation(permalink) {
  * @example toDomainNotation('/:slug/')               // => '/{slug}/'
  * @example toDomainNotation('/:primary_tag/:slug/')  // => '/{primary_tag}/{slug}/'
  * @example toDomainNotation('/{slug}/')              // => '/{slug}/' (idempotent)
- *
- * @param {string} permalink permalink in `:slug` (infrastructure) notation
- * @returns {string} permalink in `{slug}` (domain) notation
  */
-function toDomainNotation(permalink) {
+export function toDomainNotation(permalink: string): string {
     return permalink.replace(/:(\w+)/g, '{$1}');
 }
-
-module.exports = {
-    toExpressNotation,
-    toDomainNotation
-};

--- a/ghost/core/core/frontend/services/routing/taxonomy-router.js
+++ b/ghost/core/core/frontend/services/routing/taxonomy-router.js
@@ -5,6 +5,7 @@ const RSSRouter = require('./rss-router');
 const urlUtils = require('../../../shared/url-utils').default;
 const controllers = require('./controllers');
 const middleware = require('./middleware');
+const {toExpressNotation} = require('./permalink-adapter');
 
 /**
  * @description Taxonomies are groupings of posts based on a common relation.
@@ -17,8 +18,9 @@ class TaxonomyRouter extends ParentRouter {
         this.taxonomyKey = key;
         this.RESOURCE_CONFIG = RESOURCE_CONFIG;
 
+        // convert domain `{slug}` -> Express/URL-service `:slug` at this boundary
         this.permalinks = {
-            value: permalinks
+            value: toExpressNotation(permalinks)
         };
 
         this.permalinks.getValue = () => {

--- a/ghost/core/core/server/services/route-settings/activation-bridge.ts
+++ b/ghost/core/core/server/services/route-settings/activation-bridge.ts
@@ -117,14 +117,11 @@ function expandRouteData(routeData: RouteData | undefined): ExpandedData {
     return merged;
 }
 
-function convertSlugsToColons(value: string): string {
-    return value.replace(/{(\w+)}/g, ':$1');
-}
-
 /**
- * Router-facing shapes. RouterManager consumes the domain model after the two
- * conversions the bridge still applies: `data` expanded to `{query, router}`,
- * and collection/taxonomy permalinks rewritten to `:slug`.
+ * Router-facing shapes. RouterManager consumes the domain model after the one
+ * conversion the bridge still applies: `data` expanded to `{query, router}`.
+ * Collection/taxonomy permalinks are left in domain `{slug}` form — the routers
+ * translate them to `:slug` at their boundary via the permalink adapter.
  *
  * Routes and collections are written as their domain counterpart with just
  * `data` overridden to the expanded shape — `Omit<…, 'data'> & {data?}` rather
@@ -132,7 +129,8 @@ function convertSlugsToColons(value: string): string {
  * extension can only add fields, not retype them). That keeps the delta from
  * the domain model explicit: `data` is the only structural difference. When the
  * bridge is removed (HKG-1898) the override falls away and these collapse back
- * to `Route` / `CollectionConfig`.
+ * to `Route` / `CollectionConfig`. The remaining `data` conversion peels off in
+ * HKG-1897.
  */
 type RouterChannelRoute = Omit<ChannelRoute, 'data'> & {data?: ExpandedData};
 type RouterTemplateRoute = Omit<TemplateRoute, 'data'> & {data?: ExpandedData};
@@ -202,7 +200,7 @@ function buildRouterRoute(route: Route): RouterRoute {
 function buildRouterCollection(collection: CollectionConfig): RouterCollection {
     const result: RouterCollection = {
         path: collection.path,
-        permalink: convertSlugsToColons(collection.permalink),
+        permalink: collection.permalink,
         templates: collection.templates || []
     };
 
@@ -238,7 +236,7 @@ export function buildRouterSettings(settings: RouteSettings): RouterSettings {
     const taxonomies: RouterTaxonomy[] = [];
     for (const [key, value] of Object.entries(settings.taxonomies)) {
         if (value) {
-            taxonomies.push({key, permalink: convertSlugsToColons(value)});
+            taxonomies.push({key, permalink: value});
         }
     }
 

--- a/ghost/core/test/integration/services/route-settings/dynamic-routing-service.test.ts
+++ b/ghost/core/test/integration/services/route-settings/dynamic-routing-service.test.ts
@@ -75,8 +75,8 @@ describe('Integration: DynamicRoutingService over a real FileStore', function ()
         const expanded = await service.loadRouteSettings();
 
         assert.deepEqual(expanded.routes, [{path: '/about/', type: 'template', templates: ['about']}]);
-        assert.deepEqual(expanded.collections, [{path: '/', permalink: '/:slug/', templates: ['index']}]);
-        assert.deepEqual(expanded.taxonomies, [{key: 'tag', permalink: '/tag/:slug/'}]);
+        assert.deepEqual(expanded.collections, [{path: '/', permalink: '/{slug}/', templates: ['index']}]);
+        assert.deepEqual(expanded.taxonomies, [{key: 'tag', permalink: '/tag/{slug}/'}]);
     });
 
     it('loadRouteSettings logs ROUTE_SETTINGS_VALIDATION_ERROR and rethrows when the file fails validation', async function () {

--- a/ghost/core/test/legacy/mock-express-style/api-vs-frontend.test.js
+++ b/ghost/core/test/legacy/mock-express-style/api-vs-frontend.test.js
@@ -358,19 +358,19 @@ describe('Frontend behavior tests', function () {
 
                     collections: {
                         '/podcast/': {
-                            permalink: '/podcast/:slug/',
+                            permalink: '/podcast/{slug}/',
                             filter: 'featured:true'
                         },
 
                         '/something/': {
-                            permalink: '/something/:slug/',
+                            permalink: '/something/{slug}/',
                             filter: 'featured:false'
                         }
                     },
 
                     taxonomies: {
-                        tag: '/categories/:slug/',
-                        author: '/authors/:slug/'
+                        tag: '/categories/{slug}/',
+                        author: '/authors/{slug}/'
                     }
                 }));
 
@@ -525,7 +525,7 @@ describe('Frontend behavior tests', function () {
                         },
 
                         '/': {
-                            permalink: '/:slug/'
+                            permalink: '/{slug}/'
                         }
                     },
 
@@ -617,7 +617,7 @@ describe('Frontend behavior tests', function () {
 
                     collections: {
                         '/something/': {
-                            permalink: '/:primary_author/:slug/'
+                            permalink: '/{primary_author}/{slug}/'
                         }
                     },
 
@@ -693,7 +693,7 @@ describe('Frontend behavior tests', function () {
 
                     collections: {
                         '/something/': {
-                            permalink: '/something/:primary_tag/:slug/'
+                            permalink: '/something/{primary_tag}/{slug}/'
                         }
                     },
 
@@ -802,7 +802,7 @@ describe('Frontend behavior tests', function () {
 
                     collections: {
                         '/food/': {
-                            permalink: '/food/:slug/',
+                            permalink: '/food/{slug}/',
                             filter: 'tag:bacon+tag:-chorizo',
                             data: {
                                 query: {
@@ -821,7 +821,7 @@ describe('Frontend behavior tests', function () {
                             }
                         },
                         '/sport/': {
-                            permalink: '/sport/:slug/',
+                            permalink: '/sport/{slug}/',
                             filter: 'tag:chorizo+tag:-bacon',
                             data: {
                                 query: {
@@ -842,8 +842,8 @@ describe('Frontend behavior tests', function () {
                     },
 
                     taxonomies: {
-                        tag: '/categories/:slug/',
-                        author: '/authors/:slug/'
+                        tag: '/categories/{slug}/',
+                        author: '/authors/{slug}/'
                     }
                 }));
 
@@ -943,11 +943,11 @@ describe('Frontend behavior tests', function () {
 
                     collections: {
                         '/': {
-                            permalink: '/:slug/',
+                            permalink: '/{slug}/',
                             templates: ['default']
                         },
                         '/magic/': {
-                            permalink: '/magic/:slug/'
+                            permalink: '/magic/{slug}/'
                         }
                     }
                 }));
@@ -1004,7 +1004,7 @@ describe('Frontend behavior tests', function () {
 
                     collections: {
                         '/': {
-                            permalink: '/:slug/',
+                            permalink: '/{slug}/',
                             templates: ['something', 'default']
                         }
                     }
@@ -1051,11 +1051,11 @@ describe('Frontend behavior tests', function () {
 
                     collections: {
                         '/': {
-                            permalink: '/:slug/',
+                            permalink: '/{slug}/',
                             templates: ['something', 'default']
                         },
                         '/magic/': {
-                            permalink: '/magic/:slug/',
+                            permalink: '/magic/{slug}/',
                             templates: ['something', 'default']
                         }
                     }
@@ -1228,13 +1228,13 @@ describe('Frontend behavior tests', function () {
 
                     collections: {
                         '/': {
-                            permalink: '/:slug/'
+                            permalink: '/{slug}/'
                         }
                     },
 
                     taxonomies: {
-                        tag: '/tag/:slug/',
-                        author: '/author/:slug/'
+                        tag: '/tag/{slug}/',
+                        author: '/author/{slug}/'
                     }
                 }));
 
@@ -1450,17 +1450,17 @@ describe('Frontend behavior tests', function () {
 
                 collections: {
                     '/podcast/': {
-                        permalink: '/:slug/',
+                        permalink: '/{slug}/',
                         filter: 'featured:true',
                         templates: ['home'],
                         rss: false
                     },
                     '/music/': {
-                        permalink: '/:slug/',
+                        permalink: '/{slug}/',
                         rss: false
                     },
                     '/': {
-                        permalink: '/:slug/'
+                        permalink: '/{slug}/'
                     }
                 },
 

--- a/ghost/core/test/unit/frontend/services/routing/collection-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/collection-router.test.js
@@ -73,6 +73,17 @@ describe('UNIT - services/routing/CollectionRouter', function () {
             assert.equal(mountRouterSpy.args[0][1], collectionRouter.rssRouter.router());
         });
 
+        it('converts a domain {slug} permalink to :slug notation', function () {
+            const collectionRouter = new CollectionRouter('/', {permalink: '/{primary_tag}/{slug}/'}, RESOURCE_CONFIG, routerCreatedSpy);
+
+            // the router owns the {slug} -> :slug conversion via the permalink adapter
+            assert.equal(collectionRouter.getPermalinks().getValue(), '/:primary_tag/:slug/');
+
+            // and the express routes are mounted with :slug
+            assert.equal(mountRouteSpy.args[2][0], '/:primary_tag/:slug/:options(edit)?/');
+            assert.equal(mountRouteSpy.args[3][0], '/:primary_tag/:slug.md');
+        });
+
         it('router name', function () {
             const collectionRouter1 = new CollectionRouter('/', {permalink: '/:slug/'}, RESOURCE_CONFIG, routerCreatedSpy);
             const collectionRouter2 = new CollectionRouter('/podcast/', {permalink: '/:slug/'}, RESOURCE_CONFIG, routerCreatedSpy);

--- a/ghost/core/test/unit/frontend/services/routing/permalink-adapter.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/permalink-adapter.test.js
@@ -1,0 +1,66 @@
+const assert = require('node:assert/strict');
+const {toExpressNotation, toDomainNotation} = require('../../../../../core/frontend/services/routing/permalink-adapter');
+
+describe('UNIT - services/routing/permalink-adapter', function () {
+    describe('toExpressNotation', function () {
+        it('converts a single {slug} placeholder to :slug', function () {
+            assert.equal(toExpressNotation('/{slug}/'), '/:slug/');
+        });
+
+        it('converts every placeholder in a multi-segment permalink', function () {
+            assert.equal(toExpressNotation('/{primary_tag}/{slug}/'), '/:primary_tag/:slug/');
+        });
+
+        it('handles date-style permalinks', function () {
+            assert.equal(toExpressNotation('/{year}/{month}/{slug}/'), '/:year/:month/:slug/');
+        });
+
+        it('converts placeholders adjacent to non-slash separators', function () {
+            assert.equal(toExpressNotation('/{year}-{month}-{day}-{slug}/'), '/:year-:month-:day-:slug/');
+        });
+
+        it('leaves a permalink with no placeholder untouched', function () {
+            assert.equal(toExpressNotation('/about/'), '/about/');
+        });
+
+        it('is idempotent — already-converted :slug notation is unchanged', function () {
+            assert.equal(toExpressNotation('/:slug/'), '/:slug/');
+            assert.equal(toExpressNotation('/:primary_tag/:slug/'), '/:primary_tag/:slug/');
+        });
+    });
+
+    describe('toDomainNotation', function () {
+        it('converts a single :slug placeholder to {slug}', function () {
+            assert.equal(toDomainNotation('/:slug/'), '/{slug}/');
+        });
+
+        it('converts every placeholder in a multi-segment permalink', function () {
+            assert.equal(toDomainNotation('/:primary_tag/:slug/'), '/{primary_tag}/{slug}/');
+        });
+
+        it('converts placeholders adjacent to non-slash separators', function () {
+            assert.equal(toDomainNotation('/:year-:month-:day-:slug/'), '/{year}-{month}-{day}-{slug}/');
+        });
+
+        it('leaves a permalink with no placeholder untouched', function () {
+            assert.equal(toDomainNotation('/about/'), '/about/');
+        });
+
+        it('is idempotent — already-converted {slug} notation is unchanged', function () {
+            assert.equal(toDomainNotation('/{slug}/'), '/{slug}/');
+            assert.equal(toDomainNotation('/{primary_tag}/{slug}/'), '/{primary_tag}/{slug}/');
+        });
+    });
+
+    describe('round-trip', function () {
+        it('domain → express → domain returns the original', function () {
+            const domain = '/{primary_tag}/{slug}/';
+            assert.equal(toDomainNotation(toExpressNotation(domain)), domain);
+        });
+
+        it('express → domain → express returns the original', function () {
+            const express = '/:primary_tag/:slug/';
+            assert.equal(toExpressNotation(toDomainNotation(express)), express);
+        });
+    });
+});

--- a/ghost/core/test/unit/frontend/services/routing/taxonomy-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/taxonomy-router.test.js
@@ -66,6 +66,17 @@ describe('UNIT - services/routing/TaxonomyRouter', function () {
         assert(taxonomyRouter.mountRoute.args[2][1].name.includes('_redirectEditOption'));
     });
 
+    it('converts a domain {slug} permalink to :slug notation', function () {
+        const taxonomyRouter = new TaxonomyRouter('tag', '/tag/{slug}/', {}, routerCreatedSpy);
+
+        // the router owns the {slug} -> :slug conversion via the permalink adapter
+        assert.equal(taxonomyRouter.getPermalinks().getValue(), '/tag/:slug/');
+
+        // and the express routes are mounted with :slug
+        assert.equal(taxonomyRouter.mountRoute.args[0][0], '/tag/:slug/');
+        assert.equal(taxonomyRouter.mountRoute.args[1][0], '/tag/:slug/page/:page(\\d+)');
+    });
+
     it('_prepareContext behaves as expected', function () {
         const taxonomyRouter = new TaxonomyRouter('tag', '/tag/:slug/', RESOURCE_CONFIG, routerCreatedSpy);
         taxonomyRouter._prepareContext(req, res, next);

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -39,7 +39,7 @@ describe('DB version integrity', function () {
     const currentSchemaHash = 'c0fe7246714201a82b75f80308d5e300';
     const currentFixturesHash = '065b413e1d1f4f95fa7cb7734c5e7934';
     const currentSettingsHash = '8650db85b9a61afe4797ad6333066c62';
-    const currentRoutesHash = '96a7d0955083bae3f79522b23a1d698d';
+    const currentRoutesHash = '66467df9cfcaf50e31649aa51e605491';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,
     // and the values above will need updating as confirmation

--- a/ghost/core/test/unit/server/services/route-settings/activation-bridge.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/activation-bridge.test.ts
@@ -25,8 +25,9 @@ describe('activation-bridge', function () {
 
         // Characterisation tests for the router-facing array output. Each item
         // carries its own `path`; routes use the domain `type`/`contentType`
-        // names; permalinks are already in `:slug` notation and `data` is still
-        // expanded to `{query, router}` (peeled off in later cleanup PRs).
+        // names; permalinks stay in domain `{slug}` notation (the routers convert
+        // to `:slug` via the permalink adapter) and `data` is still expanded to
+        // `{query, router}` (peeled off in later cleanup PRs).
         describe('produces the expected array output', function () {
             const cases: Array<{name: string; raw: unknown; expected: object}> = [
                 {
@@ -67,9 +68,9 @@ describe('activation-bridge', function () {
                     }
                 },
                 {
-                    name: 'collection with permalink converts {slug} to :slug',
+                    name: 'collection permalink stays in domain {slug} notation',
                     raw: {routes: {}, collections: {'/': {permalink: '/{slug}/', template: 'index'}}, taxonomies: {}},
-                    expected: {routes: [], collections: [{path: '/', permalink: '/:slug/', templates: ['index']}], taxonomies: []}
+                    expected: {routes: [], collections: [{path: '/', permalink: '/{slug}/', templates: ['index']}], taxonomies: []}
                 },
                 {
                     name: 'collection with filter and data',
@@ -78,7 +79,7 @@ describe('activation-bridge', function () {
                         routes: [],
                         collections: [{
                             path: '/podcast/',
-                            permalink: '/podcast/:slug/',
+                            permalink: '/podcast/{slug}/',
                             templates: ['podcast'],
                             data: {
                                 query: {tag: {controller: 'tagsPublic', type: 'read', resource: 'tags', options: {slug: 'podcast', visibility: 'public'}}},
@@ -90,9 +91,9 @@ describe('activation-bridge', function () {
                     }
                 },
                 {
-                    name: 'taxonomies become {key, permalink} entries in :slug notation',
+                    name: 'taxonomies become {key, permalink} entries in domain {slug} notation',
                     raw: {routes: {}, collections: {}, taxonomies: {tag: '/tag/{slug}/', author: '/author/{slug}/'}},
-                    expected: {routes: [], collections: [], taxonomies: [{key: 'tag', permalink: '/tag/:slug/'}, {key: 'author', permalink: '/author/:slug/'}]}
+                    expected: {routes: [], collections: [], taxonomies: [{key: 'tag', permalink: '/tag/{slug}/'}, {key: 'author', permalink: '/author/{slug}/'}]}
                 },
                 {
                     name: 'channel route copies order and limit',
@@ -102,7 +103,7 @@ describe('activation-bridge', function () {
                 {
                     name: 'collection copies order, limit and rss',
                     raw: {routes: {}, collections: {'/': {permalink: '/{slug}/', template: 'index', order: 'published_at asc', limit: 10, rss: false}}, taxonomies: {}},
-                    expected: {routes: [], collections: [{path: '/', permalink: '/:slug/', templates: ['index'], order: 'published_at asc', limit: 10, rss: false}], taxonomies: []}
+                    expected: {routes: [], collections: [{path: '/', permalink: '/{slug}/', templates: ['index'], order: 'published_at asc', limit: 10, rss: false}], taxonomies: []}
                 }
             ];
 

--- a/ghost/core/test/unit/server/services/route-settings/dynamic-routing-service.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/dynamic-routing-service.test.ts
@@ -52,8 +52,8 @@ describe('UNIT: DynamicRoutingService (store-backed)', function () {
         const expanded = await service.loadRouteSettings();
 
         assert.deepEqual(expanded.routes, [{path: '/about/', type: 'template', templates: ['about']}]);
-        assert.deepEqual(expanded.collections, [{path: '/', permalink: '/:slug/', templates: ['index']}]);
-        assert.deepEqual(expanded.taxonomies, [{key: 'tag', permalink: '/tag/:slug/'}]);
+        assert.deepEqual(expanded.collections, [{path: '/', permalink: '/{slug}/', templates: ['index']}]);
+        assert.deepEqual(expanded.taxonomies, [{key: 'tag', permalink: '/tag/{slug}/'}]);
     });
 
     describe('loadRouteSettings validation failure', function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1896

Third PR in the route-settings DDD cleanup (step 3.3). Stacked on #29617 (HKG-1895) — **base is `princi-hkg-1895-…`; retarget to `main` once that merges.**

## Summary

The activation bridge used to convert permalinks from the domain model's `{slug}` notation to Express/URL-service `:slug` notation eagerly, baking infrastructure notation into the router-facing data at the very edge of the server. This PR introduces the **Permalink Adapter** — the single named anti-corruption boundary where `{slug}` ↔ `:slug` translation happens — and moves the conversion to the routers that actually mount Express routes and register with the URL service.

Routing behaviour is **byte-identical**.

## What changed

- **`permalink-adapter.js`** (new) — `toExpressNotation('/{slug}/')` → `/:slug/` and `toDomainNotation('/:slug/')` → `/{slug}/`. Stateless helpers, both idempotent (an already-converted permalink passes through unchanged). `toExpressNotation` serves both Express route mounting and the URL service; `toDomainNotation` is the reverse for the download/serialize path (no production caller yet — wired up in HKG-1897).
- **`collection-router.js`, `taxonomy-router.js`** — call `toExpressNotation()` on the permalink at construction, so both `getPermalinks().getValue()` (URL service) and `mountRoute` (Express) read the converted value from one place.
- **`activation-bridge.ts`** — dropped `convertSlugsToColons`; collection and taxonomy permalinks now pass through in domain `{slug}` form. The remaining `data` → `{query, router}` expansion peels off in HKG-1897.

## Testing

- New `permalink-adapter.test.js` — both directions: single/multi/date/hyphen-adjacent placeholders, no-placeholder pass-through, idempotency, round-trip.
- `activation-bridge` + `dynamic-routing-service` (unit + integration) expectations updated to `{slug}` passthrough.
- Router unit suites gained `{slug}`-input cases proving the routers perform the conversion (assert `:slug` output + mounted routes).
- **`api-vs-frontend` behavioural suite: 60 passing** — proves routing output is byte-identical (fixtures now model the bridge's real `{slug}` output; they convert via the routers).
- **Integrity routes canary rehashed.** The default `routes.yaml` on disk is unchanged; only the bridge's normalised in-memory representation moved `:slug` → `{slug}`. Route settings are stored as verbatim YAML bytes and re-normalised on boot, so **no migration is required** — the canary hash is the only thing that needed updating.
- `pnpm lint` (incl. `tsc --noEmit`) + dependency-cruiser clean. 260 unit + 65 DB-backed tests green.
