### PR TITLE
Restricted notification creation to administrators

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.56/2026-08-04-14-42-39-restrict-notification-add-permission-to-administrators.js
+++ b/ghost/core/core/server/data/migrations/versions/6.56/2026-08-04-14-42-39-restrict-notification-add-permission-to-administrators.js
@@ -1,0 +1,12 @@
+const {combineTransactionalMigrations, removePermissionFromRole} = require('../../utils');
+
+module.exports = combineTransactionalMigrations(
+    removePermissionFromRole({
+        permission: 'Add notifications',
+        role: 'Editor'
+    }),
+    removePermissionFromRole({
+        permission: 'Add notifications',
+        role: 'Super Editor'
+    })
+);

--- a/ghost/core/core/server/data/schema/fixtures/fixtures.json
+++ b/ghost/core/core/server/data/schema/fixtures/fixtures.json
@@ -1066,7 +1066,7 @@
                     "gift_link": "manage"
                 },
                 "Super Editor": {
-                    "notification": "all",
+                    "notification": ["browse", "destroy"],
                     "post": "all",
                     "setting": ["browse", "read"],
                     "slug": "all",
@@ -1091,7 +1091,7 @@
                     "gift_link": "manage"
                 },
                 "Editor": {
-                    "notification": "all",
+                    "notification": ["browse", "destroy"],
                     "post": "all",
                     "setting": ["browse", "read"],
                     "slug": "all",

--- a/ghost/core/test/e2e-api/admin/__snapshots__/notifications.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/notifications.test.js.snap
@@ -81,15 +81,6 @@ Object {
       "status": "alert",
       "type": "info",
     },
-    Object {
-      "custom": true,
-      "dismissible": true,
-      "id": StringMatching /\\[a-f0-9\\]\\{24\\}/,
-      "location": "bottom",
-      "message": "test notification",
-      "status": "alert",
-      "type": "info",
-    },
   ],
 }
 `;
@@ -98,7 +89,7 @@ exports[`Notifications API As Editor Read notifications 2: [headers] 1`] = `
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "463",
+  "content-length": "315",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-api/admin/notifications.test.js
+++ b/ghost/core/test/e2e-api/admin/notifications.test.js
@@ -1,5 +1,6 @@
 const assert = require('node:assert/strict');
-const {agentProvider, fixtureManager, matchers} = require('../../utils/e2e-framework');
+const {agentProvider, fixtureManager, matchers, resetRateLimits} = require('../../utils/e2e-framework');
+const testUtils = require('../../utils');
 const {anyContentVersion, anyObjectId, anyEtag, anyLocationFor} = matchers;
 
 const matchNotification = {
@@ -12,7 +13,8 @@ describe('Notifications API', function () {
     beforeAll(async function () {
         agent = await agentProvider.getAdminAPIAgent();
         await fixtureManager.init('users');
-        await agent.loginAsOwner();
+        await resetRateLimits();
+        await agent.loginAsAdmin();
     });
 
     it('Can add notification', async function () {
@@ -89,10 +91,11 @@ describe('Notifications API', function () {
 
     describe('As Editor', function () {
         beforeAll(async function () {
+            await resetRateLimits();
             await agent.loginAsEditor();
         });
 
-        it('Add notification', async function () {
+        it('Cannot add notification', async function () {
             const newNotification = {
                 type: 'info',
                 message: 'test notification',
@@ -104,15 +107,7 @@ describe('Notifications API', function () {
                 .body({
                     notifications: [newNotification]
                 })
-                .expectStatus(201)
-                .matchBodySnapshot({
-                    notifications: [matchNotification]
-                })
-                .matchHeaderSnapshot({
-                    'content-version': anyContentVersion,
-                    etag: anyEtag,
-                    location: anyLocationFor('notifications')
-                });
+                .expectStatus(403);
         });
 
         it('Read notifications', async function () {
@@ -120,20 +115,42 @@ describe('Notifications API', function () {
                 .get('notifications')
                 .expectStatus(200)
                 .matchBodySnapshot({
-                    notifications: new Array(3).fill(matchNotification)
+                    notifications: new Array(2).fill(matchNotification)
                 })
                 .matchHeaderSnapshot({
                     'content-version': anyContentVersion,
                     etag: anyEtag
                 })
                 .expect(({body}) => {
-                    assert.equal(body.notifications.length, 3);
+                    assert.equal(body.notifications.length, 2);
                 });
+        });
+    });
+
+    describe('As Super Editor', function () {
+        beforeAll(async function () {
+            const {email, password} = testUtils.DataGenerator.Content.users[9];
+            await resetRateLimits();
+            await agent.loginAs(email, password);
+        });
+
+        it('Cannot add notification', async function () {
+            await agent
+                .post('notifications')
+                .body({
+                    notifications: [{
+                        type: 'info',
+                        message: 'test notification',
+                        custom: true
+                    }]
+                })
+                .expectStatus(403);
         });
     });
 
     describe('As Author', function () {
         beforeAll(async function () {
+            await resetRateLimits();
             await agent.loginAsAuthor();
         });
 
@@ -163,8 +180,8 @@ describe('Notifications API', function () {
         let notification;
 
         beforeAll(async function () {
-            // First editor creates a notification
-            await agent.loginAsEditor();
+            await resetRateLimits();
+            await agent.loginAsAdmin();
 
             const newNotification = {
                 type: 'info',
@@ -180,6 +197,8 @@ describe('Notifications API', function () {
                 .expectStatus(201);
 
             notification = body.notifications[0];
+            await resetRateLimits();
+            await agent.loginAsEditor();
         });
 
         it('if one user dismisses a notification, it is still visible to other users', async function () {
@@ -210,6 +229,7 @@ describe('Notifications API', function () {
 
         it('second user can dismiss the notification', async function () {
             // Switch to a second user and check the notification is still visible
+            await resetRateLimits();
             await agent.loginAsAdmin();
             await agent
                 .get('notifications')

--- a/ghost/core/test/e2e-api/admin/notifications.test.js
+++ b/ghost/core/test/e2e-api/admin/notifications.test.js
@@ -1,6 +1,5 @@
 const assert = require('node:assert/strict');
-const {agentProvider, fixtureManager, matchers, resetRateLimits} = require('../../utils/e2e-framework');
-const testUtils = require('../../utils');
+const {agentProvider, fixtureManager, matchers} = require('../../utils/e2e-framework');
 const {anyContentVersion, anyObjectId, anyEtag, anyLocationFor} = matchers;
 
 const matchNotification = {
@@ -8,13 +7,18 @@ const matchNotification = {
 };
 
 describe('Notifications API', function () {
-    let agent;
+    let adminAgent;
+    let editorAgent;
+    let superEditorAgent;
+    let authorAgent;
 
     beforeAll(async function () {
-        agent = await agentProvider.getAdminAPIAgent();
+        adminAgent = await agentProvider.getAdminAPIAgent({staffTokenRole: 'admin'});
+        editorAgent = await agentProvider.getAdminAPIAgent({staffTokenRole: 'editor'});
+        superEditorAgent = await agentProvider.getAdminAPIAgent({staffTokenRole: 'superEditor'});
+        authorAgent = await agentProvider.getAdminAPIAgent({staffTokenRole: 'author'});
+
         await fixtureManager.init('users');
-        await resetRateLimits();
-        await agent.loginAsAdmin();
     });
 
     it('Can add notification', async function () {
@@ -25,7 +29,7 @@ describe('Notifications API', function () {
             id: '59a952be7d79ed06b0d21133'
         };
 
-        await agent
+        await adminAgent
             .post('notifications')
             .body({
                 notifications: [newNotification]
@@ -47,7 +51,7 @@ describe('Notifications API', function () {
         };
 
         // create the notification to deleted
-        const {body: jsonResponse} = await agent
+        const {body: jsonResponse} = await adminAgent
             .post('notifications')
             .body({
                 notifications: [newNotification]
@@ -64,7 +68,7 @@ describe('Notifications API', function () {
 
         const notification = jsonResponse.notifications[0];
 
-        await agent
+        await adminAgent
             .delete(`notifications/${notification.id}/`)
             .expectEmptyBody()
             .matchHeaderSnapshot({
@@ -73,7 +77,7 @@ describe('Notifications API', function () {
             })
             .expectStatus(204);
 
-        await agent
+        await adminAgent
             .get('notifications')
             .matchBodySnapshot({
                 notifications: [matchNotification]
@@ -90,11 +94,6 @@ describe('Notifications API', function () {
     });
 
     describe('As Editor', function () {
-        beforeAll(async function () {
-            await resetRateLimits();
-            await agent.loginAsEditor();
-        });
-
         it('Cannot add notification', async function () {
             const newNotification = {
                 type: 'info',
@@ -102,7 +101,7 @@ describe('Notifications API', function () {
                 custom: true
             };
 
-            await agent
+            await editorAgent
                 .post('notifications')
                 .body({
                     notifications: [newNotification]
@@ -111,7 +110,7 @@ describe('Notifications API', function () {
         });
 
         it('Read notifications', async function () {
-            await agent
+            await editorAgent
                 .get('notifications')
                 .expectStatus(200)
                 .matchBodySnapshot({
@@ -128,14 +127,8 @@ describe('Notifications API', function () {
     });
 
     describe('As Super Editor', function () {
-        beforeAll(async function () {
-            const {email, password} = testUtils.DataGenerator.Content.users[9];
-            await resetRateLimits();
-            await agent.loginAs(email, password);
-        });
-
         it('Cannot add notification', async function () {
-            await agent
+            await superEditorAgent
                 .post('notifications')
                 .body({
                     notifications: [{
@@ -149,11 +142,6 @@ describe('Notifications API', function () {
     });
 
     describe('As Author', function () {
-        beforeAll(async function () {
-            await resetRateLimits();
-            await agent.loginAsAuthor();
-        });
-
         it('Add notification', async function () {
             const newNotification = {
                 type: 'info',
@@ -161,7 +149,7 @@ describe('Notifications API', function () {
                 custom: true
             };
 
-            await agent
+            await authorAgent
                 .post('notifications')
                 .body({
                     notifications: [newNotification]
@@ -170,7 +158,7 @@ describe('Notifications API', function () {
         });
 
         it('Read notifications', async function () {
-            await agent
+            await authorAgent
                 .get('notifications')
                 .expectStatus(403);
         });
@@ -180,16 +168,13 @@ describe('Notifications API', function () {
         let notification;
 
         beforeAll(async function () {
-            await resetRateLimits();
-            await agent.loginAsAdmin();
-
             const newNotification = {
                 type: 'info',
                 message: 'multiple views',
                 custom: true
             };
 
-            const {body} = await agent
+            const {body} = await adminAgent
                 .post('notifications')
                 .body({
                     notifications: [newNotification]
@@ -197,13 +182,11 @@ describe('Notifications API', function () {
                 .expectStatus(201);
 
             notification = body.notifications[0];
-            await resetRateLimits();
-            await agent.loginAsEditor();
         });
 
         it('if one user dismisses a notification, it is still visible to other users', async function () {
             // Editor can see the notification
-            await agent
+            await editorAgent
                 .get('notifications')
                 .expectStatus(200)
                 .expect(({body}) => {
@@ -212,13 +195,13 @@ describe('Notifications API', function () {
                 });
 
             // Editor deletes the notification (simulate dismissing)
-            await agent
+            await editorAgent
                 .delete(`notifications/${notification.id}`)
                 .expectEmptyBody()
                 .expectStatus(204);
 
             // Editor now cannot see the notification
-            await agent
+            await editorAgent
                 .get('notifications')
                 .expectStatus(200)
                 .expect(({body}) => {
@@ -229,9 +212,7 @@ describe('Notifications API', function () {
 
         it('second user can dismiss the notification', async function () {
             // Switch to a second user and check the notification is still visible
-            await resetRateLimits();
-            await agent.loginAsAdmin();
-            await agent
+            await adminAgent
                 .get('notifications')
                 .expectStatus(200)
                 .expect(({body}) => {
@@ -240,13 +221,13 @@ describe('Notifications API', function () {
                 });
 
             // Second user deletes the notification
-            await agent
+            await adminAgent
                 .delete(`notifications/${notification.id}`)
                 .expectEmptyBody()
                 .expectStatus(204);
 
             // Second user now cannot see the notification
-            await agent
+            await adminAgent
                 .get('notifications')
                 .expectStatus(200)
                 .expect(({body}) => {

--- a/ghost/core/test/integration/migrations/migration.test.js
+++ b/ghost/core/test/integration/migrations/migration.test.js
@@ -102,7 +102,7 @@ describe('Migrations', function () {
             assertHavePermission(permissions, 'Send mail', ['Administrator', 'Admin Integration']);
 
             assertHavePermission(permissions, 'Browse notifications', ['Administrator', 'Editor', 'Admin Integration', 'Super Editor']);
-            assertHavePermission(permissions, 'Add notifications', ['Administrator', 'Editor', 'Admin Integration', 'Super Editor']);
+            assertHavePermission(permissions, 'Add notifications', ['Administrator', 'Admin Integration']);
             assertHavePermission(permissions, 'Delete notifications', ['Administrator', 'Editor', 'Admin Integration', 'Super Editor']);
 
             assertHavePermission(permissions, 'Browse posts', ['Administrator', 'Editor', 'Author', 'Contributor', 'Admin Integration', 'Super Editor']);

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -36,7 +36,7 @@ const parseYaml = require('../../../../../core/server/services/route-settings/ya
 describe('DB version integrity', function () {
     // Only these variables should need updating
     const currentSchemaHash = '47fc91e205277e2c751ff58592785240';
-    const currentFixturesHash = '065b413e1d1f4f95fa7cb7734c5e7934';
+    const currentFixturesHash = '4e0c7b4fe3c1593e9d1fae1a891389ca';
     const currentSettingsHash = '8650db85b9a61afe4797ad6333066c62';
     const currentRoutesHash = 'd8c25fa01bf6d22a2bcb05ba0de70dc1';
 

--- a/ghost/core/test/utils/agents/admin-api-test-agent.js
+++ b/ghost/core/test/utils/agents/admin-api-test-agent.js
@@ -8,7 +8,8 @@ const roleMap = {
     admin: 1,
     editor: 2,
     author: 3,
-    contributor: 7
+    contributor: 7,
+    superEditor: 9
 };
 
 const getRoleUserFromFixtures = (role) => {
@@ -17,8 +18,8 @@ const getRoleUserFromFixtures = (role) => {
 };
 
 const getUserApiKeyForRole = (role) => {
-    const roleIndex = Object.keys(roleMap).indexOf(role);
-    const {id: apiKeyId, secret: apiKeySecret} = DataGenerator.forKnex.user_api_keys[roleIndex];
+    const userId = DataGenerator.Content.users[roleMap[role]].id;
+    const {id: apiKeyId, secret: apiKeySecret} = DataGenerator.forKnex.user_api_keys.find(apiKey => apiKey.user_id === userId);
     return {apiKeyId, apiKeySecret};
 };
 

--- a/ghost/core/test/utils/e2e-framework.js
+++ b/ghost/core/test/utils/e2e-framework.js
@@ -240,6 +240,7 @@ const getContentAPIAgent = async () => {
  *
  * @param {Object} [options={}]
  * @param {boolean} [options.members] Include members in the boot process
+ * @param {string} [options.staffTokenRole] Authenticate with the fixture staff token for this role
  * @returns {Promise<InstanceType<AdminAPITestAgent>>} agent
  */
 const getAdminAPIAgent = async (options = {}) => {
@@ -253,10 +254,16 @@ const getAdminAPIAgent = async (options = {}) => {
         const app = await startGhost(bootOptions);
         const originURL = configUtils.config.get('url');
 
-        return new AdminAPITestAgent(app, {
+        const agent = new AdminAPITestAgent(app, {
             apiURL: '/ghost/api/admin/',
             originURL
         });
+
+        if (options.staffTokenRole) {
+            await agent.useStaffTokenFor(options.staffTokenRole);
+        }
+
+        return agent;
     } catch (error) {
         error.message = `Unable to create test agent. ${error.message}`;
         throw error;

--- a/ghost/core/test/utils/fixtures/fixtures.json
+++ b/ghost/core/test/utils/fixtures/fixtures.json
@@ -1220,7 +1220,7 @@
                     "gift_link": "manage"
                 },
                 "Editor": {
-                    "notification": "all",
+                    "notification": ["browse", "destroy"],
                     "post": "all",
                     "setting": ["browse", "read"],
                     "slug": "all",
@@ -1257,7 +1257,7 @@
                     "recommendation": ["browse", "read"]
                 },
                 "Super Editor": {
-                    "notification": "all",
+                    "notification": ["browse", "destroy"],
                     "post": "all",
                     "setting": ["browse", "read"],
                     "slug": "all",


### PR DESCRIPTION
## What changed

- removed `notification:add` from the Editor and Super Editor roles
- retained `notification:browse` and `notification:destroy` so those roles can still view and dismiss notifications
- added a migration for existing installs and aligned production/test fixtures and integrity expectations
- added API regression coverage for Administrator, Editor, and Super Editor notification creation permissions

## Why

Notifications are a system-wide administrative channel. Editor-tier roles need to view and dismiss them, but do not need to create them.

This PR is intentionally limited to permission changes. Notification HTML sanitization can be evaluated separately.

Thanks to @pptx704 for reporting this permission gap in #29746.

## Validation

- `pnpm nx run ghost:test:unit` — 7,710 tests passed
- `pnpm nx run ghost:test:integration -- test/integration/migrations/migration.test.js` — 4 tests passed
- `pnpm nx run ghost:test:e2e -- test/e2e-api/admin/notifications.test.js` — 9 tests passed
- focused ESLint on all changed JavaScript files
- schema fixture integrity test