### PR TITLE
Fixed Security Vulnerability:  Notification HTML reaching Ghost Admin unsanitised

### DIFF
--- a/apps/admin-x-settings/src/components/settings/general/about.tsx
+++ b/apps/admin-x-settings/src/components/settings/general/about.tsx
@@ -67,7 +67,11 @@ const AboutModal = NiceModal.create<RoutingModalProps>(() => {
                         upgradeStatus?.message && (
                             <div className='gh-prose-links mb-4 rounded-sm border border-green p-5'>
                                 <strong>Update available!</strong>
-                                <div dangerouslySetInnerHTML={{__html: upgradeStatus.message}}/>
+                                {/* Rendered as text, not HTML. Notification bodies are
+                                    attacker-influenced, and nothing currently supplies this
+                                    prop - so there is no markup to preserve here. Anything
+                                    reinstating rich rendering must sanitise first. */}
+                                <div>{upgradeStatus.message}</div>
                             </div>
                         )
                     }

--- a/apps/ember-admin/app/services/notifications.js
+++ b/apps/ember-admin/app/services/notifications.js
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/ember';
+import DOMPurify from 'dompurify';
 import Service, {inject as service} from '@ember/service';
 import {TrackedArray} from 'tracked-built-ins';
 import {dasherize} from '@ember/string';
@@ -68,9 +69,11 @@ export default class NotificationsService extends Service {
             }
         }
 
-        // If this is an alert message from the server, treat it as html safe
+        // Server notifications are rendered unescaped so release notes can carry
+        // links. Purify before marking them html safe - the server sanitises on
+        // write and on read, and this is the second layer behind that.
         if (message.constructor.modelName === 'notification' && message.status === 'alert') {
-            message.message = htmlSafe(message.message);
+            message.message = htmlSafe(DOMPurify.sanitize(message.message ?? ''));
         }
 
         if (!message.status) {

--- a/apps/ember-admin/app/services/upgrade-status.js
+++ b/apps/ember-admin/app/services/upgrade-status.js
@@ -1,3 +1,4 @@
+import DOMPurify from 'dompurify';
 import Service, {inject as service} from '@ember/service';
 import classic from 'ember-classic-decorator';
 import {get, set} from '@ember/object';
@@ -14,7 +15,9 @@ export default class UpgradeStatusService extends Service {
     // where the `location` is not 'top' and `custom` is false
     handleUpgradeNotification(notification) {
         let message = get(notification, 'message');
-        set(this, 'message', htmlSafe(message));
+        // Rendered unescaped by the About modal, so purify before trusting it.
+        // The server sanitises this too - this is the second layer, not the only one.
+        set(this, 'message', htmlSafe(DOMPurify.sanitize(message ?? '')));
     }
 
     // called when a MaintenanceError is encountered

--- a/ghost/core/core/server/data/migrations/versions/6.56/2026-08-04-10-00-00-remove-add-notifications-permission-from-editors.js
+++ b/ghost/core/core/server/data/migrations/versions/6.56/2026-08-04-10-00-00-remove-add-notifications-permission-from-editors.js
@@ -1,0 +1,20 @@
+const {combineTransactionalMigrations, removePermissionFromRole} = require('../../utils');
+
+// Notifications are broadcast to every Owner, Administrator and Editor who
+// loads Ghost Admin, and the clients render their HTML unescaped. That makes
+// "Add notifications" an admin-to-admin broadcast channel, which no editor-tier
+// role needs - nothing in Ghost Admin posts notifications, the endpoint exists
+// for the update-check service and for integrations.
+//
+// Browse and destroy are deliberately retained so editors can still see and
+// dismiss notifications.
+module.exports = combineTransactionalMigrations(
+    removePermissionFromRole({
+        permission: 'Add notifications',
+        role: 'Editor'
+    }),
+    removePermissionFromRole({
+        permission: 'Add notifications',
+        role: 'Super Editor'
+    })
+);

--- a/ghost/core/core/server/data/schema/fixtures/fixtures.json
+++ b/ghost/core/core/server/data/schema/fixtures/fixtures.json
@@ -1066,7 +1066,7 @@
                     "gift_link": "manage"
                 },
                 "Super Editor": {
-                    "notification": "all",
+                    "notification": ["browse", "destroy"],
                     "post": "all",
                     "setting": ["browse", "read"],
                     "slug": "all",
@@ -1091,7 +1091,7 @@
                     "gift_link": "manage"
                 },
                 "Editor": {
-                    "notification": "all",
+                    "notification": ["browse", "destroy"],
                     "post": "all",
                     "setting": ["browse", "read"],
                     "slug": "all",

--- a/ghost/core/core/server/services/notifications/notification-email.ts
+++ b/ghost/core/core/server/services/notifications/notification-email.ts
@@ -1,4 +1,4 @@
-import {sanitizeEmailHtml} from './sanitize-email-html';
+import {sanitizeNotificationHtml} from './sanitize-notification-html';
 
 interface Mailer {
     send(options: {to: string; subject: string; html: string; text?: string}): Promise<unknown>;
@@ -48,7 +48,7 @@ export class NotificationEmailService {
         if (!to.length) {
             return;
         }
-        const message = sanitizeEmailHtml(content);
+        const message = sanitizeNotificationHtml(content);
         const siteUrl = this.getSiteUrl();
         for (const recipient of to) {
             const {html, text} = await this.generateEmailContent({

--- a/ghost/core/core/server/services/notifications/notifications.js
+++ b/ghost/core/core/server/services/notifications/notifications.js
@@ -5,11 +5,29 @@ const errors = require('@tryghost/errors');
 const ghostVersion = require('@tryghost/version');
 const tpl = require('@tryghost/tpl');
 const ObjectId = require('bson-objectid').default;
+const {sanitizeNotificationHtml} = require('./sanitize-notification-html');
 
 const messages = {
     noPermissionToDismissNotif: 'You do not have permission to dismiss this notification.',
     notificationDoesNotExist: 'Notification does not exist.'
 };
+
+/**
+ * Notification bodies are rendered as HTML by Ghost Admin, so every value that
+ * can reach a client goes through the shared sanitiser first. Non-string
+ * messages are passed through untouched for the caller's own validation to
+ * reject - coercing them here would mask malformed records.
+ *
+ * @param {unknown} message
+ * @returns {unknown} sanitised message when it is a string, otherwise the input
+ */
+function sanitizeMessage(message) {
+    if (typeof message !== 'string') {
+        return message;
+    }
+
+    return sanitizeNotificationHtml(message);
+}
 
 class Notifications {
     /**
@@ -42,6 +60,11 @@ class Notifications {
 
         allNotifications.forEach((notification) => {
             notification.addedAt = moment(notification.addedAt).toDate();
+            // Sanitise on read as well as on write. Installs upgrading from a
+            // version without write-side sanitisation may already hold unsafe
+            // HTML in the `notifications` setting, and clients render this
+            // unescaped - so the read path has to be safe on its own.
+            notification.message = sanitizeMessage(notification.message);
         });
 
         return allNotifications;
@@ -145,7 +168,13 @@ class Notifications {
             });
 
             if (!isDuplicate) {
-                notificationsToAdd.push(Object.assign({}, defaults, notification, overrides));
+                const toAdd = Object.assign({}, defaults, notification, overrides);
+                // Sanitise before the notification is persisted, so untrusted
+                // HTML never reaches the `notifications` setting in the first
+                // place. Sources include the update-check feed and any API
+                // client holding the "Add notifications" permission.
+                toAdd.message = sanitizeMessage(toAdd.message);
+                notificationsToAdd.push(toAdd);
             }
         });
 

--- a/ghost/core/core/server/services/notifications/sanitize-notification-html.ts
+++ b/ghost/core/core/server/services/notifications/sanitize-notification-html.ts
@@ -1,9 +1,14 @@
 import sanitizeHtml from 'sanitize-html';
 
-// Even though the upstream feed is operated by Ghost org, the resulting HTML
-// is rendered into admin inboxes on the receiving install. A compromised or
-// malformed feed entry must not be able to ship scripts, event handlers, or
-// non-http(s) URLs to recipients via this path.
+// Notification bodies reach admin users as *rendered HTML*, both in email and
+// in Ghost Admin itself (the client marks server notifications `htmlSafe`).
+// Two untrusted sources feed this: the upstream update-check feed, and any API
+// client permitted to POST /notifications/. Neither must be able to ship
+// scripts, event handlers, or non-http(s) URLs to an admin's browser.
+//
+// This is the single enforced trust boundary for notification HTML - the
+// clients deliberately render it unescaped so release notes can carry links,
+// so the guarantee has to hold here.
 const ALLOWED_TAGS = [
     'p', 'br', 'hr',
     'strong', 'b', 'em', 'i', 'u', 'code',
@@ -30,6 +35,6 @@ const SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
     }
 };
 
-export function sanitizeEmailHtml(html: string): string {
+export function sanitizeNotificationHtml(html: string): string {
     return sanitizeHtml(html, SANITIZE_OPTIONS);
 }

--- a/ghost/core/test/unit/server/services/notifications/__snapshots__/sanitize-notification-html.test.ts.snap
+++ b/ghost/core/test/unit/server/services/notifications/__snapshots__/sanitize-notification-html.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`sanitizeEmailHtml preserves safe formatting and neutralises dangerous content 1 1`] = `
+exports[`sanitizeNotificationHtml preserves safe formatting and neutralises dangerous content 1 1`] = `
 Object {
   "output": "
     <h2>Ghost 6.50.0 is now available</h2>

--- a/ghost/core/test/unit/server/services/notifications/notifications.test.js
+++ b/ghost/core/test/unit/server/services/notifications/notifications.test.js
@@ -47,6 +47,67 @@ describe('Notifications Service', function () {
             assert.equal(createdNotification.message, 'Hello test world!');
             assert.equal(createdNotification.createdAtVersion, '4.1.0');
         });
+
+        it('strips scripts and event handlers from the message before storing', function () {
+            const settingsCache = {
+                get: sinon.fake.returns([])
+            };
+
+            const notificationsSvc = new Notifications({settingsCache});
+
+            const {notificationsToAdd} = notificationsSvc.add({
+                notifications: [{
+                    custom: true,
+                    status: 'alert',
+                    message: '<b>ok</b><img src=x onerror="alert(1)"><script>alert(2)</script>'
+                }]
+            });
+
+            const message = notificationsToAdd[0].message;
+
+            assert.equal(message.includes('onerror'), false);
+            assert.equal(message.includes('<script'), false);
+            assert.equal(message.includes('<img'), false);
+            assert.equal(message.includes('<b>ok</b>'), true);
+        });
+
+        it('leaves a non-string message untouched for the caller to reject', function () {
+            const settingsCache = {
+                get: sinon.fake.returns([])
+            };
+
+            const notificationsSvc = new Notifications({settingsCache});
+
+            const {notificationsToAdd} = notificationsSvc.add({
+                notifications: [{custom: true, status: 'alert', message: {nested: 'object'}}]
+            });
+
+            assert.deepEqual(notificationsToAdd[0].message, {nested: 'object'});
+        });
+    });
+
+    describe('fetchAllNotifications', function () {
+        it('sanitises unsafe HTML that is already stored in settings', function () {
+            // Installs upgrading from a version without write-side sanitisation
+            // can hold unsafe HTML in the `notifications` setting already, and
+            // Ghost Admin renders notification bodies unescaped.
+            const settingsCache = {
+                get: sinon.fake.returns([{
+                    id: '130f7c24-113a-4768-a698-12a8b34223f1',
+                    dismissible: true,
+                    status: 'alert',
+                    message: '<b>stored</b><img src=x onerror="alert(1)">',
+                    addedAt: '2026-08-04T10:00:00.000Z'
+                }])
+            };
+
+            const notificationsSvc = new Notifications({settingsCache});
+            const [notification] = notificationsSvc.fetchAllNotifications();
+
+            assert.equal(notification.message.includes('onerror'), false);
+            assert.equal(notification.message.includes('<img'), false);
+            assert.equal(notification.message.includes('<b>stored</b>'), true);
+        });
     });
 
     describe('browse', function () {

--- a/ghost/core/test/unit/server/services/notifications/sanitize-notification-html.test.ts
+++ b/ghost/core/test/unit/server/services/notifications/sanitize-notification-html.test.ts
@@ -1,5 +1,5 @@
 const {assertMatchSnapshot} = require('../../../../utils/assertions');
-const {sanitizeEmailHtml} = require('../../../../../core/server/services/notifications/sanitize-email-html');
+const {sanitizeNotificationHtml} = require('../../../../../core/server/services/notifications/sanitize-notification-html');
 
 // The script tag, on* handler, and javascript: URL are deliberate negative
 // cases — the snapshot must show them stripped.
@@ -15,8 +15,8 @@ const FIXTURE_MESSAGE_HTML = `
     <p><a href="javascript:alert(1)" onclick="alert(1)">do not click</a></p>
 `;
 
-describe('sanitizeEmailHtml', function () {
+describe('sanitizeNotificationHtml', function () {
     it('preserves safe formatting and neutralises dangerous content', function () {
-        assertMatchSnapshot({output: sanitizeEmailHtml(FIXTURE_MESSAGE_HTML)});
+        assertMatchSnapshot({output: sanitizeNotificationHtml(FIXTURE_MESSAGE_HTML)});
     });
 });


### PR DESCRIPTION
# Fixed notification HTML reaching Ghost Admin unsanitised

> ### ⚠️ Unpatched at time of writing
> This describes a live vulnerability in current Ghost, with a working proof of concept. It has not been reported to Ghost Security or assigned a CVE. Treat this PR as sensitive until a patch ships upstream — see *Disclosure* below.

## Classification

| | |
|---|---|
| **Class** | Stored (persistent) cross-site scripting leading to horizontal-to-vertical privilege escalation |
| **CWE-79** | Improper neutralization of input during web page generation — notification bodies are persisted and served without sanitisation |
| **CWE-116** | Improper encoding or escaping of output — both admin clients explicitly mark server notifications as trusted HTML (`htmlSafe`, `dangerouslySetInnerHTML`) |
| **CWE-269** | Improper privilege management — `Add notifications` is granted to the Editor and Super Editor roles, making the sink reachable below the administrator boundary |
| **CWE-1188** | Insecure default — the `status` field defaults to `'alert'`, which is precisely the value that triggers the HTML-trusted render path |
| **Severity** | High — CVSS 3.1 base **8.7** (`AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:N`). Scoring availability as `A:H`, on the basis that a compromised Owner session can destroy site content, yields 9.0 (Critical). Unofficial, self-assessed. |
| **Vector** | Remote, authenticated. Requires only an Editor-tier account — the lowest role that holds the permission. |
| **Interaction** | Minimal. The payload renders in the admin alert bar on *any* admin page load; the victim need not click attacker-controlled content. |
| **Affected** | Confirmed exploitable end-to-end against a live **6.21** instance. The vulnerable code paths are unchanged in `main` as of this branch. No claim is made about the full affected range — the pattern predates 6.21. |
| **Fixed in** | This PR. |

### Why this is an escalation, not self-XSS

Editors are a semi-trusted role on multi-author publications. The primitive lets an Editor execute JavaScript in the admin origin under the session of every Owner, Administrator and Editor who opens Ghost Admin — crossing a role boundary Ghost otherwise enforces server-side. From there the attacker inherits the victim's ambient session against the Admin API.

### Aggravating factor: no in-product remediation

`DELETE /notifications/:id` does not delete. `destroy()` only marks the notification seen for the calling user; `destroyAll` is not exposed over HTTP, and `notifications` is a `core`-group setting with no settings-API write path. An injected payload therefore cannot be removed through the admin UI, and deleting the attacker's account does not clear it. Eviction otherwise requires direct database access — which is why the fix sanitises on read as well as on write, so upgrading alone neutralises already-stored payloads.

## Summary

Ghost stores notification bodies without sanitising them, and both admin clients render those bodies as trusted HTML. Because the `Add notifications` permission is granted to the Editor and Super Editor roles, a user holding an editor-tier account can persist arbitrary HTML — including script — that executes in the admin-origin session of every Owner, Administrator and Editor who loads Ghost Admin.

This is a privilege escalation across a staff role boundary, not merely self-XSS.

## The vulnerability

The chain has four links, all in current `main`:

1. **No sanitisation on write.** `services/notifications/notifications.js` `add()` merges caller input straight into the `notifications` setting. `message` is never sanitised. The `status` field defaults to `'alert'`.
2. **The endpoint is reachable by editors.** `fixtures.json` grants `notification: "all"` to `Editor` and `Super Editor`, which includes the `Add notifications` permission. `POST /ghost/api/admin/notifications/` therefore succeeds for an Editor.
3. **The client routes it to the alert path.** `apps/ember-admin/app/services/session.js` → `loadServerNotifications()`:
   ```js
   e.top || e.custom ? this.notifications.handleNotification(e) : this.upgradeStatus.handleUpgradeNotification(e)
   ```
4. **The client marks it HTML-trusted.** `apps/ember-admin/app/services/notifications.js` → `handleNotification()`:
   ```js
   // If this is an alert message from the server, treat it as html safe
   if (message.constructor.modelName === 'notification' && message.status === 'alert') {
       message.message = htmlSafe(message.message);
   }
   ```
   `gh-alert.hbs` then renders `{{@message.message}}`. The double-stache would normally escape, but `htmlSafe()` overrides that.

`apps/ember-admin/app/services/upgrade-status.js` applies `htmlSafe()` on the same data for the other branch, and `admin-x-settings`' About modal rendered it via `dangerouslySetInnerHTML`.

There is no `Content-Security-Policy` on `/ghost/`, so nothing contains the payload once it lands.

## Impact

An Editor obtains code execution in the Owner's admin origin. The alert bar renders on **every** admin page load, so no interaction beyond opening Ghost Admin is required, and the payload persists in the `notifications` setting until explicitly deleted.

Verified end-to-end against a live Ghost **6.21** instance with an account whose only role was `Editor`.

## Proof of concept

Minimal, non-destructive. Steps 1–2 as an Editor; step 3 observed as Owner.

```bash
# 1. Authenticate as an Editor (relay the emailed 2FA code if prompted)
curl -c j.txt -X POST https://SITE/ghost/api/admin/session/ \
  -H 'Content-Type: application/json' -H 'Origin: https://SITE' \
  -d '{"username":"editor@example.com","password":"..."}'

# 2. Store markup. Note: role is Editor, response is 201, markup returned verbatim
curl -b j.txt -X POST https://SITE/ghost/api/admin/notifications/ \
  -H 'Content-Type: application/json' -H 'Origin: https://SITE' \
  -d '{"notifications":[{"custom":true,"status":"alert","message":"<b>XSSPROOF</b>"}]}'

# 3. Load https://SITE/ghost/ as Owner.
#    Vulnerable: renders as bold "XSSPROOF".
#    Patched:    renders as the literal text <b>XSSPROOF</b>.
```

Swapping the `<b>` for `<img src=x onerror=...>` yields script execution in the Owner's session; that variant was confirmed but is omitted here deliberately.

**Cleanup is not straightforward, which is part of the finding.** `DELETE /ghost/api/admin/notifications/<id>/` does not delete — `destroy()` only sets `seen` and appends the caller to `seenBy`:

```js
// @NOTE: We don't remove the notifications, because otherwise we will receive them again from the service.
allNotifications[i].seen = true;
allNotifications[i].seenBy.push(user.id);
```

The record stays in the `notifications` setting and continues to render for every staff user who has not individually dismissed it. `destroyAll` exists but is explicitly not exposed over HTTP, and `notifications` is a `core`-group setting, so there is no supported API path to purge an injected payload. Removing one requires dismissing as each affected user, or editing the setting directly in the database.

This materially raises severity: the payload is not just persistent, it is **not removable through the admin UI**, and deleting the attacker's account does not clear it. Note that the read-side sanitisation in this PR neutralises already-stored payloads on upgrade, without operator intervention — that is the main reason it is not write-side only.

## Higher-severity variants

Not demonstrated, but reachable from the same primitive once script runs in an Owner session:

- **Durable backdoor.** The payload can call the Admin API with the Owner's ambient session — create an Administrator user, mint an integration Admin API key, or add a webhook. Access then survives removal of the original editor account and the notification itself.
- **Self-reinstatement.** The payload can re-POST itself before being dismissed. Combined with `destroy()` being dismiss-only and `destroyAll` not being exposed over HTTP, an injected notification cannot be removed through the admin UI at all — eviction requires direct database access.
- **Member data exfiltration.** Admin sessions can browse the full member list — email addresses, Stripe subscription state, labels — for silent bulk exfiltration.
- **Content and distribution abuse.** Posts can be created or edited and newsletters dispatched to the entire member list under the site's sending identity.
- **Fleet-wide variant via the upstream feed.** The same unsanitised sink is fed by `updates.ghost.org` through `update-check-service.js` (`message: message.content`). A compromise of that feed would deliver HTML into the admin of every install that polls it. Notably the *email* rendering of this exact content was already sanitised, with a code comment naming a compromised feed as the threat — the in-app path simply lacked the equivalent guard.
- **Residual phishing after sanitisation.** Even with script stripped, an attacker-controlled banner in official admin chrome can carry an allowlisted `<a>` to an external site. That is why this PR also removes the permission rather than relying on sanitisation alone.

## The fix

- **Sanitise on write and on read** (`notifications.js`). Write-side stops new unsafe HTML being persisted. Read-side matters independently: installs upgrading from an affected version may already hold unsafe HTML in the `notifications` setting, and this covers them without a data migration.
- **Reuse the existing sanitiser**, renamed `sanitize-email-html.ts` → `sanitize-notification-html.ts` since it is no longer email-specific. The allowlist is unchanged: links and formatting are preserved; `script`, event handlers and non-http(s) schemes are stripped. Release notifications render exactly as before.
- **Defence in depth in the clients.** The Ember notification and upgrade-status services now run `DOMPurify.sanitize()` before `htmlSafe()`. `dompurify` was already a dependency there. The React About modal's `dangerouslySetInnerHTML` is replaced with text rendering — nothing in the repo currently supplies that prop, so there is no markup to preserve and no new dependency was added.
- **Least privilege.** `Add notifications` is dropped from `Editor` and `Super Editor` in `fixtures.json`, with a migration for existing installs. `browse` and `destroy` are retained so editors can still see and dismiss notifications. Nothing in Ghost Admin posts notifications — the endpoint exists for the update-check service and integrations — so this removes no working functionality.

## Testing

- `test/unit/server/services/notifications/notifications.test.js` — 12 passed, including three new cases covering write-side sanitisation, read-side sanitisation of already-stored HTML, and non-string message passthrough.
- `sanitize-notification-html.test.ts` — 1 passed (snapshot renamed and updated).
- `notification-email.test.ts` — 3 passed.
- `test/unit/server/services/update-check` — 14 passed.
- ESLint clean across `ghost/core`, `apps/ember-admin` and `apps/admin-x-settings`.

Not run: the Ember acceptance suite, and a live migration against a seeded database. Both are worth exercising in CI.

## Notes for reviewers

- The clients still render notification HTML unescaped by design, so release notes can carry links. The server sanitiser is now the enforced boundary; the client DOMPurify calls are a second layer, not the primary control.
- Separately worth considering, both out of scope here: there is no `Content-Security-Policy` on `/ghost/`, and the admin session cookie is `SameSite=None` (deliberate, for the comments-ui auth iframe), which leaves the Origin check as the sole CSRF barrier on these endpoints.

## Disclosure
This issue was automatically identified, tested, and fixed by **Warden** (in development), an autonomous penetration testing agent using _DeepSeek V4 Flash_.