### PR TITLE
🐛 Fixed Portal email preference toggles missing accessible names

### DIFF
--- a/apps/portal/src/components/common/newsletter-management.jsx
+++ b/apps/portal/src/components/common/newsletter-management.jsx
@@ -23,6 +23,7 @@ function NewsletterPrefSection({newsletter, subscribedNewsletters, setSubscribed
     const isChecked = subscribedNewsletters.some((d) => {
         return d.id === newsletter?.id;
     });
+    const labelId = `portal-toggle-label-${newsletter.id}`;
 
     const handleToggle = () => {
         let updatedNewsletters = [];
@@ -45,6 +46,7 @@ function NewsletterPrefSection({newsletter, subscribedNewsletters, setSubscribed
             role="button"
             tabIndex={0}
             aria-pressed={isChecked}
+            aria-labelledby={labelId}
             onClick={handleToggle}
             onKeyDown={(e) => {
                 if (e.target !== e.currentTarget) {
@@ -57,7 +59,7 @@ function NewsletterPrefSection({newsletter, subscribedNewsletters, setSubscribed
             }}
         >
             <div className='gh-portal-list-detail'>
-                <h3>{newsletter.name}</h3>
+                <h3 id={labelId}>{newsletter.name}</h3>
                 <p>{newsletter?.description}</p>
             </div>
             <div style={{display: 'flex', alignItems: 'center'}} onClick={(e) => e.stopPropagation()}>
@@ -96,6 +98,8 @@ function CommentsSection({updateCommentNotifications, isCommentsEnabled, enableC
         }
     };
 
+    const labelId = 'portal-toggle-label-comments';
+
     return (
         <section
             className='gh-portal-list-toggle-wrapper gh-portal-list-clickable'
@@ -103,6 +107,7 @@ function CommentsSection({updateCommentNotifications, isCommentsEnabled, enableC
             role="button"
             tabIndex={0}
             aria-pressed={isChecked}
+            aria-labelledby={labelId}
             onClick={handleToggle}
             onKeyDown={(e) => {
                 if (e.target !== e.currentTarget) {
@@ -115,7 +120,7 @@ function CommentsSection({updateCommentNotifications, isCommentsEnabled, enableC
             }}
         >
             <div className='gh-portal-list-detail'>
-                <h3>{t('Comments')}</h3>
+                <h3 id={labelId}>{t('Comments')}</h3>
                 <p>{t('Get notified when someone replies to your comment')}</p>
             </div>
             <div style={{display: 'flex', alignItems: 'center'}} onClick={(e) => e.stopPropagation()}>
@@ -153,6 +158,8 @@ function UpdatesAndAnnouncementsSection({updateUpdatesAndAnnouncements, canChang
         }
     };
 
+    const labelId = 'portal-toggle-label-updates-and-announcements';
+
     return (
         <section
             className='gh-portal-list-toggle-wrapper gh-portal-list-clickable'
@@ -160,6 +167,7 @@ function UpdatesAndAnnouncementsSection({updateUpdatesAndAnnouncements, canChang
             role="button"
             tabIndex={0}
             aria-pressed={!!enableUpdatesAndAnnouncements}
+            aria-labelledby={labelId}
             onClick={handleToggle}
             onKeyDown={(e) => {
                 if (e.target !== e.currentTarget) {
@@ -172,7 +180,7 @@ function UpdatesAndAnnouncementsSection({updateUpdatesAndAnnouncements, canChang
             }}
         >
             <div className='gh-portal-list-detail'>
-                <h3>{t('Updates & announcements')}</h3>
+                <h3 id={labelId}>{t('Updates & announcements')}</h3>
                 <p>{t('Occasional updates from {siteTitle}', {siteTitle: site?.title})}</p>
             </div>
             <div style={{display: 'flex', alignItems: 'center'}} onClick={(e) => e.stopPropagation()}>

--- a/apps/portal/src/components/common/switch.jsx
+++ b/apps/portal/src/components/common/switch.jsx
@@ -107,9 +107,10 @@ function Switch({id, label = '', onToggle, checked = false, disabled = false, da
     // focus order so keyboard/SR users get a single stop with the correct
     // toggle state.
     const wrapperProps = presentational ? {'aria-hidden': true} : {};
+    // Never emit an empty aria-label — that announces a nameless checkbox.
     const inputProps = presentational
         ? {tabIndex: -1}
-        : {'aria-label': label};
+        : (label ? {'aria-label': label} : {});
 
     return (
         <div className="gh-portal-for-switch" data-test-switch={dataTestId} {...wrapperProps}>

--- a/apps/portal/src/components/pages/AccountHomePage/components/email-newsletter-action.jsx
+++ b/apps/portal/src/components/pages/AccountHomePage/components/email-newsletter-action.jsx
@@ -16,12 +16,15 @@ function EmailNewsletterAction() {
         doAction('updateNewsletterPreference', {newsletters: subscribedNewsletters});
     };
 
+    const labelId = 'portal-toggle-label-email-newsletter';
+
     return (
         <section
             className='gh-portal-list-clickable'
             role="button"
             tabIndex={0}
             aria-pressed={subscribed}
+            aria-labelledby={labelId}
             onClick={onToggleSubscription}
             onKeyDown={(e) => {
                 if (e.target !== e.currentTarget) {
@@ -34,7 +37,7 @@ function EmailNewsletterAction() {
             }}
         >
             <div className='gh-portal-list-detail email-newsletter'>
-                <h3>{t('Email newsletter')}</h3>
+                <h3 id={labelId}>{t('Email newsletter')}</h3>
                 <p>{label} {hasMemberGotEmailSuppression({member}) && subscribed && <button
                     className='gh-portal-btn-text gh-email-faq-page-button'
                     onClick={(e) => {

--- a/apps/portal/src/components/pages/newsletter-selection-page.jsx
+++ b/apps/portal/src/components/pages/newsletter-selection-page.jsx
@@ -38,6 +38,8 @@ function NewsletterPrefSection({newsletter, subscribedNewsletters, setSubscribed
         setSubscribedNewsletters(updatedNewsletters);
     };
 
+    const labelId = `portal-toggle-label-${newsletter.id}`;
+
     return (
         <section
             className='gh-portal-list-toggle-wrapper gh-portal-list-clickable'
@@ -45,6 +47,7 @@ function NewsletterPrefSection({newsletter, subscribedNewsletters, setSubscribed
             role="button"
             tabIndex={0}
             aria-pressed={isChecked}
+            aria-labelledby={labelId}
             onClick={handleToggle}
             onKeyDown={(e) => {
                 if (e.target !== e.currentTarget) {
@@ -57,7 +60,7 @@ function NewsletterPrefSection({newsletter, subscribedNewsletters, setSubscribed
             }}
         >
             <div className='gh-portal-list-detail gh-portal-list-big'>
-                <h3>{newsletter.name}</h3>
+                <h3 id={labelId}>{newsletter.name}</h3>
                 <p>{newsletter.description}</p>
             </div>
             <div onClick={(e) => e.stopPropagation()}>

--- a/apps/portal/test/unit/components/common/newsletter-management.test.jsx
+++ b/apps/portal/test/unit/components/common/newsletter-management.test.jsx
@@ -1,6 +1,6 @@
 import {render, fireEvent, act} from '../../../utils/test-utils';
 import NewsletterManagement from '../../../../src/components/common/newsletter-management';
-import {getSiteData, getMemberData} from '../../../../src/utils/fixtures-generator';
+import {getSiteData, getMemberData, getNewslettersData} from '../../../../src/utils/fixtures-generator';
 
 const noop = () => {};
 
@@ -31,6 +31,51 @@ const renderManagement = (overrides = {}) => {
 };
 
 describe('NewsletterManagement', () => {
+    test('wires accessible names from the visible titles to each preference toggle', () => {
+        const newsletters = getNewslettersData({numOfNewsletters: 1}).map(n => ({
+            ...n,
+            id: 'n1',
+            name: 'Weekly Digest'
+        }));
+        const site = getSiteData({
+            newsletters,
+            labs: {automations: true}
+        });
+
+        const {getByRole, getByTestId} = render(
+            <NewsletterManagement
+                hasNewslettersEnabled={true}
+                subscribedNewsletters={[]}
+                updateSubscribedNewsletters={noop}
+                updateCommentNotifications={vi.fn().mockResolvedValue(undefined)}
+                updateUpdatesAndAnnouncements={vi.fn().mockResolvedValue(undefined)}
+                unsubscribeAll={noop}
+                isPaidMember={false}
+                isCommentsEnabled={true}
+                enableCommentNotifications={false}
+                canChangeUpdatesAndAnnouncements={true}
+                enableUpdatesAndAnnouncements={false}
+            />,
+            {
+                overrideContext: {
+                    site,
+                    member: getMemberData()
+                }
+            }
+        );
+
+        const commentToggle = getByRole('button', {name: 'Comments'});
+        expect(commentToggle).toHaveAttribute('aria-labelledby', 'portal-toggle-label-comments');
+        expect(commentToggle.querySelector('#portal-toggle-label-comments')).toHaveTextContent('Comments');
+
+        const updatesToggle = getByRole('button', {name: 'Updates & announcements'});
+        expect(updatesToggle).toHaveAttribute('aria-labelledby', 'portal-toggle-label-updates-and-announcements');
+
+        const newsletterToggle = getByTestId('newsletter-toggle');
+        expect(newsletterToggle).toHaveAttribute('aria-labelledby', 'portal-toggle-label-n1');
+        expect(newsletterToggle.querySelector('#portal-toggle-label-n1')).toHaveTextContent('Weekly Digest');
+    });
+
     describe('CommentsSection isUpdating guard', () => {
         test('coalesces rapid double-clicks on the inner Switch into a single update', async () => {
             // Slow update: stays pending so the second click hits the guard.

--- a/apps/portal/test/unit/components/common/switch.test.jsx
+++ b/apps/portal/test/unit/components/common/switch.test.jsx
@@ -109,4 +109,13 @@ describe('Switch', () => {
         expect(input).not.toHaveAttribute('tabindex');
         expect(input).toHaveAttribute('aria-label', 'Accessible');
     });
+
+    test('does not set an empty aria-label when label is omitted', () => {
+        const {container} = render(
+            <Switch id="unlabelled-switch" onToggle={() => {}} />
+        );
+        const input = container.querySelector('input[type="checkbox"]');
+
+        expect(input).not.toHaveAttribute('aria-label');
+    });
 });


### PR DESCRIPTION
## Summary
- Portal email-preference rows already used `role=\"button\"` + a presentational Switch, but the visual titles (`h3`) were not programmatically tied to the control.
- Each toggle row now exposes `aria-labelledby` pointing at its title id, and `Switch` no longer emits an empty `aria-label` when no label text is provided.

## Test plan
- [x] Unit: Switch empty-label + NewsletterManagement aria-labelledby coverage
- [ ] Screen reader: Email preferences page announces each toggle with its title (Comments / newsletter name / Updates & announcements)

Closes #29667
