### PR TITLE
Added React tag detail screen behind the tagDetailsReact flag

### DIFF
--- a/apps/admin-x-framework/src/api/tags.ts
+++ b/apps/admin-x-framework/src/api/tags.ts
@@ -11,30 +11,29 @@ export type Tag = {
     name: string;
     slug: string;
     url: string;
-    description: string;
+    description: string | null;
     visibility: 'public' | 'internal';
+    feature_image: string | null;
+    meta_title: string | null;
+    meta_description: string | null;
+    twitter_image: string | null;
+    twitter_title: string | null;
+    twitter_description: string | null;
+    og_image: string | null;
+    og_title: string | null;
+    og_description: string | null;
+    codeinjection_head: string | null;
+    codeinjection_foot: string | null;
+    canonical_url: string | null;
+    accent_color: string | null;
+    created_at?: string;
+    updated_at?: string | null;
     count?: {
         posts: number;
     };
-
-    // XXX: Ensure the types match the casing in the API response by either
-    // transforming them to camelCase or using snake_case
-    // metaTitle: string;
-    // metaDescription: string;
-    // twitterImage: string;
-    // twitterTitle: string;
-    // twitterDescription: string;
-    // ogImage: string;
-    // ogTitle: string;
-    // ogDescription: string;
-    // codeinjectionHead: string;
-    // codeinjectionFoot: string;
-    // canonicalUrl: string;
-    // accentColor: string;
-    // featureImage: string;
-    // createdAtUTC: string;
-    // updatedAtUTC: string;
 };
+
+export type TagEditableData = Partial<Omit<Tag, 'id' | 'url' | 'count' | 'created_at' | 'updated_at'>>;
 
 export interface TagsResponseType {
     meta?: Meta;
@@ -91,7 +90,31 @@ export const getTag = createQueryWithId<TagsResponseType>({
     path: id => `/tags/${id}/`
 });
 
+// Mirrors Ember's `queryRecord('tag', {slug})`, which the admin API serves at
+// the dedicated `/tags/slug/:slug/` route.
+export const getTagBySlug = createQueryWithId<TagsResponseType>({
+    dataType,
+    path: slug => `/tags/slug/${slug}/`
+});
+
+export const useAddTag = createMutation<TagsResponseType, TagEditableData>({
+    method: 'POST',
+    path: () => '/tags/',
+    searchParams: () => ({include: 'count.posts'}),
+    body: tag => ({tags: [tag]}),
+    invalidateQueries: {dataType}
+});
+
+export const useEditTag = createMutation<TagsResponseType, TagEditableData & {id: string}>({
+    method: 'PUT',
+    path: ({id}) => `/tags/${id}/`,
+    searchParams: () => ({include: 'count.posts'}),
+    body: ({id, ...rest}) => ({tags: [{id, ...rest}]}),
+    invalidateQueries: {dataType}
+});
+
 export const useDeleteTag = createMutation<unknown, string>({
     method: 'DELETE',
-    path: id => `/tags/${id}/`
+    path: id => `/tags/${id}/`,
+    invalidateQueries: {dataType}
 });

--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -76,6 +76,10 @@ const features: Feature[] = [{
     description: 'Renders the member detail screen (/members/:id) from the React app instead of the Ember screen. Gates the migration behind a runtime toggle so we can compare both implementations.',
     flag: 'memberDetailsReact'
 }, {
+    title: 'React tag details',
+    description: 'Renders the tag detail screen (/tags/:slug) from the React app instead of the Ember screen. Gates the migration behind a runtime toggle so we can compare both implementations.',
+    flag: 'tagDetailsReact'
+}, {
     title: 'Member custom fields',
     description: 'Let admins create and manage custom field definitions for members',
     flag: 'membersCustomFields'

--- a/apps/admin-x-settings/src/hooks/use-pintura-editor.ts
+++ b/apps/admin-x-settings/src/hooks/use-pintura-editor.ts
@@ -39,6 +39,7 @@ declare global {
                 willClose: () => boolean;
             }) => {
                 on: (event: string, callback: (result: { dest: File }) => void) => void;
+                destroy: () => void;
             };
         }
     }

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -42,6 +42,7 @@
         "@tryghost/nql-lang": "catalog:",
         "@tryghost/nql-string": "workspace:*",
         "@tryghost/shade": "workspace:*",
+        "@tryghost/string": "catalog:",
         "@tryghost/timezone-data": "catalog:",
         "@uiw/react-codemirror": "catalog:",
         "@xyflow/react": "12.11.1",

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -24,6 +24,7 @@
         "@tryghost/koenig-lexical": "workspace:*",
         "@tryghost/nql-lang": "catalog:",
         "@tryghost/shade": "workspace:*",
+        "@tryghost/string": "catalog:",
         "@xyflow/react": "12.11.1",
         "dequal": "catalog:",
         "i18n-iso-countries": "7.14.0",

--- a/apps/admin/src/ember-bridge/ember-bridge.test.tsx
+++ b/apps/admin/src/ember-bridge/ember-bridge.test.tsx
@@ -40,6 +40,7 @@ function createMockStateBridge(sidebarVisible = true) {
         onUpdate: vi.fn(),
         onInvalidate: vi.fn(),
         onDelete: vi.fn(),
+        isFeatureEnabled: vi.fn().mockReturnValue(false),
         on,
         off,
         sidebarVisible,
@@ -62,13 +63,14 @@ declare global {
 
 let useEmberDataSync: typeof import('./ember-bridge').useEmberDataSync;
 let useEmberAuthSync: typeof import('./ember-bridge').useEmberAuthSync;
+let useEmberFeatureFlag: typeof import('./ember-bridge').useEmberFeatureFlag;
 let useSidebarVisibility: typeof import('./ember-bridge').useSidebarVisibility;
 let useEmberRouting: typeof import('./ember-bridge').useEmberRouting;
 
 beforeEach(async () => {
     vi.resetModules();
     vi.useRealTimers();
-    ({ useEmberDataSync, useEmberAuthSync, useSidebarVisibility, useEmberRouting } = await import('./ember-bridge'));
+    ({ useEmberDataSync, useEmberAuthSync, useEmberFeatureFlag, useSidebarVisibility, useEmberRouting } = await import('./ember-bridge'));
     delete window.EmberBridge;
 });
 
@@ -76,6 +78,40 @@ afterEach(() => {
     delete window.EmberBridge;
     vi.clearAllTimers();
     vi.useRealTimers();
+});
+
+describe('useEmberFeatureFlag', () => {
+    test('updates when Ember feature ownership changes', async () => {
+        const mock = createMockStateBridge();
+        let enabled = false;
+        mock.stateBridge.isFeatureEnabled = vi.fn(() => enabled);
+        window.EmberBridge = {state: mock.stateBridge};
+
+        const {result} = renderHook(() => useEmberFeatureFlag('tagDetailsReact'));
+        expect(result.current).toBe(false);
+
+        enabled = true;
+        act(() => mock.emit('featureFlagsChange', undefined));
+
+        await waitFor(() => expect(result.current).toBe(true));
+    });
+
+    test('updates when the Ember bridge becomes available after subscribing', async () => {
+        vi.useFakeTimers();
+        const mock = createMockStateBridge();
+        mock.stateBridge.isFeatureEnabled = vi.fn(() => true);
+
+        const {result} = renderHook(() => useEmberFeatureFlag('tagDetailsReact'));
+        expect(result.current).toBeUndefined();
+
+        window.EmberBridge = {state: mock.stateBridge};
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(100);
+        });
+
+        expect(mock.onSpy).toHaveBeenCalledWith('featureFlagsChange', expect.any(Function));
+        expect(result.current).toBe(true);
+    });
 });
 
 describe('useEmberDataSync', () => {

--- a/apps/admin/src/ember-bridge/ember-bridge.test.tsx
+++ b/apps/admin/src/ember-bridge/ember-bridge.test.tsx
@@ -112,6 +112,16 @@ describe('useEmberFeatureFlag', () => {
         expect(mock.onSpy).toHaveBeenCalledWith('featureFlagsChange', expect.any(Function));
         expect(result.current).toBe(true);
     });
+
+    test('distinguishes loading Ember settings from an unavailable bridge', () => {
+        const mock = createMockStateBridge();
+        mock.stateBridge.isFeatureEnabled = vi.fn(() => undefined);
+        window.EmberBridge = {state: mock.stateBridge};
+
+        const {result} = renderHook(() => useEmberFeatureFlag('tagDetailsReact'));
+
+        expect(result.current).toBeNull();
+    });
 });
 
 describe('useEmberDataSync', () => {

--- a/apps/admin/src/ember-bridge/ember-bridge.tsx
+++ b/apps/admin/src/ember-bridge/ember-bridge.tsx
@@ -20,7 +20,7 @@ export interface StateBridge {
     onUpdate: (dataType: string, response: unknown) => void;
     onInvalidate: (dataType: string) => void;
     onDelete: (dataType: string, id: string) => void;
-    isFeatureEnabled?: (name: string) => boolean;
+    isFeatureEnabled?: (name: string) => boolean | undefined;
     preloadAdminThemeStylesheet?: () => Promise<void>;
     applyAdminThemePreference?: (mode: 'light' | 'dark' | 'system') => Promise<void> | void;
     on<K extends keyof StateBridgeEventMap>(event: K, callback: (event: StateBridgeEventMap[K]) => void): void;

--- a/apps/admin/src/ember-bridge/ember-bridge.tsx
+++ b/apps/admin/src/ember-bridge/ember-bridge.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useBrowseConfig } from "@tryghost/admin-x-framework/api/config";
 
@@ -13,12 +13,14 @@ export type StateBridgeEventMap = {
     sidebarVisibilityChange: SidebarVisibilityChangeEvent;
     routeChange: RouteChangeEvent;
     openGiftLinkModal: OpenGiftLinkModalEvent;
+    featureFlagsChange: undefined;
 }
 
 export interface StateBridge {
     onUpdate: (dataType: string, response: unknown) => void;
     onInvalidate: (dataType: string) => void;
     onDelete: (dataType: string, id: string) => void;
+    isFeatureEnabled?: (name: string) => boolean;
     preloadAdminThemeStylesheet?: () => Promise<void>;
     applyAdminThemePreference?: (mode: 'light' | 'dark' | 'system') => Promise<void> | void;
     on<K extends keyof StateBridgeEventMap>(event: K, callback: (event: StateBridgeEventMap[K]) => void): void;
@@ -121,7 +123,8 @@ function waitForStateBridge(onReady: (stateBridge: StateBridge) => void): () => 
 
 function onEmberStateBridgeEvent<K extends keyof StateBridgeEventMap>(
     event: K,
-    handler: (event: StateBridgeEventMap[K]) => void
+    handler: (event: StateBridgeEventMap[K]) => void,
+    onReady?: () => void
 ): () => void {
     let unsubscribe: (() => void) | null = null;
     let isMounted = true;
@@ -132,6 +135,7 @@ function onEmberStateBridgeEvent<K extends keyof StateBridgeEventMap>(
         }
         stateBridge.on(event, handler);
         unsubscribe = () => stateBridge.off(event, handler);
+        onReady?.();
     });
 
     return () => {
@@ -214,6 +218,18 @@ export function useSubscriptionStatus() {
     }, []);
 
     return subscriptionStatus;
+}
+
+/** Reads Ember's authoritative Labs state and updates when it changes. */
+export function useEmberFeatureFlag(flag: string): boolean | undefined {
+    const subscribe = useCallback((callback: () => void) => {
+        return onEmberStateBridgeEvent('featureFlagsChange', callback, callback);
+    }, []);
+    const getSnapshot = useCallback(() => {
+        return window.EmberBridge?.state.isFeatureEnabled?.(flag);
+    }, [flag]);
+
+    return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }
 
 /**

--- a/apps/admin/src/ember-bridge/ember-bridge.tsx
+++ b/apps/admin/src/ember-bridge/ember-bridge.tsx
@@ -220,13 +220,21 @@ export function useSubscriptionStatus() {
     return subscriptionStatus;
 }
 
-/** Reads Ember's authoritative Labs state and updates when it changes. */
-export function useEmberFeatureFlag(flag: string): boolean | undefined {
+/**
+ * Reads Ember's authoritative Labs state and updates when it changes.
+ * `null` means Ember is present but its settings are still loading;
+ * `undefined` means there is no Ember feature reader (standalone React).
+ */
+export function useEmberFeatureFlag(flag: string): boolean | null | undefined {
     const subscribe = useCallback((callback: () => void) => {
         return onEmberStateBridgeEvent('featureFlagsChange', callback, callback);
     }, []);
     const getSnapshot = useCallback(() => {
-        return window.EmberBridge?.state.isFeatureEnabled?.(flag);
+        const stateBridge = window.EmberBridge?.state;
+        if (!stateBridge?.isFeatureEnabled) {
+            return undefined;
+        }
+        return stateBridge.isFeatureEnabled(flag) ?? null;
     }, [flag]);
 
     return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);

--- a/apps/admin/src/ember-bridge/index.ts
+++ b/apps/admin/src/ember-bridge/index.ts
@@ -3,6 +3,6 @@ export { EmberProvider } from "./ember-provider";
 export { useEmberContext } from "./ember-context";
 export { EmberFallback } from "./ember-fallback";
 export { ForceUpgradeGuard } from "./force-upgrade-guard";
-export { useEmberAuthSync, useEmberDataSync, useSidebarVisibility, useSubscriptionStatus, useEmberRouting, useForceUpgrade, subscribeOpenGiftLinkModal } from "./ember-bridge";
+export { useEmberAuthSync, useEmberDataSync, useEmberFeatureFlag, useSidebarVisibility, useSubscriptionStatus, useEmberRouting, useForceUpgrade, subscribeOpenGiftLinkModal } from "./ember-bridge";
 export type { EmberDataChangeEvent, EmberRouting, OpenGiftLinkModalEvent } from "./ember-bridge";
 export type { RouteHandle } from "./force-upgrade-guard";

--- a/apps/admin/src/flag-gated-route.test.tsx
+++ b/apps/admin/src/flag-gated-route.test.tsx
@@ -76,6 +76,22 @@ describe('FlagGatedRoute', () => {
         expect(screen.queryByTestId('ember-fallback')).not.toBeInTheDocument();
     });
 
+    it('uses config ownership while Ember feature state is loading', async () => {
+        mockUseBrowseConfig.mockReturnValue(withLabs({someFlag: true}));
+        window.EmberBridge = {
+            state: {
+                isFeatureEnabled: () => undefined
+            }
+        } as unknown as typeof window.EmberBridge;
+
+        render(<FlagGatedRoute component={ReactScreen} flag="someFlag" />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('react-screen')).toBeInTheDocument();
+        });
+        expect(screen.queryByTestId('ember-fallback')).not.toBeInTheDocument();
+    });
+
     it('uses Ember ownership while the two flag sources disagree', async () => {
         mockUseBrowseConfig.mockReturnValue(withLabs({someFlag: false}));
         window.EmberBridge = {

--- a/apps/admin/src/flag-gated-route.test.tsx
+++ b/apps/admin/src/flag-gated-route.test.tsx
@@ -13,7 +13,13 @@ vi.mock('@tryghost/admin-x-framework/api/config', () => ({
 
 vi.mock('./ember-bridge', () => ({
     EmberFallback: () => React.createElement('div', {'data-testid': 'ember-fallback'}),
-    useEmberFeatureFlag: (flag: string) => window.EmberBridge?.state.isFeatureEnabled?.(flag)
+    useEmberFeatureFlag: (flag: string) => {
+        const stateBridge = window.EmberBridge?.state;
+        if (!stateBridge?.isFeatureEnabled) {
+            return undefined;
+        }
+        return stateBridge.isFeatureEnabled(flag) ?? null;
+    }
 }));
 
 const ReactScreen = lazy(() => Promise.resolve({
@@ -76,7 +82,7 @@ describe('FlagGatedRoute', () => {
         expect(screen.queryByTestId('ember-fallback')).not.toBeInTheDocument();
     });
 
-    it('uses config ownership while Ember feature state is loading', async () => {
+    it('renders nothing while Ember feature state is loading', () => {
         mockUseBrowseConfig.mockReturnValue(withLabs({someFlag: true}));
         window.EmberBridge = {
             state: {
@@ -84,12 +90,11 @@ describe('FlagGatedRoute', () => {
             }
         } as unknown as typeof window.EmberBridge;
 
-        render(<FlagGatedRoute component={ReactScreen} flag="someFlag" />);
+        const {container} = render(<FlagGatedRoute component={ReactScreen} flag="someFlag" />);
 
-        await waitFor(() => {
-            expect(screen.getByTestId('react-screen')).toBeInTheDocument();
-        });
+        expect(container).toBeEmptyDOMElement();
         expect(screen.queryByTestId('ember-fallback')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('react-screen')).not.toBeInTheDocument();
     });
 
     it('uses Ember ownership while the two flag sources disagree', async () => {

--- a/apps/admin/src/flag-gated-route.test.tsx
+++ b/apps/admin/src/flag-gated-route.test.tsx
@@ -12,7 +12,8 @@ vi.mock('@tryghost/admin-x-framework/api/config', () => ({
 }));
 
 vi.mock('./ember-bridge', () => ({
-    EmberFallback: () => React.createElement('div', {'data-testid': 'ember-fallback'})
+    EmberFallback: () => React.createElement('div', {'data-testid': 'ember-fallback'}),
+    useEmberFeatureFlag: (flag: string) => window.EmberBridge?.state.isFeatureEnabled?.(flag)
 }));
 
 const ReactScreen = lazy(() => Promise.resolve({
@@ -31,6 +32,7 @@ const withLabs = (labs: Record<string, unknown>) => configResult({data: {config:
 describe('FlagGatedRoute', () => {
     beforeEach(() => {
         mockUseBrowseConfig.mockReset();
+        delete window.EmberBridge;
     });
 
     it('renders nothing while config is loading', () => {
@@ -56,6 +58,48 @@ describe('FlagGatedRoute', () => {
         render(<FlagGatedRoute component={ReactScreen} flag="someFlag" />);
 
         expect(screen.getByTestId('ember-fallback')).toBeInTheDocument();
+    });
+
+    it('uses the Ember feature state when the config query fails', async () => {
+        mockUseBrowseConfig.mockReturnValue(configResult({isError: true, data: undefined}));
+        window.EmberBridge = {
+            state: {
+                isFeatureEnabled: (flag: string) => flag === 'someFlag'
+            }
+        } as unknown as typeof window.EmberBridge;
+
+        render(<FlagGatedRoute component={ReactScreen} flag="someFlag" />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('react-screen')).toBeInTheDocument();
+        });
+        expect(screen.queryByTestId('ember-fallback')).not.toBeInTheDocument();
+    });
+
+    it('uses Ember ownership while the two flag sources disagree', async () => {
+        mockUseBrowseConfig.mockReturnValue(withLabs({someFlag: false}));
+        window.EmberBridge = {
+            state: {
+                isFeatureEnabled: () => true
+            }
+        } as unknown as typeof window.EmberBridge;
+
+        const {unmount} = render(<FlagGatedRoute component={ReactScreen} flag="someFlag" />);
+        await waitFor(() => {
+            expect(screen.getByTestId('react-screen')).toBeInTheDocument();
+        });
+        unmount();
+
+        mockUseBrowseConfig.mockReturnValue(withLabs({someFlag: true}));
+        window.EmberBridge = {
+            state: {
+                isFeatureEnabled: () => false
+            }
+        } as unknown as typeof window.EmberBridge;
+        render(<FlagGatedRoute component={ReactScreen} flag="someFlag" />);
+
+        expect(screen.getByTestId('ember-fallback')).toBeInTheDocument();
+        expect(screen.queryByTestId('react-screen')).not.toBeInTheDocument();
     });
 
     it('renders Ember when the config query resolves with no data', () => {

--- a/apps/admin/src/flag-gated-route.tsx
+++ b/apps/admin/src/flag-gated-route.tsx
@@ -1,4 +1,4 @@
-import { EmberFallback } from "./ember-bridge";
+import { EmberFallback, useEmberFeatureFlag } from "./ember-bridge";
 import { Suspense, type ComponentType, type LazyExoticComponent } from "react";
 import { useBrowseConfig } from "@tryghost/admin-x-framework/api/config";
 
@@ -8,9 +8,10 @@ import { useBrowseConfig } from "@tryghost/admin-x-framework/api/config";
  * flag in Developer Experiments swaps implementations without a rebuild — the
  * routes table is static and evaluated once at module load.
  *
- * Ember owns the route unless the flag says otherwise, which makes it the safe
- * default in every uncertain case: config failed, config came back empty, flag
- * absent or not a boolean. Only an explicit `true` renders React.
+ * In the integrated admin, Ember's synchronously exposed feature state is the
+ * ownership authority for both routers. This prevents brief split-brain states
+ * while a Labs setting propagates between the Ember service and React cache.
+ * Standalone React/test environments fall back to the config query.
  *
  * The one case that is NOT safe to default to Ember is config still loading.
  * Falling back there would un-hide the Ember shell and flash the Ember screen
@@ -26,6 +27,17 @@ export function FlagGatedRoute({ flag, component: Component }: {
     component: LazyExoticComponent<ComponentType>;
 }) {
     const { data: config, isError, isLoading } = useBrowseConfig();
+    const emberFlag = useEmberFeatureFlag(flag);
+
+    const renderReact = () => (
+        <Suspense fallback={null}>
+            <Component />
+        </Suspense>
+    );
+
+    if (typeof emberFlag === 'boolean') {
+        return emberFlag ? renderReact() : <EmberFallback />;
+    }
 
     if (isLoading) {
         return null;
@@ -39,9 +51,5 @@ export function FlagGatedRoute({ flag, component: Component }: {
         return <EmberFallback />;
     }
 
-    return (
-        <Suspense fallback={null}>
-            <Component />
-        </Suspense>
-    );
+    return renderReact();
 }

--- a/apps/admin/src/flag-gated-route.tsx
+++ b/apps/admin/src/flag-gated-route.tsx
@@ -11,7 +11,9 @@ import { useBrowseConfig } from "@tryghost/admin-x-framework/api/config";
  * In the integrated admin, Ember's synchronously exposed feature state is the
  * ownership authority for both routers. This prevents brief split-brain states
  * while a Labs setting propagates between the Ember service and React cache.
- * Standalone React/test environments fall back to the config query.
+ * While Ember is present but its Labs settings are still loading, React does
+ * not claim the route. Standalone React/test environments (where there is no
+ * Ember feature reader) fall back to the config query.
  *
  * The one case that is NOT safe to default to Ember is config still loading.
  * Falling back there would un-hide the Ember shell and flash the Ember screen
@@ -37,6 +39,10 @@ export function FlagGatedRoute({ flag, component: Component }: {
 
     if (typeof emberFlag === 'boolean') {
         return emberFlag ? renderReact() : <EmberFallback />;
+    }
+
+    if (emberFlag === null) {
+        return null;
     }
 
     if (isLoading) {

--- a/apps/admin/src/home-redirect.tsx
+++ b/apps/admin/src/home-redirect.tsx
@@ -41,14 +41,14 @@ const HomeRedirect = () => {
     }
 
     if (hasAdminAccess(currentUser)) {
-        return <Navigate replace to="/analytics" />;
+        return <Navigate to="/analytics" replace />;
     }
 
     if (isContributorUser(currentUser)) {
-        return <Navigate replace to="/posts" />;
+        return <Navigate to="/posts" replace />;
     }
 
-    return <Navigate replace to="/site" />;
+    return <Navigate to="/site" replace />;
 };
 
 export default HomeRedirect;

--- a/apps/admin/src/hooks/use-pintura-editor.test.ts
+++ b/apps/admin/src/hooks/use-pintura-editor.test.ts
@@ -1,0 +1,57 @@
+import {act, renderHook, waitFor} from '@testing-library/react';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {usePinturaEditor} from './use-pintura-editor';
+
+const {mockUsePinturaConfig} = vi.hoisted(() => ({
+    mockUsePinturaConfig: vi.fn()
+}));
+
+vi.mock('@tryghost/admin-x-framework/hooks', () => ({
+    usePinturaConfig: mockUsePinturaConfig
+}));
+
+describe('usePinturaEditor', () => {
+    let processHandler: ((result: {dest: File}) => void) | undefined;
+    const openDefaultEditor = vi.fn((_options: {src: string}) => ({
+        on: (event: string, callback: (result: {dest: File}) => void) => {
+            if (event === 'process') {
+                processHandler = callback;
+            }
+        }
+    }));
+
+    beforeEach(() => {
+        mockUsePinturaConfig.mockReturnValue({
+            jsUrl: 'https://cdn.example.com/pintura.js',
+            cssUrl: 'https://cdn.example.com/pintura.css'
+        });
+        window.pintura = {openDefaultEditor};
+        const link = document.createElement('link');
+        link.rel = 'stylesheet';
+        link.href = 'https://cdn.example.com/pintura.css';
+        document.head.appendChild(link);
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+        processHandler = undefined;
+        document.head.querySelectorAll('link[href="https://cdn.example.com/pintura.css"]').forEach(link => link.remove());
+        Reflect.deleteProperty(window, 'pintura');
+    });
+
+    it('opens the configured editor and passes the processed file to the save handler', async () => {
+        const handleSave = vi.fn();
+        const {result} = renderHook(() => usePinturaEditor());
+        await waitFor(() => expect(result.current.isEnabled).toBe(true));
+
+        act(() => result.current.openEditor({image: '/content/images/tag.jpg', handleSave}));
+
+        expect(openDefaultEditor).toHaveBeenCalledOnce();
+        const editedImageUrl = new URL(openDefaultEditor.mock.calls[0][0].src);
+        expect(editedImageUrl.pathname).toBe('/content/images/tag.jpg');
+        expect(editedImageUrl.searchParams.get('v')).toMatch(/^\d+$/);
+        const edited = new File(['image'], 'edited.jpg', {type: 'image/jpeg'});
+        act(() => processHandler?.({dest: edited}));
+        expect(handleSave).toHaveBeenCalledWith(edited);
+    });
+});

--- a/apps/admin/src/hooks/use-pintura-editor.test.ts
+++ b/apps/admin/src/hooks/use-pintura-editor.test.ts
@@ -54,4 +54,14 @@ describe('usePinturaEditor', () => {
         act(() => processHandler?.({dest: edited}));
         expect(handleSave).toHaveBeenCalledWith(edited);
     });
+
+    it('disables the editor when the integration is turned off', async () => {
+        const {result, rerender} = renderHook(() => usePinturaEditor());
+        await waitFor(() => expect(result.current.isEnabled).toBe(true));
+
+        mockUsePinturaConfig.mockReturnValue(null);
+        rerender();
+
+        expect(result.current.isEnabled).toBe(false);
+    });
 });

--- a/apps/admin/src/hooks/use-pintura-editor.test.ts
+++ b/apps/admin/src/hooks/use-pintura-editor.test.ts
@@ -2,8 +2,13 @@ import {act, renderHook, waitFor} from '@testing-library/react';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {usePinturaEditor} from './use-pintura-editor';
 
-const {mockUsePinturaConfig} = vi.hoisted(() => ({
+const {mockTrackEvent, mockUsePinturaConfig} = vi.hoisted(() => ({
+    mockTrackEvent: vi.fn(),
     mockUsePinturaConfig: vi.fn()
+}));
+
+vi.mock('@tryghost/admin-x-framework', () => ({
+    trackEvent: mockTrackEvent
 }));
 
 vi.mock('@tryghost/admin-x-framework/hooks', () => ({
@@ -12,15 +17,18 @@ vi.mock('@tryghost/admin-x-framework/hooks', () => ({
 
 describe('usePinturaEditor', () => {
     let processHandler: ((result: {dest: File}) => void) | undefined;
+    const destroy = vi.fn();
     const openDefaultEditor = vi.fn((_options: {src: string}) => ({
         on: (event: string, callback: (result: {dest: File}) => void) => {
             if (event === 'process') {
                 processHandler = callback;
             }
-        }
+        },
+        destroy
     }));
 
     beforeEach(() => {
+        destroy.mockClear();
         mockUsePinturaConfig.mockReturnValue({
             jsUrl: 'https://cdn.example.com/pintura.js',
             cssUrl: 'https://cdn.example.com/pintura.css'
@@ -47,12 +55,40 @@ describe('usePinturaEditor', () => {
         act(() => result.current.openEditor({image: '/content/images/tag.jpg', handleSave}));
 
         expect(openDefaultEditor).toHaveBeenCalledOnce();
+        expect(mockTrackEvent).toHaveBeenCalledWith('Image Edit Button Clicked', {location: 'admin'});
         const editedImageUrl = new URL(openDefaultEditor.mock.calls[0][0].src);
         expect(editedImageUrl.pathname).toBe('/content/images/tag.jpg');
         expect(editedImageUrl.searchParams.get('v')).toMatch(/^\d+$/);
         const edited = new File(['image'], 'edited.jpg', {type: 'image/jpeg'});
         act(() => processHandler?.({dest: edited}));
-        expect(handleSave).toHaveBeenCalledWith(edited);
+        await waitFor(() => {
+            expect(handleSave).toHaveBeenCalledWith(edited);
+            expect(mockTrackEvent).toHaveBeenCalledWith('Image Edit Saved', {location: 'admin'});
+        });
+    });
+
+    it('destroys an open editor when its owner unmounts', async () => {
+        const {result, unmount} = renderHook(() => usePinturaEditor());
+        await waitFor(() => expect(result.current.isEnabled).toBe(true));
+
+        act(() => result.current.openEditor({image: '/content/images/tag.jpg', handleSave: vi.fn()}));
+        expect(result.current.isOpen).toBe(true);
+
+        unmount();
+
+        expect(destroy).toHaveBeenCalledOnce();
+    });
+
+    it('does not track a saved edit when the image handler rejects it', async () => {
+        const handleSave = vi.fn().mockResolvedValue(false);
+        const {result} = renderHook(() => usePinturaEditor());
+        await waitFor(() => expect(result.current.isEnabled).toBe(true));
+
+        act(() => result.current.openEditor({image: '/content/images/tag.jpg', handleSave}));
+        act(() => processHandler?.({dest: new File(['image'], 'edited.jpg', {type: 'image/jpeg'})}));
+
+        await waitFor(() => expect(handleSave).toHaveBeenCalledOnce());
+        expect(mockTrackEvent).not.toHaveBeenCalledWith('Image Edit Saved', {location: 'admin'});
     });
 
     it('disables the editor when the integration is turned off', async () => {

--- a/apps/admin/src/hooks/use-pintura-editor.ts
+++ b/apps/admin/src/hooks/use-pintura-editor.ts
@@ -1,0 +1,129 @@
+import {usePinturaConfig} from '@tryghost/admin-x-framework/hooks';
+import {useCallback, useEffect, useRef, useState} from 'react';
+
+interface OpenEditorParams {
+    image: string;
+    handleSave: (file: File) => void | Promise<void>;
+}
+
+/** Loads Ghost's configured Pintura editor and exposes the legacy image-edit action. */
+export function usePinturaEditor({disabled = false}: {disabled?: boolean} = {}) {
+    const config = usePinturaConfig();
+    const [scriptLoaded, setScriptLoaded] = useState(false);
+    const [cssLoaded, setCssLoaded] = useState(false);
+    const [isOpen, setIsOpen] = useState(false);
+    const allowClose = useRef(false);
+
+    useEffect(() => {
+        const jsUrl = config?.jsUrl;
+        if (!jsUrl) {
+            return;
+        }
+
+        if (window.pintura) {
+            setScriptLoaded(true);
+            return;
+        }
+
+        const importScript = async () => {
+            try {
+                const url = new URL(jsUrl);
+                await import(/* @vite-ignore */ `${url.protocol}//${url.host}${url.pathname}`);
+                setScriptLoaded(true);
+            } catch {
+                // The edit action stays hidden when the optional editor fails to load.
+            }
+        };
+        void importScript();
+    }, [config?.jsUrl]);
+
+    useEffect(() => {
+        const cssUrl = config?.cssUrl;
+        if (!cssUrl) {
+            return;
+        }
+
+        const existingLink = document.querySelector(`link[href="${cssUrl}"]`);
+        if (existingLink) {
+            setCssLoaded(true);
+            return;
+        }
+
+        const link = document.createElement('link');
+        link.rel = 'stylesheet';
+        link.type = 'text/css';
+        link.href = cssUrl;
+        link.onload = () => setCssLoaded(true);
+        document.head.appendChild(link);
+    }, [config?.cssUrl]);
+
+    const isEnabled = !disabled && scriptLoaded && cssLoaded;
+    const openEditor = useCallback(({image, handleSave}: OpenEditorParams) => {
+        const pintura = window.pintura;
+        if (!image || !isEnabled || !pintura) {
+            return;
+        }
+
+        allowClose.current = false;
+        const imageUrl = new URL(image, window.location.origin);
+        if (!imageUrl.searchParams.has('v')) {
+            imageUrl.searchParams.set('v', Date.now().toString());
+        }
+
+        const editor = pintura.openDefaultEditor({
+            src: imageUrl.href,
+            enableTransparencyGrid: true,
+            util: 'crop',
+            utils: ['crop', 'filter', 'finetune', 'redact', 'annotate', 'trim', 'frame', 'resize'],
+            frameOptions: [
+                [undefined, locale => locale.labelNone],
+                ['solidSharp', locale => locale.frameLabelMatSharp],
+                ['solidRound', locale => locale.frameLabelMatRound],
+                ['lineSingle', locale => locale.frameLabelLineSingle],
+                ['hook', locale => locale.frameLabelCornerHooks],
+                ['polaroid', locale => locale.frameLabelPolaroid]
+            ],
+            cropSelectPresetFilter: 'landscape',
+            cropSelectPresetOptions: [
+                [undefined, 'Custom'], [1, 'Square'], [2 / 1, '2:1'], [3 / 2, '3:2'], [4 / 3, '4:3'], [16 / 10, '16:10'], [16 / 9, '16:9'],
+                [1 / 2, '1:2'], [2 / 3, '2:3'], [3 / 4, '3:4'], [10 / 16, '10:16'], [9 / 16, '9:16']
+            ],
+            locale: {labelButtonExport: 'Save and close'},
+            previewPad: true,
+            willClose: () => {
+                if (allowClose.current) {
+                    setIsOpen(false);
+                    return true;
+                }
+                return false;
+            }
+        });
+        editor.on('process', result => void handleSave(result.dest));
+        setIsOpen(true);
+    }, [isEnabled]);
+
+    useEffect(() => {
+        if (!isOpen) {
+            return;
+        }
+
+        const handleCloseClick = (event: MouseEvent) => {
+            if (event.target instanceof Element && event.target.closest('.PinturaModal button[title="Close"]')) {
+                allowClose.current = true;
+            }
+        };
+        const handleEscape = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                event.stopPropagation();
+            }
+        };
+        window.addEventListener('click', handleCloseClick, {capture: true});
+        window.addEventListener('keydown', handleEscape, {capture: true});
+        return () => {
+            window.removeEventListener('click', handleCloseClick, {capture: true});
+            window.removeEventListener('keydown', handleEscape, {capture: true});
+        };
+    }, [isOpen]);
+
+    return {isEnabled, openEditor};
+}

--- a/apps/admin/src/hooks/use-pintura-editor.ts
+++ b/apps/admin/src/hooks/use-pintura-editor.ts
@@ -57,7 +57,7 @@ export function usePinturaEditor({disabled = false}: {disabled?: boolean} = {}) 
         document.head.appendChild(link);
     }, [config?.cssUrl]);
 
-    const isEnabled = !disabled && scriptLoaded && cssLoaded;
+    const isEnabled = !disabled && !!config && scriptLoaded && cssLoaded;
     const openEditor = useCallback(({image, handleSave}: OpenEditorParams) => {
         const pintura = window.pintura;
         if (!image || !isEnabled || !pintura) {

--- a/apps/admin/src/hooks/use-pintura-editor.ts
+++ b/apps/admin/src/hooks/use-pintura-editor.ts
@@ -1,9 +1,10 @@
 import {usePinturaConfig} from '@tryghost/admin-x-framework/hooks';
+import {trackEvent} from '@tryghost/admin-x-framework';
 import {useCallback, useEffect, useRef, useState} from 'react';
 
 interface OpenEditorParams {
     image: string;
-    handleSave: (file: File) => void | Promise<void>;
+    handleSave: (file: File) => void | boolean | Promise<void | boolean>;
 }
 
 /** Loads Ghost's configured Pintura editor and exposes the legacy image-edit action. */
@@ -13,6 +14,7 @@ export function usePinturaEditor({disabled = false}: {disabled?: boolean} = {}) 
     const [cssLoaded, setCssLoaded] = useState(false);
     const [isOpen, setIsOpen] = useState(false);
     const allowClose = useRef(false);
+    const editorRef = useRef<{destroy: () => void} | null>(null);
 
     useEffect(() => {
         const jsUrl = config?.jsUrl;
@@ -60,7 +62,7 @@ export function usePinturaEditor({disabled = false}: {disabled?: boolean} = {}) 
     const isEnabled = !disabled && !!config && scriptLoaded && cssLoaded;
     const openEditor = useCallback(({image, handleSave}: OpenEditorParams) => {
         const pintura = window.pintura;
-        if (!image || !isEnabled || !pintura) {
+        if (!image || !isEnabled || !pintura || editorRef.current) {
             return;
         }
 
@@ -70,6 +72,7 @@ export function usePinturaEditor({disabled = false}: {disabled?: boolean} = {}) 
             imageUrl.searchParams.set('v', Date.now().toString());
         }
 
+        trackEvent('Image Edit Button Clicked', {location: 'admin'});
         const editor = pintura.openDefaultEditor({
             src: imageUrl.href,
             enableTransparencyGrid: true,
@@ -92,15 +95,44 @@ export function usePinturaEditor({disabled = false}: {disabled?: boolean} = {}) 
             previewPad: true,
             willClose: () => {
                 if (allowClose.current) {
+                    editorRef.current = null;
                     setIsOpen(false);
                     return true;
                 }
                 return false;
             }
         });
-        editor.on('process', result => void handleSave(result.dest));
+        editorRef.current = editor;
+        editor.on('process', (result) => {
+            void Promise.resolve().then(() => handleSave(result.dest)).then((saved) => {
+                if (saved !== false) {
+                    trackEvent('Image Edit Saved', {location: 'admin'});
+                }
+            }).catch(() => {});
+        });
+        editor.on('destroy', () => {
+            if (editorRef.current === editor) {
+                editorRef.current = null;
+                setIsOpen(false);
+            }
+        });
         setIsOpen(true);
     }, [isEnabled]);
+
+    useEffect(() => {
+        if (!isEnabled && editorRef.current) {
+            const editor = editorRef.current;
+            editorRef.current = null;
+            editor.destroy();
+            setIsOpen(false);
+        }
+    }, [isEnabled]);
+
+    useEffect(() => () => {
+        const editor = editorRef.current;
+        editorRef.current = null;
+        editor?.destroy();
+    }, []);
 
     useEffect(() => {
         if (!isOpen) {
@@ -125,5 +157,5 @@ export function usePinturaEditor({disabled = false}: {disabled?: boolean} = {}) 
         };
     }, [isOpen]);
 
-    return {isEnabled, openEditor};
+    return {isEnabled, isOpen, openEditor};
 }

--- a/apps/admin/src/member-detail-gate.test.tsx
+++ b/apps/admin/src/member-detail-gate.test.tsx
@@ -13,7 +13,13 @@ vi.mock('@tryghost/admin-x-framework/api/config', () => ({
 
 vi.mock('./ember-bridge', () => ({
     EmberFallback: () => React.createElement('div', {'data-testid': 'ember-fallback'}),
-    useEmberFeatureFlag: (flag: string) => window.EmberBridge?.state.isFeatureEnabled?.(flag)
+    useEmberFeatureFlag: (flag: string) => {
+        const stateBridge = window.EmberBridge?.state;
+        if (!stateBridge?.isFeatureEnabled) {
+            return undefined;
+        }
+        return stateBridge.isFeatureEnabled(flag) ?? null;
+    }
 }));
 
 vi.mock('./members/detail/member-detail', () => ({

--- a/apps/admin/src/member-detail-gate.test.tsx
+++ b/apps/admin/src/member-detail-gate.test.tsx
@@ -12,7 +12,8 @@ vi.mock('@tryghost/admin-x-framework/api/config', () => ({
 }));
 
 vi.mock('./ember-bridge', () => ({
-    EmberFallback: () => React.createElement('div', {'data-testid': 'ember-fallback'})
+    EmberFallback: () => React.createElement('div', {'data-testid': 'ember-fallback'}),
+    useEmberFeatureFlag: (flag: string) => window.EmberBridge?.state.isFeatureEnabled?.(flag)
 }));
 
 vi.mock('./members/detail/member-detail', () => ({

--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -119,7 +119,7 @@ const appRoutes: RouteObject[] = [
         // `tagDetailsReact` Labs flag.
         path: "/tags/:tagSlug",
         Component: TagDetailGate,
-        handle: { ...emberFallbackHandle, requiresAccess: canManageTags } satisfies RouteHandle & AccessRouteHandle,
+        handle: {requiresAccess: canManageTags} satisfies AccessRouteHandle,
     },
     membersRoute,
     {

--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -14,6 +14,7 @@ import type { RouteHandle } from "./ember-bridge";
 import HomeRedirect from "./home-redirect";
 import { EmberListWithGiftLinks } from "./gift-link-modal-host";
 import { MemberDetailGate } from "./member-detail-gate";
+import { TagDetailGate } from "./tag-detail-gate";
 import { OnboardingRedirect } from "./onboarding/onboarding-redirect";
 import { type AccessRouteHandle, RouteAccessGuard } from "./route-access-guard";
 import { canAccessSettingsRoute } from "./settings/settings-access";
@@ -34,7 +35,6 @@ const EMBER_ROUTES: string[] = [
     "/posts/analytics/:postId/debug",
     "/restore",
     "/editor/*",
-    "/tags/new",
     "/explore/*",
     "/migrate/*",
     "/members-activity",
@@ -111,12 +111,15 @@ const appRoutes: RouteObject[] = [
         lazy: lazyComponent(() => import("./automations/editor")),
     },
     {
-        // The tag detail route delegates to Ember. It must be declared
-        // so navigating from the tag list to a detail page doesn't trip
-        // the router error fallback before Ember takes over.
+        // Covers both edit (`:tagSlug`) and create (the sentinel `new`) —
+        // Ember's router declared `/tags/new` before `/tags/:tag_slug`, so a
+        // tag with the literal slug "new" was already unreachable.
+        //
+        // TagDetailGate serves Ember or React depending on the
+        // `tagDetailsReact` Labs flag.
         path: "/tags/:tagSlug",
-        Component: EmberFallback,
-        handle: { ...emberFallbackHandle, requiresAccess: canManageTags } satisfies RouteHandle & AccessRouteHandle,
+        Component: TagDetailGate,
+        handle: { requiresAccess: canManageTags } satisfies AccessRouteHandle,
     },
     membersRoute,
     {

--- a/apps/admin/src/routes.tsx
+++ b/apps/admin/src/routes.tsx
@@ -119,7 +119,7 @@ const appRoutes: RouteObject[] = [
         // `tagDetailsReact` Labs flag.
         path: "/tags/:tagSlug",
         Component: TagDetailGate,
-        handle: { requiresAccess: canManageTags } satisfies AccessRouteHandle,
+        handle: { ...emberFallbackHandle, requiresAccess: canManageTags } satisfies RouteHandle & AccessRouteHandle,
     },
     membersRoute,
     {

--- a/apps/admin/src/settings/app/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/labs/private-features.tsx
@@ -76,6 +76,10 @@ const features: Feature[] = [{
     description: 'Renders the member detail screen (/members/:id) from the React app instead of the Ember screen. Gates the migration behind a runtime toggle so we can compare both implementations.',
     flag: 'memberDetailsReact'
 }, {
+    title: 'React tag details',
+    description: 'Renders the tag detail screen (/tags/:slug) from the React app instead of the Ember screen. Gates the migration behind a runtime toggle so we can compare both implementations.',
+    flag: 'tagDetailsReact'
+}, {
     title: 'Member custom fields',
     description: 'Let admins create and manage custom field definitions for members',
     flag: 'membersCustomFields'

--- a/apps/admin/src/settings/app/hooks/use-pintura-editor.ts
+++ b/apps/admin/src/settings/app/hooks/use-pintura-editor.ts
@@ -39,6 +39,7 @@ declare global {
                 willClose: () => boolean;
             }) => {
                 on: (event: string, callback: (result: { dest: File }) => void) => void;
+                destroy: () => void;
             };
         }
     }

--- a/apps/admin/src/tag-detail-gate.test.tsx
+++ b/apps/admin/src/tag-detail-gate.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import {TagDetailGate} from './tag-detail-gate';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {render, screen, waitFor} from '@testing-library/react';
+
+const {mockUseBrowseConfig} = vi.hoisted(() => ({
+    mockUseBrowseConfig: vi.fn()
+}));
+
+vi.mock('@tryghost/admin-x-framework/api/config', () => ({
+    useBrowseConfig: mockUseBrowseConfig
+}));
+
+vi.mock('./ember-bridge', () => ({
+    EmberFallback: () => React.createElement('div', {'data-testid': 'ember-fallback'})
+}));
+
+vi.mock('./tags/detail/tag-detail', () => ({
+    default: () => React.createElement('div', {'data-testid': 'react-tag-detail'})
+}));
+
+const configResult = (overrides: Record<string, unknown>) => ({
+    data: undefined,
+    isError: false,
+    isLoading: false,
+    ...overrides
+});
+
+const withLabs = (labs: Record<string, boolean>) => configResult({data: {config: {labs}}});
+
+describe('TagDetailGate', () => {
+    beforeEach(() => {
+        mockUseBrowseConfig.mockReset();
+    });
+
+    it('renders Ember while the flag is off', () => {
+        mockUseBrowseConfig.mockReturnValue(withLabs({tagDetailsReact: false}));
+
+        render(<TagDetailGate />);
+
+        expect(screen.getByTestId('ember-fallback')).toBeInTheDocument();
+    });
+
+    it('renders React while the flag is on', async () => {
+        mockUseBrowseConfig.mockReturnValue(withLabs({tagDetailsReact: true}));
+
+        render(<TagDetailGate />);
+
+        // The React screen is lazily imported, so it arrives a tick later.
+        await waitFor(() => {
+            expect(screen.getByTestId('react-tag-detail')).toBeInTheDocument();
+        });
+    });
+
+    it('renders Ember when the flag is absent from config', () => {
+        mockUseBrowseConfig.mockReturnValue(withLabs({}));
+
+        render(<TagDetailGate />);
+
+        expect(screen.getByTestId('ember-fallback')).toBeInTheDocument();
+    });
+
+    it('renders Ember when the config query fails', () => {
+        // A failed config read must not blank the screen — Ember owns this URL
+        // by default and still serves it, so degrading to Ember keeps the tag
+        // detail working.
+        mockUseBrowseConfig.mockReturnValue(configResult({isError: true, data: undefined}));
+
+        render(<TagDetailGate />);
+
+        expect(screen.getByTestId('ember-fallback')).toBeInTheDocument();
+    });
+
+    it('renders Ember when the config query resolves with no data', () => {
+        mockUseBrowseConfig.mockReturnValue(configResult({data: undefined}));
+
+        render(<TagDetailGate />);
+
+        expect(screen.getByTestId('ember-fallback')).toBeInTheDocument();
+    });
+
+    it('renders nothing while config is loading', () => {
+        // Deliberately not falling back to Ember here: doing so would un-hide
+        // the Ember shell and flash the old screen on every cold load for
+        // admins who have the flag on.
+        mockUseBrowseConfig.mockReturnValue(configResult({isLoading: true}));
+
+        const {container} = render(<TagDetailGate />);
+
+        expect(screen.queryByTestId('ember-fallback')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('react-tag-detail')).not.toBeInTheDocument();
+        expect(container).toBeEmptyDOMElement();
+    });
+});

--- a/apps/admin/src/tag-detail-gate.test.tsx
+++ b/apps/admin/src/tag-detail-gate.test.tsx
@@ -12,7 +12,8 @@ vi.mock('@tryghost/admin-x-framework/api/config', () => ({
 }));
 
 vi.mock('./ember-bridge', () => ({
-    EmberFallback: () => React.createElement('div', {'data-testid': 'ember-fallback'})
+    EmberFallback: () => React.createElement('div', {'data-testid': 'ember-fallback'}),
+    useEmberFeatureFlag: (flag: string) => window.EmberBridge?.state.isFeatureEnabled?.(flag)
 }));
 
 vi.mock('./tags/detail/tag-detail', () => ({
@@ -31,6 +32,7 @@ const withLabs = (labs: Record<string, boolean>) => configResult({data: {config:
 describe('TagDetailGate', () => {
     beforeEach(() => {
         mockUseBrowseConfig.mockReset();
+        delete window.EmberBridge;
     });
 
     it('renders Ember while the flag is off', () => {
@@ -69,6 +71,22 @@ describe('TagDetailGate', () => {
         render(<TagDetailGate />);
 
         expect(screen.getByTestId('ember-fallback')).toBeInTheDocument();
+    });
+
+    it('keeps React ownership when its config query fails but Ember has the flag', async () => {
+        mockUseBrowseConfig.mockReturnValue(configResult({isError: true, data: undefined}));
+        window.EmberBridge = {
+            state: {
+                isFeatureEnabled: (flag: string) => flag === 'tagDetailsReact'
+            }
+        } as unknown as typeof window.EmberBridge;
+
+        render(<TagDetailGate />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('react-tag-detail')).toBeInTheDocument();
+        });
+        expect(screen.queryByTestId('ember-fallback')).not.toBeInTheDocument();
     });
 
     it('renders Ember when the config query resolves with no data', () => {

--- a/apps/admin/src/tag-detail-gate.test.tsx
+++ b/apps/admin/src/tag-detail-gate.test.tsx
@@ -13,7 +13,13 @@ vi.mock('@tryghost/admin-x-framework/api/config', () => ({
 
 vi.mock('./ember-bridge', () => ({
     EmberFallback: () => React.createElement('div', {'data-testid': 'ember-fallback'}),
-    useEmberFeatureFlag: (flag: string) => window.EmberBridge?.state.isFeatureEnabled?.(flag)
+    useEmberFeatureFlag: (flag: string) => {
+        const stateBridge = window.EmberBridge?.state;
+        if (!stateBridge?.isFeatureEnabled) {
+            return undefined;
+        }
+        return stateBridge.isFeatureEnabled(flag) ?? null;
+    }
 }));
 
 vi.mock('./tags/detail/tag-detail', () => ({

--- a/apps/admin/src/tag-detail-gate.tsx
+++ b/apps/admin/src/tag-detail-gate.tsx
@@ -1,0 +1,16 @@
+import { FlagGatedRoute } from "./flag-gated-route";
+import { lazy } from "react";
+
+/**
+ * Serves `/tags/:tagSlug` — covering both edit (`:tagSlug`) and create (the
+ * `new` sentinel) — from the React tag detail screen when the
+ * `tagDetailsReact` Labs flag is on, and from Ember otherwise. The gating
+ * semantics (loading, error, and flag branching) live in FlagGatedRoute.
+ */
+const TagDetailReact = lazy(() => import("./tags/detail/tag-detail"));
+
+export function TagDetailGate() {
+    return <FlagGatedRoute component={TagDetailReact} flag="tagDetailsReact" />;
+}
+
+export default TagDetailGate;

--- a/apps/admin/src/tags/detail/tag-color-field.tsx
+++ b/apps/admin/src/tags/detail/tag-color-field.tsx
@@ -4,6 +4,7 @@ import {Input, Label} from '@tryghost/shade/components';
 interface TagColorFieldProps {
     value: string;
     disabled?: boolean;
+    errorId?: string;
     onChange: (color: string) => void;
     onError: (message: string | null) => void;
 }
@@ -17,7 +18,7 @@ const HEX_COLOR_REGEX = /#[0-9A-Fa-f]{6}$/;
  * debounce on input, immediate normalization on blur, and the same error
  * copy for a malformed hex value.
  */
-const TagColorField: React.FC<TagColorFieldProps> = ({value, disabled, onChange, onError}) => {
+const TagColorField: React.FC<TagColorFieldProps> = ({value, disabled, errorId, onChange, onError}) => {
     const [text, setText] = React.useState(value.replace(/^#/, ''));
     const lastValueRef = React.useRef(value);
     const debounceRef = React.useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
@@ -71,6 +72,8 @@ const TagColorField: React.FC<TagColorFieldProps> = ({value, disabled, onChange,
             <Label htmlFor='tag-accent-color'>Color</Label>
             <div className='flex items-center gap-2'>
                 <Input
+                    aria-describedby={errorId}
+                    aria-invalid={!!errorId}
                     aria-label='Accent color hex value'
                     autoCorrect='off'
                     disabled={disabled}

--- a/apps/admin/src/tags/detail/tag-color-field.tsx
+++ b/apps/admin/src/tags/detail/tag-color-field.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Input, Label} from '@tryghost/shade/components';
+import {InputGroup, InputGroupAddon, InputGroupInput, InputGroupText, Label} from '@tryghost/shade/components';
 
 interface TagColorFieldProps {
     value: string;
@@ -12,8 +12,9 @@ interface TagColorFieldProps {
 const HEX_COLOR_REGEX = /#[0-9A-Fa-f]{6}$/;
 
 /**
- * The tag accent colour control: a hex text input (no leading `#`) plus a
- * native colour picker swatch, porting Ember `tag-form.js`
+ * The tag accent colour control, arranged like Ember's `.input-color`: one
+ * bordered control with the swatch (the native colour-picker trigger) on the
+ * left, a static `#` prefix, and the hex text input. Ports `tag-form.js`
  * `updateAccentColor` — immediate normalization keeps the form draft in sync
  * before keyboard saves, with the same error copy for a malformed hex value.
  */
@@ -61,12 +62,35 @@ const TagColorField: React.FC<TagColorFieldProps> = ({value, disabled, errorId, 
     return (
         <div className='flex flex-col gap-1.5'>
             <Label htmlFor='tag-accent-color'>Color</Label>
-            <div className='flex items-center gap-2'>
-                <Input
+            <InputGroup className='w-36' data-disabled={disabled ? 'true' : undefined}>
+                <InputGroupAddon align='inline-start'>
+                    <div
+                        className='relative size-6 shrink-0 overflow-hidden rounded-sm border border-border'
+                        style={{backgroundColor: value || '#ffffff'}}
+                        // Keep the addon's focus-the-text-input click handler
+                        // from hijacking the native colour-picker trigger.
+                        onClick={e => e.stopPropagation()}
+                    >
+                        <input
+                            aria-label='Accent color picker'
+                            className='absolute inset-0 size-full cursor-pointer opacity-0'
+                            disabled={disabled}
+                            type='color'
+                            value={value || '#ffffff'}
+                            onChange={(e) => {
+                                setText(e.target.value.replace(/^#/, ''));
+                                applyColor(e.target.value);
+                            }}
+                        />
+                    </div>
+                    <InputGroupText className='font-mono'>#</InputGroupText>
+                </InputGroupAddon>
+                <InputGroupInput
                     aria-describedby={errorId}
                     aria-invalid={!!errorId}
                     aria-label='Accent color hex value'
                     autoCorrect='off'
+                    className='font-mono'
                     disabled={disabled}
                     id='tag-accent-color'
                     maxLength={6}
@@ -78,23 +102,7 @@ const TagColorField: React.FC<TagColorFieldProps> = ({value, disabled, errorId, 
                         applyColor(e.target.value);
                     }}
                 />
-                <div
-                    className='relative size-9 shrink-0 overflow-hidden rounded-md border border-input'
-                    style={{backgroundColor: value || '#ffffff'}}
-                >
-                    <input
-                        aria-label='Accent color picker'
-                        className='absolute inset-0 size-full cursor-pointer opacity-0'
-                        disabled={disabled}
-                        type='color'
-                        value={value || '#ffffff'}
-                        onChange={(e) => {
-                            setText(e.target.value.replace(/^#/, ''));
-                            applyColor(e.target.value);
-                        }}
-                    />
-                </div>
-            </div>
+            </InputGroup>
         </div>
     );
 };

--- a/apps/admin/src/tags/detail/tag-color-field.tsx
+++ b/apps/admin/src/tags/detail/tag-color-field.tsx
@@ -14,14 +14,12 @@ const HEX_COLOR_REGEX = /#[0-9A-Fa-f]{6}$/;
 /**
  * The tag accent colour control: a hex text input (no leading `#`) plus a
  * native colour picker swatch, porting Ember `tag-form.js`
- * `updateAccentColor` / `debounceUpdateAccentColorTask` — the same 10ms
- * debounce on input, immediate normalization on blur, and the same error
- * copy for a malformed hex value.
+ * `updateAccentColor` — immediate normalization keeps the form draft in sync
+ * before keyboard saves, with the same error copy for a malformed hex value.
  */
 const TagColorField: React.FC<TagColorFieldProps> = ({value, disabled, errorId, onChange, onError}) => {
     const [text, setText] = React.useState(value.replace(/^#/, ''));
     const lastValueRef = React.useRef(value);
-    const debounceRef = React.useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
     // Adopt external changes (initial load, a background refetch) without
     // clobbering in-progress typing on unrelated re-renders.
@@ -31,8 +29,6 @@ const TagColorField: React.FC<TagColorFieldProps> = ({value, disabled, errorId, 
             setText(value.replace(/^#/, ''));
         }
     }, [value]);
-
-    React.useEffect(() => () => clearTimeout(debounceRef.current), []);
 
     const applyColor = (input: string) => {
         onError(null);
@@ -62,11 +58,6 @@ const TagColorField: React.FC<TagColorFieldProps> = ({value, disabled, errorId, 
         }
     };
 
-    const scheduleApply = (input: string) => {
-        clearTimeout(debounceRef.current);
-        debounceRef.current = setTimeout(() => applyColor(input), 10);
-    };
-
     return (
         <div className='flex flex-col gap-1.5'>
             <Label htmlFor='tag-accent-color'>Color</Label>
@@ -84,7 +75,7 @@ const TagColorField: React.FC<TagColorFieldProps> = ({value, disabled, errorId, 
                     onBlur={e => applyColor(e.target.value)}
                     onChange={(e) => {
                         setText(e.target.value);
-                        scheduleApply(e.target.value);
+                        applyColor(e.target.value);
                     }}
                 />
                 <div
@@ -99,7 +90,7 @@ const TagColorField: React.FC<TagColorFieldProps> = ({value, disabled, errorId, 
                         value={value || '#ffffff'}
                         onChange={(e) => {
                             setText(e.target.value.replace(/^#/, ''));
-                            scheduleApply(e.target.value);
+                            applyColor(e.target.value);
                         }}
                     />
                 </div>

--- a/apps/admin/src/tags/detail/tag-color-field.tsx
+++ b/apps/admin/src/tags/detail/tag-color-field.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import {Input, Label} from '@tryghost/shade/components';
+
+interface TagColorFieldProps {
+    value: string;
+    disabled?: boolean;
+    onChange: (color: string) => void;
+    onError: (message: string | null) => void;
+}
+
+const HEX_COLOR_REGEX = /#[0-9A-Fa-f]{6}$/;
+
+/**
+ * The tag accent colour control: a hex text input (no leading `#`) plus a
+ * native colour picker swatch, porting Ember `tag-form.js`
+ * `updateAccentColor` / `debounceUpdateAccentColorTask` — the same 10ms
+ * debounce on input, immediate normalization on blur, and the same error
+ * copy for a malformed hex value.
+ */
+const TagColorField: React.FC<TagColorFieldProps> = ({value, disabled, onChange, onError}) => {
+    const [text, setText] = React.useState(value.replace(/^#/, ''));
+    const lastValueRef = React.useRef(value);
+    const debounceRef = React.useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+    // Adopt external changes (initial load, a background refetch) without
+    // clobbering in-progress typing on unrelated re-renders.
+    React.useEffect(() => {
+        if (value !== lastValueRef.current) {
+            lastValueRef.current = value;
+            setText(value.replace(/^#/, ''));
+        }
+    }, [value]);
+
+    React.useEffect(() => () => clearTimeout(debounceRef.current), []);
+
+    const applyColor = (input: string) => {
+        onError(null);
+
+        if (input === '') {
+            if (value !== '') {
+                lastValueRef.current = '';
+                onChange('');
+            }
+            return;
+        }
+
+        let newColor = input;
+        if (newColor[0] !== '#') {
+            newColor = `#${newColor}`;
+        }
+
+        if (HEX_COLOR_REGEX.test(newColor)) {
+            if (newColor === value) {
+                return;
+            }
+            lastValueRef.current = newColor;
+            setText(newColor.replace(/^#/, ''));
+            onChange(newColor);
+        } else {
+            onError('The colour should be in valid hex format');
+        }
+    };
+
+    const scheduleApply = (input: string) => {
+        clearTimeout(debounceRef.current);
+        debounceRef.current = setTimeout(() => applyColor(input), 10);
+    };
+
+    return (
+        <div className='flex flex-col gap-1.5'>
+            <Label htmlFor='tag-accent-color'>Color</Label>
+            <div className='flex items-center gap-2'>
+                <Input
+                    aria-label='Accent color hex value'
+                    autoCorrect='off'
+                    disabled={disabled}
+                    id='tag-accent-color'
+                    maxLength={6}
+                    placeholder='15171A'
+                    value={text}
+                    onBlur={e => applyColor(e.target.value)}
+                    onChange={(e) => {
+                        setText(e.target.value);
+                        scheduleApply(e.target.value);
+                    }}
+                />
+                <div
+                    className='relative size-9 shrink-0 overflow-hidden rounded-md border border-input'
+                    style={{backgroundColor: value || '#ffffff'}}
+                >
+                    <input
+                        aria-label='Accent color picker'
+                        className='absolute inset-0 size-full cursor-pointer opacity-0'
+                        disabled={disabled}
+                        type='color'
+                        value={value || '#ffffff'}
+                        onChange={(e) => {
+                            setText(e.target.value.replace(/^#/, ''));
+                            scheduleApply(e.target.value);
+                        }}
+                    />
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default TagColorField;

--- a/apps/admin/src/tags/detail/tag-delete-modal.tsx
+++ b/apps/admin/src/tags/detail/tag-delete-modal.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import {Button, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, LoadingIndicator} from '@tryghost/shade/components';
-import {toast} from 'sonner';
 import {useDeleteTag} from '@tryghost/admin-x-framework/api/tags';
-import {useNavigate} from '@tryghost/admin-x-framework';
+import {useHandleError, useNavigate} from '@tryghost/admin-x-framework';
 import {formatNumber} from '@tryghost/shade/utils';
 import type {Tag} from '@tryghost/admin-x-framework/api/tags';
 
@@ -27,20 +26,36 @@ interface TagDeleteModalProps {
  */
 const TagDeleteModal: React.FC<TagDeleteModalProps> = ({open, onOpenChange, tag, displayName, onPendingChange, allowLeaveWithUnsavedChanges}) => {
     const navigate = useNavigate();
+    const handleError = useHandleError();
     const deleteTag = useDeleteTag();
     const postsCount = tag.count?.posts ?? 0;
+    const mountedRef = React.useRef(true);
+
+    React.useEffect(() => {
+        mountedRef.current = true;
+        return () => {
+            mountedRef.current = false;
+        };
+    }, []);
 
     const onConfirm = async () => {
         onPendingChange(true);
         try {
             await deleteTag.mutateAsync(tag.id);
+            if (!mountedRef.current) {
+                return;
+            }
             onOpenChange(false);
             allowLeaveWithUnsavedChanges();
             navigate('/tags');
-        } catch {
-            toast.error('Couldn’t delete the tag. Please try again.');
+        } catch (error) {
+            if (mountedRef.current) {
+                handleError(error);
+            }
         } finally {
-            onPendingChange(false);
+            if (mountedRef.current) {
+                onPendingChange(false);
+            }
         }
     };
 

--- a/apps/admin/src/tags/detail/tag-delete-modal.tsx
+++ b/apps/admin/src/tags/detail/tag-delete-modal.tsx
@@ -3,12 +3,15 @@ import {Button, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHe
 import {toast} from 'sonner';
 import {useDeleteTag} from '@tryghost/admin-x-framework/api/tags';
 import {useNavigate} from '@tryghost/admin-x-framework';
+import {formatNumber} from '@tryghost/shade/utils';
 import type {Tag} from '@tryghost/admin-x-framework/api/tags';
 
 interface TagDeleteModalProps {
     open: boolean;
     onOpenChange: (open: boolean) => void;
     tag: Tag;
+    displayName: string;
+    onPendingChange: (pending: boolean) => void;
     /**
      * Invoked right before we `navigate('/tags')` so the parent's
      * unsaved-changes blocker doesn't intercept the redirect for a tag that
@@ -22,12 +25,13 @@ interface TagDeleteModalProps {
  * body names the tag, reports how many posts it will be removed from, and a
  * successful delete returns to the tags list.
  */
-const TagDeleteModal: React.FC<TagDeleteModalProps> = ({open, onOpenChange, tag, allowLeaveWithUnsavedChanges}) => {
+const TagDeleteModal: React.FC<TagDeleteModalProps> = ({open, onOpenChange, tag, displayName, onPendingChange, allowLeaveWithUnsavedChanges}) => {
     const navigate = useNavigate();
     const deleteTag = useDeleteTag();
     const postsCount = tag.count?.posts ?? 0;
 
     const onConfirm = async () => {
+        onPendingChange(true);
         try {
             await deleteTag.mutateAsync(tag.id);
             onOpenChange(false);
@@ -35,6 +39,8 @@ const TagDeleteModal: React.FC<TagDeleteModalProps> = ({open, onOpenChange, tag,
             navigate('/tags');
         } catch {
             toast.error('Couldn’t delete the tag. Please try again.');
+        } finally {
+            onPendingChange(false);
         }
     };
 
@@ -49,9 +55,9 @@ const TagDeleteModal: React.FC<TagDeleteModalProps> = ({open, onOpenChange, tag,
                 <DialogHeader>
                     <DialogTitle>Are you sure you want to delete this tag?</DialogTitle>
                     <DialogDescription>
-                        You’re about to delete the tag &quot;<strong>{tag.name}</strong>&quot;.{' '}
+                        You’re about to delete the tag &quot;<strong>{displayName}</strong>&quot;.{' '}
                         {postsCount > 0 && (
-                            <>It will be removed from <span data-testid='delete-tag-posts-count'>{postsCount} {postsCount === 1 ? 'post' : 'posts'}</span>.{' '}</>
+                            <>It will be removed from <span data-testid='delete-tag-posts-count'>{formatNumber(postsCount)} {postsCount === 1 ? 'post' : 'posts'}</span>.{' '}</>
                         )}
                         This is permanent! We warned you, k?
                     </DialogDescription>

--- a/apps/admin/src/tags/detail/tag-delete-modal.tsx
+++ b/apps/admin/src/tags/detail/tag-delete-modal.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import {Button, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, LoadingIndicator} from '@tryghost/shade/components';
+import {toast} from 'sonner';
+import {useDeleteTag} from '@tryghost/admin-x-framework/api/tags';
+import {useNavigate} from '@tryghost/admin-x-framework';
+import type {Tag} from '@tryghost/admin-x-framework/api/tags';
+
+interface TagDeleteModalProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    tag: Tag;
+    /**
+     * Invoked right before we `navigate('/tags')` so the parent's
+     * unsaved-changes blocker doesn't intercept the redirect for a tag that
+     * has just been deleted.
+     */
+    allowLeaveWithUnsavedChanges: () => void;
+}
+
+/**
+ * Confirms permanent tag deletion, porting Ember's `delete-tag-modal`: the
+ * body names the tag, reports how many posts it will be removed from, and a
+ * successful delete returns to the tags list.
+ */
+const TagDeleteModal: React.FC<TagDeleteModalProps> = ({open, onOpenChange, tag, allowLeaveWithUnsavedChanges}) => {
+    const navigate = useNavigate();
+    const deleteTag = useDeleteTag();
+    const postsCount = tag.count?.posts ?? 0;
+
+    const onConfirm = async () => {
+        try {
+            await deleteTag.mutateAsync(tag.id);
+            onOpenChange(false);
+            allowLeaveWithUnsavedChanges();
+            navigate('/tags');
+        } catch {
+            toast.error('Couldn’t delete the tag. Please try again.');
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={(next) => {
+            if (deleteTag.isPending) {
+                return;
+            }
+            onOpenChange(next);
+        }}>
+            <DialogContent data-testid='delete-tag-modal'>
+                <DialogHeader>
+                    <DialogTitle>Are you sure you want to delete this tag?</DialogTitle>
+                    <DialogDescription>
+                        You’re about to delete the tag &quot;<strong>{tag.name}</strong>&quot;.{' '}
+                        {postsCount > 0 && (
+                            <>It will be removed from <span data-testid='delete-tag-posts-count'>{postsCount} {postsCount === 1 ? 'post' : 'posts'}</span>.{' '}</>
+                        )}
+                        This is permanent! We warned you, k?
+                    </DialogDescription>
+                </DialogHeader>
+
+                <DialogFooter>
+                    <Button
+                        data-testid='cancel-delete-tag'
+                        disabled={deleteTag.isPending}
+                        variant='outline'
+                        onClick={() => onOpenChange(false)}
+                    >
+                        Cancel
+                    </Button>
+                    <Button
+                        data-testid='confirm-delete-tag'
+                        disabled={deleteTag.isPending}
+                        variant='destructive'
+                        autoFocus
+                        onClick={() => void onConfirm()}
+                    >
+                        {deleteTag.isPending ? (
+                            <>
+                                <LoadingIndicator size='sm' />
+                                <span className='sr-only'>Deleting</span>
+                            </>
+                        ) : 'Delete'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+export default TagDeleteModal;

--- a/apps/admin/src/tags/detail/tag-detail-edit.test.ts
+++ b/apps/admin/src/tags/detail/tag-detail-edit.test.ts
@@ -49,11 +49,27 @@ describe('getTagEditableSlice', () => {
 });
 
 describe('normalizeTagDraft', () => {
-    it('trims every field, matching Ember trimming values as they are set', () => {
-        const normalized = normalizeTagDraft(draft({name: '  News  ', description: ' about news '}));
+    it('trims ordinary fields while preserving code injection whitespace', () => {
+        const normalized = normalizeTagDraft(draft({
+            name: '  News  ',
+            description: ' about news ',
+            codeinjectionHead: '\n<script>head()</script>\n',
+            codeinjectionFoot: '  <script>foot()</script>  '
+        }));
 
         expect(normalized.name).toBe('News');
         expect(normalized.description).toBe('about news');
+        expect(normalized.codeinjectionHead).toBe('\n<script>head()</script>\n');
+        expect(normalized.codeinjectionFoot).toBe('  <script>foot()</script>  ');
+    });
+
+    it('does not mark existing code injection whitespace as a change', () => {
+        const serverSlice = getTagEditableSlice({
+            codeinjection_head: '\n<script>head()</script>\n',
+            codeinjection_foot: '  <script>foot()</script>  '
+        });
+
+        expect(normalizeTagDraft(serverSlice)).toEqual(serverSlice);
     });
 });
 
@@ -125,6 +141,16 @@ describe('buildTagSavePayload', () => {
         expect(payload.meta_title).toBe('Meta');
         expect(payload.canonical_url).toBeNull();
         expect(payload.accent_color).toBeNull();
+    });
+
+    it('preserves code injection whitespace in the save payload', () => {
+        const payload = buildTagSavePayload(draft({
+            codeinjectionHead: '\n<script>head()</script>\n',
+            codeinjectionFoot: '  <script>foot()</script>  '
+        }), 'News');
+
+        expect(payload.codeinjection_head).toBe('\n<script>head()</script>\n');
+        expect(payload.codeinjection_foot).toBe('  <script>foot()</script>  ');
     });
 
     it('derives visibility when the name changed, like Ember updateVisibility on save', () => {

--- a/apps/admin/src/tags/detail/tag-detail-edit.test.ts
+++ b/apps/admin/src/tags/detail/tag-detail-edit.test.ts
@@ -26,7 +26,7 @@ const draft = (overrides: Partial<TagEditableFields> = {}): TagEditableFields =>
 });
 
 describe('getTagEditableSlice', () => {
-    it('maps snake_case API fields and normalizes null to empty strings', () => {
+    it('maps snake_case API fields, preserves values and normalizes null to empty strings', () => {
         const slice = getTagEditableSlice({
             name: ' News ',
             slug: 'news',
@@ -38,7 +38,7 @@ describe('getTagEditableSlice', () => {
             codeinjection_head: null
         });
 
-        expect(slice.name).toBe('News');
+        expect(slice.name).toBe(' News ');
         expect(slice.description).toBe('');
         expect(slice.featureImage).toBe('https://example.com/img.png');
         expect(slice.metaTitle).toBe('Meta');
@@ -70,6 +70,16 @@ describe('normalizeTagDraft', () => {
         });
 
         expect(normalizeTagDraft(serverSlice)).toEqual(serverSlice);
+    });
+
+    it('preserves whitespace in untouched ordinary fields', () => {
+        const draftWithWhitespace = draft({description: '\nImportant\n', metaTitle: ' Meta title '});
+
+        expect(normalizeTagDraft(draftWithWhitespace, new Set())).toEqual(draftWithWhitespace);
+        expect(normalizeTagDraft(draftWithWhitespace, new Set(['description']))).toMatchObject({
+            description: 'Important',
+            metaTitle: ' Meta title '
+        });
     });
 });
 
@@ -151,6 +161,16 @@ describe('buildTagSavePayload', () => {
 
         expect(payload.codeinjection_head).toBe('\n<script>head()</script>\n');
         expect(payload.codeinjection_foot).toBe('  <script>foot()</script>  ');
+    });
+
+    it('preserves untouched server whitespace in the save payload', () => {
+        const payload = buildTagSavePayload(draft({
+            description: '\nImportant\n',
+            metaTitle: ' Meta title '
+        }), 'News', new Set());
+
+        expect(payload.description).toBe('\nImportant\n');
+        expect(payload.meta_title).toBe(' Meta title ');
     });
 
     it('derives visibility when the name changed, like Ember updateVisibility on save', () => {

--- a/apps/admin/src/tags/detail/tag-detail-edit.test.ts
+++ b/apps/admin/src/tags/detail/tag-detail-edit.test.ts
@@ -1,0 +1,203 @@
+import {describe, expect, it} from 'vitest';
+import {
+    buildTagSavePayload,
+    charLength,
+    deriveTagVisibility,
+    generateSlugFromName,
+    getBlogDomain,
+    getSeoDescription,
+    getSeoTitle,
+    getSeoUrl,
+    getSlugUrlPreview,
+    getTagEditableSlice,
+    getTagUrl,
+    normalizeTagDraft,
+    truncateText,
+    validateTagDraft,
+    validateTagField
+} from './tag-detail-edit';
+import type {TagEditableFields} from './tag-detail-edit';
+
+const draft = (overrides: Partial<TagEditableFields> = {}): TagEditableFields => ({
+    ...getTagEditableSlice({}),
+    name: 'News',
+    slug: 'news',
+    ...overrides
+});
+
+describe('getTagEditableSlice', () => {
+    it('maps snake_case API fields and normalizes null to empty strings', () => {
+        const slice = getTagEditableSlice({
+            name: ' News ',
+            slug: 'news',
+            description: null,
+            feature_image: 'https://example.com/img.png',
+            meta_title: 'Meta',
+            canonical_url: null,
+            accent_color: '#ff0000',
+            codeinjection_head: null
+        });
+
+        expect(slice.name).toBe('News');
+        expect(slice.description).toBe('');
+        expect(slice.featureImage).toBe('https://example.com/img.png');
+        expect(slice.metaTitle).toBe('Meta');
+        expect(slice.canonicalUrl).toBe('');
+        expect(slice.accentColor).toBe('#ff0000');
+        expect(slice.codeinjectionHead).toBe('');
+    });
+});
+
+describe('normalizeTagDraft', () => {
+    it('trims every field, matching Ember trimming values as they are set', () => {
+        const normalized = normalizeTagDraft(draft({name: '  News  ', description: ' about news '}));
+
+        expect(normalized.name).toBe('News');
+        expect(normalized.description).toBe('about news');
+    });
+});
+
+describe('deriveTagVisibility', () => {
+    it('marks names starting with # internal and everything else public', () => {
+        expect(deriveTagVisibility('#internal')).toBe('internal');
+        expect(deriveTagVisibility('News')).toBe('public');
+        expect(deriveTagVisibility('not#internal')).toBe('public');
+    });
+});
+
+describe('generateSlugFromName', () => {
+    it('slugifies the name', () => {
+        expect(generateSlugFromName('Weekly News')).toBe('weekly-news');
+    });
+
+    it('prefixes internal tag slugs with hash-', () => {
+        expect(generateSlugFromName('#Internal Tag')).toBe('hash-internal-tag');
+    });
+});
+
+describe('validateTagField', () => {
+    it('requires a name', () => {
+        expect(validateTagField('name', draft({name: ''}))).toBe('You must specify a name for the tag.');
+        expect(validateTagField('name', draft({name: '   '}))).toBe('You must specify a name for the tag.');
+    });
+
+    it('rejects names starting with a comma', () => {
+        expect(validateTagField('name', draft({name: ',News'}))).toBe('Tag names can\'t start with commas.');
+    });
+
+    it('caps name, slug, description and meta fields at their Ember limits', () => {
+        expect(validateTagField('name', draft({name: 'a'.repeat(192)}))).toBe('Tag names cannot be longer than 191 characters.');
+        expect(validateTagField('name', draft({name: 'a'.repeat(191)}))).toBeNull();
+        expect(validateTagField('slug', draft({slug: 'a'.repeat(192)}))).toBe('URL cannot be longer than 191 characters.');
+        expect(validateTagField('description', draft({description: 'a'.repeat(501)}))).toBe('Description cannot be longer than 500 characters.');
+        expect(validateTagField('metaTitle', draft({metaTitle: 'a'.repeat(301)}))).toBe('Meta Title cannot be longer than 300 characters.');
+        expect(validateTagField('metaDescription', draft({metaDescription: 'a'.repeat(501)}))).toBe('Meta Description cannot be longer than 500 characters.');
+    });
+
+    it('accepts empty canonical URLs and rejects unparseable ones', () => {
+        expect(validateTagField('canonicalUrl', draft({canonicalUrl: ''}))).toBeNull();
+        expect(validateTagField('canonicalUrl', draft({canonicalUrl: 'https://example.com/canonical'}))).toBeNull();
+        expect(validateTagField('canonicalUrl', draft({canonicalUrl: 'not a url'}))).toBe('The url should be a valid url');
+    });
+});
+
+describe('validateTagDraft', () => {
+    it('collects every field error', () => {
+        const errors = validateTagDraft(draft({name: '', canonicalUrl: 'nope'}));
+
+        expect(errors).toEqual({
+            name: 'You must specify a name for the tag.',
+            canonicalUrl: 'The url should be a valid url'
+        });
+    });
+
+    it('is empty for a valid draft', () => {
+        expect(validateTagDraft(draft())).toEqual({});
+    });
+});
+
+describe('buildTagSavePayload', () => {
+    it('maps the draft to snake_case with empty optional fields as null', () => {
+        const payload = buildTagSavePayload(draft({metaTitle: 'Meta', canonicalUrl: ''}), 'News');
+
+        expect(payload.name).toBe('News');
+        expect(payload.slug).toBe('news');
+        expect(payload.meta_title).toBe('Meta');
+        expect(payload.canonical_url).toBeNull();
+        expect(payload.accent_color).toBeNull();
+    });
+
+    it('derives visibility when the name changed, like Ember updateVisibility on save', () => {
+        expect(buildTagSavePayload(draft({name: '#internal'}), 'News').visibility).toBe('internal');
+        expect(buildTagSavePayload(draft({name: 'Renamed'}), 'News').visibility).toBe('public');
+    });
+
+    it('derives visibility for new tags', () => {
+        expect(buildTagSavePayload(draft({name: '#internal'}), null).visibility).toBe('internal');
+    });
+
+    it('leaves visibility untouched when the name is unchanged', () => {
+        expect(buildTagSavePayload(draft(), 'News').visibility).toBeUndefined();
+    });
+});
+
+describe('URL helpers', () => {
+    const blogUrl = 'https://example.com';
+
+    it('builds the tag URL from the slug with a trailing slash', () => {
+        expect(getTagUrl(draft(), blogUrl)).toBe('https://example.com/tag/news/');
+    });
+
+    it('prefers the canonical URL for the tag URL', () => {
+        expect(getTagUrl(draft({canonicalUrl: 'https://elsewhere.com/news'}), blogUrl)).toBe('https://elsewhere.com/news/');
+        expect(getTagUrl(draft({canonicalUrl: 'https://elsewhere.com/news/'}), blogUrl)).toBe('https://elsewhere.com/news/');
+    });
+
+    it('renders the scheme-stripped slug preview, omitting the empty slug', () => {
+        expect(getSlugUrlPreview('news', blogUrl)).toBe('example.com/tag/news/');
+        expect(getSlugUrlPreview('', blogUrl)).toBe('example.com/tag/');
+    });
+
+    it('strips the scheme and trailing slash for the blog domain', () => {
+        expect(getBlogDomain('https://example.com/')).toBe('example.com');
+        expect(getBlogDomain('http://localhost:2368')).toBe('localhost:2368');
+    });
+});
+
+describe('SEO derivations', () => {
+    it('falls back from meta title to "name - site title"', () => {
+        expect(getSeoTitle(draft({metaTitle: 'Custom'}), 'Site')).toBe('Custom');
+        expect(getSeoTitle(draft(), 'Site')).toBe('News - Site');
+        expect(getSeoTitle(draft(), '')).toBe('News');
+    });
+
+    it('caps the SEO title at 70 characters with an ellipsis', () => {
+        const long = 'a'.repeat(80);
+        expect(getSeoTitle(draft({metaTitle: long}), 'Site')).toBe(`${'a'.repeat(70)}…`);
+    });
+
+    it('falls back from meta description to the tag description and caps at 156', () => {
+        expect(getSeoDescription(draft({metaDescription: 'Meta desc'}))).toBe('Meta desc');
+        expect(getSeoDescription(draft({description: 'Tag desc'}))).toBe('Tag desc');
+        expect(getSeoDescription(draft({description: 'b'.repeat(200)}))).toBe(`${'b'.repeat(156)}…`);
+    });
+
+    it('caps the SEO URL at 70 characters', () => {
+        const url = getSeoUrl(draft({slug: 's'.repeat(100)}), 'https://example.com');
+        expect(url.length).toBe(71);
+        expect(url.endsWith('…')).toBe(true);
+    });
+});
+
+describe('charLength and truncateText', () => {
+    it('counts unicode code points like the Ember countdown helper', () => {
+        expect(charLength('abc')).toBe(3);
+        expect(charLength('😀😀')).toBe(2);
+    });
+
+    it('truncates with the ellipsis inside the limit, like ember-cli-string-helpers', () => {
+        expect(truncateText('short')).toBe('short');
+        expect(truncateText('a'.repeat(140))).toBe(`${'a'.repeat(137)}...`);
+        expect(truncateText('a'.repeat(150), 149)).toBe(`${'a'.repeat(146)}...`);
+    });
+});

--- a/apps/admin/src/tags/detail/tag-detail-edit.ts
+++ b/apps/admin/src/tags/detail/tag-detail-edit.ts
@@ -1,0 +1,263 @@
+import {slugify} from '@tryghost/string';
+import type {Tag, TagEditableData} from '@tryghost/admin-x-framework/api/tags';
+
+/**
+ * The editable slice of a tag, used for dirty detection (draft vs server) and
+ * the save payload. camelCase mirrors the Ember model attribute names; the
+ * snake_case mapping to the API happens in `getTagEditableSlice` /
+ * `buildTagSavePayload`. Missing fields normalize to '' so a tag with a null
+ * field and a draft with '' don't read as dirty.
+ */
+export interface TagEditableFields {
+    name: string;
+    slug: string;
+    description: string;
+    featureImage: string;
+    metaTitle: string;
+    metaDescription: string;
+    canonicalUrl: string;
+    twitterImage: string;
+    twitterTitle: string;
+    twitterDescription: string;
+    ogImage: string;
+    ogTitle: string;
+    ogDescription: string;
+    codeinjectionHead: string;
+    codeinjectionFoot: string;
+    accentColor: string;
+}
+
+export type TagFieldName = keyof TagEditableFields;
+
+// Character limits from Ember's tag validator (`validators/tag-settings.js`).
+export const NAME_MAX_LENGTH = 191;
+export const SLUG_MAX_LENGTH = 191;
+export const DESCRIPTION_MAX_LENGTH = 500;
+export const META_TITLE_MAX_LENGTH = 300;
+export const META_DESCRIPTION_MAX_LENGTH = 500;
+
+// Recommended lengths shown as character countdowns (`tag-form.hbs`).
+export const META_TITLE_RECOMMENDED_LENGTH = 70;
+export const META_DESCRIPTION_RECOMMENDED_LENGTH = 156;
+export const X_TITLE_RECOMMENDED_LENGTH = 70;
+export const X_DESCRIPTION_RECOMMENDED_LENGTH = 125;
+export const FACEBOOK_TITLE_RECOMMENDED_LENGTH = 100;
+export const FACEBOOK_DESCRIPTION_RECOMMENDED_LENGTH = 65;
+
+export function getTagEditableSlice(tag: Partial<Tag>): TagEditableFields {
+    return {
+        name: (tag.name ?? '').trim(),
+        slug: (tag.slug ?? '').trim(),
+        description: (tag.description ?? '').trim(),
+        featureImage: (tag.feature_image ?? '').trim(),
+        metaTitle: (tag.meta_title ?? '').trim(),
+        metaDescription: (tag.meta_description ?? '').trim(),
+        canonicalUrl: (tag.canonical_url ?? '').trim(),
+        twitterImage: (tag.twitter_image ?? '').trim(),
+        twitterTitle: (tag.twitter_title ?? '').trim(),
+        twitterDescription: (tag.twitter_description ?? '').trim(),
+        ogImage: (tag.og_image ?? '').trim(),
+        ogTitle: (tag.og_title ?? '').trim(),
+        ogDescription: (tag.og_description ?? '').trim(),
+        codeinjectionHead: tag.codeinjection_head ?? '',
+        codeinjectionFoot: tag.codeinjection_foot ?? '',
+        accentColor: (tag.accent_color ?? '').trim()
+    };
+}
+
+/**
+ * Normalize a draft for dirty comparison and saving. Ember trims every value as
+ * it is set on the model (`tag-form.js` `setTagProperty`), so trimmed values are
+ * what the server ever receives; trimming here instead keeps typing in the
+ * controlled inputs natural while the outcome stays identical.
+ */
+export function normalizeTagDraft(draft: TagEditableFields): TagEditableFields {
+    const normalized = {} as TagEditableFields;
+    for (const key of Object.keys(draft) as TagFieldName[]) {
+        normalized[key] = draft[key].trim();
+    }
+    return normalized;
+}
+
+/** Ember `models/tag.js` `updateVisibility()`: a leading `#` makes a tag internal. */
+export function deriveTagVisibility(name: string): 'public' | 'internal' {
+    return /^#/.test(name) ? 'internal' : 'public';
+}
+
+/**
+ * Client-side slug preview for new tags, matching Ember `tag-form.js`
+ * `setTagProperty`: slugified name, with internal tags (leading `#`) prefixed
+ * `hash-`. The server re-runs its own slug generator on save for uniqueness.
+ */
+export function generateSlugFromName(name: string): string {
+    let slug = slugify(name);
+    if (/^#/.test(name)) {
+        slug = `hash-${slug}`;
+    }
+    return slug;
+}
+
+/** Unicode-code-point length, matching Ember's validator and countdown helper. */
+export function charLength(value: string): number {
+    return Array.from(value).length;
+}
+
+/**
+ * Per-field validation, porting `validators/tag-settings.js` verbatim
+ * (messages included). Fields without validator rules return null.
+ */
+export function validateTagField(field: TagFieldName, draft: TagEditableFields): string | null {
+    const value = draft[field].trim();
+    switch (field) {
+    case 'name':
+        if (value === '') {
+            return 'You must specify a name for the tag.';
+        }
+        if (/^,/.test(value)) {
+            return 'Tag names can\'t start with commas.';
+        }
+        if (charLength(value) > NAME_MAX_LENGTH) {
+            return 'Tag names cannot be longer than 191 characters.';
+        }
+        return null;
+    case 'slug':
+        return charLength(value) > SLUG_MAX_LENGTH ? 'URL cannot be longer than 191 characters.' : null;
+    case 'description':
+        return charLength(value) > DESCRIPTION_MAX_LENGTH ? 'Description cannot be longer than 500 characters.' : null;
+    case 'metaTitle':
+        return charLength(value) > META_TITLE_MAX_LENGTH ? 'Meta Title cannot be longer than 300 characters.' : null;
+    case 'metaDescription':
+        return charLength(value) > META_DESCRIPTION_MAX_LENGTH ? 'Meta Description cannot be longer than 500 characters.' : null;
+    case 'canonicalUrl':
+        return validateCanonicalUrl(value);
+    default:
+        return null;
+    }
+}
+
+/** Ember `tag-form.js` `validateCanonicalUrl`: empty is fine, otherwise must parse as a URL. */
+export function validateCanonicalUrl(value: string): string | null {
+    if (value === '') {
+        return null;
+    }
+    try {
+        new URL(value);
+        return null;
+    } catch {
+        return 'The url should be a valid url';
+    }
+}
+
+const VALIDATED_FIELDS: TagFieldName[] = ['name', 'slug', 'description', 'metaTitle', 'metaDescription', 'canonicalUrl'];
+
+/** Validate the whole draft, as Ember does on save. Empty object means valid. */
+export function validateTagDraft(draft: TagEditableFields): Partial<Record<TagFieldName, string>> {
+    const errors: Partial<Record<TagFieldName, string>> = {};
+    for (const field of VALIDATED_FIELDS) {
+        const error = validateTagField(field, draft);
+        if (error) {
+            errors[field] = error;
+        }
+    }
+    return errors;
+}
+
+/**
+ * The save payload for a tag. All editable fields are sent, matching Ember's
+ * whole-model serialization. `visibility` is included only when the name
+ * changed (or the tag is new) — Ember's `models/tag.js` `save()` recomputes it
+ * from the name in exactly that case, and the server only ever forces
+ * internal, never back to public, so the client value matters on renames.
+ */
+export function buildTagSavePayload(draft: TagEditableFields, serverName: string | null): TagEditableData {
+    const normalized = normalizeTagDraft(draft);
+    const payload: TagEditableData = {
+        name: normalized.name,
+        slug: normalized.slug,
+        description: normalized.description,
+        feature_image: normalized.featureImage || null,
+        meta_title: normalized.metaTitle || null,
+        meta_description: normalized.metaDescription || null,
+        canonical_url: normalized.canonicalUrl || null,
+        twitter_image: normalized.twitterImage || null,
+        twitter_title: normalized.twitterTitle || null,
+        twitter_description: normalized.twitterDescription || null,
+        og_image: normalized.ogImage || null,
+        og_title: normalized.ogTitle || null,
+        og_description: normalized.ogDescription || null,
+        codeinjection_head: normalized.codeinjectionHead || null,
+        codeinjection_foot: normalized.codeinjectionFoot || null,
+        accent_color: normalized.accentColor || null
+    };
+    if (serverName === null || normalized.name !== serverName) {
+        payload.visibility = deriveTagVisibility(normalized.name);
+    }
+    return payload;
+}
+
+/**
+ * The tag's public URL: canonical URL when set, `{blogUrl}/tag/{slug}` otherwise,
+ * always with a trailing slash (`controllers/tag.js` `tagURL`).
+ */
+export function getTagUrl(draft: Pick<TagEditableFields, 'canonicalUrl' | 'slug'>, blogUrl: string): string {
+    let url = draft.canonicalUrl || `${blogUrl}/tag/${draft.slug}`;
+    if (!url.endsWith('/')) {
+        url += '/';
+    }
+    return url;
+}
+
+/** Scheme-stripped URL preview shown under the slug field (`gh-url-preview`). */
+export function getSlugUrlPreview(slug: string, blogUrl: string): string {
+    const schemeIndex = blogUrl.indexOf('://');
+    const host = schemeIndex === -1 ? blogUrl : blogUrl.slice(schemeIndex + 3);
+    return `${host}/tag/${slug ? `${slug}/` : ''}`;
+}
+
+/** `ember-cli-string-helpers` `truncate` with `useEllipsis` — ellipsis counts toward the limit. */
+export function truncateText(value: string, characterLimit = 140): string {
+    const limit = characterLimit - 3;
+    if (value.length > limit) {
+        return `${value.substring(0, limit)}...`;
+    }
+    return value;
+}
+
+export interface TagSeoContext {
+    siteTitle: string;
+    siteMetaDescription: string;
+    blogUrl: string;
+}
+
+/** `tag-form.js` `seoTitle`: meta title, else "{name} - {site title}", capped at 70 chars. */
+export function getSeoTitle(draft: Pick<TagEditableFields, 'name' | 'metaTitle'>, siteTitle: string): string {
+    const tagName = siteTitle ? `${draft.name} - ${siteTitle}` : draft.name;
+    let title = draft.metaTitle || tagName;
+    if (title.length > 70) {
+        title = `${title.substring(0, 70).trim()}…`;
+    }
+    return title;
+}
+
+/** `tag-form.js` `seoDescription`: meta description, else the tag description, capped at 156 chars. */
+export function getSeoDescription(draft: Pick<TagEditableFields, 'description' | 'metaDescription'>): string {
+    let description = draft.metaDescription || draft.description;
+    if (description.length > 156) {
+        description = `${description.substring(0, 156).trim()}…`;
+    }
+    return description;
+}
+
+/** `tag-form.js` `seoURL`: the tag URL capped at 70 chars. */
+export function getSeoUrl(draft: Pick<TagEditableFields, 'canonicalUrl' | 'slug'>, blogUrl: string): string {
+    let url = getTagUrl(draft, blogUrl);
+    if (url.length > 70) {
+        url = `${url.substring(0, 70).trim()}…`;
+    }
+    return url;
+}
+
+/** `config.blogDomain` equivalent: the blog URL without scheme or trailing slash. */
+export function getBlogDomain(blogUrl: string): string {
+    return blogUrl.replace(/^[a-zA-Z0-9-]+:\/\//, '').replace(/\/$/, '');
+}

--- a/apps/admin/src/tags/detail/tag-detail-edit.ts
+++ b/apps/admin/src/tags/detail/tag-detail-edit.ts
@@ -46,34 +46,35 @@ export const FACEBOOK_DESCRIPTION_RECOMMENDED_LENGTH = 65;
 
 export function getTagEditableSlice(tag: Partial<Tag>): TagEditableFields {
     return {
-        name: (tag.name ?? '').trim(),
-        slug: (tag.slug ?? '').trim(),
-        description: (tag.description ?? '').trim(),
-        featureImage: (tag.feature_image ?? '').trim(),
-        metaTitle: (tag.meta_title ?? '').trim(),
-        metaDescription: (tag.meta_description ?? '').trim(),
-        canonicalUrl: (tag.canonical_url ?? '').trim(),
-        twitterImage: (tag.twitter_image ?? '').trim(),
-        twitterTitle: (tag.twitter_title ?? '').trim(),
-        twitterDescription: (tag.twitter_description ?? '').trim(),
-        ogImage: (tag.og_image ?? '').trim(),
-        ogTitle: (tag.og_title ?? '').trim(),
-        ogDescription: (tag.og_description ?? '').trim(),
+        name: tag.name ?? '',
+        slug: tag.slug ?? '',
+        description: tag.description ?? '',
+        featureImage: tag.feature_image ?? '',
+        metaTitle: tag.meta_title ?? '',
+        metaDescription: tag.meta_description ?? '',
+        canonicalUrl: tag.canonical_url ?? '',
+        twitterImage: tag.twitter_image ?? '',
+        twitterTitle: tag.twitter_title ?? '',
+        twitterDescription: tag.twitter_description ?? '',
+        ogImage: tag.og_image ?? '',
+        ogTitle: tag.og_title ?? '',
+        ogDescription: tag.og_description ?? '',
         codeinjectionHead: tag.codeinjection_head ?? '',
         codeinjectionFoot: tag.codeinjection_foot ?? '',
-        accentColor: (tag.accent_color ?? '').trim()
+        accentColor: tag.accent_color ?? ''
     };
 }
 
 /**
- * Normalize a draft for dirty comparison and saving. Ember trims ordinary
- * form values as they are set on the model (`tag-form.js` `setTagProperty`),
- * but its code editors preserve code injection verbatim.
+ * Normalize a draft for dirty comparison and saving. Ember trims an ordinary
+ * form value when that field is edited (`tag-form.js` `setTagProperty`) but
+ * preserves untouched server data and code injection verbatim.
  */
-export function normalizeTagDraft(draft: TagEditableFields): TagEditableFields {
+export function normalizeTagDraft(draft: TagEditableFields, touchedFields?: ReadonlySet<TagFieldName>): TagEditableFields {
     const normalized = {} as TagEditableFields;
     for (const key of Object.keys(draft) as TagFieldName[]) {
-        normalized[key] = key === 'codeinjectionHead' || key === 'codeinjectionFoot' ? draft[key] : draft[key].trim();
+        const shouldTrim = key !== 'codeinjectionHead' && key !== 'codeinjectionFoot' && (!touchedFields || touchedFields.has(key));
+        normalized[key] = shouldTrim ? draft[key].trim() : draft[key];
     }
     return normalized;
 }
@@ -168,8 +169,8 @@ export function validateTagDraft(draft: TagEditableFields): Partial<Record<TagFi
  * from the name in exactly that case, and the server only ever forces
  * internal, never back to public, so the client value matters on renames.
  */
-export function buildTagSavePayload(draft: TagEditableFields, serverName: string | null): TagEditableData {
-    const normalized = normalizeTagDraft(draft);
+export function buildTagSavePayload(draft: TagEditableFields, serverName: string | null, touchedFields?: ReadonlySet<TagFieldName>): TagEditableData {
+    const normalized = normalizeTagDraft(draft, touchedFields);
     const payload: TagEditableData = {
         name: normalized.name,
         slug: normalized.slug,

--- a/apps/admin/src/tags/detail/tag-detail-edit.ts
+++ b/apps/admin/src/tags/detail/tag-detail-edit.ts
@@ -66,15 +66,14 @@ export function getTagEditableSlice(tag: Partial<Tag>): TagEditableFields {
 }
 
 /**
- * Normalize a draft for dirty comparison and saving. Ember trims every value as
- * it is set on the model (`tag-form.js` `setTagProperty`), so trimmed values are
- * what the server ever receives; trimming here instead keeps typing in the
- * controlled inputs natural while the outcome stays identical.
+ * Normalize a draft for dirty comparison and saving. Ember trims ordinary
+ * form values as they are set on the model (`tag-form.js` `setTagProperty`),
+ * but its code editors preserve code injection verbatim.
  */
 export function normalizeTagDraft(draft: TagEditableFields): TagEditableFields {
     const normalized = {} as TagEditableFields;
     for (const key of Object.keys(draft) as TagFieldName[]) {
-        normalized[key] = draft[key].trim();
+        normalized[key] = key === 'codeinjectionHead' || key === 'codeinjectionFoot' ? draft[key] : draft[key].trim();
     }
     return normalized;
 }

--- a/apps/admin/src/tags/detail/tag-detail-edit.ts
+++ b/apps/admin/src/tags/detail/tag-detail-edit.ts
@@ -66,9 +66,9 @@ export function getTagEditableSlice(tag: Partial<Tag>): TagEditableFields {
 }
 
 /**
- * Normalize a draft for dirty comparison and saving. Ember trims an ordinary
- * form value when that field is edited (`tag-form.js` `setTagProperty`) but
- * preserves untouched server data and code injection verbatim.
+ * Normalize a draft for dirty comparison and saving. Ember trims every edited
+ * value (`tag-form.js` `setTagProperty`), code injection included; we trim only
+ * touched ordinary fields and deliberately keep code injection verbatim.
  */
 export function normalizeTagDraft(draft: TagEditableFields, touchedFields?: ReadonlySet<TagFieldName>): TagEditableFields {
     const normalized = {} as TagEditableFields;

--- a/apps/admin/src/tags/detail/tag-detail-form.tsx
+++ b/apps/admin/src/tags/detail/tag-detail-form.tsx
@@ -4,7 +4,7 @@ import TagImageField from './tag-image-field';
 import {Accordion, AccordionContent, AccordionItem, AccordionTrigger, Input, Label, Textarea} from '@tryghost/shade/components';
 import {DESCRIPTION_MAX_LENGTH, FACEBOOK_DESCRIPTION_RECOMMENDED_LENGTH, FACEBOOK_TITLE_RECOMMENDED_LENGTH, META_DESCRIPTION_RECOMMENDED_LENGTH, META_TITLE_RECOMMENDED_LENGTH, X_DESCRIPTION_RECOMMENDED_LENGTH, X_TITLE_RECOMMENDED_LENGTH, charLength, getBlogDomain, getSeoDescription, getSeoTitle, getSeoUrl, getSlugUrlPreview, validateTagField} from './tag-detail-edit';
 import {FacebookCardPreview, SeoPreview, XCardPreview} from './tag-detail-previews';
-import {cn} from '@tryghost/shade/utils';
+import {cn, formatNumber} from '@tryghost/shade/utils';
 import {getSettingValue, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
 import type {TagEditableFields, TagFieldName} from './tag-detail-edit';
 
@@ -29,8 +29,8 @@ const UsedCharacters: React.FC<{value: string; limit: number; prefix: 'Maximum' 
     const used = charLength(value);
     return (
         <p className='text-sm text-muted-foreground'>
-            {prefix}: <span className='font-semibold text-foreground'>{limit}</span> characters. You’ve used{' '}
-            <span className={cn('font-semibold', used > limit ? 'text-destructive' : 'text-state-success')}>{used}</span>
+            {prefix}: <span className='font-semibold text-foreground'>{formatNumber(limit)}</span> characters. You’ve used{' '}
+            <span className={cn('font-semibold', used > limit ? 'text-destructive' : 'text-state-success')}>{formatNumber(used)}</span>
         </p>
     );
 };
@@ -49,6 +49,7 @@ const TagDetailForm: React.FC<TagDetailFormProps> = ({draft, errors, blogUrl, di
     const siteTitle = getSettingValue<string>(settingsData?.settings ?? [], 'title') ?? '';
     const siteMetaTitle = getSettingValue<string>(settingsData?.settings ?? [], 'meta_title') ?? '';
     const siteMetaDescription = getSettingValue<string>(settingsData?.settings ?? [], 'meta_description') ?? '';
+    const unsplashEnabled = getSettingValue<boolean>(settingsData?.settings ?? [], 'unsplash') ?? false;
 
     const validateOnBlur = (field: TagFieldName) => {
         onFieldError(field, validateTagField(field, draft));
@@ -126,6 +127,7 @@ const TagDetailForm: React.FC<TagDetailFormProps> = ({draft, errors, blogUrl, di
                     disabled={disabled}
                     id='tag-image'
                     label='Tag image'
+                    unsplashEnabled={unsplashEnabled}
                     uploadText='Upload tag image'
                     value={draft.featureImage}
                     onChange={featureImage => onChange({featureImage})}
@@ -196,6 +198,7 @@ const TagDetailForm: React.FC<TagDetailFormProps> = ({draft, errors, blogUrl, di
                                     disabled={disabled}
                                     id='twitter-image'
                                     label='X image'
+                                    unsplashEnabled={unsplashEnabled}
                                     uploadText='Add X image'
                                     value={draft.twitterImage}
                                     onChange={twitterImage => onChange({twitterImage})}
@@ -246,6 +249,7 @@ const TagDetailForm: React.FC<TagDetailFormProps> = ({draft, errors, blogUrl, di
                                     disabled={disabled}
                                     id='og-image'
                                     label='Facebook image'
+                                    unsplashEnabled={unsplashEnabled}
                                     uploadText='Add Facebook image'
                                     value={draft.ogImage}
                                     onChange={ogImage => onChange({ogImage})}

--- a/apps/admin/src/tags/detail/tag-detail-form.tsx
+++ b/apps/admin/src/tags/detail/tag-detail-form.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import TagColorField from './tag-color-field';
 import TagImageField from './tag-image-field';
-import {Accordion, AccordionContent, AccordionItem, AccordionTrigger, Input, Label, Textarea} from '@tryghost/shade/components';
+import {Accordion, AccordionContent, AccordionItem, AccordionTrigger, FieldError, Input, Label, Textarea} from '@tryghost/shade/components';
 import {DESCRIPTION_MAX_LENGTH, FACEBOOK_DESCRIPTION_RECOMMENDED_LENGTH, FACEBOOK_TITLE_RECOMMENDED_LENGTH, META_DESCRIPTION_RECOMMENDED_LENGTH, META_TITLE_RECOMMENDED_LENGTH, X_DESCRIPTION_RECOMMENDED_LENGTH, X_TITLE_RECOMMENDED_LENGTH, charLength, getBlogDomain, getSeoDescription, getSeoTitle, getSeoUrl, getSlugUrlPreview, validateTagField} from './tag-detail-edit';
 import {FacebookCardPreview, SeoPreview, XCardPreview} from './tag-detail-previews';
 import {cn, formatNumber} from '@tryghost/shade/utils';
@@ -15,14 +15,10 @@ interface TagDetailFormProps {
     disabled?: boolean;
     onChange: (patch: Partial<TagEditableFields>) => void;
     onFieldError: (field: TagFieldName, message: string | null) => void;
+    onImageUploadPendingChange: (field: 'featureImage' | 'twitterImage' | 'ogImage', pending: boolean) => void;
 }
 
-const FieldError: React.FC<{message?: string}> = ({message}) => {
-    if (!message) {
-        return null;
-    }
-    return <p className='text-sm text-destructive'>{message}</p>;
-};
+const errorId = (field: TagFieldName) => `tag-${field}-error`;
 
 /** Ember's `gh-count-down-characters`: the used count, red once past the limit. */
 const UsedCharacters: React.FC<{value: string; limit: number; prefix: 'Maximum' | 'Recommended'}> = ({value, limit, prefix}) => {
@@ -44,7 +40,7 @@ const SectionTrigger: React.FC<{title: string; description: string}> = ({title, 
     </AccordionTrigger>
 );
 
-const TagDetailForm: React.FC<TagDetailFormProps> = ({draft, errors, blogUrl, disabled, onChange, onFieldError}) => {
+const TagDetailForm: React.FC<TagDetailFormProps> = ({draft, errors, blogUrl, disabled, onChange, onFieldError, onImageUploadPendingChange}) => {
     const {data: settingsData} = useBrowseSettings({});
     const siteTitle = getSettingValue<string>(settingsData?.settings ?? [], 'title') ?? '';
     const siteMetaTitle = getSettingValue<string>(settingsData?.settings ?? [], 'meta_title') ?? '';
@@ -69,6 +65,7 @@ const TagDetailForm: React.FC<TagDetailFormProps> = ({draft, errors, blogUrl, di
                         <div className='flex flex-1 flex-col gap-1.5'>
                             <Label htmlFor='tag-name'>Name</Label>
                             <Input
+                                aria-describedby={errors.name ? errorId('name') : undefined}
                                 aria-invalid={!!errors.name}
                                 disabled={disabled}
                                 id='tag-name'
@@ -79,14 +76,15 @@ const TagDetailForm: React.FC<TagDetailFormProps> = ({draft, errors, blogUrl, di
                         </div>
                         <TagColorField
                             disabled={disabled}
+                            errorId={errors.accentColor ? errorId('accentColor') : undefined}
                             value={draft.accentColor}
                             onChange={accentColor => onChange({accentColor})}
                             onError={message => onFieldError('accentColor', message)}
                         />
                     </div>
                     <div className='-mt-4 flex flex-col gap-1'>
-                        <FieldError message={errors.name} />
-                        <FieldError message={errors.accentColor} />
+                        <FieldError className='text-sm' id={errorId('name')}>{errors.name}</FieldError>
+                        <FieldError className='text-sm' id={errorId('accentColor')}>{errors.accentColor}</FieldError>
                         <p className='text-sm text-muted-foreground'>
                             Start with # to create internal tags.{' '}
                             <a className='underline' href='https://ghost.org/help/organising-content/#private-tags' rel='noopener noreferrer' target='_blank'>Learn more</a>
@@ -96,6 +94,7 @@ const TagDetailForm: React.FC<TagDetailFormProps> = ({draft, errors, blogUrl, di
                     <div className='flex flex-col gap-1.5'>
                         <Label htmlFor='tag-slug'>Slug</Label>
                         <Input
+                            aria-describedby={errors.slug ? errorId('slug') : undefined}
                             aria-invalid={!!errors.slug}
                             disabled={disabled}
                             id='tag-slug'
@@ -104,12 +103,13 @@ const TagDetailForm: React.FC<TagDetailFormProps> = ({draft, errors, blogUrl, di
                             onChange={e => onChange({slug: e.target.value})}
                         />
                         <p className='text-sm text-muted-foreground' data-testid='tag-slug-preview'>{getSlugUrlPreview(draft.slug, blogUrl)}</p>
-                        <FieldError message={errors.slug} />
+                        <FieldError className='text-sm' id={errorId('slug')}>{errors.slug}</FieldError>
                     </div>
 
                     <div className='flex flex-col gap-1.5'>
                         <Label htmlFor='tag-description'>Description</Label>
                         <Textarea
+                            aria-describedby={errors.description ? errorId('description') : undefined}
                             aria-invalid={!!errors.description}
                             className='min-h-24'
                             disabled={disabled}
@@ -118,7 +118,7 @@ const TagDetailForm: React.FC<TagDetailFormProps> = ({draft, errors, blogUrl, di
                             onBlur={() => validateOnBlur('description')}
                             onChange={e => onChange({description: e.target.value})}
                         />
-                        <FieldError message={errors.description} />
+                        <FieldError className='text-sm' id={errorId('description')}>{errors.description}</FieldError>
                         <UsedCharacters limit={DESCRIPTION_MAX_LENGTH} prefix='Maximum' value={draft.description} />
                     </div>
                 </div>
@@ -131,6 +131,7 @@ const TagDetailForm: React.FC<TagDetailFormProps> = ({draft, errors, blogUrl, di
                     uploadText='Upload tag image'
                     value={draft.featureImage}
                     onChange={featureImage => onChange({featureImage})}
+                    onPendingChange={pending => onImageUploadPendingChange('featureImage', pending)}
                 />
             </div>
 
@@ -143,6 +144,7 @@ const TagDetailForm: React.FC<TagDetailFormProps> = ({draft, errors, blogUrl, di
                                 <div className='flex flex-col gap-1.5'>
                                     <Label htmlFor='meta-title'>Meta title</Label>
                                     <Input
+                                        aria-describedby={errors.metaTitle ? errorId('metaTitle') : undefined}
                                         aria-invalid={!!errors.metaTitle}
                                         disabled={disabled}
                                         id='meta-title'
@@ -151,12 +153,13 @@ const TagDetailForm: React.FC<TagDetailFormProps> = ({draft, errors, blogUrl, di
                                         onBlur={() => validateOnBlur('metaTitle')}
                                         onChange={e => onChange({metaTitle: e.target.value})}
                                     />
-                                    <FieldError message={errors.metaTitle} />
+                                    <FieldError className='text-sm' id={errorId('metaTitle')}>{errors.metaTitle}</FieldError>
                                     <UsedCharacters limit={META_TITLE_RECOMMENDED_LENGTH} prefix='Recommended' value={draft.metaTitle} />
                                 </div>
                                 <div className='flex flex-col gap-1.5'>
                                     <Label htmlFor='meta-description'>Meta description</Label>
                                     <Textarea
+                                        aria-describedby={errors.metaDescription ? errorId('metaDescription') : undefined}
                                         aria-invalid={!!errors.metaDescription}
                                         disabled={disabled}
                                         id='meta-description'
@@ -165,12 +168,13 @@ const TagDetailForm: React.FC<TagDetailFormProps> = ({draft, errors, blogUrl, di
                                         onBlur={() => validateOnBlur('metaDescription')}
                                         onChange={e => onChange({metaDescription: e.target.value})}
                                     />
-                                    <FieldError message={errors.metaDescription} />
+                                    <FieldError className='text-sm' id={errorId('metaDescription')}>{errors.metaDescription}</FieldError>
                                     <UsedCharacters limit={META_DESCRIPTION_RECOMMENDED_LENGTH} prefix='Recommended' value={draft.metaDescription} />
                                 </div>
                                 <div className='flex flex-col gap-1.5'>
                                     <Label htmlFor='canonical-url'>Canonical URL</Label>
                                     <Input
+                                        aria-describedby={errors.canonicalUrl ? errorId('canonicalUrl') : undefined}
                                         aria-invalid={!!errors.canonicalUrl}
                                         disabled={disabled}
                                         id='canonical-url'
@@ -178,7 +182,7 @@ const TagDetailForm: React.FC<TagDetailFormProps> = ({draft, errors, blogUrl, di
                                         onBlur={() => validateOnBlur('canonicalUrl')}
                                         onChange={e => onChange({canonicalUrl: e.target.value})}
                                     />
-                                    <FieldError message={errors.canonicalUrl} />
+                                    <FieldError className='text-sm' id={errorId('canonicalUrl')}>{errors.canonicalUrl}</FieldError>
                                 </div>
                             </div>
                             <div className='flex flex-col gap-1.5'>
@@ -202,6 +206,7 @@ const TagDetailForm: React.FC<TagDetailFormProps> = ({draft, errors, blogUrl, di
                                     uploadText='Add X image'
                                     value={draft.twitterImage}
                                     onChange={twitterImage => onChange({twitterImage})}
+                                    onPendingChange={pending => onImageUploadPendingChange('twitterImage', pending)}
                                 />
                                 <div className='flex flex-col gap-1.5'>
                                     <Label htmlFor='twitter-title'>X title</Label>
@@ -253,6 +258,7 @@ const TagDetailForm: React.FC<TagDetailFormProps> = ({draft, errors, blogUrl, di
                                     uploadText='Add Facebook image'
                                     value={draft.ogImage}
                                     onChange={ogImage => onChange({ogImage})}
+                                    onPendingChange={pending => onImageUploadPendingChange('ogImage', pending)}
                                 />
                                 <div className='flex flex-col gap-1.5'>
                                     <Label htmlFor='og-title'>Facebook title</Label>

--- a/apps/admin/src/tags/detail/tag-detail-form.tsx
+++ b/apps/admin/src/tags/detail/tag-detail-form.tsx
@@ -15,6 +15,7 @@ interface TagDetailFormProps {
     disabled?: boolean;
     onChange: (patch: Partial<TagEditableFields>) => void;
     onFieldError: (field: TagFieldName, message: string | null) => void;
+    onImageBusyChange: (field: 'featureImage' | 'twitterImage' | 'ogImage', busy: boolean) => void;
     onImageUploadPendingChange: (field: 'featureImage' | 'twitterImage' | 'ogImage', pending: boolean) => void;
 }
 
@@ -40,7 +41,7 @@ const SectionTrigger: React.FC<{title: string; description: string}> = ({title, 
     </AccordionTrigger>
 );
 
-const TagDetailForm: React.FC<TagDetailFormProps> = ({draft, errors, blogUrl, disabled, onChange, onFieldError, onImageUploadPendingChange}) => {
+const TagDetailForm: React.FC<TagDetailFormProps> = ({draft, errors, blogUrl, disabled, onChange, onFieldError, onImageBusyChange, onImageUploadPendingChange}) => {
     const {data: settingsData} = useBrowseSettings({});
     const siteTitle = getSettingValue<string>(settingsData?.settings ?? [], 'title') ?? '';
     const siteMetaTitle = getSettingValue<string>(settingsData?.settings ?? [], 'meta_title') ?? '';
@@ -130,8 +131,9 @@ const TagDetailForm: React.FC<TagDetailFormProps> = ({draft, errors, blogUrl, di
                     unsplashEnabled={unsplashEnabled}
                     uploadText='Upload tag image'
                     value={draft.featureImage}
+                    onBusyChange={busy => onImageBusyChange('featureImage', busy)}
                     onChange={featureImage => onChange({featureImage})}
-                    onPendingChange={pending => onImageUploadPendingChange('featureImage', pending)}
+                    onUploadPendingChange={pending => onImageUploadPendingChange('featureImage', pending)}
                 />
             </div>
 
@@ -205,8 +207,9 @@ const TagDetailForm: React.FC<TagDetailFormProps> = ({draft, errors, blogUrl, di
                                     unsplashEnabled={unsplashEnabled}
                                     uploadText='Add X image'
                                     value={draft.twitterImage}
+                                    onBusyChange={busy => onImageBusyChange('twitterImage', busy)}
                                     onChange={twitterImage => onChange({twitterImage})}
-                                    onPendingChange={pending => onImageUploadPendingChange('twitterImage', pending)}
+                                    onUploadPendingChange={pending => onImageUploadPendingChange('twitterImage', pending)}
                                 />
                                 <div className='flex flex-col gap-1.5'>
                                     <Label htmlFor='twitter-title'>X title</Label>
@@ -257,8 +260,9 @@ const TagDetailForm: React.FC<TagDetailFormProps> = ({draft, errors, blogUrl, di
                                     unsplashEnabled={unsplashEnabled}
                                     uploadText='Add Facebook image'
                                     value={draft.ogImage}
+                                    onBusyChange={busy => onImageBusyChange('ogImage', busy)}
                                     onChange={ogImage => onChange({ogImage})}
-                                    onPendingChange={pending => onImageUploadPendingChange('ogImage', pending)}
+                                    onUploadPendingChange={pending => onImageUploadPendingChange('ogImage', pending)}
                                 />
                                 <div className='flex flex-col gap-1.5'>
                                     <Label htmlFor='og-title'>Facebook title</Label>

--- a/apps/admin/src/tags/detail/tag-detail-form.tsx
+++ b/apps/admin/src/tags/detail/tag-detail-form.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import TagColorField from './tag-color-field';
 import TagImageField from './tag-image-field';
-import {Accordion, AccordionContent, AccordionItem, AccordionTrigger, FieldError, Input, Label, Textarea} from '@tryghost/shade/components';
+import {Accordion, AccordionContent, AccordionItem, AccordionTrigger, Card, CardContent, FieldError, Input, Label, Textarea} from '@tryghost/shade/components';
 import {DESCRIPTION_MAX_LENGTH, FACEBOOK_DESCRIPTION_RECOMMENDED_LENGTH, FACEBOOK_TITLE_RECOMMENDED_LENGTH, META_DESCRIPTION_RECOMMENDED_LENGTH, META_TITLE_RECOMMENDED_LENGTH, X_DESCRIPTION_RECOMMENDED_LENGTH, X_TITLE_RECOMMENDED_LENGTH, charLength, getBlogDomain, getSeoDescription, getSeoTitle, getSeoUrl, getSlugUrlPreview, validateTagField} from './tag-detail-edit';
 import {FacebookCardPreview, SeoPreview, XCardPreview} from './tag-detail-previews';
 import {cn, formatNumber} from '@tryghost/shade/utils';
@@ -60,280 +60,290 @@ const TagDetailForm: React.FC<TagDetailFormProps> = ({draft, errors, blogUrl, di
 
     return (
         <div className='flex flex-col gap-8' data-testid='tag-detail-form'>
-            <div className='grid items-start gap-6 lg:grid-cols-2'>
-                <div className='flex flex-col gap-5'>
-                    <div className='flex items-start gap-3'>
-                        <div className='flex flex-1 flex-col gap-1.5'>
-                            <Label htmlFor='tag-name'>Name</Label>
-                            <Input
-                                aria-describedby={errors.name ? errorId('name') : undefined}
-                                aria-invalid={!!errors.name}
-                                disabled={disabled}
-                                id='tag-name'
-                                value={draft.name}
-                                onBlur={() => validateOnBlur('name')}
-                                onChange={e => onChange({name: e.target.value})}
-                            />
-                        </div>
-                        <TagColorField
-                            disabled={disabled}
-                            errorId={errors.accentColor ? errorId('accentColor') : undefined}
-                            value={draft.accentColor}
-                            onChange={accentColor => onChange({accentColor})}
-                            onError={message => onFieldError('accentColor', message)}
-                        />
-                    </div>
-                    <div className='-mt-4 flex flex-col gap-1'>
-                        <FieldError className='text-sm' id={errorId('name')}>{errors.name}</FieldError>
-                        <FieldError className='text-sm' id={errorId('accentColor')}>{errors.accentColor}</FieldError>
-                        <p className='text-sm text-muted-foreground'>
-                            Start with # to create internal tags.{' '}
-                            <a className='underline' href='https://ghost.org/help/organising-content/#private-tags' rel='noopener noreferrer' target='_blank'>Learn more</a>
-                        </p>
-                    </div>
-
-                    <div className='flex flex-col gap-1.5'>
-                        <Label htmlFor='tag-slug'>Slug</Label>
-                        <Input
-                            aria-describedby={errors.slug ? errorId('slug') : undefined}
-                            aria-invalid={!!errors.slug}
-                            disabled={disabled}
-                            id='tag-slug'
-                            value={draft.slug}
-                            onBlur={() => validateOnBlur('slug')}
-                            onChange={e => onChange({slug: e.target.value})}
-                        />
-                        <p className='text-sm text-muted-foreground' data-testid='tag-slug-preview'>{getSlugUrlPreview(draft.slug, blogUrl)}</p>
-                        <FieldError className='text-sm' id={errorId('slug')}>{errors.slug}</FieldError>
-                    </div>
-
-                    <div className='flex flex-col gap-1.5'>
-                        <Label htmlFor='tag-description'>Description</Label>
-                        <Textarea
-                            aria-describedby={errors.description ? errorId('description') : undefined}
-                            aria-invalid={!!errors.description}
-                            className='min-h-24'
-                            disabled={disabled}
-                            id='tag-description'
-                            value={draft.description}
-                            onBlur={() => validateOnBlur('description')}
-                            onChange={e => onChange({description: e.target.value})}
-                        />
-                        <FieldError className='text-sm' id={errorId('description')}>{errors.description}</FieldError>
-                        <UsedCharacters limit={DESCRIPTION_MAX_LENGTH} prefix='Maximum' value={draft.description} />
-                    </div>
-                </div>
-
-                <TagImageField
-                    disabled={disabled}
-                    id='tag-image'
-                    label='Tag image'
-                    unsplashEnabled={unsplashEnabled}
-                    uploadText='Upload tag image'
-                    value={draft.featureImage}
-                    onBusyChange={busy => onImageBusyChange('featureImage', busy)}
-                    onChange={featureImage => onChange({featureImage})}
-                    onUploadPendingChange={pending => onImageUploadPendingChange('featureImage', pending)}
-                />
-            </div>
-
-            <Accordion type='multiple'>
-                <AccordionItem value='metadata'>
-                    <SectionTrigger description='Extra content for search engines.' title='Meta data' />
-                    <AccordionContent>
-                        <div className='grid items-start gap-6 pt-2 lg:grid-cols-3'>
-                            <div className='flex flex-col gap-5 lg:col-span-2'>
-                                <div className='flex flex-col gap-1.5'>
-                                    <Label htmlFor='meta-title'>Meta title</Label>
+            {/* Card 1 mirrors Ember's main form block; card 2 groups the
+                collapsible sections — the member detail screen's card idiom. */}
+            <Card>
+                <CardContent className='p-6'>
+                    <div className='grid items-start gap-6 lg:grid-cols-2'>
+                        <div className='flex flex-col gap-5'>
+                            <div className='flex items-start gap-3'>
+                                <div className='flex flex-1 flex-col gap-1.5'>
+                                    <Label htmlFor='tag-name'>Name</Label>
                                     <Input
-                                        aria-describedby={errors.metaTitle ? errorId('metaTitle') : undefined}
-                                        aria-invalid={!!errors.metaTitle}
+                                        aria-describedby={errors.name ? errorId('name') : undefined}
+                                        aria-invalid={!!errors.name}
                                         disabled={disabled}
-                                        id='meta-title'
-                                        placeholder={draft.name}
-                                        value={draft.metaTitle}
-                                        onBlur={() => validateOnBlur('metaTitle')}
-                                        onChange={e => onChange({metaTitle: e.target.value})}
+                                        id='tag-name'
+                                        value={draft.name}
+                                        onBlur={() => validateOnBlur('name')}
+                                        onChange={e => onChange({name: e.target.value})}
                                     />
-                                    <FieldError className='text-sm' id={errorId('metaTitle')}>{errors.metaTitle}</FieldError>
-                                    <UsedCharacters limit={META_TITLE_RECOMMENDED_LENGTH} prefix='Recommended' value={draft.metaTitle} />
                                 </div>
-                                <div className='flex flex-col gap-1.5'>
-                                    <Label htmlFor='meta-description'>Meta description</Label>
-                                    <Textarea
-                                        aria-describedby={errors.metaDescription ? errorId('metaDescription') : undefined}
-                                        aria-invalid={!!errors.metaDescription}
-                                        disabled={disabled}
-                                        id='meta-description'
-                                        placeholder={draft.description}
-                                        value={draft.metaDescription}
-                                        onBlur={() => validateOnBlur('metaDescription')}
-                                        onChange={e => onChange({metaDescription: e.target.value})}
-                                    />
-                                    <FieldError className='text-sm' id={errorId('metaDescription')}>{errors.metaDescription}</FieldError>
-                                    <UsedCharacters limit={META_DESCRIPTION_RECOMMENDED_LENGTH} prefix='Recommended' value={draft.metaDescription} />
-                                </div>
-                                <div className='flex flex-col gap-1.5'>
-                                    <Label htmlFor='canonical-url'>Canonical URL</Label>
-                                    <Input
-                                        aria-describedby={errors.canonicalUrl ? errorId('canonicalUrl') : undefined}
-                                        aria-invalid={!!errors.canonicalUrl}
-                                        disabled={disabled}
-                                        id='canonical-url'
-                                        value={draft.canonicalUrl}
-                                        onBlur={() => validateOnBlur('canonicalUrl')}
-                                        onChange={e => onChange({canonicalUrl: e.target.value})}
-                                    />
-                                    <FieldError className='text-sm' id={errorId('canonicalUrl')}>{errors.canonicalUrl}</FieldError>
-                                </div>
-                            </div>
-                            <div className='flex flex-col gap-1.5'>
-                                <Label>Search Engine Result Preview</Label>
-                                <SeoPreview description={seoDescription} title={seoTitle} url={seoUrl} />
-                            </div>
-                        </div>
-                    </AccordionContent>
-                </AccordionItem>
-
-                <AccordionItem value='x-card'>
-                    <SectionTrigger description='Customized structured data for X.' title='X card' />
-                    <AccordionContent>
-                        <div className='grid items-start gap-6 pt-2 lg:grid-cols-3'>
-                            <div className='flex flex-col gap-5 lg:col-span-2'>
-                                <TagImageField
+                                <TagColorField
                                     disabled={disabled}
-                                    id='twitter-image'
-                                    label='X image'
-                                    unsplashEnabled={unsplashEnabled}
-                                    uploadText='Add X image'
-                                    value={draft.twitterImage}
-                                    onBusyChange={busy => onImageBusyChange('twitterImage', busy)}
-                                    onChange={twitterImage => onChange({twitterImage})}
-                                    onUploadPendingChange={pending => onImageUploadPendingChange('twitterImage', pending)}
-                                />
-                                <div className='flex flex-col gap-1.5'>
-                                    <Label htmlFor='twitter-title'>X title</Label>
-                                    <Input
-                                        disabled={disabled}
-                                        id='twitter-title'
-                                        placeholder={draft.name}
-                                        value={draft.twitterTitle}
-                                        onChange={e => onChange({twitterTitle: e.target.value})}
-                                    />
-                                    <UsedCharacters limit={X_TITLE_RECOMMENDED_LENGTH} prefix='Recommended' value={draft.twitterTitle} />
-                                </div>
-                                <div className='flex flex-col gap-1.5'>
-                                    <Label htmlFor='twitter-description'>X description</Label>
-                                    <Textarea
-                                        disabled={disabled}
-                                        id='twitter-description'
-                                        placeholder={draft.description}
-                                        value={draft.twitterDescription}
-                                        onChange={e => onChange({twitterDescription: e.target.value})}
-                                    />
-                                    <UsedCharacters limit={X_DESCRIPTION_RECOMMENDED_LENGTH} prefix='Recommended' value={draft.twitterDescription} />
-                                </div>
-                            </div>
-                            <div className='flex flex-col gap-1.5'>
-                                <Label>X preview</Label>
-                                <XCardPreview
-                                    description={draft.twitterDescription || seoDescription || siteMetaDescription || ''}
-                                    domain={blogDomain}
-                                    image={draft.twitterImage || draft.featureImage}
-                                    siteHeader={socialSiteHeader}
-                                    title={draft.twitterTitle || seoTitle}
+                                    errorId={errors.accentColor ? errorId('accentColor') : undefined}
+                                    value={draft.accentColor}
+                                    onChange={accentColor => onChange({accentColor})}
+                                    onError={message => onFieldError('accentColor', message)}
                                 />
                             </div>
-                        </div>
-                    </AccordionContent>
-                </AccordionItem>
+                            <div className='-mt-4 flex flex-col gap-1'>
+                                <FieldError className='text-sm' id={errorId('name')}>{errors.name}</FieldError>
+                                <FieldError className='text-sm' id={errorId('accentColor')}>{errors.accentColor}</FieldError>
+                                <p className='text-sm text-muted-foreground'>
+                                    Start with # to create internal tags.{' '}
+                                    <a className='underline' href='https://ghost.org/help/organising-content/#private-tags' rel='noopener noreferrer' target='_blank'>Learn more</a>
+                                </p>
+                            </div>
 
-                <AccordionItem value='facebook-card'>
-                    <SectionTrigger description='Customize Open Graph data.' title='Facebook card' />
-                    <AccordionContent>
-                        <div className='grid items-start gap-6 pt-2 lg:grid-cols-3'>
-                            <div className='flex flex-col gap-5 lg:col-span-2'>
-                                <TagImageField
+                            <div className='flex flex-col gap-1.5'>
+                                <Label htmlFor='tag-slug'>Slug</Label>
+                                <Input
+                                    aria-describedby={errors.slug ? errorId('slug') : undefined}
+                                    aria-invalid={!!errors.slug}
                                     disabled={disabled}
-                                    id='og-image'
-                                    label='Facebook image'
-                                    unsplashEnabled={unsplashEnabled}
-                                    uploadText='Add Facebook image'
-                                    value={draft.ogImage}
-                                    onBusyChange={busy => onImageBusyChange('ogImage', busy)}
-                                    onChange={ogImage => onChange({ogImage})}
-                                    onUploadPendingChange={pending => onImageUploadPendingChange('ogImage', pending)}
+                                    id='tag-slug'
+                                    value={draft.slug}
+                                    onBlur={() => validateOnBlur('slug')}
+                                    onChange={e => onChange({slug: e.target.value})}
                                 />
-                                <div className='flex flex-col gap-1.5'>
-                                    <Label htmlFor='og-title'>Facebook title</Label>
-                                    <Input
-                                        disabled={disabled}
-                                        id='og-title'
-                                        placeholder={draft.name}
-                                        value={draft.ogTitle}
-                                        onChange={e => onChange({ogTitle: e.target.value})}
-                                    />
-                                    <UsedCharacters limit={FACEBOOK_TITLE_RECOMMENDED_LENGTH} prefix='Recommended' value={draft.ogTitle} />
-                                </div>
-                                <div className='flex flex-col gap-1.5'>
-                                    <Label htmlFor='og-description'>Facebook description</Label>
-                                    <Textarea
-                                        disabled={disabled}
-                                        id='og-description'
-                                        placeholder={draft.description}
-                                        value={draft.ogDescription}
-                                        onChange={e => onChange({ogDescription: e.target.value})}
-                                    />
-                                    <UsedCharacters limit={FACEBOOK_DESCRIPTION_RECOMMENDED_LENGTH} prefix='Recommended' value={draft.ogDescription} />
-                                </div>
+                                <p className='text-sm text-muted-foreground' data-testid='tag-slug-preview'>{getSlugUrlPreview(draft.slug, blogUrl)}</p>
+                                <FieldError className='text-sm' id={errorId('slug')}>{errors.slug}</FieldError>
                             </div>
-                            <div className='flex flex-col gap-1.5'>
-                                <Label>Facebook preview</Label>
-                                {/* The description chain deliberately skips ogDescription: Ember read a
-                                    nonexistent `facebookDescription` attribute, so ogDescription never
-                                    fed this preview (`tag-form.js` `facebookDescription`). */}
-                                <FacebookCardPreview
-                                    description={seoDescription || siteMetaDescription || ''}
-                                    domain={blogDomain}
-                                    image={draft.ogImage || draft.featureImage}
-                                    siteHeader={socialSiteHeader}
-                                    title={draft.ogTitle || seoTitle}
-                                />
-                            </div>
-                        </div>
-                    </AccordionContent>
-                </AccordionItem>
 
-                <AccordionItem value='code-injection'>
-                    <SectionTrigger description='Add styles/scripts to the header and footer.' title='Code injection' />
-                    <AccordionContent>
-                        <div className='flex flex-col gap-5 pt-2'>
                             <div className='flex flex-col gap-1.5'>
-                                <Label htmlFor='codeinjection-head'>Tag header <code className='ml-1 font-normal'>{'{{ghost_head}}'}</code></Label>
+                                <Label htmlFor='tag-description'>Description</Label>
                                 <Textarea
-                                    className='min-h-32 font-mono text-sm'
+                                    aria-describedby={errors.description ? errorId('description') : undefined}
+                                    aria-invalid={!!errors.description}
+                                    className='min-h-24'
                                     disabled={disabled}
-                                    id='codeinjection-head'
-                                    spellCheck={false}
-                                    value={draft.codeinjectionHead}
-                                    onChange={e => onChange({codeinjectionHead: e.target.value})}
+                                    id='tag-description'
+                                    value={draft.description}
+                                    onBlur={() => validateOnBlur('description')}
+                                    onChange={e => onChange({description: e.target.value})}
                                 />
-                            </div>
-                            <div className='flex flex-col gap-1.5'>
-                                <Label htmlFor='codeinjection-foot'>Tag footer <code className='ml-1 font-normal'>{'{{ghost_foot}}'}</code></Label>
-                                <Textarea
-                                    className='min-h-32 font-mono text-sm'
-                                    disabled={disabled}
-                                    id='codeinjection-foot'
-                                    spellCheck={false}
-                                    value={draft.codeinjectionFoot}
-                                    onChange={e => onChange({codeinjectionFoot: e.target.value})}
-                                />
+                                <FieldError className='text-sm' id={errorId('description')}>{errors.description}</FieldError>
+                                <UsedCharacters limit={DESCRIPTION_MAX_LENGTH} prefix='Maximum' value={draft.description} />
                             </div>
                         </div>
-                    </AccordionContent>
-                </AccordionItem>
-            </Accordion>
+
+                        <TagImageField
+                            disabled={disabled}
+                            id='tag-image'
+                            label='Tag image'
+                            unsplashEnabled={unsplashEnabled}
+                            uploadText='Upload tag image'
+                            value={draft.featureImage}
+                            onBusyChange={busy => onImageBusyChange('featureImage', busy)}
+                            onChange={featureImage => onChange({featureImage})}
+                            onUploadPendingChange={pending => onImageUploadPendingChange('featureImage', pending)}
+                        />
+                    </div>
+                </CardContent>
+            </Card>
+
+            <Card>
+                <CardContent className='px-6 py-2'>
+                    <Accordion type='multiple'>
+                        <AccordionItem className='last:border-b-0' value='metadata'>
+                            <SectionTrigger description='Extra content for search engines.' title='Meta data' />
+                            <AccordionContent>
+                                <div className='grid items-start gap-6 pt-2 lg:grid-cols-3'>
+                                    <div className='flex flex-col gap-5 lg:col-span-2'>
+                                        <div className='flex flex-col gap-1.5'>
+                                            <Label htmlFor='meta-title'>Meta title</Label>
+                                            <Input
+                                                aria-describedby={errors.metaTitle ? errorId('metaTitle') : undefined}
+                                                aria-invalid={!!errors.metaTitle}
+                                                disabled={disabled}
+                                                id='meta-title'
+                                                placeholder={draft.name}
+                                                value={draft.metaTitle}
+                                                onBlur={() => validateOnBlur('metaTitle')}
+                                                onChange={e => onChange({metaTitle: e.target.value})}
+                                            />
+                                            <FieldError className='text-sm' id={errorId('metaTitle')}>{errors.metaTitle}</FieldError>
+                                            <UsedCharacters limit={META_TITLE_RECOMMENDED_LENGTH} prefix='Recommended' value={draft.metaTitle} />
+                                        </div>
+                                        <div className='flex flex-col gap-1.5'>
+                                            <Label htmlFor='meta-description'>Meta description</Label>
+                                            <Textarea
+                                                aria-describedby={errors.metaDescription ? errorId('metaDescription') : undefined}
+                                                aria-invalid={!!errors.metaDescription}
+                                                disabled={disabled}
+                                                id='meta-description'
+                                                placeholder={draft.description}
+                                                value={draft.metaDescription}
+                                                onBlur={() => validateOnBlur('metaDescription')}
+                                                onChange={e => onChange({metaDescription: e.target.value})}
+                                            />
+                                            <FieldError className='text-sm' id={errorId('metaDescription')}>{errors.metaDescription}</FieldError>
+                                            <UsedCharacters limit={META_DESCRIPTION_RECOMMENDED_LENGTH} prefix='Recommended' value={draft.metaDescription} />
+                                        </div>
+                                        <div className='flex flex-col gap-1.5'>
+                                            <Label htmlFor='canonical-url'>Canonical URL</Label>
+                                            <Input
+                                                aria-describedby={errors.canonicalUrl ? errorId('canonicalUrl') : undefined}
+                                                aria-invalid={!!errors.canonicalUrl}
+                                                disabled={disabled}
+                                                id='canonical-url'
+                                                value={draft.canonicalUrl}
+                                                onBlur={() => validateOnBlur('canonicalUrl')}
+                                                onChange={e => onChange({canonicalUrl: e.target.value})}
+                                            />
+                                            <FieldError className='text-sm' id={errorId('canonicalUrl')}>{errors.canonicalUrl}</FieldError>
+                                        </div>
+                                    </div>
+                                    <div className='flex flex-col gap-1.5'>
+                                        <Label>Search Engine Result Preview</Label>
+                                        <SeoPreview description={seoDescription} title={seoTitle} url={seoUrl} />
+                                    </div>
+                                </div>
+                            </AccordionContent>
+                        </AccordionItem>
+
+                        <AccordionItem className='last:border-b-0' value='x-card'>
+                            <SectionTrigger description='Customized structured data for X.' title='X card' />
+                            <AccordionContent>
+                                <div className='grid items-start gap-6 pt-2 lg:grid-cols-3'>
+                                    <div className='flex flex-col gap-5 lg:col-span-2'>
+                                        <TagImageField
+                                            disabled={disabled}
+                                            id='twitter-image'
+                                            label='X image'
+                                            unsplashEnabled={unsplashEnabled}
+                                            uploadText='Add X image'
+                                            value={draft.twitterImage}
+                                            onBusyChange={busy => onImageBusyChange('twitterImage', busy)}
+                                            onChange={twitterImage => onChange({twitterImage})}
+                                            onUploadPendingChange={pending => onImageUploadPendingChange('twitterImage', pending)}
+                                        />
+                                        <div className='flex flex-col gap-1.5'>
+                                            <Label htmlFor='twitter-title'>X title</Label>
+                                            <Input
+                                                disabled={disabled}
+                                                id='twitter-title'
+                                                placeholder={draft.name}
+                                                value={draft.twitterTitle}
+                                                onChange={e => onChange({twitterTitle: e.target.value})}
+                                            />
+                                            <UsedCharacters limit={X_TITLE_RECOMMENDED_LENGTH} prefix='Recommended' value={draft.twitterTitle} />
+                                        </div>
+                                        <div className='flex flex-col gap-1.5'>
+                                            <Label htmlFor='twitter-description'>X description</Label>
+                                            <Textarea
+                                                disabled={disabled}
+                                                id='twitter-description'
+                                                placeholder={draft.description}
+                                                value={draft.twitterDescription}
+                                                onChange={e => onChange({twitterDescription: e.target.value})}
+                                            />
+                                            <UsedCharacters limit={X_DESCRIPTION_RECOMMENDED_LENGTH} prefix='Recommended' value={draft.twitterDescription} />
+                                        </div>
+                                    </div>
+                                    <div className='flex flex-col gap-1.5'>
+                                        <Label>X preview</Label>
+                                        <XCardPreview
+                                            description={draft.twitterDescription || seoDescription || siteMetaDescription || ''}
+                                            domain={blogDomain}
+                                            image={draft.twitterImage || draft.featureImage}
+                                            siteHeader={socialSiteHeader}
+                                            title={draft.twitterTitle || seoTitle}
+                                        />
+                                    </div>
+                                </div>
+                            </AccordionContent>
+                        </AccordionItem>
+
+                        <AccordionItem className='last:border-b-0' value='facebook-card'>
+                            <SectionTrigger description='Customize Open Graph data.' title='Facebook card' />
+                            <AccordionContent>
+                                <div className='grid items-start gap-6 pt-2 lg:grid-cols-3'>
+                                    <div className='flex flex-col gap-5 lg:col-span-2'>
+                                        <TagImageField
+                                            disabled={disabled}
+                                            id='og-image'
+                                            label='Facebook image'
+                                            unsplashEnabled={unsplashEnabled}
+                                            uploadText='Add Facebook image'
+                                            value={draft.ogImage}
+                                            onBusyChange={busy => onImageBusyChange('ogImage', busy)}
+                                            onChange={ogImage => onChange({ogImage})}
+                                            onUploadPendingChange={pending => onImageUploadPendingChange('ogImage', pending)}
+                                        />
+                                        <div className='flex flex-col gap-1.5'>
+                                            <Label htmlFor='og-title'>Facebook title</Label>
+                                            <Input
+                                                disabled={disabled}
+                                                id='og-title'
+                                                placeholder={draft.name}
+                                                value={draft.ogTitle}
+                                                onChange={e => onChange({ogTitle: e.target.value})}
+                                            />
+                                            <UsedCharacters limit={FACEBOOK_TITLE_RECOMMENDED_LENGTH} prefix='Recommended' value={draft.ogTitle} />
+                                        </div>
+                                        <div className='flex flex-col gap-1.5'>
+                                            <Label htmlFor='og-description'>Facebook description</Label>
+                                            <Textarea
+                                                disabled={disabled}
+                                                id='og-description'
+                                                placeholder={draft.description}
+                                                value={draft.ogDescription}
+                                                onChange={e => onChange({ogDescription: e.target.value})}
+                                            />
+                                            <UsedCharacters limit={FACEBOOK_DESCRIPTION_RECOMMENDED_LENGTH} prefix='Recommended' value={draft.ogDescription} />
+                                        </div>
+                                    </div>
+                                    <div className='flex flex-col gap-1.5'>
+                                        <Label>Facebook preview</Label>
+                                        {/* The description chain deliberately skips ogDescription: Ember read a
+                                            nonexistent `facebookDescription` attribute, so ogDescription never
+                                            fed this preview (`tag-form.js` `facebookDescription`). */}
+                                        <FacebookCardPreview
+                                            description={seoDescription || siteMetaDescription || ''}
+                                            domain={blogDomain}
+                                            image={draft.ogImage || draft.featureImage}
+                                            siteHeader={socialSiteHeader}
+                                            title={draft.ogTitle || seoTitle}
+                                        />
+                                    </div>
+                                </div>
+                            </AccordionContent>
+                        </AccordionItem>
+
+                        <AccordionItem className='last:border-b-0' value='code-injection'>
+                            <SectionTrigger description='Add styles/scripts to the header and footer.' title='Code injection' />
+                            <AccordionContent>
+                                <div className='flex flex-col gap-5 pt-2'>
+                                    <div className='flex flex-col gap-1.5'>
+                                        <Label htmlFor='codeinjection-head'>Tag header <code className='ml-1 font-normal'>{'{{ghost_head}}'}</code></Label>
+                                        <Textarea
+                                            className='min-h-32 font-mono text-sm'
+                                            disabled={disabled}
+                                            id='codeinjection-head'
+                                            spellCheck={false}
+                                            value={draft.codeinjectionHead}
+                                            onChange={e => onChange({codeinjectionHead: e.target.value})}
+                                        />
+                                    </div>
+                                    <div className='flex flex-col gap-1.5'>
+                                        <Label htmlFor='codeinjection-foot'>Tag footer <code className='ml-1 font-normal'>{'{{ghost_foot}}'}</code></Label>
+                                        <Textarea
+                                            className='min-h-32 font-mono text-sm'
+                                            disabled={disabled}
+                                            id='codeinjection-foot'
+                                            spellCheck={false}
+                                            value={draft.codeinjectionFoot}
+                                            onChange={e => onChange({codeinjectionFoot: e.target.value})}
+                                        />
+                                    </div>
+                                </div>
+                            </AccordionContent>
+                        </AccordionItem>
+                    </Accordion>
+                </CardContent>
+            </Card>
         </div>
     );
 };

--- a/apps/admin/src/tags/detail/tag-detail-form.tsx
+++ b/apps/admin/src/tags/detail/tag-detail-form.tsx
@@ -1,0 +1,327 @@
+import React from 'react';
+import TagColorField from './tag-color-field';
+import TagImageField from './tag-image-field';
+import {Accordion, AccordionContent, AccordionItem, AccordionTrigger, Input, Label, Textarea} from '@tryghost/shade/components';
+import {DESCRIPTION_MAX_LENGTH, FACEBOOK_DESCRIPTION_RECOMMENDED_LENGTH, FACEBOOK_TITLE_RECOMMENDED_LENGTH, META_DESCRIPTION_RECOMMENDED_LENGTH, META_TITLE_RECOMMENDED_LENGTH, X_DESCRIPTION_RECOMMENDED_LENGTH, X_TITLE_RECOMMENDED_LENGTH, charLength, getBlogDomain, getSeoDescription, getSeoTitle, getSeoUrl, getSlugUrlPreview, validateTagField} from './tag-detail-edit';
+import {FacebookCardPreview, SeoPreview, XCardPreview} from './tag-detail-previews';
+import {cn} from '@tryghost/shade/utils';
+import {getSettingValue, useBrowseSettings} from '@tryghost/admin-x-framework/api/settings';
+import type {TagEditableFields, TagFieldName} from './tag-detail-edit';
+
+interface TagDetailFormProps {
+    draft: TagEditableFields;
+    errors: Partial<Record<TagFieldName, string>>;
+    blogUrl: string;
+    disabled?: boolean;
+    onChange: (patch: Partial<TagEditableFields>) => void;
+    onFieldError: (field: TagFieldName, message: string | null) => void;
+}
+
+const FieldError: React.FC<{message?: string}> = ({message}) => {
+    if (!message) {
+        return null;
+    }
+    return <p className='text-sm text-destructive'>{message}</p>;
+};
+
+/** Ember's `gh-count-down-characters`: the used count, red once past the limit. */
+const UsedCharacters: React.FC<{value: string; limit: number; prefix: 'Maximum' | 'Recommended'}> = ({value, limit, prefix}) => {
+    const used = charLength(value);
+    return (
+        <p className='text-sm text-muted-foreground'>
+            {prefix}: <span className='font-semibold text-foreground'>{limit}</span> characters. You’ve used{' '}
+            <span className={cn('font-semibold', used > limit ? 'text-destructive' : 'text-state-success')}>{used}</span>
+        </p>
+    );
+};
+
+const SectionTrigger: React.FC<{title: string; description: string}> = ({title, description}) => (
+    <AccordionTrigger className='hover:no-underline'>
+        <span className='flex flex-col gap-0.5 text-left'>
+            <span className='text-base font-semibold'>{title}</span>
+            <span className='text-sm font-normal text-muted-foreground'>{description}</span>
+        </span>
+    </AccordionTrigger>
+);
+
+const TagDetailForm: React.FC<TagDetailFormProps> = ({draft, errors, blogUrl, disabled, onChange, onFieldError}) => {
+    const {data: settingsData} = useBrowseSettings({});
+    const siteTitle = getSettingValue<string>(settingsData?.settings ?? [], 'title') ?? '';
+    const siteMetaTitle = getSettingValue<string>(settingsData?.settings ?? [], 'meta_title') ?? '';
+    const siteMetaDescription = getSettingValue<string>(settingsData?.settings ?? [], 'meta_description') ?? '';
+
+    const validateOnBlur = (field: TagFieldName) => {
+        onFieldError(field, validateTagField(field, draft));
+    };
+
+    const seoTitle = getSeoTitle(draft, siteTitle);
+    const seoDescription = getSeoDescription(draft);
+    const seoUrl = getSeoUrl(draft, blogUrl);
+    const socialSiteHeader = siteMetaTitle || siteTitle;
+    const blogDomain = getBlogDomain(blogUrl);
+
+    return (
+        <div className='flex flex-col gap-8' data-testid='tag-detail-form'>
+            <div className='grid items-start gap-6 lg:grid-cols-2'>
+                <div className='flex flex-col gap-5'>
+                    <div className='flex items-start gap-3'>
+                        <div className='flex flex-1 flex-col gap-1.5'>
+                            <Label htmlFor='tag-name'>Name</Label>
+                            <Input
+                                aria-invalid={!!errors.name}
+                                disabled={disabled}
+                                id='tag-name'
+                                value={draft.name}
+                                onBlur={() => validateOnBlur('name')}
+                                onChange={e => onChange({name: e.target.value})}
+                            />
+                        </div>
+                        <TagColorField
+                            disabled={disabled}
+                            value={draft.accentColor}
+                            onChange={accentColor => onChange({accentColor})}
+                            onError={message => onFieldError('accentColor', message)}
+                        />
+                    </div>
+                    <div className='-mt-4 flex flex-col gap-1'>
+                        <FieldError message={errors.name} />
+                        <FieldError message={errors.accentColor} />
+                        <p className='text-sm text-muted-foreground'>
+                            Start with # to create internal tags.{' '}
+                            <a className='underline' href='https://ghost.org/help/organising-content/#private-tags' rel='noopener noreferrer' target='_blank'>Learn more</a>
+                        </p>
+                    </div>
+
+                    <div className='flex flex-col gap-1.5'>
+                        <Label htmlFor='tag-slug'>Slug</Label>
+                        <Input
+                            aria-invalid={!!errors.slug}
+                            disabled={disabled}
+                            id='tag-slug'
+                            value={draft.slug}
+                            onBlur={() => validateOnBlur('slug')}
+                            onChange={e => onChange({slug: e.target.value})}
+                        />
+                        <p className='text-sm text-muted-foreground' data-testid='tag-slug-preview'>{getSlugUrlPreview(draft.slug, blogUrl)}</p>
+                        <FieldError message={errors.slug} />
+                    </div>
+
+                    <div className='flex flex-col gap-1.5'>
+                        <Label htmlFor='tag-description'>Description</Label>
+                        <Textarea
+                            aria-invalid={!!errors.description}
+                            className='min-h-24'
+                            disabled={disabled}
+                            id='tag-description'
+                            value={draft.description}
+                            onBlur={() => validateOnBlur('description')}
+                            onChange={e => onChange({description: e.target.value})}
+                        />
+                        <FieldError message={errors.description} />
+                        <UsedCharacters limit={DESCRIPTION_MAX_LENGTH} prefix='Maximum' value={draft.description} />
+                    </div>
+                </div>
+
+                <TagImageField
+                    disabled={disabled}
+                    id='tag-image'
+                    label='Tag image'
+                    uploadText='Upload tag image'
+                    value={draft.featureImage}
+                    onChange={featureImage => onChange({featureImage})}
+                />
+            </div>
+
+            <Accordion type='multiple'>
+                <AccordionItem value='metadata'>
+                    <SectionTrigger description='Extra content for search engines.' title='Meta data' />
+                    <AccordionContent>
+                        <div className='grid items-start gap-6 pt-2 lg:grid-cols-3'>
+                            <div className='flex flex-col gap-5 lg:col-span-2'>
+                                <div className='flex flex-col gap-1.5'>
+                                    <Label htmlFor='meta-title'>Meta title</Label>
+                                    <Input
+                                        aria-invalid={!!errors.metaTitle}
+                                        disabled={disabled}
+                                        id='meta-title'
+                                        placeholder={draft.name}
+                                        value={draft.metaTitle}
+                                        onBlur={() => validateOnBlur('metaTitle')}
+                                        onChange={e => onChange({metaTitle: e.target.value})}
+                                    />
+                                    <FieldError message={errors.metaTitle} />
+                                    <UsedCharacters limit={META_TITLE_RECOMMENDED_LENGTH} prefix='Recommended' value={draft.metaTitle} />
+                                </div>
+                                <div className='flex flex-col gap-1.5'>
+                                    <Label htmlFor='meta-description'>Meta description</Label>
+                                    <Textarea
+                                        aria-invalid={!!errors.metaDescription}
+                                        disabled={disabled}
+                                        id='meta-description'
+                                        placeholder={draft.description}
+                                        value={draft.metaDescription}
+                                        onBlur={() => validateOnBlur('metaDescription')}
+                                        onChange={e => onChange({metaDescription: e.target.value})}
+                                    />
+                                    <FieldError message={errors.metaDescription} />
+                                    <UsedCharacters limit={META_DESCRIPTION_RECOMMENDED_LENGTH} prefix='Recommended' value={draft.metaDescription} />
+                                </div>
+                                <div className='flex flex-col gap-1.5'>
+                                    <Label htmlFor='canonical-url'>Canonical URL</Label>
+                                    <Input
+                                        aria-invalid={!!errors.canonicalUrl}
+                                        disabled={disabled}
+                                        id='canonical-url'
+                                        value={draft.canonicalUrl}
+                                        onBlur={() => validateOnBlur('canonicalUrl')}
+                                        onChange={e => onChange({canonicalUrl: e.target.value})}
+                                    />
+                                    <FieldError message={errors.canonicalUrl} />
+                                </div>
+                            </div>
+                            <div className='flex flex-col gap-1.5'>
+                                <Label>Search Engine Result Preview</Label>
+                                <SeoPreview description={seoDescription} title={seoTitle} url={seoUrl} />
+                            </div>
+                        </div>
+                    </AccordionContent>
+                </AccordionItem>
+
+                <AccordionItem value='x-card'>
+                    <SectionTrigger description='Customized structured data for X.' title='X card' />
+                    <AccordionContent>
+                        <div className='grid items-start gap-6 pt-2 lg:grid-cols-3'>
+                            <div className='flex flex-col gap-5 lg:col-span-2'>
+                                <TagImageField
+                                    disabled={disabled}
+                                    id='twitter-image'
+                                    label='X image'
+                                    uploadText='Add X image'
+                                    value={draft.twitterImage}
+                                    onChange={twitterImage => onChange({twitterImage})}
+                                />
+                                <div className='flex flex-col gap-1.5'>
+                                    <Label htmlFor='twitter-title'>X title</Label>
+                                    <Input
+                                        disabled={disabled}
+                                        id='twitter-title'
+                                        placeholder={draft.name}
+                                        value={draft.twitterTitle}
+                                        onChange={e => onChange({twitterTitle: e.target.value})}
+                                    />
+                                    <UsedCharacters limit={X_TITLE_RECOMMENDED_LENGTH} prefix='Recommended' value={draft.twitterTitle} />
+                                </div>
+                                <div className='flex flex-col gap-1.5'>
+                                    <Label htmlFor='twitter-description'>X description</Label>
+                                    <Textarea
+                                        disabled={disabled}
+                                        id='twitter-description'
+                                        placeholder={draft.description}
+                                        value={draft.twitterDescription}
+                                        onChange={e => onChange({twitterDescription: e.target.value})}
+                                    />
+                                    <UsedCharacters limit={X_DESCRIPTION_RECOMMENDED_LENGTH} prefix='Recommended' value={draft.twitterDescription} />
+                                </div>
+                            </div>
+                            <div className='flex flex-col gap-1.5'>
+                                <Label>X preview</Label>
+                                <XCardPreview
+                                    description={draft.twitterDescription || seoDescription || siteMetaDescription || ''}
+                                    domain={blogDomain}
+                                    image={draft.twitterImage || draft.featureImage}
+                                    siteHeader={socialSiteHeader}
+                                    title={draft.twitterTitle || seoTitle}
+                                />
+                            </div>
+                        </div>
+                    </AccordionContent>
+                </AccordionItem>
+
+                <AccordionItem value='facebook-card'>
+                    <SectionTrigger description='Customize Open Graph data.' title='Facebook card' />
+                    <AccordionContent>
+                        <div className='grid items-start gap-6 pt-2 lg:grid-cols-3'>
+                            <div className='flex flex-col gap-5 lg:col-span-2'>
+                                <TagImageField
+                                    disabled={disabled}
+                                    id='og-image'
+                                    label='Facebook image'
+                                    uploadText='Add Facebook image'
+                                    value={draft.ogImage}
+                                    onChange={ogImage => onChange({ogImage})}
+                                />
+                                <div className='flex flex-col gap-1.5'>
+                                    <Label htmlFor='og-title'>Facebook title</Label>
+                                    <Input
+                                        disabled={disabled}
+                                        id='og-title'
+                                        placeholder={draft.name}
+                                        value={draft.ogTitle}
+                                        onChange={e => onChange({ogTitle: e.target.value})}
+                                    />
+                                    <UsedCharacters limit={FACEBOOK_TITLE_RECOMMENDED_LENGTH} prefix='Recommended' value={draft.ogTitle} />
+                                </div>
+                                <div className='flex flex-col gap-1.5'>
+                                    <Label htmlFor='og-description'>Facebook description</Label>
+                                    <Textarea
+                                        disabled={disabled}
+                                        id='og-description'
+                                        placeholder={draft.description}
+                                        value={draft.ogDescription}
+                                        onChange={e => onChange({ogDescription: e.target.value})}
+                                    />
+                                    <UsedCharacters limit={FACEBOOK_DESCRIPTION_RECOMMENDED_LENGTH} prefix='Recommended' value={draft.ogDescription} />
+                                </div>
+                            </div>
+                            <div className='flex flex-col gap-1.5'>
+                                <Label>Facebook preview</Label>
+                                {/* The description chain deliberately skips ogDescription: Ember read a
+                                    nonexistent `facebookDescription` attribute, so ogDescription never
+                                    fed this preview (`tag-form.js` `facebookDescription`). */}
+                                <FacebookCardPreview
+                                    description={seoDescription || siteMetaDescription || ''}
+                                    domain={blogDomain}
+                                    image={draft.ogImage || draft.featureImage}
+                                    siteHeader={socialSiteHeader}
+                                    title={draft.ogTitle || seoTitle}
+                                />
+                            </div>
+                        </div>
+                    </AccordionContent>
+                </AccordionItem>
+
+                <AccordionItem value='code-injection'>
+                    <SectionTrigger description='Add styles/scripts to the header and footer.' title='Code injection' />
+                    <AccordionContent>
+                        <div className='flex flex-col gap-5 pt-2'>
+                            <div className='flex flex-col gap-1.5'>
+                                <Label htmlFor='codeinjection-head'>Tag header <code className='ml-1 font-normal'>{'{{ghost_head}}'}</code></Label>
+                                <Textarea
+                                    className='min-h-32 font-mono text-sm'
+                                    disabled={disabled}
+                                    id='codeinjection-head'
+                                    spellCheck={false}
+                                    value={draft.codeinjectionHead}
+                                    onChange={e => onChange({codeinjectionHead: e.target.value})}
+                                />
+                            </div>
+                            <div className='flex flex-col gap-1.5'>
+                                <Label htmlFor='codeinjection-foot'>Tag footer <code className='ml-1 font-normal'>{'{{ghost_foot}}'}</code></Label>
+                                <Textarea
+                                    className='min-h-32 font-mono text-sm'
+                                    disabled={disabled}
+                                    id='codeinjection-foot'
+                                    spellCheck={false}
+                                    value={draft.codeinjectionFoot}
+                                    onChange={e => onChange({codeinjectionFoot: e.target.value})}
+                                />
+                            </div>
+                        </div>
+                    </AccordionContent>
+                </AccordionItem>
+            </Accordion>
+        </div>
+    );
+};
+
+export default TagDetailForm;

--- a/apps/admin/src/tags/detail/tag-detail-previews.tsx
+++ b/apps/admin/src/tags/detail/tag-detail-previews.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import {FacebookLogo, GoogleLogo, XLogo} from '@tryghost/shade/components';
+import {LucideIcon} from '@tryghost/shade/utils';
+import {truncateText} from './tag-detail-edit';
+
+/**
+ * Static mock previews for the metadata sections, porting the Ember tag form's
+ * search/X/Facebook cards including their placeholder copy and decoration.
+ */
+
+const SEO_DESCRIPTION_FALLBACK = 'Search engines will automatically show a custom preview of content related to the search term here if no custom meta description is set.';
+
+export const SeoPreview: React.FC<{url: string; title: string; description: string}> = ({url, title, description}) => (
+    <div className='rounded-md border border-border bg-surface-elevated p-4' data-testid='seo-preview'>
+        <div className='mb-6 flex items-center gap-4'>
+            <GoogleLogo className='h-6' />
+            <div className='flex h-9 flex-1 items-center justify-end rounded-full border border-border px-3'>
+                <LucideIcon.Search className='size-4 text-muted-foreground' />
+            </div>
+        </div>
+        <div className='flex flex-col gap-0.5'>
+            <span className='truncate text-sm text-muted-foreground'>{url}</span>
+            <span className='text-lg' data-testid='seo-preview-title'>{title}</span>
+            <span className='text-sm text-muted-foreground' data-testid='seo-preview-description'>
+                {description ? truncateText(description, 149) : SEO_DESCRIPTION_FALLBACK}
+            </span>
+        </div>
+    </div>
+);
+
+const FakePostLines: React.FC = () => (
+    <div className='mt-2 mb-3 flex flex-col gap-2'>
+        <span className='h-2 w-full rounded-sm bg-muted' />
+        <span className='h-2 w-3/5 rounded-sm bg-muted' />
+    </div>
+);
+
+export const XCardPreview: React.FC<{
+    siteHeader: string;
+    domain: string;
+    image: string;
+    title: string;
+    description: string;
+}> = ({siteHeader, domain, image, title, description}) => (
+    <div className='rounded-md border border-border bg-surface-elevated p-4' data-testid='x-card-preview'>
+        <div className='flex gap-3'>
+            <XLogo className='mt-1 size-5 shrink-0' />
+            <div className='min-w-0 flex-1'>
+                <span className='text-sm font-semibold'>{siteHeader}</span>
+                <span className='ml-1 text-sm text-muted-foreground'>12 hrs</span>
+                <FakePostLines />
+                <div className='overflow-hidden rounded-md border border-border'>
+                    {image && (
+                        <div className='h-32 bg-muted bg-cover bg-center' style={{backgroundImage: `url(${image})`}} />
+                    )}
+                    <div className='flex flex-col gap-0.5 p-3'>
+                        <span className='truncate text-sm font-semibold' data-testid='x-card-preview-title'>{title}</span>
+                        <span className='text-sm text-muted-foreground' data-testid='x-card-preview-description'>{truncateText(description)}</span>
+                        <span className='flex items-center gap-1 text-sm text-muted-foreground'>
+                            <LucideIcon.Link className='size-3.5' />
+                            {domain}
+                        </span>
+                    </div>
+                </div>
+                <div className='mt-2 flex items-center gap-6 text-sm text-muted-foreground'>
+                    <span className='flex items-center gap-1'><LucideIcon.MessageCircle className='size-3.5' />2</span>
+                    <span className='flex items-center gap-1'><LucideIcon.Repeat2 className='size-3.5' />11</span>
+                    <span className='flex items-center gap-1'><LucideIcon.Heart className='size-3.5' />32</span>
+                    <span className='flex items-center gap-1'><LucideIcon.Share className='size-3.5' /></span>
+                </div>
+            </div>
+        </div>
+    </div>
+);
+
+export const FacebookCardPreview: React.FC<{
+    siteHeader: string;
+    domain: string;
+    image: string;
+    title: string;
+    description: string;
+}> = ({siteHeader, domain, image, title, description}) => (
+    <div className='rounded-md border border-border bg-surface-elevated p-4' data-testid='facebook-card-preview'>
+        <div className='flex items-center gap-3'>
+            <FacebookLogo className='size-8 shrink-0' />
+            <div className='flex flex-col'>
+                <span className='text-sm font-semibold'>{siteHeader}</span>
+                <span className='text-sm text-muted-foreground'>12 hrs</span>
+            </div>
+        </div>
+        <FakePostLines />
+        <div className='overflow-hidden rounded-md border border-border'>
+            {image && (
+                <div className='h-32 bg-muted bg-cover bg-center' style={{backgroundImage: `url(${image})`}} />
+            )}
+            <div className='flex flex-col gap-0.5 p-3'>
+                <span className='text-xs text-muted-foreground uppercase'>{domain}</span>
+                <span className='truncate text-sm font-semibold' data-testid='facebook-card-preview-title'>{truncateText(title)}</span>
+                <span className='text-sm text-muted-foreground' data-testid='facebook-card-preview-description'>{truncateText(description)}</span>
+            </div>
+        </div>
+        <div className='mt-2 flex items-center gap-4 text-sm text-muted-foreground'>
+            <span className='flex items-center gap-1'><LucideIcon.ThumbsUp className='size-3.5' /><LucideIcon.Heart className='size-3.5' />182</span>
+            <span>7 comments</span>
+            <span>2 shares</span>
+        </div>
+    </div>
+);

--- a/apps/admin/src/tags/detail/tag-detail.acceptance.test.tsx
+++ b/apps/admin/src/tags/detail/tag-detail.acceptance.test.tsx
@@ -1,0 +1,138 @@
+import {describe, expect, it} from 'vitest';
+import {page} from 'vitest/browser';
+
+import {currentRoute, fakeAdminEndpoint, fakeTags, renderAdminApp, tag, type Tag} from '@test-utils/acceptance';
+
+const FLAGS = {labs: {tagDetailsReact: true}};
+
+/**
+ * A working single-tag fake: the slug read serves the latest state and writes
+ * update it, so the post-save refetch reflects what was saved — the shape a
+ * real server has, which the screen's dirty tracking depends on.
+ */
+function fakeTagWorld(t: Tag) {
+    let current = t;
+    fakeAdminEndpoint('GET', new RegExp(`^/tags/slug/${t.slug}/`), () => ({tags: [current]}));
+    const saveApi = fakeAdminEndpoint('PUT', new RegExp(`^/tags/${t.id}/`), ({body}) => {
+        current = {...current, ...(body as {tags: Partial<Tag>[]}).tags[0]};
+        return {tags: [current]};
+    });
+    return saveApi;
+}
+
+describe('Tag detail (tagDetailsReact on)', () => {
+    it('renders the seeded tag', async () => {
+        const t = tag({name: 'News', slug: 'news', description: 'All the news', count: {posts: 3}});
+        fakeTagWorld(t);
+        await renderAdminApp(`/tags/${t.slug}`, FLAGS);
+
+        await expect.element(page.getByTestId('tag-detail-title')).toHaveTextContent('News');
+        await expect.element(page.getByLabelText('Name', {exact: true})).toHaveValue('News');
+        await expect.element(page.getByLabelText('Slug', {exact: true})).toHaveValue('news');
+        await expect.element(page.getByLabelText('Description', {exact: true})).toHaveValue('All the news');
+        await expect.element(page.getByRole('button', {name: 'Delete tag', exact: true})).toBeVisible();
+    });
+
+    it('saves edits and reports the saved state', async () => {
+        const t = tag({name: 'News', slug: 'news', visibility: 'public'});
+        const saveApi = fakeTagWorld(t);
+        await renderAdminApp(`/tags/${t.slug}`, FLAGS);
+
+        await page.getByLabelText('Name', {exact: true}).fill('Renamed');
+        await page.getByRole('button', {name: 'Save'}).click();
+
+        await expect.element(page.getByRole('button', {name: 'Saved'})).toBeVisible();
+        const saved = (saveApi.lastRequest?.body as {tags: Array<Record<string, unknown>>}).tags[0];
+        expect(saved.name).toBe('Renamed');
+        expect(saved.slug).toBe('news');
+        // The name changed, so the payload re-derives visibility (Ember
+        // `models/tag.js` recomputes it in `save()` whenever the name changed).
+        expect(saved.visibility).toBe('public');
+    });
+
+    it('creates a tag from /tags/new, generating the slug from the name', async () => {
+        const created = tag({name: 'Weekly News', slug: 'weekly-news'});
+        const createApi = fakeAdminEndpoint('POST', new RegExp('^/tags/'), {tags: [created]});
+        fakeTagWorld(created);
+        await renderAdminApp('/tags/new', FLAGS);
+
+        await expect.element(page.getByTestId('tag-detail-title')).toHaveTextContent('New tag');
+        await page.getByLabelText('Name', {exact: true}).fill('Weekly News');
+        await expect.element(page.getByLabelText('Slug', {exact: true})).toHaveValue('weekly-news');
+
+        await page.getByRole('button', {name: 'Save'}).click();
+
+        // Ember replaces `/tags/new` with the saved tag's route after creating.
+        await expect.poll(currentRoute).toBe('/tags/weekly-news');
+        const sent = (createApi.lastRequest?.body as {tags: Array<Record<string, unknown>>}).tags[0];
+        expect(sent.name).toBe('Weekly News');
+        expect(sent.visibility).toBe('public');
+    });
+
+    it('shows validation errors instead of saving an invalid tag', async () => {
+        const t = tag({name: 'News', slug: 'news'});
+        const saveApi = fakeTagWorld(t);
+        await renderAdminApp(`/tags/${t.slug}`, FLAGS);
+
+        await page.getByLabelText('Name', {exact: true}).fill('');
+        await page.getByRole('button', {name: 'Save'}).click();
+
+        await expect.element(page.getByText('You must specify a name for the tag.').first()).toBeVisible();
+        expect(saveApi.requests.length).toBe(0);
+    });
+
+    it('deletes the tag after confirming, reporting the posts it is used on', async () => {
+        const t = tag({name: 'News', slug: 'news', count: {posts: 3}});
+        fakeTags([t]);
+        fakeTagWorld(t);
+        const deleteApi = fakeAdminEndpoint('DELETE', new RegExp(`^/tags/${t.id}/`), null, {status: 204});
+        await renderAdminApp(`/tags/${t.slug}`, FLAGS);
+
+        await page.getByRole('button', {name: 'Delete tag', exact: true}).click();
+
+        await expect.element(page.getByText('Are you sure you want to delete this tag?')).toBeVisible();
+        await expect.element(page.getByTestId('delete-tag-posts-count')).toHaveTextContent('3 posts');
+
+        await page.getByTestId('confirm-delete-tag').click();
+
+        await expect.poll(currentRoute).toBe('/tags');
+        expect(deleteApi.requests.length).toBe(1);
+    });
+
+    it('guards leaving with unsaved edits via the breadcrumb', async () => {
+        const t = tag({name: 'News', slug: 'news'});
+        fakeTags([t]);
+        fakeTagWorld(t);
+        await renderAdminApp(`/tags/${t.slug}`, FLAGS);
+
+        await page.getByLabelText('Name', {exact: true}).fill('Renamed');
+        await page.getByTestId('tag-detail').getByRole('link', {name: 'Tags'}).click();
+
+        // The dialog carries Ember's ConfirmUnsavedChangesModal copy.
+        await expect.element(page.getByText('Are you sure you want to leave this page?')).toBeVisible();
+        await page.getByRole('button', {name: 'Stay'}).click();
+        await expect.element(page.getByLabelText('Name', {exact: true})).toHaveValue('Renamed');
+
+        await page.getByTestId('tag-detail').getByRole('link', {name: 'Tags'}).click();
+        await page.getByRole('button', {name: 'Leave'}).click();
+        await expect.poll(currentRoute).toBe('/tags');
+    });
+});
+
+describe('Tag detail (tagDetailsReact off)', () => {
+    // No tag fakes are declared in these tests on purpose: if the React screen
+    // mounted it would fetch the tag and fail the spec as an unhandled request.
+    it('defers /tags/:slug to Ember', async () => {
+        await renderAdminApp('/tags/news');
+
+        await expect.poll(currentRoute).toBe('/tags/news');
+        expect(page.getByTestId('tag-detail').query()).toBeNull();
+    });
+
+    it('defers /tags/new to Ember', async () => {
+        await renderAdminApp('/tags/new');
+
+        await expect.poll(currentRoute).toBe('/tags/new');
+        expect(page.getByTestId('tag-detail').query()).toBeNull();
+    });
+});

--- a/apps/admin/src/tags/detail/tag-detail.acceptance.test.tsx
+++ b/apps/admin/src/tags/detail/tag-detail.acceptance.test.tsx
@@ -50,6 +50,22 @@ describe('Tag detail (tagDetailsReact on)', () => {
         expect(saved.visibility).toBe('public');
     });
 
+    it('guards edits made after a same-slug save', async () => {
+        const t = tag({name: 'News', slug: 'news', visibility: 'public'});
+        fakeTags([t]);
+        fakeTagWorld(t);
+        await renderAdminApp(`/tags/${t.slug}`, FLAGS);
+
+        await page.getByLabelText('Name', {exact: true}).fill('Renamed');
+        await page.getByRole('button', {name: 'Save'}).click();
+        await expect.element(page.getByRole('button', {name: 'Saved'})).toBeVisible();
+
+        await page.getByLabelText('Description', {exact: true}).fill('A later edit');
+        await page.getByTestId('tag-detail').getByRole('link', {name: 'Tags'}).click();
+
+        await expect.element(page.getByText('Are you sure you want to leave this page?')).toBeVisible();
+    });
+
     it('creates a tag from /tags/new, generating the slug from the name', async () => {
         const created = tag({name: 'Weekly News', slug: 'weekly-news'});
         const createApi = fakeAdminEndpoint('POST', new RegExp('^/tags/'), {tags: [created]});

--- a/apps/admin/src/tags/detail/tag-detail.acceptance.test.tsx
+++ b/apps/admin/src/tags/detail/tag-detail.acceptance.test.tsx
@@ -60,6 +60,24 @@ describe('Tag detail (tagDetailsReact on)', () => {
         await expect.element(page.getByRole('heading', {name: 'Unsplash'})).toBeVisible();
     });
 
+    it('does not treat an open image picker as a dirty tag', async () => {
+        const t = tag({name: 'News', slug: 'news', feature_image: null});
+        fakeTags([t]);
+        fakeTagWorld(t);
+        fakeEndpoint('GET', 'https://api.unsplash.com/photos', []);
+        await renderAdminApp(`/tags/${t.slug}`, FLAGS);
+
+        await page.getByRole('button', {name: 'Select tag image from Unsplash'}).click();
+        await expect.element(page.getByRole('heading', {name: 'Unsplash'})).toBeVisible();
+
+        const backLink = document.querySelector<HTMLAnchorElement>('[data-test-link="tags-back"]');
+        expect(backLink).not.toBeNull();
+        backLink?.click();
+
+        await expect.poll(currentRoute).toBe('/tags');
+        expect(page.getByText('Are you sure you want to leave this page?').query()).toBeNull();
+    });
+
     it('saves edits and reports the saved state', async () => {
         const t = tag({name: 'News', slug: 'news', visibility: 'public'});
         const saveApi = fakeTagWorld(t);
@@ -220,6 +238,93 @@ describe('Tag detail (tagDetailsReact on)', () => {
 
         pendingSave.resolve({tags: [{...t, name: 'Renamed'}]});
         await expect.element(page.getByRole('button', {name: 'Delete tag'})).toBeEnabled();
+    });
+
+    it('includes an immediately typed accent color in a keyboard save', async () => {
+        let current = tag({name: 'News', slug: 'news', accent_color: '#112233'});
+        fakeAdminEndpoint('GET', new RegExp(`^/tags/slug/${current.slug}/`), () => ({tags: [current]}));
+        const pendingSave = deferred<{tags: Tag[]}>();
+        const saveApi = fakeAdminEndpoint('PUT', new RegExp(`^/tags/${current.id}/`), async () => {
+            const response = await pendingSave.promise;
+            current = response.tags[0];
+            return response;
+        });
+        await renderAdminApp(`/tags/${current.slug}`, FLAGS);
+
+        await page.getByLabelText('Accent color hex value').fill('AABBCC');
+        await userEvent.keyboard('{Meta>}s{/Meta}');
+        await expect.poll(() => saveApi.requests.length).toBe(1);
+
+        const savedPayload = (saveApi.lastRequest?.body as {tags: Array<Record<string, unknown>>}).tags[0];
+        expect(savedPayload.accent_color).toBe('#AABBCC');
+        pendingSave.resolve({tags: [{...current, accent_color: '#AABBCC'}]});
+        await expect.element(page.getByRole('button', {name: 'Saved'})).toBeVisible();
+    });
+
+    it('waits for a pending save before continuing navigation', async () => {
+        let current = tag({name: 'News', slug: 'news'});
+        fakeTags([current]);
+        fakeAdminEndpoint('GET', new RegExp(`^/tags/slug/${current.slug}/`), () => ({tags: [current]}));
+        const pendingSave = deferred<{tags: Tag[]}>();
+        const saveApi = fakeAdminEndpoint('PUT', new RegExp(`^/tags/${current.id}/`), async () => {
+            const response = await pendingSave.promise;
+            current = response.tags[0];
+            return response;
+        });
+        await renderAdminApp(`/tags/${current.slug}`, FLAGS);
+
+        await page.getByLabelText('Name', {exact: true}).fill('Renamed');
+        await page.getByRole('button', {name: 'Save'}).click();
+        await expect.poll(() => saveApi.requests.length).toBe(1);
+        await page.getByTestId('tag-detail').getByRole('link', {name: 'Tags'}).click();
+
+        expect(page.getByText('Are you sure you want to leave this page?').query()).toBeNull();
+        await expect.poll(currentRoute).toBe('/tags/news');
+
+        pendingSave.resolve({tags: [{...current, name: 'Renamed'}]});
+        await expect.poll(currentRoute).toBe('/tags');
+    });
+
+    it('keeps the requested destination when a pending create resolves', async () => {
+        const created = tag({name: 'Weekly News', slug: 'weekly-news'});
+        fakeTags([]);
+        const pendingCreate = deferred<{tags: Tag[]}>();
+        const createApi = fakeAdminEndpoint('POST', new RegExp('^/tags/'), () => pendingCreate.promise);
+        await renderAdminApp('/tags/new', FLAGS);
+
+        await page.getByLabelText('Name', {exact: true}).fill('Weekly News');
+        await page.getByRole('button', {name: 'Save'}).click();
+        await expect.poll(() => createApi.requests.length).toBe(1);
+        await page.getByTestId('tag-detail').getByRole('link', {name: 'Tags'}).click();
+
+        expect(page.getByText('Are you sure you want to leave this page?').query()).toBeNull();
+        pendingCreate.resolve({tags: [created]});
+        await expect.poll(currentRoute).toBe('/tags');
+    });
+
+    it('shows the corrective API context when saving fails validation', async () => {
+        const t = tag({name: 'News', slug: 'news'});
+        fakeAdminEndpoint('GET', new RegExp(`^/tags/slug/${t.slug}/`), {tags: [t]});
+        fakeAdminEndpoint('PUT', new RegExp(`^/tags/${t.id}/`), {
+            errors: [{
+                code: null,
+                context: 'X title cannot be longer than 300 characters.',
+                details: null,
+                ghostErrorCode: null,
+                help: '',
+                id: 'validation-error',
+                message: 'Validation error, cannot edit tag.',
+                property: 'twitter_title',
+                type: 'ValidationError'
+            }]
+        }, {status: 422});
+        await renderAdminApp(`/tags/${t.slug}`, FLAGS);
+
+        await page.getByLabelText('Name', {exact: true}).fill('Renamed');
+        await page.getByRole('button', {name: 'Save'}).click();
+
+        await expect.element(page.getByText('X title cannot be longer than 300 characters.')).toBeVisible();
+        await expect.element(page.getByRole('button', {name: 'Retry'})).toBeVisible();
     });
 
     it('deletes the tag after confirming, reporting the posts it is used on', async () => {

--- a/apps/admin/src/tags/detail/tag-detail.acceptance.test.tsx
+++ b/apps/admin/src/tags/detail/tag-detail.acceptance.test.tsx
@@ -1,6 +1,7 @@
 import {describe, expect, it} from 'vitest';
 import {page, userEvent} from 'vitest/browser';
 
+import {deferred} from '@/utils/deferred';
 import {configResponse, currentRoute, fakeAdminEndpoint, fakeEndpoint, fakeTags, renderAdminApp, tag, type Tag} from '@test-utils/acceptance';
 
 const FLAGS = {labs: {tagDetailsReact: true}};
@@ -120,6 +121,7 @@ describe('Tag detail (tagDetailsReact on)', () => {
 
         // Ember replaces `/tags/new` with the saved tag's route after creating.
         await expect.poll(currentRoute).toBe('/tags/weekly-news');
+        await expect.element(page.getByRole('button', {name: 'Saved'})).toBeVisible();
         const sent = (createApi.lastRequest?.body as {tags: Array<Record<string, unknown>>}).tags[0];
         expect(sent.name).toBe('Weekly News');
         expect(sent.visibility).toBe('public');
@@ -133,8 +135,91 @@ describe('Tag detail (tagDetailsReact on)', () => {
         await page.getByLabelText('Name', {exact: true}).fill('');
         await page.getByRole('button', {name: 'Save'}).click();
 
-        await expect.element(page.getByText('You must specify a name for the tag.').first()).toBeVisible();
+        const nameInput = page.getByLabelText('Name', {exact: true});
+        const fieldError = page.elementLocator(document.getElementById('tag-name-error')!);
+        await expect.element(fieldError).toHaveTextContent('You must specify a name for the tag.');
+        await expect.element(nameInput).toHaveAttribute('aria-describedby', 'tag-name-error');
         expect(saveApi.requests.length).toBe(0);
+    });
+
+    it('waits for an image upload before allowing the tag to save', async () => {
+        const t = tag({name: 'News', slug: 'news', feature_image: null});
+        const saveApi = fakeTagWorld(t);
+        const pendingUpload = deferred<{images: {url: string; ref: null}[]}>();
+        const uploadApi = fakeAdminEndpoint('POST', '/images/upload/', () => pendingUpload.promise);
+        await renderAdminApp(`/tags/${t.slug}`, FLAGS);
+
+        const uploadInput = page.getByLabelText('Upload tag image');
+        await expect.element(uploadInput).toBeVisible();
+        await userEvent.upload(uploadInput.element(), new File(['image'], 'tag.png', {type: 'image/png'}));
+        await expect.poll(() => uploadApi.requests.length).toBe(1);
+        await expect.element(page.getByRole('button', {name: 'Save'})).toBeDisabled();
+        await expect.element(page.getByRole('button', {name: 'Delete tag'})).toBeDisabled();
+        await expect.element(page.getByRole('button', {name: 'Select tag image from Unsplash'})).toBeDisabled();
+
+        pendingUpload.resolve({images: [{url: 'https://example.com/tag.png', ref: null}]});
+        await expect.element(page.getByRole('button', {name: 'Save'})).toBeEnabled();
+        await page.getByRole('button', {name: 'Save'}).click();
+
+        await expect.element(page.getByRole('button', {name: 'Saved'})).toBeVisible();
+        const saved = (saveApi.lastRequest?.body as {tags: Array<Record<string, unknown>>}).tags[0];
+        expect(saved.feature_image).toBe('https://example.com/tag.png');
+    });
+
+    it('rejects image formats that the legacy uploader does not support', async () => {
+        const t = tag({name: 'News', slug: 'news', feature_image: null});
+        fakeTagWorld(t);
+        await renderAdminApp(`/tags/${t.slug}`, FLAGS);
+
+        await page.getByLabelText('Upload tag image').upload(new File(['image'], 'tag.bmp', {type: 'image/bmp'}));
+
+        await expect.element(page.getByText(/The image type you uploaded is not supported/)).toBeVisible();
+    });
+
+    it('shows the legacy message when an image exceeds the server limit', async () => {
+        const t = tag({name: 'News', slug: 'news', feature_image: null});
+        fakeTagWorld(t);
+        fakeAdminEndpoint('POST', '/images/upload/', null, {status: 413});
+        await renderAdminApp(`/tags/${t.slug}`, FLAGS);
+
+        await page.getByLabelText('Upload tag image').upload(new File(['image'], 'tag.png', {type: 'image/png'}));
+
+        await expect.element(page.getByText('The image you uploaded was larger than the maximum file size your server allows.')).toBeVisible();
+    });
+
+    it('clears save state when navigating to another tag', async () => {
+        const first = tag({name: 'First', slug: 'first'});
+        const second = tag({name: 'Second', slug: 'second'});
+        fakeTags([first, second]);
+        fakeTagWorld(first);
+        fakeTagWorld(second);
+        await renderAdminApp(`/tags/${first.slug}`, FLAGS);
+
+        await page.getByRole('button', {name: 'Save'}).click();
+        await expect.element(page.getByRole('button', {name: 'Saved'})).toBeVisible();
+        await page.getByTestId('tag-detail').getByRole('link', {name: 'Tags'}).click();
+        await page.getByRole('link', {name: 'Second', exact: true}).click();
+
+        await expect.element(page.getByTestId('tag-detail-title')).toHaveTextContent('Second');
+        await expect.element(page.getByRole('button', {name: 'Save', exact: true})).toBeVisible();
+        expect(page.getByRole('button', {name: 'Saved'}).query()).toBeNull();
+    });
+
+    it('does not allow deletion while a tag save is pending', async () => {
+        const t = tag({name: 'News', slug: 'news'});
+        fakeAdminEndpoint('GET', new RegExp(`^/tags/slug/${t.slug}/`), {tags: [t]});
+        const pendingSave = deferred<{tags: Tag[]}>();
+        const saveApi = fakeAdminEndpoint('PUT', new RegExp(`^/tags/${t.id}/`), () => pendingSave.promise);
+        await renderAdminApp(`/tags/${t.slug}`, FLAGS);
+
+        await page.getByLabelText('Name', {exact: true}).fill('Renamed');
+        await page.getByRole('button', {name: 'Save'}).click();
+        await expect.poll(() => saveApi.requests.length).toBe(1);
+
+        await expect.element(page.getByRole('button', {name: 'Delete tag'})).toBeDisabled();
+
+        pendingSave.resolve({tags: [{...t, name: 'Renamed'}]});
+        await expect.element(page.getByRole('button', {name: 'Delete tag'})).toBeEnabled();
     });
 
     it('deletes the tag after confirming, reporting the posts it is used on', async () => {
@@ -153,6 +238,17 @@ describe('Tag detail (tagDetailsReact on)', () => {
 
         await expect.poll(currentRoute).toBe('/tags');
         expect(deleteApi.requests.length).toBe(1);
+    });
+
+    it('uses the current draft name in the delete confirmation', async () => {
+        const t = tag({name: 'News', slug: 'news'});
+        fakeTagWorld(t);
+        await renderAdminApp(`/tags/${t.slug}`, FLAGS);
+
+        await page.getByLabelText('Name', {exact: true}).fill('Draft name');
+        await page.getByRole('button', {name: 'Delete tag', exact: true}).click();
+
+        await expect.element(page.getByTestId('delete-tag-modal').getByText('Draft name', {exact: true})).toBeVisible();
     });
 
     it('guards leaving with unsaved edits via the breadcrumb', async () => {

--- a/apps/admin/src/tags/detail/tag-detail.acceptance.test.tsx
+++ b/apps/admin/src/tags/detail/tag-detail.acceptance.test.tsx
@@ -34,19 +34,17 @@ describe('Tag detail (tagDetailsReact on)', () => {
         await expect.element(page.getByRole('button', {name: 'Delete tag', exact: true})).toBeVisible();
     });
 
-    it('remains accessible during a force upgrade', async () => {
-        const t = tag({name: 'News', slug: 'news'});
+    it('redirects to billing during a force upgrade', async () => {
         const config = configResponse(FLAGS);
         config.config.hostSettings = {forceUpgrade: true};
-        fakeTagWorld(t);
 
-        await renderAdminApp(`/tags/${t.slug}`, {
+        await renderAdminApp('/tags/news', {
             ...FLAGS,
             boot: {browseConfig: {response: config}}
         });
 
-        await expect.poll(currentRoute).toBe('/tags/news');
-        await expect.element(page.getByTestId('tag-detail-title')).toHaveTextContent('News');
+        await expect.poll(currentRoute).toBe('/pro');
+        expect(page.getByTestId('tag-detail').query()).toBeNull();
     });
 
     it('offers Unsplash for an empty tag image', async () => {

--- a/apps/admin/src/tags/detail/tag-detail.acceptance.test.tsx
+++ b/apps/admin/src/tags/detail/tag-detail.acceptance.test.tsx
@@ -1,7 +1,7 @@
 import {describe, expect, it} from 'vitest';
-import {page} from 'vitest/browser';
+import {page, userEvent} from 'vitest/browser';
 
-import {currentRoute, fakeAdminEndpoint, fakeTags, renderAdminApp, tag, type Tag} from '@test-utils/acceptance';
+import {configResponse, currentRoute, fakeAdminEndpoint, fakeEndpoint, fakeTags, renderAdminApp, tag, type Tag} from '@test-utils/acceptance';
 
 const FLAGS = {labs: {tagDetailsReact: true}};
 
@@ -33,6 +33,32 @@ describe('Tag detail (tagDetailsReact on)', () => {
         await expect.element(page.getByRole('button', {name: 'Delete tag', exact: true})).toBeVisible();
     });
 
+    it('remains accessible during a force upgrade', async () => {
+        const t = tag({name: 'News', slug: 'news'});
+        const config = configResponse(FLAGS);
+        config.config.hostSettings = {forceUpgrade: true};
+        fakeTagWorld(t);
+
+        await renderAdminApp(`/tags/${t.slug}`, {
+            ...FLAGS,
+            boot: {browseConfig: {response: config}}
+        });
+
+        await expect.poll(currentRoute).toBe('/tags/news');
+        await expect.element(page.getByTestId('tag-detail-title')).toHaveTextContent('News');
+    });
+
+    it('offers Unsplash for an empty tag image', async () => {
+        const t = tag({name: 'News', slug: 'news', feature_image: null});
+        fakeTagWorld(t);
+        fakeEndpoint('GET', 'https://api.unsplash.com/photos', []);
+        await renderAdminApp(`/tags/${t.slug}`, FLAGS);
+
+        await page.getByRole('button', {name: 'Select tag image from Unsplash'}).click();
+
+        await expect.element(page.getByRole('heading', {name: 'Unsplash'})).toBeVisible();
+    });
+
     it('saves edits and reports the saved state', async () => {
         const t = tag({name: 'News', slug: 'news', visibility: 'public'});
         const saveApi = fakeTagWorld(t);
@@ -48,6 +74,19 @@ describe('Tag detail (tagDetailsReact on)', () => {
         // The name changed, so the payload re-derives visibility (Ember
         // `models/tag.js` recomputes it in `save()` whenever the name changed).
         expect(saved.visibility).toBe('public');
+    });
+
+    it('preserves whitespace in untouched fields on a clean save', async () => {
+        const t = tag({name: 'News', slug: 'news', description: '\nImportant\n', meta_title: ' Meta title '});
+        const saveApi = fakeTagWorld(t);
+        await renderAdminApp(`/tags/${t.slug}`, FLAGS);
+
+        await page.getByRole('button', {name: 'Save'}).click();
+
+        await expect.element(page.getByRole('button', {name: 'Saved'})).toBeVisible();
+        const saved = (saveApi.lastRequest?.body as {tags: Array<Record<string, unknown>>}).tags[0];
+        expect(saved.description).toBe('\nImportant\n');
+        expect(saved.meta_title).toBe(' Meta title ');
     });
 
     it('guards edits made after a same-slug save', async () => {
@@ -73,7 +112,8 @@ describe('Tag detail (tagDetailsReact on)', () => {
         await renderAdminApp('/tags/new', FLAGS);
 
         await expect.element(page.getByTestId('tag-detail-title')).toHaveTextContent('New tag');
-        await page.getByLabelText('Name', {exact: true}).fill('Weekly News');
+        const nameInput = page.getByLabelText('Name', {exact: true});
+        await userEvent.type(nameInput.element(), 'Weekly News');
         await expect.element(page.getByLabelText('Slug', {exact: true})).toHaveValue('weekly-news');
 
         await page.getByRole('button', {name: 'Save'}).click();

--- a/apps/admin/src/tags/detail/tag-detail.acceptance.test.tsx
+++ b/apps/admin/src/tags/detail/tag-detail.acceptance.test.tsx
@@ -30,6 +30,9 @@ describe('Tag detail (tagDetailsReact on)', () => {
         await expect.element(page.getByTestId('tag-detail-title')).toHaveTextContent('News');
         await expect.element(page.getByLabelText('Name', {exact: true})).toHaveValue('News');
         await expect.element(page.getByLabelText('Slug', {exact: true})).toHaveValue('news');
+        // The host comes from the site endpoint's `url` (config has no
+        // blogUrl), scheme-stripped — never a bare `/tag/news/` path.
+        await expect.element(page.getByTestId('tag-slug-preview')).toHaveTextContent('test.com/tag/news/');
         await expect.element(page.getByLabelText('Description', {exact: true})).toHaveValue('All the news');
         await expect.element(page.getByRole('button', {name: 'Delete tag', exact: true})).toBeVisible();
     });

--- a/apps/admin/src/tags/detail/tag-detail.tsx
+++ b/apps/admin/src/tags/detail/tag-detail.tsx
@@ -13,7 +13,7 @@ import {dequal} from 'dequal';
 import {getTagBySlug, useAddTag, useEditTag} from '@tryghost/admin-x-framework/api/tags';
 import {toast} from 'sonner';
 import {useBlocker} from 'react-router';
-import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
+import {useBrowseSite} from '@tryghost/admin-x-framework/api/site';
 import {useHashLinkNavigationGuard} from '@/hooks/use-hash-link-navigation-guard';
 import type {TagsResponseType} from '@tryghost/admin-x-framework/api/tags';
 import type {TagEditableFields, TagFieldName} from './tag-detail-edit';
@@ -44,8 +44,10 @@ const TagDetail: React.FC = () => {
     const notFound = !isCreating && !isLoading && (error as {response?: Response} | null)?.response?.status === 404;
     const loadError = !isCreating && !isLoading && !!error && !notFound;
 
-    const {data: configData} = useBrowseConfig();
-    const blogUrl = configData?.config?.blogUrl ?? '';
+    // `blogUrl` is not part of the config API response — Ember derives it
+    // client-side from the site endpoint's `url` (`config-manager.js`).
+    const {data: siteData} = useBrowseSite();
+    const blogUrl = siteData?.site.url.replace(/\/$/, '') ?? '';
 
     const editMutation = useEditTag();
     const addMutation = useAddTag();
@@ -313,7 +315,9 @@ const TagDetail: React.FC = () => {
         saveLabel = 'Saved';
     }
 
-    const showEditor = !!draft && (isCreating || !!tag);
+    // Holding on `blogUrl` keeps host-less URL previews from ever painting;
+    // the shell's sidebar has normally warmed the site query already.
+    const showEditor = !!draft && !!blogUrl && (isCreating || !!tag);
     let title = '';
     if (isCreating) {
         title = 'New tag';

--- a/apps/admin/src/tags/detail/tag-detail.tsx
+++ b/apps/admin/src/tags/detail/tag-detail.tsx
@@ -146,11 +146,13 @@ const TagDetail: React.FC = () => {
                 toast.error('Couldn’t save the tag.');
                 return;
             }
-            // Ember replaces the route with the saved tag's slug after every
-            // save (`controllers/tag.js` `saveTask`), which moves `/tags/new`
-            // to the new slug and follows slug renames.
-            bypassGuardRef.current = true;
-            navigate(`/tags/${saved.slug}`, {replace: true});
+            // Move `/tags/new` to the saved tag and follow slug renames. A
+            // same-slug save needs no navigation; setting the bypass in that
+            // case would leave the unsaved-changes guard disabled indefinitely.
+            if (saved.slug !== tagSlug) {
+                bypassGuardRef.current = true;
+                navigate(`/tags/${saved.slug}`, {replace: true});
+            }
         };
         const onError = (saveError: unknown) => {
             const apiMessage = (saveError as {data?: {errors?: {message?: string | null}[]}} | null)?.data?.errors?.[0]?.message;
@@ -176,7 +178,7 @@ const TagDetail: React.FC = () => {
             },
             onError
         });
-    }, [draft, errors.accentColor, isCreating, tag, activeMutation.isPending, addMutation, editMutation, navigate]);
+    }, [draft, errors.accentColor, isCreating, tag, tagSlug, activeMutation.isPending, addMutation, editMutation, navigate]);
 
     // Cmd/Ctrl+S saves, matching the `{{on-key "cmd+s"}}` binding on the
     // Ember save button.

--- a/apps/admin/src/tags/detail/tag-detail.tsx
+++ b/apps/admin/src/tags/detail/tag-detail.tsx
@@ -5,7 +5,7 @@ import {Box, Container} from '@tryghost/shade/primitives';
 import {Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator, Button, type ButtonProps, LoadingIndicator, Skeleton} from '@tryghost/shade/components';
 import {DetailPage} from '@tryghost/shade/page-templates';
 import {DirtyConfirmDialog, PageHeader} from '@tryghost/shade/patterns';
-import {Link, useConfirmUnload, useNavigate, useParams} from '@tryghost/admin-x-framework';
+import {Link, useConfirmUnload, useHandleError, useNavigate, useParams} from '@tryghost/admin-x-framework';
 import {LucideIcon} from '@tryghost/shade/utils';
 import {NotFound} from '@/not-found';
 import {buildTagSavePayload, generateSlugFromName, getTagEditableSlice, getTagUrl, normalizeTagDraft, validateTagDraft} from './tag-detail-edit';
@@ -15,6 +15,7 @@ import {toast} from 'sonner';
 import {useBlocker} from 'react-router';
 import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
 import {useHashLinkNavigationGuard} from '@/hooks/use-hash-link-navigation-guard';
+import type {TagsResponseType} from '@tryghost/admin-x-framework/api/tags';
 import type {TagEditableFields, TagFieldName} from './tag-detail-edit';
 
 // The create screen reuses this route with the sentinel slug "new". Safe
@@ -29,6 +30,7 @@ type SaveStatus = 'idle' | 'pending' | 'success' | 'error';
 const TagDetail: React.FC = () => {
     const {tagSlug = ''} = useParams<{tagSlug: string}>();
     const navigate = useNavigate();
+    const handleError = useHandleError();
     const isCreating = tagSlug === CREATE_SLUG;
 
     // `include=count.posts` mirrors the Ember route so the delete modal can
@@ -64,10 +66,13 @@ const TagDetail: React.FC = () => {
     const hasChangedSlugRef = React.useRef(false);
     // Lets our own post-save redirect through the unsaved-changes blocker.
     const bypassGuardRef = React.useRef(false);
+    const blockedNavigationRef = React.useRef(false);
+    const proceedBlockedNavigationRef = React.useRef<() => void>(() => {});
     const [saveStatus, setSaveStatus] = React.useState<SaveStatus>('idle');
     const [showDelete, setShowDelete] = React.useState(false);
     const [isDeleting, setIsDeleting] = React.useState(false);
-    const [pendingImageUploads, setPendingImageUploads] = React.useState<Set<TagImageFieldName>>(new Set());
+    const [busyImageFields, setBusyImageFields] = React.useState<Set<TagImageFieldName>>(new Set());
+    const [uploadingImageFields, setUploadingImageFields] = React.useState<Set<TagImageFieldName>>(new Set());
 
     React.useEffect(() => {
         if (isCreating) {
@@ -104,22 +109,40 @@ const TagDetail: React.FC = () => {
     // Preserve the successful state only across our own post-save slug redirect.
     React.useEffect(() => {
         bypassGuardRef.current = false;
+        blockedNavigationRef.current = false;
         setShowDelete(false);
         setIsDeleting(false);
-        setPendingImageUploads(new Set());
+        setBusyImageFields(new Set());
+        setUploadingImageFields(new Set());
         setSaveStatus(savedRouteRef.current === tagSlug ? 'success' : 'idle');
         savedRouteRef.current = null;
         addMutation.reset();
         editMutation.reset();
     }, [tagSlug]);
 
-    const serverSlice = isCreating ? lastServerSliceRef.current : (tag ? getTagEditableSlice(tag) : undefined);
+    const serverSlice = lastServerSliceRef.current;
     const hasUnsavedChanges = !!draft && !!serverSlice && !dequal(normalizeTagDraft(draft, touchedFieldsRef.current), serverSlice);
-    const hasPendingImageUpload = pendingImageUploads.size > 0;
-    const isBusy = activeMutation.isPending || hasPendingImageUpload || isDeleting || showDelete;
+    const hasBusyImageField = busyImageFields.size > 0;
+    const hasPendingImageUpload = uploadingImageFields.size > 0;
+    const isBusy = activeMutation.isPending || hasBusyImageField || isDeleting || showDelete;
+
+    const onImageBusyChange = React.useCallback((field: TagImageFieldName, busy: boolean) => {
+        setBusyImageFields((current) => {
+            if (current.has(field) === busy) {
+                return current;
+            }
+            const next = new Set(current);
+            if (busy) {
+                next.add(field);
+            } else {
+                next.delete(field);
+            }
+            return next;
+        });
+    }, []);
 
     const onImageUploadPendingChange = React.useCallback((field: TagImageFieldName, pending: boolean) => {
-        setPendingImageUploads((current) => {
+        setUploadingImageFields((current) => {
             if (current.has(field) === pending) {
                 return current;
             }
@@ -186,7 +209,7 @@ const TagDetail: React.FC = () => {
         const submittedRoute = tagSlug;
         const submittedTagId = tag?.id;
         setSaveStatus('pending');
-        const onSuccess = (response: {tags?: {slug: string}[]}) => {
+        const onSuccess = (response: TagsResponseType) => {
             if (routeKeyRef.current !== submittedRoute) {
                 return;
             }
@@ -196,8 +219,15 @@ const TagDetail: React.FC = () => {
                 toast.error('Couldn’t save the tag.');
                 return;
             }
+            const savedSlice = getTagEditableSlice(saved);
+            lastServerSliceRef.current = savedSlice;
+            setDraft(savedSlice);
             touchedFieldsRef.current.clear();
             setSaveStatus('success');
+            if (blockedNavigationRef.current) {
+                proceedBlockedNavigationRef.current();
+                return;
+            }
             // Move `/tags/new` to the saved tag and follow slug renames. A
             // same-slug save needs no navigation; setting the bypass in that
             // case would leave the unsaved-changes guard disabled indefinitely.
@@ -212,8 +242,7 @@ const TagDetail: React.FC = () => {
                 return;
             }
             setSaveStatus('error');
-            const apiMessage = (saveError as {data?: {errors?: {message?: string | null}[]}} | null)?.data?.errors?.[0]?.message;
-            toast.error(apiMessage || 'Couldn’t save the tag.');
+            handleError(saveError);
         };
 
         if (isCreating) {
@@ -228,17 +257,11 @@ const TagDetail: React.FC = () => {
                 if (routeKeyRef.current !== submittedRoute || draftTagIdRef.current !== submittedTagId) {
                     return;
                 }
-                const saved = response.tags?.[0];
-                if (saved) {
-                    const savedSlice = getTagEditableSlice(saved);
-                    lastServerSliceRef.current = savedSlice;
-                    setDraft(savedSlice);
-                }
                 onSuccess(response);
             },
             onError
         });
-    }, [draft, errors.accentColor, isCreating, tag, tagSlug, isBusy, addMutation, editMutation, navigate]);
+    }, [draft, errors.accentColor, isCreating, tag, tagSlug, isBusy, addMutation, editMutation, navigate, handleError]);
 
     // Cmd/Ctrl+S saves, matching the `{{on-key "cmd+s"}}` binding on the
     // Ember save button.
@@ -262,6 +285,14 @@ const TagDetail: React.FC = () => {
     // route aborts and never registers into the `unsaved-changes` service.
     const anchorGuard = useHashLinkNavigationGuard(shouldGuardNavigation);
     const isBlocked = blocker.state === 'blocked' || anchorGuard.isBlocked;
+    blockedNavigationRef.current = isBlocked;
+    proceedBlockedNavigationRef.current = () => {
+        if (anchorGuard.isBlocked) {
+            anchorGuard.proceed();
+        } else {
+            blocker.proceed?.();
+        }
+    };
     // DirtyConfirmDialog's confirm action auto-closes the dialog, firing
     // onOpenChange(false) while the blocker still reads as blocked; without
     // this flag the close handler would reset the very navigation the user
@@ -358,11 +389,12 @@ const TagDetail: React.FC = () => {
                                 errors={errors}
                                 onChange={onFieldChange}
                                 onFieldError={onFieldError}
+                                onImageBusyChange={onImageBusyChange}
                                 onImageUploadPendingChange={onImageUploadPendingChange}
                             />
                             {!isCreating && tag && (
                                 <div>
-                                    <Button disabled={activeMutation.isPending || hasPendingImageUpload} variant='destructive' onClick={() => setShowDelete(true)}>Delete tag</Button>
+                                    <Button disabled={activeMutation.isPending || hasBusyImageField} variant='destructive' onClick={() => setShowDelete(true)}>Delete tag</Button>
                                 </div>
                             )}
                         </div>
@@ -371,6 +403,7 @@ const TagDetail: React.FC = () => {
 
                 {!isCreating && tag && (
                     <TagDeleteModal
+                        key={tag.id}
                         allowLeaveWithUnsavedChanges={() => {
                             bypassGuardRef.current = true;
                         }}
@@ -383,7 +416,7 @@ const TagDetail: React.FC = () => {
                 )}
 
                 <DirtyConfirmDialog
-                    open={isBlocked}
+                    open={isBlocked && !activeMutation.isPending}
                     onConfirm={() => {
                         leaveConfirmedRef.current = true;
                         if (anchorGuard.isBlocked) {

--- a/apps/admin/src/tags/detail/tag-detail.tsx
+++ b/apps/admin/src/tags/detail/tag-detail.tsx
@@ -1,0 +1,349 @@
+import React from 'react';
+import TagDeleteModal from './tag-delete-modal';
+import TagDetailForm from './tag-detail-form';
+import {Box, Container} from '@tryghost/shade/primitives';
+import {Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator, Button, type ButtonProps, LoadingIndicator, Skeleton} from '@tryghost/shade/components';
+import {DetailPage} from '@tryghost/shade/page-templates';
+import {DirtyConfirmDialog, PageHeader} from '@tryghost/shade/patterns';
+import {Link, useConfirmUnload, useNavigate, useParams} from '@tryghost/admin-x-framework';
+import {LucideIcon} from '@tryghost/shade/utils';
+import {NotFound} from '@/not-found';
+import {buildTagSavePayload, generateSlugFromName, getTagEditableSlice, getTagUrl, normalizeTagDraft, validateTagDraft} from './tag-detail-edit';
+import {dequal} from 'dequal';
+import {getTagBySlug, useAddTag, useEditTag} from '@tryghost/admin-x-framework/api/tags';
+import {toast} from 'sonner';
+import {useBlocker} from 'react-router';
+import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
+import {useHashLinkNavigationGuard} from '@/hooks/use-hash-link-navigation-guard';
+import type {TagEditableFields, TagFieldName} from './tag-detail-edit';
+
+// The create screen reuses this route with the sentinel slug "new". Safe
+// because Ember's router declared `/tags/new` before `/tags/:tag_slug`, so a
+// tag with the literal slug "new" was already unreachable in the admin.
+const CREATE_SLUG = 'new';
+
+type TagFieldErrors = Partial<Record<TagFieldName, string>>;
+
+const TagDetail: React.FC = () => {
+    const {tagSlug = ''} = useParams<{tagSlug: string}>();
+    const navigate = useNavigate();
+    const isCreating = tagSlug === CREATE_SLUG;
+
+    // `include=count.posts` mirrors the Ember route so the delete modal can
+    // report how many posts the tag will be removed from.
+    const {data, isLoading, error, refetch} = getTagBySlug(tagSlug, {
+        enabled: !!tagSlug && !isCreating,
+        searchParams: {include: 'count.posts'},
+        defaultErrorHandler: false
+    });
+    const tag = data?.tags?.[0];
+    const notFound = !isCreating && !isLoading && (error as {response?: Response} | null)?.response?.status === 404;
+    const loadError = !isCreating && !isLoading && !!error && !notFound;
+
+    const {data: configData} = useBrowseConfig();
+    const blogUrl = configData?.config?.blogUrl ?? '';
+
+    const editMutation = useEditTag();
+    const addMutation = useAddTag();
+    const activeMutation = isCreating ? addMutation : editMutation;
+
+    // Draft holds the user's in-progress edits; the query cache stays server truth.
+    const [draft, setDraft] = React.useState<TagEditableFields | undefined>(undefined);
+    const [errors, setErrors] = React.useState<TagFieldErrors>({});
+    const draftTagIdRef = React.useRef<string | undefined>(undefined);
+    const lastServerSliceRef = React.useRef<TagEditableFields | undefined>(undefined);
+    // Whether the user has manually edited the slug on the create screen —
+    // once they have, name changes stop regenerating it (Ember `tag-form.js`
+    // `hasChangedSlug`). Clearing the slug re-enables regeneration.
+    const hasChangedSlugRef = React.useRef(false);
+    // Lets our own post-save redirect through the unsaved-changes blocker.
+    const bypassGuardRef = React.useRef(false);
+
+    React.useEffect(() => {
+        if (isCreating) {
+            if (draftTagIdRef.current !== CREATE_SLUG) {
+                draftTagIdRef.current = CREATE_SLUG;
+                hasChangedSlugRef.current = false;
+                const empty = getTagEditableSlice({});
+                lastServerSliceRef.current = empty;
+                setDraft(empty);
+                setErrors({});
+            }
+            return;
+        }
+        if (!tag) {
+            return;
+        }
+        const nextServerSlice = getTagEditableSlice(tag);
+        if (draftTagIdRef.current !== tag.id) {
+            draftTagIdRef.current = tag.id;
+            lastServerSliceRef.current = nextServerSlice;
+            setDraft(nextServerSlice);
+            setErrors({});
+            return;
+        }
+        // Same tag, fresh server data: adopt it only if the user hasn't edited.
+        const previousServerSlice = lastServerSliceRef.current;
+        lastServerSliceRef.current = nextServerSlice;
+        setDraft(prev => ((!prev || (previousServerSlice && dequal(normalizeTagDraft(prev), previousServerSlice))) ? nextServerSlice : prev));
+    }, [tag, isCreating]);
+
+    // Reset the post-save redirect bypass whenever the route target changes.
+    React.useEffect(() => {
+        bypassGuardRef.current = false;
+    }, [tagSlug]);
+
+    const serverSlice = isCreating ? lastServerSliceRef.current : (tag ? getTagEditableSlice(tag) : undefined);
+    const hasUnsavedChanges = !!draft && !!serverSlice && !dequal(normalizeTagDraft(draft), serverSlice);
+
+    const onFieldChange = (patch: Partial<TagEditableFields>) => {
+        if (activeMutation.isError) {
+            activeMutation.reset();
+        }
+        if (isCreating && patch.name !== undefined && !hasChangedSlugRef.current) {
+            patch = {...patch, slug: generateSlugFromName(patch.name)};
+        }
+        if (patch.slug !== undefined) {
+            hasChangedSlugRef.current = !!patch.slug;
+        }
+        setDraft(prev => (prev ? {...prev, ...patch} : prev));
+    };
+
+    const onFieldError = (field: TagFieldName, message: string | null) => {
+        setErrors((prev) => {
+            if (message === null) {
+                if (!(field in prev)) {
+                    return prev;
+                }
+                const rest = {...prev};
+                delete rest[field];
+                return rest;
+            }
+            return {...prev, [field]: message};
+        });
+    };
+
+    const onSave = React.useCallback(() => {
+        if (!draft || activeMutation.isPending) {
+            return;
+        }
+        const validationErrors: TagFieldErrors = {...validateTagDraft(draft)};
+        // The colour field validates itself on input/blur; a lingering error
+        // there blocks saving exactly like Ember's pre-save errors check.
+        if (errors.accentColor) {
+            validationErrors.accentColor = errors.accentColor;
+        }
+        setErrors(validationErrors);
+        const firstError = Object.values(validationErrors)[0];
+        if (firstError) {
+            toast.error(firstError);
+            return;
+        }
+
+        const onSuccess = (response: {tags?: {slug: string}[]}) => {
+            const saved = response.tags?.[0];
+            if (!saved) {
+                toast.error('Couldn’t save the tag.');
+                return;
+            }
+            // Ember replaces the route with the saved tag's slug after every
+            // save (`controllers/tag.js` `saveTask`), which moves `/tags/new`
+            // to the new slug and follows slug renames.
+            bypassGuardRef.current = true;
+            navigate(`/tags/${saved.slug}`, {replace: true});
+        };
+        const onError = (saveError: unknown) => {
+            const apiMessage = (saveError as {data?: {errors?: {message?: string | null}[]}} | null)?.data?.errors?.[0]?.message;
+            toast.error(apiMessage || 'Couldn’t save the tag.');
+        };
+
+        if (isCreating) {
+            addMutation.mutate(buildTagSavePayload(draft, null), {onSuccess, onError});
+            return;
+        }
+        if (!tag || draftTagIdRef.current !== tag.id) {
+            return;
+        }
+        editMutation.mutate({id: tag.id, ...buildTagSavePayload(draft, getTagEditableSlice(tag).name)}, {
+            onSuccess: (response) => {
+                const saved = response.tags?.[0];
+                if (saved) {
+                    const savedSlice = getTagEditableSlice(saved);
+                    lastServerSliceRef.current = savedSlice;
+                    setDraft(savedSlice);
+                }
+                onSuccess(response);
+            },
+            onError
+        });
+    }, [draft, errors.accentColor, isCreating, tag, activeMutation.isPending, addMutation, editMutation, navigate]);
+
+    // Cmd/Ctrl+S saves, matching the `{{on-key "cmd+s"}}` binding on the
+    // Ember save button.
+    React.useEffect(() => {
+        const onKeyDown = (event: KeyboardEvent) => {
+            if ((event.metaKey || event.ctrlKey) && event.key === 's') {
+                event.preventDefault();
+                onSave();
+            }
+        };
+        document.addEventListener('keydown', onKeyDown);
+        return () => document.removeEventListener('keydown', onKeyDown);
+    }, [onSave]);
+
+    useConfirmUnload(activeMutation.isPending || hasUnsavedChanges);
+    const blocker = useBlocker(({currentLocation, nextLocation}) => !bypassGuardRef.current && hasUnsavedChanges && currentLocation.pathname !== nextLocation.pathname);
+    // Native `<a href="#/…">` navigations (the sidebar, links into Ember
+    // routes) never reach the react-router blocker above. Ember's own guard
+    // can't cover this screen either: with `tagDetailsReact` on, the Ember tag
+    // route aborts and never registers into the `unsaved-changes` service.
+    const anchorGuard = useHashLinkNavigationGuard(hasUnsavedChanges);
+    const isBlocked = blocker.state === 'blocked' || anchorGuard.isBlocked;
+    // DirtyConfirmDialog's confirm action auto-closes the dialog, firing
+    // onOpenChange(false) while the blocker still reads as blocked; without
+    // this flag the close handler would reset the very navigation the user
+    // just confirmed.
+    const leaveConfirmedRef = React.useRef(false);
+
+    const [showDelete, setShowDelete] = React.useState(false);
+
+    // Save button state (Save / Saving / Saved / Retry), mirroring the Ember
+    // task button. Unlike the member screen, the button stays enabled with no
+    // unsaved changes — Ember lets a clean tag be re-saved.
+    let saveLabel: React.ReactNode = 'Save';
+    let saveVariant: ButtonProps['variant'] = 'default';
+    if (activeMutation.isPending) {
+        saveLabel = <><LoadingIndicator size='sm' /><span className='sr-only'>Saving</span></>;
+    } else if (activeMutation.isError) {
+        saveLabel = 'Retry';
+        saveVariant = 'destructive';
+    } else if (activeMutation.isSuccess && !hasUnsavedChanges) {
+        saveLabel = 'Saved';
+    }
+
+    const showEditor = !!draft && (isCreating || !!tag);
+    let title = '';
+    if (isCreating) {
+        title = 'New tag';
+    } else if (draft && showEditor) {
+        title = draft.name;
+    } else if (tag) {
+        title = tag.name;
+    }
+
+    if (notFound) {
+        return <NotFound />;
+    }
+
+    return (
+        <Box className='size-full'><Container className='relative flex h-full flex-col' size='page'>
+            <DetailPage data-testid='tag-detail'>
+                <DetailPage.Header>
+                    <PageHeader blurredBackground={false} sticky={false}>
+                        <PageHeader.Left>
+                            <Breadcrumb>
+                                <BreadcrumbList>
+                                    <BreadcrumbItem>
+                                        <BreadcrumbLink asChild>
+                                            <Link data-test-link='tags-back' to='/tags'>Tags</Link>
+                                        </BreadcrumbLink>
+                                    </BreadcrumbItem>
+                                    <BreadcrumbSeparator />
+                                    <BreadcrumbItem>
+                                        {!isCreating && isLoading ? (
+                                            <Skeleton className='h-4 w-40' />
+                                        ) : (
+                                            <BreadcrumbPage className='truncate' data-testid='tag-detail-title'>
+                                                {title}
+                                            </BreadcrumbPage>
+                                        )}
+                                    </BreadcrumbItem>
+                                </BreadcrumbList>
+                            </Breadcrumb>
+                        </PageHeader.Left>
+                        {showEditor && draft && (
+                            <PageHeader.Actions>
+                                <PageHeader.ActionGroup>
+                                    <Button variant='outline' asChild>
+                                        <a href={getTagUrl(draft, blogUrl)} rel='noopener noreferrer' target='_blank'>
+                                            View
+                                            <LucideIcon.ExternalLink />
+                                        </a>
+                                    </Button>
+                                    <Button className='min-w-16' disabled={activeMutation.isPending} variant={saveVariant} onClick={onSave}>
+                                        {saveLabel}
+                                    </Button>
+                                </PageHeader.ActionGroup>
+                            </PageHeader.Actions>
+                        )}
+                    </PageHeader>
+                </DetailPage.Header>
+
+                <DetailPage.Body>
+                    {loadError && (
+                        <div className='flex flex-1 flex-col items-center justify-center gap-3' data-testid='tag-detail-load-error'>
+                            <p className='text-muted-foreground'>Couldn’t load this tag.</p>
+                            <Button variant='outline' onClick={() => void refetch()}>Retry</Button>
+                        </div>
+                    )}
+
+                    {showEditor && draft && (
+                        <div className='flex flex-col gap-8'>
+                            <TagDetailForm
+                                blogUrl={blogUrl}
+                                disabled={activeMutation.isPending}
+                                draft={draft}
+                                errors={errors}
+                                onChange={onFieldChange}
+                                onFieldError={onFieldError}
+                            />
+                            {!isCreating && tag && (
+                                <div>
+                                    <Button variant='destructive' onClick={() => setShowDelete(true)}>Delete tag</Button>
+                                </div>
+                            )}
+                        </div>
+                    )}
+                </DetailPage.Body>
+
+                {!isCreating && tag && (
+                    <TagDeleteModal
+                        allowLeaveWithUnsavedChanges={() => {
+                            bypassGuardRef.current = true;
+                        }}
+                        open={showDelete}
+                        tag={tag}
+                        onOpenChange={setShowDelete}
+                    />
+                )}
+
+                <DirtyConfirmDialog
+                    open={isBlocked}
+                    onConfirm={() => {
+                        leaveConfirmedRef.current = true;
+                        if (anchorGuard.isBlocked) {
+                            anchorGuard.proceed();
+                        } else {
+                            blocker.proceed?.();
+                        }
+                    }}
+                    onOpenChange={(open) => {
+                        if (open) {
+                            return;
+                        }
+                        if (leaveConfirmedRef.current) {
+                            leaveConfirmedRef.current = false;
+                            return;
+                        }
+                        if (isBlocked) {
+                            blocker.reset?.();
+                            anchorGuard.reset();
+                        }
+                    }}
+                />
+            </DetailPage>
+        </Container></Box>
+    );
+};
+
+export default TagDetail;

--- a/apps/admin/src/tags/detail/tag-detail.tsx
+++ b/apps/admin/src/tags/detail/tag-detail.tsx
@@ -52,6 +52,7 @@ const TagDetail: React.FC = () => {
     const [errors, setErrors] = React.useState<TagFieldErrors>({});
     const draftTagIdRef = React.useRef<string | undefined>(undefined);
     const lastServerSliceRef = React.useRef<TagEditableFields | undefined>(undefined);
+    const touchedFieldsRef = React.useRef<Set<TagFieldName>>(new Set());
     // Whether the user has manually edited the slug on the create screen —
     // once they have, name changes stop regenerating it (Ember `tag-form.js`
     // `hasChangedSlug`). Clearing the slug re-enables regeneration.
@@ -64,6 +65,7 @@ const TagDetail: React.FC = () => {
             if (draftTagIdRef.current !== CREATE_SLUG) {
                 draftTagIdRef.current = CREATE_SLUG;
                 hasChangedSlugRef.current = false;
+                touchedFieldsRef.current.clear();
                 const empty = getTagEditableSlice({});
                 lastServerSliceRef.current = empty;
                 setDraft(empty);
@@ -77,6 +79,7 @@ const TagDetail: React.FC = () => {
         const nextServerSlice = getTagEditableSlice(tag);
         if (draftTagIdRef.current !== tag.id) {
             draftTagIdRef.current = tag.id;
+            touchedFieldsRef.current.clear();
             lastServerSliceRef.current = nextServerSlice;
             setDraft(nextServerSlice);
             setErrors({});
@@ -85,7 +88,7 @@ const TagDetail: React.FC = () => {
         // Same tag, fresh server data: adopt it only if the user hasn't edited.
         const previousServerSlice = lastServerSliceRef.current;
         lastServerSliceRef.current = nextServerSlice;
-        setDraft(prev => ((!prev || (previousServerSlice && dequal(normalizeTagDraft(prev), previousServerSlice))) ? nextServerSlice : prev));
+        setDraft(prev => ((!prev || (previousServerSlice && dequal(normalizeTagDraft(prev, touchedFieldsRef.current), previousServerSlice))) ? nextServerSlice : prev));
     }, [tag, isCreating]);
 
     // Reset the post-save redirect bypass whenever the route target changes.
@@ -94,16 +97,20 @@ const TagDetail: React.FC = () => {
     }, [tagSlug]);
 
     const serverSlice = isCreating ? lastServerSliceRef.current : (tag ? getTagEditableSlice(tag) : undefined);
-    const hasUnsavedChanges = !!draft && !!serverSlice && !dequal(normalizeTagDraft(draft), serverSlice);
+    const hasUnsavedChanges = !!draft && !!serverSlice && !dequal(normalizeTagDraft(draft, touchedFieldsRef.current), serverSlice);
 
     const onFieldChange = (patch: Partial<TagEditableFields>) => {
         if (activeMutation.isError) {
             activeMutation.reset();
         }
+        const manuallyChangedSlug = patch.slug !== undefined;
+        for (const field of Object.keys(patch) as TagFieldName[]) {
+            touchedFieldsRef.current.add(field);
+        }
         if (isCreating && patch.name !== undefined && !hasChangedSlugRef.current) {
             patch = {...patch, slug: generateSlugFromName(patch.name)};
         }
-        if (patch.slug !== undefined) {
+        if (manuallyChangedSlug) {
             hasChangedSlugRef.current = !!patch.slug;
         }
         setDraft(prev => (prev ? {...prev, ...patch} : prev));
@@ -146,6 +153,7 @@ const TagDetail: React.FC = () => {
                 toast.error('Couldn’t save the tag.');
                 return;
             }
+            touchedFieldsRef.current.clear();
             // Move `/tags/new` to the saved tag and follow slug renames. A
             // same-slug save needs no navigation; setting the bypass in that
             // case would leave the unsaved-changes guard disabled indefinitely.
@@ -160,13 +168,13 @@ const TagDetail: React.FC = () => {
         };
 
         if (isCreating) {
-            addMutation.mutate(buildTagSavePayload(draft, null), {onSuccess, onError});
+            addMutation.mutate(buildTagSavePayload(draft, null, touchedFieldsRef.current), {onSuccess, onError});
             return;
         }
         if (!tag || draftTagIdRef.current !== tag.id) {
             return;
         }
-        editMutation.mutate({id: tag.id, ...buildTagSavePayload(draft, getTagEditableSlice(tag).name)}, {
+        editMutation.mutate({id: tag.id, ...buildTagSavePayload(draft, getTagEditableSlice(tag).name, touchedFieldsRef.current)}, {
             onSuccess: (response) => {
                 const saved = response.tags?.[0];
                 if (saved) {

--- a/apps/admin/src/tags/detail/tag-detail.tsx
+++ b/apps/admin/src/tags/detail/tag-detail.tsx
@@ -23,6 +23,8 @@ import type {TagEditableFields, TagFieldName} from './tag-detail-edit';
 const CREATE_SLUG = 'new';
 
 type TagFieldErrors = Partial<Record<TagFieldName, string>>;
+type TagImageFieldName = 'featureImage' | 'twitterImage' | 'ogImage';
+type SaveStatus = 'idle' | 'pending' | 'success' | 'error';
 
 const TagDetail: React.FC = () => {
     const {tagSlug = ''} = useParams<{tagSlug: string}>();
@@ -53,12 +55,19 @@ const TagDetail: React.FC = () => {
     const draftTagIdRef = React.useRef<string | undefined>(undefined);
     const lastServerSliceRef = React.useRef<TagEditableFields | undefined>(undefined);
     const touchedFieldsRef = React.useRef<Set<TagFieldName>>(new Set());
+    const routeKeyRef = React.useRef(tagSlug);
+    routeKeyRef.current = tagSlug;
+    const savedRouteRef = React.useRef<string | null>(null);
     // Whether the user has manually edited the slug on the create screen —
     // once they have, name changes stop regenerating it (Ember `tag-form.js`
     // `hasChangedSlug`). Clearing the slug re-enables regeneration.
     const hasChangedSlugRef = React.useRef(false);
     // Lets our own post-save redirect through the unsaved-changes blocker.
     const bypassGuardRef = React.useRef(false);
+    const [saveStatus, setSaveStatus] = React.useState<SaveStatus>('idle');
+    const [showDelete, setShowDelete] = React.useState(false);
+    const [isDeleting, setIsDeleting] = React.useState(false);
+    const [pendingImageUploads, setPendingImageUploads] = React.useState<Set<TagImageFieldName>>(new Set());
 
     React.useEffect(() => {
         if (isCreating) {
@@ -91,18 +100,44 @@ const TagDetail: React.FC = () => {
         setDraft(prev => ((!prev || (previousServerSlice && dequal(normalizeTagDraft(prev, touchedFieldsRef.current), previousServerSlice))) ? nextServerSlice : prev));
     }, [tag, isCreating]);
 
-    // Reset the post-save redirect bypass whenever the route target changes.
+    // Reset route-scoped UI and mutation state whenever the target changes.
+    // Preserve the successful state only across our own post-save slug redirect.
     React.useEffect(() => {
         bypassGuardRef.current = false;
+        setShowDelete(false);
+        setIsDeleting(false);
+        setPendingImageUploads(new Set());
+        setSaveStatus(savedRouteRef.current === tagSlug ? 'success' : 'idle');
+        savedRouteRef.current = null;
+        addMutation.reset();
+        editMutation.reset();
     }, [tagSlug]);
 
     const serverSlice = isCreating ? lastServerSliceRef.current : (tag ? getTagEditableSlice(tag) : undefined);
     const hasUnsavedChanges = !!draft && !!serverSlice && !dequal(normalizeTagDraft(draft, touchedFieldsRef.current), serverSlice);
+    const hasPendingImageUpload = pendingImageUploads.size > 0;
+    const isBusy = activeMutation.isPending || hasPendingImageUpload || isDeleting || showDelete;
+
+    const onImageUploadPendingChange = React.useCallback((field: TagImageFieldName, pending: boolean) => {
+        setPendingImageUploads((current) => {
+            if (current.has(field) === pending) {
+                return current;
+            }
+            const next = new Set(current);
+            if (pending) {
+                next.add(field);
+            } else {
+                next.delete(field);
+            }
+            return next;
+        });
+    }, []);
 
     const onFieldChange = (patch: Partial<TagEditableFields>) => {
-        if (activeMutation.isError) {
+        if (saveStatus === 'error') {
             activeMutation.reset();
         }
+        setSaveStatus('idle');
         const manuallyChangedSlug = patch.slug !== undefined;
         for (const field of Object.keys(patch) as TagFieldName[]) {
             touchedFieldsRef.current.add(field);
@@ -131,7 +166,7 @@ const TagDetail: React.FC = () => {
     };
 
     const onSave = React.useCallback(() => {
-        if (!draft || activeMutation.isPending) {
+        if (!draft || isBusy || (!isCreating && (!tag || draftTagIdRef.current !== tag.id))) {
             return;
         }
         const validationErrors: TagFieldErrors = {...validateTagDraft(draft)};
@@ -143,26 +178,40 @@ const TagDetail: React.FC = () => {
         setErrors(validationErrors);
         const firstError = Object.values(validationErrors)[0];
         if (firstError) {
+            setSaveStatus('idle');
             toast.error(firstError);
             return;
         }
 
+        const submittedRoute = tagSlug;
+        const submittedTagId = tag?.id;
+        setSaveStatus('pending');
         const onSuccess = (response: {tags?: {slug: string}[]}) => {
+            if (routeKeyRef.current !== submittedRoute) {
+                return;
+            }
             const saved = response.tags?.[0];
             if (!saved) {
+                setSaveStatus('error');
                 toast.error('Couldn’t save the tag.');
                 return;
             }
             touchedFieldsRef.current.clear();
+            setSaveStatus('success');
             // Move `/tags/new` to the saved tag and follow slug renames. A
             // same-slug save needs no navigation; setting the bypass in that
             // case would leave the unsaved-changes guard disabled indefinitely.
             if (saved.slug !== tagSlug) {
+                savedRouteRef.current = saved.slug;
                 bypassGuardRef.current = true;
                 navigate(`/tags/${saved.slug}`, {replace: true});
             }
         };
         const onError = (saveError: unknown) => {
+            if (routeKeyRef.current !== submittedRoute) {
+                return;
+            }
+            setSaveStatus('error');
             const apiMessage = (saveError as {data?: {errors?: {message?: string | null}[]}} | null)?.data?.errors?.[0]?.message;
             toast.error(apiMessage || 'Couldn’t save the tag.');
         };
@@ -171,11 +220,14 @@ const TagDetail: React.FC = () => {
             addMutation.mutate(buildTagSavePayload(draft, null, touchedFieldsRef.current), {onSuccess, onError});
             return;
         }
-        if (!tag || draftTagIdRef.current !== tag.id) {
+        if (!tag) {
             return;
         }
         editMutation.mutate({id: tag.id, ...buildTagSavePayload(draft, getTagEditableSlice(tag).name, touchedFieldsRef.current)}, {
             onSuccess: (response) => {
+                if (routeKeyRef.current !== submittedRoute || draftTagIdRef.current !== submittedTagId) {
+                    return;
+                }
                 const saved = response.tags?.[0];
                 if (saved) {
                     const savedSlice = getTagEditableSlice(saved);
@@ -186,7 +238,7 @@ const TagDetail: React.FC = () => {
             },
             onError
         });
-    }, [draft, errors.accentColor, isCreating, tag, tagSlug, activeMutation.isPending, addMutation, editMutation, navigate]);
+    }, [draft, errors.accentColor, isCreating, tag, tagSlug, isBusy, addMutation, editMutation, navigate]);
 
     // Cmd/Ctrl+S saves, matching the `{{on-key "cmd+s"}}` binding on the
     // Ember save button.
@@ -201,13 +253,14 @@ const TagDetail: React.FC = () => {
         return () => document.removeEventListener('keydown', onKeyDown);
     }, [onSave]);
 
-    useConfirmUnload(activeMutation.isPending || hasUnsavedChanges);
-    const blocker = useBlocker(({currentLocation, nextLocation}) => !bypassGuardRef.current && hasUnsavedChanges && currentLocation.pathname !== nextLocation.pathname);
+    const shouldGuardNavigation = activeMutation.isPending || hasPendingImageUpload || isDeleting || hasUnsavedChanges;
+    useConfirmUnload(shouldGuardNavigation);
+    const blocker = useBlocker(({currentLocation, nextLocation}) => !bypassGuardRef.current && shouldGuardNavigation && currentLocation.pathname !== nextLocation.pathname);
     // Native `<a href="#/…">` navigations (the sidebar, links into Ember
     // routes) never reach the react-router blocker above. Ember's own guard
     // can't cover this screen either: with `tagDetailsReact` on, the Ember tag
     // route aborts and never registers into the `unsaved-changes` service.
-    const anchorGuard = useHashLinkNavigationGuard(hasUnsavedChanges);
+    const anchorGuard = useHashLinkNavigationGuard(shouldGuardNavigation);
     const isBlocked = blocker.state === 'blocked' || anchorGuard.isBlocked;
     // DirtyConfirmDialog's confirm action auto-closes the dialog, firing
     // onOpenChange(false) while the blocker still reads as blocked; without
@@ -215,19 +268,17 @@ const TagDetail: React.FC = () => {
     // just confirmed.
     const leaveConfirmedRef = React.useRef(false);
 
-    const [showDelete, setShowDelete] = React.useState(false);
-
     // Save button state (Save / Saving / Saved / Retry), mirroring the Ember
     // task button. Unlike the member screen, the button stays enabled with no
     // unsaved changes — Ember lets a clean tag be re-saved.
     let saveLabel: React.ReactNode = 'Save';
     let saveVariant: ButtonProps['variant'] = 'default';
-    if (activeMutation.isPending) {
+    if (saveStatus === 'pending') {
         saveLabel = <><LoadingIndicator size='sm' /><span className='sr-only'>Saving</span></>;
-    } else if (activeMutation.isError) {
+    } else if (saveStatus === 'error') {
         saveLabel = 'Retry';
         saveVariant = 'destructive';
-    } else if (activeMutation.isSuccess && !hasUnsavedChanges) {
+    } else if (saveStatus === 'success' && !hasUnsavedChanges) {
         saveLabel = 'Saved';
     }
 
@@ -280,7 +331,7 @@ const TagDetail: React.FC = () => {
                                             <LucideIcon.ExternalLink />
                                         </a>
                                     </Button>
-                                    <Button className='min-w-16' disabled={activeMutation.isPending} variant={saveVariant} onClick={onSave}>
+                                    <Button className='min-w-16' disabled={isBusy} variant={saveVariant} onClick={onSave}>
                                         {saveLabel}
                                     </Button>
                                 </PageHeader.ActionGroup>
@@ -300,16 +351,18 @@ const TagDetail: React.FC = () => {
                     {showEditor && draft && (
                         <div className='flex flex-col gap-8'>
                             <TagDetailForm
+                                key={isCreating ? CREATE_SLUG : tag?.id}
                                 blogUrl={blogUrl}
-                                disabled={activeMutation.isPending}
+                                disabled={activeMutation.isPending || isDeleting}
                                 draft={draft}
                                 errors={errors}
                                 onChange={onFieldChange}
                                 onFieldError={onFieldError}
+                                onImageUploadPendingChange={onImageUploadPendingChange}
                             />
                             {!isCreating && tag && (
                                 <div>
-                                    <Button variant='destructive' onClick={() => setShowDelete(true)}>Delete tag</Button>
+                                    <Button disabled={activeMutation.isPending || hasPendingImageUpload} variant='destructive' onClick={() => setShowDelete(true)}>Delete tag</Button>
                                 </div>
                             )}
                         </div>
@@ -321,9 +374,11 @@ const TagDetail: React.FC = () => {
                         allowLeaveWithUnsavedChanges={() => {
                             bypassGuardRef.current = true;
                         }}
+                        displayName={draft?.name ?? tag.name}
                         open={showDelete}
                         tag={tag}
                         onOpenChange={setShowDelete}
+                        onPendingChange={setIsDeleting}
                     />
                 )}
 

--- a/apps/admin/src/tags/detail/tag-image-field.tsx
+++ b/apps/admin/src/tags/detail/tag-image-field.tsx
@@ -29,7 +29,8 @@ interface TagImageFieldProps {
     disabled?: boolean;
     unsplashEnabled?: boolean;
     onChange: (url: string) => void;
-    onPendingChange?: (pending: boolean) => void;
+    onBusyChange?: (busy: boolean) => void;
+    onUploadPendingChange?: (pending: boolean) => void;
 }
 
 /**
@@ -37,25 +38,36 @@ interface TagImageFieldProps {
  * standing in for Ember's `GhImageUploaderWithPreview`: an upload dropzone
  * when empty, a preview with edit/remove actions when set.
  */
-const TagImageField: React.FC<TagImageFieldProps> = ({id, label, uploadText, value, disabled, unsplashEnabled, onChange, onPendingChange}) => {
+const TagImageField: React.FC<TagImageFieldProps> = ({id, label, uploadText, value, disabled, unsplashEnabled, onChange, onBusyChange, onUploadPendingChange}) => {
     const {mutateAsync: uploadImage, isPending} = useUploadImage();
     const {unsplashConfig} = useFramework();
     const editor = usePinturaEditor({disabled});
     const [showUnsplash, setShowUnsplash] = React.useState(false);
+    const [operationPending, setOperationPending] = React.useState(false);
     const mountedRef = React.useRef(true);
     const operationPendingRef = React.useRef(false);
-    const onPendingChangeRef = React.useRef(onPendingChange);
-    onPendingChangeRef.current = onPendingChange;
+    const onBusyChangeRef = React.useRef(onBusyChange);
+    onBusyChangeRef.current = onBusyChange;
+    const onUploadPendingChangeRef = React.useRef(onUploadPendingChange);
+    onUploadPendingChangeRef.current = onUploadPendingChange;
 
     React.useEffect(() => {
         mountedRef.current = true;
         return () => {
             mountedRef.current = false;
-            if (operationPendingRef.current) {
-                onPendingChangeRef.current?.(false);
-            }
+            onBusyChangeRef.current?.(false);
+            onUploadPendingChangeRef.current?.(false);
         };
     }, []);
+
+    const isBusy = operationPending || showUnsplash || editor.isOpen;
+    React.useEffect(() => {
+        onBusyChangeRef.current?.(isBusy);
+    }, [isBusy]);
+
+    React.useEffect(() => {
+        onUploadPendingChangeRef.current?.(operationPending);
+    }, [operationPending]);
 
     React.useEffect(() => {
         if (isPending) {
@@ -65,15 +77,16 @@ const TagImageField: React.FC<TagImageFieldProps> = ({id, label, uploadText, val
 
     const handleUpload = async (file: File) => {
         if (operationPendingRef.current) {
-            return;
+            return false;
         }
         operationPendingRef.current = true;
-        onPendingChangeRef.current?.(true);
+        setOperationPending(true);
         try {
             const response = await uploadImage({file});
             if (mountedRef.current) {
                 onChange(getImageUrl(response));
             }
+            return true;
         } catch (error) {
             let message = 'Couldn’t upload the image.';
             if (error instanceof UnsupportedMediaTypeError) {
@@ -86,15 +99,16 @@ const TagImageField: React.FC<TagImageFieldProps> = ({id, label, uploadText, val
             if (mountedRef.current) {
                 toast.error(message);
             }
+            return false;
         } finally {
             operationPendingRef.current = false;
             if (mountedRef.current) {
-                onPendingChangeRef.current?.(false);
+                setOperationPending(false);
             }
         }
     };
 
-    const fieldDisabled = disabled || isPending;
+    const fieldDisabled = disabled || operationPending || isPending;
 
     return (
         <Stack gap='sm'>

--- a/apps/admin/src/tags/detail/tag-image-field.tsx
+++ b/apps/admin/src/tags/detail/tag-image-field.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import {ImageUpload, ImageUploadAction, ImageUploadActions, ImageUploadDropzone, ImageUploadImage, ImageUploadPreview} from '@tryghost/shade/patterns';
+import {Label, LoadingIndicator} from '@tryghost/shade/components';
+import {LucideIcon} from '@tryghost/shade/utils';
+import {getImageUrl, useUploadImage} from '@tryghost/admin-x-framework/api/images';
+import {toast} from 'sonner';
+
+interface TagImageFieldProps {
+    id: string;
+    label: string;
+    uploadText: string;
+    value: string;
+    disabled?: boolean;
+    onChange: (url: string) => void;
+}
+
+/**
+ * One image slot on the tag form (tag image, X image, Facebook image),
+ * standing in for Ember's `GhImageUploaderWithPreview`: an upload dropzone
+ * when empty, a preview with a remove action when set.
+ */
+const TagImageField: React.FC<TagImageFieldProps> = ({id, label, uploadText, value, disabled, onChange}) => {
+    const {mutateAsync: uploadImage, isPending} = useUploadImage();
+
+    const handleUpload = async (file: File) => {
+        try {
+            const response = await uploadImage({file});
+            onChange(getImageUrl(response));
+        } catch {
+            toast.error('Couldn’t upload the image.');
+        }
+    };
+
+    return (
+        <div className='flex flex-col gap-1.5'>
+            <Label htmlFor={id}>{label}</Label>
+            <ImageUpload className='h-40'>
+                {value ? (
+                    <ImageUploadPreview>
+                        <ImageUploadImage alt='' src={value} />
+                        <ImageUploadActions>
+                            <ImageUploadAction aria-label={`Remove ${label.toLowerCase()}`} disabled={disabled} onClick={() => onChange('')}>
+                                <LucideIcon.Trash2 />
+                            </ImageUploadAction>
+                        </ImageUploadActions>
+                    </ImageUploadPreview>
+                ) : (
+                    <ImageUploadDropzone
+                        accept={{'image/*': []}}
+                        disabled={disabled || isPending}
+                        inputAriaLabel={uploadText}
+                        inputId={id}
+                        onDropAccepted={(files) => {
+                            if (files[0]) {
+                                void handleUpload(files[0]);
+                            }
+                        }}
+                        onDropRejected={() => toast.error('The image type you uploaded is not supported. Please use .GIF, .JPG, .JPEG, .PNG, .SVG, .SVGZ, .WEBP')}
+                    >
+                        {isPending ? (
+                            <LoadingIndicator size='sm' />
+                        ) : (
+                            <span className='text-sm text-muted-foreground'>{uploadText}</span>
+                        )}
+                    </ImageUploadDropzone>
+                )}
+            </ImageUpload>
+        </div>
+    );
+};
+
+export default TagImageField;

--- a/apps/admin/src/tags/detail/tag-image-field.tsx
+++ b/apps/admin/src/tags/detail/tag-image-field.tsx
@@ -8,7 +8,18 @@ import {createPortal} from 'react-dom';
 import {getImageUrl, useUploadImage} from '@tryghost/admin-x-framework/api/images';
 import {useFramework} from '@tryghost/admin-x-framework';
 import {usePinturaEditor} from '@/hooks/use-pintura-editor';
+import {JSONError, RequestEntityTooLargeError, UnsupportedMediaTypeError} from '@tryghost/admin-x-framework/errors';
 import {toast} from 'sonner';
+
+const ACCEPTED_IMAGE_TYPES = {
+    'image/gif': ['.gif'],
+    'image/jpeg': ['.jpg', '.jpeg'],
+    'image/png': ['.png'],
+    'image/svg+xml': ['.svg', '.svgz'],
+    'image/webp': ['.webp']
+};
+
+const UNSUPPORTED_IMAGE_MESSAGE = 'The image type you uploaded is not supported. Please use .GIF, .JPG, .JPEG, .PNG, .SVG, .SVGZ, .WEBP';
 
 interface TagImageFieldProps {
     id: string;
@@ -18,6 +29,7 @@ interface TagImageFieldProps {
     disabled?: boolean;
     unsplashEnabled?: boolean;
     onChange: (url: string) => void;
+    onPendingChange?: (pending: boolean) => void;
 }
 
 /**
@@ -25,20 +37,64 @@ interface TagImageFieldProps {
  * standing in for Ember's `GhImageUploaderWithPreview`: an upload dropzone
  * when empty, a preview with edit/remove actions when set.
  */
-const TagImageField: React.FC<TagImageFieldProps> = ({id, label, uploadText, value, disabled, unsplashEnabled, onChange}) => {
+const TagImageField: React.FC<TagImageFieldProps> = ({id, label, uploadText, value, disabled, unsplashEnabled, onChange, onPendingChange}) => {
     const {mutateAsync: uploadImage, isPending} = useUploadImage();
     const {unsplashConfig} = useFramework();
     const editor = usePinturaEditor({disabled});
     const [showUnsplash, setShowUnsplash] = React.useState(false);
+    const mountedRef = React.useRef(true);
+    const operationPendingRef = React.useRef(false);
+    const onPendingChangeRef = React.useRef(onPendingChange);
+    onPendingChangeRef.current = onPendingChange;
+
+    React.useEffect(() => {
+        mountedRef.current = true;
+        return () => {
+            mountedRef.current = false;
+            if (operationPendingRef.current) {
+                onPendingChangeRef.current?.(false);
+            }
+        };
+    }, []);
+
+    React.useEffect(() => {
+        if (isPending) {
+            setShowUnsplash(false);
+        }
+    }, [isPending]);
 
     const handleUpload = async (file: File) => {
+        if (operationPendingRef.current) {
+            return;
+        }
+        operationPendingRef.current = true;
+        onPendingChangeRef.current?.(true);
         try {
             const response = await uploadImage({file});
-            onChange(getImageUrl(response));
-        } catch {
-            toast.error('Couldn’t upload the image.');
+            if (mountedRef.current) {
+                onChange(getImageUrl(response));
+            }
+        } catch (error) {
+            let message = 'Couldn’t upload the image.';
+            if (error instanceof UnsupportedMediaTypeError) {
+                message = UNSUPPORTED_IMAGE_MESSAGE;
+            } else if (error instanceof RequestEntityTooLargeError) {
+                message = 'The image you uploaded was larger than the maximum file size your server allows.';
+            } else if (error instanceof JSONError && error.data?.errors[0]?.message) {
+                message = error.data.errors[0].message;
+            }
+            if (mountedRef.current) {
+                toast.error(message);
+            }
+        } finally {
+            operationPendingRef.current = false;
+            if (mountedRef.current) {
+                onPendingChangeRef.current?.(false);
+            }
         }
     };
+
+    const fieldDisabled = disabled || isPending;
 
     return (
         <Stack gap='sm'>
@@ -49,11 +105,11 @@ const TagImageField: React.FC<TagImageFieldProps> = ({id, label, uploadText, val
                         <ImageUploadImage alt='' src={value} />
                         <ImageUploadActions>
                             {editor.isEnabled && (
-                                <ImageUploadAction aria-label={`Edit ${label.toLowerCase()}`} disabled={disabled} onClick={() => editor.openEditor({image: value, handleSave: handleUpload})}>
+                                <ImageUploadAction aria-label={`Edit ${label.toLowerCase()}`} disabled={fieldDisabled} onClick={() => editor.openEditor({image: value, handleSave: handleUpload})}>
                                     <LucideIcon.Pencil />
                                 </ImageUploadAction>
                             )}
-                            <ImageUploadAction aria-label={`Remove ${label.toLowerCase()}`} disabled={disabled} onClick={() => onChange('')}>
+                            <ImageUploadAction aria-label={`Remove ${label.toLowerCase()}`} disabled={fieldDisabled} onClick={() => onChange('')}>
                                 <LucideIcon.Trash2 />
                             </ImageUploadAction>
                         </ImageUploadActions>
@@ -61,8 +117,8 @@ const TagImageField: React.FC<TagImageFieldProps> = ({id, label, uploadText, val
                 ) : (
                     <>
                         <ImageUploadDropzone
-                            accept={{'image/*': []}}
-                            disabled={disabled || isPending}
+                            accept={ACCEPTED_IMAGE_TYPES}
+                            disabled={fieldDisabled}
                             inputAriaLabel={uploadText}
                             inputId={id}
                             onDropAccepted={(files) => {
@@ -70,7 +126,7 @@ const TagImageField: React.FC<TagImageFieldProps> = ({id, label, uploadText, val
                                     void handleUpload(files[0]);
                                 }
                             }}
-                            onDropRejected={() => toast.error('The image type you uploaded is not supported. Please use .GIF, .JPG, .JPEG, .PNG, .SVG, .SVGZ, .WEBP')}
+                            onDropRejected={() => toast.error(UNSUPPORTED_IMAGE_MESSAGE)}
                         >
                             {isPending ? (
                                 <LoadingIndicator size='sm' />
@@ -80,7 +136,7 @@ const TagImageField: React.FC<TagImageFieldProps> = ({id, label, uploadText, val
                         </ImageUploadDropzone>
                         {unsplashEnabled && (
                             <ImageUploadActions className='top-1 right-1 opacity-100'>
-                                <ImageUploadAction aria-label={`Select ${label.toLowerCase()} from Unsplash`} disabled={disabled} onClick={() => setShowUnsplash(true)}>
+                                <ImageUploadAction aria-label={`Select ${label.toLowerCase()} from Unsplash`} disabled={fieldDisabled} onClick={() => setShowUnsplash(true)}>
                                     <LucideIcon.Images />
                                 </ImageUploadAction>
                             </ImageUploadActions>

--- a/apps/admin/src/tags/detail/tag-image-field.tsx
+++ b/apps/admin/src/tags/detail/tag-image-field.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
+import {UnsplashSearchModal} from '@tryghost/kg-unsplash-selector';
 import {ImageUpload, ImageUploadAction, ImageUploadActions, ImageUploadDropzone, ImageUploadImage, ImageUploadPreview} from '@tryghost/shade/patterns';
 import {Label, LoadingIndicator} from '@tryghost/shade/components';
 import {LucideIcon} from '@tryghost/shade/utils';
+import {Stack} from '@tryghost/shade/primitives';
+import {createPortal} from 'react-dom';
 import {getImageUrl, useUploadImage} from '@tryghost/admin-x-framework/api/images';
+import {useFramework} from '@tryghost/admin-x-framework';
+import {usePinturaEditor} from '@/hooks/use-pintura-editor';
 import {toast} from 'sonner';
 
 interface TagImageFieldProps {
@@ -11,16 +16,20 @@ interface TagImageFieldProps {
     uploadText: string;
     value: string;
     disabled?: boolean;
+    unsplashEnabled?: boolean;
     onChange: (url: string) => void;
 }
 
 /**
  * One image slot on the tag form (tag image, X image, Facebook image),
  * standing in for Ember's `GhImageUploaderWithPreview`: an upload dropzone
- * when empty, a preview with a remove action when set.
+ * when empty, a preview with edit/remove actions when set.
  */
-const TagImageField: React.FC<TagImageFieldProps> = ({id, label, uploadText, value, disabled, onChange}) => {
+const TagImageField: React.FC<TagImageFieldProps> = ({id, label, uploadText, value, disabled, unsplashEnabled, onChange}) => {
     const {mutateAsync: uploadImage, isPending} = useUploadImage();
+    const {unsplashConfig} = useFramework();
+    const editor = usePinturaEditor({disabled});
+    const [showUnsplash, setShowUnsplash] = React.useState(false);
 
     const handleUpload = async (file: File) => {
         try {
@@ -32,40 +41,67 @@ const TagImageField: React.FC<TagImageFieldProps> = ({id, label, uploadText, val
     };
 
     return (
-        <div className='flex flex-col gap-1.5'>
+        <Stack gap='sm'>
             <Label htmlFor={id}>{label}</Label>
             <ImageUpload className='h-40'>
                 {value ? (
                     <ImageUploadPreview>
                         <ImageUploadImage alt='' src={value} />
                         <ImageUploadActions>
+                            {editor.isEnabled && (
+                                <ImageUploadAction aria-label={`Edit ${label.toLowerCase()}`} disabled={disabled} onClick={() => editor.openEditor({image: value, handleSave: handleUpload})}>
+                                    <LucideIcon.Pencil />
+                                </ImageUploadAction>
+                            )}
                             <ImageUploadAction aria-label={`Remove ${label.toLowerCase()}`} disabled={disabled} onClick={() => onChange('')}>
                                 <LucideIcon.Trash2 />
                             </ImageUploadAction>
                         </ImageUploadActions>
                     </ImageUploadPreview>
                 ) : (
-                    <ImageUploadDropzone
-                        accept={{'image/*': []}}
-                        disabled={disabled || isPending}
-                        inputAriaLabel={uploadText}
-                        inputId={id}
-                        onDropAccepted={(files) => {
-                            if (files[0]) {
-                                void handleUpload(files[0]);
-                            }
-                        }}
-                        onDropRejected={() => toast.error('The image type you uploaded is not supported. Please use .GIF, .JPG, .JPEG, .PNG, .SVG, .SVGZ, .WEBP')}
-                    >
-                        {isPending ? (
-                            <LoadingIndicator size='sm' />
-                        ) : (
-                            <span className='text-sm text-muted-foreground'>{uploadText}</span>
+                    <>
+                        <ImageUploadDropzone
+                            accept={{'image/*': []}}
+                            disabled={disabled || isPending}
+                            inputAriaLabel={uploadText}
+                            inputId={id}
+                            onDropAccepted={(files) => {
+                                if (files[0]) {
+                                    void handleUpload(files[0]);
+                                }
+                            }}
+                            onDropRejected={() => toast.error('The image type you uploaded is not supported. Please use .GIF, .JPG, .JPEG, .PNG, .SVG, .SVGZ, .WEBP')}
+                        >
+                            {isPending ? (
+                                <LoadingIndicator size='sm' />
+                            ) : (
+                                <span className='text-sm text-muted-foreground'>{uploadText}</span>
+                            )}
+                        </ImageUploadDropzone>
+                        {unsplashEnabled && (
+                            <ImageUploadActions className='top-1 right-1 opacity-100'>
+                                <ImageUploadAction aria-label={`Select ${label.toLowerCase()} from Unsplash`} disabled={disabled} onClick={() => setShowUnsplash(true)}>
+                                    <LucideIcon.Images />
+                                </ImageUploadAction>
+                            </ImageUploadActions>
                         )}
-                    </ImageUploadDropzone>
+                    </>
                 )}
             </ImageUpload>
-        </div>
+            {showUnsplash && createPortal(
+                <UnsplashSearchModal
+                    unsplashProviderConfig={unsplashConfig}
+                    onClose={() => setShowUnsplash(false)}
+                    onImageInsert={(image) => {
+                        if (image.src) {
+                            onChange(image.src);
+                        }
+                        setShowUnsplash(false);
+                    }}
+                />,
+                document.body
+            )}
+        </Stack>
     );
 };
 

--- a/apps/ember-admin/app/routes/member.js
+++ b/apps/ember-admin/app/routes/member.js
@@ -42,7 +42,7 @@ export default class MembersRoute extends MembersManagementRoute {
         // subtree unrendered, so the `data-testid` and `data-test-link`
         // attributes exist in only one tree and the queryRecord below doesn't
         // fire for a screen nobody sees.
-        if (this.feature.memberDetailsReact) {
+        if (this.feature.memberDetailsReact === true) {
             transition.abort();
         }
     }

--- a/apps/ember-admin/app/routes/tag.js
+++ b/apps/ember-admin/app/routes/tag.js
@@ -25,7 +25,7 @@ export default class TagRoute extends AuthenticatedRoute {
 
         // React owns this URL when the flag is on. Keep the Ember route from
         // loading and rendering a second tag editor behind the React screen.
-        if (this.feature.tagDetailsReact) {
+        if (this.feature.tagDetailsReact === true) {
             transition.abort();
         }
     }

--- a/apps/ember-admin/app/routes/tag.js
+++ b/apps/ember-admin/app/routes/tag.js
@@ -5,6 +5,7 @@ import {action} from '@ember/object';
 import {inject as service} from '@ember/service';
 
 export default class TagRoute extends AuthenticatedRoute {
+    @service feature;
     @service modals;
     @service router;
     @service session;
@@ -15,11 +16,17 @@ export default class TagRoute extends AuthenticatedRoute {
     _requiresBackgroundRefresh = true;
     _unregisterUnsavedChanges = null;
 
-    beforeModel() {
+    beforeModel(transition) {
         super.beforeModel(...arguments);
 
         if (this.session.user.isAuthorOrContributor) {
             return this.transitionTo('index');
+        }
+
+        // React owns this URL when the flag is on. Keep the Ember route from
+        // loading and rendering a second tag editor behind the React screen.
+        if (this.feature.tagDetailsReact) {
+            transition.abort();
         }
     }
 

--- a/apps/ember-admin/app/services/feature.js
+++ b/apps/ember-admin/app/services/feature.js
@@ -83,6 +83,7 @@ export default class FeatureService extends Service {
     @feature('lexicalIndicators') lexicalIndicators;
     @feature('editorExcerpt') editorExcerpt;
     @feature('memberDetailsReact') memberDetailsReact;
+    @feature('tagDetailsReact') tagDetailsReact;
     @feature('paywallImprovements') paywallImprovements;
     @feature('automations') automations;
     @feature('csvContentImporter') csvContentImporter;

--- a/apps/ember-admin/app/services/feature.js
+++ b/apps/ember-admin/app/services/feature.js
@@ -83,6 +83,7 @@ export default class FeatureService extends Service {
     @feature('lexicalIndicators') lexicalIndicators;
     @feature('editorExcerpt') editorExcerpt;
     @feature('memberDetailsReact') memberDetailsReact;
+    @feature('tagDetailsReact') tagDetailsReact;
     @feature('previewByTier') previewByTier;
     @feature('paywallImprovements') paywallImprovements;
     @feature('automations') automations;

--- a/apps/ember-admin/app/services/session.js
+++ b/apps/ember-admin/app/services/session.js
@@ -42,9 +42,12 @@ export default class SessionService extends ESASessionService {
     }
 
     async postAuthPreparation() {
+        const featureFetch = this.feature.fetch()
+            .finally(() => this.stateBridge.triggerFeatureFlagsChange());
+
         await RSVP.all([
             this.configManager.fetchAuthenticated(),
-            this.feature.fetch(),
+            featureFetch,
             this.settings.fetch(),
             this.membersUtils.fetch()
         ]);

--- a/apps/ember-admin/app/services/state-bridge.js
+++ b/apps/ember-admin/app/services/state-bridge.js
@@ -48,6 +48,10 @@ export default class StateBridgeService extends Service.extend(Evented) {
      */
     @action
     isFeatureEnabled(name) {
+        if (!this.settings.settingsModel) {
+            return undefined;
+        }
+
         return this.feature[name] === true;
     }
 

--- a/apps/ember-admin/app/services/state-bridge.js
+++ b/apps/ember-admin/app/services/state-bridge.js
@@ -32,6 +32,7 @@ export default class StateBridgeService extends Service.extend(Evented) {
     @service feature;
     @service membersUtils;
     @service router;
+    @service search;
     @service session;
     @service settings;
     @service store;
@@ -166,6 +167,11 @@ export default class StateBridgeService extends Service.extend(Evented) {
         if (dataType === 'TiersResponseType') {
             // membersUtils has local state which needs to be updated
             this.membersUtils.reload();
+        }
+
+        if (dataType === 'TagsResponseType') {
+            // Ember's tag model expires global search after create/update/delete.
+            this.search.expireContent();
         }
     }
 

--- a/apps/ember-admin/app/services/state-bridge.js
+++ b/apps/ember-admin/app/services/state-bridge.js
@@ -20,6 +20,7 @@ const emberDataTypeMapping = {
     NewslettersResponseType: {type: 'newsletter'},
     RecommendationResponseType: {type: 'recommendation'},
     SettingsResponseType: {type: 'setting', singleton: true},
+    TagsResponseType: {type: 'tag'},
     ThemesResponseType: {type: 'theme'},
     TiersResponseType: {type: 'tier'},
     UsersResponseType: {type: 'user'},

--- a/apps/ember-admin/app/services/state-bridge.js
+++ b/apps/ember-admin/app/services/state-bridge.js
@@ -41,6 +41,21 @@ export default class StateBridgeService extends Service.extend(Evented) {
 
     @inject config;
 
+    /**
+     * Gives React the same synchronous Labs route-ownership decision Ember
+     * uses. Both routers must share one authority or they can each defer to
+     * the other while state is loading.
+     */
+    @action
+    isFeatureEnabled(name) {
+        return this.feature[name] === true;
+    }
+
+    @action
+    triggerFeatureFlagsChange() {
+        this.trigger('featureFlagsChange');
+    }
+
     constructor() {
         super(...arguments);
         this.router.on('routeDidChange', this, this.handleRouteDidChange);
@@ -119,9 +134,10 @@ export default class StateBridgeService extends Service.extend(Evented) {
 
             // TODO: Reloading settings does not trigger a re-fetch of the
             // feature flags. We should maybe find a better way to do this.
-            this.settings.reload().then(() => {
-                this.feature.fetch();
-            });
+            this.triggerFeatureFlagsChange();
+            this.settings.reload()
+                .then(() => this.feature.fetch())
+                .finally(() => this.triggerFeatureFlagsChange());
         }
 
         if (dataType === 'TiersResponseType') {

--- a/apps/ember-admin/tests/unit/routes/tag-test.js
+++ b/apps/ember-admin/tests/unit/routes/tag-test.js
@@ -1,0 +1,35 @@
+import Service from '@ember/service';
+import sinon from 'sinon';
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {setupTest} from 'ember-mocha';
+
+describe('Unit: Route: tag', function () {
+    setupTest();
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it('aborts the Ember transition when React owns the tag detail route', function () {
+        const requireAuthentication = sinon.spy();
+        class SessionStub extends Service {
+            isAuthenticated = true;
+            user = {isAuthorOrContributor: false};
+            requireAuthentication = requireAuthentication;
+        }
+        class FeatureStub extends Service {
+            tagDetailsReact = true;
+        }
+        this.owner.register('service:session', SessionStub);
+        this.owner.register('service:feature', FeatureStub);
+
+        const route = this.owner.lookup('route:tag');
+        const transition = {abort: sinon.spy()};
+
+        route.beforeModel(transition);
+
+        expect(requireAuthentication.calledOnce).to.be.true;
+        expect(transition.abort.calledOnce).to.be.true;
+    });
+});

--- a/apps/ember-admin/tests/unit/routes/tag-test.js
+++ b/apps/ember-admin/tests/unit/routes/tag-test.js
@@ -32,4 +32,24 @@ describe('Unit: Route: tag', function () {
         expect(requireAuthentication.calledOnce).to.be.true;
         expect(transition.abort.calledOnce).to.be.true;
     });
+
+    it('keeps Ember ownership when the feature flag is not a boolean', function () {
+        class SessionStub extends Service {
+            isAuthenticated = true;
+            user = {isAuthorOrContributor: false};
+            requireAuthentication = sinon.spy();
+        }
+        class FeatureStub extends Service {
+            tagDetailsReact = 'true';
+        }
+        this.owner.register('service:session', SessionStub);
+        this.owner.register('service:feature', FeatureStub);
+
+        const route = this.owner.lookup('route:tag');
+        const transition = {abort: sinon.spy()};
+
+        route.beforeModel(transition);
+
+        expect(transition.abort.called).to.be.false;
+    });
 });

--- a/apps/ember-admin/tests/unit/services/session-test.js
+++ b/apps/ember-admin/tests/unit/services/session-test.js
@@ -23,6 +23,29 @@ describe('Unit: Service: session', function () {
         sinon.restore();
     });
 
+    describe('#postAuthPreparation', function () {
+        it('notifies React when the initial feature fetch completes', async function () {
+            service.postAuthPreparation.restore();
+            service.user = {role: {name: 'Administrator'}};
+            const stateBridge = this.owner.lookup('service:state-bridge');
+            const featureFlagsChange = sinon.spy();
+            stateBridge.on('featureFlagsChange', featureFlagsChange);
+
+            sinon.stub(service.configManager, 'fetchAuthenticated').resolves();
+            sinon.stub(service.feature, 'fetch').resolves();
+            sinon.stub(service.settings, 'fetch').resolves();
+            sinon.stub(service.membersUtils, 'fetch').resolves();
+            sinon.stub(service.frontend, 'loginIfNeeded').resolves();
+            sinon.stub(service.themeManagement, 'fetch').resolves();
+            sinon.stub(service, 'loadServerNotifications');
+            sinon.stub(service.koenig, 'fetch');
+
+            await service.postAuthPreparation();
+
+            expect(featureFlagsChange.calledOnce).to.be.true;
+        });
+    });
+
     describe('#handleAuthenticationTask', function () {
         it('populates the user and runs postAuthPreparation when no user is loaded', async function () {
             service.user = null;

--- a/apps/ember-admin/tests/unit/services/state-bridge-test.js
+++ b/apps/ember-admin/tests/unit/services/state-bridge-test.js
@@ -1,4 +1,5 @@
 import EmberObject from '@ember/object';
+import Service from '@ember/service';
 import sinon from 'sinon';
 import {describe, it} from 'mocha';
 import {expect} from 'chai';
@@ -22,14 +23,21 @@ const buildMockModelCollection = (models) => {
 describe('Unit: Service: state-bridge', function () {
     setupTest();
 
-    let service, store, config, settings, membersUtils, themeManagement, ui;
+    let service, store, config, settings, membersUtils, search, themeManagement, ui;
 
     beforeEach(function () {
+        this.owner.register('service:search', Service.extend({
+            isContentStale: false,
+            expireContent() {
+                this.set('isContentStale', true);
+            }
+        }));
         service = this.owner.lookup('service:state-bridge');
         store = this.owner.lookup('service:store');
         config = this.owner.lookup('config:main');
         settings = this.owner.lookup('service:settings');
         membersUtils = this.owner.lookup('service:members-utils');
+        search = this.owner.lookup('service:search');
         themeManagement = this.owner.lookup('service:theme-management');
         ui = this.owner.lookup('service:ui');
 
@@ -39,6 +47,7 @@ describe('Unit: Service: state-bridge', function () {
         sinon.spy(store, 'unloadAll');
         sinon.spy(settings, 'reload');
         sinon.spy(membersUtils, 'reload');
+        search.isContentStale = false;
     });
 
     afterEach(function () {
@@ -298,6 +307,7 @@ describe('Unit: Service: state-bridge', function () {
 
             expect(store.unloadAll.calledOnce).to.be.true;
             expect(store.unloadAll.calledWith('tag')).to.be.true;
+            expect(search.isContentStale).to.be.true;
         });
 
         it('reloads membersUtils when tiers are invalidated', function () {

--- a/apps/ember-admin/tests/unit/services/state-bridge-test.js
+++ b/apps/ember-admin/tests/unit/services/state-bridge-test.js
@@ -56,7 +56,14 @@ describe('Unit: Service: state-bridge', function () {
     });
 
     describe('#isFeatureEnabled', function () {
+        it('does not claim route ownership before Labs settings load', function () {
+            settings.settingsModel = null;
+
+            expect(service.isFeatureEnabled('tagDetailsReact')).to.be.undefined;
+        });
+
         it('exposes the same strict Labs state used by Ember routes', function () {
+            settings.settingsModel = {};
             sinon.stub(feature, 'tagDetailsReact').get(() => true);
             sinon.stub(feature, 'memberDetailsReact').get(() => 'true');
 

--- a/apps/ember-admin/tests/unit/services/state-bridge-test.js
+++ b/apps/ember-admin/tests/unit/services/state-bridge-test.js
@@ -291,6 +291,15 @@ describe('Unit: Service: state-bridge', function () {
             expect(store.unloadAll.calledWith('integration')).to.be.true;
         });
 
+        it('unloads all tags when tag queries are invalidated', function () {
+            run(() => {
+                service.onInvalidate('TagsResponseType');
+            });
+
+            expect(store.unloadAll.calledOnce).to.be.true;
+            expect(store.unloadAll.calledWith('tag')).to.be.true;
+        });
+
         it('reloads membersUtils when tiers are invalidated', function () {
             run(() => {
                 service.onInvalidate('TiersResponseType');

--- a/apps/ember-admin/tests/unit/services/state-bridge-test.js
+++ b/apps/ember-admin/tests/unit/services/state-bridge-test.js
@@ -23,7 +23,7 @@ const buildMockModelCollection = (models) => {
 describe('Unit: Service: state-bridge', function () {
     setupTest();
 
-    let service, store, config, settings, membersUtils, search, themeManagement, ui;
+    let service, store, config, feature, settings, membersUtils, search, themeManagement, ui;
 
     beforeEach(function () {
         this.owner.register('service:search', Service.extend({
@@ -35,6 +35,7 @@ describe('Unit: Service: state-bridge', function () {
         service = this.owner.lookup('service:state-bridge');
         store = this.owner.lookup('service:store');
         config = this.owner.lookup('config:main');
+        feature = this.owner.lookup('service:feature');
         settings = this.owner.lookup('service:settings');
         membersUtils = this.owner.lookup('service:members-utils');
         search = this.owner.lookup('service:search');
@@ -52,6 +53,17 @@ describe('Unit: Service: state-bridge', function () {
 
     afterEach(function () {
         sinon.restore();
+    });
+
+    describe('#isFeatureEnabled', function () {
+        it('exposes the same strict Labs state used by Ember routes', function () {
+            sinon.stub(feature, 'tagDetailsReact').get(() => true);
+            sinon.stub(feature, 'memberDetailsReact').get(() => 'true');
+
+            expect(service.isFeatureEnabled('tagDetailsReact')).to.be.true;
+            expect(service.isFeatureEnabled('memberDetailsReact')).to.be.false;
+            expect(service.isFeatureEnabled('missingFlag')).to.be.false;
+        });
     });
 
     describe('#onUpdate', function () {

--- a/apps/shade/src/components.ts
+++ b/apps/shade/src/components.ts
@@ -1,4 +1,5 @@
 // UI components — basic reusable controls
+export * from './components/ui/accordion';
 export * from './components/ui/alert-dialog';
 export * from './components/ui/action-list';
 export * from './components/ui/animated-number';

--- a/e2e/helpers/pages/admin/tags/tag-details-page.ts
+++ b/e2e/helpers/pages/admin/tags/tag-details-page.ts
@@ -20,10 +20,7 @@ export class TagDetailsPage extends AdminPage {
         this.saveButtonSuccess = page.getByRole('button', {name: 'Saved'});
         this.deleteButton = page.getByRole('button', {name: 'Delete tag'});
 
-        // Both the Ember and React trees can be in the DOM at once, and the
-        // React screen reuses the same data-test attribute — the visibility
-        // filter picks whichever implementation is active.
-        this.backLink = page.locator('[data-test-link="tags-back"]').filter({visible: true});
+        this.backLink = page.locator('[data-test-link="tags-back"]');
     }
 
     async fillTagName(name: string) {

--- a/e2e/helpers/pages/admin/tags/tag-details-page.ts
+++ b/e2e/helpers/pages/admin/tags/tag-details-page.ts
@@ -20,7 +20,10 @@ export class TagDetailsPage extends AdminPage {
         this.saveButtonSuccess = page.getByRole('button', {name: 'Saved'});
         this.deleteButton = page.getByRole('button', {name: 'Delete tag'});
 
-        this.backLink = page.locator('[data-test-link="tags-back"]');
+        // Both the Ember and React trees can be in the DOM at once, and the
+        // React screen reuses the same data-test attribute — the visibility
+        // filter picks whichever implementation is active.
+        this.backLink = page.locator('[data-test-link="tags-back"]').filter({visible: true});
     }
 
     async fillTagName(name: string) {
@@ -44,4 +47,3 @@ export class TagDetailsPage extends AdminPage {
         await this.backLink.click();
     }
 }
-

--- a/e2e/helpers/pages/admin/tags/tag-editor-page.ts
+++ b/e2e/helpers/pages/admin/tags/tag-editor-page.ts
@@ -1,5 +1,6 @@
 import {Locator, Page} from '@playwright/test';
 import {TagDetailsPage} from './tag-details-page';
+import {confirmDeleteTag, deleteTagModal, deleteTagPostsCount} from '@tryghost/test-data/selectors/tags';
 
 export class TagEditorPage extends TagDetailsPage {
     readonly deleteModal: Locator;
@@ -11,9 +12,15 @@ export class TagEditorPage extends TagDetailsPage {
 
         this.pageUrl = '/ghost/#/tags';
 
-        this.deleteModal = page.locator('[data-test-modal="confirm-delete-tag"]');
-        this.deleteModalPostsCount = this.deleteModal.locator('[data-test-text="posts-count"]');
-        this.deleteModalConfirmButton = this.deleteModal.locator('[data-test-button="confirm"]');
+        // Ember renders data-test-* attributes; React renders data-testid.
+        // Match either so the same flows drive both implementations.
+        this.deleteModal = page.locator('[data-test-modal="confirm-delete-tag"]')
+            .or(page.getByTestId(deleteTagModal))
+            .filter({visible: true});
+        this.deleteModalPostsCount = this.deleteModal.locator('[data-test-text="posts-count"]')
+            .or(this.deleteModal.getByTestId(deleteTagPostsCount));
+        this.deleteModalConfirmButton = this.deleteModal.locator('[data-test-button="confirm"]')
+            .or(this.deleteModal.getByTestId(confirmDeleteTag));
     }
 
     async gotoTagBySlug(slug: string) {
@@ -35,4 +42,3 @@ export class TagEditorPage extends TagDetailsPage {
         await this.deleteModalConfirmButton.click();
     }
 }
-

--- a/e2e/tests/admin/tags/tag-detail.test.ts
+++ b/e2e/tests/admin/tags/tag-detail.test.ts
@@ -1,0 +1,78 @@
+import {NewTagsPage, TagEditorPage, TagsPage} from '@/admin-pages';
+import {TagFactory, createTagFactory} from '@/data-factory';
+import {expect, test} from '@/helpers/playwright';
+import {usePerTestIsolation} from '@/helpers/playwright/isolation';
+
+/**
+ * The tag detail screen exists twice while the Ember-to-React migration is in
+ * flight, behind the `tagDetailsReact` Labs flag. The same journeys run
+ * against both implementations — a test may not branch on the implementation;
+ * a failure under only one flag state is a real user-facing difference.
+ */
+
+usePerTestIsolation();
+
+for (const {implementation, tagDetailsReact} of [
+    {implementation: 'Ember', tagDetailsReact: false},
+    {implementation: 'React', tagDetailsReact: true}
+] as const) {
+    test.describe(`Ghost Admin - Tag Detail (${implementation})`, () => {
+        test.use({labs: {tagDetailsReact}});
+
+        let tagFactory: TagFactory;
+
+        test.beforeEach(({page}) => {
+            tagFactory = createTagFactory(page.request);
+        });
+
+        test('opening a tag from the list and editing it - changes are saved', async ({page}) => {
+            const tag = await tagFactory.create({name: 'Getting Started', slug: 'getting-started', feature_image: null});
+            const tagsPage = new TagsPage(page);
+            const tagEditor = new TagEditorPage(page);
+
+            await tagsPage.goto();
+            await tagsPage.waitForPageToFullyLoad();
+            await tagsPage.getTagLinkByName(tag.name).click();
+            await expect(tagEditor.nameInput).toHaveValue('Getting Started');
+            await expect(tagEditor.slugInput).toHaveValue('getting-started');
+
+            await tagEditor.updateTag('Getting Started Updated', 'getting-started-updated');
+            await tagEditor.goBackToTagsList();
+            await tagsPage.waitForPageToFullyLoad();
+
+            await expect(tagsPage.getTagLinkByName('Getting Started Updated')).toBeVisible();
+            await expect(tagsPage.getTagLinkByName('Getting Started Updated')).toContainText('getting-started-updated');
+        });
+
+        test('creating a tag via the new tag screen - appears in the tags list', async ({page}) => {
+            const newTagsPage = new NewTagsPage(page);
+            const tagsPage = new TagsPage(page);
+
+            await newTagsPage.goto();
+            await newTagsPage.createTag('Fresh Tag', 'fresh-tag');
+            await newTagsPage.goBackToTagsList();
+            await tagsPage.waitForPageToFullyLoad();
+
+            await expect(tagsPage.getTagLinkByName('Fresh Tag')).toBeVisible();
+            await expect(tagsPage.getTagLinkByName('Fresh Tag')).toContainText('fresh-tag');
+        });
+
+        test('deleting a tag from the detail screen - removed from the tags list', async ({page}) => {
+            const tag = await tagFactory.create({name: 'Disposable', slug: 'disposable', feature_image: null});
+            const tagsPage = new TagsPage(page);
+            const tagEditor = new TagEditorPage(page);
+
+            await tagEditor.gotoTagBySlug(tag.slug);
+            await expect(tagEditor.nameInput).toHaveValue('Disposable');
+
+            await tagEditor.deleteTag();
+            await expect(tagEditor.deleteModal).toBeVisible();
+            await tagEditor.confirmDelete();
+
+            await expect(tagEditor.deleteModal).toBeHidden();
+            await expect(page).toHaveURL(tagsPage.pageUrl);
+            await tagsPage.waitForPageToFullyLoad();
+            await expect(tagsPage.getTagLinkByName('Disposable')).toBeHidden();
+        });
+    });
+}

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -65,7 +65,8 @@ const PRIVATE_FEATURES = [
     'memberDetailsReact',
     'membersCustomFields',
     'paywallImprovements',
-    'giftSubCustomization'
+    'giftSubCustomization',
+    'tagDetailsReact'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -65,7 +65,8 @@ const PRIVATE_FEATURES = [
     'memberDetailsReact',
     'membersCustomFields',
     'previewByTier',
-    'paywallImprovements'
+    'paywallImprovements',
+    'tagDetailsReact'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -41,6 +41,7 @@ Object {
       "smarterCounts": true,
       "stripeAutomaticTax": true,
       "superEditors": true,
+      "tagDetailsReact": true,
       "tagsX": true,
       "themeTranslation": true,
       "urlCache": true,

--- a/packages/testing/test-data/src/selectors/tags.ts
+++ b/packages/testing/test-data/src/selectors/tags.ts
@@ -8,6 +8,11 @@ export const tagsPage = "tags-page";
 export const tagsList = "tags-list";
 export const tagListRow = "tag-list-row";
 export const tagsHeaderTabs = "tags-header-tabs";
+export const tagDetail = "tag-detail";
+export const tagDetailTitle = "tag-detail-title";
+export const deleteTagModal = "delete-tag-modal";
+export const deleteTagPostsCount = "delete-tag-posts-count";
+export const confirmDeleteTag = "confirm-delete-tag";
 
 // accessible names
 export const publicTab = "Public tags";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -710,6 +710,9 @@ importers:
       '@tryghost/shade':
         specifier: workspace:*
         version: link:../shade
+      '@tryghost/string':
+        specifier: 'catalog:'
+        version: 0.3.5
       '@tryghost/timezone-data':
         specifier: 'catalog:'
         version: 1.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -656,6 +656,9 @@ importers:
       '@tryghost/shade':
         specifier: workspace:*
         version: link:../shade
+      '@tryghost/string':
+        specifier: 'catalog:'
+        version: 0.3.5
       '@xyflow/react':
         specifier: 12.11.1
         version: 12.11.1(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -822,7 +825,7 @@ importers:
         version: 8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@7.0.2))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   apps/admin-x-framework:
     dependencies:
@@ -29781,20 +29784,6 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser-playwright@4.1.9(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(playwright@1.61.1)(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.9)':
-    dependencies:
-      '@vitest/browser': 4.1.9(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.9)
-      '@vitest/mocker': 4.1.9(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
-      playwright: 1.61.1
-      tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
-    transitivePeerDependencies:
-      - bufferutil
-      - msw
-      - utf-8-validate
-      - vite
-    optional: true
-
   '@vitest/browser-playwright@4.1.9(msw@2.14.6(@types/node@26.0.0)(typescript@7.0.2))(playwright@1.61.1)(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.9)':
     dependencies:
       '@vitest/browser': 4.1.9(msw@2.14.6(@types/node@26.0.0)(typescript@7.0.2))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.9)
@@ -29862,24 +29851,6 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser@4.1.9(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.9)':
-    dependencies:
-      '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.9(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
-      '@vitest/utils': 4.1.9
-      magic-string: 0.30.21
-      pngjs: 7.0.0
-      sirv: 3.0.2
-      tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
-      ws: 8.21.0
-    transitivePeerDependencies:
-      - bufferutil
-      - msw
-      - utf-8-validate
-      - vite
-    optional: true
-
   '@vitest/browser@4.1.9(msw@2.14.6(@types/node@26.0.0)(typescript@7.0.2))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.9)':
     dependencies:
       '@blazediff/core': 1.9.1
@@ -29910,9 +29881,9 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(@typescript/typescript6@6.0.2))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(@typescript/typescript6@6.0.2))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
     optionalDependencies:
-      '@vitest/browser': 4.1.9(msw@2.14.6(@types/node@26.0.0)(@typescript/typescript6@6.0.2))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/browser': 4.1.9(msw@2.14.6(@types/node@22.20.0)(@typescript/typescript6@6.0.2))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.9)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -29956,15 +29927,6 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.14.6(@types/node@26.0.0)(@typescript/typescript6@6.0.2)
-      vite: 8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
-
-  '@vitest/mocker@4.1.9(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 4.1.9
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      msw: 2.14.6(@types/node@26.0.0)(typescript@5.9.3)
       vite: 8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.9(msw@2.14.6(@types/node@26.0.0)(typescript@7.0.2))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))':
@@ -30011,7 +29973,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(@typescript/typescript6@6.0.2))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@22.20.0)(@typescript/typescript6@6.0.2))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -41008,32 +40970,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3):
-    dependencies:
-      '@inquirer/confirm': 6.1.1(@types/node@26.0.0)
-      '@mswjs/interceptors': 0.41.9
-      '@open-draft/deferred-promise': 3.0.0
-      '@types/statuses': 2.0.6
-      cookie: 1.1.1
-      graphql: 16.14.2
-      headers-polyfill: 5.0.1
-      is-node-process: 1.2.0
-      outvariant: 1.4.3
-      path-to-regexp: 6.3.0
-      picocolors: 1.1.1
-      rettime: 0.11.11
-      statuses: 2.0.2
-      strict-event-emitter: 0.5.1
-      tough-cookie: 6.0.1
-      type-fest: 5.7.0
-      until-async: 3.0.2
-      yargs: 17.7.3
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
-
   msw@2.14.6(@types/node@26.0.0)(typescript@7.0.2):
     dependencies:
       '@inquirer/confirm': 6.1.1(@types/node@26.0.0)
@@ -46529,38 +46465,6 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@types/node': 26.0.0
       '@vitest/browser-playwright': 4.1.9(msw@2.14.6(@types/node@26.0.0)(@typescript/typescript6@6.0.2))(playwright@1.61.1)(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.9)
-      '@vitest/coverage-v8': 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
-      '@vitest/ui': 4.1.9(vitest@4.1.9)
-      jsdom: 29.1.1(@noble/hashes@1.8.0)
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.9
-      '@vitest/runner': 4.1.9
-      '@vitest/snapshot': 4.1.9
-      '@vitest/spy': 4.1.9
-      '@vitest/utils': 4.1.9
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.3
-      pathe: 2.0.3
-      picomatch: 4.0.5
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.2.4
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@types/node': 26.0.0
-      '@vitest/browser-playwright': 4.1.9(msw@2.14.6(@types/node@26.0.0)(typescript@5.9.3))(playwright@1.61.1)(vite@8.1.3(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.9)
       '@vitest/coverage-v8': 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       '@vitest/ui': 4.1.9(vitest@4.1.9)
       jsdom: 29.1.1(@noble/hashes@1.8.0)


### PR DESCRIPTION
Pilot Ember-to-React screen migration: the tag detail screen (`/tags/:slug` and `/tags/new`) rebuilt in `apps/admin`, behind the new `tagDetailsReact` private feature flag. With the flag off (the default everywhere), both routes keep rendering the Ember screen exactly as today; only an explicit `labs.tagDetailsReact: true` serves the React implementation. No Ember code is removed — Ember's tag route stays intact and cedes ownership at runtime when the flag is on.

## Changes

- **Flag**: `tagDetailsReact` registered in `PRIVATE_FEATURES` (`ghost/core/core/shared/labs.js`) and in the Ember feature service, with a toggle in the Labs → private features UI. Config API snapshot regenerated (one added labs line).
- **Gate architecture** (`apps/admin/src/flag-gated-route.tsx` + `state-bridge.js`): both routers share one flag authority. React prefers Ember's synchronous feature state via the bridge (`isFeatureEnabled`, broadcast on a new `featureFlagsChange` event after Labs settings hydrate); `undefined` means no bridge (standalone/tests) and falls back to the config query with strict `=== true`, `null` means Labs still loading and holds a paint. Ember's `routes/tag.js` aborts its own transition in `beforeModel` when the flag is on (`tag/new` inherits it), so the hidden Ember editor never mounts alongside the React screen and the two routers cannot split-brain during settings propagation.
- **Routing** (`apps/admin/src/routes.tsx`): `/tags/new` leaves `EMBER_ROUTES` and the explicit `/tags/:tagSlug` Ember fallback is replaced by a single flag-gated route. `new` acts as the create sentinel — Ember's router declared `tag.new` before `tag`, so a tag with the literal slug `new` was already unreachable. The route keeps `requiresAccess: canManageTags` and (deliberately) does not set `allowInForceUpgrade`, matching the tags list route, so in force-upgrade mode the detail URL redirects to `/pro` like the list does.
- **Screen** (`apps/admin/src/tags/detail/`): container with draft/dirty tracking, pure edit/validation module, form, colour field, image field (Unsplash picker gated on the `unsplash` setting; Pintura image editing via a new `use-pintura-editor` hook), previews, and delete modal — shade components throughout. Save state is decoupled from mutation state so button states don't leak across routes; stale responses are guarded by route/tag id.
- **State bridge**: `TagsResponseType` mapped in `emberDataTypeMapping`, so React-side tag mutations unload Ember Data's copies and expire Ember's client-side search index.
- **Framework** (`apps/admin-x-framework/src/api/tags.ts`): the `Tag` type gains the full snake_case field set that was previously commented out; new `getTagBySlug` (the admin API's `/tags/slug/:slug/` route, which the Ember serializer already used), `useAddTag`, `useEditTag`; `useDeleteTag` now invalidates the tags query cache.
- **Shade**: `Accordion` (already implemented with stories) is now exported from `@tryghost/shade/components`.
- **`apps/admin` dependency**: `@tryghost/string` (catalog) — the same slugify Ember uses, so client-side slug previews cannot diverge.

## Parity checklist (vs the Ember screen)

Ported field-for-field from `tag.hbs` / `tag-form.hbs` / `controllers/tag.js` / `routes/tag.js` / `models/tag.js` / `validators/tag-settings.js`:

- [x] Breadcrumb `Tags → {name}` (live-updates while typing) / `New tag`; back link keeps `data-test-link="tags-back"`
- [x] **View** button opening `canonical_url || {blogUrl}/tag/{slug}/` in a new tab
- [x] **Save** task button states (Save → spinner → Saved / Retry on failure); stays enabled with no changes, like Ember's task button (a clean save re-PUTs); saving with the same slug neither navigates nor disarms the leave guard
- [x] `Cmd/Ctrl+S` saves — including while the unsaved-changes dialog is up, in which case the pending navigation continues after a successful save
- [x] **Name**: required, no leading comma, max 191 — Ember's exact messages; "Start with # to create internal tags" hint with help link
- [x] **Accent colour**: hex input (no `#`, maxlength 6) + native colour picker; input applies per keystroke so a typed colour lands before a keyboard save; blur normalization (`#` prefixed), `The colour should be in valid hex format`; error blocks save; renders under the name row like Ember
- [x] **Slug**: max 191; scheme-stripped URL preview (`{host}/tag/{slug}/`); auto-generated from the name on the create screen via `@tryghost/string` slugify with the `hash-` prefix for `#` names, stopping once the slug is edited manually (and resuming if cleared)
- [x] **Description**: max 500 + "Maximum: 500 characters. You've used N" countdown (code-point counting, red when over)
- [x] **Tag image / X image / Facebook image**: upload + remove (admin images API), Unsplash when enabled, Pintura editing when configured; upload lifecycle is unmount-safe and overlap-locked with Ember's exact unsupported-type/too-large messages
- [x] **Meta data** section: meta title (rec. 70 / max 300), meta description (rec. 156 / max 500), canonical URL (`The url should be a valid url` on blur), Search Engine Result Preview with Ember's fallback chains and 70/156/70-char caps and the no-description placeholder copy
- [x] **X card** section: title (rec. 70), description (rec. 125), preview falling back through `twitter_* → meta → site meta description`, image falling back to the tag image
- [x] **Facebook card** section: title (rec. 100), description (rec. 65), preview title/image fallbacks; the preview description chain deliberately skips `og_description` because Ember read a nonexistent `facebookDescription` attribute — replicated, with a comment at the site
- [x] **Code injection** section: header/footer fields, whitespace preserved through normalize/save
- [x] **Visibility**: derived from a leading `#` when (and only when) the name changed — Ember's `updateVisibility`-on-save rule, which the server needs for internal→public renames
- [x] **Save flow**: skips the API entirely when validation fails (field errors render; the first message surfaces as an error toast, standing in for Ember's alert); success replace-navigates to the saved slug (moves `/tags/new` to the new tag and follows slug renames); API failures surface the server message
- [x] **Delete**: button below the form, hidden on the create screen; confirmation modal with Ember's copy including the "It will be removed from N post(s)." line (`include=count.posts` on the read, formatted count); returns to `/tags` on success
- [x] **Unsaved changes guard**: react-router blocker + native hash-anchor interception + `beforeunload`, with Ember's `ConfirmUnsavedChangesModal` copy (via shade's `DirtyConfirmDialog`); bypassed for the screen's own post-save/post-delete redirects
- [x] **Missing tag** renders the 404 screen ("Page not found", matching Ember's error route); non-404 load failures render a retry state
- [x] **Authors/contributors** are redirected away (`requiresAccess: canManageTags`, the same rule the tags list uses, standing in for Ember's `beforeModel` redirect)

Known divergences (all deliberate, none visible with the flag off):

- Code injection uses monospace textareas — `apps/admin` has no CodeMirror component and importing `admin-x-settings`' is off-limits; syntax highlighting can follow when a code editor lands in shade
- Code injection whitespace is preserved verbatim on save; Ember trims every edited value (`setTagProperty`), code injection included
- No per-file upload progress bar on the image pickers (no equivalent in `apps/admin`/shade yet)
- The delete modal stays open showing the error when the delete API call fails (Ember closed it either way)
- Preview cards are restyled with shade semantic tokens rather than pixel-cloning the Ember CSS

## Verification

- `apps/admin`: `pnpm lint`, `pnpm typecheck`, `pnpm test:unit` (1132 passed — gate, edit-module, image/save-lifecycle tests), `pnpm test:acceptance` (421 passed — flag-on render/save/create/validation/delete/leave-guard/force-upgrade specs and flag-off deferral to Ember for both URLs)
- `apps/admin-x-framework`: `pnpm lint`, `pnpm test:unit` (484 passed)
- `apps/ember-admin` (via `pnpm nx run ghost-admin:test`): 1165 passed — includes new unit tests for the tag-route abort and the state-bridge feature/tag mappings
- `apps/shade`: `pnpm lint`, build
- `ghost/core`: `test/unit/shared/labs.test.js` (19 passed); `test/e2e-api/admin/config.test.js` + `settings.test.js` green — the snapshot diff is exactly the one `tagDetailsReact` line in the labs block
- `e2e`: `tests/admin/tags/tag-detail.test.ts` runs the same journeys against both implementations via `test.use({labs: {tagDetailsReact}})` describes — green in CI across all E2E shards
