### PR TITLE
🐛 Fixed SVG favicons not rendering in bookmark cards

### DIFF
--- a/ghost/core/core/server/services/oembed/oembed-service.js
+++ b/ghost/core/core/server/services/oembed/oembed-service.js
@@ -44,33 +44,14 @@ const messages = {
     unconvertibleSvg: 'SVG image is too large or compressed to convert.'
 };
 
-// Matches the `icon` entry in imageOptimization.internalImageSizes. Bounding
-// both dimensions matters: given only a width, a few hundred bytes declaring an
-// extreme aspect ratio render to tens of megabytes.
 const SVG_RASTER_SIZE = 256;
 const SVG_RASTER_TIMEOUT_SECONDS = 10;
-
-// Render cost tracks the markup libvips sees, not the bytes we were sent, and
-// neither the timeout above nor a byte cap alone bounds it — filter primitives
-// cost output-area time, and gzip hides its true size until libvips inflates it.
 const MAX_SVG_BYTES = 32 * 1024;
 const GZIP_MAGIC = [0x1f, 0x8b];
 
 const SVG_EXTENSIONS = new Set(['.svg', '.svgz']);
 const SVG_SNIFF_BYTES = 1024;
 
-/**
- * Whether these bytes should be rasterized rather than stored as they are.
- *
- * Local storage types a file from its name, so an SVG only reaches a browser as
- * a document when stored under a `.svg` name. Treating the URL's extension as a
- * trigger means every such name is converted or not stored, which is what makes
- * a missed sniff harmless rather than a stored script.
- *
- * @param {Buffer} buffer
- * @param {string} ext
- * @returns {boolean}
- */
 const shouldRasterize = (buffer, ext) => {
     if (SVG_EXTENSIONS.has(ext.toLowerCase())) {
         return true;
@@ -222,10 +203,6 @@ class OEmbedService {
         const baseName = ext ? path.basename(fileName, ext) : fileName;
         const name = this.imageStore.getSanitizedFileName(baseName);
 
-        // An SVG under our own origin is a document that can carry script, and
-        // these bytes come from whatever site the author bookmarked. A PNG
-        // carries nothing, and browsers sniff it where they will not sniff SVG,
-        // which is why only SVG icons render broken today.
         if (shouldRasterize(imageBuffer, ext)) {
             if (imageBuffer.length > MAX_SVG_BYTES || GZIP_MAGIC.every((byte, index) => imageBuffer[index] === byte)) {
                 throw new errors.ValidationError({

--- a/ghost/core/core/server/services/oembed/oembed-service.js
+++ b/ghost/core/core/server/services/oembed/oembed-service.js
@@ -9,6 +9,7 @@ const charset = require('charset');
 const iconv = require('iconv-lite');
 const path = require('path');
 const crypto = require('crypto');
+const imageTransform = require('@tryghost/image-transform');
 
 // Some sites block non-standard user agents so we need to mimic a typical browser
 // Note: the Ghost/5.0 string _may_ be in use by 3rd parties so use caution when updating across majors
@@ -39,7 +40,45 @@ const messages = {
     insufficientMetadata: 'URL contains insufficient metadata.',
     unknownProvider: 'No provider found for supplied URL.',
     unableToFetchOembed: 'Unable to fetch requested embed.',
-    unauthorized: 'URL contains a private resource.'
+    unauthorized: 'URL contains a private resource.',
+    unconvertibleSvg: 'SVG image is too large or compressed to convert.'
+};
+
+// Matches the `icon` entry in imageOptimization.internalImageSizes. Bounding
+// both dimensions matters: given only a width, a few hundred bytes declaring an
+// extreme aspect ratio render to tens of megabytes.
+const SVG_RASTER_SIZE = 256;
+const SVG_RASTER_TIMEOUT_SECONDS = 10;
+
+// Render cost tracks the markup libvips sees, not the bytes we were sent, and
+// neither the timeout above nor a byte cap alone bounds it — filter primitives
+// cost output-area time, and gzip hides its true size until libvips inflates it.
+const MAX_SVG_BYTES = 32 * 1024;
+const GZIP_MAGIC = [0x1f, 0x8b];
+
+const SVG_EXTENSIONS = new Set(['.svg', '.svgz']);
+const SVG_SNIFF_BYTES = 1024;
+
+/**
+ * Whether these bytes should be rasterized rather than stored as they are.
+ *
+ * Local storage types a file from its name, so an SVG only reaches a browser as
+ * a document when stored under a `.svg` name. Treating the URL's extension as a
+ * trigger means every such name is converted or not stored, which is what makes
+ * a missed sniff harmless rather than a stored script.
+ *
+ * @param {Buffer} buffer
+ * @param {string} ext
+ * @returns {boolean}
+ */
+const shouldRasterize = (buffer, ext) => {
+    if (SVG_EXTENSIONS.has(ext.toLowerCase())) {
+        return true;
+    }
+
+    const head = buffer.subarray(0, SVG_SNIFF_BYTES).toString('utf8').trimStart();
+
+    return head.startsWith('<') && /<svg[\s:>]/i.test(head);
 };
 
 /**
@@ -175,13 +214,38 @@ class OEmbedService {
         }
 
         // Fetch image buffer from the URL
-        const imageBuffer = await this.fetchImageBuffer(imageUrl);
+        let imageBuffer = await this.fetchImageBuffer(imageUrl);
 
         // Extract file name from URL
         const fileName = path.basename(new URL(imageUrl).pathname);
-        const ext = path.extname(fileName);
+        let ext = path.extname(fileName);
         const baseName = ext ? path.basename(fileName, ext) : fileName;
         const name = this.imageStore.getSanitizedFileName(baseName);
+
+        // An SVG under our own origin is a document that can carry script, and
+        // these bytes come from whatever site the author bookmarked. A PNG
+        // carries nothing, and browsers sniff it where they will not sniff SVG,
+        // which is why only SVG icons render broken today.
+        if (shouldRasterize(imageBuffer, ext)) {
+            if (imageBuffer.length > MAX_SVG_BYTES || GZIP_MAGIC.every((byte, index) => imageBuffer[index] === byte)) {
+                throw new errors.ValidationError({
+                    message: tpl(messages.unconvertibleSvg),
+                    context: imageUrl
+                });
+            }
+
+            imageBuffer = await imageTransform.resizeFromBuffer(imageBuffer, {
+                // without `format` this returns the original bytes whenever they
+                // are smaller, storing the SVG under a .png name
+                format: 'png',
+                width: SVG_RASTER_SIZE,
+                height: SVG_RASTER_SIZE,
+                withoutEnlargement: false,
+                timeout: SVG_RASTER_TIMEOUT_SECONDS
+            });
+
+            ext = '.png';
+        }
 
         const uniqueFileName = `${name}-${crypto.randomUUID()}${ext}`;
         const targetPath = path.join(imageType, uniqueFileName);

--- a/ghost/core/test/unit/server/services/oembed/oembed-service.test.js
+++ b/ghost/core/test/unit/server/services/oembed/oembed-service.test.js
@@ -2,6 +2,8 @@ const assert = require('node:assert/strict');
 const nock = require('nock');
 const got = require('got').default;
 const sinon = require('sinon');
+const sharp = require('sharp');
+const zlib = require('zlib');
 
 const OembedService = require('../../../../../core/server/services/oembed/oembed-service');
 
@@ -806,6 +808,139 @@ describe('oembed-service', function () {
                 () => service.processImageFromUrl('https://example.com/broken.png', 'thumbnail'),
                 {message: 'Network error'}
             );
+        });
+
+        describe('SVG bookmark images', function () {
+            const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+            const SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><circle cx="8" cy="8" r="7" fill="red"/></svg>';
+
+            const buildService = (saveRaw, bytes) => new OembedService({
+                config: {
+                    getContentPath() {
+                        return '/tmp/content/images';
+                    }
+                },
+                imageStore: {
+                    getSanitizedFileName: sinon.stub().returns('favicon'),
+                    saveRaw
+                },
+                externalRequest() {
+                    return {
+                        buffer: async () => Buffer.from(bytes)
+                    };
+                }
+            });
+
+            it('stores an SVG icon as a PNG', async function () {
+                const saveRaw = sinon.stub().resolves('/stored');
+
+                await buildService(saveRaw, SVG).processImageFromUrl('https://example.com/favicon.svg', 'icon');
+
+                sinon.assert.calledOnce(saveRaw);
+                assert.match(saveRaw.firstCall.args[1], new RegExp(`^icon/favicon-${UUID_RE.source}\\.png$`));
+                assert.deepEqual(saveRaw.firstCall.args[0].subarray(0, 8), PNG_MAGIC);
+            });
+
+            it('bounds the output in both dimensions', async function () {
+                // Given only a width the height follows the source, so a few
+                // hundred bytes of extreme aspect ratio become tens of megabytes.
+                const saveRaw = sinon.stub().resolves('/stored');
+                const tall = '<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="8000"><rect width="1000" height="8000"/></svg>';
+
+                await buildService(saveRaw, tall).processImageFromUrl('https://example.com/favicon.svg', 'thumbnail');
+
+                const {width, height} = await sharp(saveRaw.firstCall.args[0]).metadata();
+                assert.equal(width, 256);
+                assert.equal(height, 256);
+            });
+
+            it('renders up to the target size rather than the source size', async function () {
+                const saveRaw = sinon.stub().resolves('/stored');
+
+                await buildService(saveRaw, SVG).processImageFromUrl('https://example.com/favicon.svg', 'icon');
+
+                const {width} = await sharp(saveRaw.firstCall.args[0]).metadata();
+                assert.equal(width, 256);
+            });
+
+            it('converts an SVG served under a misleading name', async function () {
+                const saveRaw = sinon.stub().resolves('/stored');
+
+                await buildService(saveRaw, SVG).processImageFromUrl('https://example.com/favicon.ico', 'icon');
+
+                assert.match(saveRaw.firstCall.args[1], /\.png$/);
+            });
+
+            it('converts a namespace-prefixed <svg:svg> root', async function () {
+                const saveRaw = sinon.stub().resolves('/stored');
+                const prefixed = '<svg:svg xmlns:svg="http://www.w3.org/2000/svg" width="16" height="16"><svg:circle cx="8" cy="8" r="7"/></svg:svg>';
+
+                await buildService(saveRaw, prefixed).processImageFromUrl('https://example.com/favicon.ico', 'icon');
+
+                assert.match(saveRaw.firstCall.args[1], /\.png$/);
+            });
+
+            it('converts anything served under an .svg name, whatever its case', async function () {
+                // Padding defeats the content sniff, so the extension is what
+                // guarantees nothing is stored as an SVG document.
+                const saveRaw = sinon.stub().resolves('/stored');
+                const padded = `<!--${'x'.repeat(2000)}-->${SVG}`;
+
+                await buildService(saveRaw, padded).processImageFromUrl('https://example.com/favicon.SVG', 'icon');
+
+                assert.match(saveRaw.firstCall.args[1], /\.png$/);
+            });
+
+            it('rejects a gzipped SVG rather than inflating it', async function () {
+                // libvips inflates these internally, so the byte cap cannot see
+                // their real size: 10KB on the wire took 47s to render.
+                const saveRaw = sinon.stub().resolves('/stored');
+
+                await assert.rejects(
+                    () => buildService(saveRaw, zlib.gzipSync(Buffer.from(SVG)))
+                        .processImageFromUrl('https://example.com/favicon.svgz', 'icon'),
+                    {message: /too large or compressed/}
+                );
+                sinon.assert.notCalled(saveRaw);
+            });
+
+            it('rejects an SVG too large to convert', async function () {
+                const saveRaw = sinon.stub().resolves('/stored');
+                const huge = `<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64"><!--${'x'.repeat(64 * 1024)}--><circle r="8"/></svg>`;
+
+                await assert.rejects(
+                    () => buildService(saveRaw, huge).processImageFromUrl('https://example.com/favicon.svg', 'icon'),
+                    {message: /too large or compressed/}
+                );
+                sinon.assert.notCalled(saveRaw);
+            });
+
+            it('rejects markup that is not a convertible image', async function () {
+                const saveRaw = sinon.stub().resolves('/stored');
+                const service = buildService(saveRaw, '<!doctype html><html><body><svg><h1>404</h1></body></html>');
+
+                await assert.rejects(() => service.processImageFromUrl('https://example.com/favicon.svg', 'icon'));
+                sinon.assert.notCalled(saveRaw);
+            });
+
+            it('leaves raster images untouched', async function () {
+                const saveRaw = sinon.stub().resolves('/stored');
+
+                await buildService(saveRaw, PNG_MAGIC).processImageFromUrl('https://example.com/favicon.PNG', 'icon');
+
+                assert.deepEqual(saveRaw.firstCall.args[0], PNG_MAGIC);
+                // extension case is preserved, so existing URLs do not change
+                assert.match(saveRaw.firstCall.args[1], /\.PNG$/);
+            });
+
+            it('does not convert a raster file containing the text <svg', async function () {
+                const saveRaw = sinon.stub().resolves('/stored');
+                const png = Buffer.concat([PNG_MAGIC, Buffer.from('<svg width="1">')]);
+
+                await buildService(saveRaw, png).processImageFromUrl('https://example.com/favicon.png', 'icon');
+
+                assert.deepEqual(saveRaw.firstCall.args[0], png);
+            });
         });
     });
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1930/substack-favicon-broken

Bookmark card icons are stored without a content type, so GCS serves them as an
octet-stream. Browsers sniff raster formats and render them anyway, but they do
not sniff SVG, so SVG favicons in bookmark cards show as broken images.
Reported via escalation.

> **Note:** this PR has been rebuilt twice and earlier review comments refer to
> older versions. It previously sanitized SVG with DOMPurify and stored it as
> `image/svg+xml` (~600 lines), then rasterized but also plumbed a content type
> through the storage adapter. Both are gone.

## Why this path and not image cards

Image cards go through `save()`, which has always passed `file.type` from the
upload middleware. Bookmark icons go through `saveRaw()` — they are fetched
server-side rather than uploaded — and `saveRaw()` never set a type. Same class
of bug as #26637, on the half of the storage interface that fix did not cover.

## What this does

Converts bookmark SVGs to PNG before storing them, using the conversion
`handle-image-sizes.js` already applies when it converts an SVG. Nothing else
changes — no storage interface change, no content type, no changeset.

A PNG needs no content type to render: browsers sniff it, which is exactly why
every PNG and JPG favicon already renders fine from the same octet-stream that
breaks SVG. Converting also means we never store a document that can carry
script under our own origin, and these bytes come from whatever site an author
bookmarked.

Local storage types a file by its extension, so the URL's extension triggers
conversion in its own right. Everything that could be stored under a `.svg`
name is converted or not stored at all, which makes a missed content sniff
harmless rather than a stored script — on `main` an SVG favicon is already
served as `image/svg+xml` from the site's own origin, unsanitized.

Review confirmed no SSRF, no local file read and no XXE reach librsvg, that the
PNG output carries no metadata from the source, and that the naming invariant
survives case variants, percent-encoding, double extensions, query strings and
gzip.

## Bounds

Rasterizing untrusted input needs bounding, and the obvious bounds do not hold.
Each of these was measured, and each was found by building the shape designed to
defeat the previous bound:

| | unbounded | bounded |
|---|---|---|
| filter-heavy SVG, single render | 106,102ms | 811ms |
| 4 concurrent, threadpool probe | 226,772ms | 1,480ms |
| 266-byte extreme aspect ratio | 30MB stored | 219KB stored |
| `.svgz`, 10KB inflating to 1.1MB | 47,685ms | rejected in 1ms |

- `timeout` does not constrain librsvg — it renders during load, before libvips
  checks its deadline
- input size alone does not either, because filter primitives cost output-area
  time rather than parse time
- neither says anything about the output, so both dimensions are fixed at
  256x256, matching the `icon` entry in `imageOptimization.internalImageSizes`
- gzip hides its size from a byte cap entirely, so compressed input is rejected
  rather than converted

## Known limitations

- **Forward-only.** Existing stored icons keep their octet-stream and stay
  broken. A header-only backfill is not safe for the SVGs, since those bytes
  were never converted; re-fetching is the right remediation, and it mints a new
  URL so the bookmark cards in post content need updating too.
- **Self-hosted SVG icons lose vector crispness** — 256px rather than vector.
  Not visible at the 20px a bookmark icon renders at.
- **SVG thumbnails are cropped to 256x256.** SVG og:images are rare, the card
  already crops with `object-fit: cover`, and a wider target is most of the DoS
  exposure above.
- **Gzipped SVGs, SVGs over 32KB, and installs without sharp** fall back to
  `DEFAULT_BOOKMARK_ICON`.
- **`.html`/`.xhtml` from an attacker's URL are still stored verbatim** and
  served executable from the site's own origin on self-hosted. Unchanged from
  main and out of scope here — needs its own fix.
- `external-media-inliner` has the same missing content type and is untouched.

## Testing

50 oembed unit tests. Every guard has a test that fails when the guard is
removed, including the extension match being case-insensitive, which is what
the naming invariant rests on.
