### PR TITLE
🏎 Ran post growth stats aggregates in parallel

### DIFF
--- a/ghost/core/core/server/services/stats/posts-stats-service.js
+++ b/ghost/core/core/server/services/stats/posts-stats-service.js
@@ -399,29 +399,33 @@ class PostsStatsService {
 
     async getGrowthStatsForPost(postId) {
         try {
-            const freeMembers = await this.knex('members_created_events as mce')
-                .countDistinct('mce.member_id as free_members')
-                .leftJoin('members_subscription_created_events as msce', function () {
-                    this.on('mce.member_id', '=', 'msce.member_id')
-                        .andOn('mce.attribution_id', '=', 'msce.attribution_id');
-                })
-                .where('mce.attribution_id', postId)
-                .whereIn('mce.attribution_type', ['post', 'page'])
-                .where('msce.id', null);
+            // The three aggregates only depend on postId, so run them together:
+            // the wait becomes the slowest query instead of the sum of all three.
+            const [freeMembers, paidMembers, mrr] = await Promise.all([
+                this.knex('members_created_events as mce')
+                    .countDistinct('mce.member_id as free_members')
+                    .leftJoin('members_subscription_created_events as msce', function () {
+                        this.on('mce.member_id', '=', 'msce.member_id')
+                            .andOn('mce.attribution_id', '=', 'msce.attribution_id');
+                    })
+                    .where('mce.attribution_id', postId)
+                    .whereIn('mce.attribution_type', ['post', 'page'])
+                    .where('msce.id', null),
 
-            const paidMembers = await this.knex('members_subscription_created_events as msce')
-                .countDistinct('msce.member_id as paid_members')
-                .where('msce.attribution_id', postId)
-                .whereIn('msce.attribution_type', ['post', 'page']);
+                this.knex('members_subscription_created_events as msce')
+                    .countDistinct('msce.member_id as paid_members')
+                    .where('msce.attribution_id', postId)
+                    .whereIn('msce.attribution_type', ['post', 'page']),
 
-            const mrr = await this.knex('members_subscription_created_events as msce')
-                .sum('mpse.mrr_delta as mrr')
-                .join('members_paid_subscription_events as mpse', function () {
-                    this.on('mpse.subscription_id', '=', 'msce.subscription_id');
-                    this.andOn('mpse.member_id', '=', 'msce.member_id');
-                })
-                .where('msce.attribution_id', postId)
-                .whereIn('msce.attribution_type', ['post', 'page']);
+                this.knex('members_subscription_created_events as msce')
+                    .sum('mpse.mrr_delta as mrr')
+                    .join('members_paid_subscription_events as mpse', function () {
+                        this.on('mpse.subscription_id', '=', 'msce.subscription_id');
+                        this.andOn('mpse.member_id', '=', 'msce.member_id');
+                    })
+                    .where('msce.attribution_id', postId)
+                    .whereIn('msce.attribution_type', ['post', 'page'])
+            ]);
 
             return {
                 data: [

--- a/ghost/core/test/unit/server/services/stats/posts.test.js
+++ b/ghost/core/test/unit/server/services/stats/posts.test.js
@@ -750,40 +750,6 @@ describe('PostsStatsService', function () {
 
             assert.deepEqual(result.data, expectedResults, 'Results should match expected order and counts for free_members desc');
         });
-
-        it('issues its three aggregates concurrently', async function () {
-            await _createFreeSignup('post_concurrent', 'referrer_1');
-
-            // Each query resolves only once all three have started. If they were
-            // still awaited one after another this would deadlock rather than
-            // return, so the assertion is that it resolves at all.
-            const started = [];
-            let releaseAll;
-            const allStarted = new Promise((resolve) => {
-                releaseAll = resolve;
-            });
-            const realKnex = service.knex;
-            service.knex = function (...args) {
-                const builder = realKnex.apply(this, args);
-                const originalThen = builder.then.bind(builder);
-                builder.then = function (onFulfilled, onRejected) {
-                    started.push(true);
-                    if (started.length === 3) {
-                        releaseAll();
-                    }
-                    return allStarted.then(() => originalThen(onFulfilled, onRejected));
-                };
-                return builder;
-            };
-
-            try {
-                const result = await service.getGrowthStatsForPost('post_concurrent');
-                assert.equal(started.length, 3, 'all three aggregates should be in flight together');
-                assert.equal(result.data[0].post_id, 'post_concurrent');
-            } finally {
-                service.knex = realKnex;
-            }
-        });
     });
 
     describe('getTopPostsViews', function () {

--- a/ghost/core/test/unit/server/services/stats/posts.test.js
+++ b/ghost/core/test/unit/server/services/stats/posts.test.js
@@ -750,6 +750,40 @@ describe('PostsStatsService', function () {
 
             assert.deepEqual(result.data, expectedResults, 'Results should match expected order and counts for free_members desc');
         });
+
+        it('issues its three aggregates concurrently', async function () {
+            await _createFreeSignup('post_concurrent', 'referrer_1');
+
+            // Each query resolves only once all three have started. If they were
+            // still awaited one after another this would deadlock rather than
+            // return, so the assertion is that it resolves at all.
+            const started = [];
+            let releaseAll;
+            const allStarted = new Promise((resolve) => {
+                releaseAll = resolve;
+            });
+            const realKnex = service.knex;
+            service.knex = function (...args) {
+                const builder = realKnex.apply(this, args);
+                const originalThen = builder.then.bind(builder);
+                builder.then = function (onFulfilled, onRejected) {
+                    started.push(true);
+                    if (started.length === 3) {
+                        releaseAll();
+                    }
+                    return allStarted.then(() => originalThen(onFulfilled, onRejected));
+                };
+                return builder;
+            };
+
+            try {
+                const result = await service.getGrowthStatsForPost('post_concurrent');
+                assert.equal(started.length, 3, 'all three aggregates should be in flight together');
+                assert.equal(result.data[0].post_id, 'post_concurrent');
+            } finally {
+                service.knex = realKnex;
+            }
+        });
     });
 
     describe('getTopPostsViews', function () {


### PR DESCRIPTION
Got some code for us? Awesome 🎊!

### Why are you making it?

`getGrowthStatsForPost` in `posts-stats-service.js` awaits three aggregate queries one after another. Each one only depends on `postId` — none of them reads another's result — so the response ends up waiting for the sum of three round trips where it only needs to wait for the slowest.

These are not trivial queries: one is a `countDistinct` over `members_created_events` with a `leftJoin`, one a `countDistinct` over `members_subscription_created_events`, and one a `sum` over that table joined to `members_paid_subscription_events`. On a site with a lot of member events they are the whole cost of the request.

### What does it do?

Wraps the three in `Promise.all`. The wait becomes the slowest query instead of the sum.

**The query bodies are unchanged** — same tables, joins, `where`s and aliases, and the destructuring keeps the same order. Only the awaiting changed. `this.knex(...)` goes through the connection pool here (no transaction is involved), so they genuinely run side by side.

### Why is this something Ghost users or developers need?

It is the post growth/analytics path, so it is a wait a user sits in front of. Three round trips become one, and it gets better the slower the database is — which is exactly when it is felt.

### How I verified it

- The existing `getGrowthStatsForPost` tests pass unchanged, so the results are identical (`47 passed` in `test/unit/server/services/stats/posts.test.js`).
- Added a test that holds each query until all three have started. If they are ever awaited sequentially again the third never starts and the test times out. **I confirmed it fails on `main` before this change** and passes with it — a test that cannot fail would not be worth adding.

### One thing worth flagging

On the error path the behaviour shifts slightly: previously a failure in the first query meant the other two never ran, now all three are in flight before one can reject. The rejection still lands in the same `try/catch`, which logs and returns `{data: []}`, so the outcome for the caller is the same — it is just that two extra reads may have been issued. Happy to switch to `Promise.allSettled` or leave it sequential if you would rather not have that.

I could not run `pnpm lint` locally — it fails to resolve its config for every file, including ones I did not touch, which looks like a workspace install issue on my side rather than anything in this change. Relying on CI for it.

Please check your PR against these items:

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works
