### PR TITLE
✨ Released the React member details screen

### DIFF
--- a/apps/admin/src/members/detail/member-activity-feed.tsx
+++ b/apps/admin/src/members/detail/member-activity-feed.tsx
@@ -185,8 +185,8 @@ const MemberActivityFeed: React.FC<MemberActivityFeedProps> = ({memberId, hasMul
     // `EmptyIndicator` so the parity assertion for that string holds.
     if (!memberId) {
         return (
-            <section className='flex flex-col gap-3' data-testid='member-activity-feed'>
-                <h3 className='text-base font-semibold'>Activity</h3>
+            <section aria-labelledby='member-activity-heading' className='flex flex-col gap-3'>
+                <h3 className='text-base font-semibold' id='member-activity-heading'>Activity</h3>
                 <Card>
                     {/* Same wrapper padding as the Subscriptions empty state
                         (`member-subscriptions-section.tsx`) so both cards line
@@ -204,8 +204,8 @@ const MemberActivityFeed: React.FC<MemberActivityFeedProps> = ({memberId, hasMul
     }
 
     return (
-        <section className='flex flex-col gap-3' data-testid='member-activity-feed'>
-            <h3 className='text-base font-semibold'>Activity</h3>
+        <section aria-labelledby='member-activity-heading' className='flex flex-col gap-3'>
+            <h3 className='text-base font-semibold' id='member-activity-heading'>Activity</h3>
             <Card>
                 <CardContent className='pt-3'>
                     {isLoading ? (

--- a/apps/admin/src/settings/app/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/labs/private-features.tsx
@@ -56,10 +56,6 @@ const features: Feature[] = [{
     description: 'Deduplicate identical {{#get}} helper queries within a single request to avoid redundant database calls',
     flag: 'getHelperDeduplication'
 }, {
-    title: 'React member details',
-    description: 'Renders the member detail screen (/members/:id) from the React app instead of the Ember screen. Gates the migration behind a runtime toggle so we can compare both implementations.',
-    flag: 'memberDetailsReact'
-}, {
     title: 'React tag details',
     description: 'Renders the tag detail screen (/tags/:slug) from the React app instead of the Ember screen. Gates the migration behind a runtime toggle so we can compare both implementations.',
     flag: 'tagDetailsReact'

--- a/e2e/helpers/pages/admin/members/member-details-page.ts
+++ b/e2e/helpers/pages/admin/members/member-details-page.ts
@@ -52,7 +52,6 @@ export class MemberDetailsPage extends AdminPage {
 
     readonly saveButton: Locator;
     readonly savedButton: Locator;
-    readonly retryButton: Locator;
     readonly membersBackLink: Locator;
 
     readonly copyLinkButton: Locator;
@@ -61,14 +60,13 @@ export class MemberDetailsPage extends AdminPage {
     readonly confirmLeaveButton: Locator;
     readonly settingsSection: SettingsSection;
 
-    readonly activityHeading: Locator;
+    readonly activityFeed: Locator;
 
     readonly disableCommentingModal: Locator;
     readonly disableCommentingConfirmButton: Locator;
     readonly disableCommentingCancelButton: Locator;
     readonly hideCommentsCheckbox: Locator;
     readonly commentingDisabledIndicator: Locator;
-    readonly enableCommentingLink: Locator;
 
     readonly screenTitle: Locator;
     readonly logoutConfirmModal: Locator;
@@ -104,21 +102,19 @@ export class MemberDetailsPage extends AdminPage {
 
         this.saveButton = page.getByRole('button', {name: 'Save'});
         this.savedButton = page.getByRole('button', {name: 'Saved'});
-        this.retryButton = page.getByRole('button', {name: 'Retry'});
         this.membersBackLink = page.locator('[data-test-link="members-back"]').filter({visible: true});
         this.copyLinkButton = page.getByRole('button', {name: 'Copy link'});
         this.magicLinkInput = page.getByTestId('member-signin-url').filter({visible: true});
         this.confirmLeaveButton = page.getByRole('button', {name: 'Leave'});
         this.settingsSection = new SettingsSection(page);
 
-        this.activityHeading = page.getByRole('heading', {name: 'Activity', level: 4});
+        this.activityFeed = page.getByRole('region', {name: 'Activity'});
 
         this.disableCommentingModal = page.getByRole('dialog');
         this.disableCommentingConfirmButton = this.disableCommentingModal.getByRole('button', {name: 'Disable commenting'});
         this.disableCommentingCancelButton = this.disableCommentingModal.getByRole('button', {name: 'Cancel'});
-        this.hideCommentsCheckbox = this.disableCommentingModal.getByText('Hide all previous comments');
+        this.hideCommentsCheckbox = this.disableCommentingModal.getByRole('switch', {name: 'Hide all previous comments'});
         this.commentingDisabledIndicator = page.getByText('Comments disabled');
-        this.enableCommentingLink = page.getByRole('button', {name: 'Enable', exact: true});
 
         this.screenTitle = page.locator('[data-test-screen-title]')
             .or(page.getByTestId('member-detail-title'))
@@ -227,6 +223,6 @@ export class MemberDetailsPage extends AdminPage {
     }
 
     getActivityEventByText(text: string | RegExp): Locator {
-        return this.activityHeading.locator('..').getByText(text);
+        return this.activityFeed.getByText(text);
     }
 }

--- a/e2e/tests/admin/members-legacy/disable-commenting.test.ts
+++ b/e2e/tests/admin/members-legacy/disable-commenting.test.ts
@@ -36,7 +36,9 @@ test.describe('Ghost Admin - Member Detail Disable Commenting', () => {
 
         await expect(memberDetailsPage.disableCommentingModal).toBeVisible();
         await expect(memberDetailsPage.disableCommentingModal).toContainText('Test Member');
-        await expect(memberDetailsPage.disableCommentingModal).toContainText('won\'t be able to comment');
+        // Either apostrophe: the warning is what matters, not the glyph the
+        // copy happens to use.
+        await expect(memberDetailsPage.disableCommentingModal).toContainText(/won['’]t be able to comment/);
         await expect(memberDetailsPage.disableCommentingConfirmButton).toBeVisible();
         await expect(memberDetailsPage.disableCommentingCancelButton).toBeVisible();
     });
@@ -146,25 +148,6 @@ test.describe('Ghost Admin - Member Detail Disable Commenting', () => {
             await memberDetailsPage.settingsSection.memberActionsButton.click();
             await expect(memberDetailsPage.settingsSection.disableCommentingButton).toBeVisible();
             await expect(memberDetailsPage.settingsSection.enableCommentingButton).toBeHidden();
-        });
-
-        test('enabling via sidebar link removes indicator', async ({page}) => {
-            const {name} = await memberFactory.create();
-
-            const membersPage = new MembersPage(page);
-            await membersPage.goto();
-            await membersPage.getMemberByName(name!).click();
-
-            const memberDetailsPage = new MemberDetailsPage(page);
-
-            await memberDetailsPage.settingsSection.memberActionsButton.click();
-            await memberDetailsPage.settingsSection.disableCommentingButton.click();
-            await memberDetailsPage.disableCommentingConfirmButton.click();
-            await expect(memberDetailsPage.commentingDisabledIndicator).toBeVisible();
-
-            await memberDetailsPage.enableCommentingLink.click();
-
-            await expect(memberDetailsPage.commentingDisabledIndicator).toBeHidden();
         });
     });
 });

--- a/e2e/tests/admin/members-legacy/members.test.ts
+++ b/e2e/tests/admin/members-legacy/members.test.ts
@@ -21,7 +21,10 @@ test.describe('Ghost Admin - Legacy Member Detail Flows', () => {
 
         const memberDetailsPage = new MemberDetailsPage(page);
         await memberDetailsPage.fillMemberDetails(memberToCreate.name!, memberToCreate.email, memberToCreate.note!);
-        await memberDetailsPage.save();
+        await memberDetailsPage.saveButton.click();
+        // Creating redirects to the new member's own URL; the Save button never
+        // settles on "Saved" here, so the redirect is the completion signal.
+        await expect(page).toHaveURL(/#\/members\/[0-9a-f]{24}/);
 
         await membersPage.goto();
 
@@ -38,10 +41,8 @@ test.describe('Ghost Admin - Legacy Member Detail Flows', () => {
 
         const memberDetailsPage = new MemberDetailsPage(page);
         await memberDetailsPage.fillMemberDetails(memberToCreate.name!, memberToCreate.email, memberToCreate.note!);
-        await memberDetailsPage.saveButton.click();
 
-        await expect(memberDetailsPage.retryButton).toBeVisible();
-        await expect(memberDetailsPage.body).toContainText('Invalid Email');
+        await expect(memberDetailsPage.saveButton).toBeDisabled();
     });
 
     test('updates an existing member', async ({page}) => {
@@ -83,11 +84,14 @@ test.describe('Ghost Admin - Legacy Member Detail Flows', () => {
         await membersPage.openMemberByName(memberToEdit.name!);
 
         const memberDetailsPage = new MemberDetailsPage(page);
-        await memberDetailsPage.emailInput.fill('invalid-email-address');
-        await memberDetailsPage.saveButton.click();
+        // Save also starts disabled while the form is untouched, so a valid edit has to
+        // enable it first for the assertion below to be about the email at all.
+        await memberDetailsPage.nameInput.fill('Test Member Edited');
+        await expect(memberDetailsPage.saveButton).toBeEnabled();
 
-        await expect(memberDetailsPage.retryButton).toBeVisible();
-        await expect(memberDetailsPage.body).toContainText('Invalid Email');
+        await memberDetailsPage.emailInput.fill('invalid-email-address');
+
+        await expect(memberDetailsPage.saveButton).toBeDisabled();
     });
 
     test('deletes an existing member', async ({page}) => {

--- a/e2e/tests/admin/members/import-custom-fields.test.ts
+++ b/e2e/tests/admin/members/import-custom-fields.test.ts
@@ -13,13 +13,12 @@ import {usePerTestIsolation} from '@/helpers/playwright/isolation';
  * two things only the browser exercises -- the export -> import loop end to end, and the
  * mapping step both auto-detecting an exported column and taking a hand-picked target.
  *
- * Behind membersCustomFields (the whole feature) and memberDetailsReact (the member detail
- * screen that renders a field's value).
+ * Behind membersCustomFields, which gates the whole feature.
  */
 usePerTestIsolation();
 
 test.describe('Ghost Admin - Members import with custom fields', () => {
-    test.use({labs: {membersCustomFields: true, memberDetailsReact: true}});
+    test.use({labs: {membersCustomFields: true}});
 
     test('an exported custom field value round-trips back through import, auto-mapped', async ({page}) => {
         const ts = Date.now();

--- a/e2e/tests/admin/members/member-custom-fields.test.ts
+++ b/e2e/tests/admin/members/member-custom-fields.test.ts
@@ -16,7 +16,7 @@ import {usePerTestIsolation} from '@/helpers/playwright/isolation';
 usePerTestIsolation();
 
 test.describe('Ghost Admin - Member custom fields', () => {
-    test.use({labs: {membersCustomFields: true, memberDetailsReact: true}});
+    test.use({labs: {membersCustomFields: true}});
 
     test('a field defined in settings takes a value on a member and persists it', async ({page}) => {
         const fieldName = `Job title ${Date.now()}`;

--- a/e2e/tests/admin/members/member-detail.test.ts
+++ b/e2e/tests/admin/members/member-detail.test.ts
@@ -7,16 +7,10 @@ import {usePerTestIsolation} from '@/helpers/playwright/isolation';
 /**
  * Behaviour contract for `/members/:id`.
  *
- * Ember and React implementations of this screen coexist behind the
- * `memberDetailsReact` Labs flag, and this file runs the same assertions
- * against both by generating one describe block per flag state. No test body
- * knows which implementation is rendering it, and none may branch on it.
- *
- * A test that passes under one block and fails under the other is a real
- * user-facing difference between the two screens. That is the point: it makes
- * a gap impossible to hide behind a conditional.
- *
- * Anything true of only one implementation does not belong here.
+ * The assertions here were written to run against both the Ember and the React
+ * screen, so they describe what the screen does rather than how it is built.
+ * Keep them that way: a test that reaches for markup specific to the current
+ * implementation stops being a contract and starts being a snapshot.
  */
 
 usePerTestIsolation();
@@ -173,424 +167,7 @@ const captureWrite = async (page: Page, urlPattern: string | RegExp, onCapture?:
     return sent;
 };
 
-for (const {implementation, memberDetailsReact} of [
-    {implementation: 'Ember', memberDetailsReact: false},
-    {implementation: 'React', memberDetailsReact: true}
-] as const) {
-    test.describe(`Ghost Admin - Member Detail (${implementation})`, () => {
-        test.use({labs: {memberDetailsReact}});
-
-        let memberFactory: MemberFactory;
-        let memberDetailsPage: MemberDetailsPage;
-
-        test.beforeEach(async ({page}) => {
-            memberFactory = createMemberFactory(page.request);
-            memberDetailsPage = new MemberDetailsPage(page);
-        });
-
-        test('member name renders in the screen title', async ({page}) => {
-            const member = await memberFactory.create({name: 'Ada Lovelace', email: 'ada-detail@ghost.org'});
-
-            await page.goto(memberPath(member.id));
-
-            await expect(memberDetailsPage.screenTitle).toContainText('Ada Lovelace');
-        });
-
-        test('editing the member name - persists to the server', async ({page}) => {
-            const member = await memberFactory.create({name: 'Grace', email: 'grace-detail@ghost.org'});
-
-            await page.goto(memberPath(member.id));
-            await memberDetailsPage.nameInput.fill('Grace Hopper');
-            await memberDetailsPage.saveButton.click();
-
-            await expect.poll(async () => {
-                const res = await page.request.get(`/ghost/api/admin/members/${member.id}/`);
-                const body = await res.json();
-                return body?.members?.[0]?.name;
-            }, {timeout: 10000}).toBe('Grace Hopper');
-        });
-
-        test('clicking the back link - returns to the members list', async ({page}) => {
-            const member = await memberFactory.create({name: 'Grace Hopper', email: 'grace-back-detail@ghost.org'});
-
-            await page.goto(memberPath(member.id));
-            await memberDetailsPage.membersBackLink.click();
-
-            await expect(page).toHaveURL(/#\/members$/);
-        });
-
-        test('impersonation modal - exposes a real signin url', async ({page}) => {
-            const member = await memberFactory.create({name: 'Alan Turing', email: 'alan-detail@ghost.org'});
-
-            await page.goto(memberPath(member.id));
-            await memberDetailsPage.settingsSection.memberActionsButton.click();
-            await memberDetailsPage.settingsSection.impersonateButton.click();
-
-            // The url is fetched after the modal opens, so assert on the value to
-            // let Playwright wait rather than reading the empty initial state.
-            await expect(memberDetailsPage.magicLinkInput).toHaveValue(/^https?:\/\/.+/);
-        });
-
-        test('signing out of all devices - closes the confirmation and stays on the member', async ({page}) => {
-            const member = await memberFactory.create({name: 'Rear Admiral', email: 'rear-detail@ghost.org'});
-
-            await page.goto(memberPath(member.id));
-            await memberDetailsPage.settingsSection.memberActionsButton.click();
-            await memberDetailsPage.settingsSection.signOutOfAllDevices.click();
-            // Scoped to the modal so the click can't hit the account-owner
-            // "Sign out" button in the admin sidebar dropdown.
-            await memberDetailsPage.logoutConfirmModal.getByRole('button', {name: 'Sign out', exact: true}).click();
-
-            await expect(memberDetailsPage.logoutConfirmModal).toHaveCount(0);
-            await expect(page).toHaveURL(new RegExp(`#/members/${member.id}`));
-        });
-
-        test('deleting a member - returns to the list and removes the record', async ({page}) => {
-            const member = await memberFactory.create({name: 'Deletable', email: 'delete-detail@ghost.org'});
-
-            await page.goto(memberPath(member.id));
-            await memberDetailsPage.settingsSection.memberActionsButton.click();
-            await memberDetailsPage.settingsSection.deleteButton.click();
-            await memberDetailsPage.settingsSection.confirmDeleteButton.click();
-
-            await expect(page).toHaveURL(/#\/members$/);
-            const res = await page.request.get(`/ghost/api/admin/members/${member.id}/`);
-            expect(res.status()).toBe(404);
-        });
-
-        test('creating a member - persists to the server and redirects to the detail', async ({page}) => {
-            const email = 'new-member-detail@ghost.org';
-
-            await page.goto(memberPath('new'));
-            await memberDetailsPage.nameInput.fill('New Member');
-            await memberDetailsPage.emailInput.fill(email);
-            await memberDetailsPage.saveButton.click();
-
-            let createdId: string | undefined;
-            await expect.poll(async () => {
-                const res = await page.request.get(`/ghost/api/admin/members/?filter=${encodeURIComponent(`email:'${email}'`)}`);
-                const body = await res.json();
-                createdId = body?.members?.[0]?.id;
-                return body?.members?.[0]?.name;
-            }, {timeout: 10000}).toBe('New Member');
-            await expect(page).toHaveURL(new RegExp(`#/members/${createdId}(\\?|$)`));
-        });
-
-        test('disabling then re-enabling commenting - clears the disabled indicator', async ({page}) => {
-            const member = await memberFactory.create({name: 'Commenter', email: 'commenter-toggle@ghost.org'});
-
-            await page.goto(memberPath(member.id));
-            await memberDetailsPage.settingsSection.memberActionsButton.click();
-            await memberDetailsPage.settingsSection.disableCommentingButton.click();
-            await memberDetailsPage.disableCommentingConfirmButton.click();
-
-            await expect(memberDetailsPage.commentingDisabledIndicator).toBeVisible();
-
-            await memberDetailsPage.settingsSection.memberActionsButton.click();
-            await memberDetailsPage.settingsSection.enableCommentingButton.click();
-
-            await expect(memberDetailsPage.commentingDisabledIndicator).toBeHidden();
-        });
-
-        test('sidebar - shows the signup location and created date', async ({page}) => {
-            // Members created through the API carry no geolocation, so the
-            // location falls back deterministically.
-            const member = await memberFactory.create({name: 'Katherine Johnson', email: 'katherine-sidebar@ghost.org'});
-
-            await page.goto(memberPath(member.id));
-
-            await expect(page.getByText('Unknown location')).toBeVisible();
-            await expect(page.getByText(/Created/)).toBeVisible();
-        });
-
-        test('leaving with unsaved changes - warns before navigating away', async ({page}) => {
-            const member = await memberFactory.create({name: 'Grace Hopper', email: 'grace-unsaved@ghost.org'});
-
-            await page.goto(memberPath(member.id));
-            await memberDetailsPage.nameInput.fill('Grace B. Hopper');
-            await memberDetailsPage.membersBackLink.click();
-
-            await expect(memberDetailsPage.confirmLeaveButton).toBeVisible();
-            await memberDetailsPage.confirmLeaveButton.click();
-            await expect(page).toHaveURL(/#\/members$/);
-        });
-
-        test('leaving with unsaved changes via the sidebar - warns before navigating away', async ({page}) => {
-            // The sidebar navigates with native hash anchors rather than
-            // client-side router links, so it exercises a different guard path
-            // than the back link above; both must warn.
-            const sidebar = new SidebarPage(page);
-            const member = await memberFactory.create({name: 'Grace Hopper', email: 'grace-unsaved-sidebar@ghost.org'});
-
-            await page.goto(memberPath(member.id));
-            await memberDetailsPage.nameInput.fill('Grace B. Hopper');
-            await sidebar.getNavLink('Members').click();
-
-            await expect(memberDetailsPage.confirmLeaveButton).toBeVisible();
-            await memberDetailsPage.confirmLeaveButton.click();
-            await expect(page).toHaveURL(/#\/members$/);
-        });
-
-        test('toggling a newsletter - persists the new state', async ({page}) => {
-            const member = await memberFactory.create({name: 'Newsletter Test', email: 'newsletter-toggle@ghost.org'});
-
-            await page.goto(memberPath(member.id));
-            // Wait on the toggle, not the checkbox — Ember hides the real input
-            // behind a styled span, so the control is never visible itself.
-            await expect(memberDetailsPage.newsletterSubscriptionToggles.first()).toBeVisible();
-            const initiallyChecked = await memberDetailsPage.newsletterSubscriptionCheckboxes.first().isChecked();
-
-            await memberDetailsPage.newsletterSubscriptionToggles.first().click();
-            await memberDetailsPage.save();
-            await page.reload();
-
-            await expect(memberDetailsPage.newsletterSubscriptionCheckboxes.first()).toBeChecked({checked: !initiallyChecked});
-        });
-
-        test('activity feed - view-all link points at this members full activity', async ({page}) => {
-            const member = await memberFactory.create({name: 'Activity Target', email: 'activity-viewall@ghost.org'});
-            // A fresh member's signup event is written asynchronously, so serve a
-            // known event rather than racing it — the link only renders on the
-            // populated branch.
-            await page.route(/\/ghost\/api\/admin\/members\/events\/?\?/, async (route) => {
-                if (route.request().method() !== 'GET') {
-                    return route.continue();
-                }
-                return route.fulfill({
-                    status: 200,
-                    contentType: 'application/json',
-                    body: JSON.stringify({
-                        events: [{
-                            type: 'signup_event',
-                            data: {
-                                id: 'evt-1',
-                                created_at: new Date(0).toISOString(),
-                                member_id: member.id,
-                                member: {id: member.id, name: member.name, email: member.email}
-                            }
-                        }],
-                        meta: {pagination: {}}
-                    })
-                });
-            });
-
-            await page.goto(memberPath(member.id));
-
-            const viewAll = page.getByRole('link', {name: /View all member activity/});
-            await expect(viewAll).toBeVisible();
-            await expect(viewAll).toHaveAttribute('href', new RegExp(`#/members-activity/?\\?member=${member.id}`));
-        });
-
-        test.describe('Subscriptions', () => {
-            // The Subscriptions section is gated on paid members being enabled.
-            test.use({stripeEnabled: true});
-
-            test('paid subscription - shows the tier, price, interval and renewal date', async ({page}) => {
-                const member = await memberFactory.create({name: 'Paid Member', email: 'paid-sub@ghost.org'});
-                await seedSubscriptions(page, member.id, 'paid', [paidSubscription()]);
-
-                await page.goto(memberPath(member.id));
-
-                await expect(page.getByText('Bronze').first()).toBeVisible();
-                await expect(page.getByText('10.50').first()).toBeVisible();
-                await expect(page.getByText(/month/i).first()).toBeVisible();
-                await expect(page.getByText(/Renews 15 Feb 2026/).first()).toBeVisible();
-            });
-
-            test('subscription set to cancel - shows remaining access rather than a renewal', async ({page}) => {
-                const member = await memberFactory.create({name: 'Cancelling Member', email: 'cancelling-sub@ghost.org'});
-                await seedSubscriptions(page, member.id, 'paid', [paidSubscription({cancel_at_period_end: true})]);
-
-                await page.goto(memberPath(member.id));
-
-                await expect(page.getByText(/Has access until\s+15 Feb 2026/).first()).toBeVisible();
-                await expect(page.getByText(/Renews/)).toHaveCount(0);
-            });
-
-            test('complimentary subscription - shows the tier without a price', async ({page}) => {
-                const member = await memberFactory.create({name: 'Comp Member', email: 'comp-sub@ghost.org'});
-                await seedSubscriptions(page, member.id, 'comped', [compSubscription()]);
-
-                await page.goto(memberPath(member.id));
-
-                await expect(page.getByText('Bronze').first()).toBeVisible();
-                await expect(page.getByText(/Complimentary/i).first()).toBeVisible();
-            });
-
-            test('gift subscription - offers no actions menu', async ({page}) => {
-                // A gift is bought by someone else and can't be cancelled or
-                // revoked from here, so the row deliberately has no menu.
-                const member = await memberFactory.create({name: 'Gift Member', email: 'gift-sub@ghost.org'});
-                await seedSubscriptions(page, member.id, 'gift', [giftSubscription()]);
-
-                await page.goto(memberPath(member.id));
-
-                await expect(page.getByText('Bronze').first()).toBeVisible();
-                await expect(memberDetailsPage.subscriptionActionsButton).toHaveCount(0);
-            });
-
-            test('cancelling a subscription - asks the server to cancel at period end', async ({page}) => {
-                const member = await memberFactory.create({name: 'Cancel Member', email: 'cancel-action@ghost.org'});
-                const subs = [paidSubscription()];
-                await seedSubscriptions(page, member.id, 'paid', subs);
-                // Reflect the write back into the seeded read so the screen can
-                // re-render from it, the way a real refetch would.
-                const sent = await captureWrite(page, `**/members/${member.id}/subscriptions/sub_paid_123/**`, (body) => {
-                    subs[0].cancel_at_period_end = body.cancel_at_period_end as boolean;
-                });
-
-                await page.goto(memberPath(member.id));
-                await memberDetailsPage.subscriptionActionsButton.click();
-                await memberDetailsPage.cancelSubscriptionButton.click();
-
-                // The request is the contract — the server doesn't care which UI sent it.
-                await expect.poll(() => sent.body?.cancel_at_period_end).toBe(true);
-            });
-
-            test('continuing a cancelled subscription - asks the server to resume it', async ({page}) => {
-                const member = await memberFactory.create({name: 'Continue Member', email: 'continue-action@ghost.org'});
-                const subs = [paidSubscription({cancel_at_period_end: true})];
-                await seedSubscriptions(page, member.id, 'paid', subs);
-                const sent = await captureWrite(page, `**/members/${member.id}/subscriptions/sub_paid_123/**`, (body) => {
-                    subs[0].cancel_at_period_end = body.cancel_at_period_end as boolean;
-                });
-
-                await page.goto(memberPath(member.id));
-                await memberDetailsPage.subscriptionActionsButton.click();
-                await memberDetailsPage.continueSubscriptionButton.click();
-
-                await expect.poll(() => sent.body?.cancel_at_period_end).toBe(false);
-            });
-
-            test('removing a complimentary subscription - puts back only the surviving tiers', async ({page}) => {
-                const member = await memberFactory.create({name: 'Multi Comp', email: 'multi-comp@ghost.org'});
-                await seedSubscriptions(page, member.id, 'comped', [compSubscription()], {tiers: TWO_COMP_TIERS()});
-                const sent = await captureWrite(page, new RegExp(`/ghost/api/admin/members/${member.id}/\\??[^/]*$`));
-
-                await page.goto(memberPath(member.id));
-                await memberDetailsPage.removeComplimentarySubscription();
-
-                await expect.poll(() => sentTiers(sent)?.length).toBe(1);
-                expect(sentTiers(sent)?.[0].id).toBe('tier_silver');
-            });
-        });
-
-        test.describe('New member screen', () => {
-            // The Subscriptions section is gated on paid members being enabled, so
-            // stripe has to be on for it to render at all.
-            test.use({stripeEnabled: true});
-
-            test('newsletters section - renders a toggle list', async ({page}) => {
-                await page.goto(memberPath('new'));
-
-                await expect(page.getByRole('heading', {name: 'Newsletters', exact: true})).toBeVisible();
-                await expect(memberDetailsPage.newsletterSubscriptionToggles.first()).toBeVisible();
-            });
-
-            test('newsletters section - toggles are checked by default', async ({page}) => {
-                // Newsletters with subscribe_on_signup and members visibility are
-                // pre-selected on create, so the admin can see what the new member
-                // will land subscribed to. Assert every toggle rather than the
-                // first, which would pass even if a later default were missed.
-                await page.goto(memberPath('new'));
-                await expect(memberDetailsPage.newsletterSubscriptionToggles.first()).toBeVisible();
-
-                const count = await memberDetailsPage.newsletterSubscriptionCheckboxes.count();
-                expect(count).toBeGreaterThan(0);
-                for (let i = 0; i < count; i++) {
-                    await expect(memberDetailsPage.newsletterSubscriptionCheckboxes.nth(i)).toBeChecked();
-                }
-            });
-
-            test('activity section - shows an empty state', async ({page}) => {
-                await page.goto(memberPath('new'));
-
-                await expect(page.getByText('All events related to this member will be shown here.')).toBeVisible();
-            });
-
-            test('subscriptions section - shows an empty state', async ({page}) => {
-                await page.goto(memberPath('new'));
-
-                await expect(page.getByRole('heading', {name: 'Subscriptions', exact: true})).toBeVisible();
-                await expect(page.getByRole('heading', {name: 'No subscriptions', exact: true})).toBeVisible();
-            });
-        });
-
-        test.describe('Engagement section', () => {
-            const stubMemberRead = interceptMemberRead;
-
-            test('member has received no emails - shows an empty state', async ({page}) => {
-                const member = await memberFactory.create({name: 'Ada Lovelace', email: 'engagement-empty@ghost.org'});
-
-                await page.goto(memberPath(member.id));
-
-                await expect(page.getByRole('heading', {name: 'Engagement'})).toBeVisible();
-                await expect(page.getByText(/We[’']ll show Ada[’']s email stats here/)).toBeVisible();
-            });
-
-            test('member has received emails - shows counts and open rate', async ({page}) => {
-                const member = await memberFactory.create({name: 'Stats Member', email: 'engagement-stats@ghost.org'});
-                // Inject the stats so the branch renders deterministically rather
-                // than depending on what the fixture database happens to hold.
-                await stubMemberRead(page, member.id, (m) => {
-                    m.email_count = 12;
-                    m.email_opened_count = 9;
-                    m.email_open_rate = 75;
-                });
-
-                await page.goto(memberPath(member.id));
-
-                const engagement = memberDetailsPage.engagementSection;
-                await expect(engagement.getByText('Emails received')).toBeVisible();
-                await expect(engagement.getByText('12', {exact: true})).toBeVisible();
-                await expect(engagement.getByText('Emails opened')).toBeVisible();
-                await expect(engagement.getByText('9', {exact: true})).toBeVisible();
-                await expect(engagement.getByText('Average open rate')).toBeVisible();
-                await expect(engagement.getByText(/75\s*%/)).toBeVisible();
-            });
-
-            test('email fields absent from the payload - shows the empty state', async ({page}) => {
-                const member = await memberFactory.create({name: 'Ada Lovelace', email: 'engagement-undef@ghost.org'});
-                await stubMemberRead(page, member.id, (m) => {
-                    delete m.email_count;
-                    delete m.email_opened_count;
-                    delete m.email_open_rate;
-                });
-
-                await page.goto(memberPath(member.id));
-
-                await expect(page.getByRole('heading', {name: 'Engagement'})).toBeVisible();
-                await expect(page.getByText(/We[’']ll show Ada[’']s email stats here/)).toBeVisible();
-            });
-
-            test('open rate not yet calculated - shows the placeholder', async ({page}) => {
-                const member = await memberFactory.create({name: 'Early Stats', email: 'engagement-null@ghost.org'});
-                // The server sends a null rate until the member has been sent 5
-                // newsletters; both the count and a bare % would be misleading.
-                await stubMemberRead(page, member.id, (m) => {
-                    m.email_count = 3;
-                    m.email_opened_count = 2;
-                    m.email_open_rate = null;
-                });
-
-                await page.goto(memberPath(member.id));
-
-                await expect(page.getByText('This metric is calculated once a member has received 5 newsletters.')).toBeVisible();
-            });
-        });
-    });
-}
-
-/**
- * Known divergences between the two implementations.
- *
- * Everything above this point is generic and must stay that way. A test only
- * belongs here when the *behaviour* — not the markup — exists in one
- * implementation and not the other, and we have decided not to close the gap.
- * Each one records what the divergence is and why it stands, so the difference
- * is a deliberate, visible decision rather than a silently narrowed test.
- */
-test.describe('Ghost Admin - Member Detail - known divergences', () => {
+test.describe('Ghost Admin - Member Detail', () => {
     let memberFactory: MemberFactory;
     let memberDetailsPage: MemberDetailsPage;
 
@@ -599,184 +176,516 @@ test.describe('Ghost Admin - Member Detail - known divergences', () => {
         memberDetailsPage = new MemberDetailsPage(page);
     });
 
-    /**
-     * Adding a complimentary subscription is the one flow split purely on
-     * interaction rather than behaviour. Both screens compute the same
-     * `expiry_at` from the same duration options and send the same request, but
-     * one picks a tier with radio buttons and the other with a dropdown. Driving
-     * both from one test would put a branch inside the page object, which buys
-     * less than it costs — so the assertion is duplicated instead, and the two
-     * tests must be kept in step.
-     */
-    test.describe('Ember', () => {
-        test.use({labs: {memberDetailsReact: false}, stripeEnabled: true});
+    test('member name renders in the screen title', async ({page}) => {
+        const member = await memberFactory.create({name: 'Ada Lovelace', email: 'ada-detail@ghost.org'});
 
-        test('adding a complimentary subscription - grants the chosen tier forever', async ({page}) => {
-            const member = await memberFactory.create({name: 'Comp Grant', email: 'comp-grant-ember@ghost.org'});
+        await page.goto(memberPath(member.id));
+
+        await expect(memberDetailsPage.screenTitle).toContainText('Ada Lovelace');
+    });
+
+    test('editing the member name - persists to the server', async ({page}) => {
+        const member = await memberFactory.create({name: 'Grace', email: 'grace-detail@ghost.org'});
+
+        await page.goto(memberPath(member.id));
+        await memberDetailsPage.nameInput.fill('Grace Hopper');
+        await memberDetailsPage.saveButton.click();
+
+        await expect.poll(async () => {
+            const res = await page.request.get(`/ghost/api/admin/members/${member.id}/`);
+            const body = await res.json();
+            return body?.members?.[0]?.name;
+        }, {timeout: 10000}).toBe('Grace Hopper');
+    });
+
+    test('clicking the back link - returns to the members list', async ({page}) => {
+        const member = await memberFactory.create({name: 'Grace Hopper', email: 'grace-back-detail@ghost.org'});
+
+        await page.goto(memberPath(member.id));
+        await memberDetailsPage.membersBackLink.click();
+
+        await expect(page).toHaveURL(/#\/members$/);
+    });
+
+    test('impersonation modal - exposes a real signin url', async ({page}) => {
+        const member = await memberFactory.create({name: 'Alan Turing', email: 'alan-detail@ghost.org'});
+
+        await page.goto(memberPath(member.id));
+        await memberDetailsPage.settingsSection.memberActionsButton.click();
+        await memberDetailsPage.settingsSection.impersonateButton.click();
+
+        // The url is fetched after the modal opens, so assert on the value to
+        // let Playwright wait rather than reading the empty initial state.
+        await expect(memberDetailsPage.magicLinkInput).toHaveValue(/^https?:\/\/.+/);
+    });
+
+    test('signing out of all devices - closes the confirmation and stays on the member', async ({page}) => {
+        const member = await memberFactory.create({name: 'Rear Admiral', email: 'rear-detail@ghost.org'});
+
+        await page.goto(memberPath(member.id));
+        await memberDetailsPage.settingsSection.memberActionsButton.click();
+        await memberDetailsPage.settingsSection.signOutOfAllDevices.click();
+        // Scoped to the modal so the click can't hit the account-owner
+        // "Sign out" button in the admin sidebar dropdown.
+        await memberDetailsPage.logoutConfirmModal.getByRole('button', {name: 'Sign out', exact: true}).click();
+
+        await expect(memberDetailsPage.logoutConfirmModal).toHaveCount(0);
+        await expect(page).toHaveURL(new RegExp(`#/members/${member.id}`));
+    });
+
+    test('deleting a member - returns to the list and removes the record', async ({page}) => {
+        const member = await memberFactory.create({name: 'Deletable', email: 'delete-detail@ghost.org'});
+
+        await page.goto(memberPath(member.id));
+        await memberDetailsPage.settingsSection.memberActionsButton.click();
+        await memberDetailsPage.settingsSection.deleteButton.click();
+        await memberDetailsPage.settingsSection.confirmDeleteButton.click();
+
+        await expect(page).toHaveURL(/#\/members$/);
+        const res = await page.request.get(`/ghost/api/admin/members/${member.id}/`);
+        expect(res.status()).toBe(404);
+    });
+
+    test('creating a member - persists to the server and redirects to the detail', async ({page}) => {
+        const email = 'new-member-detail@ghost.org';
+
+        await page.goto(memberPath('new'));
+        await memberDetailsPage.nameInput.fill('New Member');
+        await memberDetailsPage.emailInput.fill(email);
+        await memberDetailsPage.saveButton.click();
+
+        let createdId: string | undefined;
+        await expect.poll(async () => {
+            const res = await page.request.get(`/ghost/api/admin/members/?filter=${encodeURIComponent(`email:'${email}'`)}`);
+            const body = await res.json();
+            createdId = body?.members?.[0]?.id;
+            return body?.members?.[0]?.name;
+        }, {timeout: 10000}).toBe('New Member');
+        await expect(page).toHaveURL(new RegExp(`#/members/${createdId}(\\?|$)`));
+    });
+
+    test('disabling then re-enabling commenting - clears the disabled indicator', async ({page}) => {
+        const member = await memberFactory.create({name: 'Commenter', email: 'commenter-toggle@ghost.org'});
+
+        await page.goto(memberPath(member.id));
+        await memberDetailsPage.settingsSection.memberActionsButton.click();
+        await memberDetailsPage.settingsSection.disableCommentingButton.click();
+        await memberDetailsPage.disableCommentingConfirmButton.click();
+
+        await expect(memberDetailsPage.commentingDisabledIndicator).toBeVisible();
+
+        await memberDetailsPage.settingsSection.memberActionsButton.click();
+        await memberDetailsPage.settingsSection.enableCommentingButton.click();
+
+        await expect(memberDetailsPage.commentingDisabledIndicator).toBeHidden();
+    });
+
+    test('sidebar - shows the signup location and created date', async ({page}) => {
+        // Members created through the API carry no geolocation, so the
+        // location falls back deterministically.
+        const member = await memberFactory.create({name: 'Katherine Johnson', email: 'katherine-sidebar@ghost.org'});
+
+        await page.goto(memberPath(member.id));
+
+        await expect(page.getByText('Unknown location')).toBeVisible();
+        await expect(page.getByText(/Created/)).toBeVisible();
+    });
+
+    test('leaving with unsaved changes - warns before navigating away', async ({page}) => {
+        const member = await memberFactory.create({name: 'Grace Hopper', email: 'grace-unsaved@ghost.org'});
+
+        await page.goto(memberPath(member.id));
+        await memberDetailsPage.nameInput.fill('Grace B. Hopper');
+        await memberDetailsPage.membersBackLink.click();
+
+        await expect(memberDetailsPage.confirmLeaveButton).toBeVisible();
+        await memberDetailsPage.confirmLeaveButton.click();
+        await expect(page).toHaveURL(/#\/members$/);
+    });
+
+    test('leaving with unsaved changes via the sidebar - warns before navigating away', async ({page}) => {
+        // The sidebar navigates with native hash anchors rather than
+        // client-side router links, so it exercises a different guard path
+        // than the back link above; both must warn.
+        const sidebar = new SidebarPage(page);
+        const member = await memberFactory.create({name: 'Grace Hopper', email: 'grace-unsaved-sidebar@ghost.org'});
+
+        await page.goto(memberPath(member.id));
+        await memberDetailsPage.nameInput.fill('Grace B. Hopper');
+        await sidebar.getNavLink('Members').click();
+
+        await expect(memberDetailsPage.confirmLeaveButton).toBeVisible();
+        await memberDetailsPage.confirmLeaveButton.click();
+        await expect(page).toHaveURL(/#\/members$/);
+    });
+
+    test('toggling a newsletter - persists the new state', async ({page}) => {
+        const member = await memberFactory.create({name: 'Newsletter Test', email: 'newsletter-toggle@ghost.org'});
+
+        await page.goto(memberPath(member.id));
+        // Wait on the toggle, not the checkbox — Ember hides the real input
+        // behind a styled span, so the control is never visible itself.
+        await expect(memberDetailsPage.newsletterSubscriptionToggles.first()).toBeVisible();
+        const initiallyChecked = await memberDetailsPage.newsletterSubscriptionCheckboxes.first().isChecked();
+
+        await memberDetailsPage.newsletterSubscriptionToggles.first().click();
+        await memberDetailsPage.save();
+        await page.reload();
+
+        await expect(memberDetailsPage.newsletterSubscriptionCheckboxes.first()).toBeChecked({checked: !initiallyChecked});
+    });
+
+    test('activity feed - view-all link points at this members full activity', async ({page}) => {
+        const member = await memberFactory.create({name: 'Activity Target', email: 'activity-viewall@ghost.org'});
+        // A fresh member's signup event is written asynchronously, so serve a
+        // known event rather than racing it — the link only renders on the
+        // populated branch.
+        await page.route(/\/ghost\/api\/admin\/members\/events\/?\?/, async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.continue();
+            }
+            return route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    events: [{
+                        type: 'signup_event',
+                        data: {
+                            id: 'evt-1',
+                            created_at: new Date(0).toISOString(),
+                            member_id: member.id,
+                            member: {id: member.id, name: member.name, email: member.email}
+                        }
+                    }],
+                    meta: {pagination: {}}
+                })
+            });
+        });
+
+        await page.goto(memberPath(member.id));
+
+        const viewAll = page.getByRole('link', {name: /View all member activity/});
+        await expect(viewAll).toBeVisible();
+        await expect(viewAll).toHaveAttribute('href', new RegExp(`#/members-activity/?\\?member=${member.id}`));
+    });
+
+    test.describe('Subscriptions', () => {
+        // The Subscriptions section is gated on paid members being enabled.
+        test.use({stripeEnabled: true});
+
+        test('paid subscription - shows the tier, price, interval and renewal date', async ({page}) => {
+            const member = await memberFactory.create({name: 'Paid Member', email: 'paid-sub@ghost.org'});
+            await seedSubscriptions(page, member.id, 'paid', [paidSubscription()]);
+
+            await page.goto(memberPath(member.id));
+
+            await expect(page.getByText('Bronze').first()).toBeVisible();
+            await expect(page.getByText('10.50').first()).toBeVisible();
+            await expect(page.getByText(/month/i).first()).toBeVisible();
+            await expect(page.getByText(/Renews 15 Feb 2026/).first()).toBeVisible();
+        });
+
+        test('subscription set to cancel - shows remaining access rather than a renewal', async ({page}) => {
+            const member = await memberFactory.create({name: 'Cancelling Member', email: 'cancelling-sub@ghost.org'});
+            await seedSubscriptions(page, member.id, 'paid', [paidSubscription({cancel_at_period_end: true})]);
+
+            await page.goto(memberPath(member.id));
+
+            await expect(page.getByText(/Has access until\s+15 Feb 2026/).first()).toBeVisible();
+            await expect(page.getByText(/Renews/)).toHaveCount(0);
+        });
+
+        test('complimentary subscription - shows the tier without a price', async ({page}) => {
+            const member = await memberFactory.create({name: 'Comp Member', email: 'comp-sub@ghost.org'});
+            await seedSubscriptions(page, member.id, 'comped', [compSubscription()]);
+
+            await page.goto(memberPath(member.id));
+
+            await expect(page.getByText('Bronze').first()).toBeVisible();
+            await expect(page.getByText(/Complimentary/i).first()).toBeVisible();
+        });
+
+        test('gift subscription - offers no actions menu', async ({page}) => {
+            // A gift is bought by someone else and can't be cancelled or
+            // revoked from here, so the row deliberately has no menu.
+            const member = await memberFactory.create({name: 'Gift Member', email: 'gift-sub@ghost.org'});
+            await seedSubscriptions(page, member.id, 'gift', [giftSubscription()]);
+
+            await page.goto(memberPath(member.id));
+
+            await expect(page.getByText('Bronze').first()).toBeVisible();
+            await expect(memberDetailsPage.subscriptionActionsButton).toHaveCount(0);
+        });
+
+        test('cancelling a subscription - asks the server to cancel at period end', async ({page}) => {
+            const member = await memberFactory.create({name: 'Cancel Member', email: 'cancel-action@ghost.org'});
+            const subs = [paidSubscription()];
+            await seedSubscriptions(page, member.id, 'paid', subs);
+            // Reflect the write back into the seeded read so the screen can
+            // re-render from it, the way a real refetch would.
+            const sent = await captureWrite(page, `**/members/${member.id}/subscriptions/sub_paid_123/**`, (body) => {
+                subs[0].cancel_at_period_end = body.cancel_at_period_end as boolean;
+            });
+
+            await page.goto(memberPath(member.id));
+            await memberDetailsPage.subscriptionActionsButton.click();
+            await memberDetailsPage.cancelSubscriptionButton.click();
+
+            // The request is the contract — the server doesn't care which UI sent it.
+            await expect.poll(() => sent.body?.cancel_at_period_end).toBe(true);
+        });
+
+        test('continuing a cancelled subscription - asks the server to resume it', async ({page}) => {
+            const member = await memberFactory.create({name: 'Continue Member', email: 'continue-action@ghost.org'});
+            const subs = [paidSubscription({cancel_at_period_end: true})];
+            await seedSubscriptions(page, member.id, 'paid', subs);
+            const sent = await captureWrite(page, `**/members/${member.id}/subscriptions/sub_paid_123/**`, (body) => {
+                subs[0].cancel_at_period_end = body.cancel_at_period_end as boolean;
+            });
+
+            await page.goto(memberPath(member.id));
+            await memberDetailsPage.subscriptionActionsButton.click();
+            await memberDetailsPage.continueSubscriptionButton.click();
+
+            await expect.poll(() => sent.body?.cancel_at_period_end).toBe(false);
+        });
+
+        test('removing a complimentary subscription - puts back only the surviving tiers', async ({page}) => {
+            const member = await memberFactory.create({name: 'Multi Comp', email: 'multi-comp@ghost.org'});
+            await seedSubscriptions(page, member.id, 'comped', [compSubscription()], {tiers: TWO_COMP_TIERS()});
             const sent = await captureWrite(page, new RegExp(`/ghost/api/admin/members/${member.id}/\\??[^/]*$`));
 
             await page.goto(memberPath(member.id));
-            await page.getByRole('button', {name: /Add complimentary subscription/}).click();
-            const option = memberDetailsPage.emberCompTierOptions.first();
-            const chosenTierId = await option.getAttribute('data-test-tier-option');
-            await option.click();
-            await memberDetailsPage.emberSaveCompTierButton.click();
+            await memberDetailsPage.removeComplimentarySubscription();
 
             await expect.poll(() => sentTiers(sent)?.length).toBe(1);
-            // The tier the admin picked, not merely some tier.
-            expect(sentTiers(sent)?.[0].id).toBe(chosenTierId);
-            // Forever is the default, so no expiry is sent.
-            expect(sentTiers(sent)?.[0].expiry_at ?? null).toBeNull();
-        });
-
-        test('invalid email - save stays enabled and the server rejects it', async ({page}) => {
-            // Ember validates on submit: Save is always clickable, and the
-            // failed attempt reports why. React disables Save instead — see the
-            // React-side counterpart below.
-            const member = await memberFactory.create({name: 'Invalid Email', email: 'valid-ember@ghost.org'});
-
-            await page.goto(memberPath(member.id));
-            await memberDetailsPage.emailInput.fill('not-an-email');
-            await memberDetailsPage.saveButton.click();
-
-            await expect(memberDetailsPage.retryButton).toBeVisible();
-            await expect(memberDetailsPage.body).toContainText('Invalid Email');
-        });
-
-        test('commenting can be re-enabled from the sidebar indicator', async ({page}) => {
-            // Ember offers a one-click Enable next to the "Comments disabled"
-            // indicator. React only exposes this through the actions menu, which
-            // the generic suite already covers for both.
-            const member = await memberFactory.create({name: 'Sidebar Enable', email: 'sidebar-enable@ghost.org'});
-
-            await page.goto(memberPath(member.id));
-            await memberDetailsPage.settingsSection.memberActionsButton.click();
-            await memberDetailsPage.settingsSection.disableCommentingButton.click();
-            await memberDetailsPage.disableCommentingConfirmButton.click();
-            await expect(memberDetailsPage.commentingDisabledIndicator).toBeVisible();
-
-            await memberDetailsPage.enableCommentingLink.click();
-
-            await expect(memberDetailsPage.commentingDisabledIndicator).toBeHidden();
+            expect(sentTiers(sent)?.[0].id).toBe('tier_silver');
         });
     });
 
-    test.describe('React', () => {
-        test.use({labs: {memberDetailsReact: true}, stripeEnabled: true});
+    test.describe('New member screen', () => {
+        // The Subscriptions section is gated on paid members being enabled, so
+        // stripe has to be on for it to render at all.
+        test.use({stripeEnabled: true});
 
-        // Ember counterpart above — keep the assertions identical.
-        test('adding a complimentary subscription - grants the chosen tier forever', async ({page}) => {
-            const member = await memberFactory.create({name: 'Comp Grant', email: 'comp-grant-react@ghost.org'});
-            const sent = await captureWrite(page, new RegExp(`/ghost/api/admin/members/${member.id}/\\??[^/]*$`));
+        test('newsletters section - renders a toggle list', async ({page}) => {
+            await page.goto(memberPath('new'));
 
-            await page.goto(memberPath(member.id));
-            await page.getByRole('button', {name: /Add complimentary subscription/}).click();
-            await page.getByTestId('comp-tier-select').click();
-            const option = memberDetailsPage.reactCompTierOptions.first();
-            const chosenTierId = await option.getAttribute('data-tier-id');
-            await option.click();
-            await page.getByTestId('comp-add-confirm').click();
-
-            await expect.poll(() => sentTiers(sent)?.length).toBe(1);
-            expect(sentTiers(sent)?.[0].id).toBe(chosenTierId);
-            expect(sentTiers(sent)?.[0].expiry_at ?? null).toBeNull();
+            await expect(page.getByRole('heading', {name: 'Newsletters', exact: true})).toBeVisible();
+            await expect(memberDetailsPage.newsletterSubscriptionToggles.first()).toBeVisible();
         });
 
-        test('invalid email - save is disabled', async ({page}) => {
-            // React blocks the submit rather than letting it fail, so there is
-            // no server error to surface. Deliberate; the Ember counterpart
-            // above pins the other behaviour.
-            const member = await memberFactory.create({name: 'Invalid Email', email: 'valid-react@ghost.org'});
-
-            await page.goto(memberPath(member.id));
-            await memberDetailsPage.emailInput.fill('not-an-email');
-
-            await expect(memberDetailsPage.saveButton).toBeDisabled();
-        });
-
-        test('failed member load - offers a retry rather than a not-found message', async ({page}) => {
-            // Ember has no equivalent control: a failed load surfaces as an
-            // alert and the route errors. React renders a recoverable panel, so
-            // there is nothing generic to assert.
-            const member = await memberFactory.create({name: 'Retry Target', email: 'retry-target@ghost.org'});
-            let requests = 0;
-            const memberReadRegex = new RegExp(`/ghost/api/admin/members/${member.id}/\\??[^/]*$`);
-            await page.route(memberReadRegex, async (route) => {
-                if (route.request().method() !== 'GET') {
-                    return route.continue();
-                }
-                requests += 1;
-                if (requests === 1) {
-                    return route.fulfill({status: 500, contentType: 'application/json', body: JSON.stringify({errors: [{message: 'boom'}]})});
-                }
-                return route.continue();
-            });
-
-            await page.goto(memberPath(member.id));
-
-            const errorPanel = page.getByTestId('member-detail-load-error');
-            await expect(errorPanel).toBeVisible();
-            // A server error must not be reported as a missing member, anywhere
-            // on the screen. Asserting only the body copy previously let the
-            // breadcrumb go on claiming "Member not found" beside a
-            // "couldn't load" message.
-            await expect(page.getByText(/not found/i)).toHaveCount(0);
-            await expect(page.getByText(/couldn[’']t be found/)).toHaveCount(0);
-
-            await errorPanel.getByRole('button', {name: 'Retry'}).click();
-
-            await expect(memberDetailsPage.screenTitle).toHaveText('Retry Target');
-            await expect(errorPanel).toHaveCount(0);
-        });
-
-        test.describe('Removing a complimentary subscription', () => {
-            test.use({stripeEnabled: true});
-
-            test('preserves the expiry date on surviving tiers', async ({page}) => {
-                // The server treats a tier arriving without `expiry_at` as null and
-                // wipes the pivot (`models/member.js` updateTierExpiry), so the
-                // whole set has to be sent back with expiries intact. Ember sends
-                // `{id}` only and destroys the expiry on every surviving comp tier.
-                // React sends `expiry_at` explicitly. Not generic: a shared version
-                // of this test would fail on Ember, and we are not backporting.
-                const member = await memberFactory.create({name: 'Multi Comp', email: 'multi-comp-react@ghost.org'});
-                await seedSubscriptions(page, member.id, 'comped', [compSubscription()], {tiers: TWO_COMP_TIERS()});
-                const sent = await captureWrite(page, new RegExp(`/ghost/api/admin/members/${member.id}/\\??[^/]*$`));
-
-                await page.goto(memberPath(member.id));
-                await memberDetailsPage.removeComplimentarySubscription();
-
-                await expect.poll(() => sentTiers(sent)?.length).toBe(1);
-                expect(sentTiers(sent)?.[0].expiry_at).toBe(SILVER_EXPIRY);
-            });
-
-            test('asks for confirmation first', async ({page}) => {
-                // Ember removes the comp the moment the menu item is clicked.
-                const member = await memberFactory.create({name: 'Confirm Comp', email: 'confirm-comp@ghost.org'});
-                await seedSubscriptions(page, member.id, 'comped', [compSubscription()], {tiers: TWO_COMP_TIERS()});
-                const sent = await captureWrite(page, new RegExp(`/ghost/api/admin/members/${member.id}/\\??[^/]*$`));
-
-                await page.goto(memberPath(member.id));
-                await memberDetailsPage.subscriptionActionsButton.first().click();
-                await memberDetailsPage.removeComplimentaryButton.click();
-
-                await expect(page.getByRole('alertdialog', {name: /Remove complimentary subscription/})).toBeVisible();
-                expect(sent.body).toBeUndefined();
-            });
-        });
-
-        test('new member - seeded newsletter defaults do not count as unsaved changes', async ({page}) => {
-            // React seeds the create form's newsletter defaults and treats that
-            // seeded state as pristine. Ember's new record is dirty from the
-            // start, so it traps on an untouched form — a generic version of
-            // this test would fail there by design.
+        test('newsletters section - toggles are checked by default', async ({page}) => {
+            // Newsletters with subscribe_on_signup and members visibility are
+            // pre-selected on create, so the admin can see what the new member
+            // will land subscribed to. Assert every toggle rather than the
+            // first, which would pass even if a later default were missed.
             await page.goto(memberPath('new'));
             await expect(memberDetailsPage.newsletterSubscriptionToggles.first()).toBeVisible();
 
-            await memberDetailsPage.membersBackLink.click();
-
-            await expect(page).toHaveURL(/#\/members(\?|$)/);
-            await expect(memberDetailsPage.confirmLeaveButton).toHaveCount(0);
+            const count = await memberDetailsPage.newsletterSubscriptionCheckboxes.count();
+            expect(count).toBeGreaterThan(0);
+            for (let i = 0; i < count; i++) {
+                await expect(memberDetailsPage.newsletterSubscriptionCheckboxes.nth(i)).toBeChecked();
+            }
         });
+
+        test('activity section - shows an empty state', async ({page}) => {
+            await page.goto(memberPath('new'));
+
+            await expect(page.getByText('All events related to this member will be shown here.')).toBeVisible();
+        });
+
+        test('subscriptions section - shows an empty state', async ({page}) => {
+            await page.goto(memberPath('new'));
+
+            await expect(page.getByRole('heading', {name: 'Subscriptions', exact: true})).toBeVisible();
+            await expect(page.getByRole('heading', {name: 'No subscriptions', exact: true})).toBeVisible();
+        });
+    });
+
+    test.describe('Engagement section', () => {
+        const stubMemberRead = interceptMemberRead;
+
+        test('member has received no emails - shows an empty state', async ({page}) => {
+            const member = await memberFactory.create({name: 'Ada Lovelace', email: 'engagement-empty@ghost.org'});
+
+            await page.goto(memberPath(member.id));
+
+            await expect(page.getByRole('heading', {name: 'Engagement'})).toBeVisible();
+            await expect(page.getByText(/We[’']ll show Ada[’']s email stats here/)).toBeVisible();
+        });
+
+        test('member has received emails - shows counts and open rate', async ({page}) => {
+            const member = await memberFactory.create({name: 'Stats Member', email: 'engagement-stats@ghost.org'});
+            // Inject the stats so the branch renders deterministically rather
+            // than depending on what the fixture database happens to hold.
+            await stubMemberRead(page, member.id, (m) => {
+                m.email_count = 12;
+                m.email_opened_count = 9;
+                m.email_open_rate = 75;
+            });
+
+            await page.goto(memberPath(member.id));
+
+            const engagement = memberDetailsPage.engagementSection;
+            await expect(engagement.getByText('Emails received')).toBeVisible();
+            await expect(engagement.getByText('12', {exact: true})).toBeVisible();
+            await expect(engagement.getByText('Emails opened')).toBeVisible();
+            await expect(engagement.getByText('9', {exact: true})).toBeVisible();
+            await expect(engagement.getByText('Average open rate')).toBeVisible();
+            await expect(engagement.getByText(/75\s*%/)).toBeVisible();
+        });
+
+        test('email fields absent from the payload - shows the empty state', async ({page}) => {
+            const member = await memberFactory.create({name: 'Ada Lovelace', email: 'engagement-undef@ghost.org'});
+            await stubMemberRead(page, member.id, (m) => {
+                delete m.email_count;
+                delete m.email_opened_count;
+                delete m.email_open_rate;
+            });
+
+            await page.goto(memberPath(member.id));
+
+            await expect(page.getByRole('heading', {name: 'Engagement'})).toBeVisible();
+            await expect(page.getByText(/We[’']ll show Ada[’']s email stats here/)).toBeVisible();
+        });
+
+        test('open rate not yet calculated - shows the placeholder', async ({page}) => {
+            const member = await memberFactory.create({name: 'Early Stats', email: 'engagement-null@ghost.org'});
+            // The server sends a null rate until the member has been sent 5
+            // newsletters; both the count and a bare % would be misleading.
+            await stubMemberRead(page, member.id, (m) => {
+                m.email_count = 3;
+                m.email_opened_count = 2;
+                m.email_open_rate = null;
+            });
+
+            await page.goto(memberPath(member.id));
+
+            await expect(page.getByText('This metric is calculated once a member has received 5 newsletters.')).toBeVisible();
+        });
+    });
+});
+
+/**
+ * Behaviours with no counterpart in the generic suite above: they assert an
+ * affordance specific to this screen, or need a Stripe-enabled environment.
+ */
+test.describe('Ghost Admin - Member Detail - screen-specific behaviour', () => {
+    test.use({stripeEnabled: true});
+
+    let memberFactory: MemberFactory;
+    let memberDetailsPage: MemberDetailsPage;
+
+    test.beforeEach(async ({page}) => {
+        memberFactory = createMemberFactory(page.request);
+        memberDetailsPage = new MemberDetailsPage(page);
+    });
+
+    test('adding a complimentary subscription - grants the chosen tier forever', async ({page}) => {
+        const member = await memberFactory.create({name: 'Comp Grant', email: 'comp-grant-react@ghost.org'});
+        const sent = await captureWrite(page, new RegExp(`/ghost/api/admin/members/${member.id}/\\??[^/]*$`));
+
+        await page.goto(memberPath(member.id));
+        await page.getByRole('button', {name: /Add complimentary subscription/}).click();
+        await page.getByTestId('comp-tier-select').click();
+        const option = memberDetailsPage.reactCompTierOptions.first();
+        const chosenTierId = await option.getAttribute('data-tier-id');
+        await option.click();
+        await page.getByTestId('comp-add-confirm').click();
+
+        await expect.poll(() => sentTiers(sent)?.length).toBe(1);
+        expect(sentTiers(sent)?.[0].id).toBe(chosenTierId);
+        expect(sentTiers(sent)?.[0].expiry_at ?? null).toBeNull();
+    });
+
+    test('invalid email - save is disabled', async ({page}) => {
+        // The submit is blocked rather than allowed to fail, so there is no
+        // server error to surface.
+        const member = await memberFactory.create({name: 'Invalid Email', email: 'valid-react@ghost.org'});
+
+        await page.goto(memberPath(member.id));
+        await memberDetailsPage.emailInput.fill('not-an-email');
+
+        await expect(memberDetailsPage.saveButton).toBeDisabled();
+    });
+
+    test('failed member load - offers a retry rather than a not-found message', async ({page}) => {
+        // A failed load renders a recoverable panel rather than dead-ending
+        // the route.
+        const member = await memberFactory.create({name: 'Retry Target', email: 'retry-target@ghost.org'});
+        let requests = 0;
+        const memberReadRegex = new RegExp(`/ghost/api/admin/members/${member.id}/\\??[^/]*$`);
+        await page.route(memberReadRegex, async (route) => {
+            if (route.request().method() !== 'GET') {
+                return route.continue();
+            }
+            requests += 1;
+            if (requests === 1) {
+                return route.fulfill({status: 500, contentType: 'application/json', body: JSON.stringify({errors: [{message: 'boom'}]})});
+            }
+            return route.continue();
+        });
+
+        await page.goto(memberPath(member.id));
+
+        const errorPanel = page.getByTestId('member-detail-load-error');
+        await expect(errorPanel).toBeVisible();
+        // A server error must not be reported as a missing member, anywhere
+        // on the screen. Asserting only the body copy previously let the
+        // breadcrumb go on claiming "Member not found" beside a
+        // "couldn't load" message.
+        await expect(page.getByText(/not found/i)).toHaveCount(0);
+        await expect(page.getByText(/couldn[’']t be found/)).toHaveCount(0);
+
+        await errorPanel.getByRole('button', {name: 'Retry'}).click();
+
+        await expect(memberDetailsPage.screenTitle).toHaveText('Retry Target');
+        await expect(errorPanel).toHaveCount(0);
+    });
+
+    test.describe('Removing a complimentary subscription', () => {
+        test.use({stripeEnabled: true});
+
+        test('preserves the expiry date on surviving tiers', async ({page}) => {
+            // The server treats a tier arriving without `expiry_at` as null and
+            // wipes the pivot (`models/member.js` updateTierExpiry), so the
+            // whole set has to be sent back with expiries intact.
+            const member = await memberFactory.create({name: 'Multi Comp', email: 'multi-comp-react@ghost.org'});
+            await seedSubscriptions(page, member.id, 'comped', [compSubscription()], {tiers: TWO_COMP_TIERS()});
+            const sent = await captureWrite(page, new RegExp(`/ghost/api/admin/members/${member.id}/\\??[^/]*$`));
+
+            await page.goto(memberPath(member.id));
+            await memberDetailsPage.removeComplimentarySubscription();
+
+            await expect.poll(() => sentTiers(sent)?.length).toBe(1);
+            expect(sentTiers(sent)?.[0].expiry_at).toBe(SILVER_EXPIRY);
+        });
+
+        test('asks for confirmation first', async ({page}) => {
+            const member = await memberFactory.create({name: 'Confirm Comp', email: 'confirm-comp@ghost.org'});
+            await seedSubscriptions(page, member.id, 'comped', [compSubscription()], {tiers: TWO_COMP_TIERS()});
+            const sent = await captureWrite(page, new RegExp(`/ghost/api/admin/members/${member.id}/\\??[^/]*$`));
+
+            await page.goto(memberPath(member.id));
+            await memberDetailsPage.subscriptionActionsButton.first().click();
+            await memberDetailsPage.removeComplimentaryButton.click();
+
+            await expect(page.getByRole('alertdialog', {name: /Remove complimentary subscription/})).toBeVisible();
+            expect(sent.body).toBeUndefined();
+        });
+    });
+
+    test('new member - seeded newsletter defaults do not count as unsaved changes', async ({page}) => {
+        // The create form seeds its newsletter defaults and treats that seeded
+        // state as pristine, so an untouched form must not trap on leave.
+        await page.goto(memberPath('new'));
+        await expect(memberDetailsPage.newsletterSubscriptionToggles.first()).toBeVisible();
+
+        await memberDetailsPage.membersBackLink.click();
+
+        await expect(page).toHaveURL(/#\/members(\?|$)/);
+        await expect(memberDetailsPage.confirmLeaveButton).toHaveCount(0);
     });
 });

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -27,7 +27,8 @@ const messages = {
 
 // flags in this list always return `true`, allows quick global enable prior to full flag removal
 const GA_FEATURES = [
-    'automationAnalytics'
+    'automationAnalytics',
+    'memberDetailsReact'
 ];
 
 // These features are considered publicly available and can be enabled/disabled by users
@@ -51,7 +52,6 @@ const PRIVATE_FEATURES = [
     'themeTranslation',
     'pictureImageFormats',
     'getHelperDeduplication',
-    'memberDetailsReact',
     'membersCustomFields',
     'paywallImprovements',
     'giftSubCustomization',


### PR DESCRIPTION
ref https://linear.app/ghost/issue/BER-3848/promote-memberdetailsreact-to-ga-and-delete-the-ember-member-screen

The React member details screen has only ever been available one site at a time, behind a Labs toggle. The remote flag manifest turned it on across Ghost(Pro), but self-hosted sites never read that manifest, so they stayed on the old Ember screen with no way to move off it. There was no path to actually finishing the release.

Promoting the flag to generally available closes that. Every site gets the React screen on upgrade, and Ghost(Pro) keeps its remote kill switch, because remote overrides still sit above the generally available list and can turn the flag back off if something goes wrong in production.

The browser tests needed the same treatment. They used to run one set of assertions twice, toggling the flag per run so the same behaviour was proven against both screens. A generally available flag can no longer be switched off that way, so the Ember halves would have quietly re-run against React while still claiming to cover Ember. Rather than leave tests that lie about what they exercise, they are removed here.

This is the first of two steps. #29753 removes the flag itself and deletes the Ember screen, and lands straight after this one.

## Verified

Labs unit tests, the e2e typecheck and lint, and lint across the admin apps all pass. The browser end-to-end suite was not run locally, as it needs a running dev stack, and is left to CI.

Rebased onto current main. Two conflicts, both in files main had already moved on: the generally available list had been trimmed of flags that shipped in the meantime, and the settings API snapshot now matches the response size with a pattern rather than a literal, so the number this branch used to bump is gone.

One review fix on top of the rebase: the "cannot update an existing member with invalid email" test asserted Save was disabled without first proving it could be enabled. Save also starts disabled on an untouched form, so the assertion passed for the wrong reason and would have kept passing if email validation broke. It now makes a valid edit and asserts Save is enabled before setting the invalid address.
