### PR TITLE
Fixed Admin home redirect prop ordering

### DIFF
--- a/apps/admin/src/home-redirect.tsx
+++ b/apps/admin/src/home-redirect.tsx
@@ -41,14 +41,14 @@ const HomeRedirect = () => {
     }
 
     if (hasAdminAccess(currentUser)) {
-        return <Navigate replace to="/analytics" />;
+        return <Navigate to="/analytics" replace />;
     }
 
     if (isContributorUser(currentUser)) {
-        return <Navigate replace to="/posts" />;
+        return <Navigate to="/posts" replace />;
     }
 
-    return <Navigate replace to="/site" />;
+    return <Navigate to="/site" replace />;
 };
 
 export default HomeRedirect;


### PR DESCRIPTION
## Summary

- reorder `Navigate` props in the Admin home redirect to satisfy `react/jsx-sort-props`
- preserve the existing redirect destinations and replace-history behavior

## Root cause

The shared React ESLint configuration now requires shorthand JSX props to appear after explicit props. The home redirect used `replace` before `to`, causing the lint job on `main` to fail in three places.

## Validation

- `pnpm nx run @tryghost/admin:lint`
- `git diff --check`