### PR TITLE
Log fetch shape on URL service compare errors

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/url.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/utils/url.js
@@ -24,14 +24,20 @@ const forPost = (id, attrs, frame, type = 'posts') => {
         return attrs;
     }
 
-    // Diagnostic only: hand the compare-mode URL service the producing api
-    // endpoint. The parity/thin-resource logs capture a caller stack, but it
-    // truncates at the async api-framework boundary and never names the
-    // endpoint; the api-framework Frame carries it, so pass it through. Omitted
-    // for non-api callers (mentions, email) whose frame has no endpoint fields.
+    // Diagnostic only: pass the producing api endpoint and the fetch shape the
+    // input serializer decided on (withRelated/columns/forcedUrlRelations) to
+    // the compare-mode URL service, so a thin-resource throw names its producer
+    // and shows whether the URL force-load ran. Read only into the compare log.
     const options = {absolute: true};
     if (frame && (frame.docName || frame.method)) {
-        options.serializerContext = {apiType: frame.apiType, docName: frame.docName, method: frame.method};
+        options.serializerContext = {
+            apiType: frame.apiType,
+            docName: frame.docName,
+            method: frame.method,
+            withRelated: frame.options && frame.options.withRelated,
+            columns: frame.options && frame.options.columns,
+            forcedUrlRelations: frame.forcedUrlRelations
+        };
     }
 
     attrs.url = urlService.facade.getUrlForResource({...attrs, id, type}, options);

--- a/ghost/core/core/server/services/url/url-service-facade.ts
+++ b/ghost/core/core/server/services/url/url-service-facade.ts
@@ -48,7 +48,14 @@ export interface UrlOptions {
     // throw names its producer in the logs. The compare-log caller stack
     // truncates at the async api-framework boundary, so the stack alone can't.
     // Ignored by both backends; only read into the compare context.
-    serializerContext?: {apiType?: string; docName?: string; method?: string};
+    serializerContext?: {
+        apiType?: string;
+        docName?: string;
+        method?: string;
+        withRelated?: unknown;
+        columns?: unknown;
+        forcedUrlRelations?: unknown;
+    };
 }
 
 /**
@@ -251,6 +258,9 @@ export class UrlServiceFacade {
             id: resource.id,
             status: (resource as Record<string, unknown>).status,
             resourceKeys: Object.keys(resource),
+            // Diagnostic: what the lazy backend considers required right now,
+            // to pair against the serializer's withRelated/columns.
+            requiredRelations: this.lazyUrlService ? this.lazyUrlService.getRequiredRelations() : undefined,
             caller: caller.stack,
             ...extra
         };

--- a/ghost/core/test/unit/api/canary/utils/serializers/output/utils/url.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/output/utils/url.test.js
@@ -44,16 +44,26 @@ describe('Unit: endpoints/utils/serializers/output/utils/url', function () {
             assert.deepEqual(options, {absolute: true});
         });
 
-        it('passes the api endpoint identity (serializerContext) for compare diagnostics', function () {
-            // The compare-log caller stack truncates at the async api-framework
-            // boundary, so the api-framework Frame's endpoint identity is
-            // threaded to the URL service to pin producers in production.
+        it('passes the api endpoint identity and fetch shape (serializerContext) for compare diagnostics', function () {
             const post = pageModel(testUtils.DataGenerator.forKnex.createPost({id: 'id1', mobiledoc: '{}', html: 'html'}));
 
-            urlUtil.forPost(post.id, post, {options: {}, apiType: 'admin', docName: 'posts', method: 'read'});
+            urlUtil.forPost(post.id, post, {
+                options: {withRelated: ['tags'], columns: ['url']},
+                forcedUrlRelations: ['tags'],
+                apiType: 'admin',
+                docName: 'posts',
+                method: 'read'
+            });
 
             const [, options] = getUrlForResourceStub.firstCall.args;
-            assert.deepEqual(options.serializerContext, {apiType: 'admin', docName: 'posts', method: 'read'});
+            assert.deepEqual(options.serializerContext, {
+                apiType: 'admin',
+                docName: 'posts',
+                method: 'read',
+                withRelated: ['tags'],
+                columns: ['url'],
+                forcedUrlRelations: ['tags']
+            });
         });
 
         it('still passes id when attrs has been stripped (e.g. fields=url)', function () {

--- a/ghost/core/test/unit/server/services/url/url-service-facade.test.js
+++ b/ghost/core/test/unit/server/services/url/url-service-facade.test.js
@@ -326,6 +326,7 @@ describe('UrlServiceFacade', function () {
                 getUrlForResource: sinon.stub().returns('/lazy/'),
                 ownsResource: sinon.stub().returns(false),
                 resolveUrl: sinon.stub().resolves({type: 'posts', id: 'lazy'}),
+                getRequiredRelations: sinon.stub().returns([]),
                 hasFinished: sinon.stub().returns(true),
                 onRouterAddedType: sinon.stub(),
                 onRouterUpdated: sinon.stub(),


### PR DESCRIPTION
A handful of `LAZY_URL_COMPARE_ERROR` thin-resource throws remain in compare mode. They come from steady-state admin API reads (a bulk URL-reader hitting `/posts/slug/…?fields=…,url`): the URL force-load should have loaded the relations the collection filter needs, yet the resource reaches the URL service thin.

Static analysis and every reproduction say this can't happen — a stable service with the tag-filtered router registered should return `['tags']` from `getRequiredRelations()` and force the load. So the only way to resolve it is to have production report the runtime state that actually decided the fetch.

This extends the existing compare diagnostic. The output serializer already threads the producing endpoint into the URL service as `serializerContext`; it now also carries the fetch shape the input serializer produced — `withRelated`, `columns`, and `forcedUrlRelations`. The facade records the lazy backend's live `getRequiredRelations()` alongside it. When a thin resource throws during comparison, the log then shows whether the force-load was skipped (`columns` had no `url`), ran blind (`requiredRelations` was empty), or was overwritten (`requiredRelations: ['tags']` but `withRelated` lacks it).

Diagnostic-only and compare-mode-only: the fields are read solely into the compare context; both URL backends ignore them.
