### PR TITLE
🐛 Fixed unescaped output from the concat helper

### DIFF
--- a/ghost/core/core/frontend/helpers/concat.js
+++ b/ghost/core/core/frontend/helpers/concat.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const {SafeString} = require('../services/handlebars');
 
 module.exports = function concat(...args) {
@@ -7,5 +8,7 @@ module.exports = function concat(...args) {
     // Flatten arrays - if an argument is an array, spread its elements
     const flattenedArgs = args.flat();
 
-    return new SafeString(flattenedArgs.join(separator));
+    const escapedArgs = flattenedArgs.map(arg => (arg instanceof SafeString ? arg.toString() : _.escape(arg)));
+
+    return new SafeString(escapedArgs.join(separator));
 };

--- a/ghost/core/test/unit/frontend/helpers/concat.test.js
+++ b/ghost/core/test/unit/frontend/helpers/concat.test.js
@@ -153,4 +153,16 @@ describe('{{concat}} helper', function () {
         const expected = '[object Object] | my-post';
         shouldCompileToExpected(templateString, {post: {title: 'My Post', slug: 'my-post'}}, expected);
     });
+
+    it('escapes unsafe HTML in plain string arguments', function () {
+        let templateString = '{{concat "Post title: " title}}';
+        let expected = 'Post title: How to use the &lt;script&gt; tag';
+        shouldCompileToExpected(templateString, {title: 'How to use the <script> tag'}, expected);
+    });
+
+    it('does not escape SafeString arguments', function () {
+        let templateString = '{{concat safe}}';
+        let expected = '<b>bold</b>';
+        shouldCompileToExpected(templateString, {safe: new SafeString('<b>bold</b>')}, expected);
+    });
 });


### PR DESCRIPTION
The `{{concat}}` helper placed its joined output straight into a `SafeString`, so Handlebars never escaped it. Passing untrusted values (e.g. a post title) through it — `{{concat "Post title: " title}}` — rendered raw HTML, so a `<script>` in the title output unescaped, even though `{{title}}` on its own is escaped. Same class of bug as the `split` helper in #29298.

**Fix:** escape each non-`SafeString` argument before joining, leaving `SafeString` args (from `url`, `split`, etc.) untouched. I used lodash `_.escape` (as the `excerpt` helper does) rather than Handlebars `escapeExpression`, because `escapeExpression` also escapes `=`, which would break concat's URL-building use case (`{{concat url "?a=" b}}`). `_.escape` escapes only `< > & " '`, so the XSS is neutralised and all existing concat tests still pass.

fixes #29595

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [x] I've written an automated test to prove my change works