### PR TITLE
Added multi-month gift subscription handling

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -87,6 +87,10 @@ const features: Feature[] = [{
     title: 'Paywall improvements',
     description: 'Enables paywall usability, discoverability and email customization improvements',
     flag: 'paywallImprovements'
+}, {
+    title: 'Gift subscription customization',
+    description: 'Enables fixed-duration gift subscription purchases before publisher configuration is available',
+    flag: 'giftSubCustomization'
 }];
 
 const AlphaFeatures: React.FC = () => {

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -49,6 +49,7 @@
         "@sentry/react": "catalog:",
         "@testing-library/jest-dom": "catalog:",
         "@testing-library/react": "catalog:react17",
+        "@types/react": "catalog:react17",
         "@testing-library/user-event": "14.6.1",
         "@tryghost/i18n": "workspace:*",
         "@vitest/coverage-v8": "catalog:",

--- a/apps/portal/src/actions.js
+++ b/apps/portal/src/actions.js
@@ -371,10 +371,10 @@ async function continueGiftSubscription({state, api}) {
 
 async function checkoutGift({data, state, api}) {
     try {
-        const {tierId, cadence, email} = data;
+        const {tierId, cadence, duration, email} = data;
         await api.member.checkoutGift({
             tierId,
-            cadence,
+            ...(duration === undefined ? {cadence} : {duration}),
             ...(email ? {email} : {})
         });
         return {

--- a/apps/portal/src/app.jsx
+++ b/apps/portal/src/app.jsx
@@ -597,7 +597,8 @@ export default class App extends React.Component {
             const token = qParams.get('gift_token');
             const tierId = qParams.get('gift_tier');
             const cadence = qParams.get('gift_cadence');
-            clearURLParams(['stripe', 'gift_token', 'gift_tier', 'gift_cadence']);
+            const duration = qParams.get('gift_duration');
+            clearURLParams(['stripe', 'gift_token', 'gift_tier', 'gift_cadence', 'gift_duration']);
             if (token) {
                 return {
                     showPopup: true,
@@ -605,7 +606,8 @@ export default class App extends React.Component {
                     pageData: {
                         token,
                         tierId,
-                        cadence
+                        cadence,
+                        duration: duration ? Number(duration) : null
                     }
                 };
             }

--- a/apps/portal/src/app.jsx
+++ b/apps/portal/src/app.jsx
@@ -14,6 +14,7 @@ import {transformPortalAnchorToRelative} from './utils/transform-portal-anchor-t
 import {getActivePage, isAccountPage, isOfferPage} from './pages';
 import ActionHandler from './actions';
 import {getGiftRedemptionErrorMessage} from './utils/gift-redemption-notification';
+import {GIFT_DURATION_CATALOGUE} from './utils/gift-subscriptions';
 import './app.css';
 import {hasRecommendations, arePaidMembersEnabled, createNotification, createPopupNotification, hasAvailablePrices, getCurrencySymbol, getFirstpromoterId, getPriceIdFromPageQuery, getProductCadenceFromPrice, getProductFromId, getQueryPrice, getSiteDomain, isActiveOffer, isRetentionOffer, isComplimentaryMember, isInviteOnly, isPaidMember, isRecentMember, isSentryEventAllowed, removePortalLinkFromUrl} from './utils/helpers';
 import {validateHexColor} from './utils/sanitize-html';
@@ -597,7 +598,7 @@ export default class App extends React.Component {
             const token = qParams.get('gift_token');
             const tierId = qParams.get('gift_tier');
             const cadence = qParams.get('gift_cadence');
-            const duration = qParams.get('gift_duration');
+            const duration = Number(qParams.get('gift_duration'));
             clearURLParams(['stripe', 'gift_token', 'gift_tier', 'gift_cadence', 'gift_duration']);
             if (token) {
                 return {
@@ -607,7 +608,7 @@ export default class App extends React.Component {
                         token,
                         tierId,
                         cadence,
-                        duration: duration ? Number(duration) : null
+                        duration: GIFT_DURATION_CATALOGUE.includes(duration) ? duration : null
                     }
                 };
             }

--- a/apps/portal/src/components/common/gift-card.jsx
+++ b/apps/portal/src/components/common/gift-card.jsx
@@ -10,7 +10,7 @@ const GiftCard = ({cardRef, duration, tierName, name, giftValue, siteIcon, siteT
                 <div className='gh-portal-gift-checkout-card-notch' aria-hidden='true' />
                 {hasMeta && (
                     <div className='gh-portal-gift-checkout-card-meta'>
-                        <div className='gh-portal-gift-checkout-card-duration'>{duration}</div>
+                        <div className='gh-portal-gift-checkout-card-duration' data-testid='gift-card-duration'>{duration}</div>
                         <div className='gh-portal-gift-checkout-card-tier'>{t('{tierName} membership', {tierName})}</div>
                     </div>
                 )}
@@ -25,7 +25,7 @@ const GiftCard = ({cardRef, duration, tierName, name, giftValue, siteIcon, siteT
                         {giftValue && (
                             <div className='gh-portal-gift-checkout-card-detail'>
                                 <div className='gh-portal-gift-checkout-card-detail-label'>{t('Gift value')}</div>
-                                <div className='gh-portal-gift-checkout-card-detail-value'>{giftValue}</div>
+                                <div className='gh-portal-gift-checkout-card-detail-value' data-testid='gift-card-value'>{giftValue}</div>
                             </div>
                         )}
                     </div>

--- a/apps/portal/src/components/pages/gift-page.jsx
+++ b/apps/portal/src/components/pages/gift-page.jsx
@@ -692,12 +692,11 @@ function GiftDurationSelector({availableDurations, selectedDuration, setSelected
     }
 
     return (
-        <div className='gh-portal-gift-duration-selector' role='radiogroup' aria-label={t('Plan')}>
+        <div className='gh-portal-gift-duration-selector' role='group' aria-label={t('Plan')}>
             {availableDurations.map(duration => (
                 <button
                     type='button'
-                    role='radio'
-                    aria-checked={duration === selectedDuration}
+                    aria-pressed={duration === selectedDuration}
                     className={'gh-portal-btn' + (duration === selectedDuration ? ' active' : '')}
                     data-test-gift-duration={duration}
                     key={duration}

--- a/apps/portal/src/components/pages/gift-page.jsx
+++ b/apps/portal/src/components/pages/gift-page.jsx
@@ -10,6 +10,7 @@ import giftCardNoiseUrl from '../../images/gift-card-noise.webp';
 import giftCardOrbUrl from '../../images/gift-card-orb.webp';
 import {getAvailableProducts, getCurrencySymbol, formatNumber, getStripeAmount, isCookiesDisabled, getActiveInterval} from '../../utils/helpers';
 import {getGiftDurationLabel} from '../../utils/gift-redemption-notification';
+import {getActiveGiftDuration, getAvailableGiftDurations, getGiftPrice, getGiftProducts} from '../../utils/gift-subscriptions';
 import {ValidateInputForm} from '../../utils/form';
 import {t} from '../../utils/i18n';
 import useCardTilt from '../../utils/use-card-tilt';
@@ -121,6 +122,33 @@ export const GiftPageStyles = `
 
 .gh-portal-gift-checkout .gh-portal-products-pricetoggle {
     margin: 0;
+}
+
+.gh-portal-gift-duration-selector {
+    display: flex;
+    gap: 4px;
+    padding: 4px;
+    min-height: 44px;
+    border-radius: 999px;
+    background: #F3F3F3;
+}
+
+.gh-portal-gift-duration-selector .gh-portal-btn {
+    flex: 1;
+    height: 36px !important;
+    padding: 0 8px;
+    border: 0;
+    border-radius: 999px;
+    background: transparent;
+    color: var(--grey5);
+    font-size: 1.4rem;
+    white-space: nowrap;
+}
+
+.gh-portal-gift-duration-selector .gh-portal-btn.active {
+    color: var(--grey0);
+    background: var(--white);
+    box-shadow: 0 1px 3px rgba(var(--blackrgb), 0.08);
 }
 
 .gh-portal-gift-checkout-email .gh-portal-input-labelcontainer {
@@ -658,6 +686,30 @@ function GiftPriceSwitch({selectedInterval, setSelectedInterval}) {
     );
 }
 
+function GiftDurationSelector({availableDurations, selectedDuration, setSelectedDuration}) {
+    if (availableDurations.length <= 1) {
+        return null;
+    }
+
+    return (
+        <div className='gh-portal-gift-duration-selector' role='radiogroup' aria-label={t('Plan')}>
+            {availableDurations.map(duration => (
+                <button
+                    type='button'
+                    role='radio'
+                    aria-checked={duration === selectedDuration}
+                    className={'gh-portal-btn' + (duration === selectedDuration ? ' active' : '')}
+                    data-test-gift-duration={duration}
+                    key={duration}
+                    onClick={() => setSelectedDuration(duration)}
+                >
+                    {getGiftDurationLabel({cadence: 'month', duration})}
+                </button>
+            ))}
+        </div>
+    );
+}
+
 export function formatGiftValue(price) {
     const {amount, currency} = price ?? {};
     if (amount === null || amount === undefined || !currency) {
@@ -674,6 +726,7 @@ function getTierPriceLabel(product, selectedInterval) {
 const GiftPage = () => {
     const {site, member, brandColor, action, doAction} = useContext(AppContext);
     const [selectedInterval, setSelectedInterval] = useState(null);
+    const [selectedDuration, setSelectedDuration] = useState(null);
     const [selectedProductId, setSelectedProductId] = useState(null);
     const [email, setEmail] = useState('');
     const [errors, setErrors] = useState({});
@@ -745,8 +798,17 @@ const GiftPage = () => {
     }
 
     const {portal_plans: portalPlans, portal_default_plan: portalDefaultPlan} = site;
+    const hasGiftCustomization = !!site.labs?.giftSubCustomization;
     const activeInterval = getActiveInterval({portalPlans, portalDefaultPlan, selectedInterval});
-    const products = getAvailableProducts({site}).filter(p => p.type === 'paid');
+    const availableDurations = hasGiftCustomization ? getAvailableGiftDurations({site}) : [];
+    const activeDuration = hasGiftCustomization ? getActiveGiftDuration({
+        availableDurations,
+        portalDefaultPlan,
+        selectedDuration
+    }) : null;
+    const products = hasGiftCustomization
+        ? getGiftProducts({site, duration: activeDuration})
+        : getAvailableProducts({site}).filter(p => p.type === 'paid');
 
     const siteIcon = site.icon;
     const siteTitle = site.title || '';
@@ -828,7 +890,7 @@ const GiftPage = () => {
 
         doAction('checkoutGift', {
             tierId: activeProduct.id,
-            cadence: activeInterval,
+            ...(hasGiftCustomization ? {duration: activeDuration} : {cadence: activeInterval}),
             ...(!isLoggedIn ? {email: customerEmail} : {})
         });
     };
@@ -860,10 +922,18 @@ const GiftPage = () => {
 
                             <div className='gh-portal-gift-checkout-section'>
                                 <div className='gh-portal-gift-checkout-label'>{isSingleTier ? t('Membership details') : t('Tier')}</div>
-                                <GiftPriceSwitch
-                                    selectedInterval={activeInterval}
-                                    setSelectedInterval={setSelectedInterval}
-                                />
+                                {hasGiftCustomization ? (
+                                    <GiftDurationSelector
+                                        availableDurations={availableDurations}
+                                        selectedDuration={activeDuration}
+                                        setSelectedDuration={setSelectedDuration}
+                                    />
+                                ) : (
+                                    <GiftPriceSwitch
+                                        selectedInterval={activeInterval}
+                                        setSelectedInterval={setSelectedInterval}
+                                    />
+                                )}
                             </div>
 
                             <div className='gh-portal-gift-checkout-section'>
@@ -894,7 +964,11 @@ const GiftPage = () => {
                                                     <div className='gh-portal-gift-checkout-tier-content'>
                                                         <div className='gh-portal-gift-checkout-tier-heading'>
                                                             <span className='gh-portal-gift-checkout-tier-name'>{product.name}</span>
-                                                            <span className='gh-portal-gift-checkout-tier-price'>{getTierPriceLabel(product, activeInterval)}</span>
+                                                            <span className='gh-portal-gift-checkout-tier-price'>
+                                                                {hasGiftCustomization
+                                                                    ? formatGiftValue(getGiftPrice(product, activeDuration))
+                                                                    : getTierPriceLabel(product, activeInterval)}
+                                                            </span>
                                                         </div>
                                                         {product.description && (
                                                             <p className='gh-portal-gift-checkout-tier-description'>{product.description}</p>
@@ -948,9 +1022,13 @@ const GiftPage = () => {
                             <div className='gh-portal-gift-checkout-card-stack'>
                                 <GiftCard
                                     cardRef={cardRef}
-                                    duration={getGiftDurationLabel({cadence: activeInterval, duration: 1})}
+                                    duration={hasGiftCustomization
+                                        ? getGiftDurationLabel({cadence: 'month', duration: activeDuration})
+                                        : getGiftDurationLabel({cadence: activeInterval, duration: 1})}
                                     tierName={activeProduct.name}
-                                    giftValue={getTierPriceLabel(activeProduct, activeInterval)}
+                                    giftValue={hasGiftCustomization
+                                        ? formatGiftValue(getGiftPrice(activeProduct, activeDuration))
+                                        : getTierPriceLabel(activeProduct, activeInterval)}
                                     siteIcon={siteIcon}
                                     siteTitle={siteTitle}
                                 />

--- a/apps/portal/src/components/pages/gift-success-page.jsx
+++ b/apps/portal/src/components/pages/gift-success-page.jsx
@@ -6,6 +6,7 @@ import GiftDetailsToggle from '../common/gift-details-toggle';
 import copyTextToClipboard from '../../utils/copy-to-clipboard';
 import {getAvailableProducts} from '../../utils/helpers';
 import {getGiftDurationLabel} from '../../utils/gift-redemption-notification';
+import {getGiftPrice} from '../../utils/gift-subscriptions';
 import {t} from '../../utils/i18n';
 import useCardTilt from '../../utils/use-card-tilt';
 import {formatGiftValue} from './gift-page';
@@ -147,8 +148,8 @@ const GiftSuccessPage = () => {
                                     }) : null}
                                     tierName={tier && cadence ? tier.name : null}
                                     giftValue={tier && cadence ? formatGiftValue(
-                                        cadence === 'month' && duration
-                                            ? {...tier.monthlyPrice, amount: tier.monthlyPrice.amount * duration}
+                                        duration
+                                            ? getGiftPrice(tier, duration)
                                             : cadence === 'month' ? tier.monthlyPrice : tier.yearlyPrice
                                     ) : null}
                                     siteIcon={siteIcon}

--- a/apps/portal/src/components/pages/gift-success-page.jsx
+++ b/apps/portal/src/components/pages/gift-success-page.jsx
@@ -90,6 +90,7 @@ const GiftSuccessPage = () => {
     const token = pageData?.token;
     const tierId = pageData?.tierId;
     const cadence = pageData?.cadence;
+    const duration = pageData?.duration;
     const siteUrl = site?.url || '';
     const siteIcon = site?.icon;
     const siteTitle = site?.title || '';
@@ -121,7 +122,7 @@ const GiftSuccessPage = () => {
 
                             <div className='gh-portal-gift-checkout-section'>
                                 <div className='gh-portal-gift-success-link'>
-                                    <span className='gh-portal-gift-success-link-url'>{redeemUrl}</span>
+                                    <span className='gh-portal-gift-success-link-url' data-testid='gift-redeem-link'>{redeemUrl}</span>
                                     <button className='gh-portal-gift-success-copy' onClick={handleCopy} type='button'>
                                         {copied ? <CheckIcon /> : <CopyIcon />}
                                         {copied ? t('Copied') : t('Copy')}
@@ -140,9 +141,16 @@ const GiftSuccessPage = () => {
                             <div className='gh-portal-gift-checkout-card-stack' data-revealing={showDetails}>
                                 <GiftCard
                                     cardRef={cardRef}
-                                    duration={tier && cadence ? getGiftDurationLabel({cadence, duration: 1}) : null}
+                                    duration={tier && cadence ? getGiftDurationLabel({
+                                        cadence: duration ? 'month' : cadence,
+                                        duration: duration || 1
+                                    }) : null}
                                     tierName={tier && cadence ? tier.name : null}
-                                    giftValue={tier && cadence ? formatGiftValue(cadence === 'month' ? tier.monthlyPrice : tier.yearlyPrice) : null}
+                                    giftValue={tier && cadence ? formatGiftValue(
+                                        cadence === 'month' && duration
+                                            ? {...tier.monthlyPrice, amount: tier.monthlyPrice.amount * duration}
+                                            : cadence === 'month' ? tier.monthlyPrice : tier.yearlyPrice
+                                    ) : null}
                                     siteIcon={siteIcon}
                                     siteTitle={siteTitle}
                                 />

--- a/apps/portal/src/utils/api.js
+++ b/apps/portal/src/utils/api.js
@@ -622,7 +622,7 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}) {
             });
         },
 
-        async checkoutGift({tierId, cadence, email: customerEmail} = {}) {
+        async checkoutGift({tierId, cadence, duration, email: customerEmail} = {}) {
             const siteUrlObj = new URL(siteUrl);
             const url = endpointFor({type: 'members', resource: 'create-stripe-checkout-session'});
 
@@ -643,7 +643,7 @@ function setupGhostApi({siteUrl = window.location.origin, apiUrl, apiKey}) {
                 },
                 type: 'gift',
                 tierId,
-                cadence,
+                ...(duration === undefined ? {cadence} : {duration}),
                 cancelUrl: cancelUrlObj.href
             };
 

--- a/apps/portal/src/utils/fixtures-generator.js
+++ b/apps/portal/src/utils/fixtures-generator.js
@@ -36,7 +36,7 @@ export function getSiteData({
     portalProducts = products.map(p => p.id),
     accentColor: accent_color = '#45C32E',
     portalPlans: portal_plans = ['free', 'monthly', 'yearly'],
-    portalDefaultPlan: portal_default_plan,
+    portalDefaultPlan: portal_default_plan = '',
     membersSignupAccess: members_signup_access = 'all',
     freePriceName: free_price_name = 'Free',
     freePriceDescription: free_price_description = 'Free preview',

--- a/apps/portal/src/utils/fixtures-generator.js
+++ b/apps/portal/src/utils/fixtures-generator.js
@@ -36,6 +36,7 @@ export function getSiteData({
     portalProducts = products.map(p => p.id),
     accentColor: accent_color = '#45C32E',
     portalPlans: portal_plans = ['free', 'monthly', 'yearly'],
+    portalDefaultPlan: portal_default_plan,
     membersSignupAccess: members_signup_access = 'all',
     freePriceName: free_price_name = 'Free',
     freePriceDescription: free_price_description = 'Free preview',
@@ -51,7 +52,8 @@ export function getSiteData({
     posts = getPostsData(),
     commentsEnabled,
     recommendations = [],
-    recommendationsEnabled
+    recommendationsEnabled,
+    labs = {}
 } = {}) {
     return {
         title,
@@ -70,6 +72,7 @@ export function getSiteData({
         portal_button,
         portal_name,
         portal_plans,
+        ...(portal_default_plan ? {portal_default_plan} : {}),
         portal_button_icon,
         portal_button_signup_text,
         portal_button_style,
@@ -78,6 +81,7 @@ export function getSiteData({
         newsletters,
         recommendations,
         recommendations_enabled: !!recommendationsEnabled,
+        labs,
         editor_default_email_recipients,
         posts
     };

--- a/apps/portal/src/utils/gift-subscriptions.ts
+++ b/apps/portal/src/utils/gift-subscriptions.ts
@@ -1,0 +1,111 @@
+export const GIFT_DURATION_CATALOGUE = [1, 3, 6, 12] as const;
+
+export type GiftDuration = typeof GIFT_DURATION_CATALOGUE[number];
+
+interface GiftPrice {
+    amount?: unknown;
+    currency?: unknown;
+    [key: string]: unknown;
+}
+
+interface ValidGiftPrice extends GiftPrice {
+    amount: number;
+    currency: string;
+}
+
+interface GiftProduct {
+    id: string;
+    type?: string;
+    monthlyPrice?: GiftPrice | null;
+    yearlyPrice?: GiftPrice | null;
+}
+
+interface GiftSite {
+    paid_members_enabled?: boolean;
+    portal_plans?: string[];
+    portal_products?: string[];
+    products?: GiftProduct[];
+}
+
+function getPriceForDuration(product: GiftProduct, duration: GiftDuration): GiftPrice | null | undefined {
+    if (duration === 12) {
+        return product.yearlyPrice;
+    }
+
+    return product.monthlyPrice;
+}
+
+function hasValidPrice(price: GiftPrice | null | undefined): price is ValidGiftPrice {
+    return !!price
+        && typeof price.amount === 'number'
+        && Number.isSafeInteger(price.amount)
+        && price.amount > 0
+        && typeof price.currency === 'string'
+        && !!price.currency;
+}
+
+function isDurationEnabled({portalPlans, duration}: {portalPlans: string[]; duration: GiftDuration}): boolean {
+    return duration === 12
+        ? portalPlans.includes('yearly')
+        : portalPlans.includes('monthly');
+}
+
+export function getGiftPrice(product: GiftProduct, duration: GiftDuration): ValidGiftPrice | null {
+    const price = getPriceForDuration(product, duration);
+
+    if (!hasValidPrice(price)) {
+        return null;
+    }
+
+    return {
+        ...price,
+        amount: duration === 12 ? price.amount : price.amount * duration
+    };
+}
+
+export function getGiftProducts({site, duration}: {site?: GiftSite | null | undefined; duration: GiftDuration}): GiftProduct[] {
+    const {
+        paid_members_enabled: paidMembersEnabled,
+        portal_plans: portalPlans = [],
+        portal_products: portalProducts,
+        products = []
+    } = site || {};
+
+    if (!paidMembersEnabled || !isDurationEnabled({portalPlans, duration})) {
+        return [];
+    }
+
+    return products.filter(product => (
+        product?.type === 'paid'
+        && (!Array.isArray(portalProducts) || portalProducts.includes(product.id))
+        && !!getGiftPrice(product, duration)
+    )).sort((productA, productB) => (
+        (getGiftPrice(productA, duration)?.amount ?? 0) - (getGiftPrice(productB, duration)?.amount ?? 0)
+    ));
+}
+
+export function getAvailableGiftDurations({site}: {site?: GiftSite | null | undefined}): GiftDuration[] {
+    return GIFT_DURATION_CATALOGUE.filter(duration => getGiftProducts({site, duration}).length > 0);
+}
+
+export function getActiveGiftDuration({
+    availableDurations,
+    portalDefaultPlan,
+    selectedDuration
+}: {
+    availableDurations: readonly GiftDuration[];
+    portalDefaultPlan?: string | null;
+    selectedDuration?: GiftDuration | null;
+}): GiftDuration | null {
+    if (selectedDuration && availableDurations.includes(selectedDuration)) {
+        return selectedDuration;
+    }
+
+    const defaultDuration: GiftDuration = portalDefaultPlan === 'yearly' ? 12 : 1;
+
+    if (availableDurations.includes(defaultDuration)) {
+        return defaultDuration;
+    }
+
+    return availableDurations[0] ?? null;
+}

--- a/apps/portal/src/utils/gift-subscriptions.ts
+++ b/apps/portal/src/utils/gift-subscriptions.ts
@@ -84,8 +84,7 @@ export function getGiftProducts({site, duration}: {site: Site | null; duration: 
         return [];
     }
 
-    // portal_products is only respected on multi-tier sites, matching getAvailableProducts
-    const portalProductIds = Array.isArray(portalProducts) && products.length > 1 ? portalProducts : null;
+    const portalProductIds = Array.isArray(portalProducts) ? portalProducts : null;
 
     return products.filter(product => (
         product?.type === 'paid'

--- a/apps/portal/src/utils/gift-subscriptions.ts
+++ b/apps/portal/src/utils/gift-subscriptions.ts
@@ -36,15 +36,15 @@ interface Site {
     products?: Product[];
 }
 
-function getPriceForDuration(product: Product, duration: GiftDuration): Price | null | undefined {
+function getPriceForDuration(product: Product, duration: GiftDuration): Price | null {
     if (duration === 12) {
-        return product.yearlyPrice;
+        return product.yearlyPrice ?? null;
     }
 
-    return product.monthlyPrice;
+    return product.monthlyPrice ?? null;
 }
 
-function hasValidPrice(price: Price | null | undefined): price is ValidPrice {
+function hasValidPrice(price: Price | null): price is ValidPrice {
     return !!price
         && typeof price.amount === 'number'
         && Number.isSafeInteger(price.amount)
@@ -72,7 +72,7 @@ export function getGiftPrice(product: Product, duration: GiftDuration): ValidPri
     };
 }
 
-export function getGiftProducts({site, duration}: {site?: Site | null | undefined; duration: GiftDuration}): Product[] {
+export function getGiftProducts({site, duration}: {site: Site | null; duration: GiftDuration}): Product[] {
     const {
         paid_members_enabled: paidMembersEnabled,
         portal_plans: portalPlans = [],
@@ -99,7 +99,7 @@ export function getGiftProducts({site, duration}: {site?: Site | null | undefine
     )).map(({product}) => product);
 }
 
-export function getAvailableGiftDurations({site}: {site?: Site | null | undefined}): GiftDuration[] {
+export function getAvailableGiftDurations({site}: {site: Site | null}): GiftDuration[] {
     return GIFT_DURATION_CATALOGUE.filter(duration => getGiftProducts({site, duration}).length > 0);
 }
 
@@ -109,8 +109,8 @@ export function getActiveGiftDuration({
     selectedDuration
 }: {
     availableDurations: readonly GiftDuration[];
-    portalDefaultPlan?: PortalDefaultPlan | null;
-    selectedDuration?: GiftDuration | null;
+    portalDefaultPlan: PortalDefaultPlan | null;
+    selectedDuration: GiftDuration | null;
 }): GiftDuration | null {
     if (selectedDuration && availableDurations.includes(selectedDuration)) {
         return selectedDuration;

--- a/apps/portal/src/utils/gift-subscriptions.ts
+++ b/apps/portal/src/utils/gift-subscriptions.ts
@@ -1,3 +1,6 @@
+// Must match the server-owned catalogue in
+// ghost/core/core/server/services/members/members-api/utils/gift-checkout-offer.js
+// until later customization work makes durations server-provided
 export const GIFT_DURATION_CATALOGUE = [1, 3, 6, 12] as const;
 
 export type GiftDuration = typeof GIFT_DURATION_CATALOGUE[number];
@@ -75,13 +78,19 @@ export function getGiftProducts({site, duration}: {site?: GiftSite | null | unde
         return [];
     }
 
+    // portal_products is only respected on multi-tier sites, matching getAvailableProducts
+    const portalProductIds = Array.isArray(portalProducts) && products.length > 1 ? portalProducts : null;
+
     return products.filter(product => (
         product?.type === 'paid'
-        && (!Array.isArray(portalProducts) || portalProducts.includes(product.id))
+        && (!portalProductIds || portalProductIds.includes(product.id))
         && !!getGiftPrice(product, duration)
-    )).sort((productA, productB) => (
-        (getGiftPrice(productA, duration)?.amount ?? 0) - (getGiftPrice(productB, duration)?.amount ?? 0)
-    ));
+    )).map(product => ({
+        product,
+        amount: getGiftPrice(product, duration)?.amount ?? 0
+    })).sort((productA, productB) => (
+        productA.amount - productB.amount
+    )).map(({product}) => product);
 }
 
 export function getAvailableGiftDurations({site}: {site?: GiftSite | null | undefined}): GiftDuration[] {

--- a/apps/portal/src/utils/gift-subscriptions.ts
+++ b/apps/portal/src/utils/gift-subscriptions.ts
@@ -5,32 +5,38 @@ export const GIFT_DURATION_CATALOGUE = [1, 3, 6, 12] as const;
 
 export type GiftDuration = typeof GIFT_DURATION_CATALOGUE[number];
 
-interface GiftPrice {
+type PortalPlan = 'free' | 'monthly' | 'yearly';
+
+// portal_default_plan is server-validated to the paid plans only
+type PortalDefaultPlan = Exclude<PortalPlan, 'free'>;
+
+interface Price {
     amount?: unknown;
     currency?: unknown;
     [key: string]: unknown;
 }
 
-interface ValidGiftPrice extends GiftPrice {
+interface ValidPrice extends Price {
     amount: number;
     currency: string;
 }
 
-interface GiftProduct {
+interface Product {
     id: string;
     type?: string;
-    monthlyPrice?: GiftPrice | null;
-    yearlyPrice?: GiftPrice | null;
+    monthlyPrice?: Price | null;
+    yearlyPrice?: Price | null;
 }
 
-interface GiftSite {
+// the slice of Portal's site data that gift purchasing reads
+interface Site {
     paid_members_enabled?: boolean;
-    portal_plans?: string[];
+    portal_plans?: PortalPlan[];
     portal_products?: string[];
-    products?: GiftProduct[];
+    products?: Product[];
 }
 
-function getPriceForDuration(product: GiftProduct, duration: GiftDuration): GiftPrice | null | undefined {
+function getPriceForDuration(product: Product, duration: GiftDuration): Price | null | undefined {
     if (duration === 12) {
         return product.yearlyPrice;
     }
@@ -38,7 +44,7 @@ function getPriceForDuration(product: GiftProduct, duration: GiftDuration): Gift
     return product.monthlyPrice;
 }
 
-function hasValidPrice(price: GiftPrice | null | undefined): price is ValidGiftPrice {
+function hasValidPrice(price: Price | null | undefined): price is ValidPrice {
     return !!price
         && typeof price.amount === 'number'
         && Number.isSafeInteger(price.amount)
@@ -47,13 +53,13 @@ function hasValidPrice(price: GiftPrice | null | undefined): price is ValidGiftP
         && !!price.currency;
 }
 
-function isDurationEnabled({portalPlans, duration}: {portalPlans: string[]; duration: GiftDuration}): boolean {
+function isDurationEnabled({portalPlans, duration}: {portalPlans: PortalPlan[]; duration: GiftDuration}): boolean {
     return duration === 12
         ? portalPlans.includes('yearly')
         : portalPlans.includes('monthly');
 }
 
-export function getGiftPrice(product: GiftProduct, duration: GiftDuration): ValidGiftPrice | null {
+export function getGiftPrice(product: Product, duration: GiftDuration): ValidPrice | null {
     const price = getPriceForDuration(product, duration);
 
     if (!hasValidPrice(price)) {
@@ -66,7 +72,7 @@ export function getGiftPrice(product: GiftProduct, duration: GiftDuration): Vali
     };
 }
 
-export function getGiftProducts({site, duration}: {site?: GiftSite | null | undefined; duration: GiftDuration}): GiftProduct[] {
+export function getGiftProducts({site, duration}: {site?: Site | null | undefined; duration: GiftDuration}): Product[] {
     const {
         paid_members_enabled: paidMembersEnabled,
         portal_plans: portalPlans = [],
@@ -93,7 +99,7 @@ export function getGiftProducts({site, duration}: {site?: GiftSite | null | unde
     )).map(({product}) => product);
 }
 
-export function getAvailableGiftDurations({site}: {site?: GiftSite | null | undefined}): GiftDuration[] {
+export function getAvailableGiftDurations({site}: {site?: Site | null | undefined}): GiftDuration[] {
     return GIFT_DURATION_CATALOGUE.filter(duration => getGiftProducts({site, duration}).length > 0);
 }
 
@@ -103,7 +109,7 @@ export function getActiveGiftDuration({
     selectedDuration
 }: {
     availableDurations: readonly GiftDuration[];
-    portalDefaultPlan?: string | null;
+    portalDefaultPlan?: PortalDefaultPlan | null;
     selectedDuration?: GiftDuration | null;
 }): GiftDuration | null {
     if (selectedDuration && availableDurations.includes(selectedDuration)) {

--- a/apps/portal/src/utils/helpers.js
+++ b/apps/portal/src/utils/helpers.js
@@ -366,7 +366,7 @@ export function getAvailableProducts({site}) {
     }).filter((product) => {
         return !!(Object.keys(product.monthlyPrice).length > 0 && Object.keys(product.yearlyPrice).length > 0);
     }).filter((product) => {
-        if (portalProducts && products.length > 1) {
+        if (portalProducts) {
             return portalProducts.includes(product.id);
         }
         return true;

--- a/apps/portal/test/actions.test.ts
+++ b/apps/portal/test/actions.test.ts
@@ -692,6 +692,27 @@ describe('checkoutGift action', () => {
         expect(result.action).toBe('checkoutGift:success');
     });
 
+    test('passes a fixed duration through to api.member.checkoutGift', async () => {
+        const mockApi = {
+            member: {
+                checkoutGift: vi.fn(() => Promise.resolve())
+            }
+        };
+
+        const result = await ActionHandler({
+            action: 'checkoutGift',
+            data: {tierId: 'tier_123', duration: 3},
+            state: {},
+            api: mockApi
+        });
+
+        expect(mockApi.member.checkoutGift).toHaveBeenCalledWith({
+            tierId: 'tier_123',
+            duration: 3
+        });
+        expect(result.action).toBe('checkoutGift:success');
+    });
+
     test('returns failed action with notification on error', async () => {
         const mockApi = {
             member: {

--- a/apps/portal/test/api.test.js
+++ b/apps/portal/test/api.test.js
@@ -175,6 +175,39 @@ describe('Portal API gift checkout', () => {
         });
         expect(window.location.assign).toHaveBeenCalledWith('https://checkout.stripe.com/gift-session');
     });
+
+    test('sends duration without cadence for customized gift checkout', async () => {
+        const ghostApi = setupGhostApi({siteUrl: 'https://example.com'});
+        const requestSpy = vi.spyOn(window, 'fetch').mockImplementation((url) => {
+            if (url.includes('/members/api/session/')) {
+                return Promise.resolve(new Response('identity-token', {status: 200}));
+            }
+
+            return Promise.resolve(new Response(JSON.stringify({
+                url: 'https://checkout.stripe.com/gift-session'
+            }), {
+                status: 200,
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            }));
+        });
+
+        await ghostApi.member.checkoutGift({
+            tierId: 'tier_123',
+            duration: 3
+        });
+
+        const [, request] = requestSpy.mock.calls.at(-1);
+        const body = JSON.parse(request.body);
+
+        expect(body).toMatchObject({
+            type: 'gift',
+            tierId: 'tier_123',
+            duration: 3
+        });
+        expect(body).not.toHaveProperty('cadence');
+    });
 });
 
 describe('Portal API member checkout', () => {

--- a/apps/portal/test/portal-links.test.jsx
+++ b/apps/portal/test/portal-links.test.jsx
@@ -601,15 +601,17 @@ describe('Portal Data links:', () => {
 
     describe('?stripe=gift-purchase-success', () => {
         test('opens gift success page', async () => {
-            window.location.href = 'https://portal.localhost/?stripe=gift-purchase-success&gift_token=abc123';
-            window.location.search = '?stripe=gift-purchase-success&gift_token=abc123';
+            const site = FixtureSite.singleTier.basic;
+            const tierId = site.products.find(product => product.type === 'paid').id;
+            window.location.href = `https://portal.localhost/?stripe=gift-purchase-success&gift_token=abc123&gift_tier=${tierId}&gift_cadence=year&gift_duration=12`;
+            window.location.search = `?stripe=gift-purchase-success&gift_token=abc123&gift_tier=${tierId}&gift_cadence=year&gift_duration=12`;
             window.location.hash = '';
             window.location.pathname = '/';
 
             let {
                 popupFrame, triggerButtonFrame, ...utils
             } = await setup({
-                site: FixtureSite.singleTier.basic,
+                site,
                 showPopup: false
             });
 
@@ -623,6 +625,9 @@ describe('Portal Data links:', () => {
 
             const redeemUrl = within(popupFrame.contentDocument).queryByText(/\/gift\/abc123$/);
             expect(redeemUrl).toBeInTheDocument();
+
+            const duration = within(popupFrame.contentDocument).queryByText('12 months');
+            expect(duration).toBeInTheDocument();
         });
 
         test('does not open gift success page when gift_token is missing', async () => {

--- a/apps/portal/test/unit/components/pages/gift-page.test.jsx
+++ b/apps/portal/test/unit/components/pages/gift-page.test.jsx
@@ -1,0 +1,129 @@
+import {fireEvent, render} from '../../../utils/test-utils';
+import GiftPage from '../../../../src/components/pages/gift-page';
+import {getPriceData, getProductData, getSiteData} from '../../../../src/utils/fixtures-generator';
+
+function buildSite(overrides = {}) {
+    const product = getProductData({
+        id: 'tier_123',
+        name: 'Premium',
+        monthlyPrice: getPriceData({amount: 500, interval: 'month'}),
+        yearlyPrice: getPriceData({amount: 5000, interval: 'year'})
+    });
+
+    return getSiteData({
+        products: [product],
+        portalProducts: [product.id],
+        portalDefaultPlan: 'monthly',
+        ...overrides
+    });
+}
+
+function setup(site) {
+    return render(<GiftPage />, {
+        overrideContext: {
+            site,
+            member: {
+                email: 'buyer@example.com',
+                status: 'free'
+            }
+        }
+    });
+}
+
+describe('GiftPage', () => {
+    test('preserves the cadence selector and cadence-only checkout when customization is disabled', () => {
+        const {getByRole, mockDoActionFn, queryByRole} = setup(buildSite());
+
+        expect(getByRole('button', {name: '1 month'})).toBeInTheDocument();
+        expect(getByRole('button', {name: '1 year'})).toBeInTheDocument();
+        expect(queryByRole('radio', {name: '3 months'})).not.toBeInTheDocument();
+
+        fireEvent.click(getByRole('button', {name: 'Continue'}));
+
+        expect(mockDoActionFn).toHaveBeenCalledWith('checkoutGift', {
+            tierId: 'tier_123',
+            cadence: 'month'
+        });
+    });
+
+    test('offers the full fixed-duration catalogue and updates the price and request', () => {
+        const site = buildSite({
+            labs: {
+                giftSubCustomization: true
+            }
+        });
+        const {getAllByText, getByRole, mockDoActionFn} = setup(site);
+
+        expect(getByRole('radio', {name: '1 month'})).toBeChecked();
+        expect(getByRole('radio', {name: '3 months'})).toBeInTheDocument();
+        expect(getByRole('radio', {name: '6 months'})).toBeInTheDocument();
+        expect(getByRole('radio', {name: '12 months'})).toBeInTheDocument();
+        expect(getAllByText('$5').length).toBeGreaterThan(0);
+
+        fireEvent.click(getByRole('radio', {name: '3 months'}));
+
+        expect(getByRole('radio', {name: '3 months'})).toBeChecked();
+        expect(getAllByText('$15').length).toBeGreaterThan(0);
+
+        fireEvent.click(getByRole('button', {name: 'Continue'}));
+
+        expect(mockDoActionFn).toHaveBeenCalledWith('checkoutGift', {
+            tierId: 'tier_123',
+            duration: 3
+        });
+    });
+
+    test('defaults to 12 months for a yearly Portal default', () => {
+        const site = buildSite({
+            labs: {
+                giftSubCustomization: true
+            },
+            portalDefaultPlan: 'yearly'
+        });
+        const {getByRole, mockDoActionFn} = setup(site);
+
+        expect(getByRole('radio', {name: '12 months'})).toBeChecked();
+
+        fireEvent.click(getByRole('button', {name: 'Continue'}));
+
+        expect(mockDoActionFn).toHaveBeenCalledWith('checkoutGift', {
+            tierId: 'tier_123',
+            duration: 12
+        });
+    });
+
+    test('omits the selector when only one duration is available', () => {
+        const site = buildSite({
+            labs: {
+                giftSubCustomization: true
+            },
+            portalPlans: ['yearly']
+        });
+        const {getByRole, mockDoActionFn, queryByRole} = setup(site);
+
+        expect(queryByRole('radiogroup', {name: 'Plan'})).not.toBeInTheDocument();
+
+        fireEvent.click(getByRole('button', {name: 'Continue'}));
+
+        expect(mockDoActionFn).toHaveBeenCalledWith('checkoutGift', {
+            tierId: 'tier_123',
+            duration: 12
+        });
+    });
+
+    test('falls back to the first available duration when the default plan is unavailable', () => {
+        const site = buildSite({
+            labs: {
+                giftSubCustomization: true
+            },
+            portalPlans: ['monthly'],
+            portalDefaultPlan: 'yearly'
+        });
+        const {getByRole, queryByRole} = setup(site);
+
+        expect(getByRole('radio', {name: '1 month'})).toBeChecked();
+        expect(getByRole('radio', {name: '3 months'})).toBeInTheDocument();
+        expect(getByRole('radio', {name: '6 months'})).toBeInTheDocument();
+        expect(queryByRole('radio', {name: '12 months'})).not.toBeInTheDocument();
+    });
+});

--- a/apps/portal/test/unit/components/pages/gift-page.test.tsx
+++ b/apps/portal/test/unit/components/pages/gift-page.test.tsx
@@ -2,7 +2,9 @@ import {fireEvent, render} from '../../../utils/test-utils';
 import GiftPage from '../../../../src/components/pages/gift-page';
 import {getPriceData, getProductData, getSiteData} from '../../../../src/utils/fixtures-generator';
 
-function buildSite(overrides = {}) {
+type SiteData = ReturnType<typeof getSiteData>;
+
+function buildSite(overrides: Partial<Parameters<typeof getSiteData>[0]> = {}) {
     const product = getProductData({
         id: 'tier_123',
         name: 'Premium',
@@ -18,7 +20,7 @@ function buildSite(overrides = {}) {
     });
 }
 
-function setup(site) {
+function setup(site: SiteData) {
     return render(<GiftPage />, {
         overrideContext: {
             site,

--- a/apps/portal/test/unit/components/pages/gift-page.test.tsx
+++ b/apps/portal/test/unit/components/pages/gift-page.test.tsx
@@ -38,7 +38,7 @@ describe('GiftPage', () => {
 
         expect(getByRole('button', {name: '1 month'})).toBeInTheDocument();
         expect(getByRole('button', {name: '1 year'})).toBeInTheDocument();
-        expect(queryByRole('radio', {name: '3 months'})).not.toBeInTheDocument();
+        expect(queryByRole('button', {name: '3 months'})).not.toBeInTheDocument();
 
         fireEvent.click(getByRole('button', {name: 'Continue'}));
 
@@ -56,15 +56,16 @@ describe('GiftPage', () => {
         });
         const {getAllByText, getByRole, mockDoActionFn} = setup(site);
 
-        expect(getByRole('radio', {name: '1 month'})).toBeChecked();
-        expect(getByRole('radio', {name: '3 months'})).toBeInTheDocument();
-        expect(getByRole('radio', {name: '6 months'})).toBeInTheDocument();
-        expect(getByRole('radio', {name: '12 months'})).toBeInTheDocument();
+        expect(getByRole('button', {name: '1 month'})).toHaveAttribute('aria-pressed', 'true');
+        expect(getByRole('button', {name: '3 months'})).toHaveAttribute('aria-pressed', 'false');
+        expect(getByRole('button', {name: '6 months'})).toBeInTheDocument();
+        expect(getByRole('button', {name: '12 months'})).toBeInTheDocument();
         expect(getAllByText('$5').length).toBeGreaterThan(0);
 
-        fireEvent.click(getByRole('radio', {name: '3 months'}));
+        fireEvent.click(getByRole('button', {name: '3 months'}));
 
-        expect(getByRole('radio', {name: '3 months'})).toBeChecked();
+        expect(getByRole('button', {name: '1 month'})).toHaveAttribute('aria-pressed', 'false');
+        expect(getByRole('button', {name: '3 months'})).toHaveAttribute('aria-pressed', 'true');
         expect(getAllByText('$15').length).toBeGreaterThan(0);
 
         fireEvent.click(getByRole('button', {name: 'Continue'}));
@@ -84,7 +85,7 @@ describe('GiftPage', () => {
         });
         const {getByRole, mockDoActionFn} = setup(site);
 
-        expect(getByRole('radio', {name: '12 months'})).toBeChecked();
+        expect(getByRole('button', {name: '12 months'})).toHaveAttribute('aria-pressed', 'true');
 
         fireEvent.click(getByRole('button', {name: 'Continue'}));
 
@@ -103,7 +104,7 @@ describe('GiftPage', () => {
         });
         const {getByRole, mockDoActionFn, queryByRole} = setup(site);
 
-        expect(queryByRole('radiogroup', {name: 'Plan'})).not.toBeInTheDocument();
+        expect(queryByRole('group', {name: 'Plan'})).not.toBeInTheDocument();
 
         fireEvent.click(getByRole('button', {name: 'Continue'}));
 
@@ -123,9 +124,9 @@ describe('GiftPage', () => {
         });
         const {getByRole, queryByRole} = setup(site);
 
-        expect(getByRole('radio', {name: '1 month'})).toBeChecked();
-        expect(getByRole('radio', {name: '3 months'})).toBeInTheDocument();
-        expect(getByRole('radio', {name: '6 months'})).toBeInTheDocument();
-        expect(queryByRole('radio', {name: '12 months'})).not.toBeInTheDocument();
+        expect(getByRole('button', {name: '1 month'})).toHaveAttribute('aria-pressed', 'true');
+        expect(getByRole('button', {name: '3 months'})).toBeInTheDocument();
+        expect(getByRole('button', {name: '6 months'})).toBeInTheDocument();
+        expect(queryByRole('button', {name: '12 months'})).not.toBeInTheDocument();
     });
 });

--- a/apps/portal/test/unit/components/pages/gift-success-page.test.tsx
+++ b/apps/portal/test/unit/components/pages/gift-success-page.test.tsx
@@ -1,0 +1,50 @@
+import GiftSuccessPage from '../../../../src/components/pages/gift-success-page';
+import {getPriceData, getProductData, getSiteData} from '../../../../src/utils/fixtures-generator';
+import {render} from '../../../utils/test-utils';
+
+function setup({monthlyPrice}: {monthlyPrice: ReturnType<typeof getPriceData> | null}) {
+    const product = {
+        ...getProductData({
+            id: 'tier_123',
+            name: 'Premium',
+            yearlyPrice: getPriceData({amount: 5000, interval: 'year'})
+        }),
+        monthlyPrice
+    };
+    const site = getSiteData({
+        products: [product],
+        portalProducts: [product.id]
+    });
+
+    return render(<GiftSuccessPage />, {
+        overrideContext: {
+            site,
+            pageData: {
+                token: 'abc123',
+                tierId: 'tier_123',
+                cadence: 'month',
+                duration: 3
+            }
+        }
+    });
+}
+
+describe('GiftSuccessPage', () => {
+    test('shows the multiplied monthly price as the gift value', () => {
+        const {getByTestId} = setup({
+            monthlyPrice: getPriceData({amount: 500, interval: 'month'})
+        });
+
+        expect(getByTestId('gift-redeem-link')).toHaveTextContent('/gift/abc123');
+        expect(getByTestId('gift-card-duration')).toHaveTextContent('3 months');
+        expect(getByTestId('gift-card-value')).toHaveTextContent('$15');
+    });
+
+    test('renders without card details when the tier no longer has a monthly price', () => {
+        const {getByTestId, queryByTestId} = setup({monthlyPrice: null});
+
+        expect(getByTestId('gift-redeem-link')).toHaveTextContent('/gift/abc123');
+        expect(queryByTestId('gift-card-duration')).not.toBeInTheDocument();
+        expect(queryByTestId('gift-card-value')).not.toBeInTheDocument();
+    });
+});

--- a/apps/portal/tsconfig.json
+++ b/apps/portal/tsconfig.json
@@ -13,7 +13,7 @@
     /* Language and Environment */
     "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    "jsx": "react-jsx",                                  /* Specify what JSX code is generated. */
     // "libReplacement": true,                           /* Enable lib replacement. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */

--- a/e2e/helpers/environment/service-managers/ghost-manager.ts
+++ b/e2e/helpers/environment/service-managers/ghost-manager.ts
@@ -414,6 +414,10 @@ export class GhostManager {
             `${caddyfilePath}:/etc/caddy/Caddyfile:ro`
         ];
 
+        if (mode === 'dev') {
+            binds.push(`${REPO_ROOT}/apps:/srv/apps:ro`);
+        }
+
         // Environment variables for Caddy
         const env = [
             `GHOST_BACKEND=${ghostBackend}:${TEST_ENVIRONMENT.ghost.port}`,

--- a/e2e/helpers/pages/portal/gift-page.ts
+++ b/e2e/helpers/pages/portal/gift-page.ts
@@ -1,0 +1,30 @@
+import {Locator, Page} from '@playwright/test';
+import {PortalPage} from './portal-page';
+
+export class PortalGiftPage extends PortalPage {
+    readonly buyerEmailInput: Locator;
+    readonly continueButton: Locator;
+    readonly giftCardDuration: Locator;
+    readonly giftCardValue: Locator;
+    readonly giftRedeemLink: Locator;
+    readonly successTitle: Locator;
+
+    constructor(page: Page) {
+        super(page);
+
+        this.buyerEmailInput = this.portalFrame.getByLabel('Your email');
+        this.continueButton = this.portalFrame.getByRole('button', {name: 'Continue'});
+        this.giftCardDuration = this.portalFrame.getByTestId('gift-card-duration');
+        this.giftCardValue = this.portalFrame.getByTestId('gift-card-value');
+        this.giftRedeemLink = this.portalFrame.getByTestId('gift-redeem-link');
+        this.successTitle = this.portalFrame.getByRole('heading', {name: 'Your gift is ready'});
+    }
+
+    durationOption(label: string): Locator {
+        return this.portalFrame.getByRole('radio', {name: label, exact: true});
+    }
+
+    tierOption(name: string): Locator {
+        return this.portalFrame.getByRole('radio').filter({hasText: name});
+    }
+}

--- a/e2e/helpers/pages/portal/gift-page.ts
+++ b/e2e/helpers/pages/portal/gift-page.ts
@@ -21,7 +21,7 @@ export class PortalGiftPage extends PortalPage {
     }
 
     durationOption(label: string): Locator {
-        return this.portalFrame.getByRole('radio', {name: label, exact: true});
+        return this.portalFrame.getByRole('button', {name: label, exact: true});
     }
 
     tierOption(name: string): Locator {

--- a/e2e/helpers/pages/portal/index.ts
+++ b/e2e/helpers/pages/portal/index.ts
@@ -1,6 +1,7 @@
 export * from './account-home-page';
 export * from './account-page';
 export * from './account-plan-page';
+export * from './gift-page';
 export * from './newsletter-management-page';
 export * from './offer-page';
 export * from './portal-page';

--- a/e2e/helpers/pages/stripe/fake-checkout-page.ts
+++ b/e2e/helpers/pages/stripe/fake-checkout-page.ts
@@ -26,7 +26,7 @@ export class FakeStripeCheckoutPage extends BasePage {
         await this.title.waitFor({state: 'visible'});
     }
 
-    async waitUntilDonationReady(): Promise<void> {
+    async waitUntilPaymentReady(): Promise<void> {
         await this.waitUntilLoaded();
         await this.totalAmount.waitFor({state: 'visible'});
     }

--- a/e2e/helpers/playwright/flows/donations.ts
+++ b/e2e/helpers/playwright/flows/donations.ts
@@ -11,7 +11,7 @@ interface CompleteDonationOptions {
 
 export async function completeDonationViaFakeCheckout(page: Page, stripe: StripeTestService, opts: CompleteDonationOptions = {}): Promise<void> {
     const checkoutPage = new FakeStripeCheckoutPage(page);
-    await checkoutPage.waitUntilDonationReady();
+    await checkoutPage.waitUntilPaymentReady();
 
     if (opts.amount) {
         await checkoutPage.changeAmountTo(opts.amount);

--- a/e2e/helpers/services/stripe/builders.ts
+++ b/e2e/helpers/services/stripe/builders.ts
@@ -86,7 +86,14 @@ export type StripeCheckoutSessionResponse = Omit<Pick<Stripe.Checkout.Session, '
 
 export interface StripeCheckoutSessionRequest {
     discounts?: Array<{coupon: string}>;
-    line_items?: Array<{price: string; quantity: number}>;
+    line_items?: Array<{
+        price?: string;
+        price_data?: {
+            currency: string;
+            unit_amount: number;
+        };
+        quantity: number;
+    }>;
     subscription_data?: {
         items: Array<{plan: string}>;
         metadata?: Record<string, unknown>;
@@ -314,6 +321,39 @@ export function buildDonationCheckoutCompletedEvent(opts: {
                         value: opts.donationMessage
                     }
                 }] : []
+            }
+        }
+    };
+}
+
+export function buildGiftCheckoutCompletedEvent(opts: {
+    amount: number;
+    currency: string;
+    customerEmail: string;
+    customerId?: string | null;
+    metadata: Record<string, string>;
+    name: string;
+    paymentIntent: string;
+    sessionId: string;
+}): StripeEvent {
+    return {
+        id: generateId('evt'),
+        object: 'event',
+        type: 'checkout.session.completed',
+        data: {
+            object: {
+                id: opts.sessionId,
+                object: 'checkout.session',
+                mode: 'payment',
+                amount_total: opts.amount,
+                currency: opts.currency,
+                customer: opts.customerId ?? null,
+                customer_details: {
+                    email: opts.customerEmail,
+                    name: opts.name
+                },
+                metadata: opts.metadata,
+                payment_intent: opts.paymentIntent
             }
         }
     };

--- a/e2e/helpers/services/stripe/fake-stripe-server.ts
+++ b/e2e/helpers/services/stripe/fake-stripe-server.ts
@@ -509,7 +509,20 @@ export class FakeStripeServer extends FakeServer {
     }
 
     private getCheckoutPrice(session: RecordedStripeCheckoutSession): StripePrice | null {
-        const priceId = session.request.line_items?.[0]?.price ?? session.request.subscription_data?.items[0]?.plan;
+        const lineItem = session.request.line_items?.[0];
+        const inlinePrice = lineItem?.price_data;
+
+        if (inlinePrice) {
+            return buildPrice({
+                id: `price_inline_${session.response.id}`,
+                currency: inlinePrice.currency,
+                unit_amount: inlinePrice.unit_amount,
+                type: 'one_time',
+                recurring: null
+            });
+        }
+
+        const priceId = lineItem?.price ?? session.request.subscription_data?.items[0]?.plan;
 
         if (!priceId) {
             return null;
@@ -684,17 +697,40 @@ export class FakeStripeServer extends FakeServer {
 
         const lineItems = Array.isArray(value)
             ? value
-            : Object.values(value as Record<string, {price?: string; quantity?: number | string}>);
+            : Object.values(value as Record<string, {
+                price?: string;
+                price_data?: {
+                    currency?: string;
+                    unit_amount?: number | string;
+                };
+                quantity?: number | string;
+            }>);
 
         return lineItems
-            .filter((item): item is {price?: string; quantity?: number | string} => item !== null && typeof item === 'object')
+            .filter((item): item is {
+                price?: string;
+                price_data?: {
+                    currency?: string;
+                    unit_amount?: number | string;
+                };
+                quantity?: number | string;
+            } => item !== null && typeof item === 'object')
             .map((item) => {
+                const currency = this.parseString(item.price_data?.currency);
+                const unitAmount = this.parseNumber(item.price_data?.unit_amount);
+
                 return {
-                    price: this.parseString(item?.price) ?? '',
+                    price: this.parseString(item.price),
+                    ...(currency && unitAmount !== undefined ? {
+                        price_data: {
+                            currency,
+                            unit_amount: unitAmount
+                        }
+                    } : {}),
                     quantity: this.parseNumber(item?.quantity) ?? 1
                 };
             })
-            .filter(item => item.price);
+            .filter(item => item.price || item.price_data);
     }
 
     private parseSubscriptionItemsUpdate(value: unknown): Array<{id: string; price: string}> {

--- a/e2e/helpers/services/stripe/stripe-service.ts
+++ b/e2e/helpers/services/stripe/stripe-service.ts
@@ -6,6 +6,7 @@ import {
     buildCustomer,
     buildDiscount,
     buildDonationCheckoutCompletedEvent,
+    buildGiftCheckoutCompletedEvent,
     buildInvoicePaymentSucceededEvent,
     buildPaymentMethod,
     buildPrice,
@@ -100,6 +101,46 @@ export class StripeTestService {
             sessionId: session.response.id,
             ...opts
         });
+    }
+
+    async completeLatestGiftCheckout(opts: {
+        email?: string;
+        name?: string;
+    } = {}): Promise<void> {
+        const session = this.getCheckoutSessions()
+            .filter(item => item.response.mode === 'payment' && item.response.metadata.ghost_gift === 'true')
+            .at(-1);
+
+        if (!session) {
+            throw new Error('No recorded gift checkout session found');
+        }
+
+        const inlinePrice = session.request.line_items?.[0]?.price_data;
+        const customer = session.response.customer
+            ? this.getCustomers().find(item => item.id === session.response.customer) ?? null
+            : null;
+        const email = opts.email ?? session.response.customer_email ?? customer?.email;
+
+        if (!inlinePrice || !email) {
+            throw new Error(`Gift checkout session ${session.response.id} is missing price or customer data`);
+        }
+
+        const event = buildGiftCheckoutCompletedEvent({
+            amount: inlinePrice.unit_amount,
+            currency: inlinePrice.currency,
+            customerEmail: email,
+            customerId: session.response.customer,
+            metadata: session.response.metadata,
+            name: opts.name ?? customer?.name ?? 'Test Gift Buyer',
+            paymentIntent: `pi_gift_${session.response.id}`,
+            sessionId: session.response.id
+        });
+        const response = await this.webhookClient.sendWebhook(event);
+
+        if (!response.ok) {
+            const body = await response.text();
+            throw new Error(`checkout.session.completed gift webhook failed (${response.status}): ${body}`);
+        }
     }
 
     async createPaidMemberViaWebhooks(opts: {email: string; name: string}): Promise<CreatedPaidMember> {

--- a/e2e/tests/public/portal-donations.test.ts
+++ b/e2e/tests/public/portal-donations.test.ts
@@ -22,7 +22,7 @@ test.describe('Ghost Public - Portal Donations', () => {
         await homePage.gotoPortalSupport();
 
         const checkoutPage = new FakeStripeCheckoutPage(page);
-        await checkoutPage.waitUntilDonationReady();
+        await checkoutPage.waitUntilPaymentReady();
         await expect(checkoutPage.totalAmount).toHaveText('$5.00');
 
         await completeDonationViaFakeCheckout(page, stripe!, {
@@ -56,7 +56,7 @@ test.describe('Ghost Public - Portal Donations', () => {
         await homePage.gotoPortalSupport();
 
         const checkoutPage = new FakeStripeCheckoutPage(page);
-        await checkoutPage.waitUntilDonationReady();
+        await checkoutPage.waitUntilPaymentReady();
         await expect(checkoutPage.emailInput).toHaveValue(member.email);
 
         await completeDonationViaFakeCheckout(page, stripe!, {
@@ -77,7 +77,7 @@ test.describe('Ghost Public - Portal Donations', () => {
         await homePage.gotoPortalSupport();
 
         const checkoutPage = new FakeStripeCheckoutPage(page);
-        await checkoutPage.waitUntilDonationReady();
+        await checkoutPage.waitUntilPaymentReady();
         await expect(checkoutPage.totalAmount).toHaveText('€98.00');
 
         await completeDonationViaFakeCheckout(page, stripe!, {

--- a/e2e/tests/public/portal-gifts.test.ts
+++ b/e2e/tests/public/portal-gifts.test.ts
@@ -32,7 +32,7 @@ test.describe('Ghost Public - Portal Gifts', () => {
         await portalGiftPage.continueButton.click();
 
         const checkoutPage = new FakeStripeCheckoutPage(page);
-        await checkoutPage.waitUntilDonationReady();
+        await checkoutPage.waitUntilPaymentReady();
         await expect(checkoutPage.totalAmount).toHaveText('$15.00');
         await checkoutPage.submitPayment();
         await stripe!.completeLatestGiftCheckout({

--- a/e2e/tests/public/portal-gifts.test.ts
+++ b/e2e/tests/public/portal-gifts.test.ts
@@ -1,0 +1,53 @@
+import {FakeStripeCheckoutPage, PortalGiftPage} from '@/helpers/pages';
+import {createPaidPortalTier, expect, test} from '@/helpers/playwright';
+
+test.describe('Ghost Public - Portal Gifts', () => {
+    test.use({
+        labs: {giftSubCustomization: true},
+        stripeEnabled: true
+    });
+
+    test('a buyer completes a 3-month gift through Stripe checkout', async ({page, stripe}) => {
+        const tierName = `Three Month Gift ${Date.now()}`;
+        await createPaidPortalTier(page.request, {
+            name: tierName,
+            currency: 'usd',
+            monthly_price: 500,
+            yearly_price: 5000
+        }, {stripe: stripe!});
+
+        await page.goto('/#/portal/gift');
+
+        const portalGiftPage = new PortalGiftPage(page);
+        await portalGiftPage.waitForPortalToOpen();
+        const buyerEmail = `gift-buyer-${Date.now()}@example.com`;
+
+        await portalGiftPage.buyerEmailInput.fill(buyerEmail);
+        await portalGiftPage.durationOption('3 months').click();
+        const tier = portalGiftPage.tierOption(tierName);
+        await tier.click();
+
+        await expect(tier).toContainText('$15');
+        await expect(portalGiftPage.giftCardValue).toHaveText('$15');
+        await portalGiftPage.continueButton.click();
+
+        const checkoutPage = new FakeStripeCheckoutPage(page);
+        await checkoutPage.waitUntilDonationReady();
+        await expect(checkoutPage.totalAmount).toHaveText('$15.00');
+        await checkoutPage.submitPayment();
+        await stripe!.completeLatestGiftCheckout({
+            email: buyerEmail,
+            name: 'Test Gift Buyer'
+        });
+
+        const checkoutSession = stripe!.getCheckoutSessions().at(-1);
+        expect(checkoutSession).toBeDefined();
+
+        await page.goto(checkoutSession!.response.success_url);
+        await portalGiftPage.waitForPortalToOpen();
+
+        await expect(portalGiftPage.successTitle).toBeVisible();
+        await expect(portalGiftPage.giftCardDuration).toHaveText('3 months');
+        await expect(portalGiftPage.giftRedeemLink).toContainText('/gift/');
+    });
+});

--- a/e2e/tests/public/stripe-donation-checkout.test.ts
+++ b/e2e/tests/public/stripe-donation-checkout.test.ts
@@ -70,7 +70,7 @@ test.describe('Ghost Public - Stripe Donation Checkout', () => {
 
         const fakeCheckoutPage = new FakeStripeCheckoutPage(page);
         await fakeCheckoutPage.goto(sessionResponse.url);
-        await fakeCheckoutPage.waitUntilDonationReady();
+        await fakeCheckoutPage.waitUntilPaymentReady();
 
         await stripe!.completeLatestDonationCheckout({
             donationMessage,

--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -8,6 +8,7 @@ const errors = require('@tryghost/errors');
 const {isEmail} = require('@tryghost/validator');
 const normalizeEmail = require('../utils/normalize-email');
 const hasActiveOffer = require('../utils/has-active-offer');
+const {resolveGiftDuration, validateGiftCheckoutOffer} = require('../utils/gift-checkout-offer');
 const {getInboxLinks} = require('../../../../lib/get-inbox-links');
 const {SIGNUP_CONTEXTS} = require('../../../lib/member-signup-contexts');
 /** @typedef {import('../../../lib/member-signup-contexts').SignupContext} SignupContext */
@@ -849,12 +850,35 @@ module.exports = class RouterController {
                 });
             }
 
-            const data = await this._getSubscriptionCheckoutData(req.body);
+            let data;
+
+            if (this.labsService.isSet('giftSubCustomization')) {
+                const resolvedDuration = resolveGiftDuration(req.body);
+                const subscriptionData = await this._getSubscriptionCheckoutData({
+                    tierId: req.body.tierId,
+                    cadence: resolvedDuration.cadence
+                });
+                const giftOffer = validateGiftCheckoutOffer({
+                    tier: subscriptionData.tier,
+                    portalPlans: this._settingsCache.get('portal_plans'),
+                    duration: req.body.duration,
+                    cadence: req.body.cadence
+                });
+
+                data = {
+                    ...subscriptionData,
+                    ...giftOffer
+                };
+            } else {
+                data = {
+                    ...await this._getSubscriptionCheckoutData(req.body),
+                    duration: 1
+                };
+            }
 
             response = await this._createGiftCheckoutSession({
                 ...options,
                 ...data,
-                duration: 1, // gifts are currently 1 month or 1 year only
                 successUrl: siteUrl,
                 cancelUrl: options.cancelUrl || siteUrl
             });

--- a/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
+++ b/ghost/core/core/server/services/members/members-api/controllers/router-controller.js
@@ -853,16 +853,15 @@ module.exports = class RouterController {
             let data;
 
             if (this.labsService.isSet('giftSubCustomization')) {
-                const resolvedDuration = resolveGiftDuration(req.body);
+                const resolvedOffer = resolveGiftDuration(req.body);
                 const subscriptionData = await this._getSubscriptionCheckoutData({
                     tierId: req.body.tierId,
-                    cadence: resolvedDuration.cadence
+                    cadence: resolvedOffer.cadence
                 });
                 const giftOffer = validateGiftCheckoutOffer({
                     tier: subscriptionData.tier,
                     portalPlans: this._settingsCache.get('portal_plans'),
-                    duration: req.body.duration,
-                    cadence: req.body.cadence
+                    offer: resolvedOffer
                 });
 
                 data = {

--- a/ghost/core/core/server/services/members/members-api/services/payments-service.js
+++ b/ghost/core/core/server/services/members/members-api/services/payments-service.js
@@ -168,6 +168,8 @@ class PaymentsService {
      * @param {import('../../../tiers/tier')} params.tier
      * @param {'month'|'year'} params.cadence
      * @param {number} params.duration
+     * @param {number} [params.totalMonths]
+     * @param {number} [params.amount]
      * @param {string} params.successUrl
      * @param {string} params.cancelUrl
      * @param {object} params.metadata
@@ -177,13 +179,13 @@ class PaymentsService {
      *
      * @returns {Promise<string>}
      */
-    async getGiftPaymentLink({tier, cadence, duration, metadata, successUrl, cancelUrl, member, isAuthenticated, email}) {
+    async getGiftPaymentLink({tier, cadence, duration, totalMonths, amount: requestedAmount, metadata, successUrl, cancelUrl, member, isAuthenticated, email}) {
         let customer = null;
         if (member && isAuthenticated) {
             customer = await this.getCustomerForMember(member);
         }
 
-        const amount = tier.getPrice(cadence);
+        const amount = requestedAmount ?? tier.getPrice(cadence);
         const currency = tier.currency.toLowerCase();
 
         const token = this.giftService.service.generateToken();
@@ -193,6 +195,9 @@ class PaymentsService {
         successUrlObj.searchParams.set('gift_token', token);
         successUrlObj.searchParams.set('gift_tier', tier.id.toHexString());
         successUrlObj.searchParams.set('gift_cadence', cadence);
+        if (totalMonths !== undefined) {
+            successUrlObj.searchParams.set('gift_duration', String(totalMonths));
+        }
 
         const data = {
             amount,

--- a/ghost/core/core/server/services/members/members-api/utils/gift-checkout-offer.js
+++ b/ghost/core/core/server/services/members/members-api/utils/gift-checkout-offer.js
@@ -1,0 +1,80 @@
+const {BadRequestError} = require('@tryghost/errors');
+
+const GIFT_DURATION_CATALOGUE = new Map([
+    [1, {cadence: 'month', billingDuration: 1, portalPlan: 'monthly', priceProperty: 'monthlyPrice', multiplier: 1}],
+    [3, {cadence: 'month', billingDuration: 3, portalPlan: 'monthly', priceProperty: 'monthlyPrice', multiplier: 3}],
+    [6, {cadence: 'month', billingDuration: 6, portalPlan: 'monthly', priceProperty: 'monthlyPrice', multiplier: 6}],
+    [12, {cadence: 'year', billingDuration: 1, portalPlan: 'yearly', priceProperty: 'yearlyPrice', multiplier: 1}]
+]);
+
+function invalidGiftOffer(context) {
+    return new BadRequestError({
+        message: 'Bad Request.',
+        context
+    });
+}
+
+function resolveGiftDuration({duration, cadence}) {
+    let totalMonths = duration;
+
+    if (totalMonths === undefined) {
+        if (cadence === 'month') {
+            totalMonths = 1;
+        } else if (cadence === 'year') {
+            totalMonths = 12;
+        } else {
+            throw invalidGiftOffer('Expected a supported gift duration or legacy cadence');
+        }
+    }
+
+    if (!Number.isInteger(totalMonths) || !GIFT_DURATION_CATALOGUE.has(totalMonths)) {
+        throw invalidGiftOffer(`Unsupported gift duration "${totalMonths}"`);
+    }
+
+    const offer = GIFT_DURATION_CATALOGUE.get(totalMonths);
+
+    if (cadence !== undefined && cadence !== offer.cadence) {
+        throw invalidGiftOffer(`Gift duration "${totalMonths}" conflicts with cadence "${cadence}"`);
+    }
+
+    return {
+        ...offer,
+        totalMonths
+    };
+}
+
+function validateGiftCheckoutOffer({tier, portalPlans, duration, cadence}) {
+    const offer = resolveGiftDuration({duration, cadence});
+
+    if (tier.status !== 'active' || tier.visibility !== 'public' || tier.type !== 'paid') {
+        throw invalidGiftOffer('The requested tier is not available for gift purchases');
+    }
+
+    if (!Array.isArray(portalPlans) || !portalPlans.includes(offer.portalPlan)) {
+        throw invalidGiftOffer(`The ${offer.portalPlan} Portal plan is not available`);
+    }
+
+    const unitAmount = tier[offer.priceProperty];
+
+    if (!Number.isSafeInteger(unitAmount) || unitAmount <= 0 || typeof tier.currency !== 'string' || !tier.currency) {
+        throw invalidGiftOffer('The requested tier does not have a valid gift price');
+    }
+
+    const amount = unitAmount * offer.multiplier;
+
+    if (!Number.isSafeInteger(amount)) {
+        throw invalidGiftOffer('The requested gift amount is invalid');
+    }
+
+    return {
+        cadence: offer.cadence,
+        duration: offer.billingDuration,
+        totalMonths: offer.totalMonths,
+        amount
+    };
+}
+
+module.exports = {
+    resolveGiftDuration,
+    validateGiftCheckoutOffer
+};

--- a/ghost/core/core/server/services/members/members-api/utils/gift-checkout-offer.js
+++ b/ghost/core/core/server/services/members/members-api/utils/gift-checkout-offer.js
@@ -1,5 +1,7 @@
 const {BadRequestError} = require('@tryghost/errors');
 
+// Mirrored by the Portal catalogue in apps/portal/src/utils/gift-subscriptions.ts
+// until later customization work makes durations server-provided
 const GIFT_DURATION_CATALOGUE = new Map([
     [1, {cadence: 'month', billingDuration: 1, portalPlan: 'monthly', priceProperty: 'monthlyPrice', multiplier: 1}],
     [3, {cadence: 'month', billingDuration: 3, portalPlan: 'monthly', priceProperty: 'monthlyPrice', multiplier: 3}],
@@ -39,18 +41,18 @@ function resolveGiftDuration({duration, cadence}) {
 
     return {
         ...offer,
-        totalMonths
+        totalMonths,
+        isCadenceOnly: duration === undefined
     };
 }
 
-function validateGiftCheckoutOffer({tier, portalPlans, duration, cadence}) {
-    const offer = resolveGiftDuration({duration, cadence});
-
+function validateGiftCheckoutOffer({tier, portalPlans, offer}) {
     if (tier.status !== 'active' || tier.visibility !== 'public' || tier.type !== 'paid') {
         throw invalidGiftOffer('The requested tier is not available for gift purchases');
     }
 
-    if (!Array.isArray(portalPlans) || !portalPlans.includes(offer.portalPlan)) {
+    // legacy cadence-only requests predate the Portal plan gate, keep them working
+    if (!offer.isCadenceOnly && (!Array.isArray(portalPlans) || !portalPlans.includes(offer.portalPlan))) {
         throw invalidGiftOffer(`The ${offer.portalPlan} Portal plan is not available`);
     }
 

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -65,7 +65,8 @@ const PRIVATE_FEATURES = [
     'memberDetailsReact',
     'membersCustomFields',
     'previewByTier',
-    'paywallImprovements'
+    'paywallImprovements',
+    'giftSubCustomization'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -28,6 +28,7 @@ Object {
       "explore": true,
       "featurebaseFeedback": true,
       "getHelperDeduplication": true,
+      "giftSubCustomization": true,
       "importMemberTier": true,
       "indexnow": true,
       "lexicalIndicators": true,

--- a/ghost/core/test/e2e-api/members/__snapshots__/gift-subscriptions.test.js.snap
+++ b/ghost/core/test/e2e-api/members/__snapshots__/gift-subscriptions.test.js.snap
@@ -59,3 +59,75 @@ Object {
   ],
 }
 `;
+
+exports[`Gift Subscriptions Purchase a gift rejects unsupported, malformed, conflicting and non-paid customized gift offers 1: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "Unsupported gift duration \\"2\\"",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Bad Request.",
+      "property": null,
+      "type": "BadRequestError",
+    },
+  ],
+}
+`;
+
+exports[`Gift Subscriptions Purchase a gift rejects unsupported, malformed, conflicting and non-paid customized gift offers 2: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "Unsupported gift duration \\"3\\"",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Bad Request.",
+      "property": null,
+      "type": "BadRequestError",
+    },
+  ],
+}
+`;
+
+exports[`Gift Subscriptions Purchase a gift rejects unsupported, malformed, conflicting and non-paid customized gift offers 3: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "Gift duration \\"3\\" conflicts with cadence \\"year\\"",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Bad Request.",
+      "property": null,
+      "type": "BadRequestError",
+    },
+  ],
+}
+`;
+
+exports[`Gift Subscriptions Purchase a gift rejects unsupported, malformed, conflicting and non-paid customized gift offers 4: [body] 1`] = `
+Object {
+  "errors": Array [
+    Object {
+      "code": null,
+      "context": "The requested tier is not available for gift purchases",
+      "details": null,
+      "ghostErrorCode": null,
+      "help": null,
+      "id": StringMatching /\\[a-f0-9\\]\\{8\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{4\\}-\\[a-f0-9\\]\\{12\\}/,
+      "message": "Bad Request.",
+      "property": null,
+      "type": "BadRequestError",
+    },
+  ],
+}
+`;

--- a/ghost/core/test/e2e-api/members/gift-subscriptions.test.js
+++ b/ghost/core/test/e2e-api/members/gift-subscriptions.test.js
@@ -391,7 +391,9 @@ describe('Gift Subscriptions', function () {
         });
 
         it('keeps legacy cadence-only gift checkout compatible when customization is enabled', async function () {
-            enableGiftCustomization();
+            mockManager.mockLabsEnabled('giftSubCustomization');
+            // legacy clients predate the Portal plan gate, so a disabled yearly plan must not block them
+            mockManager.mockSetting('portal_plans', ['free', 'monthly']);
             const paidTier = await getPaidTier();
 
             await membersAgent.post('/api/create-stripe-checkout-session/')

--- a/ghost/core/test/e2e-api/members/gift-subscriptions.test.js
+++ b/ghost/core/test/e2e-api/members/gift-subscriptions.test.js
@@ -40,6 +40,11 @@ function toWebhookMetadata(metadata) {
     return result;
 }
 
+function enableGiftCustomization() {
+    mockManager.mockLabsEnabled('giftSubCustomization');
+    mockManager.mockSetting('portal_plans', ['free', 'monthly', 'yearly']);
+}
+
 function addYears(date, years) {
     const nextDate = new Date(date);
     nextDate.setFullYear(nextDate.getFullYear() + years);
@@ -135,6 +140,7 @@ describe('Gift Subscriptions', function () {
     beforeEach(function () {
         mockManager.mockStripe();
         mockManager.mockMail();
+        mockManager.mockLabsDisabled('giftSubCustomization');
     });
 
     afterEach(async function () {
@@ -271,6 +277,137 @@ describe('Gift Subscriptions', function () {
             assert.equal(gift.get('status'), 'purchased');
         });
 
+        it('traces a customized 3-month gift from checkout through redemption and member access', async function () {
+            enableGiftCustomization();
+
+            const paidTier = await getPaidTier();
+            const buyerEmail = `gift-multi-month-buyer-${giftSequence + 1}@example.com`;
+            const redeemerEmail = `gift-multi-month-redeemer-${giftSequence + 1}@example.com`;
+            const expectedAmount = paidTier.monthly_price * 3;
+
+            await membersAgent.post('/api/create-stripe-checkout-session/')
+                .body({
+                    type: 'gift',
+                    tierId: paidTier.id,
+                    duration: 3,
+                    metadata: {}
+                })
+                .expectStatus(200);
+
+            const checkoutSession = getLatestCheckoutSession();
+
+            assert.equal(checkoutSession.metadata.cadence, 'month');
+            assert.equal(String(checkoutSession.metadata.duration), '3');
+            assert.equal(checkoutSession.metadata.tier_id, paidTier.id);
+            assert.ok(checkoutSession.success_url.includes('gift_duration=3'));
+
+            await stripeMocker.sendWebhook({
+                type: 'checkout.session.completed',
+                data: {
+                    object: {
+                        id: checkoutSession.id,
+                        mode: 'payment',
+                        amount_total: expectedAmount,
+                        currency: paidTier.currency.toLowerCase(),
+                        customer: checkoutSession.customer,
+                        customer_details: {email: buyerEmail},
+                        metadata: toWebhookMetadata(checkoutSession.metadata),
+                        payment_intent: `pi_gift_multi_month_${giftSequence + 1}`
+                    }
+                }
+            });
+
+            await DomainEvents.allSettled();
+
+            const gift = await models.Gift.findOne({
+                token: checkoutSession.metadata.gift_token
+            }, {require: true});
+
+            assert.equal(gift.get('cadence'), 'month');
+            assert.equal(gift.get('duration'), 3);
+            assert.equal(gift.get('amount'), expectedAmount);
+
+            const {body: redeemableBody} = await membersAgent
+                .get(`/api/gifts/${gift.get('token')}/redeem/`)
+                .expectStatus(200);
+
+            assert.equal(redeemableBody.gifts[0].duration, 3);
+            assert.equal(redeemableBody.gifts[0].amount, expectedAmount);
+
+            const redeemerAgent = membersAgent.duplicate();
+            await redeemerAgent.loginAs(redeemerEmail);
+
+            const {body: redeemedBody} = await redeemerAgent
+                .post(`/api/gifts/${gift.get('token')}/redeem/`)
+                .body({})
+                .expectStatus(200);
+
+            await DomainEvents.allSettled();
+            await gift.refresh();
+
+            const redeemer = await models.Member.findOne({email: redeemerEmail}, {
+                require: true,
+                withRelated: ['products']
+            });
+            const expectedConsumption = new Date(gift.get('redeemed_at'));
+            expectedConsumption.setMonth(expectedConsumption.getMonth() + 3);
+
+            assert.equal(redeemedBody.gifts[0].duration, 3);
+            assert.equal(redeemer.get('status'), 'gift');
+            assert.equal(redeemer.related('products').models[0].id, paidTier.id);
+            assert.equal(gift.get('consumes_at').toISOString(), expectedConsumption.toISOString());
+
+            mockManager.assert.sentEmail({
+                subject: /gift subscription purchased/i,
+                to: 'jbloggs@example.com'
+            });
+            mockManager.assert.sentEmail({
+                subject: /your gift is ready/i,
+                to: buyerEmail
+            });
+            mockManager.assert.sentEmail({
+                subject: /gift subscription redeemed/i,
+                to: 'jbloggs@example.com'
+            });
+            mockManager.assert.sentEmailCount(3);
+        });
+
+        it('rejects unsupported, malformed, conflicting and non-paid customized gift offers', async function () {
+            enableGiftCustomization();
+
+            for (const request of [
+                {duration: 2},
+                {duration: '3'},
+                {duration: 3, cadence: 'year'}
+            ]) {
+                await expectGiftCheckoutError(request);
+            }
+
+            const freeTier = await models.Product.findOne({type: 'free'}, {require: true});
+            await expectGiftCheckoutError({
+                tierId: freeTier.id,
+                duration: 3
+            });
+        });
+
+        it('keeps legacy cadence-only gift checkout compatible when customization is enabled', async function () {
+            enableGiftCustomization();
+            const paidTier = await getPaidTier();
+
+            await membersAgent.post('/api/create-stripe-checkout-session/')
+                .body({
+                    type: 'gift',
+                    tierId: paidTier.id,
+                    cadence: 'year',
+                    metadata: {}
+                })
+                .expectStatus(200);
+
+            const checkoutSession = getLatestCheckoutSession();
+            assert.equal(checkoutSession.metadata.cadence, 'year');
+            assert.equal(String(checkoutSession.metadata.duration), '1');
+        });
+
         it('Includes gift token in the purchase success URL', async function () {
             const paidTier = await getPaidTier();
 
@@ -343,14 +480,16 @@ describe('Gift Subscriptions', function () {
     });
 
     describe('Refund a gift', function () {
-        it('Marks gift as refunded when Stripe charge.refunded webhook is received', async function () {
+        it('Marks a multi-month gift as refunded when Stripe charge.refunded webhook is received', async function () {
+            enableGiftCustomization();
             const paidTier = await getPaidTier();
+            const expectedAmount = paidTier.monthly_price * 3;
 
             await membersAgent.post('/api/create-stripe-checkout-session/')
                 .body({
                     type: 'gift',
                     tierId: paidTier.id,
-                    cadence: 'month',
+                    duration: 3,
                     metadata: {}
                 })
                 .expectStatus(200);
@@ -365,7 +504,7 @@ describe('Gift Subscriptions', function () {
                     object: {
                         id: checkoutSession.id,
                         mode: 'payment',
-                        amount_total: paidTier.monthly_price,
+                        amount_total: expectedAmount,
                         currency: paidTier.currency.toLowerCase(),
                         customer: checkoutSession.customer,
                         customer_details: {email: 'refund-buyer@example.com'},
@@ -383,6 +522,8 @@ describe('Gift Subscriptions', function () {
             }, {require: true});
 
             assert.equal(gift.get('status'), 'purchased');
+            assert.equal(gift.get('duration'), 3);
+            assert.equal(gift.get('amount'), expectedAmount);
 
             // Send charge.refunded webhook
             await stripeMocker.sendWebhook({
@@ -1067,7 +1208,7 @@ describe('Gift Subscriptions', function () {
     describe('Continue a gift subscription as paid subscription', function () {
         let continueSequence = 0;
 
-        async function setupGiftMember({cadence = 'year', consumesInDays = 30, tierId, giftTierId} = {}) {
+        async function setupGiftMember({cadence = 'year', duration = 1, consumesInDays = 30, tierId, giftTierId} = {}) {
             continueSequence += 1;
             const paidTier = await getPaidTier();
             const effectiveTierId = tierId ?? paidTier.id;
@@ -1087,7 +1228,7 @@ describe('Gift Subscriptions', function () {
                 redeemer_member_id: member.id,
                 tier_id: effectiveGiftTierId,
                 cadence,
-                duration: 1,
+                duration,
                 currency: 'usd',
                 amount: 5000,
                 stripe_checkout_session_id: `cs_gift_continue_${continueSequence}`,
@@ -1113,7 +1254,7 @@ describe('Gift Subscriptions', function () {
         }
 
         it('applies remaining gift days as trial and continues to checkout on the same tier/cadence', async function () {
-            const {identityToken, gift, paidTier} = await setupGiftMember({cadence: 'month', consumesInDays: 30});
+            const {identityToken, gift, paidTier} = await setupGiftMember({cadence: 'month', duration: 3, consumesInDays: 30});
 
             await membersAgent.post('/api/create-stripe-checkout-session/')
                 .body({

--- a/ghost/core/test/unit/server/services/gifts/gift.test.ts
+++ b/ghost/core/test/unit/server/services/gifts/gift.test.ts
@@ -235,6 +235,37 @@ describe('Gift', function () {
             assert.equal(redeemed.consumesAt?.toISOString(), '2026-03-03T12:00:00.000Z');
         });
 
+        it('keeps multi-month rollover behavior stable at month end', function () {
+            const threeMonthGift = buildGift({
+                cadence: 'month',
+                duration: 3
+            });
+            const sixMonthGift = buildGift({
+                cadence: 'month',
+                duration: 6
+            });
+
+            const redeemedThreeMonthGift = threeMonthGift.redeem({
+                memberId: 'member_2',
+                redeemedAt: new Date('2026-01-31T12:00:00.000Z')
+            });
+            const redeemedSixMonthGift = sixMonthGift.redeem({
+                memberId: 'member_2',
+                redeemedAt: new Date('2024-08-31T12:00:00.000Z')
+            });
+
+            assert.deepEqual([
+                redeemedThreeMonthGift.consumesAt?.getFullYear(),
+                redeemedThreeMonthGift.consumesAt?.getMonth(),
+                redeemedThreeMonthGift.consumesAt?.getDate()
+            ], [2026, 4, 1]);
+            assert.deepEqual([
+                redeemedSixMonthGift.consumesAt?.getFullYear(),
+                redeemedSixMonthGift.consumesAt?.getMonth(),
+                redeemedSixMonthGift.consumesAt?.getDate()
+            ], [2025, 2, 3]);
+        });
+
         it('keeps yearly redemption math stable across leap years', function () {
             const gift = buildGift({
                 cadence: 'year',

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
@@ -875,6 +875,42 @@ describe('RouterController', function () {
                 }));
             });
 
+            it('exempts legacy cadence-only clients from the Portal plan gate', async function () {
+                const controller = customizedGiftController({
+                    settingsCache: {
+                        get: sinon.stub().callsFake(key => (key === 'portal_plans' ? ['monthly'] : undefined))
+                    }
+                });
+
+                await controller.createCheckoutSession({
+                    body: {type: 'gift', tierId: 'tier_123', cadence: 'year', metadata: {}}
+                }, mockRes);
+
+                sinon.assert.calledWith(getGiftLinkSpy, sinon.match({
+                    cadence: 'year',
+                    duration: 1,
+                    totalMonths: 12,
+                    amount: 50000
+                }));
+            });
+
+            it('rejects explicit durations disabled in Portal', async function () {
+                const controller = customizedGiftController({
+                    settingsCache: {
+                        get: sinon.stub().callsFake(key => (key === 'portal_plans' ? ['monthly'] : undefined))
+                    }
+                });
+
+                await assert.rejects(
+                    () => controller.createCheckoutSession({
+                        body: {type: 'gift', tierId: 'tier_123', duration: 12, metadata: {}}
+                    }, mockRes),
+                    errors.BadRequestError
+                );
+
+                sinon.assert.notCalled(getGiftLinkSpy);
+            });
+
             it('rejects conflicting cadence and duration before creating checkout', async function () {
                 const controller = customizedGiftController();
 

--- a/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/controllers/router-controller.test.js
@@ -78,7 +78,7 @@ describe('RouterController', function () {
             configured: true
         };
         labsService = {
-            isSet: sinon.stub().returns(true)
+            isSet: sinon.stub().callsFake(flag => flag !== 'giftSubCustomization')
         };
         settingsCache = {
             get: sinon.stub().withArgs('all_blocked_email_domains').returns(['spam.xyz'])
@@ -794,10 +794,28 @@ describe('RouterController', function () {
                         read: sinon.stub().resolves({
                             id: {toHexString: () => 'tier_123'},
                             status: 'active',
+                            visibility: 'public',
+                            type: 'paid',
+                            currency: 'USD',
+                            monthlyPrice: price,
+                            yearlyPrice: price * 10,
                             getPrice: sinon.stub().returns(price)
                         })
                     }
                 };
+            }
+
+            function customizedGiftController(overrides = {}) {
+                return createGiftController({
+                    tiersService: paidTierService(),
+                    labsService: {
+                        isSet: sinon.stub().callsFake(flag => flag === 'giftSubCustomization')
+                    },
+                    settingsCache: {
+                        get: sinon.stub().callsFake(key => key === 'portal_plans' ? ['monthly', 'yearly'] : undefined)
+                    },
+                    ...overrides
+                });
             }
 
             it('calls getGiftPaymentLink with correct options', async function () {
@@ -812,6 +830,62 @@ describe('RouterController', function () {
                     successUrl: 'https://example.com/',
                     cancelUrl: 'https://example.com/'
                 }));
+            });
+
+            it('keeps the legacy cadence-only path when customization is disabled', async function () {
+                const controller = createGiftController({tiersService: paidTierService()});
+
+                await controller.createCheckoutSession({
+                    body: {type: 'gift', tierId: 'tier_123', cadence: 'year', duration: 3, metadata: {}}
+                }, mockRes);
+
+                sinon.assert.calledWith(getGiftLinkSpy, sinon.match({
+                    cadence: 'year',
+                    duration: 1
+                }));
+            });
+
+            it('derives cadence, billing duration and amount for a customized multi-month gift', async function () {
+                const controller = customizedGiftController();
+
+                await controller.createCheckoutSession({
+                    body: {type: 'gift', tierId: 'tier_123', duration: 3, metadata: {}}
+                }, mockRes);
+
+                sinon.assert.calledWith(getGiftLinkSpy, sinon.match({
+                    cadence: 'month',
+                    duration: 3,
+                    totalMonths: 3,
+                    amount: 15000
+                }));
+            });
+
+            it('keeps legacy cadence-only clients compatible when customization is enabled', async function () {
+                const controller = customizedGiftController();
+
+                await controller.createCheckoutSession({
+                    body: {type: 'gift', tierId: 'tier_123', cadence: 'year', metadata: {}}
+                }, mockRes);
+
+                sinon.assert.calledWith(getGiftLinkSpy, sinon.match({
+                    cadence: 'year',
+                    duration: 1,
+                    totalMonths: 12,
+                    amount: 50000
+                }));
+            });
+
+            it('rejects conflicting cadence and duration before creating checkout', async function () {
+                const controller = customizedGiftController();
+
+                await assert.rejects(
+                    () => controller.createCheckoutSession({
+                        body: {type: 'gift', tierId: 'tier_123', cadence: 'year', duration: 3, metadata: {}}
+                    }, mockRes),
+                    errors.BadRequestError
+                );
+
+                sinon.assert.notCalled(getGiftLinkSpy);
             });
 
             it('uses cancelUrl from the request body when provided', async function () {

--- a/ghost/core/test/unit/server/services/members/members-api/services/payments-service.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/payments-service.test.js
@@ -383,7 +383,7 @@ describe('PaymentsService', function () {
             assert.equal(args.metadata.gift_token, 'AbCdEfGhIjKl');
         });
 
-        it('appends gift token, tier and cadence to success URL', async function () {
+        it('appends gift token, tier and cadence to legacy success URLs', async function () {
             const tier = await createTier({monthlyPrice: 5000, yearlyPrice: 50000});
 
             await service.getGiftPaymentLink({...defaultGiftOptions, tier, cadence: 'year'});
@@ -395,6 +395,26 @@ describe('PaymentsService', function () {
             assert.equal(successUrl.searchParams.get('gift_token'), args.metadata.gift_token);
             assert.equal(successUrl.searchParams.get('gift_tier'), tier.id.toHexString());
             assert.equal(successUrl.searchParams.get('gift_cadence'), 'year');
+            assert.equal(successUrl.searchParams.get('gift_duration'), null);
+        });
+
+        it('uses an authoritative requested amount for fixed-duration gifts', async function () {
+            const tier = await createTier();
+
+            await service.getGiftPaymentLink({
+                ...defaultGiftOptions,
+                tier,
+                cadence: 'month',
+                duration: 3,
+                totalMonths: 3,
+                amount: 3000
+            });
+
+            const args = getStripeArgs();
+            const successUrl = new URL(args.successUrl);
+            assert.equal(args.amount, 3000);
+            assert.equal(args.metadata.duration, '3');
+            assert.equal(successUrl.searchParams.get('gift_duration'), '3');
         });
 
         it('prevents caller metadata from overwriting gift-specific keys', async function () {

--- a/ghost/core/test/unit/server/services/members/members-api/utils/gift-checkout-offer.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/utils/gift-checkout-offer.test.js
@@ -23,7 +23,8 @@ describe('gift checkout offer', function () {
                 portalPlan: 'monthly',
                 priceProperty: 'monthlyPrice',
                 multiplier: 1,
-                totalMonths: 1
+                totalMonths: 1,
+                isCadenceOnly: false
             });
             assert.deepEqual(resolveGiftDuration({duration: 3}), {
                 cadence: 'month',
@@ -31,7 +32,8 @@ describe('gift checkout offer', function () {
                 portalPlan: 'monthly',
                 priceProperty: 'monthlyPrice',
                 multiplier: 3,
-                totalMonths: 3
+                totalMonths: 3,
+                isCadenceOnly: false
             });
             assert.deepEqual(resolveGiftDuration({duration: 6}), {
                 cadence: 'month',
@@ -39,7 +41,8 @@ describe('gift checkout offer', function () {
                 portalPlan: 'monthly',
                 priceProperty: 'monthlyPrice',
                 multiplier: 6,
-                totalMonths: 6
+                totalMonths: 6,
+                isCadenceOnly: false
             });
             assert.deepEqual(resolveGiftDuration({duration: 12}), {
                 cadence: 'year',
@@ -47,13 +50,15 @@ describe('gift checkout offer', function () {
                 portalPlan: 'yearly',
                 priceProperty: 'yearlyPrice',
                 multiplier: 1,
-                totalMonths: 12
+                totalMonths: 12,
+                isCadenceOnly: false
             });
         });
 
         it('maps legacy cadence-only requests', function () {
             assert.equal(resolveGiftDuration({cadence: 'month'}).totalMonths, 1);
             assert.equal(resolveGiftDuration({cadence: 'year'}).totalMonths, 12);
+            assert.equal(resolveGiftDuration({cadence: 'year'}).isCadenceOnly, true);
         });
 
         it('accepts matching cadence and duration', function () {
@@ -81,7 +86,7 @@ describe('gift checkout offer', function () {
             assert.deepEqual(validateGiftCheckoutOffer({
                 tier,
                 portalPlans: ['monthly', 'yearly'],
-                duration: 3
+                offer: resolveGiftDuration({duration: 3})
             }), {
                 cadence: 'month',
                 duration: 3,
@@ -92,7 +97,7 @@ describe('gift checkout offer', function () {
             assert.deepEqual(validateGiftCheckoutOffer({
                 tier,
                 portalPlans: ['monthly', 'yearly'],
-                duration: 12
+                offer: resolveGiftDuration({duration: 12})
             }), {
                 cadence: 'year',
                 duration: 1,
@@ -110,7 +115,7 @@ describe('gift checkout offer', function () {
                 assert.throws(() => validateGiftCheckoutOffer({
                     tier: unavailableTier,
                     portalPlans: ['monthly', 'yearly'],
-                    duration: 3
+                    offer: resolveGiftDuration({duration: 3})
                 }), BadRequestError);
             }
         });
@@ -119,13 +124,26 @@ describe('gift checkout offer', function () {
             assert.throws(() => validateGiftCheckoutOffer({
                 tier,
                 portalPlans: ['yearly'],
-                duration: 3
+                offer: resolveGiftDuration({duration: 3})
             }), BadRequestError);
             assert.throws(() => validateGiftCheckoutOffer({
                 tier,
                 portalPlans: ['monthly'],
-                duration: 12
+                offer: resolveGiftDuration({duration: 12})
             }), BadRequestError);
+        });
+
+        it('exempts legacy cadence-only requests from the Portal plan gate', function () {
+            assert.deepEqual(validateGiftCheckoutOffer({
+                tier,
+                portalPlans: ['monthly'],
+                offer: resolveGiftDuration({cadence: 'year'})
+            }), {
+                cadence: 'year',
+                duration: 1,
+                totalMonths: 12,
+                amount: 5000
+            });
         });
 
         it('rejects missing or invalid prices and currency', function () {
@@ -138,7 +156,7 @@ describe('gift checkout offer', function () {
                 assert.throws(() => validateGiftCheckoutOffer({
                     tier: invalidTier,
                     portalPlans: ['monthly'],
-                    duration: 3
+                    offer: resolveGiftDuration({duration: 3})
                 }), BadRequestError);
             }
         });

--- a/ghost/core/test/unit/server/services/members/members-api/utils/gift-checkout-offer.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/utils/gift-checkout-offer.test.js
@@ -1,0 +1,146 @@
+const assert = require('node:assert/strict');
+const {BadRequestError} = require('@tryghost/errors');
+const {
+    resolveGiftDuration,
+    validateGiftCheckoutOffer
+} = require('../../../../../../../core/server/services/members/members-api/utils/gift-checkout-offer');
+
+describe('gift checkout offer', function () {
+    const tier = {
+        status: 'active',
+        visibility: 'public',
+        type: 'paid',
+        currency: 'USD',
+        monthlyPrice: 500,
+        yearlyPrice: 5000
+    };
+
+    describe('resolveGiftDuration', function () {
+        it('maps total months to the stored cadence and billing duration', function () {
+            assert.deepEqual(resolveGiftDuration({duration: 1}), {
+                cadence: 'month',
+                billingDuration: 1,
+                portalPlan: 'monthly',
+                priceProperty: 'monthlyPrice',
+                multiplier: 1,
+                totalMonths: 1
+            });
+            assert.deepEqual(resolveGiftDuration({duration: 3}), {
+                cadence: 'month',
+                billingDuration: 3,
+                portalPlan: 'monthly',
+                priceProperty: 'monthlyPrice',
+                multiplier: 3,
+                totalMonths: 3
+            });
+            assert.deepEqual(resolveGiftDuration({duration: 6}), {
+                cadence: 'month',
+                billingDuration: 6,
+                portalPlan: 'monthly',
+                priceProperty: 'monthlyPrice',
+                multiplier: 6,
+                totalMonths: 6
+            });
+            assert.deepEqual(resolveGiftDuration({duration: 12}), {
+                cadence: 'year',
+                billingDuration: 1,
+                portalPlan: 'yearly',
+                priceProperty: 'yearlyPrice',
+                multiplier: 1,
+                totalMonths: 12
+            });
+        });
+
+        it('maps legacy cadence-only requests', function () {
+            assert.equal(resolveGiftDuration({cadence: 'month'}).totalMonths, 1);
+            assert.equal(resolveGiftDuration({cadence: 'year'}).totalMonths, 12);
+        });
+
+        it('accepts matching cadence and duration', function () {
+            assert.equal(resolveGiftDuration({cadence: 'month', duration: 3}).cadence, 'month');
+            assert.equal(resolveGiftDuration({cadence: 'year', duration: 12}).cadence, 'year');
+        });
+
+        it('rejects malformed, unsupported and conflicting requests', function () {
+            for (const request of [
+                {},
+                {duration: '3'},
+                {duration: 2},
+                {duration: 3.5},
+                {duration: 3, cadence: 'year'},
+                {duration: 12, cadence: 'month'},
+                {cadence: 'week'}
+            ]) {
+                assert.throws(() => resolveGiftDuration(request), BadRequestError);
+            }
+        });
+    });
+
+    describe('validateGiftCheckoutOffer', function () {
+        it('derives authoritative amounts from the tier price', function () {
+            assert.deepEqual(validateGiftCheckoutOffer({
+                tier,
+                portalPlans: ['monthly', 'yearly'],
+                duration: 3
+            }), {
+                cadence: 'month',
+                duration: 3,
+                totalMonths: 3,
+                amount: 1500
+            });
+
+            assert.deepEqual(validateGiftCheckoutOffer({
+                tier,
+                portalPlans: ['monthly', 'yearly'],
+                duration: 12
+            }), {
+                cadence: 'year',
+                duration: 1,
+                totalMonths: 12,
+                amount: 5000
+            });
+        });
+
+        it('rejects unavailable tiers', function () {
+            for (const unavailableTier of [
+                {...tier, status: 'archived'},
+                {...tier, visibility: 'none'},
+                {...tier, type: 'free'}
+            ]) {
+                assert.throws(() => validateGiftCheckoutOffer({
+                    tier: unavailableTier,
+                    portalPlans: ['monthly', 'yearly'],
+                    duration: 3
+                }), BadRequestError);
+            }
+        });
+
+        it('rejects durations disabled in Portal', function () {
+            assert.throws(() => validateGiftCheckoutOffer({
+                tier,
+                portalPlans: ['yearly'],
+                duration: 3
+            }), BadRequestError);
+            assert.throws(() => validateGiftCheckoutOffer({
+                tier,
+                portalPlans: ['monthly'],
+                duration: 12
+            }), BadRequestError);
+        });
+
+        it('rejects missing or invalid prices and currency', function () {
+            for (const invalidTier of [
+                {...tier, monthlyPrice: null},
+                {...tier, monthlyPrice: 0},
+                {...tier, monthlyPrice: 1.5},
+                {...tier, currency: null}
+            ]) {
+                assert.throws(() => validateGiftCheckoutOffer({
+                    tier: invalidTier,
+                    portalPlans: ['monthly'],
+                    duration: 3
+                }), BadRequestError);
+            }
+        });
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1654,6 +1654,9 @@ importers:
       '@tryghost/i18n':
         specifier: workspace:*
         version: link:../../packages/i18n
+      '@types/react':
+        specifier: catalog:react17
+        version: 17.0.93
       '@typescript/native':
         specifier: 'catalog:'
         version: typescript@7.0.2


### PR DESCRIPTION
refs https://linear.app/ghost/issue/BER-3833

## What changed

- Added the private `giftSubCustomization` Labs flag.
- Added a fixed Portal gift catalogue of 1, 3, 6, and 12 months, including Portal-plan-aware defaults, availability, selection, and pricing.
- Added authoritative Members checkout validation for the requested tier and duration. One, three, and six months use the monthly tier price; twelve months uses the yearly tier price.
- Preserved cadence-only requests and the existing monthly/yearly Portal flow while the flag is disabled.
- Carried the resolved duration through Stripe metadata, purchase persistence, success state, redemption, refunds, notifications, and paid-subscription continuation

## Why

This is the first validation slice for configurable gift subscriptions. The duration catalogue is intentionally fixed and server-owned so the complete purchase and redemption path can be exercised before publisher-facing customization is introduced.

Keeping the work behind a private flag preserves the current public contract while establishing the duration model, authoritative pricing boundary, and end-to-end integration needed by the later customization work.