### PR TITLE
Stopped republishing public apps whose bundle has not changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1949,6 +1949,10 @@ jobs:
       # shared input changes (the lockfile, a workflow file) — so most runs
       # rebuild a bundle byte-identical to the published one. Publishing those
       # burns a patch version and a jsDelivr purge for no change on any site.
+      #
+      # The steps below gate on `!= 'false'` rather than `== 'true'`: publishing
+      # an identical bundle is harmless, silently skipping a real change is not,
+      # so anything other than a definite "unchanged" publishes.
       - name: Check whether the bundle changed
         id: bundle
         run: |
@@ -1956,21 +1960,21 @@ jobs:
           echo "changed=$CHANGED" >> $GITHUB_OUTPUT
 
       - name: Configure .npmrc
-        if: steps.bundle.outputs.changed == 'true'
+        if: steps.bundle.outputs.changed != 'false'
         run: |
           echo "@tryghost:registry=https://registry.npmjs.org/" >> ~/.npmrc
 
       # --provenance is explicit rather than relying on pnpm's auto-detection,
       # which degrades to a warning if it can't confirm visibility.
       - name: Publish to npm
-        if: steps.bundle.outputs.changed == 'true'
+        if: steps.bundle.outputs.changed != 'false'
         working-directory: ${{ matrix.package_path }}
         run: |
           pnpm publish --access public --provenance --no-git-checks
 
       - name: Replace version placeholders in cdn-paths
         id: cdn_paths
-        if: steps.bundle.outputs.changed == 'true'
+        if: steps.bundle.outputs.changed != 'false'
         run: |
           cdn_paths="${{ matrix.cdn_paths }}"
           echo "cdn_paths<<EOF" >> $GITHUB_OUTPUT
@@ -1978,11 +1982,11 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Print cdn_paths
-        if: steps.bundle.outputs.changed == 'true'
+        if: steps.bundle.outputs.changed != 'false'
         run: echo "${{ steps.cdn_paths.outputs.cdn_paths }}"
 
       - name: Purge jsDelivr cache
-        if: steps.bundle.outputs.changed == 'true'
+        if: steps.bundle.outputs.changed != 'false'
         uses: gacts/purge-jsdelivr-cache@8d92aea944f1a3e8ad70505379e1a8ac72d56b73 # v1
         with:
           url: ${{ steps.cdn_paths.outputs.cdn_paths }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1945,19 +1945,32 @@ jobs:
       - name: Build the package
         run: pnpm nx build ${{ matrix.package_name }}
 
+      # This job is gated on nx's affected set, which goes global whenever a
+      # shared input changes (the lockfile, a workflow file) — so most runs
+      # rebuild a bundle byte-identical to the published one. Publishing those
+      # burns a patch version and a jsDelivr purge for no change on any site.
+      - name: Check whether the bundle changed
+        id: bundle
+        run: |
+          CHANGED=$(node "$GITHUB_WORKSPACE/scripts/public-app-bundle-changed.js" "${{ matrix.package_name }}")
+          echo "changed=$CHANGED" >> $GITHUB_OUTPUT
+
       - name: Configure .npmrc
+        if: steps.bundle.outputs.changed == 'true'
         run: |
           echo "@tryghost:registry=https://registry.npmjs.org/" >> ~/.npmrc
 
       # --provenance is explicit rather than relying on pnpm's auto-detection,
       # which degrades to a warning if it can't confirm visibility.
       - name: Publish to npm
+        if: steps.bundle.outputs.changed == 'true'
         working-directory: ${{ matrix.package_path }}
         run: |
           pnpm publish --access public --provenance --no-git-checks
 
       - name: Replace version placeholders in cdn-paths
         id: cdn_paths
+        if: steps.bundle.outputs.changed == 'true'
         run: |
           cdn_paths="${{ matrix.cdn_paths }}"
           echo "cdn_paths<<EOF" >> $GITHUB_OUTPUT
@@ -1965,9 +1978,11 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Print cdn_paths
+        if: steps.bundle.outputs.changed == 'true'
         run: echo "${{ steps.cdn_paths.outputs.cdn_paths }}"
 
       - name: Purge jsDelivr cache
+        if: steps.bundle.outputs.changed == 'true'
         uses: gacts/purge-jsdelivr-cache@8d92aea944f1a3e8ad70505379e1a8ac72d56b73 # v1
         with:
           url: ${{ steps.cdn_paths.outputs.cdn_paths }}

--- a/scripts/public-app-bundle-changed.js
+++ b/scripts/public-app-bundle-changed.js
@@ -1,0 +1,180 @@
+// Whether a public app's freshly built bundle differs from the one already
+// published on its major.minor line.
+//
+// The publish job fires on every merge to main where nx marks the app affected,
+// and nx marks every project affected whenever a global input changes — the
+// pnpm lockfile, a workflow file. Most of those merges rebuild a byte-identical
+// bundle, so gating on "affected" alone burns a patch version per dependency
+// bump anywhere in the monorepo.
+//
+// What sites actually receive is umd/, so that is what this compares. LICENSE
+// and README.md ship in the tarball too but never reach a rendered site, and a
+// change to either is not worth a CDN purge.
+//
+// Sourcemaps are excluded: they are derived from the bundle they accompany, so
+// they carry no signal the bundle itself doesn't, and their mappings shift with
+// the length of the version string masked below.
+
+import {execFileSync} from 'node:child_process';
+import {createHash} from 'node:crypto';
+import {existsSync, mkdtempSync, readdirSync, readFileSync, rmSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join, relative} from 'node:path';
+
+import {ROOT_DIR} from './lib/constants.js';
+import {appForPackageName, readDefaults, DEFAULTS_REPO_PATH} from './lib/public-apps.js';
+import {readJson} from './lib/utils.js';
+
+const VERSION_PLACEHOLDER = '\0version\0';
+
+/**
+ * A content hash over a directory tree — every file's path and bytes, in a
+ * stable order. Deliberately ignores mtimes and modes, which differ between a
+ * fresh build and an extracted tarball without the bundle differing.
+ *
+ * Portal bakes its own version into its bundle (REACT_APP_VERSION, for its
+ * Sentry release tag), and the publish job sets that version immediately before
+ * building — so the two sides are always one patch apart on a string that says
+ * nothing about the bundle's behaviour. Masking it is what makes them
+ * comparable at all.
+ *
+ * @param {string} dir
+ * @param {string} version - the version baked into this copy, masked before hashing
+ * @returns {string}
+ */
+export function hashBundle(dir, version) {
+    const hash = createHash('sha256');
+
+    for (const file of listFiles(dir).sort()) {
+        hash.update(file);
+        hash.update('\0');
+        hash.update(maskVersion(readFileSync(join(dir, file)), version));
+        hash.update('\0');
+    }
+
+    return hash.digest('hex');
+}
+
+/**
+ * @param {Buffer} contents
+ * @param {string} version
+ * @returns {Buffer}
+ */
+export function maskVersion(contents, version) {
+    // latin1 round-trips arbitrary bytes, so this is safe on any asset that
+    // happens to sit in umd/ alongside the JS and CSS.
+    const masked = contents.toString('latin1').replaceAll(version, VERSION_PLACEHOLDER);
+
+    return Buffer.from(masked, 'latin1');
+}
+
+/**
+ * Every file under `dir` worth comparing, as paths relative to it.
+ *
+ * @param {string} dir
+ * @returns {string[]}
+ */
+function listFiles(dir) {
+    return readdirSync(dir, {recursive: true, withFileTypes: true})
+        .filter(entry => entry.isFile() && !entry.name.endsWith('.map'))
+        .map(entry => relative(dir, join(entry.parentPath, entry.name)));
+}
+
+/**
+ * Downloads and extracts the newest published tarball on `versionLine`.
+ *
+ * @param {string} packageName
+ * @param {string} versionLine - e.g. "1.8"
+ * @param {string} destination
+ * @returns {string|null} the extracted package directory, or null when the line
+ *   has nothing published yet
+ */
+function fetchPublishedPackage(packageName, versionLine, destination) {
+    // `~1.8` resolves to the newest patch on the line — the one jsDelivr serves,
+    // and the only one worth comparing against.
+    const spec = `${packageName}@~${versionLine}`;
+    let tarball;
+
+    try {
+        const output = execFileSync('npm', ['pack', spec, '--pack-destination', destination, '--json'], {
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'pipe']
+        });
+        tarball = JSON.parse(output)[0].filename;
+    } catch (error) {
+        const combined = `${error.stdout || ''}${error.stderr || ''}`;
+        if (combined.includes('E404') || combined.includes('ETARGET') || combined.includes('No matching version')) {
+            return null;
+        }
+        throw new Error(`Failed to fetch ${spec}: ${combined || error.message}`);
+    }
+
+    execFileSync('tar', ['-xzf', join(destination, tarball), '-C', destination]);
+
+    return join(destination, 'package');
+}
+
+async function main() {
+    const packageName = process.argv[2];
+
+    if (!packageName) {
+        throw new Error('Usage: node scripts/public-app-bundle-changed.js <package-name>');
+    }
+
+    const app = appForPackageName(packageName);
+    const appDir = join(ROOT_DIR, app.path);
+
+    const defaults = await readDefaults();
+    const versionLine = defaults[app.configKey]?.version;
+
+    if (typeof versionLine !== 'string') {
+        throw new Error(`${DEFAULTS_REPO_PATH} has no "${app.configKey}.version" for ${packageName}`);
+    }
+
+    const builtBundle = join(appDir, 'umd');
+
+    if (!existsSync(builtBundle)) {
+        throw new Error(`${app.path}/umd does not exist — build the package before comparing it`);
+    }
+
+    const workDir = mkdtempSync(join(tmpdir(), 'public-app-bundle-'));
+
+    try {
+        const publishedDir = fetchPublishedPackage(packageName, versionLine, workDir);
+
+        if (!publishedDir) {
+            report(true, `Nothing published on the ${versionLine} line yet`);
+            return;
+        }
+
+        const publishedBundle = join(publishedDir, 'umd');
+        const publishedVersion = (await readJson(join(publishedDir, 'package.json'))).version;
+
+        const changed = !existsSync(publishedBundle)
+            || hashBundle(publishedBundle, publishedVersion) !== hashBundle(builtBundle, (await readJson(join(appDir, 'package.json'))).version);
+
+        report(changed, `${changed ? 'Bundle differs from' : 'Bundle is identical to'} ${packageName}@${publishedVersion}`);
+    } finally {
+        rmSync(workDir, {recursive: true, force: true});
+    }
+}
+
+/**
+ * @param {boolean} changed
+ * @param {string} reason
+ */
+function report(changed, reason) {
+    console.error(`${reason} — ${changed ? 'publishing' : 'skipping'}.`);
+
+    // Stdout is the contract — the workflow captures this into a step output.
+    process.stdout.write(String(changed));
+}
+
+if (import.meta.main) {
+    try {
+        await main();
+    } catch (error) {
+        console.error(error.message);
+        process.exit(1);
+    }
+}

--- a/scripts/public-app-bundle-changed.js
+++ b/scripts/public-app-bundle-changed.js
@@ -1,4 +1,4 @@
-// Whether a public app's freshly built bundle differs from the one already
+// Whether a public app's freshly built package differs from the one already
 // published on its major.minor line.
 //
 // The publish job fires on every merge to main where nx marks the app affected,
@@ -7,9 +7,10 @@
 // bundle, so gating on "affected" alone burns a patch version per dependency
 // bump anywhere in the monorepo.
 //
-// What sites actually receive is umd/, so that is what this compares. LICENSE
-// and README.md ship in the tarball too but never reach a rendered site, and a
-// change to either is not worth a CDN purge.
+// Compare packed packages rather than source package.json files so pnpm's
+// catalog/workspace dependency normalization is included. LICENSE and README.md
+// ship in the tarball too but never reach a rendered site, and a change to either
+// is not worth a CDN purge.
 //
 // Sourcemaps are excluded: they are derived from the bundle they accompany, so
 // they carry no signal the bundle itself doesn't, and their mappings shift with
@@ -17,7 +18,7 @@
 
 import {execFileSync} from 'node:child_process';
 import {createHash} from 'node:crypto';
-import {existsSync, mkdtempSync, readdirSync, readFileSync, rmSync} from 'node:fs';
+import {existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import {join, relative} from 'node:path';
 
@@ -28,9 +29,9 @@ import {readJson} from './lib/utils.js';
 const VERSION_PLACEHOLDER = '\0version\0';
 
 /**
- * A content hash over a directory tree — every file's path and bytes, in a
+ * A content hash over the publish-relevant files in a packed package, in a
  * stable order. Deliberately ignores mtimes and modes, which differ between a
- * fresh build and an extracted tarball without the bundle differing.
+ * fresh pack and an extracted published tarball without the package differing.
  *
  * Portal bakes its own version into its bundle (REACT_APP_VERSION, for its
  * Sentry release tag), and the publish job sets that version immediately before
@@ -42,7 +43,7 @@ const VERSION_PLACEHOLDER = '\0version\0';
  * @param {string} version - the version baked into this copy, masked before hashing
  * @returns {string}
  */
-export function hashBundle(dir, version) {
+export function hashPackage(dir, version) {
     const hash = createHash('sha256');
 
     for (const file of listFiles(dir).sort()) {
@@ -69,15 +70,18 @@ export function maskVersion(contents, version) {
 }
 
 /**
- * Every file under `dir` worth comparing, as paths relative to it.
+ * Every file under `dir` worth comparing, as paths relative to it. README and
+ * LICENSE changes do not affect sites, and sourcemaps are derived from the
+ * bundle they accompany.
  *
  * @param {string} dir
  * @returns {string[]}
  */
 function listFiles(dir) {
     return readdirSync(dir, {recursive: true, withFileTypes: true})
-        .filter(entry => entry.isFile() && !entry.name.endsWith('.map'))
-        .map(entry => relative(dir, join(entry.parentPath, entry.name)));
+        .filter(entry => entry.isFile())
+        .map(entry => relative(dir, join(entry.parentPath, entry.name)))
+        .filter(file => file !== 'LICENSE' && file !== 'README.md' && !file.endsWith('.map'));
 }
 
 /**
@@ -114,6 +118,31 @@ function fetchPublishedPackage(packageName, versionLine, destination) {
     return join(destination, 'package');
 }
 
+/**
+ * Packs the local app exactly as pnpm will normalize it for publication, then
+ * extracts it for comparison.
+ *
+ * @param {string} appDir
+ * @param {string} destination
+ * @returns {string} the extracted package directory
+ */
+function packLocalPackage(appDir, destination) {
+    const output = execFileSync('pnpm', ['pack', '--pack-destination', destination, '--json'], {
+        cwd: appDir,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe']
+    });
+    const result = JSON.parse(output);
+
+    if (typeof result.filename !== 'string') {
+        throw new Error(`Failed to pack ${appDir}: ${result.error?.message || output}`);
+    }
+
+    execFileSync('tar', ['-xzf', result.filename, '-C', destination]);
+
+    return join(destination, 'package');
+}
+
 async function main() {
     const packageName = process.argv[2];
 
@@ -140,20 +169,25 @@ async function main() {
     const workDir = mkdtempSync(join(tmpdir(), 'public-app-bundle-'));
 
     try {
-        const publishedDir = fetchPublishedPackage(packageName, versionLine, workDir);
+        const publishedWorkDir = join(workDir, 'published');
+        const localWorkDir = join(workDir, 'local');
+        mkdirSync(publishedWorkDir);
+        mkdirSync(localWorkDir);
+
+        const publishedDir = fetchPublishedPackage(packageName, versionLine, publishedWorkDir);
 
         if (!publishedDir) {
             report(true, `Nothing published on the ${versionLine} line yet`);
             return;
         }
 
-        const publishedBundle = join(publishedDir, 'umd');
+        const localDir = packLocalPackage(appDir, localWorkDir);
         const publishedVersion = (await readJson(join(publishedDir, 'package.json'))).version;
+        const localVersion = (await readJson(join(localDir, 'package.json'))).version;
 
-        const changed = !existsSync(publishedBundle)
-            || hashBundle(publishedBundle, publishedVersion) !== hashBundle(builtBundle, (await readJson(join(appDir, 'package.json'))).version);
+        const changed = hashPackage(publishedDir, publishedVersion) !== hashPackage(localDir, localVersion);
 
-        report(changed, `${changed ? 'Bundle differs from' : 'Bundle is identical to'} ${packageName}@${publishedVersion}`);
+        report(changed, `${changed ? 'Package differs from' : 'Package is identical to'} ${packageName}@${publishedVersion}`);
     } finally {
         rmSync(workDir, {recursive: true, force: true});
     }

--- a/scripts/public-app-bundle-changed.js
+++ b/scripts/public-app-bundle-changed.js
@@ -7,10 +7,12 @@
 // bundle, so gating on "affected" alone burns a patch version per dependency
 // bump anywhere in the monorepo.
 //
-// Compare packed packages rather than source package.json files so pnpm's
-// catalog/workspace dependency normalization is included. LICENSE and README.md
-// ship in the tarball too but never reach a rendered site, and a change to either
-// is not worth a CDN purge.
+// Both sides are compared as packed packages rather than as built umd/
+// directories, so a manifest-only release still counts as a change — pnpm
+// rewrites `catalog:` and `workspace:` specifiers into real ranges at pack time,
+// and none of that shows up in the bundle. LICENSE and README.md ship in the
+// tarball too but never reach a rendered site, and a change to either is not
+// worth a CDN purge.
 //
 // Sourcemaps are excluded: they are derived from the bundle they accompany, so
 // they carry no signal the bundle itself doesn't, and their mappings shift with
@@ -37,7 +39,8 @@ const VERSION_PLACEHOLDER = '\0version\0';
  * Sentry release tag), and the publish job sets that version immediately before
  * building — so the two sides are always one patch apart on a string that says
  * nothing about the bundle's behaviour. Masking it is what makes them
- * comparable at all.
+ * comparable at all. The manifest is handled structurally instead — see
+ * normalizeForHash.
  *
  * @param {string} dir
  * @param {string} version - the version baked into this copy, masked before hashing
@@ -49,11 +52,33 @@ export function hashPackage(dir, version) {
     for (const file of listFiles(dir).sort()) {
         hash.update(file);
         hash.update('\0');
-        hash.update(maskVersion(readFileSync(join(dir, file)), version));
+        hash.update(normalizeForHash(file, readFileSync(join(dir, file)), version));
         hash.update('\0');
     }
 
     return hash.digest('hex');
+}
+
+/**
+ * @param {string} file - path relative to the package root
+ * @param {Buffer} contents
+ * @param {string} version
+ * @returns {Buffer}
+ */
+function normalizeForHash(file, contents, version) {
+    // The manifest differs from the published one by exactly the version being
+    // released, so drop the field outright. Masking the string here would also
+    // rewrite any dependency pinned to the same value — @tryghost/i18n
+    // normalizes to "0.0.0", which is also what an app's own version field
+    // holds outside the publish job.
+    if (file === 'package.json') {
+        const manifest = JSON.parse(contents.toString('utf8'));
+        delete manifest.version;
+
+        return Buffer.from(JSON.stringify(manifest));
+    }
+
+    return maskVersion(contents, version);
 }
 
 /**

--- a/scripts/test/public-app-bundle-changed.test.js
+++ b/scripts/test/public-app-bundle-changed.test.js
@@ -4,7 +4,7 @@ import {mkdtempSync, mkdirSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 
-import {hashBundle, maskVersion} from '../public-app-bundle-changed.js';
+import {hashPackage, maskVersion} from '../public-app-bundle-changed.js';
 
 describe('maskVersion', () => {
     it('replaces every occurrence of the version', () => {
@@ -21,7 +21,7 @@ describe('maskVersion', () => {
     });
 });
 
-describe('hashBundle', () => {
+describe('hashPackage', () => {
     let dir;
 
     const bundle = (name, files) => {
@@ -44,34 +44,48 @@ describe('hashBundle', () => {
     it('matches for identical trees', () => {
         const files = {'app.js': 'console.log(1)', 'app.css': 'a{}', 'nested/deep.js': 'x'};
 
-        assert.strictEqual(hashBundle(bundle('a', files), '1.0.0'), hashBundle(bundle('b', files), '1.0.0'));
+        assert.strictEqual(hashPackage(bundle('a', files), '1.0.0'), hashPackage(bundle('b', files), '1.0.0'));
     });
 
     it('matches when only the baked-in version differs', () => {
         const a = bundle('version-a', {'app.js': 'const r="portal@2.69.16|ghost@x"'});
         const b = bundle('version-b', {'app.js': 'const r="portal@2.69.222|ghost@x"'});
 
-        assert.strictEqual(hashBundle(a, '2.69.16'), hashBundle(b, '2.69.222'));
+        assert.strictEqual(hashPackage(a, '2.69.16'), hashPackage(b, '2.69.222'));
     });
 
     it('differs when the bundle content differs', () => {
         const a = bundle('content-a', {'app.js': 'console.log(1)'});
         const b = bundle('content-b', {'app.js': 'console.log(2)'});
 
-        assert.notStrictEqual(hashBundle(a, '1.0.0'), hashBundle(b, '1.0.0'));
+        assert.notStrictEqual(hashPackage(a, '1.0.0'), hashPackage(b, '1.0.0'));
     });
 
     it('differs when a file is renamed', () => {
         const a = bundle('name-a', {'app.js': 'same'});
         const b = bundle('name-b', {'other.js': 'same'});
 
-        assert.notStrictEqual(hashBundle(a, '1.0.0'), hashBundle(b, '1.0.0'));
+        assert.notStrictEqual(hashPackage(a, '1.0.0'), hashPackage(b, '1.0.0'));
+    });
+
+    it('differs when publish-relevant package metadata changes', () => {
+        const a = bundle('manifest-a', {'package.json': '{"dependencies":{"@tryghost/i18n":"0.0.0"}}'});
+        const b = bundle('manifest-b', {'package.json': '{"dependencies":{}}'});
+
+        assert.notStrictEqual(hashPackage(a, '1.0.0'), hashPackage(b, '1.0.0'));
     });
 
     it('ignores sourcemaps, whose mappings shift with the masked version', () => {
         const a = bundle('map-a', {'app.js': 'same', 'app.js.map': '{"mappings":"AAAA"}'});
         const b = bundle('map-b', {'app.js': 'same', 'app.js.map': '{"mappings":"CCCC"}'});
 
-        assert.strictEqual(hashBundle(a, '1.0.0'), hashBundle(b, '1.0.0'));
+        assert.strictEqual(hashPackage(a, '1.0.0'), hashPackage(b, '1.0.0'));
+    });
+
+    it('ignores documentation-only changes', () => {
+        const a = bundle('docs-a', {'app.js': 'same', 'README.md': 'old', LICENSE: 'old'});
+        const b = bundle('docs-b', {'app.js': 'same', 'README.md': 'new', LICENSE: 'new'});
+
+        assert.strictEqual(hashPackage(a, '1.0.0'), hashPackage(b, '1.0.0'));
     });
 });

--- a/scripts/test/public-app-bundle-changed.test.js
+++ b/scripts/test/public-app-bundle-changed.test.js
@@ -1,0 +1,77 @@
+import {describe, it, before, after} from 'node:test';
+import assert from 'node:assert';
+import {mkdtempSync, mkdirSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+
+import {hashBundle, maskVersion} from '../public-app-bundle-changed.js';
+
+describe('maskVersion', () => {
+    it('replaces every occurrence of the version', () => {
+        const masked = maskVersion(Buffer.from('a@1.2.3|b@1.2.3'), '1.2.3').toString('latin1');
+
+        assert.ok(!masked.includes('1.2.3'));
+        assert.strictEqual(masked.split('\0version\0').length - 1, 2);
+    });
+
+    it('leaves other content byte-identical', () => {
+        const contents = Buffer.from([0x00, 0xff, 0x7f, 0x80, 0x41]);
+
+        assert.deepStrictEqual(maskVersion(contents, '9.9.9'), contents);
+    });
+});
+
+describe('hashBundle', () => {
+    let dir;
+
+    const bundle = (name, files) => {
+        const root = join(dir, name);
+        mkdirSync(join(root, 'nested'), {recursive: true});
+        for (const [file, contents] of Object.entries(files)) {
+            writeFileSync(join(root, file), contents);
+        }
+        return root;
+    };
+
+    before(() => {
+        dir = mkdtempSync(join(tmpdir(), 'hash-bundle-test-'));
+    });
+
+    after(() => {
+        rmSync(dir, {recursive: true, force: true});
+    });
+
+    it('matches for identical trees', () => {
+        const files = {'app.js': 'console.log(1)', 'app.css': 'a{}', 'nested/deep.js': 'x'};
+
+        assert.strictEqual(hashBundle(bundle('a', files), '1.0.0'), hashBundle(bundle('b', files), '1.0.0'));
+    });
+
+    it('matches when only the baked-in version differs', () => {
+        const a = bundle('version-a', {'app.js': 'const r="portal@2.69.16|ghost@x"'});
+        const b = bundle('version-b', {'app.js': 'const r="portal@2.69.222|ghost@x"'});
+
+        assert.strictEqual(hashBundle(a, '2.69.16'), hashBundle(b, '2.69.222'));
+    });
+
+    it('differs when the bundle content differs', () => {
+        const a = bundle('content-a', {'app.js': 'console.log(1)'});
+        const b = bundle('content-b', {'app.js': 'console.log(2)'});
+
+        assert.notStrictEqual(hashBundle(a, '1.0.0'), hashBundle(b, '1.0.0'));
+    });
+
+    it('differs when a file is renamed', () => {
+        const a = bundle('name-a', {'app.js': 'same'});
+        const b = bundle('name-b', {'other.js': 'same'});
+
+        assert.notStrictEqual(hashBundle(a, '1.0.0'), hashBundle(b, '1.0.0'));
+    });
+
+    it('ignores sourcemaps, whose mappings shift with the masked version', () => {
+        const a = bundle('map-a', {'app.js': 'same', 'app.js.map': '{"mappings":"AAAA"}'});
+        const b = bundle('map-b', {'app.js': 'same', 'app.js.map': '{"mappings":"CCCC"}'});
+
+        assert.strictEqual(hashBundle(a, '1.0.0'), hashBundle(b, '1.0.0'));
+    });
+});

--- a/scripts/test/public-app-bundle-changed.test.js
+++ b/scripts/test/public-app-bundle-changed.test.js
@@ -88,4 +88,27 @@ describe('hashPackage', () => {
 
         assert.strictEqual(hashPackage(a, '1.0.0'), hashPackage(b, '1.0.0'));
     });
+
+    it('matches when the manifests differ only by the version being released', () => {
+        const manifest = version => JSON.stringify({name: '@tryghost/x', version, dependencies: {}});
+        const a = bundle('manifest-version-a', {'package.json': manifest('1.8.233')});
+        const b = bundle('manifest-version-b', {'package.json': manifest('1.8.232')});
+
+        assert.strictEqual(hashPackage(a, '1.8.233'), hashPackage(b, '1.8.232'));
+    });
+
+    // The app's own version is "0.0.0" outside the publish job, and
+    // @tryghost/i18n normalizes to "0.0.0" in the packed manifest. Masking the
+    // version as a raw string would rewrite the dependency on one side only.
+    it('does not let a version equal to a dependency version corrupt the manifest', () => {
+        const manifest = version => JSON.stringify({
+            name: '@tryghost/x',
+            version,
+            dependencies: {'@tryghost/i18n': '0.0.0'}
+        });
+        const a = bundle('manifest-collide-a', {'package.json': manifest('0.0.0')});
+        const b = bundle('manifest-collide-b', {'package.json': manifest('1.8.232')});
+
+        assert.strictEqual(hashPackage(a, '0.0.0'), hashPackage(b, '1.8.232'));
+    });
 });


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/issues/29710

## Problem

`publish_public_apps` is gated on nx's affected set, and nx marks *every* project affected whenever a shared input changes — `pnpm-lock.yaml`, `package.json`, or (via the `AFFECTED_ARG=""` escape hatch in job_setup) anything under `.github/` or `scripts/`. A dependency bump anywhere in the monorepo therefore republishes all six public apps with byte-identical output.

#28980 flagged this when auto-publishing landed — "identical bundles, forward-only, harmless but noisy" — and suggested a strict-`--affected` output as the fix if it ever mattered. It has since produced ~95 releases per app in three weeks:

| app | releases since 2026-07-14 | latest |
|---|---|---|
| portal | 99 | 2.69.223 |
| signup-form | 95 | 0.3.235 |
| sodo-search | 95 | 1.8.232 |
| comments-ui | 95 | 1.5.229 |
| announcement-bar | 95 | 1.1.218 |
| admin-toolbar | 94 | 0.1.202 |

Near-identical counts across six independent apps is the tell: they publish together because the trigger is global. Extracting `sodo-search@1.8.220` and `@1.8.231` — 11 releases, 6 days apart — `diff -rq` reports only `package.json`.

Classifying the 286 first-parent main commits since 2026-07-14 by what puts sodo-search in the affected set: 43 root lockfile/package.json, 26 `.github/`+`scripts/`, 6 `configs/`, 4 `packages/i18n`, and 5 that actually touched `apps/sodo-search`.

## Approach

Pack the built app with pnpm, compare its publish-relevant contents against what's already published, and skip the publish and the jsDelivr purge when they match.

Comparing the *packed package* rather than narrowing the affected *inputs* covers both triggers with one mechanism, and stays correct in the case that makes narrowing unsafe: a lockfile change that genuinely alters a bundled dependency still publishes. Packing locally also applies pnpm's catalog/workspace dependency normalization, so manifest-only changes still publish even when the UMD bundle is identical.

## What changed

- **`scripts/public-app-bundle-changed.js`** (new) — resolves the app's line from `defaults.json`, `npm pack`s `<pkg>@~<line>` (the newest patch, i.e. what jsDelivr serves), `pnpm pack`s the local build, and content-hashes both packed packages. Version strings, sourcemaps, README, and LICENSE are excluded; publish-relevant manifest changes are included. Prints `true`/`false`.
- **`ci.yml → publish_public_apps`** — a `Check whether the bundle changed` step after the build; `Configure .npmrc`, `Publish to npm`, the cdn-path steps and `Purge jsDelivr cache` are gated on its output.

Two wrinkles the hash has to account for, both verified empirically rather than assumed:

- **Portal bakes its own version into its bundle** (`REACT_APP_VERSION`, for its Sentry release tag), and the publish job sets that version immediately before building — so the two sides always differ on a string that says nothing about behaviour. The version is masked on both sides before hashing. Without this the gate is a no-op for portal specifically.
- **Sourcemaps are excluded.** They are derived from the bundle they accompany, so they carry no independent signal, and their VLQ mappings shift with the *length* of that masked version string (`2.69.16` vs `2.69.222`).

## Verification

The build turns out to be reproducible across runners, which is what makes this work at all — a locally built bundle at `origin/main` hashes equal to the published tarball for all six apps:

```
portal:           identical to @tryghost/portal@2.69.222 — skipping
sodo-search:      identical to @tryghost/sodo-search@1.8.232 — skipping
comments-ui:      identical to @tryghost/comments-ui@1.5.229 — skipping
signup-form:      identical to @tryghost/signup-form@0.3.235 — skipping
announcement-bar: identical to @tryghost/announcement-bar@1.1.218 — skipping
admin-toolbar:    identical to @tryghost/admin-toolbar@0.1.202 — skipping
```

So at this commit, a lockfile-only merge would publish nothing — which is the point.

The other direction, on portal (the version-sensitive app): editing one string in `apps/portal/src/app.jsx` and rebuilding flips it to `differs — publishing`, and restoring the file flips it back. Same check on sodo-search with a one-line source addition.

- `pnpm --filter @internal/scripts test` — 64 pass, including `hashPackage` coverage for identical trees, content and manifest changes, renames, version-only differences, documentation-only differences, and sourcemap-only differences
- `ci.yml` parsed and asserted: every side-effectful step in the publish job is gated, the build and check steps are not

## Note for reviewers

A failure inside the check fails the step, which blocks that app's publish rather than publishing blindly. That's the safe direction — publishing is forward-only, so the next merge that affects the app retries.

This does not change *what* gets published or the version scheme, only how often.