### PR TITLE
🐛 Fixed feature image alt text silently disappearing when too long

### DIFF
--- a/apps/ember-admin/app/components/gh-editor-feature-image.hbs
+++ b/apps/ember-admin/app/components/gh-editor-feature-image.hbs
@@ -57,6 +57,7 @@
                         placeholder="Add alt text to the feature image"
                         class="gh-editor-feature-image-alttext {{if @isHidden "faded"}}"
                         name="alt"
+                        maxlength="191"
                         value={{@alt}}
                         {{autofocus}}
                         {{on "input" this.onAltInput}}


### PR DESCRIPTION
Fixes #29623.

The feature image alt text field had no `maxlength`, so a user could type past the 191-character limit enforced by the server. Autosave runs with `silent: true` and the validation-error handler is gated on `!options.silent`, so the client validator failure was swallowed and no request was ever sent — the over-length text was then silently discarded on navigation.

Per @9larsons' guidance in the issue (impose the 191 limit rather than extend it, which would be a separate proposal), this adds `maxlength="191"` to the alt input so the unsaveable state can no longer be reached. The value matches the client validator (`isLength {max: 191}`) and server validation.

### Notes for reviewers
- `maxlength` counts UTF-16 units while the validator counts code points, so the field is very slightly stricter for emoji/astral characters — always the safe direction (anything the field allows still passes the server), so the bug cannot recur.
- This guards new input. Pre-existing values over 191 (only creatable by bypassing model validation, since the column is VARCHAR(2000)) are not retro-trimmed, and the general `silent: true` swallow is untouched — consistent with the maintainer note that this "may need patching as well."

### Test
Reproduced the issue on this branch (typing 192 chars → autosave silently drops it), then confirmed the fix: the field now hard-stops at 191, autosave succeeds, and nothing is lost on navigation.
