### PR TITLE
♿ Improved newsletter email footer text contrast

### DIFF
--- a/ghost/core/core/server/services/email-rendering/partials/base-styles.hbs
+++ b/ghost/core/core/server/services/email-rendering/partials/base-styles.hbs
@@ -91,11 +91,9 @@ table td {
 
 .footer {
     {{#if backgroundIsDark}}
-        color: #ffffff;
-        color: rgba(255, 255, 255, .6);
+        color: #ADB5BD;
     {{else}}
-        color: #15212a;
-        color: rgba(0, 0, 0, 0.6);
+        color: #5B6B73;
     {{/if}}
     margin-top: 20px;
     text-align: center;
@@ -109,11 +107,9 @@ table td {
 
 .footer a {
     {{#if backgroundIsDark}}
-        color: #ffffff;
-        color: rgba(255, 255, 255, .6);
+        color: #ADB5BD;
     {{else}}
-        color: #15212a;
-        color: rgba(0, 0, 0, 0.6);
+        color: #5B6B73;
     {{/if}}
     text-decoration: underline;
     font-size: 13px;


### PR DESCRIPTION
## Summary
- Newsletter email footers used \`rgba(0, 0, 0, 0.6)\` / \`rgba(255, 255, 255, 0.6)\`, which often renders near \`#738A94\` (~3.6:1 on white) and fails WCAG 1.4.3 for small text including the unsubscribe link.
- Switched to solid \`#5B6B73\` (light) and \`#ADB5BD\` (dark), both above 4.5:1 against their backgrounds.

## Test plan
- [ ] Send / preview a newsletter email on a light background — footer + unsubscribe readable, contrast ≥ 4.5:1
- [ ] Same check on a dark newsletter background

Closes #29666

Made with [Cursor](https://cursor.com)