### PR TITLE
✨ Added specific-tier option to editor preview

### DIFF
--- a/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin-x-settings/src/components/settings/advanced/labs/private-features.tsx
@@ -80,10 +80,6 @@ const features: Feature[] = [{
     description: 'Let admins create and manage custom field definitions for members',
     flag: 'membersCustomFields'
 }, {
-    title: 'Preview by tier',
-    description: 'Preview posts and emails as a member of a specific tier',
-    flag: 'previewByTier'
-}, {
     title: 'Paywall improvements',
     description: 'Enables paywall usability, discoverability and email customization improvements',
     flag: 'paywallImprovements'

--- a/apps/ember-admin/app/components/editor/modals/preview/email.js
+++ b/apps/ember-admin/app/components/editor/modals/preview/email.js
@@ -28,7 +28,6 @@ html::-webkit-scrollbar-thumb:hover {
 // TODO: remove duplication with <ModalPostEmailPreview>
 export default class ModalPostPreviewEmailComponent extends Component {
     @service ajax;
-    @service feature;
     @service ghostPaths;
     @service session;
     @service settings;
@@ -53,14 +52,8 @@ export default class ModalPostPreviewEmailComponent extends Component {
             !!(this.settings.mailgunApiKey && this.settings.mailgunDomain && this.settings.mailgunBaseUrl);
     }
 
-    // older backends only understand the deprecated memberSegment param;
-    // remove the legacy branch when the previewByTier flag is GA
     get _audienceParams() {
         const {memberStatus, memberTier} = this.args;
-
-        if (!this.feature.previewByTier) {
-            return {memberSegment: memberStatus === 'paid' ? 'status:-free' : 'status:free'};
-        }
 
         const params = {member_status: memberStatus};
         if (memberTier) {

--- a/apps/ember-admin/app/components/editor/publish-management.js
+++ b/apps/ember-admin/app/components/editor/publish-management.js
@@ -148,7 +148,7 @@ export default class PublishManagement extends Component {
     // its tier selector synchronously; a failed fetch degrades the preview to
     // the free/paid audience options and is retried on the next open
     async _ensureTiersLoaded() {
-        if (!this.feature.previewByTier || !this.settings.paidMembersEnabled || this.loadTiersTask.lastSuccessful) {
+        if (!this.settings.paidMembersEnabled || this.loadTiersTask.lastSuccessful) {
             return;
         }
 

--- a/apps/ember-admin/app/services/feature.js
+++ b/apps/ember-admin/app/services/feature.js
@@ -83,7 +83,6 @@ export default class FeatureService extends Service {
     @feature('lexicalIndicators') lexicalIndicators;
     @feature('editorExcerpt') editorExcerpt;
     @feature('memberDetailsReact') memberDetailsReact;
-    @feature('previewByTier') previewByTier;
     @feature('paywallImprovements') paywallImprovements;
     @feature('automations') automations;
     @feature('csvContentImporter') csvContentImporter;

--- a/apps/ember-admin/tests/acceptance/editor/post-email-preview-test.js
+++ b/apps/ember-admin/tests/acceptance/editor/post-email-preview-test.js
@@ -1,7 +1,6 @@
 import loginAsRole from '../../helpers/login-as-role';
 import {click, find, findAll, focus, waitFor, waitUntil} from '@ember/test-helpers';
 import {clickTrigger, selectChoose} from 'ember-power-select/test-support/helpers';
-import {disableLabsFlag, enableLabsFlag} from '../../helpers/labs-flag';
 import {disableMembers, disablePaidMembers, enableMembers, enablePaidMembers} from '../../helpers/members';
 import {enableMailgun} from '../../helpers/mailgun';
 import {expect} from 'chai';
@@ -18,7 +17,6 @@ describe('Acceptance: Post email preview', function () {
         enableMailgun(this.server);
         enableMembers(this.server);
         enablePaidMembers(this.server);
-        enableLabsFlag(this.server, 'previewByTier');
         await loginAsRole('Administrator', this.server);
     });
 
@@ -117,30 +115,6 @@ describe('Acceptance: Post email preview', function () {
         const tierRequestBody = JSON.parse(tierRequest.requestBody);
         expect(tierRequestBody.member_status).to.equal('paid');
         expect(tierRequestBody.member_tier).to.equal('archive');
-    });
-
-    it('sends the legacy memberSegment param and hides tiers without the previewByTier flag', async function () {
-        disableLabsFlag(this.server, 'previewByTier');
-        this.server.create('tier', {name: 'Archive', slug: 'archive', type: 'paid', active: false});
-
-        await openEmailPreviewModal.call(this);
-
-        // no Tier option without the flag
-        await clickTrigger('[data-test-select="preview-segment"]');
-        const options = findAll('.ember-power-select-option');
-        expect(options.length).to.equal(2);
-        expect(options[0].textContent.trim()).to.equal('Free member');
-        expect(options[1].textContent.trim()).to.equal('Paid member');
-
-        // older backends only understand memberSegment
-        await selectChoose('[data-test-select="preview-segment"]', 'Paid member');
-        await click(find('[data-test-button="post-preview-test-email"]'));
-        await click(find('[data-test-button="send-test-email"]'));
-        const [lastRequest] = this.server.pretender.handledRequests.slice(-1);
-        const requestBody = JSON.parse(lastRequest.requestBody);
-        expect(requestBody.memberSegment).to.equal('status:-free');
-        expect(requestBody.member_status).to.be.undefined;
-        expect(requestBody.member_tier).to.be.undefined;
     });
 
     it('hides segment dropdown when only one option is available', async function () {

--- a/apps/ember-admin/tests/acceptance/editor/post-preview-test.js
+++ b/apps/ember-admin/tests/acceptance/editor/post-preview-test.js
@@ -1,6 +1,5 @@
 import loginAsRole from '../../helpers/login-as-role';
 import {click, find, findAll} from '@ember/test-helpers';
-import {disableLabsFlag, enableLabsFlag} from '../../helpers/labs-flag';
 import {enableMailgun} from '../../helpers/mailgun';
 import {enableMembers, enablePaidMembers} from '../../helpers/members';
 import {expect} from 'chai';
@@ -18,7 +17,6 @@ describe('Acceptance: Post preview', function () {
         enableMailgun(this.server);
         enableMembers(this.server);
         enablePaidMembers(this.server);
-        enableLabsFlag(this.server, 'previewByTier');
         await loginAsRole('Administrator', this.server);
     });
 
@@ -64,16 +62,6 @@ describe('Acceptance: Post preview', function () {
         url = new URL(find('[data-test-link="open-draft"]').href);
         expect(url.searchParams.get('member_status')).to.equal('paid');
         expect(url.searchParams.get('member_tier')).to.equal('archive');
-    });
-
-    it('hides the tier option without the previewByTier flag', async function () {
-        disableLabsFlag(this.server, 'previewByTier');
-        this.server.create('tier', {name: 'Archived tier', slug: 'archive', type: 'paid', active: false});
-        await openPreviewModal.call(this);
-
-        await click('[data-test-select="preview-segment"] .ember-power-select-trigger');
-        const options = findAll('.ember-power-select-option').map(element => element.textContent.trim());
-        expect(options).to.deep.equal(['Public visitor', 'Free member', 'Paid member']);
     });
 
     it('remembers the selected tier when the preview is reopened', async function () {

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -64,7 +64,6 @@ const PRIVATE_FEATURES = [
     'getHelperDeduplication',
     'memberDetailsReact',
     'membersCustomFields',
-    'previewByTier',
     'paywallImprovements',
     'giftSubCustomization'
 ];

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -38,7 +38,6 @@ Object {
       "membersCustomFields": true,
       "paywallImprovements": true,
       "pictureImageFormats": true,
-      "previewByTier": true,
       "smarterCounts": true,
       "stripeAutomaticTax": true,
       "superEditors": true,


### PR DESCRIPTION
closes https://linear.app/ghost/issue/BER-3820/

- when previewing a post in the editor it's now possible to select a specific tier, alongside the free/paid options
- useful when checking paywalls and tier-specific content when full content is only available to a limited paid audience
