### PR TITLE
🐛 Fixed Unsplash search dropping the latest query

### DIFF
--- a/koenig/kg-unsplash-selector/src/UnsplashSearchModal.tsx
+++ b/koenig/kg-unsplash-selector/src/UnsplashSearchModal.tsx
@@ -32,6 +32,7 @@ export const UnsplashSearchModal : React.FC<UnsplashModalProps> = ({onClose, onI
     const [isLoading, setIsLoading] = useState<boolean>(UnsplashLib.searchIsRunning() || true);
     const initLoadRef = useRef<boolean>(false);
     const [searchTerm, setSearchTerm] = useState<string>('');
+    const searchTermRef = useRef<string>('');
     const [zoomedImg, setZoomedImg] = useState<Photo | null>(null);
     const [dataset, setDataset] = useState<Photo[][] | []>([]);
 
@@ -91,9 +92,11 @@ export const UnsplashSearchModal : React.FC<UnsplashModalProps> = ({onClose, onI
         const query = e.target.value;
         if (query.length > 2) {
             setZoomedImg(null);
+            searchTermRef.current = query;
             setSearchTerm(query);
         }
         if (query.length === 0) {
+            searchTermRef.current = '';
             setSearchTerm('');
             initLoadRef.current = false;
             await loadInitPhotos();
@@ -102,10 +105,15 @@ export const UnsplashSearchModal : React.FC<UnsplashModalProps> = ({onClose, onI
 
     const search = React.useCallback(async () => {
         if (searchTerm) {
+            const termAtRequest = searchTerm;
             setIsLoading(true);
             setDataset([]);
             UnsplashLib.clearPhotos();
-            await UnsplashLib.updateSearch(searchTerm);
+            await UnsplashLib.updateSearch(termAtRequest);
+            // A newer search may have started while this one was in flight.
+            if (searchTermRef.current !== termAtRequest) {
+                return;
+            }
             const columns = UnsplashLib.getColumns();
             if (columns) {
                 setDataset(columns);

--- a/koenig/kg-unsplash-selector/src/api/UnsplashProvider.ts
+++ b/koenig/kg-unsplash-selector/src/api/UnsplashProvider.ts
@@ -10,6 +10,7 @@ export class UnsplashProvider implements IUnsplashProvider {
     SEARCH_IS_RUNNING: boolean = false;
     LAST_REQUEST_URL: string = '';
     IS_LOADING: boolean = false;
+    private searchAbortController: AbortController | null = null;
 
     constructor(HEADERS: DefaultHeaderTypes) {
         this.HEADERS = HEADERS;
@@ -19,23 +20,23 @@ export class UnsplashProvider implements IUnsplashProvider {
         if (this.REQUEST_IS_RUNNING) {
             return null;
         }
-    
+
         this.LAST_REQUEST_URL = url;
         const options = {
             method: 'GET',
             headers: this.HEADERS as unknown as HeadersInit
         };
-    
+
         try {
             this.REQUEST_IS_RUNNING = true;
             this.IS_LOADING = true;
-    
+
             const response = await fetch(url, options);
             const checkedResponse = await this.checkStatus(response);
             this.extractPagination(checkedResponse);
-    
+
             const jsonResponse = await checkedResponse.json();
-            
+
             if ('results' in jsonResponse) {
                 return jsonResponse.results;
             } else {
@@ -106,14 +107,53 @@ export class UnsplashProvider implements IUnsplashProvider {
     }
 
     public async searchPhotos(term: string): Promise<Photo[]> {
-        const url = `${this.API_URL}/search/photos?query=${term}&per_page=30`;
-
-        const request = await this.makeRequest(url);
-        if (request) {
-            return request as Photo[];
+        // Abort any in-flight search so a newer query (e.g. "Germany") is not
+        // silently dropped while a partial term request (e.g. "Germ") is running.
+        // Previously makeRequest() returned null when REQUEST_IS_RUNNING was true,
+        // which caused the full typed query to never hit the Unsplash API.
+        if (this.searchAbortController) {
+            this.searchAbortController.abort();
         }
+        this.searchAbortController = new AbortController();
+        const {signal} = this.searchAbortController;
 
-        return [];
+        const url = `${this.API_URL}/search/photos?query=${encodeURIComponent(term)}&per_page=30`;
+        this.LAST_REQUEST_URL = url;
+        this.SEARCH_IS_RUNNING = true;
+        this.IS_LOADING = true;
+
+        try {
+            const response = await fetch(url, {
+                method: 'GET',
+                headers: this.HEADERS as unknown as HeadersInit,
+                signal
+            });
+            const checkedResponse = await this.checkStatus(response);
+            this.extractPagination(checkedResponse);
+
+            const jsonResponse = await checkedResponse.json();
+            if (signal.aborted) {
+                return [];
+            }
+
+            if ('results' in jsonResponse) {
+                return jsonResponse.results;
+            }
+
+            return jsonResponse;
+        } catch (error) {
+            if (error instanceof DOMException && error.name === 'AbortError') {
+                return [];
+            }
+            this.ERROR = error as string;
+            return [];
+        } finally {
+            // Only clear search state if this is still the active search.
+            if (this.searchAbortController?.signal === signal) {
+                this.SEARCH_IS_RUNNING = false;
+                this.IS_LOADING = false;
+            }
+        }
     }
 
     public async triggerDownload(photo: Pick<Photo, 'links'>): Promise<void> {
@@ -126,10 +166,10 @@ export class UnsplashProvider implements IUnsplashProvider {
         if (response.status >= 200 && response.status < 300) {
             return response;
         }
-    
+
         let errorText = '';
         let responseTextPromise: Promise<string>; // or Promise<string> if you know the type
-    
+
         const contentType = response.headers.get('content-type');
         if (contentType === 'application/json') {
             responseTextPromise = response.json().then(json => (json).errors[0]); // or cast to a specific type if you know it
@@ -138,18 +178,18 @@ export class UnsplashProvider implements IUnsplashProvider {
         } else {
             throw new Error('Unsupported content type');
         }
-    
+
         return responseTextPromise.then((responseText: string) => { // you can type responseText based on what you expect
             if (response.status === 403 && response.headers.get('x-ratelimit-remaining') === '0') {
                 // we've hit the rate limit on the API
                 errorText = 'Unsplash API rate limit reached, please try again later.';
             }
-    
+
             errorText = errorText || responseText || `Error ${response.status}: Uh-oh! Trouble reaching the Unsplash API`;
-    
+
             // set error text for display in UI
             this.ERROR = errorText;
-    
+
             // throw error to prevent further processing
             let error = new Error(errorText) as Error; // or create a custom Error class
             throw error;

--- a/koenig/kg-unsplash-selector/src/api/UnsplashService.ts
+++ b/koenig/kg-unsplash-selector/src/api/UnsplashService.ts
@@ -18,6 +18,7 @@ export class UnsplashService implements IUnsplashService {
     private photoUseCases: PhotoUseCases;
     private masonryService: MasonryService;
     public photos: Photo[] = [];
+    private currentSearchTerm: string | null = null;
 
     constructor(photoUseCases: PhotoUseCases, masonryService: MasonryService) {
         this.photoUseCases = photoUseCases;
@@ -46,7 +47,12 @@ export class UnsplashService implements IUnsplashService {
     }
 
     async updateSearch(term: string) {
+        this.currentSearchTerm = term;
         let results = await this.photoUseCases.searchPhotos(term);
+        // Ignore stale responses if a newer search started while this one was in flight.
+        if (this.currentSearchTerm !== term) {
+            return;
+        }
         this.photos = results;
         this.layoutPhotos();
     }

--- a/koenig/kg-unsplash-selector/test/unit/UnsplashProvider.test.ts
+++ b/koenig/kg-unsplash-selector/test/unit/UnsplashProvider.test.ts
@@ -1,0 +1,63 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {UnsplashProvider} from '../../src/api/UnsplashProvider';
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+    return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: {'Content-Type': 'application/json', ...(init.headers || {})},
+        ...init
+    });
+}
+
+describe('UnsplashProvider search race', () => {
+    beforeEach(() => {
+        vi.stubGlobal('fetch', vi.fn());
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    it('aborts an in-flight search so a newer query is not dropped', async () => {
+        let resolveGerm: ((value: Response) => void) | undefined;
+        const germPromise = new Promise<Response>((resolve) => {
+            resolveGerm = resolve;
+        });
+
+        const fetchMock = vi.mocked(fetch);
+        fetchMock
+            .mockImplementationOnce((_url, init) => {
+                // Keep "Germ" pending until after "Germany" starts.
+                return new Promise((resolve, reject) => {
+                    const signal = init?.signal;
+                    if (signal) {
+                        signal.addEventListener('abort', () => {
+                            reject(new DOMException('Aborted', 'AbortError'));
+                        });
+                    }
+                    void germPromise.then(resolve).catch(reject);
+                });
+            })
+            .mockImplementationOnce(() => Promise.resolve(jsonResponse({
+                results: [{id: 'germany-photo', width: 100, height: 100}]
+            })));
+
+        const provider = new UnsplashProvider({Authorization: 'Client-ID test'});
+
+        const germSearch = provider.searchPhotos('Germ');
+        // Let the first fetch start before kicking off the second search.
+        await Promise.resolve();
+
+        const germanySearch = provider.searchPhotos('Germany');
+        const germanyResults = await germanySearch;
+
+        expect(germanyResults).toEqual([{id: 'germany-photo', width: 100, height: 100}]);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(String(fetchMock.mock.calls[1][0])).toContain('query=Germany');
+
+        // Completing the aborted "Germ" request must not throw or overwrite state.
+        resolveGerm?.(jsonResponse({results: [{id: 'germ-photo', width: 50, height: 50}]}));
+        await expect(germSearch).resolves.toEqual([]);
+    });
+});


### PR DESCRIPTION
## Summary
- Searching while a previous Unsplash request was in flight returned \`null\` and dropped the newer term (e.g. \`Germ\` ran, \`Germany\` never fired).
- Searches now abort the previous request and ignore stale results in the service/modal.

## Test plan
- [x] Unit: newer search is not dropped while an older one is pending
- [ ] Manual: type \`Germany\` quickly in the Unsplash modal and confirm the network request uses the full term

Closes #24640
