### PR TITLE
Added API adapter and moved routing controllers onto RouteData

### DIFF
--- a/ghost/core/core/frontend/services/data/fetch-data.js
+++ b/ghost/core/core/frontend/services/data/fetch-data.js
@@ -3,6 +3,7 @@
  * Dynamically build and execute queries on the API
  */
 const _ = require('lodash');
+const {resolveRouteData} = require('../routing/api-adapter');
 
 // The default settings for a default post query
 const queryDefaults = {
@@ -93,9 +94,11 @@ async function fetchData(pathOptions, routerOptions, locals) {
     // The filter can in theory contain a "%s" e.g. filter="primary_tag:%s"
     promises.push(processQuery(postQuery, pathOptions.slug, locals));
 
+    const apiCalls = resolveRouteData(routerOptions.data);
+
     // CASE: fetch more data defined by the router e.g. tags, authors - see TaxonomyRouter
-    _.each(routerOptions.data, function (query, name) {
-        const dataQueryOptions = _.merge(query, defaultDataQueryOptions[name]);
+    _.each(apiCalls, function (apiCall, name) {
+        const dataQueryOptions = _.merge(apiCall, defaultDataQueryOptions[name]);
         promises.push(processQuery(dataQueryOptions, pathOptions.slug, locals));
     });
 
@@ -107,11 +110,11 @@ async function fetchData(pathOptions, routerOptions, locals) {
 
         let resultIndex = 1;
 
-        _.each(routerOptions.data, function (config, name) {
+        _.each(apiCalls, function (apiCall, name) {
             if (results[resultIndex]) {
-                response.data[name] = results[resultIndex][config.resource];
+                response.data[name] = results[resultIndex][apiCall.resource];
 
-                if (config.type === 'browse') {
+                if (apiCall.type === 'browse') {
                     response.data[name].meta = results[resultIndex].meta;
                 }
 

--- a/ghost/core/core/frontend/services/data/fetch-data.js
+++ b/ghost/core/core/frontend/services/data/fetch-data.js
@@ -98,7 +98,9 @@ async function fetchData(pathOptions, routerOptions, locals) {
 
     // CASE: fetch more data defined by the router e.g. tags, authors - see TaxonomyRouter
     _.each(apiCalls, function (apiCall, name) {
-        const dataQueryOptions = _.merge(apiCall, defaultDataQueryOptions[name]);
+        // Merge into a fresh object: the resolved spec is read again below to
+        // shape the response, so it must stay as the adapter resolved it.
+        const dataQueryOptions = _.merge({}, apiCall, defaultDataQueryOptions[name]);
         promises.push(processQuery(dataQueryOptions, pathOptions.slug, locals));
     });
 

--- a/ghost/core/core/frontend/services/routing/api-adapter.ts
+++ b/ghost/core/core/frontend/services/routing/api-adapter.ts
@@ -1,0 +1,157 @@
+import _ from 'lodash';
+import errors from '@tryghost/errors';
+import {QUERY} from './config';
+import type {RouteData, DataEntry, DataShortForm, DataLongFormEntry} from '@tryghost/adapter-base-route-settings';
+
+/**
+ * A resolved Content API call: which controller to reach for, which method to
+ * call on it, and the options to call it with.
+ */
+export interface ApiCallSpec {
+    controller: string;
+    type: 'read' | 'browse';
+    resource: string;
+    options: Record<string, unknown>;
+}
+
+/**
+ * The resource read that a data entry claims — the router that declares it owns
+ * that slug, and other routers redirect to it.
+ */
+export interface ResourceRead {
+    resource: string;
+    slug: string;
+}
+
+interface ResourceConfig {
+    controller: string;
+    type?: 'read' | 'browse';
+    resource: string;
+    options?: Record<string, unknown>;
+}
+
+/**
+ * Not every entry in QUERY is reachable from route data — `previews` and `email`
+ * are internal routers with no `type`, so they resolve to no API call.
+ */
+const RESOURCE_CONFIGS: Record<string, ResourceConfig | undefined> = QUERY;
+
+/**
+ * The entry fields the Content API accepts as query options. Everything else on
+ * a data entry is routing metadata (`redirect`) or unsupported (`fields`), and
+ * is deliberately not forwarded.
+ */
+const ALLOWED_QUERY_OPTIONS = ['limit', 'order', 'filter', 'include', 'slug', 'visibility', 'status', 'page'];
+
+function unknownResource(resource: string) {
+    return new errors.IncorrectUsageError({message: `Unknown route data resource: ${resource}`});
+}
+
+// Shorthand names a resource the short way (`tag`), long form the way the API
+// does (`tags`). Both land on the same config.
+function splitShortForm(shortForm: DataShortForm): [string, string] {
+    const [key, slug] = shortForm.split('.');
+    return [key, slug];
+}
+
+function shortFormConfig(key: string): ResourceConfig | undefined {
+    return RESOURCE_CONFIGS[key];
+}
+
+function longFormConfig(resource: string): ResourceConfig | undefined {
+    return Object.values(RESOURCE_CONFIGS).find(config => config?.resource === resource);
+}
+
+function resolveShortForm(shortForm: DataShortForm): ApiCallSpec {
+    const [key, slug] = splitShortForm(shortForm);
+    const config = shortFormConfig(key);
+
+    if (!config?.type) {
+        throw unknownResource(key);
+    }
+
+    return {
+        controller: config.controller,
+        type: config.type,
+        resource: config.resource,
+        options: {...config.options, slug}
+    };
+}
+
+function resolveLongForm(entry: DataLongFormEntry): ApiCallSpec {
+    const config = longFormConfig(entry.resource);
+
+    if (!config) {
+        throw unknownResource(entry.resource);
+    }
+
+    const options: Record<string, unknown> = _.pick(entry, ALLOWED_QUERY_OPTIONS);
+
+    return {
+        controller: config.controller,
+        type: entry.type,
+        resource: config.resource,
+        // A `read` targets one known resource, so the resource defaults (e.g.
+        // `visibility: public` for tags) apply. A `browse` is author-driven and
+        // takes only what the entry asked for.
+        options: entry.type === 'read' ? _.defaults(options, config.options) : options
+    };
+}
+
+/**
+ * Resolve a single route data entry into a Content API call.
+ *
+ * This is the one place that knows how a domain `resource` maps onto a Ghost API
+ * controller — routes.yaml talks about `tags`, the API is reached via
+ * `tagsPublic`. Callers work with the domain model and never name a controller.
+ *
+ * @example resolveApiCall('tag.food')
+ *   // => {controller: 'tagsPublic', type: 'read', resource: 'tags', options: {slug: 'food', visibility: 'public'}}
+ */
+export function resolveApiCall(entry: DataEntry): ApiCallSpec {
+    return typeof entry === 'string' ? resolveShortForm(entry) : resolveLongForm(entry);
+}
+
+/**
+ * Resolve a route's whole `data` block, keyed the way the theme sees it.
+ *
+ * Top-level shorthand (`data: tag.food`) has no author-given name, so it is
+ * keyed by its resource shorthand — `tag` — matching what themes already expect.
+ */
+export function resolveRouteData(routeData?: RouteData): Record<string, ApiCallSpec> {
+    if (!routeData) {
+        return {};
+    }
+
+    if (typeof routeData === 'string') {
+        const [key] = splitShortForm(routeData);
+
+        return {[key]: resolveApiCall(routeData)};
+    }
+
+    return _.mapValues(routeData, entry => resolveApiCall(entry));
+}
+
+/**
+ * The resource read a data entry claims, or `null` if it claims none.
+ *
+ * Only a `read` names a single resource; a `browse` pulls a set and claims
+ * nothing. Unlike {@link resolveApiCall} this answers a routing question, so an
+ * entry it cannot make sense of is simply not a claim rather than an error.
+ *
+ * @example resolveResourceRead('tag.food') // => {resource: 'tags', slug: 'food'}
+ */
+export function resolveResourceRead(entry: DataEntry): ResourceRead | null {
+    if (typeof entry === 'string') {
+        const [key, slug] = splitShortForm(entry);
+        const config = shortFormConfig(key);
+
+        return config?.type === 'read' ? {resource: config.resource, slug} : null;
+    }
+
+    if (entry.type !== 'read') {
+        return null;
+    }
+
+    return longFormConfig(entry.resource) ? {resource: entry.resource, slug: entry.slug} : null;
+}

--- a/ghost/core/core/frontend/services/routing/collection-router.js
+++ b/ghost/core/core/frontend/services/routing/collection-router.js
@@ -36,7 +36,7 @@ class CollectionRouter extends ParentRouter {
         this.templates = (object.templates || []).reverse();
 
         this.filter = object.filter;
-        this.data = object.data || {query: {}, router: {}};
+        this.data = object.data || {};
         this.order = object.order;
         this.limit = object.limit;
 
@@ -118,7 +118,7 @@ class CollectionRouter extends ParentRouter {
             templates: this.templates,
             identifier: this.identifier,
             name: this.routerName,
-            data: this.data.query
+            data: this.data
         };
 
         next();

--- a/ghost/core/core/frontend/services/routing/controllers/static.js
+++ b/ghost/core/core/frontend/services/routing/controllers/static.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 const debug = require('@tryghost/debug')('services:routing:controllers:static');
 const renderer = require('../../rendering');
+const {resolveRouteData} = require('../api-adapter');
 
 function processQuery(query, locals) {
     const api = require('../../proxy').api;
@@ -35,10 +36,10 @@ function processQuery(query, locals) {
 module.exports = function staticController(req, res, next) {
     debug('staticController', res.routerOptions);
 
-    let promises = [];
+    const apiCalls = resolveRouteData(res.routerOptions.data);
 
-    _.each(res.routerOptions.data, function (query) {
-        promises.push(processQuery(query, res.locals));
+    const promises = _.map(apiCalls, function (apiCall) {
+        return processQuery(apiCall, res.locals);
     });
 
     return Promise.all(promises)
@@ -49,13 +50,13 @@ module.exports = function staticController(req, res, next) {
                 response.data = {};
 
                 let resultIndex = 0;
-                _.each(res.routerOptions.data, function (config, name) {
-                    response.data[name] = result[resultIndex][config.resource];
+                _.each(apiCalls, function (apiCall, name) {
+                    response.data[name] = result[resultIndex][apiCall.resource];
 
-                    if (config.type === 'browse') {
+                    if (apiCall.type === 'browse') {
                         response.data[name].meta = result[resultIndex].meta;
                         // @TODO: remove in Ghost 3.0 (see https://github.com/TryGhost/Ghost/issues/10434)
-                        response.data[name][config.resource] = result[resultIndex][config.resource];
+                        response.data[name][apiCall.resource] = result[resultIndex][apiCall.resource];
                     }
 
                     resultIndex = resultIndex + 1;

--- a/ghost/core/core/frontend/services/routing/parent-router.js
+++ b/ghost/core/core/frontend/services/routing/parent-router.js
@@ -13,6 +13,7 @@ const express = require('../../../shared/express');
 const _ = require('lodash');
 const url = require('url');
 const security = require('@tryghost/security');
+const {resolveResourceRead} = require('./api-adapter');
 const urlUtils = require('../../../shared/url-utils').default;
 const registry = require('./registry');
 
@@ -197,6 +198,11 @@ class ParentRouter {
 
     /**
      * @description Figure out if the router has a redirect enabled.
+     *
+     * A route claims a resource by reading it: `data: tag.bacon` on this router
+     * means /tag/bacon/ should redirect here from wherever else it lives. Only
+     * `read` entries claim a slug, and an entry can opt out with `redirect: false`.
+     *
      * @param {string} routerType
      * @param {string} slug
      * @returns {boolean}
@@ -204,14 +210,21 @@ class ParentRouter {
     isRedirectEnabled(routerType, slug) {
         debug('isRedirectEnabled', this.name, this.route && this.route.value, routerType, slug);
 
-        if (!this.data || !Object.keys(this.data.router)) {
+        if (!this.data) {
             return false;
         }
 
-        return _.find(this.data.router, function (entries, type) {
-            if (routerType === type) {
-                return _.find(entries, {redirect: true, slug: slug});
+        // Top-level shorthand (`data: tag.bacon`) is a single unnamed entry.
+        const entries = typeof this.data === 'string' ? [this.data] : Object.values(this.data);
+
+        return entries.some((entry) => {
+            if (typeof entry !== 'string' && entry.redirect === false) {
+                return false;
             }
+
+            const read = resolveResourceRead(entry);
+
+            return !!read && read.resource === routerType && read.slug === slug;
         });
     }
 

--- a/ghost/core/core/frontend/services/routing/permalink-adapter.ts
+++ b/ghost/core/core/frontend/services/routing/permalink-adapter.ts
@@ -12,7 +12,7 @@ export function toExpressNotation(permalink: string): string {
 /**
  * Convert an Express / URL-service permalink back into domain-model notation.
  * Will be used on the download path when serialising the canonical shape back
- * to YAML (wired up in HKG-1897) — no production caller yet.
+ * to YAML — no production caller yet.
  *
  * @example toDomainNotation('/:slug/')               // => '/{slug}/'
  * @example toDomainNotation('/:primary_tag/:slug/')  // => '/{primary_tag}/{slug}/'

--- a/ghost/core/core/frontend/services/routing/static-routes-router.js
+++ b/ghost/core/core/frontend/services/routing/static-routes-router.js
@@ -15,7 +15,7 @@ class StaticRoutesRouter extends ParentRouter {
 
         this.route = {value: mainRoute};
         this.templates = object.templates || [];
-        this.data = object.data || {query: {}, router: {}};
+        this.data = object.data || {};
         this.routerName = mainRoute === '/' ? 'index' : mainRoute.replace(/\//g, '');
         this.routerCreated = routerCreated;
 
@@ -80,7 +80,7 @@ class StaticRoutesRouter extends ParentRouter {
             filter: this.filter,
             limit: this.limit,
             order: this.order,
-            data: this.data.query,
+            data: this.data,
             templates: this.templates
         };
 
@@ -117,7 +117,7 @@ class StaticRoutesRouter extends ParentRouter {
                     message: `Missing template ${res.routerOptions.templates.map(x => `${x}.hbs`).join(', ')} for route "${req.originalUrl}".`
                 });
             },
-            data: this.data.query,
+            data: this.data,
             context: [this.routerName],
             contentType: this.contentType
         };

--- a/ghost/core/core/frontend/services/routing/taxonomy-router.js
+++ b/ghost/core/core/frontend/services/routing/taxonomy-router.js
@@ -76,7 +76,9 @@ class TaxonomyRouter extends ParentRouter {
             type: 'channel',
             name: this.taxonomyKey,
             permalinks: this.permalinks.getValue(),
-            data: {[this.taxonomyKey]: this.RESOURCE_CONFIG.QUERY[this.taxonomyKey]},
+            // Route data in domain form — the API adapter resolves it to a
+            // controller call, and fetch-data fills `%s` in from the request.
+            data: {[this.taxonomyKey]: {type: 'read', resource: this.getResourceType(), slug: '%s'}},
             filter: this.RESOURCE_CONFIG.TAXONOMIES[this.taxonomyKey].filter,
             resourceType: this.getResourceType(),
             context: [this.taxonomyKey],

--- a/ghost/core/core/server/services/route-settings/activation-bridge.ts
+++ b/ghost/core/core/server/services/route-settings/activation-bridge.ts
@@ -1,172 +1,46 @@
-import _ from 'lodash';
-import errors from '@tryghost/errors';
-import {QUERY} from '../../../frontend/services/routing/config';
 import type {
     RouteSettings,
     Route,
     ChannelRoute,
     TemplateRoute,
-    CollectionConfig,
-    RouteData,
-    DataShortForm,
-    DataShortFormResource,
-    DataReadEntry,
-    DataBrowseEntry
+    CollectionConfig
 } from '@tryghost/adapter-base-route-settings';
 
-interface ExpandedData {
-    query: Record<string, any>;
-    router: Record<string, any[]>;
-}
-
-function expandShortFormData(shortForm: DataShortForm, resourceKey?: string): ExpandedData {
-
-    const [key, slug] = shortForm.split('.') as [DataShortFormResource, string];
-    const queryConfig = QUERY[key];
-
-    const data: ExpandedData = {
-        query: {},
-        router: {}
-    };
-
-    const effectiveKey = resourceKey || key;
-    data.query[effectiveKey] = _.cloneDeep(queryConfig);
-    data.query[effectiveKey].options.slug = slug;
-
-    const routerKey = queryConfig.resource;
-    data.router[routerKey] = [{slug, redirect: true}];
-
-    return data;
-}
-
-function expandLongFormEntry(key: string, entry: DataReadEntry | DataBrowseEntry): ExpandedData {
-    const defaultResource = Object.values(QUERY).find(item => item.resource === entry.resource);
-
-    if (!defaultResource) {
-        throw new errors.IncorrectUsageError({message: `Unknown route data resource: ${entry.resource}`});
-    }
-
-    const data: ExpandedData = {
-        query: {},
-        router: {}
-    };
-
-    data.query[key] = {
-        type: entry.type,
-        resource: defaultResource.resource
-    };
-
-    data.query[key] = _.defaults(data.query[key], _.omit(defaultResource, 'options'));
-
-    const allowedQueryOptions = ['limit', 'order', 'filter', 'include', 'slug', 'visibility', 'status', 'page'];
-    data.query[key].options = _.pick(entry, allowedQueryOptions);
-
-    if (entry.type === 'read') {
-        const defaultOptions = 'options' in defaultResource ? defaultResource.options : undefined;
-        data.query[key].options = _.defaults(data.query[key].options, defaultOptions);
-    }
-
-    const routerKey = defaultResource.resource;
-    if (!data.router[routerKey]) {
-        data.router[routerKey] = [];
-    }
-
-    if (entry.type === 'read') {
-        const allowedRouterOptions = ['redirect', 'slug'];
-        let routerEntry = _.pick(entry, allowedRouterOptions);
-        routerEntry = _.defaults(routerEntry, {redirect: true});
-        data.router[routerKey].push(routerEntry);
-    } else {
-        data.router[routerKey].push({redirect: true});
-    }
-
-    return data;
-}
-
-function expandRouteData(routeData: RouteData | undefined): ExpandedData {
-    if (!routeData) {
-        return {query: {}, router: {}};
-    }
-
-    if (typeof routeData === 'string') {
-        return expandShortFormData(routeData);
-    }
-
-    const merged: ExpandedData = {query: {}, router: {}};
-
-    for (const [key, entry] of Object.entries(routeData)) {
-        let expanded: ExpandedData;
-
-        if (typeof entry === 'string') {
-            expanded = expandShortFormData(entry, key);
-        } else {
-            expanded = expandLongFormEntry(key, entry);
-        }
-
-        _.merge(merged.query, expanded.query);
-
-        for (const [routerKey, routerEntries] of Object.entries(expanded.router)) {
-            if (merged.router[routerKey]) {
-                merged.router[routerKey] = merged.router[routerKey].concat(routerEntries);
-            } else {
-                merged.router[routerKey] = routerEntries;
-            }
-        }
-    }
-
-    return merged;
-}
-
 /**
- * Router-facing shapes. RouterManager consumes the domain model after the one
- * conversion the bridge still applies: `data` expanded to `{query, router}`.
- * Collection/taxonomy permalinks are left in domain `{slug}` form — the routers
- * translate them to `:slug` at their boundary via the permalink adapter.
+ * Routes and collections now reach RouterManager as their domain types —
+ * `data` is passed through untouched and resolved to API calls at the request
+ * boundary by the api adapter, and permalinks stay in `{slug}` form for the
+ * permalink adapter to convert at mount time.
  *
- * Routes and collections are written as their domain counterpart with just
- * `data` overridden to the expanded shape — `Omit<…, 'data'> & {data?}` rather
- * than `extends`, because the override changes `data`'s type (interface
- * extension can only add fields, not retype them). That keeps the delta from
- * the domain model explicit: `data` is the only structural difference. When the
- * bridge is removed (HKG-1898) the override falls away and these collapse back
- * to `Route` / `CollectionConfig`. The remaining `data` conversion peels off in
- * HKG-1897.
+ * All that is left of the bridge is flattening the taxonomies map into entries
+ * that carry their own key. It goes away entirely in HKG-1898.
  */
-type RouterChannelRoute = Omit<ChannelRoute, 'data'> & {data?: ExpandedData};
-type RouterTemplateRoute = Omit<TemplateRoute, 'data'> & {data?: ExpandedData};
-type RouterRoute = RouterChannelRoute | RouterTemplateRoute;
 
-type RouterCollection = Omit<CollectionConfig, 'data'> & {data?: ExpandedData};
-
-// Taxonomies and RouteSettings have no direct domain counterpart to derive from:
-// the domain stores taxonomies as a `{tag, author}` map, which the bridge
-// flattens into these `{key, permalink}` entries, and RouterSettings drops
-// `yamlSource` and swaps all three array element types (routes, collections,
-// taxonomies) — so they stay standalone.
+// Taxonomies have no direct domain counterpart to derive from: the domain stores
+// them as a `{tag, author}` map, which the bridge flattens into these
+// `{key, permalink}` entries.
 interface RouterTaxonomy {
     key: string;
     permalink: string;
 }
 
 export interface RouterSettings {
-    routes: RouterRoute[];
-    collections: RouterCollection[];
+    routes: Route[];
+    collections: CollectionConfig[];
     taxonomies: RouterTaxonomy[];
 }
 
-function buildRouterRoute(route: Route): RouterRoute {
-    const data = route.data !== undefined ? expandRouteData(route.data) : undefined;
-
-    // Build per branch: RouterRoute is a discriminated union, so each member is
+function buildRouterRoute(route: Route): Route {
+    // Build per branch: Route is a discriminated union, so each member is
     // constructed as its concrete type. `route` is narrowed by the check.
     if (route.type === 'channel') {
-        const result: RouterChannelRoute = {
+        const result: ChannelRoute = {
             path: route.path,
             type: 'channel',
             templates: route.templates || []
         };
-        if (data !== undefined) {
-            result.data = data;
+        if (route.data !== undefined) {
+            result.data = route.data;
         }
         if (route.filter !== undefined) {
             result.filter = route.filter;
@@ -183,13 +57,13 @@ function buildRouterRoute(route: Route): RouterRoute {
         return result;
     }
 
-    const result: RouterTemplateRoute = {
+    const result: TemplateRoute = {
         path: route.path,
         type: 'template',
         templates: route.templates || []
     };
-    if (data !== undefined) {
-        result.data = data;
+    if (route.data !== undefined) {
+        result.data = route.data;
     }
     if (route.contentType !== undefined) {
         result.contentType = route.contentType;
@@ -197,15 +71,15 @@ function buildRouterRoute(route: Route): RouterRoute {
     return result;
 }
 
-function buildRouterCollection(collection: CollectionConfig): RouterCollection {
-    const result: RouterCollection = {
+function buildRouterCollection(collection: CollectionConfig): CollectionConfig {
+    const result: CollectionConfig = {
         path: collection.path,
         permalink: collection.permalink,
         templates: collection.templates || []
     };
 
     if (collection.data !== undefined) {
-        result.data = expandRouteData(collection.data);
+        result.data = collection.data;
     }
     if (collection.filter !== undefined) {
         result.filter = collection.filter;
@@ -225,9 +99,8 @@ function buildRouterCollection(collection: CollectionConfig): RouterCollection {
 
 /**
  * Converts a RouteSettings domain model into the array shape that
- * RouterManager.start() iterates. Each route/collection carries its own `path`,
- * and taxonomies become `{key, permalink}` entries, so the routing layer no
- * longer reads paths from map keys.
+ * RouterManager.start() iterates. Taxonomies become `{key, permalink}` entries
+ * so the routing layer no longer reads keys from a map.
  *
  * Temporary adapter: removed in HKG-1898 once the routers consume the domain
  * model directly.

--- a/ghost/core/test/legacy/mock-express-style/api-vs-frontend.test.js
+++ b/ghost/core/test/legacy/mock-express-style/api-vs-frontend.test.js
@@ -782,19 +782,7 @@ describe('Frontend behavior tests', function () {
                     routes: {
                         '/my-page/': {
                             data: {
-                                query: {
-                                    page: {
-                                        controller: 'pagesPublic',
-                                        resource: 'pages',
-                                        type: 'read',
-                                        options: {
-                                            slug: 'static-page-test'
-                                        }
-                                    }
-                                },
-                                router: {
-                                    pages: [{redirect: true, slug: 'static-page-test'}]
-                                }
+                                page: {type: 'read', resource: 'pages', slug: 'static-page-test'}
                             },
                             templates: ['page']
                         }
@@ -805,38 +793,14 @@ describe('Frontend behavior tests', function () {
                             permalink: '/food/{slug}/',
                             filter: 'tag:bacon+tag:-chorizo',
                             data: {
-                                query: {
-                                    tag: {
-                                        controller: 'tagsPublic',
-                                        resource: 'tags',
-                                        type: 'read',
-                                        options: {
-                                            slug: 'bacon'
-                                        }
-                                    }
-                                },
-                                router: {
-                                    tags: [{redirect: true, slug: 'bacon'}]
-                                }
+                                tag: {type: 'read', resource: 'tags', slug: 'bacon'}
                             }
                         },
                         '/sport/': {
                             permalink: '/sport/{slug}/',
                             filter: 'tag:chorizo+tag:-bacon',
                             data: {
-                                query: {
-                                    apollo: {
-                                        controller: 'tagsPublic',
-                                        resource: 'tags',
-                                        type: 'read',
-                                        options: {
-                                            slug: 'chorizo'
-                                        }
-                                    }
-                                },
-                                router: {
-                                    tags: [{redirect: false, slug: 'chorizo'}]
-                                }
+                                apollo: {type: 'read', resource: 'tags', slug: 'chorizo', redirect: false}
                             }
                         }
                     },
@@ -1122,19 +1086,7 @@ describe('Frontend behavior tests', function () {
                             type: 'channel',
                             filter: 'tag:kitchen-sink',
                             data: {
-                                query: {
-                                    tag: {
-                                        controller: 'tagsPublic',
-                                        resource: 'tags',
-                                        type: 'read',
-                                        options: {
-                                            slug: 'kitchen-sink'
-                                        }
-                                    }
-                                },
-                                router: {
-                                    tags: [{redirect: true, slug: 'kitchen-sink'}]
-                                }
+                                tag: {type: 'read', resource: 'tags', slug: 'kitchen-sink'}
                             }
                         },
 
@@ -1142,19 +1094,7 @@ describe('Frontend behavior tests', function () {
                             type: 'channel',
                             filter: 'tag:bacon',
                             data: {
-                                query: {
-                                    tag: {
-                                        controller: 'tagsPublic',
-                                        resource: 'tags',
-                                        type: 'read',
-                                        options: {
-                                            slug: 'bacon'
-                                        }
-                                    }
-                                },
-                                router: {
-                                    tags: [{redirect: true, slug: 'bacon'}]
-                                }
+                                tag: {type: 'read', resource: 'tags', slug: 'bacon'}
                             },
                             templates: ['default']
                         },
@@ -1163,20 +1103,7 @@ describe('Frontend behavior tests', function () {
                             type: 'channel',
                             filter: 'author:joe-bloggs',
                             data: {
-                                query: {
-                                    joe: {
-                                        controller: 'authorsPublic',
-                                        resource: 'authors',
-                                        type: 'read',
-                                        options: {
-                                            slug: 'joe-bloggs',
-                                            redirect: false
-                                        }
-                                    }
-                                },
-                                router: {
-                                    authors: [{redirect: false, slug: 'joe-bloggs'}]
-                                }
+                                joe: {type: 'read', resource: 'authors', slug: 'joe-bloggs', redirect: false}
                             }
                         },
 
@@ -1188,40 +1115,14 @@ describe('Frontend behavior tests', function () {
                         '/channel5/': {
                             type: 'channel',
                             data: {
-                                query: {
-                                    tag: {
-                                        controller: 'authorsPublic',
-                                        resource: 'authors',
-                                        type: 'read',
-                                        options: {
-                                            slug: 'joe-bloggs',
-                                            redirect: false
-                                        }
-                                    }
-                                },
-                                router: {
-                                    authors: [{redirect: false, slug: 'joe-bloggs'}]
-                                }
+                                tag: {type: 'read', resource: 'authors', slug: 'joe-bloggs', redirect: false}
                             }
                         },
 
                         '/channel6/': {
                             type: 'channel',
                             data: {
-                                query: {
-                                    post: {
-                                        controller: 'postsPublic',
-                                        resource: 'posts',
-                                        type: 'read',
-                                        options: {
-                                            slug: 'html-ipsum',
-                                            redirect: true
-                                        }
-                                    }
-                                },
-                                router: {
-                                    posts: [{redirect: true, slug: 'html-ipsum'}]
-                                }
+                                post: {type: 'read', resource: 'posts', slug: 'html-ipsum'}
                             }
                         }
                     },

--- a/ghost/core/test/unit/frontend/services/data/fetch-data.test.js
+++ b/ghost/core/test/unit/frontend/services/data/fetch-data.test.js
@@ -205,4 +205,21 @@ describe('Unit - frontend/data/fetch-data', function () {
 
         assert.deepEqual(routeData, {post: {type: 'browse', resource: 'posts'}});
     });
+
+    it('should apply the per-name query defaults without losing the resolved resource', async function () {
+        // `post` is one of the names that carries default options, so the
+        // defaults are merged in on top of what the adapter resolved.
+        const routerOptions = {
+            data: {post: {type: 'browse', resource: 'posts'}}
+        };
+
+        const result = await data.fetchData({}, routerOptions, locals);
+
+        sinon.assert.calledTwice(browsePostsStub);
+        assert.equal(browsePostsStub.secondCall.args[0].include, 'authors,tags,tiers');
+
+        // The response is still keyed off the resolved `posts` resource
+        assert.equal(result.data.post.length, posts.length);
+        assert.deepEqual(result.data.post.meta, {pagination: {pages: 2}});
+    });
 });

--- a/ghost/core/test/unit/frontend/services/data/fetch-data.test.js
+++ b/ghost/core/test/unit/frontend/services/data/fetch-data.test.js
@@ -96,10 +96,8 @@ describe('Unit - frontend/data/fetch-data', function () {
                 featured: {
                     type: 'browse',
                     resource: 'posts',
-                    options: {
-                        filter: 'featured:true',
-                        limit: 3
-                    }
+                    filter: 'featured:true',
+                    limit: 3
                 }
             }
         };
@@ -129,11 +127,7 @@ describe('Unit - frontend/data/fetch-data', function () {
 
         const routerOptions = {
             data: {
-                featured: {
-                    type: 'browse',
-                    resource: 'posts',
-                    options: {filter: 'featured:true', limit: 3}
-                }
+                featured: {type: 'browse', resource: 'posts', filter: 'featured:true', limit: 3}
             }
         };
 
@@ -162,15 +156,12 @@ describe('Unit - frontend/data/fetch-data', function () {
             slug: 'testing'
         };
 
+        // The taxonomy router hands over a read entry with a `%s` placeholder
+        // for the slug, which fetch-data fills in from the request path.
         const routerOptions = {
             filter: 'tags:%s',
             data: {
-                tag: {
-                    controller: 'tagsPublic',
-                    type: 'read',
-                    resource: 'tags',
-                    options: {slug: '%s'}
-                }
+                tag: {type: 'read', resource: 'tags', slug: '%s'}
             }
         };
 
@@ -191,5 +182,27 @@ describe('Unit - frontend/data/fetch-data', function () {
         assert.equal(browsePostsStub.firstCall.args[0].filter, 'tags:testing');
         assert(!('slug' in browsePostsStub.firstCall.args[0]));
         assert.equal(readTagsStub.firstCall.args[0].slug, 'testing');
+        // The read defaults for tags are resolved alongside the slug
+        assert.equal(readTagsStub.firstCall.args[0].visibility, 'public');
+    });
+
+    it('should handle shorthand data entries', async function () {
+        const routerOptions = {
+            data: {'my-tag': 'tag.bacon'}
+        };
+
+        const result = await data.fetchData({}, routerOptions, locals);
+
+        assert('my-tag' in result.data);
+        assert.equal(result.data['my-tag'].length, tags.length);
+        assert.equal(readTagsStub.firstCall.args[0].slug, 'bacon');
+    });
+
+    it('should not mutate the route data it was given', async function () {
+        const routeData = {post: {type: 'browse', resource: 'posts'}};
+
+        await data.fetchData({}, {data: routeData}, locals);
+
+        assert.deepEqual(routeData, {post: {type: 'browse', resource: 'posts'}});
     });
 });

--- a/ghost/core/test/unit/frontend/services/routing/api-adapter.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/api-adapter.test.js
@@ -1,0 +1,177 @@
+const assert = require('node:assert/strict');
+const {resolveApiCall, resolveRouteData, resolveResourceRead} = require('../../../../../core/frontend/services/routing/api-adapter');
+
+describe('UNIT - services/routing/api-adapter', function () {
+    describe('resolveApiCall - short form', function () {
+        it('resolves tag shorthand to the public tags controller', function () {
+            assert.deepEqual(resolveApiCall('tag.food'), {
+                controller: 'tagsPublic',
+                type: 'read',
+                resource: 'tags',
+                options: {slug: 'food', visibility: 'public'}
+            });
+        });
+
+        it('resolves author shorthand', function () {
+            assert.deepEqual(resolveApiCall('author.jane'), {
+                controller: 'authorsPublic',
+                type: 'read',
+                resource: 'authors',
+                options: {slug: 'jane'}
+            });
+        });
+
+        it('resolves post shorthand', function () {
+            assert.deepEqual(resolveApiCall('post.welcome'), {
+                controller: 'postsPublic',
+                type: 'read',
+                resource: 'posts',
+                options: {slug: 'welcome'}
+            });
+        });
+
+        it('resolves page shorthand', function () {
+            assert.deepEqual(resolveApiCall('page.about'), {
+                controller: 'pagesPublic',
+                type: 'read',
+                resource: 'pages',
+                options: {slug: 'about'}
+            });
+        });
+
+        it('does not leak the slug into the shared resource config', function () {
+            assert.equal(resolveApiCall('tag.first').options.slug, 'first');
+            assert.equal(resolveApiCall('tag.second').options.slug, 'second');
+        });
+
+        it('throws for an unsupported shorthand resource', function () {
+            assert.throws(() => resolveApiCall('unknown.thing'), /Unknown route data resource: unknown/);
+        });
+    });
+
+    describe('resolveApiCall - long form read', function () {
+        it('merges the resource default options', function () {
+            assert.deepEqual(resolveApiCall({type: 'read', resource: 'tags', slug: 'food'}), {
+                controller: 'tagsPublic',
+                type: 'read',
+                resource: 'tags',
+                options: {slug: 'food', visibility: 'public'}
+            });
+        });
+
+        it('lets the entry override a default option', function () {
+            assert.deepEqual(resolveApiCall({type: 'read', resource: 'tags', slug: 'food', visibility: 'all'}), {
+                controller: 'tagsPublic',
+                type: 'read',
+                resource: 'tags',
+                options: {slug: 'food', visibility: 'all'}
+            });
+        });
+
+        it('keeps the redirect flag out of the API options', function () {
+            const spec = resolveApiCall({type: 'read', resource: 'posts', slug: 'welcome', redirect: false});
+
+            assert.deepEqual(spec.options, {slug: 'welcome'});
+        });
+    });
+
+    describe('resolveApiCall - long form browse', function () {
+        it('does not apply read defaults to a browse entry', function () {
+            assert.deepEqual(resolveApiCall({type: 'browse', resource: 'tags'}), {
+                controller: 'tagsPublic',
+                type: 'browse',
+                resource: 'tags',
+                options: {}
+            });
+        });
+
+        it('passes the supported query options through', function () {
+            const spec = resolveApiCall({
+                type: 'browse',
+                resource: 'posts',
+                filter: 'featured:true',
+                limit: 3,
+                order: 'published_at desc',
+                include: 'tags',
+                visibility: 'public',
+                status: 'published',
+                page: 2
+            });
+
+            assert.deepEqual(spec.options, {
+                filter: 'featured:true',
+                limit: 3,
+                order: 'published_at desc',
+                include: 'tags',
+                visibility: 'public',
+                status: 'published',
+                page: 2
+            });
+        });
+
+        it('does not pass unsupported entry keys to the API', function () {
+            // `fields` is accepted by the parser but has never been forwarded to
+            // the Content API — preserved here so the behaviour stays explicit.
+            const spec = resolveApiCall({type: 'browse', resource: 'posts', fields: 'title'});
+
+            assert.deepEqual(spec.options, {});
+        });
+
+        it('throws for an unsupported resource', function () {
+            assert.throws(() => resolveApiCall({type: 'browse', resource: 'widgets'}), /Unknown route data resource: widgets/);
+        });
+    });
+
+    describe('resolveRouteData', function () {
+        it('returns an empty map when a route has no data', function () {
+            assert.deepEqual(resolveRouteData(undefined), {});
+        });
+
+        it('keys top-level shorthand by its resource', function () {
+            assert.deepEqual(resolveRouteData('tag.food'), {
+                tag: {
+                    controller: 'tagsPublic',
+                    type: 'read',
+                    resource: 'tags',
+                    options: {slug: 'food', visibility: 'public'}
+                }
+            });
+        });
+
+        it('preserves the author-defined names of a data map', function () {
+            const resolved = resolveRouteData({
+                'my-tag': 'tag.food',
+                featured: {type: 'browse', resource: 'posts', filter: 'featured:true'}
+            });
+
+            assert.deepEqual(Object.keys(resolved), ['my-tag', 'featured']);
+            assert.equal(resolved['my-tag'].controller, 'tagsPublic');
+            assert.equal(resolved.featured.options.filter, 'featured:true');
+        });
+    });
+
+    describe('resolveResourceRead', function () {
+        it('resolves shorthand to the long-form resource', function () {
+            assert.deepEqual(resolveResourceRead('tag.food'), {resource: 'tags', slug: 'food'});
+            assert.deepEqual(resolveResourceRead('author.jane'), {resource: 'authors', slug: 'jane'});
+        });
+
+        it('resolves a long form read', function () {
+            assert.deepEqual(resolveResourceRead({type: 'read', resource: 'pages', slug: 'about'}), {
+                resource: 'pages',
+                slug: 'about'
+            });
+        });
+
+        it('a browse entry claims no resource', function () {
+            assert.equal(resolveResourceRead({type: 'browse', resource: 'posts', filter: 'featured:true'}), null);
+        });
+
+        it('an unknown resource claims nothing rather than throwing', function () {
+            // This runs on the request path, so an entry it cannot make sense of
+            // must not take the page down.
+            assert.equal(resolveResourceRead({type: 'read', resource: 'widgets', slug: 'a'}), null);
+            assert.equal(resolveResourceRead('unknown.thing'), null);
+        });
+    });
+});

--- a/ghost/core/test/unit/frontend/services/routing/collection-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/collection-router.test.js
@@ -198,5 +198,17 @@ describe('UNIT - services/routing/CollectionRouter', function () {
                 limit: 19
             });
         });
+
+        it('passes route data through in domain form', function () {
+            const collectionRouter = new CollectionRouter('/podcast/', {
+                permalink: '/podcast/{slug}/',
+                data: {'my-tag': 'tag.podcast'}
+            }, RESOURCE_CONFIG, routerCreatedSpy);
+
+            collectionRouter._prepareEntriesContext(req, res, next);
+
+            sinon.assert.calledOnce(next);
+            assert.deepEqual(res.routerOptions.data, {'my-tag': 'tag.podcast'});
+        });
     });
 });

--- a/ghost/core/test/unit/frontend/services/routing/controllers/static.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/controllers/static.test.js
@@ -1,3 +1,4 @@
+const assert = require('node:assert/strict');
 const {assertExists} = require('../../../../../utils/assertions');
 const sinon = require('sinon');
 const {deferred} = require('../../../../../utils/deferred')
@@ -92,20 +93,97 @@ describe('Unit - services/routing/controllers/static', function () {
         const {promise, done} = deferred();
         res.routerOptions.data = {
             tag: {
-                controller: 'tagsPublic',
-                resource: 'tags',
                 type: 'read',
-                options: {
-                    slug: 'bacon'
-                }
+                resource: 'tags',
+                slug: 'bacon'
             }
         };
 
-        tagsReadStub = sinon.stub().resolves({tags: [{slug: 'bacon'}]});
+        tagsReadStub.resolves({tags: [{slug: 'bacon'}]});
 
         renderer.renderer.callsFake(function () {
             sinon.assert.called(tagsReadStub);
             sinon.assert.calledOnce(renderer.formatResponse.entries);
+            done();
+        });
+
+        controllers.static(req, res, failTest(done));
+        return promise;
+    });
+
+    it('resolves the API call from a route data entry', function () {
+        const {promise, done} = deferred();
+        res.routerOptions.data = {tag: 'tag.bacon'};
+
+        tagsReadStub.resolves({tags: [{slug: 'bacon'}]});
+
+        renderer.renderer.callsFake(function () {
+            // `tags` resolves to the tagsPublic controller, and the resource
+            // defaults (visibility) are merged in for a read.
+            assert.deepEqual(tagsReadStub.firstCall.args[0], {
+                slug: 'bacon',
+                visibility: 'public',
+                context: {member: undefined}
+            });
+            done();
+        });
+
+        controllers.static(req, res, failTest(done));
+        return promise;
+    });
+
+    it('keys the response data by the name the route gave it', function () {
+        const {promise, done} = deferred();
+        res.routerOptions.data = {'my-tag': 'tag.bacon'};
+
+        tagsReadStub.resolves({tags: [{slug: 'bacon'}]});
+
+        renderer.renderer.callsFake(function () {
+            const response = renderer.formatResponse.entries.firstCall.args[0];
+
+            assert.deepEqual(response.data['my-tag'], [{slug: 'bacon'}]);
+            done();
+        });
+
+        controllers.static(req, res, failTest(done));
+        return promise;
+    });
+
+    it('requests relations for a post or page entry', function () {
+        const {promise, done} = deferred();
+        const pagesReadStub = sinon.stub().resolves({pages: [{slug: 'team'}]});
+        sinon.stub(api, 'pagesPublic').get(() => {
+            return {read: pagesReadStub};
+        });
+
+        res.routerOptions.data = {team: 'page.team'};
+
+        renderer.renderer.callsFake(function () {
+            assert.equal(pagesReadStub.firstCall.args[0].include, 'authors,tags,tiers');
+            done();
+        });
+
+        controllers.static(req, res, failTest(done));
+        return promise;
+    });
+
+    it('attaches browse meta to the response', function () {
+        const {promise, done} = deferred();
+        const postsBrowseStub = sinon.stub().resolves({posts: [{slug: 'welcome'}], meta: {pagination: {}}});
+        sinon.stub(api, 'postsPublic').get(() => {
+            return {browse: postsBrowseStub};
+        });
+
+        res.routerOptions.data = {
+            featured: {type: 'browse', resource: 'posts', filter: 'featured:true', limit: 3}
+        };
+
+        renderer.renderer.callsFake(function () {
+            assert.equal(postsBrowseStub.firstCall.args[0].filter, 'featured:true');
+            assert.equal(postsBrowseStub.firstCall.args[0].limit, 3);
+
+            const response = renderer.formatResponse.entries.firstCall.args[0];
+            assert.deepEqual(response.data.featured.meta, {pagination: {}});
             done();
         });
 

--- a/ghost/core/test/unit/frontend/services/routing/parent-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/parent-router.test.js
@@ -288,75 +288,85 @@ describe('UNIT - services/routing/ParentRouter', function () {
             assert.equal(parentRouter.isRedirectEnabled('tags', 'bacon'), false);
         });
 
-        it('data keys are undefined', function () {
+        it('data is empty', function () {
             const parentRouter = new ParentRouter();
-            parentRouter.data = {query: {}, router: {}};
-            assert.equal(parentRouter.isRedirectEnabled('tags', 'bacon'), undefined);
+            parentRouter.data = {};
+            assert.equal(parentRouter.isRedirectEnabled('tags', 'bacon'), false);
         });
 
-        it('no redirect when unspecified slug', function () {
+        it('no redirect for a browse entry', function () {
             const parentRouter = new ParentRouter();
 
-            parentRouter.data = {
-                query: {},
-                router: {
-                    tags: [{redirect: true}]
-                }
-            };
+            parentRouter.data = {featured: {type: 'browse', resource: 'tags'}};
 
-            assert.equal(parentRouter.isRedirectEnabled('tags', 'bacon'), undefined);
+            assert.equal(parentRouter.isRedirectEnabled('tags', 'bacon'), false);
         });
 
         it('no redirect when wrong slug', function () {
             const parentRouter = new ParentRouter();
 
-            parentRouter.data = {
-                query: {},
-                router: {
-                    tags: [{redirect: true, slug: 'cheese'}]
-                }
-            };
+            parentRouter.data = {tag: {type: 'read', resource: 'tags', slug: 'cheese'}};
 
-            assert.equal(parentRouter.isRedirectEnabled('tags', 'bacon'), undefined);
+            assert.equal(parentRouter.isRedirectEnabled('tags', 'bacon'), false);
         });
 
-        it('no redirect when tag redirect=false', function () {
+        it('no redirect when wrong resource', function () {
             const parentRouter = new ParentRouter();
 
-            parentRouter.data = {
-                query: {},
-                router: {
-                    tags: [{redirect: false, slug: 'bacon'}]
-                }
-            };
+            parentRouter.data = {page: {type: 'read', resource: 'pages', slug: 'bacon'}};
 
-            assert.equal(parentRouter.isRedirectEnabled('tags', 'bacon'), undefined);
+            assert.equal(parentRouter.isRedirectEnabled('tags', 'bacon'), false);
+        });
+
+        it('no redirect when the entry opts out', function () {
+            const parentRouter = new ParentRouter();
+
+            parentRouter.data = {tag: {type: 'read', resource: 'tags', slug: 'bacon', redirect: false}};
+
+            assert.equal(parentRouter.isRedirectEnabled('tags', 'bacon'), false);
         });
 
         it('redirect (tags)', function () {
             const parentRouter = new ParentRouter();
 
-            parentRouter.data = {
-                query: {},
-                router: {
-                    tags: [{redirect: true, slug: 'bacon'}]
-                }
-            };
+            parentRouter.data = {tag: {type: 'read', resource: 'tags', slug: 'bacon'}};
 
-            assertExists(parentRouter.isRedirectEnabled('tags', 'bacon'));
+            assert.equal(parentRouter.isRedirectEnabled('tags', 'bacon'), true);
         });
 
         it('redirect (pages)', function () {
             const parentRouter = new ParentRouter();
 
+            parentRouter.data = {home: {type: 'read', resource: 'pages', slug: 'home'}};
+
+            assert.equal(parentRouter.isRedirectEnabled('pages', 'home'), true);
+        });
+
+        it('redirect from a named shorthand entry', function () {
+            const parentRouter = new ParentRouter();
+
+            parentRouter.data = {'my-tag': 'tag.bacon'};
+
+            assert.equal(parentRouter.isRedirectEnabled('tags', 'bacon'), true);
+        });
+
+        it('redirect from top-level shorthand', function () {
+            const parentRouter = new ParentRouter();
+
+            parentRouter.data = 'tag.bacon';
+
+            assert.equal(parentRouter.isRedirectEnabled('tags', 'bacon'), true);
+        });
+
+        it('redirect when one of several entries matches', function () {
+            const parentRouter = new ParentRouter();
+
             parentRouter.data = {
-                query: {},
-                router: {
-                    pages: [{redirect: true, slug: 'home'}]
-                }
+                featured: {type: 'browse', resource: 'posts', filter: 'featured:true'},
+                tag: 'tag.bacon'
             };
 
-            assertExists(parentRouter.isRedirectEnabled('pages', 'home'));
+            assert.equal(parentRouter.isRedirectEnabled('tags', 'bacon'), true);
         });
     });
 });

--- a/ghost/core/test/unit/frontend/services/routing/static-routes-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/static-routes-router.test.js
@@ -55,7 +55,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
 
         it('initialize with data+filter', function () {
             const staticRoutesRouter = new StaticRoutesRouter('/about/', {
-                data: {query: {}, router: {}},
+                data: {},
                 filter: 'tag:test'
             }, routerCreatedSpy);
 
@@ -112,7 +112,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
             it('initialize with controller+data+filter', function () {
                 const staticRoutesRouter = new StaticRoutesRouter('/channel/', {
                     type: 'channel',
-                    data: {query: {}, router: {}},
+                    data: {},
                     filter: 'tag:test'
                 }, routerCreatedSpy);
 
@@ -167,7 +167,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
             it('initialize with controller+data', function () {
                 const staticRoutesRouter = new StaticRoutesRouter('/channel/', {
                     type: 'channel',
-                    data: {query: {}, router: {}}
+                    data: {}
                 }, routerCreatedSpy);
 
                 assert.equal(staticRoutesRouter.filter, undefined);
@@ -178,7 +178,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
 
                 new StaticRoutesRouter('/channel/', {
                     type: 'channel',
-                    data: {query: {}, router: {}},
+                    data: {},
                     filter: 'author:michi'
                 }, routerCreatedSpy);
 
@@ -198,7 +198,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
             it('with data+filter', function () {
                 const staticRoutesRouter = new StaticRoutesRouter('/channel/', {
                     type: 'channel',
-                    data: {query: {}, router: {}},
+                    data: {},
                     filter: 'tag:test'
                 }, routerCreatedSpy);
 
@@ -219,7 +219,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
             it('with data', function () {
                 const staticRoutesRouter = new StaticRoutesRouter('/nothingcomparestoyou/', {
                     type: 'channel',
-                    data: {query: {type: 'read'}, router: {}}
+                    data: {'my-tag': 'tag.test'}
                 }, routerCreatedSpy);
 
                 staticRoutesRouter._prepareChannelContext(req, res, next);
@@ -229,7 +229,7 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
                     context: ['nothingcomparestoyou'],
                     name: 'nothingcomparestoyou',
                     filter: undefined,
-                    data: {type: 'read'},
+                    data: {'my-tag': 'tag.test'},
                     limit: undefined,
                     order: undefined,
                     templates: []

--- a/ghost/core/test/unit/frontend/services/routing/taxonomy-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/taxonomy-router.test.js
@@ -87,7 +87,7 @@ describe('UNIT - services/routing/TaxonomyRouter', function () {
             name: 'tag',
             permalinks: '/tag/:slug/',
             resourceType: RESOURCE_CONFIG.QUERY.tag.resource,
-            data: {tag: RESOURCE_CONFIG.QUERY.tag},
+            data: {tag: {type: 'read', resource: RESOURCE_CONFIG.TAXONOMIES.tag.resource, slug: '%s'}},
             filter: RESOURCE_CONFIG.TAXONOMIES.tag.filter,
             context: ['tag'],
             slugTemplate: true,

--- a/ghost/core/test/unit/server/services/route-settings/activation-bridge.test.ts
+++ b/ghost/core/test/unit/server/services/route-settings/activation-bridge.test.ts
@@ -26,8 +26,8 @@ describe('activation-bridge', function () {
         // Characterisation tests for the router-facing array output. Each item
         // carries its own `path`; routes use the domain `type`/`contentType`
         // names; permalinks stay in domain `{slug}` notation (the routers convert
-        // to `:slug` via the permalink adapter) and `data` is still expanded to
-        // `{query, router}` (peeled off in later cleanup PRs).
+        // to `:slug` via the permalink adapter) and `data` is passed through
+        // untouched (the api adapter resolves it at request time).
         describe('produces the expected array output', function () {
             const cases: Array<{name: string; raw: unknown; expected: object}> = [
                 {
@@ -51,18 +51,10 @@ describe('activation-bridge', function () {
                     expected: {routes: [{path: '/featured/', type: 'channel', templates: [], filter: 'featured:true', rss: false}], collections: [], taxonomies: []}
                 },
                 {
-                    name: 'route with shortform data expands to {query, router}',
+                    name: 'route data is passed through in domain form',
                     raw: {routes: {'/food/': {template: 'food', data: 'tag.food'}}, collections: {}, taxonomies: {}},
                     expected: {
-                        routes: [{
-                            path: '/food/',
-                            type: 'template',
-                            templates: ['food'],
-                            data: {
-                                query: {tag: {controller: 'tagsPublic', type: 'read', resource: 'tags', options: {slug: 'food', visibility: 'public'}}},
-                                router: {tags: [{slug: 'food', redirect: true}]}
-                            }
-                        }],
+                        routes: [{path: '/food/', type: 'template', templates: ['food'], data: 'tag.food'}],
                         collections: [],
                         taxonomies: []
                     }
@@ -81,10 +73,7 @@ describe('activation-bridge', function () {
                             path: '/podcast/',
                             permalink: '/podcast/{slug}/',
                             templates: ['podcast'],
-                            data: {
-                                query: {tag: {controller: 'tagsPublic', type: 'read', resource: 'tags', options: {slug: 'podcast', visibility: 'public'}}},
-                                router: {tags: [{slug: 'podcast', redirect: true}]}
-                            },
+                            data: 'tag.podcast',
                             filter: 'tag:podcast'
                         }],
                         taxonomies: []


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1897

Phase 3 steps 3.4, 3.5 and 3.6 of the [route settings refactor](https://linear.app/ghost/document/route-settings-refactor-implementation-plan-33c53876468e). Follows #29617 (RouterManager arrays) and #29662 (permalink adapter).

## What this changes

The activation bridge used to expand every `routes.yaml` `data:` block **at boot** into a `{query, router}` structure with Ghost API controller names baked in:

```js
data: {
  query:  {tag: {controller: 'tagsPublic', type: 'read', resource: 'tags', options: {slug: 'food', visibility: 'public'}}},
  router: {tags: [{slug: 'food', redirect: true}]}
}
```

`tagsPublic` is an API implementation detail, not a domain concept, and the routers were carrying it around all the way to the request path.

This adds **`frontend/services/routing/api-adapter.ts`** — the second anti-corruption layer alongside the permalink adapter — as the single named place where a domain `resource` becomes a Content API call, resolved at call time:

- `resolveApiCall(entry)` → `{controller, type, resource, options}`
- `resolveRouteData(routeData)` → the same, keyed the way the theme sees it (handles top-level shorthand)
- `resolveResourceRead(entry)` → `{resource, slug} | null`, the routing-side question

The three consumers now work with the domain `RouteData` the routers already hold:

| File | Before | After |
|---|---|---|
| `controllers/static.js` | `api[query.controller][query.type](query.options)` | resolves `RouteData` through the adapter |
| `data/fetch-data.js` | same, plus `%s` replacement | same change, `%s` handling untouched |
| `parent-router.js` `isRedirectEnabled` | `_.find(this.data.router, …)` | asks `resolveResourceRead` |

`TaxonomyRouter` now emits its data in domain form too, so `res.routerOptions.data` is uniformly `RouteData`.

With the `data` conversion gone, the bridge is down to flattening the taxonomies map — HKG-1898 can delete it outright.

## Behaviour is unchanged

This is a pure refactor; no theme-visible output changes.

The new resolver was differential-tested against the deleted expansion (`expandShortFormData` / `expandLongFormEntry` / `expandRouteData` run in-process side by side)

Two deliberate non-behavioural improvements fall out:

- `isRedirectEnabled` now returns a real boolean. Its JSDoc already said `@returns {boolean}` while `_.find` returned an entry or `undefined`; the only caller uses it for truthiness.
- The per-request objects are freshly built, so `_.merge(…)` in `fetch-data.js` no longer mutates a router-held object shared across requests. It was idempotent, so not a live bug, but it was a real footgun.

`fields` stays unforwarded to the API — the parser accepts it but the old allowlist never passed it through, and there is now a test pinning that.

## Risk

Touches the public site request path. The mitigations are the differential test above plus:

- `test/legacy/mock-express-style/api-vs-frontend.test.js` — the 8 `data:` fixtures are rewritten in domain form; this is the suite that covers collections with a data key, channels, and cross-router 301s
- new `api-adapter.test.js` (26 cases), plus `static.js`, `fetch-data.js` and `isRedirectEnabled` coverage for shorthand, browse, `redirect: false`, and resource mismatch

`resolveResourceRead` returns `null` rather than throwing for an entry it cannot interpret, so the redirect path — which now runs per request instead of at boot — cannot take a page down. `resolveApiCall` still throws for an unknown resource, but the parser's `z.enum` gates every store and the upload path, so it is unreachable for validated settings.

The schema integrity hash is unaffected: `default-routes.yaml` has no `data:` block.
