### PR TITLE
🐛 Fixed share button by loading Portal without memberships

### DIFF
--- a/ghost/core/core/frontend/helpers/ghost_head.js
+++ b/ghost/core/core/frontend/helpers/ghost_head.js
@@ -77,10 +77,8 @@ function finaliseStructuredData(meta) {
 }
 
 function getMembersHelper(data, frontendKey, excludeList) {
-    // Do not load Portal if both Memberships and Tips & Donations and Recommendations are disabled
-    if (!settingsCache.get('members_enabled') && !settingsCache.get('donations_enabled') && !settingsCache.get('recommendations_enabled')) {
-        return '';
-    }
+    // Always load Portal when not excluded: the share modal (#/share) needs it even
+    // when Memberships, Tips & Donations, and Recommendations are all disabled.
     let membersHelper = '';
     if (!excludeList.has('portal')) {
         const {scriptUrl} = getFrontendAppConfig('portal');

--- a/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost-head.test.js.snap
+++ b/ghost/core/test/unit/frontend/helpers/__snapshots__/ghost-head.test.js.snap
@@ -2219,7 +2219,7 @@ Object {
 }
 `;
 
-exports[`{{ghost_head}} helper members scripts skips portal and stripe when members are disabled 1 1`] = `
+exports[`{{ghost_head}} helper members scripts includes portal even when members are disabled 1 1`] = `
 Object {
   "rendered": "<meta name=\\"description\\" content=\\"site description\\">
     <link rel=\\"canonical\\" href=\\"http://127.0.0.1:2369/\\">
@@ -2264,6 +2264,70 @@ Object {
     <meta name=\\"generator\\" content=\\"Ghost 4.3\\">
     <link rel=\\"alternate\\" type=\\"application/rss+xml\\" title=\\"Ghost\\" href=\\"http://localhost:65530/rss/\\">
     
+    <script defer src=\\"https://cdn.jsdelivr.net/ghost/portal@~[[VERSION]]/umd/portal.min.js\\" data-i18n=\\"true\\" data-ghost=\\"http://127.0.0.1:2369/\\" data-key=\\"xyz\\" data-api=\\"http://127.0.0.1:2369/ghost/api/content/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script><style id=\\"gh-members-styles\\">.gh-post-upgrade-cta-content,
+.gh-post-upgrade-cta {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    text-align: center;
+    width: 100%;
+    color: #ffffff;
+    font-size: 16px;
+}
+
+.gh-post-upgrade-cta-content {
+    border-radius: 8px;
+    padding: 40px 4vw;
+}
+
+.gh-post-upgrade-cta h2 {
+    color: #ffffff;
+    font-size: 28px;
+    letter-spacing: -0.2px;
+    margin: 0;
+    padding: 0;
+}
+
+.gh-post-upgrade-cta p {
+    margin: 20px 0 0;
+    padding: 0;
+}
+
+.gh-post-upgrade-cta small {
+    font-size: 16px;
+    letter-spacing: -0.2px;
+}
+
+.gh-post-upgrade-cta a {
+    color: #ffffff;
+    cursor: pointer;
+    font-weight: 500;
+    box-shadow: none;
+    text-decoration: underline;
+}
+
+.gh-post-upgrade-cta a:hover {
+    color: #ffffff;
+    opacity: 0.8;
+    box-shadow: none;
+    text-decoration: underline;
+}
+
+.gh-post-upgrade-cta a.gh-btn {
+    display: block;
+    background: #ffffff;
+    text-decoration: none;
+    margin: 28px 0 0;
+    padding: 8px 18px;
+    border-radius: 4px;
+    font-size: 16px;
+    font-weight: 600;
+}
+
+.gh-post-upgrade-cta a.gh-btn:hover {
+    opacity: 0.92;
+}</style>
     <script defer src=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/sodo-search.min.js\\" data-key=\\"xyz\\" data-styles=\\"https://cdn.jsdelivr.net/ghost/sodo-search@~[[VERSION]]/umd/main.css\\" data-sodo-search=\\"http://127.0.0.1:2369/\\" data-locale=\\"en\\" crossorigin=\\"anonymous\\"></script>
     
     <link href=\\"http://127.0.0.1:2369/webmentions/receive/\\" rel=\\"webmention\\">",

--- a/ghost/core/test/unit/frontend/helpers/ghost-head.test.js
+++ b/ghost/core/test/unit/frontend/helpers/ghost-head.test.js
@@ -1306,9 +1306,12 @@ describe('{{ghost_head}} helper', function () {
             }));
         });
 
-        it('skips portal and stripe when members are disabled', async function () {
+        it('includes portal even when members are disabled', async function () {
+            // Share modal (#/share) still needs Portal when memberships are off.
             getStub.withArgs('members_enabled').returns(false);
-            getStub.withArgs('paid_members_enabled').returns(true);
+            getStub.withArgs('paid_members_enabled').returns(false);
+            getStub.withArgs('donations_enabled').returns(false);
+            getStub.withArgs('recommendations_enabled').returns(false);
 
             await testGhostHead(testUtils.createHbsResponse({
                 locals: {


### PR DESCRIPTION
## Summary
- \`ghost_head\` skipped Portal entirely when Memberships, Tips & Donations, and Recommendations were all off.
- The Source theme share button / \`#/share\` still needs Portal in that case.
- Portal now loads unless explicitly excluded; Stripe remains gated on paid members.

## Test plan
- [ ] With members/donations/recommendations off, open a post and click Share / visit \`#/share\` — modal opens
- [ ] Unit snapshot: members scripts include Portal even when members are disabled

Closes #27415

Made with [Cursor](https://cursor.com)