### PR TITLE
Added a navigation seam over the settings routing provider

### DIFF
--- a/apps/admin/src/settings/app/components/providers/settings-router.tsx
+++ b/apps/admin/src/settings/app/components/providers/settings-router.tsx
@@ -1,7 +1,8 @@
 import React, {useEffect} from 'react';
 import {staffProfileModalPaths} from './routing/staff-profile-paths';
-import {useRouteChangeCallback, useRouting} from '@tryghost/admin-x-framework/routing';
+import {useRouteChangeCallback} from '@tryghost/admin-x-framework/routing';
 import {useScrollSectionContext} from '@/settings/app/hooks/use-scroll-section';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import type {ModalName} from './routing/modals';
 
 const staffProfilePaths = Object.fromEntries(
@@ -49,7 +50,7 @@ export const loadModals = () => import('./routing/modals');
 
 const SettingsRouter: React.FC = () => {
     const {updateNavigatedSection, scrollToSection} = useScrollSectionContext();
-    const {route, updateRoute} = useRouting();
+    const {route, updateRoute} = useSettingsNavigation();
     // get current route
     useRouteChangeCallback((newPath, oldPath) => {
         if (newPath === oldPath) {

--- a/apps/admin/src/settings/app/components/settings/advanced/history-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/history-modal.tsx
@@ -4,7 +4,8 @@ import {type Action, getActionTitle, getContextResource, getLinkTarget, isBulkAc
 import {ActionList, ActionListItem, ActionListItemContent, Avatar, Button, Field, FieldLabel, LoadingIndicator, MultiSelectCombobox, NoValueLabel, NoValueLabelIcon, Popover, PopoverContent, PopoverTrigger, Switch, inputSurface} from '@tryghost/shade/components';
 import {ChevronDown, History, Pen, Plus, Trash2, X} from 'lucide-react';
 import {Inline, Stack} from '@tryghost/shade/primitives';
-import {type RoutingModalProps, useRouting} from '@tryghost/admin-x-framework/routing';
+import {type RoutingModalProps} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {SettingsModal} from '@tryghost/shade/patterns';
 import {type User} from '@tryghost/admin-x-framework/api/users';
 import {formatNumber} from '@tryghost/shade/utils';
@@ -69,7 +70,7 @@ const HistoryFilter: React.FC<{
     toggleEventType: (event: string, included: boolean) => void;
     toggleResourceType: (resource: string, included: boolean) => void;
 }> = ({userId, excludedEvents, excludedResources, toggleEventType, toggleResourceType}) => {
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const usersApi = useFilterableApi<User, 'users', 'name'>({path: '/users/', filterKey: 'name', responseKey: 'users'});
 
     const [staffOptions, setStaffOptions] = useState<Array<{label: string; value: string}>>([]);
@@ -222,7 +223,7 @@ const HistoryFilter: React.FC<{
 };
 
 const HistoryActionDescription: React.FC<{action: Action}> = ({action}) => {
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const contextResource = getContextResource(action);
 
     if (action.resource_type === 'security_action' && action.context?.action_name === 'reset_authentication') {
@@ -276,7 +277,7 @@ const PAGE_SIZE = 200;
 
 const HistoryModal = NiceModal.create<RoutingModalProps>(({params}) => {
     const modal = useModal();
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
 
     const [excludedEvents, setExcludedEvents] = useState<string[]>([]);
     const [excludedResources, setExcludedResources] = useState<string[]>(['label']);

--- a/apps/admin/src/settings/app/components/settings/advanced/history.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/history.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import TopLevelGroup from '@/settings/app/components/top-level-group';
 import {Button} from '@tryghost/shade/components';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {withErrorBoundary} from '@/settings/app/components/error-boundary';
 
 const History: React.FC<{ keywords: string[] }> = ({keywords}) => {
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const openHistoryModal = () => {
         updateRoute('history/view');
     };

--- a/apps/admin/src/settings/app/components/settings/advanced/integrations.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/integrations.tsx
@@ -13,7 +13,7 @@ import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {toast} from 'sonner';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {withErrorBoundary} from '@/settings/app/components/error-boundary';
 
 interface IntegrationItemProps {
@@ -49,7 +49,7 @@ const IntegrationItem: React.FC<IntegrationItemProps> = ({
     testId,
     custom = false
 }) => {
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
 
     const handleClick = (e?: React.MouseEvent<HTMLElement>) => {
         // Prevent the click event from bubbling up when clicking the delete button
@@ -94,7 +94,7 @@ const IntegrationItem: React.FC<IntegrationItemProps> = ({
 
 const BuiltInIntegrations: React.FC = () => {
     const {config} = useGlobalData();
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
 
     const openModal = (modal: string) => {
         updateRoute(modal);
@@ -198,7 +198,7 @@ const BuiltInIntegrations: React.FC = () => {
 };
 
 const CustomIntegrations: React.FC<{integrations: Integration[]}> = ({integrations}) => {
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const {mutateAsync: deleteIntegration} = useDeleteIntegration();
     const handleError = useHandleError();
 
@@ -251,7 +251,7 @@ const CustomIntegrations: React.FC<{integrations: Integration[]}> = ({integratio
 const Integrations: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const [selectedTab, setSelectedTab] = useState<'built-in' | 'custom'>('built-in');
     const {data: {integrations} = {integrations: []}} = useBrowseIntegrations();
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
 
     const buttons = (
         <Button

--- a/apps/admin/src/settings/app/components/settings/advanced/integrations/add-integration-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/integrations/add-integration-modal.tsx
@@ -3,14 +3,15 @@ import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import React, {useEffect, useState} from 'react';
 import {Field, FieldError, FieldGroup, FieldLabel, Input} from '@tryghost/shade/components';
 import {HostLimitError, useLimiter} from '@/settings/app/hooks/use-limiter';
-import {type RoutingModalProps, useRouting} from '@tryghost/admin-x-framework/routing';
+import {type RoutingModalProps} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {SettingsModal} from '@tryghost/shade/patterns';
 import {useCreateIntegration} from '@tryghost/admin-x-framework/api/integrations';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 
 const AddIntegrationModal: React.FC<RoutingModalProps> = () => {
     const modal = useModal();
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const [name, setName] = useState('');
     const [errors, setErrors] = useState({name: ''});
     const {mutateAsync: createIntegration} = useCreateIntegration();

--- a/apps/admin/src/settings/app/components/settings/advanced/integrations/content-api-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/integrations/content-api-modal.tsx
@@ -6,11 +6,11 @@ import {LucideIcon} from '@tryghost/shade/utils';
 import {SettingsModal} from '@tryghost/shade/patterns';
 import {getGhostPaths} from '@tryghost/admin-x-framework/helpers';
 import {useBrowseIntegrations} from '@tryghost/admin-x-framework/api/integrations';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 
 const ContentApiModal = NiceModal.create(() => {
     const modal = NiceModal.useModal();
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const {data: {integrations} = {integrations: []}} = useBrowseIntegrations();
 
     const integration = integrations.find(({slug}) => slug === 'ghost-core-content');

--- a/apps/admin/src/settings/app/components/settings/advanced/integrations/custom-integration-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/integrations/custom-integration-modal.tsx
@@ -9,7 +9,8 @@ import {Box, Stack} from '@tryghost/shade/primitives';
 import {Field, FieldError, FieldLabel, Input} from '@tryghost/shade/components';
 import {ImageUpload, ImageUploadAction, ImageUploadActions, ImageUploadDropzone, ImageUploadImage, ImageUploadPreview} from '@tryghost/shade/patterns';
 import {type Integration, useBrowseIntegrations, useEditIntegration} from '@tryghost/admin-x-framework/api/integrations';
-import {type RoutingModalProps, useRouting} from '@tryghost/admin-x-framework/routing';
+import {type RoutingModalProps} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {SettingsModal} from '@tryghost/shade/patterns';
 import {Trash2} from 'lucide-react';
 import {getGhostPaths} from '@tryghost/admin-x-framework/helpers';
@@ -18,7 +19,7 @@ import {useForm, useHandleError} from '@tryghost/admin-x-framework/hooks';
 
 const CustomIntegrationModalContent: React.FC<{integration: Integration}> = ({integration}) => {
     const modal = useModal();
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
 
     const {mutateAsync: editIntegration} = useEditIntegration();
     const {mutateAsync: refreshAPIKey} = useRefreshAPIKey();

--- a/apps/admin/src/settings/app/components/settings/advanced/integrations/first-promoter-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/integrations/first-promoter-modal.tsx
@@ -7,10 +7,10 @@ import {SettingsModal} from '@tryghost/shade/patterns';
 import {useEffect, useState} from 'react';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 
 const FirstPromoterModal = NiceModal.create(() => {
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
 
     const {settings} = useGlobalData();
     const {mutateAsync: editSettings} = useEditSettings();

--- a/apps/admin/src/settings/app/components/settings/advanced/integrations/pintura-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/integrations/pintura-modal.tsx
@@ -9,11 +9,11 @@ import {toast} from 'sonner';
 import {useEffect, useState} from 'react';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {useUploadFile} from '@tryghost/admin-x-framework/api/files';
 
 const PinturaModal = NiceModal.create(() => {
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const [uploadingState, setUploadingState] = useState({
         js: false,
         css: false

--- a/apps/admin/src/settings/app/components/settings/advanced/integrations/slack-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/integrations/slack-modal.tsx
@@ -7,10 +7,10 @@ import {Button, Field, FieldDescription, FieldError, FieldGroup, FieldLabel, Fie
 import {SettingsModal} from '@tryghost/shade/patterns';
 import {getSettingValues, useTestSlack} from '@tryghost/admin-x-framework/api/settings';
 import {toast} from 'sonner';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 
 const SlackModal = NiceModal.create(() => {
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
 
     const {localSettings, updateSetting, handleSave, validate, errors, clearError, okProps} = useSettingGroup({
         onValidate: () => {

--- a/apps/admin/src/settings/app/components/settings/advanced/integrations/transistor-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/integrations/transistor-modal.tsx
@@ -13,10 +13,10 @@ import {useEffect, useState} from 'react';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useRefreshAPIKey} from '@tryghost/admin-x-framework/api/api-keys';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 
 const TransistorModal = NiceModal.create(() => {
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const {config, settings} = useGlobalData();
     const {mutateAsync: editSettings} = useEditSettings();
     const {data: {integrations} = {integrations: []}} = useBrowseIntegrations();

--- a/apps/admin/src/settings/app/components/settings/advanced/integrations/unsplash-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/integrations/unsplash-modal.tsx
@@ -7,10 +7,10 @@ import {SettingsModal} from '@tryghost/shade/patterns';
 import {useEffect, useState} from 'react';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 
 const UnsplashModal = NiceModal.create(() => {
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const {settings} = useGlobalData();
     const [unsplashEnabled] = getSettingValues<boolean>(settings, ['unsplash']);
     const {mutateAsync: editSettings} = useEditSettings();

--- a/apps/admin/src/settings/app/components/settings/advanced/integrations/zapier-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/integrations/zapier-modal.tsx
@@ -13,7 +13,7 @@ import {useEffect, useState} from 'react';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useRefreshAPIKey} from '@tryghost/admin-x-framework/api/api-keys';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {useSettingsApp} from '@/settings/app/components/providers/settings-app-provider';
 
 export interface ZapierTemplate {
@@ -25,7 +25,7 @@ export interface ZapierTemplate {
 
 const ZapierModal = NiceModal.create(() => {
     const modal = NiceModal.useModal();
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const {zapierTemplates} = useSettingsApp();
     const {data: {integrations} = {integrations: []}} = useBrowseIntegrations();
     const {config} = useGlobalData();

--- a/apps/admin/src/settings/app/components/settings/advanced/migration-tools/migration-tools-import.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/migration-tools/migration-tools-import.tsx
@@ -4,10 +4,10 @@ import React from 'react';
 import UniversalImportModal from './universal-import-modal';
 import {Button} from '@tryghost/shade/components';
 import {LucideIcon} from '@tryghost/shade/utils';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 
 const MigrationToolsImport: React.FC = () => {
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
 
     const handleImportContent = () => {
         NiceModal.show(UniversalImportModal);

--- a/apps/admin/src/settings/app/components/settings/email/emails.tsx
+++ b/apps/admin/src/settings/app/components/settings/email/emails.tsx
@@ -15,7 +15,7 @@ import {LucideIcon} from '@tryghost/shade/utils';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {useVerifyAutomatedEmailSender} from '@tryghost/admin-x-framework/api/automated-emails';
 
 export const searchKeywords = {
@@ -64,7 +64,7 @@ const isAutomatedEmailVerificationRoute = () => {
 };
 
 const EmailsGroup: React.FC<{ keywords: string[]; newslettersEnabled: boolean }> = ({keywords, newslettersEnabled}) => {
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const verifyEmailToken = useQueryParams().getParam('verifyEmail');
     const {mutateAsync: verifySenderUpdate} = useVerifyAutomatedEmailSender();
     const handleError = useHandleError();

--- a/apps/admin/src/settings/app/components/settings/email/enable-newsletters.tsx
+++ b/apps/admin/src/settings/app/components/settings/email/enable-newsletters.tsx
@@ -7,13 +7,13 @@ import {type Setting, getSettingValues, useEditSettings} from '@tryghost/admin-x
 import {SettingGroupContent} from '@tryghost/shade/patterns';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {withErrorBoundary} from '@/settings/app/components/error-boundary';
 
 const EnableNewsletters: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {settings} = useGlobalData();
     const {mutateAsync: editSettings} = useEditSettings();
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const handleError = useHandleError();
 
     const [newslettersEnabled, membersSignupAccess] = getSettingValues<string>(settings, ['editor_default_email_recipients', 'members_signup_access']);

--- a/apps/admin/src/settings/app/components/settings/email/newsletters.tsx
+++ b/apps/admin/src/settings/app/components/settings/email/newsletters.tsx
@@ -11,12 +11,12 @@ import {type Newsletter, type NewslettersResponseType, newslettersDataType, useB
 import {arrayMove} from '@dnd-kit/sortable';
 import {formatNumber} from '@tryghost/shade/utils';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {withErrorBoundary} from '@/settings/app/components/error-boundary';
 
 const NavigateToNewsletter = ({id, children}: {id: string; children: ReactNode}) => {
     const modal = useModal();
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
 
     return <Button className='h-auto p-0 text-green hover:text-green' type='button' variant='link' onClick={() => {
         updateRoute(`newsletters/${id}`);
@@ -25,7 +25,7 @@ const NavigateToNewsletter = ({id, children}: {id: string; children: ReactNode})
 };
 
 const Newsletters: React.FC<{ keywords: string[] }> = ({keywords}) => {
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const openNewsletterModal = () => {
         updateRoute('newsletters/new');
     };

--- a/apps/admin/src/settings/app/components/settings/email/newsletters/add-newsletter-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/email/newsletters/add-newsletter-modal.tsx
@@ -4,7 +4,8 @@ import React, {useEffect, useState} from 'react';
 import useFeatureFlag from '@/settings/app/hooks/use-feature-flag';
 import {Field, FieldContent, FieldDescription, FieldError, FieldGroup, FieldLabel, Input, Switch, Textarea} from '@tryghost/shade/components';
 import {HostLimitError, useLimiter} from '@/settings/app/hooks/use-limiter';
-import {type RoutingModalProps, useRouting} from '@tryghost/admin-x-framework/routing';
+import {type RoutingModalProps} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {SettingsModal} from '@tryghost/shade/patterns';
 import {formatNumber} from '@tryghost/shade/utils';
 import {useAddNewsletter} from '@tryghost/admin-x-framework/api/newsletters';
@@ -13,7 +14,7 @@ import {useForm, useHandleError} from '@tryghost/admin-x-framework/hooks';
 
 const AddNewsletterModal: React.FC<RoutingModalProps> = () => {
     const modal = useModal();
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const returnRoute = useFeatureFlag('automations') ? 'emails' : 'newsletters';
     const handleError = useHandleError();
     const [isCheckingLimit, setIsCheckingLimit] = useState(true);

--- a/apps/admin/src/settings/app/components/settings/email/newsletters/newsletter-detail-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/email/newsletters/newsletter-detail-modal.tsx
@@ -16,7 +16,8 @@ import {Inline, Stack} from '@tryghost/shade/primitives';
 import {LucideIcon} from '@tryghost/shade/utils';
 import {type Newsletter, useBrowseNewsletters, useEditNewsletter} from '@tryghost/admin-x-framework/api/newsletters';
 import {PreviewModalContent} from '@/settings/app/components/settings/preview-modal';
-import {type RoutingModalProps, useRouting} from '@tryghost/admin-x-framework/routing';
+import {type RoutingModalProps} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {getSettingValue, getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {hasSendingDomain, isManagedEmail, sendingDomain} from '@tryghost/admin-x-framework/api/config';
 import {renderReplyToEmail, renderSenderEmail} from '@/settings/app/utils/newsletter-emails';
@@ -97,7 +98,7 @@ const Sidebar: React.FC<{
     clearError: (field: string) => void;
 }> = ({newsletter, onlyOne, updateNewsletter, validate, errors, clearError}) => {
     type FontOption = {value: string; label: string; className?: string};
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const {mutateAsync: editNewsletter} = useEditNewsletter();
     const limiter = useLimiter();
     const {settings, config, siteData} = useGlobalData();
@@ -685,7 +686,7 @@ const Sidebar: React.FC<{
 const NewsletterDetailModalContent: React.FC<{newsletter: Newsletter; onlyOne: boolean;}> = ({newsletter, onlyOne}) => {
     const {config} = useGlobalData();
     const {mutateAsync: editNewsletter} = useEditNewsletter();
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const returnRoute = useFeatureFlag('automations') ? 'emails' : 'newsletters';
     const handleError = useHandleError();
 

--- a/apps/admin/src/settings/app/components/settings/email/newsletters/newsletters-list.tsx
+++ b/apps/admin/src/settings/app/components/settings/email/newsletters/newsletters-list.tsx
@@ -3,7 +3,7 @@ import {ActionList, ActionListItem, ActionListItemActions, ActionListItemContent
 import {Inline} from '@tryghost/shade/primitives';
 import {LucideIcon, formatNumber} from '@tryghost/shade/utils';
 import {type Newsletter} from '@tryghost/admin-x-framework/api/newsletters';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 
 interface NewslettersListProps {
     newsletters: Newsletter[];
@@ -23,7 +23,7 @@ const NewsletterItemContainer: React.FC<Partial<SortableItemContainerProps>> = (
 }) => {
     void separator; // we don't use the separator prop and it will error if it gets passed to the DragIndicator component
 
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
 
     const showDetails = () => {
         updateRoute({route: `newsletters/${id}`});

--- a/apps/admin/src/settings/app/components/settings/email/newsletters/newsletters-tab-content.tsx
+++ b/apps/admin/src/settings/app/components/settings/email/newsletters/newsletters-tab-content.tsx
@@ -10,12 +10,12 @@ import {type Newsletter, type NewslettersResponseType, newslettersDataType, useB
 import {arrayMove} from '@dnd-kit/sortable';
 import {formatNumber} from '@tryghost/shade/utils';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {withErrorBoundary} from '@/settings/app/components/error-boundary';
 
 const NavigateToNewsletter = ({id, children}: {id: string; children: ReactNode}) => {
     const modal = useModal();
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
 
     return <Button className='h-auto p-0 text-green hover:text-green' type='button' variant='link' onClick={() => {
         updateRoute(`newsletters/${id}`);

--- a/apps/admin/src/settings/app/components/settings/general/about.tsx
+++ b/apps/admin/src/settings/app/components/settings/general/about.tsx
@@ -1,7 +1,8 @@
 import NiceModal from '@ebay/nice-modal-react';
 import {GhostLogo, Separator} from '@tryghost/shade/components';
 import {LucideIcon} from '@tryghost/shade/utils';
-import {type RoutingModalProps, useRouting} from '@tryghost/admin-x-framework/routing';
+import {type RoutingModalProps} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {SettingsModal} from '@tryghost/shade/patterns';
 import {linkToGitHubReleases} from '@/settings/app/utils/link-to-github-releases';
 import {showDatabaseWarning} from '@/settings/app/utils/show-database-warning';
@@ -22,7 +23,7 @@ function VersionLink({label, version}: {label: string; version: string}) {
 }
 
 const AboutModal = NiceModal.create<RoutingModalProps>(() => {
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const globalData = useGlobalData();
     const config = globalData.config;
     const upgradeStatus = useUpgradeStatus();

--- a/apps/admin/src/settings/app/components/settings/general/invite-user-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/general/invite-user-modal.tsx
@@ -12,7 +12,7 @@ import {useBrowseUsers} from '@tryghost/admin-x-framework/api/users';
 import {useEffect, useState} from 'react';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 
 type RoleType = 'administrator' | 'editor' | 'author' | 'contributor' | 'super editor';
 
@@ -27,7 +27,7 @@ const InviteUserModal = NiceModal.create(() => {
     });
     const limiter = useLimiter();
 
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const {config} = useGlobalData();
     const editorBeta = config.labs.superEditors;
     const [email, setEmail] = useState<string>('');

--- a/apps/admin/src/settings/app/components/settings/general/user-detail-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/general/user-detail-modal.tsx
@@ -16,7 +16,8 @@ import {HostLimitError, useLimiter} from '@/settings/app/hooks/use-limiter';
 import {ImageUpload, ImageUploadAction, ImageUploadActions, ImageUploadDropzone, ImageUploadImage, ImageUploadPreview} from '@tryghost/shade/patterns';
 import {LucideIcon} from '@tryghost/shade/utils';
 import {Pencil, Trash2} from 'lucide-react';
-import {type RoutingModalProps, useRouting} from '@tryghost/admin-x-framework/routing';
+import {type RoutingModalProps} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {SOCIAL_PLATFORM_CONFIGS, SOCIAL_PLATFORM_KEYS, getSocialValidationError} from '@/settings/app/utils/social-urls/index';
 import {SettingsModal} from '@tryghost/shade/patterns';
 import {Text} from '@tryghost/shade/primitives';
@@ -75,7 +76,7 @@ export interface UserDetailProps {
 }
 
 const UserDetailModalContent: React.FC<{user: User; onDeletingUserChange: (isDeleting: boolean) => void}> = ({user, onDeletingUserChange}) => {
-    const {updateRoute, route} = useRouting();
+    const {updateRoute, route} = useSettingsNavigation();
 
     const getTabFromPath = (path: string): string => {
         const lastSegment = path.split('/').pop() || '';
@@ -463,7 +464,7 @@ const UserDetailModalContent: React.FC<{user: User; onDeletingUserChange: (isDel
 
 const UserDetailModal: React.FC<RoutingModalProps> = ({params}) => {
     const {currentUser} = useGlobalData();
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const handleError = useHandleError();
     const [isDeletingUser, setIsDeletingUser] = useState(false);
 

--- a/apps/admin/src/settings/app/components/settings/general/users.tsx
+++ b/apps/admin/src/settings/app/components/settings/general/users.tsx
@@ -13,7 +13,7 @@ import {getSettingValue, useEditSettings} from '@tryghost/admin-x-framework/api/
 import {toast} from 'sonner';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {withErrorBoundary} from '@/settings/app/components/error-boundary';
 
 interface OwnerProps {
@@ -33,7 +33,7 @@ interface InviteListProps {
 }
 
 const Owner: React.FC<OwnerProps> = ({user}) => {
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const {currentUser} = useGlobalData();
 
     const showDetailModal = () => {
@@ -61,7 +61,7 @@ const Owner: React.FC<OwnerProps> = ({user}) => {
 };
 
 const UsersList: React.FC<UsersListProps> = ({users, groupname}) => {
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const {currentUser} = useGlobalData();
 
     const showDetailModal = (user: User) => {
@@ -226,7 +226,7 @@ const Users: React.FC<{ keywords: string[], highlight?: boolean }> = ({keywords,
         invitesHasNextPage,
         fetchNextInvitePage
     } = useStaffUsers();
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const {settings, config, currentUser} = useGlobalData();
 
     const showInviteModal = () => {

--- a/apps/admin/src/settings/app/components/settings/growth/embed-signup/embed-signup-form-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/growth/embed-signup/embed-signup-form-modal.tsx
@@ -7,7 +7,7 @@ import {SettingsModal} from '@tryghost/shade/patterns';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {useEffect, useState} from 'react';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 
 const EmbedSignupFormModal = NiceModal.create(() => {
     const modal = useModal();
@@ -19,7 +19,7 @@ const EmbedSignupFormModal = NiceModal.create(() => {
     const [generatedScript, setGeneratedScript] = useState<string>('');
     const [isCopied, setIsCopied] = useState(false);
 
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const {config} = useGlobalData();
     const {localSettings, siteData} = useSettingGroup();
     const [accentColor, title, description, locale, icon] = getSettingValues<string>(localSettings, ['accent_color', 'title', 'description', 'locale', 'icon']);

--- a/apps/admin/src/settings/app/components/settings/growth/embed-signup/embed-signup-form.tsx
+++ b/apps/admin/src/settings/app/components/settings/growth/embed-signup/embed-signup-form.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import TopLevelGroup from '@/settings/app/components/top-level-group';
 import {Button} from '@tryghost/shade/components';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 
 const EmbedSignupForm: React.FC<{ keywords: string[] }> = ({keywords}) => {
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const openPreviewModal = () => {
         updateRoute('embed-signup-form/show');
     };

--- a/apps/admin/src/settings/app/components/settings/growth/explore.tsx
+++ b/apps/admin/src/settings/app/components/settings/growth/explore.tsx
@@ -11,14 +11,14 @@ import {SettingGroupContent} from '@tryghost/shade/patterns';
 import {useBrowseMembers} from '@tryghost/admin-x-framework/api/members';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {withErrorBoundary} from '@/settings/app/components/error-boundary';
 
 const Explore: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {settings} = useGlobalData();
     const {mutateAsync: editSettings} = useEditSettings();
     const handleError = useHandleError();
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
 
     // Get members count
     const {refetch: fetchMembers} = useBrowseMembers({

--- a/apps/admin/src/settings/app/components/settings/growth/explore/testimonials-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/growth/explore/testimonials-modal.tsx
@@ -10,7 +10,7 @@ import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {toast} from 'sonner';
 import {useForm, useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 
 interface FormState {
     content: string;
@@ -19,7 +19,7 @@ interface FormState {
 
 const TestimonialsModal = NiceModal.create(() => {
     const platformErrorId = React.useId();
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const handleError = useHandleError();
     const modal = useModal();
     const {settings, currentUser, siteData, config} = useGlobalData();

--- a/apps/admin/src/settings/app/components/settings/growth/network.tsx
+++ b/apps/admin/src/settings/app/components/settings/growth/network.tsx
@@ -10,14 +10,14 @@ import {getGhostPaths} from '@tryghost/admin-x-framework/helpers';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useLimiter} from '@/settings/app/hooks/use-limiter';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {withErrorBoundary} from '@/settings/app/components/error-boundary';
 
 const Network: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {settings} = useGlobalData();
     const {mutateAsync: editSettings} = useEditSettings();
     const handleError = useHandleError();
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
 
     // The Network toggle is disabled in Admin settings if:
     // 1. (Ghost (Pro) only) the feature is disabled by config

--- a/apps/admin/src/settings/app/components/settings/growth/offers.tsx
+++ b/apps/admin/src/settings/app/components/settings/growth/offers.tsx
@@ -5,11 +5,11 @@ import {checkStripeEnabled} from '@tryghost/admin-x-framework/api/settings';
 import {getPaidActiveTiers, useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
 import {useBrowseOffers} from '@tryghost/admin-x-framework/api/offers';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {withErrorBoundary} from '@/settings/app/components/error-boundary';
 
 const Offers: React.FC<{ keywords: string[] }> = ({keywords}) => {
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const {settings, config} = useGlobalData();
 
     const {data: {offers: allOffers = []} = {}} = useBrowseOffers();

--- a/apps/admin/src/settings/app/components/settings/growth/offers/add-offer-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/growth/offers/add-offer-modal.tsx
@@ -13,7 +13,7 @@ import {useAddOffer} from '@tryghost/admin-x-framework/api/offers';
 import {useBrowseOffers} from '@tryghost/admin-x-framework/api/offers';
 import {useEffect, useMemo, useState} from 'react';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 
 // we should replace this with a library
 function slugify(text: string): string {
@@ -324,7 +324,7 @@ const AddOfferModal = () => {
     ];
 
     const [href, setHref] = useState<string>('');
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const {data: {tiers} = {}} = useBrowseTiers();
     const activeTiers = getPaidActiveTiers(tiers || []);
     const tierCadenceOptions = getTiersCadences(activeTiers);

--- a/apps/admin/src/settings/app/components/settings/growth/offers/edit-offer-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/growth/offers/edit-offer-modal.tsx
@@ -14,7 +14,7 @@ import {getOfferPortalPreviewUrl, type offerPortalPreviewUrlTypes} from '@/setti
 import {toast} from 'sonner';
 import {useEffect, useState} from 'react';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 
 function formatTimestamp(timestamp: string): string {
     const date = new Date(timestamp);
@@ -39,7 +39,7 @@ const Sidebar: React.FC<{
             const [nameLength, setNameLength] = useState(offer?.name.length || 0);
             const nameLengthColor = nameLength > 40 ? 'text-red' : 'text-green';
 
-            const {updateRoute} = useRouting();
+            const {updateRoute} = useSettingsNavigation();
 
             useEffect(() => {
                 if (offer?.name) {
@@ -164,7 +164,7 @@ const Sidebar: React.FC<{
 
 const EditOfferModal: React.FC<{id: string}> = ({id}) => {
     const {siteData} = useGlobalData();
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const handleError = useHandleError();
     const {mutateAsync: editOffer} = useEditOffer();
 

--- a/apps/admin/src/settings/app/components/settings/growth/offers/edit-retention-offer-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/growth/offers/edit-retention-offer-modal.tsx
@@ -12,7 +12,7 @@ import {getPaidActiveTiers, useBrowseTiers} from '@tryghost/admin-x-framework/ap
 import {toast} from 'sonner';
 import {useEffect, useMemo, useState} from 'react';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 
 type RetentionOfferFormState = {
     enabled: boolean;
@@ -359,7 +359,7 @@ const RetentionOfferSidebar: React.FC<{
 };
 
 const EditRetentionOfferModal: React.FC<{id: string}> = ({id}) => {
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const {siteData} = useGlobalData();
     const {data: {tiers = []} = {}} = useBrowseTiers();
     const {data: {offers: allOffers = []} = {}, isFetched: hasFetchedOffers, isFetching: isFetchingOffers} = useBrowseOffers();

--- a/apps/admin/src/settings/app/components/settings/growth/offers/offer-success.tsx
+++ b/apps/admin/src/settings/app/components/settings/growth/offers/offer-success.tsx
@@ -9,10 +9,10 @@ import {formatNumber} from '@tryghost/shade/utils';
 import {getHomepageUrl} from '@tryghost/admin-x-framework/api/site';
 import {useEffect, useState} from 'react';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 
 const OfferSuccess: React.FC<{id: string}> = ({id}) => {
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const {data: {offers: offerById = []} = {}} = useBrowseOffersById(id ? id : '');
 
     const [offer, setOffer] = useState<Offer>();

--- a/apps/admin/src/settings/app/components/settings/growth/offers/offers-container-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/growth/offers/offers-container-modal.tsx
@@ -4,7 +4,7 @@ import EditRetentionOfferModal from './edit-retention-offer-modal';
 import NiceModal from '@ebay/nice-modal-react';
 import OfferSuccess from './offer-success';
 import {OffersIndexModal} from './offers-index';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 
 type OffersRouteHandlerProps = {
     route: string;
@@ -30,7 +30,7 @@ const OffersRouteHandler: React.FC<OffersRouteHandlerProps> = ({route}) => {
 };
 
 const OffersContainerModal = () => {
-    const {route} = useRouting();
+    const {route} = useSettingsNavigation();
     return <OffersRouteHandler route={route} />;
 };
 

--- a/apps/admin/src/settings/app/components/settings/growth/offers/offers-index.tsx
+++ b/apps/admin/src/settings/app/components/settings/growth/offers/offers-index.tsx
@@ -10,7 +10,7 @@ import {currencyToDecimal, getSymbol} from '@/settings/app/utils/currency';
 import {toast} from 'sonner';
 import {useModal} from '@ebay/nice-modal-react';
 import {useOffersShowArchived, useSortingState} from '@/settings/app/components/providers/settings-app-provider';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 
 export type OfferType = 'percent' | 'fixed' | 'trial';
 
@@ -260,7 +260,7 @@ const sortOfferListItems = (items: OfferListItem[], sortOption: string, sortDire
 
 export const OffersIndexModal: React.FC = () => {
     const modal = useModal();
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const {data: {offers: allOffers = []} = {}} = useBrowseOffers();
     const {data: {tiers: allTiers} = {}} = useBrowseTiers();
     const signupOffers = allOffers.filter(offer => offer.redemption_type === 'signup');

--- a/apps/admin/src/settings/app/components/settings/growth/recommendations.tsx
+++ b/apps/admin/src/settings/app/components/settings/growth/recommendations.tsx
@@ -9,7 +9,7 @@ import {formatNumber} from '@tryghost/shade/utils';
 import {keepPreviousData} from '@tanstack/react-query';
 import {useBrowseIncomingRecommendations, useBrowseRecommendations} from '@tryghost/admin-x-framework/api/recommendations';
 import {useReferrerHistory} from '@tryghost/admin-x-framework/api/referrers';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {withErrorBoundary} from '@/settings/app/components/error-boundary';
 
 const Recommendations: React.FC<{ keywords: string[] }> = ({keywords}) => {
@@ -95,7 +95,7 @@ const Recommendations: React.FC<{ keywords: string[] }> = ({keywords}) => {
     );
 
     // Add a new recommendation
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const openAddNewRecommendationModal = () => {
         updateRoute('recommendations/add');
     };

--- a/apps/admin/src/settings/app/components/settings/growth/recommendations/add-recommendation-modal-confirm.tsx
+++ b/apps/admin/src/settings/app/components/settings/growth/recommendations/add-recommendation-modal-confirm.tsx
@@ -9,7 +9,7 @@ import {LucideIcon} from '@tryghost/shade/utils';
 import {SettingsModal} from '@tryghost/shade/patterns';
 import {toast} from 'sonner';
 import {useForm, useHandleError} from '@tryghost/admin-x-framework/hooks';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 
 interface AddRecommendationModalProps {
     recommendation: EditOrAddRecommendation,
@@ -18,7 +18,7 @@ interface AddRecommendationModalProps {
 
 const AddRecommendationModalConfirm: React.FC<AddRecommendationModalProps> = ({recommendation, animate}) => {
     const modal = useModal();
-    const {updateRoute, route} = useRouting();
+    const {updateRoute, route} = useSettingsNavigation();
     const {mutateAsync: addRecommendation} = useAddRecommendation();
     const handleError = useHandleError();
 

--- a/apps/admin/src/settings/app/components/settings/growth/recommendations/add-recommendation-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/growth/recommendations/add-recommendation-modal.tsx
@@ -5,7 +5,8 @@ import {AlreadyExistsError} from '@tryghost/admin-x-framework/errors';
 import {type EditOrAddRecommendation, useCheckRecommendation} from '@tryghost/admin-x-framework/api/recommendations';
 import {type ErrorMessages, useForm} from '@tryghost/admin-x-framework/hooks';
 import {Field, FieldDescription, FieldError, FieldGroup, FieldLabel, Input, LoadingIndicator} from '@tryghost/shade/components';
-import {type RoutingModalProps, useRouting} from '@tryghost/admin-x-framework/routing';
+import {type RoutingModalProps} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {SettingsModal} from '@tryghost/shade/patterns';
 import {formatUrl} from '@/settings/app/utils/format-url';
 import {toast} from 'sonner';
@@ -38,7 +39,7 @@ const validateUrl = function (errors: ErrorMessages, url: string) {
 const AddRecommendationModal: React.FC<RoutingModalProps & AddRecommendationModalProps> = ({searchParams, recommendation, animate}) => {
     const [enterPressed, setEnterPressed] = useState(false);
     const modal = useModal();
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const {mutateAsync: checkRecommendation} = useCheckRecommendation();
 
     // Handle a URL that was passed via the URL

--- a/apps/admin/src/settings/app/components/settings/growth/recommendations/edit-recommendation-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/growth/recommendations/edit-recommendation-modal.tsx
@@ -4,7 +4,8 @@ import React from 'react';
 import RecommendationDescriptionForm, {validateDescriptionForm} from './recommendation-description-form';
 import {Button} from '@tryghost/shade/components';
 import {type Recommendation, useDeleteRecommendation, useEditRecommendation} from '@tryghost/admin-x-framework/api/recommendations';
-import {type RoutingModalProps, useRouting} from '@tryghost/admin-x-framework/routing';
+import {type RoutingModalProps} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {SettingsModal} from '@tryghost/shade/patterns';
 import {toast} from 'sonner';
 import {useForm, useHandleError} from '@tryghost/admin-x-framework/hooks';
@@ -16,7 +17,7 @@ interface EditRecommendationModalProps {
 
 const EditRecommendationModal: React.FC<RoutingModalProps & EditRecommendationModalProps> = ({recommendation, animate}) => {
     const modal = useModal();
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const {mutateAsync: editRecommendation} = useEditRecommendation();
     const {mutateAsync: deleteRecommendation} = useDeleteRecommendation();
     const handleError = useHandleError();

--- a/apps/admin/src/settings/app/components/settings/growth/recommendations/incoming-recommendation-list.tsx
+++ b/apps/admin/src/settings/app/components/settings/growth/recommendations/incoming-recommendation-list.tsx
@@ -6,7 +6,7 @@ import {type IncomingRecommendation} from '@tryghost/admin-x-framework/api/recom
 import {Inline} from '@tryghost/shade/primitives';
 import {type ReferrerHistoryItem} from '@tryghost/admin-x-framework/api/referrers';
 import {cn, formatNumber} from '@tryghost/shade/utils';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 
 interface IncomingRecommendationListProps {
     incomingRecommendations: IncomingRecommendation[],
@@ -16,7 +16,7 @@ interface IncomingRecommendationListProps {
 }
 
 const IncomingRecommendationItem: React.FC<{incomingRecommendation: IncomingRecommendation, stats: ReferrerHistoryItem[]}> = ({incomingRecommendation, stats}) => {
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
 
     const signups = useMemo(() => {
         // Note: this should match the `getDomainFromUrl` method from OutboundLinkTagger

--- a/apps/admin/src/settings/app/components/settings/growth/recommendations/recommendation-list.tsx
+++ b/apps/admin/src/settings/app/components/settings/growth/recommendations/recommendation-list.tsx
@@ -7,7 +7,7 @@ import {ActionList, ActionListItem, ActionListItemContent, Button, LoadingIndica
 import {Inline} from '@tryghost/shade/primitives';
 import {LucideIcon, formatNumber} from '@tryghost/shade/utils';
 import {type Recommendation} from '@tryghost/admin-x-framework/api/recommendations';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 
 interface RecommendationListProps {
     recommendations: Recommendation[],
@@ -16,7 +16,7 @@ interface RecommendationListProps {
 }
 
 const RecommendationItem: React.FC<{recommendation: Recommendation}> = ({recommendation}) => {
-    const {route} = useRouting();
+    const {route} = useSettingsNavigation();
 
     // Navigate to the edit page, without changing the route
     // This helps to avoid fetching the recommendation
@@ -71,7 +71,7 @@ const RecommendationList: React.FC<RecommendationListProps> = ({recommendations,
     } = useSettingGroup();
     const recommendationsURL = `${siteData?.url.replace(/\/$/, '')}/#/portal/recommendations`;
 
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const openAddNewRecommendationModal = () => {
         updateRoute('recommendations/add');
     };

--- a/apps/admin/src/settings/app/components/settings/membership/analytics.tsx
+++ b/apps/admin/src/settings/app/components/settings/membership/analytics.tsx
@@ -5,7 +5,7 @@ import {Field, FieldContent, FieldDescription, FieldLabel, Separator, Switch} fr
 import {HostLimitError, useLimiter} from '@/settings/app/hooks/use-limiter';
 import {SettingGroupContent} from '@tryghost/shade/patterns';
 import {getSettingValues, isSettingReadOnly} from '@tryghost/admin-x-framework/api/settings';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {withErrorBoundary} from '@/settings/app/components/error-boundary';
 
 const Analytics: React.FC<{ keywords: string[] }> = ({keywords}) => {
@@ -26,7 +26,7 @@ const Analytics: React.FC<{ keywords: string[] }> = ({keywords}) => {
 
     const [isWebAnalyticsLimited, setIsWebAnalyticsLimited] = useState(false);
     const limiter = useLimiter();
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
 
     useEffect(() => {
         if (limiter?.isLimited('limitAnalytics')) {

--- a/apps/admin/src/settings/app/components/settings/membership/member-emails/welcome-email-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/membership/member-emails/welcome-email-modal.tsx
@@ -12,7 +12,7 @@ import {getWelcomeEmailValidationErrors} from './welcome-email-validation';
 import {useBrowseAutomatedEmails, useEditAutomatedEmail, usePreviewWelcomeEmail} from '@tryghost/admin-x-framework/api/automated-emails';
 import {useForm, useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {useWelcomeEmailPreview} from './use-welcome-email-preview';
 import {useWelcomeEmailSenderDetails} from '@/settings/app/hooks/use-welcome-email-sender-details';
 
@@ -101,7 +101,7 @@ const WelcomeEmailModal = NiceModal.create<WelcomeEmailModalProps>(({emailType =
     const modal = useModal();
     const {settings: globalSettings, config} = useGlobalData();
     const [siteTitle, defaultEmailAddress, supportEmailAddress] = getSettingValues<string>(globalSettings, ['title', 'default_email_address', 'support_email_address']);
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const {mutateAsync: editAutomatedEmail} = useEditAutomatedEmail();
     const {mutateAsync: previewWelcomeEmail} = usePreviewWelcomeEmail();
     const {data: automatedEmailsData} = useBrowseAutomatedEmails();

--- a/apps/admin/src/settings/app/components/settings/membership/portal.tsx
+++ b/apps/admin/src/settings/app/components/settings/membership/portal.tsx
@@ -5,7 +5,7 @@ import UserAddIcon from '@/settings/app/assets/images/portal-splash-user-add.png
 import {Button} from '@tryghost/shade/components';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {withErrorBoundary} from '@/settings/app/components/error-boundary';
 
 const SignupOptionImage: React.FC<{color:string, title: string, price: string}> = ({title, color, price}) => {
@@ -25,7 +25,7 @@ const SignupOptionImage: React.FC<{color:string, title: string, price: string}> 
 };
 
 const Portal: React.FC<{ keywords: string[] }> = ({keywords}) => {
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const {settings} = useGlobalData();
     const [accentColor, icon, membersSignupAccess] = getSettingValues<string>(settings, ['accent_color', 'icon', 'members_signup_access']);
 

--- a/apps/admin/src/settings/app/components/settings/membership/portal/portal-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/membership/portal/portal-modal.tsx
@@ -14,7 +14,7 @@ import {type Tier, useBrowseTiers, useEditTier} from '@tryghost/admin-x-framewor
 import {fullEmailAddress} from '@tryghost/admin-x-framework/api/site';
 import {useFocusContext} from '@tryghost/shade/app';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {verifyEmailToken} from '@tryghost/admin-x-framework/api/email-verification';
 
 type PreviewTab = 'signup' | 'account' | 'links';
@@ -64,7 +64,7 @@ const Sidebar: React.FC<{
 };
 
 const PortalModal: React.FC = () => {
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const {darkMode} = useFocusContext();
 
     const [selectedPreviewTab, setSelectedPreviewTab] = useState<PreviewTab>('signup');

--- a/apps/admin/src/settings/app/components/settings/membership/stripe/stripe-connect-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/membership/stripe/stripe-connect-modal.tsx
@@ -22,7 +22,7 @@ import {useBrowseMembers} from '@tryghost/admin-x-framework/api/members';
 import {useBrowseTiers, useEditTier} from '@tryghost/admin-x-framework/api/tiers';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 
 const RETRY_PRODUCT_SAVE_POLL_LENGTH = 1000;
 const RETRY_PRODUCT_SAVE_MAX_POLL = 15 * RETRY_PRODUCT_SAVE_POLL_LENGTH;
@@ -257,7 +257,7 @@ const Direct: React.FC<{onClose: () => void}> = ({onClose}) => {
 const StripeConnectModal: React.FC = () => {
     const {config, settings} = useGlobalData();
     const stripeConnectAccountId = getSettingValue(settings, 'stripe_connect_account_id');
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const [step, setStep] = useState<'start' | 'connect'>('start');
     const mainModal = useModal();
     const limiter = useLimiter();

--- a/apps/admin/src/settings/app/components/settings/membership/tiers.tsx
+++ b/apps/admin/src/settings/app/components/settings/membership/tiers.tsx
@@ -11,7 +11,7 @@ import {type Tier, getActiveTiers, getArchivedTiers, useBrowseTiers} from '@tryg
 import {checkStripeEnabled} from '@tryghost/admin-x-framework/api/settings';
 import {formatNumber} from '@tryghost/shade/utils';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {withErrorBoundary} from '@/settings/app/components/error-boundary';
 
 const StripeConnectedButton: React.FC<{className?: string; onClick: () => void;}> = ({className, onClick}) => {
@@ -33,7 +33,7 @@ const Tiers: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {data: {tiers, meta, isEnd} = {}, fetchNextPage} = useBrowseTiers();
     const activeTiers = getActiveTiers(tiers || []);
     const archivedTiers = getArchivedTiers(tiers || []);
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const limiter = useLimiter();
 
     const openConnectModal = async () => {

--- a/apps/admin/src/settings/app/components/settings/membership/tiers/tier-detail-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/membership/tiers/tier-detail-modal.tsx
@@ -10,7 +10,8 @@ import {Button, Combobox, ComboboxContent, ComboboxTrigger, ComboboxValue, Field
 import {type ErrorMessages, useForm, useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {Inline, Text} from '@tryghost/shade/primitives';
 import {LucideIcon} from '@tryghost/shade/utils';
-import {type RoutingModalProps, useRouting} from '@tryghost/admin-x-framework/routing';
+import {type RoutingModalProps} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {SettingsModal} from '@tryghost/shade/patterns';
 import {type Tier, useAddTier, useBrowseTiers, useEditTier} from '@tryghost/admin-x-framework/api/tiers';
 import {currencies, currencySelectGroups, validateCurrencyAmount} from '@/settings/app/utils/currency';
@@ -25,7 +26,7 @@ const TierDetailModalContent: React.FC<{tier?: Tier}> = ({tier}) => {
     const isFreeTier = tier?.type === 'free';
     const [currencyOpen, setCurrencyOpen] = React.useState(false);
 
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const {mutateAsync: updateTier} = useEditTier();
     const {mutateAsync: createTier} = useAddTier();
     const {mutateAsync: editSettings} = useEditSettings();

--- a/apps/admin/src/settings/app/components/settings/membership/tiers/tiers-list.tsx
+++ b/apps/admin/src/settings/app/components/settings/membership/tiers/tiers-list.tsx
@@ -6,7 +6,7 @@ import {type Tier} from '@tryghost/admin-x-framework/api/tiers';
 import {TrialDaysLabel} from './tier-detail-preview';
 import {currencyToDecimal, getSymbol} from '@/settings/app/utils/currency';
 import {formatNumber} from '@tryghost/shade/utils';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 
 interface TiersListProps {
     tab?: 'active-tiers' | 'archive-tiers' | 'free-tier';
@@ -22,7 +22,7 @@ const cardContainerClasses = clsx(
 );
 
 const TierCard: React.FC<TierCardProps> = ({tier}) => {
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const currency = tier?.currency || 'USD';
     const currencySymbol = currency ? getSymbol(currency) : '$';
 
@@ -55,7 +55,7 @@ const TiersList: React.FC<TiersListProps> = ({
     tab,
     tiers
 }) => {
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const openTierModal = () => {
         updateRoute('tiers/add');
     };

--- a/apps/admin/src/settings/app/components/settings/site/announcement-bar-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/site/announcement-bar-modal.tsx
@@ -13,7 +13,7 @@ import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {toast} from 'sonner';
 import {useBrowsePosts} from '@tryghost/admin-x-framework/api/posts';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 
 type SidebarProps = {
     announcementContent?: string;
@@ -126,7 +126,7 @@ const AnnouncementBarModal: React.FC = () => {
     const [announcementVisibility] = getSettingValues<string[]>(localSettings, ['announcement_visibility']);
     const [paidMembersEnabled] = getSettingValues<boolean>(localSettings, ['paid_members_enabled']);
     const visibilitySettings = JSON.parse(announcementVisibility?.toString() || '[]') as string[];
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const [selectedPreviewTab, setSelectedPreviewTab] = useState('homepage');
     const [previewDevice, setPreviewDevice] = useState<'desktop' | 'mobile'>('desktop');
 

--- a/apps/admin/src/settings/app/components/settings/site/announcement-bar.tsx
+++ b/apps/admin/src/settings/app/components/settings/site/announcement-bar.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import TopLevelGroup from '@/settings/app/components/top-level-group';
 import {Button} from '@tryghost/shade/components';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {withErrorBoundary} from '@/settings/app/components/error-boundary';
 
 const AnnouncementBar: React.FC<{ keywords: string[] }> = ({keywords}) => {
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const openModal = () => {
         updateRoute('announcement-bar/edit');
     };

--- a/apps/admin/src/settings/app/components/settings/site/change-theme.tsx
+++ b/apps/admin/src/settings/app/components/settings/site/change-theme.tsx
@@ -9,14 +9,14 @@ import {Text} from '@tryghost/shade/primitives';
 import {type Theme, useBrowseThemes} from '@tryghost/admin-x-framework/api/themes';
 import {downloadFile, getGhostPaths} from '@tryghost/admin-x-framework/helpers';
 import {useCheckThemeLimitError} from '@/settings/app/hooks/use-check-theme-limit-error';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {withErrorBoundary} from '@/settings/app/components/error-boundary';
 
 const ChangeTheme: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const [themeLimitError, setThemeLimitError] = useState<string|null>(null);
     const [isCheckingLimit, setIsCheckingLimit] = useState(false);
     const {checkThemeLimitError} = useCheckThemeLimitError();
-    const {route, updateRoute} = useRouting();
+    const {route, updateRoute} = useSettingsNavigation();
     const {data: themesData} = useBrowseThemes();
     const activeTheme = themesData?.themes.find((theme: Theme) => theme.active);
 

--- a/apps/admin/src/settings/app/components/settings/site/design-and-theme-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/site/design-and-theme-modal.tsx
@@ -4,13 +4,14 @@ import LimitModal from '@/settings/app/components/limit-modal';
 import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import React, {useCallback, useEffect, useState} from 'react';
 import ThemeCodeEditorModal from './theme/theme-code-editor-modal';
-import {type RoutingModalProps, useRouting} from '@tryghost/admin-x-framework/routing';
+import {type RoutingModalProps} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {parseEditingThemeRoute} from './theme/theme-editor-utils';
 import {useCheckThemeLimitError} from '@/settings/app/hooks/use-check-theme-limit-error';
 
 const DesignAndThemeModal: React.FC<RoutingModalProps> = ({pathName}) => {
     const modal = useModal();
-    const {route, updateRoute} = useRouting();
+    const {route, updateRoute} = useSettingsNavigation();
     const currentPath = route || pathName;
     const [themeChangeError, setThemeChangeError] = useState<string|null>(null);
     const [isCheckingLimit, setIsCheckingLimit] = useState(false);

--- a/apps/admin/src/settings/app/components/settings/site/design-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/site/design-modal.tsx
@@ -12,7 +12,7 @@ import {getHomepageUrl} from '@tryghost/admin-x-framework/api/site';
 import {useBrowsePosts} from '@tryghost/admin-x-framework/api/posts';
 import {useForm, useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 
 const Sidebar: React.FC<{
     globalSettings: GlobalSettingValues
@@ -71,7 +71,7 @@ const DesignModal: React.FC = () => {
     const handleError = useHandleError();
     const [selectedPreviewTab, setSelectedPreviewTab] = useState('homepage');
     const [previewDevice, setPreviewDevice] = useState<'desktop' | 'mobile'>('desktop');
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
 
     const refParam = useQueryParams().getParam('ref');
 

--- a/apps/admin/src/settings/app/components/settings/site/design-setting.tsx
+++ b/apps/admin/src/settings/app/components/settings/site/design-setting.tsx
@@ -2,11 +2,11 @@ import DesignSettingsImg from '@/settings/app/assets/images/design-settings.png'
 import React from 'react';
 import TopLevelGroup from '@/settings/app/components/top-level-group';
 import {Button} from '@tryghost/shade/components';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {withErrorBoundary} from '@/settings/app/components/error-boundary';
 
 const DesignSetting: React.FC<{ keywords: string[] }> = ({keywords}) => {
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const openPreviewModal = () => {
         updateRoute('design/edit');
     };

--- a/apps/admin/src/settings/app/components/settings/site/navigation-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/site/navigation-modal.tsx
@@ -6,11 +6,11 @@ import {SettingsModal} from '@tryghost/shade/patterns';
 import {Tabs, TabsContent, TabsList, TabsTrigger} from '@tryghost/shade/components';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {useCallback, useMemo, useState} from 'react';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 
 const NavigationModal = NiceModal.create(() => {
     const modal = useModal();
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const {
         localSettings,
         updateSetting,

--- a/apps/admin/src/settings/app/components/settings/site/navigation.tsx
+++ b/apps/admin/src/settings/app/components/settings/site/navigation.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import TopLevelGroup from '@/settings/app/components/top-level-group';
 import {Button} from '@tryghost/shade/components';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {withErrorBoundary} from '@/settings/app/components/error-boundary';
 
 const Navigation: React.FC<{ keywords: string[] }> = ({keywords}) => {
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const openPreviewModal = () => {
         updateRoute('navigation/edit');
     };

--- a/apps/admin/src/settings/app/components/settings/site/theme-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/site/theme-modal.tsx
@@ -15,7 +15,7 @@ import {PageHeader, SettingsModal} from '@tryghost/shade/patterns';
 import {toast} from 'sonner';
 import {useCheckThemeLimitError} from '@/settings/app/hooks/use-check-theme-limit-error';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 
 interface ThemeToolbarProps {
     selectedTheme: OfficialTheme|null;
@@ -57,7 +57,7 @@ const ThemeToolbar: React.FC<ThemeToolbarProps> = ({
     themes
 }) => {
     const modal = useModal();
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const {mutateAsync: uploadTheme} = useUploadTheme();
     const {checkThemeLimitError, isThemeLimited} = useCheckThemeLimitError();
     const handleError = useHandleError();
@@ -307,7 +307,7 @@ const ChangeThemeModal: React.FC<ChangeThemeModalProps> = ({source, themeRef}) =
     const [isInstalling, setInstalling] = useState(false);
     const [installedFromMarketplace, setInstalledFromMarketplace] = useState(false);
     const [isMounted, setIsMounted] = useState(false);
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
 
     const modal = useModal();
     const {data: {themes} = {}} = useBrowseThemes();

--- a/apps/admin/src/settings/app/components/settings/site/theme/advanced-theme-settings.tsx
+++ b/apps/admin/src/settings/app/components/settings/site/theme/advanced-theme-settings.tsx
@@ -13,7 +13,7 @@ import {downloadFile, getGhostPaths} from '@tryghost/admin-x-framework/helpers';
 import {toast} from 'sonner';
 import {useCheckThemeLimitError} from '@/settings/app/hooks/use-check-theme-limit-error';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 
 interface ThemeActionProps {
     theme: Theme;
@@ -58,7 +58,7 @@ const ThemeActions: React.FC<ThemeActionProps> = ({
     const {mutateAsync: deleteTheme} = useDeleteTheme();
     const {refreshActiveThemeData} = useCustomFonts();
     const handleError = useHandleError();
-    const {route, updateRoute} = useRouting();
+    const {route, updateRoute} = useSettingsNavigation();
     const {checkThemeLimitError} = useCheckThemeLimitError();
 
     const handleActivate = async () => {

--- a/apps/admin/src/settings/app/components/settings/site/theme/theme-code-editor-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/site/theme/theme-code-editor-modal.tsx
@@ -27,7 +27,7 @@ import {toast} from 'sonner';
 import {useBrowseThemes} from '@tryghost/admin-x-framework/api/themes';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useQueryClient} from '@tanstack/react-query';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import type {SelectedNode} from './theme-file-tree';
 import type {ThemeEditorConfirmModalProps} from './theme-editor-confirm-modal';
 import type {ThemeEditorFile} from './theme-editor-utils';
@@ -235,7 +235,7 @@ const editorSelectionTheme = EditorView.theme({
 
 const ThemeCodeEditorModal: React.FC<{themeName: string}> = ({themeName}) => {
     const modal = useModal();
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const queryClient = useQueryClient();
     const handleError = useHandleError();
     const {data: themesData} = useBrowseThemes();

--- a/apps/admin/src/settings/app/components/sidebar.tsx
+++ b/apps/admin/src/settings/app/components/sidebar.tsx
@@ -19,7 +19,7 @@ import {searchKeywords as siteSearchKeywords} from './settings/site/site-setting
 
 import useFeatureFlag from '@/settings/app/hooks/use-feature-flag';
 import {useGlobalData} from './providers/global-data-provider';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {useScrollSectionContext, useScrollSectionNav} from '@/settings/app/hooks/use-scroll-section';
 import {useSearch} from './providers/settings-app-provider';
 
@@ -96,7 +96,7 @@ const PrivateBadge: React.FC = () => (
 
 const Sidebar: React.FC = () => {
     const {filter, setFilter, checkVisible, noResult, setNoResult} = useSearch();
-    const {updateRoute} = useRouting();
+    const {updateRoute} = useSettingsNavigation();
     const searchInputRef = useRef<HTMLInputElement | null>(null);
     const {isAnyTextFieldFocused} = useFocusContext();
     const {settings, config} = useGlobalData();

--- a/apps/admin/src/settings/app/components/top-level-group.tsx
+++ b/apps/admin/src/settings/app/components/top-level-group.tsx
@@ -10,7 +10,7 @@ import {
     SettingGroupTitle
 } from '@tryghost/shade/patterns';
 import {createComponentId} from '@/settings/app/utils/search';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {useScrollSection} from '@/settings/app/hooks/use-scroll-section';
 import {useSearch} from './providers/settings-app-provider';
 
@@ -56,7 +56,7 @@ const TopLevelGroup: React.FC<TopLevelGroupProps> = ({
     onCancel
 }) => {
     const {checkVisible, noResult, registerComponent, unregisterComponent} = useSearch();
-    const {route} = useRouting();
+    const {route} = useSettingsNavigation();
     const [highlight, setHighlight] = useState(false);
     const {ref} = useScrollSection(navid);
     const uniqueId = useId();

--- a/apps/admin/src/settings/app/hooks/use-settings-navigation.ts
+++ b/apps/admin/src/settings/app/hooks/use-settings-navigation.ts
@@ -1,0 +1,8 @@
+import {useRouting} from '@tryghost/admin-x-framework/routing';
+
+// Seam over the legacy RoutingProvider: call sites depend on this hook so the
+// router swap can happen here without touching them again.
+export function useSettingsNavigation() {
+    const {route, updateRoute, loadingModal} = useRouting();
+    return {route, updateRoute, loadingModal};
+}

--- a/apps/admin/src/settings/app/main-content.tsx
+++ b/apps/admin/src/settings/app/main-content.tsx
@@ -9,7 +9,7 @@ import {canAccessSettings, isEditorUser} from '@tryghost/admin-x-framework/api/u
 import {toast} from 'sonner';
 import {useGlobalData} from './components/providers/global-data-provider';
 import {useGlobalDirtyState} from '@tryghost/shade/utils';
-import {useRouting} from '@tryghost/admin-x-framework/routing';
+import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 
 const EMPTY_KEYWORDS: string[] = [];
 const OPEN_SHADE_MODAL_SELECTOR = ':is([role="dialog"], [role="alertdialog"])[data-state="open"]';
@@ -27,7 +27,7 @@ const Page: React.FC<{children: ReactNode}> = ({children}) => {
 
 const MainContent: React.FC = () => {
     const {currentUser} = useGlobalData();
-    const {loadingModal} = useRouting();
+    const {loadingModal} = useSettingsNavigation();
     const {isDirty} = useGlobalDirtyState();
     const {confirm, dialogProps} = useDirtyConfirmation();
 


### PR DESCRIPTION
First step toward native settings routing. Settings is the last consumer of the deprecated `admin-x-framework` `RoutingProvider`; replacing it means touching every navigation call site, so this PR routes them all through one settings-local seam first — the upcoming router swap then happens inside a single hook without touching screen call sites again.

## What changed

- New `useSettingsNavigation()` in `apps/admin/src/settings/app/hooks/use-settings-navigation.ts` — a pass-through to the framework's `useRouting()` (same `route`/`updateRoute`/`loadingModal` surface).
- All 65 files that called `useRouting()` now call the seam instead (143 `updateRoute` call sites). No behavior change by construction: the hook delegates to the same provider.
- Deliberately untouched (they are the router swap's own surface, not screen call sites): the `RoutingProvider` mount in `app.tsx`, `settings-router.tsx`'s `useRouteChangeCallback` (the same-path re-scroll consumer), and the type-only `RoutingModalProps` imports.

Contract the seam preserves for the swap: same-path navigation stays history-entry-free — a sidebar re-click re-scrolls via the `routeChange` event without pushing a history entry.

## Verification

- Unit: 125 files / 1320 tests pass
- Acceptance: 55 files / 406 tests pass (includes all settings navigation/modal specs, unchanged)
- `tsc -b`, full lint clean
- Independent review agent machine-verified all 65 files are import-line-only changes (non-import diff empty vs main) and that the dropped `eventTarget` field has zero consumers in the settings tree