### PR TITLE
Fixed memoized member lookups in link click repository after failures

### DIFF
--- a/ghost/core/core/server/services/link-tracking/link-click-repository.js
+++ b/ghost/core/core/server/services/link-tracking/link-click-repository.js
@@ -32,7 +32,12 @@ module.exports = class LinkClickRepository {
 
         // Memoize the findOne function
         this.memoizedFindOne = _.memoize(async (uuid, options) => {
-            return await this.#Member.findOne({uuid}, options);
+            try {
+                return await this.#Member.findOne({uuid}, options);
+            } catch (error) {
+                this.memoizedFindOne.cache.delete(uuid);
+                throw error;
+            }
         });
     }
 

--- a/ghost/core/test/unit/server/services/link-tracking/link-click-repository.test.js
+++ b/ghost/core/test/unit/server/services/link-tracking/link-click-repository.test.js
@@ -251,5 +251,17 @@ describe('UNIT: LinkClickRepository class', function () {
                 uuid: linkClicks[0].member_uuid
             }, {transacting});
         });
+
+        it('should retry a memoized member lookup after it fails', async function () {
+            configUtils.set('linkClickTrackingCacheMemberUuid', true);
+            const error = new Error('member lookup failed');
+            memberStub.findOne.onFirstCall().rejects(error);
+
+            await assert.rejects(linkClickRepository.save(linkClicks[0]), error);
+            await linkClickRepository.save(linkClicks[1]);
+
+            sinon.assert.calledTwice(memberStub.findOne);
+            sinon.assert.calledOnce(memberLinkClickEventModelStub.add);
+        });
     });
 });


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1506/fix-memoized-member-lookup-in-link-click-repository

A failed member lookup was permanently cached, causing later link clicks for the same member to fail until Ghost restarted. Evicting only rejected lookups preserves successful memoization while allowing recovery from transient database errors.

## Summary

- Evict rejected member lookup promises from the link-click repository cache
- Add regression coverage proving subsequent lookups retry successfully