### PR TITLE
Improved Web analytics boot race coverage

### DIFF
--- a/apps/admin/src/analytics/analytics.acceptance.test.tsx
+++ b/apps/admin/src/analytics/analytics.acceptance.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
     TINYBIRD_SITE_UUID,
+    currentRoute,
     fakeAdminStats,
     fakeNewsletters,
     fakePosts,
@@ -12,6 +13,7 @@ import {
     renderAdminApp,
     webAnalyticsBootOverrides,
 } from "@test-utils/acceptance";
+import { deferred } from "@/utils/deferred";
 import { analyticsScreen } from "./analytics.screen";
 
 const LATEST_POST_ID = "64d623b64676110001e897d1";
@@ -126,17 +128,12 @@ describe("Analytics overview", () => {
 });
 
 describe("Analytics web traffic", () => {
-    it("renders the seeded KPIs, top content, sources and locations", async () => {
-        // Force the lazy Web route to render before settings boot finishes.
+    it("stays on the Web route while settings load, then renders seeded analytics", async () => {
         const boot = webAnalyticsBootOverrides();
         const settings = boot.browseSettings?.response;
+        const pendingSettings = deferred<unknown>();
         boot.browseSettings = {
-            response: async () => {
-                await new Promise<void>((resolve) => {
-                    setTimeout(resolve, 100);
-                });
-                return settings;
-            },
+            response: () => pendingSettings.promise,
         };
         seedAnalyticsWorld();
         seedTopPostsViews();
@@ -149,9 +146,19 @@ describe("Analytics web traffic", () => {
         }]);
         fakeTinybirdPipe("api_top_sources", [{ source: "google.com", visits: 170 }]);
         fakeTinybirdPipe("api_top_locations", [{ location: "US", visits: 200 }]);
-        await renderAdminApp("/analytics/web", { boot });
 
-        await expect.element(analyticsScreen.webGraph()).toBeVisible();
+        try {
+            await renderAdminApp("/analytics/web", { boot });
+
+            // Prove the lazy route renders while settings are still unresolved.
+            // Resolving settings only after this assertion makes the ordering
+            // deterministic instead of relying on an arbitrary response delay.
+            await expect.element(analyticsScreen.dateRangeSelect()).toBeVisible();
+            await expect.poll(currentRoute).toBe("/analytics/web");
+        } finally {
+            pendingSettings.resolve(settings);
+        }
+
         await expect.element(analyticsScreen.webGraph().getByRole("tab", { name: "Unique visitors" })).toHaveTextContent("250");
 
         await expect.element(analyticsScreen.topContentCard()).toHaveTextContent("Attack of the Clones");


### PR DESCRIPTION
## What changed

- replaced the 100 ms settings-response delay with a deferred response
- waits until the analytics route has rendered, then verifies the URL is still `/analytics/web` before releasing settings
- keeps the existing seeded analytics assertions after settings resolve

## Why

The regression test added in #29779 reproduced the race, but its fixed delay did not guarantee the intended ordering: a sufficiently slow lazy-route load could let settings resolve first and allow the old redirect behavior to pass.

The deferred response cannot resolve until the test has observed the route. This directly proves that unresolved settings do not navigate away from Web analytics, without depending on machine speed.

## Mutation check

Temporarily restoring the old `if (!webAnalyticsEnabled)` condition fails this test with:

```
expected "/analytics" to be "/analytics/web"
```

Restoring the merged condition makes it pass.

[PLA-307](https://linear.app/ghost/issue/PLA-307/fix-web-analytics-redirect-race-during-admin-boot)

## Validation

- focused analytics acceptance suite: 5/5 passed
- Admin ESLint passed
- Admin typecheck passed
- full CI-shaped Admin acceptance suite: 56 files, 429/429 tests passed
- focused suite rerun after rebasing onto current main: 5/5 passed