### PR TITLE
🐛 Fixed Web analytics loading during slow Admin boot

### DIFF
--- a/apps/admin/src/analytics/analytics.acceptance.test.tsx
+++ b/apps/admin/src/analytics/analytics.acceptance.test.tsx
@@ -127,6 +127,17 @@ describe("Analytics overview", () => {
 
 describe("Analytics web traffic", () => {
     it("renders the seeded KPIs, top content, sources and locations", async () => {
+        // Force the lazy Web route to render before settings boot finishes.
+        const boot = webAnalyticsBootOverrides();
+        const settings = boot.browseSettings?.response;
+        boot.browseSettings = {
+            response: async () => {
+                await new Promise<void>((resolve) => {
+                    setTimeout(resolve, 100);
+                });
+                return settings;
+            },
+        };
         seedAnalyticsWorld();
         seedTopPostsViews();
         fakeAdminStats.topContent([{
@@ -138,7 +149,7 @@ describe("Analytics web traffic", () => {
         }]);
         fakeTinybirdPipe("api_top_sources", [{ source: "google.com", visits: 170 }]);
         fakeTinybirdPipe("api_top_locations", [{ location: "US", visits: 200 }]);
-        await renderAdminApp("/analytics/web", { boot: webAnalyticsBootOverrides() });
+        await renderAdminApp("/analytics/web", { boot });
 
         await expect.element(analyticsScreen.webGraph()).toBeVisible();
         await expect.element(analyticsScreen.webGraph().getByRole("tab", { name: "Unique visitors" })).toHaveTextContent("250");

--- a/apps/admin/src/analytics/views/stats/web/web.tsx
+++ b/apps/admin/src/analytics/views/stats/web/web.tsx
@@ -149,7 +149,10 @@ const Web: React.FC = () => {
     // Calculate combined loading state
     const isPageLoading = isConfigLoading;
 
-    if (!webAnalyticsEnabled) {
+    // The Web tab is hidden when analytics is off, but a direct link can still
+    // land here. Wait until settings have loaded before redirecting so enabled
+    // sites are not bounced to Overview during boot.
+    if (appSettings && !webAnalyticsEnabled) {
         return (
             <Navigate to='/' />
         );


### PR DESCRIPTION
## What changed

- wait for Admin settings to finish loading before treating Web analytics as disabled
- preserve the existing redirect for sites where Web analytics is explicitly disabled
- delay the settings boot response in the acceptance test so the race is exercised deterministically

## Root cause

`appSettings` is loaded asynchronously by the Admin app provider. The Web analytics route derived:

```ts
const webAnalyticsEnabled = appSettings?.analytics?.webAnalytics === true;
```

and immediately redirected whenever that value was false. While settings were still unresolved, `appSettings` was `undefined`, so an enabled site could be permanently redirected to Analytics Overview before the lazy Web route finished booting.

This is why locator polling could not fix the failure: the page was no longer rendering the Web route. The earlier router-level readiness attempt was removed after this PR's own CI run reproduced the same failure.

## Regression safety

- unresolved settings render the route's existing loading state
- explicitly disabled Web analytics still redirects after settings resolve
- enabled Web analytics remains on the requested route
- no shared router or acceptance-harness behavior changes

[PLA-307](https://linear.app/ghost/issue/PLA-307/fix-admin-acceptance-test-race-when-rendering-lazy-routes)

## Validation

- delayed-settings regression test fails on the old behavior and passes with this fix
- focused analytics acceptance suite: 5/5 passed
- Admin lint and typecheck passed
- `CI=true pnpm nx run @tryghost/admin:test:acceptance --skip-nx-cache`: 56 files, 429/429 tests passed