### PR TITLE
Stored composite custom field values as leaf rows

### DIFF
--- a/apps/admin/src/members/detail/member-detail-edit.test.ts
+++ b/apps/admin/src/members/detail/member-detail-edit.test.ts
@@ -108,9 +108,16 @@ describe('buildCustomFieldSavePayload', () => {
             .toEqual({id: 'mem_1', custom_fields: {job_title: null}});
     });
 
-    it('sends a normalized address whole, and null when every sub-field is empty', () => {
+    it('names every part the editor showed, so an emptied one is cleared rather than kept', () => {
+        // A write touches the parts it names. Leaving `line2` out would read as "no
+        // change" and the stored one would survive the person deleting it.
         expect(buildCustomFieldSavePayload('mem_1', 'home_address', {line1: ' 1 Main St ', line2: '', city: 'Berlin', postal_code: '10115', country: 'DE'}))
-            .toEqual({id: 'mem_1', custom_fields: {home_address: {line1: '1 Main St', city: 'Berlin', postal_code: '10115', country: 'DE'}}});
+            .toEqual({id: 'mem_1', custom_fields: {home_address: {line1: '1 Main St', line2: '', city: 'Berlin', postal_code: '10115', country: 'DE'}}});
+    });
+
+    it('sends an address emptied of everything as a cleared field', () => {
+        // Every part empty is not an address of empties, it is no address — which the
+        // field-level null already says.
         expect(buildCustomFieldSavePayload('mem_1', 'home_address', {line1: '', city: '  '}))
             .toEqual({id: 'mem_1', custom_fields: {home_address: null}});
     });
@@ -353,17 +360,41 @@ describe('getCustomFieldValidationErrors', () => {
         expect(errors).toEqual({'home_address.line1': 'Use 255 characters or fewer.'});
     });
 
-    it('validates the normalized value, so an address of nothing but whitespace reads as cleared', () => {
+    it('raises nothing for an address of nothing but whitespace, which reads as cleared', () => {
         const whitespaceOnly = {line1: '  ', city: '  '};
 
-        // The schema rejects this outright, so no errors can only mean normalization
-        // ran first — without that check the assertion below passes either way.
-        expect(MEMBER_CUSTOM_FIELD_TYPES.address.value.safeParse(whitespaceOnly).success).toBe(false);
+        // The schema trims each part, so this names two parts as empty — a valid request
+        // to clear them, not a malformed address.
+        expect(MEMBER_CUSTOM_FIELD_TYPES.address.value.safeParse(whitespaceOnly).success).toBe(true);
         expect(getCustomFieldValidationErrors({home_address: whitespaceOnly}, fields)).toEqual({});
 
-        // "Cleared" is the other half of the claim: the save sends null, not an object.
+        // And with nothing left in it, the save clears the field outright.
         expect(buildCustomFieldSavePayload('m1', 'home_address', whitespaceOnly).custom_fields)
             .toEqual({home_address: null});
+    });
+
+    it('lets a sub-field with a format be emptied, not just one with a bound', () => {
+        // Emptying the country box is the one way a person removes a country while
+        // keeping the address. Its rule is a pattern rather than a length, so unless the
+        // catalog treats empty as a clear the save is refused and the box cannot be
+        // emptied at all.
+        const clearedCountry = {line1: '62 Ghost Lane', line2: '', city: 'Dublin', state: '', postal_code: '', country: ''};
+
+        expect(getCustomFieldValidationErrors({home_address: clearedCountry}, fields)).toEqual({});
+        expect(buildCustomFieldSavePayload('m1', 'home_address', clearedCountry).custom_fields)
+            .toEqual({home_address: clearedCountry});
+    });
+
+    it('checks the value the save sends, not the one the screen shows', () => {
+        // The two differ on emptied parts: the save names them so they clear, the display
+        // form drops them. Validating the display form would pass a payload the server
+        // then rejects, which is exactly how an unclearable country went unnoticed.
+        const emptiedParts = {line1: '62 Ghost Lane', country: ''};
+
+        expect(getEditableCustomFieldValues({home_address: emptiedParts}).home_address).toEqual({line1: '62 Ghost Lane'});
+        expect(buildCustomFieldSavePayload('m1', 'home_address', emptiedParts).custom_fields)
+            .toEqual({home_address: emptiedParts});
+        expect(getCustomFieldValidationErrors({home_address: emptiedParts}, fields)).toEqual({});
     });
 });
 

--- a/apps/admin/src/members/detail/member-detail-edit.ts
+++ b/apps/admin/src/members/detail/member-detail-edit.ts
@@ -90,6 +90,25 @@ export function getEditableCustomFieldValues(customFields: Record<string, unknow
 }
 
 /**
+ * An address as the save should send it: every part the editor showed, trimmed, keeping
+ * the empty ones.
+ *
+ * A write touches the parts it names, so a part the person emptied has to be named — sent
+ * as empty rather than left out, which would read as "no change". An address with nothing
+ * left in it is a cleared field, which the caller says with `null` instead.
+ */
+function addressToSave(value: Record<string, unknown>): EditableAddressValue | undefined {
+    const address: EditableAddressValue = {};
+    for (const subfield of ADDRESS_SUBFIELD_KEYS) {
+        const subvalue = value[subfield];
+        if (typeof subvalue === 'string') {
+            address[subfield] = subvalue.trim();
+        }
+    }
+    return Object.values(address).some(part => part !== '') ? address : undefined;
+}
+
+/**
  * An address value reduced to its known sub-fields, trimmed, with empty
  * sub-fields dropped. Undefined when nothing remains, so an all-blank address
  * normalizes to "no value" exactly like an empty string does.
@@ -248,6 +267,18 @@ export function buildMemberFieldEditPayload(
 }
 
 /**
+ * A value exactly as the save will send it, or undefined for one that clears the field.
+ *
+ * One statement of that, because validating anything else is validating a value nobody
+ * sends: the editor keeps an emptied address part so the save can name it, while the
+ * display form drops it, and a check run against the second cannot see what the first
+ * would be told about.
+ */
+function customFieldValueToSave(value: EditableCustomFieldValue): EditableCustomFieldValue | undefined {
+    return typeof value === 'string' ? (value.trim() || undefined) : addressToSave(value);
+}
+
+/**
  * The save payload for ONE custom field, from the per-field editor. Merge
  * semantics do the rest: only this key is touched, `null` clears it, and an
  * address is sent whole (the merge is per field, not per sub-field).
@@ -257,10 +288,7 @@ export function buildCustomFieldSavePayload(
     fieldKey: string,
     value: EditableCustomFieldValue
 ): EditMemberData {
-    const normalized = typeof value === 'string'
-        ? (value.trim() || undefined)
-        : normalizeAddressValue(value);
-    return {id: memberId, custom_fields: {[fieldKey]: normalized ?? null}};
+    return {id: memberId, custom_fields: {[fieldKey]: customFieldValueToSave(value) ?? null}};
 }
 
 // What to do about a malformed address sub-field, in plain words. Schema messages
@@ -309,9 +337,12 @@ export function getCustomFieldValidationErrors(
     fields: MemberCustomField[]
 ): Record<string, string> {
     const errors: Record<string, string> = {};
-    const values = getEditableCustomFieldValues(draftCustomFields);
     for (const field of fields) {
-        const value = values[field.key];
+        const draft = draftCustomFields[field.key];
+        // Checked as the save would send it, so what passes here is what the server is
+        // asked to accept. A value that clears the field is always valid: no field is
+        // required, and a clear says nothing for a rule to be about.
+        const value = draft === undefined ? undefined : customFieldValueToSave(draft);
         if (value === undefined) {
             continue;
         }

--- a/ghost/core/core/server/data/migrations/versions/6.57/2026-08-04-18-00-00-store-custom-field-values-as-leaf-rows.js
+++ b/ghost/core/core/server/data/migrations/versions/6.57/2026-08-04-18-00-00-store-custom-field-values-as-leaf-rows.js
@@ -1,0 +1,87 @@
+const logging = require('@tryghost/logging');
+const {createNonTransactionalMigration} = require('../../utils');
+const {addColumn, dropColumn, addUnique, dropUnique, addIndex, dropIndex} = require('../../../schema/commands');
+
+const TABLE = 'members_custom_field_values';
+
+// Named rather than derived: knex would build the name from the table and all three
+// columns, which comes to 65 characters, and MySQL stops at 64.
+const LEAF_UNIQUE = 'members_custom_field_values_leaf_unique';
+
+// A composite value used to live in one row as a JSON blob. It now occupies one row per
+// part, keyed by `path`, so a part can be read, written and — the reason for the change —
+// indexed on its own.
+//
+// Stored values are discarded rather than converted. Custom fields are behind a private
+// flag and have never been released, so no site can hold a value except by having been
+// opted in deliberately, while a conversion step would run on every Ghost database that
+// exists for as long as this migration does. Carrying data-moving code across all of them
+// to serve the handful of installs that could have data is the wrong side of that trade,
+// and rolling back already discards composites for want of a catalog this cannot read —
+// so discarding in both directions is at least the same answer twice.
+async function discardStoredValues(knex) {
+    const discarded = await knex(TABLE).del();
+    if (discarded > 0) {
+        logging.warn(`Discarded ${discarded} custom field value(s): the storage format changed before the feature was released`);
+    }
+}
+
+// Column changes ask for `auto` so MySQL picks an in-place algorithm where it can; the
+// helpers otherwise default to a full table copy, which blocks writes.
+//
+// Both foreign keys on this table need an index, and MySQL refuses to drop the last one
+// serving either. It counts an index whose leftmost column is the referencing column, so
+// the order of these steps matters: the replacement has to exist before the thing it
+// replaces goes. SQLite has no such rule, which is why this only bites on MySQL.
+// Every step is written to be safe to repeat. This migration is not transactional, so a
+// crash part-way leaves the table half-changed with nothing recorded as done — and
+// knex-migrator will run it again on the next boot. The constraint and index helpers
+// already swallow "it is already there"; the column steps have to ask.
+module.exports = createNonTransactionalMigration(
+    async function up(knex) {
+        // First, so that every later step works on an empty table: nothing can collide
+        // with the new constraint, and no row has to be read, decoded or rewritten.
+        await discardStoredValues(knex);
+
+        if (!await knex.schema.hasColumn(TABLE, 'path')) {
+            await addColumn(TABLE, 'path', knex, undefined, {algorithm: 'auto'});
+        }
+
+        // Added before the old constraint is dropped, so `member_id` stays leftmost and
+        // covers that foreign key the moment it exists.
+        await addUnique(TABLE, ['member_id', 'custom_field_id', 'path'], knex, LEAF_UNIQUE);
+        await dropUnique(TABLE, ['member_id', 'custom_field_id'], knex);
+
+        if (await knex.schema.hasColumn(TABLE, 'value_json')) {
+            await dropColumn(TABLE, 'value_json', knex, {}, {algorithm: 'auto'});
+        }
+        await addIndex(TABLE, ['custom_field_id', 'path'], knex);
+
+        // Only present if this migration has been rolled back and re-applied: `down` adds
+        // it so MySQL keeps an index over the foreign key while the composite one goes.
+        // The composite covers that key again now, so the standalone one would be drift
+        // against a fresh install.
+        await dropIndex(TABLE, ['custom_field_id'], knex);
+    },
+    async function down(knex) {
+        // Same reasoning in reverse, and the same first step: a value is one row per part
+        // now, and putting the parts back together would need the field-type catalog this
+        // deliberately does not read.
+        await discardStoredValues(knex);
+
+        await addUnique(TABLE, ['member_id', 'custom_field_id'], knex);
+        await dropUnique(TABLE, ['member_id', 'custom_field_id', 'path'], knex, LEAF_UNIQUE);
+
+        // `custom_field_id` needs its own index back before the composite one goes, or
+        // MySQL is left with nothing covering that foreign key and refuses the drop.
+        await addIndex(TABLE, ['custom_field_id'], knex);
+        await dropIndex(TABLE, ['custom_field_id', 'path'], knex);
+
+        if (!await knex.schema.hasColumn(TABLE, 'value_json')) {
+            await addColumn(TABLE, 'value_json', knex, {type: 'text', maxlength: 65535, nullable: true}, {algorithm: 'auto'});
+        }
+        if (await knex.schema.hasColumn(TABLE, 'path')) {
+            await dropColumn(TABLE, 'path', knex, {}, {algorithm: 'auto'});
+        }
+    }
+);

--- a/ghost/core/core/server/data/migrations/versions/6.57/2026-08-04-18-00-00-store-custom-field-values-as-leaf-rows.js
+++ b/ghost/core/core/server/data/migrations/versions/6.57/2026-08-04-18-00-00-store-custom-field-values-as-leaf-rows.js
@@ -4,8 +4,8 @@ const {addColumn, dropColumn, addUnique, dropUnique, addIndex, dropIndex} = requ
 
 const TABLE = 'members_custom_field_values';
 
-// Named because knex derives one from the table and all three columns, which comes to 65
-// characters, and MySQL stops at 64.
+// Named explicitly; the derived name would overrun MySQL's identifier limit, which
+// schema.test.js checks for every table.
 const LEAF_UNIQUE = 'members_custom_field_values_leaf_unique';
 
 // Values are discarded rather than converted: custom fields sit behind a private flag and

--- a/ghost/core/core/server/data/migrations/versions/6.57/2026-08-04-18-00-00-store-custom-field-values-as-leaf-rows.js
+++ b/ghost/core/core/server/data/migrations/versions/6.57/2026-08-04-18-00-00-store-custom-field-values-as-leaf-rows.js
@@ -4,21 +4,12 @@ const {addColumn, dropColumn, addUnique, dropUnique, addIndex, dropIndex} = requ
 
 const TABLE = 'members_custom_field_values';
 
-// Named rather than derived: knex would build the name from the table and all three
-// columns, which comes to 65 characters, and MySQL stops at 64.
+// Named because knex derives one from the table and all three columns, which comes to 65
+// characters, and MySQL stops at 64.
 const LEAF_UNIQUE = 'members_custom_field_values_leaf_unique';
 
-// A composite value used to live in one row as a JSON blob. It now occupies one row per
-// part, keyed by `path`, so a part can be read, written and — the reason for the change —
-// indexed on its own.
-//
-// Stored values are discarded rather than converted. Custom fields are behind a private
-// flag and have never been released, so no site can hold a value except by having been
-// opted in deliberately, while a conversion step would run on every Ghost database that
-// exists for as long as this migration does. Carrying data-moving code across all of them
-// to serve the handful of installs that could have data is the wrong side of that trade,
-// and rolling back already discards composites for want of a catalog this cannot read —
-// so discarding in both directions is at least the same answer twice.
+// Values are discarded rather than converted: custom fields sit behind a private flag and
+// have never been released, so only a site deliberately opted in can hold one.
 async function discardStoredValues(knex) {
     const discarded = await knex(TABLE).del();
     if (discarded > 0) {
@@ -29,26 +20,26 @@ async function discardStoredValues(knex) {
 // Column changes ask for `auto` so MySQL picks an in-place algorithm where it can; the
 // helpers otherwise default to a full table copy, which blocks writes.
 //
-// Both foreign keys on this table need an index, and MySQL refuses to drop the last one
-// serving either. It counts an index whose leftmost column is the referencing column, so
-// the order of these steps matters: the replacement has to exist before the thing it
-// replaces goes. SQLite has no such rule, which is why this only bites on MySQL.
-// Every step is written to be safe to repeat. This migration is not transactional, so a
-// crash part-way leaves the table half-changed with nothing recorded as done — and
-// knex-migrator will run it again on the next boot. The constraint and index helpers
-// already swallow "it is already there"; the column steps have to ask.
+// Two constraints shape the order of everything below.
+//
+// MySQL refuses to drop the last index serving a foreign key, counting any index whose
+// leftmost column is the referencing one, so each replacement is added before the thing
+// it replaces is dropped.
+//
+// This migration is not transactional, so a crash leaves the table half-changed with
+// nothing recorded as done and knex-migrator runs it again on the next boot. Every step
+// therefore tolerates having already happened: the constraint and index helpers swallow
+// that themselves, the column steps ask first.
 module.exports = createNonTransactionalMigration(
     async function up(knex) {
-        // First, so that every later step works on an empty table: nothing can collide
-        // with the new constraint, and no row has to be read, decoded or rewritten.
+        // First, so nothing can collide with the new constraint.
         await discardStoredValues(knex);
 
         if (!await knex.schema.hasColumn(TABLE, 'path')) {
             await addColumn(TABLE, 'path', knex, undefined, {algorithm: 'auto'});
         }
 
-        // Added before the old constraint is dropped, so `member_id` stays leftmost and
-        // covers that foreign key the moment it exists.
+        // `member_id` stays leftmost, covering that foreign key the moment this exists.
         await addUnique(TABLE, ['member_id', 'custom_field_id', 'path'], knex, LEAF_UNIQUE);
         await dropUnique(TABLE, ['member_id', 'custom_field_id'], knex);
 
@@ -57,23 +48,19 @@ module.exports = createNonTransactionalMigration(
         }
         await addIndex(TABLE, ['custom_field_id', 'path'], knex);
 
-        // Only present if this migration has been rolled back and re-applied: `down` adds
-        // it so MySQL keeps an index over the foreign key while the composite one goes.
-        // The composite covers that key again now, so the standalone one would be drift
-        // against a fresh install.
+        // Only present after a rollback, where `down` adds it to keep a foreign key
+        // covered. Leaving it would be drift against a fresh install.
         await dropIndex(TABLE, ['custom_field_id'], knex);
     },
     async function down(knex) {
-        // Same reasoning in reverse, and the same first step: a value is one row per part
-        // now, and putting the parts back together would need the field-type catalog this
-        // deliberately does not read.
+        // Rebuilding a composite would need the field-type catalog, which a migration must
+        // not read: it has to keep working when the catalog moves on.
         await discardStoredValues(knex);
 
         await addUnique(TABLE, ['member_id', 'custom_field_id'], knex);
         await dropUnique(TABLE, ['member_id', 'custom_field_id', 'path'], knex, LEAF_UNIQUE);
 
-        // `custom_field_id` needs its own index back before the composite one goes, or
-        // MySQL is left with nothing covering that foreign key and refuses the drop.
+        // Back before the composite one goes, or MySQL has nothing covering that key.
         await addIndex(TABLE, ['custom_field_id'], knex);
         await dropIndex(TABLE, ['custom_field_id', 'path'], knex);
 

--- a/ghost/core/core/server/data/schema/commands.js
+++ b/ghost/core/core/server/data/schema/commands.js
@@ -276,13 +276,18 @@ async function dropIndex(tableName, columns, transaction = db.knex) {
  * @param {string} tableName - name of the table to add unique constraint to
  * @param {string|string[]} columns - column(s) to form unique constraint with
  * @param {import('knex').Knex} [transaction] - connection object containing knex reference
+ * @param {string} [indexName] - name for the constraint; knex derives one from the table
+ * and every column when omitted, which can overrun MySQL's 64-character limit
  */
-async function addUnique(tableName, columns, transaction = db.knex) {
+async function addUnique(tableName, columns, transaction = db.knex, indexName) {
     try {
         logging.info(`Adding unique constraint for '${columns}' in table '${tableName}'`);
 
         return await transaction.schema.table(tableName, function (table) {
-            table.unique(columns);
+            // Knex derives a name from the table and every column when it is not given
+            // one, and that can overrun MySQL's 64-character identifier limit on a wide
+            // table or a constraint over several columns.
+            table.unique(columns, indexName ? {indexName} : undefined);
         });
     } catch (err) {
         if (err.code === 'SQLITE_ERROR') {
@@ -304,12 +309,14 @@ async function addUnique(tableName, columns, transaction = db.knex) {
  * @param {string|string[]} columns - column(s) unique constraint was formed
  * @param {import('knex').Knex} transaction - connection object containing knex reference
  */
-async function dropUnique(tableName, columns, transaction = db.knex) {
+async function dropUnique(tableName, columns, transaction = db.knex, indexName) {
     try {
         logging.info(`Dropping unique constraint for '${columns}' in table '${tableName}'`);
 
         return await transaction.schema.table(tableName, function (table) {
-            table.dropUnique(columns);
+            // Named constraints have to be dropped by that name: the one knex would
+            // derive from the columns is not what is on the table.
+            table.dropUnique(columns, indexName);
         });
     } catch (err) {
         if (err.code === 'SQLITE_ERROR') {
@@ -542,7 +549,16 @@ function createTable(table, transaction = db.knex, tableSpec = schema[table]) {
             });
         }
         if (tableSpec['@@UNIQUE_CONSTRAINTS@@']) {
-            tableSpec['@@UNIQUE_CONSTRAINTS@@'].forEach(unique => t.unique(unique));
+            tableSpec['@@UNIQUE_CONSTRAINTS@@'].forEach((unique) => {
+                // An entry is normally the columns alone, and knex names the constraint
+                // after the table and every one of them. The object form is for when
+                // that derived name would overrun MySQL's 64-character limit.
+                if (unique && typeof unique === 'object' && !Array.isArray(unique)) {
+                    t.unique(unique.columns, {indexName: unique.indexName});
+                } else {
+                    t.unique(unique);
+                }
+            });
         }
         if (tableSpec['@@PRIMARY_KEY@@']) {
             t.primary(tableSpec['@@PRIMARY_KEY@@']);

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -682,15 +682,34 @@ module.exports = {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         custom_field_id: {type: 'string', maxlength: 24, nullable: false, references: 'members_custom_fields.id', cascadeDelete: true},
         member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
-        // Exactly one value column is populated per row, chosen by the field
-        // type's storage type in @tryghost/custom-field-types, whose byte bound
-        // on long_text matches this column exactly.
+        // Which part of the field's value this row carries. A scalar has one part and
+        // stores it under the empty path; a composite stores one row per sub-field it
+        // fills, under that sub-field's key. Not nullable, because MySQL counts NULLs
+        // as distinct in a unique index and the constraint below would stop holding.
+        path: {type: 'string', maxlength: 191, nullable: false, defaultTo: ''},
+        // One row, one value: a part a member has not filled in has no row at all. The
+        // column stays nullable even so, because making it NOT NULL is only reachable
+        // through knex's dropNullable, which rewrites the column on MySQL and widens
+        // TEXT to MEDIUMTEXT — a migrated site would then accept sixteen megabytes in a
+        // column a fresh install bounds at 65,535 bytes. The bound matching long_text's
+        // exactly is worth more than the schema restating what the write path enforces.
         value_text: {type: 'text', maxlength: 65535, nullable: true},
-        value_json: {type: 'text', maxlength: 65535, nullable: true},
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: true},
+        // Named, because the name knex derives from the table and all three columns is
+        // 65 characters and MySQL stops at 64. The migration that first created this
+        // table already shortened a column for the same reason; a third column spends
+        // what headroom that bought.
         '@@UNIQUE_CONSTRAINTS@@': [
-            ['member_id', 'custom_field_id']
+            {columns: ['member_id', 'custom_field_id', 'path'], indexName: 'members_custom_field_values_leaf_unique'}
+        ],
+        // What a segment filter looks up: every member holding a given value for a
+        // given part of a given field. The value itself is not in the index — it is
+        // TEXT, so MySQL would need a prefix length, and the schema's index builder
+        // applies one length to every column in a composite index rather than to a
+        // single chosen one.
+        '@@INDEXES@@': [
+            ['custom_field_id', 'path']
         ]
     },
     members_stripe_customers: {

--- a/ghost/core/core/server/services/members-custom-fields/queries.ts
+++ b/ghost/core/core/server/services/members-custom-fields/queries.ts
@@ -3,20 +3,11 @@ import {FIELD_STATUS} from './schema';
 
 const FIELDS_TABLE = 'members_custom_fields';
 
-// Shared query builders over the field definitions, used by both the definitions
-// service and the values service.
-//
-// The `status = 'active'` filter is the one invariant worth centralising: archived
-// fields must stay out of every read and every write, and that's enforced by a
-// filter, not a database constraint — nothing stops a value row referencing an
-// archived field, so a query that forgets the filter is a silent bug. Keeping the
-// filter in one builder means there's one place to get it right.
+// Archived fields must stay out of every read and write, and nothing in the database
+// enforces that — no constraint stops a value row referencing an archived field. A query
+// that forgets the filter is a silent bug, so the filter lives in one place.
 
-/**
- * The active field definitions. Takes the executor — a knex instance or a
- * transaction — so the same query runs standalone or inside a write's
- * transaction; callers chain their own `select`/`orderBy`/`whereIn` onto it.
- */
+/** Takes the executor so the same query runs standalone or inside a write's transaction. */
 export function activeFields(db: Knex) {
     return db(FIELDS_TABLE).where('status', FIELD_STATUS.active);
 }

--- a/ghost/core/core/server/services/members-custom-fields/schema.ts
+++ b/ghost/core/core/server/services/members-custom-fields/schema.ts
@@ -3,20 +3,15 @@ import type {Knex} from 'knex';
 import {FieldTypeSchema} from '@tryghost/custom-field-types';
 import {DbDate} from '../../lib/db-date';
 
-// A field's lifecycle state. `archived` is a soft state: the field drops out of
-// the values path but stays visible in the definition list (with its status) so
-// admins can find, rename, restore, or permanently delete it. The values mirror
-// schema.js's `isIn` constraint on the column — which is static config and can't
-// import this, so that one stays literal with a pointer back here.
+// `archived` is soft: the field drops out of the values path but stays in the definition
+// list so it can be renamed, restored or deleted. Mirrors schema.js's `isIn` on the
+// column, which is static config and cannot import this.
 export const FIELD_STATUS = {active: 'active', archived: 'archived'} as const;
 export type FieldStatus = typeof FIELD_STATUS[keyof typeof FIELD_STATUS];
 export const FieldStatusSchema = z.enum([FIELD_STATUS.active, FIELD_STATUS.archived]);
 
-// The members_custom_fields row: the single source for the read projection and the
-// knex table type below. `type` is validated as the field-type enum here (the DB
-// only stores registered types), so the row already carries the narrow type and
-// the definition codec needs no cast. `status` travels with the row: it's part of
-// the read projection so the definition list can group active vs archived.
+// The single source for the read projection and the knex table type below. `type` parses
+// as the field-type enum, so the row carries the narrow type and no codec needs a cast.
 export const DbCustomField = z.object({
     id: z.string(),
     key: z.string(),
@@ -29,18 +24,15 @@ export const DbCustomField = z.object({
 
 type CustomFieldRow = z.infer<typeof DbCustomField>;
 
-// One part of a member's value for one field. `path` says which part: empty for a
-// scalar, which has one, and the sub-field's key for a composite, which has a row per
-// part it fills. What those paths mean is the storage module's business (see
-// storage.ts), so the row itself carries them as plain strings.
+// One part of a member's value. What a `path` means is storage.ts's business, so the row
+// carries it as a plain string.
 export const DbCustomFieldValue = z.object({
     id: z.string(),
     custom_field_id: z.string(),
     member_id: z.string(),
     path: z.string(),
-    // Mirrors the column, which is nullable. Nothing here writes a null — a part with
-    // no value has no row — but the row type describes the table rather than the
-    // subset of it this service produces.
+    // Nullable like the column, though nothing here writes a null: a part with no value
+    // has no row.
     value_text: z.string().nullable(),
     created_at: DbDate,
     updated_at: DbDate.nullable()
@@ -48,14 +40,11 @@ export const DbCustomFieldValue = z.object({
 
 type CustomFieldValueRow = z.infer<typeof DbCustomFieldValue>;
 
-// The leaf join a read needs: the field's key travels with the row so a value can be
-// assembled without a second lookup.
+// The field's key travels with the row so a value assembles without a second lookup.
 //
-// `type` is parsed as the field-type enum but takes no part in the assembly — which
-// shape to rebuild is read from the paths themselves, so a row survives its type
-// changing shape. It is here as a gate: a value whose type has left the catalog is one
-// the definitions list no longer returns either, and handing it out under a contract
-// nothing can interpret helps nobody. Failing to parse is what drops it.
+// `type` takes no part in the assembly and is here as a gate: a value whose type has left
+// the catalog is one the definitions list no longer returns either, so failing to parse
+// is what drops it.
 export const DbCustomFieldLeaf = z.object({
     member_id: z.string(),
     key: z.string(),

--- a/ghost/core/core/server/services/members-custom-fields/schema.ts
+++ b/ghost/core/core/server/services/members-custom-fields/schema.ts
@@ -29,38 +29,39 @@ export const DbCustomField = z.object({
 
 type CustomFieldRow = z.infer<typeof DbCustomField>;
 
-// A member's stored value for one field. `value_text`/`value_json` are the raw
-// columns — which one carries the value, and how it decodes, is the storage
-// codec's business (see storage.ts), so they're plain nullable strings here.
+// One part of a member's value for one field. `path` says which part: empty for a
+// scalar, which has one, and the sub-field's key for a composite, which has a row per
+// part it fills. What those paths mean is the storage module's business (see
+// storage.ts), so the row itself carries them as plain strings.
 export const DbCustomFieldValue = z.object({
     id: z.string(),
     custom_field_id: z.string(),
     member_id: z.string(),
+    path: z.string(),
+    // Mirrors the column, which is nullable. Nothing here writes a null — a part with
+    // no value has no row — but the row type describes the table rather than the
+    // subset of it this service produces.
     value_text: z.string().nullable(),
-    value_json: z.string().nullable(),
     created_at: DbDate,
     updated_at: DbDate.nullable()
 });
 
 type CustomFieldValueRow = z.infer<typeof DbCustomFieldValue>;
 
-// A composite value once decoded: sub-field keys to values, and no narrower. Which
-// sub-fields a composite has is its field type's business, not the row's.
+// The leaf join a read needs: the field's key travels with the row so a value can be
+// assembled without a second lookup.
 //
-// It doubles as the guard on a stored blob. A JSON column can just as easily hold an
-// array, a null or a bare number, and a record rejects all three — so parsing against
-// this is what narrows the type, with no assertion needed.
-export const StoredCompositeValue = z.record(z.string(), z.unknown());
-
-// The value join a read needs: the field's identity and type travel with the
-// stored columns, so a row can be decoded without a second lookup. `type` is
-// parsed as the field-type enum, which narrows it with no cast.
-export const DbCustomFieldValueWithField = z.object({
+// `type` is parsed as the field-type enum but takes no part in the assembly — which
+// shape to rebuild is read from the paths themselves, so a row survives its type
+// changing shape. It is here as a gate: a value whose type has left the catalog is one
+// the definitions list no longer returns either, and handing it out under a contract
+// nothing can interpret helps nobody. Failing to parse is what drops it.
+export const DbCustomFieldLeaf = z.object({
     member_id: z.string(),
     key: z.string(),
     type: FieldTypeSchema,
-    value_text: z.string().nullable(),
-    value_json: z.string().nullable()
+    path: z.string(),
+    value_text: z.string()
 });
 
 declare module 'knex/types/tables' {

--- a/ghost/core/core/server/services/members-custom-fields/storage.ts
+++ b/ghost/core/core/server/services/members-custom-fields/storage.ts
@@ -56,14 +56,16 @@ function isSafeSegment(segment: string): boolean {
 }
 
 /**
- * The leaves a value occupies, at any depth.
+ * Every leaf a value names, at any depth, including the ones it names as empty.
  *
- * A part with nothing in it contributes no leaf, which is what keeps "not set" and "set
- * to nothing" one state in storage instead of two that read alike.
+ * Naming is the unit of a write: a path a value does not mention is left alone, and one
+ * it mentions as empty is being cleared. Both readings are needed, so this reports what
+ * was named and leaves the caller to say what to do about it — `leavesToWrite` splits
+ * them. A stored leaf is never empty, because an empty one is a deletion.
  */
 export function leavesFor(value: unknown, path: string = ROOT_PATH): Leaf[] {
     if (typeof value === 'string') {
-        return value === '' ? [] : [{path, value_text: value}];
+        return [{path, value_text: value}];
     }
 
     // Anything that is neither a string nor a record has no leaves to be made of. Saying
@@ -75,9 +77,21 @@ export function leavesFor(value: unknown, path: string = ROOT_PATH): Leaf[] {
         });
     }
 
-    return Object.entries(value).flatMap(([key, part]) => {
-        return leavesFor(part, path === ROOT_PATH ? key : `${path}${SEPARATOR}${key}`);
-    });
+    // An undefined part is one the value does not name at all, which is not the same as
+    // naming it empty: the first leaves the stored part alone, the second removes it.
+    return Object.entries(value)
+        .filter(([, part]) => part !== undefined)
+        .flatMap(([key, part]) => leavesFor(part, path === ROOT_PATH ? key : `${path}${SEPARATOR}${key}`));
+}
+
+/** A value split into the leaves it sets and the paths it clears. */
+export function leavesToWrite(value: unknown): {set: Leaf[], cleared: string[]} {
+    const named = leavesFor(value);
+
+    return {
+        set: named.filter(leaf => leaf.value_text !== ''),
+        cleared: named.filter(leaf => leaf.value_text === '').map(leaf => leaf.path)
+    };
 }
 
 /** The value a set of leaves adds up to, rebuilt to whatever depth their paths describe. */

--- a/ghost/core/core/server/services/members-custom-fields/storage.ts
+++ b/ghost/core/core/server/services/members-custom-fields/storage.ts
@@ -1,47 +1,143 @@
-import {FIELD_TYPES, type FieldType, type StorageType} from '@tryghost/custom-field-types';
+import errors from '@tryghost/errors';
 
-// The backend half of the storage-type contract: the catalog says which storage
-// type a field type routes to, and this says what that means in the database —
-// the column, and how a value crosses the boundary. Adding a field type that
-// reuses an existing storage type needs nothing here.
+// How a value becomes rows, and rows become values again.
+//
+// A value is a tree and the database stores its leaves: one string per leaf, under the
+// path that addresses it. A value with no parts is a single leaf at the root; a value
+// with parts is one leaf per part, under that part's key; a part that is itself a record
+// nests, and its leaves are addressed with a dotted path. A part a member left out gets
+// no leaf, so "not set" is the absence of a row rather than a row saying nothing.
+//
+// Keeping the leaves apart rather than as one blob is what lets a segment filter reach a
+// part directly: `path = 'country' AND value_text = 'GB'` is an ordinary predicate over
+// indexed columns, where reaching inside a JSON column is not. A dotted path is the same
+// vocabulary a filter is written in, so `shipping_address.line1` is the layout rather
+// than a translation of it.
+//
+// Nothing here consults a field type. A value arrives already parsed against its own, so
+// a record's keys are exactly the parts that type declares; and a row read back is
+// rebuilt as what it was written as rather than as whatever the type says today.
 
-export type ValueColumn = 'value_text' | 'value_json';
+/** Separates the segments of a path, and the notation a filter addresses a part by. */
+const SEPARATOR = '.';
 
-interface StorageCodec {
-    column: ValueColumn;
-    encode(value: unknown): string;
-    decode(stored: string): unknown;
+/** The path of a value's root — the whole value, for one that has no parts. Empty rather than null: a unique index does not constrain nulls, so nulls would let the same leaf be stored twice. */
+export const ROOT_PATH = '';
+
+export interface Leaf {
+    path: string;
+    value_text: string;
 }
 
-const STORAGE_CODECS = {
-    // The value is already a string by the time it gets here — the field type's
-    // schema validated it — so encoding is identity.
-    text: {
-        column: 'value_text',
-        encode: value => String(value),
-        decode: stored => stored
-    },
-    json: {
-        column: 'value_json',
-        encode: value => JSON.stringify(value),
-        decode: stored => JSON.parse(stored)
-    }
-} as const satisfies Record<StorageType, StorageCodec>;
+/** A leaf as it comes back from the database, still carrying who and what it belongs to. */
+export interface StoredLeaf extends Leaf {
+    member_id: string;
+    key: string;
+}
 
-export function storageCodecFor(type: FieldType): StorageCodec {
-    return STORAGE_CODECS[FIELD_TYPES[type].storageType];
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 /**
- * The value columns for a row, with the one this field type doesn't use
- * explicitly nulled — the "exactly one column populated" invariant is written
- * out on every insert and update rather than left to convention.
+ * Whether a path segment can be a key of a plain object and mean only itself.
+ *
+ * A rebuilt value is an ordinary object, so a segment naming something every object
+ * already has — `__proto__` above all — would reach the prototype instead of the value,
+ * and writing through `__proto__` reaches every object in the process. No path written
+ * here can contain one, because a path is built from catalog part names; this makes that
+ * a property of the codec rather than of its callers, since the paths it rebuilds from
+ * come out of the database and only have to get there once.
+ *
+ * The same rule guards field keys in the definitions service, for the same reason.
  */
-export function storageColumnsFor(type: FieldType, value: unknown): Record<ValueColumn, string | null> {
-    const codec = storageCodecFor(type);
-    return {
-        value_text: null,
-        value_json: null,
-        [codec.column]: codec.encode(value)
-    };
+function isSafeSegment(segment: string): boolean {
+    return !(segment in Object.prototype);
+}
+
+/**
+ * The leaves a value occupies, at any depth.
+ *
+ * A part with nothing in it contributes no leaf, which is what keeps "not set" and "set
+ * to nothing" one state in storage instead of two that read alike.
+ */
+export function leavesFor(value: unknown, path: string = ROOT_PATH): Leaf[] {
+    if (typeof value === 'string') {
+        return value === '' ? [] : [{path, value_text: value}];
+    }
+
+    // Anything that is neither a string nor a record has no leaves to be made of. Saying
+    // so here rather than storing it: a row whose value is not a string is one the read
+    // path rejects and drops, so writing one loses the value silently and for good.
+    if (!isRecord(value)) {
+        throw new errors.IncorrectUsageError({
+            message: `A custom field value must be a string or a record of them, not ${value === null ? 'null' : typeof value}.`
+        });
+    }
+
+    return Object.entries(value).flatMap(([key, part]) => {
+        return leavesFor(part, path === ROOT_PATH ? key : `${path}${SEPARATOR}${key}`);
+    });
+}
+
+/** The value a set of leaves adds up to, rebuilt to whatever depth their paths describe. */
+export function valueFromLeaves(leaves: readonly Leaf[]): unknown {
+    const root = leaves.find(leaf => leaf.path === ROOT_PATH);
+    if (root) {
+        return root.value_text;
+    }
+
+    const value: Record<string, unknown> = {};
+    for (const leaf of leaves) {
+        const segments = leaf.path.split(SEPARATOR);
+        if (!segments.every(isSafeSegment)) {
+            continue;
+        }
+
+        const last = segments.pop() as string;
+        // Walk to the record this leaf hangs off, creating the ones in between. A path
+        // of one segment leaves this loop untouched and assigns straight onto the value.
+        //
+        // A segment already holding a string is replaced rather than descended into.
+        // Only a path that both is and contains another can produce that, which no
+        // value written through here does; rebuilding what the rows describe still
+        // beats throwing, because this runs over every member in a list response.
+        const parent = segments.reduce<Record<string, unknown>>((target, segment) => {
+            if (!isRecord(target[segment])) {
+                target[segment] = {};
+            }
+            return target[segment] as Record<string, unknown>;
+        }, value);
+        parent[last] = leaf.value_text;
+    }
+
+    return value;
+}
+
+/**
+ * Every member's values, keyed by member and then by field key.
+ *
+ * The other half of reading: a value is spread across as many rows as it has leaves, so
+ * they have to be gathered back together before any of them means anything. A member with
+ * no rows is absent from the result rather than present and empty.
+ */
+export function valuesFromLeaves(leaves: readonly StoredLeaf[]): Map<string, Record<string, unknown>> {
+    const byMemberAndField = new Map<string, Map<string, Leaf[]>>();
+
+    for (const {member_id: memberId, key, path, value_text: valueText} of leaves) {
+        const fields = byMemberAndField.get(memberId) ?? new Map<string, Leaf[]>();
+        const forField = fields.get(key) ?? [];
+        forField.push({path, value_text: valueText});
+        fields.set(key, forField);
+        byMemberAndField.set(memberId, fields);
+    }
+
+    const byMember = new Map<string, Record<string, unknown>>();
+    for (const [memberId, fields] of byMemberAndField) {
+        byMember.set(memberId, Object.fromEntries(
+            [...fields].map(([key, forField]) => [key, valueFromLeaves(forField)])
+        ));
+    }
+
+    return byMember;
 }

--- a/ghost/core/core/server/services/members-custom-fields/storage.ts
+++ b/ghost/core/core/server/services/members-custom-fields/storage.ts
@@ -1,27 +1,17 @@
 import errors from '@tryghost/errors';
 
-// How a value becomes rows, and rows become values again.
+// A value is a tree; the database stores one row per leaf, under the path addressing it.
+// A value with no parts is a single leaf at the root, a part is a leaf under its key, and
+// a nested part is addressed with a dotted path.
 //
-// A value is a tree and the database stores its leaves: one string per leaf, under the
-// path that addresses it. A value with no parts is a single leaf at the root; a value
-// with parts is one leaf per part, under that part's key; a part that is itself a record
-// nests, and its leaves are addressed with a dotted path. A part a member left out gets
-// no leaf, so "not set" is the absence of a row rather than a row saying nothing.
-//
-// Keeping the leaves apart rather than as one blob is what lets a segment filter reach a
-// part directly: `path = 'country' AND value_text = 'GB'` is an ordinary predicate over
-// indexed columns, where reaching inside a JSON column is not. A dotted path is the same
-// vocabulary a filter is written in, so `shipping_address.line1` is the layout rather
-// than a translation of it.
-//
-// Nothing here consults a field type. A value arrives already parsed against its own, so
-// a record's keys are exactly the parts that type declares; and a row read back is
-// rebuilt as what it was written as rather than as whatever the type says today.
+// Nothing here may consult a field type. Values arrive already parsed against their own,
+// and rows are rebuilt as what they were written as rather than as what the type says
+// today, so a type that changes shape does not rewrite what members already have.
 
-/** Separates the segments of a path, and the notation a filter addresses a part by. */
+/** Also the notation a segment filter addresses a part by, so the two cannot drift. */
 const SEPARATOR = '.';
 
-/** The path of a value's root — the whole value, for one that has no parts. Empty rather than null: a unique index does not constrain nulls, so nulls would let the same leaf be stored twice. */
+/** Empty rather than null: a unique index does not constrain nulls, which would let the same leaf be stored twice. */
 export const ROOT_PATH = '';
 
 export interface Leaf {
@@ -29,7 +19,6 @@ export interface Leaf {
     value_text: string;
 }
 
-/** A leaf as it comes back from the database, still carrying who and what it belongs to. */
 export interface StoredLeaf extends Leaf {
     member_id: string;
     key: string;
@@ -40,45 +29,31 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 /**
- * Whether a path segment can be a key of a plain object and mean only itself.
- *
- * A rebuilt value is an ordinary object, so a segment naming something every object
- * already has — `__proto__` above all — would reach the prototype instead of the value,
- * and writing through `__proto__` reaches every object in the process. No path written
- * here can contain one, because a path is built from catalog part names; this makes that
- * a property of the codec rather than of its callers, since the paths it rebuilds from
- * come out of the database and only have to get there once.
- *
- * The same rule guards field keys in the definitions service, for the same reason.
+ * Values are rebuilt into plain objects, so a segment naming something every object
+ * already has would reach the prototype instead of the value — and a write through
+ * `__proto__` reaches every object in the process. Paths come out of the database, so
+ * this holds here rather than trusting whatever put them there.
  */
 function isSafeSegment(segment: string): boolean {
     return !(segment in Object.prototype);
 }
 
-/**
- * Every leaf a value names, at any depth, including the ones it names as empty.
- *
- * Naming is the unit of a write: a path a value does not mention is left alone, and one
- * it mentions as empty is being cleared. Both readings are needed, so this reports what
- * was named and leaves the caller to say what to do about it — `leavesToWrite` splits
- * them. A stored leaf is never empty, because an empty one is a deletion.
- */
+/** Every leaf a value names, at any depth, including the ones it names as empty. */
 export function leavesFor(value: unknown, path: string = ROOT_PATH): Leaf[] {
     if (typeof value === 'string') {
         return [{path, value_text: value}];
     }
 
-    // Anything that is neither a string nor a record has no leaves to be made of. Saying
-    // so here rather than storing it: a row whose value is not a string is one the read
-    // path rejects and drops, so writing one loses the value silently and for good.
+    // Thrown rather than stored: the read path rejects a non-string row, so writing one
+    // loses the value with nothing to say it ever arrived.
     if (!isRecord(value)) {
         throw new errors.IncorrectUsageError({
             message: `A custom field value must be a string or a record of them, not ${value === null ? 'null' : typeof value}.`
         });
     }
 
-    // An undefined part is one the value does not name at all, which is not the same as
-    // naming it empty: the first leaves the stored part alone, the second removes it.
+    // Undefined means the value does not name the part, which is not the same as naming
+    // it empty: the first leaves what is stored alone, the second clears it.
     return Object.entries(value)
         .filter(([, part]) => part !== undefined)
         .flatMap(([key, part]) => leavesFor(part, path === ROOT_PATH ? key : `${path}${SEPARATOR}${key}`));
@@ -109,13 +84,9 @@ export function valueFromLeaves(leaves: readonly Leaf[]): unknown {
         }
 
         const last = segments.pop() as string;
-        // Walk to the record this leaf hangs off, creating the ones in between. A path
-        // of one segment leaves this loop untouched and assigns straight onto the value.
-        //
-        // A segment already holding a string is replaced rather than descended into.
-        // Only a path that both is and contains another can produce that, which no
-        // value written through here does; rebuilding what the rows describe still
-        // beats throwing, because this runs over every member in a list response.
+        // A segment already holding a string is replaced rather than descended into: this
+        // runs over every member of a list response, so a contradictory pair of paths
+        // should cost one odd value rather than the whole response.
         const parent = segments.reduce<Record<string, unknown>>((target, segment) => {
             if (!isRecord(target[segment])) {
                 target[segment] = {};
@@ -128,13 +99,7 @@ export function valueFromLeaves(leaves: readonly Leaf[]): unknown {
     return value;
 }
 
-/**
- * Every member's values, keyed by member and then by field key.
- *
- * The other half of reading: a value is spread across as many rows as it has leaves, so
- * they have to be gathered back together before any of them means anything. A member with
- * no rows is absent from the result rather than present and empty.
- */
+/** Every member's values, keyed by member and then field key; a member with no rows is absent. */
 export function valuesFromLeaves(leaves: readonly StoredLeaf[]): Map<string, Record<string, unknown>> {
     const byMemberAndField = new Map<string, Map<string, Leaf[]>>();
 

--- a/ghost/core/core/server/services/members-custom-fields/values-service.ts
+++ b/ghost/core/core/server/services/members-custom-fields/values-service.ts
@@ -195,6 +195,9 @@ export class CustomFieldValuesService {
             if (!field) {
                 // Unknown (or archived) key. Rejected rather than ignored: a typo
                 // that silently drops a value is worse than a failed save.
+                // Refused rather than ignored: a typo that silently drops what somebody
+                // typed is worse than a save that fails. The catalog applies the same rule
+                // one level down, to the parts of a composite value.
                 throw new errors.ValidationError({message: `Unknown custom field: ${key}`, property: `custom_fields.${key}`});
             }
 

--- a/ghost/core/core/server/services/members-custom-fields/values-service.ts
+++ b/ghost/core/core/server/services/members-custom-fields/values-service.ts
@@ -11,31 +11,19 @@ import {leavesToWrite, valuesFromLeaves, type StoredLeaf} from './storage';
 const FIELDS_TABLE = 'members_custom_fields';
 const VALUES_TABLE = 'members_custom_field_values';
 
-// Matches the `members_custom_fields.key` column (schema.js), so no key a site
-// could actually have minted is ever refused by it.
+/** Matches the `members_custom_fields.key` column, so no key a site could hold is refused. */
 const MAX_KEY_LENGTH = 191;
 
-// Rows per upsert. A member can be written up to the field limit at once and a record
-// type has a row per part, so one statement can carry several hundred: SQLite compiles a
-// multi-row upsert into a compound SELECT and stops at 500 terms.
+/** SQLite compiles a multi-row upsert into a compound SELECT and stops at 500 terms. */
 const UPSERT_CHUNK = 400;
 
-/**
- * A leaf as it is written: the table's own row, derived rather than restated so a column
- * that changes shape in `schema.ts` changes here too instead of drifting quietly.
- */
+/** Derived, not restated, so a column changing shape in `schema.ts` changes here too. */
 type DbLeafRow = z.infer<typeof DbCustomFieldValue>;
 
-// Values arrive keyed by field key. Each value stays `unknown` here: it is
-// validated by its own field type's schema, which isn't known until the key is
-// resolved to a definition.
+// Values stay `unknown`: each is validated by its own field type, which is not known
+// until the key is resolved to a definition.
 const ValuesInput = z.record(z.string().max(MAX_KEY_LENGTH), z.unknown());
 
-// The field facts the value path needs: the id to write the FK, the key to match
-// input against, the name for error messages, and the type to pick the validator
-// and storage column. All columns on members_custom_fields, so a value operation
-// resolves them with a direct query rather than routing through the definitions
-// service — the same way the read path already joins the table directly.
 interface ActiveField {
     id: string;
     key: string;
@@ -43,30 +31,20 @@ interface ActiveField {
     type: FieldType;
 }
 
-// A resolved, validated write. `value` absent means clear (delete the row).
+/** An absent `value` means clear the field. */
 interface PlannedWrite {
     field: ActiveField;
     value?: unknown;
 }
 
 /**
- * The value half of member custom fields: reading and writing what a member holds
- * for each defined field. It belongs to the member aggregate — a value is data
- * about a member — while field definitions belong to the site's settings; that
- * aggregate boundary, not a technical layer, is why this is a separate service.
- *
- * It owns the `members_custom_field_values` table and reads `members_custom_fields`
- * directly for the reference data it needs (which fields are active, and how they
- * validate), rather than calling the definitions service — the same way the other
- * knex services here talk to the database.
+ * What a member holds for each defined field. Separate from the definitions service
+ * because a value belongs to the member and a definition belongs to the site's settings,
+ * which are different aggregates rather than different layers.
  */
 export class CustomFieldValuesService {
     private knex: Knex;
-    /**
-     * @private
-     * A getter rather than a number: the ceiling is an operator setting that can
-     * change between requests.
-     */
+    /** A getter, not a number: the ceiling is an operator setting that changes between requests. */
     private getMaxDefinitions: () => number;
 
     constructor({knex, getMaxDefinitions}: {knex: Knex, getMaxDefinitions: () => number}) {
@@ -74,11 +52,6 @@ export class CustomFieldValuesService {
         this.getMaxDefinitions = getMaxDefinitions;
     }
 
-    /**
-     * The active fields for a set of keys, keyed by key, for resolving a write.
-     * Scoped to the keys the caller is actually writing rather than every active
-     * field, since a publisher may have defined many and an edit touches few.
-     */
     private async activeFieldsByKey(keys: string[]): Promise<Map<string, ActiveField>> {
         if (keys.length === 0) {
             return new Map();
@@ -90,20 +63,11 @@ export class CustomFieldValuesService {
     }
 
     /**
-     * Members' values for every active field, keyed by member id, then by field
-     * key. A member with no values is absent from the outer map; a field a member
-     * has no value for is absent from the inner one — "not set" is the absence of
-     * a key, told apart from a value by not being there. Archived fields are
-     * excluded to match the definitions `browse`: their values stay in the
-     * database, they just stop being addressable.
+     * Members' values, keyed by member id then field key; anything absent is unset.
      *
-     * One query for the whole set, so a member list can't turn into an N+1. Putting the
-     * rows back together is storage's business; this reads them and decides which ones
-     * count.
-     *
-     * Reading is best-effort per row: one that doesn't parse is dropped and logged
-     * rather than failing the whole read. Stored data outlives the catalog, so a single
-     * stale row must not take down a member's payload.
+     * Archived fields are excluded to match the definitions browse: their values stay in
+     * the database and stop being addressable. A row that will not parse is dropped and
+     * logged rather than failing the read, so one stale row cannot take down a member.
      */
     async getValuesForMembers(memberIds: string[]): Promise<Map<string, Record<string, unknown>>> {
         if (memberIds.length === 0) {
@@ -113,8 +77,6 @@ export class CustomFieldValuesService {
         const rows = await this.knex(VALUES_TABLE)
             .join(FIELDS_TABLE, `${VALUES_TABLE}.custom_field_id`, `${FIELDS_TABLE}.id`)
             .whereIn(`${VALUES_TABLE}.member_id`, memberIds)
-            // Read join, so the status filter is qualified and lives inline — it
-            // shares the invariant's vocabulary with queries.ts, not its builder.
             .where(`${FIELDS_TABLE}.status`, FIELD_STATUS.active)
             .orderBy(`${FIELDS_TABLE}.created_at`, 'asc')
             .orderBy(`${FIELDS_TABLE}.id`, 'asc')
@@ -133,12 +95,7 @@ export class CustomFieldValuesService {
         return valuesFromLeaves(leaves);
     }
 
-    /**
-     * @private
-     * Input as the values object it claims to be, rejecting anything that isn't
-     * one. Shared by every caller so they cannot disagree on what a values object
-     * is, or on the error when it isn't one.
-     */
+    /** Shared by every caller so they cannot disagree on what a values object is. */
     private parseValues(input: unknown): Record<string, unknown> {
         const parsed = ValuesInput.safeParse(input);
         if (!parsed.success) {
@@ -149,12 +106,8 @@ export class CustomFieldValuesService {
     }
 
     /**
-     * Whether input names any values. An absent key names none; anything present
-     * that isn't a values object throws, with the same error resolving it would
-     * have raised.
-     *
-     * Answers the shape question alone, with no catalog lookup, so it can be asked
-     * before a write is known to be permitted.
+     * Whether input names any values. Asks the shape question alone, with no catalog
+     * lookup, so it can be asked before a write is known to be permitted.
      */
     namesValues(input: unknown): boolean {
         if (input === undefined) {
@@ -165,20 +118,16 @@ export class CustomFieldValuesService {
     }
 
     /**
-     * Resolve input into the writes it implies, rejecting anything invalid, and
-     * writing nothing. Returned so a caller can validate before it commits to a
-     * change it would have to unwind (the member edit and the importer both validate
-     * up front, before opening a transaction), then apply the same plan without
-     * re-resolving or re-validating.
+     * Resolve input into the writes it implies, writing nothing. Returned so a caller can
+     * validate before opening a transaction it would otherwise have to unwind, then apply
+     * the same plan without re-resolving it.
      */
     async planWrite(input: unknown): Promise<PlannedWrite[]> {
         const values = this.parseValues(input);
         const keys = Object.keys(values);
 
-        // A write cannot name more fields than the site may define, so the
-        // definitions ceiling bounds it. This also holds the lookup below within the
-        // database driver's bound-parameter limit, which one key per parameter would
-        // otherwise exceed.
+        // Bounded by the definitions ceiling, which also holds the lookup below inside
+        // the driver's bound-parameter limit.
         const maxKeys = this.getMaxDefinitions();
         if (keys.length > maxKeys) {
             throw new errors.ValidationError({
@@ -193,25 +142,22 @@ export class CustomFieldValuesService {
         for (const [key, raw] of Object.entries(values)) {
             const field = byKey.get(key);
             if (!field) {
-                // Unknown (or archived) key. Rejected rather than ignored: a typo
-                // that silently drops a value is worse than a failed save.
-                // Refused rather than ignored: a typo that silently drops what somebody
-                // typed is worse than a save that fails. The catalog applies the same rule
-                // one level down, to the parts of a composite value.
+                // Unknown or archived. Refused rather than ignored: a typo that silently
+                // drops what somebody typed is worse than a save that fails. The catalog
+                // applies the same rule to the parts of a composite value.
                 throw new errors.ValidationError({message: `Unknown custom field: ${key}`, property: `custom_fields.${key}`});
             }
 
-            // `null` clears any field. An empty string clears a scalar — an emptied
-            // input — but for a value with parts '' is not a value at all, so it is
-            // left to fail validation rather than being read as a silent delete.
+            // `null` clears any field, and `''` clears one with no parts. For a value
+            // with parts `''` names nothing, so it is left to fail validation rather than
+            // being read as a silent delete.
             if (raw === null || (raw === '' && subFieldsOf(field.type) === null)) {
                 writes.push({field});
                 continue;
             }
 
-            // The field type owns what a valid value is — core just runs it. For a
-            // composite the issue path points at the offending sub-field, so the
-            // property reads `custom_fields.home_address.postal_code`.
+            // The issue path names the offending part, so `property` reads
+            // `custom_fields.home_address.postal_code`.
             const value = FIELD_TYPES[field.type].value.safeParse(raw);
             if (!value.success) {
                 const issue = value.error.issues[0];
@@ -230,19 +176,13 @@ export class CustomFieldValuesService {
     /**
      * Apply a plan from `planWrite`.
      *
-     * Merge, not replace: only the fields in the plan are touched, so a caller
-     * that doesn't know about a field can't erase it.
+     * A write touches the paths it names and nothing else, at every level: naming a path
+     * with an empty value clears that part, naming the field with `null` clears all of
+     * them, and saying nothing about a path leaves it alone. There is no whole-value
+     * replace, so a caller that does not know about a field cannot erase it.
      *
-     * That rule holds at every level, because a part of a value is a field too: a write
-     * touches the paths it names and nothing else. Naming a path with an empty value
-     * clears that one leaf; naming the field itself with `null` clears all of them.
-     *
-     * There is no whole-value replace, and there was never a reason for one beyond a blob
-     * only being writable whole. A caller that means to empty a part says so.
-     *
-     * Always transactional, so a mid-batch failure rolls the batch back. Given an
-     * executor it joins that transaction -- the importer passes its per-member one, so a
-     * failed value write takes the member with it; given none it opens its own.
+     * Always transactional. Given an executor it joins that transaction, so the importer's
+     * failed value write takes its member with it; given none it opens its own.
      */
     async applyWrite(
         memberId: string,
@@ -254,10 +194,9 @@ export class CustomFieldValuesService {
         }
 
         const apply = async (trx: Knex) => {
-            // The plan already describes everything this member is having written, so it
-            // is turned into rows first and sent as whole statements — a handful per
-            // member rather than one per part. One timestamp for the lot, too: a write
-            // happened once, however many rows record it.
+            // Built first, then sent as whole statements: a handful per member rather
+            // than one per part, under one timestamp, because a write happened once
+            // however many rows record it.
             const now = new Date();
             const clearedFields: string[] = [];
             const clearedPaths: Array<{fieldId: string, paths: string[]}> = [];
@@ -290,8 +229,7 @@ export class CustomFieldValuesService {
             }
 
             if (clearedPaths.length > 0) {
-                // Each field clears its own paths, so the pairs go in one statement as a
-                // group per field rather than a statement per field.
+                // One statement with a group per field, rather than a statement per field.
                 await trx(VALUES_TABLE).where('member_id', memberId).where((builder) => {
                     for (const {fieldId, paths} of clearedPaths) {
                         builder.orWhere(pair => pair.where('custom_field_id', fieldId).whereIn('path', paths));
@@ -300,22 +238,19 @@ export class CustomFieldValuesService {
             }
 
             for (let from = 0; from < rows.length; from += UPSERT_CHUNK) {
-                // Typed as the plain row rather than through the registered table type:
-                // `merge` takes its column list as `keyof` the builder's record, and for a
-                // composite registration that is the scope names rather than the columns.
+                // Typed as the plain row because `merge` takes its columns as `keyof` the
+                // builder's record, which for a composite table registration is the scope
+                // names rather than the columns.
                 await trx<DbLeafRow>(VALUES_TABLE)
                     .insert(rows.slice(from, from + UPSERT_CHUNK))
-                    // The unique index on (member_id, custom_field_id, path) is what makes
-                    // this an upsert per part rather than a read-then-write race. Naming
-                    // the columns rather than giving values takes each from the row that
-                    // lost the conflict, so every part still updates to its own value.
+                    // Naming the columns rather than giving values takes each from the row
+                    // that lost the conflict, so every part updates to its own value.
                     .onConflict(['member_id', 'custom_field_id', 'path'])
                     .merge(['value_text', 'updated_at']);
             }
         };
 
-        // isTransaction is knex's marker for a transactor: join an existing transaction
-        // rather than nesting a savepoint under it, otherwise open one.
+        // knex's marker for a transactor: join it rather than nesting a savepoint under it.
         if (executor.isTransaction) {
             await apply(executor);
         } else {

--- a/ghost/core/core/server/services/members-custom-fields/values-service.ts
+++ b/ghost/core/core/server/services/members-custom-fields/values-service.ts
@@ -4,9 +4,9 @@ import logging from '@tryghost/logging';
 import type {Knex} from 'knex';
 import {z} from 'zod';
 import {FIELD_TYPES, subFieldsOf, type FieldType} from '@tryghost/custom-field-types';
-import {DbCustomFieldValueWithField, FIELD_STATUS, StoredCompositeValue} from './schema';
+import {DbCustomFieldLeaf, FIELD_STATUS} from './schema';
 import {activeFields} from './queries';
-import {storageCodecFor, storageColumnsFor} from './storage';
+import {leavesFor, valuesFromLeaves, type StoredLeaf} from './storage';
 
 const FIELDS_TABLE = 'members_custom_fields';
 const VALUES_TABLE = 'members_custom_field_values';
@@ -19,21 +19,6 @@ const MAX_KEY_LENGTH = 191;
 // validated by its own field type's schema, which isn't known until the key is
 // resolved to a definition.
 const ValuesInput = z.record(z.string().max(MAX_KEY_LENGTH), z.unknown());
-
-// JSON.parse as a total function. Anything unreadable — unparseable text, or the null
-// a nullable column can always return — reads as `undefined`, which no value schema
-// accepts. That way a corrupt blob is turned away by the same check that turns away a
-// well-formed one of the wrong shape, instead of needing a branch of its own.
-function decodeJson(raw: string | null): unknown {
-    if (raw === null) {
-        return undefined;
-    }
-    try {
-        return JSON.parse(raw);
-    } catch {
-        return undefined;
-    }
-}
 
 // The field facts the value path needs: the id to write the FK, the key to match
 // input against, the name for error messages, and the type to pick the validator
@@ -101,17 +86,17 @@ export class CustomFieldValuesService {
      * excluded to match the definitions `browse`: their values stay in the
      * database, they just stop being addressable.
      *
-     * One query for the whole set, so a member list can't turn into an N+1.
+     * One query for the whole set, so a member list can't turn into an N+1. Putting the
+     * rows back together is storage's business; this reads them and decides which ones
+     * count.
      *
-     * Reading is best-effort per value: a stored value whose type has since left
-     * the catalog, or that won't decode, is omitted and logged rather than failing
-     * the whole read. Stored data outlives the catalog, so one stale row must not
-     * take down a member's payload.
+     * Reading is best-effort per row: one that doesn't parse is dropped and logged
+     * rather than failing the whole read. Stored data outlives the catalog, so a single
+     * stale row must not take down a member's payload.
      */
     async getValuesForMembers(memberIds: string[]): Promise<Map<string, Record<string, unknown>>> {
-        const byMember = new Map<string, Record<string, unknown>>();
         if (memberIds.length === 0) {
-            return byMember;
+            return new Map();
         }
 
         const rows = await this.knex(VALUES_TABLE)
@@ -122,27 +107,19 @@ export class CustomFieldValuesService {
             .where(`${FIELDS_TABLE}.status`, FIELD_STATUS.active)
             .orderBy(`${FIELDS_TABLE}.created_at`, 'asc')
             .orderBy(`${FIELDS_TABLE}.id`, 'asc')
-            .select(`${VALUES_TABLE}.member_id`, `${FIELDS_TABLE}.key`, `${FIELDS_TABLE}.type`, `${VALUES_TABLE}.value_text`, `${VALUES_TABLE}.value_json`);
+            .orderBy(`${VALUES_TABLE}.path`, 'asc')
+            .select(`${VALUES_TABLE}.member_id`, `${FIELDS_TABLE}.key`, `${FIELDS_TABLE}.type`, `${VALUES_TABLE}.path`, `${VALUES_TABLE}.value_text`);
 
+        const leaves: StoredLeaf[] = [];
         for (const row of rows) {
             try {
-                const {member_id: memberId, key, type, ...stored} = DbCustomFieldValueWithField.parse(row);
-                const codec = storageCodecFor(type);
-                const raw = stored[codec.column];
-                // The column the type routes to is the only one that can hold this
-                // field's value; a null there means the row is not carrying one.
-                if (raw === null) {
-                    continue;
-                }
-                const values = byMember.get(memberId) ?? {};
-                values[key] = codec.decode(raw);
-                byMember.set(memberId, values);
+                leaves.push(DbCustomFieldLeaf.parse(row));
             } catch (err) {
-                logging.warn(`Skipping undecodable custom field value (field '${row.key}', type '${row.type}'): ${err instanceof Error ? err.message : String(err)}`);
+                logging.warn(`Skipping unreadable custom field value (field '${row.key}', path '${row.path}'): ${err instanceof Error ? err.message : String(err)}`);
             }
         }
 
-        return byMember;
+        return valuesFromLeaves(leaves);
     }
 
     /**
@@ -210,11 +187,10 @@ export class CustomFieldValuesService {
                 throw new errors.ValidationError({message: `Unknown custom field: ${key}`, property: `custom_fields.${key}`});
             }
 
-            // `null` clears any field. An empty string clears a text-backed field —
-            // an emptied input — but for any other storage type '' is a value to
-            // validate, not a clear, so nothing is coerced: a string sent to a
-            // (future) non-text field fails validation rather than silently deleting.
-            if (raw === null || (raw === '' && FIELD_TYPES[field.type].storageType === 'text')) {
+            // `null` clears any field. An empty string clears a scalar — an emptied
+            // input — but for a value with parts '' is not a value at all, so it is
+            // left to fail validation rather than being read as a silent delete.
+            if (raw === null || (raw === '' && subFieldsOf(field.type) === null)) {
                 writes.push({field});
                 continue;
             }
@@ -238,125 +214,38 @@ export class CustomFieldValuesService {
     }
 
     /**
-     * @private
-     * The composite values this member already holds for the fields in a plan,
-     * keyed by field id. Composites only: a scalar has nothing to merge into.
-     *
-     * Read through the caller's executor, never the base connection. On a
-     * single-connection pool a read off `this.knex` inside an open transaction
-     * waits for the connection that transaction is holding, and hangs.
-     *
-     * A blob that won't decode is left out, so the write replaces it rather than
-     * merging into something unreadable.
-     */
-    private async storedComposites(trx: Knex, memberId: string, writes: PlannedWrite[]): Promise<Map<string, Record<string, unknown>>> {
-        const composites = new Map<string, Record<string, unknown>>();
-        // Merging is only meaningful for a value with parts, which is a fact about the
-        // type's shape rather than the column it lands in. Asking the storage type
-        // instead would sweep in the first json-backed type that isn't a record — a
-        // multi-select held as a list, say — and log a decode failure for every row of
-        // an import, over a value that reads back perfectly well.
-        const fieldIds = writes
-            .filter(({field, value}) => value !== undefined && subFieldsOf(field.type) !== null)
-            .map(({field}) => field.id);
-
-        if (fieldIds.length === 0) {
-            return composites;
-        }
-
-        const rows = await trx(VALUES_TABLE)
-            .where('member_id', memberId)
-            .whereIn('custom_field_id', fieldIds)
-            .whereNotNull('value_json')
-            .select('custom_field_id', 'value_json')
-            // Merging reads a value and writes it back, so the row has to stay still in
-            // between: without the lock a write committing after this read is overwritten
-            // by the sub-fields it just replaced. knex omits this on SQLite, which needs
-            // no lock — its pool is a single connection, so writes never overlap.
-            .forUpdate();
-
-        for (const row of rows) {
-            // The blob is the edge here: the columns come from a query written just
-            // above, but whatever an earlier write left in value_json is unknown until
-            // it is read back. Parsing it is what narrows the type, and it rejects the
-            // array, null or bare number the column could equally be holding.
-            const stored = StoredCompositeValue.safeParse(decodeJson(row.value_json));
-            if (stored.success) {
-                composites.set(row.custom_field_id, stored.data);
-                continue;
-            }
-            logging.warn(`Replacing an unreadable custom field value rather than merging into it (member '${memberId}', field '${row.custom_field_id}').`);
-        }
-
-        return composites;
-    }
-
-    /**
-     * @private
-     * The stored sub-fields with the incoming ones written over them, re-checked
-     * against the field type before it is handed back.
-     *
-     * The re-check is what makes this safe to write without a second thought. Both
-     * halves were valid when they were written, but "valid" is a moving target: the
-     * stored half may predate a change to the type, so it can carry a sub-field the
-     * type has since dropped or a bound it has since tightened. Parsing the result
-     * strips what no longer belongs instead of faithfully persisting it on every
-     * import from here on.
-     *
-     * A merged value that won't parse falls back to the incoming value alone rather
-     * than failing. The row is trying to write something valid, and refusing it over
-     * data that was already in the database punishes the wrong write.
-     */
-    private mergeComposite(field: ActiveField, existing: Record<string, unknown>, incoming: Record<string, unknown>): unknown {
-        const merged = FIELD_TYPES[field.type].value.safeParse({...existing, ...incoming});
-        if (merged.success) {
-            return merged.data;
-        }
-
-        logging.warn(`Replacing a custom field value that no longer validates rather than merging into it (field '${field.key}').`);
-        return incoming;
-    }
-
-    /**
      * Apply a plan from `planWrite`.
      *
      * Merge, not replace: only the fields in the plan are touched, so a caller
      * that doesn't know about a field can't erase it.
      *
-     * `mergeComposites` extends that same rule from a field to a composite's
-     * sub-fields, because a sub-field is a field: a row writes the sub-fields it
-     * fills and leaves the rest alone, exactly as a blank `name` column leaves a
-     * member's name alone. The CSV import needs it — without it a file naming one
-     * address column would replace the whole address, clearing five sub-fields it
-     * never mentioned. The API does not merge: a PUT sends a whole address, so
-     * what it sends is what should be stored.
+     * `mergeComposites` extends that same rule from a field to a composite's parts,
+     * because a part is a field: a row writes the parts it fills and leaves the rest
+     * alone, exactly as a blank `name` column leaves a member's name alone. The CSV
+     * import needs it — without it a file naming one address column would clear five
+     * parts it never mentioned. The API does not merge: a request there sends a whole
+     * address, so what it sends is what should be stored.
      *
-     * The merge is asked for here rather than at plan time, where the caller's intent
-     * is otherwise expressed, because it cannot happen before a transaction is open:
-     * it reads the stored value and writes it back, and the row lock that keeps those
-     * two steps together only exists inside the transaction. `planWrite` runs before
-     * one is opened -- the importer plans a row, then opens a transaction per member --
-     * so a merge decided there would have to read outside the lock it depends on.
+     * It is asked for here rather than at plan time only because that is where it has
+     * always been asked for. It used to have to be: merging read the stored value and
+     * wrote it back under a lock that exists only inside the transaction. Neither branch
+     * reads anything now, so this could move to `planWrite` alongside the rest of what a
+     * caller is asking for, and probably should when something else touches it.
      *
-     * Always transactional, so a mid-batch failure rolls the batch back. Passed an
+     * Always transactional, so a mid-batch failure rolls the batch back. Given an
      * executor it joins that transaction -- the importer passes its per-member one, so a
-     * failed value write takes the member with it; passed nothing it opens its own.
+     * failed value write takes the member with it; given none it opens its own.
      */
     async applyWrite(
         memberId: string,
         writes: PlannedWrite[],
-        executor: Knex = this.knex,
-        {mergeComposites = false}: {mergeComposites?: boolean} = {}
+        {executor = this.knex, mergeComposites = false}: {executor?: Knex, mergeComposites?: boolean} = {}
     ): Promise<void> {
         if (writes.length === 0) {
             return;
         }
 
         const apply = async (trx: Knex) => {
-            const stored = mergeComposites
-                ? await this.storedComposites(trx, memberId, writes)
-                : new Map<string, Record<string, unknown>>();
-
             for (const {field, value} of writes) {
                 const target = {member_id: memberId, custom_field_id: field.id};
 
@@ -365,24 +254,30 @@ export class CustomFieldValuesService {
                     continue;
                 }
 
-                // Both sides of the merge go through the same shape check, so it joins
-                // two objects the type system knows about rather than two assertions.
-                // The plan already validated `value` against its field type, so for a
-                // composite this parse cannot fail; a scalar simply doesn't match, and
-                // falls through to being written as it stands.
-                const existing = stored.get(field.id);
-                const incoming = StoredCompositeValue.safeParse(value);
-                const merged = existing && incoming.success
-                    ? this.mergeComposite(field, existing, incoming.data)
-                    : value;
+                const leaves = leavesFor(value);
 
-                const valueColumns = storageColumnsFor(field.type, merged);
-                await trx(VALUES_TABLE)
-                    .insert({id: new ObjectID().toHexString(), ...target, ...valueColumns, created_at: new Date()})
-                    // The unique index on (member_id, custom_field_id) is
-                    // what makes this an upsert rather than a read-then-write race.
-                    .onConflict(['member_id', 'custom_field_id'])
-                    .merge({...valueColumns, updated_at: new Date()});
+                if (!mergeComposites) {
+                    // Replacing: the parts this value does not fill should not survive it.
+                    // Scoped to the paths being written so the upsert below still owns the
+                    // rows it is about to touch.
+                    await trx(VALUES_TABLE)
+                        .where(target)
+                        .whereNotIn('path', leaves.map(leaf => leaf.path))
+                        .del();
+                }
+
+                // One statement per part. Batching them would mean naming the columns to
+                // take from the row that lost the conflict, and each part needs its own
+                // value, so the merge could not be written as one object — a part at a
+                // time keeps the write plain and the timestamps right.
+                for (const leaf of leaves) {
+                    await trx(VALUES_TABLE)
+                        .insert({id: new ObjectID().toHexString(), ...target, ...leaf, created_at: new Date()})
+                        // The unique index on (member_id, custom_field_id, path) is what
+                        // makes this an upsert per part rather than a read-then-write race.
+                        .onConflict(['member_id', 'custom_field_id', 'path'])
+                        .merge({value_text: leaf.value_text, updated_at: new Date()});
+                }
             }
         };
 

--- a/ghost/core/core/server/services/members-custom-fields/values-service.ts
+++ b/ghost/core/core/server/services/members-custom-fields/values-service.ts
@@ -14,7 +14,15 @@ const VALUES_TABLE = 'members_custom_field_values';
 /** Matches the `members_custom_fields.key` column, so no key a site could hold is refused. */
 const MAX_KEY_LENGTH = 191;
 
-/** SQLite compiles a multi-row upsert into a compound SELECT and stops at 500 terms. */
+/**
+ * Rows per insert statement, bounded by knex rather than by either database. SQLite takes
+ * a multi-row `VALUES` perfectly well; knex's SQLite dialect emits that form only for a
+ * single row and compiles anything longer into `INSERT ... SELECT ? UNION ALL SELECT ?`,
+ * which SQLite refuses past 500 terms.
+ *
+ * Open as knex#721 since 2015, with an approved but unmerged fix in knex#5780. This can
+ * go when that lands; until then the alternative is hand-written upsert SQL per engine.
+ */
 const UPSERT_CHUNK = 400;
 
 /** Derived, not restated, so a column changing shape in `schema.ts` changes here too. */

--- a/ghost/core/core/server/services/members-custom-fields/values-service.ts
+++ b/ghost/core/core/server/services/members-custom-fields/values-service.ts
@@ -4,9 +4,9 @@ import logging from '@tryghost/logging';
 import type {Knex} from 'knex';
 import {z} from 'zod';
 import {FIELD_TYPES, subFieldsOf, type FieldType} from '@tryghost/custom-field-types';
-import {DbCustomFieldLeaf, FIELD_STATUS} from './schema';
+import {DbCustomFieldLeaf, DbCustomFieldValue, FIELD_STATUS} from './schema';
 import {activeFields} from './queries';
-import {leavesFor, valuesFromLeaves, type StoredLeaf} from './storage';
+import {leavesToWrite, valuesFromLeaves, type StoredLeaf} from './storage';
 
 const FIELDS_TABLE = 'members_custom_fields';
 const VALUES_TABLE = 'members_custom_field_values';
@@ -14,6 +14,17 @@ const VALUES_TABLE = 'members_custom_field_values';
 // Matches the `members_custom_fields.key` column (schema.js), so no key a site
 // could actually have minted is ever refused by it.
 const MAX_KEY_LENGTH = 191;
+
+// Rows per upsert. A member can be written up to the field limit at once and a record
+// type has a row per part, so one statement can carry several hundred: SQLite compiles a
+// multi-row upsert into a compound SELECT and stops at 500 terms.
+const UPSERT_CHUNK = 400;
+
+/**
+ * A leaf as it is written: the table's own row, derived rather than restated so a column
+ * that changes shape in `schema.ts` changes here too instead of drifting quietly.
+ */
+type DbLeafRow = z.infer<typeof DbCustomFieldValue>;
 
 // Values arrive keyed by field key. Each value stays `unknown` here: it is
 // validated by its own field type's schema, which isn't known until the key is
@@ -219,18 +230,12 @@ export class CustomFieldValuesService {
      * Merge, not replace: only the fields in the plan are touched, so a caller
      * that doesn't know about a field can't erase it.
      *
-     * `mergeComposites` extends that same rule from a field to a composite's parts,
-     * because a part is a field: a row writes the parts it fills and leaves the rest
-     * alone, exactly as a blank `name` column leaves a member's name alone. The CSV
-     * import needs it — without it a file naming one address column would clear five
-     * parts it never mentioned. The API does not merge: a request there sends a whole
-     * address, so what it sends is what should be stored.
+     * That rule holds at every level, because a part of a value is a field too: a write
+     * touches the paths it names and nothing else. Naming a path with an empty value
+     * clears that one leaf; naming the field itself with `null` clears all of them.
      *
-     * It is asked for here rather than at plan time only because that is where it has
-     * always been asked for. It used to have to be: merging read the stored value and
-     * wrote it back under a lock that exists only inside the transaction. Neither branch
-     * reads anything now, so this could move to `planWrite` alongside the rest of what a
-     * caller is asking for, and probably should when something else touches it.
+     * There is no whole-value replace, and there was never a reason for one beyond a blob
+     * only being writable whole. A caller that means to empty a part says so.
      *
      * Always transactional, so a mid-batch failure rolls the batch back. Given an
      * executor it joins that transaction -- the importer passes its per-member one, so a
@@ -239,45 +244,70 @@ export class CustomFieldValuesService {
     async applyWrite(
         memberId: string,
         writes: PlannedWrite[],
-        {executor = this.knex, mergeComposites = false}: {executor?: Knex, mergeComposites?: boolean} = {}
+        {executor = this.knex}: {executor?: Knex} = {}
     ): Promise<void> {
         if (writes.length === 0) {
             return;
         }
 
         const apply = async (trx: Knex) => {
-            for (const {field, value} of writes) {
-                const target = {member_id: memberId, custom_field_id: field.id};
+            // The plan already describes everything this member is having written, so it
+            // is turned into rows first and sent as whole statements — a handful per
+            // member rather than one per part. One timestamp for the lot, too: a write
+            // happened once, however many rows record it.
+            const now = new Date();
+            const clearedFields: string[] = [];
+            const clearedPaths: Array<{fieldId: string, paths: string[]}> = [];
+            const rows: DbLeafRow[] = [];
 
+            for (const {field, value} of writes) {
                 if (value === undefined) {
-                    await trx(VALUES_TABLE).where(target).del();
+                    clearedFields.push(field.id);
                     continue;
                 }
 
-                const leaves = leavesFor(value);
-
-                if (!mergeComposites) {
-                    // Replacing: the parts this value does not fill should not survive it.
-                    // Scoped to the paths being written so the upsert below still owns the
-                    // rows it is about to touch.
-                    await trx(VALUES_TABLE)
-                        .where(target)
-                        .whereNotIn('path', leaves.map(leaf => leaf.path))
-                        .del();
+                const {set, cleared} = leavesToWrite(value);
+                if (cleared.length > 0) {
+                    clearedPaths.push({fieldId: field.id, paths: cleared});
                 }
 
-                // One statement per part. Batching them would mean naming the columns to
-                // take from the row that lost the conflict, and each part needs its own
-                // value, so the merge could not be written as one object — a part at a
-                // time keeps the write plain and the timestamps right.
-                for (const leaf of leaves) {
-                    await trx(VALUES_TABLE)
-                        .insert({id: new ObjectID().toHexString(), ...target, ...leaf, created_at: new Date()})
-                        // The unique index on (member_id, custom_field_id, path) is what
-                        // makes this an upsert per part rather than a read-then-write race.
-                        .onConflict(['member_id', 'custom_field_id', 'path'])
-                        .merge({value_text: leaf.value_text, updated_at: new Date()});
-                }
+                rows.push(...set.map(leaf => ({
+                    id: new ObjectID().toHexString(),
+                    member_id: memberId,
+                    custom_field_id: field.id,
+                    path: leaf.path,
+                    value_text: leaf.value_text,
+                    created_at: now,
+                    updated_at: now
+                })));
+            }
+
+            if (clearedFields.length > 0) {
+                await trx(VALUES_TABLE).where('member_id', memberId).whereIn('custom_field_id', clearedFields).del();
+            }
+
+            if (clearedPaths.length > 0) {
+                // Each field clears its own paths, so the pairs go in one statement as a
+                // group per field rather than a statement per field.
+                await trx(VALUES_TABLE).where('member_id', memberId).where((builder) => {
+                    for (const {fieldId, paths} of clearedPaths) {
+                        builder.orWhere(pair => pair.where('custom_field_id', fieldId).whereIn('path', paths));
+                    }
+                }).del();
+            }
+
+            for (let from = 0; from < rows.length; from += UPSERT_CHUNK) {
+                // Typed as the plain row rather than through the registered table type:
+                // `merge` takes its column list as `keyof` the builder's record, and for a
+                // composite registration that is the scope names rather than the columns.
+                await trx<DbLeafRow>(VALUES_TABLE)
+                    .insert(rows.slice(from, from + UPSERT_CHUNK))
+                    // The unique index on (member_id, custom_field_id, path) is what makes
+                    // this an upsert per part rather than a read-then-write race. Naming
+                    // the columns rather than giving values takes each from the row that
+                    // lost the conflict, so every part still updates to its own value.
+                    .onConflict(['member_id', 'custom_field_id', 'path'])
+                    .merge(['value_text', 'updated_at']);
             }
         };
 

--- a/ghost/core/core/server/services/members/import-export/import/importer.ts
+++ b/ghost/core/core/server/services/members/import-export/import/importer.ts
@@ -99,8 +99,7 @@ type CustomFieldPlan = unknown;
 // The custom fields collaborator as the import needs it. activeFields is the field set a
 // custom_fields.* column is read against, empty when the feature is off; planWrite
 // validates a row's values (throwing so the row fails whole) and applyWrite persists
-// them, merging a composite's sub-fields into whatever is already stored, both on the
-// row's transaction.
+// them, touching only the parts the row named, both on the row's transaction.
 export interface CustomFieldsImport {
     activeFields(): Promise<CsvField[]>;
     planWrite(values: Record<string, unknown>): Promise<CustomFieldPlan[]>;

--- a/ghost/core/core/server/services/members/import-export/index.ts
+++ b/ghost/core/core/server/services/members/import-export/index.ts
@@ -33,7 +33,7 @@ interface ImporterServices {
         definitions: {browse(): Promise<CsvField[]>};
         values: {
             planWrite(values: Record<string, unknown>): Promise<unknown[]>;
-            applyWrite(memberId: string, plan: unknown[], options?: {executor?: Knex, mergeComposites?: boolean}): Promise<void>;
+            applyWrite(memberId: string, plan: unknown[], options?: {executor?: Knex}): Promise<void>;
         };
     };
 }
@@ -87,11 +87,7 @@ export function makeImporter(deps: ImporterServices) {
     const customFields: CustomFieldsImport = {
         activeFields: async () => (labs.isSet('membersCustomFields') ? deps.customFields.definitions.browse() : []),
         planWrite: values => deps.customFields.values.planWrite(values),
-        // mergeComposites: a sub-field is a field, so a row writes the sub-fields it fills
-        // and leaves the rest alone, the same rule a blank `name` column follows. Without
-        // it a file naming one address column would replace the whole address, clearing
-        // five sub-fields it never mentioned.
-        applyWrite: (memberId, plan, executor) => deps.customFields.values.applyWrite(memberId, plan, {executor, mergeComposites: true})
+        applyWrite: (memberId, plan, executor) => deps.customFields.values.applyWrite(memberId, plan, {executor})
     };
 
     return new MembersCSVImporter({

--- a/ghost/core/core/server/services/members/import-export/index.ts
+++ b/ghost/core/core/server/services/members/import-export/index.ts
@@ -33,7 +33,7 @@ interface ImporterServices {
         definitions: {browse(): Promise<CsvField[]>};
         values: {
             planWrite(values: Record<string, unknown>): Promise<unknown[]>;
-            applyWrite(memberId: string, plan: unknown[], executor: Knex, options?: {mergeComposites?: boolean}): Promise<void>;
+            applyWrite(memberId: string, plan: unknown[], options?: {executor?: Knex, mergeComposites?: boolean}): Promise<void>;
         };
     };
 }
@@ -91,7 +91,7 @@ export function makeImporter(deps: ImporterServices) {
         // and leaves the rest alone, the same rule a blank `name` column follows. Without
         // it a file naming one address column would replace the whole address, clearing
         // five sub-fields it never mentioned.
-        applyWrite: (memberId, plan, executor) => deps.customFields.values.applyWrite(memberId, plan, executor, {mergeComposites: true})
+        applyWrite: (memberId, plan, executor) => deps.customFields.values.applyWrite(memberId, plan, {executor, mergeComposites: true})
     };
 
     return new MembersCSVImporter({

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ghost",
-    "version": "6.56.1-rc.0",
+    "version": "6.57.0-rc.0",
     "description": "The professional publishing platform",
     "author": "Ghost Foundation",
     "homepage": "https://ghost.org",

--- a/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
@@ -1144,13 +1144,21 @@ describe('Member Custom Fields Admin API', function () {
             assert.equal(body.errors[0].property, `custom_fields.${field.key}`);
         });
 
-        it('strips unknown sub-fields of a composite value', async function () {
+        it('refuses a part of a composite value it does not recognise', async function () {
             const field = await createField({name: 'Home address', type: 'address'});
             const memberId = await createMember();
             const address = {line1: '62 Ghost Lane', city: 'Dublin', postal_code: 'D02', country: 'IE'};
 
-            await setValues(memberId, {[field.key]: {...address, sneaky: 'x'}});
+            await setValues(memberId, {[field.key]: address});
 
+            // The same answer an unknown field key gets, one level down. A misspelled part
+            // used to be dropped in silence, which loses what somebody typed and tells
+            // them it saved.
+            const body = await setValues(memberId, {[field.key]: {...address, city: 'Cork', citty: 'Dublin'}}, 422);
+            assert.equal(body.errors[0].property, `custom_fields.${field.key}`);
+
+            // The parts it named alongside the typo are not written either: a refused write
+            // leaves what was already stored exactly as it was.
             assert.deepEqual(await readValues(memberId), {[field.key]: address});
         });
 

--- a/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
@@ -1094,6 +1094,18 @@ describe('Member Custom Fields Admin API', function () {
             assert.deepEqual(await readValues(memberId), {[field.key]: {city: 'Bristol', country: 'GB'}});
         });
 
+        it('drops a part sent as an empty string rather than storing it as one', async function () {
+            const field = await createField({name: 'Home address', type: 'address'});
+            const memberId = await createMember();
+
+            // A part with nothing in it gets no row, so it reads back absent rather than
+            // present-and-empty. That is the whole point of a row per part: there is no
+            // place to record "this part is empty" separately from "this part is unset".
+            await setValues(memberId, {[field.key]: {line1: '62 Ghost Lane', city: ''}});
+
+            assert.deepEqual(await readValues(memberId), {[field.key]: {line1: '62 Ghost Lane'}});
+        });
+
         it('rejects an address with nothing in it', async function () {
             const field = await createField({name: 'Home address', type: 'address'});
             const memberId = await createMember();

--- a/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
@@ -1072,17 +1072,46 @@ describe('Member Custom Fields Admin API', function () {
             assert.deepEqual(await readValues(memberId), {[field.key]: address});
         });
 
-        it('replaces a stored address rather than merging into it', async function () {
+        it('writes the parts a request names and leaves the rest alone', async function () {
             const field = await createField({name: 'Home address', type: 'address'});
             const memberId = await createMember();
 
             await setValues(memberId, {[field.key]: {line1: '62 Ghost Lane', city: 'Dublin', country: 'IE'}});
             await setValues(memberId, {[field.key]: {city: 'Cork'}});
 
-            // A PUT sends a whole address, so what it sends is what is stored. The CSV
-            // import is the one caller that merges, because a file carries only the
-            // columns the publisher exported.
-            assert.deepEqual(await readValues(memberId), {[field.key]: {city: 'Cork'}});
+            // A part of a value is a field, so the rule is the same one level down as it
+            // is one level up: naming a field writes it and omitting one leaves it.
+            assert.deepEqual(await readValues(memberId), {
+                [field.key]: {line1: '62 Ghost Lane', city: 'Cork', country: 'IE'}
+            });
+        });
+
+        it('clears the part a request names as empty', async function () {
+            const field = await createField({name: 'Home address', type: 'address'});
+            const memberId = await createMember();
+
+            await setValues(memberId, {[field.key]: {line1: '62 Ghost Lane', city: 'Dublin', country: 'IE'}});
+            await setValues(memberId, {[field.key]: {city: ''}});
+
+            // Emptying is said out loud, because absence already means "no change".
+            assert.deepEqual(await readValues(memberId), {
+                [field.key]: {line1: '62 Ghost Lane', country: 'IE'}
+            });
+        });
+
+        it('clears a part whose rule is a format, not only one bounded by length', async function () {
+            const field = await createField({name: 'Home address', type: 'address'});
+            const memberId = await createMember();
+
+            await setValues(memberId, {[field.key]: {line1: '62 Ghost Lane', city: 'Dublin', country: 'IE'}});
+            await setValues(memberId, {[field.key]: {country: ''}});
+
+            // Every part clears the same way. A country's rule is a pattern that nothing
+            // empty can match, so a rule per part would make this the one part a member
+            // could be given but never rid of.
+            assert.deepEqual(await readValues(memberId), {
+                [field.key]: {line1: '62 Ghost Lane', city: 'Dublin'}
+            });
         });
 
         it('stores a country code in one case whichever case it arrives in', async function () {

--- a/ghost/core/test/e2e-api/admin/members-import-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/members-import-custom-fields.test.ts
@@ -52,6 +52,16 @@ describe('Members import — custom fields', function () {
         return res.body.members.find((m: {email: string}) => m.email === email);
     };
 
+    // The rows behind a member's values, which is the only place the storage model is
+    // visible: the API hands back an assembled value either way.
+    const storedLeaves = async (email: string): Promise<Array<{path: string, value_text: string}>> => {
+        const member = await findMember(email);
+        return models.Base.knex('members_custom_field_values')
+            .where('member_id', member.id)
+            .orderBy('path')
+            .select('path', 'value_text');
+    };
+
     beforeAll(async function () {
         await localUtils.startGhost();
         request = supertest.agent(config.get('url'));
@@ -216,41 +226,29 @@ describe('Members import — custom fields', function () {
         assert.equal(member.custom_fields?.[key], undefined, 'the whitespace cell set no address');
     });
 
-    // The stored blob is the one thing a merge cannot take on trust: it was written by
-    // older code, by a migration, or by hand. Anything that will not read back as a record
-    // is replaced rather than merged into, so a bad row can neither fail the import nor
-    // leak into the value that replaces it.
-    for (const [shape, stored] of [
-        ['an array', '[1,2]'],
-        ['a bare number', '42'],
-        ['a null', 'null'],
-        ['unparseable text', 'not json at all']
-    ] as const) {
-        it(`replaces a stored address holding ${shape} rather than merging into it`, async function () {
-            const key = await createField('Shipping Address', 'address');
-            const email = `cf-corrupt-${shape.replace(/\s+/g, '-')}@example.com`;
-            const columns = ['line1', 'city'].map(sub => `custom_fields.${key}.${sub}`).join(',');
+    // The parts of an address are rows, so an import that names one column touches one
+    // row and leaves its siblings where they are. Asserting the rows rather than the
+    // assembled value is what pins the storage itself: read back through the API these
+    // two cases look identical.
+    it('writes one row per part, and touches only the parts a file names', async function () {
+        const key = await createField('Shipping Address', 'address');
+        const email = 'cf-leaf-rows@example.com';
+        const columns = ['line1', 'city', 'country'].map(sub => `custom_fields.${key}.${sub}`).join(',');
 
-            await importCSV(`email,${columns}\n${email},1 High Street,London\n`);
-            // Scoped to this member: an unqualified update would corrupt every value row
-            // the suite holds, and the damage would surface as an unrelated test failing
-            // in whatever order the runner happened to pick.
-            const corrupted = await findMember(email);
-            await models.Base.knex('members_custom_field_values')
-                .where('member_id', corrupted.id)
-                .update({value_json: stored});
+        await importCSV(`email,${columns}\n${email},1 High Street,London,GB\n`);
+        assert.deepEqual(await storedLeaves(email), [
+            {path: 'city', value_text: 'London'},
+            {path: 'country', value_text: 'GB'},
+            {path: 'line1', value_text: '1 High Street'}
+        ]);
 
-            const res = await importCSV(`email,custom_fields.${key}.city\n${email},Bristol\n`);
-            assert.equal(res.status, 201);
-            assert.equal(res.body.meta.stats.imported, 1);
-
-            assert.deepEqual(
-                (await findMember(email)).custom_fields?.[key],
-                {city: 'Bristol'},
-                'the unreadable value was replaced, not merged into'
-            );
-        });
-    }
+        await importCSV(`email,custom_fields.${key}.city\n${email},Bristol\n`);
+        assert.deepEqual(await storedLeaves(email), [
+            {path: 'city', value_text: 'Bristol'},
+            {path: 'country', value_text: 'GB'},
+            {path: 'line1', value_text: '1 High Street'}
+        ], 'only the named part moved');
+    });
 
     // A composite can still be invalid, and when it is the whole row fails like any other.
     it('fails a row whose address has a malformed sub-field', async function () {

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const parseYaml = require('../../../../../core/server/services/route-settings/ya
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '47fc91e205277e2c751ff58592785240';
+    const currentSchemaHash = 'f5780f506a6a4f2597e48ef2c267ce72';
     const currentFixturesHash = '4e0c7b4fe3c1593e9d1fae1a891389ca';
     const currentSettingsHash = '8650db85b9a61afe4797ad6333066c62';
     const currentRoutesHash = 'd8c25fa01bf6d22a2bcb05ba0de70dc1';

--- a/ghost/core/test/unit/server/data/schema/schema.test.js
+++ b/ghost/core/test/unit/server/data/schema/schema.test.js
@@ -78,6 +78,55 @@ describe('schema validations', function () {
         });
     });
 
+    // MySQL rejects an identifier over 64 characters, and knex derives index and
+    // constraint names from the table plus every column in them, so a wide index on a
+    // long table name overruns it. SQLite has no such limit, so a migration that trips
+    // this passes locally and fails on a production upgrade. Checked here, against the
+    // declared schema, rather than waiting to find out.
+    it('derives index and constraint names that MySQL will accept', function () {
+        const MAX_IDENTIFIER = 64;
+        // How knex builds a name when it is not given one.
+        const derived = (tableName, columns, type) => `${tableName}_${[].concat(columns).join('_')}_${type}`;
+
+        const tooLong = [];
+        const check = (name, what) => {
+            if (name.length > MAX_IDENTIFIER) {
+                tooLong.push(`${what}: ${name} (${name.length} chars)`);
+            }
+        };
+
+        _.each(schema, function (table, tableName) {
+            _.each(table['@@INDEXES@@'] ?? [], function (index) {
+                const columns = _.isPlainObject(index) ? index.columns : index;
+                const name = _.isPlainObject(index) && index.indexName ? index.indexName : derived(tableName, columns, 'index');
+                check(name, `${tableName} index`);
+            });
+
+            _.each(table['@@UNIQUE_CONSTRAINTS@@'] ?? [], function (unique) {
+                const columns = _.isPlainObject(unique) ? unique.columns : unique;
+                const name = _.isPlainObject(unique) && unique.indexName ? unique.indexName : derived(tableName, columns, 'unique');
+                check(name, `${tableName} unique constraint`);
+            });
+
+            _.each(table, function (column, columnName) {
+                if (columnName.startsWith('@@')) {
+                    return;
+                }
+                if (column.unique) {
+                    check(derived(tableName, columnName, 'unique'), `${tableName} unique column`);
+                }
+                if (column.index) {
+                    check(derived(tableName, columnName, 'index'), `${tableName} index column`);
+                }
+                if (column.references) {
+                    check(column.constraintName ?? derived(tableName, columnName, 'foreign'), `${tableName} foreign key`);
+                }
+            });
+        });
+
+        assert.deepEqual(tooLong, [], `These names exceed MySQL's ${MAX_IDENTIFIER}-character limit. Give the index an explicit, shorter \`indexName\`.`);
+    });
+
     it('has correct isIn validation structure', async function () {
         const tablesOnlyValidation = _.cloneDeep(schema);
 

--- a/ghost/core/test/unit/server/data/seeders/data-generator.test.js
+++ b/ghost/core/test/unit/server/data/seeders/data-generator.test.js
@@ -36,7 +36,13 @@ describe('Data Generator', function () {
 
                     if (rowName === '@@UNIQUE_CONSTRAINTS@@') {
                         for (const constraints of row) {
-                            table.unique(constraints);
+                            // A constraint is normally its columns; the object form names
+                            // it, for when the derived name would overrun MySQL's limit.
+                            if (constraints && typeof constraints === 'object' && !Array.isArray(constraints)) {
+                                table.unique(constraints.columns, {indexName: constraints.indexName});
+                            } else {
+                                table.unique(constraints);
+                            }
                         }
                         break;
                     } else if (rowName === '@@INDEXES@@') {

--- a/ghost/core/test/unit/server/services/members-custom-fields/storage.test.ts
+++ b/ghost/core/test/unit/server/services/members-custom-fields/storage.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import {describe, it} from 'vitest';
-import {ROOT_PATH, leavesFor, valueFromLeaves, valuesFromLeaves} from '../../../../../core/server/services/members-custom-fields/storage';
+import {ROOT_PATH, leavesFor, leavesToWrite, valueFromLeaves, valuesFromLeaves} from '../../../../../core/server/services/members-custom-fields/storage';
 
 // Every edge of the row model lives in these three functions, and they are pure, so this
 // is the one place a unit test is cheaper than driving the HTTP boundary. The behaviour
@@ -19,11 +19,10 @@ describe('custom field value storage', function () {
             ]);
         });
 
-        it('gives an empty part no leaf at all', function () {
-            // The row model has no way to say "this part is empty" apart from "this part
-            // is unset", and it does not need one: they are the same state.
+        it('names an empty part too, because naming is what a write acts on', function () {
             assert.deepEqual(leavesFor({line1: '1 High St', city: ''}), [
-                {path: 'line1', value_text: '1 High St'}
+                {path: 'line1', value_text: '1 High St'},
+                {path: 'city', value_text: ''}
             ]);
         });
 
@@ -35,6 +34,15 @@ describe('custom field value storage', function () {
             for (const value of [null, 42, true]) {
                 assert.throws(() => leavesFor(value), /must be a string or a record/);
             }
+        });
+
+        it('splits what a value names into what it sets and what it clears', function () {
+            // A path not mentioned appears in neither list, which is how "leave it alone"
+            // is expressed: by saying nothing about it.
+            assert.deepEqual(leavesToWrite({line1: '1 High St', city: ''}), {
+                set: [{path: 'line1', value_text: '1 High St'}],
+                cleared: ['city']
+            });
         });
     });
 

--- a/ghost/core/test/unit/server/services/members-custom-fields/storage.test.ts
+++ b/ghost/core/test/unit/server/services/members-custom-fields/storage.test.ts
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict';
+import {describe, it} from 'vitest';
+import {ROOT_PATH, leavesFor, valueFromLeaves, valuesFromLeaves} from '../../../../../core/server/services/members-custom-fields/storage';
+
+// Every edge of the row model lives in these three functions, and they are pure, so this
+// is the one place a unit test is cheaper than driving the HTTP boundary. The behaviour
+// they add up to — a value surviving a round trip through the database — is proven in the
+// members custom-fields API tests; what is proven here is the shape of each step.
+describe('custom field value storage', function () {
+    describe('a value becomes leaves', function () {
+        it('gives a value with no parts a single leaf at the empty path', function () {
+            assert.deepEqual(leavesFor('Ghosts'), [{path: ROOT_PATH, value_text: 'Ghosts'}]);
+        });
+
+        it('gives a value with parts one leaf each, in the order the type declares them', function () {
+            assert.deepEqual(leavesFor({line1: '1 High St', city: 'London'}), [
+                {path: 'line1', value_text: '1 High St'},
+                {path: 'city', value_text: 'London'}
+            ]);
+        });
+
+        it('gives an empty part no leaf at all', function () {
+            // The row model has no way to say "this part is empty" apart from "this part
+            // is unset", and it does not need one: they are the same state.
+            assert.deepEqual(leavesFor({line1: '1 High St', city: ''}), [
+                {path: 'line1', value_text: '1 High St'}
+            ]);
+        });
+
+        it('refuses a value that is neither a string nor a record of them', function () {
+            // Storing one would write a row the read path then rejects and drops, so the
+            // value would be gone with nothing to say it ever arrived. Nothing reaches
+            // here without being parsed first, which is what makes arriving with one a
+            // mistake in the caller rather than something a member did.
+            for (const value of [null, 42, true]) {
+                assert.throws(() => leavesFor(value), /must be a string or a record/);
+            }
+        });
+    });
+
+    describe('leaves become a value', function () {
+        it('round-trips both shapes', function () {
+            for (const value of ['Ghosts', {line1: '1 High St', city: 'London'}]) {
+                assert.deepEqual(valueFromLeaves(leavesFor(value)), value);
+            }
+        });
+
+        it('rebuilds a nested value from dotted paths', function () {
+            // Nothing nests today, but the codec is written for a tree rather than for
+            // one level, so the depth is not a case anyone has to come back and add.
+            const nested = {company: {address: {city: 'London'}}, note: 'vip'};
+            assert.deepEqual(leavesFor(nested).map(l => l.path).sort(), ['company.address.city', 'note']);
+            assert.deepEqual(valueFromLeaves(leavesFor(nested)), nested);
+        });
+
+        it('reads the shape from the leaves rather than from any field type', function () {
+            // A leaf at the empty path is the whole value; anything else is a part of
+            // one. So a row written before its type changed reads back as what it was.
+            assert.equal(valueFromLeaves([{path: ROOT_PATH, value_text: 'Ghosts'}]), 'Ghosts');
+            assert.deepEqual(valueFromLeaves([{path: 'city', value_text: 'London'}]), {city: 'London'});
+        });
+
+        it('ignores a path naming something every object already has', function () {
+            // A rebuilt value is an ordinary object, so `__proto__` as a key would reach
+            // the prototype every other object shares rather than the value. No path
+            // written here can contain one, and a path only has to reach the database
+            // once for that to stop being a comfort.
+            assert.deepEqual(valueFromLeaves([
+                {path: '__proto__.polluted', value_text: 'yes'},
+                {path: 'city', value_text: 'London'}
+            ]), {city: 'London'});
+            assert.equal(({} as Record<string, unknown>).polluted, undefined);
+        });
+
+        it('rebuilds what the leaves describe when one path is a part of another', function () {
+            // Impossible from anything written through here, and still worth settling:
+            // this runs over every member of a list response, so guessing wrong should
+            // cost one odd value rather than the whole response.
+            //
+            // The deeper leaf wins because it arrives second, and it arrives second
+            // because the read orders by path — 'company' sorts before 'company.city'.
+            assert.deepEqual(valueFromLeaves([
+                {path: 'company', value_text: 'Ghost'},
+                {path: 'company.city', value_text: 'London'}
+            ]), {company: {city: 'London'}});
+        });
+    });
+
+    describe('rows become every member’s values', function () {
+        it('gathers each value from every row belonging to it', function () {
+            const values = valuesFromLeaves([
+                {member_id: 'm1', key: 'home_address', path: 'city', value_text: 'London'},
+                {member_id: 'm1', key: 'nickname', path: ROOT_PATH, value_text: 'Bex'},
+                {member_id: 'm2', key: 'home_address', path: 'country', value_text: 'IE'},
+                {member_id: 'm1', key: 'home_address', path: 'line1', value_text: '1 High St'}
+            ]);
+
+            // m1's address arrives split by two unrelated rows; nothing depends on the
+            // rows for one value being next to each other.
+            assert.deepEqual(values.get('m1'), {
+                home_address: {city: 'London', line1: '1 High St'},
+                nickname: 'Bex'
+            });
+            assert.deepEqual(values.get('m2'), {home_address: {country: 'IE'}});
+        });
+
+        it('leaves a member with no rows out entirely', function () {
+            assert.deepEqual([...valuesFromLeaves([]).keys()], []);
+        });
+    });
+});

--- a/packages/custom-field-types/src/index.ts
+++ b/packages/custom-field-types/src/index.ts
@@ -3,10 +3,9 @@ import {z} from 'zod';
 /**
  * The shared catalog of member custom field types.
  *
- * Single source of truth for two tier-neutral facts about a field type: which
- * storage type its value lives in, and how a value is validated. Ghost core
- * imports it to *enforce* validation (and to route storage); admin imports the
- * same schemas for instant form feedback. Neither drifts.
+ * Single source of truth for two tier-neutral facts about a field type: what a valid
+ * value is, and whether a value has parts. Ghost core imports it to *enforce* validation;
+ * admin imports the same schemas for instant form feedback. Neither drifts.
  *
  * This module is deliberately pure data: no presentation (labels, icons, input
  * controls stay in the frontend), no storage codecs (columns and
@@ -24,23 +23,12 @@ import {z} from 'zod';
  */
 
 /**
- * Field types: the open, growing set a publisher picks. Many field types share
- * one storage type (short_text and long_text both store as text), yet each
- * carries its own validation even when the storage is identical — which is why
- * validation hangs off the field type, not the storage type. Declared once here
- * as the source for the union type, the zod enum, and the FIELD_TYPES keys.
+ * Field types: the open, growing set a publisher picks. Declared once here as the source
+ * for the union type, the zod enum, and the FIELD_TYPES keys.
  */
 export const FIELD_TYPE_IDS = ['short_text', 'long_text', 'address'] as const;
 export type FieldType = typeof FIELD_TYPE_IDS[number];
 export const FieldTypeSchema = z.enum(FIELD_TYPE_IDS);
-
-export interface FieldTypeDefinition {
-    /**
-     * The authoritative validation for a value of this type. The backend runs it
-     * as the gate; the frontend runs the same schema for instant feedback.
-     */
-    value: z.ZodType;
-}
 
 /**
  * Long text is bounded in bytes, not characters, because the storage column it
@@ -56,106 +44,190 @@ export const MAX_LONG_TEXT_BYTES = 65535;
 const byteLength = (value: string): number => new TextEncoder().encode(value).length;
 
 /**
- * A sub-field as a write may name it: absent, meaning it is not being spoken about;
- * empty, meaning clear it; or a value of its own kind.
+ * The value builders a field type is assembled from.
  *
- * Emptying is a statement about the write rather than about the sub-field, so it belongs
- * here rather than inside each rule. A rule that is a bound admits the empty string on
- * its own and would not have needed this; one that is a format does not, and would
- * otherwise leave the sub-field with no way of being emptied at all — which is how a
- * country code became the one part of an address a person could set but never remove.
+ * A leaf type is one of these; a composite type is a record of them. The same builder
+ * serves both, so "this part is a short text" and "this field is a short text" are one
+ * statement rather than two that can drift.
  *
- * Trimming before the choice rather than after is what keeps a sub-field of spaces the
- * same as an empty one for every rule alike.
+ * Each builder names what a value is rather than taking a size, so a part is declared as
+ * the thing it is and its bound lives with everything else true of that thing. A number
+ * passed in at the call site would have to be read back the other way — 32 explains
+ * nothing about why a postal code is shorter than a street.
  */
-const clearable = <T extends z.ZodType<unknown, string>>(subField: T) => z.string().trim().pipe(z.union([z.literal(''), subField])).optional();
+/**
+ * Text as it arrives: trimmed, once, for every type and every part built on it.
+ *
+ * Said here rather than in each builder so the types cannot disagree about whitespace —
+ * a value of nothing but spaces is nothing, whichever field it was typed into. Trimming
+ * before any other rule also makes the bounds measure the value rather than the padding.
+ */
+const text = () => z.string().trim();
+
+const shortText = () => text().max(255);
+
+const longText = () => text().refine(value => byteLength(value) <= MAX_LONG_TEXT_BYTES, {
+    message: `Value must be at most ${MAX_LONG_TEXT_BYTES} bytes.`
+});
 
 /**
- * The address value — a composite type, modelled on Stripe's Address object.
- * Because it is one zod object, invalid sub-fields surface per path (the caller
- * can point at `postal_code` specifically) with no bespoke composite handling.
- *
- * Every sub-field is optional, because none of them exists everywhere: there is
- * no postal code in Ireland or Hong Kong, and no city in an Irish townland
- * address. Which sub-fields a particular address needs is a per-country question,
- * and only the collection form knows the country — so requiring any of them here
- * would leave a correctly-shaped form unable to produce a valid value.
- *
- * What holds instead is that an address must say something. An object with
- * nothing filled in is not an empty address, it is no address, and a value is
- * cleared by omitting it rather than by emptying it.
- *
- * Every sub-field is bounded. An address is a delivery address, so the bounds are
- * set by what a courier will accept, not by what the column could hold — and a
- * composite with unbounded members is a composite with no bound at all.
+ * A postal code, bounded well under a street address because no country's is long. The
+ * bound is a sanity limit rather than a format: postal codes vary too much between
+ * countries to check the shape of one without knowing which country it is for, and the
+ * country is a sibling part rather than something this can see.
  */
-export const AddressValue = z.object({
-    line1: clearable(z.string().trim().max(255)),
-    line2: clearable(z.string().trim().max(255)),
-    city: clearable(z.string().trim().max(255)),
-    state: clearable(z.string().trim().max(255)),
-    postal_code: clearable(z.string().trim().max(32)),
+const postalCode = () => text().max(32);
+
+/**
+ * The shape of an ISO 3166-1 alpha-2 code, deliberately not checked against the actual
+ * list of them. A closed list would put Ghost in the position of deciding whose country
+ * is real, which is not a judgement a publishing platform should be making of its
+ * members, and there is no defensible answer for Kosovo, Taiwan, Palestine or Western
+ * Sahara. Anything well-formed is stored, and the collection form offers a list to pick
+ * from without being the arbiter of it.
+ *
+ * Case is normalised, because that is a question about the same country rather than
+ * about which countries exist. Left alone, `gb` and `GB` are two values for one place: a
+ * filter for one silently misses the other, and nothing can tell them apart afterwards to
+ * repair it.
+ *
+ * Two ASCII letters rather than any two characters, which is what alpha-2 means. Counting
+ * the characters of the result would be wrong in both directions, because uppercasing
+ * does not preserve length: `ß` becomes `SS` and would pass a length-of-two rule from one
+ * character, while `aß` becomes `ASS` and would fail it from two.
+ */
+const countryCode = () => text().regex(/^[A-Za-z]{2}$/).toUpperCase();
+
+/**
+ * A value of a field type, or of one part of one: text, whatever rules narrow it.
+ *
+ * Both ends are pinned to a string. Storage keeps one string per leaf, so a type parsing
+ * to anything else is one whose values can be written and never read back — a fact worth
+ * learning from the compiler rather than from a 500 on the first save.
+ */
+type PartSchema = z.ZodType<string, string>;
+
+/**
+ * A part as a write may name it: absent, meaning it is not being spoken about; empty,
+ * meaning clear it; or a value of its own kind.
+ *
+ * Emptying is a statement about the write rather than about the part, so it is stated
+ * once here rather than inside each builder. A rule that is a bound admits the empty
+ * string on its own and would never have needed this; one that is a format does not, and
+ * would otherwise leave its part the only one that could be set but never removed.
+ *
+ * Trimming before the choice rather than after is what keeps a part of nothing but
+ * whitespace the same as an empty one for every rule alike.
+ */
+const clearable = <T extends PartSchema>(part: T) => text().pipe(z.union([z.literal(''), part])).optional();
+
+/**
+ * A field type: either a leaf, which is a value in its own right, or a record of named
+ * fields, which is a value made of them.
+ *
+ * A record's `value` is derived from its parts rather than written beside them, so the
+ * parts are declared once and everything downstream — validation, the CSV columns, the
+ * paths a filter may address, what admin renders — reads the same declaration.
+ */
+export interface FieldTypeDefinition {
+    value: z.ZodType;
     /**
-     * The shape of an ISO 3166-1 alpha-2 code, deliberately not checked against the
-     * actual list of them. A closed list would put Ghost in the position of deciding
-     * whose country is real, which is not a judgement a publishing platform should be
-     * making of its members, and there is no defensible answer for Kosovo, Taiwan,
-     * Palestine or Western Sahara. Anything well-formed is stored, and the collection
-     * form offers a list to pick from without being the arbiter of it.
+     * Present on a record type only: the fields it is made of, in declaration order.
      *
-     * Case is normalised, because that is a question about the same country rather than
-     * about which countries exist. Left alone, `gb` and `GB` are two values for one
-     * place: a filter for one silently misses the other, and nothing can tell them apart
-     * afterwards to repair it. Normalising on the way in is the only point at which that
-     * is cheap.
-     *
-     * Shape is two ASCII letters rather than any two characters, which is what alpha-2
-     * means. Counting characters instead would be wrong in both directions once case is
-     * normalised, because uppercasing does not preserve length: `ß` becomes `SS` and
-     * would pass a length-of-two rule from one character, while `aß` becomes `ASS` and
-     * would fail it from two. Checking the shape of the input settles both, and turns
-     * away the `12` and `!!` that a bare length check always allowed through.
+     * These are the parts as declared — each one's own rule, and nothing about how a
+     * write may name it. Validate a value against the type's `value`, not against these:
+     * a write also accepts an empty part, which clears it, and no part's own rule says so.
      */
-    country: clearable(z.string().trim().regex(/^[A-Za-z]{2}$/).toUpperCase())
-}).refine(
-    // An address has to name a part. What it says about that part is up to it: a value
-    // sets the part, and an empty one clears it, because a write acts on the parts it
-    // names and an address naming nothing asks for nothing.
-    //
-    // Storing an address with nothing in it is not something this has to prevent — a
-    // part with no value gets no row, so an address of empties leaves none behind.
-    //
-    // The type check is load-bearing rather than defensive. An optional sub-field that
-    // is explicitly undefined survives parsing as a key holding undefined, and a bare
-    // presence check would let `{line1: undefined}` through as if it named something.
-    address => Object.values(address).some(value => typeof value === 'string'),
-    {message: 'An address must name at least one part.'}
-);
+    fields?: Record<string, PartSchema>;
+}
+
+/**
+ * A field type as it is declared: a schema, for a type that is a value in its own right,
+ * or a record built by `record`, for one made of parts.
+ */
+type FieldTypeDeclaration = PartSchema | FieldTypeDefinition;
+
+/** A declaration as the catalog exposes it. A bare schema is a value with no parts. */
+type Defined<D> = D extends z.ZodType ? {value: D} : D;
+
+/**
+ * The catalog, from what each type was declared as.
+ *
+ * A type that is simply a value says so by being one, with no wrapper to write for the
+ * common case; a type made of parts says so by being a `record`, which is where the
+ * work happens and so is worth naming at the call site.
+ */
+function defineFieldTypes<D extends Record<FieldType, FieldTypeDeclaration>>(declarations: D): {[K in keyof D]: Defined<D[K]>} {
+    // The mapping is restated for the type system, which cannot follow a conditional
+    // type through `Object.fromEntries`.
+    return Object.fromEntries(
+        Object.entries(declarations).map(([type, declared]) => [type, declared instanceof z.ZodType ? {value: declared} : declared])
+    ) as {[K in keyof D]: Defined<D[K]>};
+}
+
+/**
+ * Every part of a record is optional, because none of an address's exists everywhere:
+ * there is no postal code in Ireland or Hong Kong, and no city in an Irish townland
+ * address. Which parts a particular value needs is a per-country question and only the
+ * collection form knows the country, so requiring any here would leave a correctly filled
+ * form unable to produce a valid value.
+ *
+ * What holds instead is that a value must name a part. What it says about that part is up
+ * to it: a value sets the part, an empty one clears it. Storing a record with nothing in
+ * it is not something this has to prevent — a part with no value gets no row.
+ *
+ * The type check below is load-bearing rather than defensive. An optional part that is
+ * explicitly undefined survives parsing as a key holding undefined, and a bare presence
+ * check would let `{line1: undefined}` through as if it named something.
+ */
+function record<F extends Record<string, PartSchema>>(fields: F) {
+    // `Object.fromEntries` widens away the key-to-schema mapping, so the shape is
+    // restated for the type system. Without it a record's value infers as `unknown` and
+    // every type built on one goes with it.
+    const shape = Object.fromEntries(
+        Object.entries(fields).map(([key, part]) => [key, clearable(part)])
+    ) as {[K in keyof F]: ReturnType<typeof clearable<F[K]>>};
+
+    const value = z.object(shape).refine(
+        parts => Object.values(parts).some(part => typeof part === 'string'),
+        {message: 'A value must name at least one part.'}
+    );
+
+    return {value, fields};
+}
+
+export const FIELD_TYPES = defineFieldTypes({
+    short_text: shortText(),
+    long_text: longText(),
+    // An address is a delivery address, so its bounds are what a courier will accept
+    // rather than what the column could hold. Modelled on Stripe's Address object.
+    address: record({
+        line1: shortText(),
+        line2: shortText(),
+        city: shortText(),
+        state: shortText(),
+        postal_code: postalCode(),
+        country: countryCode()
+    })
+});
+
+/**
+ * An address value, for the admin types built on it. Named separately because admin
+ * speaks of an address, where the catalog only knows a record of parts.
+ */
+export const AddressValue = FIELD_TYPES.address.value;
 export type Address = z.infer<typeof AddressValue>;
 
-export const FIELD_TYPES = {
-    // Characters, not bytes: 255 of anything fits the column with room to spare,
-    // and a character count is the limit a publisher can reason about.
-    short_text: {value: z.string().max(255)},
-    long_text: {
-        value: z.string().refine(value => byteLength(value) <= MAX_LONG_TEXT_BYTES, {
-            message: `Value must be at most ${MAX_LONG_TEXT_BYTES} bytes.`
-        })
-    },
-    address: {value: AddressValue}
-} as const satisfies Record<FieldType, FieldTypeDefinition>;
-
 /**
- * The sub-fields of a composite type in declaration order, or null for a scalar.
+ * The parts of a record type in declaration order, or null for a leaf.
  *
- * Derived from the value schema rather than declared alongside it, so the two cannot
- * drift: adding a sub-field is one edit and every consumer sees it. It is also the
- * only honest test of what "composite" means here — a value is composite when it has
- * parts, which is a fact about its shape and not about the column it happens to be
- * stored in. Two field types can share a storage type and disagree about this, so
- * anything asking "does this value have parts?" has to ask the shape.
+ * Read from the declaration rather than reverse-engineered from the schema it produced,
+ * so adding a part is one edit and every consumer — the CSV columns, the paths a filter
+ * may address, what admin renders — sees it.
  */
 export function subFieldsOf(type: FieldType): string[] | null {
-    const {value} = FIELD_TYPES[type];
-    return value instanceof z.ZodObject ? Object.keys(value.shape) : null;
+    // Read through the interface rather than off the literal: a leaf has no `fields` key
+    // at all, and this is the one place that has to treat both kinds the same way.
+    const {fields}: FieldTypeDefinition = FIELD_TYPES[type];
+    return fields ? Object.keys(fields) : null;
 }

--- a/packages/custom-field-types/src/index.ts
+++ b/packages/custom-field-types/src/index.ts
@@ -56,6 +56,21 @@ export const MAX_LONG_TEXT_BYTES = 65535;
 const byteLength = (value: string): number => new TextEncoder().encode(value).length;
 
 /**
+ * A sub-field as a write may name it: absent, meaning it is not being spoken about;
+ * empty, meaning clear it; or a value of its own kind.
+ *
+ * Emptying is a statement about the write rather than about the sub-field, so it belongs
+ * here rather than inside each rule. A rule that is a bound admits the empty string on
+ * its own and would not have needed this; one that is a format does not, and would
+ * otherwise leave the sub-field with no way of being emptied at all — which is how a
+ * country code became the one part of an address a person could set but never remove.
+ *
+ * Trimming before the choice rather than after is what keeps a sub-field of spaces the
+ * same as an empty one for every rule alike.
+ */
+const clearable = <T extends z.ZodType<unknown, string>>(subField: T) => z.string().trim().pipe(z.union([z.literal(''), subField])).optional();
+
+/**
  * The address value — a composite type, modelled on Stripe's Address object.
  * Because it is one zod object, invalid sub-fields surface per path (the caller
  * can point at `postal_code` specifically) with no bespoke composite handling.
@@ -75,11 +90,11 @@ const byteLength = (value: string): number => new TextEncoder().encode(value).le
  * composite with unbounded members is a composite with no bound at all.
  */
 export const AddressValue = z.object({
-    line1: z.string().trim().max(255).optional(),
-    line2: z.string().trim().max(255).optional(),
-    city: z.string().trim().max(255).optional(),
-    state: z.string().trim().max(255).optional(),
-    postal_code: z.string().trim().max(32).optional(),
+    line1: clearable(z.string().trim().max(255)),
+    line2: clearable(z.string().trim().max(255)),
+    city: clearable(z.string().trim().max(255)),
+    state: clearable(z.string().trim().max(255)),
+    postal_code: clearable(z.string().trim().max(32)),
     /**
      * The shape of an ISO 3166-1 alpha-2 code, deliberately not checked against the
      * actual list of them. A closed list would put Ghost in the position of deciding
@@ -101,19 +116,20 @@ export const AddressValue = z.object({
      * would fail it from two. Checking the shape of the input settles both, and turns
      * away the `12` and `!!` that a bare length check always allowed through.
      */
-    country: z.string().trim().regex(/^[A-Za-z]{2}$/).toUpperCase().optional()
+    country: clearable(z.string().trim().regex(/^[A-Za-z]{2}$/).toUpperCase())
 }).refine(
-    // Every sub-field is trimmed above, so whitespace has already become the empty
-    // string by the time this runs. Trimming is what stops `{line1: '   '}` being
-    // stored: admin trims a sub-field away before rendering it, so an address of
-    // spaces would be one no screen could show, and none could clear either.
+    // An address has to name a part. What it says about that part is up to it: a value
+    // sets the part, and an empty one clears it, because a write acts on the parts it
+    // names and an address naming nothing asks for nothing.
     //
-    // The type check is load-bearing, not defensive. A sub-field that is optional
-    // and explicitly undefined survives parsing as a key holding undefined, and
-    // `undefined !== ''` on its own would let `{line1: undefined}` satisfy a rule
-    // whose whole purpose is to reject an address with nothing in it.
-    address => Object.values(address).some(value => typeof value === 'string' && value !== ''),
-    {message: 'An address must have at least one part filled in.'}
+    // Storing an address with nothing in it is not something this has to prevent — a
+    // part with no value gets no row, so an address of empties leaves none behind.
+    //
+    // The type check is load-bearing rather than defensive. An optional sub-field that
+    // is explicitly undefined survives parsing as a key holding undefined, and a bare
+    // presence check would let `{line1: undefined}` through as if it named something.
+    address => Object.values(address).some(value => typeof value === 'string'),
+    {message: 'An address must name at least one part.'}
 );
 export type Address = z.infer<typeof AddressValue>;
 

--- a/packages/custom-field-types/src/index.ts
+++ b/packages/custom-field-types/src/index.ts
@@ -20,6 +20,12 @@ import {z} from 'zod';
  *
  * Behaviour is proven where it matters, in the members custom-fields and member
  * export HTTP API integration tests, rather than in isolated unit tests here.
+ *
+ * One rule spans both tiers and both depths: a name nobody recognises is an error, never
+ * a silent drop. A misspelled field key is refused by the values service, which is the
+ * only thing that knows which fields a site has defined; a misspelled part is refused
+ * here, because a type's parts are declared in this file and nowhere else. Each is
+ * enforced where the names are known, and neither quietly discards what it was given.
  */
 
 /**
@@ -188,7 +194,10 @@ function record<F extends Record<string, PartSchema>>(fields: F) {
         Object.entries(fields).map(([key, part]) => [key, clearable(part)])
     ) as {[K in keyof F]: ReturnType<typeof clearable<F[K]>>};
 
-    const value = z.object(shape).refine(
+    // Strict, so a part nobody declared is refused rather than dropped on the floor. The
+    // values service refuses an unrecognised field key for the same reason: a typo that
+    // silently loses what a member typed is worse than a save that fails and says so.
+    const value = z.strictObject(shape).refine(
         parts => Object.values(parts).some(part => typeof part === 'string'),
         {message: 'A value must name at least one part.'}
     );

--- a/packages/custom-field-types/src/index.ts
+++ b/packages/custom-field-types/src/index.ts
@@ -3,70 +3,58 @@ import {z} from 'zod';
 /**
  * The shared catalog of member custom field types.
  *
- * Single source of truth for two tier-neutral facts about a field type: what a valid
- * value is, and whether a value has parts. Ghost core imports it to *enforce* validation;
- * admin imports the same schemas for instant form feedback. Neither drifts.
+ * ## What a field type is
  *
- * This module is deliberately pure data: no presentation (labels, icons, input
- * controls stay in the frontend), no storage codecs (columns and
- * serialize/deserialize stay in the backend), and no lookup helpers (consumers
- * index `FIELD_TYPES` directly).
+ * A publisher defines fields; a field has a type; a type says what a valid value is. That
+ * last statement lives here and nowhere else, so that Ghost core, which enforces it, and
+ * admin, which gives instant feedback against it, cannot disagree about what is valid.
  *
- * The package admits one thing beyond data, in `./csv`: how a value maps onto
- * CSV columns. That belongs here rather than in either tier because both need
- * the same answer — the backend to write the export and read an import, admin to
- * offer the columns as mapping targets — and a disagreement between them is a
- * file that silently stops round-tripping.
+ * A type is one of two things. Most are a value in their own right, declared as the
+ * schema that value must satisfy. An address is a *record*: a set of named parts, each a
+ * value in the same sense, from which the whole type's schema is derived. Nothing stops a
+ * part being a record itself.
  *
- * Behaviour is proven where it matters, in the members custom-fields and member
- * export HTTP API integration tests, rather than in isolated unit tests here.
+ * ## What a write may say
  *
- * One rule spans both tiers and both depths: a name nobody recognises is an error, never
- * a silent drop. A misspelled field key is refused by the values service, which is the
- * only thing that knows which fields a site has defined; a misspelled part is refused
- * here, because a type's parts are declared in this file and nowhere else. Each is
- * enforced where the names are known, and neither quietly discards what it was given.
+ * A value is text, and so is every part of one. A write names what it means to change: a
+ * name it does not mention is left as it was, and a name given an empty string is being
+ * cleared. That is why every part accepts empty regardless of its own rule — emptying is
+ * a statement about the write, not about the part.
+ *
+ * A name nobody recognises is an error rather than a silent drop, at both depths. A
+ * misspelled field key is refused by the values service, which alone knows which fields a
+ * site has defined; a misspelled part is refused here, because a type's parts are declared
+ * in this file and nowhere else. Each is enforced where the names are known.
+ *
+ * ## What this package will not do
+ *
+ * No presentation: labels, icons and input controls belong to the frontend. No storage:
+ * columns and codecs belong to the backend. One exception lives in `./csv` — how a value
+ * maps onto CSV columns — because both tiers need the same answer and a disagreement
+ * between them is a file that silently stops round-tripping.
  */
 
-/**
- * Field types: the open, growing set a publisher picks. Declared once here as the source
- * for the union type, the zod enum, and the FIELD_TYPES keys.
- */
+/** The source for the union type, the zod enum and the `FIELD_TYPES` keys alike. */
 export const FIELD_TYPE_IDS = ['short_text', 'long_text', 'address'] as const;
 export type FieldType = typeof FIELD_TYPE_IDS[number];
 export const FieldTypeSchema = z.enum(FIELD_TYPE_IDS);
 
 /**
- * Long text is bounded in bytes, not characters, because the storage column it
- * routes to is bounded in bytes (MySQL TEXT holds 65,535 of them). A character
- * bound would accept a multibyte value that the column then can't hold: 65,535
- * emoji is four times over. Shopify documents its metafield limits in bytes for
- * the same reason.
- *
- * TextEncoder rather than Buffer: this package runs in the browser too.
+ * Bytes, not characters, because MySQL TEXT holds 65,535 of them: a character bound would
+ * accept a multibyte value the column cannot hold, and 65,535 emoji is four times over.
  */
 export const MAX_LONG_TEXT_BYTES = 65535;
 
+// TextEncoder rather than Buffer: this package runs in the browser too.
 const byteLength = (value: string): number => new TextEncoder().encode(value).length;
 
 /**
- * The value builders a field type is assembled from.
+ * Every value and every part is built from this, so no two types can disagree about
+ * whitespace: a value of nothing but spaces is nothing, whichever field it was typed
+ * into. Trimming first also makes each bound measure the value rather than its padding.
  *
- * A leaf type is one of these; a composite type is a record of them. The same builder
- * serves both, so "this part is a short text" and "this field is a short text" are one
- * statement rather than two that can drift.
- *
- * Each builder names what a value is rather than taking a size, so a part is declared as
- * the thing it is and its bound lives with everything else true of that thing. A number
- * passed in at the call site would have to be read back the other way — 32 explains
- * nothing about why a postal code is shorter than a street.
- */
-/**
- * Text as it arrives: trimmed, once, for every type and every part built on it.
- *
- * Said here rather than in each builder so the types cannot disagree about whitespace —
- * a value of nothing but spaces is nothing, whichever field it was typed into. Trimming
- * before any other rule also makes the bounds measure the value rather than the padding.
+ * Builders are named after what a value is rather than taking a size, so that a bound
+ * lives with everything else true of that thing instead of as a number at the call site.
  */
 const text = () => z.string().trim();
 
@@ -85,118 +73,74 @@ const longText = () => text().refine(value => byteLength(value) <= MAX_LONG_TEXT
 const postalCode = () => text().max(32);
 
 /**
- * The shape of an ISO 3166-1 alpha-2 code, deliberately not checked against the actual
- * list of them. A closed list would put Ghost in the position of deciding whose country
- * is real, which is not a judgement a publishing platform should be making of its
- * members, and there is no defensible answer for Kosovo, Taiwan, Palestine or Western
- * Sahara. Anything well-formed is stored, and the collection form offers a list to pick
- * from without being the arbiter of it.
+ * The shape of an ISO 3166-1 alpha-2 code, deliberately not checked against the list of
+ * them: a closed list would make Ghost the arbiter of whose country is real, and there is
+ * no defensible answer for Kosovo, Taiwan, Palestine or Western Sahara. The collection
+ * form can offer a list to pick from without this deciding what exists.
  *
- * Case is normalised, because that is a question about the same country rather than
- * about which countries exist. Left alone, `gb` and `GB` are two values for one place: a
- * filter for one silently misses the other, and nothing can tell them apart afterwards to
- * repair it.
+ * Case is normalised so that `gb` and `GB` are not two values for one place, which a
+ * filter for either would silently half-miss.
  *
- * Two ASCII letters rather than any two characters, which is what alpha-2 means. Counting
- * the characters of the result would be wrong in both directions, because uppercasing
- * does not preserve length: `ß` becomes `SS` and would pass a length-of-two rule from one
- * character, while `aß` becomes `ASS` and would fail it from two.
+ * Checked as two ASCII letters on the way in rather than by length on the way out, because
+ * uppercasing does not preserve length: `ß` becomes `SS` and `aß` becomes `ASS`.
  */
 const countryCode = () => text().regex(/^[A-Za-z]{2}$/).toUpperCase();
 
 /**
- * A value of a field type, or of one part of one: text, whatever rules narrow it.
- *
- * Both ends are pinned to a string. Storage keeps one string per leaf, so a type parsing
- * to anything else is one whose values can be written and never read back — a fact worth
- * learning from the compiler rather than from a 500 on the first save.
+ * Both ends are pinned to a string because storage keeps one string per leaf: a type
+ * parsing to anything else could be written and never read back, which is better learned
+ * from the compiler than from a 500 on the first save.
  */
 type PartSchema = z.ZodType<string, string>;
 
 /**
- * A part as a write may name it: absent, meaning it is not being spoken about; empty,
- * meaning clear it; or a value of its own kind.
+ * A part as a write may name it: absent, empty, or a value of its own kind.
  *
- * Emptying is a statement about the write rather than about the part, so it is stated
- * once here rather than inside each builder. A rule that is a bound admits the empty
- * string on its own and would never have needed this; one that is a format does not, and
- * would otherwise leave its part the only one that could be set but never removed.
- *
- * Trimming before the choice rather than after is what keeps a part of nothing but
- * whitespace the same as an empty one for every rule alike.
+ * A rule that is a bound would admit empty on its own; one that is a format would not,
+ * and would leave its part the only one that could be set but never removed.
  */
 const clearable = <T extends PartSchema>(part: T) => text().pipe(z.union([z.literal(''), part])).optional();
 
-/**
- * A field type: either a leaf, which is a value in its own right, or a record of named
- * fields, which is a value made of them.
- *
- * A record's `value` is derived from its parts rather than written beside them, so the
- * parts are declared once and everything downstream — validation, the CSV columns, the
- * paths a filter may address, what admin renders — reads the same declaration.
- */
 export interface FieldTypeDefinition {
     value: z.ZodType;
     /**
-     * Present on a record type only: the fields it is made of, in declaration order.
-     *
-     * These are the parts as declared — each one's own rule, and nothing about how a
-     * write may name it. Validate a value against the type's `value`, not against these:
-     * a write also accepts an empty part, which clears it, and no part's own rule says so.
+     * A record type's parts, in declaration order. Each part's own rule, and nothing
+     * about how a write may name it: validate against `value`, never against these.
      */
     fields?: Record<string, PartSchema>;
 }
 
-/**
- * A field type as it is declared: a schema, for a type that is a value in its own right,
- * or a record built by `record`, for one made of parts.
- */
 type FieldTypeDeclaration = PartSchema | FieldTypeDefinition;
 
-/** A declaration as the catalog exposes it. A bare schema is a value with no parts. */
 type Defined<D> = D extends z.ZodType ? {value: D} : D;
 
-/**
- * The catalog, from what each type was declared as.
- *
- * A type that is simply a value says so by being one, with no wrapper to write for the
- * common case; a type made of parts says so by being a `record`, which is where the
- * work happens and so is worth naming at the call site.
- */
+/** A type that is simply a value is declared as one; a record announces itself. */
 function defineFieldTypes<D extends Record<FieldType, FieldTypeDeclaration>>(declarations: D): {[K in keyof D]: Defined<D[K]>} {
-    // The mapping is restated for the type system, which cannot follow a conditional
-    // type through `Object.fromEntries`.
+    // Restated for the type system, which cannot follow a conditional through
+    // `Object.fromEntries`.
     return Object.fromEntries(
         Object.entries(declarations).map(([type, declared]) => [type, declared instanceof z.ZodType ? {value: declared} : declared])
     ) as {[K in keyof D]: Defined<D[K]>};
 }
 
 /**
- * Every part of a record is optional, because none of an address's exists everywhere:
- * there is no postal code in Ireland or Hong Kong, and no city in an Irish townland
- * address. Which parts a particular value needs is a per-country question and only the
- * collection form knows the country, so requiring any here would leave a correctly filled
- * form unable to produce a valid value.
- *
- * What holds instead is that a value must name a part. What it says about that part is up
- * to it: a value sets the part, an empty one clears it. Storing a record with nothing in
- * it is not something this has to prevent — a part with no value gets no row.
+ * Every part is optional, because none of an address's exists everywhere: there is no
+ * postal code in Ireland or Hong Kong, and no city in an Irish townland address. Which
+ * parts a value needs is a per-country question, and only the collection form knows the
+ * country. What holds instead is that a value must name at least one part.
  *
  * The type check below is load-bearing rather than defensive. An optional part that is
  * explicitly undefined survives parsing as a key holding undefined, and a bare presence
  * check would let `{line1: undefined}` through as if it named something.
  */
 function record<F extends Record<string, PartSchema>>(fields: F) {
-    // `Object.fromEntries` widens away the key-to-schema mapping, so the shape is
-    // restated for the type system. Without it a record's value infers as `unknown` and
-    // every type built on one goes with it.
+    // Restated for the type system, which loses the key-to-schema mapping through
+    // `Object.fromEntries`; without it every type built on a record infers as `unknown`.
     const shape = Object.fromEntries(
         Object.entries(fields).map(([key, part]) => [key, clearable(part)])
     ) as {[K in keyof F]: ReturnType<typeof clearable<F[K]>>};
 
-    // Strict, so a part nobody declared is refused rather than dropped on the floor. The
-    // values service refuses an unrecognised field key for the same reason: a typo that
-    // silently loses what a member typed is worse than a save that fails and says so.
+    // Strict, so a part nobody declared is refused rather than dropped.
     const value = z.strictObject(shape).refine(
         parts => Object.values(parts).some(part => typeof part === 'string'),
         {message: 'A value must name at least one part.'}
@@ -220,23 +164,13 @@ export const FIELD_TYPES = defineFieldTypes({
     })
 });
 
-/**
- * An address value, for the admin types built on it. Named separately because admin
- * speaks of an address, where the catalog only knows a record of parts.
- */
+/** Named for the admin types built on it, which speak of an address rather than a record. */
 export const AddressValue = FIELD_TYPES.address.value;
 export type Address = z.infer<typeof AddressValue>;
 
-/**
- * The parts of a record type in declaration order, or null for a leaf.
- *
- * Read from the declaration rather than reverse-engineered from the schema it produced,
- * so adding a part is one edit and every consumer — the CSV columns, the paths a filter
- * may address, what admin renders — sees it.
- */
+/** The parts of a record type in declaration order, or null for a type with none. */
 export function subFieldsOf(type: FieldType): string[] | null {
-    // Read through the interface rather than off the literal: a leaf has no `fields` key
-    // at all, and this is the one place that has to treat both kinds the same way.
+    // Through the interface, not the literal: a type with no parts has no `fields` key.
     const {fields}: FieldTypeDefinition = FIELD_TYPES[type];
     return fields ? Object.keys(fields) : null;
 }

--- a/packages/custom-field-types/src/index.ts
+++ b/packages/custom-field-types/src/index.ts
@@ -24,13 +24,6 @@ import {z} from 'zod';
  */
 
 /**
- * Storage types: the small, closed set of database columns a value can live in.
- * The backend owns the column and its serialize/deserialize per storage type;
- * everything here only needs to know which one a field type routes to.
- */
-export type StorageType = 'text' | 'json';
-
-/**
  * Field types: the open, growing set a publisher picks. Many field types share
  * one storage type (short_text and long_text both store as text), yet each
  * carries its own validation even when the storage is identical — which is why
@@ -42,8 +35,6 @@ export type FieldType = typeof FIELD_TYPE_IDS[number];
 export const FieldTypeSchema = z.enum(FIELD_TYPE_IDS);
 
 export interface FieldTypeDefinition {
-    /** The storage column a value of this type is persisted in (backend concern). */
-    storageType: StorageType;
     /**
      * The authoritative validation for a value of this type. The backend runs it
      * as the gate; the frontend runs the same schema for instant feedback.
@@ -129,14 +120,13 @@ export type Address = z.infer<typeof AddressValue>;
 export const FIELD_TYPES = {
     // Characters, not bytes: 255 of anything fits the column with room to spare,
     // and a character count is the limit a publisher can reason about.
-    short_text: {storageType: 'text', value: z.string().max(255)},
+    short_text: {value: z.string().max(255)},
     long_text: {
-        storageType: 'text',
         value: z.string().refine(value => byteLength(value) <= MAX_LONG_TEXT_BYTES, {
             message: `Value must be at most ${MAX_LONG_TEXT_BYTES} bytes.`
         })
     },
-    address: {storageType: 'json', value: AddressValue}
+    address: {value: AddressValue}
 } as const satisfies Record<FieldType, FieldTypeDefinition>;
 
 /**

--- a/packages/custom-field-types/src/index.ts
+++ b/packages/custom-field-types/src/index.ts
@@ -74,9 +74,9 @@ const postalCode = () => text().max(32);
 
 /**
  * The shape of an ISO 3166-1 alpha-2 code, deliberately not checked against the list of
- * them: a closed list would make Ghost the arbiter of whose country is real, and there is
- * no defensible answer for Kosovo, Taiwan, Palestine or Western Sahara. The collection
- * form can offer a list to pick from without this deciding what exists.
+ * them. Membership of that list is contested, and a closed list here would make Ghost the
+ * arbiter of it for every member of every site. The collection form can offer countries to
+ * pick from without this deciding which ones exist.
  *
  * Case is normalised so that `gb` and `GB` are not two values for one place, which a
  * filter for either would silently half-miss.

--- a/packages/custom-field-types/test/index.test.ts
+++ b/packages/custom-field-types/test/index.test.ts
@@ -50,7 +50,7 @@ describe('custom-field-types catalog', function () {
     // The rule that replaced per-sub-field requiredness. An end-to-end test can't
     // pin it: the CSV and admin paths both strip blank sub-fields before a value
     // reaches the catalog, so neither ever presents the empty case this rejects.
-    describe('an address must have at least one sub-field filled in', function () {
+    describe('an address must name at least one part', function () {
         const parse = (value: unknown) => FIELD_TYPES.address.value.safeParse(value).success;
 
         it('accepts a partial address', function () {
@@ -60,16 +60,28 @@ describe('custom-field-types catalog', function () {
             assert.equal(parse({line1: 'Cloonlara', state: 'Co. Clare', country: 'IE'}), true);
         });
 
-        it('rejects an address with nothing in it', function () {
+        it('rejects an address that names nothing', function () {
             assert.equal(parse({}), false);
-            // A key present but explicitly undefined survives parsing, so it reaches the
-            // rule as a value and has to be turned away as one.
+            // A key present but explicitly undefined names nothing either: undefined is
+            // how a value says it has no opinion about a part.
             assert.equal(parse({line1: undefined}), false);
             assert.equal(parse({line1: undefined, country: undefined}), false);
         });
 
-        it('rejects an address whose every sub-field is blank', function () {
-            assert.equal(parse({line1: '', city: '', postal_code: ''}), false);
+        it('accepts an address that names parts as empty, which is how they are cleared', function () {
+            assert.equal(parse({line1: '', city: ''}), true);
+        });
+
+        it('lets a sub-field whose rule is a format be emptied too', function () {
+            // Empty is a statement about the write, not about the sub-field, so every
+            // sub-field takes it alike. A bound admits the empty string on its own; a
+            // pattern does not, which would leave a country the one part of an address
+            // that could be set but never removed.
+            assert.equal(parse({line1: '62 Ghost Lane', city: 'Dublin', country: ''}), true);
+            assert.equal(parse({country: ''}), true);
+
+            // Emptying it is still the only thing that gets in for free.
+            assert.equal(parse({country: 'DEU'}), false);
         });
 
         it('normalises the case of a country code, so one country is one value', function () {
@@ -116,13 +128,12 @@ describe('custom-field-types catalog', function () {
             assert.equal(FIELD_TYPES.address.value.safeParse({line1: `  ${'x'.repeat(255)}  `}).success, true);
         });
 
-        it('rejects an address whose every sub-field is only whitespace', function () {
-            // Admin trims a sub-field away before rendering it, so an address of
-            // spaces is one no screen could show, and none could clear either.
-            assert.equal(parse({line1: '   ', city: '\t'}), false);
-            // Two spaces satisfy country's own two-character rule, so only the
-            // composite rule can reject this one.
-            assert.equal(parse({country: '  '}), false);
+        it('reads a part of nothing but whitespace as empty, so it clears', function () {
+            // Trimming happens per part above, so whitespace has already become the empty
+            // string by the time the rule runs — and empty is an instruction, not a value.
+            const result = FIELD_TYPES.address.value.safeParse({line1: '   ', city: '\t'});
+            assert.equal(result.success, true);
+            assert.deepEqual(result.data, {line1: '', city: ''});
         });
     });
 });

--- a/packages/custom-field-types/test/index.test.ts
+++ b/packages/custom-field-types/test/index.test.ts
@@ -148,6 +148,14 @@ describe('custom-field-types catalog', function () {
             assert.equal(FIELD_TYPES.address.value.safeParse({line1: `  ${'x'.repeat(255)}  `}).success, true);
         });
 
+        it('refuses a part it does not recognise, rather than dropping it', function () {
+            // The parts of a type are declared in one place, so a name that is not one of
+            // them is a mistake worth saying out loud. Dropping it silently would store a
+            // value missing whatever the typo was meant to fill in.
+            assert.equal(parse({line1: '62 Ghost Lane', citty: 'Dublin'}), false);
+            assert.equal(parse({line1: '62 Ghost Lane', city: 'Dublin'}), true);
+        });
+
         it('bounds each part by what that part is, not by the record holding it', function () {
             // A postal code is its own kind of thing rather than a short text that happens
             // to be in an address: no country writes one longer than this, and a street

--- a/packages/custom-field-types/test/index.test.ts
+++ b/packages/custom-field-types/test/index.test.ts
@@ -19,6 +19,26 @@ describe('custom-field-types catalog', function () {
         });
     });
 
+    describe('text is trimmed, whatever type it belongs to', function () {
+        // Trimming decides whether a value is stored at all: a value that trims to
+        // nothing is a clear. Two text types disagreeing about that would mean the same
+        // keystrokes emptying one field and filling another.
+        it('trims every text type alike', function () {
+            for (const type of ['short_text', 'long_text'] as const) {
+                const padded = FIELD_TYPES[type].value.safeParse('  Ghosts  ');
+                assert.equal(padded.success && padded.data, 'Ghosts', type);
+
+                const blank = FIELD_TYPES[type].value.safeParse('   ');
+                assert.equal(blank.success && blank.data, '', type);
+            }
+        });
+
+        it('measures a bound against the value rather than its padding', function () {
+            assert.equal(FIELD_TYPES.short_text.value.safeParse(`  ${'x'.repeat(255)}  `).success, true);
+            assert.equal(FIELD_TYPES.short_text.value.safeParse('x'.repeat(256)).success, false);
+        });
+    });
+
     // The one piece of real logic in here, and the one an end-to-end test can't
     // pin precisely: the bound is counted in bytes, because the column it routes
     // to is sized in bytes. A character-based bound would accept a multibyte
@@ -126,6 +146,16 @@ describe('custom-field-types catalog', function () {
 
             // A value that reaches the limit exactly still fits once its padding is gone.
             assert.equal(FIELD_TYPES.address.value.safeParse({line1: `  ${'x'.repeat(255)}  `}).success, true);
+        });
+
+        it('bounds each part by what that part is, not by the record holding it', function () {
+            // A postal code is its own kind of thing rather than a short text that happens
+            // to be in an address: no country writes one longer than this, and a street
+            // address needs the room a postal code does not.
+            assert.equal(parse({postal_code: 'x'.repeat(32)}), true);
+            assert.equal(parse({postal_code: 'x'.repeat(33)}), false);
+            assert.equal(parse({line1: 'x'.repeat(255)}), true);
+            assert.equal(parse({line1: 'x'.repeat(256)}), false);
         });
 
         it('reads a part of nothing but whitespace as empty, so it clears', function () {

--- a/packages/custom-field-types/test/index.test.ts
+++ b/packages/custom-field-types/test/index.test.ts
@@ -1,19 +1,21 @@
 import assert from 'node:assert/strict';
 import {describe, it} from 'vitest';
-import {FIELD_TYPES, FIELD_TYPE_IDS, MAX_LONG_TEXT_BYTES} from '../src/index.ts';
+import {FIELD_TYPES, FIELD_TYPE_IDS, MAX_LONG_TEXT_BYTES, subFieldsOf} from '../src/index.ts';
 
-// This asserts only the catalog's *contract* — which field types exist and which
-// storage type each routes to. The behavioural outcomes (per-type value
-// validation, the composite address round-tripping, sub-field 422s) are proven
-// end-to-end through the members custom-fields HTTP API integration tests, which
-// exercise this catalog together with the backend storage and the wire format.
+// This asserts only the catalog's *contract* — which field types exist, and which of
+// them have parts. The behavioural outcomes (per-type value validation, the composite
+// address round-tripping, sub-field 422s) are proven end-to-end through the members
+// custom-fields HTTP API integration tests, which exercise this catalog together with
+// the backend storage and the wire format.
 describe('custom-field-types catalog', function () {
-    it('offers the expected field types and their storage routing', function () {
-        const routing = Object.fromEntries(FIELD_TYPE_IDS.map(id => [id, FIELD_TYPES[id].storageType]));
-        assert.deepEqual(routing, {
-            short_text: 'text',
-            long_text: 'text',
-            address: 'json'
+    it('offers the expected field types, and says which of them have parts', function () {
+        // Whether a value has parts is the only structural fact the backend reads off a
+        // type: it decides how many rows the value occupies and what they are keyed by.
+        const parts = Object.fromEntries(FIELD_TYPE_IDS.map(id => [id, subFieldsOf(id)]));
+        assert.deepEqual(parts, {
+            short_text: null,
+            long_text: null,
+            address: ['line1', 'line2', 'city', 'state', 'postal_code', 'country']
         });
     });
 


### PR DESCRIPTION
A composite value like an address used to live in one row as a JSON blob. It now occupies one row per part, addressed by a path.

**Before**

```mermaid
flowchart LR
    UI["Member screen"] --> API["Admin API"] --> SVC["Values service"] --> DB[("One row per field<br>the whole address as JSON")]
    CAT["Shared field catalog"] -.-> UI
    CAT -.-> API
    SEG["Filter members by country"] -.->|"reaches inside the JSON, no index"| DB
```

**After**

```mermaid
flowchart LR
    UI["Member screen"] --> API["Admin API"] --> SVC["Values service"] --> DB[("One row per part<br>addressed by a path")]
    CAT["Shared field catalog"] -.-> UI
    CAT -.-> API
    SEG["Filter members by country"] -.->|"an indexed seek to that part"| DB
    classDef changed fill:#dbeafe,stroke:#2563eb,color:#1e3a8a
    class CAT,SVC,DB changed
```

The shaded layers are the ones that changed: the shared catalog, the values service and the rows themselves. The member screen, the Admin API and the CSV columns are untouched, and still see one address.

### Storing each part of a composite value on its own row

**Problem**

A composite value like an address lived in a single row as a JSON blob, so no part of it could be reached on its own. Filtering members by the country they live in meant looking inside the blob, and a JSON path cannot use an index, so a saved segment scanned the whole table every time it was evaluated.

**Solution**

Each part now occupies its own row, under a path that names it and indexed alongside the field it belongs to. Asking for everyone in a given country becomes an ordinary predicate that seeks straight to that part, rather than a scan of every stored value. The index covers the field and the part but not the value, so it narrows the work to the members who filled that part rather than answering the question outright.

The value model above storage is unchanged: the API, the CSV columns and the member screen all still see one address.

Values already stored are discarded rather than converted. Custom fields have never been released, so only a site deliberately opted into the flag can be holding one, while a conversion step would run on every Ghost database for as long as the migration exists. Rolling back already discards composite values, so discarding on the way forward is at least the same answer twice.

The migration targets the next minor, because a released version's migrations have already run on sites at that version and anything added to it afterwards would be skipped. That carries the usual version bump with it.

### Writing the parts a request names

**Problem**

Applying a write had two modes, one that merged a composite's parts into what was stored and one that replaced the value whole, and the caller chose between them. Neither was a fact about composites. Replacing a value whole was never a considered behaviour, only what a blob made unavoidable, and it outlived the blob.

**Solution**

One rule at every level: naming something writes it, naming it as empty clears it, and saying nothing about it leaves it alone. A part of a value is a field, so the rule that already held for fields holds one level down too.

Emptying now means the same thing for every part whatever its own rule. That matters where the rule is a pattern rather than a length: nothing empty can match the shape of a country code, so a country used to be the one part of an address a member could be given but never rid of.

### Declaring a composite's parts once

**Problem**

Whether a field type had parts was answered by inspecting the schema an address happened to compile to, which reads the answer out of an artefact rather than a declaration. Each part carried a size written beside it, and a bare number explains nothing about why a postal code is shorter than a street.

**Solution**

A field type is assembled from named builders, so a part is declared as the thing it is and its bounds sit with everything else true of that thing. The same builder describes a whole field and a part of one.

A composite carries its parts as data and derives its validation from them, so adding a part is a single edit that the CSV columns, the paths a filter can address and the member screen all pick up.

Text is trimmed in one place rather than restated per type, so the two text types no longer disagree about whitespace: a value of nothing but spaces clears the field whichever one it was typed into.

### Refusing a part nobody declared

**Problem**

A misspelled field name was refused, and a misspelled part of an address was dropped in silence. The same mistake got two different answers depending on how deep it was made, and the quieter answer was the worse one: the save reported success while whatever the typo was meant to fill in was simply gone, with nothing afterwards able to tell it had ever been sent.

**Solution**

A name nobody recognises is now an error at either depth. The parts of a type are declared in one place, so a name that is not one of them can be recognised as a mistake and said out loud.

The two halves cannot sit next to each other, because only the server knows which fields a site has defined and only the shared catalogue knows what parts a type has. So the rule is written down once, and each half enforces it over the names it is the authority on.

### Cutting the comments back to what the code cannot say

**Problem**

Most of the comments in this area either restated the line beneath them or recorded how the code arrived at its present shape. History a reader cannot check is worse than no comment, because it still has to be read before it can be dismissed.

**Solution**

What survives is the part that is not in the code and not inferrable from it: limits the database imposes, an ordering that only matters on one engine, a decision about the world that a regular expression cannot express, and the traps that would otherwise be found by hitting them.

The shared package keeps a longer explanation, because somebody meeting custom field types for the first time needs the concept before the code means anything. It now explains what a field type is rather than what it used to be.

Two real defects surfaced while doing this: one point stated twice in consecutive lines, and a documentation block left describing something that had moved.

### Checking index names against the identifier limit

**Problem**

MySQL rejects an identifier longer than 64 characters, and names for indexes and constraints are built from the table name plus every column in them, so a wide index on a long table name overruns it. This migration needed an explicit shorter name for exactly that reason.

**Solution**

The declared schema is now walked for every index, unique constraint and foreign key, and the check fails with the offending name and its length.

Worth a test rather than a comment because SQLite has no such limit: a migration that trips it passes every local run and only fails when a site upgrades. The check covers every table, not just the one this change touches.