### PR TITLE
Added internal package migration skill

### DIFF
--- a/.agents/skills/migrate-internal-package/SKILL.md
+++ b/.agents/skills/migrate-internal-package/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: migrate-internal-package
+description: Move a package from another TryGhost repository into Ghost as an internal-only workspace package while preserving its Git history. Use for package migrations from repositories such as TryGhost/SDK or TryGhost/framework, including the history import PR, exceptional merge-commit handoff, source-repository removal PR, optional npm deprecation, migration cleanup, and modernization handoff.
+---
+
+# Migrate an internal package into Ghost
+
+Move a package from another TryGhost repository into Ghost without losing its
+history or creating a period where neither repository owns it. Keep migration
+mechanics separate from Ghost's lifetime package standards.
+
+## Authority boundaries
+
+Explain every cross-repository or administrative action before it happens.
+
+- A request for instructions is not permission to perform the action.
+- If the user says "tell me how, I do it", provide the command and wait.
+- Require explicit authorization before changing repository settings, merging a
+  PR, deprecating npm versions, or force-pushing.
+- Never ask for, display, or store credentials or OTPs.
+
+## Confirm this workflow applies
+
+Before changing either repository, record the source repository, its default
+branch, the package path within it, the destination path in Ghost, and whether
+the package has been published to npm. Then:
+
+1. Find every Ghost and source-repository reference to the package name and
+   directory.
+2. Inspect its npm metadata, README, documentation, release configuration and
+   known public consumers.
+3. Confirm Ghost is the real owner and can consume it via `workspace:*`.
+4. Identify any need for independent releases or supported external use.
+
+Publication or download counts alone do not prove that a package must remain a
+supported public API. If supported external consumers still need new releases,
+stop: this internal-only workflow is the wrong publishing model.
+
+## Produce these work products in order
+
+1. A green Ghost import PR with reachable source history.
+2. After it merges, a green source-repository removal PR.
+3. npm deprecation if the package was published and new direct use is
+   unsupported.
+4. A focused Ghost cleanup PR for stale migration-specific automation.
+5. A Ghost modernization PR assessed against the current package template and
+   comparable internal packages.
+
+Keep the history import and modernization separate. The import establishes
+ownership and provenance; later commits can modernize code without obscuring
+the move.
+
+## 1. Import the history into Ghost
+
+Read
+[`references/history-and-merge.md`](references/history-and-merge.md) completely
+before manipulating history.
+
+Use an unsquashed `git subtree` import from the recorded source repository and
+package path. Do not copy the current files, pass `--squash`, or recreate old
+commits manually.
+
+After the subtree commit, add focused integration commits that:
+
+- make the package private with an internal placeholder version;
+- switch Ghost consumers to `workspace:*`;
+- update the lockfile with `pnpm`;
+- minimally adapt configuration and tests to work in Ghost;
+- retain runtime behavior for the later modernization PR.
+
+Verify that the subtree commit has two parents and that representative file
+history crosses into the source repository before opening the PR.
+
+## 2. Merge the import without rewriting history
+
+This is the exceptional PR. It must use GitHub's **Create a merge commit**
+method:
+
+- squash merge discards the imported ancestry;
+- rebase merge cannot preserve the subtree merge topology.
+
+Make CI green, then stop at the merge checkpoint. If the merge-commit option is
+disabled, an authorized org admin should run:
+
+```bash
+.agents/skills/migrate-internal-package/scripts/merge-history-pr \
+    TryGhost/Ghost \
+    <pr-number> \
+    <source-split-tip> \
+    --confirm
+```
+
+An agent without admin authority should provide that exact handoff rather than
+attempting a workaround. The script performs preflight checks, records and
+temporarily changes the setting, uses the correct merge form, restores the
+setting, and verifies the resulting history.
+
+Afterward, independently fetch `main` and confirm the source split tip is an
+ancestor before starting source-repository cleanup.
+
+## 3. Remove the package from the source repository
+
+Branch from the latest source default branch only after the Ghost import is
+verified on `main`. Remove:
+
+- the package directory;
+- workspace and lockfile entries;
+- release, Changesets and publishing configuration;
+- package-specific Renovate rules;
+- tests, documentation and examples that claim source-repository ownership;
+- remaining source-repository consumers or imports.
+
+Search with both the npm name and directory name. The source-repository PR
+should link to the merged Ghost PR and state that Ghost now owns the
+implementation. Use that repository's normal merge policy; this PR does not
+contain imported ancestry.
+
+## 4. Deprecate npm when appropriate
+
+If the package was published and new direct use is now unsupported, deprecate
+all historical versions rather than unpublishing them:
+
+```bash
+npm deprecate '@tryghost/<package>@*' \
+  'This package is now maintained as an internal Ghost workspace package. Existing versions remain available for older Ghost releases; direct use is unsupported.'
+npm view @tryghost/<package> deprecated
+```
+
+This preserves installation for old Ghost releases. Authentication and OTP are
+human checkpoints; verify the public metadata after the authorized user runs
+the mutation.
+
+## 5. Remove migration-specific automation
+
+Search `.github/renovate.json5` and related release automation for rules that
+still treat the package as sourced or released from the former repository or
+npm. Prefer a small,
+standalone cleanup PR so the later conversion remains focused.
+
+## 6. Hand off to the package golden path
+
+Compare the package against `packages/_template`, current comparable internal
+packages, and any canonical package guidance in the repository. Do not turn
+this one-time migration skill into the source of lifetime package standards.
+
+For a legacy `lib/*.js` package, preserve file lineage with three focused
+commits:
+
+1. `Moved ... sources from lib to src` — paths and path references only.
+2. `Changed ... file extensions to TypeScript` — mechanical renames and the
+   minimum compilation scaffolding.
+3. `Converted ... to TypeScript` — types, ESM semantics and cleanup.
+
+Use `git diff --summary` after mechanical commits and confirm Git recognizes
+the files as renames. A small CommonJS forwarding shim may correctly appear as
+a deletion when a real ESM export replaces it.
+
+This modernization PR may be rebase-merged when the commits are independently
+valid and intentionally ordered. That does not alter the merge-commit
+requirement for the earlier subtree import.
+
+## Completion criteria
+
+Do not call the migration complete until:
+
+- the source split history is reachable from Ghost `main`;
+- Ghost consumes the workspace package;
+- the source repository no longer consumes or publishes it;
+- npm status matches the chosen support policy;
+- stale migration automation is gone;
+- the package satisfies the repository's current internal-package standards;
+- relevant package, consumer and archive checks pass;
+- temporarily changed repository settings are restored.
+
+At each boundary, distinguish what is merged from what is merely prepared and
+report the exact verification performed.
+
+## Exclusions
+
+Do not use this workflow for packages that remain public, independently
+versioned, or supported for third-party use. This skill describes privileged
+operations but does not authorize them.

--- a/.agents/skills/migrate-internal-package/references/history-and-merge.md
+++ b/.agents/skills/migrate-internal-package/references/history-and-merge.md
@@ -1,0 +1,123 @@
+# History-preserving package import
+
+Read this reference before creating the Ghost import PR.
+
+## Create package-only source history
+
+Work from an up-to-date clone of the source repository. Use its actual default
+branch and a temporary branch name that cannot be confused with a product
+branch. For example, when the default branch is `main`:
+
+```bash
+git fetch origin
+git switch --detach origin/main
+git subtree split \
+  --prefix=<source-package-path> \
+  -b migrate-<package>-history
+```
+
+Record the split tip and inspect the resulting package-only history:
+
+```bash
+git rev-parse migrate-<package>-history
+git log --oneline --reverse migrate-<package>-history
+```
+
+`git subtree split` retains the relevant commit authorship and chronology while
+excluding unrelated source-repository paths.
+
+## Attach the history to Ghost
+
+From a branch based on freshly fetched Ghost `origin/main`, fetch the local
+source split and add it without `--squash`:
+
+```bash
+git fetch /absolute/path/to/source-repository migrate-<package>-history
+git subtree add \
+  --prefix=packages/<ghost-directory> \
+  FETCH_HEAD
+```
+
+The resulting commit should include:
+
+```text
+git-subtree-dir: packages/<ghost-directory>
+git-subtree-mainline: <ghost-parent>
+git-subtree-split: <source-split-tip>
+```
+
+Verify the topology before adding integration commits:
+
+```bash
+git show --no-patch --format='%H%nparents: %P%n%B' HEAD
+git log --graph --oneline --decorate --all --max-count=40
+git log --follow -- packages/<ghost-directory>/path/to/representative-file
+```
+
+The subtree commit must have two parents, and its second parent must equal the
+recorded split tip.
+
+The Admin API schema migration from TryGhost/SDK is a known-good example:
+
+- subtree commit: `a8fa1f10f23`
+- source split tip and second parent: `345f740bb4d`
+- GitHub merge commit on Ghost `main`: `6f2ae064fed`
+- import branch tip and second GitHub merge parent: `56f9cf0e1d2`
+
+## Validate the pull request
+
+Expect GitHub to show imported source commits in the PR commit list. Before the
+merge checkpoint:
+
+```bash
+gh pr checks <pr-number> --repo TryGhost/Ghost
+gh pr view <pr-number> --repo TryGhost/Ghost \
+  --json state,isDraft,mergeable,mergeStateStatus,headRefOid,baseRefOid
+```
+
+Resolve real failures and base conflicts without flattening the subtree merge.
+Verify the graph again after any branch update.
+
+## Use the guarded merge operation
+
+The merge must retain both the subtree topology and the import branch as the
+second parent of GitHub's merge commit. Do not manually reproduce the
+repository-setting sequence from prose.
+
+An authorized admin should run:
+
+```bash
+.agents/skills/migrate-internal-package/scripts/merge-history-pr \
+    TryGhost/Ghost \
+    <pr-number> \
+    <source-split-tip> \
+    --confirm
+```
+
+Use `--dry-run` instead of `--confirm` for read-only preflight. The script:
+
+1. verifies authentication, PR state, checks and imported-history reachability;
+2. records the current `allow_merge_commit` setting;
+3. enables merge commits only when necessary;
+4. merges with `--merge --match-head-commit`;
+5. restores the setting through an exit trap;
+6. verifies the merged commit has two parents;
+7. verifies the source split tip remains an ancestor of the merged result.
+
+If branch protection or a merge queue blocks the operation, report the exact
+blocker. Do not add `--admin` or bypass policy.
+
+## Verify independently
+
+After the script succeeds, fetch the remote rather than relying only on its
+output:
+
+```bash
+git fetch origin main
+git log --first-parent --oneline origin/main --max-count=10
+git show --no-patch --format='%H%nparents: %P%n%s' origin/main
+git merge-base --is-ancestor <source-split-tip> origin/main
+```
+
+The final command must exit zero. Only then begin cleanup in the source
+repository.

--- a/.agents/skills/migrate-internal-package/scripts/merge-history-pr
+++ b/.agents/skills/migrate-internal-package/scripts/merge-history-pr
@@ -86,8 +86,10 @@ setting_changed=false
 restore_setting() {
     if [[ $setting_changed == true ]]; then
         printf 'Restoring allow_merge_commit=%s...\n' "$original_setting" >&2
-        gh api --method PATCH "repos/$repo" \
-            -F "allow_merge_commit=$original_setting" >/dev/null
+        if ! gh api --method PATCH "repos/$repo" \
+            -F "allow_merge_commit=$original_setting" >/dev/null; then
+            return 1
+        fi
         setting_changed=false
     fi
 }

--- a/.agents/skills/migrate-internal-package/scripts/merge-history-pr
+++ b/.agents/skills/migrate-internal-package/scripts/merge-history-pr
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage:
+  merge-history-pr OWNER/REPO PR_NUMBER SOURCE_SPLIT_TIP --dry-run
+  merge-history-pr OWNER/REPO PR_NUMBER SOURCE_SPLIT_TIP --confirm
+
+Safely merge a Ghost history-import PR with a merge commit. The script records
+the repository's merge-commit setting, enables it only when needed, restores it
+on every exit path, and verifies that SOURCE_SPLIT_TIP remains reachable.
+
+--dry-run  Run read-only preflight checks without changing or merging anything.
+--confirm  Confirm explicit authorization to change settings and merge the PR.
+EOF
+}
+
+fail() {
+    printf 'error: %s\n' "$*" >&2
+    exit 1
+}
+
+[[ $# -eq 4 ]] || {
+    usage >&2
+    exit 2
+}
+
+repo=$1
+pr_number=$2
+split_tip=$3
+mode=$4
+
+[[ $repo =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] ||
+    fail "repository must be OWNER/REPO"
+[[ $pr_number =~ ^[1-9][0-9]*$ ]] ||
+    fail "PR number must be a positive integer"
+[[ $split_tip =~ ^[0-9a-fA-F]{40}$ ]] ||
+    fail "source split tip must be a full 40-character Git SHA"
+[[ $mode == --dry-run || $mode == --confirm ]] ||
+    fail "fourth argument must be --dry-run or --confirm"
+
+command -v gh >/dev/null || fail "gh is required"
+
+printf 'Checking GitHub authentication...\n'
+gh auth status >/dev/null
+
+state=$(gh pr view "$pr_number" --repo "$repo" --json state --jq '.state')
+is_draft=$(gh pr view "$pr_number" --repo "$repo" --json isDraft --jq '.isDraft')
+mergeable=$(gh pr view "$pr_number" --repo "$repo" --json mergeable --jq '.mergeable')
+merge_state=$(gh pr view "$pr_number" --repo "$repo" --json mergeStateStatus --jq '.mergeStateStatus')
+head_sha=$(gh pr view "$pr_number" --repo "$repo" --json headRefOid --jq '.headRefOid')
+
+[[ $state == OPEN ]] || fail "PR is not open (state: $state)"
+[[ $is_draft == false ]] || fail "PR is still a draft"
+[[ $mergeable == MERGEABLE ]] ||
+    fail "PR is not currently mergeable (mergeable: $mergeable)"
+
+printf 'Checking PR checks...\n'
+gh pr checks "$pr_number" --repo "$repo"
+
+history_status=$(gh api "repos/$repo/compare/$split_tip...$head_sha" --jq '.status')
+[[ $history_status == ahead || $history_status == identical ]] ||
+    fail "source split tip is not an ancestor of the PR head (compare status: $history_status)"
+
+original_setting=$(gh api "repos/$repo" --jq '.allow_merge_commit')
+[[ $original_setting == true || $original_setting == false ]] ||
+    fail "could not read the repository merge-commit setting"
+
+printf 'Preflight passed:\n'
+printf '  repository: %s\n' "$repo"
+printf '  PR:         %s\n' "$pr_number"
+printf '  head:       %s\n' "$head_sha"
+printf '  split tip:  %s\n' "$split_tip"
+printf '  merge state:%s\n' " $merge_state"
+printf '  setting:    allow_merge_commit=%s\n' "$original_setting"
+
+if [[ $mode == --dry-run ]]; then
+    printf 'Dry run complete; no settings changed and no merge performed.\n'
+    exit 0
+fi
+
+setting_changed=false
+
+restore_setting() {
+    if [[ $setting_changed == true ]]; then
+        printf 'Restoring allow_merge_commit=%s...\n' "$original_setting" >&2
+        gh api --method PATCH "repos/$repo" \
+            -F "allow_merge_commit=$original_setting" >/dev/null
+        setting_changed=false
+    fi
+}
+
+cleanup() {
+    exit_status=$?
+    trap - EXIT INT TERM
+    if ! restore_setting; then
+        printf 'CRITICAL: failed to restore the repository merge setting.\n' >&2
+        exit_status=1
+    fi
+    exit "$exit_status"
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+if [[ $original_setting == false ]]; then
+    printf 'Temporarily enabling merge commits...\n'
+    setting_changed=true
+    gh api --method PATCH "repos/$repo" \
+        -F allow_merge_commit=true >/dev/null
+fi
+
+printf 'Merging PR %s with a merge commit...\n' "$pr_number"
+gh pr merge "$pr_number" --repo "$repo" --merge \
+    --match-head-commit "$head_sha"
+
+restore_setting
+
+restored_setting=$(gh api "repos/$repo" --jq '.allow_merge_commit')
+[[ $restored_setting == "$original_setting" ]] ||
+    fail "repository merge setting was not restored"
+
+merged_at=$(gh pr view "$pr_number" --repo "$repo" --json mergedAt --jq '.mergedAt')
+merge_sha=$(gh pr view "$pr_number" --repo "$repo" --json mergeCommit --jq '.mergeCommit.oid')
+[[ -n $merged_at && $merged_at != null ]] || fail "PR does not report as merged"
+[[ $merge_sha =~ ^[0-9a-fA-F]{40}$ ]] || fail "could not determine merge commit SHA"
+
+parent_count=$(gh api "repos/$repo/commits/$merge_sha" --jq '.parents | length')
+[[ $parent_count == 2 ]] ||
+    fail "merged commit has $parent_count parents; expected 2"
+
+merged_history_status=$(gh api \
+    "repos/$repo/compare/$split_tip...$merge_sha" \
+    --jq '.status')
+[[ $merged_history_status == ahead || $merged_history_status == identical ]] ||
+    fail "source split tip is not an ancestor of the merged commit"
+
+trap - EXIT INT TERM
+
+printf 'History-preserving merge verified:\n'
+printf '  merge commit: %s\n' "$merge_sha"
+printf '  parents:      %s\n' "$parent_count"
+printf '  setting:      allow_merge_commit=%s (restored)\n' "$restored_setting"

--- a/.claude/skills/migrate-internal-package
+++ b/.claude/skills/migrate-internal-package
@@ -1,0 +1,1 @@
+../../.agents/skills/migrate-internal-package


### PR DESCRIPTION
## Summary

- Adds a reusable workflow for moving internal-only packages from another TryGhost repository, including SDK or Framework, into Ghost without losing their Git history.
- Documents the subtree import and exceptional merge-commit requirements, then separates source-repository cleanup, optional npm deprecation and package modernization into explicit stages.
- Includes a guarded admin script that validates the PR and imported ancestry, temporarily enables merge commits when required, restores the repository setting and verifies the resulting topology.
- Exposes the canonical `.agents` skill through the repository's `.claude/skills` symlink convention.

This PR intentionally contains only the migration workflow. Canonical lifetime standards for packages and their mechanical enforcement remain separate.

## Testing

- [x] `pnpm lint:docs`
- [x] `bash -n .agents/skills/migrate-internal-package/scripts/merge-history-pr`
- [x] Exercised the script's usage and argument-validation path
- [x] `git diff --check origin/main...HEAD`
- [x] Confirmed the merge script remains executable
- [x] Confirmed `.claude/skills/migrate-internal-package` resolves to the canonical skill
- [x] Previously exercised dry-run, successful-merge and failed-merge restoration paths with a mocked `gh` command; the generalization does not change that control flow
