### PR TITLE
Gave custom field validation rules their own wording

### DIFF
--- a/apps/admin-x-framework/src/api/members.ts
+++ b/apps/admin-x-framework/src/api/members.ts
@@ -220,7 +220,14 @@ export type ImportMembersCompleteResponseType = {
         originalImportSize?: number;
         stats: {
             imported: number;
-            invalid?: Array<Record<string, string> & {error: string}>;
+            // The submitted row echoed back, so the remaining keys are whatever columns the
+            // CSV had. `errors` is why the row failed; `error` is those reasons written out
+            // for the error report's single cell.
+            invalid?: Array<{
+                [column: string]: unknown;
+                error: string;
+                errors: string[];
+            }>;
         };
         import_label?: ImportMembersImportLabel | null;
     };

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/mapping.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/mapping.ts
@@ -210,7 +210,9 @@ export function formatImportError(error: string): string {
             'Invalid email address'
         )
         .replace(
-            /No such customer:[^,]*/,
+            // Runs to the end: this is handed one reason, and Stripe puts the customer id
+            // after the colon.
+            /No such customer:[\s\S]*/,
             'Could not find Stripe customer'
         );
 }

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/upload.test.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/upload.test.ts
@@ -46,9 +46,9 @@ describe('buildImportResponse', () => {
                 stats: {
                     imported: 1,
                     invalid: [
-                        {email: 'a@test.com', error: 'Value in [members.email] cannot be blank.'},
-                        {email: 'b@test.com', error: 'Value in [members.email] cannot be blank.'},
-                        {email: 'c@test.com', error: 'Validation (isEmail) failed for email'}
+                        {email: 'a@test.com', errors: ['Value in [members.email] cannot be blank.'], error: 'Value in [members.email] cannot be blank.'},
+                        {email: 'b@test.com', errors: ['Value in [members.email] cannot be blank.'], error: 'Value in [members.email] cannot be blank.'},
+                        {email: 'c@test.com', errors: ['Validation (isEmail) failed for email'], error: 'Validation (isEmail) failed for email'}
                     ]
                 },
                 import_label: {name: 'Test Import', slug: 'test-import'}
@@ -69,11 +69,11 @@ describe('buildImportResponse', () => {
                 stats: {
                     imported: 0,
                     invalid: [
-                        {email: '', error: 'Value in [members.email] cannot be blank.'},
-                        {email: 'x', error: 'Value in [members.note] exceeds maximum length of 2000 characters.'},
-                        {email: 'y', error: 'Value in [members.subscribed] must be one of true, false, 0 or 1.'},
-                        {email: 'z', error: 'Validation (isEmail) failed for email'},
-                        {email: 'w', error: 'No such customer:cus_abc123'}
+                        {email: '', errors: ['Value in [members.email] cannot be blank.'], error: 'Value in [members.email] cannot be blank.'},
+                        {email: 'x', errors: ['Value in [members.note] exceeds maximum length of 2000 characters.'], error: 'Value in [members.note] exceeds maximum length of 2000 characters.'},
+                        {email: 'y', errors: ['Value in [members.subscribed] must be one of true, false, 0 or 1.'], error: 'Value in [members.subscribed] must be one of true, false, 0 or 1.'},
+                        {email: 'z', errors: ['Validation (isEmail) failed for email'], error: 'Validation (isEmail) failed for email'},
+                        {email: 'w', errors: ['No such customer:cus_abc123'], error: 'No such customer:cus_abc123'}
                     ]
                 },
                 import_label: {name: 'Errors', slug: 'errors'}
@@ -88,13 +88,17 @@ describe('buildImportResponse', () => {
         expect(messages).toContain('Could not find Stripe customer');
     });
 
-    it('splits comma-separated errors into separate entries', () => {
+    it('gives a row that failed twice one entry per failure', () => {
         const result = buildImportResponse({
             meta: {
                 stats: {
                     imported: 0,
                     invalid: [
-                        {email: 'a@test.com', error: 'Value in [members.email] cannot be blank.,Validation (isEmail) failed for email'}
+                        {
+                            email: 'a@test.com',
+                            errors: ['Value in [members.email] cannot be blank.', 'Validation (isEmail) failed for email'],
+                            error: 'Value in [members.email] cannot be blank.\nValidation (isEmail) failed for email'
+                        }
                     ]
                 },
                 import_label: {name: 'Test', slug: 'test'}
@@ -105,6 +109,45 @@ describe('buildImportResponse', () => {
             {message: 'Missing email address', count: 1},
             {message: 'Invalid email address', count: 1}
         ]);
+    });
+
+    it('keeps a reason whole however it is punctuated', () => {
+        // A reason may quote a cell the publisher wrote, and a CSV cell legally holds
+        // both a comma and a newline.
+        const punctuated = 'custom_fields.home-address.country: Enter a 2-letter country code, like US.';
+        const multiline = '"Gold\nPlan" is not a valid tier.';
+        const result = buildImportResponse({
+            meta: {
+                stats: {
+                    imported: 0,
+                    invalid: [
+                        {email: 'a@test.com', errors: [punctuated], error: punctuated},
+                        {email: 'b@test.com', errors: [punctuated], error: punctuated},
+                        {email: 'c@test.com', errors: [multiline], error: multiline}
+                    ]
+                },
+                import_label: {name: 'Test', slug: 'test'}
+            }
+        });
+
+        expect(result.errorList).toEqual([
+            {message: punctuated, count: 2},
+            {message: multiline, count: 1}
+        ]);
+    });
+
+    it('drops a reason that humanises to nothing rather than listing a blank bullet', () => {
+        const result = buildImportResponse({
+            meta: {
+                stats: {
+                    imported: 0,
+                    invalid: [{email: 'a@test.com', errors: ['  ', 'Validation (isEmail) failed for email'], error: '  \nValidation (isEmail) failed for email'}]
+                },
+                import_label: {name: 'Test', slug: 'test'}
+            }
+        });
+
+        expect(result.errorList).toEqual([{message: 'Invalid email address', count: 1}]);
     });
 
     it('uses a default name when import_label is missing', () => {
@@ -135,7 +178,7 @@ describe('buildImportResponse', () => {
             meta: {
                 stats: {
                     imported: 0,
-                    invalid: [{email: 'bad', error: 'Validation (isEmail) failed for email'}]
+                    invalid: [{email: 'bad', errors: ['Validation (isEmail) failed for email'], error: 'Validation (isEmail) failed for email'}]
                 },
                 import_label: {name: 'Test', slug: 'test'}
             }
@@ -144,5 +187,30 @@ describe('buildImportResponse', () => {
         expect(mockCreateObjectURL).toHaveBeenCalledTimes(1);
         const blob = mockCreateObjectURL.mock.calls[0][0] as Blob;
         expect(blob.type).toBe('text/csv');
+    });
+
+    it('writes the error file with the submitted columns and no others', async () => {
+        // The file echoes the row back, so every key on it becomes a column.
+        buildImportResponse({
+            meta: {
+                stats: {
+                    imported: 0,
+                    invalid: [{
+                        email: 'a@test.com',
+                        'custom_fields.home-address.country': 'IRL',
+                        errors: ['Missing email address', 'custom_fields.home-address.country: Enter a 2-letter country code, like US.'],
+                        error: 'Missing email address\ncustom_fields.home-address.country: Enter a 2-letter country code, like US.'
+                    }]
+                },
+                import_label: {name: 'Test', slug: 'test'}
+            }
+        });
+
+        const csv = await (mockCreateObjectURL.mock.calls[0][0] as Blob).text();
+        // CRLF between rows; a reason may itself contain a bare newline.
+        const [header] = csv.split('\r\n');
+
+        expect(header).toBe('"email","custom_fields.home-address.country","error"');
+        expect(csv).toContain('"Missing email address\ncustom_fields.home-address.country: Enter a 2-letter country code, like US."');
     });
 });

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/upload.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/upload.ts
@@ -11,16 +11,20 @@ export function buildImportResponse(importData: ImportMembersCompleteResponseTyp
     const errorListMap: Record<string, {message: string; count: number}> = {};
 
     const errorsWithFormattedMessages = erroredMembers.map((row) => {
-        const formattedError = formatImportError(row.error);
-        formattedError.split(',').forEach((errorMsg: string) => {
-            const trimmed = errorMsg.trim();
-            if (errorListMap[trimmed]) {
-                errorListMap[trimmed].count += 1;
+        const {errors, ...columns} = row;
+        const formatted = errors
+            .map(reason => formatImportError(reason).trim())
+            .filter(Boolean);
+        for (const reason of formatted) {
+            if (errorListMap[reason]) {
+                errorListMap[reason].count += 1;
             } else {
-                errorListMap[trimmed] = {message: trimmed, count: 1};
+                errorListMap[reason] = {message: reason, count: 1};
             }
-        });
-        return {...row, error: formattedError};
+        }
+        // `errors` is dropped rather than spread: the error CSV echoes the submitted row
+        // back, so every key here becomes a column of the downloaded file.
+        return {...columns, error: formatted.join('\n')};
     });
 
     const errorCsv = unparseErrorCSV(errorsWithFormattedMessages);

--- a/apps/admin/src/members/detail/member-detail-custom-fields.acceptance.test.tsx
+++ b/apps/admin/src/members/detail/member-detail-custom-fields.acceptance.test.tsx
@@ -206,7 +206,7 @@ describe('Member detail custom fields', () => {
             errors: [{
                 property: 'custom_fields.job_title',
                 context: 'Rejected by the server for reasons the client could not know.',
-                message: 'Invalid value for custom field \'Job title\'.'
+                message: 'Validation error, cannot edit member.'
             }]
         }, {status: 422});
         await renderAdminApp(`/members/${m.id}`, FLAGS);

--- a/apps/admin/src/members/detail/member-detail-edit.test.ts
+++ b/apps/admin/src/members/detail/member-detail-edit.test.ts
@@ -345,9 +345,30 @@ describe('getCustomFieldValidationErrors', () => {
         expect(getCustomFieldValidationErrors({home_address: {country: 'HK'}}, fields)).toEqual({});
     });
 
-    it('explains a malformed country code rather than echoing the schema message', () => {
-        const errors = getCustomFieldValidationErrors({home_address: {...validAddress, country: 'DEU'}}, fields);
-        expect(errors).toEqual({'home_address.country': 'Enter a 2-letter country code, like US.'});
+    it('explains a malformed country code in words a person can act on, however it was wrong', () => {
+        // Spelled out rather than read from the catalog: the API returns this same string,
+        // and an expectation computed from the catalog would pass whatever it said.
+        const message = 'Enter a 2-letter country code, like US.';
+
+        for (const country of ['DEU', '12', 'D']) {
+            expect(getCustomFieldValidationErrors({home_address: {...validAddress, country}}, fields))
+                .toEqual({'home_address.country': message});
+        }
+    });
+
+    it('reports every part that is wrong, not just the first', () => {
+        // The server stops at the first issue because it only needs to refuse the write.
+        // The screen is placing a message under each input, so it needs all of them.
+        const errors = getCustomFieldValidationErrors(
+            {job_title: 'x'.repeat(256), home_address: {country: 'DEU', line1: 'x'.repeat(256)}},
+            fields
+        );
+
+        expect(errors).toEqual({
+            job_title: 'Use 255 characters or fewer.',
+            'home_address.country': 'Enter a 2-letter country code, like US.',
+            'home_address.line1': 'Use 255 characters or fewer.'
+        });
     });
 
     it('reports an over-long short_text value with the limit a person can act on', () => {
@@ -402,11 +423,13 @@ describe('parseCustomFieldServerErrors', () => {
     const serverError = (apiErrors: Array<{property?: string | null; context?: string | null; message?: string | null}>) => ({data: {errors: apiErrors}});
 
     it('maps a custom-fields 422 onto its dotted field path, preferring context', () => {
+        // `message` is the same generic line on every rejected edit; the reason a person
+        // reads is in `context`.
         expect(parseCustomFieldServerErrors(serverError([{
             property: 'custom_fields.home_address.postal_code',
-            context: 'Required',
-            message: 'Invalid value for custom field \'Home address\'.'
-        }]))).toEqual({'home_address.postal_code': 'Required'});
+            context: 'Use 32 characters or fewer.',
+            message: 'Validation error, cannot edit member.'
+        }]))).toEqual({'home_address.postal_code': 'Use 32 characters or fewer.'});
     });
 
     it('falls back to the message when context is empty', () => {

--- a/apps/admin/src/members/detail/member-detail-edit.ts
+++ b/apps/admin/src/members/detail/member-detail-edit.ts
@@ -291,46 +291,14 @@ export function buildCustomFieldSavePayload(
     return {id: memberId, custom_fields: {[fieldKey]: customFieldValueToSave(value) ?? null}};
 }
 
-// What to do about a malformed address sub-field, in plain words. Schema messages
-// (zod's "Invalid input: expected string…") never reach the screen — the schema
-// decides WHETHER a value is valid, this copy says what to do about it.
-//
-// Country is the only sub-field that needs its own copy, because it is the only
-// one whose rule is not a length bound. No sub-field is required, so every other
-// one can fail only by being too long, and the generic length message says that
-// better than a per-sub-field phrasing could: it names the limit.
-const COUNTRY_CODE_MESSAGE = 'Enter a 2-letter country code, like US.';
-
-/** A schema issue translated into copy a person can act on. */
-function friendlyValidationMessage(
-    field: MemberCustomField,
-    issue: {code?: string; path: ReadonlyArray<PropertyKey>; maximum?: unknown}
-): string {
-    if (field.type === 'address' && issue.path[0] === 'country') {
-        return COUNTRY_CODE_MESSAGE;
-    }
-    // The composite's own rule, which names no sub-field: an address has to say
-    // something. The editor normalizes an all-blank address to a clear before it
-    // validates, so this is a backstop rather than a message the screen shows.
-    if (field.type === 'address' && issue.path.length === 0) {
-        return 'Enter at least one part of the address.';
-    }
-    const tooBigMaximum = issue.code === 'too_big' && typeof issue.maximum === 'number' ? issue.maximum : undefined;
-    if (tooBigMaximum !== undefined) {
-        return `Use ${tooBigMaximum} characters or fewer.`;
-    }
-    // The remaining scalar rule is long_text's byte bound; characters are the
-    // unit a person can reason about, bytes are not.
-    return 'This text is too long to save. Shorten it a little.';
-}
-
 /**
  * Client-side validation of custom field values against the shared catalog
- * schemas — the same schemas the server enforces, so the two can never
- * disagree on substance. Returns messages keyed by `fieldKey` (scalar) or
- * `fieldKey.subfield` (composite sub-field), matching the path shape of the
- * server's 422 `property` so both error sources render through one map.
- * Cleared/empty values are always valid — fields are optional.
+ * schemas. Each rule carries its own message, so what this returns for a
+ * violation is the same sentence the server returns for it, and the screen
+ * reads the same whichever tier caught it. Returns messages keyed by
+ * `fieldKey` (scalar) or `fieldKey.subfield` (composite sub-field), matching
+ * the path shape of the server's 422 `property` so both error sources render
+ * through one map. Cleared/empty values are always valid — fields are optional.
  */
 export function getCustomFieldValidationErrors(
     draftCustomFields: Record<string, EditableCustomFieldValue>,
@@ -356,7 +324,7 @@ export function getCustomFieldValidationErrors(
         if (!result.success) {
             for (const issue of result.error.issues) {
                 const key = [field.key, ...issue.path].join('.');
-                errors[key] ??= friendlyValidationMessage(field, issue);
+                errors[key] ??= issue.message;
             }
         }
     }

--- a/ghost/core/core/server/services/members-custom-fields/values-service.ts
+++ b/ghost/core/core/server/services/members-custom-fields/values-service.ts
@@ -164,14 +164,15 @@ export class CustomFieldValuesService {
                 continue;
             }
 
-            // The issue path names the offending part, so `property` reads
-            // `custom_fields.home_address.postal_code`.
+            // Message only, no `context`: the API error handler moves a message into
+            // `context` when `context` is empty and prepends it when it is not, so
+            // anything added here reaches the client glued to the front of the reason.
+            // Which field failed rides in `property`.
             const value = FIELD_TYPES[field.type].value.safeParse(raw);
             if (!value.success) {
                 const issue = value.error.issues[0];
                 throw new errors.ValidationError({
-                    message: `Invalid value for custom field '${field.name}'.`,
-                    context: issue.message,
+                    message: issue.message,
                     property: [`custom_fields.${key}`, ...issue.path].join('.')
                 });
             }

--- a/ghost/core/core/server/services/members/import-export/import/completion-email.ts
+++ b/ghost/core/core/server/services/members/import-export/import/completion-email.ts
@@ -34,14 +34,19 @@ interface EmailPayload {
 
 // Turn an ORM validation error into copy a member manager can act on. Presentation
 // only: the API response keeps the raw messages, and just the emailed report is
-// rewritten.
-function humaniseError(message: string): string {
+// rewritten. Takes one reason at a time, so a rewrite matching to the end of its input
+// cannot consume the reason after it.
+function humaniseReason(message: string): string {
     return message
         .replace('Value in [members.email] cannot be blank.', 'Missing email address')
         .replace('Value in [members.note] exceeds maximum length of 2000 characters.', '"Note" exceeds maximum length of 2000 characters')
         .replace('Value in [members.subscribed] must be one of true, false, 0 or 1.', 'Value in "Subscribed to emails" must be "true" or "false"')
         .replace('Validation (isEmail) failed for email', 'Invalid email address')
-        .replace(/No such customer:[^,]*/, 'Could not find Stripe customer');
+        .replace(/No such customer:[\s\S]*/, 'Could not find Stripe customer');
+}
+
+function humaniseError(row: ImportErrorRow): string {
+    return row.errors.map(humaniseReason).join('\n');
 }
 
 // One row of the fixed, member-vocabulary part of the error report, in emit order.
@@ -93,7 +98,7 @@ function toErrorReportRow(row: ImportErrorRow): ErrorReportRow {
         labels: stringifyLabels(row.labels),
         tiers: '',
         gift_id: row.gift_id || null,
-        error: humaniseError(row.error)
+        error: humaniseError(row)
     };
 }
 

--- a/ghost/core/core/server/services/members/import-export/import/importer.ts
+++ b/ghost/core/core/server/services/members/import-export/import/importer.ts
@@ -432,15 +432,16 @@ class MembersCSVImporter {
                 imported += 1;
             } catch (error) {
                 const errorList: unknown[] = Array.isArray(error) ? error : [error];
-                const errorMessage = errorList
+                const reasons = errorList
                     .map(e => (typeof e === 'object' && e !== null && 'message' in e ? e.message : undefined))
-                    .join(', ');
+                    .filter((message): message is string => typeof message === 'string');
+                const errorMessage = reasons.join('\n');
                 // trx is unset if the row failed before the transaction opened (a bad
                 // custom field value or gift combination).
                 if (trx) {
                     await trx.rollback();
                 }
-                importErrors.push({...row, error: errorMessage});
+                importErrors.push({...row, error: errorMessage, errors: reasons});
             }
         }
 

--- a/ghost/core/core/server/services/members/import-export/import/importer.ts
+++ b/ghost/core/core/server/services/members/import-export/import/importer.ts
@@ -332,7 +332,7 @@ class MembersCSVImporter {
                 // before any member write -- so there is no reason to hold a transaction
                 // across it, and doing so would deadlock the single-connection SQLite pool.
                 const customFieldPlan = activeCustomFields.length > 0
-                    ? await this._customFields.planWrite(fieldValuesFromCsvRow(activeCustomFields, row, stripFormulaGuard))
+                    ? await namingTheColumn(() => this._customFields.planWrite(fieldValuesFromCsvRow(activeCustomFields, row, stripFormulaGuard)))
                     : [];
 
                 trx = await this._knex.transaction(undefined, {doNotRejectOnRollback: false});
@@ -454,6 +454,26 @@ class MembersCSVImporter {
             return {imported, errors: importErrors, importLabel: importLabelModel?.toJSON()};
         }
         return {imported: 0, errors: importErrors};
+    }
+}
+
+// A row error is read next to a spreadsheet, and a value rejection states only what the
+// value should be — the same sentence Admin shows under a single input, where the field is
+// already on screen. `property` is the dotted path a default export writes as its column
+// header, so prefixing with it names the column a publisher has to go and fix.
+//
+// A rejection about the whole request carries the bare namespace and names no field after
+// it, so it is left alone rather than made to point at a column that does not exist.
+async function namingTheColumn<T>(plan: () => Promise<T>): Promise<T> {
+    try {
+        return await plan();
+    } catch (error) {
+        const {property, message} = (error ?? {}) as {property?: unknown; message?: unknown};
+        const namesAField = typeof property === 'string' && property.includes('.');
+        if (!namesAField || typeof message !== 'string') {
+            throw error;
+        }
+        throw new errors.DataImportError({message: `${property}: ${message}`});
     }
 }
 

--- a/ghost/core/core/server/services/members/import-export/import/row.ts
+++ b/ghost/core/core/server/services/members/import-export/import/row.ts
@@ -42,7 +42,11 @@ export type MemberImportRow = z.infer<typeof memberImportRowSchema>;
 
 // A row that failed to import, carrying the raw message that stopped it. The message is
 // left raw here; turning it into human copy is a presentation concern.
-export type ImportErrorRow = MemberImportRow & {error: string};
+// A row can fail for more than one reason. `errors` is the list; `error` is that list
+// written out for the error report's single cell. Two fields because a reason may quote a
+// cell the publisher wrote, and a CSV cell legally holds commas and newlines, so no
+// separator survives being split back apart.
+export type ImportErrorRow = MemberImportRow & {error: string; errors: string[]};
 
 // The persisted import label as plain data -- taken off the Bookshelf model before it
 // leaves the kernel, so the result and the email carry only what they show.

--- a/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
@@ -882,6 +882,84 @@ describe('Member Custom Fields Admin API', function () {
             await setValues(memberId, {[field.key]: ''}, 422);
         });
 
+        describe('what a rejected value says', function () {
+            // `message` is the generic "cannot edit member" every rejection carries; the
+            // reason a person reads is `context`.
+            async function reasonFor(customFields: Record<string, unknown>, memberId: string) {
+                const body = await setValues(memberId, customFields, 422);
+                return body.errors[0].context;
+            }
+
+            it('gives a length failure the limit rather than the measurement', async function () {
+                const field = await createField({name: 'Job title'});
+                const memberId = await createMember();
+
+                assert.equal(
+                    await reasonFor({[field.key]: 'x'.repeat(256)}, memberId),
+                    'Use 255 characters or fewer.'
+                );
+            });
+
+            it('gives a sub-field failure the sub-field\'s own limit, not the field\'s', async function () {
+                // postal_code is bounded well under the 255 its siblings carry, and the
+                // reason has to name the bound that actually stopped the save.
+                const field = await createField({name: 'Home address', type: 'address'});
+                const memberId = await createMember();
+
+                assert.equal(
+                    await reasonFor({[field.key]: {postal_code: 'x'.repeat(33)}}, memberId),
+                    'Use 32 characters or fewer.'
+                );
+            });
+
+            it('says what a country code should be, whichever way it was wrong', async function () {
+                // One rule broken three ways; fixing any of them needs the same sentence.
+                const field = await createField({name: 'Home address', type: 'address'});
+                const memberId = await createMember();
+                const expected = 'Enter a 2-letter country code, like US.';
+
+                assert.equal(await reasonFor({[field.key]: {country: 'IRL'}}, memberId), expected);
+                assert.equal(await reasonFor({[field.key]: {country: '12'}}, memberId), expected);
+                assert.equal(await reasonFor({[field.key]: {country: 'D'}}, memberId), expected);
+            });
+
+            it('asks for a part when an address names none', async function () {
+                const field = await createField({name: 'Home address', type: 'address'});
+                const memberId = await createMember();
+
+                assert.equal(
+                    await reasonFor({[field.key]: {}}, memberId),
+                    'Enter at least one part of the address.'
+                );
+            });
+
+            it('hands the caller a sentence rather than schema wording', async function () {
+                // Covers what the API can be sent, not only what the editor sends. The
+                // catalog's own test walks every rule; this proves the sentence survives
+                // the service, the error handler and the wire.
+                const address = await createField({name: 'Home address', type: 'address'});
+                const text = await createField({name: 'Job title'});
+                const memberId = await createMember();
+                const schemaWording = /Too big|Too small|Invalid input|Unrecognized|expected /;
+
+                const reasons = [
+                    await reasonFor({[text.key]: 'x'.repeat(256)}, memberId),
+                    await reasonFor({[text.key]: 42}, memberId),
+                    await reasonFor({[address.key]: {line1: 'x'.repeat(256)}}, memberId),
+                    await reasonFor({[address.key]: {postal_code: 'x'.repeat(33)}}, memberId),
+                    await reasonFor({[address.key]: {country: 'IRL'}}, memberId),
+                    await reasonFor({[address.key]: {city: 42}}, memberId),
+                    await reasonFor({[address.key]: {}}, memberId)
+                ];
+
+                for (const reason of reasons) {
+                    assert.doesNotMatch(reason, schemaWording);
+                    // A sentence, not a fragment: something a screen can show unedited.
+                    assert.match(reason, /^[A-Z].*\.$/);
+                }
+            });
+        });
+
         it('omits a stored value whose type is no longer valid, without failing the read', async function () {
             // Stored data outlives the catalog: if a value's field type is later
             // dropped or renamed, reading the member must degrade — omit that one

--- a/ghost/core/test/e2e-api/admin/members-import-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/members-import-custom-fields.test.ts
@@ -259,7 +259,11 @@ describe('Members import — custom fields', function () {
         assert.equal(res.status, 201);
         assert.equal(res.body.meta.stats.imported, 0);
         assert.equal(res.body.meta.stats.invalid.length, 1);
-        assert.match(res.body.meta.stats.invalid[0].error, /Shipping Address/);
+        // Read next to a spreadsheet, so it names the column down to the sub-field.
+        assert.equal(
+            res.body.meta.stats.invalid[0].error,
+            `custom_fields.${key}.country: Enter a 2-letter country code, like US.`
+        );
 
         assert.equal(await findMember(email), undefined, 'the failed row created no member');
     });
@@ -272,7 +276,10 @@ describe('Members import — custom fields', function () {
         assert.equal(res.status, 201);
         assert.equal(res.body.meta.stats.imported, 0);
         assert.equal(res.body.meta.stats.invalid.length, 1);
-        assert.match(res.body.meta.stats.invalid[0].error, /Nickname/);
+        assert.equal(
+            res.body.meta.stats.invalid[0].error,
+            `custom_fields.${key}: Use 255 characters or fewer.`
+        );
 
         assert.equal(await findMember(email), undefined);
     });

--- a/ghost/core/test/e2e-api/admin/members-import-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/members-import-custom-fields.test.ts
@@ -268,6 +268,20 @@ describe('Members import — custom fields', function () {
         assert.equal(await findMember(email), undefined, 'the failed row created no member');
     });
 
+    // A reason carries the punctuation of the copy it quotes; this one has a comma in it.
+    it('carries a row\'s reasons as a list, so punctuation inside one cannot split it', async function () {
+        const key = await createField('Shipping Address', 'address');
+        const email = 'cf-reason-list@example.com';
+
+        const res = await importCSV(`email,custom_fields.${key}.country\n${email},IRL\n`);
+        assert.equal(res.status, 201);
+        assert.equal(res.body.meta.stats.invalid.length, 1);
+
+        const reason = `custom_fields.${key}.country: Enter a 2-letter country code, like US.`;
+        assert.deepEqual(res.body.meta.stats.invalid[0].errors, [reason]);
+        assert.equal(res.body.meta.stats.invalid[0].error, reason);
+    });
+
     it('fails a row whose value is too long for its field type', async function () {
         const key = await createField('Nickname', 'short_text');
         const email = 'cf-too-long@example.com';

--- a/ghost/core/test/unit/server/services/members/import-export/import/completion-email.test.ts
+++ b/ghost/core/test/unit/server/services/members/import-export/import/completion-email.test.ts
@@ -38,9 +38,9 @@ describe('members import completion email', function () {
 
     it('rewrites raw ORM validation errors into human copy', function () {
         const email = build([
-            {email: '', subscribed: true, complimentary_plan: false, labels: [], error: 'Value in [members.email] cannot be blank.'},
-            {email: 'bad', subscribed: true, complimentary_plan: false, labels: [], error: 'Validation (isEmail) failed for email'},
-            {email: 'x', subscribed: true, complimentary_plan: false, labels: [], error: 'No such customer: cus_123'}
+            {email: '', subscribed: true, complimentary_plan: false, labels: [], error: 'Value in [members.email] cannot be blank.', errors: ['Value in [members.email] cannot be blank.']},
+            {email: 'bad', subscribed: true, complimentary_plan: false, labels: [], error: 'Validation (isEmail) failed for email', errors: ['Validation (isEmail) failed for email']},
+            {email: 'x', subscribed: true, complimentary_plan: false, labels: [], error: 'No such customer: cus_123', errors: ['No such customer: cus_123']}
         ]);
         const report = email.attachments[0].content;
 
@@ -57,7 +57,8 @@ describe('members import completion email', function () {
             email: 'x@example.com', name: 'Sam', note: 'a note',
             subscribed: false, complimentary_plan: true, stripe_customer_id: 'cus_1',
             labels: [{name: 'vip'}, {name: 'gold'}], gift_id: 'gift_1',
-            error: 'Validation (isEmail) failed for email'
+            error: 'Validation (isEmail) failed for email',
+            errors: ['Validation (isEmail) failed for email']
         }]).attachments[0].content;
 
         const [header, row] = report.split('\r\n');
@@ -67,7 +68,7 @@ describe('members import completion email', function () {
     });
 
     it('escapes CSV-injection characters so a spreadsheet cannot run them', function () {
-        const report = build([{email: 'x@example.com', name: '=1+2', subscribed: true, complimentary_plan: false, labels: [], error: 'nope'}]).attachments[0].content;
+        const report = build([{email: 'x@example.com', name: '=1+2', subscribed: true, complimentary_plan: false, labels: [], error: 'nope', errors: ['nope']}]).attachments[0].content;
         const row = report.split('\r\n')[1];
         assert.ok(row.includes(`"'=1+2"`), 'formula-leading value is quoted and apostrophe-escaped');
     });

--- a/packages/custom-field-types/src/index.ts
+++ b/packages/custom-field-types/src/index.ts
@@ -26,12 +26,28 @@ import {z} from 'zod';
  * site has defined; a misspelled part is refused here, because a type's parts are declared
  * in this file and nowhere else. Each is enforced where the names are known.
  *
+ * ## What a failure says
+ *
+ * A rule carries the sentence shown when it is broken, so the two cannot drift. Each
+ * states what is expected rather than what went wrong, so one sentence covers every way
+ * of breaking that rule.
+ *
+ * The sentences are plain literals with no interpolation, so each is usable as a
+ * translation key. Nothing here translates: Ghost's parser reads `t()` calls out of the
+ * app that renders a string, so that app owns the step. Admin, the only one today, is not
+ * translated at all.
+ *
+ * Two failures keep zod's own wording, both reachable only by a client sending the wrong
+ * JSON shape: a composite handed something that is not an object, and a part nobody
+ * declared. Naming the offending key serves whoever has to fix that client.
+ *
  * ## What this package will not do
  *
- * No presentation: labels, icons and input controls belong to the frontend. No storage:
- * columns and codecs belong to the backend. One exception lives in `./csv` — how a value
- * maps onto CSV columns — because both tiers need the same answer and a disagreement
- * between them is a file that silently stops round-tripping.
+ * No presentation beyond that sentence: labels, icons and input controls belong to the
+ * frontend, and so does any wording that depends on where it appears rather than on which
+ * rule was broken. No storage: columns and codecs belong to the backend. One exception
+ * lives in `./csv` — how a value maps onto CSV columns — because both tiers need the same
+ * answer and a disagreement between them is a file that silently stops round-tripping.
  */
 
 /** The source for the union type, the zod enum and the `FIELD_TYPES` keys alike. */
@@ -56,12 +72,12 @@ const byteLength = (value: string): number => new TextEncoder().encode(value).le
  * Builders are named after what a value is rather than taking a size, so that a bound
  * lives with everything else true of that thing instead of as a number at the call site.
  */
-const text = () => z.string().trim();
+const text = () => z.string({error: 'Enter text.'}).trim();
 
-const shortText = () => text().max(255);
+const shortText = () => text().max(255, {error: 'Use 255 characters or fewer.'});
 
 const longText = () => text().refine(value => byteLength(value) <= MAX_LONG_TEXT_BYTES, {
-    message: `Value must be at most ${MAX_LONG_TEXT_BYTES} bytes.`
+    error: 'This text is too long to save. Shorten it a little.'
 });
 
 /**
@@ -70,7 +86,7 @@ const longText = () => text().refine(value => byteLength(value) <= MAX_LONG_TEXT
  * countries to check the shape of one without knowing which country it is for, and the
  * country is a sibling part rather than something this can see.
  */
-const postalCode = () => text().max(32);
+const postalCode = () => text().max(32, {error: 'Use 32 characters or fewer.'});
 
 /**
  * The shape of an ISO 3166-1 alpha-2 code, deliberately not checked against the list of
@@ -84,7 +100,7 @@ const postalCode = () => text().max(32);
  * Checked as two ASCII letters on the way in rather than by length on the way out, because
  * uppercasing does not preserve length: `ß` becomes `SS` and `aß` becomes `ASS`.
  */
-const countryCode = () => text().regex(/^[A-Za-z]{2}$/).toUpperCase();
+const countryCode = () => text().regex(/^[A-Za-z]{2}$/, {error: 'Enter a 2-letter country code, like US.'}).toUpperCase();
 
 /**
  * Both ends are pinned to a string because storage keeps one string per leaf: a type
@@ -133,17 +149,18 @@ function defineFieldTypes<D extends Record<FieldType, FieldTypeDeclaration>>(dec
  * explicitly undefined survives parsing as a key holding undefined, and a bare presence
  * check would let `{line1: undefined}` through as if it named something.
  */
-function record<F extends Record<string, PartSchema>>(fields: F) {
+function record<F extends Record<string, PartSchema>>(fields: F, {error}: {error: string}) {
     // Restated for the type system, which loses the key-to-schema mapping through
     // `Object.fromEntries`; without it every type built on a record infers as `unknown`.
     const shape = Object.fromEntries(
         Object.entries(fields).map(([key, part]) => [key, clearable(part)])
     ) as {[K in keyof F]: ReturnType<typeof clearable<F[K]>>};
 
-    // Strict, so a part nobody declared is refused rather than dropped.
+    // Strict, so a part nobody declared is refused rather than dropped. That refusal keeps
+    // zod's wording, which names the offending key.
     const value = z.strictObject(shape).refine(
         parts => Object.values(parts).some(part => typeof part === 'string'),
-        {message: 'A value must name at least one part.'}
+        {error}
     );
 
     return {value, fields};
@@ -161,7 +178,7 @@ export const FIELD_TYPES = defineFieldTypes({
         state: shortText(),
         postal_code: postalCode(),
         country: countryCode()
-    })
+    }, {error: 'Enter at least one part of the address.'})
 });
 
 /** Named for the admin types built on it, which speak of an address rather than a record. */

--- a/packages/custom-field-types/test/index.test.ts
+++ b/packages/custom-field-types/test/index.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import {describe, it} from 'vitest';
-import {FIELD_TYPES, FIELD_TYPE_IDS, MAX_LONG_TEXT_BYTES, subFieldsOf} from '../src/index.ts';
+import {FIELD_TYPES, FIELD_TYPE_IDS, MAX_LONG_TEXT_BYTES, subFieldsOf, type FieldType} from '../src/index.ts';
 
 // This asserts only the catalog's *contract* — which field types exist, and which of
 // them have parts. The behavioural outcomes (per-type value validation, the composite
@@ -172,6 +172,53 @@ describe('custom-field-types catalog', function () {
             const result = FIELD_TYPES.address.value.safeParse({line1: '   ', city: '\t'});
             assert.equal(result.success, true);
             assert.deepEqual(result.data, {line1: '', city: ''});
+        });
+    });
+
+    describe('what a broken rule says', function () {
+        const reasonFor = (type: FieldType, value: unknown): string | null => {
+            const result = FIELD_TYPES[type].value.safeParse(value);
+            return result.success ? null : result.error.issues[0]?.message ?? null;
+        };
+
+        it('states what each rule expects', function () {
+            assert.equal(reasonFor('short_text', 'x'.repeat(256)), 'Use 255 characters or fewer.');
+            assert.equal(reasonFor('long_text', 'x'.repeat(MAX_LONG_TEXT_BYTES + 1)), 'This text is too long to save. Shorten it a little.');
+            assert.equal(reasonFor('address', {line1: 'x'.repeat(256)}), 'Use 255 characters or fewer.');
+            assert.equal(reasonFor('address', {postal_code: 'x'.repeat(33)}), 'Use 32 characters or fewer.');
+            assert.equal(reasonFor('address', {country: 'IRL'}), 'Enter a 2-letter country code, like US.');
+            assert.equal(reasonFor('address', {}), 'Enter at least one part of the address.');
+            assert.equal(reasonFor('short_text', 42), 'Enter text.');
+            assert.equal(reasonFor('address', {city: 42}), 'Enter text.');
+        });
+
+        it('says the same thing however one rule was broken', function () {
+            const expected = 'Enter a 2-letter country code, like US.';
+            for (const country of ['IRL', '12', 'D', 'ÜÜ']) {
+                assert.equal(reasonFor('address', {country}), expected, country);
+            }
+        });
+
+        it('holds a sentence for every rule a value can break', function () {
+            // Notices a rule added without wording, which falls back to zod's phrasing.
+            const brokenValues: Array<[FieldType, unknown]> = [
+                ['short_text', 'x'.repeat(256)],
+                ['short_text', 42],
+                ['long_text', 'x'.repeat(MAX_LONG_TEXT_BYTES + 1)],
+                ['address', {}],
+                ['address', {city: 42}],
+                ...subFieldsOf('address')!.map(part => [
+                    'address', {[part]: 'x'.repeat(256)}
+                ] as [FieldType, unknown])
+            ];
+
+            for (const [type, value] of brokenValues) {
+                const reason = reasonFor(type, value);
+                assert.ok(reason, `${type} ${JSON.stringify(value)} should be rejected`);
+                assert.doesNotMatch(reason, /Too big|Too small|Invalid input|expected /, `${type} ${JSON.stringify(value)}`);
+                // A whole sentence: a screen shows it unedited.
+                assert.match(reason, /^[A-Z].*\.$/, `${type} ${JSON.stringify(value)}`);
+            }
         });
     });
 });


### PR DESCRIPTION
## Problem

The same rejected custom field value read two different ways depending on which tier caught it. Typing `IRL` into a country box got "Enter a 2-letter country code, like US." from Admin, and "Too big: expected string to have <=2 characters" from the server, because the API carried zod's raw wording straight through.

Underneath that, Admin worked out which rule had failed from incidental properties of the failure — a zod issue code plus a path — and wrote its own copy from them. Any rule that didn't fit those guesses fell through to "This text is too long to save", whether or not length had anything to do with it. Giving the postal code a format rule would have produced exactly that, silently.

## Solution

Each rule in the shared catalog now carries the sentence shown when it is broken. Each states what is expected rather than what went wrong, so one sentence covers every way a value can break that rule and nobody has to work out which way it was: too long, not letters, and too short are one message, because they are one thing to fix.

The sentence travels as the rejection's message, which is what the API error handler surfaces on its own, so the server and the browser now return the identical string for the identical value. Admin renders it as given, and the function that used to invent copy is gone.

A CSV row error is read next to a spreadsheet rather than under an input, so the importer adds the column it is about — the one piece of wording that genuinely depends on where it appears.

## Not doing

Translation plumbing. The sentences are plain literals with no interpolation, so each is already a usable translation key, but Ghost extracts keys from `t()` calls in the app that renders them, and the only app rendering these today is Admin, which isn't translated. Portal doesn't consume custom fields at all yet. Wiring extraction now would build a seam with nothing on the other side of it.

Discriminated error codes. They were the original plan for this ticket, and they turn out to be unnecessary for copy once a rule states its own expectation. Worth adding later if a consumer needs to branch on a failure rather than show it.

ref BER-3845
