### PR TITLE
Reset automation email analytics counts

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.57/2026-08-04-18-54-14-reset-automation-email-analytics.js
+++ b/ghost/core/core/server/data/migrations/versions/6.57/2026-08-04-18-54-14-reset-automation-email-analytics.js
@@ -1,0 +1,25 @@
+const logging = require('@tryghost/logging');
+const {createTransactionalMigration} = require('../../utils');
+
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        logging.info('Resetting automation email analytics counts');
+
+        const updatedRevisions = await knex('automation_action_revisions').update({
+            email_sent_count: null,
+            email_opened_count: null,
+            email_clicked_count: null
+        });
+
+        logging.info(`Reset automation email analytics counts for ${updatedRevisions} action revisions`);
+
+        const deletedRecipients = await knex('automated_email_recipients')
+            .whereNotNull('automation_action_revision_id')
+            .del();
+
+        logging.info(`Deleted ${deletedRecipients} automation email recipient rows`);
+    },
+    async function down() {
+        logging.info('Skipping rollback for automation email analytics reset');
+    }
+);

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ghost",
-    "version": "6.56.1-rc.0",
+    "version": "6.57.0-rc.0",
     "description": "The professional publishing platform",
     "author": "Ghost Foundation",
     "homepage": "https://ghost.org",


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1495/reset-automation-analytics-data-before-launch

## Summary

Automation emails have been sending during the beta before open and click tracking was available. Keeping those historical sends in the denominator would skew rates once tracking starts, so this migration establishes a clean analytics baseline for 6.57.

- Resets sent, opened, and clicked counts on automation action revisions to NULL.
- Deletes recipient rows tied to automation action revisions while preserving welcome-email recipients.
- Prevents late events for pre-cutover automation emails from affecting the new counters.
- Bumps Ghost core to 6.57.0-rc.0.

Deleting these recipient rows intentionally removes the beta automation-email sent-event history.

## Testing

- Core unit suite: 592 test files and 7,710 tests passed.
- Schema integrity test passed.
- Migration ESLint passed.
- Isolated migration verification passed twice, confirming idempotency and preservation of welcome-email recipients.