### PR TITLE
🐛 Fixed Analytics crashing with empty growth history

### DIFF
--- a/apps/admin/src/analytics/analytics.acceptance.test.tsx
+++ b/apps/admin/src/analytics/analytics.acceptance.test.tsx
@@ -4,6 +4,7 @@ import {
     TINYBIRD_SITE_UUID,
     currentRoute,
     fakeAdminStats,
+    fakeAnalyticsOverview,
     fakeNewsletters,
     fakePosts,
     fakeTinybirdPipe,
@@ -87,11 +88,7 @@ function seedTopPostsViews() {
 
 describe("Analytics overview", () => {
     it("renders zero KPIs when growth history is empty", async () => {
-        fakeAdminStats.memberCount();
-        fakeAdminStats.mrr();
-        fakeAdminStats.subscriptions();
-        fakeAdminStats.topPostViews();
-        fakePosts([]);
+        fakeAnalyticsOverview();
         await renderAdminApp("/analytics");
 
         await expect.element(analyticsScreen.membersValue()).toHaveTextContent(/^0$/);

--- a/apps/admin/src/analytics/analytics.acceptance.test.tsx
+++ b/apps/admin/src/analytics/analytics.acceptance.test.tsx
@@ -86,6 +86,18 @@ function seedTopPostsViews() {
 }
 
 describe("Analytics overview", () => {
+    it("renders zero KPIs when growth history is empty", async () => {
+        fakeAdminStats.memberCount();
+        fakeAdminStats.mrr();
+        fakeAdminStats.subscriptions();
+        fakeAdminStats.topPostViews();
+        fakePosts([]);
+        await renderAdminApp("/analytics");
+
+        await expect.element(analyticsScreen.membersValue()).toHaveTextContent(/^0$/);
+        await expect.element(analyticsScreen.mrrValue()).toHaveTextContent(/^\$0$/);
+    });
+
     it("renders the seeded KPIs, latest post and top posts", async () => {
         const { postsApi } = seedAnalyticsWorld();
         seedTopPostsViews();

--- a/apps/admin/src/analytics/views/stats/overview/components/overview-kpis.tsx
+++ b/apps/admin/src/analytics/views/stats/overview/components/overview-kpis.tsx
@@ -222,7 +222,7 @@ const OverviewKPIs:React.FC<OverviewKPIsProps> = ({
                     iconName='User'
                     linkto='/analytics/growth/'
                     title='Members'
-                    trendingFromValue={`${formatNumber(membersChartData[0].value)}`}
+                    trendingFromValue={`${formatNumber(membersChartData[0]?.value ?? 0)}`}
                     onClick={() => {
                         navigate('/analytics/growth/?tab=total-members');
                     }}
@@ -249,7 +249,7 @@ const OverviewKPIs:React.FC<OverviewKPIsProps> = ({
                     iconName='Coins'
                     linkto='/analytics/growth/'
                     title='MRR'
-                    trendingFromValue={`${currencySymbol}${formatNumber(mrrChartData[0].value)}`}
+                    trendingFromValue={`${currencySymbol}${formatNumber(mrrChartData[0]?.value ?? 0)}`}
                     onClick={() => {
                         navigate('/analytics/growth/?tab=mrr');
                     }}

--- a/apps/admin/src/settings/layout.acceptance.test.tsx
+++ b/apps/admin/src/settings/layout.acceptance.test.tsx
@@ -1,23 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { userEvent } from "vitest/browser";
 
-import { currentRoute, fakeAdminStats, fakePosts, fakeSettingsScreens, fakeTiers, renderAdminApp, settingsResponse, tier } from "@test-utils/acceptance";
+import { currentRoute, fakeAnalyticsOverview, fakeSettingsScreens, fakeTiers, renderAdminApp, settingsResponse, tier } from "@test-utils/acceptance";
 import { settingsScreen } from "./settings.screen";
-
-function fakeAnalyticsOverview() {
-    const today = new Date().toISOString().slice(0, 10);
-    fakeAdminStats.memberCount({
-        stats: [{ date: today }],
-        totals: { paid: 0, free: 0, comped: 0, gift: 0 },
-    });
-    fakeAdminStats.mrr({
-        stats: [{ date: today }],
-        totals: [{ currency: "usd", mrr: 0 }],
-    });
-    fakeAdminStats.subscriptions();
-    fakeAdminStats.topPostViews();
-    fakePosts([]);
-}
 
 describe("Settings layout", () => {
     it("leaves immediately when the page is clean", async () => {

--- a/apps/admin/src/settings/layout.acceptance.test.tsx
+++ b/apps/admin/src/settings/layout.acceptance.test.tsx
@@ -1,22 +1,39 @@
 import { describe, expect, it } from "vitest";
 import { userEvent } from "vitest/browser";
 
-import { currentRoute, fakeSettingsScreens, fakeTiers, renderAdminApp, settingsResponse, tier } from "@test-utils/acceptance";
+import { currentRoute, fakeAdminStats, fakePosts, fakeSettingsScreens, fakeTiers, renderAdminApp, settingsResponse, tier } from "@test-utils/acceptance";
 import { settingsScreen } from "./settings.screen";
+
+function fakeAnalyticsOverview() {
+    const today = new Date().toISOString().slice(0, 10);
+    fakeAdminStats.memberCount({
+        stats: [{ date: today }],
+        totals: { paid: 0, free: 0, comped: 0, gift: 0 },
+    });
+    fakeAdminStats.mrr({
+        stats: [{ date: today }],
+        totals: [{ currency: "usd", mrr: 0 }],
+    });
+    fakeAdminStats.subscriptions();
+    fakeAdminStats.topPostViews();
+    fakePosts([]);
+}
 
 describe("Settings layout", () => {
     it("leaves immediately when the page is clean", async () => {
         fakeSettingsScreens();
+        fakeAnalyticsOverview();
         await renderAdminApp("/settings");
 
         await settingsScreen.exitButton().click();
 
-        await expect.poll(currentRoute).toBe("/");
+        await expect.poll(currentRoute).toBe("/analytics");
         await expect(settingsScreen.confirmationModal()).toHaveCount(0);
     });
 
     it("can stay on or leave a dirty page from the confirmation", async () => {
         fakeSettingsScreens();
+        fakeAnalyticsOverview();
         await renderAdminApp("/settings");
 
         await settingsScreen.editTitle("New Site Title");
@@ -29,7 +46,7 @@ describe("Settings layout", () => {
 
         await settingsScreen.exitButton().click();
         await settingsScreen.confirmationAction("Leave").click();
-        await expect.poll(currentRoute).toBe("/");
+        await expect.poll(currentRoute).toBe("/analytics");
     });
 
     it("confirms before leaving a dirty page with Escape", async () => {

--- a/apps/admin/src/settings/navigation-history.acceptance.test.tsx
+++ b/apps/admin/src/settings/navigation-history.acceptance.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { currentRoute, fakeAdminStats, fakePosts, fakeSettingsScreens, renderAdminApp } from "@test-utils/acceptance";
+import { currentRoute, fakeAnalyticsOverview, fakeSettingsScreens, renderAdminApp } from "@test-utils/acceptance";
 import { settingsScreen } from "./settings.screen";
 
 // Settings navigations are real router pushes; these specs pin the history
@@ -22,15 +22,11 @@ describe("Settings navigation history", () => {
 
     it("returns to settings with the back button after exiting", async () => {
         fakeSettingsScreens();
-        fakeAdminStats.memberCount();
-        fakeAdminStats.mrr();
-        fakeAdminStats.subscriptions();
-        fakeAdminStats.topPostViews();
-        fakePosts([]);
+        fakeAnalyticsOverview();
         await renderAdminApp("/settings");
 
         await settingsScreen.exitButton().click();
-        await expect.poll(currentRoute).not.toBe("/settings");
+        await expect.poll(currentRoute).toBe("/analytics");
 
         window.history.back();
 

--- a/apps/admin/test-utils/acceptance/analytics.ts
+++ b/apps/admin/test-utils/acceptance/analytics.ts
@@ -1,0 +1,11 @@
+import { fakePosts } from "./resources";
+import { fakeAdminStats } from "./stats";
+
+/** Empty request graph for mounting the Analytics overview. */
+export function fakeAnalyticsOverview(): void {
+    fakeAdminStats.memberCount();
+    fakeAdminStats.mrr();
+    fakeAdminStats.subscriptions();
+    fakeAdminStats.topPostViews();
+    fakePosts([]);
+}

--- a/apps/admin/test-utils/acceptance/index.ts
+++ b/apps/admin/test-utils/acceptance/index.ts
@@ -1,4 +1,5 @@
 /** Acceptance-harness public surface — see README.md for the spec anatomy. */
+export { fakeAnalyticsOverview } from "./analytics";
 export { currentRoute, renderAdminApp } from "./render-admin-app";
 export type { RenderAdminAppOptions } from "./render-admin-app";
 export { defineResource, fakeActions, fakeAutomations, fakeComments, fakeEditSettings, fakeIntegrations, fakeInvites, fakeLabels, fakeMembers, fakeNewsletters, fakeOffers, fakePosts, fakeRoles, fakeSettingsScreens, fakeTags, fakeThemes, fakeTiers, fakeUsers } from "./resources";
@@ -7,7 +8,7 @@ export { allowUnhandledRequests, fakeAdminEndpoint, fakeEndpoint, fakeSitePrevie
 export type { CapturedEndpointRequest, EndpointCapture, FakeAdminEndpointResponse, FakeEndpointOptions, SitePreviewCapture, SitePreviewRequest } from "./worker";
 export { TINYBIRD_SITE_UUID, fakeTinybirdPipe, fakeTinybirdToken, webAnalyticsBootOverrides } from "./tinybird";
 export type { TinybirdPipeCapture, TinybirdPipeQuery } from "./tinybird";
-export { fakeAdminStats, fakeAnalyticsOverview } from "./stats";
+export { fakeAdminStats } from "./stats";
 
 // Test-data re-exports, so a spec needs a single import surface.
 export { activeThemeResponse, analyticsActiveVisitors, analyticsDevice, analyticsGiftLinkVisits, analyticsKpi, analyticsLocation, analyticsSource, analyticsUtmCampaign, analyticsUtmContent, analyticsUtmMedium, analyticsUtmSource, analyticsUtmTerm, automation, browseResponse, changelogEntry, comment, commentThread, configResponse, currentUserResponse, defaultThemesResponse, label, member, memberStatusStat, mrrHistoryStat, newsletter, newsletterBasicStat, newsletterClickStat, newsletterSubscriberStat, newsletterSubscriberValue, offer, post, postGrowthStat, postReferrerStat, postStats, reply, retentionOffer, settingsResponse, siteResponse, staffInvite, staffRole, staffUser, subscriptionStat, tag, theme, tier, topContentStat, topPostStat, topPostViewsStat } from "@tryghost/test-data";

--- a/apps/admin/test-utils/acceptance/index.ts
+++ b/apps/admin/test-utils/acceptance/index.ts
@@ -7,7 +7,7 @@ export { allowUnhandledRequests, fakeAdminEndpoint, fakeEndpoint, fakeSitePrevie
 export type { CapturedEndpointRequest, EndpointCapture, FakeAdminEndpointResponse, FakeEndpointOptions, SitePreviewCapture, SitePreviewRequest } from "./worker";
 export { TINYBIRD_SITE_UUID, fakeTinybirdPipe, fakeTinybirdToken, webAnalyticsBootOverrides } from "./tinybird";
 export type { TinybirdPipeCapture, TinybirdPipeQuery } from "./tinybird";
-export { fakeAdminStats } from "./stats";
+export { fakeAdminStats, fakeAnalyticsOverview } from "./stats";
 
 // Test-data re-exports, so a spec needs a single import surface.
 export { activeThemeResponse, analyticsActiveVisitors, analyticsDevice, analyticsGiftLinkVisits, analyticsKpi, analyticsLocation, analyticsSource, analyticsUtmCampaign, analyticsUtmContent, analyticsUtmMedium, analyticsUtmSource, analyticsUtmTerm, automation, browseResponse, changelogEntry, comment, commentThread, configResponse, currentUserResponse, defaultThemesResponse, label, member, memberStatusStat, mrrHistoryStat, newsletter, newsletterBasicStat, newsletterClickStat, newsletterSubscriberStat, newsletterSubscriberValue, offer, post, postGrowthStat, postReferrerStat, postStats, reply, retentionOffer, settingsResponse, siteResponse, staffInvite, staffRole, staffUser, subscriptionStat, tag, theme, tier, topContentStat, topPostStat, topPostViewsStat } from "@tryghost/test-data";

--- a/apps/admin/test-utils/acceptance/stats.ts
+++ b/apps/admin/test-utils/acceptance/stats.ts
@@ -29,7 +29,6 @@ import type {
 } from "@tryghost/admin-x-framework/api/stats";
 
 import { fakeAdminEndpoint, type EndpointCapture } from "./worker";
-import { fakePosts } from "./resources";
 
 type InputOf<TBuilder> = TBuilder extends (input: infer TInput) => unknown ? NonNullable<TInput> : never;
 
@@ -148,19 +147,3 @@ export const fakeAdminStats = {
         return fakeAdminEndpoint("GET", endpoint("/stats/newsletter-click-stats/"), response);
     },
 };
-
-/** Minimal valid request graph for the Analytics overview destination. */
-export function fakeAnalyticsOverview(): void {
-    const today = new Date().toISOString().slice(0, 10);
-    fakeAdminStats.memberCount({
-        stats: [{ date: today }],
-        totals: { paid: 0, free: 0, comped: 0, gift: 0 },
-    });
-    fakeAdminStats.mrr({
-        stats: [{ date: today }],
-        totals: [{ currency: "usd", mrr: 0 }],
-    });
-    fakeAdminStats.subscriptions();
-    fakeAdminStats.topPostViews();
-    fakePosts([]);
-}

--- a/apps/admin/test-utils/acceptance/stats.ts
+++ b/apps/admin/test-utils/acceptance/stats.ts
@@ -29,6 +29,7 @@ import type {
 } from "@tryghost/admin-x-framework/api/stats";
 
 import { fakeAdminEndpoint, type EndpointCapture } from "./worker";
+import { fakePosts } from "./resources";
 
 type InputOf<TBuilder> = TBuilder extends (input: infer TInput) => unknown ? NonNullable<TInput> : never;
 
@@ -147,3 +148,19 @@ export const fakeAdminStats = {
         return fakeAdminEndpoint("GET", endpoint("/stats/newsletter-click-stats/"), response);
     },
 };
+
+/** Minimal valid request graph for the Analytics overview destination. */
+export function fakeAnalyticsOverview(): void {
+    const today = new Date().toISOString().slice(0, 10);
+    fakeAdminStats.memberCount({
+        stats: [{ date: today }],
+        totals: { paid: 0, free: 0, comped: 0, gift: 0 },
+    });
+    fakeAdminStats.mrr({
+        stats: [{ date: today }],
+        totals: [{ currency: "usd", mrr: 0 }],
+    });
+    fakeAdminStats.subscriptions();
+    fakeAdminStats.topPostViews();
+    fakePosts([]);
+}


### PR DESCRIPTION
## What changed

- wait for the settled `/analytics` destination before exercising browser Back from Settings
- share an empty Analytics overview scenario across the Settings exit/history suites and the Analytics regression test
- keep typed stats endpoint helpers narrowly scoped; the composed request graph lives in its own Analytics helper
- render zero-valued member and MRR deltas when growth history is empty
- cover empty growth-history responses with exact KPI assertions

## Why

The root route dispatches the default Owner test user through `/` to `/analytics`. The history test only waited until it was no longer on Settings, so it could invoke Back during that redirect or after Analytics started loading.

Its member and MRR mocks returned empty series. When Analytics won the race, `OverviewKPIs` dereferenced the first item in an empty array, React Router replaced the app with its error boundary, and the test could no longer find the Settings sidebar after navigating back.

Waiting for the terminal destination removes the history race. The shared scenario deliberately keeps the API histories empty, so every consumer exercises the previously crashing path instead of relying on synthetic dated data.

## Validation

- full Admin acceptance suite: 57 files, 434 tests passed
- focused Analytics and Settings acceptance tests: 3 files, 13 tests passed
- Settings navigation-history suite: 10 consecutive runs passed
- Admin TypeScript check passed
- Admin lint passed
- independent review of the tidied fixture boundary and regression coverage: no findings
