### PR TITLE
🐛 Fixed a failed member import leaving the publisher without an email

### DIFF
--- a/ghost/core/core/server/services/members/import-export/import/completion-email.ts
+++ b/ghost/core/core/server/services/members/import-export/import/completion-email.ts
@@ -1,22 +1,28 @@
 import {serialize} from '../csv';
+import renderImportEmail, {headingFor, type ImportEmailSummary} from './email-template';
 import {isCustomFieldColumn} from '@tryghost/custom-field-types/csv';
 import type {MemberImportRow, ImportErrorRow, ImportLabel, Label} from './row';
-
-const emailTemplate = require('./email-template');
 
 // The finished import as the email reads it: how many imported and which rows
 // failed. Structural, so the importer's richer result satisfies it directly.
 interface ImportSummary {
     imported: number;
     errors: ImportErrorRow[];
+    importLabel?: ImportLabel;
 }
 
-interface CompletionEmailInput {
-    result: ImportSummary;
+export interface EmailLinks {
+    siteUrl(): URL;
+    membersUrl(labelSlug?: string): URL;
+}
+
+// A null result is an import that never produced one. It stopped before writing anything,
+// which by then can only be our doing: the file was parsed and mapped inside the request.
+interface ImportEmailInput {
+    result: ImportSummary | null;
     recipient: string;
     labelName: string;
-    importLabel: ImportLabel | null;
-    urlFor: (type: string, data: unknown, absolute: boolean) => string;
+    links: EmailLinks;
 }
 
 interface EmailPayload {
@@ -102,15 +108,12 @@ function toErrorReportRow(row: ImportErrorRow): ErrorReportRow {
     };
 }
 
-// The error report attached to the completion email: the failed rows as CSV. It shares
-// the serialiser with the export but not the shaping -- the export writes db members,
-// this echoes submitted rows. Member columns come from the shaper's keys (so the type
+// The error report attached to the completion email: the failed rows as CSV, called only
+// when there are rows to list. It shares the serialiser with the export but not the
+// shaping -- the export writes db members, this echoes submitted rows. Member columns come from the shaper's keys (so the type
 // stays the single source); the custom_fields.* columns across the rows are threaded in
 // before the last error column, and each row's custom cells merged on.
 function buildErrorReport(errors: ImportErrorRow[]): string {
-    if (errors.length === 0) {
-        return serialize([]);
-    }
     const memberColumns = Object.keys(toErrorReportRow(errors[0])).filter(column => column !== 'error');
     const customColumns = [...new Set(errors.flatMap(row => Object.keys(customFieldCells(row))))];
     const columns = [...memberColumns, ...customColumns, 'error'];
@@ -118,29 +121,32 @@ function buildErrorReport(errors: ImportErrorRow[]): string {
     return serialize(rows, {columns});
 }
 
-// Compose the completion email for a finished import: the summary and its links,
-// plus the attached error report. Owns how the outcome is presented, so the
-// importer yields only the result and never touches email or CSV formatting.
-export default function buildCompletionEmail({result, recipient, labelName, importLabel, urlFor}: CompletionEmailInput): EmailPayload {
-    const siteUrl = new URL(urlFor('home', null, true));
-    const membersUrl = new URL('members', urlFor('admin', null, true));
-    if (importLabel) {
-        membersUrl.searchParams.set('label', importLabel.slug);
-    }
-
-    const html = emailTemplate({result, siteUrl, membersUrl, emailRecipient: recipient, importLabel});
-    const subject = result.imported > 0 ? 'Your member import is complete' : 'Your member import was unsuccessful';
+// The one email an import sends, whatever became of it. What the publisher is told and
+// what is attached both follow from the result: no result means nothing was written, so
+// there is nothing in their file to fix and an attached CSV would say there was, and no
+// failed rows means there is nothing for a report to list.
+export default function buildImportEmail({result, recipient, labelName, links}: ImportEmailInput): EmailPayload {
+    const summary: ImportEmailSummary = !result ? 'did-not-run' : (result.imported > 0 ? 'added' : 'all-failed');
 
     return {
         to: recipient,
-        subject,
-        html,
+        subject: headingFor[summary],
+        html: renderImportEmail({
+            summary,
+            imported: result?.imported ?? 0,
+            errorCount: result?.errors.length ?? 0,
+            siteUrl: links.siteUrl(),
+            membersUrl: links.membersUrl(result?.importLabel?.slug),
+            emailRecipient: recipient
+        }),
         forceTextContent: true,
-        attachments: [{
-            filename: `${labelName} - Errors.csv`,
-            content: buildErrorReport(result.errors),
-            contentType: 'text/csv',
-            contentDisposition: 'attachment'
-        }]
+        attachments: result?.errors.length
+            ? [{
+                filename: `${labelName} - Errors.csv`,
+                content: buildErrorReport(result.errors),
+                contentType: 'text/csv',
+                contentDisposition: 'attachment'
+            }]
+            : []
     };
 }

--- a/ghost/core/core/server/services/members/import-export/import/email-template.ts
+++ b/ghost/core/core/server/services/members/import-export/import/email-template.ts
@@ -1,15 +1,40 @@
-function formatNumber(number) {
-    return number.toLocaleString();
+function formatNumber(value: number): string {
+    return value.toLocaleString();
 }
 
-const iff = (cond, yes, no) => (cond ? yes : no);
-module.exports = ({result, siteUrl, membersUrl, emailRecipient}) => `
+const iff = (cond: boolean, yes: string, no: string): string => (cond ? yes : no);
+
+// The outcomes this email knows how to render. Exhaustive: a state added here without a
+// paragraph below sends a heading and nothing else, to a publisher, from a background job.
+export type ImportEmailSummary = 'did-not-run' | 'all-failed' | 'added';
+
+// The heading is a pure function of the outcome, and the subject is the same sentence, so
+// both are read from here rather than derived twice and left to disagree.
+export const headingFor: Record<ImportEmailSummary, string> = {
+    'did-not-run': 'Your member import could not be completed',
+    'all-failed': 'Your member import was unsuccessful',
+    added: 'Your member import is complete'
+};
+
+interface ImportEmailProps {
+    summary: ImportEmailSummary;
+    imported: number;
+    errorCount: number;
+    siteUrl: URL;
+    membersUrl: URL;
+    emailRecipient: string;
+}
+
+// The states are exclusive, so each paragraph below tests for exactly one.
+export default function renderImportEmail({summary, imported, errorCount, siteUrl, membersUrl, emailRecipient}: ImportEmailProps): string {
+    const heading = headingFor[summary];
+    return `
 <!doctype html>
 <html>
   <head>
     <meta name="viewport" content="width=device-width">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <title>Your member import is complete</title>
+    <title>${heading}</title>
     <style>
     /* -------------------------------------
         RESPONSIVE AND MOBILE FRIENDLY STYLES
@@ -115,7 +140,7 @@ module.exports = ({result, siteUrl, membersUrl, emailRecipient}) => `
           <div class="content" style="box-sizing: border-box; display: block; Margin: 0 auto; max-width: 600px; padding: 30px 20px;">
 
             <!-- START CENTERED CONTAINER -->
-            <span class="preheader" style="color: transparent; display: none; height: 0; max-height: 0; max-width: 0; opacity: 0; overflow: hidden; mso-hide: all; visibility: hidden; width: 0;">Your member import is complete</span>
+            <span class="preheader" style="color: transparent; display: none; height: 0; max-height: 0; max-width: 0; opacity: 0; overflow: hidden; mso-hide: all; visibility: hidden; width: 0;">${heading}</span>
             <table class="main" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%; background: #ffffff; border-radius: 8px;">
 
               <!-- START MAIN CONTENT AREA -->
@@ -127,32 +152,32 @@ module.exports = ({result, siteUrl, membersUrl, emailRecipient}) => `
                       </tr>
                       <tr>
                           <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; vertical-align: top;">
-                            <p class="title" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 21px; color: #3A464C; font-weight: normal; line-height: 25px; margin-bottom: 30px; margin-top: 50px; font-weight: 600; color: #15212A;">${iff(result.imported > 0, `Your member import is complete`, `Your member import was unsuccessful`)}</p>
+                            <p class="title" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 21px; color: #3A464C; font-weight: normal; line-height: 25px; margin-bottom: 30px; margin-top: 50px; font-weight: 600; color: #15212A;">${heading}</p>
                           </td>
                       </tr>
-                    ${iff(result.imported === 0 && result.errors.length === 0, `
+                    ${iff(summary === 'did-not-run', `
                     <tr>
                       <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; padding-bottom: 16px;">
-                          <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 0px;">No members were added.</p>
+                          <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 0px;">Something went wrong on our end and your import couldn't be completed. There's nothing wrong with your file. Please try uploading it again.</p>
                       </td>
                     </tr>
                     `, ``)}
-                    ${iff(result.imported > 0, `
+                    ${iff(summary === 'added', `
                     <tr>
                       <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; padding-bottom: 16px;">
-                          <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 0px;">A total of <strong style="font-weight: 600;">${formatNumber(result.imported)}</strong> ${iff(result.imported === 1, 'person', 'people')} were successfully added or updated in your list of members, and now have access to your site.</p>
+                          <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 0px;">A total of <strong style="font-weight: 600;">${formatNumber(imported)}</strong> ${iff(imported === 1, 'person was', 'people were')} successfully added or updated in your list of members, and now ${iff(imported === 1, 'has', 'have')} access to your site.</p>
                       </td>
                     </tr>`, ``)}
-                    ${iff(result.errors.length > 0, `
+                    ${iff(errorCount > 0, `
                     <tr>
                       <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; padding-bottom: 16px;">
                         <p style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 16px; color: #3A464C; font-weight: normal; margin: 0; line-height: 25px; margin-bottom: 0px;">
-                        ${iff(result.imported === 0, `No members were added.`, `<strong style="font-weight: 600;">${formatNumber(result.errors.length)}</strong> ${iff(result.errors.length === 1, `member was`, `members were`)} skipped due to errors.`)} There's a validated CSV file attached to this email with the list of errors so that you can fix them and re-upload the CSV to complete the import.</p>
+                        ${iff(summary === 'all-failed', `No members were added.`, `<strong style="font-weight: 600;">${formatNumber(errorCount)}</strong> ${iff(errorCount === 1, `member was`, `members were`)} skipped due to errors.`)} The CSV file attached to this email lists each one with the reason it wasn't imported.</p>
                       </td>
                     </tr>`, '')}
                     <tr>
                       <td style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 14px; vertical-align: top; padding-bottom: 12px; padding-top: 16px;">
-                        <a href="${membersUrl.href}" target="_blank" style="display: inline-block; color: #ffffff; background-color: #15212A; border: solid 1px #15212A; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: #15212A;">${iff(result.imported > 0, `View members`, `Try again`)}</a>
+                        <a href="${membersUrl.href}" target="_blank" style="display: inline-block; color: #ffffff; background-color: #15212A; border: solid 1px #15212A; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; font-weight: normal; margin: 0; padding: 9px 22px 10px; border-color: #15212A;">${iff(summary === 'added', `View members`, `Try again`)}</a>
                       </td>
                     </tr>
                   </table>
@@ -179,4 +204,4 @@ module.exports = ({result, siteUrl, membersUrl, emailRecipient}) => `
   </body>
 </html>
 `;
-
+}

--- a/ghost/core/core/server/services/members/import-export/import/importer.ts
+++ b/ghost/core/core/server/services/members/import-export/import/importer.ts
@@ -1,5 +1,5 @@
 import moment from 'moment-timezone';
-import buildCompletionEmail from './completion-email';
+import buildImportEmail, {type EmailLinks} from './completion-email';
 import {stripFormulaGuard} from '../csv';
 import {fieldValuesFromCsvRow, type CsvField} from '@tryghost/custom-field-types/csv';
 import type {Knex} from 'knex';
@@ -9,7 +9,6 @@ import type {RowSpool, SpooledRows} from './spool';
 const metrics = require('@tryghost/metrics');
 const errors = require('@tryghost/errors');
 const tpl = require('@tryghost/tpl');
-const logging = require('@tryghost/logging');
 
 // The members CSV importer, sliced into one concern per method. Two entry points by
 // design: importCSV decides inline-vs-deferred by load, since a large import must not
@@ -90,8 +89,12 @@ export interface GiftService {
 export interface EmailNotifications {
     send(options: object): Promise<unknown>;
     getDefaultRecipient(): Promise<string>;
-    urlFor(type: string, data: unknown, absolute: boolean): string;
+    links: EmailLinks;
 }
+
+// Must not throw: it is called from catch and finally blocks that exist to stop an error
+// escaping.
+export type FailureReporter = (error: unknown) => void;
 
 // Opaque to the import: planWrite produces it, applyWrite consumes it.
 type CustomFieldPlan = unknown;
@@ -117,6 +120,7 @@ interface ImporterDeps {
     gifts: GiftService;
     customFields: CustomFieldsImport;
     email: EmailNotifications;
+    report: FailureReporter;
     addJob: (job: {job: () => Promise<void>; offloaded: boolean; name: string}) => void;
     getTimezone: () => string;
     getInlineThreshold: () => number;
@@ -138,14 +142,23 @@ interface MemberImportValues {
     newsletters?: unknown;
 }
 
-// The kernel does the importing, so it is what knows whether anything imported and,
-// if so, which label the members were tagged with (a label is only persisted once
-// attached to a member). The label is absent when nothing imported; the orchestrator
-// reads it as null and never fetches it itself.
+// The label is absent when nothing imported: it is only persisted once a member carries it.
 interface ImportResult {
     imported: number;
     errors: ImportErrorRow[];
     importLabel?: ImportLabel;
+}
+
+interface PreparedRun {
+    defaultTier: Tier;
+    activeCustomFields: CsvField[];
+    globalLabels: Label[];
+}
+
+interface WrittenRows {
+    imported: number;
+    errors: ImportErrorRow[];
+    archivableStripePriceIds: string[];
 }
 
 // What the domain service returns: an import that ran inline carries its stats and
@@ -201,11 +214,12 @@ class MembersCSVImporter {
     private _gifts: GiftService;
     private _customFields: CustomFieldsImport;
     private _email: EmailNotifications;
+    private _report: FailureReporter;
     private _addJob: (job: {job: () => Promise<void>; offloaded: boolean; name: string}) => void;
     private _getTimezone: () => string;
     private _getInlineThreshold: () => number;
 
-    constructor({knex, readRows, spool, members, tiers, stripe, gifts, customFields, email, addJob, getTimezone, getInlineThreshold}: ImporterDeps) {
+    constructor({knex, readRows, spool, members, tiers, stripe, gifts, customFields, email, report, addJob, getTimezone, getInlineThreshold}: ImporterDeps) {
         this._knex = knex;
         this._readRows = readRows;
         this._spool = spool;
@@ -215,6 +229,7 @@ class MembersCSVImporter {
         this._gifts = gifts;
         this._customFields = customFields;
         this._email = email;
+        this._report = report;
         this._addJob = addJob;
         this._getTimezone = getTimezone;
         this._getInlineThreshold = getInlineThreshold;
@@ -226,8 +241,7 @@ class MembersCSVImporter {
         const extraLabels = request.extraLabels ?? [];
 
         if (canImportInline(rows.length, hasExpensiveColumns(rows), this._getInlineThreshold())) {
-            const result = await this.importRows(rows, labelName, extraLabels);
-            await verificationTrigger.testImportThreshold();
+            const result = await this.importRows(rows, labelName, extraLabels, verificationTrigger);
             return {deferred: false, originalImportSize: rows.length, result};
         }
 
@@ -237,9 +251,7 @@ class MembersCSVImporter {
 
     async importInline(request: ImportRequest, verificationTrigger: VerificationTrigger): Promise<ImportResult> {
         const rows = await this._readRows(request.filePath, request.mapping);
-        const result = await this.importRows(rows, buildImportLabelName(this._getTimezone()), request.extraLabels ?? []);
-        await verificationTrigger.testImportThreshold();
-        return result;
+        return this.importRows(rows, buildImportLabelName(this._getTimezone()), request.extraLabels ?? [], verificationTrigger);
     }
 
     private async deferImport(
@@ -259,61 +271,94 @@ class MembersCSVImporter {
         });
     }
 
-    // Swallows its own errors: a failed import or email must not leave the queued job
-    // rejected, and the verification trigger must still run afterwards either way.
+    // Must resolve in every case: the job manager reads a rejected inline job as a defect
+    // in the job itself, and there is no retry behind it.
     private async runImportJob(
         spooled: SpooledRows,
         {labelName, extraLabels, emailRecipient}: {labelName: string; extraLabels: Label[]; emailRecipient: string},
         verificationTrigger: VerificationTrigger
     ): Promise<void> {
+        // Null until the import produces one: parsing and mapping already happened inside
+        // the request, so anything failing from here is ours rather than the file's.
+        let result: ImportResult | null = null;
         try {
             const spooledRows = await spooled.read();
-            const result = await this.importRows(spooledRows, labelName, extraLabels);
-            const importLabel = result.importLabel ?? null;
-            await this._email.send(buildCompletionEmail({
-                result,
-                recipient: emailRecipient,
-                labelName,
-                importLabel,
-                urlFor: this._email.urlFor
-            }));
-        } catch (e) {
-            logging.error('Error in members import job');
-            logging.error(e);
+            result = await this.importRows(spooledRows, labelName, extraLabels, verificationTrigger);
+        } catch (error) {
+            // importRows only throws before its write loop, so nothing was written.
+            this._report(error);
         } finally {
-            await spooled.remove();
+            await this.settle(() => spooled.remove());
         }
 
-        try {
-            await verificationTrigger.testImportThreshold();
-        } catch (e) {
-            logging.error('Error in members import job when testing import threshold');
-            logging.error(e);
-        }
+        // Whatever became of it, the publisher hears exactly once. If this is what fails,
+        // there is nobody left to tell but us.
+        await this.settle(() => this._email.send(buildImportEmail({
+            result,
+            recipient: emailRecipient,
+            labelName,
+            links: this._email.links
+        })));
     }
 
-    // The members import kernel, shared by the inline and deferred paths. Each row is
-    // created or updated in its own transaction, so one row's failure rolls back only
-    // itself; failures are collected, and any Stripe prices an import tier created are
-    // archived at the end.
-    private async importRows(rows: MemberImportRow[], labelName: string, extraLabels: Label[]): Promise<ImportResult> {
-        const importLabel: Label = {name: labelName};
-        const globalLabels: Label[] = [importLabel, ...extraLabels];
-        const performStart = Date.now();
-        const defaultTier = await this._tiers.getDefault();
-        // The field set a custom_fields.* column is read against; empty when the feature
-        // is off, so a carried-through column is dropped and the write boundary stays shut.
-        const activeCustomFields = await this._customFields.activeFields();
+    // Only the write itself may throw. Callers rely on that to tell an import that never
+    // ran from one that ran and then failed to tidy up after itself.
+    private async importRows(
+        rows: MemberImportRow[],
+        labelName: string,
+        extraLabels: Label[],
+        verificationTrigger: VerificationTrigger
+    ): Promise<ImportResult> {
+        const startedAt = Date.now();
+        const prepared = await this.prepareRun(labelName, extraLabels);
+        const written = await this.writeRows(rows, prepared);
+        const result: ImportResult = {imported: written.imported, errors: written.errors};
+
+        // Bookkeeping, and the publisher's result is already in hand. Nothing below is
+        // load-bearing for what they are told, so it is left to throw into one report
+        // rather than each step defending itself. The label is read first because only
+        // it reaches the publisher, as the link their email arrives with.
+        await this.settle(async () => {
+            if (written.imported > 0) {
+                result.importLabel = (await this._members.getImportLabel(labelName))?.toJSON();
+            }
+            await metrics.metric('members-import', {
+                imported: written.imported,
+                errors: written.errors.length,
+                value: Date.now() - startedAt
+            });
+            await this.archiveStripePrices(written.archivableStripePriceIds);
+            await verificationTrigger.testImportThreshold();
+        });
+
+        return result;
+    }
+
+    private async prepareRun(labelName: string, extraLabels: Label[]): Promise<PreparedRun> {
+        return {
+            defaultTier: await this._tiers.getDefault(),
+            // Empty when the feature is off, so a carried-through column is dropped.
+            activeCustomFields: await this._customFields.activeFields(),
+            globalLabels: [{name: labelName}, ...extraLabels]
+        };
+    }
+
+    // Must not throw: once a row has committed, an import that failed halfway is not one
+    // that never ran.
+    private async writeRows(rows: MemberImportRow[], prepared: PreparedRun): Promise<WrittenRows> {
+        const {defaultTier, activeCustomFields} = prepared;
         const tierIdCache = new Map();
         const archivableStripePriceIds: string[] = [];
         // Copied per row: the member model stamps ids and trims names onto these in
         // place, and each row runs in its own transaction that can roll back. A
         // caller can hand in a nameless label, which the model would drop anyway.
-        const cloneGlobalLabels = (): Label[] => globalLabels
+        const cloneGlobalLabels = (): Label[] => prepared.globalLabels
             .map(label => ({...label}))
             .filter(label => label.name);
 
         let imported = 0;
+        let rollbackFailures = 0;
+        let firstRollbackFailure: unknown;
         const importErrors: ImportErrorRow[] = [];
         for (const row of rows) {
             let trx: Knex.Transaction | undefined;
@@ -437,24 +482,52 @@ class MembersCSVImporter {
                     .filter((message): message is string => typeof message === 'string');
                 const errorMessage = reasons.join('\n');
                 // trx is unset if the row failed before the transaction opened (a bad
-                // custom field value or gift combination).
+                // custom field value or gift combination). A rejected rollback must not
+                // escape: rows before this one are already committed, and a throw leaving
+                // here would be read as an import that never wrote anything.
                 if (trx) {
-                    await trx.rollback();
+                    try {
+                        await trx.rollback();
+                    } catch (rollbackError) {
+                        firstRollbackFailure ??= rollbackError;
+                        rollbackFailures += 1;
+                    }
                 }
                 importErrors.push({...row, error: errorMessage, errors: reasons});
             }
         }
 
-        await Promise.all(archivableStripePriceIds.map(id => this._stripe.archivePrice(id)));
-        metrics.metric('members-import', {imported, errors: importErrors.length, value: Date.now() - performStart});
-
-        if (imported > 0) {
-            // The import label exists now that members carry it, so fetch it to report.
-            // Guarded against a null lookup in case a row is ever counted without it.
-            const importLabelModel = await this._members.getImportLabel(labelName);
-            return {imported, errors: importErrors, importLabel: importLabelModel?.toJSON()};
+        if (rollbackFailures > 0) {
+            this._report(new errors.InternalServerError({
+                message: `Failed to roll back ${rollbackFailures} of ${rows.length} member rows`,
+                err: firstRollbackFailure
+            }));
         }
-        return {imported: 0, errors: importErrors};
+
+        return {imported, errors: importErrors, archivableStripePriceIds};
+    }
+
+    private async settle<T>(work: () => T | Promise<T>): Promise<T | undefined> {
+        try {
+            return await work();
+        } catch (error) {
+            this._report(error);
+            return undefined;
+        }
+    }
+
+
+    private async archiveStripePrices(priceIds: string[]): Promise<void> {
+        // allSettled so one unarchivable price neither hides the others nor stops them
+        // being attempted.
+        const attempts = await Promise.allSettled(priceIds.map(id => this._stripe.archivePrice(id)));
+        const failed = attempts.filter(attempt => attempt.status === 'rejected');
+        if (failed.length > 0) {
+            throw new errors.InternalServerError({
+                message: `Failed to archive ${failed.length} of ${attempts.length} Stripe prices created by this import`,
+                err: failed[0].reason
+            });
+        }
     }
 }
 

--- a/ghost/core/core/server/services/members/import-export/import/spool.ts
+++ b/ghost/core/core/server/services/members/import-export/import/spool.ts
@@ -4,9 +4,8 @@ import crypto from 'node:crypto';
 import fs from 'fs-extra';
 import type {MemberImportRow} from './row';
 
-// A handle to rows written to a spool: the deferred job reads them back once it
-// runs, then removes the file. Removal swallows errors -- a failed cleanup must
-// never fail the import it was cleaning up after.
+// remove() lets its failures out rather than hiding them: the file holds member names,
+// emails and Stripe customer ids, so one left behind is worth knowing about.
 export interface SpooledRows {
     read(): Promise<MemberImportRow[]>;
     remove(): Promise<void>;
@@ -30,7 +29,7 @@ export function createRowSpool(): RowSpool {
                     return JSON.parse(await fs.readFile(spoolPath, 'utf8'));
                 },
                 async remove() {
-                    await fs.remove(spoolPath).catch(() => {});
+                    await fs.remove(spoolPath);
                 }
             };
         }

--- a/ghost/core/core/server/services/members/import-export/index.ts
+++ b/ghost/core/core/server/services/members/import-export/index.ts
@@ -1,6 +1,6 @@
 import type {Knex} from 'knex';
 import type {CsvField} from '@tryghost/custom-field-types/csv';
-import MembersCSVImporter, {type MembersRepository, type GiftService, type EmailNotifications, type Tier, type CustomFieldsImport} from './import/importer';
+import MembersCSVImporter, {type MembersRepository, type GiftService, type EmailNotifications, type Tier, type CustomFieldsImport, type FailureReporter} from './import/importer';
 import readMemberRows from './import/reader';
 import {createRowSpool} from './import/spool';
 import MembersCSVExporter, {type ExportOptions, type CustomFieldDefinition} from './export/exporter';
@@ -9,6 +9,8 @@ const MembersCSVImporterStripeUtils = require('./import/stripe-utils');
 const db = require('../../../data/db');
 const models = require('../../../models');
 const labs = require('../../../../shared/labs');
+const logging = require('@tryghost/logging');
+const sentry = require('../../../../shared/sentry');
 
 // The raw collaborators the members service hands the import composition root, before
 // they are adapted into the ports the importer declares. The members repository is the
@@ -22,7 +24,7 @@ interface ImporterServices {
         reassignRedeemer(input: {giftId: string; memberId: string; transacting?: Knex.Transaction}): Promise<void>;
     };
     sendEmail: EmailNotifications['send'];
-    urlFor: EmailNotifications['urlFor'];
+    urlFor(type: string, data: unknown, absolute: boolean): string;
     addJob(job: {job: () => Promise<void>; offloaded: boolean; name: string}): void;
     getTimezone(): string;
     getInlineThreshold(): number;
@@ -68,7 +70,16 @@ export function makeImporter(deps: ImporterServices) {
     const email: EmailNotifications = {
         send: deps.sendEmail,
         getDefaultRecipient: async () => (await models.User.getOwnerUser()).get('email'),
-        urlFor: deps.urlFor
+        links: {
+            siteUrl: () => new URL(deps.urlFor('home', null, true)),
+            membersUrl: (labelSlug?: string) => {
+                const url = new URL('members', deps.urlFor('admin', null, true));
+                if (labelSlug) {
+                    url.searchParams.set('label', labelSlug);
+                }
+                return url;
+            }
+        }
     };
 
     // Gifts is initialised at boot and always present at request time; the getter
@@ -90,6 +101,17 @@ export function makeImporter(deps: ImporterServices) {
         applyWrite: (memberId, plan, executor) => deps.customFields.values.applyWrite(memberId, plan, {executor})
     };
 
+    // Inline jobs never reach the job manager's Sentry handler, which is wired to the
+    // offloaded worker path only, so a throw here would be seen by nobody.
+    const report: FailureReporter = (error) => {
+        try {
+            logging.error({event: {name: 'members.import.error'}, err: error}, 'Members import failure');
+            sentry.captureException(error);
+        } catch {
+            // Callers report from catch and finally blocks, so this must not throw.
+        }
+    };
+
     return new MembersCSVImporter({
         knex: deps.knex,
         readRows: readMemberRows,
@@ -106,6 +128,7 @@ export function makeImporter(deps: ImporterServices) {
         gifts,
         customFields,
         email,
+        report,
         addJob: deps.addJob,
         getTimezone: deps.getTimezone,
         getInlineThreshold: deps.getInlineThreshold

--- a/ghost/core/test/unit/server/services/members/import-export/import/completion-email.test.ts
+++ b/ghost/core/test/unit/server/services/members/import-export/import/completion-email.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import buildCompletionEmail from '../../../../../../../core/server/services/members/import-export/import/completion-email';
+import buildImportEmail from '../../../../../../../core/server/services/members/import-export/import/completion-email';
 import type {ImportErrorRow} from '../../../../../../../core/server/services/members/import-export/import/row';
 
 // The completion email is exercised end-to-end by the deferred parity test; this pins
@@ -7,33 +7,53 @@ import type {ImportErrorRow} from '../../../../../../../core/server/services/mem
 // humanising of raw ORM validation errors, and the shaping of failed rows into the
 // import-shaped error report (its own serialiser, separate from the export CSV).
 describe('members import completion email', function () {
-    const urlFor = () => 'http://localhost/';
+    const links = {
+        siteUrl: () => new URL('http://localhost/'),
+        membersUrl: () => new URL('http://localhost/ghost/members')
+    };
 
-    const build = (errors: ImportErrorRow[]) => buildCompletionEmail({
+    const build = (errors: ImportErrorRow[]) => buildImportEmail({
         result: {imported: 0, errors},
         recipient: 'owner@example.com',
         labelName: 'Import 2026-01-01 00:00',
-        importLabel: null,
-        urlFor
+        links
     });
 
+    const failedRow: ImportErrorRow = {email: 'x@example.com', name: 'X', subscribed: true, complimentary_plan: false, labels: [], error: 'nope', errors: ['nope']};
+
     it('names the attachment after the import label', function () {
-        const email = build([]);
+        const email = build([failedRow]);
         assert.equal(email.attachments[0].filename, 'Import 2026-01-01 00:00 - Errors.csv');
         assert.equal(email.attachments[0].contentType, 'text/csv');
+    });
+
+    it('attaches no report when no row failed', function () {
+        assert.deepEqual(build([]).attachments, []);
     });
 
     it('titles the email by whether anything imported', function () {
         assert.match(build([]).subject, /unsuccessful/);
 
-        const someImported = buildCompletionEmail({
+        const someImported = buildImportEmail({
             result: {imported: 1, errors: []},
             recipient: 'owner@example.com',
             labelName: 'Import 2026-01-01 00:00',
-            importLabel: null,
-            urlFor
+            links
         });
         assert.match(someImported.subject, /complete/);
+    });
+
+    it('agrees with itself when a single member imported', function () {
+        const email = buildImportEmail({
+            result: {imported: 1, errors: []},
+            recipient: 'owner@example.com',
+            labelName: 'Import 2026-01-01 00:00',
+            links
+        });
+
+        assert.match(email.html, /1<\/strong> person was successfully added/);
+        assert.match(email.html, /now has access to your site/);
+        assert.doesNotMatch(email.html, /person were/);
     });
 
     it('rewrites raw ORM validation errors into human copy', function () {

--- a/ghost/core/test/unit/server/services/members/import-export/import/error-handling.test.ts
+++ b/ghost/core/test/unit/server/services/members/import-export/import/error-handling.test.ts
@@ -1,0 +1,546 @@
+import assert from 'node:assert/strict';
+import type {Knex} from 'knex';
+import MembersCSVImporter from '../../../../../../../core/server/services/members/import-export/import/importer';
+import type {MemberImportRow} from '../../../../../../../core/server/services/members/import-export/import/row';
+
+const errors = require('@tryghost/errors');
+
+// Asserted exactly rather than by pattern: the failure subject contains the word
+// "completed", so a /complete/ match would pass for all three.
+const COMPLETED = 'Your member import is complete';
+const UNSUCCESSFUL = 'Your member import was unsuccessful';
+const COULD_NOT_COMPLETE = 'Your member import could not be completed';
+
+const expectedFailure = () => new errors.DataImportError({message: 'Member already exists'});
+
+const row = (email: string): MemberImportRow => ({
+    email,
+    name: 'Test Member',
+    note: undefined,
+    subscribed: true,
+    labels: [],
+    id: undefined,
+    complimentary_plan: undefined,
+    stripe_customer_id: undefined,
+    created_at: undefined,
+    import_tier: undefined,
+    gift_id: undefined
+});
+
+const member = (values: {name?: string; note?: string}) => ({
+    id: 'member_1',
+    name: values.name ?? '',
+    note: values.note ?? '',
+    related: () => ({toJSON: () => [], length: 0})
+});
+
+interface SentEmail {
+    to: string;
+    subject: string;
+    html: string;
+    attachments: Array<{filename: string; content: string}>;
+}
+
+// Collaborators are handed back as `deps` so a test can repoint the seam it is breaking.
+function harness(
+    rows: MemberImportRow[] = [row('first@example.com'), row('second@example.com')],
+    // Zero sends every non-empty file down the deferred path.
+    inlineThreshold = 0
+) {
+    const sent: SentEmail[] = [];
+    const reported: unknown[] = [];
+    const created: string[] = [];
+    const createFailures = new Map<string, unknown>();
+    const archivedPrices: string[] = [];
+    const jobs: Array<{name: string; job: () => Promise<void>}> = [];
+    let spoolRemoved = false;
+    // The importer reads knex once, at construction, so a test cannot swap it afterwards.
+    let rollback: () => Promise<void> = async () => {};
+    let removalFailure: Error | undefined;
+
+    const deps = {
+        knex: {
+            transaction: async () => ({commit: async () => {}, rollback: () => rollback()})
+        } as unknown as Knex,
+        readRows: async () => rows,
+        spool: {
+            write: async (spooledRows: MemberImportRow[]) => ({
+                read: async () => spooledRows,
+                remove: async () => {
+                    spoolRemoved = true;
+                    if (removalFailure) {
+                        throw removalFailure;
+                    }
+                }
+            })
+        },
+        members: {
+            get: async () => null,
+            create: async (values: {email?: string; name?: string; note?: string}) => {
+                const failure = createFailures.get(values.email ?? '');
+                if (failure) {
+                    throw failure;
+                }
+                created.push(values.email ?? '');
+                return member(values);
+            },
+            update: async (values: {name?: string; note?: string}) => member(values),
+            getCustomerIdByEmail: async () => undefined,
+            linkStripeCustomer: async () => {},
+            getImportLabel: async (name: string) => ({toJSON: () => ({name, slug: 'import-2026-01-01'})})
+        },
+        tiers: {
+            getDefault: async () => ({id: 'tier_default'}),
+            getByName: async () => ({id: 'tier_named'})
+        },
+        stripe: {
+            forceStripeSubscriptionToProduct: async () => ({isNewStripePrice: true, stripePriceId: 'price_1'}),
+            archivePrice: async (id: string) => {
+                archivedPrices.push(id);
+            }
+        },
+        gifts: {
+            reassignRedeemer: async () => {}
+        },
+        customFields: {
+            activeFields: async () => [],
+            planWrite: async () => [],
+            applyWrite: async () => {}
+        },
+        email: {
+            send: async (payload: SentEmail) => {
+                sent.push(payload);
+            },
+            getDefaultRecipient: async () => 'owner@example.com',
+            links: {
+                siteUrl: () => new URL('http://localhost/'),
+                membersUrl: (labelSlug?: string) => {
+                    const url = new URL('http://localhost/ghost/members');
+                    if (labelSlug) {
+                        url.searchParams.set('label', labelSlug);
+                    }
+                    return url;
+                }
+            }
+        },
+        report: (error: unknown) => {
+            reported.push(error);
+        },
+        addJob: (job: {name: string; job: () => Promise<void>}) => {
+            jobs.push(job);
+        },
+        getTimezone: () => 'Etc/UTC',
+        getInlineThreshold: () => inlineThreshold
+    };
+
+    const importer = new MembersCSVImporter(deps);
+    const noopVerification = {testImportThreshold: async () => {}};
+
+    // The job is invoked directly rather than through the job manager.
+    const run = async (verification = noopVerification) => {
+        await importer.importCSV({filePath: 'members.csv', requestUserEmail: 'importer@example.com'}, verification);
+        assert.equal(jobs.length, 1, 'expected the import to be deferred to a background job');
+        await jobs[0].job();
+    };
+
+    return {
+        deps,
+        importer,
+        run,
+        sent,
+        reported,
+        created,
+        archivedPrices,
+        onlyEmail: () => {
+            assert.equal(sent.length, 1, 'expected the publisher to be told exactly once');
+            return sent[0];
+        },
+        // Exactly one, and the error itself: what is reported matters as much as that
+        // something was.
+        onlyReport: () => {
+            assert.equal(reported.length, 1, `expected exactly one report, got ${reported.length}`);
+            return reported[0] as Error;
+        },
+        spoolRemoved: () => spoolRemoved,
+        failRollbackWith: (error: Error) => {
+            rollback = async () => {
+                throw error;
+            };
+        },
+        failSpoolRemovalWith: (error: Error) => {
+            removalFailure = error;
+        },
+        failCreateFor: (email: string, error: unknown) => {
+            createFailures.set(email, error);
+        }
+    };
+}
+
+// Carries enough Stripe and tier data to make the import create a price it must archive.
+const rowNeedingPriceCleanup = (email: string): MemberImportRow => ({
+    ...row(email),
+    stripe_customer_id: 'cus_1',
+    import_tier: 'Gold'
+});
+
+describe('members import error handling', function () {
+    describe('a row that fails', function () {
+        it('collects a row the publisher can fix and imports the rest', async function () {
+            const h = harness();
+            h.failCreateFor('first@example.com', expectedFailure());
+
+            await h.run();
+
+            assert.deepEqual(h.created, ['second@example.com']);
+            const email = h.onlyEmail();
+            assert.equal(email.subject, COMPLETED);
+            assert.ok(email.html.includes(email.subject));
+            assert.match(email.attachments[0].content, /first@example.com/);
+            assert.match(email.attachments[0].content, /Member already exists/);
+        });
+
+        it('never reports a failed row to anyone but the publisher', async function () {
+            const h = harness();
+            h.failCreateFor('first@example.com', new TypeError("Cannot read properties of undefined (reading 'id')"));
+            h.failCreateFor('second@example.com', new errors.DataImportError({message: 'Member already exists'}));
+
+            await h.run();
+
+            // A row that failed is a row that failed. Whose fault it was decides nothing, so
+            // nothing inspects the error -- which is also why a row's values, which a driver
+            // inlines into its message, cannot reach a log or an error tracker from here.
+            assert.deepEqual(h.reported, []);
+            const attached = h.onlyEmail().attachments[0].content;
+            assert.match(attached, /first@example.com/);
+            assert.match(attached, /second@example.com/);
+        });
+
+        it('rewrites a raw Stripe rejection into something readable', async function () {
+            const h = harness();
+            h.deps.members.create = async () => {
+                throw new errors.DataImportError({message: 'No such customer: cus_missing'});
+            };
+
+            await h.run();
+
+            const email = h.onlyEmail();
+            assert.equal(email.subject, UNSUCCESSFUL);
+            assert.match(email.attachments[0].content, /Could not find Stripe customer/);
+            assert.deepEqual(h.reported, []);
+        });
+
+        it('reports an import where every row failed as unsuccessful', async function () {
+            const h = harness();
+            h.deps.members.create = async () => {
+                throw expectedFailure();
+            };
+
+            await h.run();
+
+            const email = h.onlyEmail();
+            assert.equal(email.subject, UNSUCCESSFUL);
+            assert.match(email.attachments[0].content, /Member already exists/);
+        });
+    });
+
+    describe('a run that fails before writing anything', function () {
+        it('writes nothing and tells the publisher the import did not run', async function () {
+            const h = harness();
+            h.deps.tiers.getDefault = async () => {
+                throw new Error('Database is gone');
+            };
+
+            await h.run();
+
+            assert.deepEqual(h.created, []);
+            assert.equal(h.onlyEmail().subject, COULD_NOT_COMPLETE);
+            assert.match(h.onlyReport().message, /Database is gone/);
+        });
+
+        it('attaches no error report to an import that never ran', async function () {
+            const h = harness();
+            h.deps.tiers.getDefault = async () => {
+                throw new Error('Database is gone');
+            };
+
+            await h.run();
+
+            const email = h.onlyEmail();
+            assert.deepEqual(email.attachments, []);
+            assert.match(email.html, /nothing wrong with your file/);
+            assert.ok(email.html.includes(email.subject));
+        });
+
+        it('treats an unresolvable custom field set the same way', async function () {
+            const h = harness();
+            h.deps.customFields.activeFields = async () => {
+                throw new Error('Custom fields unavailable');
+            };
+
+            await h.run();
+
+            assert.deepEqual(h.created, []);
+            assert.equal(h.onlyEmail().subject, COULD_NOT_COMPLETE);
+        });
+
+        it('tells the publisher when the spooled rows cannot be read back', async function () {
+            const h = harness();
+            h.deps.spool.write = async () => ({
+                read: async (): Promise<MemberImportRow[]> => {
+                    throw new Error('ENOENT: no such file or directory');
+                },
+                remove: async () => {}
+            });
+
+            await h.run();
+
+            assert.deepEqual(h.created, []);
+            assert.equal(h.onlyEmail().subject, COULD_NOT_COMPLETE);
+            assert.match(h.onlyReport().message, /ENOENT/);
+        });
+    });
+
+    describe('a run whose rollback fails', function () {
+        it('reports a run of failed rollbacks once rather than once each', async function () {
+            const h = harness([row('a@example.com'), row('b@example.com'), row('c@example.com')]);
+            h.failRollbackWith(new Error('Connection lost'));
+            h.deps.members.create = async () => {
+                throw expectedFailure();
+            };
+
+            await h.run();
+
+            // One report for the run, carrying how far it spread, with the rejection that
+            // caused it still reachable on the stack.
+            const reported = h.onlyReport();
+            assert.match(reported.message, /Failed to roll back 3 of 3 member rows/);
+            assert.match(reported.stack ?? '', /Connection lost/);
+        });
+
+        it('does not report an import that wrote members as one that never ran', async function () {
+            const h = harness([row('first@example.com'), row('second@example.com'), row('third@example.com')]);
+            h.failRollbackWith(new Error('Connection lost'));
+            h.failCreateFor('second@example.com', expectedFailure());
+
+            await h.run();
+
+            assert.deepEqual(h.created, ['first@example.com', 'third@example.com']);
+            assert.equal(h.onlyEmail().subject, COMPLETED);
+            assert.match(h.onlyReport().message, /Failed to roll back 1 of 3 member rows/);
+        });
+    });
+
+    describe('a run that fails after writing everything', function () {
+        it('keeps a completed import completed when Stripe price cleanup fails', async function () {
+            const h = harness([rowNeedingPriceCleanup('first@example.com')]);
+            h.deps.stripe.archivePrice = async () => {
+                throw new Error('Stripe is unreachable');
+            };
+
+            await h.run();
+
+            assert.deepEqual(h.created, ['first@example.com']);
+            const email = h.onlyEmail();
+            assert.equal(email.subject, COMPLETED);
+            assert.match(email.html, /import-2026-01-01/);
+            const cleanup = h.onlyReport();
+            // How many were left behind is the part worth alerting on, and the rejection
+            // that caused it still has to reach whoever reads the alert. Ghost's errors
+            // fold a cause in rather than exposing it, so the stack is where it survives.
+            assert.match(cleanup.message, /Failed to archive 1 of 1/);
+            assert.match(cleanup.stack ?? '', /Stripe is unreachable/);
+        });
+
+        it('still reports a completed import when the label lookup fails', async function () {
+            const h = harness();
+            h.deps.members.getImportLabel = async () => {
+                throw new Error('Label lookup failed');
+            };
+
+            await h.run();
+
+            assert.deepEqual(h.created, ['first@example.com', 'second@example.com']);
+            assert.equal(h.onlyEmail().subject, COMPLETED);
+            assert.match(h.onlyReport().message, /Label lookup failed/);
+        });
+    });
+
+    describe('a failure that cannot be delivered', function () {
+        it('reports a completion email that cannot be sent', async function () {
+            const h = harness();
+            h.deps.email.send = async () => {
+                throw new Error('SMTP is down');
+            };
+
+            await h.run();
+
+            assert.match(h.onlyReport().message, /SMTP is down/);
+        });
+
+        it('reports a failing verification trigger without losing the email', async function () {
+            const h = harness();
+
+            await h.run({
+                testImportThreshold: async () => {
+                    throw new Error('Verification trigger failed');
+                }
+            });
+
+            assert.equal(h.onlyEmail().subject, COMPLETED);
+            assert.match(h.onlyReport().message, /Verification trigger failed/);
+        });
+    });
+
+    describe('whatever else fails', function () {
+        it('always removes the spooled rows', async function () {
+            const h = harness();
+            h.deps.tiers.getDefault = async () => {
+                throw new Error('Database is gone');
+            };
+
+            await h.run();
+
+            assert.equal(h.spoolRemoved(), true);
+        });
+
+        it('reports rows left on disk without silencing the publisher', async function () {
+            const h = harness();
+            h.failSpoolRemovalWith(new Error('EACCES: permission denied'));
+
+            await h.run();
+
+            assert.equal(h.onlyEmail().subject, COMPLETED);
+            assert.match(h.onlyReport().message, /EACCES/);
+        });
+
+        it('survives a spool that throws before it returns a promise', async function () {
+            const h = harness();
+            h.deps.spool.write = async (spooledRows: MemberImportRow[]) => ({
+                read: async () => spooledRows,
+                // Synchronous, so .catch() on the returned promise would never see it.
+                remove: (() => {
+                    throw new Error('EACCES: permission denied');
+                }) as unknown as () => Promise<void>
+            });
+
+            await h.run();
+
+            assert.equal(h.onlyEmail().subject, COMPLETED);
+            assert.match(h.onlyReport().message, /EACCES/);
+        });
+
+        it('never rejects the queued job', async function () {
+            const h = harness();
+            h.deps.tiers.getDefault = async () => {
+                throw new Error('Database is gone');
+            };
+            h.deps.email.send = async () => {
+                throw new Error('SMTP is down');
+            };
+
+            await assert.doesNotReject(() => h.run({
+                testImportThreshold: async () => {
+                    throw new Error('Verification trigger failed');
+                }
+            }));
+        });
+    });
+
+    describe('an import with no request waiting on it', function () {
+        const runInline = (h: ReturnType<typeof harness>) => h.importer.importInline(
+            {filePath: 'members.csv', requestUserEmail: null},
+            {testImportThreshold: async () => {}}
+        );
+
+        it('returns the rows that failed rather than raising', async function () {
+            const h = harness();
+            h.deps.members.create = async () => {
+                throw new TypeError("Cannot read properties of undefined (reading 'id')");
+            };
+
+            // The site import runs every one of its importers inside a single transaction
+            // with no catch between them, so raising here takes the posts, tags and users
+            // imported alongside the members down with it.
+            const result = await runInline(h);
+
+            assert.equal(result.imported, 0);
+            assert.equal(result.errors.length, 2);
+        });
+
+        it('reports what landed when the run completed', async function () {
+            const h = harness();
+
+            const result = await runInline(h);
+
+            assert.equal(result.imported, 2);
+            assert.deepEqual(result.errors, []);
+        });
+    });
+
+    describe('an import that runs while the request is open', function () {
+        it('surfaces a setup failure to the caller instead of swallowing it', async function () {
+            const h = harness(undefined, 100);
+            h.deps.tiers.getDefault = async () => {
+                throw new Error('Database is gone');
+            };
+
+            await assert.rejects(
+                () => h.importer.importCSV(
+                    {filePath: 'members.csv', requestUserEmail: 'importer@example.com'},
+                    {testImportThreshold: async () => {}}
+                ),
+                /Database is gone/
+            );
+            assert.equal(h.sent.length, 0);
+        });
+
+        it('answers with what landed when only the check after it failed', async function () {
+            const h = harness(undefined, 100);
+
+            // The members are already written by the time the threshold is tested, so a
+            // failure there must not answer the request as though the import had not run.
+            const outcome = await h.importer.importCSV(
+                {filePath: 'members.csv', requestUserEmail: 'importer@example.com'},
+                {testImportThreshold: async () => {
+                    throw new Error('Verification trigger failed');
+                }}
+            );
+
+            assert.equal(outcome.deferred, false);
+            assert.equal(outcome.deferred === false && outcome.result.imported, 2);
+            assert.match(h.onlyReport().message, /Verification trigger failed/);
+        });
+
+        it('still answers with the failed rows when the publisher can fix them', async function () {
+            const h = harness(undefined, 100);
+            h.deps.members.create = async () => {
+                throw expectedFailure();
+            };
+
+            const outcome = await h.importer.importCSV(
+                {filePath: 'members.csv', requestUserEmail: 'importer@example.com'},
+                {testImportThreshold: async () => {}}
+            );
+
+            assert.equal(outcome.deferred, false);
+            assert.equal(outcome.deferred === false && outcome.result.errors.length, 2);
+        });
+
+        it('does not fail the request when only the cleanup after it failed', async function () {
+            const h = harness(undefined, 100);
+            h.deps.members.getImportLabel = async () => {
+                throw new Error('Label lookup failed');
+            };
+
+            const outcome = await h.importer.importCSV(
+                {filePath: 'members.csv', requestUserEmail: 'importer@example.com'},
+                {testImportThreshold: async () => {}}
+            );
+
+            assert.equal(outcome.deferred, false);
+            assert.equal(outcome.deferred === false && outcome.result.imported, 2);
+            assert.equal(outcome.deferred === false && outcome.result.importLabel, undefined);
+            assert.match(h.onlyReport().message, /Label lookup failed/);
+        });
+    });
+});


### PR DESCRIPTION
## Problem

A member import too large to run inside the request is accepted straight away and reported by email when the background job finishes. If that job failed, no email was ever sent. The publisher saw "we'll email you", and then nothing arrived, ever. An import that had failed and one still running looked identical to them, indefinitely.

Nobody else found out either. Queued imports run in-process, where a thrown error never reaches the error tracker, so the only trace was a line in the server log.

The steps that run after the rows are written were unguarded too, so one of them failing could report an import that had already landed as one that never ran.

## Solution

Every queued import now sends exactly one email, whatever became of it, and there are only three things it can say. An import that stopped before writing anything says it could not be completed and that there is nothing wrong with the file, and carries no attachment, because there is nothing in the file to fix and attaching a report would claim there was. An import that wrote nothing says it was unsuccessful. An import that wrote something reports how many members landed.

Whenever rows failed, they come back as an attached CSV listing each one with its reason. The import no longer tries to work out whose fault a row was. If a row failed, it failed, and the publisher is told which row and why, so they can act on it. Removing that judgement is most of this change: it deleted the failure taxonomy, the per-error-type classification, and the scrubbing that classification made necessary.

Everything the publisher cannot be shown goes to logging and the error tracker instead: a run that never started, a rollback that would not roll back, the cleanup steps, and the email itself if it cannot be sent. These are gathered once per import rather than once per row, so a database that stops accepting writes mid-import produces one alert rather than tens of thousands. Row values never travel with them, which is now true by construction rather than by scrubbing, because row errors never reach that path at all.

What runs after the last row is written is bookkeeping nobody is waiting on: reading the import label, recording metrics, archiving Stripe prices, re-checking the member threshold. None of it is load-bearing for what the publisher is told, so it is left to fail into a single report rather than having each step defend itself, and none of it can retract an import that already landed. Only three things are guarded: the job boundary, because a rejected job reports nothing and there is no retry behind it; the email, because it is the deliverable; and the removal of the spooled rows, because the run has to release what it allocated.

Imports small enough to answer inside the request now fail properly when they cannot run at all, instead of answering with success and every line of the file listed as an error.

## How failures are handled

Solid arrows are the import's path. Dotted arrows are failures the publisher never sees, which are logged and sent to the error tracker without ever carrying row values.

```mermaid
flowchart TD
    START([Import request]) --> READ[Parse the CSV, apply the column mapping]
    READ -->|cannot parse or map| REQFAIL[Request fails, nothing imported]
    READ --> ROUTE{Small, and no Stripe columns?}

    ROUTE -->|yes, answer now| PREP1[Prepare the run]
    PREP1 -->|cannot start| REQFAIL
    PREP1 --> WRITE1[Write each row in its own transaction]
    WRITE1 --> RESP[Respond with what landed, plus every failed row]

    ROUTE -->|no, too slow to hold the request| SPOOL[Spool the rows, accept the request]
    SPOOL --> JOB[Background job, must always resolve]
    JOB --> PREP2[Prepare the run]
    PREP2 -->|cannot start| NORESULT[No result: nothing was written]
    PREP2 --> WRITE2[Write each row in its own transaction]
    WRITE2 --> SETTLERUN[Bookkeeping: label, metrics,<br/>Stripe prices, member threshold]
    SETTLERUN --> RESULT[Result: what landed, plus every failed row]

    NORESULT --> EMAIL{The one email}
    RESULT --> EMAIL
    EMAIL -->|nothing was written| M1[Could not be completed.<br/>Nothing is wrong with your file.<br/>No attachment]
    EMAIL -->|nothing landed| M2[Unsuccessful, with a CSV<br/>listing every failed row and why]
    EMAIL -->|something landed| M3[Complete, with a CSV of the failed<br/>rows if there were any]

    PREP2 -.-> SINK[(Logged and sent to the error tracker)]
    WRITE2 -. rollback failures, folded into one .-> SINK
    SETTLERUN -. reported once, never reaches the publisher .-> SINK
    SPOOLCLEAN[Remove the spooled rows] -.-> SINK
    JOB --> SPOOLCLEAN
    EMAIL -. cannot be sent .-> SINK

    classDef publisher fill:#e8f4ea,stroke:#4a7c59,color:#14281d
    classDef ours fill:#f4ecec,stroke:#8c5a5a,color:#2b1414
    class REQFAIL,RESP,M1,M2,M3 publisher
    class SINK ours
```

Reference: https://linear.app/ghost/issue/BER-3816
