### PR TITLE
Fixed automation open tracking lock order

### DIFF
--- a/ghost/core/core/server/services/automations/database-automations-repository.ts
+++ b/ghost/core/core/server/services/automations/database-automations-repository.ts
@@ -301,6 +301,15 @@ export function createDatabaseAutomationsRepository({
             }
 
             await knex.transaction(async (trx) => {
+                const revisionIds: string[] = [];
+                for (const {openedAt, automationActionRevisionId} of eventsByAutomatedEmailRecipientId.values()) {
+                    if (openedAt) {
+                        revisionIds.push(automationActionRevisionId);
+                    }
+                }
+
+                const sortedRevisionIds = await lockActionRevisions(trx, revisionIds);
+
                 const notYetOpened = await lockNotYetOpened(trx, eventsByAutomatedEmailRecipientId);
                 const newOpensPerRevision = new Map<string, number>();
 
@@ -327,11 +336,11 @@ export function createDatabaseAutomationsRepository({
                     }
                 }
 
-                // Keep lock acquisition order consistent across concurrent transactions to avoid deadlocks.
-                const revisions = [...newOpensPerRevision.entries()]
-                    .sort(([left], [right]) => left.localeCompare(right));
-
-                for (const [id, opens] of revisions) {
+                for (const id of sortedRevisionIds) {
+                    const opens = newOpensPerRevision.get(id);
+                    if (!opens) {
+                        continue;
+                    }
                     await trx('automation_action_revisions')
                         .where({id})
                         .update({
@@ -343,12 +352,7 @@ export function createDatabaseAutomationsRepository({
 
         async trackEmailClicked({automationActionRevisionId, memberId, clickedAt}, {transacting} = {}) {
             const trackClick = async (trx: Knex.Transaction) => {
-                // Match recordEmailSent's lock order to avoid deadlocks.
-                await trx('automation_action_revisions')
-                    .select('id')
-                    .where({id: automationActionRevisionId})
-                    .forUpdate()
-                    .first();
+                await lockActionRevisions(trx, [automationActionRevisionId]);
 
                 const recipient = await trx('automated_email_recipients')
                     .select('id', 'clicked_at')
@@ -392,6 +396,27 @@ export function createDatabaseAutomationsRepository({
             await knex.transaction(trackClick);
         }
     };
+}
+
+/**
+ * Transactions that touch action revisions and automated email recipients must
+ * lock revisions first. Keep multi-revision lock acquisition deterministic.
+ */
+async function lockActionRevisions(
+    trx: Knex.Transaction,
+    revisionIds: ReadonlyArray<string>
+): Promise<string[]> {
+    const sortedRevisionIds = [...new Set(revisionIds)]
+        .sort((left, right) => left.localeCompare(right));
+
+    if (sortedRevisionIds.length > 0) {
+        await trx('automation_action_revisions')
+            .select('id')
+            .whereIn('id', sortedRevisionIds)
+            .forUpdate();
+    }
+
+    return sortedRevisionIds;
 }
 
 /**

--- a/ghost/core/core/server/services/automations/database-automations-repository.ts
+++ b/ghost/core/core/server/services/automations/database-automations-repository.ts
@@ -301,14 +301,14 @@ export function createDatabaseAutomationsRepository({
             }
 
             await knex.transaction(async (trx) => {
-                const revisionIds: string[] = [];
+                const revisionIds = new Set<string>();
                 for (const {openedAt, automationActionRevisionId} of eventsByAutomatedEmailRecipientId.values()) {
                     if (openedAt) {
-                        revisionIds.push(automationActionRevisionId);
+                        revisionIds.add(automationActionRevisionId);
                     }
                 }
 
-                const sortedRevisionIds = await lockActionRevisions(trx, revisionIds);
+                const orderedRevisionIds = await lockActionRevisions(trx, revisionIds);
 
                 const notYetOpened = await lockNotYetOpened(trx, eventsByAutomatedEmailRecipientId);
                 const newOpensPerRevision = new Map<string, number>();
@@ -336,7 +336,7 @@ export function createDatabaseAutomationsRepository({
                     }
                 }
 
-                for (const id of sortedRevisionIds) {
+                for (const id of orderedRevisionIds) {
                     const opens = newOpensPerRevision.get(id);
                     if (!opens) {
                         continue;
@@ -399,12 +399,14 @@ export function createDatabaseAutomationsRepository({
 }
 
 /**
- * Transactions that touch action revisions and automated email recipients must
- * lock revisions first. Keep multi-revision lock acquisition deterministic.
+ * Lock revisions before recipients because inserting a recipient takes a shared
+ * foreign-key lock on its revision. Updating that revision later can deadlock
+ * with another transaction that has already locked the revision and is waiting
+ * for the recipient. Keep multi-revision lock acquisition deterministic.
  */
 async function lockActionRevisions(
     trx: Knex.Transaction,
-    revisionIds: ReadonlyArray<string>
+    revisionIds: Iterable<string>
 ): Promise<string[]> {
     const sortedRevisionIds = [...new Set(revisionIds)]
         .sort((left, right) => left.localeCompare(right));

--- a/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
+++ b/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
@@ -2109,6 +2109,40 @@ describe('automations repository', function () {
             assert.equal(updatedRevision.email_sent_count, 1);
         });
 
+        it('updates the action revision before inserting the recipient', async function () {
+            const revision = await knex('automation_action_revisions').select('id').first();
+            assert(revision);
+
+            const queries: string[] = [];
+            const recordQuery = ({sql}: {sql: string}) => queries.push(sql);
+            knex.on('query', recordQuery);
+
+            try {
+                await repo.recordEmailSent({
+                    automationActionRevisionId: revision.id,
+                    memberEmail: 'member@example.com',
+                    memberId: 'member-id',
+                    memberName: 'Test Member',
+                    memberUuid: '00000000-0000-4000-8000-000000000001',
+                    trackClicks: true,
+                    trackOpens: true
+                });
+            } finally {
+                knex.off('query', recordQuery);
+            }
+
+            const revisionUpdateIndex = queries.findIndex(sql => (
+                sql.startsWith('update') && sql.includes('automation_action_revisions')
+            ));
+            const recipientInsertIndex = queries.findIndex(sql => (
+                sql.startsWith('insert') && sql.includes('automated_email_recipients')
+            ));
+
+            assert.notEqual(revisionUpdateIndex, -1);
+            assert.notEqual(recipientInsertIndex, -1);
+            assert(revisionUpdateIndex < recipientInsertIndex);
+        });
+
         it('supports recipients without a Mailgun message ID', async function () {
             const revision = await knex('automation_action_revisions').select('id').first();
             assert(revision);
@@ -2266,8 +2300,8 @@ describe('automations repository', function () {
         });
 
         it('locks the action revision before selecting the recipient', async function () {
-            const queries: string[] = [];
-            const recordQuery = ({sql}: {sql: string}) => queries.push(sql);
+            const queries: Array<{sql: string; bindings: unknown[]}> = [];
+            const recordQuery = (query: {sql: string; bindings: unknown[]}) => queries.push(query);
             knex.on('query', recordQuery);
 
             try {
@@ -2276,14 +2310,16 @@ describe('automations repository', function () {
                 knex.off('query', recordQuery);
             }
 
-            const revisionSelect = queries.findIndex(query => (
-                query.startsWith('select') && query.includes('automation_action_revisions')
+            const revisionSelect = queries.findIndex(({sql}) => (
+                sql.startsWith('select') && sql.includes('automation_action_revisions')
             ));
-            const recipientSelect = queries.findIndex(query => (
-                query.startsWith('select') && query.includes('automated_email_recipients')
+            const recipientSelect = queries.findIndex(({sql}) => (
+                sql.startsWith('select') && sql.includes('automated_email_recipients')
             ));
 
             assert.notEqual(revisionSelect, -1);
+            assert.equal(queries[revisionSelect].sql.includes('where `id` in (?)'), true);
+            assert.deepEqual(queries[revisionSelect].bindings, [firstRevisionId]);
             assert.notEqual(recipientSelect, -1);
             assert(revisionSelect < recipientSelect);
         });
@@ -2503,6 +2539,51 @@ describe('automations repository', function () {
             }]);
             assert.equal(await getOpenedCount(firstRevisionId), null);
             assert.equal(await getOpenedCount(secondRevisionId), null);
+        });
+
+        it('locks unique action revisions in sorted order before locking recipients for opens', async function () {
+            const queries: Array<{sql: string; bindings: unknown[]}> = [];
+            const recordQuery = (query: {sql: string; bindings: unknown[]}) => queries.push(query);
+            knex.on('query', recordQuery);
+
+            try {
+                await repo.trackEmailDeliveredAndOpened(new Map([
+                    ['recipient-2', open(EARLIER, secondRevisionId)],
+                    ['recipient-3', open(EARLIER, firstRevisionId)],
+                    ['recipient-1', open(EARLIER, firstRevisionId)]
+                ]));
+            } finally {
+                knex.off('query', recordQuery);
+            }
+
+            const revisionLocks = queries.filter(({sql}) => (
+                sql.startsWith('select') && sql.includes('automation_action_revisions')
+            ));
+            const recipientLockIndex = queries.findIndex(({sql}) => (
+                sql.startsWith('select') && sql.includes('automated_email_recipients')
+            ));
+
+            assert.equal(revisionLocks.length, 1);
+            assert.equal(revisionLocks[0].sql.includes('where `id` in (?, ?)'), true);
+            assert.deepEqual(revisionLocks[0].bindings, [firstRevisionId, secondRevisionId]);
+            assert.notEqual(recipientLockIndex, -1);
+            assert(queries.indexOf(revisionLocks[0]) < recipientLockIndex);
+        });
+
+        it('does not lock action revisions for delivery-only events', async function () {
+            const queries: string[] = [];
+            const recordQuery = ({sql}: {sql: string}) => queries.push(sql);
+            knex.on('query', recordQuery);
+
+            try {
+                await repo.trackEmailDeliveredAndOpened(new Map([
+                    ['recipient-1', delivered(EARLIER, firstRevisionId)]
+                ]));
+            } finally {
+                knex.off('query', recordQuery);
+            }
+
+            assert.equal(queries.some(query => query.includes('automation_action_revisions')), false);
         });
 
         it('tracks delivers and opens, leaving untouched recipients alone', async function () {


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1507

Open and click tracking could lock action revisions and recipients in opposite orders, allowing concurrent events for the same automated email to deadlock.

Revision rows are now locked first in deterministic order, while delivery-only events avoid unnecessary revision locks.