### PR TITLE
Gated lazy URL readiness on router registration

### DIFF
--- a/ghost/core/core/server/services/url/lazy-url-service.ts
+++ b/ghost/core/core/server/services/url/lazy-url-service.ts
@@ -133,6 +133,9 @@ export class LazyUrlService implements LazyUrlServiceBackend {
     private requiredRelations: string[] | null;
     private baseFilters: Map<string, BaseFilter>;
     private excludedFilterFields: Map<string, Set<string>>;
+    // True once routers have been registered; hasFinished() returns it so the
+    // maintenance middleware holds requests until routing is ready.
+    private routersReady: boolean;
 
     constructor({urlUtils = localUtils, findResource}: LazyUrlServiceDeps) {
         if (typeof findResource !== 'function') {
@@ -146,6 +149,7 @@ export class LazyUrlService implements LazyUrlServiceBackend {
         this.requiredRelations = null;
         this.baseFilters = buildBaseFilters();
         this.excludedFilterFields = buildExcludedFilterFields();
+        this.routersReady = false;
     }
 
     onRouterAddedType(identifier: string, filter: string | null, resourceType: string, permalink: string): void {
@@ -158,6 +162,7 @@ export class LazyUrlService implements LazyUrlServiceBackend {
             compiledFilter: buildFilter(filter)
         });
         this.requiredRelations = null;
+        this.routersReady = true;
     }
 
     onRouterUpdated(): void {
@@ -169,6 +174,7 @@ export class LazyUrlService implements LazyUrlServiceBackend {
     reset(): void {
         this.routerConfigs = [];
         this.requiredRelations = null;
+        this.routersReady = false;
     }
 
     getRequiredRelations(): string[] {
@@ -246,7 +252,7 @@ export class LazyUrlService implements LazyUrlServiceBackend {
     }
 
     hasFinished(): boolean {
-        return true;
+        return this.routersReady;
     }
 
     getUrlForResource(resource: Resource, options: UrlOptions = {}): string {

--- a/ghost/core/test/unit/server/services/url/lazy-url-service.test.js
+++ b/ghost/core/test/unit/server/services/url/lazy-url-service.test.js
@@ -365,12 +365,6 @@ describe('LazyUrlService', function () {
         });
     });
 
-    describe('hasFinished', function () {
-        it('always returns true', function () {
-            assert.equal(new LazyUrlService({urlUtils, findResource: noopFindResource}).hasFinished(), true);
-        });
-    });
-
     describe('reset', function () {
         it('drops all registered router configs', function () {
             const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
@@ -802,6 +796,28 @@ describe('LazyUrlService', function () {
 
             assert.deepEqual(service.getRequiredFields('posts').sort(), ['primary_tag', 'slug', 'status', 'type']);
             assert.deepEqual(service.getRequiredFields('pages').sort(), ['primary_author', 'slug', 'status', 'type']);
+        });
+    });
+
+    // hasFinished() gates the maintenance middleware, so it must report not-ready
+    // until routers are registered (it was previously hardcoded true).
+    describe('hasFinished — readiness gating', function () {
+        it('is not finished before any router is registered', function () {
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
+            assert.equal(service.hasFinished(), false);
+        });
+
+        it('is finished once routers are registered', function () {
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
+            service.onRouterAddedType('default', null, 'posts', '/:slug/');
+            assert.equal(service.hasFinished(), true);
+        });
+
+        it('is not finished again after a reset (route-reload window)', function () {
+            const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
+            service.onRouterAddedType('default', null, 'posts', '/:slug/');
+            service.reset();
+            assert.equal(service.hasFinished(), false);
         });
     });
 });


### PR DESCRIPTION
The lazy URL service reported `hasFinished()` as a hardcoded `true`. Ghost's maintenance middleware (`core/app.js`) holds a site in maintenance (503) until `urlService.facade.hasFinished()`, so in lazy-authoritative mode the site would leave maintenance before its routers were registered.

A request served in that window builds URLs against an empty router set: the URL-relation force-load reads `getRequiredRelations()` — empty, because no routers are registered yet — and under-fetches, so the resource reaches the URL service without the relations a filtered collection needs. In lazy-authoritative mode that either throws (a 500) or silently returns a wrong URL / `/404/`. It's the same root cause behind the residual `LAZY_URL_COMPARE_ERROR` thin-resource logs today, where compare mode falls back to the eager service and masks the impact.

`hasFinished()` now reflects whether routers have actually been registered, so the maintenance gate holds until routing is ready — the contract the eager service already honors.

Routers register together in one synchronous batch (`RouterManager.start()`), so flipping ready on the first `onRouterAddedType` is observably the same as on the last: no request can see a partial set. A dedicated `setRouters()` batch call would make that atomicity explicit and is the intended follow-up; this is the minimal change that makes the gate correct today.
