### PR TITLE
Removed the escapeNqlString re-export shim in apps/admin

### DIFF
--- a/apps/admin/src/comments/comments.tsx
+++ b/apps/admin/src/comments/comments.tsx
@@ -8,7 +8,7 @@ import {ListPage} from '@tryghost/shade/page-templates';
 import {LucideIcon} from '@tryghost/shade/utils';
 import {adminCommentIncludes, useBrowseComments} from '@tryghost/admin-x-framework/api/comments';
 import {keepPreviousData} from '@tanstack/react-query';
-import {escapeNqlString} from '@/shared/filters';
+import {escapeNqlString} from '@tryghost/nql-string';
 import {getSiteTimezone} from '@tryghost/admin-x-framework/utils/get-site-timezone';
 import {serializeCommentFilters} from './comment-filter-query';
 import {shouldDelayCommentDateFilterHydration, useFilterState} from './hooks/use-filter-state';

--- a/apps/admin/src/members/hooks/resource-search-filter.ts
+++ b/apps/admin/src/members/hooks/resource-search-filter.ts
@@ -1,4 +1,4 @@
-import {escapeNqlString} from '@/shared/filters';
+import {escapeNqlString} from '@tryghost/nql-string';
 
 export function buildResourceFilter(baseFilter: string, search: string): string {
     if (!search) {

--- a/apps/admin/src/members/member-fields.ts
+++ b/apps/admin/src/members/member-fields.ts
@@ -1,4 +1,5 @@
-import {DATE_FILTER_OPERATORS, DEFAULT_DATE_OPERATOR, type FilterCodec, dateCodec, defineFields, escapeNqlString, extractComparator, numberCodec, scalarCodec, setCodec, textCodec, withFutureRelativeOperator, withPastRelativeOperator} from '@/shared/filters';
+import {DATE_FILTER_OPERATORS, DEFAULT_DATE_OPERATOR, type FilterCodec, dateCodec, defineFields, extractComparator, numberCodec, scalarCodec, setCodec, textCodec, withFutureRelativeOperator, withPastRelativeOperator} from '@/shared/filters';
+import {escapeNqlString} from '@tryghost/nql-string';
 import {MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FIELD, MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER, NO_MULTIPLE_ACTIVE_STRIPE_CUSTOMERS_FILTER} from './multiple-active-subscriptions';
 
 const TEXT_OPERATORS = ['is', 'contains', 'does-not-contain', 'starts-with', 'ends-with'] as const;

--- a/apps/admin/src/shared/filter-sources/use-email-post-value-source.ts
+++ b/apps/admin/src/shared/filter-sources/use-email-post-value-source.ts
@@ -1,7 +1,7 @@
 import {type Post, type PostsResponseType, useBrowsePostsInfinite} from '@tryghost/admin-x-framework/api/posts';
 import {type ValueSource} from '@tryghost/shade/patterns';
 import {createGhostBrowseValueSource} from './create-ghost-browse-value-source';
-import {escapeNqlString} from '@/shared/filters/filter-normalization';
+import {escapeNqlString} from '@tryghost/nql-string';
 import {keepPreviousData} from '@tanstack/react-query';
 
 const EMAIL_BASE_FILTER = '(status:published,status:sent)+newsletter_id:-null';

--- a/apps/admin/src/shared/filter-sources/use-label-value-source.ts
+++ b/apps/admin/src/shared/filter-sources/use-label-value-source.ts
@@ -4,7 +4,7 @@ import {type ValueSource, type ValueSourceParams, type ValueSourceState} from '@
 import {buildQuotedListFilter, filterOptionsByQuery, mergeFilterOptions} from './utils';
 import {createGhostBrowseValueSource} from './create-ghost-browse-value-source';
 import {createHybridValueSource} from './create-hybrid-value-source';
-import {escapeNqlString} from '@/shared/filters/filter-normalization';
+import {escapeNqlString} from '@tryghost/nql-string';
 import {keepPreviousData} from '@tanstack/react-query';
 
 const LABEL_PAGE_LIMIT = '100';

--- a/apps/admin/src/shared/filter-sources/use-post-resource-value-source.ts
+++ b/apps/admin/src/shared/filter-sources/use-post-resource-value-source.ts
@@ -3,7 +3,7 @@ import {type Post, type PostsResponseType, useBrowsePostsInfinite} from '@trygho
 import {type ValueSource} from '@tryghost/shade/patterns';
 import {createCombinedValueSource} from './create-combined-value-source';
 import {createGhostBrowseValueSource} from './create-ghost-browse-value-source';
-import {escapeNqlString} from '@/shared/filters/filter-normalization';
+import {escapeNqlString} from '@tryghost/nql-string';
 import {keepPreviousData} from '@tanstack/react-query';
 
 function buildPublishedFilter(query: string) {

--- a/apps/admin/src/shared/filter-sources/utils.ts
+++ b/apps/admin/src/shared/filter-sources/utils.ts
@@ -1,5 +1,5 @@
 import {type FilterOption} from '@tryghost/shade/patterns';
-import {escapeNqlString} from '@/shared/filters/filter-normalization';
+import {escapeNqlString} from '@tryghost/nql-string';
 
 export function buildQuotedListFilter(key: string, values: string[]): string | undefined {
     if (values.length === 0) {

--- a/apps/admin/src/shared/filters/filter-codecs.ts
+++ b/apps/admin/src/shared/filters/filter-codecs.ts
@@ -1,5 +1,6 @@
 import {DATE_FILTER_OPERATORS} from './filter-date';
-import {escapeNqlString, formatDateInTimezone, getDayBoundsInUtc} from './filter-normalization';
+import {escapeNqlString} from '@tryghost/nql-string';
+import {formatDateInTimezone, getDayBoundsInUtc} from './filter-normalization';
 import {extractComparator} from './filter-ast';
 import type {FilterCodec} from './filter-types';
 

--- a/apps/admin/src/shared/filters/filter-normalization.test.ts
+++ b/apps/admin/src/shared/filters/filter-normalization.test.ts
@@ -1,6 +1,7 @@
 import nqlLang from '@tryghost/nql-lang';
 import {describe, expect, it} from 'vitest';
-import {escapeNqlString, formatDateInTimezone, getDayBoundsInUtc} from './filter-normalization';
+import {escapeNqlString} from '@tryghost/nql-string';
+import {formatDateInTimezone, getDayBoundsInUtc} from './filter-normalization';
 
 describe('filter-normalization', () => {
     it('escapes single quotes for NQL strings', () => {

--- a/apps/admin/src/shared/filters/filter-normalization.ts
+++ b/apps/admin/src/shared/filters/filter-normalization.ts
@@ -1,7 +1,5 @@
 import {Temporal} from 'temporal-polyfill';
 
-export {escapeNqlString} from '@tryghost/nql-string';
-
 const DATE_ONLY_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
 const LEGACY_UTC_DATE_TIME_PATTERN = /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,3}))?$/;
 


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost/pull/29650

A follow-up from a review of #29650, stacked on `mike-onc-1920` so it can land with it.

## Problem

The consolidation into `@tryghost/nql-string` stopped short in apps/admin: every other workspace (ember-admin, admin-x-framework, ghost/core) imports the package directly, but nine apps/admin call sites still routed through a bare re-export shim in `filter-normalization.ts`, leaving two apparent sources for the same function.

## Solution

The re-export shim is deleted and all apps/admin import sites point at `@tryghost/nql-string` directly, returning `filter-normalization.ts` to holding only date-normalization code.
