### PR TITLE
Added automation run steps to automated email recipients

### DIFF
--- a/ghost/core/core/server/services/automations/automations-repository.ts
+++ b/ghost/core/core/server/services/automations/automations-repository.ts
@@ -90,6 +90,7 @@ export type AutomatedEmailEvents = {
 
 export type RecordEmailSentOptions = Readonly<{
     automationActionRevisionId: string;
+    automationRunStepId: string;
     mailgunMessageId?: string;
     memberEmail: string;
     memberId: string;

--- a/ghost/core/core/server/services/automations/database-automations-repository.ts
+++ b/ghost/core/core/server/services/automations/database-automations-repository.ts
@@ -276,6 +276,7 @@ export function createDatabaseAutomationsRepository({
                     member_email: options.memberEmail,
                     member_name: options.memberName,
                     automation_action_revision_id: options.automationActionRevisionId,
+                    automation_run_step_id: options.automationRunStepId,
                     ...(options.mailgunMessageId ? {mailgun_message_id: options.mailgunMessageId} : {}),
                     track_clicks: options.trackClicks,
                     track_opens: options.trackOpens,

--- a/ghost/core/core/server/services/automations/poll.ts
+++ b/ghost/core/core/server/services/automations/poll.ts
@@ -210,6 +210,7 @@ const processStep = async ({
             try {
                 await automationsApi.recordEmailSent({
                     automationActionRevisionId: step.automation_action_revision_id,
+                    automationRunStepId: step.id,
                     ...(mailgunMessageId ? {mailgunMessageId} : {}),
                     memberEmail: member.get('email'),
                     memberId: step.member_id,

--- a/ghost/core/test/integration/services/email-analytics/automation-email-analytics.test.js
+++ b/ghost/core/test/integration/services/email-analytics/automation-email-analytics.test.js
@@ -72,6 +72,8 @@ describe('Automation email analytics', function () {
 
     async function cleanupTables() {
         await testUtils.knex('automated_email_recipients').del();
+        await testUtils.knex('automation_run_steps').del();
+        await testUtils.knex('automation_runs').del();
         await testUtils.knex('automation_action_revisions').del();
         await testUtils.knex('automation_actions').del();
         await testUtils.knex('automations').del();
@@ -99,6 +101,32 @@ describe('Automation email analytics', function () {
             created_at: now,
             updated_at: now,
             ...attrs
+        });
+    }
+
+    async function createRunStep({revision, member}) {
+        const now = new Date();
+        const action = await testUtils.knex('automation_actions')
+            .where('id', revision.action_id)
+            .first();
+        assert.ok(action, `expected action ${revision.action_id} to exist`);
+
+        const run = await insert('automation_runs', {
+            id: ObjectId().toHexString(),
+            automation_id: action.automation_id,
+            member_id: member.id,
+            member_email: member.email,
+            created_at: now,
+            updated_at: now
+        });
+
+        return insert('automation_run_steps', {
+            id: ObjectId().toHexString(),
+            automation_run_id: run.id,
+            automation_action_revision_id: revision.id,
+            ready_at: now,
+            created_at: now,
+            updated_at: now
         });
     }
 
@@ -135,8 +163,10 @@ describe('Automation email analytics', function () {
 
     async function recordEmailSent({revision, mailgunMessageId, trackClicks = true, trackOpens = true}) {
         const member = await createMember();
+        const step = await createRunStep({revision, member});
         await automationsApi.recordEmailSent({
             automationActionRevisionId: revision.id,
+            automationRunStepId: step.id,
             mailgunMessageId,
             memberEmail: member.email,
             memberId: member.id,

--- a/ghost/core/test/integration/services/email-analytics/automation-email-analytics.test.js
+++ b/ghost/core/test/integration/services/email-analytics/automation-email-analytics.test.js
@@ -120,7 +120,7 @@ describe('Automation email analytics', function () {
             updated_at: now
         });
 
-        return insert('automation_run_steps', {
+        return await insert('automation_run_steps', {
             id: ObjectId().toHexString(),
             automation_run_id: run.id,
             automation_action_revision_id: revision.id,

--- a/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
+++ b/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
@@ -154,6 +154,7 @@ const createDatabase = async (): Promise<Knex> => {
     await database.schema.createTable('automated_email_recipients', (table) => {
         table.text('id').primary();
         table.text('automation_action_revision_id').references('id').inTable('automation_action_revisions');
+        table.text('automation_run_step_id').references('id').inTable('automation_run_steps');
         table.text('member_id');
         table.text('member_uuid');
         table.text('member_email');
@@ -512,6 +513,17 @@ describe('automations repository', function () {
         await knex('automation_run_steps').insert(step);
 
         return step;
+    };
+
+    const insertStepForRevision = async (revisionId: string) => {
+        const action = await knex('automation_action_revisions as revisions')
+            .select('actions.automation_id')
+            .innerJoin('automation_actions as actions', 'actions.id', 'revisions.action_id')
+            .where('revisions.id', revisionId)
+            .first();
+        assert(action, 'Expected action revision to exist');
+        const run = await insertRun(action.automation_id);
+        return await insertStep(run.id, revisionId);
     };
 
     const getStepById = async (id: string) => {
@@ -2069,9 +2081,11 @@ describe('automations repository', function () {
         it('records the recipient and increments the action revision count', async function () {
             const revision = await knex('automation_action_revisions').select('id').first();
             assert(revision);
+            const step = await insertStepForRevision(revision.id);
 
             await repo.recordEmailSent({
                 automationActionRevisionId: revision.id,
+                automationRunStepId: step.id,
                 mailgunMessageId: 'mailgun-message-id',
                 memberEmail: 'member@example.com',
                 memberId: 'member-id',
@@ -2085,6 +2099,7 @@ describe('automations repository', function () {
             assert.deepEqual(recipient, {
                 id: recipient.id,
                 automation_action_revision_id: revision.id,
+                automation_run_step_id: step.id,
                 member_id: 'member-id',
                 member_uuid: '00000000-0000-4000-8000-000000000001',
                 member_email: 'member@example.com',
@@ -2112,6 +2127,7 @@ describe('automations repository', function () {
         it('updates the action revision before inserting the recipient', async function () {
             const revision = await knex('automation_action_revisions').select('id').first();
             assert(revision);
+            const step = await insertStepForRevision(revision.id);
 
             const queries: string[] = [];
             const recordQuery = ({sql}: {sql: string}) => queries.push(sql);
@@ -2120,6 +2136,7 @@ describe('automations repository', function () {
             try {
                 await repo.recordEmailSent({
                     automationActionRevisionId: revision.id,
+                    automationRunStepId: step.id,
                     memberEmail: 'member@example.com',
                     memberId: 'member-id',
                     memberName: 'Test Member',
@@ -2146,9 +2163,11 @@ describe('automations repository', function () {
         it('supports recipients without a Mailgun message ID', async function () {
             const revision = await knex('automation_action_revisions').select('id').first();
             assert(revision);
+            const step = await insertStepForRevision(revision.id);
 
             await repo.recordEmailSent({
                 automationActionRevisionId: revision.id,
+                automationRunStepId: step.id,
                 memberEmail: 'member@example.com',
                 memberId: 'member-id',
                 memberName: null,

--- a/ghost/core/test/unit/server/services/automations/poll.test.ts
+++ b/ghost/core/test/unit/server/services/automations/poll.test.ts
@@ -368,6 +368,7 @@ describe('automations poll', function () {
         }));
         sinon.assert.calledOnceWithExactly(automationsApi.recordEmailSent, {
             automationActionRevisionId: 'revision-id',
+            automationRunStepId: step.id,
             mailgunMessageId: 'mailgun-message-id',
             memberEmail: 'member@example.com',
             memberId: 'member-id',
@@ -437,6 +438,7 @@ describe('automations poll', function () {
         await poll(options);
 
         sinon.assert.calledOnceWithExactly(automationsApi.recordEmailSent, sinon.match({
+            automationRunStepId: step.id,
             trackClicks: true
         }));
         sinon.assert.calledOnceWithExactly(memberWelcomeEmailService.api.sendAutomationEmail, sinon.match({
@@ -453,6 +455,7 @@ describe('automations poll', function () {
         await poll(options);
 
         sinon.assert.calledOnceWithExactly(automationsApi.recordEmailSent, sinon.match({
+            automationRunStepId: step.id,
             trackClicks: false
         }));
         sinon.assert.calledOnceWithExactly(memberWelcomeEmailService.api.sendAutomationEmail, sinon.match({
@@ -470,6 +473,7 @@ describe('automations poll', function () {
         await poll(options);
 
         sinon.assert.calledOnceWithExactly(automationsApi.recordEmailSent, sinon.match({
+            automationRunStepId: step.id,
             trackClicks: false
         }));
         sinon.assert.calledOnceWithExactly(memberWelcomeEmailService.api.sendAutomationEmail, sinon.match({
@@ -496,6 +500,7 @@ describe('automations poll', function () {
         }));
         sinon.assert.calledOnceWithExactly(automationsApi.recordEmailSent, {
             automationActionRevisionId: 'revision-id',
+            automationRunStepId: step.id,
             memberEmail: 'member@example.com',
             memberId: 'member-id',
             memberName: 'Test Member',

--- a/ghost/core/test/utils/automations-fixtures.ts
+++ b/ghost/core/test/utils/automations-fixtures.ts
@@ -107,11 +107,9 @@ export async function cleanupAutomationsFixture(): Promise<void> {
             .whereIn('automation_run_id', runIds)
             .pluck('id');
 
-        if (runStepIds.length > 0) {
-            await db.knex('automated_email_recipients')
-                .whereIn('automation_run_step_id', runStepIds)
-                .del();
-        }
+        await db.knex('automated_email_recipients')
+            .whereIn('automation_run_step_id', runStepIds)
+            .del();
 
         await db.knex('automation_run_steps')
             .whereIn('automation_run_id', runIds)

--- a/ghost/core/test/utils/automations-fixtures.ts
+++ b/ghost/core/test/utils/automations-fixtures.ts
@@ -103,6 +103,16 @@ export async function cleanupAutomationsFixture(): Promise<void> {
         .pluck('id');
 
     if (runIds.length > 0) {
+        const runStepIds: string[] = await db.knex('automation_run_steps')
+            .whereIn('automation_run_id', runIds)
+            .pluck('id');
+
+        if (runStepIds.length > 0) {
+            await db.knex('automated_email_recipients')
+                .whereIn('automation_run_step_id', runStepIds)
+                .del();
+        }
+
         await db.knex('automation_run_steps')
             .whereIn('automation_run_id', runIds)
             .del();


### PR DESCRIPTION
refs https://linear.app/ghost/issue/NY-1509/update-click-tracking-to-eliminate-the-most-recently-received-email

Automated email recipients need an unambiguous link to the run step that produced them so downstream analytics can identify an exact delivery. This persists that relationship during automated sends and updates affected fixture cleanup and ordering coverage to respect the new foreign key.

Stack: 1 of 3. The next PR adds the run step to tracked email links.

Validation:
- Automations acceptance tests: 4 passed
- Automations repository tests: 74 passed
