### PR TITLE
Added benchmarking for production docker image

### DIFF
--- a/.github/actions/install-hyperfine/action.yml
+++ b/.github/actions/install-hyperfine/action.yml
@@ -1,0 +1,26 @@
+name: 'Install hyperfine'
+description: 'Installs a pinned hyperfine build. Bumping the version breaks comparability with existing benchmark history.'
+inputs:
+  version:
+    description: 'hyperfine release to install'
+    required: false
+    default: '1.18.0'
+  sha256:
+    description: 'Checksum of the x86_64-unknown-linux-gnu tarball; update alongside version'
+    required: false
+    default: '0cf1779354f46037df145bce9dd298d28aee341ac789b6a377ad77855029bc8e'
+
+runs:
+  using: 'composite'
+  steps:
+    - shell: bash
+      env:
+        HYPERFINE_VERSION: ${{ inputs.version }}
+        HYPERFINE_SHA256: ${{ inputs.sha256 }}
+      run: |
+        TARBALL="hyperfine-v${HYPERFINE_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+        wget --tries=3 --timeout=30 "https://github.com/sharkdp/hyperfine/releases/download/v${HYPERFINE_VERSION}/${TARBALL}"
+        echo "${HYPERFINE_SHA256}  ${TARBALL}" | sha256sum --check --strict
+        tar -zxf "${TARBALL}"
+        mv "hyperfine-v${HYPERFINE_VERSION}-x86_64-unknown-linux-gnu/hyperfine" /usr/local/bin
+        chmod +x /usr/local/bin/hyperfine

--- a/.github/actions/report-boot-benchmark/action.yml
+++ b/.github/actions/report-boot-benchmark/action.yml
@@ -1,0 +1,159 @@
+name: 'Report boot benchmark'
+description: 'Writes a hyperfine boot measurement to the job summary and, on push runs, appends it to a Ghost-Benchmarks series.'
+inputs:
+  results-file:
+    description: 'hyperfine --export-json output, relative to the workspace'
+    required: true
+  series:
+    description: 'Suite name in the benchmark data - each series charts separately'
+    required: true
+  metric:
+    description: 'Metric name within the series'
+    required: true
+  title:
+    description: 'Heading for the job summary'
+    required: true
+  github-token:
+    description: 'Write-scoped token for TryGhost/Ghost-Benchmarks. Publishing is skipped on PRs.'
+    required: false
+    default: ''
+  data-dir:
+    description: 'Subdirectory of the benchmarks repo holding this series. Empty means the root series - use a subdirectory for anything new.'
+    required: false
+    default: ''
+  site-url:
+    description: 'Published benchmark site. Read anonymously for the comparison line - Pages is public even though the repo is not.'
+    required: false
+    default: 'https://tryghost.github.io/Ghost-Benchmarks'
+
+runs:
+  using: 'composite'
+  steps:
+    # Larger runners are not a uniform CPU: boot times differ by ~35% between hosts,
+    # which swamps most real regressions. Measure the host so a jump in the series can
+    # be told apart from a slower machine.
+    - name: Measure host
+      id: host
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+      run: |
+        # /proc/cpuinfo has no model name on arm64, so prefer lscpu and fall back.
+        cpu_model="$(lscpu 2>/dev/null | sed -n 's/^Model name:[[:space:]]*//p' | head -1)"
+        if [ -z "$cpu_model" ] || [ "$cpu_model" = "-" ]; then
+            cpu_model="$(sed -n 's/^model name[[:space:]]*: //p' /proc/cpuinfo 2>/dev/null | head -1)"
+        fi
+        # Digits only: anything else downstream is consumed as JSON.
+        calibration="$(node "${ACTION_PATH}/calibration.js" | tr -dc '0-9')"
+
+        {
+          echo "cpu-model=${cpu_model:-unknown}"
+          echo "cpu-count=$(nproc 2>/dev/null || echo '?')"
+          echo "calibration=${calibration:-0}"
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Convert data
+      id: convert
+      shell: bash
+      env:
+        RESULTS_FILE: ${{ inputs.results-file }}
+        METRIC: ${{ inputs.metric }}
+        CPU_MODEL: ${{ steps.host.outputs.cpu-model }}
+        CPU_COUNT: ${{ steps.host.outputs.cpu-count }}
+        CALIBRATION: ${{ steps.host.outputs.calibration }}
+      run: |
+        # Calibration rides along as its own metric (charted next to the boot time, so
+        # the two can be compared) and the CPU model as `extra`, which the chart shows
+        # on hover.
+        FORMATTED="${RESULTS_FILE%.json}-formatted.json"
+        jq --arg metric "$METRIC" \
+          --arg host "${CPU_MODEL} (${CPU_COUNT} cores)" \
+          --argjson calibration "${CALIBRATION:-0}" \
+          '[
+            {
+              name: $metric,
+              unit: "s",
+              value: .results[0].median,
+              range: ((.results[0].max - .results[0].min) | tostring),
+              extra: $host
+            }
+          ] + (if $calibration > 0 then [
+            {
+              name: "Compile calibration",
+              unit: "ms",
+              value: $calibration,
+              extra: $host
+            }
+          ] else [] end)' \
+          < "$RESULTS_FILE" > "$FORMATTED"
+        echo "formatted-file=$FORMATTED" >> "$GITHUB_OUTPUT"
+
+    # Numbers on the job page rather than buried in the log, with the latest main
+    # data point for context. Never fails the job.
+    - name: Write result to job summary
+      shell: bash
+      continue-on-error: true
+      env:
+        RESULTS_FILE: ${{ inputs.results-file }}
+        SERIES: ${{ inputs.series }}
+        METRIC: ${{ inputs.metric }}
+        TITLE: ${{ inputs.title }}
+        SITE_URL: ${{ inputs.site-url }}
+        DATA_DIR: ${{ inputs.data-dir }}
+        CPU_MODEL: ${{ steps.host.outputs.cpu-model }}
+        CPU_COUNT: ${{ steps.host.outputs.cpu-count }}
+        CALIBRATION: ${{ steps.host.outputs.calibration }}
+      run: |
+        {
+          echo "### $TITLE"
+          echo
+          echo "| metric | ms |"
+          echo "|---|---|"
+          jq -r '.results[0] | "| median | \(.median*1000|round) |\n| mean ± σ | \(.mean*1000|round) ± \(.stddev*1000|round) |\n| min | \(.min*1000|round) |\n| max | \(.max*1000|round) |"' < "$RESULTS_FILE"
+          echo
+          echo "Host: ${CPU_MODEL} (${CPU_COUNT} cores), compile calibration ${CALIBRATION} ms."
+        } >> "$GITHUB_STEP_SUMMARY"
+
+        if curl -fsSL --max-time 60 "${SITE_URL}/${DATA_DIR:+$DATA_DIR/}data.js" -o "${RUNNER_TEMP}/benchmark-data.js"; then
+          baseline=$(sed '1s/^window\.BENCHMARK_DATA = //' "${RUNNER_TEMP}/benchmark-data.js" | jq -r \
+            --arg series "$SERIES" --arg metric "$METRIC" \
+            '(.entries[$series] // []) | max_by(.date)
+             | [(.benches[] | select(.name == $metric) | .value),
+                ((.benches[] | select(.name == "Compile calibration") | .value) // 0),
+                .commit.id[0:9]] | @tsv' 2>/dev/null || true)
+        else
+          baseline=""
+        fi
+
+        if [ -n "$baseline" ]; then
+          median=$(jq -r '.results[0].median' < "$RESULTS_FILE")
+          IFS=$'\t' read -r base_boot base_calibration base_commit <<< "$baseline"
+          # A boot delta only means something if the calibration held steady - the two
+          # move together when the runner changed rather than the code.
+          awk -v cur="$median" -v base="$base_boot" -v commit="$base_commit" \
+              -v cur_cal="$CALIBRATION" -v base_cal="$base_calibration" 'BEGIN {
+            printf "\nLatest main data point (%s): %d ms - this run is %+d ms (%+.1f%%)\n", commit, base * 1000, (cur - base) * 1000, (cur - base) / base * 100
+            if (base_cal > 0) {
+              printf "Calibration then %d ms vs now %d ms (%+.1f%%)\n", base_cal, cur_cal, (cur_cal - base_cal) / base_cal * 100
+            } else {
+              printf "That data point predates calibration, so the hosts cannot be compared.\n"
+            }
+          }' >> "$GITHUB_STEP_SUMMARY"
+        else
+          printf '\nNo published data point to compare against yet.\n' >> "$GITHUB_STEP_SUMMARY"
+        fi
+
+    # Push runs only: a pull_request run executes PR-authored code, so it never gets
+    # the write-scoped token, and unmerged results stay out of the series. No token
+    # means summary-only, so callers can use this action without publishing.
+    - name: Publish to benchmark series
+      if: github.event_name != 'pull_request' && inputs.github-token != ''
+      uses: benchmark-action/github-action-benchmark@4bdcce38c94cec68da58d012ac24b7b1155efe8b # v1.20.7
+      with:
+        name: ${{ inputs.series }}
+        tool: 'customSmallerIsBetter'
+        output-file-path: ${{ steps.convert.outputs.formatted-file }}
+        benchmark-data-dir-path: ${{ inputs.data-dir }}
+        gh-repository: github.com/TryGhost/Ghost-Benchmarks
+        github-token: ${{ inputs.github-token }}
+        auto-push: true

--- a/.github/actions/report-boot-benchmark/calibration.js
+++ b/.github/actions/report-boot-benchmark/calibration.js
@@ -1,0 +1,22 @@
+// Times a fixed amount of JS compilation. Boot is dominated by V8 compiling modules,
+// so this tracks the same hardware characteristic and gives the summary a way to tell
+// "this runner is slower" apart from "this commit is slower". Prints milliseconds.
+const vm = require('node:vm');
+
+const ITERATIONS = 300;
+
+// Built up-front so the measured loop is compilation only. Identifiers vary per
+// iteration because V8's compilation cache would otherwise serve every repeat.
+const sources = Array.from({length: ITERATIONS}, (_, i) => Array.from(
+    {length: 800},
+    (_, n) => `function f${i}_${n}(a, b) { return a * ${n} + b; }`
+).join('\n'));
+
+const start = process.hrtime.bigint();
+for (let i = 0; i < ITERATIONS; i++) {
+    new vm.Script(sources[i], {filename: `calibration-${i}.js`});
+}
+
+// Printed as a string: console.log of a number goes through util.inspect, which wraps
+// it in ANSI colour codes when FORCE_COLOR is set, as it is across this workflow.
+console.log(`${Math.round(Number(process.hrtime.bigint() - start) / 1e6)}`);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -488,19 +488,7 @@ jobs:
         run: pnpm install --frozen-lockfile --force
 
       - name: Install hyperfine
-        # The checksum must be updated alongside HYPERFINE_VERSION. Note that
-        # bumping the version also breaks comparability with existing data
-        # points, so it should be a deliberate decision, not a routine upgrade.
-        env:
-          HYPERFINE_VERSION: 1.18.0
-          HYPERFINE_SHA256: 0cf1779354f46037df145bce9dd298d28aee341ac789b6a377ad77855029bc8e
-        run: |
-          TARBALL="hyperfine-v${HYPERFINE_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
-          wget "https://github.com/sharkdp/hyperfine/releases/download/v${HYPERFINE_VERSION}/${TARBALL}"
-          echo "${HYPERFINE_SHA256}  ${TARBALL}" | sha256sum --check --strict
-          tar -zxf "${TARBALL}"
-          mv "hyperfine-v${HYPERFINE_VERSION}-x86_64-unknown-linux-gnu/hyperfine" /usr/local/bin
-          chmod +x /usr/local/bin/hyperfine
+        uses: ./.github/actions/install-hyperfine
 
       - name: Build TS code
         run: pnpm nx run-many -t build:tsc
@@ -509,26 +497,106 @@ jobs:
         working-directory: ghost/core
         run: hyperfine --show-output --warmup 3 'GHOST_CI_SHUTDOWN_AFTER_BOOT=1 node index.js' --export-json boot-perf.json
 
-      - name: Convert data
-        working-directory: ghost/core
-        run: |
-          jq '[{ name: "Boot time", unit: "s", value: .results[0].median, range: ((.results[0].max - .results[0].min) | tostring) }]' < boot-perf.json > boot-perf-formatted.json
-
-      # Publishing is restricted to push runs. A `perf-tests`-labelled PR runs
-      # everything above and reports the numbers in the log, but never receives
-      # the write-scoped token, because a pull_request run executes PR-authored
-      # code (install scripts, build, boot). It also keeps unmerged PR results
-      # out of the main-branch series.
-      - name: Run analysis
-        if: github.event_name != 'pull_request'
-        uses: benchmark-action/github-action-benchmark@4bdcce38c94cec68da58d012ac24b7b1155efe8b # v1.20.7
+      - name: Report result
+        uses: ./.github/actions/report-boot-benchmark
         with:
-          tool: 'customSmallerIsBetter'
-          output-file-path: ghost/core/boot-perf-formatted.json
-          benchmark-data-dir-path: ""
-          gh-repository: github.com/TryGhost/Ghost-Benchmarks
+          results-file: ghost/core/boot-perf.json
+          series: Benchmark
+          metric: Boot time
+          title: Boot time (dev tree)
           github-token: ${{ secrets.CANARY_DOCKER_BUILD }}
-          auto-push: true
+
+  # Boot time of the production image, as a series separate from job_perf-tests:
+  # that one tracks the code, this one tracks what ships (NODE_ENV=production, no
+  # devDependencies, jemalloc, baked compile cache). Never merge them - a base image
+  # bump would land in the code series as a regression with no Ghost commit behind it.
+  job_perf-tests-image:
+    name: Performance tests (production image)
+    runs-on:
+      labels: ubuntu-latest-4-cores
+    needs: [job_setup, job_docker]
+    # Registry path only: the core image is pushed to GHCR, never saved as an artifact.
+    if: |
+      needs.job_docker.result == 'success' &&
+      needs.job_docker.outputs.use-artifact == 'false' &&
+      ((needs.job_setup.outputs.changed_core == 'true' && needs.job_setup.outputs.is_development == 'true') || needs.job_setup.outputs.has_perf_tests_label == 'true')
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      # Only for .github/actions/load-docker-image; nothing is built from source here.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Install hyperfine
+        uses: ./.github/actions/install-hyperfine
+
+      - name: Load core image
+        uses: ./.github/actions/load-docker-image
+        id: load
+        with:
+          use-artifact: 'false'
+          image-tags: ${{ needs.job_docker.outputs.image-core-tags }}
+
+      - name: Start MySQL
+        # Own network rather than a service container, so Ghost can reach it by name.
+        # Pinned by digest: a MySQL bump moves the measurement, so it should be a
+        # deliberate baseline change rather than drift in the series.
+        run: |
+          docker network create ghost-perf
+          docker run -d --name mysql --network ghost-perf \
+            --tmpfs /var/lib/mysql \
+            -e MYSQL_DATABASE=ghost \
+            -e MYSQL_ROOT_PASSWORD=root \
+            --health-cmd "mysqladmin ping -h 127.0.0.1 -uroot -proot" \
+            --health-interval=2s \
+            --health-timeout=5s \
+            --health-retries=60 \
+            mysql:8.0@sha256:7dcddc01f13bab2f15cde676d44d01f61fc9f99fe7785e86196dfc07d358ae2b
+          for _ in $(seq 1 60); do
+            if [ "$(docker inspect -f '{{.State.Health.Status}}' mysql)" = "healthy" ]; then
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "MySQL did not become healthy"
+          docker logs mysql
+          exit 1
+
+      - name: Start Ghost container
+        # Kept alive with `sleep` so each measured run is a `docker exec`; timing
+        # `docker run` would put container create/start inside the measurement.
+        env:
+          IMAGE_TAG: ${{ steps.load.outputs.image-tag }}
+        run: |
+          docker run -d --name ghost --network ghost-perf --entrypoint sleep \
+            -e GHOST_CI_SHUTDOWN_AFTER_BOOT=1 \
+            -e database__client=mysql \
+            -e database__connection__host=mysql \
+            -e database__connection__user=root \
+            -e database__connection__password=root \
+            -e database__connection__database=ghost \
+            "$IMAGE_TAG" infinity
+
+      - name: Run migrations (discarded first boot)
+        # A fresh database costs ~6.5s of migrations vs ~2.3s steady state.
+        run: docker exec ghost node index.js
+
+      - name: Run hyperfine on boot
+        run: hyperfine --show-output --warmup 3 'docker exec ghost node index.js' --export-json boot-perf-image.json
+
+      - name: Report result
+        uses: ./.github/actions/report-boot-benchmark
+        with:
+          results-file: boot-perf-image.json
+          # Own subdirectory in the benchmarks repo (like dx/), so this series gets its
+          # own chart and data file and the root series is left untouched.
+          data-dir: docker
+          series: Production image
+          metric: Boot time
+          title: Boot time (production image)
+          github-token: ${{ secrets.CANARY_DOCKER_BUILD }}
 
   job_unit-tests:
     runs-on: ubuntu-latest
@@ -1557,6 +1625,7 @@ jobs:
 
     outputs:
       use-artifact: ${{ steps.strategy.outputs.use-artifact }}
+      image-core-tags: ${{ steps.meta-core.outputs.tags }}
       image-e2e-name: ${{ steps.strategy.outputs.image-e2e-name }}
       image-e2e-tags: ${{ steps.meta-e2e.outputs.tags }}
 


### PR DESCRIPTION
no ref
- allow benchmarks of dev tree as well as docker image to benchmark docker-specific boot time improvements

split out from #29790 to make the benchmark measurements appear