### PR TITLE
Added automation run step ID to automated email recipients

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.56/2026-08-03-19-27-51-add-automation-run-step-id-to-automated-email-recipients.js
+++ b/ghost/core/core/server/data/migrations/versions/6.56/2026-08-03-19-27-51-add-automation-run-step-id-to-automated-email-recipients.js
@@ -1,0 +1,8 @@
+const {createAddColumnMigration} = require('../../utils');
+
+module.exports = createAddColumnMigration('automated_email_recipients', 'automation_run_step_id', {
+    type: 'string',
+    maxlength: 24,
+    nullable: true,
+    references: 'automation_run_steps.id'
+}, {algorithm: 'auto'});

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -1339,6 +1339,7 @@ module.exports = {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         automated_email_id: {type: 'string', maxlength: 24, nullable: true, references: 'welcome_email_automated_emails.id'},
         automation_action_revision_id: {type: 'string', maxlength: 24, nullable: true, references: 'automation_action_revisions.id'},
+        automation_run_step_id: {type: 'string', maxlength: 24, nullable: true, references: 'automation_run_steps.id'},
         member_id: {type: 'string', maxlength: 24, nullable: false, index: true},
         member_uuid: {type: 'string', maxlength: 36, nullable: false},
         member_email: {type: 'string', maxlength: 191, nullable: false},

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ghost",
-    "version": "6.55.1-rc.0",
+    "version": "6.56.0-rc.0",
     "description": "The professional publishing platform",
     "author": "Ghost Foundation",
     "homepage": "https://ghost.org",

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -36,7 +36,7 @@ const parseYaml = require('../../../../../core/server/services/route-settings/ya
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'c0fe7246714201a82b75f80308d5e300';
+    const currentSchemaHash = '47fc91e205277e2c751ff58592785240';
     const currentFixturesHash = '065b413e1d1f4f95fa7cb7734c5e7934';
     const currentSettingsHash = '8650db85b9a61afe4797ad6333066c62';
     const currentRoutesHash = '66467df9cfcaf50e31649aa51e605491';


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1508/add-automation-run-step-id-fk-to-automated-email-recipients

## Summary

- Linked automated email recipients to automation run steps through a nullable foreign key.
- Added the corresponding database migration and updated schema integrity metadata.

## Testing

- Updated the schema integrity unit test hash.