### PR TITLE
🐛 Fixed keyboard focus trapping in empty comment threads

### DIFF
--- a/apps/comments-ui/src/components/content/forms/main-form.tsx
+++ b/apps/comments-ui/src/components/content/forms/main-form.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useMemo, useRef} from 'react';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {Form, FormWrapper} from './form';
 import {scrollToElement} from '../../../utils/helpers';
 import {useAppContext} from '../../../app-context';
@@ -30,7 +30,8 @@ const MainForm: React.FC<Props> = ({commentsCount}) => {
     }, [postId, dispatchAction, editor]);
 
     // C keyboard shortcut to focus main form
-    const formEl = useRef(null);
+    const formEl = useRef<HTMLDivElement>(null);
+    const [hasFocusWithin, setHasFocusWithin] = useState(false);
 
     useEffect(() => {
         if (!editor) {
@@ -91,10 +92,22 @@ const MainForm: React.FC<Props> = ({commentsCount}) => {
         submit
     };
 
-    const isOpen = editor?.isFocused || hasContent;
+    const isOpen = editor?.isFocused || hasContent || hasFocusWithin;
+
+    const handleBlur = useCallback((event: React.FocusEvent<HTMLDivElement>) => {
+        if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+            setHasFocusWithin(false);
+        }
+    }, []);
 
     return (
-        <div ref={formEl} className='px-3 pb-2 pt-3' data-testid="main-form">
+        <div
+            ref={formEl}
+            className='px-3 pb-2 pt-3'
+            data-testid="main-form"
+            onBlurCapture={handleBlur}
+            onFocusCapture={() => setHasFocusWithin(true)}
+        >
             <FormWrapper editor={editor} isOpen={isOpen} reduced={false}>
                 <Form
                     editor={editor}

--- a/apps/comments-ui/test/e2e/main-form.test.ts
+++ b/apps/comments-ui/test/e2e/main-form.test.ts
@@ -45,4 +45,25 @@ test.describe('Main form', async () => {
         await page.locator('body').click();
         await expect(frame.locator('[data-testid="main-form"] [data-testid="form-header"]')).toBeVisible();
     });
+
+    test('allows keyboard focus to leave an empty comments frame', async ({page}) => {
+        const {frame} = await initializeTest(page);
+        await page.evaluate(() => {
+            const button = document.createElement('button');
+            button.id = 'after-comments';
+            button.textContent = 'After comments';
+            document.body.append(button);
+        });
+
+        const editor = frame.getByTestId('editor');
+        const expertiseButton = frame.getByTestId('expertise-button');
+
+        await editor.focus();
+        await page.keyboard.press('Tab');
+        await page.waitForTimeout(200);
+        await expect(expertiseButton).toBeFocused();
+
+        await page.keyboard.press('Tab');
+        await expect(page.locator('#after-comments')).toBeFocused();
+    });
 });


### PR DESCRIPTION
## Summary

- keep the main comment form expanded while keyboard focus remains within any of its controls
- allow focus to move from the editor through the profile action and out of the comments iframe
- add an acceptance test covering a signed-in member tabbing past an empty comment thread

## Root cause

The form was considered open only while the editor was focused or contained text. Tabbing from the editor to the dynamically rendered **Add your expertise** button blurred the editor, which immediately unmounted the focused button. With no comment controls following it, Firefox restarted sequential focus navigation at the beginning of the iframe.

## Testing

- `pnpm exec playwright test test/e2e/main-form.test.ts --project=chromium --workers=1 --reporter=line`
- new focus regression verified with Playwright Firefox 151
- `pnpm --filter @tryghost/comments-ui test:types`
- `pnpm --filter @tryghost/comments-ui lint:code`

Fixes https://github.com/TryGhost/Ghost/issues/29708