### PR TITLE
🎨 Improved tier select sizing in the post preview header

### DIFF
--- a/apps/ember-admin/app/styles/layouts/post-preview.css
+++ b/apps/ember-admin/app/styles/layouts/post-preview.css
@@ -138,15 +138,13 @@
 }
 
 .gh-preview-tier {
-    flex: 0 0 180px;
-    width: 180px;
-    min-width: 180px;
+    flex: 0 1 auto;
+    width: auto;
     max-width: 180px;
 }
 
-.gh-preview-tier .gh-preview-segment-trigger {
-    width: 100%;
-    max-width: 100%;
+.gh-preview-tier-dropdown.ember-power-select-dropdown {
+    max-width: 280px;
 }
 
 .gh-preview-tier .ember-power-select-selected-item,


### PR DESCRIPTION
The tier select in the post preview header (Preview → "Specific tier") was pinned to a fixed 180px. A short tier name like "Bronze" left a wide gap between the label and its chevron, which read as odd next to the segment select beside it, since that one sizes to its content.

The dropdown had no width ceiling at all. Tier names are user-defined, so a long one stretched the dropdown across the viewport — the `text-overflow: ellipsis` already on the options never fired, because nothing gave it a width to apply against.

The trigger now sizes to the tier name up to a 180px cap, and the dropdown is capped at 280px so longer names truncate.