### PR TITLE
🐛 Fixed feature image alt validation still capped at 191 characters

### DIFF
--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -117,7 +117,7 @@ module.exports = {
         meta_description: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 500}}},
         email_subject: {type: 'string', maxlength: 300, nullable: true},
         frontmatter: {type: 'text', maxlength: 65535, nullable: true},
-        feature_image_alt: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 191}}},
+        feature_image_alt: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 2000}}},
         feature_image_caption: {type: 'text', maxlength: 65535, nullable: true},
         email_only: {type: 'boolean', nullable: false, defaultTo: false}
     },
@@ -426,7 +426,7 @@ module.exports = {
         post_status: {type: 'string', maxlength: 50, nullable: true, validations: {isIn: [['draft', 'published', 'scheduled', 'sent']]}},
         reason: {type: 'string', maxlength: 50, nullable: true},
         feature_image: {type: 'string', maxlength: 2000, nullable: true},
-        feature_image_alt: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 191}}},
+        feature_image_alt: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 2000}}},
         feature_image_caption: {type: 'text', maxlength: 65535, nullable: true},
         custom_excerpt: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 300}}}
     },


### PR DESCRIPTION
## Summary
- The DB column for `feature_image_alt` was migrated to 2000 chars, but schema validation still used `isLength: {max: 191}`.
- Autosave failures were silent because validation ran client/server-side before a request with `silent: true`.
- Updated both `posts` and `post_revisions` schema validations to `max: 2000`.

## Test plan
- [ ] Set feature image alt to >191 and <2000 chars, confirm autosave succeeds
- [ ] Confirm >2000 still fails with a visible error on explicit save

Closes #29623

Made with [Cursor](https://cursor.com)