### PR TITLE
Normalised an address country code to two uppercase letters

### DIFF
--- a/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
@@ -1085,6 +1085,15 @@ describe('Member Custom Fields Admin API', function () {
             assert.deepEqual(await readValues(memberId), {[field.key]: {city: 'Cork'}});
         });
 
+        it('stores a country code in one case whichever case it arrives in', async function () {
+            const field = await createField({name: 'Home address', type: 'address'});
+            const memberId = await createMember();
+
+            await setValues(memberId, {[field.key]: {city: 'Bristol', country: 'gb'}});
+
+            assert.deepEqual(await readValues(memberId), {[field.key]: {city: 'Bristol', country: 'GB'}});
+        });
+
         it('rejects an address with nothing in it', async function () {
             const field = await createField({name: 'Home address', type: 'address'});
             const memberId = await createMember();

--- a/ghost/core/test/e2e-api/admin/members-import-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/members-import-custom-fields.test.ts
@@ -189,6 +189,19 @@ describe('Members import — custom fields', function () {
         );
     });
 
+    // Where messy country codes actually come from: a spreadsheet exported from something
+    // else, where the column was typed by hand over several years.
+    it('normalises the case of an imported country code', async function () {
+        const key = await createField('Shipping Address', 'address');
+        const email = 'cf-country-case@example.com';
+
+        const res = await importCSV(`email,custom_fields.${key}.country\n${email},gb\n`);
+        assert.equal(res.status, 201);
+        assert.equal(res.body.meta.stats.imported, 1);
+
+        assert.deepEqual((await findMember(email)).custom_fields?.[key], {country: 'GB'});
+    });
+
     // A stray space is not data. Read as a value it would make this address all-whitespace,
     // fail its "at least one part" rule, and take the member's name and email down with it.
     it('reads a whitespace-only address cell as blank rather than failing the row', async function () {

--- a/packages/custom-field-types/src/index.ts
+++ b/packages/custom-field-types/src/index.ts
@@ -89,9 +89,28 @@ export const AddressValue = z.object({
     city: z.string().trim().max(255).optional(),
     state: z.string().trim().max(255).optional(),
     postal_code: z.string().trim().max(32).optional(),
-    // Two characters only — the shape of an ISO 3166-1 alpha-2 code, not validated
-    // against the actual country list.
-    country: z.string().trim().length(2).optional()
+    /**
+     * The shape of an ISO 3166-1 alpha-2 code, deliberately not checked against the
+     * actual list of them. A closed list would put Ghost in the position of deciding
+     * whose country is real, which is not a judgement a publishing platform should be
+     * making of its members, and there is no defensible answer for Kosovo, Taiwan,
+     * Palestine or Western Sahara. Anything well-formed is stored, and the collection
+     * form offers a list to pick from without being the arbiter of it.
+     *
+     * Case is normalised, because that is a question about the same country rather than
+     * about which countries exist. Left alone, `gb` and `GB` are two values for one
+     * place: a filter for one silently misses the other, and nothing can tell them apart
+     * afterwards to repair it. Normalising on the way in is the only point at which that
+     * is cheap.
+     *
+     * Shape is two ASCII letters rather than any two characters, which is what alpha-2
+     * means. Counting characters instead would be wrong in both directions once case is
+     * normalised, because uppercasing does not preserve length: `ß` becomes `SS` and
+     * would pass a length-of-two rule from one character, while `aß` becomes `ASS` and
+     * would fail it from two. Checking the shape of the input settles both, and turns
+     * away the `12` and `!!` that a bare length check always allowed through.
+     */
+    country: z.string().trim().regex(/^[A-Za-z]{2}$/).toUpperCase().optional()
 }).refine(
     // Every sub-field is trimmed above, so whitespace has already become the empty
     // string by the time this runs. Trimming is what stops `{line1: '   '}` being

--- a/packages/custom-field-types/test/index.test.ts
+++ b/packages/custom-field-types/test/index.test.ts
@@ -70,6 +70,41 @@ describe('custom-field-types catalog', function () {
             assert.equal(parse({line1: '', city: '', postal_code: ''}), false);
         });
 
+        it('normalises the case of a country code, so one country is one value', function () {
+            const parsed = FIELD_TYPES.address.value.safeParse({country: 'gb'});
+            assert.equal(parsed.success && parsed.data.country, 'GB');
+
+            // Whichever way it arrives, it is stored the same way, so a filter for one
+            // form cannot miss members holding another.
+            for (const written of ['GB', 'gb', 'Gb', ' gB ']) {
+                const result = FIELD_TYPES.address.value.safeParse({country: written});
+                assert.equal(result.success && result.data.country, 'GB', `expected ${JSON.stringify(written)} to normalise`);
+            }
+        });
+
+        it('accepts any well-formed country code, without ruling on which countries exist', function () {
+            // XK is not an ISO-assigned code, and it is what Kosovo is written as. Ghost
+            // stores it rather than refusing a member's own country.
+            for (const code of ['XK', 'TW', 'PS', 'EH']) {
+                assert.equal(FIELD_TYPES.address.value.safeParse({country: code}).success, true, code);
+            }
+        });
+
+        it('takes two ASCII letters as a country code and nothing else', function () {
+            const parseCountry = (country: string) => FIELD_TYPES.address.value.safeParse({country});
+
+            // Uppercasing is not length-preserving, so a rule counting the characters of
+            // the result is wrong both ways: one character can become two, and two can
+            // become three. Checking the shape of the input is what settles it.
+            assert.equal(parseCountry('ß').success, false, 'ß uppercases to SS');
+            assert.equal(parseCountry('aß').success, false, 'aß uppercases to ASS');
+            assert.equal(parseCountry('ﬁ').success, false, 'the fi ligature uppercases to FI');
+
+            // A bare length check let these through; a country code has letters in it.
+            assert.equal(parseCountry('12').success, false);
+            assert.equal(parseCountry('!!').success, false);
+        });
+
         it('trims a sub-field, so its bound measures the value and not the padding', function () {
             const result = FIELD_TYPES.address.value.safeParse({line1: '  1 Main St  ', country: ' GB '});
             assert.equal(result.success, true);


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3842

Stacked on #29717, which it shares a file with. Retargets to main once that merges.

## Problem

A country code is stored exactly as it arrives. The same country can be written `GB`, `gb` or `Gb`, and Ghost keeps each as a distinct value.

A filter for one form silently misses members holding another. Worse, once both are in the database nothing can tell them apart, because the difference carries no meaning — there is no way to know later which rows were meant to be the same place.

## Solution

Case is normalised as the value is parsed, so one country is one stored value however it was typed. That is the only point at which it costs nothing; afterwards it is a data repair.

This covers every way a value arrives: the API, the CSV import, and the admin screen.

## The shape it is checked against

Two ASCII letters, rather than any two characters.

That is what alpha-2 means, and what the rule always claimed to be, but it had been checking length alone. Two things follow from tightening it, and both are reasons to do it in the same change rather than later.

Counting characters stops working once case is normalised, because uppercasing does not preserve length. `ß` uppercases to `SS`, so one character would satisfy a rule asking for two. `aß` uppercases to `ASS`, so two characters would fail it. Checking the shape of the input avoids the question entirely.

It also turns away the digits and punctuation a length check always allowed. `12` and `!!` were storable country codes before this.

## What this deliberately does not add

A list of countries to check against.

That would put Ghost in the position of ruling on whose country is real, which has no defensible answer for Kosovo, Taiwan, Palestine or Western Sahara, and is not a judgement a publishing platform should be making of its members. Rejecting a code means telling someone their country does not exist.

Anything well-formed is stored. A list belongs to the form doing the collecting, where it can guide someone without being the arbiter of what is allowed.

## Follow-ups

The country picker in the admin screen is the other half of BER-3842 and comes later, alongside the rest of the address collection work. It will use the country list Ghost already ships and already renders in Stats, so the naming decisions stay consistent with what publishers see elsewhere.

Normalising obvious aliases on import, such as `UK` to `GB`, is a separate question. That is an import heuristic rather than a validity rule, and it belongs with the importer.

---

Behind the `membersCustomFields` flag.
