### PR TITLE
Added a consumer-controlled close path to the settings modal chrome

### DIFF
--- a/apps/admin/src/settings/app/components/settings/preview-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/preview-modal.tsx
@@ -72,10 +72,15 @@ export interface PreviewModalProps {
 
     onCancel?: () => void;
     onOk?: () => void;
+    /** Supersedes the NiceModal close path; without it the modal must be mounted through NiceModal. Keep its presence stable across renders — toggling defined/undefined remounts the modal subtree. */
+    onClose?: () => void;
     afterClose?: () => void;
 }
 
-export const PreviewModalContent: React.FC<PreviewModalProps> = ({
+type PreviewModalContentBaseProps = Omit<PreviewModalProps, 'onClose'> & {requestClose: () => void};
+
+const PreviewModalContentBase: React.FC<PreviewModalContentBaseProps> = ({
+    requestClose,
     testId,
     title,
     titleHeadingLevel = 4,
@@ -109,7 +114,6 @@ export const PreviewModalContent: React.FC<PreviewModalProps> = ({
     onOk,
     afterClose
 }) => {
-    const modal = useModal();
     const {setGlobalDirtyState} = useGlobalDirtyState();
     const {confirm, dialogProps} = useDirtyConfirmation();
 
@@ -184,7 +188,7 @@ export const PreviewModalContent: React.FC<PreviewModalProps> = ({
 
     const handleCancel = onCancel || (() => {
         confirm(dirty, () => {
-            modal.remove();
+            requestClose();
             afterClose?.();
         });
     });
@@ -203,6 +207,7 @@ export const PreviewModalContent: React.FC<PreviewModalProps> = ({
             title=''
             width={width}
             hideXOnMobile
+            onClose={requestClose}
         >
             <Inline align='stretch' className='h-full grow' gap='none'>
                 <Box className={cn(
@@ -247,4 +252,16 @@ export const PreviewModalContent: React.FC<PreviewModalProps> = ({
             <DirtyConfirmDialog {...dialogProps} />
         </SettingsModal>
     );
+};
+
+const NicePreviewModalContent: React.FC<Omit<PreviewModalContentBaseProps, 'requestClose'>> = (props) => {
+    const modal = useModal();
+    return <PreviewModalContentBase {...props} requestClose={() => modal.remove()} />;
+};
+
+export const PreviewModalContent: React.FC<PreviewModalProps> = ({onClose, ...props}) => {
+    if (onClose) {
+        return <PreviewModalContentBase {...props} requestClose={onClose} />;
+    }
+    return <NicePreviewModalContent {...props} />;
 };

--- a/apps/shade/src/components/patterns/settings-modal.tsx
+++ b/apps/shade/src/components/patterns/settings-modal.tsx
@@ -44,6 +44,8 @@ export interface SettingsModalProps {
     onCancel?: () => void;
     topRightContent?: 'close' | React.ReactNode;
     hideXOnMobile?: boolean;
+    /** Supersedes the NiceModal close path; without it the modal must be mounted through NiceModal. Keep its presence stable across renders — toggling defined/undefined remounts the modal subtree. */
+    onClose?: () => void;
     afterClose?: () => void;
     children?: React.ReactNode;
     backDrop?: boolean;
@@ -122,7 +124,9 @@ const headerOffsets: Record<SettingsModalSize, string> = {
     bleed: '-inset-x-10'
 };
 
-const SettingsModal = forwardRef<HTMLElement, SettingsModalProps>(({
+type SettingsModalContentProps = Omit<SettingsModalProps, 'onClose'> & {requestClose: () => void};
+
+const SettingsModalContent = forwardRef<HTMLElement, SettingsModalContentProps>(({
     'aria-label': ariaLabel,
     className,
     size = 'md',
@@ -146,6 +150,7 @@ const SettingsModal = forwardRef<HTMLElement, SettingsModalProps>(({
     onCancel,
     topRightContent,
     hideXOnMobile = false,
+    requestClose,
     afterClose,
     children,
     backDrop = true,
@@ -159,7 +164,6 @@ const SettingsModal = forwardRef<HTMLElement, SettingsModalProps>(({
     enableCMDS = true,
     allowBackgroundInteraction = false
 }, ref) => {
-    const modal = useModal();
     const {setGlobalDirtyState} = useGlobalDirtyState();
     const {confirm, dialogProps} = useDirtyConfirmation();
     const [animationFinished, setAnimationFinished] = useState(false);
@@ -169,7 +173,7 @@ const SettingsModal = forwardRef<HTMLElement, SettingsModalProps>(({
 
     const removeModal = () => {
         confirm(dirty, () => {
-            modal.remove();
+            requestClose();
             afterClose?.();
         });
     };
@@ -353,6 +357,22 @@ const SettingsModal = forwardRef<HTMLElement, SettingsModalProps>(({
             <DirtyConfirmDialog {...dialogProps} />
         </>
     );
+});
+
+SettingsModalContent.displayName = 'SettingsModalContent';
+
+const NiceSettingsModal = forwardRef<HTMLElement, Omit<SettingsModalContentProps, 'requestClose'>>((props, ref) => {
+    const modal = useModal();
+    return <SettingsModalContent ref={ref} {...props} requestClose={() => modal.remove()} />;
+});
+
+NiceSettingsModal.displayName = 'NiceSettingsModal';
+
+const SettingsModal = forwardRef<HTMLElement, SettingsModalProps>(({onClose, ...props}, ref) => {
+    if (onClose) {
+        return <SettingsModalContent ref={ref} {...props} requestClose={onClose} />;
+    }
+    return <NiceSettingsModal ref={ref} {...props} />;
 });
 
 SettingsModal.displayName = 'SettingsModal';


### PR DESCRIPTION
Second step toward native settings routing (follows #29762).

`SettingsModal` (shade) and `PreviewModalContent` (settings) could only close through NiceModal's `modal.remove()` — and `useModal()` throws when a component mounts outside a NiceModal context. That blocks mounting settings modals as route elements, which the upcoming router swap needs.

## What changed

- Both components gain an optional `onClose` prop that supersedes the NiceModal close path (X button, backdrop click, footer Cancel, Escape, and the dirty-confirm flow all funnel through it).
- Internally each is split into a base component taking a required `requestClose`, plus a thin NiceModal bridge that supplies `modal.remove` — chosen per render by the presence of `onClose`, so no conditional hooks.
- `PreviewModalContent` threads `onClose` through to its inner `SettingsModal`.
- The `id='modal-backdrop'` DOM contract (settings' Escape handler checks it) is untouched.

No consumer passes `onClose` yet — behavior is unchanged by construction.

## Verification

- Shade: build green, lint clean, unit 34 files / 289 tests
- Admin: `tsc -b` clean, lint clean, unit 125 files / 1320 tests
- Acceptance: 405/406 — the 1 failure is the known pre-existing load flake (`layout.acceptance` dirty-exit poll racing the `/` → `/analytics` home redirect; passes isolated; identical signature predates this change)