### PR TITLE
Populated automation recipient click timestamps and counts

### DIFF
--- a/ghost/core/core/server/services/automations/automations-api.ts
+++ b/ghost/core/core/server/services/automations/automations-api.ts
@@ -375,3 +375,9 @@ export async function trackEmailDeliveredAndOpened(
 ) {
     return await repository.trackEmailDeliveredAndOpened(...args);
 }
+
+export async function trackEmailClicked(
+    ...args: Parameters<AutomationsRepository['trackEmailClicked']>
+) {
+    await repository.trackEmailClicked(...args);
+}

--- a/ghost/core/core/server/services/automations/automations-repository.ts
+++ b/ghost/core/core/server/services/automations/automations-repository.ts
@@ -1,4 +1,5 @@
 import type {ReadonlyDeep} from 'type-fest';
+import type {Knex} from 'knex';
 
 export interface Pagination {
     page: number;
@@ -195,4 +196,15 @@ export interface AutomationsRepository {
     trackEmailDeliveredAndOpened(
         eventsByAutomatedEmailRecipientId: ReadonlyDeep<Map<string, AutomatedEmailEvents>>
     ): Promise<void>;
+    /**
+     * Track the first click for an automated email recipient.
+     *
+     */
+    trackEmailClicked(options: {
+        automationActionRevisionId: string;
+        memberId: string;
+        clickedAt: Readonly<Date>;
+    }, transactionOptions?: {
+        transacting?: Knex.Transaction;
+    }): Promise<void>;
 }

--- a/ghost/core/core/server/services/automations/database-automations-repository.ts
+++ b/ghost/core/core/server/services/automations/database-automations-repository.ts
@@ -307,6 +307,50 @@ export function createDatabaseAutomationsRepository({
                         });
                 }
             });
+        },
+
+        async trackEmailClicked({automationActionRevisionId, memberId, clickedAt}, {transacting} = {}) {
+            const trackClick = async (trx: Knex.Transaction) => {
+                const recipient = await trx('automated_email_recipients')
+                    .select('id', 'clicked_at')
+                    .where({
+                        automation_action_revision_id: automationActionRevisionId,
+                        member_id: memberId,
+                        track_clicks: true
+                    })
+                    .where('created_at', '<=', toDatabaseDate(clickedAt))
+                    .orderBy('created_at', 'desc')
+                    .orderBy('id', 'desc')
+                    .forUpdate()
+                    .first();
+
+                if (!recipient || recipient.clicked_at !== null) {
+                    return;
+                }
+
+                const updated = await trx('automated_email_recipients')
+                    .where({id: recipient.id})
+                    .whereNull('clicked_at')
+                    .update({clicked_at: clickedAt});
+
+                if (updated === 0) {
+                    return;
+                }
+
+                await trx('automation_action_revisions')
+                    .where({id: automationActionRevisionId})
+                    .update({
+                        email_clicked_count: trx.raw('COALESCE(email_clicked_count, 0) + 1')
+                    });
+
+            };
+
+            if (transacting) {
+                await trackClick(transacting);
+                return;
+            }
+
+            await knex.transaction(trackClick);
         }
     };
 }

--- a/ghost/core/core/server/services/automations/database-automations-repository.ts
+++ b/ghost/core/core/server/services/automations/database-automations-repository.ts
@@ -311,6 +311,13 @@ export function createDatabaseAutomationsRepository({
 
         async trackEmailClicked({automationActionRevisionId, memberId, clickedAt}, {transacting} = {}) {
             const trackClick = async (trx: Knex.Transaction) => {
+                // Match recordEmailSent's lock order to avoid deadlocks.
+                await trx('automation_action_revisions')
+                    .select('id')
+                    .where({id: automationActionRevisionId})
+                    .forUpdate()
+                    .first();
+
                 const recipient = await trx('automated_email_recipients')
                     .select('id', 'clicked_at')
                     .where({

--- a/ghost/core/core/server/services/link-tracking/click-event.js
+++ b/ghost/core/core/server/services/link-tracking/click-event.js
@@ -7,6 +7,8 @@ module.exports = class ClickEvent {
     member_uuid;
     /** @type {ObjectID} */
     link_id;
+    /** @type {Date | undefined} */
+    timestamp;
 
     constructor(data) {
         if (!data.id) {
@@ -21,5 +23,6 @@ module.exports = class ClickEvent {
 
         this.member_uuid = data.member_uuid;
         this.link_id = data.link_id;
+        this.timestamp = data.timestamp;
     }
 };

--- a/ghost/core/core/server/services/link-tracking/index.js
+++ b/ghost/core/core/server/services/link-tracking/index.js
@@ -5,6 +5,13 @@ const urlUtils = require('../../../shared/url-utils').default;
 
 class LinkTrackingServiceWrapper {
     #initPromise;
+    #automationsApi;
+
+    constructor({
+        automationsApi = require('../automations/automations-api')
+    } = {}) {
+        this.#automationsApi = automationsApi;
+    }
 
     async init() {
         if (this.service) {
@@ -57,7 +64,9 @@ class LinkTrackingServiceWrapper {
             linkClickRepository,
             postLinkRepository,
             DomainEvents,
-            urlUtils
+            urlUtils,
+            automationsApi: this.#automationsApi,
+            runInTransaction: callback => models.Base.transaction(callback)
         });
 
         await service.init();

--- a/ghost/core/core/server/services/link-tracking/link-click-repository.js
+++ b/ghost/core/core/server/services/link-tracking/link-click-repository.js
@@ -92,7 +92,11 @@ module.exports = class LinkClickRepository {
 
         if (options.transacting) {
             options.transacting.executionPromise.then(() => {
-                this.#DomainEvents.dispatch(event);
+                try {
+                    this.#DomainEvents.dispatch(event);
+                } catch (error) {
+                    sentry.captureException(error);
+                }
             }, () => undefined);
         } else {
             this.#DomainEvents.dispatch(event);

--- a/ghost/core/core/server/services/link-tracking/link-click-repository.js
+++ b/ghost/core/core/server/services/link-tracking/link-click-repository.js
@@ -31,8 +31,8 @@ module.exports = class LinkClickRepository {
         this.#DomainEvents = deps.DomainEvents;
 
         // Memoize the findOne function
-        this.memoizedFindOne = _.memoize(async (uuid) => {
-            return await this.#Member.findOne({uuid});
+        this.memoizedFindOne = _.memoize(async (uuid, options) => {
+            return await this.#Member.findOne({uuid}, options);
         });
     }
 
@@ -60,11 +60,12 @@ module.exports = class LinkClickRepository {
      */
     async save(linkClick, options = {}) {
         let member;
+        const memberLookupOptions = options.transacting ? {transacting: options.transacting} : undefined;
 
         if (config && config.get('linkClickTrackingCacheMemberUuid')) {
-            member = await this.memoizedFindOne(linkClick.member_uuid);
+            member = await this.memoizedFindOne(linkClick.member_uuid, memberLookupOptions);
         } else {
-            member = await this.#Member.findOne({uuid: linkClick.member_uuid});
+            member = await this.#Member.findOne({uuid: linkClick.member_uuid}, memberLookupOptions);
         }
 
         if (!member) {

--- a/ghost/core/core/server/services/link-tracking/link-click-repository.js
+++ b/ghost/core/core/server/services/link-tracking/link-click-repository.js
@@ -54,9 +54,11 @@ module.exports = class LinkClickRepository {
 
     /**
      * @param {LinkClick} linkClick
-     * @returns {Promise<void>}
+     * @param {object} [options]
+     * @param {object} [options.transacting]
+     * @returns {Promise<string | undefined>}
      */
-    async save(linkClick) {
+    async save(linkClick, options = {}) {
         let member;
 
         if (config && config.get('linkClickTrackingCacheMemberUuid')) {
@@ -76,11 +78,25 @@ module.exports = class LinkClickRepository {
             // Only store the pathname (no support for variable query strings)
             redirect_id: linkClick.link_id.toHexString(),
             member_id: member.id
-        }, {});
+        }, options);
 
         linkClick.event_id = ObjectID.createFromHexString(model.id);
+        const timestamp = linkClick.timestamp ?? new Date();
 
-        // Dispatch event
-        this.#DomainEvents.dispatch(this.#MemberLinkClickEvent.create({memberId: member.id, memberLastSeenAt: member.get('last_seen_at'), linkId: linkClick.link_id.toHexString()}, new Date()));
+        const event = this.#MemberLinkClickEvent.create({
+            memberId: member.id,
+            memberLastSeenAt: member.get('last_seen_at'),
+            linkId: linkClick.link_id.toHexString()
+        }, timestamp);
+
+        if (options.transacting) {
+            options.transacting.executionPromise.then(() => {
+                this.#DomainEvents.dispatch(event);
+            }, () => undefined);
+        } else {
+            this.#DomainEvents.dispatch(event);
+        }
+
+        return member.id;
     }
 };

--- a/ghost/core/core/server/services/link-tracking/link-click-tracking-service.js
+++ b/ghost/core/core/server/services/link-tracking/link-click-tracking-service.js
@@ -10,7 +10,7 @@ const moment = require('moment');
 
 /**
  * @typedef {object} ILinkClickRepository
- * @prop {(event: LinkClick) => Promise<void>} save
+ * @prop {(event: LinkClick, options?: {transacting?: object}) => Promise<string | undefined>} save
  * @prop {({filter: string}) => Promise<LinkClick[]>} getAll
  */
 
@@ -61,6 +61,10 @@ class LinkClickTrackingService {
     #LinkRedirect;
     /** @type {Object} */
     #urlUtils;
+    /** @type {object} */
+    #automationsApi;
+    /** @type {(callback: (transacting: object) => Promise<void>) => Promise<void>} */
+    #runInTransaction;
 
     /**
      * @param {object} deps
@@ -69,6 +73,8 @@ class LinkClickTrackingService {
      * @param {IPostLinkRepository} deps.postLinkRepository
      * @param {DomainEvents} deps.DomainEvents
      * @param {urlUtils} deps.urlUtils
+     * @param {object} deps.automationsApi
+     * @param {(callback: (transacting: object) => Promise<void>) => Promise<void>} deps.runInTransaction
      */
     constructor(deps) {
         this.#linkClickRepository = deps.linkClickRepository;
@@ -76,6 +82,8 @@ class LinkClickTrackingService {
         this.#postLinkRepository = deps.postLinkRepository;
         this.#DomainEvents = deps.DomainEvents;
         this.#urlUtils = deps.urlUtils;
+        this.#automationsApi = deps.automationsApi;
+        this.#runInTransaction = deps.runInTransaction;
     }
 
     async init() {
@@ -256,9 +264,28 @@ class LinkClickTrackingService {
 
             const click = new LinkClick({
                 member_uuid: uuid,
-                link_id: event.data.link.link_id
+                link_id: event.data.link.link_id,
+                timestamp: event.timestamp
             });
-            await this.#linkClickRepository.save(click);
+
+            const automationActionRevisionId = event.data.link.automationActionRevisionId;
+            if (!automationActionRevisionId) {
+                await this.#linkClickRepository.save(click);
+                return;
+            }
+
+            await this.#runInTransaction(async (transacting) => {
+                const memberId = await this.#linkClickRepository.save(click, {transacting});
+                if (!memberId) {
+                    return;
+                }
+
+                await this.#automationsApi.trackEmailClicked({
+                    automationActionRevisionId,
+                    memberId,
+                    clickedAt: event.timestamp
+                }, {transacting});
+            });
         });
     }
 }

--- a/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
+++ b/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
@@ -2080,6 +2080,189 @@ describe('automations repository', function () {
         });
     });
 
+    describe('trackEmailClicked', function () {
+        const FIRST_CLICK = new Date('2026-01-01T00:00:00.000Z');
+        const LATER_CLICK = new Date('2026-02-02T00:00:00.000Z');
+        const EARLIER_DELIVERY = new Date('2025-11-01T00:00:00.000Z');
+        const LATER_DELIVERY = new Date('2025-12-01T00:00:00.000Z');
+
+        let firstRevisionId: string;
+        let secondRevisionId: string;
+
+        const insertRecipient = async ({
+            id,
+            revisionId = firstRevisionId,
+            memberId = 'member-id',
+            trackClicks = true,
+            createdAt = EARLIER_DELIVERY
+        }: {
+            id: string;
+            revisionId?: string;
+            memberId?: string;
+            trackClicks?: boolean;
+            createdAt?: Date;
+        }): Promise<void> => {
+            await knex('automated_email_recipients').insert({
+                id,
+                automation_action_revision_id: revisionId,
+                member_id: memberId,
+                track_clicks: trackClicks,
+                created_at: toDatabaseDate(createdAt)
+            });
+        };
+
+        const trackClick = async ({
+            memberId = 'member-id',
+            clickedAt = FIRST_CLICK
+        }: {
+            memberId?: string;
+            clickedAt?: Date;
+        } = {}): Promise<void> => {
+            await repo.trackEmailClicked({
+                automationActionRevisionId: firstRevisionId,
+                memberId,
+                clickedAt
+            });
+        };
+
+        const getClickedAt = async (id: string): Promise<Date | null> => {
+            const row = await knex('automated_email_recipients')
+                .select('clicked_at')
+                .where({id})
+                .first();
+            assert(row, 'Expected recipient to exist');
+            return row.clicked_at === null ? null : new Date(row.clicked_at as number);
+        };
+
+        const getClickedCount = async (revisionId: string): Promise<number | null> => {
+            const row = await knex('automation_action_revisions')
+                .select('email_clicked_count')
+                .where({id: revisionId})
+                .first();
+            assert(row, 'Expected revision to exist');
+            return row.email_clicked_count;
+        };
+
+        beforeEach(async function () {
+            const revisions = await knex('automation_action_revisions')
+                .select('id')
+                .orderBy('id')
+                .limit(2);
+            const [firstRevision, secondRevision] = revisions;
+            assert(firstRevision);
+            assert(secondRevision);
+            firstRevisionId = firstRevision.id;
+            secondRevisionId = secondRevision.id;
+
+            await insertRecipient({id: 'tracked-recipient'});
+        });
+
+        it('records the first click and increments the click count', async function () {
+            await trackClick();
+
+            assert.deepEqual(await getClickedAt('tracked-recipient'), FIRST_CLICK);
+            assert.equal(await getClickedCount(firstRevisionId), 1);
+        });
+
+        it('does not update recipients for another member or revision', async function () {
+            await insertRecipient({
+                id: 'other-member-recipient',
+                memberId: 'other-member-id'
+            });
+            await insertRecipient({
+                id: 'other-revision-recipient',
+                revisionId: secondRevisionId
+            });
+
+            await trackClick();
+
+            assert.deepEqual(await getClickedAt('tracked-recipient'), FIRST_CLICK);
+            assert.equal(await getClickedAt('other-member-recipient'), null);
+            assert.equal(await getClickedAt('other-revision-recipient'), null);
+            assert.equal(await getClickedCount(secondRevisionId), null);
+        });
+
+        it('keeps the first click timestamp on subsequent clicks', async function () {
+            await trackClick();
+            await trackClick({clickedAt: LATER_CLICK});
+
+            assert.deepEqual(await getClickedAt('tracked-recipient'), FIRST_CLICK);
+            assert.equal(await getClickedCount(firstRevisionId), 1);
+        });
+
+        it('increments an existing click count', async function () {
+            await knex('automation_action_revisions')
+                .where({id: firstRevisionId})
+                .update({email_clicked_count: 5});
+
+            await trackClick();
+
+            assert.equal(await getClickedCount(firstRevisionId), 6);
+        });
+
+        it('only tracks the most recent recipient when a member received the same revision more than once', async function () {
+            await insertRecipient({
+                id: 'other-delivery-recipient',
+                createdAt: LATER_DELIVERY
+            });
+
+            await trackClick();
+            await trackClick({clickedAt: LATER_CLICK});
+
+            assert.equal(await getClickedAt('tracked-recipient'), null);
+            assert.deepEqual(await getClickedAt('other-delivery-recipient'), FIRST_CLICK);
+            assert.equal(await getClickedCount(firstRevisionId), 1);
+        });
+
+        it('does not track clicks for recipients with tracking disabled', async function () {
+            await insertRecipient({
+                id: 'tracking-disabled-recipient',
+                memberId: 'disabled-member-id',
+                trackClicks: false
+            });
+            await trackClick({memberId: 'disabled-member-id'});
+
+            assert.equal(await getClickedAt('tracking-disabled-recipient'), null);
+            assert.equal(await getClickedCount(firstRevisionId), null);
+        });
+
+        it('rolls back the timestamp when incrementing the count fails', async function () {
+            await knex.raw(`
+                CREATE TRIGGER fail_email_clicked_count
+                BEFORE UPDATE OF email_clicked_count ON automation_action_revisions
+                BEGIN
+                    SELECT RAISE(FAIL, 'click count update failed');
+                END
+            `);
+
+            try {
+                await assert.rejects(trackClick(), /click count update failed/);
+            } finally {
+                await knex.raw('DROP TRIGGER fail_email_clicked_count');
+            }
+
+            assert.equal(await getClickedAt('tracked-recipient'), null);
+            assert.equal(await getClickedCount(firstRevisionId), null);
+        });
+
+        it('joins an existing transaction and rolls back both analytics updates with it', async function () {
+            const error = new Error('outer transaction failed');
+
+            await assert.rejects(knex.transaction(async (transacting) => {
+                await repo.trackEmailClicked({
+                    automationActionRevisionId: firstRevisionId,
+                    memberId: 'member-id',
+                    clickedAt: FIRST_CLICK
+                }, {transacting});
+
+                throw error;
+            }), error);
+
+            assert.equal(await getClickedAt('tracked-recipient'), null);
+            assert.equal(await getClickedCount(firstRevisionId), null);
+        });
+    });
+
     describe('trackEmailDeliveredAndOpened', function () {
         const EARLIER = new Date('2026-01-01T00:00:00.000Z');
         const LATER = new Date('2026-02-02T00:00:00.000Z');

--- a/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
+++ b/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
@@ -2164,6 +2164,29 @@ describe('automations repository', function () {
             assert.equal(await getClickedCount(firstRevisionId), 1);
         });
 
+        it('locks the action revision before selecting the recipient', async function () {
+            const queries: string[] = [];
+            const recordQuery = ({sql}: {sql: string}) => queries.push(sql);
+            knex.on('query', recordQuery);
+
+            try {
+                await trackClick();
+            } finally {
+                knex.off('query', recordQuery);
+            }
+
+            const revisionSelect = queries.findIndex(query => (
+                query.startsWith('select') && query.includes('automation_action_revisions')
+            ));
+            const recipientSelect = queries.findIndex(query => (
+                query.startsWith('select') && query.includes('automated_email_recipients')
+            ));
+
+            assert.notEqual(revisionSelect, -1);
+            assert.notEqual(recipientSelect, -1);
+            assert(revisionSelect < recipientSelect);
+        });
+
         it('does not update recipients for another member or revision', async function () {
             await insertRecipient({
                 id: 'other-member-recipient',

--- a/ghost/core/test/unit/server/services/link-tracking/index.test.ts
+++ b/ghost/core/test/unit/server/services/link-tracking/index.test.ts
@@ -1,11 +1,14 @@
 import assert from 'node:assert/strict';
 import sinon from 'sinon';
+import ObjectID from 'bson-objectid';
 
 const DomainEvents = require('@tryghost/domain-events');
 
+const models = require('../../../../../core/server/models');
 const linkRedirection = require('../../../../../core/server/services/link-redirection');
 const linkTracking = require('../../../../../core/server/services/link-tracking');
 const LinkClickTrackingService = require('../../../../../core/server/services/link-tracking/link-click-tracking-service');
+const RedirectEvent = require('../../../../../core/server/services/link-redirection/redirect-event');
 
 describe('LinkTrackingServiceWrapper', function () {
     const originalLinkRedirectionService = linkRedirection.service;
@@ -66,5 +69,53 @@ describe('LinkTrackingServiceWrapper', function () {
 
         sinon.assert.calledTwice(init);
         assert.ok(wrapper.service);
+    });
+
+    it('wires automation click persistence and analytics to the same transaction', async function () {
+        linkRedirection.service = {};
+        linkRedirection.linkRedirectRepository = {};
+
+        const subscribe = sinon.stub(DomainEvents, 'subscribe');
+        const member = {
+            id: 'member-id',
+            get: sinon.stub().returns(null)
+        };
+        sinon.stub(models.Member, 'findOne').resolves(member);
+        sinon.stub(models.MemberClickEvent, 'add').resolves({id: ObjectID().toHexString()});
+        const trackEmailClicked = sinon.stub().resolves();
+
+        const executionPromise = Promise.resolve();
+        const transacting = {executionPromise};
+        const transaction = sinon.stub(models.Base, 'transaction').callsFake(async (...args: unknown[]) => {
+            const callback = args[0] as (trx: typeof transacting) => Promise<unknown>;
+            return await callback(transacting);
+        });
+
+        const wrapper = new linkTracking.LinkTrackingServiceWrapper({
+            automationsApi: {trackEmailClicked}
+        });
+        await wrapper.init();
+
+        const subscriber = subscribe.firstCall.args[1];
+        const clickedAt = new Date('2026-07-29T12:34:56.000Z');
+        const linkId = ObjectID();
+        await subscriber(RedirectEvent.create({
+            url: new URL('https://example.com/destination?m=memberUuid'),
+            link: {
+                link_id: linkId,
+                automationActionRevisionId: 'revision-id'
+            }
+        }, clickedAt));
+
+        sinon.assert.calledOnce(transaction);
+        sinon.assert.calledOnceWithExactly(models.MemberClickEvent.add, {
+            redirect_id: linkId.toHexString(),
+            member_id: 'member-id'
+        }, {transacting});
+        sinon.assert.calledOnceWithExactly(trackEmailClicked, {
+            automationActionRevisionId: 'revision-id',
+            memberId: 'member-id',
+            clickedAt
+        }, {transacting});
     });
 });

--- a/ghost/core/test/unit/server/services/link-tracking/link-click-repository.test.js
+++ b/ghost/core/test/unit/server/services/link-tracking/link-click-repository.test.js
@@ -3,6 +3,7 @@ const assert = require('node:assert/strict');
 const ObjectID = require('bson-objectid').default;
 const createKnex = require('knex');
 const configUtils = require('../../../../utils/config-utils');
+const sentry = require('../../../../../core/shared/sentry');
 
 const LinkClickRepository = require('../../../../../core/server/services/link-tracking/link-click-repository');
 const LinkClick = require('../../../../../core/server/services/link-tracking/click-event');
@@ -188,6 +189,20 @@ describe('UNIT: LinkClickRepository class', function () {
             sinon.assert.calledOnceWithExactly(domainEventsStub.dispatch, event);
         });
 
+        it('should report dispatch failures after its transaction commits', async function () {
+            const error = new Error('dispatch failed');
+            const execution = deferred();
+            const transacting = {executionPromise: execution.promise};
+            const captureException = sinon.stub(sentry, 'captureException');
+            domainEventsStub.dispatch.throws(error);
+
+            await linkClickRepository.save(linkClicks[0], {transacting});
+            execution.resolve();
+            await execution.promise;
+
+            sinon.assert.calledOnceWithExactly(captureException, error);
+        });
+
         it('should not dispatch a member click event when its transaction rolls back', async function () {
             const error = new Error('transaction rolled back');
             const execution = deferred();
@@ -198,6 +213,13 @@ describe('UNIT: LinkClickRepository class', function () {
             await assert.rejects(execution.promise, error);
 
             sinon.assert.notCalled(domainEventsStub.dispatch);
+        });
+
+        it('should propagate dispatch failures without a transaction', async function () {
+            const error = new Error('dispatch failed');
+            domainEventsStub.dispatch.throws(error);
+
+            await assert.rejects(linkClickRepository.save(linkClicks[0]), error);
         });
 
         it('should not dispatch when saving the click fails', async function () {

--- a/ghost/core/test/unit/server/services/link-tracking/link-click-repository.test.js
+++ b/ghost/core/test/unit/server/services/link-tracking/link-click-repository.test.js
@@ -1,6 +1,7 @@
 const sinon = require('sinon');
 const assert = require('node:assert/strict');
 const ObjectID = require('bson-objectid').default;
+const createKnex = require('knex');
 const configUtils = require('../../../../utils/config-utils');
 
 const LinkClickRepository = require('../../../../../core/server/services/link-tracking/link-click-repository');
@@ -113,10 +114,64 @@ describe('UNIT: LinkClickRepository class', function () {
             const memberId = await linkClickRepository.save(linkClicks[0], {transacting});
 
             assert.equal(memberId, 'member-id');
+            sinon.assert.calledOnceWithExactly(memberStub.findOne, {
+                uuid: linkClicks[0].member_uuid
+            }, {transacting});
             sinon.assert.calledOnceWithExactly(memberLinkClickEventModelStub.add, {
                 redirect_id: linkClicks[0].link_id.toHexString(),
                 member_id: 'member-id'
             }, {transacting});
+        });
+
+        it('should reuse the transaction connection for the member lookup', async function () {
+            const database = createKnex({
+                client: 'better-sqlite3',
+                connection: {
+                    filename: ':memory:'
+                },
+                pool: {
+                    min: 1,
+                    max: 1
+                },
+                acquireConnectionTimeout: 100,
+                useNullAsDefault: true
+            });
+
+            try {
+                await database.schema.createTable('members', (table) => {
+                    table.text('id').primary();
+                    table.text('uuid').notNullable();
+                    table.text('last_seen_at');
+                });
+                await database('members').insert({
+                    id: 'member-id',
+                    uuid: linkClicks[0].member_uuid,
+                    last_seen_at: 'last-seen-at'
+                });
+
+                const Member = {
+                    async findOne(query, options = {}) {
+                        const queryBuilder = options.transacting || database;
+                        const row = await queryBuilder('members').where(query).first();
+                        return row ? {
+                            id: row.id,
+                            get: key => row[key]
+                        } : null;
+                    }
+                };
+                const repository = new LinkClickRepository({
+                    MemberLinkClickEventModel: memberLinkClickEventModelStub,
+                    Member,
+                    MemberLinkClickEvent: memberLinkClickEventStub,
+                    DomainEvents: domainEventsStub
+                });
+
+                await database.transaction(async (transacting) => {
+                    await repository.save(linkClicks[0], {transacting});
+                });
+            } finally {
+                await database.destroy();
+            }
         });
 
         it('should dispatch a member click event after its transaction commits', async function () {
@@ -165,10 +220,14 @@ describe('UNIT: LinkClickRepository class', function () {
 
         it('should use memoized findOne when cacheMemberUuidLinkClick is true', async function () {
             configUtils.set('linkClickTrackingCacheMemberUuid', true);
-            await linkClickRepository.save(linkClicks[0]);
-            sinon.assert.calledOnce(memberStub.findOne);
-            await linkClickRepository.save(linkClicks[1]);
-            sinon.assert.calledOnce(memberStub.findOne);
+            const transacting = {executionPromise: Promise.resolve()};
+
+            await linkClickRepository.save(linkClicks[0], {transacting});
+            await linkClickRepository.save(linkClicks[1], {transacting});
+
+            sinon.assert.calledOnceWithExactly(memberStub.findOne, {
+                uuid: linkClicks[0].member_uuid
+            }, {transacting});
         });
     });
 });

--- a/ghost/core/test/unit/server/services/link-tracking/link-click-repository.test.js
+++ b/ghost/core/test/unit/server/services/link-tracking/link-click-repository.test.js
@@ -1,9 +1,21 @@
 const sinon = require('sinon');
+const assert = require('node:assert/strict');
 const ObjectID = require('bson-objectid').default;
 const configUtils = require('../../../../utils/config-utils');
 
 const LinkClickRepository = require('../../../../../core/server/services/link-tracking/link-click-repository');
 const LinkClick = require('../../../../../core/server/services/link-tracking/click-event');
+
+function deferred() {
+    let resolve;
+    let reject;
+    const promise = new Promise((resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+    });
+
+    return {promise, resolve, reject};
+}
 
 const linkClicks = [
     new LinkClick({
@@ -22,18 +34,26 @@ describe('UNIT: LinkClickRepository class', function () {
     let memberLinkClickEventModelStub;
     let memberLinkClickEventStub;
     let domainEventsStub;
+    let member;
+    let event;
 
     beforeEach(function () {
+        member = {
+            id: 'member-id',
+            get: sinon.stub().returns('last-seen-at')
+        };
+        event = {};
+
         memberStub = {
-            findOne: sinon.stub()
+            findOne: sinon.stub().resolves(member)
         };
 
         memberLinkClickEventModelStub = {
-            add: sinon.stub()
+            add: sinon.stub().resolves({id: ObjectID().toHexString()})
         };
 
         memberLinkClickEventStub = {
-            create: sinon.stub()
+            create: sinon.stub().returns(event)
         };
 
         domainEventsStub = {
@@ -58,15 +78,6 @@ describe('UNIT: LinkClickRepository class', function () {
         });
 
         it('should save a link click event when member is found', async function () {
-            const member = {
-                id: 'member-id',
-                get: sinon.stub().returns('last-seen-at')
-            };
-
-            memberStub.findOne.resolves(member);
-            memberLinkClickEventModelStub.add.resolves({id: ObjectID().toHexString()});
-            // configStub.get.withArgs('linkClickTrackingCacheMemberUuid').returns(true);
-
             await linkClickRepository.save(linkClicks[0]);
 
             sinon.assert.calledOnce(memberStub.findOne);
@@ -79,6 +90,67 @@ describe('UNIT: LinkClickRepository class', function () {
             memberStub.findOne.resolves(null);
             await linkClickRepository.save(linkClicks[0]);
             sinon.assert.notCalled(memberLinkClickEventModelStub.add);
+            sinon.assert.notCalled(memberLinkClickEventStub.create);
+            sinon.assert.notCalled(domainEventsStub.dispatch);
+        });
+
+        it('should preserve the click timestamp when dispatching the member link click event', async function () {
+            const timestamp = new Date('2026-07-29T12:34:56.000Z');
+            const linkClick = new LinkClick({
+                link_id: linkClicks[0].link_id,
+                member_uuid: 'test-uuid',
+                timestamp
+            });
+
+            await linkClickRepository.save(linkClick);
+
+            assert.equal(memberLinkClickEventStub.create.firstCall.args[1], timestamp);
+        });
+
+        it('should use the supplied transaction and return the member ID', async function () {
+            const transacting = {executionPromise: Promise.resolve()};
+
+            const memberId = await linkClickRepository.save(linkClicks[0], {transacting});
+
+            assert.equal(memberId, 'member-id');
+            sinon.assert.calledOnceWithExactly(memberLinkClickEventModelStub.add, {
+                redirect_id: linkClicks[0].link_id.toHexString(),
+                member_id: 'member-id'
+            }, {transacting});
+        });
+
+        it('should dispatch a member click event after its transaction commits', async function () {
+            const execution = deferred();
+            const transacting = {executionPromise: execution.promise};
+
+            await linkClickRepository.save(linkClicks[0], {transacting});
+
+            sinon.assert.notCalled(domainEventsStub.dispatch);
+
+            execution.resolve();
+            await execution.promise;
+
+            sinon.assert.calledOnceWithExactly(domainEventsStub.dispatch, event);
+        });
+
+        it('should not dispatch a member click event when its transaction rolls back', async function () {
+            const error = new Error('transaction rolled back');
+            const execution = deferred();
+            const transacting = {executionPromise: execution.promise};
+
+            await linkClickRepository.save(linkClicks[0], {transacting});
+            execution.reject(error);
+            await assert.rejects(execution.promise, error);
+
+            sinon.assert.notCalled(domainEventsStub.dispatch);
+        });
+
+        it('should not dispatch when saving the click fails', async function () {
+            const error = new Error('insert failed');
+
+            memberLinkClickEventModelStub.add.rejects(error);
+
+            await assert.rejects(linkClickRepository.save(linkClicks[0]), error);
             sinon.assert.notCalled(memberLinkClickEventStub.create);
             sinon.assert.notCalled(domainEventsStub.dispatch);
         });

--- a/ghost/core/test/unit/server/services/link-tracking/link-click-tracking-service.test.js
+++ b/ghost/core/test/unit/server/services/link-tracking/link-click-tracking-service.test.js
@@ -142,56 +142,128 @@ describe('LinkClickTrackingService', function () {
     });
 
     describe('subscribe', function () {
-        it('Ignores redirects without a member id', async function () {
-            const event = RedirectEvent.create({
-                url: new URL('https://example.com/destination'),
-                link: {}
-            });
-            const save = sinon.stub().resolves();
+        const CLICKED_AT = new Date('2026-07-29T12:34:56.000Z');
+
+        let subscriber;
+        let save;
+        let trackEmailClicked;
+        let runInTransaction;
+        let transacting;
+
+        const createRedirectEvent = ({
+            memberUuid = 'memberUuid',
+            automationActionRevisionId,
+            linkId = new ObjectID(),
+            timestamp = CLICKED_AT
+        } = {}) => {
+            const url = new URL('https://example.com/destination');
+            if (memberUuid) {
+                url.searchParams.set('m', memberUuid);
+            }
+
+            return RedirectEvent.create({
+                url,
+                link: {
+                    link_id: linkId,
+                    ...(automationActionRevisionId ? {automationActionRevisionId} : {})
+                }
+            }, timestamp);
+        };
+
+        beforeEach(function () {
+            transacting = {};
+            save = sinon.stub().resolves('member-id');
+            trackEmailClicked = sinon.stub().resolves();
+            runInTransaction = sinon.stub().callsFake(callback => callback(transacting));
 
             const service = new LinkClickTrackingService({
                 DomainEvents: {
                     subscribe: (eventType, callback) => {
                         assert.equal(eventType, RedirectEvent);
-                        callback(event);
+                        subscriber = callback;
                     }
                 },
-                linkClickRepository: {
-                    save
-                }
+                linkClickRepository: {save},
+                automationsApi: {trackEmailClicked},
+                runInTransaction
             });
 
             service.subscribe();
+        });
+
+        it('Ignores redirects without a member id', async function () {
+            await subscriber(createRedirectEvent({memberUuid: null}));
+
             sinon.assert.notCalled(save);
         });
 
-        it('Tracks redirects with a member id', async function () {
+        it('Saves member clicks for newsletter redirects', async function () {
             const linkId = new ObjectID();
-            const event = RedirectEvent.create({
-                url: new URL('https://example.com/destination?m=memberId'),
-                link: {
-                    link_id: linkId
-                }
-            });
-            const save = sinon.stub().resolves();
-
-            const service = new LinkClickTrackingService({
-                DomainEvents: {
-                    subscribe: (eventType, callback) => {
-                        assert.equal(eventType, RedirectEvent);
-                        callback(event);
-                    }
-                },
-                linkClickRepository: {
-                    save
-                }
+            const event = createRedirectEvent({
+                memberUuid: 'memberId',
+                linkId
             });
 
-            service.subscribe();
-            sinon.assert.calledOnce(save);
+            await subscriber(event);
 
-            assert.equal(save.firstCall.args[0].member_uuid, 'memberId');
-            assert.equal(save.firstCall.args[0].link_id, linkId);
+            sinon.assert.calledOnceWithExactly(save, sinon.match({
+                member_uuid: 'memberId',
+                link_id: linkId,
+                timestamp: CLICKED_AT
+            }));
+            sinon.assert.notCalled(runInTransaction);
+        });
+
+        it('Saves automation clicks and analytics in the same transaction', async function () {
+            const linkId = new ObjectID();
+            const event = createRedirectEvent({
+                linkId,
+                automationActionRevisionId: 'revision-id'
+            });
+
+            await subscriber(event);
+
+            sinon.assert.calledOnceWithExactly(runInTransaction, sinon.match.func);
+            sinon.assert.calledOnceWithExactly(save, sinon.match.object, {transacting});
+            sinon.assert.calledOnceWithExactly(trackEmailClicked, {
+                automationActionRevisionId: 'revision-id',
+                memberId: 'member-id',
+                clickedAt: CLICKED_AT
+            }, {transacting});
+        });
+
+        it('Propagates raw click persistence failures', async function () {
+            const error = new Error('click insert failed');
+            const event = createRedirectEvent({
+                automationActionRevisionId: 'revision-id'
+            });
+            save.rejects(error);
+
+            await assert.rejects(subscriber(event), error);
+            sinon.assert.notCalled(trackEmailClicked);
+        });
+
+        it('Skips automation analytics when the member cannot be found', async function () {
+            const event = createRedirectEvent({
+                memberUuid: 'unknownMemberUuid',
+                automationActionRevisionId: 'revision-id'
+            });
+            save.resolves();
+
+            await subscriber(event);
+
+            sinon.assert.notCalled(trackEmailClicked);
+        });
+
+        it('Propagates automation analytics failures so the transaction rolls back', async function () {
+            const error = new Error('analytics update failed');
+            const event = createRedirectEvent({
+                automationActionRevisionId: 'revision-id'
+            });
+            trackEmailClicked.rejects(error);
+
+            await assert.rejects(subscriber(event), error);
+            sinon.assert.calledOnceWithExactly(trackEmailClicked, sinon.match.object, {transacting});
         });
     });
 


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1493/populate-automated-email-recipientsclicked-at-when-member-clicks-an
closes https://linear.app/ghost/issue/NY-1494/increment-email-clicked-count-when-a-member-clicks-on-an-automation

_I recommend reviewing this PR [commit by commit](https://github.com/TryGhost/Ghost/pull/29665/commits)._

## Summary

- populate automated email recipient `clicked_at` when a member first clicks an automation link
- increment the linked automation action revision `email_clicked_count` in the same transaction
- preserve the first-click timestamp and aggregate count while continuing to record every raw member click event
- ignore recipients without click tracking and keep newsletter click behavior unchanged

## Testing

- targeted link tracking and automations repository unit tests
- first-click, repeated-click, existing-count, disabled-tracking, and multiple-recipient coverage
- targeted ESLint and dependency-cruiser checks
- Ghost Core TypeScript check

Manual testing: https://cap.so/s/setwxfewphypdp9