### PR TITLE
Updated members area copy to say newsletters instead of emails

### DIFF
--- a/apps/admin/src/members/components/member-table-chrome.tsx
+++ b/apps/admin/src/members/components/member-table-chrome.tsx
@@ -65,7 +65,7 @@ export const MembersTableHeader = ({
                 </TableHead>
                 {showEmailOpenRate && (
                     <TableHead className="bg-transparent px-4" style={columnStyles.openRate}>
-                        Open rate
+                        Newsletter open rate
                     </TableHead>
                 )}
                 <TableHead className="bg-transparent px-4" style={columnStyles.location}>

--- a/apps/admin/src/members/detail/member-detail-sidebar.tsx
+++ b/apps/admin/src/members/detail/member-detail-sidebar.tsx
@@ -125,17 +125,17 @@ const MemberDetailSidebar: React.FC<MemberDetailSidebarProps> = ({member, draftN
                                 // "this member" when no name is known.
                                 <p className='text-muted-foreground'>
                                     {name
-                                        ? `We’ll show ${getFirstName(name)}’s email stats here once they receive their first newsletter.`
-                                        : 'We’ll show this member’s email stats here once they receive their first newsletter.'}
+                                        ? `We’ll show ${getFirstName(name)}’s newsletter stats here once they receive their first newsletter.`
+                                        : 'We’ll show this member’s newsletter stats here once they receive their first newsletter.'}
                                 </p>
                             ) : (
                                 <div className='flex flex-col gap-4'>
                                     <div className='flex flex-col gap-0.5'>
-                                        <p className='text-muted-foreground'>Emails received</p>
+                                        <p className='text-muted-foreground'>Newsletters received</p>
                                         <p className='text-2xl font-semibold'>{member.email_count}</p>
                                     </div>
                                     <div className='flex flex-col gap-0.5'>
-                                        <p className='text-muted-foreground'>Emails opened</p>
+                                        <p className='text-muted-foreground'>Newsletters opened</p>
                                         {/* Ember Data defaults this to `0`
                                             too (`ghost/admin/app/models/member.js:21`),
                                             so mirror that here for parity. */}

--- a/apps/admin/src/members/detail/member-event.ts
+++ b/apps/admin/src/members/detail/member-event.ts
@@ -193,10 +193,10 @@ function getAction(event: RawMemberEvent, hasMultipleNewsletters: boolean): stri
         return 'changed paid subscription';
     }
     if (event.type === 'email_opened_event') {
-        return 'opened email';
+        return 'opened newsletter';
     }
     if (event.type === 'email_sent_event') {
-        return 'sent email';
+        return 'sent newsletter';
     }
     if (event.type === 'automated_email_sent_event') {
         const auto = event.data.automatedEmail as {source?: string; slug?: string; subject?: string} | undefined;
@@ -212,13 +212,13 @@ function getAction(event: RawMemberEvent, hasMultipleNewsletters: boolean): stri
         return subject ? `received automated email: ${subject}` : 'received automated email';
     }
     if (event.type === 'email_delivered_event') {
-        return 'received email';
+        return 'received newsletter';
     }
     if (event.type === 'email_failed_event') {
-        return 'bounced email';
+        return 'bounced newsletter';
     }
     if (event.type === 'email_complaint_event') {
-        return 'email flagged as spam';
+        return 'newsletter flagged as spam';
     }
     if (event.type === 'comment_event') {
         return event.data.parent ? 'replied to comment' : 'commented';

--- a/apps/admin/src/members/member-fields.ts
+++ b/apps/admin/src/members/member-fields.ts
@@ -345,7 +345,7 @@ const baseMemberFields = defineFields({
     email_count: {
         operators: NUMBER_OPERATORS,
         ui: {
-            label: 'Emails sent (all time)',
+            label: 'Newsletters sent (all time)',
             type: 'number',
             defaultOperator: 'is-greater',
             min: 0,
@@ -356,7 +356,7 @@ const baseMemberFields = defineFields({
     email_opened_count: {
         operators: NUMBER_OPERATORS,
         ui: {
-            label: 'Emails opened (all time)',
+            label: 'Newsletters opened (all time)',
             type: 'number',
             defaultOperator: 'is-greater',
             min: 0,
@@ -367,7 +367,7 @@ const baseMemberFields = defineFields({
     email_open_rate: {
         operators: NUMBER_OPERATORS,
         ui: {
-            label: 'Open rate (all time)',
+            label: 'Newsletter open rate (all time)',
             type: 'number',
             defaultOperator: 'is-greater',
             min: 0,
@@ -380,10 +380,10 @@ const baseMemberFields = defineFields({
     'emails.post_id': {
         operators: SCALAR_OPERATORS,
         ui: {
-            label: 'Sent email',
+            label: 'Sent newsletter',
             type: 'select',
             searchable: true,
-            placeholder: 'Select an email...',
+            placeholder: 'Select a newsletter...',
             className: 'w-64'
         },
         codec: scalarCodec({quoteStrings: true})
@@ -391,10 +391,10 @@ const baseMemberFields = defineFields({
     'opened_emails.post_id': {
         operators: SCALAR_OPERATORS,
         ui: {
-            label: 'Opened email',
+            label: 'Opened newsletter',
             type: 'select',
             searchable: true,
-            placeholder: 'Select an email...',
+            placeholder: 'Select a newsletter...',
             className: 'w-64'
         },
         codec: scalarCodec({quoteStrings: true})
@@ -402,10 +402,10 @@ const baseMemberFields = defineFields({
     'clicked_links.post_id': {
         operators: SCALAR_OPERATORS,
         ui: {
-            label: 'Clicked email',
+            label: 'Clicked newsletter',
             type: 'select',
             searchable: true,
-            placeholder: 'Select an email...',
+            placeholder: 'Select a newsletter...',
             className: 'w-64'
         },
         codec: scalarCodec({quoteStrings: true})
@@ -416,7 +416,7 @@ const baseMemberFields = defineFields({
             label: 'Responded with feedback',
             type: 'select',
             searchable: true,
-            placeholder: 'Select an email...',
+            placeholder: 'Select a newsletter...',
             className: 'w-64',
             defaultOperator: '1'
         },

--- a/apps/ember-admin/app/components/gh-member-details.hbs
+++ b/apps/ember-admin/app/components/gh-member-details.hbs
@@ -88,20 +88,20 @@
                         <div class="gh-members-no-stats">
                             <p>
                                 {{#if @member.name}}
-                                    We’ll show {{first-name @member.name}}’s email stats here once they receive their first newsletter.
+                                    We’ll show {{first-name @member.name}}’s newsletter stats here once they receive their first newsletter.
                                 {{else}}
-                                    We’ll show this member’s email stats here once they receive their first newsletter.
+                                    We’ll show this member’s newsletter stats here once they receive their first newsletter.
                                 {{/if}}
                             </p>
                         </div>
                     {{else}}
                         <div class="gh-member-details-stats">
                             <div class="gh-member-details-stat">
-                                <p>Emails received</p>
+                                <p>Newsletters received</p>
                                 <div class="gh-data-summary gh-cp-data-summary">{{@member.emailCount}}</div>
                             </div>
                             <div class="gh-member-details-stat">
-                                <p>Emails opened</p>
+                                <p>Newsletters opened</p>
                                 <div class="gh-data-summary gh-cp-data-summary">{{@member.emailOpenedCount}}</div>
                             </div>
                             <div class="gh-member-details-stat open-rate">

--- a/apps/ember-admin/app/helpers/parse-member-event.js
+++ b/apps/ember-admin/app/helpers/parse-member-event.js
@@ -208,11 +208,11 @@ export default class ParseMemberEventHelper extends Helper {
         }
 
         if (event.type === 'email_opened_event') {
-            return 'opened email';
+            return 'opened newsletter';
         }
 
         if (event.type === 'email_sent_event') {
-            return 'sent email';
+            return 'sent newsletter';
         }
 
         if (event.type === 'automated_email_sent_event') {
@@ -227,15 +227,15 @@ export default class ParseMemberEventHelper extends Helper {
         }
 
         if (event.type === 'email_delivered_event') {
-            return 'received email';
+            return 'received newsletter';
         }
 
         if (event.type === 'email_failed_event') {
-            return 'bounced email';
+            return 'bounced newsletter';
         }
 
         if (event.type === 'email_complaint_event') {
-            return 'email flagged as spam';
+            return 'newsletter flagged as spam';
         }
 
         if (event.type === 'comment_event') {

--- a/apps/ember-admin/app/styles/layouts/member-activity.css
+++ b/apps/ember-admin/app/styles/layouts/member-activity.css
@@ -340,7 +340,7 @@
 }
 
 .gh-member-activity-actions-menu--suppression {
-    min-width: 260px;
+    min-width: 300px;
 }
 .gh-member-activity-actions-menu--suppression.gh-member-activity-actions-menu {
     padding: 4px 0;

--- a/apps/ember-admin/app/utils/member-event-types.js
+++ b/apps/ember-admin/app/utils/member-event-types.js
@@ -3,13 +3,13 @@ export const ALL_EVENT_TYPES = [
     {event: 'login_event', icon: 'filter-dropdown-logins', name: 'Logins', group: 'auth'},
     {event: 'subscription_event', icon: 'filter-dropdown-paid-subscriptions', name: 'Paid subscriptions', group: 'payments'},
     {event: 'payment_event', icon: 'filter-dropdown-payments', name: 'Payments', group: 'payments'},
-    {event: 'newsletter_event', icon: 'filter-dropdown-email-subscriptions', name: 'Email subscriptions', group: 'emails'},
-    {event: 'email_opened_event', icon: 'filter-dropdown-email-opened', name: 'Email opened', group: 'emails'},
-    {event: 'email_delivered_event', icon: 'filter-dropdown-email-received', name: 'Email received', group: 'emails'},
-    {event: 'email_complaint_event', icon: 'filter-dropdown-email-flagged-as-spam', name: 'Email flagged as spam', group: 'emails'},
-    {event: 'email_failed_event', icon: 'filter-dropdown-email-bounced', name: 'Email bounced', group: 'emails'},
+    {event: 'newsletter_event', icon: 'filter-dropdown-email-subscriptions', name: 'Newsletter subscriptions', group: 'emails'},
+    {event: 'email_opened_event', icon: 'filter-dropdown-email-opened', name: 'Newsletter opened', group: 'emails'},
+    {event: 'email_delivered_event', icon: 'filter-dropdown-email-received', name: 'Newsletter received', group: 'emails'},
+    {event: 'email_complaint_event', icon: 'filter-dropdown-email-flagged-as-spam', name: 'Newsletter flagged as spam', group: 'emails'},
+    {event: 'email_failed_event', icon: 'filter-dropdown-email-bounced', name: 'Newsletter bounced', group: 'emails'},
     {event: 'email_change_event', icon: 'filter-dropdown-email-address-changed', name: 'Email address changed', group: 'emails'},
-    {event: 'automated_email_sent_event', icon: 'filter-dropdown-email-received', name: 'Welcome email received', group: 'emails'},
+    {event: 'automated_email_sent_event', icon: 'filter-dropdown-email-received', name: 'Automated email received', group: 'emails'},
     {event: 'feedback_event', icon: 'filter-dropdown-feedback', name: 'Feedback', group: 'others'}
 ];
 

--- a/e2e/tests/admin/members/member-detail.test.ts
+++ b/e2e/tests/admin/members/member-detail.test.ts
@@ -525,7 +525,7 @@ for (const {implementation, memberDetailsReact} of [
                 await page.goto(memberPath(member.id));
 
                 await expect(page.getByRole('heading', {name: 'Engagement'})).toBeVisible();
-                await expect(page.getByText(/We[’']ll show Ada[’']s email stats here/)).toBeVisible();
+                await expect(page.getByText(/We[’']ll show Ada[’']s newsletter stats here/)).toBeVisible();
             });
 
             test('member has received emails - shows counts and open rate', async ({page}) => {
@@ -541,9 +541,9 @@ for (const {implementation, memberDetailsReact} of [
                 await page.goto(memberPath(member.id));
 
                 const engagement = memberDetailsPage.engagementSection;
-                await expect(engagement.getByText('Emails received')).toBeVisible();
+                await expect(engagement.getByText('Newsletters received')).toBeVisible();
                 await expect(engagement.getByText('12', {exact: true})).toBeVisible();
-                await expect(engagement.getByText('Emails opened')).toBeVisible();
+                await expect(engagement.getByText('Newsletters opened')).toBeVisible();
                 await expect(engagement.getByText('9', {exact: true})).toBeVisible();
                 await expect(engagement.getByText('Average open rate')).toBeVisible();
                 await expect(engagement.getByText(/75\s*%/)).toBeVisible();
@@ -560,7 +560,7 @@ for (const {implementation, memberDetailsReact} of [
                 await page.goto(memberPath(member.id));
 
                 await expect(page.getByRole('heading', {name: 'Engagement'})).toBeVisible();
-                await expect(page.getByText(/We[’']ll show Ada[’']s email stats here/)).toBeVisible();
+                await expect(page.getByText(/We[’']ll show Ada[’']s newsletter stats here/)).toBeVisible();
             });
 
             test('open rate not yet calculated - shows the placeholder', async ({page}) => {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1442

- automations now send and measure their own emails, so member-facing stats labelled "Emails" became ambiguous — `members.email_count` and similar fields currently only count newsletter emails
- renamed the copy in the members list column, member filters, member detail engagement stats, and the activity feed + its event type filter from "email(s)" to "newsletter(s)", in both the Ember admin and the React member detail (`memberDetailsReact` flag) so the two implementations stay in sync
- deliberately kept click events as "Clicked link in email": automation clicks are recorded in the same `members_click_events` table and surface in the same activity feed, so newsletter wording would mislabel them
- left the Analytics settings toggles as "Email opens/clicks" since those settings govern newsletter and automation emails alike

Video walkthrough showing all the spots changed - at least when this PR was opened:

https://github.com/user-attachments/assets/e2811c4c-fd01-41ba-a81f-911943ff17a9

