### PR TITLE
🐛 Fixed copied gallery cards sharing image state

### DIFF
--- a/koenig/kg-default-nodes/src/nodes/gallery/GalleryNode.ts
+++ b/koenig/kg-default-nodes/src/nodes/gallery/GalleryNode.ts
@@ -27,6 +27,16 @@ export class GalleryNode extends generateDecoratorNode({
     properties: galleryProperties,
     defaultRenderFn: renderGalleryNode
 }) {
+    // Deep-copy images on clone so copy/paste does not share array state
+    // between gallery cards (reordering one must not mutate the other).
+    static clone(node: GalleryNode) {
+        const dataset = node.getDataset();
+        return new this({
+            ...dataset,
+            images: (dataset.images ?? []).map(image => ({...image}))
+        }, node.__key);
+    }
+
     /* override */
     static get urlTransformMap() {
         return {

--- a/koenig/kg-default-nodes/test/nodes/gallery.test.ts
+++ b/koenig/kg-default-nodes/test/nodes/gallery.test.ts
@@ -167,6 +167,17 @@ describe('GalleryNode', function () {
 
             expect(cloneDataset).toEqual({...galleryNodeDataset});
         }));
+
+        it('does not share the images array with the original node', editorTest(function () {
+            const galleryNode = $createGalleryNode(dataset);
+            const clone = GalleryNode.clone(galleryNode) as GalleryNode;
+
+            expect(clone.images).not.toBe(galleryNode.images);
+            expect(clone.images[0]).not.toBe(galleryNode.images[0]);
+
+            clone.images = clone.images.slice(1);
+            expect(galleryNode.images).toHaveLength((dataset.images as unknown[]).length);
+        }));
     });
 
     describe('urlTransformMap', function () {


### PR DESCRIPTION
## Summary
- Copying a gallery card reused the same \`images\` array reference via the default decorator \`clone\`.
- \`GalleryNode.clone\` now deep-copies images so edits/reorders stay isolated.

## Test plan
- [x] Unit: clone images array/items are not shared with the original
- [ ] Manual: copy a gallery, reorder images in the copy, confirm the original is unchanged

Closes #29221
