### PR TITLE
Fixed stale automation data when reopening the editor

### DIFF
--- a/apps/admin/src/automations/components/canvas/email-performance-section.tsx
+++ b/apps/admin/src/automations/components/canvas/email-performance-section.tsx
@@ -212,7 +212,8 @@ const TopClickedLinks: React.FC<{
 }> = ({actionId, automationId, clickedCount, sentCount}) => {
     const {data, isError, isLoading} = useBrowseAutomationActionLinks(automationId, actionId, {
         defaultErrorHandler: false,
-        enabled: sentCount > 0
+        enabled: sentCount > 0,
+        refetchOnMount: 'always'
     });
     const links = data?.automation_action_links.slice(0, 10) ?? [];
 

--- a/apps/admin/src/automations/editor.test.tsx
+++ b/apps/admin/src/automations/editor.test.tsx
@@ -114,7 +114,7 @@ type MockEditMutationOptions = {
     onSuccess?: (data: AutomationDetailResponseType) => void;
     onError?: (error?: unknown) => void;
 };
-const mockUseReadAutomation = vi.fn<(...args: unknown[]) => {data?: AutomationDetailResponseType; isLoading?: boolean; isError?: boolean}>();
+const mockUseReadAutomation = vi.fn<(...args: unknown[]) => {data?: AutomationDetailResponseType; isLoading?: boolean; isFetching?: boolean; isError?: boolean}>();
 const mockUseBrowseAutomationActionLinks = vi.fn<(...args: unknown[]) => {data?: AutomationActionLinksResponseType; isLoading: boolean; isError: boolean}>();
 const mockEditMutation = {
     mutate: vi.fn<(payload: EditAutomationPayload, options: MockEditMutationOptions) => void>(),
@@ -290,6 +290,10 @@ const renderEditor = (initialEntries = ['/automations/automation-id-1']) => {
     };
 };
 
+const rerenderEditorRoute = (router: ReturnType<typeof createMemoryRouter>) => act(async () => {
+    await router.navigate('/automations/automation-id-1', {replace: true});
+});
+
 const withEmptyEmailBodies = (fixture: AutomationDetail): AutomationDetail => ({
     ...fixture,
     actions: fixture.actions.map(action => (
@@ -363,6 +367,56 @@ describe('AutomationEditor', () => {
 
         expect(screen.getByTestId('automation-canvas-loading')).toBeInTheDocument();
         expect(screen.getByRole('button', {name: 'Publish'})).toBeDisabled();
+    });
+
+    it('waits for a fresh response before cached automation data becomes editable', async () => {
+        const cachedAutomation = {
+            ...automationDetail,
+            actions: automationDetail.actions.map(action => action.type === 'send_email'
+                ? {...action, data: {...action.data, email_subject: 'Cached subject'}}
+                : action)
+        };
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [cachedAutomation]},
+            isLoading: false,
+            isFetching: true,
+            isError: false
+        });
+
+        const {router} = renderEditor();
+
+        expect(mockUseReadAutomation).toHaveBeenCalledWith('automation-id-1', {
+            defaultErrorHandler: false,
+            refetchOnMount: 'always'
+        });
+        expect(screen.getByTestId('automation-canvas-loading')).toBeInTheDocument();
+        expect(screen.queryByText('Cached subject')).not.toBeInTheDocument();
+
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [automationDetail]},
+            isLoading: false,
+            isFetching: false,
+            isError: false
+        });
+        await rerenderEditorRoute(router);
+
+        expect(screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'})).toBeInTheDocument();
+        expect(screen.queryByTestId('automation-canvas-loading')).not.toBeInTheDocument();
+    });
+
+    it('does not fall back to cached automation data when the fresh request fails', () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [automationDetail]},
+            isLoading: false,
+            isFetching: false,
+            isError: true
+        });
+
+        renderEditor();
+
+        expect(screen.getByRole('alert')).toHaveTextContent('Couldn\'t load automation');
+        expect(screen.queryByTestId('automation-canvas')).not.toBeInTheDocument();
+        expect(screen.queryByText('Welcome to The Blueprint')).not.toBeInTheDocument();
     });
 
     it('renders the error banner when the read query fails', () => {
@@ -596,7 +650,7 @@ describe('AutomationEditor', () => {
         fireEvent.click(screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'}));
 
         const sidebar = screen.getByRole('complementary', {name: 'Step details'});
-        expect(mockUseBrowseAutomationActionLinks).toHaveBeenCalledWith('automation-id-1', 'action-email', {defaultErrorHandler: false, enabled: true});
+        expect(mockUseBrowseAutomationActionLinks).toHaveBeenCalledWith('automation-id-1', 'action-email', {defaultErrorHandler: false, enabled: true, refetchOnMount: 'always'});
         expect(within(sidebar).getAllByRole('link')).toHaveLength(10);
 
         const firstLink = within(sidebar).getByRole('link', {name: 'example.com/link-1'});
@@ -658,7 +712,7 @@ describe('AutomationEditor', () => {
         fireEvent.click(screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'}));
 
         expect(screen.getByText('No emails sent yet.')).toBeInTheDocument();
-        expect(mockUseBrowseAutomationActionLinks).toHaveBeenCalledWith('automation-id-1', 'action-email', {defaultErrorHandler: false, enabled: false});
+        expect(mockUseBrowseAutomationActionLinks).toHaveBeenCalledWith('automation-id-1', 'action-email', {defaultErrorHandler: false, enabled: false, refetchOnMount: 'always'});
     });
 
     it('hides clicked links and skips the request when click tracking is off', () => {

--- a/apps/admin/src/automations/editor.test.tsx
+++ b/apps/admin/src/automations/editor.test.tsx
@@ -297,6 +297,13 @@ const rerenderEditorRoute = (router: ReturnType<typeof createMemoryRouter>) => a
     await router.navigate('/automations/automation-id-1', {replace: true});
 });
 
+const withEmailSubject = (automation: AutomationDetail, emailSubject: string): AutomationDetail => ({
+    ...automation,
+    actions: automation.actions.map(action => action.type === 'send_email'
+        ? {...action, data: {...action.data, email_subject: emailSubject}}
+        : action)
+});
+
 const withEmptyEmailBodies = (fixture: AutomationDetail): AutomationDetail => ({
     ...fixture,
     actions: fixture.actions.map(action => (
@@ -373,12 +380,7 @@ describe('AutomationEditor', () => {
     });
 
     it('waits for a fresh response before cached automation data becomes editable', async () => {
-        const cachedAutomation = {
-            ...automationDetail,
-            actions: automationDetail.actions.map(action => action.type === 'send_email'
-                ? {...action, data: {...action.data, email_subject: 'Cached subject'}}
-                : action)
-        };
+        const cachedAutomation = withEmailSubject(automationDetail, 'Cached subject');
         mockUseReadAutomation.mockReturnValue({
             data: {automations: [cachedAutomation]},
             isLoading: false,
@@ -440,8 +442,9 @@ describe('AutomationEditor', () => {
         fireEvent.blur(subjectInput);
         expect(screen.getByRole('button', {name: 'Publish changes'})).toBeEnabled();
 
+        const refreshedAutomation = withEmailSubject(automationDetail, 'Server-refreshed subject');
         mockUseReadAutomation.mockReturnValue({
-            data: {automations: [automationDetail]},
+            data: {automations: [refreshedAutomation]},
             isLoading: false,
             isFetchedAfterMount: true,
             isError: true
@@ -450,6 +453,8 @@ describe('AutomationEditor', () => {
 
         expect(screen.getByTestId('automation-canvas')).toBeInTheDocument();
         expect(screen.queryByText('Couldn\'t load automation')).not.toBeInTheDocument();
+        expect(within(sidebar).getByDisplayValue('Locally edited subject')).toBeInTheDocument();
+        expect(within(sidebar).queryByDisplayValue('Server-refreshed subject')).not.toBeInTheDocument();
         expect(screen.getByRole('button', {name: 'Publish changes'})).toBeEnabled();
 
         fireEvent.click(screen.getByRole('link', {name: 'Back to automations'}));
@@ -458,16 +463,10 @@ describe('AutomationEditor', () => {
     });
 
     it('does not reuse an old draft when navigating from A to B and back to A', async () => {
-        const withSubject = (automation: AutomationDetail, emailSubject: string): AutomationDetail => ({
-            ...automation,
-            actions: automation.actions.map(action => action.type === 'send_email'
-                ? {...action, data: {...action.data, email_subject: emailSubject}}
-                : action)
-        });
-        const initialA = withSubject(automationDetail, 'Initial A subject');
-        const freshA = withSubject(automationDetail, 'Fresh A subject');
+        const initialA = withEmailSubject(automationDetail, 'Initial A subject');
+        const freshA = withEmailSubject(automationDetail, 'Fresh A subject');
         const automationB = {
-            ...withSubject(automationDetail, 'Automation B subject'),
+            ...withEmailSubject(automationDetail, 'Automation B subject'),
             id: 'automation-id-2',
             name: 'Paid member welcome flow',
             slug: 'member-welcome-email-paid'
@@ -479,8 +478,8 @@ describe('AutomationEditor', () => {
                 return {
                     data: {automations: [automationB]},
                     isLoading: false,
-                    isFetching: true,
-                    isFetchedAfterMount: false,
+                    isFetching: false,
+                    isFetchedAfterMount: true,
                     isError: false
                 };
             }
@@ -498,7 +497,7 @@ describe('AutomationEditor', () => {
         expect(screen.getByRole('button', {name: 'Send email: Initial A subject'})).toBeInTheDocument();
 
         await act(async () => router.navigate('/automations/automation-id-2'));
-        expect(screen.getByTestId('automation-canvas-loading')).toBeInTheDocument();
+        expect(screen.getByRole('button', {name: 'Send email: Automation B subject'})).toBeInTheDocument();
 
         aResponse = 'fetching';
         await act(async () => router.navigate('/automations/automation-id-1'));

--- a/apps/admin/src/automations/editor.test.tsx
+++ b/apps/admin/src/automations/editor.test.tsx
@@ -424,6 +424,39 @@ describe('AutomationEditor', () => {
         expect(screen.queryByText('Welcome to The Blueprint')).not.toBeInTheDocument();
     });
 
+    it('keeps a dirty editing session intact when a later read refresh fails', async () => {
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [automationDetail]},
+            isLoading: false,
+            isError: false
+        });
+
+        const {router} = renderEditor();
+
+        fireEvent.click(screen.getByRole('button', {name: 'Send email: Welcome to The Blueprint'}));
+        const sidebar = screen.getByRole('complementary', {name: 'Step details'});
+        const subjectInput = within(sidebar).getByDisplayValue('Welcome to The Blueprint');
+        fireEvent.change(subjectInput, {target: {value: 'Locally edited subject'}});
+        fireEvent.blur(subjectInput);
+        expect(screen.getByRole('button', {name: 'Publish changes'})).toBeEnabled();
+
+        mockUseReadAutomation.mockReturnValue({
+            data: {automations: [automationDetail]},
+            isLoading: false,
+            isFetchedAfterMount: true,
+            isError: true
+        });
+        await rerenderEditorRoute(router);
+
+        expect(screen.getByTestId('automation-canvas')).toBeInTheDocument();
+        expect(screen.queryByText('Couldn\'t load automation')).not.toBeInTheDocument();
+        expect(screen.getByRole('button', {name: 'Publish changes'})).toBeEnabled();
+
+        fireEvent.click(screen.getByRole('link', {name: 'Back to automations'}));
+        expect(screen.getByRole('alertdialog', {name: 'Discard unsaved changes?'})).toBeInTheDocument();
+        expect(screen.queryByTestId('automations-list-route')).not.toBeInTheDocument();
+    });
+
     it('does not reuse an old draft when navigating from A to B and back to A', async () => {
         const withSubject = (automation: AutomationDetail, emailSubject: string): AutomationDetail => ({
             ...automation,

--- a/apps/admin/src/automations/editor.test.tsx
+++ b/apps/admin/src/automations/editor.test.tsx
@@ -419,6 +419,58 @@ describe('AutomationEditor', () => {
         expect(screen.queryByText('Welcome to The Blueprint')).not.toBeInTheDocument();
     });
 
+    it('does not reuse an old draft when navigating from A to B and back to A', async () => {
+        const withSubject = (automation: AutomationDetail, emailSubject: string): AutomationDetail => ({
+            ...automation,
+            actions: automation.actions.map(action => action.type === 'send_email'
+                ? {...action, data: {...action.data, email_subject: emailSubject}}
+                : action)
+        });
+        const initialA = withSubject(automationDetail, 'Initial A subject');
+        const freshA = withSubject(automationDetail, 'Fresh A subject');
+        const automationB = {
+            ...withSubject(automationDetail, 'Automation B subject'),
+            id: 'automation-id-2',
+            name: 'Paid member welcome flow',
+            slug: 'member-welcome-email-paid'
+        };
+        let aResponse: 'initial' | 'fetching' | 'fresh' = 'initial';
+
+        mockUseReadAutomation.mockImplementation((automationId) => {
+            if (automationId === 'automation-id-2') {
+                return {
+                    data: {automations: [automationB]},
+                    isLoading: false,
+                    isFetching: true,
+                    isError: false
+                };
+            }
+
+            return {
+                data: {automations: [aResponse === 'fresh' ? freshA : initialA]},
+                isLoading: false,
+                isFetching: aResponse === 'fetching',
+                isError: false
+            };
+        });
+
+        const {router} = renderEditor();
+        expect(screen.getByRole('button', {name: 'Send email: Initial A subject'})).toBeInTheDocument();
+
+        await act(async () => router.navigate('/automations/automation-id-2'));
+        expect(screen.getByTestId('automation-canvas-loading')).toBeInTheDocument();
+
+        aResponse = 'fetching';
+        await act(async () => router.navigate('/automations/automation-id-1'));
+        expect(screen.getByTestId('automation-canvas-loading')).toBeInTheDocument();
+        expect(screen.queryByText('Initial A subject')).not.toBeInTheDocument();
+
+        aResponse = 'fresh';
+        await rerenderEditorRoute(router);
+        expect(screen.getByRole('button', {name: 'Send email: Fresh A subject'})).toBeInTheDocument();
+        expect(screen.queryByText('Initial A subject')).not.toBeInTheDocument();
+    });
+
     it('renders the error banner when the read query fails', () => {
         mockUseReadAutomation.mockReturnValue({
             data: undefined,

--- a/apps/admin/src/automations/editor.test.tsx
+++ b/apps/admin/src/automations/editor.test.tsx
@@ -114,7 +114,7 @@ type MockEditMutationOptions = {
     onSuccess?: (data: AutomationDetailResponseType) => void;
     onError?: (error?: unknown) => void;
 };
-const mockUseReadAutomation = vi.fn<(...args: unknown[]) => {data?: AutomationDetailResponseType; isLoading?: boolean; isFetching?: boolean; isError?: boolean}>();
+const mockUseReadAutomation = vi.fn<(...args: unknown[]) => {data?: AutomationDetailResponseType; isLoading?: boolean; isFetching?: boolean; isError?: boolean; isFetchedAfterMount?: boolean}>();
 const mockUseBrowseAutomationActionLinks = vi.fn<(...args: unknown[]) => {data?: AutomationActionLinksResponseType; isLoading: boolean; isError: boolean}>();
 const mockEditMutation = {
     mutate: vi.fn<(payload: EditAutomationPayload, options: MockEditMutationOptions) => void>(),
@@ -135,7 +135,10 @@ vi.mock('@tryghost/admin-x-framework/api/automations', async () => {
     );
     return {
         ...actual,
-        useReadAutomation: (...args: unknown[]) => mockUseReadAutomation(...args),
+        useReadAutomation: (...args: unknown[]) => ({
+            isFetchedAfterMount: true,
+            ...mockUseReadAutomation(...args)
+        }),
         useBrowseAutomationActionLinks: (...args: unknown[]) => mockUseBrowseAutomationActionLinks(...args),
         useEditAutomation: () => mockEditMutation
     };
@@ -379,7 +382,8 @@ describe('AutomationEditor', () => {
         mockUseReadAutomation.mockReturnValue({
             data: {automations: [cachedAutomation]},
             isLoading: false,
-            isFetching: true,
+            isFetching: false,
+            isFetchedAfterMount: false,
             isError: false
         });
 
@@ -396,6 +400,7 @@ describe('AutomationEditor', () => {
             data: {automations: [automationDetail]},
             isLoading: false,
             isFetching: false,
+            isFetchedAfterMount: true,
             isError: false
         });
         await rerenderEditorRoute(router);
@@ -442,6 +447,7 @@ describe('AutomationEditor', () => {
                     data: {automations: [automationB]},
                     isLoading: false,
                     isFetching: true,
+                    isFetchedAfterMount: false,
                     isError: false
                 };
             }
@@ -450,6 +456,7 @@ describe('AutomationEditor', () => {
                 data: {automations: [aResponse === 'fresh' ? freshA : initialA]},
                 isLoading: false,
                 isFetching: aResponse === 'fetching',
+                isFetchedAfterMount: aResponse !== 'fetching',
                 isError: false
             };
         });

--- a/apps/admin/src/automations/editor.tsx
+++ b/apps/admin/src/automations/editor.tsx
@@ -51,8 +51,9 @@ const getActionErrors = (automation: AutomationDetail): Record<string, string> =
 const AutomationEditor: React.FC = () => {
     const {id = ''} = useParams<{id: string}>();
 
-    const {data, isLoading: isLoadingAutomation, isError} = useReadAutomation(id, {
-        defaultErrorHandler: false
+    const {data, isLoading: isLoadingAutomation, isFetching: isFetchingAutomation, isError} = useReadAutomation(id, {
+        defaultErrorHandler: false,
+        refetchOnMount: 'always'
     });
     const automation = data?.automations[0];
 
@@ -64,18 +65,18 @@ const AutomationEditor: React.FC = () => {
     const navigationBlockerReasonRef = React.useRef<'automation' | 'email' | null>(null);
     const isBlockedEmailNavigationLeavingEditorRef = React.useRef(false);
 
-    // Draft is the user-facing, locally mutable copy. The React Query cache stays as server truth;
-    // staged edits (adding steps, etc.) live here until the user publishes. Seeded once when the
-    // automation first loads, and reset to the response after every successful edit.
-    const [draft, setDraft] = React.useState<AutomationDetail | undefined>(undefined);
+    // Draft is the user-facing, locally mutable copy. Wait for the mount refetch to finish before
+    // seeding it so cached automation data can never become an editable stale draft.
+    const [draftState, setDraft] = React.useState<AutomationDetail | undefined>(undefined);
     React.useEffect(() => {
-        if (automation) {
+        if (automation && !isFetchingAutomation && !isError) {
             setDraft((oldDraft) => {
                 return oldDraft?.id === automation.id ? oldDraft : automation;
             });
         }
-    }, [automation]);
-    const isInitializingDraft = !!automation && !draft;
+    }, [automation, isError, isFetchingAutomation]);
+    const draft = draftState?.id === id ? draftState : undefined;
+    const isInitializingDraft = !draft && !isError && (isLoadingAutomation || isFetchingAutomation || !!automation);
     const isEditorLoading = isLoadingAutomation || isInitializingDraft;
 
     // Only compare the fields the user can edit; server-stamped fields like `updated_at` would

--- a/apps/admin/src/automations/editor.tsx
+++ b/apps/admin/src/automations/editor.tsx
@@ -48,14 +48,13 @@ const getActionErrors = (automation: AutomationDetail): Record<string, string> =
     return errors;
 };
 
-const AutomationEditor: React.FC = () => {
-    const {id = ''} = useParams<{id: string}>();
-
-    const {data, isLoading: isLoadingAutomation, isFetching: isFetchingAutomation, isError} = useReadAutomation(id, {
+const AutomationEditor: React.FC<{id: string}> = ({id}) => {
+    const {data, isFetching: isFetchingAutomation, isError} = useReadAutomation(id, {
         defaultErrorHandler: false,
         refetchOnMount: 'always'
     });
     const automation = data?.automations[0];
+    const freshAutomation = !isFetchingAutomation && !isError && automation?.id === id ? automation : undefined;
 
     const editMutation = useEditAutomation();
     const [editState, setEditState] = React.useState<AutomationEditState>({phase: 'idle'});
@@ -67,17 +66,15 @@ const AutomationEditor: React.FC = () => {
 
     // Draft is the user-facing, locally mutable copy. Wait for the mount refetch to finish before
     // seeding it so cached automation data can never become an editable stale draft.
-    const [draftState, setDraft] = React.useState<AutomationDetail | undefined>(undefined);
+    const [draft, setDraft] = React.useState<AutomationDetail | undefined>(undefined);
     React.useEffect(() => {
-        if (automation && !isFetchingAutomation && !isError) {
-            setDraft((oldDraft) => {
-                return oldDraft?.id === automation.id ? oldDraft : automation;
-            });
+        if (!freshAutomation) {
+            return;
         }
-    }, [automation, isError, isFetchingAutomation]);
-    const draft = draftState?.id === id ? draftState : undefined;
-    const isInitializingDraft = !draft && !isError && (isLoadingAutomation || isFetchingAutomation || !!automation);
-    const isEditorLoading = isLoadingAutomation || isInitializingDraft;
+
+        setDraft(currentDraft => currentDraft ?? freshAutomation);
+    }, [freshAutomation]);
+    const isEditorLoading = !draft && !isError;
 
     // Only compare the fields the user can edit; server-stamped fields like `updated_at` would
     // otherwise flip the dirty flag immediately after every successful publish.
@@ -544,4 +541,10 @@ const AutomationEditor: React.FC = () => {
     );
 };
 
-export default AutomationEditor;
+const AutomationEditorRoute: React.FC = () => {
+    const {id = ''} = useParams<{id: string}>();
+
+    return <AutomationEditor key={id} id={id} />;
+};
+
+export default AutomationEditorRoute;

--- a/apps/admin/src/automations/editor.tsx
+++ b/apps/admin/src/automations/editor.tsx
@@ -50,7 +50,7 @@ const getActionErrors = (automation: AutomationDetail): Record<string, string> =
 };
 
 const AutomationEditor: React.FC<{id: string}> = ({id}) => {
-    const {automation, isError} = useAutomationForEditing(id);
+    const {automation, isError: isReadError} = useAutomationForEditing(id);
 
     const editMutation = useEditAutomation();
     const [editState, setEditState] = React.useState<AutomationEditState>({phase: 'idle'});
@@ -60,23 +60,26 @@ const AutomationEditor: React.FC<{id: string}> = ({id}) => {
     const navigationBlockerReasonRef = React.useRef<'automation' | 'email' | null>(null);
     const isBlockedEmailNavigationLeavingEditorRef = React.useRef(false);
 
-    // Draft is the user-facing, locally mutable copy. Seed it once so later query updates cannot
-    // overwrite edits made during this editing session.
+    // Keep the saved snapshot separate from the live query result. Later query updates or errors
+    // must not redefine the dirty state or overwrite edits made during this editing session.
+    const [savedAutomation, setSavedAutomation] = React.useState<AutomationDetail | undefined>(undefined);
     const [draft, setDraft] = React.useState<AutomationDetail | undefined>(undefined);
     React.useEffect(() => {
         if (!automation) {
             return;
         }
 
+        setSavedAutomation(currentAutomation => currentAutomation ?? automation);
         setDraft(currentDraft => currentDraft ?? automation);
     }, [automation]);
-    const isEditorLoading = !draft && !isError;
+    const isEditorLoading = !draft && !isReadError;
+    const isEditorError = !draft && isReadError;
 
     // Only compare the fields the user can edit; server-stamped fields like `updated_at` would
     // otherwise flip the dirty flag immediately after every successful publish.
     const hasUnsavedChanges = !!draft
-        && !!automation
-        && !dequal(editableSlice(draft), editableSlice(automation));
+        && !!savedAutomation
+        && !dequal(editableSlice(draft), editableSlice(savedAutomation));
 
     const onDraftChange = (next: AutomationDetail) => {
         setDraft(next);
@@ -158,7 +161,9 @@ const AutomationEditor: React.FC<{id: string}> = ({id}) => {
             },
             {
                 onSuccess: (response) => {
-                    setDraft(response.automations[0]);
+                    const savedDraft = response.automations[0];
+                    setSavedAutomation(savedDraft);
+                    setDraft(savedDraft);
                     setActionErrors({});
                     setEditState({phase: 'idle'});
                 },
@@ -417,7 +422,7 @@ const AutomationEditor: React.FC<{id: string}> = ({id}) => {
                 actionErrors={actionErrors}
                 automation={draft}
                 isEmailNavigationBlocked={isEmailNavigationBlocked}
-                isError={isError}
+                isError={isEditorError}
                 isLoading={isEditorLoading}
                 onChange={onDraftChange}
                 onDiscardBlockedEmailNavigation={(closeEmailModal) => {

--- a/apps/admin/src/automations/editor.tsx
+++ b/apps/admin/src/automations/editor.tsx
@@ -49,8 +49,8 @@ const getActionErrors = (automation: AutomationDetail): Record<string, string> =
     return errors;
 };
 
-const AutomationEditor: React.FC<{id: string}> = ({id}) => {
-    const {automation, isError: isReadError} = useAutomationForEditing(id);
+const AutomationEditorContent: React.FC<{automationId: string}> = ({automationId}) => {
+    const {automation, isError: isReadError} = useAutomationForEditing(automationId);
 
     const editMutation = useEditAutomation();
     const [editState, setEditState] = React.useState<AutomationEditState>({phase: 'idle'});
@@ -542,10 +542,10 @@ const AutomationEditor: React.FC<{id: string}> = ({id}) => {
     );
 };
 
-const AutomationEditorRoute: React.FC = () => {
-    const {id = ''} = useParams<{id: string}>();
+const AutomationEditor: React.FC = () => {
+    const {id: automationId = ''} = useParams<{id: string}>();
 
-    return <AutomationEditor key={id} id={id} />;
+    return <AutomationEditorContent key={automationId} automationId={automationId} />;
 };
 
-export default AutomationEditorRoute;
+export default AutomationEditor;

--- a/apps/admin/src/automations/editor.tsx
+++ b/apps/admin/src/automations/editor.tsx
@@ -1,8 +1,9 @@
 import AutomationCanvas, {EMAIL_STEP_QUERY_PARAM} from './components/canvas/automation-canvas';
 import AutomationHeader from './components/automation-header';
+import {useAutomationForEditing} from './hooks/use-automation-for-editing';
 import React from 'react';
 import {AlertDialog, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, Button, type ButtonProps, LoadingIndicator} from '@tryghost/shade/components';
-import {useEditAutomation, useReadAutomation} from '@tryghost/admin-x-framework/api/automations';
+import {useEditAutomation} from '@tryghost/admin-x-framework/api/automations';
 import type {AutomationDetail, AutomationStatus} from '@tryghost/admin-x-framework/api/automations';
 import {dequal} from 'dequal';
 import {isEmptyEmailLexical} from './utils';
@@ -49,12 +50,7 @@ const getActionErrors = (automation: AutomationDetail): Record<string, string> =
 };
 
 const AutomationEditor: React.FC<{id: string}> = ({id}) => {
-    const {data, isFetching: isFetchingAutomation, isError} = useReadAutomation(id, {
-        defaultErrorHandler: false,
-        refetchOnMount: 'always'
-    });
-    const automation = data?.automations[0];
-    const freshAutomation = !isFetchingAutomation && !isError && automation?.id === id ? automation : undefined;
+    const {automation, isError} = useAutomationForEditing(id);
 
     const editMutation = useEditAutomation();
     const [editState, setEditState] = React.useState<AutomationEditState>({phase: 'idle'});
@@ -64,16 +60,16 @@ const AutomationEditor: React.FC<{id: string}> = ({id}) => {
     const navigationBlockerReasonRef = React.useRef<'automation' | 'email' | null>(null);
     const isBlockedEmailNavigationLeavingEditorRef = React.useRef(false);
 
-    // Draft is the user-facing, locally mutable copy. Wait for the mount refetch to finish before
-    // seeding it so cached automation data can never become an editable stale draft.
+    // Draft is the user-facing, locally mutable copy. Seed it once so later query updates cannot
+    // overwrite edits made during this editing session.
     const [draft, setDraft] = React.useState<AutomationDetail | undefined>(undefined);
     React.useEffect(() => {
-        if (!freshAutomation) {
+        if (!automation) {
             return;
         }
 
-        setDraft(currentDraft => currentDraft ?? freshAutomation);
-    }, [freshAutomation]);
+        setDraft(currentDraft => currentDraft ?? automation);
+    }, [automation]);
     const isEditorLoading = !draft && !isError;
 
     // Only compare the fields the user can edit; server-stamped fields like `updated_at` would

--- a/apps/admin/src/automations/hooks/use-automation-for-editing.ts
+++ b/apps/admin/src/automations/hooks/use-automation-for-editing.ts
@@ -1,0 +1,15 @@
+import {useReadAutomation} from '@tryghost/admin-x-framework/api/automations';
+
+export const useAutomationForEditing = (id: string) => {
+    const {data, isError, isFetchedAfterMount} = useReadAutomation(id, {
+        defaultErrorHandler: false,
+        refetchOnMount: 'always'
+    });
+    const fetchedAutomation = data?.automations[0];
+    const automation = isFetchedAfterMount && !isError && fetchedAutomation?.id === id ? fetchedAutomation : undefined;
+
+    return {
+        automation,
+        isError
+    };
+};


### PR DESCRIPTION
closes https://linear.app/tryghost/issue/NY-1511

Automation details and clicked links remained fresh for five minutes. If one person navigated away, another saved changes, and the first returned within that window, the returning editor could show the older graph and analytics and allow edits against that cached version.

Forcing a background refetch alone was not enough because cached data could still seed the editable draft before the response arrived. We considered reconciling local drafts with successive server snapshots, but that introduced merge state without solving the underlying concurrent-editor case.

The editor now refetches on mount and waits for a successful response before seeding its draft, so returning users see intervening changes and current stats before editing. Once seeded, local edits remain isolated from query refreshes, and a failed refresh shows an error rather than exposing stale editable data. Clicked links also refresh when their section mounts while retaining the zero-send request guard.

This protects the navigate-away-and-return scenario. If two people keep the editor open simultaneously, a later save can still overwrite the other version until server-side collision detection is added.