### PR TITLE
🐛 Fixed background images changing header card layout

### DIFF
--- a/.changeset/gentle-headers-parse.md
+++ b/.changeset/gentle-headers-parse.md
@@ -1,0 +1,5 @@
+---
+"@tryghost/kg-default-nodes": patch
+---
+
+Fixed full-width header cards being imported as split layouts when they contain background images.

--- a/koenig/kg-default-nodes/src/nodes/header/parsers/header-parser.ts
+++ b/koenig/kg-default-nodes/src/nodes/header/parsers/header-parser.ts
@@ -53,7 +53,14 @@ export function parseHeaderNode(HeaderNode: new (data: Record<string, unknown>) 
                         const buttonElement = div.querySelector('.kg-header-card-button');
                         const alignment = div.classList.contains('kg-align-center') ? 'center' : '';
                         const backgroundImageSrc = div.querySelector('.kg-header-card-image')?.getAttribute('src');
-                        const layout = backgroundImageSrc ? 'split' : '';
+                        let layout = '';
+                        if (div.classList.contains('kg-layout-split')) {
+                            layout = 'split';
+                        } else if (div.classList.contains('kg-width-full')) {
+                            layout = 'full';
+                        } else if (div.classList.contains('kg-width-wide')) {
+                            layout = 'wide';
+                        }
                         const backgroundColor = div.classList.contains('kg-style-accent') ? 'accent' : div.getAttribute('data-background-color');
                         const buttonColor = buttonElement?.getAttribute('data-button-color') || '';
                         const textColor = headerElement?.getAttribute('data-text-color') || '';

--- a/koenig/kg-default-nodes/test/nodes/header.test.ts
+++ b/koenig/kg-default-nodes/test/nodes/header.test.ts
@@ -313,9 +313,9 @@ describe('HeaderNode', function () {
         describe('importDOM', function () {
             it('parses a header card V2', editorTest(function () {
                 const htmlstring = `
-                    <div class="kg-card kg-header-card kg-v2 kg-style-accent" data-background-color="#abcdef">
-                        <picture><img class="kg-header-card-image" src="https://example.com/image.jpg" alt="" /></picture>
+                    <div class="kg-card kg-header-card kg-v2 kg-style-accent kg-layout-split kg-width-full" data-background-color="#abcdef">
                         <div class="kg-header-card-content">
+                            <picture><img class="kg-header-card-image" src="https://example.com/image.jpg" alt="" /></picture>
                             <div class="kg-header-card-text kg-align-center">
                                 <h2 class="kg-header-card-heading" data-text-color="#abcdef">Header</h2>
                                 <p class="kg-header-card-subheading" data-text-color="#abcdef">Subheader</p>
@@ -339,6 +339,25 @@ describe('HeaderNode', function () {
                 expect(node.buttonUrl).toBe('https://example.com');
                 expect(node.buttonText).toBe('Button');
                 expect(node.buttonTextColor).toBe('#abcdef');
+            }));
+
+            it('preserves a full layout when parsing a header card with a background image', editorTest(function () {
+                const htmlstring = `
+                    <div class="kg-card kg-header-card kg-v2 kg-width-full kg-content-wide" data-background-color="#000000">
+                        <picture><img class="kg-header-card-image" src="https://example.com/image.jpg" alt="" /></picture>
+                        <div class="kg-header-card-content">
+                            <div class="kg-header-card-text kg-align-center">
+                                <h2 class="kg-header-card-heading" data-text-color="#ffffff">Header</h2>
+                                <p class="kg-header-card-subheading" data-text-color="#ffffff">Subheader</p>
+                            </div>
+                        </div>
+                    </div>`;
+                const document = createDocument(htmlstring);
+                const nodes = $generateNodesFromDOM(editor, document) as HeaderNode[];
+
+                expect(nodes.length).toBe(1);
+                expect(nodes[0].backgroundImageSrc).toBe('https://example.com/image.jpg');
+                expect(nodes[0].layout).toBe('full');
             }));
 
             it('does not parse a v1 header as v2', editorTest(function () {


### PR DESCRIPTION
fixes #29268

Header card imports now derive V2 layout from the renderer’s layout classes instead of assuming every card with an image is split. The existing split fixture now matches rendered split markup, and a regression test covers full-width background-image HTML.

Validation:
- focused header suite: 23 tests passed
- package build and TypeScript check passed
- source and test lint passed with zero errors (23 unrelated existing pending-test warnings)
- commit hooks and changeset validation passed

AI assistance was used to analyze the parser and prepare the patch; I reviewed every changed line and the validation results.