### PR TITLE
Added warning modal before publishing with ineffective free preview

### DIFF
--- a/apps/ember-admin/app/components/editor/modals/public-preview-warning.hbs
+++ b/apps/ember-admin/app/components/editor/modals/public-preview-warning.hbs
@@ -1,0 +1,31 @@
+<div
+    class="modal-content gh-tk-reminder"
+    data-test-modal="public-preview-warning"
+    data-testid={{concat "public-preview-warning-" @data.warning}}
+>
+    <header class="modal-header">
+        {{#if (eq @data.warning "no-content-before")}}
+            <h1>Nothing above the public preview</h1>
+        {{else if (eq @data.warning "no-content-after")}}
+            <h1>Nothing below the public preview</h1>
+        {{else}}
+            <h1>Public preview has no effect</h1>
+        {{/if}}
+    </header>
+    <button type="button" class="close" title="Close" {{on "click" @close}}>{{svg-jar "close"}}<span class="hidden">Close</span></button>
+
+    <div class="modal-body">
+        {{#if (eq @data.warning "no-content-before")}}
+            <p>Add some content above the public preview so everyone has something to read before the paywall.</p>
+        {{else if (eq @data.warning "no-content-after")}}
+            <p>Add some content below the public preview for subscribers who have access to the full post.</p>
+        {{else}}
+            <p>This post is public, so everyone can read the full post and the public preview won’t have any effect.</p>
+        {{/if}}
+    </div>
+
+    <div class="modal-footer">
+        <button type="button" class="gh-btn" {{on "click" (fn @close true)}} data-test-button="continue-with-public-preview-warning"><span>Continue to publish</span></button>
+        <button type="button" class="gh-btn gh-btn-black" {{on "click" @close}} data-test-button="back-to-editor"><span>Back to editor</span></button>
+    </div>
+</div>

--- a/apps/ember-admin/app/components/editor/publish-management.js
+++ b/apps/ember-admin/app/components/editor/publish-management.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import EmailFailedError from 'ghost-admin/errors/email-failed-error';
 import PreviewModal from './modals/preview';
+import PublicPreviewWarningModal from './modals/public-preview-warning';
 import PublishFlowModal from './modals/publish-flow';
 import PublishOptionsResource from 'ghost-admin/helpers/publish-options';
 import TkReminderModal from './modals/tk-reminder';
@@ -59,6 +60,14 @@ export default class PublishManagement extends Component {
             });
 
             if (ignoreTks !== true) {
+                return;
+            }
+        } else if (isValid && this.feature.paywallImprovements && this.publishOptions.publicPreviewWarning) {
+            const ignorePublicPreviewWarning = await this.modals.open(PublicPreviewWarningModal, {
+                warning: this.publishOptions.publicPreviewWarning
+            });
+
+            if (ignorePublicPreviewWarning !== true) {
                 return;
             }
         }

--- a/apps/ember-admin/app/templates/lexical-editor.hbs
+++ b/apps/ember-admin/app/templates/lexical-editor.hbs
@@ -115,6 +115,7 @@
                 <Editor::PublishManagement
                     @post={{this.post}}
                     @hasUnsavedChanges={{this.hasDirtyAttributes}}
+                    @tkCount={{this.tkCount}}
                     @beforePublish={{perform this.beforeSaveTask}}
                     @afterPublish={{this.afterSave}}
                     @saveTask={{this.saveTask}}

--- a/apps/ember-admin/app/utils/public-preview-warning.js
+++ b/apps/ember-admin/app/utils/public-preview-warning.js
@@ -1,0 +1,64 @@
+const PUBLIC_ACCESS = 'public-access';
+const NO_CONTENT_BEFORE = 'no-content-before';
+const NO_CONTENT_AFTER = 'no-content-after';
+
+function parseLexicalState(lexical) {
+    if (!lexical) {
+        return null;
+    }
+
+    try {
+        return typeof lexical === 'string' ? JSON.parse(lexical) : lexical;
+    } catch {
+        return null;
+    }
+}
+
+function lexicalNodeHasContent(node) {
+    if (!node || node.type === 'paywall' || node.type === 'linebreak') {
+        return false;
+    }
+
+    if (typeof node.text === 'string') {
+        return !!node.text.trim();
+    }
+
+    if (node.type === 'text' || node.type === 'extended-text') {
+        return false;
+    }
+
+    if (Array.isArray(node.children)) {
+        return node.children.some(lexicalNodeHasContent);
+    }
+
+    return node.type !== 'paragraph' && node.type !== 'root';
+}
+
+export function getPublicPreviewWarning(post) {
+    const state = parseLexicalState(post.lexicalScratch || post.lexical);
+    const children = state?.root?.children;
+
+    if (!Array.isArray(children)) {
+        return null;
+    }
+
+    const publicPreviewIndex = children.findIndex(node => node?.type === 'paywall');
+
+    if (publicPreviewIndex === -1) {
+        return null;
+    }
+
+    if (post.visibility === 'public') {
+        return PUBLIC_ACCESS;
+    }
+
+    if (!children.slice(0, publicPreviewIndex).some(lexicalNodeHasContent)) {
+        return NO_CONTENT_BEFORE;
+    }
+
+    if (!children.slice(publicPreviewIndex + 1).some(lexicalNodeHasContent)) {
+        return NO_CONTENT_AFTER;
+    }
+
+    return null;
+}

--- a/apps/ember-admin/app/utils/publish-options.js
+++ b/apps/ember-admin/app/utils/publish-options.js
@@ -1,5 +1,6 @@
 import moment from 'moment-timezone';
 import {action} from '@ember/object';
+import {getPublicPreviewWarning} from 'ghost-admin/utils/public-preview-warning';
 import {htmlSafe} from '@ember/template';
 import {task} from 'ember-concurrency';
 import {tracked} from '@glimmer/tracking';
@@ -44,6 +45,10 @@ export default class PublishOptions {
 
     get willOnlyEmail() {
         return this.publishType === 'send';
+    }
+
+    get publicPreviewWarning() {
+        return getPublicPreviewWarning(this.post);
     }
 
     // publish date ------------------------------------------------------------

--- a/apps/ember-admin/tests/acceptance/editor/publish-flow-test.js
+++ b/apps/ember-admin/tests/acceptance/editor/publish-flow-test.js
@@ -1,16 +1,37 @@
 import loginAsRole from '../../helpers/login-as-role';
 import moment from 'moment-timezone';
-import {blur, click, fillIn, find, findAll, waitFor} from '@ember/test-helpers';
+import {blur, click, fillIn, find, findAll, triggerEvent, waitFor} from '@ember/test-helpers';
 import {cleanupMockAnalyticsApps, mockAnalyticsApps} from '../../helpers/mock-analytics-apps';
 import {clickTrigger, removeMultipleOption, selectChoose} from 'ember-power-select/test-support/helpers';
 import {disableMailgun, enableMailgun} from '../../helpers/mailgun';
 import {disableMembers, enableMembers} from '../../helpers/members';
 import {disableNewsletters, enableNewsletters} from '../../helpers/newsletters';
+import {enableLabsFlag} from '../../helpers/labs-flag';
 import {enableStripe} from '../../helpers/stripe';
 import {expect} from 'chai';
 import {setupApplicationTest} from 'ember-mocha';
 import {setupMirage} from 'ember-cli-mirage/test-support';
 import {visit} from '../../helpers/visit';
+
+function lexicalParagraph(text) {
+    return {
+        children: text ? [{text, type: 'extended-text'}] : [],
+        type: 'paragraph'
+    };
+}
+
+function lexicalWithPublicPreview({before = 'Public preview content', after = 'Full post content'} = {}) {
+    return JSON.stringify({
+        root: {
+            children: [
+                lexicalParagraph(before),
+                {type: 'paywall'},
+                lexicalParagraph(after)
+            ],
+            type: 'root'
+        }
+    });
+}
 
 describe('Acceptance: Publish flow', function () {
     let hooks = setupApplicationTest();
@@ -67,6 +88,99 @@ describe('Acceptance: Publish flow', function () {
         await visit(`/editor/post/${post.id}`);
 
         expect(search.isContentStale).to.be.false;
+    });
+
+    describe('public preview warnings', function () {
+        beforeEach(async function () {
+            enableLabsFlag(this.server, 'paywallImprovements');
+            await loginAsRole('Administrator', this.server);
+        });
+
+        it('warns when a public post contains a public preview', async function () {
+            const post = this.server.create('post', {
+                lexical: lexicalWithPublicPreview(),
+                status: 'draft',
+                visibility: 'public'
+            });
+
+            await visit(`/editor/post/${post.id}`);
+            await click('[data-test-button="publish-flow"]');
+
+            expect(find('[data-testid="public-preview-warning-public-access"]')).to.exist;
+        });
+
+        it('warns when there is no content above the public preview', async function () {
+            const post = this.server.create('post', {
+                lexical: lexicalWithPublicPreview({before: ''}),
+                status: 'draft',
+                visibility: 'paid'
+            });
+
+            await visit(`/editor/post/${post.id}`);
+            await click('[data-test-button="publish-flow"]');
+
+            expect(find('[data-testid="public-preview-warning-no-content-before"]')).to.exist;
+
+            await click('[data-test-button="continue-with-public-preview-warning"]');
+
+            expect(find('[data-test-modal="public-preview-warning"]')).to.not.exist;
+            expect(find('[data-test-publish-flow="options"]')).to.exist;
+        });
+
+        it('warns when there is no content below the public preview', async function () {
+            const post = this.server.create('post', {
+                lexical: lexicalWithPublicPreview({after: ''}),
+                status: 'draft',
+                visibility: 'members'
+            });
+
+            await visit(`/editor/post/${post.id}`);
+            await click('[data-test-button="publish-flow"]');
+
+            expect(find('[data-testid="public-preview-warning-no-content-after"]')).to.exist;
+
+            await click('[data-test-button="back-to-editor"]');
+
+            expect(find('[data-test-modal="public-preview-warning"]')).to.not.exist;
+            expect(find('[data-test-modal="publish-flow"]')).to.not.exist;
+        });
+
+        it('shows only the TK warning from the mobile publish flow when both warning types apply', async function () {
+            const post = this.server.create('post', {
+                lexical: lexicalWithPublicPreview(),
+                status: 'draft',
+                visibility: 'public'
+            });
+
+            await visit(`/editor/post/${post.id}`);
+            await fillIn('[data-test-editor-title-input]', 'Draft with TK placeholder');
+            await triggerEvent('.gh-editor-mobile-menu [data-test-button="publish-flow"]', 'click');
+
+            expect(find('[data-test-modal="tk-reminder"]')).to.exist;
+            expect(find('[data-test-modal="public-preview-warning"]')).to.not.exist;
+
+            await click('[data-test-modal="tk-reminder"] .modal-footer .gh-btn:not(.gh-btn-black)');
+
+            expect(find('[data-test-modal="tk-reminder"]')).to.not.exist;
+            expect(find('[data-test-modal="public-preview-warning"]')).to.not.exist;
+            expect(find('[data-test-publish-flow="options"]')).to.exist;
+        });
+    });
+
+    it('does not warn about public previews when paywall improvements are disabled', async function () {
+        await loginAsRole('Administrator', this.server);
+
+        const post = this.server.create('post', {
+            lexical: lexicalWithPublicPreview(),
+            status: 'draft',
+            visibility: 'public'
+        });
+
+        await visit(`/editor/post/${post.id}`);
+        await click('[data-test-button="publish-flow"]');
+
+        expect(find('[data-test-modal="public-preview-warning"]')).to.not.exist;
+        expect(find('[data-test-publish-flow="options"]')).to.exist;
     });
 
     it('handles timezones correctly when scheduling');

--- a/apps/ember-admin/tests/unit/utils/public-preview-warning-test.js
+++ b/apps/ember-admin/tests/unit/utils/public-preview-warning-test.js
@@ -1,0 +1,103 @@
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {getPublicPreviewWarning} from 'ghost-admin/utils/public-preview-warning';
+
+function paragraph(text = '', type = 'extended-text') {
+    return {
+        children: text ? [{text, type}] : [],
+        type: 'paragraph'
+    };
+}
+
+function lexicalWithPublicPreview({
+    before = [paragraph('Public preview content')],
+    after = [paragraph('Full post content')]
+} = {}) {
+    return JSON.stringify({
+        root: {
+            children: [
+                ...before,
+                {type: 'paywall'},
+                ...after
+            ],
+            type: 'root'
+        }
+    });
+}
+
+describe('Unit: Util: public-preview-warning', function () {
+    it('returns no warning without a valid public preview', function () {
+        expect(getPublicPreviewWarning({
+            lexical: null,
+            visibility: 'paid'
+        })).to.be.null;
+
+        expect(getPublicPreviewWarning({
+            lexical: '{not-valid-json',
+            visibility: 'paid'
+        })).to.be.null;
+
+        expect(getPublicPreviewWarning({
+            lexical: JSON.stringify({root: {children: [paragraph('Post content')]}}),
+            visibility: 'paid'
+        })).to.be.null;
+    });
+
+    it('warns for public access before checking surrounding content', function () {
+        expect(getPublicPreviewWarning({
+            lexical: lexicalWithPublicPreview({before: [], after: []}),
+            visibility: 'public'
+        })).to.equal('public-access');
+    });
+
+    it('warns when there is no meaningful content above the public preview', function () {
+        expect(getPublicPreviewWarning({
+            lexical: lexicalWithPublicPreview({
+                before: [
+                    paragraph(),
+                    paragraph('   '),
+                    {type: 'linebreak'}
+                ]
+            }),
+            visibility: 'paid'
+        })).to.equal('no-content-before');
+    });
+
+    it('warns when there is no meaningful content below the public preview', function () {
+        expect(getPublicPreviewWarning({
+            lexical: lexicalWithPublicPreview({
+                after: [
+                    paragraph(),
+                    paragraph('\n\t', 'text'),
+                    {type: 'linebreak'}
+                ]
+            }),
+            visibility: 'members'
+        })).to.equal('no-content-after');
+    });
+
+    it('prioritizes missing content above when both sides are empty', function () {
+        expect(getPublicPreviewWarning({
+            lexical: lexicalWithPublicPreview({before: [], after: []}),
+            visibility: 'paid'
+        })).to.equal('no-content-before');
+    });
+
+    it('counts visible non-text cards as content', function () {
+        expect(getPublicPreviewWarning({
+            lexical: lexicalWithPublicPreview({
+                before: [{src: 'https://example.com/image.jpg', type: 'image'}],
+                after: [{url: 'https://example.com/video', type: 'embed'}]
+            }),
+            visibility: 'paid'
+        })).to.be.null;
+    });
+
+    it('uses unsaved lexical scratch state when available', function () {
+        expect(getPublicPreviewWarning({
+            lexical: lexicalWithPublicPreview(),
+            lexicalScratch: lexicalWithPublicPreview({before: []}),
+            visibility: 'paid'
+        })).to.equal('no-content-before');
+    });
+});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3827/

Authors could publish and email posts where the public preview silently exposes no useful preview or gated content. Added modal warning for the "invalid" preview cases when opening the publish flow modal.

Invalid cases:
- public preview (paywall) card has been added but post is set to public
- preview card is at the beginning of the post meaning an empty email could be sent
- preview card is at end of the post meaning all content is public

If TKs exist in the post that warning modal always takes precedence over an invalid paywall so we don't show multiple/consecutive warning modals.