### PR TITLE
🎨 Improved production docker build boot performance

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -82,6 +82,7 @@ RUN cd /home/ghost && node -e "require('better-sqlite3'); console.log('better-sq
 FROM node:$NODE_VERSION-bookworm-slim AS core
 
 ENV NODE_ENV=production
+ENV NODE_COMPILE_CACHE=/home/ghost/.compile-cache
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libjemalloc2 fontconfig && \
@@ -112,6 +113,13 @@ ENV GHOST_BUILD_VERSION=${GHOST_BUILD_VERSION}
 
 USER ghost
 ENV LD_PRELOAD=libjemalloc.so.2
+
+# Boot once to warm Node's V8 compile cache — 15-20% off every container start.
+# Must run here, as the runtime user: Node namespaces the cache directory by uid
+# (and writes entries 0600), so a cache warmed by root in an earlier stage is one
+# the runtime never looks at. Images built on top can re-run the script to cache
+# their own code, as long as they do it as the same user.
+RUN bin/warm-compile-cache.sh
 
 EXPOSE 2368
 

--- a/ghost/core/bin/warm-compile-cache.sh
+++ b/ghost/core/bin/warm-compile-cache.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Warms Node's on-disk V8 compile cache by booting Ghost once, so the modules don't
+# have to be compiled again on every boot. Run at image build time: Ghost's own
+# Dockerfile does it, and images built on top should re-run it after adding code
+# (custom adapters, patches) so those modules land in the cache too.
+#
+# Cache entries are keyed by absolute module path, Node version and arch, so the
+# warming build must use the same app directory and base image as the runtime.
+#
+#   NODE_COMPILE_CACHE   cache location; defaults to <app>/.compile-cache
+
+set -euo pipefail
+
+APP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CACHE_DIR="${NODE_COMPILE_CACHE:-${APP_DIR}/.compile-cache}"
+
+mkdir -p "$CACHE_DIR"
+# Node writes nothing and reports no error when the directory isn't writable, so a
+# warming run would silently do nothing.
+if [ ! -w "$CACHE_DIR" ]; then
+    echo "Compile cache directory is not writable: ${CACHE_DIR}" >&2
+    exit 1
+fi
+
+count_entries() {
+    find "$CACHE_DIR" -type f | wc -l | tr -d ' '
+}
+
+before="$(count_entries)"
+
+cd "$APP_DIR"
+
+# Boot reaches the database before most services load, so warming without a working
+# one silently caches under half the modules. No database is reachable during a build,
+# so default to a throwaway sqlite one.
+if [ -z "${database__client:-}" ]; then
+    warm_db="$(mktemp "${TMPDIR:-/tmp}/ghost-warm-db.XXXXXX")"
+    trap 'rm -f "$warm_db"' EXIT
+    export database__client="better-sqlite3"
+    export database__connection__filename="$warm_db"
+fi
+
+# Boot writes into content/ (logs, settings); put it back so warming leaves no trace
+# in the image. stdout logging keeps most of it from happening in the first place.
+content_snapshot="$(mktemp -d "${TMPDIR:-/tmp}/ghost-warm-content.XXXXXX")"
+cp -a content/. "$content_snapshot"
+
+NODE_ENV="${NODE_ENV:-production}" \
+    NODE_COMPILE_CACHE="$CACHE_DIR" \
+    GHOST_CI_SHUTDOWN_AFTER_BOOT=1 \
+    logging__transports='["stdout"]' \
+    node index.js
+
+rm -rf content
+mkdir content
+cp -a "$content_snapshot/." content
+rm -rf "$content_snapshot"
+
+echo "Compile cache warmed: ${before} -> $(count_entries) entries in ${CACHE_DIR}"

--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -315,6 +315,7 @@ async function initAppService() {
     debug('Begin: App Service');
     const appService = require('./frontend/services/apps');
     await appService.init();
+    debug('End: App Service');
 }
 
 /**

--- a/ghost/core/core/server/services/media-inliner/external-media-inliner.js
+++ b/ghost/core/core/server/services/media-inliner/external-media-inliner.js
@@ -5,7 +5,6 @@ const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
 const string = require('@tryghost/string');
 const path = require('path');
-const convert = require('heic-convert');
 
 let fileTypeFromBuffer;
 
@@ -102,20 +101,25 @@ class ExternalMediaInliner {
         }
 
         // If the file is heic or heif, attempt to convert it to jpeg
-        try {
-            if (extension === 'heic' || extension === 'heif') {
+        if (extension === 'heic' || extension === 'heif') {
+            // Lazy: pulls in libheif-js, a WASM codec costing ~50ms to load at boot.
+            // Deliberately outside the try — a missing codec is not a conversion error,
+            // and swallowing it would store an unconvertible .heic in its place.
+            const convert = require('heic-convert');
+
+            try {
                 body = await convert({
                     buffer: body,
                     format: 'JPEG'
                 });
 
                 extension = 'jpg';
+            } catch (error) {
+                logging.error(`Error converting file to JPEG: ${requestURL}`);
+                logging.error(new errors.DataImportError({
+                    err: error
+                }));
             }
-        } catch (error) {
-            logging.error(`Error converting file to JPEG: ${requestURL}`);
-            logging.error(new errors.DataImportError({
-                err: error
-            }));
         }
 
         const removeExtRegExp = new RegExp(`.${extension}`, '');


### PR DESCRIPTION
no ref
- add node_compile_cache to docker image to speed up cold starts
- add missing debug end statement
- defer require of heic-convert due to WASM build