### PR TITLE
Fixed custom integration webhook footer layout

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/integrations/custom-integration-modal.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/integrations/custom-integration-modal.tsx
@@ -88,7 +88,6 @@ const CustomIntegrationModalContent: React.FC<{integration: Integration}> = ({in
         buttonsDisabled={okProps.disabled}
         cancelLabel='Close'
         dirty={saveState === 'unsaved'}
-        footerClassName={!integration.webhooks?.length ? 'border-t border-border' : undefined}
         okLabel={okProps.label || 'Save'}
         okVariant={okProps.variant}
         size='md'
@@ -165,7 +164,7 @@ const CustomIntegrationModalContent: React.FC<{integration: Integration}> = ({in
             </Stack>
         </Stack>
 
-        <Box className='mt-8 -mb-6'>
+        <Box className='mt-8'>
             <WebhooksTable integration={integration} />
         </Box>
     </SettingsModal>;

--- a/apps/admin-x-settings/src/components/settings/advanced/integrations/webhooks-table.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/integrations/webhooks-table.tsx
@@ -55,11 +55,12 @@ const WebhooksTable: React.FC<{integration: Integration}> = ({integration}) => {
                 >
                     <LucideIcon.Webhook />
                 </EmptyIndicator>
+                <Separator />
             </Stack>
         );
     }
 
-    return (<Stack gap='md'>
+    return (<Stack gap='none'>
         <Table>
             <TableHeader>
                 <TableRow>
@@ -108,7 +109,7 @@ const WebhooksTable: React.FC<{integration: Integration}> = ({integration}) => {
                 ))}
             </TableBody>
         </Table>
-        <Inline justify='center'>
+        <Inline className='py-4' justify='center'>
             <Button
                 size='sm'
                 type='button'
@@ -118,6 +119,7 @@ const WebhooksTable: React.FC<{integration: Integration}> = ({integration}) => {
                 <LucideIcon.Plus /> Add webhook
             </Button>
         </Inline>
+        <Separator />
     </Stack>);
 };
 

--- a/apps/admin-x-settings/test/unit/components/settings/webhooks-table.test.tsx
+++ b/apps/admin-x-settings/test/unit/components/settings/webhooks-table.test.tsx
@@ -24,8 +24,30 @@ describe('WebhooksTable', () => {
         expect(screen.getByRole('button', {name: 'Add webhook'})).toHaveClass('border-control-border');
         const separators = container.querySelectorAll('[data-orientation="horizontal"]');
 
-        expect(separators).toHaveLength(1);
+        expect(separators).toHaveLength(2);
         expect(container.querySelector('[class*="z-[300]"]')).not.toBeInTheDocument();
         expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    });
+
+    it('keeps the add action and bottom separator inside a populated webhook section', () => {
+        const integration = {
+            id: 'integration-id',
+            webhooks: [{
+                id: 'webhook-id',
+                name: 'Webhook name',
+                event: 'post.edited',
+                target_url: 'https://example.com/webhook'
+            }]
+        } as unknown as Integration;
+
+        const {container} = render(<WebhooksTable integration={integration} />);
+
+        const table = screen.getByRole('table');
+        const addButton = screen.getByRole('button', {name: 'Add webhook'});
+        const separator = container.querySelector('[data-orientation="horizontal"]')!;
+
+        expect(table.compareDocumentPosition(addButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+        expect(addButton.compareDocumentPosition(separator) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+        expect(separator).toBeInTheDocument();
     });
 });


### PR DESCRIPTION
## What changed

- Kept the populated-state **Add webhook** action inside the scrollable webhook section and above the sticky modal footer.
- Moved the lower divider from the footer into the webhook section for both empty and populated states.
- Removed the negative bottom offset that pulled webhook content beneath the footer.
- Added regression coverage for both section boundaries and populated content ordering.

## Why

The webhook section had been offset into the sticky footer. With an existing webhook, this could place the Add webhook action below the footer. In the empty state, a footer-owned border also overlapped the footer's scroll shadow.

Keeping the action and both boundaries within the webhook section lets the sticky footer retain its normal shadow and spacing without owning table presentation.

## Verification

- Visually verified empty and populated custom integration modals.
- Verified the Add webhook action remains above the sticky footer while scrolled.
- `pnpm --filter @tryghost/admin-x-settings test -- --run test/unit/components/settings/webhooks-table.test.tsx` — 224 tests passed, including type checking.
- `pnpm --filter @tryghost/admin-x-settings lint` — passed.

ref https://linear.app/ghost/issue/DES-1461