### PR TITLE
🐛 Fixed a post URL becoming /404/ when the API is asked for specific fields

### DIFF
--- a/ghost/core/core/server/api/endpoints/utils/serializers/input/utils/url.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/input/utils/url.js
@@ -72,11 +72,12 @@ const forSetting = (attrs) => {
 // resource as thin. Force them back into the fetch and record them on the
 // frame — the output mapper strips them from the response after the URL is
 // built. No-op under the eager service (getRequiredFields → []).
-const forceUrlColumnsWhenLazy = (frame, routerType) => {
+const forceUrlColumnsWhenLazy = (frame, routerType, extraColumns = []) => {
     if (!Array.isArray(frame.options.columns) || !frame.options.columns.includes('url')) {
         return;
     }
-    const forced = urlService.facade.getRequiredFields(routerType).filter(field => !frame.options.columns.includes(field));
+    const required = new Set([...urlService.facade.getRequiredFields(routerType), ...extraColumns]);
+    const forced = [...required].filter(field => !frame.options.columns.includes(field));
     if (forced.length) {
         frame.forcedUrlColumns = forced;
         frame.options.columns.push(...forced);
@@ -105,7 +106,13 @@ const forceUrlRelationsWhenLazy = (frame, routerType) => {
             frame.options.withRelated = [...requested, ...forced];
         }
     }
-    forceUrlColumnsWhenLazy(frame, routerType);
+    // Both backends look the URL up by `model.id`, and Bookshelf matches
+    // eager-loaded rows back to their parent by the same key — so a `?fields=`
+    // list that omits it serializes /404/ and leaves the relations above
+    // unattached, silently and without a key on the model at all. A read
+    // looked up by id already carries it; nothing else does.
+    const lookedUpById = Boolean(frame.data && frame.data.id);
+    forceUrlColumnsWhenLazy(frame, routerType, lookedUpById ? [] : ['id']);
 };
 
 // Options-object variant of forceUrlColumnsWhenLazy for endpoints that build

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/posts.js
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/mappers/posts.js
@@ -148,7 +148,10 @@ module.exports = async (model, frame, options = {}) => {
             // are being passed by reference in tags/authors. Might be refactored into more explicit call
             // in the future, but is good enough for current use-case
             if (relation === 'tags' && jsonModel.tags) {
-                jsonModel.tags = jsonModel.tags.map(tag => mapTag(tag, frame));
+                // The forced URL columns belong to the post, not to the tags
+                // hanging off it — an included tag keeps its own id and slug.
+                const tagFrame = frame.forcedUrlColumns ? {...frame, forcedUrlColumns: null} : frame;
+                jsonModel.tags = jsonModel.tags.map(tag => mapTag(tag, tagFrame));
             }
 
             if (relation === 'authors' && jsonModel.authors) {

--- a/ghost/core/test/e2e-api/content/posts.test.js
+++ b/ghost/core/test/e2e-api/content/posts.test.js
@@ -214,6 +214,18 @@ describe('Posts Content API', function () {
             .matchBodySnapshot();
     });
 
+    it('Can request the url of a single post with a narrowed fields list', async function () {
+        // `findOne` drops the primary key when `?fields` omits it, and the URL
+        // is looked up by id — so without the serializer forcing it back in,
+        // the post serializes /404/ instead of its own URL.
+        const {body} = await agent
+            .get('posts/slug/welcome/?fields=title,url')
+            .expectStatus(200);
+
+        assert.doesNotMatch(body.posts[0].url, /\/404\//);
+        assert.deepEqual(Object.keys(body.posts[0]).sort(), ['slug', 'title', 'url']);
+    });
+
     it('Can include relations', async function () {
         await agent
             .get('posts/?include=tags,authors')

--- a/ghost/core/test/integration/url-serializer-parity.test.js
+++ b/ghost/core/test/integration/url-serializer-parity.test.js
@@ -191,6 +191,68 @@ describe('Integration: Content API serializer → lazy URL parity (primary_tag p
         });
     });
 
+    // `findOne` intersects the requested columns with the permitted attributes
+    // and — unlike `findPage` — never unions `defaultColumnsToFetch()` back in,
+    // so the primary key reaches the query only if the serializer forces it.
+    // Without it the mapper hands the URL service `id: undefined` and Bookshelf
+    // matches no eager-loaded rows, so the post serializes /404/ with no tags.
+    describe('single-post read with ?fields (findOne drops the primary key)', function () {
+        async function readPipeline({slug, id, fields, include}) {
+            const frame = {
+                apiType: 'content',
+                original: {context: {}},
+                data: id ? {id} : {slug},
+                options: {context: {public: true}}
+            };
+            if (fields) {
+                frame.options.columns = fields.split(',');
+            }
+            if (include) {
+                frame.options.withRelated = include.split(',');
+            }
+
+            inputSerializer.read({}, frame);
+
+            const model = await models.Post.findOne(frame.data, frame.options);
+            assert.ok(model, `expected a post for ${JSON.stringify(frame.data)}`);
+
+            return await postsMapper(model, frame, {});
+        }
+
+        it('builds the real URL on a read whose fields omit id', async function () {
+            const mapped = await readPipeline({slug: 'public-first', fields: 'title,url,published_at'});
+
+            assert.equal(mapped.url, eager.getUrlByResourceId(posts.publicFirst.id, {absolute: true}));
+            assert.doesNotMatch(mapped.url, /\/404\//);
+        });
+
+        it('does not leak the forced primary key into the response', async function () {
+            const mapped = await readPipeline({slug: 'public-first', fields: 'title,url,published_at'});
+
+            assert.equal(mapped.id, undefined);
+        });
+
+        it('keeps the primary key a read looked up by id already returns', async function () {
+            // The model already carries the key it was fetched by, so nothing
+            // is forced and nothing is stripped.
+            const mapped = await readPipeline({id: posts.publicFirst.id, fields: 'title,url'});
+
+            assert.equal(mapped.id, posts.publicFirst.id);
+        });
+
+        it('leaves the ids of included relations alone', async function () {
+            // The forced columns belong to the post, not to its relations.
+            const mapped = await readPipeline({
+                slug: 'public-first',
+                fields: 'title,url',
+                include: 'tags'
+            });
+
+            assert.equal(mapped.tags.length, 1);
+            assert.ok(mapped.tags[0].id, 'expected the included tag to keep its id');
+        });
+    });
+
     describe('tag-filtered browse (joins posts_tags)', function () {
         it('tag-filtered ?fields=url browse serializes the same URL lazy/eager', async function () {
             const mapped = await browsePipeline({

--- a/ghost/core/test/unit/api/canary/utils/serializers/input/utils/url.test.js
+++ b/ghost/core/test/unit/api/canary/utils/serializers/input/utils/url.test.js
@@ -65,4 +65,75 @@ describe('Unit: endpoints/utils/serializers/input/utils/url', function () {
             assert.equal(frame.forcedUrlColumns, undefined);
         });
     });
+
+    describe('forceUrlRelationsWhenLazy', function () {
+        it('forces the primary key into a narrowed fetch', function () {
+            // Both backends look the URL up by `model.id`, so this is not
+            // specific to the lazy service — hence no required relations here.
+            sinon.stub(urlService.facade, 'getRequiredRelations').returns([]);
+            sinon.stub(urlService.facade, 'getRequiredFields').withArgs('posts').returns(['status']);
+            const frame = {options: {columns: ['url', 'title']}};
+
+            urlUtil.forceUrlRelationsWhenLazy(frame, 'posts');
+
+            assert.deepEqual(frame.options.columns, ['url', 'title', 'status', 'id']);
+            assert.deepEqual(frame.forcedUrlColumns, ['status', 'id']);
+        });
+
+        it('forces the primary key so the required relations can load', function () {
+            sinon.stub(urlService.facade, 'getRequiredRelations').returns(['tags']);
+            sinon.stub(urlService.facade, 'getRequiredFields').withArgs('posts').returns([]);
+            const frame = {options: {columns: ['url', 'title']}};
+
+            urlUtil.forceUrlRelationsWhenLazy(frame, 'posts');
+
+            assert.deepEqual(frame.options.withRelated, ['tags']);
+            assert.deepEqual(frame.forcedUrlColumns, ['id']);
+        });
+
+        it('leaves a read looked up by id alone', function () {
+            // The model already carries the primary key it was fetched by, and
+            // forcing it would strip an id the caller is served today.
+            sinon.stub(urlService.facade, 'getRequiredRelations').returns(['tags']);
+            sinon.stub(urlService.facade, 'getRequiredFields').withArgs('posts').returns([]);
+            const frame = {data: {id: 'abc123'}, options: {columns: ['url', 'title']}};
+
+            urlUtil.forceUrlRelationsWhenLazy(frame, 'posts');
+
+            assert.deepEqual(frame.options.columns, ['url', 'title']);
+            assert.equal(frame.forcedUrlColumns, undefined);
+        });
+
+        it('does not duplicate the primary key when the caller requested it', function () {
+            sinon.stub(urlService.facade, 'getRequiredRelations').returns([]);
+            sinon.stub(urlService.facade, 'getRequiredFields').withArgs('posts').returns([]);
+            const frame = {options: {columns: ['url', 'id']}};
+
+            urlUtil.forceUrlRelationsWhenLazy(frame, 'posts');
+
+            assert.deepEqual(frame.options.columns, ['url', 'id']);
+            assert.equal(frame.forcedUrlColumns, undefined);
+        });
+
+        it('is a no-op when the fetch is not narrowed', function () {
+            sinon.stub(urlService.facade, 'getRequiredRelations').returns([]);
+            const frame = {options: {}};
+
+            urlUtil.forceUrlRelationsWhenLazy(frame, 'posts');
+
+            assert.equal(frame.options.columns, undefined);
+            assert.equal(frame.forcedUrlColumns, undefined);
+        });
+
+        it('is a no-op when the url will not be serialized', function () {
+            const relations = sinon.stub(urlService.facade, 'getRequiredRelations');
+            const frame = {options: {columns: ['title', 'slug']}};
+
+            urlUtil.forceUrlRelationsWhenLazy(frame, 'posts');
+
+            assert.deepEqual(frame.options.columns, ['title', 'slug']);
+            assert.equal(frame.options.withRelated, undefined);
+            sinon.assert.notCalled(relations);
+        });
+    });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1937

## The bug

A Content API read with a narrowed `?fields=` list serializes the post URL as `/404/`:

```
GET /ghost/api/content/posts/slug/welcome/?fields=title,url   →  url: <site>/404/   ✗
GET /ghost/api/content/posts/slug/welcome/                    →  url: <site>/welcome/ ✓
```

This is live today on the eager URL service — it is not specific to the lazy work.

## Why

The URL is looked up by `model.id`. `findOne` intersects the requested columns with the permitted attributes but — unlike `findPage` ([crud.js:131](https://github.com/TryGhost/Ghost/blob/main/ghost/core/core/server/models/base/plugins/crud.js#L131)) — never unions `defaultColumnsToFetch()` back in, so a `?fields=` list that doesn't name `id` leaves the primary key out of the SELECT.

Browse is unaffected (`findPage` unions it back), and so is a read looked up by id, which carries the key on the model already.

The same missing key silently empties every relation. Bookshelf matches eager-loaded rows back to their parent by primary key, so `withRelated` resolves to nothing and the relation is **never attached** — no key on the model at all, rather than an empty array:

```
fetch({columns: ['id','title','slug'], withRelated: ['tags']})  →  [slug, id, title, tags]
fetch({columns: ['title','slug'],      withRelated: ['tags']})  →  [slug, title]          ← tags gone
```

Under the lazy URL service that also strands a post whose collection filter reads tags, which is how this surfaced in production: `LAZY_URL_COMPARE_ERROR` with `missing: ["tags"]`. Every one of the 150 such events in a two-week sample carries an undefined resource id, and none of them is a browse.

## The fix

Force the primary key alongside the columns the URL service already force-loads, so it rides the existing `frame.forcedUrlColumns` machinery and the output mapper strips it before serializing.

Unioning the default columns in `findOne` instead would leak `id` and `published_at` into responses — `findOne` has no equivalent of `findPage`'s pick back down to the requested columns. I tried it; it leaks.

Second commit-worthy detail: the post's forced columns were also being stripped from its **included tags** on the way out, since the nested mapper was handed the post's frame. An included tag was losing its own `id` and `slug`. That was already true for `slug` on `main`; adding `id` to the forced set made it worse, so it's fixed here.

## Response shapes are unchanged

Verified over real HTTP against a booted Ghost, before and after:

| request | before | after |
|---|---|---|
| read by slug `?fields=title,url` | `[slug, title, url]`, url `/404/` | `[slug, title, url]`, url correct |
| read by id `?fields=title,url` | `[id, title, url]` | `[id, title, url]` |
| browse `?fields=title,url` | `[title, url]` | `[title, url]` |
| read `?fields=title,url&include=tags` | nested tag missing `id`, `slug` | nested tag intact |

No new field appears in any Content or Admin API response.

## Tests

TDD — each test was confirmed to fail against `main` before the fix landed.

- `test/unit/.../input/utils/url.test.js` — the forcing rules, including the two no-op guards and the looked-up-by-id case.
- `test/integration/url-serializer-parity.test.js` — new `readPipeline` driving the real serializer pipeline (input serializer → `findOne` → output mapper) against a lazy-authoritative facade: real URL, no leaked key, id-lookup untouched, included relations keep their ids.
- `test/e2e-api/content/posts.test.js` — covers the eager path end-to-end over HTTP, which is the case that's broken for users today.

Full local runs: e2e-api 1633 passed, integration 386 passed, e2e 367 passed, legacy 451 passed, unit 7732 passed. The 4 unit failures and the `lint:types` `subFieldsOf` error also fail on a clean `main`.

## Known adjacent issues, deliberately not in this PR

- A read looked up by id with a `:primary_tag` permalink resolves `primary_tag` to `all` — a computed-column issue on `findOne`, pre-existing and unrelated to the primary key.
- `mappers/users.js` has no `forcedUrlColumns` strip, so `authors/?fields=name,url` returns `slug`. Pre-existing on `main`.