### PR TITLE
Updated tinybird cli to latest and wire in Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,10 @@
 {
     "extends": [
-        "github>tryghost/renovate-config"
+        "github>tryghost/renovate-config",
+        // Track `# renovate:`-annotated `ARG/ENV *_VERSION` pins in Dockerfiles,
+        // for tool versions that no native manager sees (e.g. the Tinybird CLI
+        // installed via `uv tool install` in docker/tb-cli/Dockerfile).
+        "customManagers:dockerfileVersions"
     ],
     // Keep Renovate's own concurrency guardrails in place. The shared preset
     // extends :disableRateLimiting (prConcurrentLimit: 0, prHourlyLimit: 0),
@@ -282,6 +286,21 @@
                 "node"
             ],
             "enabled": false
+        },
+
+        // The Tinybird CLI declares `requires_python: >=3.10,<3.14`, so a 3.14
+        // base image would break `uv tool install tinybird` (or silently force
+        // uv to fetch a second, standalone interpreter). Cap rather than
+        // disable, so 3.13.x patches and digest re-pins still flow.
+        {
+            "description": "Cap the tb-cli base image below Python 3.14 (Tinybird CLI requires <3.14)",
+            "matchFileNames": [
+                "docker/tb-cli/Dockerfile"
+            ],
+            "matchPackageNames": [
+                "python"
+            ],
+            "allowedVersions": "<3.14"
         },
 
         // Keep `@types/*` aligned with the runtime major they describe. Type defs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,12 @@ jobs:
               - '!ghost/core/vitest.config.ts'
               - '!koenig/*/test/**'
               - *renovate_only
+            # The Analytics E2E shards normally pull a prebuilt tb-cli image
+            # from GHCR, which is only republished from main. Without this the
+            # PR that changes the Dockerfile is the one PR that never exercises
+            # it — the break lands on main and surfaces in someone else's PR.
+            tb-cli:
+              - 'docker/tb-cli/**'
 
       - name: Define Node test matrix
         id: node_matrix
@@ -254,6 +260,7 @@ jobs:
       changed_i18n_apps: ${{ steps.affected.outputs.affected_i18n_projects != '' }}
       changed_core: ${{ steps.changed.outputs.core }}
       changed_any_code: ${{ steps.changed.outputs.any-code }}
+      changed_tb_cli: ${{ steps.changed.outputs.tb-cli }}
       # Single gate for the build + browser-E2E lane. True for tags, or when a
       # changed file could affect a running Ghost instance (see the `e2e` path
       # filter above). A test-only / docs-only change keeps this false.
@@ -1608,10 +1615,17 @@ jobs:
 
       - name: Pull or build Tinybird CLI Image
         if: matrix.analytics == 'true'
+        env:
+          CHANGED_TB_CLI: ${{ needs.job_setup.outputs.changed_tb_cli }}
         run: |
           COMPOSE_IMAGE="${COMPOSE_PROJECT_NAME:-ghost-dev}-tb-cli"
-          # Try pulling pre-built image from GHCR first (fast path)
-          if docker pull ghcr.io/tryghost/tb-cli:latest 2>/dev/null; then
+          # GHCR's :latest is only republished from main, so it can't reflect a
+          # Dockerfile change under review — build from source when this PR
+          # touches it, otherwise take the prebuilt fast path.
+          if [[ "$CHANGED_TB_CLI" == 'true' ]]; then
+            echo "docker/tb-cli changed, building from source"
+            docker buildx build --load -t "$COMPOSE_IMAGE" -f docker/tb-cli/Dockerfile .
+          elif docker pull ghcr.io/tryghost/tb-cli:latest 2>/dev/null; then
             echo "Pulled tb-cli from GHCR"
             docker tag ghcr.io/tryghost/tb-cli:latest "$COMPOSE_IMAGE"
           else

--- a/docker/tb-cli/Dockerfile
+++ b/docker/tb-cli/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.14-slim@sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d762a27986facfc3355c1
+# The Tinybird CLI requires >=3.10,<3.14 — keep the base image in that range.
+# Renovate is capped at <3.14 for this file (.github/renovate.json5).
+FROM python:3.13-slim@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91
 
 # Install uv from Astral.sh
 COPY --from=ghcr.io/astral-sh/uv:0.11.6@sha256:b1e699368d24c57cda93c338a57a8c5a119009ba809305cc8e86986d4a006754 /uv /uvx /bin/
@@ -12,7 +14,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /home/tinybird
 
-RUN uv tool install tinybird@0.0.1.dev285 --python 3.13 --force
+# renovate: datasource=pypi depName=tinybird versioning=pep440
+ARG TINYBIRD_VERSION=4.6.14
+
+RUN uv tool install tinybird@${TINYBIRD_VERSION} --python 3.13 --force
 
 ENV PATH="/root/.local/bin:$PATH"
 


### PR DESCRIPTION
no ref
- tb-cli was using an old version of the tinybird-cli that's several major versions behind
- update the tb-cli to latest, lock the python version to a supported range, and add renovate to auto-update the tb-cli version