### PR TITLE
Stopped hitting IndexNow in development

### DIFF
--- a/ghost/core/core/server/services/indexnow-ping/indexnow-ping-service.ts
+++ b/ghost/core/core/server/services/indexnow-ping/indexnow-ping-service.ts
@@ -36,6 +36,7 @@ type SettingsCache = {
 };
 
 type Config = {
+    get(key: string): unknown;
     isPrivacyDisabled(key: string): boolean;
 };
 
@@ -139,6 +140,11 @@ export class IndexNowPingService {
      * Ping IndexNow with a URL.
      */
     async ping(post: Post): Promise<void> {
+        // Skip if in development
+        if (this.config.get('env') === 'development') {
+            return;
+        }
+
         // Skip pages - only ping for posts
         if (post.type === 'page') {
             return;

--- a/ghost/core/test/unit/server/services/indexnow-ping/indexnow-ping-service.test.js
+++ b/ghost/core/test/unit/server/services/indexnow-ping/indexnow-ping-service.test.js
@@ -16,7 +16,7 @@ function createService() {
     settingsCache.get.withArgs('is_private').returns(false);
     settingsCache.get.withArgs('indexnow_api_key').returns(VALID_API_KEY);
 
-    const config = {isPrivacyDisabled: sinon.stub()};
+    const config = {get: sinon.stub(), isPrivacyDisabled: sinon.stub()};
     config.isPrivacyDisabled.withArgs('useIndexNow').returns(false);
 
     const labs = {isSet: sinon.stub()};
@@ -268,6 +268,16 @@ describe('IndexNow', function () {
     });
 
     describe('ping()', function () {
+        it('does not ping in development', async function () {
+            const {service, deps} = createService();
+            deps.config.get.withArgs('env').returns('development');
+            const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
+
+            await service.ping(testPost);
+
+            sinon.assert.notCalled(deps.urlService.facade.getUrlForResource);
+        });
+
         it('with a post should execute ping', async function () {
             const {service, deps} = createService();
             nock('https://api.indexnow.org')


### PR DESCRIPTION
no ref

This change should have no user impact.

I noticed that I was getting 429s from IndexNow in development. Let's stop hitting it in development entirely, as it's never going to work there.
