### PR TITLE
Prevent shared Stripe secrets overriding E2E webhook configuration

### DIFF
--- a/docker/ghost-dev/entrypoint.sh
+++ b/docker/ghost-dev/entrypoint.sh
@@ -18,8 +18,12 @@ else
 fi
 
 
-# Configure Stripe webhook secret
-if [ -f /mnt/shared-config/.env.stripe ]; then
+# Configure Stripe webhook secret. An explicit environment value is authoritative
+# so isolated test containers do not inherit a developer Stripe secret from the
+# shared dev volume.
+if [ -n "${WEBHOOK_SECRET:-}" ]; then
+    echo "Stripe webhook secret configured from environment"
+elif [ -f /mnt/shared-config/.env.stripe ]; then
     source /mnt/shared-config/.env.stripe
     if [ -n "${STRIPE_WEBHOOK_SECRET:-}" ]; then
         export WEBHOOK_SECRET="$STRIPE_WEBHOOK_SECRET"
@@ -31,4 +35,3 @@ fi
 
 # Execute the CMD
 exec "$@"
-

--- a/e2e/helpers/environment/constants.ts
+++ b/e2e/helpers/environment/constants.ts
@@ -85,6 +85,10 @@ export const BASE_GHOST_ENV = [
     'mail__options__host=ghost-dev-mailpit',
     'mail__options__port=1025',
 
+    // Keep the test webhook signer and isolated Ghost containers deterministic,
+    // even when the shared development volume contains a live Stripe CLI secret.
+    `WEBHOOK_SECRET=${process.env.WEBHOOK_SECRET || 'DEFAULT_WEBHOOK_SECRET'}`,
+
     // Staff device verification (new-device 2FA) defaults off in development but ships
     // on in production. Force it on so the suite stays production-representative and the
     // 2FA settings UI / sign-in flow render regardless of the dev default.


### PR DESCRIPTION
## What changed

- Pass the E2E webhook secret explicitly to isolated Ghost containers.
- Treat an explicitly configured `WEBHOOK_SECRET` as authoritative before falling back to the Stripe CLI secret in the shared development volume.

## Why

Isolated Ghost E2E containers always mount the development `shared-config` volume. When a developer has previously run the local Stripe CLI service, that volume contains `.env.stripe` with a live `STRIPE_WEBHOOK_SECRET`.

Before this change, the E2E harness supplied `DEFAULT_WEBHOOK_SECRET` to the container, but the Ghost development entrypoint subsequently sourced `.env.stripe` and overwrote it. The fake Stripe service continued signing webhooks with the E2E secret while Ghost verified them with the live Stripe CLI secret, so otherwise valid `checkout.session.completed` events were rejected with HTTP 401.

This made webhook-driven browser tests dependent on workstation state: they passed without a shared Stripe configuration and failed when one existed. Explicit container configuration now wins, while normal development still falls back to `.env.stripe` when no `WEBHOOK_SECRET` is supplied.