### PR TITLE
🐛 Fixed Stripe checkout failing for accounts with Managed Payments enabled

### DIFF
--- a/ghost/core/core/server/services/stripe/stripe-api.js
+++ b/ghost/core/core/server/services/stripe/stripe-api.js
@@ -23,6 +23,12 @@ const SEARCH_MODE_RATE_LIMIT = isTesting ? 10_000 : 100;
 
 const STRIPE_API_VERSION = '2020-08-27';
 
+// Stripe's Managed Payments (merchant of record) does not support Connect, and
+// some Stripe accounts have it enabled by default for all Checkout Sessions.
+// On those accounts, session creation fails with "Managed Payments cannot be
+// used with Connect" unless it is explicitly disabled per session.
+const MANAGED_PAYMENTS_DISABLED = {enabled: false};
+
 /**
  * @typedef {import('stripe').Stripe.Customer} ICustomer
  * @typedef {import('stripe').Stripe.DeletedCustomer} IDeletedCustomer
@@ -584,6 +590,7 @@ module.exports = class StripeAPI {
 
         let stripeSessionOptions = {
             payment_method_types: this.PAYMENT_METHOD_TYPES,
+            managed_payments: MANAGED_PAYMENTS_DISABLED,
             success_url: options.successUrl || this._config.checkoutSessionSuccessUrl,
             cancel_url: options.cancelUrl || this._config.checkoutSessionCancelUrl,
             // @ts-ignore - we need to update to latest stripe library to correctly use newer features
@@ -649,6 +656,7 @@ module.exports = class StripeAPI {
 
         const stripeSessionOptions = {
             mode: 'payment',
+            managed_payments: MANAGED_PAYMENTS_DISABLED,
             success_url: successUrl || this._config.checkoutSessionSuccessUrl,
             cancel_url: cancelUrl || this._config.checkoutSessionCancelUrl,
             automatic_tax: {
@@ -715,6 +723,7 @@ module.exports = class StripeAPI {
 
         const stripeSessionOptions = {
             mode: 'payment',
+            managed_payments: MANAGED_PAYMENTS_DISABLED,
             success_url: successUrl,
             cancel_url: cancelUrl,
             automatic_tax: {
@@ -761,6 +770,7 @@ module.exports = class StripeAPI {
         await this._rateLimitBucket.throttle();
         const session = await this._stripe.checkout.sessions.create({
             mode: 'setup',
+            managed_payments: MANAGED_PAYMENTS_DISABLED,
             payment_method_types: this.PAYMENT_METHOD_TYPES,
             success_url: options.successUrl || this._config.checkoutSetupSessionSuccessUrl,
             cancel_url: options.cancelUrl || this._config.checkoutSetupSessionCancelUrl,

--- a/ghost/core/core/server/services/stripe/stripe-api.js
+++ b/ghost/core/core/server/services/stripe/stripe-api.js
@@ -23,8 +23,8 @@ const SEARCH_MODE_RATE_LIMIT = isTesting ? 10_000 : 100;
 
 const STRIPE_API_VERSION = '2020-08-27';
 
-// Stripe's Managed Payments (merchant of record) does not support Connect, and
-// some Stripe accounts have it enabled by default for all Checkout Sessions.
+// Stripe's Managed Payments does not support Connect, and some Stripe
+// accounts have it enabled by default for all Checkout Sessions.
 // On those accounts, session creation fails with "Managed Payments cannot be
 // used with Connect" unless it is explicitly disabled per session.
 const MANAGED_PAYMENTS_DISABLED = {enabled: false};

--- a/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
+++ b/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
@@ -236,7 +236,7 @@ describe('StripeAPI', function () {
         });
 
         it('createCheckoutSetupSession explicitly disables Managed Payments', async function () {
-            await api.createCheckoutSetupSession('priceId', {});
+            await api.createCheckoutSetupSession({id: mockCustomerId, email: mockCustomerEmail}, {});
 
             assert.deepEqual(mockStripe.checkout.sessions.create.firstCall.firstArg.managed_payments, {enabled: false});
         });
@@ -570,7 +570,7 @@ describe('StripeAPI', function () {
         });
 
         it('createDonationCheckoutSession explicitly disables Managed Payments', async function () {
-            await api.createDonationCheckoutSession('priceId', {});
+            await api.createDonationCheckoutSession({priceId: 'priceId', successUrl: '/success', cancelUrl: '/cancel', metadata: {}});
 
             assert.deepEqual(mockStripe.checkout.sessions.create.firstCall.firstArg.managed_payments, {enabled: false});
         });

--- a/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
+++ b/ghost/core/test/unit/server/services/stripe/stripe-api.test.js
@@ -66,6 +66,12 @@ describe('StripeAPI', function () {
             assertExists(mockStripe.checkout.sessions.create.firstCall.firstArg.cancel_url);
         });
 
+        it('explicitly disables Managed Payments', async function () {
+            await api.createCheckoutSession('priceId', null, {});
+
+            assert.deepEqual(mockStripe.checkout.sessions.create.firstCall.firstArg.managed_payments, {enabled: false});
+        });
+
         it('sets valid trialDays', async function () {
             await api.createCheckoutSession('priceId', null, {
                 trialDays: 12
@@ -227,6 +233,12 @@ describe('StripeAPI', function () {
 
             assertExists(mockStripe.checkout.sessions.create.firstCall.firstArg.success_url);
             assertExists(mockStripe.checkout.sessions.create.firstCall.firstArg.cancel_url);
+        });
+
+        it('createCheckoutSetupSession explicitly disables Managed Payments', async function () {
+            await api.createCheckoutSetupSession('priceId', {});
+
+            assert.deepEqual(mockStripe.checkout.sessions.create.firstCall.firstArg.managed_payments, {enabled: false});
         });
 
         it('createCheckoutSetupSession does not send currency if additionalPaymentMethods flag is off', async function () {
@@ -557,6 +569,12 @@ describe('StripeAPI', function () {
             assertExists(mockStripe.checkout.sessions.create.firstCall.firstArg.cancel_url);
         });
 
+        it('createDonationCheckoutSession explicitly disables Managed Payments', async function () {
+            await api.createDonationCheckoutSession('priceId', {});
+
+            assert.deepEqual(mockStripe.checkout.sessions.create.firstCall.firstArg.managed_payments, {enabled: false});
+        });
+
         it('createDonationCheckoutSession does not send currency if additionalPaymentMethods flag is off', async function () {
             mockLabsIsSet.withArgs('additionalPaymentMethods').returns(false);
             await api.createDonationCheckoutSession('priceId', {currency: 'usd'});
@@ -807,6 +825,21 @@ describe('StripeAPI', function () {
             assert.equal(args.line_items[0].price_data.unit_amount, 5000);
             assert.equal(args.line_items[0].price_data.currency, 'usd');
             assert.equal(args.line_items[0].price_data.product_data.name, 'Gift subscription — Pro (1 year)');
+        });
+
+        it('explicitly disables Managed Payments', async function () {
+            await api.createGiftCheckoutSession({
+                amount: 5000,
+                currency: 'usd',
+                tierName: 'Pro',
+                cadence: 'year',
+                duration: 1,
+                successUrl: '/gift-success',
+                cancelUrl: '/gift-cancel',
+                metadata: {}
+            });
+
+            assert.deepEqual(mockStripe.checkout.sessions.create.firstCall.firstArg.managed_payments, {enabled: false});
         });
 
         it('uses 1 month label for monthly cadence', async function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1928
ref https://ghost.slack.com/archives/CJBJ3MZFD/p1785434550639309
ref https://forum.ghost.org/t/stripe-checkout-session-fails-with-managed-payments-cannot-be-used-with-connect-on-self-hosted-ghost-6-52-1/63449/1
ref https://forum.ghost.org/t/paid-checkout-fails-for-both-the-monthly-and-annual-options/63465

## Problem

Since late July 2026, Stripe has been provisioning some new accounts with Managed Payments (their merchant-of-record product) enabled by default for all Checkout Sessions. Managed Payments does not support Connect, so on those accounts every checkout attempt fails with a 400 from Stripe:

> You specified a Stripe-Account header, but Managed Payments cannot be used with Connect.

Members cannot start any paid subscription on affected sites. Affected site owners can't always opt out themselves: on default-on accounts the Stripe dashboard states Managed Payments "can only be disabled for individual sessions" and offers no account-level toggle.

## Solution

Stripe checkout session creation now explicitly disables Managed Payments per session (`managed_payments: {enabled: false}`) on all four Checkout Session types: subscription, donation, gift, and setup.

Verified empirically against the live Stripe API using Connect-obtained test keys:

- `managed_payments[enabled]=false` is accepted under Ghost's pinned `2020-08-27` API version, on subscription-shaped (legacy `subscription_data.items`), payment-mode, and setup-mode session creation — so no API version bump or retry fallback is needed.
- stripe-node 8.222.0 (Ghost's pinned version) serializes the parameter correctly and sessions create successfully.
- The inverse (`enabled=true`) on the same Connect key reproduces the reported error verbatim, confirming the failure mechanism.
