### PR TITLE
Cleaned up the last stale apps/posts reference in a code comment

### DIFF
--- a/apps/admin-x-framework/src/api/members.ts
+++ b/apps/admin-x-framework/src/api/members.ts
@@ -618,7 +618,7 @@ const MEMBER_ACTIVITY_LIMIT = '20';
 // KNOWN LIMITATION: the cursor is `created_at`-only, without the id tie-breaker
 // Ember's version added (`+id:<'<lastId>'`). Two events emitted in the same
 // second on a page boundary can be skipped from the paginated list. The current
-// consumer (`MemberActivityFeed` in `apps/posts`) only fetches 5 events and
+// consumer (`MemberActivityFeed` in `apps/admin`) only fetches 5 events and
 // never calls `fetchNextPage`, so this is not exploitable today; add an id
 // secondary cursor before another screen starts paginating.
 function memberEventsCursor(events: MemberActivityEvent[]): string | undefined {


### PR DESCRIPTION
The `KNOWN LIMITATION` note on `memberEventsCursor` in `apps/admin-x-framework/src/api/members.ts` still pointed its consumer (`MemberActivityFeed`) at the deleted `apps/posts` workspace. The component lives in `apps/admin` (`src/members/detail/member-activity-feed.tsx`).

Comment-only change. Re-verified the claim the comment makes before touching it: the feed still fetches 5 events (`limit: '5'`) and never calls `fetchNextPage`, so the missing id tie-breaker in the cursor remains unexploitable today.

## Verification

- `git grep -n "apps/posts\|apps/stats"` across tracked files now returns no stale references
- eslint + dependency-cruiser ran clean on the file via the pre-commit hook