### PR TITLE
Added script for loading/validating custom adapters

### DIFF
--- a/ghost/core/bin/validate-adapters.ts
+++ b/ghost/core/bin/validate-adapters.ts
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+
+// Checks that custom adapters load and implement everything their base class
+// requires. Ghost only verifies an adapter fully on first use (`getAdapter`), so a
+// missing method on a storage adapter otherwise surfaces at first upload; run this
+// at image build time to fail the build instead.
+//
+// Usage: bin/validate-adapters.js <type>:<AdapterClassName> ...
+//   e.g. bin/validate-adapters.js cache:Redis sso:ProSSO storage:S3Storage
+//
+// Adapters are named explicitly rather than read from config, which may not be
+// present at build time. Run this as the user the image runs as: the modules it
+// loads land in the V8 compile cache, which is namespaced by uid.
+
+import {enableCompileCache} from 'node:module';
+import {adapterPaths} from '../core/server/services/adapter-manager/adapter-paths';
+import {baseClasses} from '../core/server/services/adapter-manager/base-classes';
+import {loadAdapterClass} from '../core/server/services/adapter-manager/utils';
+
+// No-op when NODE_COMPILE_CACHE is already set, as it is in Ghost's image.
+enableCompileCache();
+
+type AdapterType = keyof typeof baseClasses;
+
+function validate(spec: string): void {
+    const parts = spec.split(':');
+    if (parts.length !== 2 || !parts[0] || !parts[1]) {
+        throw new Error(`expected <type>:<AdapterClassName>, got "${spec}"`);
+    }
+
+    const [type, className] = parts;
+    const BaseClass = baseClasses[type as AdapterType];
+    if (!BaseClass) {
+        throw new Error(`unknown adapter type "${type}" - expected one of: ${Object.keys(baseClasses).join(', ')}`);
+    }
+
+    // Same loader the adapter manager uses, so resolution and its failure messages
+    // are identical to what the running server would report.
+    const Adapter = loadAdapterClass(type, className, adapterPaths, require);
+
+    // Matches the adapter manager's check, including its tolerance for a base class
+    // loaded from a second copy of the package, where instanceof fails.
+    const inherits = Adapter.prototype instanceof BaseClass || Object.getPrototypeOf(Adapter).name === BaseClass.name;
+    if (!inherits) {
+        throw new Error(`does not inherit from ${BaseClass.name}`);
+    }
+
+    // requiredFns is defined by the base constructor and can't be overridden by a
+    // subclass, so the base instance is the authority on what must be implemented.
+    // The bases are abstract, which constrains the type checker but not the runtime.
+    const Base = BaseClass as unknown as new () => {requiredFns: readonly string[]};
+    const missing = new Base().requiredFns.filter(fn => typeof Adapter.prototype[fn] !== 'function');
+    if (missing.length) {
+        throw new Error(`missing method(s): ${missing.join(', ')}`);
+    }
+}
+
+function main(specs: string[]): void {
+    if (!specs.length) {
+        process.stderr.write('Usage: bin/validate-adapters.js <type>:<AdapterClassName> ...\n');
+        process.exit(1);
+    }
+
+    const failures: {spec: string, message: string}[] = [];
+
+    for (const spec of specs) {
+        try {
+            validate(spec);
+            process.stdout.write(`  ok    ${spec}\n`);
+        } catch (err) {
+            failures.push({spec, message: (err as Error).message});
+            process.stdout.write(`  FAIL  ${spec}\n`);
+        }
+    }
+
+    if (failures.length) {
+        process.stderr.write(`\n${failures.length} of ${specs.length} adapter(s) failed validation:\n`);
+        for (const {spec, message} of failures) {
+            process.stderr.write(`- ${spec}: ${message}\n`);
+        }
+        process.exit(1);
+    }
+
+    process.stdout.write(`Validated ${specs.length} adapter(s).\n`);
+}
+
+main(process.argv.slice(2));

--- a/ghost/core/core/server/services/adapter-manager/adapter-manager.ts
+++ b/ghost/core/core/server/services/adapter-manager/adapter-manager.ts
@@ -1,6 +1,5 @@
-import path from 'node:path';
 import errors from '@tryghost/errors';
-import {resolveAdapterExport, resolveAdapterEntryPoint, resolveAdapterOptions, normalizeAdapterConfig, getConfiguredFeatures} from './utils';
+import {loadAdapterClass, resolveAdapterOptions, normalizeAdapterConfig, getConfiguredFeatures} from './utils';
 import type {ConfigInstance} from '../../../shared/config/loader';
 import type {
     Adapter,
@@ -186,52 +185,7 @@ export class AdapterManager<BaseClasses extends BaseClassMap = BaseClassMap> {
             });
         }
 
-        let Adapter: AdapterConstructor | null = null;
-        for (const pathToAdapters of this.pathsToAdapters) {
-            let pathToAdapter = path.join(pathToAdapters, adapterType, adapterClassName);
-            if (pathToAdapters === '') {
-                // We are loading from node_modules, we can remove the `adapterType` prefix
-                pathToAdapter = path.join(pathToAdapters, adapterClassName);
-            }
-            // An adapter directory may be a full module with its own
-            // package.json, in which case this resolves the `exports` entry
-            // point; otherwise the path passes through unchanged.
-            const moduleToLoad = resolveAdapterEntryPoint(pathToAdapter);
-
-            try {
-                const adapterModule = this.loadAdapterFromPath(moduleToLoad);
-                Adapter = resolveAdapterExport(adapterModule);
-                if (Adapter) {
-                    break;
-                }
-            } catch (err) {
-                // Catch runtime errors
-                if (!(err instanceof Error) || (err as NodeJS.ErrnoException).code !== 'MODULE_NOT_FOUND') {
-                    throw new errors.IncorrectUsageError({err: err as Error});
-                }
-
-                // Catch missing dependencies BUT NOT missing adapter.
-                // Only check the first line — Node appends a "Require stack"
-                // that includes the adapter's own path, which would false-positive.
-                const firstLine = err.message.split('\n')[0];
-                if (!firstLine.includes(pathToAdapter)) {
-                    // Name the unresolved module so the error is actionable, e.g.
-                    // "Cannot find module 'superagent'" -> 'superagent'.
-                    const missingMatch = /Cannot find module '([^']+)'/.exec(firstLine);
-                    const missingModule = missingMatch ? ` '${missingMatch[1]}'` : '';
-                    throw new errors.IncorrectUsageError({
-                        message: `You are missing a dependency${missingModule} in your adapter ${pathToAdapter}`,
-                        err: err as Error
-                    });
-                }
-            }
-        }
-
-        if (!Adapter) {
-            throw new errors.IncorrectUsageError({
-                message: `Unable to find ${adapterType} adapter ${adapterClassName} in ${this.pathsToAdapters}.`
-            });
-        }
+        const Adapter = loadAdapterClass(adapterType, adapterClassName, this.pathsToAdapters, this.loadAdapterFromPath);
 
         return {Adapter, adapterConfig: adapterConfig ?? {}, adapterType, adapterClassName};
     }

--- a/ghost/core/core/server/services/adapter-manager/adapter-paths.ts
+++ b/ghost/core/core/server/services/adapter-manager/adapter-paths.ts
@@ -1,0 +1,21 @@
+import config from '../../../shared/config';
+
+/**
+ * Where adapters are looked up, in order. Also read by bin/validate-adapters.ts,
+ * which checks adapter implementations at build time - keep this the only place
+ * the lookup order is declared, so a name resolves there exactly as it does here.
+ */
+export const adapterPaths: string[] = Array.from(new Set<string>([
+    '', // A blank path will cause us to check node_modules for the adapter
+    config.get('paths').internalAdaptersPath,
+
+    // custom docker builds may install adapters in a separate path from content,
+    // since the content dir is often bind-mounted into the container. Offering
+    // an escape hatch here to allow for this
+    config.get('paths').installedAdaptersPath ?? '',
+
+    // load adapters from content last, so that they don't override any other
+    // internal or platform-installed adapters
+    // TODO: potentially deprecate/remove as part of Ghost 7.0
+    config.getContentPath('adapters')
+]));

--- a/ghost/core/core/server/services/adapter-manager/base-classes.ts
+++ b/ghost/core/core/server/services/adapter-manager/base-classes.ts
@@ -1,0 +1,22 @@
+import {StorageBase} from 'ghost-storage-base';
+import {SchedulingBase} from '@tryghost/adapter-base-scheduling';
+import {SSOBase} from '@tryghost/adapter-base-sso';
+import {CacheBase} from '@tryghost/adapter-base-cache';
+import {RedirectsStoreBase} from '@tryghost/adapter-base-redirects';
+import {RouteSettingsStoreBase} from '@tryghost/adapter-base-route-settings';
+
+import type {BaseClassMap} from './adapter-manager';
+
+/**
+ * The base class every adapter of a given type must extend. Also read by
+ * bin/validate-adapters.js, which checks adapter implementations at build time -
+ * keep this the only place the mapping is declared.
+ */
+export const baseClasses = {
+    storage: StorageBase,
+    scheduling: SchedulingBase,
+    sso: SSOBase,
+    cache: CacheBase,
+    redirects: RedirectsStoreBase,
+    'route-settings': RouteSettingsStoreBase
+} satisfies BaseClassMap;

--- a/ghost/core/core/server/services/adapter-manager/index.ts
+++ b/ghost/core/core/server/services/adapter-manager/index.ts
@@ -1,27 +1,7 @@
-import {StorageBase} from 'ghost-storage-base';
-import {SchedulingBase} from '@tryghost/adapter-base-scheduling';
-import {SSOBase} from '@tryghost/adapter-base-sso';
-import {CacheBase} from '@tryghost/adapter-base-cache';
-import {RedirectsStoreBase} from '@tryghost/adapter-base-redirects';
-import {RouteSettingsStoreBase} from '@tryghost/adapter-base-route-settings';
-
 import {AdapterManager} from './adapter-manager';
+import {adapterPaths} from './adapter-paths';
+import {baseClasses} from './base-classes';
 import config from '../../../shared/config';
-
-const adapterPaths = new Set<string>([
-    '', // A blank path will cause us to check node_modules for the adapter
-    config.get('paths').internalAdaptersPath,
-
-    // custom docker builds may install adapters in a separate path from content,
-    // since the content dir is often bind-mounted into the container. Offering
-    // an escape hatch here to allow for this
-    config.get('paths').installedAdaptersPath ?? '',
-
-    // load adapters from content last, so that they don't override any other
-    // internal or platform-installed adapters
-    // TODO: potentially deprecate/remove as part of Ghost 7.0
-    config.getContentPath('adapters'),
-]);
 
 // A singleton adapter manager, preconfigured with the base classes for every
 // known adapter type. `getAdapter` resolves the active adapter and its options
@@ -29,15 +9,8 @@ const adapterPaths = new Set<string>([
 const adapterManager = new AdapterManager({
     loadAdapterFromPath: require,
     config,
-    pathsToAdapters: Array.from(adapterPaths),
-    baseClasses: {
-        storage: StorageBase,
-        scheduling: SchedulingBase,
-        sso: SSOBase,
-        cache: CacheBase,
-        redirects: RedirectsStoreBase,
-        'route-settings': RouteSettingsStoreBase
-    }
+    pathsToAdapters: adapterPaths,
+    baseClasses
 });
 
 export default adapterManager;

--- a/ghost/core/core/server/services/adapter-manager/utils.ts
+++ b/ghost/core/core/server/services/adapter-manager/utils.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import {createRequire} from 'node:module';
+import errors from '@tryghost/errors';
 import type {AdapterConstructor} from "./types";
 import type {ConfigInstance} from '../../../shared/config/loader';
 
@@ -120,6 +121,62 @@ export function resolveAdapterExport(moduleExport: unknown): AdapterConstructor 
     }
 
     return null;
+}
+
+/**
+* Locate and load an adapter constructor by type and class name, trying each of
+* `pathsToAdapters` in order. Shared by the adapter manager and by
+* bin/validate-adapters.ts, so a name resolves — and fails — identically at build
+* time and at runtime.
+*/
+export function loadAdapterClass(
+    adapterType: string,
+    adapterClassName: string,
+    pathsToAdapters: string[],
+    loadAdapterFromPath: (path: string) => unknown
+): AdapterConstructor {
+    for (const pathToAdapters of pathsToAdapters) {
+        let pathToAdapter = path.join(pathToAdapters, adapterType, adapterClassName);
+        if (pathToAdapters === '') {
+            // We are loading from node_modules, we can remove the `adapterType` prefix
+            pathToAdapter = path.join(pathToAdapters, adapterClassName);
+        }
+        // An adapter directory may be a full module with its own
+        // package.json, in which case this resolves the `exports` entry
+        // point; otherwise the path passes through unchanged.
+        const moduleToLoad = resolveAdapterEntryPoint(pathToAdapter);
+
+        try {
+            const Adapter = resolveAdapterExport(loadAdapterFromPath(moduleToLoad));
+            if (Adapter) {
+                return Adapter;
+            }
+        } catch (err) {
+            // Catch runtime errors
+            if (!(err instanceof Error) || (err as NodeJS.ErrnoException).code !== 'MODULE_NOT_FOUND') {
+                throw new errors.IncorrectUsageError({err: err as Error});
+            }
+
+            // Catch missing dependencies BUT NOT missing adapter.
+            // Only check the first line — Node appends a "Require stack"
+            // that includes the adapter's own path, which would false-positive.
+            const firstLine = err.message.split('\n')[0];
+            if (!firstLine.includes(pathToAdapter)) {
+                // Name the unresolved module so the error is actionable, e.g.
+                // "Cannot find module 'superagent'" -> 'superagent'.
+                const missingMatch = /Cannot find module '([^']+)'/.exec(firstLine);
+                const missingModule = missingMatch ? ` '${missingMatch[1]}'` : '';
+                throw new errors.IncorrectUsageError({
+                    message: `You are missing a dependency${missingModule} in your adapter ${pathToAdapter}`,
+                    err: err as Error
+                });
+            }
+        }
+    }
+
+    throw new errors.IncorrectUsageError({
+        message: `Unable to find ${adapterType} adapter ${adapterClassName} in ${pathsToAdapters}.`
+    });
 }
 
 function getSchedulingConfig(config: ConfigInstance) {

--- a/ghost/core/tsconfig.json
+++ b/ghost/core/tsconfig.json
@@ -100,6 +100,7 @@
         "skipLibCheck": true /* Skip type checking all .d.ts files. */
     },
     "include": [
+        "bin/**/*.ts",
         "core/**/*.ts",
         "test/**/*.ts",
         "types/**/*.d.ts"


### PR DESCRIPTION
no ref
- add script to validate adapter required functions, simulating the adapter loader in a config-agnostic environment
- script also performs the duty of adding the adapter to the compile cache
- extract some parts of adapter-manager into files for validate script to load