### PR TITLE
Removed the settings portal mount

### DIFF
--- a/apps/admin/src/settings/settings.tsx
+++ b/apps/admin/src/settings/settings.tsx
@@ -1,18 +1,11 @@
 import { App } from "./app/app";
-import { createPortal } from "react-dom";
 
 export default function Settings() {
-    return createPortal(
-        <div
-            className="shade shade-admin"
-            style={{
-                position: "absolute",
-                inset: 0,
-                zIndex: 20,
-            }}
-        >
+    // Full-screen takeover inside the shell tree (automations-editor pattern);
+    // the admin sidebar is already unmounted via the route's hideAdminSidebar.
+    return (
+        <div className="fixed inset-0 z-20">
             <App />
-        </div>,
-        document.body,
+        </div>
     );
 }

--- a/apps/admin/src/settings/settings.tsx
+++ b/apps/admin/src/settings/settings.tsx
@@ -4,7 +4,7 @@ export default function Settings() {
     // Full-screen takeover inside the shell tree (automations-editor pattern);
     // the admin sidebar is already unmounted via the route's hideAdminSidebar.
     return (
-        <div className="fixed inset-0 z-20">
+        <div className="fixed inset-0 z-50">
             <App />
         </div>
     );


### PR DESCRIPTION
Final structural piece of the native-settings work (follows #29762, #29763, #29780).

Settings was the only admin route escaping the React tree via `createPortal(document.body)` — which is why it re-declared the `shade shade-admin` scope classes and kept private z-index bookkeeping. The route element now renders a `fixed inset-0` overlay inside the shell tree, the same full-screen pattern the automations editor uses (`automations/editor.tsx`). The admin sidebar is already unmounted via the route's `hideAdminSidebar` handle, and Radix dialogs/toasts portal themselves to the body, so nothing else needed to move.

Deliberately a tiny standalone PR: if any visual regression shows up, it bisects to stacking — not to the router swap that landed in #29780.

## Verification

- Acceptance: 57 files / 433 tests pass (settings suites + history specs unchanged)
- Unit: 128 files / 1373 pass; `tsc -b` + lint clean
- Worth a quick visual pass on the known portal-sensitive spots pre-merge: Koenig floating toolbars in settings editors, Pintura, sonner toasts over open dialogs, dirty-confirm dialog stacking (none are screenshot-covered by the suite)