### PR TITLE
Added flag-gating infrastructure for Ember-to-React screen migrations

### DIFF
--- a/apps/admin-x-framework/src/hooks.ts
+++ b/apps/admin-x-framework/src/hooks.ts
@@ -3,6 +3,7 @@ export {useConfirmUnload} from './hooks/use-confirm-unload';
 export {default as useForm} from './hooks/use-form';
 export type {Dirtyable, ErrorMessages, FormHook, OkProps, SaveHandler, SaveState} from './hooks/use-form';
 export {default as useHandleError} from './hooks/use-handle-error';
+export {useFeatureFlag} from './hooks/use-feature-flag';
 export {usePermission} from './hooks/use-permissions';
 export {useKoenigFileUpload, koenigFileUploadTypes} from './hooks/use-koenig-file-upload';
 export {useKoenigFetchEmbed} from './hooks/use-koenig-fetch-embed';

--- a/apps/admin-x-framework/src/hooks/use-feature-flag.ts
+++ b/apps/admin-x-framework/src/hooks/use-feature-flag.ts
@@ -1,0 +1,10 @@
+import {useBrowseConfig} from '../api/config';
+
+/**
+ * Returns whether a Labs flag is explicitly enabled. Only boolean `true`
+ * counts — `false` while config is loading, missing, or failed.
+ */
+export const useFeatureFlag = (flag: string): boolean => {
+    const {data: config} = useBrowseConfig();
+    return config?.config.labs?.[flag] === true;
+};

--- a/apps/admin-x-framework/test/unit/hooks/use-feature-flag.test.ts
+++ b/apps/admin-x-framework/test/unit/hooks/use-feature-flag.test.ts
@@ -1,0 +1,60 @@
+import {renderHook} from '@testing-library/react';
+import {useFeatureFlag} from '../../../src/hooks/use-feature-flag';
+
+vi.mock('../../../src/api/config', () => ({
+    useBrowseConfig: vi.fn()
+}));
+
+import {useBrowseConfig} from '../../../src/api/config';
+
+const mockUseBrowseConfig = useBrowseConfig as any;
+
+const withLabs = (labs: Record<string, unknown>) => ({
+    data: {config: {labs}}
+});
+
+describe('useFeatureFlag', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns true when the flag is explicitly true', () => {
+        mockUseBrowseConfig.mockReturnValue(withLabs({myFlag: true}));
+
+        const {result} = renderHook(() => useFeatureFlag('myFlag'));
+
+        expect(result.current).toBe(true);
+    });
+
+    it('returns false when the flag is false', () => {
+        mockUseBrowseConfig.mockReturnValue(withLabs({myFlag: false}));
+
+        const {result} = renderHook(() => useFeatureFlag('myFlag'));
+
+        expect(result.current).toBe(false);
+    });
+
+    it('returns false when the flag is absent', () => {
+        mockUseBrowseConfig.mockReturnValue(withLabs({}));
+
+        const {result} = renderHook(() => useFeatureFlag('myFlag'));
+
+        expect(result.current).toBe(false);
+    });
+
+    it('returns false when config has no data yet', () => {
+        mockUseBrowseConfig.mockReturnValue({data: undefined});
+
+        const {result} = renderHook(() => useFeatureFlag('myFlag'));
+
+        expect(result.current).toBe(false);
+    });
+
+    it('returns false when the flag value is truthy but not boolean true', () => {
+        mockUseBrowseConfig.mockReturnValue(withLabs({myFlag: 'true'}));
+
+        const {result} = renderHook(() => useFeatureFlag('myFlag'));
+
+        expect(result.current).toBe(false);
+    });
+});

--- a/apps/admin/src/automations/components/canvas/automation-canvas.tsx
+++ b/apps/admin/src/automations/components/canvas/automation-canvas.tsx
@@ -16,7 +16,7 @@ import {type StepPickerType} from './step-picker';
 import {StepSidebar} from './step-sidebar';
 import {formatWait} from './format-wait';
 import {isEmptyEmailLexical} from '@/automations/utils';
-import {useFeatureFlag} from '@/hooks/use-feature-flag';
+import {useFeatureFlag} from '@tryghost/admin-x-framework/hooks';
 import {useLocation, useNavigate, useSearchParams} from '@tryghost/admin-x-framework';
 import type {EmailModalMode} from '@/automations/components/types';
 

--- a/apps/admin/src/automations/components/canvas/step-sidebar.tsx
+++ b/apps/admin/src/automations/components/canvas/step-sidebar.tsx
@@ -7,7 +7,7 @@ import {LucideIcon, cn, formatNumber} from '@tryghost/shade/utils';
 import type {MemberTier, StepSidebarDetail} from '@/automations/components/types';
 import {TRIGGER_CANVAS_ID} from './nodes';
 import {formatWait} from './format-wait';
-import {useFeatureFlag} from '@/hooks/use-feature-flag';
+import {useFeatureFlag} from '@tryghost/admin-x-framework/hooks';
 
 const MAX_WAIT_DAYS = 30;
 const WHOLE_NUMBER_PATTERN = /^\d+$/;

--- a/apps/admin/src/comments/hooks/use-comments-pinning-enabled.ts
+++ b/apps/admin/src/comments/hooks/use-comments-pinning-enabled.ts
@@ -1,12 +1,11 @@
-import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
+import {useFeatureFlag} from '@tryghost/admin-x-framework/hooks';
 
 /**
  * Returns true when the `commentsPinning` private labs flag is enabled.
  *
- * Uses useBrowseConfig directly so it works on routes that don't mount
+ * Reads the config query so it works on routes that don't mount
  * PostAnalyticsProvider (e.g. the site-wide /ghost#/comments view).
  */
 export const useCommentsPinningEnabled = (): boolean => {
-    const {data: configData} = useBrowseConfig();
-    return configData?.config?.labs?.commentsPinning === true;
+    return useFeatureFlag('commentsPinning');
 };

--- a/apps/admin/src/flag-gated-route.test.tsx
+++ b/apps/admin/src/flag-gated-route.test.tsx
@@ -1,0 +1,103 @@
+import React, {lazy} from 'react';
+import {FlagGatedRoute} from './flag-gated-route';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {render, screen, waitFor} from '@testing-library/react';
+
+const {mockUseBrowseConfig} = vi.hoisted(() => ({
+    mockUseBrowseConfig: vi.fn()
+}));
+
+vi.mock('@tryghost/admin-x-framework/api/config', () => ({
+    useBrowseConfig: mockUseBrowseConfig
+}));
+
+vi.mock('./ember-bridge', () => ({
+    EmberFallback: () => React.createElement('div', {'data-testid': 'ember-fallback'})
+}));
+
+const ReactScreen = lazy(() => Promise.resolve({
+    default: () => React.createElement('div', {'data-testid': 'react-screen'})
+}));
+
+const configResult = (overrides: Record<string, unknown>) => ({
+    data: undefined,
+    isError: false,
+    isLoading: false,
+    ...overrides
+});
+
+const withLabs = (labs: Record<string, unknown>) => configResult({data: {config: {labs}}});
+
+describe('FlagGatedRoute', () => {
+    beforeEach(() => {
+        mockUseBrowseConfig.mockReset();
+    });
+
+    it('renders nothing while config is loading', () => {
+        // Deliberately not falling back to Ember here: doing so would un-hide
+        // the Ember shell and flash the old screen on every cold load for
+        // admins who have the flag on.
+        mockUseBrowseConfig.mockReturnValue(configResult({isLoading: true}));
+
+        const {container} = render(<FlagGatedRoute component={ReactScreen} flag="someFlag" />);
+
+        expect(screen.queryByTestId('ember-fallback')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('react-screen')).not.toBeInTheDocument();
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders Ember when the config query fails', () => {
+        // A failed config read must not blank the screen — Ember owns the URL
+        // by default and still serves it, so degrading to Ember keeps the
+        // route working. Reporting is left to the framework's default error
+        // handler on useBrowseConfig.
+        mockUseBrowseConfig.mockReturnValue(configResult({isError: true, data: undefined}));
+
+        render(<FlagGatedRoute component={ReactScreen} flag="someFlag" />);
+
+        expect(screen.getByTestId('ember-fallback')).toBeInTheDocument();
+    });
+
+    it('renders Ember when the config query resolves with no data', () => {
+        mockUseBrowseConfig.mockReturnValue(configResult({data: undefined}));
+
+        render(<FlagGatedRoute component={ReactScreen} flag="someFlag" />);
+
+        expect(screen.getByTestId('ember-fallback')).toBeInTheDocument();
+    });
+
+    it('renders Ember while the flag is off', () => {
+        mockUseBrowseConfig.mockReturnValue(withLabs({someFlag: false}));
+
+        render(<FlagGatedRoute component={ReactScreen} flag="someFlag" />);
+
+        expect(screen.getByTestId('ember-fallback')).toBeInTheDocument();
+    });
+
+    it('renders Ember when the flag is absent from config', () => {
+        mockUseBrowseConfig.mockReturnValue(withLabs({}));
+
+        render(<FlagGatedRoute component={ReactScreen} flag="someFlag" />);
+
+        expect(screen.getByTestId('ember-fallback')).toBeInTheDocument();
+    });
+
+    it('renders Ember when the flag value is truthy but not boolean true', () => {
+        mockUseBrowseConfig.mockReturnValue(withLabs({someFlag: 'true'}));
+
+        render(<FlagGatedRoute component={ReactScreen} flag="someFlag" />);
+
+        expect(screen.getByTestId('ember-fallback')).toBeInTheDocument();
+    });
+
+    it('renders React while the flag is on', async () => {
+        mockUseBrowseConfig.mockReturnValue(withLabs({someFlag: true}));
+
+        render(<FlagGatedRoute component={ReactScreen} flag="someFlag" />);
+
+        // The React screen is lazily imported, so it arrives a tick later.
+        await waitFor(() => {
+            expect(screen.getByTestId('react-screen')).toBeInTheDocument();
+        });
+    });
+});

--- a/apps/admin/src/flag-gated-route.tsx
+++ b/apps/admin/src/flag-gated-route.tsx
@@ -1,0 +1,47 @@
+import { EmberFallback } from "./ember-bridge";
+import { Suspense, type ComponentType, type LazyExoticComponent } from "react";
+import { useBrowseConfig } from "@tryghost/admin-x-framework/api/config";
+
+/**
+ * Chooses which implementation serves a route while a screen migrates from
+ * Ember to React, based on a Labs flag. Read at render time so toggling the
+ * flag in Developer Experiments swaps implementations without a rebuild — the
+ * routes table is static and evaluated once at module load.
+ *
+ * Ember owns the route unless the flag says otherwise, which makes it the safe
+ * default in every uncertain case: config failed, config came back empty, flag
+ * absent or not a boolean. Only an explicit `true` renders React.
+ *
+ * The one case that is NOT safe to default to Ember is config still loading.
+ * Falling back there would un-hide the Ember shell and flash the Ember screen
+ * on every cold load for admins who have the flag on, so hold for a paint
+ * instead — the config query is normally warm from the admin shell boot.
+ *
+ * Errors are deliberately not reported here: `useBrowseConfig` already routes
+ * them through the framework's default error handler, and the shell calls the
+ * same query, so anything logged here would be a duplicate.
+ */
+export function FlagGatedRoute({ flag, component: Component }: {
+    flag: string;
+    component: LazyExoticComponent<ComponentType>;
+}) {
+    const { data: config, isError, isLoading } = useBrowseConfig();
+
+    if (isLoading) {
+        return null;
+    }
+
+    if (isError || !config) {
+        return <EmberFallback />;
+    }
+
+    if (config.config.labs?.[flag] !== true) {
+        return <EmberFallback />;
+    }
+
+    return (
+        <Suspense fallback={null}>
+            <Component />
+        </Suspense>
+    );
+}

--- a/apps/admin/src/hooks/use-feature-flag.ts
+++ b/apps/admin/src/hooks/use-feature-flag.ts
@@ -1,6 +1,0 @@
-import { useBrowseConfig } from "@tryghost/admin-x-framework/api/config";
-
-export const useFeatureFlag = (flag: string): boolean => {
-    const { data: config } = useBrowseConfig();
-    return config?.config.labs?.[flag] ?? false;
-};

--- a/apps/admin/src/layout/app-sidebar/nav-content.tsx
+++ b/apps/admin/src/layout/app-sidebar/nav-content.tsx
@@ -14,7 +14,7 @@ import { useMemberSidebarViews } from "./member-sidebar-views";
 import { useCustomSidebarViews } from "./use-custom-sidebar-views";
 import { useIsActiveLink } from "./use-is-active-link";
 import { useEmberRouting } from "@/ember-bridge";
-import { useFeatureFlag } from "@/hooks/use-feature-flag";
+import { useFeatureFlag } from "@tryghost/admin-x-framework/hooks";
 
 const LEGACY_MEMBERS_ACTIVE_ROUTES = ['member', 'member.new', 'members-activity'];
 

--- a/apps/admin/src/member-detail-gate.tsx
+++ b/apps/admin/src/member-detail-gate.tsx
@@ -1,48 +1,16 @@
-import { EmberFallback } from "./ember-bridge";
-import { Suspense, lazy } from "react";
-import { useBrowseConfig } from "@tryghost/admin-x-framework/api/config";
+import { FlagGatedRoute } from "./flag-gated-route";
+import { lazy } from "react";
 
 /**
- * Chooses which implementation serves `/members/:member_id`, based on the
- * `memberDetailsReact` Labs flag. Read at render time so toggling the flag in
- * Developer Experiments swaps implementations without a rebuild — the routes
- * table is static and evaluated once at module load.
- *
- * Ember owns this URL unless the flag says otherwise, which makes it the safe
- * default in every uncertain case: config failed, config came back empty, flag
- * absent. Only an explicit `true` renders React.
- *
- * The one case that is NOT safe to default to Ember is config still loading.
- * Falling back there would un-hide the Ember shell and flash the Ember screen
- * on every cold load for admins who have the flag on, so hold for a paint
- * instead — the config query is normally warm from the admin shell boot.
- *
- * Errors are deliberately not reported here: `useBrowseConfig` already routes
- * them through the framework's default error handler, and the shell calls the
- * same query, so anything logged here would be a duplicate.
+ * Serves `/members/:member_id` — covering both edit (`:member_id`) and create
+ * (the `new` sentinel) — from the React member detail screen when the
+ * `memberDetailsReact` Labs flag is on, and from Ember otherwise. The gating
+ * semantics (loading, error, and flag branching) live in FlagGatedRoute.
  */
 const MemberDetailReact = lazy(() => import("./members/detail/member-detail"));
 
 export function MemberDetailGate() {
-    const { data: config, isError, isLoading } = useBrowseConfig();
-
-    if (isLoading) {
-        return null;
-    }
-
-    if (isError || !config) {
-        return <EmberFallback />;
-    }
-
-    if (config.config.labs?.memberDetailsReact !== true) {
-        return <EmberFallback />;
-    }
-
-    return (
-        <Suspense fallback={null}>
-            <MemberDetailReact />
-        </Suspense>
-    );
+    return <FlagGatedRoute component={MemberDetailReact} flag="memberDetailsReact" />;
 }
 
 export default MemberDetailGate;

--- a/apps/admin/src/members/components/bulk-action-modals/import-members-modal.tsx
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members-modal.tsx
@@ -9,9 +9,8 @@ import {createInitialImportState, importReducer} from './import-members/reducer'
 import {isImportMembersCompleteResponse, useImportMembers} from '@tryghost/admin-x-framework/api/members';
 import {memberCustomFieldCsvColumns, useBrowseMemberCustomFields} from '@tryghost/admin-x-framework/api/member-custom-fields';
 import {parseCSV} from './import-members/csv';
-import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
 import {useCallback, useEffect, useMemo, useReducer, useRef} from 'react';
-import {useFeatureFlag} from '@/hooks/use-feature-flag';
+import {useFeatureFlag} from '@tryghost/admin-x-framework/hooks';
 import {useLabelPicker} from '@/members/hooks/use-label-picker';
 
 interface ImportMembersModalProps {
@@ -29,9 +28,8 @@ export function ImportMembersModal({
 }: ImportMembersModalProps) {
     const [state, dispatch] = useReducer(importReducer, undefined, createInitialImportState);
     const errorCsvUrlRef = useRef<string | null>(null);
-    const {data: configData} = useBrowseConfig();
     const {mutateAsync: importMembers} = useImportMembers();
-    const importMemberTier = configData?.config?.labs?.importMemberTier === true;
+    const importMemberTier = useFeatureFlag('importMemberTier');
 
     // Defined custom fields become mapping targets. Fetched only when the feature is on;
     // browse returns active fields only, which are the ones the importer writes to.

--- a/apps/admin/src/members/detail/member-detail.tsx
+++ b/apps/admin/src/members/detail/member-detail.tsx
@@ -21,7 +21,7 @@ import {toast} from 'sonner';
 import {useBlocker} from 'react-router';
 import {useBrowseNewsletters} from '@tryghost/admin-x-framework/api/newsletters';
 import {useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
-import {useFeatureFlag} from '@/hooks/use-feature-flag';
+import {useFeatureFlag} from '@tryghost/admin-x-framework/hooks';
 import {useHashLinkNavigationGuard} from '@/hooks/use-hash-link-navigation-guard';
 import type {MemberEditableFields} from './member-detail-edit';
 


### PR DESCRIPTION
Migrating an admin screen from Ember to React means serving the same URL from either implementation depending on a Labs flag. The member detail screen already does this with hand-rolled branching in its gate component; this PR extracts that branching into reusable infrastructure so each migrated screen gets the same safety semantics without re-implementing them.

## FlagGatedRoute

`apps/admin/src/flag-gated-route.tsx` renders a lazily-loaded React screen when a Labs flag is explicitly `true`, and falls back to Ember otherwise. The flag is read at render time — the routes table is static and evaluated once at module load, so a module-load check would need a rebuild to pick up flag changes. The branching:

- config still loading → render nothing (falling back to Ember here would flash the Ember screen on every cold load for admins with the flag on)
- config errored or missing → Ember (it still owns the URL, so degrading keeps the route working)
- flag anything other than boolean `true` → Ember
- flag `true` → the React screen, wrapped in `Suspense` with a null fallback

`MemberDetailGate` now delegates to it, keeping only the member-specific lazy import. Its existing unit tests pass unmodified.

## useFeatureFlag in admin-x-framework

The simple "is this boolean flag on" read previously lived as a local hook in `apps/admin` alongside scattered inline `config?.labs?.flag === true` reads. The hook now lives in `@tryghost/admin-x-framework/hooks` (exported like its sibling hooks), so any admin app can use it. It returns `true` only for an explicit boolean `true` — `false` while config is loading, missing, or failed. Labs values are typed `boolean` in the framework's `Config`, so call sites behave the same.

Converted in `apps/admin`: the local `@/hooks/use-feature-flag` importers (sidebar nav, member detail, member import modal, automation canvas and step sidebar) now import from the framework, and the inline labs reads in `use-comments-pinning-enabled` and the import members modal (`importMemberTier`) go through the hook. The import modal's direct `useBrowseConfig` call was only feeding that read, so it's gone too.

## Verification

- `apps/admin/src/flag-gated-route.test.tsx` covers every branch: loading holds a paint, error/no-data/flag-off/flag-absent/non-boolean-truthy fall back to Ember, flag-on renders the lazy React screen
- `apps/admin-x-framework/test/unit/hooks/use-feature-flag.test.ts` covers the hook's strict semantics
- `apps/admin-x-framework`: `pnpm lint`, `pnpm test:types`, `pnpm test:unit` — 34 files / 483 tests green
- `apps/admin`: `pnpm lint`, `pnpm typecheck`, `pnpm test:unit` (101 files / 1090 tests), `pnpm test:acceptance` (52 files / 382 tests, member detail and route access specs included) — all green