### PR TITLE
Fixed fork sync script to require custom PAT

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -12,11 +12,11 @@ name: Sync Fork
 # rather than merging or rewriting anything. Fork-local work belongs on branches
 # other than `main`.
 #
-# Auth: pushing to `main` needs a token. GITHUB_TOKEN works, but pushes made with
-# it don't trigger workflows, so the fast-forwarded `main` gets no CI run. Set the
-# `SYNC_FORK_TOKEN` secret (a PAT or GitHub App token with `contents: write`) if
-# you want CI to run on the synced commits — it's used in preference to
-# GITHUB_TOKEN when present.
+# Auth: requires the `SYNC_FORK_TOKEN` secret — a PAT or GitHub App token with
+# contents write + workflows write. GITHUB_TOKEN can't stand in: its pushes
+# don't trigger workflows, and GitHub rejects any push from it that touches
+# `.github/workflows/` (there's no `workflows` scope in `permissions:` to grant
+# — PATs and Apps only), which upstream changes regularly.
 #
 # If `main` is a protected branch, the token's identity needs permission to push
 # to it (bypass list / "Allow specified actors").
@@ -50,9 +50,26 @@ jobs:
       && github.event.repository.fork != true
     name: Fast-forward main to upstream
     runs-on: ubuntu-slim
-    permissions:
-      contents: write
     steps:
+      - name: Require SYNC_FORK_TOKEN
+        env:
+          # `secrets` isn't available in `if:`, so test for it in the script.
+          HAS_SYNC_FORK_TOKEN: ${{ secrets.SYNC_FORK_TOKEN != '' }}
+        run: |
+          set -euo pipefail
+
+          if [ "$HAS_SYNC_FORK_TOKEN" != "true" ]; then
+            {
+              echo "## ⚠️ \`SYNC_FORK_TOKEN\` is not set"
+              echo
+              echo "This workflow needs a PAT or GitHub App token with contents write + workflows write, stored as the \`SYNC_FORK_TOKEN\` secret."
+              echo
+              echo "\`GITHUB_TOKEN\` can't be used instead: pushes made with it don't trigger CI, and GitHub rejects them outright whenever upstream has changed a file under \`.github/workflows/\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::SYNC_FORK_TOKEN is not set — see job summary"
+            exit 1
+          fi
+
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: main
@@ -62,7 +79,7 @@ jobs:
           # uninitialised; a fast-forward only moves the gitlinks.
           fetch-depth: 0
           filter: blob:none
-          token: ${{ secrets.SYNC_FORK_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.SYNC_FORK_TOKEN }}
 
       - name: Fast-forward main
         run: |


### PR DESCRIPTION
no ref
- if files change in `.github/workflows`, the built-in action permissions can't push to main due to a lack of workflow permissions
- make the secret SYNC_FORK_TOKEN required for all runs to avoid a confusing fallback