### PR TITLE
Updated automation email click attribution to resolve clicks by step run

### DIFF
--- a/ghost/core/core/server/services/automations/automations-repository.ts
+++ b/ghost/core/core/server/services/automations/automations-repository.ts
@@ -209,6 +209,7 @@ export interface AutomationsRepository {
      */
     trackEmailClicked(options: {
         automationActionRevisionId: string;
+        automationRunStepId: string;
         memberId: string;
         clickedAt: Readonly<Date>;
     }, transactionOptions?: {

--- a/ghost/core/core/server/services/automations/automations-repository.ts
+++ b/ghost/core/core/server/services/automations/automations-repository.ts
@@ -90,6 +90,7 @@ export type AutomatedEmailEvents = {
 
 export type RecordEmailSentOptions = Readonly<{
     automationActionRevisionId: string;
+    automationRunStepId: string;
     mailgunMessageId?: string;
     memberEmail: string;
     memberId: string;

--- a/ghost/core/core/server/services/automations/database-automations-repository.ts
+++ b/ghost/core/core/server/services/automations/database-automations-repository.ts
@@ -276,6 +276,7 @@ export function createDatabaseAutomationsRepository({
                     member_email: options.memberEmail,
                     member_name: options.memberName,
                     automation_action_revision_id: options.automationActionRevisionId,
+                    automation_run_step_id: options.automationRunStepId,
                     ...(options.mailgunMessageId ? {mailgun_message_id: options.mailgunMessageId} : {}),
                     track_clicks: options.trackClicks,
                     track_opens: options.trackOpens,

--- a/ghost/core/core/server/services/automations/database-automations-repository.ts
+++ b/ghost/core/core/server/services/automations/database-automations-repository.ts
@@ -351,7 +351,7 @@ export function createDatabaseAutomationsRepository({
             });
         },
 
-        async trackEmailClicked({automationActionRevisionId, memberId, clickedAt}, {transacting} = {}) {
+        async trackEmailClicked({automationActionRevisionId, automationRunStepId, memberId, clickedAt}, {transacting} = {}) {
             const trackClick = async (trx: Knex.Transaction) => {
                 await lockActionRevisions(trx, [automationActionRevisionId]);
 
@@ -359,12 +359,10 @@ export function createDatabaseAutomationsRepository({
                     .select('id', 'clicked_at')
                     .where({
                         automation_action_revision_id: automationActionRevisionId,
+                        automation_run_step_id: automationRunStepId,
                         member_id: memberId,
                         track_clicks: true
                     })
-                    .where('created_at', '<=', toDatabaseDate(clickedAt))
-                    .orderBy('created_at', 'desc')
-                    .orderBy('id', 'desc')
                     .forUpdate()
                     .first();
 

--- a/ghost/core/core/server/services/automations/poll.ts
+++ b/ghost/core/core/server/services/automations/poll.ts
@@ -210,6 +210,7 @@ const processStep = async ({
             try {
                 await automationsApi.recordEmailSent({
                     automationActionRevisionId: step.automation_action_revision_id,
+                    automationRunStepId: step.id,
                     ...(mailgunMessageId ? {mailgunMessageId} : {}),
                     memberEmail: member.get('email'),
                     memberId: step.member_id,

--- a/ghost/core/core/server/services/automations/poll.ts
+++ b/ghost/core/core/server/services/automations/poll.ts
@@ -28,6 +28,7 @@ type MemberWelcomeEmailService = {
             trackOpens: boolean;
             trackClicks: boolean;
             automationActionRevisionId: string;
+            automationRunStepId: string;
         }) => Promise<unknown>;
     };
 };
@@ -202,7 +203,8 @@ const processStep = async ({
                 memberStatus,
                 trackOpens,
                 trackClicks,
-                automationActionRevisionId: step.automation_action_revision_id
+                automationActionRevisionId: step.automation_action_revision_id,
+                automationRunStepId: step.id
             });
             const mailgunMessageId = getMailgunMessageId(sendResult);
             // Only Mailgun sends can produce open events for automation emails

--- a/ghost/core/core/server/services/link-tracking/link-click-tracking-service.js
+++ b/ghost/core/core/server/services/link-tracking/link-click-tracking-service.js
@@ -281,6 +281,12 @@ class LinkClickTrackingService {
                 return;
             }
 
+            const automationRunStepId = event.data.url.searchParams.get('step');
+            if (!automationRunStepId) {
+                await this.#linkClickRepository.save(click);
+                return;
+            }
+
             await this.#runInTransaction(async (transacting) => {
                 const memberId = await this.#linkClickRepository.save(click, {transacting});
                 if (!memberId) {
@@ -289,6 +295,7 @@ class LinkClickTrackingService {
 
                 await this.#automationsApi.trackEmailClicked({
                     automationActionRevisionId,
+                    automationRunStepId,
                     memberId,
                     clickedAt: event.timestamp
                 }, {transacting});

--- a/ghost/core/core/server/services/link-tracking/link-click-tracking-service.js
+++ b/ghost/core/core/server/services/link-tracking/link-click-tracking-service.js
@@ -250,13 +250,15 @@ class LinkClickTrackingService {
      * Add first-party tracking to a URL in an automation email
      * @param {Readonly<URL>} url
      * @param {string} automationActionRevisionId
+     * @param {string} automationRunStepId
      * @param {string} memberUuid
      * @return {Promise<URL>}
      */
-    async addAutomationTrackingToUrl(url, automationActionRevisionId, memberUuid) {
+    async addAutomationTrackingToUrl(url, automationActionRevisionId, automationRunStepId, memberUuid) {
         const redirect = await this.#linkRedirectService.getOrAddAutomationRedirect(automationActionRevisionId, url);
         const trackedUrl = new URL(redirect.from.href);
         trackedUrl.searchParams.set('m', memberUuid);
+        trackedUrl.searchParams.set('step', automationRunStepId);
         return trackedUrl;
     }
 

--- a/ghost/core/core/server/services/member-welcome-emails/member-welcome-email-renderer.js
+++ b/ghost/core/core/server/services/member-welcome-emails/member-welcome-email-renderer.js
@@ -119,9 +119,10 @@ class MemberWelcomeEmailRenderer {
      * @param {string} [options.unsubscribeUrl] - When set, the footer shows an "Unsubscribe from these emails" link instead of "Manage your preferences"
      * @param {boolean} [options.trackClicks]
      * @param {string | null} [options.automationActionRevisionId]
+     * @param {string | null} [options.automationRunStepId]
      * @returns {Promise<{html: string, text: string, subject: string}>}
      */
-    async render({lexical, subject, designSettings, member, siteSettings, unsubscribeUrl, trackClicks = false, automationActionRevisionId = null}) {
+    async render({lexical, subject, designSettings, member, siteSettings, unsubscribeUrl, trackClicks = false, automationActionRevisionId = null, automationRunStepId = null}) {
         designSettings = designSettings || {};
 
         const design = emailDesign.getEmailDesign({
@@ -171,9 +172,9 @@ class MemberWelcomeEmailRenderer {
                 return originalPath;
             }
             const isTrackable = ['http:', 'https:'].includes(url.protocol);
-            if (trackClicks && automationActionRevisionId && member.uuid && isTrackable) {
+            if (trackClicks && automationActionRevisionId && automationRunStepId && member.uuid && isTrackable) {
                 await linkTracking.init();
-                return await linkTracking.service.addAutomationTrackingToUrl(url, automationActionRevisionId, member.uuid);
+                return await linkTracking.service.addAutomationTrackingToUrl(url, automationActionRevisionId, automationRunStepId, member.uuid);
             }
             return url;
         }, {base: siteSettings.url});

--- a/ghost/core/core/server/services/member-welcome-emails/service.js
+++ b/ghost/core/core/server/services/member-welcome-emails/service.js
@@ -370,10 +370,11 @@ class MemberWelcomeEmailService {
      * @param {boolean} [options.trackOpens]
      * @param {boolean} [options.trackClicks]
      * @param {string | null} [options.automationActionRevisionId]
+     * @param {string | null} [options.automationRunStepId]
      * @param {null | {url: string, oneClickUrl: string}} [options.unsubscribe] - When set, the footer links to an unsubscribe URL and the email carries one-click List-Unsubscribe headers
      * @returns {Promise<unknown>}
      */
-    async #sendEmail({member, memberStatus, email, emailType, trackOpens, trackClicks = false, automationActionRevisionId = null, unsubscribe = null}) {
+    async #sendEmail({member, memberStatus, email, emailType, trackOpens, trackClicks = false, automationActionRevisionId = null, automationRunStepId = null, unsubscribe = null}) {
         if (!member.email) {
             throw new errors.IncorrectUsageError({
                 message: MESSAGES.MISSING_RECIPIENT_EMAIL
@@ -400,7 +401,8 @@ class MemberWelcomeEmailService {
             siteSettings: this.#getSiteSettings(),
             unsubscribeUrl: unsubscribe?.url,
             trackClicks,
-            automationActionRevisionId
+            automationActionRevisionId,
+            automationRunStepId
         });
 
         const senderOptions = await this.#getEffectiveSenderOptions(
@@ -480,9 +482,10 @@ class MemberWelcomeEmailService {
      * @param {boolean} options.trackOpens
      * @param {boolean} options.trackClicks
      * @param {string} options.automationActionRevisionId
+     * @param {string} options.automationRunStepId
      * @returns {Promise<unknown>}
      */
-    async sendAutomationEmail({email, member, memberStatus, trackOpens, trackClicks, automationActionRevisionId}) {
+    async sendAutomationEmail({email, member, memberStatus, trackOpens, trackClicks, automationActionRevisionId, automationRunStepId}) {
         const designSettings = email.designSettingId ?
             await EmailDesignSetting.findOne({id: email.designSettingId}) :
             null;
@@ -510,6 +513,7 @@ class MemberWelcomeEmailService {
             trackOpens,
             trackClicks,
             automationActionRevisionId,
+            automationRunStepId,
             unsubscribe
         });
     }

--- a/ghost/core/test/integration/services/email-analytics/automation-email-analytics.test.js
+++ b/ghost/core/test/integration/services/email-analytics/automation-email-analytics.test.js
@@ -137,6 +137,7 @@ describe('Automation email analytics', function () {
         const member = await createMember();
         await automationsApi.recordEmailSent({
             automationActionRevisionId: revision.id,
+            automationRunStepId: null,
             mailgunMessageId,
             memberEmail: member.email,
             memberId: member.id,

--- a/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
+++ b/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
@@ -2242,38 +2242,47 @@ describe('automations repository', function () {
 
         let firstRevisionId: string;
         let secondRevisionId: string;
+        let trackedRunStepId: string;
 
         const insertRecipient = async ({
             id,
             revisionId = firstRevisionId,
             memberId = 'member-id',
             trackClicks = true,
-            createdAt = EARLIER_DELIVERY
+            createdAt = EARLIER_DELIVERY,
+            automationRunStepId
         }: {
             id: string;
             revisionId?: string;
             memberId?: string;
             trackClicks?: boolean;
             createdAt?: Date;
-        }): Promise<void> => {
+            automationRunStepId?: string;
+        }): Promise<string> => {
+            const runStepId = automationRunStepId ?? (await insertStepForRevision(revisionId)).id;
             await knex('automated_email_recipients').insert({
                 id,
                 automation_action_revision_id: revisionId,
+                automation_run_step_id: runStepId,
                 member_id: memberId,
                 track_clicks: trackClicks,
                 created_at: toDatabaseDate(createdAt)
             });
+            return runStepId;
         };
 
         const trackClick = async ({
             memberId = 'member-id',
-            clickedAt = FIRST_CLICK
+            clickedAt = FIRST_CLICK,
+            automationRunStepId = trackedRunStepId
         }: {
             memberId?: string;
             clickedAt?: Date;
+            automationRunStepId?: string;
         } = {}): Promise<void> => {
             await repo.trackEmailClicked({
                 automationActionRevisionId: firstRevisionId,
+                automationRunStepId,
                 memberId,
                 clickedAt
             });
@@ -2308,7 +2317,7 @@ describe('automations repository', function () {
             firstRevisionId = firstRevision.id;
             secondRevisionId = secondRevision.id;
 
-            await insertRecipient({id: 'tracked-recipient'});
+            trackedRunStepId = await insertRecipient({id: 'tracked-recipient'});
         });
 
         it('records the first click and increments the click count', async function () {
@@ -2343,21 +2352,23 @@ describe('automations repository', function () {
             assert(revisionSelect < recipientSelect);
         });
 
-        it('does not update recipients for another member or revision', async function () {
-            await insertRecipient({
+        it('does not update a run step that belongs to another member or revision', async function () {
+            const otherMemberRunStepId = await insertRecipient({
                 id: 'other-member-recipient',
                 memberId: 'other-member-id'
             });
-            await insertRecipient({
+            const otherRevisionRunStepId = await insertRecipient({
                 id: 'other-revision-recipient',
                 revisionId: secondRevisionId
             });
 
-            await trackClick();
+            await trackClick({automationRunStepId: otherMemberRunStepId});
+            await trackClick({automationRunStepId: otherRevisionRunStepId});
 
-            assert.deepEqual(await getClickedAt('tracked-recipient'), FIRST_CLICK);
+            assert.equal(await getClickedAt('tracked-recipient'), null);
             assert.equal(await getClickedAt('other-member-recipient'), null);
             assert.equal(await getClickedAt('other-revision-recipient'), null);
+            assert.equal(await getClickedCount(firstRevisionId), null);
             assert.equal(await getClickedCount(secondRevisionId), null);
         });
 
@@ -2379,7 +2390,7 @@ describe('automations repository', function () {
             assert.equal(await getClickedCount(firstRevisionId), 6);
         });
 
-        it('only tracks the most recent recipient when a member received the same revision more than once', async function () {
+        it('tracks the recipient identified by the run step when a member received the same revision more than once', async function () {
             await insertRecipient({
                 id: 'other-delivery-recipient',
                 createdAt: LATER_DELIVERY
@@ -2388,18 +2399,21 @@ describe('automations repository', function () {
             await trackClick();
             await trackClick({clickedAt: LATER_CLICK});
 
-            assert.equal(await getClickedAt('tracked-recipient'), null);
-            assert.deepEqual(await getClickedAt('other-delivery-recipient'), FIRST_CLICK);
+            assert.deepEqual(await getClickedAt('tracked-recipient'), FIRST_CLICK);
+            assert.equal(await getClickedAt('other-delivery-recipient'), null);
             assert.equal(await getClickedCount(firstRevisionId), 1);
         });
 
         it('does not track clicks for recipients with tracking disabled', async function () {
-            await insertRecipient({
+            const disabledRunStepId = await insertRecipient({
                 id: 'tracking-disabled-recipient',
                 memberId: 'disabled-member-id',
                 trackClicks: false
             });
-            await trackClick({memberId: 'disabled-member-id'});
+            await trackClick({
+                automationRunStepId: disabledRunStepId,
+                memberId: 'disabled-member-id'
+            });
 
             assert.equal(await getClickedAt('tracking-disabled-recipient'), null);
             assert.equal(await getClickedCount(firstRevisionId), null);
@@ -2430,6 +2444,7 @@ describe('automations repository', function () {
             await assert.rejects(knex.transaction(async (transacting) => {
                 await repo.trackEmailClicked({
                     automationActionRevisionId: firstRevisionId,
+                    automationRunStepId: trackedRunStepId,
                     memberId: 'member-id',
                     clickedAt: FIRST_CLICK
                 }, {transacting});

--- a/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
+++ b/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
@@ -154,6 +154,7 @@ const createDatabase = async (): Promise<Knex> => {
     await database.schema.createTable('automated_email_recipients', (table) => {
         table.text('id').primary();
         table.text('automation_action_revision_id').references('id').inTable('automation_action_revisions');
+        table.text('automation_run_step_id').references('id').inTable('automation_run_steps');
         table.text('member_id');
         table.text('member_uuid');
         table.text('member_email');
@@ -512,6 +513,17 @@ describe('automations repository', function () {
         await knex('automation_run_steps').insert(step);
 
         return step;
+    };
+
+    const insertStepForRevision = async (revisionId: string) => {
+        const action = await knex('automation_action_revisions as revisions')
+            .select('actions.automation_id')
+            .innerJoin('automation_actions as actions', 'actions.id', 'revisions.action_id')
+            .where('revisions.id', revisionId)
+            .first();
+        assert(action, 'Expected action revision to exist');
+        const run = await insertRun(action.automation_id);
+        return await insertStep(run.id, revisionId);
     };
 
     const getStepById = async (id: string) => {
@@ -2069,9 +2081,11 @@ describe('automations repository', function () {
         it('records the recipient and increments the action revision count', async function () {
             const revision = await knex('automation_action_revisions').select('id').first();
             assert(revision);
+            const step = await insertStepForRevision(revision.id);
 
             await repo.recordEmailSent({
                 automationActionRevisionId: revision.id,
+                automationRunStepId: step.id,
                 mailgunMessageId: 'mailgun-message-id',
                 memberEmail: 'member@example.com',
                 memberId: 'member-id',
@@ -2085,6 +2099,7 @@ describe('automations repository', function () {
             assert.deepEqual(recipient, {
                 id: recipient.id,
                 automation_action_revision_id: revision.id,
+                automation_run_step_id: step.id,
                 member_id: 'member-id',
                 member_uuid: '00000000-0000-4000-8000-000000000001',
                 member_email: 'member@example.com',
@@ -2112,6 +2127,7 @@ describe('automations repository', function () {
         it('updates the action revision before inserting the recipient', async function () {
             const revision = await knex('automation_action_revisions').select('id').first();
             assert(revision);
+            const step = await insertStepForRevision(revision.id);
 
             const queries: string[] = [];
             const recordQuery = ({sql}: {sql: string}) => queries.push(sql);
@@ -2120,6 +2136,7 @@ describe('automations repository', function () {
             try {
                 await repo.recordEmailSent({
                     automationActionRevisionId: revision.id,
+                    automationRunStepId: step.id,
                     memberEmail: 'member@example.com',
                     memberId: 'member-id',
                     memberName: 'Test Member',
@@ -2146,9 +2163,11 @@ describe('automations repository', function () {
         it('supports recipients without a Mailgun message ID', async function () {
             const revision = await knex('automation_action_revisions').select('id').first();
             assert(revision);
+            const step = await insertStepForRevision(revision.id);
 
             await repo.recordEmailSent({
                 automationActionRevisionId: revision.id,
+                automationRunStepId: step.id,
                 memberEmail: 'member@example.com',
                 memberId: 'member-id',
                 memberName: null,

--- a/ghost/core/test/unit/server/services/automations/poll.test.ts
+++ b/ghost/core/test/unit/server/services/automations/poll.test.ts
@@ -443,7 +443,8 @@ describe('automations poll', function () {
         }));
         sinon.assert.calledOnceWithExactly(memberWelcomeEmailService.api.sendAutomationEmail, sinon.match({
             trackClicks: true,
-            automationActionRevisionId: step.automation_action_revision_id
+            automationActionRevisionId: step.automation_action_revision_id,
+            automationRunStepId: step.id
         }));
     });
 
@@ -460,7 +461,8 @@ describe('automations poll', function () {
         }));
         sinon.assert.calledOnceWithExactly(memberWelcomeEmailService.api.sendAutomationEmail, sinon.match({
             trackClicks: false,
-            automationActionRevisionId: step.automation_action_revision_id
+            automationActionRevisionId: step.automation_action_revision_id,
+            automationRunStepId: step.id
         }));
     });
 
@@ -478,7 +480,8 @@ describe('automations poll', function () {
         }));
         sinon.assert.calledOnceWithExactly(memberWelcomeEmailService.api.sendAutomationEmail, sinon.match({
             trackClicks: false,
-            automationActionRevisionId: step.automation_action_revision_id
+            automationActionRevisionId: step.automation_action_revision_id,
+            automationRunStepId: step.id
         }));
     });
 

--- a/ghost/core/test/unit/server/services/automations/poll.test.ts
+++ b/ghost/core/test/unit/server/services/automations/poll.test.ts
@@ -368,6 +368,7 @@ describe('automations poll', function () {
         }));
         sinon.assert.calledOnceWithExactly(automationsApi.recordEmailSent, {
             automationActionRevisionId: 'revision-id',
+            automationRunStepId: step.id,
             mailgunMessageId: 'mailgun-message-id',
             memberEmail: 'member@example.com',
             memberId: 'member-id',
@@ -437,6 +438,7 @@ describe('automations poll', function () {
         await poll(options);
 
         sinon.assert.calledOnceWithExactly(automationsApi.recordEmailSent, sinon.match({
+            automationRunStepId: step.id,
             trackClicks: true
         }));
         sinon.assert.calledOnceWithExactly(memberWelcomeEmailService.api.sendAutomationEmail, sinon.match({
@@ -453,6 +455,7 @@ describe('automations poll', function () {
         await poll(options);
 
         sinon.assert.calledOnceWithExactly(automationsApi.recordEmailSent, sinon.match({
+            automationRunStepId: step.id,
             trackClicks: false
         }));
         sinon.assert.calledOnceWithExactly(memberWelcomeEmailService.api.sendAutomationEmail, sinon.match({
@@ -470,6 +473,7 @@ describe('automations poll', function () {
         await poll(options);
 
         sinon.assert.calledOnceWithExactly(automationsApi.recordEmailSent, sinon.match({
+            automationRunStepId: step.id,
             trackClicks: false
         }));
         sinon.assert.calledOnceWithExactly(memberWelcomeEmailService.api.sendAutomationEmail, sinon.match({
@@ -496,6 +500,7 @@ describe('automations poll', function () {
         }));
         sinon.assert.calledOnceWithExactly(automationsApi.recordEmailSent, {
             automationActionRevisionId: 'revision-id',
+            automationRunStepId: step.id,
             memberEmail: 'member@example.com',
             memberId: 'member-id',
             memberName: 'Test Member',

--- a/ghost/core/test/unit/server/services/link-tracking/index.test.ts
+++ b/ghost/core/test/unit/server/services/link-tracking/index.test.ts
@@ -100,7 +100,7 @@ describe('LinkTrackingServiceWrapper', function () {
         const clickedAt = new Date('2026-07-29T12:34:56.000Z');
         const linkId = ObjectID();
         await subscriber(RedirectEvent.create({
-            url: new URL('https://example.com/destination?m=memberUuid'),
+            url: new URL('https://example.com/destination?m=memberUuid&step=run-step-id'),
             link: {
                 link_id: linkId,
                 automationActionRevisionId: 'revision-id'
@@ -114,6 +114,7 @@ describe('LinkTrackingServiceWrapper', function () {
         }, {transacting});
         sinon.assert.calledOnceWithExactly(trackEmailClicked, {
             automationActionRevisionId: 'revision-id',
+            automationRunStepId: 'run-step-id',
             memberId: 'member-id',
             clickedAt
         }, {transacting});

--- a/ghost/core/test/unit/server/services/link-tracking/link-click-tracking-service.test.js
+++ b/ghost/core/test/unit/server/services/link-tracking/link-click-tracking-service.test.js
@@ -131,10 +131,11 @@ describe('LinkClickTrackingService', function () {
             const updatedUrl = await service.addAutomationTrackingToUrl(
                 new URL('https://example.com/destination'),
                 'revision-id',
+                'run-step-id',
                 '00000000-0000-4000-8000-000000000001'
             );
 
-            assert.equal(updatedUrl.href, 'https://example.com/r/uniqueslug?m=00000000-0000-4000-8000-000000000001');
+            assert.equal(updatedUrl.href, 'https://example.com/r/uniqueslug?m=00000000-0000-4000-8000-000000000001&step=run-step-id');
             sinon.assert.calledOnceWithExactly(
                 getOrAddAutomationRedirect,
                 'revision-id',

--- a/ghost/core/test/unit/server/services/link-tracking/link-click-tracking-service.test.js
+++ b/ghost/core/test/unit/server/services/link-tracking/link-click-tracking-service.test.js
@@ -156,12 +156,16 @@ describe('LinkClickTrackingService', function () {
         const createRedirectEvent = ({
             memberUuid = 'memberUuid',
             automationActionRevisionId,
+            automationRunStepId = 'run-step-id',
             linkId = new ObjectID(),
             timestamp = CLICKED_AT
         } = {}) => {
             const url = new URL('https://example.com/destination');
             if (memberUuid) {
                 url.searchParams.set('m', memberUuid);
+            }
+            if (automationRunStepId) {
+                url.searchParams.set('step', automationRunStepId);
             }
 
             return RedirectEvent.create({
@@ -230,9 +234,23 @@ describe('LinkClickTrackingService', function () {
             sinon.assert.calledOnceWithExactly(save, sinon.match.object, {transacting});
             sinon.assert.calledOnceWithExactly(trackEmailClicked, {
                 automationActionRevisionId: 'revision-id',
+                automationRunStepId: 'run-step-id',
                 memberId: 'member-id',
                 clickedAt: CLICKED_AT
             }, {transacting});
+        });
+
+        it('Saves legacy automation clicks without attributing recipient analytics', async function () {
+            const event = createRedirectEvent({
+                automationActionRevisionId: 'revision-id',
+                automationRunStepId: null
+            });
+
+            await subscriber(event);
+
+            sinon.assert.calledOnceWithExactly(save, sinon.match.object);
+            sinon.assert.notCalled(runInTransaction);
+            sinon.assert.notCalled(trackEmailClicked);
         });
 
         it('Propagates raw click persistence failures', async function () {

--- a/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
+++ b/ghost/core/test/unit/server/services/member-welcome-emails/member-welcome-email-renderer.test.js
@@ -573,10 +573,11 @@ describe('MemberWelcomeEmailRenderer', function () {
 
             beforeEach(function () {
                 sinon.stub(linkTracking, 'init').resolves();
-                addAutomationTrackingToUrl = sinon.stub().callsFake(async (url, revisionId, uuid) => {
+                addAutomationTrackingToUrl = sinon.stub().callsFake(async (url, revisionId, runStepId, uuid) => {
                     assert.equal(revisionId, 'revision-id');
                     const tracked = new URL('https://example.com/r/abc123');
                     tracked.searchParams.set('m', uuid);
+                    tracked.searchParams.set('step', runStepId);
                     return tracked;
                 });
                 sinon.define(linkTracking, 'service', {addAutomationTrackingToUrl});
@@ -591,6 +592,7 @@ describe('MemberWelcomeEmailRenderer', function () {
                     siteSettings: defaultSiteSettings,
                     trackClicks: true,
                     automationActionRevisionId: 'revision-id',
+                    automationRunStepId: 'run-step-id',
                     ...options
                 });
             };
@@ -602,10 +604,11 @@ describe('MemberWelcomeEmailRenderer', function () {
                     addAutomationTrackingToUrl,
                     sinon.match(url => url.href === 'https://external.example/page'),
                     'revision-id',
+                    'run-step-id',
                     memberUuid
                 );
-                assert(result.html.includes(`https://example.com/r/abc123?m=${memberUuid}`));
-                assert(result.text.includes(`https://example.com/r/abc123?m=${memberUuid}`));
+                assert(result.html.includes(`https://example.com/r/abc123?m=${memberUuid}&amp;step=run-step-id`));
+                assert(result.text.includes(`https://example.com/r/abc123?m=${memberUuid}&step=run-step-id`));
             });
 
             it('resolves relative links before tracking them', async function () {
@@ -618,7 +621,7 @@ describe('MemberWelcomeEmailRenderer', function () {
                 const result = await renderTracked('<p><a href="https://external.example/page">One</a><a href="https://external.example/page">Two</a></p>');
 
                 sinon.assert.calledTwice(addAutomationTrackingToUrl);
-                assert.equal((result.html.match(new RegExp(`https://example.com/r/abc123\\?m=${memberUuid}`, 'g')) || []).length, 2);
+                assert.equal((result.html.match(new RegExp(`https://example.com/r/abc123\\?m=${memberUuid}&amp;step=run-step-id`, 'g')) || []).length, 2);
             });
 
             it('leaves fragment-only, invalid, and non-web links unchanged', async function () {
@@ -650,6 +653,14 @@ describe('MemberWelcomeEmailRenderer', function () {
             it('does not rewrite links when the member UUID is absent', async function () {
                 await renderTracked('<p><a href="https://external.example/page">Link</a></p>', {
                     member: {name: 'John', email: 'john@example.com'}
+                });
+
+                sinon.assert.notCalled(addAutomationTrackingToUrl);
+            });
+
+            it('does not rewrite links when the automation run step ID is absent', async function () {
+                await renderTracked('<p><a href="https://external.example/page">Link</a></p>', {
+                    automationRunStepId: null
                 });
 
                 sinon.assert.notCalled(addAutomationTrackingToUrl);

--- a/ghost/core/test/utils/automations-fixtures.ts
+++ b/ghost/core/test/utils/automations-fixtures.ts
@@ -103,6 +103,16 @@ export async function cleanupAutomationsFixture(): Promise<void> {
         .pluck('id');
 
     if (runIds.length > 0) {
+        const runStepIds: string[] = await db.knex('automation_run_steps')
+            .whereIn('automation_run_id', runIds)
+            .pluck('id');
+
+        if (runStepIds.length > 0) {
+            await db.knex('automated_email_recipients')
+                .whereIn('automation_run_step_id', runStepIds)
+                .del();
+        }
+
         await db.knex('automation_run_steps')
             .whereIn('automation_run_id', runIds)
             .del();


### PR DESCRIPTION
refs https://linear.app/ghost/issue/NY-1509/update-click-tracking-to-eliminate-the-most-recently-received-email

Repeated deliveries of the same automation revision made recipient click analytics ambiguous. Carrying the originating run step through the send and redirect paths lets Ghost attribute clicks to the exact email delivery without relying on recency.

## Summary

- linked automated email recipients to their originating run steps
- added the run step ID to tracked links in automated emails
- resolved recipient click analytics by exact run step while preserving general click events for legacy links

## Verification

- 174 focused unit tests
- 31 database-backed integration tests
- ESLint and TypeScript checks