### PR TITLE
Fixed lint failing on main in apps/admin

### DIFF
--- a/apps/admin/src/home-redirect.tsx
+++ b/apps/admin/src/home-redirect.tsx
@@ -41,14 +41,14 @@ const HomeRedirect = () => {
     }
 
     if (hasAdminAccess(currentUser)) {
-        return <Navigate replace to="/analytics" />;
+        return <Navigate to="/analytics" replace />;
     }
 
     if (isContributorUser(currentUser)) {
-        return <Navigate replace to="/posts" />;
+        return <Navigate to="/posts" replace />;
     }
 
-    return <Navigate replace to="/site" />;
+    return <Navigate to="/site" replace />;
 };
 
 export default HomeRedirect;


### PR DESCRIPTION
Two PRs merged concurrently: #29692 added `home-redirect.tsx`, #29689 moved `apps/admin` onto the stricter shared ESLint factory. Neither branch saw the other, so the new file landed violating `react/jsx-sort-props`.

`eslint --fix` output only — 3 lines of prop reordering, no behavior change.

## Verification
- `cd apps/admin && pnpm exec eslint .` exit 0 (was 1 error on main)
- `tsc -b` clean