### PR TITLE
Cleaned stale package references out of lint tooling configs

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -10,10 +10,10 @@
  *                 rendering layer. Paths are anchored on `^ghost/core/core/`.
  *
  *   apps/       — design system layer hierarchy and public/admin separation.
- *                 shade/ and admin-x-design-system/ are leaf packages that
- *                 nothing above them may pull back into. admin-x-framework/
- *                 sits above them but below feature apps. Public UMD bundles
- *                 (portal, comments-ui, etc.) must not depend on admin libs.
+ *                 shade/ is a leaf package that nothing above it may pull
+ *                 back into. admin-x-framework/ sits above it but below
+ *                 feature apps. Public UMD bundles (portal, comments-ui,
+ *                 etc.) must not depend on admin libs.
  *
  *                 Workspace packages appear as unresolved `@tryghost/*` module
  *                 specifiers in the graph (pnpm workspace symlinks are stopped
@@ -97,20 +97,9 @@ module.exports = {
         // ============================================================
         {
             name: 'shade-is-leaf',
-            comment: 'shade/ must not depend on admin-x-framework or admin-x-design-system. It is the foundation layer.',
+            comment: 'shade/ must not depend on admin-x-framework. It is the foundation layer.',
             severity: 'error',
             from: {path: '^apps/shade/'},
-            to: {path: '^@tryghost/(admin-x-framework|admin-x-design-system)'}
-        },
-        // ============================================================
-        // apps/ — admin-x-design-system/ may consume Shade while it is being retired,
-        // but must not depend on application/framework layers
-        // ============================================================
-        {
-            name: 'admin-x-design-system-does-not-depend-on-framework',
-            comment: 'admin-x-design-system/ must not depend on admin-x-framework.',
-            severity: 'error',
-            from: {path: '^apps/admin-x-design-system/'},
             to: {path: '^@tryghost/admin-x-framework'}
         },
         // ============================================================
@@ -118,34 +107,20 @@ module.exports = {
         // ============================================================
         {
             name: 'framework-not-feature-apps',
-            comment: 'admin-x-framework/ must not depend on feature apps (activitypub, posts, admin-x-settings). The framework layer sits below the feature layer.',
+            comment: 'admin-x-framework/ must not depend on feature apps (activitypub, admin-x-settings). The framework layer sits below the feature layer.',
             severity: 'error',
             from: {path: '^apps/admin-x-framework/'},
-            to: {path: '^@tryghost/(activitypub|posts|admin-x-settings)'}
-        },
-        // ============================================================
-        // apps/ — new admin apps must not use the legacy design system
-        // ============================================================
-        {
-            name: 'new-admin-apps-not-admin-x-design-system',
-            comment: 'New admin apps must use shade, not admin-x-design-system.',
-            severity: 'error',
-            from: {
-                // Adding apps to this list is the goal as each migrates off admin-x-design-system
-                // Goal: Work up until admin-x-settings joins and admin-x-design-system can be removed
-                path: '^apps/(activitypub|posts)/'
-            },
-            to: {path: '^@tryghost/admin-x-design-system'}
+            to: {path: '^@tryghost/(activitypub|admin-x-settings)'}
         },
         // ============================================================
         // apps/ — public UMD apps must not depend on admin-only libraries
         // ============================================================
         {
             name: 'public-apps-not-admin-libs',
-            comment: 'Public UMD apps (portal, comments-ui, etc.) must not depend on admin-only libraries (shade, admin-x-framework, admin-x-design-system).',
+            comment: 'Public UMD apps (portal, comments-ui, etc.) must not depend on admin-only libraries (shade, admin-x-framework).',
             severity: 'error',
             from: {path: '^apps/(portal|comments-ui|signup-form|sodo-search|announcement-bar|admin-toolbar)/'},
-            to: {path: '^@tryghost/(shade|admin-x-framework|admin-x-design-system)'}
+            to: {path: '^@tryghost/(shade|admin-x-framework)'}
         }
     ],
     options: {

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -108,6 +108,6 @@ module.exports = {
     },
     'ghost/core/core/{server,shared,frontend}/**/*.{js,ts}': (files) =>
         buildBoundaryCommand(files),
-    'apps/{shade,admin-x-design-system,admin-x-framework,activitypub,posts,admin-x-settings,portal,comments-ui,signup-form,sodo-search,announcement-bar,admin-toolbar}/src/**/*.{js,ts,tsx,jsx}': (files) =>
+    'apps/{shade,admin-x-framework,activitypub,admin-x-settings,portal,comments-ui,signup-form,sodo-search,announcement-bar,admin-toolbar}/src/**/*.{js,ts,tsx,jsx}': (files) =>
         buildBoundaryCommand(files)
 };


### PR DESCRIPTION
## Summary

`apps/admin-x-design-system` and `apps/posts` no longer exist in the workspace, but the boundary and lint-staged configs still referenced them. This cleans out those references so the configs describe only packages that exist.

`.dependency-cruiser.cjs`:
- Deleted the `admin-x-design-system-does-not-depend-on-framework` rule — its `from` path `^apps/admin-x-design-system/` can never match.
- Deleted the `new-admin-apps-not-admin-x-design-system` rule — its `from` covered `apps/posts` (gone) and `apps/activitypub`, and its `to` targeted the deleted design-system package.
- Removed `admin-x-design-system` from the `shade-is-leaf` and `public-apps-not-admin-libs` target lists and their comments.
- Removed `posts` from the `framework-not-feature-apps` target list and comment.
- Updated the file header, which still described `admin-x-design-system/` as a current leaf package.

`.lintstagedrc.cjs`:
- Removed `admin-x-design-system` and `posts` from the workspace-dir brace glob so lint-staged stops matching paths that cannot exist.

## Verification

- `pnpm lint:boundaries` — pass (depcruise over `ghost/core/core` + `apps` with the edited config)
- `cd apps/signup-form && pnpm lint` — pass
- `cd apps/activitypub && pnpm lint` — pass
- `node -e "require('./.lintstagedrc.cjs')"` — config parses
