### PR TITLE
Address custom fields: optional parts, import merge, country normalisation

### DIFF
--- a/apps/admin-x-framework/src/api/members.ts
+++ b/apps/admin-x-framework/src/api/members.ts
@@ -501,10 +501,10 @@ export interface EditMemberData {
     tiers?: Array<{id: string; expiry_at?: string | null}>;
     // Merge semantics: only the keys present are written; `null` clears a
     // value. Values are strings for text-backed fields and composite objects
-    // for address (Partial because a draft mid-edit may hold an incomplete
-    // address — the server validates completeness, not this type). Requires
-    // the `membersCustomFields` flag server-side.
-    custom_fields?: Record<string, string | Partial<Address> | null>;
+    // for address — every sub-field of which is optional, the server asking
+    // only that one of them is filled in. Requires the `membersCustomFields`
+    // flag server-side.
+    custom_fields?: Record<string, string | Address | null>;
 }
 
 export const useEditMember = createMutation<MembersResponseType, EditMemberData>({

--- a/apps/admin/src/members/detail/member-detail-custom-fields.acceptance.test.tsx
+++ b/apps/admin/src/members/detail/member-detail-custom-fields.acceptance.test.tsx
@@ -153,23 +153,42 @@ describe('Member detail custom fields', () => {
         expect(editApi.requests).toHaveLength(0);
     });
 
-    it('blocks saving an incomplete address with inline sub-field errors, then saves once fixed', async () => {
+    it('saves an address that leaves sub-fields the country does not use empty', async () => {
+        const m = member({name: 'Ada Lovelace'});
+        const editApi = fakeMemberDetailWorld(m, {});
+        await renderAdminApp(`/members/${m.id}`, FLAGS);
+
+        // Hong Kong has no postal code, so leaving it empty is a complete address
+        // rather than an incomplete one.
+        await page.getByRole('button', {name: 'Edit Home address'}).click();
+        await modal().getByLabelText('Address line 1').fill('Flat 3, 8 Wan Chai Road');
+        await modal().getByLabelText('City').fill('Hong Kong');
+        await modal().getByLabelText('Country').fill('HK');
+        await modal().getByRole('button', {name: 'Save', exact: true}).click();
+
+        await expect.element(page.getByText('Flat 3, 8 Wan Chai Road, Hong Kong, HK')).toBeVisible();
+        const saved = editApi.lastRequest?.body as {members: Array<Record<string, unknown>>};
+        expect(saved.members[0].custom_fields).toEqual({
+            home_address: {line1: 'Flat 3, 8 Wan Chai Road', city: 'Hong Kong', country: 'HK'}
+        });
+    });
+
+    it('blocks saving a malformed country code with an inline error, then saves once fixed', async () => {
         const m = member({name: 'Ada Lovelace'});
         const editApi = fakeMemberDetailWorld(m, {});
         await renderAdminApp(`/members/${m.id}`, FLAGS);
 
         await page.getByRole('button', {name: 'Edit Home address'}).click();
         await modal().getByLabelText('Address line 1').fill('1 Main St');
+        await modal().getByLabelText('City').fill('Berlin');
+        await modal().getByLabelText('Postal code').fill('10115');
+        await modal().getByLabelText('Country').fill('DEU');
         await modal().getByRole('button', {name: 'Save', exact: true}).click();
 
-        // No request went out; the errors say what to do, in plain words.
-        await expect.element(modal().getByText('Enter a city.')).toBeVisible();
-        await expect.element(modal().getByText('Enter a postal code.')).toBeVisible();
+        // No request went out; the error says what to do, in plain words.
         await expect.element(modal().getByText('Enter a 2-letter country code, like US.')).toBeVisible();
         expect(editApi.requests).toHaveLength(0);
 
-        await modal().getByLabelText('City').fill('Berlin');
-        await modal().getByLabelText('Postal code').fill('10115');
         await modal().getByLabelText('Country').fill('DE');
         await modal().getByRole('button', {name: 'Save', exact: true}).click();
 

--- a/apps/admin/src/members/detail/member-detail-edit.test.ts
+++ b/apps/admin/src/members/detail/member-detail-edit.test.ts
@@ -1,4 +1,5 @@
 import {NOTE_MAX_LENGTH, buildCustomFieldSavePayload, buildMemberFieldEditPayload, getCustomFieldValidationErrors, getDefaultNewsletterIdsForNewMember, getEditableCustomFieldValues, getEmailErrorMessage, getMemberEditableSlice, getMemberNewslettersUiEnabled, getMemberSuppressionInfo, getNoteCharactersLeft, isDraftInSyncWithServer, isValidMemberEmail, parseCustomFieldServerErrors, resolveSlugsToLabels, toggleMemberNewsletter} from './member-detail-edit';
+import {MEMBER_CUSTOM_FIELD_TYPES} from '@tryghost/admin-x-framework/api/member-custom-fields';
 import {describe, expect, it} from 'vitest';
 import type {MemberCustomField} from '@tryghost/admin-x-framework/api/member-custom-fields';
 
@@ -329,13 +330,12 @@ describe('getCustomFieldValidationErrors', () => {
         expect(getCustomFieldValidationErrors({job_title: '', home_address: {}}, fields)).toEqual({});
     });
 
-    it('reports missing required address sub-fields in plain words, keyed by dotted path', () => {
-        const errors = getCustomFieldValidationErrors({home_address: {line1: '1 Main St'}}, fields);
-        expect(errors).toEqual({
-            'home_address.city': 'Enter a city.',
-            'home_address.postal_code': 'Enter a postal code.',
-            'home_address.country': 'Enter a 2-letter country code, like US.'
-        });
+    it('accepts a partial address — no sub-field is required', () => {
+        // The stored shape is fixed, but which parts of it exist is a per-country
+        // question, so an address without a city or postal code is valid rather
+        // than incomplete.
+        expect(getCustomFieldValidationErrors({home_address: {line1: '1 Main St'}}, fields)).toEqual({});
+        expect(getCustomFieldValidationErrors({home_address: {country: 'HK'}}, fields)).toEqual({});
     });
 
     it('explains a malformed country code rather than echoing the schema message', () => {
@@ -348,14 +348,22 @@ describe('getCustomFieldValidationErrors', () => {
         expect(errors).toEqual({job_title: 'Use 255 characters or fewer.'});
     });
 
-    it('reports an over-long required address sub-field as a length problem, not a missing one', () => {
+    it('reports an over-long address sub-field with the limit a person can act on', () => {
         const errors = getCustomFieldValidationErrors({home_address: {...validAddress, line1: 'x'.repeat(256)}}, fields);
         expect(errors).toEqual({'home_address.line1': 'Use 255 characters or fewer.'});
     });
 
-    it('validates the normalized value, so whitespace does not dodge a limit', () => {
-        const errors = getCustomFieldValidationErrors({home_address: {line1: '1 Main St', city: '  ', postal_code: '10115', country: 'DE'}}, fields);
-        expect(Object.keys(errors)).toEqual(['home_address.city']);
+    it('validates the normalized value, so an address of nothing but whitespace reads as cleared', () => {
+        const whitespaceOnly = {line1: '  ', city: '  '};
+
+        // The schema rejects this outright, so no errors can only mean normalization
+        // ran first — without that check the assertion below passes either way.
+        expect(MEMBER_CUSTOM_FIELD_TYPES.address.value.safeParse(whitespaceOnly).success).toBe(false);
+        expect(getCustomFieldValidationErrors({home_address: whitespaceOnly}, fields)).toEqual({});
+
+        // "Cleared" is the other half of the claim: the save sends null, not an object.
+        expect(buildCustomFieldSavePayload('m1', 'home_address', whitespaceOnly).custom_fields)
+            .toEqual({home_address: null});
     });
 });
 

--- a/apps/admin/src/members/detail/member-detail-edit.ts
+++ b/apps/admin/src/members/detail/member-detail-edit.ts
@@ -263,43 +263,31 @@ export function buildCustomFieldSavePayload(
     return {id: memberId, custom_fields: {[fieldKey]: normalized ?? null}};
 }
 
-// What to do about a missing or malformed address sub-field, in plain words.
-// Schema messages (zod's "Invalid input: expected string…") never reach the
-// screen — the schema decides WHETHER a value is valid, this copy says what
-// to do about it.
-const ADDRESS_SUBFIELD_MESSAGES: Record<typeof ADDRESS_SUBFIELD_KEYS[number], string> = {
-    line1: 'Enter a street address.',
-    line2: 'Enter a shorter address line.',
-    city: 'Enter a city.',
-    state: 'Enter a shorter state.',
-    postal_code: 'Enter a postal code.',
-    country: 'Enter a 2-letter country code, like US.'
-};
-
-// Required free-text sub-fields fail as too_small when missing and too_big when
-// over the limit, but their copy above only fits the missing case — so an
-// over-long value defers to the length message. The others already read
-// correctly for their over-long case (line2/state say "shorter"; country is a
-// format hint that fits a too-long code too), so they keep their copy.
-const ADDRESS_SUBFIELDS_LENGTH_ON_TOO_BIG: ReadonlySet<string> = new Set(['line1', 'city', 'postal_code']);
+// What to do about a malformed address sub-field, in plain words. Schema messages
+// (zod's "Invalid input: expected string…") never reach the screen — the schema
+// decides WHETHER a value is valid, this copy says what to do about it.
+//
+// Country is the only sub-field that needs its own copy, because it is the only
+// one whose rule is not a length bound. No sub-field is required, so every other
+// one can fail only by being too long, and the generic length message says that
+// better than a per-sub-field phrasing could: it names the limit.
+const COUNTRY_CODE_MESSAGE = 'Enter a 2-letter country code, like US.';
 
 /** A schema issue translated into copy a person can act on. */
 function friendlyValidationMessage(
     field: MemberCustomField,
     issue: {code?: string; path: ReadonlyArray<PropertyKey>; maximum?: unknown}
 ): string {
-    const tooBigMaximum = issue.code === 'too_big' && typeof issue.maximum === 'number' ? issue.maximum : undefined;
-    if (field.type === 'address') {
-        const subfield = issue.path[0];
-        if (typeof subfield === 'string') {
-            if (tooBigMaximum !== undefined && ADDRESS_SUBFIELDS_LENGTH_ON_TOO_BIG.has(subfield)) {
-                return `Use ${tooBigMaximum} characters or fewer.`;
-            }
-            if (subfield in ADDRESS_SUBFIELD_MESSAGES) {
-                return ADDRESS_SUBFIELD_MESSAGES[subfield as typeof ADDRESS_SUBFIELD_KEYS[number]];
-            }
-        }
+    if (field.type === 'address' && issue.path[0] === 'country') {
+        return COUNTRY_CODE_MESSAGE;
     }
+    // The composite's own rule, which names no sub-field: an address has to say
+    // something. The editor normalizes an all-blank address to a clear before it
+    // validates, so this is a backstop rather than a message the screen shows.
+    if (field.type === 'address' && issue.path.length === 0) {
+        return 'Enter at least one part of the address.';
+    }
+    const tooBigMaximum = issue.code === 'too_big' && typeof issue.maximum === 'number' ? issue.maximum : undefined;
     if (tooBigMaximum !== undefined) {
         return `Use ${tooBigMaximum} characters or fewer.`;
     }

--- a/ghost/core/core/server/services/members-custom-fields/schema.ts
+++ b/ghost/core/core/server/services/members-custom-fields/schema.ts
@@ -44,6 +44,14 @@ export const DbCustomFieldValue = z.object({
 
 type CustomFieldValueRow = z.infer<typeof DbCustomFieldValue>;
 
+// A composite value once decoded: sub-field keys to values, and no narrower. Which
+// sub-fields a composite has is its field type's business, not the row's.
+//
+// It doubles as the guard on a stored blob. A JSON column can just as easily hold an
+// array, a null or a bare number, and a record rejects all three — so parsing against
+// this is what narrows the type, with no assertion needed.
+export const StoredCompositeValue = z.record(z.string(), z.unknown());
+
 // The value join a read needs: the field's identity and type travel with the
 // stored columns, so a row can be decoded without a second lookup. `type` is
 // parsed as the field-type enum, which narrows it with no cast.

--- a/ghost/core/core/server/services/members-custom-fields/values-service.ts
+++ b/ghost/core/core/server/services/members-custom-fields/values-service.ts
@@ -3,8 +3,8 @@ import errors from '@tryghost/errors';
 import logging from '@tryghost/logging';
 import type {Knex} from 'knex';
 import {z} from 'zod';
-import {FIELD_TYPES, type FieldType} from '@tryghost/custom-field-types';
-import {DbCustomFieldValueWithField, FIELD_STATUS} from './schema';
+import {FIELD_TYPES, subFieldsOf, type FieldType} from '@tryghost/custom-field-types';
+import {DbCustomFieldValueWithField, FIELD_STATUS, StoredCompositeValue} from './schema';
 import {activeFields} from './queries';
 import {storageCodecFor, storageColumnsFor} from './storage';
 
@@ -19,6 +19,21 @@ const MAX_KEY_LENGTH = 191;
 // validated by its own field type's schema, which isn't known until the key is
 // resolved to a definition.
 const ValuesInput = z.record(z.string().max(MAX_KEY_LENGTH), z.unknown());
+
+// JSON.parse as a total function. Anything unreadable — unparseable text, or the null
+// a nullable column can always return — reads as `undefined`, which no value schema
+// accepts. That way a corrupt blob is turned away by the same check that turns away a
+// well-formed one of the wrong shape, instead of needing a branch of its own.
+function decodeJson(raw: string | null): unknown {
+    if (raw === null) {
+        return undefined;
+    }
+    try {
+        return JSON.parse(raw);
+    } catch {
+        return undefined;
+    }
+}
 
 // The field facts the value path needs: the id to write the FK, the key to match
 // input against, the name for error messages, and the type to pick the validator
@@ -223,21 +238,125 @@ export class CustomFieldValuesService {
     }
 
     /**
+     * @private
+     * The composite values this member already holds for the fields in a plan,
+     * keyed by field id. Composites only: a scalar has nothing to merge into.
+     *
+     * Read through the caller's executor, never the base connection. On a
+     * single-connection pool a read off `this.knex` inside an open transaction
+     * waits for the connection that transaction is holding, and hangs.
+     *
+     * A blob that won't decode is left out, so the write replaces it rather than
+     * merging into something unreadable.
+     */
+    private async storedComposites(trx: Knex, memberId: string, writes: PlannedWrite[]): Promise<Map<string, Record<string, unknown>>> {
+        const composites = new Map<string, Record<string, unknown>>();
+        // Merging is only meaningful for a value with parts, which is a fact about the
+        // type's shape rather than the column it lands in. Asking the storage type
+        // instead would sweep in the first json-backed type that isn't a record — a
+        // multi-select held as a list, say — and log a decode failure for every row of
+        // an import, over a value that reads back perfectly well.
+        const fieldIds = writes
+            .filter(({field, value}) => value !== undefined && subFieldsOf(field.type) !== null)
+            .map(({field}) => field.id);
+
+        if (fieldIds.length === 0) {
+            return composites;
+        }
+
+        const rows = await trx(VALUES_TABLE)
+            .where('member_id', memberId)
+            .whereIn('custom_field_id', fieldIds)
+            .whereNotNull('value_json')
+            .select('custom_field_id', 'value_json')
+            // Merging reads a value and writes it back, so the row has to stay still in
+            // between: without the lock a write committing after this read is overwritten
+            // by the sub-fields it just replaced. knex omits this on SQLite, which needs
+            // no lock — its pool is a single connection, so writes never overlap.
+            .forUpdate();
+
+        for (const row of rows) {
+            // The blob is the edge here: the columns come from a query written just
+            // above, but whatever an earlier write left in value_json is unknown until
+            // it is read back. Parsing it is what narrows the type, and it rejects the
+            // array, null or bare number the column could equally be holding.
+            const stored = StoredCompositeValue.safeParse(decodeJson(row.value_json));
+            if (stored.success) {
+                composites.set(row.custom_field_id, stored.data);
+                continue;
+            }
+            logging.warn(`Replacing an unreadable custom field value rather than merging into it (member '${memberId}', field '${row.custom_field_id}').`);
+        }
+
+        return composites;
+    }
+
+    /**
+     * @private
+     * The stored sub-fields with the incoming ones written over them, re-checked
+     * against the field type before it is handed back.
+     *
+     * The re-check is what makes this safe to write without a second thought. Both
+     * halves were valid when they were written, but "valid" is a moving target: the
+     * stored half may predate a change to the type, so it can carry a sub-field the
+     * type has since dropped or a bound it has since tightened. Parsing the result
+     * strips what no longer belongs instead of faithfully persisting it on every
+     * import from here on.
+     *
+     * A merged value that won't parse falls back to the incoming value alone rather
+     * than failing. The row is trying to write something valid, and refusing it over
+     * data that was already in the database punishes the wrong write.
+     */
+    private mergeComposite(field: ActiveField, existing: Record<string, unknown>, incoming: Record<string, unknown>): unknown {
+        const merged = FIELD_TYPES[field.type].value.safeParse({...existing, ...incoming});
+        if (merged.success) {
+            return merged.data;
+        }
+
+        logging.warn(`Replacing a custom field value that no longer validates rather than merging into it (field '${field.key}').`);
+        return incoming;
+    }
+
+    /**
      * Apply a plan from `planWrite`.
      *
      * Merge, not replace: only the fields in the plan are touched, so a caller
      * that doesn't know about a field can't erase it.
      *
+     * `mergeComposites` extends that same rule from a field to a composite's
+     * sub-fields, because a sub-field is a field: a row writes the sub-fields it
+     * fills and leaves the rest alone, exactly as a blank `name` column leaves a
+     * member's name alone. The CSV import needs it — without it a file naming one
+     * address column would replace the whole address, clearing five sub-fields it
+     * never mentioned. The API does not merge: a PUT sends a whole address, so
+     * what it sends is what should be stored.
+     *
+     * The merge is asked for here rather than at plan time, where the caller's intent
+     * is otherwise expressed, because it cannot happen before a transaction is open:
+     * it reads the stored value and writes it back, and the row lock that keeps those
+     * two steps together only exists inside the transaction. `planWrite` runs before
+     * one is opened -- the importer plans a row, then opens a transaction per member --
+     * so a merge decided there would have to read outside the lock it depends on.
+     *
      * Always transactional, so a mid-batch failure rolls the batch back. Passed an
      * executor it joins that transaction -- the importer passes its per-member one, so a
      * failed value write takes the member with it; passed nothing it opens its own.
      */
-    async applyWrite(memberId: string, writes: PlannedWrite[], executor: Knex = this.knex): Promise<void> {
+    async applyWrite(
+        memberId: string,
+        writes: PlannedWrite[],
+        executor: Knex = this.knex,
+        {mergeComposites = false}: {mergeComposites?: boolean} = {}
+    ): Promise<void> {
         if (writes.length === 0) {
             return;
         }
 
         const apply = async (trx: Knex) => {
+            const stored = mergeComposites
+                ? await this.storedComposites(trx, memberId, writes)
+                : new Map<string, Record<string, unknown>>();
+
             for (const {field, value} of writes) {
                 const target = {member_id: memberId, custom_field_id: field.id};
 
@@ -246,7 +365,18 @@ export class CustomFieldValuesService {
                     continue;
                 }
 
-                const valueColumns = storageColumnsFor(field.type, value);
+                // Both sides of the merge go through the same shape check, so it joins
+                // two objects the type system knows about rather than two assertions.
+                // The plan already validated `value` against its field type, so for a
+                // composite this parse cannot fail; a scalar simply doesn't match, and
+                // falls through to being written as it stands.
+                const existing = stored.get(field.id);
+                const incoming = StoredCompositeValue.safeParse(value);
+                const merged = existing && incoming.success
+                    ? this.mergeComposite(field, existing, incoming.data)
+                    : value;
+
+                const valueColumns = storageColumnsFor(field.type, merged);
                 await trx(VALUES_TABLE)
                     .insert({id: new ObjectID().toHexString(), ...target, ...valueColumns, created_at: new Date()})
                     // The unique index on (member_id, custom_field_id) is

--- a/ghost/core/core/server/services/members/import-export/import/importer.ts
+++ b/ghost/core/core/server/services/members/import-export/import/importer.ts
@@ -99,7 +99,8 @@ type CustomFieldPlan = unknown;
 // The custom fields collaborator as the import needs it. activeFields is the field set a
 // custom_fields.* column is read against, empty when the feature is off; planWrite
 // validates a row's values (throwing so the row fails whole) and applyWrite persists
-// them, both on the row's transaction.
+// them, merging a composite's sub-fields into whatever is already stored, both on the
+// row's transaction.
 export interface CustomFieldsImport {
     activeFields(): Promise<CsvField[]>;
     planWrite(values: Record<string, unknown>): Promise<CustomFieldPlan[]>;

--- a/ghost/core/core/server/services/members/import-export/index.ts
+++ b/ghost/core/core/server/services/members/import-export/index.ts
@@ -31,7 +31,7 @@ interface ImporterServices {
         definitions: {browse(): Promise<CsvField[]>};
         values: {
             planWrite(values: Record<string, unknown>): Promise<unknown[]>;
-            applyWrite(memberId: string, plan: unknown[], executor: Knex): Promise<void>;
+            applyWrite(memberId: string, plan: unknown[], executor: Knex, options?: {mergeComposites?: boolean}): Promise<void>;
         };
     };
 }
@@ -81,7 +81,11 @@ export function makeImporter(deps: ImporterServices) {
     const customFields: CustomFieldsImport = {
         activeFields: async () => (labs.isSet('membersCustomFields') ? deps.customFields.definitions.browse() : []),
         planWrite: values => deps.customFields.values.planWrite(values),
-        applyWrite: (memberId, plan, executor) => deps.customFields.values.applyWrite(memberId, plan, executor)
+        // mergeComposites: a sub-field is a field, so a row writes the sub-fields it fills
+        // and leaves the rest alone, the same rule a blank `name` column follows. Without
+        // it a file naming one address column would replace the whole address, clearing
+        // five sub-fields it never mentioned.
+        applyWrite: (memberId, plan, executor) => deps.customFields.values.applyWrite(memberId, plan, executor, {mergeComposites: true})
     };
 
     return new MembersCSVImporter({

--- a/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
@@ -1054,11 +1054,31 @@ describe('Member Custom Fields Admin API', function () {
 
             const body = await setValues(
                 memberId,
-                {[field.key]: {line1: '62 Ghost Lane', city: 'Dublin', country: 'IE'}},
+                {[field.key]: {line1: '62 Ghost Lane', city: 'Dublin', country: 'IRL'}},
                 422
             );
 
-            assert.equal(body.errors[0].property, `custom_fields.${field.key}.postal_code`);
+            assert.equal(body.errors[0].property, `custom_fields.${field.key}.country`);
+        });
+
+        it('round-trips an address that omits the sub-fields its country has no use for', async function () {
+            const field = await createField({name: 'Home address', type: 'address'});
+            const memberId = await createMember();
+            // Hong Kong has no postal code, so an address without one is complete.
+            const address = {line1: 'Flat 3, 8 Wan Chai Road', city: 'Hong Kong', country: 'HK'};
+
+            await setValues(memberId, {[field.key]: address});
+
+            assert.deepEqual(await readValues(memberId), {[field.key]: address});
+        });
+
+        it('rejects an address with nothing in it', async function () {
+            const field = await createField({name: 'Home address', type: 'address'});
+            const memberId = await createMember();
+
+            const body = await setValues(memberId, {[field.key]: {}}, 422);
+
+            assert.equal(body.errors[0].property, `custom_fields.${field.key}`);
         });
 
         it('strips unknown sub-fields of a composite value', async function () {

--- a/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
@@ -1085,6 +1085,15 @@ describe('Member Custom Fields Admin API', function () {
             assert.deepEqual(await readValues(memberId), {[field.key]: {city: 'Cork'}});
         });
 
+        it('stores a country code in one case whichever case it arrives in', async function () {
+            const field = await createField({name: 'Home address', type: 'address'});
+            const memberId = await createMember();
+
+            await setValues(memberId, {[field.key]: {city: 'Bristol', country: 'gb'}});
+
+            assert.deepEqual(await readValues(memberId), {[field.key]: {city: 'Bristol', country: 'GB'}});
+        });
+
         it('rejects an address with nothing in it', async function () {
             const field = await createField({name: 'Home address', type: 'address'});
             const memberId = await createMember();

--- a/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
@@ -1072,6 +1072,19 @@ describe('Member Custom Fields Admin API', function () {
             assert.deepEqual(await readValues(memberId), {[field.key]: address});
         });
 
+        it('replaces a stored address rather than merging into it', async function () {
+            const field = await createField({name: 'Home address', type: 'address'});
+            const memberId = await createMember();
+
+            await setValues(memberId, {[field.key]: {line1: '62 Ghost Lane', city: 'Dublin', country: 'IE'}});
+            await setValues(memberId, {[field.key]: {city: 'Cork'}});
+
+            // A PUT sends a whole address, so what it sends is what is stored. The CSV
+            // import is the one caller that merges, because a file carries only the
+            // columns the publisher exported.
+            assert.deepEqual(await readValues(memberId), {[field.key]: {city: 'Cork'}});
+        });
+
         it('rejects an address with nothing in it', async function () {
             const field = await createField({name: 'Home address', type: 'address'});
             const memberId = await createMember();

--- a/ghost/core/test/e2e-api/admin/members-exporter-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/members-exporter-custom-fields.test.ts
@@ -39,7 +39,8 @@ const FULL_ADDRESS = {
     country: 'GB'
 };
 
-// Only the sub-fields the type requires; line2 and state are optional.
+// An address filling only some of its sub-fields; the export writes a column for every
+// sub-field regardless, so the ones left out come back as empty cells.
 const MINIMAL_ADDRESS = {
     line1: '9 Long Lane',
     city: 'Bristol',

--- a/ghost/core/test/e2e-api/admin/members-import-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/members-import-custom-fields.test.ts
@@ -129,13 +129,40 @@ describe('Members import — custom fields', function () {
         assert.deepEqual(member.custom_fields?.[key], {line1: '1 High Street', city: 'London', postal_code: 'E1 6AN', country: 'GB'});
     });
 
-    // A partial composite is an invalid value, so the whole row fails like any other.
-    it('fails a row whose address is missing a required sub-field', async function () {
+    // No sub-field is required, so a spreadsheet carrying only part of an address
+    // imports the part it has instead of failing the row.
+    it('imports a row whose address fills only some sub-fields', async function () {
         const key = await createField('Shipping Address', 'address');
         const email = 'cf-partial-address@example.com';
 
-        // city alone, no line1/postal_code/country.
         const res = await importCSV(`email,custom_fields.${key}.city\n${email},London\n`);
+        assert.equal(res.status, 201);
+        assert.equal(res.body.meta.stats.imported, 1);
+
+        const member = await findMember(email);
+        assert.deepEqual(member.custom_fields?.[key], {city: 'London'});
+    });
+
+    // A stray space is not data. Read as a value it would make this address all-whitespace,
+    // fail its "at least one part" rule, and take the member's name and email down with it.
+    it('reads a whitespace-only address cell as blank rather than failing the row', async function () {
+        const key = await createField('Shipping Address', 'address');
+        const email = 'cf-address-space@example.com';
+
+        const res = await importCSV(`email,custom_fields.${key}.city\n${email},"   "\n`);
+        assert.equal(res.status, 201);
+        assert.equal(res.body.meta.stats.imported, 1);
+
+        const member = await findMember(email);
+        assert.equal(member.custom_fields?.[key], undefined, 'the whitespace cell set no address');
+    });
+
+    // A composite can still be invalid, and when it is the whole row fails like any other.
+    it('fails a row whose address has a malformed sub-field', async function () {
+        const key = await createField('Shipping Address', 'address');
+        const email = 'cf-bad-address@example.com';
+
+        const res = await importCSV(`email,custom_fields.${key}.country\n${email},IRL\n`);
         assert.equal(res.status, 201);
         assert.equal(res.body.meta.stats.imported, 0);
         assert.equal(res.body.meta.stats.invalid.length, 1);

--- a/ghost/core/test/e2e-api/admin/members-import-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/members-import-custom-fields.test.ts
@@ -189,6 +189,19 @@ describe('Members import — custom fields', function () {
         );
     });
 
+    // Where messy country codes actually come from: a spreadsheet exported from something
+    // else, where the column was typed by hand over several years.
+    it('normalises the case of an imported country code', async function () {
+        const key = await createField('Shipping Address', 'address');
+        const email = 'cf-country-case@example.com';
+
+        const res = await importCSV(`email,custom_fields.${key}.country\n${email},gb\n`);
+        assert.equal(res.status, 201);
+        assert.equal(res.body.meta.stats.imported, 1);
+
+        assert.deepEqual((await findMember(email)).custom_fields?.[key], {country: 'GB'});
+    });
+
     // A stray space is not data. Read as a value it would make this address all-whitespace,
     // fail its "at least one part" rule, and take the member's name and email down with it.
     it('reads a whitespace-only address cell as blank rather than failing the row', async function () {

--- a/ghost/core/test/e2e-api/admin/members-import-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/members-import-custom-fields.test.ts
@@ -143,6 +143,52 @@ describe('Members import — custom fields', function () {
         assert.deepEqual(member.custom_fields?.[key], {city: 'London'});
     });
 
+    // The sub-field equivalent of the blank-cell rule above: a sub-field is a field, so a
+    // row writes the ones it fills and leaves the rest alone. Without this a file naming
+    // one column would replace the whole address, clearing five it never mentioned.
+    it('leaves the rest of a stored address alone when a file names only some of its columns', async function () {
+        const key = await createField('Shipping Address', 'address');
+        const email = 'cf-address-merge@example.com';
+        const columns = ['line1', 'city', 'postal_code', 'country'].map(sub => `custom_fields.${key}.${sub}`).join(',');
+
+        await importCSV(`email,${columns}\n${email},1 High Street,London,E1 6AN,GB\n`);
+        assert.deepEqual((await findMember(email)).custom_fields?.[key], {line1: '1 High Street', city: 'London', postal_code: 'E1 6AN', country: 'GB'});
+
+        const res = await importCSV(`email,custom_fields.${key}.line1\n${email},2 Low Street\n`);
+        assert.equal(res.status, 201);
+        assert.equal(res.body.meta.stats.imported, 1);
+
+        assert.deepEqual(
+            (await findMember(email)).custom_fields?.[key],
+            {line1: '2 Low Street', city: 'London', postal_code: 'E1 6AN', country: 'GB'},
+            'the columns the file did not carry kept their stored values'
+        );
+    });
+
+    // The case worth pinning, because it surprises people: emptying a cell does not clear
+    // the stored sub-field. A sub-field is a field, and a blank cell reads as "no data for
+    // this row" there exactly as it does for a blank `name` column. No field, core or
+    // custom, can be cleared through an import.
+    it('keeps a stored sub-field when its column is present but blank', async function () {
+        const key = await createField('Shipping Address', 'address');
+        const email = 'cf-address-blank-cell@example.com';
+        const columns = ['line1', 'city', 'postal_code', 'country'].map(sub => `custom_fields.${key}.${sub}`).join(',');
+
+        await importCSV(`email,${columns}\n${email},1 High Street,London,E1 6AN,GB\n`);
+
+        // The member moves somewhere with no postal code, so the publisher empties that
+        // cell and re-imports.
+        const res = await importCSV(`email,${columns}\n${email},"Flat 3, 8 Wan Chai Road",Hong Kong,,HK\n`);
+        assert.equal(res.status, 201);
+        assert.equal(res.body.meta.stats.imported, 1);
+
+        assert.deepEqual(
+            (await findMember(email)).custom_fields?.[key],
+            {line1: 'Flat 3, 8 Wan Chai Road', city: 'Hong Kong', postal_code: 'E1 6AN', country: 'HK'},
+            'the blanked cell left the stored postal code alone'
+        );
+    });
+
     // A stray space is not data. Read as a value it would make this address all-whitespace,
     // fail its "at least one part" rule, and take the member's name and email down with it.
     it('reads a whitespace-only address cell as blank rather than failing the row', async function () {
@@ -156,6 +202,42 @@ describe('Members import — custom fields', function () {
         const member = await findMember(email);
         assert.equal(member.custom_fields?.[key], undefined, 'the whitespace cell set no address');
     });
+
+    // The stored blob is the one thing a merge cannot take on trust: it was written by
+    // older code, by a migration, or by hand. Anything that will not read back as a record
+    // is replaced rather than merged into, so a bad row can neither fail the import nor
+    // leak into the value that replaces it.
+    for (const [shape, stored] of [
+        ['an array', '[1,2]'],
+        ['a bare number', '42'],
+        ['a null', 'null'],
+        ['unparseable text', 'not json at all']
+    ] as const) {
+        it(`replaces a stored address holding ${shape} rather than merging into it`, async function () {
+            const key = await createField('Shipping Address', 'address');
+            const email = `cf-corrupt-${shape.replace(/\s+/g, '-')}@example.com`;
+            const columns = ['line1', 'city'].map(sub => `custom_fields.${key}.${sub}`).join(',');
+
+            await importCSV(`email,${columns}\n${email},1 High Street,London\n`);
+            // Scoped to this member: an unqualified update would corrupt every value row
+            // the suite holds, and the damage would surface as an unrelated test failing
+            // in whatever order the runner happened to pick.
+            const corrupted = await findMember(email);
+            await models.Base.knex('members_custom_field_values')
+                .where('member_id', corrupted.id)
+                .update({value_json: stored});
+
+            const res = await importCSV(`email,custom_fields.${key}.city\n${email},Bristol\n`);
+            assert.equal(res.status, 201);
+            assert.equal(res.body.meta.stats.imported, 1);
+
+            assert.deepEqual(
+                (await findMember(email)).custom_fields?.[key],
+                {city: 'Bristol'},
+                'the unreadable value was replaced, not merged into'
+            );
+        });
+    }
 
     // A composite can still be invalid, and when it is the whole row fails like any other.
     it('fails a row whose address has a malformed sub-field', async function () {

--- a/packages/custom-field-types/src/csv.ts
+++ b/packages/custom-field-types/src/csv.ts
@@ -1,5 +1,4 @@
-import {z} from 'zod';
-import {FIELD_TYPES, type FieldType} from './index.ts';
+import {subFieldsOf, type FieldType} from './index.ts';
 
 /**
  * How a field's value maps onto CSV columns.
@@ -32,11 +31,6 @@ const NAMESPACE = 'custom_fields';
 export interface CsvField {
     key: string;
     type: FieldType;
-}
-
-function subFieldsOf(type: FieldType): string[] | null {
-    const {value} = FIELD_TYPES[type];
-    return value instanceof z.ZodObject ? Object.keys(value.shape) : null;
 }
 
 function toCell(value: unknown): string {

--- a/packages/custom-field-types/src/csv.ts
+++ b/packages/custom-field-types/src/csv.ts
@@ -43,6 +43,14 @@ function toCell(value: unknown): string {
     return value === undefined || value === null ? '' : String(value);
 }
 
+// A cell holding nothing but whitespace carries no more data than an empty one, so both
+// read as blank. Without this a stray space is a value: it would be stored as one on a
+// scalar, and on a composite it would make an otherwise untouched address fail its "at
+// least one part filled in" rule and take the whole member row down with it.
+function isBlank(cell: string): boolean {
+    return cell.trim() === '';
+}
+
 // Shares csvCellsForFields' column derivation, so a field is written, read, and offered
 // as a mapping target under one set of column names.
 export function csvColumnsForField(field: CsvField): string[] {
@@ -99,7 +107,10 @@ export function csvCellsForFields(fields: readonly CsvField[], values: Record<st
  * note, so re-importing a partly-filled export can't wipe values a publisher didn't
  * touch. A composite whose every cell is blank is omitted too, because the export writes
  * "no address" and an all-blank address identically; one with any filled cell is read
- * from its non-blank cells and validated whole (a missing required sub-field fails).
+ * from its non-blank cells and validated whole (a malformed sub-field fails the row).
+ * No sub-field is required, so a row carrying only some of an address reads as only
+ * those sub-fields. A blank sub-field cell reads as no data for that sub-field, the
+ * same way a blank cell reads as no data for a whole field.
  */
 export function fieldValuesFromCsvRow(
     fields: readonly CsvField[],
@@ -118,7 +129,7 @@ export function fieldValuesFromCsvRow(
             const cell = row[column];
             if (typeof cell === 'string') {
                 const decoded = decodeCell(cell);
-                if (decoded !== '') {
+                if (!isBlank(decoded)) {
                     values[field.key] = decoded;
                 }
             }
@@ -129,12 +140,13 @@ export function fieldValuesFromCsvRow(
         const composite: Record<string, string> = {};
         for (const sub of subFields) {
             const cell = row[`${column}${SEPARATOR}${sub}`];
-            if (typeof cell === 'string') {
-                anyColumnPresent = true;
-                const decoded = decodeCell(cell);
-                if (decoded !== '') {
-                    composite[sub] = decoded;
-                }
+            if (typeof cell !== 'string') {
+                continue;
+            }
+            anyColumnPresent = true;
+            const decoded = decodeCell(cell);
+            if (!isBlank(decoded)) {
+                composite[sub] = decoded;
             }
         }
 

--- a/packages/custom-field-types/src/index.ts
+++ b/packages/custom-field-types/src/index.ts
@@ -66,24 +66,45 @@ const byteLength = (value: string): number => new TextEncoder().encode(value).le
 
 /**
  * The address value — a composite type, modelled on Stripe's Address object.
- * line2 and state are optional. Because it is one zod object, invalid sub-fields
- * surface per path (the caller can point at `postal_code` specifically) with no
- * bespoke composite handling.
+ * Because it is one zod object, invalid sub-fields surface per path (the caller
+ * can point at `postal_code` specifically) with no bespoke composite handling.
+ *
+ * Every sub-field is optional, because none of them exists everywhere: there is
+ * no postal code in Ireland or Hong Kong, and no city in an Irish townland
+ * address. Which sub-fields a particular address needs is a per-country question,
+ * and only the collection form knows the country — so requiring any of them here
+ * would leave a correctly-shaped form unable to produce a valid value.
+ *
+ * What holds instead is that an address must say something. An object with
+ * nothing filled in is not an empty address, it is no address, and a value is
+ * cleared by omitting it rather than by emptying it.
  *
  * Every sub-field is bounded. An address is a delivery address, so the bounds are
  * set by what a courier will accept, not by what the column could hold — and a
  * composite with unbounded members is a composite with no bound at all.
  */
 export const AddressValue = z.object({
-    line1: z.string().min(1).max(255),
-    line2: z.string().max(255).optional(),
-    city: z.string().min(1).max(255),
-    state: z.string().max(255).optional(),
-    postal_code: z.string().min(1).max(32),
+    line1: z.string().trim().max(255).optional(),
+    line2: z.string().trim().max(255).optional(),
+    city: z.string().trim().max(255).optional(),
+    state: z.string().trim().max(255).optional(),
+    postal_code: z.string().trim().max(32).optional(),
     // Two characters only — the shape of an ISO 3166-1 alpha-2 code, not validated
     // against the actual country list.
-    country: z.string().length(2)
-});
+    country: z.string().trim().length(2).optional()
+}).refine(
+    // Every sub-field is trimmed above, so whitespace has already become the empty
+    // string by the time this runs. Trimming is what stops `{line1: '   '}` being
+    // stored: admin trims a sub-field away before rendering it, so an address of
+    // spaces would be one no screen could show, and none could clear either.
+    //
+    // The type check is load-bearing, not defensive. A sub-field that is optional
+    // and explicitly undefined survives parsing as a key holding undefined, and
+    // `undefined !== ''` on its own would let `{line1: undefined}` satisfy a rule
+    // whose whole purpose is to reject an address with nothing in it.
+    address => Object.values(address).some(value => typeof value === 'string' && value !== ''),
+    {message: 'An address must have at least one part filled in.'}
+);
 export type Address = z.infer<typeof AddressValue>;
 
 export const FIELD_TYPES = {

--- a/packages/custom-field-types/src/index.ts
+++ b/packages/custom-field-types/src/index.ts
@@ -119,3 +119,18 @@ export const FIELD_TYPES = {
     },
     address: {storageType: 'json', value: AddressValue}
 } as const satisfies Record<FieldType, FieldTypeDefinition>;
+
+/**
+ * The sub-fields of a composite type in declaration order, or null for a scalar.
+ *
+ * Derived from the value schema rather than declared alongside it, so the two cannot
+ * drift: adding a sub-field is one edit and every consumer sees it. It is also the
+ * only honest test of what "composite" means here — a value is composite when it has
+ * parts, which is a fact about its shape and not about the column it happens to be
+ * stored in. Two field types can share a storage type and disagree about this, so
+ * anything asking "does this value have parts?" has to ask the shape.
+ */
+export function subFieldsOf(type: FieldType): string[] | null {
+    const {value} = FIELD_TYPES[type];
+    return value instanceof z.ZodObject ? Object.keys(value.shape) : null;
+}

--- a/packages/custom-field-types/src/index.ts
+++ b/packages/custom-field-types/src/index.ts
@@ -89,9 +89,28 @@ export const AddressValue = z.object({
     city: z.string().trim().max(255).optional(),
     state: z.string().trim().max(255).optional(),
     postal_code: z.string().trim().max(32).optional(),
-    // Two characters only — the shape of an ISO 3166-1 alpha-2 code, not validated
-    // against the actual country list.
-    country: z.string().trim().length(2).optional()
+    /**
+     * The shape of an ISO 3166-1 alpha-2 code, deliberately not checked against the
+     * actual list of them. A closed list would put Ghost in the position of deciding
+     * whose country is real, which is not a judgement a publishing platform should be
+     * making of its members, and there is no defensible answer for Kosovo, Taiwan,
+     * Palestine or Western Sahara. Anything well-formed is stored, and the collection
+     * form offers a list to pick from without being the arbiter of it.
+     *
+     * Case is normalised, because that is a question about the same country rather than
+     * about which countries exist. Left alone, `gb` and `GB` are two values for one
+     * place: a filter for one silently misses the other, and nothing can tell them apart
+     * afterwards to repair it. Normalising on the way in is the only point at which that
+     * is cheap.
+     *
+     * Shape is two ASCII letters rather than any two characters, which is what alpha-2
+     * means. Counting characters instead would be wrong in both directions once case is
+     * normalised, because uppercasing does not preserve length: `ß` becomes `SS` and
+     * would pass a length-of-two rule from one character, while `aß` becomes `ASS` and
+     * would fail it from two. Checking the shape of the input settles both, and turns
+     * away the `12` and `!!` that a bare length check always allowed through.
+     */
+    country: z.string().trim().regex(/^[A-Za-z]{2}$/).toUpperCase().optional()
 }).refine(
     // Every sub-field is trimmed above, so whitespace has already become the empty
     // string by the time this runs. Trimming is what stops `{line1: '   '}` being

--- a/packages/custom-field-types/test/index.test.ts
+++ b/packages/custom-field-types/test/index.test.ts
@@ -70,6 +70,41 @@ describe('custom-field-types catalog', function () {
             assert.equal(parse({line1: '', city: '', postal_code: ''}), false);
         });
 
+        it('normalises the case of a country code, so one country is one value', function () {
+            const parsed = FIELD_TYPES.address.value.safeParse({country: 'gb'});
+            assert.equal(parsed.success && parsed.data.country, 'GB');
+
+            // Whichever way it arrives, it is stored the same way, so a filter for one
+            // form cannot miss members holding another.
+            for (const written of ['GB', 'gb', 'Gb', ' gB ']) {
+                const result = FIELD_TYPES.address.value.safeParse({country: written});
+                assert.equal(result.success && result.data.country, 'GB', `expected ${JSON.stringify(written)} to normalise`);
+            }
+        });
+
+        it('accepts any well-formed country code, without ruling on which countries exist', function () {
+            // XK is not an ISO-assigned code, and it is what Kosovo is written as. Ghost
+            // stores it rather than refusing a member's own country.
+            for (const code of ['XK', 'TW', 'PS', 'EH']) {
+                assert.equal(FIELD_TYPES.address.value.safeParse({country: code}).success, true, code);
+            }
+        });
+
+        it('takes two ASCII letters as a country code and nothing else', function () {
+            const parseCountry = (country: string) => FIELD_TYPES.address.value.safeParse({country});
+
+            // Uppercasing is not length-preserving, so a rule counting the characters of
+            // the result is wrong both ways: one character can become two, and two can
+            // become three. Checking the shape of the input is what settles it.
+            assert.equal(parseCountry('ß').success, false, 'ß uppercases to SS');
+            assert.equal(parseCountry('aß').success, false, 'aß uppercases to ASS');
+            assert.equal(parseCountry('ﬁ').success, false, 'the fi ligature uppercases to FI');
+
+            // A bare length check let these through; a country code has letters in it.
+            assert.equal(parseCountry('12').success, false);
+            assert.equal(parseCountry('!!').success, false);
+        });
+
         it('trims a sub-field, so its bound measures the value and not the padding', function () {
             const result = FIELD_TYPES.address.value.safeParse({line1: '  1 Main St  ', country: ' GB '});
             assert.equal(result.success, true);

--- a/packages/custom-field-types/test/index.test.ts
+++ b/packages/custom-field-types/test/index.test.ts
@@ -44,4 +44,48 @@ describe('custom-field-types catalog', function () {
             assert.equal(parse('€'.repeat(21845)), true);
         });
     });
+
+    // The rule that replaced per-sub-field requiredness. An end-to-end test can't
+    // pin it: the CSV and admin paths both strip blank sub-fields before a value
+    // reaches the catalog, so neither ever presents the empty case this rejects.
+    describe('an address must have at least one sub-field filled in', function () {
+        const parse = (value: unknown) => FIELD_TYPES.address.value.safeParse(value).success;
+
+        it('accepts a partial address', function () {
+            // There is no postal code in Hong Kong and no city in an Irish
+            // townland address; both would have failed the old required set.
+            assert.equal(parse({line1: 'Flat 3, 8 Wan Chai Road', city: 'Hong Kong', country: 'HK'}), true);
+            assert.equal(parse({line1: 'Cloonlara', state: 'Co. Clare', country: 'IE'}), true);
+        });
+
+        it('rejects an address with nothing in it', function () {
+            assert.equal(parse({}), false);
+            // A key present but explicitly undefined survives parsing, so it reaches the
+            // rule as a value and has to be turned away as one.
+            assert.equal(parse({line1: undefined}), false);
+            assert.equal(parse({line1: undefined, country: undefined}), false);
+        });
+
+        it('rejects an address whose every sub-field is blank', function () {
+            assert.equal(parse({line1: '', city: '', postal_code: ''}), false);
+        });
+
+        it('trims a sub-field, so its bound measures the value and not the padding', function () {
+            const result = FIELD_TYPES.address.value.safeParse({line1: '  1 Main St  ', country: ' GB '});
+            assert.equal(result.success, true);
+            assert.deepEqual(result.data, {line1: '1 Main St', country: 'GB'});
+
+            // A value that reaches the limit exactly still fits once its padding is gone.
+            assert.equal(FIELD_TYPES.address.value.safeParse({line1: `  ${'x'.repeat(255)}  `}).success, true);
+        });
+
+        it('rejects an address whose every sub-field is only whitespace', function () {
+            // Admin trims a sub-field away before rendering it, so an address of
+            // spaces is one no screen could show, and none could clear either.
+            assert.equal(parse({line1: '   ', city: '\t'}), false);
+            // Two spaces satisfy country's own two-character rule, so only the
+            // composite rule can reject this one.
+            assert.equal(parse({country: '  '}), false);
+        });
+    });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3841

Two changes, one commit each. The first is the feature; the second is a data-loss bug it exposed.

## Address parts are now optional

**Problem.** The address field required a street address, city, postal code and country. That shape does not hold everywhere. There is no postal code in Ireland or Hong Kong, and an Irish townland address has no city.

Which parts of an address exist is a per-country question, and only the form collecting one knows the country. So a correctly filled form could produce an address Ghost refused to store.

**Solution.** Every part is optional. A single rule replaces requiredness: an address has to say something, so an address with nothing in it is no address rather than an empty one. Whitespace counts as nothing, both in a stored value and in a spreadsheet cell.

Whether a particular country needs a particular part stays unenforced, deliberately. That belongs to the form, which is where the country is known. Ghost only guarantees the shape it stores.

## An import no longer overwrites the parts it does not carry

**Problem.** An address is stored as a single value and a write replaced it whole. Importing a spreadsheet that carried only some of the address columns silently dropped the rest, reported the row as imported, and said nothing.

This predates the change above. A file without the second address line and state columns already lost those two. But making every part optional widened it from those two to any subset, and turned a loud row failure into a quiet success.

**Solution.** An import merges an address into what is already stored. Each part of an address behaves like any other field: a row writes the parts it fills and leaves the rest alone, exactly as a blank name column leaves a member's name alone.

The API still replaces rather than merges, because a request there sends a whole address and means it.

## Worth knowing before you rely on it

Emptying a cell does not clear the stored part. A publisher who exports their members, blanks a postal code and re-imports keeps the stored one.

That is consistent with every other column in a members CSV. No field can be cleared through an import, and a label cannot be removed either. It still surprises people, so a test names it rather than leaving it to be rediscovered.

Bulk clearing needs a mechanism of its own, which is https://linear.app/ghost/issue/BER-3847.

## Country codes are normalised to two uppercase letters

ref https://linear.app/ghost/issue/BER-3842 — merged in as #29731.

**Problem.** A country code was stored exactly as it arrived, so `GB`, `gb` and `Gb` were three values for one place. A filter for one silently missed members holding another, and once both were in the database nothing could tell them apart to repair it.

**Solution.** Case is normalised as the value is parsed, and the shape checked against is two ASCII letters rather than any two characters — which is what alpha-2 means, and what the rule had always claimed to be while only counting length.

No list of countries is checked against, deliberately. That would put Ghost in the position of ruling on whose country is real, which has no defensible answer for Kosovo, Taiwan, Palestine or Western Sahara. A list belongs to the form doing the collecting, where it can guide without being the arbiter.

---

Behind the `membersCustomFields` flag.
