### PR TITLE
Removed inert multi-product guard from Portal tier visibility filtering

### DIFF
--- a/apps/portal/src/utils/helpers.js
+++ b/apps/portal/src/utils/helpers.js
@@ -366,7 +366,7 @@ export function getAvailableProducts({site}) {
     }).filter((product) => {
         return !!(Object.keys(product.monthlyPrice).length > 0 && Object.keys(product.yearlyPrice).length > 0);
     }).filter((product) => {
-        if (portalProducts && products.length > 1) {
+        if (portalProducts) {
             return portalProducts.includes(product.id);
         }
         return true;


### PR DESCRIPTION
no ref

Portal's `getAvailableProducts` only applied the `portal_products` visibility filter when `products.length > 1`. That guard dates from the June 2021 multi-products beta, when `site.products` contained only paid tiers and the check meant "site opted into multiple products". Since the free tier became a product in the site payload, every paid site has at least two products, so the guard is always true in production — it only changed behaviour for degenerate payloads and test fixtures, while making the filter's semantics misleading to readers and inconsistent for any future single-product code path.

Removed the condition so `portal_products` is applied consistently whenever it is set.