### PR TITLE
Improved boot time by dropping the date-fns barrel import

### DIFF
--- a/ghost/core/core/server/adapters/route-settings/utils.ts
+++ b/ghost/core/core/server/adapters/route-settings/utils.ts
@@ -2,21 +2,6 @@ import path from 'path';
 
 const pad = (value: number, length = 2): string => String(value).padStart(length, '0');
 
-/**
- * Local-time `yyyy-MM-dd-HH-mm-ss`, matching what `date-fns` produced here
- * before it was removed.
- *
- * Deliberately hand-rolled: this module is imported by the route-settings
- * stores, which are constructed during boot, so importing the library here
- * pulled 313 extra modules onto the boot path for a helper that only ever
- * runs on upload.
- *
- * Only safe for a valid `Date`. Unlike `date-fns` it does not throw on an
- * invalid one, and it has no era handling for years before 1 AD — the sole
- * caller passes `new Date()`, so neither is reachable. If you need either,
- * or any locale- or timezone-dependent token, reach for a library rather
- * than extending this.
- */
 const timestamp = (date: Date): string => [
     pad(date.getFullYear(), 4),
     pad(date.getMonth() + 1),

--- a/ghost/core/core/server/adapters/route-settings/utils.ts
+++ b/ghost/core/core/server/adapters/route-settings/utils.ts
@@ -1,7 +1,32 @@
 import path from 'path';
-import {format} from 'date-fns';
+
+const pad = (value: number, length = 2): string => String(value).padStart(length, '0');
+
+/**
+ * Local-time `yyyy-MM-dd-HH-mm-ss`, matching what `date-fns` produced here
+ * before it was removed.
+ *
+ * Deliberately hand-rolled: this module is imported by the route-settings
+ * stores, which are constructed during boot, so importing the library here
+ * pulled 313 extra modules onto the boot path for a helper that only ever
+ * runs on upload.
+ *
+ * Only safe for a valid `Date`. Unlike `date-fns` it does not throw on an
+ * invalid one, and it has no era handling for years before 1 AD — the sole
+ * caller passes `new Date()`, so neither is reachable. If you need either,
+ * or any locale- or timezone-dependent token, reach for a library rather
+ * than extending this.
+ */
+const timestamp = (date: Date): string => [
+    pad(date.getFullYear(), 4),
+    pad(date.getMonth() + 1),
+    pad(date.getDate()),
+    pad(date.getHours()),
+    pad(date.getMinutes()),
+    pad(date.getSeconds())
+].join('-');
 
 export const getBackupRouteSettingsFilePath = (filePath: string): string => {
     const {dir, name, ext} = path.parse(filePath);
-    return path.join(dir, `${name}-${format(new Date(), 'yyyy-MM-dd-HH-mm-ss')}${ext}`);
+    return path.join(dir, `${name}-${timestamp(new Date())}${ext}`);
 };

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -159,7 +159,6 @@
         "countries-and-timezones": "3.9.0",
         "csso": "5.0.5",
         "csv-writer": "1.6.0",
-        "date-fns": "2.30.0",
         "dequal": "catalog:",
         "dompurify": "catalog:",
         "downsize-cjs": "1.1.2",

--- a/ghost/core/test/unit/server/adapters/route-settings/utils.test.ts
+++ b/ghost/core/test/unit/server/adapters/route-settings/utils.test.ts
@@ -9,11 +9,6 @@ describe('UNIT: route-settings adapter utils', function () {
             vi.useRealTimers();
         });
 
-        // The timestamp is formatted by hand, so pin the zero-padding
-        // explicitly — every field here is single-digit. The expectation is
-        // built from local-time components and CI runs the unit suite in
-        // America/New_York, so this also fails if the implementation switches
-        // to getUTC* accessors. Don't rewrite it in terms of Date.UTC.
         it('zero-pads every field of the timestamp', function () {
             vi.useFakeTimers();
             vi.setSystemTime(new Date(2026, 0, 2, 3, 4, 5));

--- a/ghost/core/test/unit/server/adapters/route-settings/utils.test.ts
+++ b/ghost/core/test/unit/server/adapters/route-settings/utils.test.ts
@@ -1,10 +1,29 @@
 import assert from 'node:assert/strict';
-import {describe, it} from 'vitest';
+import {afterEach, describe, it, vi} from 'vitest';
 
 import {getBackupRouteSettingsFilePath} from '../../../../../core/server/adapters/route-settings/utils';
 
 describe('UNIT: route-settings adapter utils', function () {
     describe('getBackupRouteSettingsFilePath', function () {
+        afterEach(function () {
+            vi.useRealTimers();
+        });
+
+        // The timestamp is formatted by hand, so pin the zero-padding
+        // explicitly — every field here is single-digit. The expectation is
+        // built from local-time components and CI runs the unit suite in
+        // America/New_York, so this also fails if the implementation switches
+        // to getUTC* accessors. Don't rewrite it in terms of Date.UTC.
+        it('zero-pads every field of the timestamp', function () {
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date(2026, 0, 2, 3, 4, 5));
+
+            assert.equal(
+                getBackupRouteSettingsFilePath('/content/settings/routes.yaml'),
+                '/content/settings/routes-2026-01-02-03-04-05.yaml'
+            );
+        });
+
         // Same naming scheme as the legacy SettingsPathManager.getBackupFilePath:
         // routes-yyyy-MM-dd-HH-mm-ss.<ext> next to the canonical file.
         it('produces a timestamped sibling path preserving the extension', function () {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2354,9 +2354,6 @@ importers:
       csv-writer:
         specifier: 1.6.0
         version: 1.6.0
-      date-fns:
-        specifier: 2.30.0
-        version: 2.30.0
       dequal:
         specifier: 'catalog:'
         version: 2.0.3


### PR DESCRIPTION
A bisect of Ghost's boot time found a step from ~1300ms to ~1420ms at 93faa3e5bf ("Switched route settings to read through the configured store", #29305). This removes the cause: an accidental `date-fns` barrel import on the boot path.

## What happened

#29305 changed `routeSettings.init()` to resolve its store through `adapterManager.getAdapter('route-settings')`. That loads `FileStore.ts` → `utils.ts`, and `utils.ts` did:

```ts
import {format} from 'date-fns';
```

That's the barrel — **313 modules**. Before the commit, the boot path only loaded the *subpath* `require('date-fns/format')` (**35 modules**) via `settings-path-manager.js`, which has since been deleted. So this was a straight regression rather than a newly introduced cost, and it has been on `main` since 15 July. `adapterManager.init()` now resolves every configured adapter in `initCore`, so it currently lands even earlier in boot than it did then.

The import exists to build a timestamped backup filename in `getBackupRouteSettingsFilePath()`. Its only callers are `FileStore.replace()` and `S3RouteSettingsStore.replace()` — the routes.yaml **upload** path. Boot never calls it. We were loading ~300 extra modules on every boot for a code path that only runs when someone uploads a routes.yaml.

## Evidence

Controlled A/B at 93faa3e5bf — require cache pre-seeded to match what is already resident at that point in boot, then load exactly what the commit newly pulls in:

| | time | new modules |
|---|---|---|
| as shipped | 121.4 ms | 305 |
| identical, barrel stubbed out | 13.3 ms | 18 |

The barrel accounts for **~108ms of the 121ms (89%)** and 287 of the 305 net-new modules.

This is independently corroborated by a separate benchmark on the release build, which measured **+264 files** in `require.cache` versus 6.52.x (3,853 → 4,117). The predicted net-new from the barrel is +272 date-fns modules (+287 including the `@babel/runtime` helpers it pulls), against a baseline that already had 41 resident — `date-fns/format` from `settings-path-manager.js` plus `date-fns/add`/`sub` from `@tryghost/nql-lang`. Two different metrics on two machines converging rules out a local artifact.

## Why hand-rolled rather than the subpath import

`import format from 'date-fns/format'` would recover ~115ms of the ~127ms available, so on milliseconds alone it is nearly as good. The reason to go further:

- **It makes the regression un-reintroducible.** With `date-fns` gone from `ghost/core/package.json`, pnpm's strict `node_modules` means `require('date-fns')` from ghost/core now fails with `MODULE_NOT_FOUND` (verified). The subpath form leaves the barrel one "organise imports" or one codemod away from silently re-landing all 120ms, with nothing in the test suite to catch it. For a regression that sat on `main` undetected for three weeks, durability matters more than the marginal 12ms.
- **The subpath ages badly.** date-fns v4 (already in the tree transitively) exports `format` as a *named* export only — `format.d.ts` has no default export — so `import format from 'date-fns/format'` becomes a type error on any upgrade, and the natural fix a future author reaches for is the barrel form.
- **`utils.ts` was the last `date-fns` reference anywhere in ghost/core**, so removing the import lets the direct dependency go too. Note this is *not* an install-size win — date-fns stays in the lockfile via `@tryghost/nql-lang` and `ember-template-lint`. It is purely a boot-path win.

There is no library behaviour being reimplemented here: `yyyy-MM-dd-HH-mm-ss` is six zero-padded local-time numeric fields with no locale- or timezone-dependent tokens.

## Verification

- Output is identical to the previous implementation **for any valid `Date`**, verified across a 200k random-date fuzz over 1970–2039 with 0 mismatches, run under several timezones including `America/New_York` and half-hour-DST zones, covering both DST transitions, leap days, year boundaries and all-single-digit fields. (It intentionally differs on inputs the sole caller cannot produce — an invalid `Date` yields `NaN` fields where date-fns throws, and there is no era handling below 1 AD. Both are documented in the JSDoc.)
- Added a test with a fixed system time pinning the zero-padding. CI runs the unit suite in `America/New_York`, so it also fails if the implementation switches to `getUTC*` accessors.
- `pnpm exec vitest run test/unit/server/adapters/route-settings/` — 46 tests across 4 files pass, including under `TZ=America/New_York`.
- `eslint` clean on both changed files; `tsc --noEmit` shows no new errors (the one reported error in `members-custom-fields/values-service.ts` is pre-existing on `main`).
- Confirmed `require('./core/server/adapters/route-settings/FileStore')` now loads **0** date-fns modules, down from 313.
- Lockfile diff is 3 lines — only the ghost/core importer entry.

## Follow-ups (deliberately not in this PR)

- **A boot-time guard in CI.** We had no boot signal at all, which is why this went unnoticed for three weeks. A `require.cache` size assertion after boot would have caught it at review time and, unlike a wall-clock threshold, wouldn't be flaky. Worth pairing with a coarse timing check, since module count is a proxy for cost rather than the cost itself.
- **`getBackupRedirectsFilePath()` in `custom-redirects/utils.ts` is a near-identical twin of this helper** but formats via `moment-timezone`, which `overrides.js` pins to UTC — so the two mirrored adapter families currently write differently-zoned backup filenames. Pre-existing, not touched here, but worth a ticket.
