### PR TITLE
Removed unnecessary `async` from automation poll calls

### DIFF
--- a/ghost/core/core/server/services/automations/service.ts
+++ b/ghost/core/core/server/services/automations/service.ts
@@ -96,14 +96,14 @@ export class AutomationsService {
             }
         };
 
-        domainEvents.subscribe(StartAutomationsPollEvent, oneAtATime(async () => poll({
+        domainEvents.subscribe(StartAutomationsPollEvent, oneAtATime(() => poll({
             automationsApi,
             memberWelcomeEmailService,
             scheduleAutomationEmailAnalyticsJob,
             enqueueAnotherPollAt: enqueuePollAt
         })));
 
-        domainEvents.subscribe(StartAutomationsPollEvent, oneAtATime(async () => welcomeEmailAutomationPoll({
+        domainEvents.subscribe(StartAutomationsPollEvent, oneAtATime(() => welcomeEmailAutomationPoll({
             memberWelcomeEmailService,
             enqueueAnotherPollAt: enqueuePollAt
         })));


### PR DESCRIPTION
no ref

This change should have no user impact.
