### PR TITLE
Put custom field definitions in an order the publisher chose

### DIFF
--- a/apps/admin-x-framework/src/api/member-custom-fields.ts
+++ b/apps/admin-x-framework/src/api/member-custom-fields.ts
@@ -109,6 +109,9 @@ export interface MemberCustomFieldsResponseType {
 }
 
 const dataType = 'MemberCustomFieldsResponseType';
+// Exported so a screen can move the list in its own cache before the request lands —
+// a drag that waits for a round-trip snaps back under the cursor.
+export const memberCustomFieldsDataType = dataType;
 
 export const useBrowseMemberCustomFields = createQuery<MemberCustomFieldsResponseType>({
     dataType,
@@ -144,6 +147,57 @@ export const useEditMemberCustomField = createMutation<MemberCustomFieldsRespons
     body: ({key: _key, ...patch}) => ({members_custom_fields: [patch]}),
     invalidateQueries: {dataType}
 });
+
+/**
+ * Set the order of the whole list.
+ *
+ * Order is a property of the list rather than of a field — no definition carries a rank
+ * — so it is stated by PUTting the collection in the order it should have. The payload
+ * has to name every field the site has, archived ones included: the API rejects a list
+ * that doesn't, which is what stops a client that loaded before a colleague added a
+ * field from writing an order that was never true of the whole list.
+ */
+export const useReorderMemberCustomFields = createMutation<MemberCustomFieldsResponseType, MemberCustomField[]>({
+    method: 'PUT',
+    path: () => '/members/custom_fields/',
+    body: fields => ({members_custom_fields: fields.map(({key}) => ({key}))}),
+    // The response is the settled order, so it is written straight to the cached lists
+    // rather than refetched. A reorder only succeeds when it named exactly the fields the
+    // site has, so a success carries no news about the set — only about its order — and
+    // there is nothing a GET would add.
+    //
+    // Several lists live under this data type, one per set of query params, and they do
+    // not hold the same fields: Settings asked for every status, a member's details and
+    // the importer asked for active fields only. So each is put into the new order rather
+    // than replaced by the response, which would hand those two archived fields they are
+    // written to assume they never see.
+    updateQueries: {
+        dataType,
+        emberUpdateType: 'skip',
+        update: (newData, currentData) => {
+            const current = currentData as MemberCustomFieldsResponseType | undefined;
+            if (!current?.members_custom_fields) {
+                return currentData;
+            }
+            const settledOrder = newData.members_custom_fields.map(({key}) => key);
+            return {...current, members_custom_fields: inOrderOf(settledOrder, current.members_custom_fields)};
+        }
+    }
+});
+
+/**
+ * A list of fields arranged to match an order given as keys, keeping whatever it holds.
+ *
+ * Takes keys rather than fields because an order is only ever a sequence of keys — which
+ * is what the API is told, and what a screen holds while a drag settles.
+ *
+ * A field the order does not mention keeps to the end rather than jumping to the front,
+ * which is where an unknown place would otherwise sort it.
+ */
+export const inOrderOf = (order: readonly string[], fields: MemberCustomField[]): MemberCustomField[] => {
+    const placeOf = new Map(order.map((key, place) => [key, place]));
+    return [...fields].sort((a, b) => (placeOf.get(a.key) ?? Infinity) - (placeOf.get(b.key) ?? Infinity));
+};
 
 // DELETE permanently removes an archived field and its collected values;
 // addressed by key. The API only allows it on an already-archived field —

--- a/apps/admin/src/settings/app/components/settings/membership/custom-fields.tsx
+++ b/apps/admin/src/settings/app/components/settings/membership/custom-fields.tsx
@@ -1,18 +1,84 @@
 import CustomFieldIcon from './custom-fields/custom-field-icon';
 import CustomFieldModal from './custom-fields/custom-field-modal';
 import NiceModal from '@ebay/nice-modal-react';
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useEffect, useMemo, useRef, useState} from 'react';
 import TopLevelGroup from '@/settings/app/components/top-level-group';
 import useFeatureFlag from '@/settings/app/hooks/use-feature-flag';
-import {ActionList, ActionListItem, ActionListItemActions, ActionListItemContent, Button, NoValueLabel, NoValueLabelIcon, Tabs, TabsContent, TabsList, TabsTrigger} from '@tryghost/shade/components';
+import {ActionList, ActionListItem, ActionListItemActions, ActionListItemContent, Button, DragIndicator, NoValueLabel, NoValueLabelIcon, type SortableItemContainerProps, SortableList, Tabs, TabsContent, TabsList, TabsTrigger} from '@tryghost/shade/components';
+import {Inline} from '@tryghost/shade/primitives';
 import {TextCursorInput} from 'lucide-react';
-import {useBrowseMemberCustomFieldsIncludingArchived, userTypeForField} from '@tryghost/admin-x-framework/api/member-custom-fields';
+import {arrayMove} from '@dnd-kit/sortable';
+import {inOrderOf, memberCustomFieldsDataType, useBrowseMemberCustomFieldsIncludingArchived, useReorderMemberCustomFields, userTypeForField} from '@tryghost/admin-x-framework/api/member-custom-fields';
+import {useHandleError} from '@tryghost/admin-x-framework/hooks';
+import {useQueryClient} from '@tryghost/admin-x-framework';
 import {withErrorBoundary} from '@/settings/app/components/error-boundary';
 import type {MemberCustomField} from '@tryghost/admin-x-framework/api/member-custom-fields';
 
 // How many fields render before the list collapses behind "Show all" — the
 // recommendations list's preview size.
 const PREVIEW_COUNT = 5;
+
+// The sortable list addresses rows by `id`; a field has no id over the API, so its key
+// is the identity throughout.
+type SortableField = MemberCustomField & {id: string};
+const withRowIds = (fields: MemberCustomField[]): SortableField[] =>
+    fields.map(field => ({...field, id: field.key}));
+
+// One row's content, shared by the plain list and the sortable one so a field reads
+// identically whether or not it can be dragged.
+const FieldRow: React.FC<{
+    field: MemberCustomField;
+    openModal: (field: MemberCustomField) => void;
+}> = ({field, openModal}) => {
+    const userType = userTypeForField(field);
+    return (
+        <>
+            <ActionListItemContent asChild>
+                <button className='flex w-full items-center gap-3 py-3 text-left' type='button' onClick={() => openModal(field)}>
+                    <span className='flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted'>
+                        <CustomFieldIcon className='size-[18px]' type={userType.id} />
+                    </span>
+                    <span className='min-w-0 grow'>
+                        <span className='block font-semibold'>{field.name}</span>
+                        <span className='block text-sm text-muted-foreground'>{userType.label}</span>
+                    </span>
+                </button>
+            </ActionListItemContent>
+            <ActionListItemActions>
+                <Button className='h-auto p-0 font-bold text-green hover:text-green/90 hover:no-underline' size='sm' type='button' variant='link' onClick={() => openModal(field)}>Edit</Button>
+            </ActionListItemActions>
+        </>
+    );
+};
+
+// The row a dragged field sits in. The drag overlay renders outside the list's wrapper,
+// so a row being dragged supplies its own ActionList to keep its styling.
+const SortableFieldRow: React.FC<SortableItemContainerProps> = ({
+    id,
+    setRef,
+    isDragging,
+    style,
+    separator,
+    children,
+    ...props
+}) => {
+    // Neither belongs on the handle button the rest is spread onto: DragIndicator errors
+    // on `separator`, and `id` is a field key that would become the button's DOM id.
+    void separator;
+    void id;
+
+    // The handle sits in a centred column because the row stretches its children.
+    const row = (
+        <ActionListItem ref={setRef} className={isDragging ? 'opacity-75' : ''} data-testid='custom-field-list-item' style={style}>
+            <Inline align='center' className='w-10 shrink-0'>
+                <DragIndicator className='h-10' isDragging={isDragging || false} {...props} />
+            </Inline>
+            {children}
+        </ActionListItem>
+    );
+
+    return isDragging ? <ActionList>{row}</ActionList> : row;
+};
 
 const FieldList: React.FC<{
     fields: MemberCustomField[];
@@ -21,7 +87,10 @@ const FieldList: React.FC<{
     showAll: boolean;
     onShowAll: () => void;
     openModal: (field: MemberCustomField) => void;
-}> = ({fields, showAll, onShowAll, openModal}) => {
+    // Absent on the archived tab: an archived field holds its place in the order but
+    // there is nowhere to see it, so there is nothing to drag it through.
+    onMove?: (key: string, overKey: string) => void;
+}> = ({fields, showAll, onShowAll, openModal, onMove}) => {
 
     if (fields.length === 0) {
         // Mirrors the newsletters list's empty state, tab for tab.
@@ -36,33 +105,34 @@ const FieldList: React.FC<{
     // The endpoint returns the full (deliberately small) list, so "Show all"
     // is a client-side reveal — same UI as the recommendations table, without
     // inventing pagination the API doesn't have.
-    const visibleFields = showAll ? fields : fields.slice(0, PREVIEW_COUNT);
+    const isTruncated = !showAll && fields.length > PREVIEW_COUNT;
+    const visibleFields = isTruncated ? fields.slice(0, PREVIEW_COUNT) : fields;
+
+    // A collapsed list is still sortable: both ends of a drag are rows on screen, and the
+    // fields behind "Show all" keep their places around the move.
+    const isSortable = Boolean(onMove);
+
     return (
         <>
-            <ActionList>
-                {visibleFields.map((field) => {
-                    const userType = userTypeForField(field);
-                    return (
+            {isSortable ? (
+                <SortableList
+                    container={props => <SortableFieldRow {...props} />}
+                    getDragHandleLabel={field => `Reorder ${field.name}`}
+                    items={withRowIds(visibleFields)}
+                    renderItem={field => <FieldRow field={field} openModal={openModal} />}
+                    wrapper={ActionList}
+                    onMove={(key, overKey) => onMove?.(key, overKey)}
+                />
+            ) : (
+                <ActionList>
+                    {visibleFields.map(field => (
                         <ActionListItem key={field.key} data-testid='custom-field-list-item'>
-                            <ActionListItemContent asChild>
-                                <button className='flex w-full items-center gap-3 py-3 text-left' type='button' onClick={() => openModal(field)}>
-                                    <span className='flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted'>
-                                        <CustomFieldIcon className='size-[18px]' type={userType.id} />
-                                    </span>
-                                    <span className='min-w-0 grow'>
-                                        <span className='block font-semibold'>{field.name}</span>
-                                        <span className='block text-sm text-muted-foreground'>{userType.label}</span>
-                                    </span>
-                                </button>
-                            </ActionListItemContent>
-                            <ActionListItemActions>
-                                <Button className='h-auto p-0 font-bold text-green hover:text-green/90 hover:no-underline' size='sm' type='button' variant='link' onClick={() => openModal(field)}>Edit</Button>
-                            </ActionListItemActions>
+                            <FieldRow field={field} openModal={openModal} />
                         </ActionListItem>
-                    );
-                })}
-            </ActionList>
-            {!showAll && fields.length > PREVIEW_COUNT && (
+                    ))}
+                </ActionList>
+            )}
+            {isTruncated && (
                 <div className='flex items-center gap-2 border-t border-border pt-2 font-bold text-green hover:opacity-80'>
                     <button type='button' onClick={onShowAll}>Show all</button>
                 </div>
@@ -80,7 +150,18 @@ const CustomFields: React.FC<{keywords: string[]}> = ({keywords}) => {
     const {data} = useBrowseMemberCustomFieldsIncludingArchived({
         enabled: hasCustomFields
     });
-    const fields = data?.members_custom_fields || [];
+    const {mutateAsync: reorderFields} = useReorderMemberCustomFields();
+    const queryClient = useQueryClient();
+    const handleError = useHandleError();
+
+    // The order just drawn, held as keys over whatever the server says — so a field added
+    // or removed elsewhere still appears or goes. It states an order, never a set.
+    const [drawnOrder, setDrawnOrder] = useState<string[] | null>(null);
+    const serverFields = data?.members_custom_fields;
+    const fields = useMemo(() => {
+        const known = serverFields || [];
+        return drawnOrder ? inOrderOf(drawnOrder, known) : known;
+    }, [serverFields, drawnOrder]);
     const [selectedTab, setSelectedTab] = useState('active-fields');
     const [showAllActive, setShowAllActive] = useState(false);
     const [showAllArchived, setShowAllArchived] = useState(false);
@@ -92,11 +173,11 @@ const CustomFields: React.FC<{keywords: string[]}> = ({keywords}) => {
     const activeFields = fields.filter(field => field.status === 'active');
     const archivedFields = fields.filter(field => field.status === 'archived');
 
-    // The collapse is an initial-view optimization only: fields append in
-    // insertion order, so a just-created (or just-reactivated) field is
-    // always LAST — exactly the hidden slot. When a tab's list grows while
-    // the screen is open, expand it so the new arrival is visible in place
-    // rather than silently swallowed behind "Show all".
+    // The collapse is an initial-view optimization only: a new field is appended to the
+    // end of the publisher's order, so it lands in exactly the hidden slot. When a tab's
+    // list grows while the screen is open, expand it so the new arrival is visible in
+    // place rather than silently swallowed behind "Show all". Expanding also puts the
+    // active list back in reach of a drag, which a truncated list does not offer.
     const previousCounts = useRef({active: 0, archived: 0});
     useEffect(() => {
         if (activeFields.length > previousCounts.current.active && previousCounts.current.active > 0) {
@@ -109,6 +190,33 @@ const CustomFields: React.FC<{keywords: string[]}> = ({keywords}) => {
     }, [activeFields.length, archivedFields.length]);
 
     const openModal = (field?: MemberCustomField) => NiceModal.show(CustomFieldModal, {field});
+
+    /**
+     * Applied to the whole list rather than the active tab: a reorder names every
+     * definition, and the archived ones keep their places around the move. Rendered
+     * immediately from local state, so letting go is the end of the interaction.
+     */
+    const onMove = (key: string, overKey: string) => {
+        const from = fields.findIndex(field => field.key === key);
+        const to = fields.findIndex(field => field.key === overKey);
+        if (from === -1 || to === -1 || from === to) {
+            return;
+        }
+
+        const reordered = arrayMove(fields, from, to);
+        setDrawnOrder(reordered.map(field => field.key));
+
+        reorderFields(reordered)
+            .catch((error) => {
+                // The server's message says what to do; refetching is how the screen
+                // learns about the field it did not know about.
+                handleError(error);
+                queryClient.invalidateQueries({queryKey: [memberCustomFieldsDataType]});
+            })
+            // Dropped either way: on success the cache holds this order, on failure the
+            // server's is the one to show.
+            .finally(() => setDrawnOrder(null));
+    };
 
     return (
         <TopLevelGroup
@@ -129,7 +237,7 @@ const CustomFields: React.FC<{keywords: string[]}> = ({keywords}) => {
                         <TabsTrigger value='active-fields'>Active</TabsTrigger>
                         <TabsTrigger value='archived-fields'>Archived</TabsTrigger>
                     </TabsList>
-                    <TabsContent value='active-fields'><FieldList fields={activeFields} openModal={openModal} showAll={showAllActive} onShowAll={() => setShowAllActive(true)} /></TabsContent>
+                    <TabsContent value='active-fields'><FieldList fields={activeFields} openModal={openModal} showAll={showAllActive} onMove={onMove} onShowAll={() => setShowAllActive(true)} /></TabsContent>
                     <TabsContent value='archived-fields'><FieldList fields={archivedFields} openModal={openModal} showAll={showAllArchived} onShowAll={() => setShowAllArchived(true)} /></TabsContent>
                 </Tabs>
             )}

--- a/apps/admin/src/settings/membership/custom-fields.acceptance.test.tsx
+++ b/apps/admin/src/settings/membership/custom-fields.acceptance.test.tsx
@@ -1,5 +1,5 @@
 import {describe, expect, it} from "vitest";
-import {page} from "vitest/browser";
+import {page, userEvent} from "vitest/browser";
 
 import {configResponse, fakeAdminEndpoint, fakeSettingsScreens, renderAdminApp, settingsResponse} from "@test-utils/acceptance";
 import {settingsScreen} from "@/settings/settings.screen";
@@ -14,7 +14,7 @@ const companyField = {
 };
 
 const archivedField = {
-    key: "old-hobby",
+    key: "old_hobby",
     name: "Old hobby",
     type: "short_text",
     status: "archived",
@@ -85,7 +85,7 @@ describe("Custom fields", () => {
         fakeSettingsScreens();
         fakeCustomFields();
         const createApi = fakeAdminEndpoint("POST", "/members/custom_fields/", {
-            members_custom_fields: [{...companyField, key: "job-title", name: "Job Title"}],
+            members_custom_fields: [{...companyField, key: "job_title", name: "Job Title"}],
         });
         await renderAdminApp("/settings", {boot: customFieldsBoot()});
 
@@ -201,7 +201,7 @@ describe("Custom fields", () => {
         fakeSettingsScreens();
         const manyFields = Array.from({length: 7}, (_, index) => ({
             ...companyField,
-            key: `field-${index}`,
+            key: `field_${index}`,
             name: `Field ${index}`,
         }));
         fakeCustomFields(manyFields);
@@ -225,7 +225,7 @@ describe("Custom fields", () => {
         fakeSettingsScreens();
         const initialFields = Array.from({length: 6}, (_, index) => ({
             ...companyField,
-            key: `field-${index}`,
+            key: `field_${index}`,
             name: `Field ${index}`,
         }));
         fakeCustomFieldsWithCreate(initialFields, {...companyField, key: "newest", name: "Newest"});
@@ -251,10 +251,200 @@ describe("Custom fields", () => {
         await expect(modal).toHaveCount(0);
     });
 
+    it("reorders a field by dragging it, sending the whole list in its new order", async () => {
+        fakeSettingsScreens();
+        const shirtField = {...companyField, key: "shirt_size", name: "Shirt size"};
+        const nicknameField = {...companyField, key: "nickname", name: "Nickname"};
+        let currentFields = [companyField, shirtField, nicknameField];
+        const browseApi = fakeAdminEndpoint("GET", new RegExp("^/members/custom_fields/\\?"), () => ({members_custom_fields: currentFields}));
+        const reorderApi = fakeAdminEndpoint("PUT", "/members/custom_fields/", (request) => {
+            const order = (request.body as {members_custom_fields: {key: string}[]}).members_custom_fields;
+            currentFields = order.map(({key}) => currentFields.find(field => field.key === key)!);
+            return {members_custom_fields: currentFields};
+        });
+        await renderAdminApp("/settings", {boot: customFieldsBoot()});
+
+        const rows = settingsScreen.customFields().getByTestId("custom-field-list-item");
+        await expect(rows).toHaveCount(3);
+        const browsesBeforeDrag = browseApi.requests.length;
+
+        // A real pointer drag of the handle onto the first row, which is what dnd-kit
+        // listens for. Note this cannot be driven from the keyboard: the sortable list
+        // does not wire dnd-kit's sortable coordinate getter, so arrow keys move a
+        // lifted item by a flat 25px and it never reaches the next row.
+        const handle = settingsScreen.customFields().getByLabelText("Reorder Nickname");
+        await expect.element(handle).toBeVisible();
+        await userEvent.dragAndDrop(handle, rows.first());
+
+        // The whole list goes up, in the order the drag left it, keys only — order is a
+        // property of the list, so a field never carries a rank. Nickname was dropped on
+        // the first row, so it takes that place and the rest shuffle down.
+        await expect.poll(() => reorderApi.lastRequest?.body).toEqual({
+            members_custom_fields: [{key: "nickname"}, {key: "company"}, {key: "shirt_size"}],
+        });
+
+        // The row stays where it was dropped rather than snapping back and jumping when
+        // the response lands.
+        await expect.element(rows.first()).toHaveTextContent("Nickname");
+
+        // And the response settles it, so the list is never re-read. A reorder only
+        // succeeds when it named exactly the fields the site has, so its response says
+        // everything a fetch would and the round-trip is not repeated.
+        expect(browseApi.requests.length).toBe(browsesBeforeDrag);
+    });
+
+    it("leaves the dragged field where it was dropped while the request is in flight", async () => {
+        fakeSettingsScreens();
+        const nicknameField = {...companyField, key: "nickname", name: "Nickname"};
+        let currentFields = [companyField, nicknameField];
+        fakeAdminEndpoint("GET", new RegExp("^/members/custom_fields/\\?"), () => ({members_custom_fields: currentFields}));
+
+        // The PUT is held open so the assertion below lands while the request is still
+        // outstanding. Without the local move, the list would revert to the server's
+        // order the moment the drag ends and the row would snap back under the cursor.
+        let releasePut: () => void = () => {};
+        const putHeld = new Promise<void>((resolve) => {
+            releasePut = resolve;
+        });
+        fakeAdminEndpoint("PUT", "/members/custom_fields/", async (request) => {
+            await putHeld;
+            const order = (request.body as {members_custom_fields: {key: string}[]}).members_custom_fields;
+            currentFields = order.map(({key}) => currentFields.find(field => field.key === key)!);
+            return {members_custom_fields: currentFields};
+        });
+        await renderAdminApp("/settings", {boot: customFieldsBoot()});
+
+        const rows = settingsScreen.customFields().getByTestId("custom-field-list-item");
+        await expect(rows).toHaveCount(2);
+
+        await userEvent.dragAndDrop(
+            settingsScreen.customFields().getByLabelText("Reorder Nickname"),
+            rows.first()
+        );
+
+        await expect.element(rows.first()).toHaveTextContent("Nickname");
+
+        // Let the request finish so it isn't left hanging. Whether the row survives the
+        // settled response is the drag test's job — repeating the assertion here would
+        // resolve against this same pre-release state and prove nothing.
+        releasePut();
+    });
+
+    it("puts the list back and says why when the order is refused", async () => {
+        fakeSettingsScreens();
+        const nicknameField = {...companyField, key: "nickname", name: "Nickname"};
+        // What the server has, and what this screen does not know about yet: a third
+        // field a colleague added since the page loaded.
+        const serverFields = [companyField, nicknameField, {...companyField, key: "added_elsewhere", name: "Added elsewhere"}];
+        let browses = 0;
+        fakeAdminEndpoint("GET", new RegExp("^/members/custom_fields/\\?"), () => {
+            browses += 1;
+            // The first load predates the colleague's field; a refetch sees it.
+            return {members_custom_fields: browses === 1 ? [companyField, nicknameField] : serverFields};
+        });
+        fakeAdminEndpoint("PUT", "/members/custom_fields/", {
+            errors: [{
+                type: "ValidationError",
+                message: "The order must name every custom field.",
+                context: "\"added_elsewhere\" is missing from the order. Reload and try again.",
+            }],
+        }, {status: 422});
+        await renderAdminApp("/settings", {boot: customFieldsBoot()});
+
+        const rows = settingsScreen.customFields().getByTestId("custom-field-list-item");
+        await expect(rows).toHaveCount(2);
+
+        await userEvent.dragAndDrop(
+            settingsScreen.customFields().getByLabelText("Reorder Nickname"),
+            rows.first()
+        );
+
+        // The server's own words reach the publisher, not a generic failure: they name
+        // the field and say what to do about it. And the list goes back to the order the
+        // server holds rather than keeping an arrangement that was refused.
+        await expect.element(page.getByText(/is missing from the order/)).toBeVisible();
+        await expect.element(rows.first()).toHaveTextContent("Company");
+    });
+
+    it("sends the archived fields too, keeping their places in the order", async () => {
+        fakeSettingsScreens();
+        const shirtField = {...companyField, key: "shirt_size", name: "Shirt size"};
+        // Archived between the two active fields, which is the arrangement that catches a
+        // move applied to the visible tab instead of the whole list.
+        let currentFields = [companyField, archivedField, shirtField];
+        fakeAdminEndpoint("GET", new RegExp("^/members/custom_fields/\\?"), () => ({members_custom_fields: currentFields}));
+        const reorderApi = fakeAdminEndpoint("PUT", "/members/custom_fields/", (request) => {
+            const order = (request.body as {members_custom_fields: {key: string}[]}).members_custom_fields;
+            currentFields = order.map(({key}) => currentFields.find(field => field.key === key)!);
+            return {members_custom_fields: currentFields};
+        });
+        await renderAdminApp("/settings", {boot: customFieldsBoot()});
+
+        const rows = settingsScreen.customFields().getByTestId("custom-field-list-item");
+        await expect(rows).toHaveCount(2);
+
+        await userEvent.dragAndDrop(
+            settingsScreen.customFields().getByLabelText("Reorder Shirt size"),
+            rows.first()
+        );
+
+        // The archived field is named even though it was never on screen: an order states
+        // the whole list, and the API refuses one that leaves a field out.
+        await expect.poll(() => reorderApi.lastRequest?.body).toEqual({
+            members_custom_fields: [{key: "shirt_size"}, {key: "company"}, {key: "old_hobby"}],
+        });
+    });
+
+
+    it("reorders from a collapsed list without disturbing the fields behind Show all", async () => {
+        fakeSettingsScreens();
+        let currentFields = Array.from({length: 7}, (_, index) => ({
+            ...companyField,
+            key: `field_${index}`,
+            name: `Field ${index}`,
+        }));
+        fakeAdminEndpoint("GET", new RegExp("^/members/custom_fields/\\?"), () => ({members_custom_fields: currentFields}));
+        const reorderApi = fakeAdminEndpoint("PUT", "/members/custom_fields/", (request) => {
+            const order = (request.body as {members_custom_fields: {key: string}[]}).members_custom_fields;
+            currentFields = order.map(({key}) => currentFields.find(field => field.key === key)!);
+            return {members_custom_fields: currentFields};
+        });
+        await renderAdminApp("/settings", {boot: customFieldsBoot()});
+
+        const rows = settingsScreen.customFields().getByTestId("custom-field-list-item");
+        await expect(rows).toHaveCount(5);
+
+        await userEvent.dragAndDrop(
+            settingsScreen.customFields().getByLabelText("Reorder Field 2"),
+            rows.first()
+        );
+
+        // The two fields the publisher cannot see are still named, and still last.
+        await expect.poll(() => reorderApi.lastRequest?.body).toEqual({
+            members_custom_fields: [
+                {key: "field_2"}, {key: "field_0"}, {key: "field_1"}, {key: "field_3"},
+                {key: "field_4"}, {key: "field_5"}, {key: "field_6"},
+            ],
+        });
+    });
+
+    it("does not offer dragging on the archived tab", async () => {
+        fakeSettingsScreens();
+        fakeCustomFields([companyField, archivedField]);
+        await renderAdminApp("/settings", {boot: customFieldsBoot()});
+
+        // An archived field holds its place in the order, but there is nowhere to see
+        // it, so there is nothing to drag it through.
+        await settingsScreen.customFields().getByRole("tab", {name: "Archived"}).click();
+
+        await expect(settingsScreen.customFields().getByTestId("custom-field-list-item")).toHaveCount(1);
+        await expect(settingsScreen.customFields().getByLabelText(/^Reorder /)).toHaveCount(0);
+    });
+
     it("permanently deletes an archived field from the header menu, after a heavy warning", async () => {
         fakeSettingsScreens();
         const customFieldsApi = fakeCustomFields([companyField, archivedField]);
-        const deleteApi = fakeAdminEndpoint("DELETE", "/members/custom_fields/old-hobby/", {});
+        const deleteApi = fakeAdminEndpoint("DELETE", "/members/custom_fields/old_hobby/", {});
         await renderAdminApp("/settings", {boot: customFieldsBoot()});
 
         await settingsScreen.customFields().getByRole("tab", {name: "Archived"}).click();
@@ -302,7 +492,7 @@ describe("Custom fields", () => {
     it("reactivates an archived field after confirmation, as a status edit", async () => {
         fakeSettingsScreens();
         const customFieldsApi = fakeCustomFields([companyField, archivedField]);
-        const editApi = fakeAdminEndpoint("PUT", "/members/custom_fields/old-hobby/", {
+        const editApi = fakeAdminEndpoint("PUT", "/members/custom_fields/old_hobby/", {
             members_custom_fields: [{...archivedField, status: "active"}],
         });
         await renderAdminApp("/settings", {boot: customFieldsBoot()});

--- a/ghost/core/core/server/api/endpoints/member-custom-fields.ts
+++ b/ghost/core/core/server/api/endpoints/member-custom-fields.ts
@@ -36,10 +36,10 @@ const controller = {
     browse: {
         headers: noCacheInvalidation,
         // `filter` narrows by status (the definition list is otherwise small and
-        // global, returned whole in a fixed order). Archived fields are hidden by
-        // default; Settings passes `filter=status:[active,archived]` to see both.
-        // No pagination/order options — a future sort_order column would change the
-        // order server-side, not add a client option.
+        // global, returned whole). Archived fields are hidden by default; Settings
+        // passes `filter=status:[active,archived]` to see both. No pagination or order
+        // options: the list comes back in the publisher's own order, which is changed
+        // by reordering it rather than by asking for it differently.
         options: ['filter'],
         permissions(frame: Frame) {
             return canThis(frame).browse.member_custom_field();
@@ -72,6 +72,18 @@ const controller = {
         // is just the one-item case and sees no change.
         query(frame: Frame) {
             return definitions!.add(requestContextFromFrame(frame), frame.data.members_custom_fields);
+        }
+    },
+
+    // Order belongs to the list, so it is set by PUTting the list. No `/order` sub-route:
+    // `order` is a key a publisher could mint, and the route would shadow it.
+    reorder: {
+        headers: noCacheInvalidation,
+        permissions(frame: Frame) {
+            return canThis(frame).edit.member_custom_field();
+        },
+        query(frame: Frame) {
+            return definitions!.reorder(requestContextFromFrame(frame), frame.data.members_custom_fields);
         }
     },
 

--- a/ghost/core/core/server/api/endpoints/utils/serializers/output/member-custom-fields.ts
+++ b/ghost/core/core/server/api/endpoints/utils/serializers/output/member-custom-fields.ts
@@ -21,5 +21,6 @@ module.exports = {
     // Create is a batch, so it returns every definition it made. The response is
     // already an array, so a one-item create looks exactly as it did before.
     add: serializeMany,
+    reorder: serializeMany,
     edit: serializeOne
 };

--- a/ghost/core/core/server/data/migrations/versions/6.58/2026-08-11-16-00-00-add-sort-order-to-members-custom-fields.js
+++ b/ghost/core/core/server/data/migrations/versions/6.58/2026-08-11-16-00-00-add-sort-order-to-members-custom-fields.js
@@ -1,0 +1,13 @@
+const {createAddColumnMigration} = require('../../utils');
+
+// The publisher's order for their custom fields. Every existing row takes the
+// default, so a site that has never reordered ends up with one value repeated —
+// which is why the read order tie-breaks on created_at: until the first reorder
+// writes real ranks, the fields still come out in the order they were created.
+// That is what makes this a column addition rather than a backfill.
+module.exports = createAddColumnMigration('members_custom_fields', 'sort_order', {
+    type: 'integer',
+    nullable: false,
+    unsigned: true,
+    defaultTo: 0
+});

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -675,6 +675,13 @@ module.exports = {
             }
         },
         status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'active', validations: {isIn: [['active', 'archived']]}},
+        // The publisher's order for the list, rewritten across every row whenever the
+        // list is reordered. Only the relative order carries meaning: creates append past
+        // the highest rank and deletes leave gaps, so the values are not a dense
+        // sequence. The default leaves a site that has never reordered with one value
+        // repeated, so reads tie-break on created_at and fall back to the order the
+        // fields were created in.
+        sort_order: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0},
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: true}
     },

--- a/ghost/core/core/server/services/members-custom-fields/actions.ts
+++ b/ghost/core/core/server/services/members-custom-fields/actions.ts
@@ -19,6 +19,7 @@ export interface ActionRecorder {
 const COMMANDS = {
     create: 'added',
     rename: 'edited',
+    reorder: 'edited',
     archive: 'archived',
     restore: 'restored',
     delete: 'deleted'
@@ -27,19 +28,26 @@ const COMMANDS = {
 export type CustomFieldVerb = keyof typeof COMMANDS;
 
 // `details` is stored in the action's `context` column (Ghost's slot for "diffs,
-// meta"). We always pass the field's `primary_name` so the log reads as a human
-// label, not a bare key — this is what keeps the timeline legible after a hard
-// delete, when the row itself is gone. `key` rides alongside it because the key is
-// how a field is addressed publicly — its id never leaves the API.
-export type CustomFieldActionDetails = {primary_name: string; key: string; previous_name?: string};
+// meta").
+//
+// A change to one field always passes its `primary_name` so the log reads as a human
+// label, not a bare key — this is what keeps the timeline legible after a hard delete,
+// when the row itself is gone. `key` rides alongside it because the key is how a field
+// is addressed publicly — its id never leaves the API.
+//
+// A reorder names no field: it carries the count and the word the feed reads it by.
+export type CustomFieldActionDetails =
+    | {primary_name: string; key: string; previous_name?: string}
+    | {action_name: 'reordered'; count: number};
 
+// `subject` is the field's row id, or null for an act that belongs to no single field.
 export type RecordCustomFieldAction =
-    (input: {context: RequestContext; verb: CustomFieldVerb; subject: string; details: CustomFieldActionDetails}) => Promise<void>;
+    (input: {context: RequestContext; verb: CustomFieldVerb; subject: string | null; details: CustomFieldActionDetails}) => Promise<void>;
 
 // Best-effort action-log write: a failed action must never fail the command that triggered it.
 export async function recordCustomFieldAction(
     {Action, context, verb, subject, details}:
-    {Action: ActionRecorder; context: RequestContext; verb: CustomFieldVerb; subject: string; details: CustomFieldActionDetails}
+    {Action: ActionRecorder; context: RequestContext; verb: CustomFieldVerb; subject: string | null; details: CustomFieldActionDetails}
 ): Promise<void> {
     if (!context.actor) {
         return;
@@ -50,7 +58,7 @@ export async function recordCustomFieldAction(
             resource_type: 'member_custom_field',
             // The field's id: this column holds 24 characters, and a key minted from
             // a publisher-chosen name is bounded by the far wider key column, so only
-            // the id fits every field.
+            // the id fits every field. Null where the act had no single field.
             resource_id: subject,
             actor_type: context.actor.type,
             actor_id: context.actor.id,

--- a/ghost/core/core/server/services/members-custom-fields/codec.ts
+++ b/ghost/core/core/server/services/members-custom-fields/codec.ts
@@ -5,6 +5,7 @@ import {CustomField} from './models';
 
 // Maps a members_custom_fields row to/from the domain CustomField (snake_case to
 // camelCase; DbDate decoding happens in DbCustomField).
+
 export const customFieldCodec = z.codec(DbCustomField, CustomField, {
     // DbCustomField validates `type` as the field-type enum, so the decoded row
     // already carries a FieldType and camelKeys preserves it — no cast needed.

--- a/ghost/core/core/server/services/members-custom-fields/definitions-service.ts
+++ b/ghost/core/core/server/services/members-custom-fields/definitions-service.ts
@@ -6,7 +6,7 @@ import {CustomField} from './models';
 import {FieldTypeSchema} from '@tryghost/custom-field-types';
 import {customFieldCodec} from './codec';
 import {FIELD_STATUS, FieldStatusSchema} from './schema';
-import {activeFields} from './queries';
+import {activeFields, inFieldOrder} from './queries';
 import {mintableKey} from './key';
 import {type RecordCustomFieldAction, type RequestContext} from './actions';
 
@@ -62,6 +62,12 @@ const AddFieldsInput = z.array(AddFieldInput)
     .min(1)
     .max(MAX_FIELDS_PER_REQUEST, {message: `Custom fields can only be created ${MAX_FIELDS_PER_REQUEST} at a time.`});
 
+// Only the key is read; the client sends whole field objects because that is the shape
+// the API speaks in.
+const ReorderInput = z.array(z.object({
+    key: z.string().min(1, {message: 'Every custom field in the order needs a key.'})
+})).min(1, {message: 'The order must name every custom field.'});
+
 // Name and status are mutable. `key` and `type` are accepted so the immutability
 // rules can reject a change loudly; they are never persisted.
 const EditFieldInput = z.object({
@@ -93,15 +99,22 @@ export class CustomFieldDefinitionsService {
         // supplied `filter` can widen that — Settings pulls active and archived
         // together in one request (`filter=status:[active,archived]`).
         //
-        // Insertion order for now — when the UI needs a persistent user-defined
-        // order, add a `sort_order` column and order by it.
+        // Whichever set comes back, it comes back in the publisher's order: filtering
+        // narrows the list, it never reorders it.
         const query = options.filter
             ? applyFilter(this.knex(TABLE), options.filter)
             : activeFields(this.knex);
-        const rows = await query
-            .orderBy('created_at', 'asc')
-            .orderBy('id', 'asc')
-            .select('*');
+        return this.list(query);
+    }
+
+    /**
+     * Decode a definition query into the domain, in the publisher's order.
+     *
+     * Typed off `activeFields` so the builder keeps the table's row type: every caller
+     * hands over a query against the definitions table, whatever it has narrowed.
+     */
+    private async list(query: ReturnType<typeof activeFields>): Promise<CustomField[]> {
+        const rows = await inFieldOrder(query).select('*');
         return rows.map(row => z.decode(customFieldCodec, row));
     }
 
@@ -156,11 +169,23 @@ export class CustomFieldDefinitionsService {
             created = await this.knex.transaction(async (trx) => {
                 await this.assertWithinLimit(trx, fields.length);
 
+                // Read once, before the loop: a batch appends as consecutive ranks, so
+                // the five fields of one request land in the order the request gave
+                // them rather than all sharing the end of the list.
+                const firstSortOrder = await this.nextSortOrder(trx);
+
                 const keys: string[] = [];
                 for (const [index, field] of fields.entries()) {
                     await this.assertNameAvailable(trx, field.name);
                     const key = await this.mintKey(trx, bases[index]);
-                    await trx(TABLE).insert({id: new ObjectID().toHexString(), key, name: field.name, type: field.type, created_at: new Date()});
+                    await trx(TABLE).insert({
+                        id: new ObjectID().toHexString(),
+                        key,
+                        name: field.name,
+                        type: field.type,
+                        sort_order: firstSortOrder + index,
+                        created_at: new Date()
+                    });
                     keys.push(key);
                 }
                 return this.readMany(trx, keys);
@@ -226,6 +251,75 @@ export class CustomFieldDefinitionsService {
             // a refusal, and has to re-derive its own payload size to explain why.
             errorDetails: {limit: max, total, requested: addedCount}
         });
+    }
+
+    /**
+     * Set the order of the whole list, stated rather than adjusted: every row gets a
+     * fresh rank, so a move is well-defined even where every rank is still the default.
+     * Returns every definition, archived included, matching what the request named.
+     */
+    async reorder(context: RequestContext, input: unknown): Promise<CustomField[]> {
+        const parsed = ReorderInput.safeParse(input);
+        if (!parsed.success) {
+            const issue = parsed.error.issues[0];
+            throw new errors.ValidationError({message: issue.message, property: propertyOf(issue.path)});
+        }
+        const keys = parsed.data.map(item => item.key);
+
+        const ordered = await this.knex.transaction(async (trx) => {
+            await this.assertNamesEveryField(trx, keys);
+
+            // Ranks come from the request's order; the statements go out in key order, so
+            // two concurrent reorders take their row locks in the same sequence and
+            // cannot deadlock. `updated_at` is left alone — the definitions did not
+            // change, the list around them did.
+            const ranks = new Map(keys.map((key, rank) => [key, rank]));
+            for (const key of [...keys].sort()) {
+                await trx(TABLE).where('key', key).update({sort_order: ranks.get(key)!});
+            }
+
+            return this.list(trx(TABLE));
+        });
+
+        await this.recordAction({
+            context,
+            verb: 'reorder',
+            subject: null,
+            details: {action_name: 'reordered', count: ordered.length}
+        });
+        return ordered;
+    }
+
+    /**
+     * A partial order is ambiguous, so a reorder that does not name every field exactly
+     * once is refused rather than half-applied. A client that loaded before a colleague
+     * added a field cannot name it, and is told to reload.
+     */
+    private async assertNamesEveryField(db: Knex, keys: string[]): Promise<void> {
+        const named = new Set(keys);
+        const existing = new Set(await db(TABLE).pluck<string[]>('key'));
+
+        const matches = named.size === keys.length
+            && named.size === existing.size
+            && keys.every(key => existing.has(key));
+
+        if (!matches) {
+            throw new errors.ValidationError({
+                message: 'The order must name every custom field exactly once. Reload and try again.',
+                property: 'key'
+            });
+        }
+    }
+
+    /** A new field is appended. Archived fields hold ranks too, so it lands past them. */
+    private async nextSortOrder(db: Knex): Promise<number> {
+        const row = await db(TABLE).max({highest: 'sort_order'}).first();
+        const highest = row?.highest;
+        // No fields yet, so this one starts the order.
+        if (highest === null || highest === undefined) {
+            return 0;
+        }
+        return Number(highest) + 1;
     }
 
     /** Read back a batch in the order its keys were created, not the table's order. */

--- a/ghost/core/core/server/services/members-custom-fields/queries.ts
+++ b/ghost/core/core/server/services/members-custom-fields/queries.ts
@@ -11,3 +11,18 @@ const FIELDS_TABLE = 'members_custom_fields';
 export function activeFields(db: Knex) {
     return db(FIELDS_TABLE).where('status', FIELD_STATUS.active);
 }
+
+/**
+ * The publisher's order, applied to every read of the list. Here for the same reason the
+ * status filter is: a read that forgets it comes back in whatever order the engine chose.
+ *
+ * `created_at` orders a site that has never reordered, where every row still holds the
+ * default rank; `id` settles the rest so the order is total.
+ */
+export function inFieldOrder<T extends Knex.QueryBuilder>(query: T): T {
+    query
+        .orderBy(`${FIELDS_TABLE}.sort_order`, 'asc')
+        .orderBy(`${FIELDS_TABLE}.created_at`, 'asc')
+        .orderBy(`${FIELDS_TABLE}.id`, 'asc');
+    return query;
+}

--- a/ghost/core/core/server/services/members-custom-fields/schema.ts
+++ b/ghost/core/core/server/services/members-custom-fields/schema.ts
@@ -22,7 +22,10 @@ export const DbCustomField = z.object({
     updated_at: DbDate.nullable()
 });
 
-type CustomFieldRow = z.infer<typeof DbCustomField>;
+// Storage only: order is a fact about the list, so no read projection carries a rank.
+type CustomFieldRank = {sort_order: number};
+
+type CustomFieldRow = z.infer<typeof DbCustomField> & CustomFieldRank;
 
 // One part of a member's value. What a `path` means is storage.ts's business, so the row
 // carries it as a plain string.
@@ -57,9 +60,9 @@ declare module 'knex/types/tables' {
     interface Tables {
         members_custom_fields: Knex.CompositeTableType<
             CustomFieldRow,
-            // `status` is DB-defaulted to 'active' on create and only ever set via
-            // update (archive/restore), so it's absent from the insert type.
-            Omit<z.input<typeof DbCustomField>, 'updated_at' | 'status'>,
+            // `status` is DB-defaulted and only set via update, so it's absent here. The
+            // rank is required: letting it default would land a new field at the top.
+            Omit<z.input<typeof DbCustomField>, 'updated_at' | 'status'> & CustomFieldRank,
             Partial<CustomFieldRow>
         >;
         members_custom_field_values: Knex.CompositeTableType<

--- a/ghost/core/core/server/services/members-custom-fields/values-service.ts
+++ b/ghost/core/core/server/services/members-custom-fields/values-service.ts
@@ -82,12 +82,13 @@ export class CustomFieldValuesService {
             return new Map();
         }
 
+        // Not ordered by field: these rows become an object keyed by field, and an object
+        // cannot carry an order. `path` is ordered so composite parts assemble the same
+        // way every time.
         const rows = await this.knex(VALUES_TABLE)
             .join(FIELDS_TABLE, `${VALUES_TABLE}.custom_field_key`, `${FIELDS_TABLE}.key`)
             .whereIn(`${VALUES_TABLE}.member_id`, memberIds)
             .where(`${FIELDS_TABLE}.status`, FIELD_STATUS.active)
-            .orderBy(`${FIELDS_TABLE}.created_at`, 'asc')
-            .orderBy(`${FIELDS_TABLE}.id`, 'asc')
             .orderBy(`${VALUES_TABLE}.path`, 'asc')
             .select(`${VALUES_TABLE}.member_id`, `${FIELDS_TABLE}.key`, `${FIELDS_TABLE}.type`, `${VALUES_TABLE}.path`, `${VALUES_TABLE}.value_text`);
 

--- a/ghost/core/core/server/web/api/endpoints/admin/routes.js
+++ b/ghost/core/core/server/web/api/endpoints/admin/routes.js
@@ -161,6 +161,8 @@ module.exports = function apiRoutes() {
     // Registered before /members/:id so the literal path isn't captured by :id.
     router.get('/members/custom_fields', mw.authAdminApi, labs.enabledMiddleware('membersCustomFields'), http(api.membersCustomFields.browse));
     router.post('/members/custom_fields', mw.authAdminApi, labs.enabledMiddleware('membersCustomFields'), http(api.membersCustomFields.add));
+    // A PUT on the collection sets the publisher's order for the whole list.
+    router.put('/members/custom_fields', mw.authAdminApi, labs.enabledMiddleware('membersCustomFields'), http(api.membersCustomFields.reorder));
     router.get('/members/custom_fields/:key', mw.authAdminApi, labs.enabledMiddleware('membersCustomFields'), http(api.membersCustomFields.read));
     router.put('/members/custom_fields/:key', mw.authAdminApi, labs.enabledMiddleware('membersCustomFields'), http(api.membersCustomFields.edit));
     router.delete('/members/custom_fields/:key', mw.authAdminApi, labs.enabledMiddleware('membersCustomFields'), http(api.membersCustomFields.destroy));

--- a/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
@@ -545,6 +545,218 @@ describe('Member Custom Fields Admin API', function () {
         });
     });
 
+    describe('Ordering', function () {
+        // Order is a property of the list, not of a field: it is set by PUTting the
+        // whole collection in the order it should have, and read back as the order
+        // the list comes out in. No field ever carries a sort order over the API.
+        async function reorder(keys: string[], status = 200) {
+            const {body} = await agent
+                .put('members/custom_fields/')
+                .body({members_custom_fields: keys.map(key => ({key}))})
+                .expectStatus(status);
+            return body;
+        }
+
+        async function browseKeys(filter?: string): Promise<string[]> {
+            const url = filter
+                ? `members/custom_fields/?filter=${encodeURIComponent(filter)}`
+                : 'members/custom_fields/';
+            const {body} = await agent.get(url).expectStatus(200);
+            return body.members_custom_fields.map((field: {key: string}) => field.key);
+        }
+
+        it('returns definitions in the order they were created until they are reordered', async function () {
+            await createField({name: 'Company'});
+            await createField({name: 'Shirt size'});
+            await createField({name: 'Address'});
+
+            assert.deepEqual(await browseKeys(), ['company', 'shirt_size', 'address']);
+        });
+
+        it('returns definitions in the order a reorder gave them', async function () {
+            await createField({name: 'Company'});
+            await createField({name: 'Shirt size'});
+            await createField({name: 'Address'});
+
+            const {members_custom_fields: reordered} = await reorder(['address', 'company', 'shirt_size']);
+
+            // The response is the new list, so a client re-syncs from it rather than
+            // trusting the order it just guessed.
+            assert.deepEqual(reordered.map((field: {key: string}) => field.key), ['address', 'company', 'shirt_size']);
+            assert.deepEqual(await browseKeys(), ['address', 'company', 'shirt_size']);
+        });
+
+        // The state every existing site is in the moment the column is added: the
+        // migration writes no ranks, so every row holds the same default and nothing
+        // tells them apart but creation time. Creating fields through the API cannot
+        // reach this state — each create appends a distinct rank — so it is set up
+        // directly, which is exactly what the migration does to a real site.
+        async function asNeverReordered() {
+            await models.Base.knex('members_custom_fields').update({sort_order: 0});
+        }
+
+        it('falls back to creation order while every field holds the default rank', async function () {
+            await createField({name: 'One'});
+            await createField({name: 'Two'});
+            await createField({name: 'Three'});
+            await asNeverReordered();
+
+            assert.deepEqual(await browseKeys(), ['one', 'two', 'three']);
+        });
+
+
+
+
+
+        it('appends a newly created field to the end of a reordered list', async function () {
+            await createField({name: 'Company'});
+            await createField({name: 'Shirt size'});
+            await reorder(['shirt_size', 'company']);
+
+            await createField({name: 'Address'});
+
+            assert.deepEqual(await browseKeys(), ['shirt_size', 'company', 'address']);
+        });
+
+        it('appends every field of a batch create in the order the batch gave them', async function () {
+            await createField({name: 'Company'});
+            await reorder(['company']);
+
+            await agent
+                .post('members/custom_fields/')
+                .body({members_custom_fields: [
+                    {name: 'Shirt size', type: 'short_text'},
+                    {name: 'Address', type: 'address'}
+                ]})
+                .expectStatus(201);
+
+            assert.deepEqual(await browseKeys(), ['company', 'shirt_size', 'address']);
+        });
+
+        // Order is one total order over every definition, so archiving takes a field
+        // out of sight without disturbing it and restoring puts it back where it was.
+        it('keeps an archived field in its place and restores it there', async function () {
+            await createField({name: 'Company'});
+            await createField({name: 'Shirt size'});
+            await createField({name: 'Address'});
+            await reorder(['address', 'company', 'shirt_size']);
+
+            await setStatus('company', 'archived');
+            assert.deepEqual(await browseKeys(), ['address', 'shirt_size']);
+            assert.deepEqual(
+                await browseKeys('status:[active,archived]'),
+                ['address', 'company', 'shirt_size']
+            );
+
+            await setStatus('company', 'active');
+            assert.deepEqual(await browseKeys(), ['address', 'company', 'shirt_size']);
+        });
+
+        it('reorders around an archived field', async function () {
+            await createField({name: 'Company'});
+            await createField({name: 'Shirt size'});
+            await createField({name: 'Address'});
+            await setStatus('shirt_size', 'archived');
+
+            // Settings holds both statuses, so the list it sends names all three.
+            const {members_custom_fields: reordered} = await reorder(['address', 'shirt_size', 'company']);
+
+            // The response mirrors the request: an order names every definition, so it
+            // returns every definition. This is the one read that does not hide archived
+            // fields, and a caller re-syncing from it gets back exactly what it sent.
+            assert.deepEqual(
+                reordered.map((field: {key: string}) => field.key),
+                ['address', 'shirt_size', 'company']
+            );
+            assert.equal(reordered[1].status, 'archived');
+
+            assert.deepEqual(await browseKeys(), ['address', 'company']);
+            assert.deepEqual(
+                await browseKeys('status:[active,archived]'),
+                ['address', 'shirt_size', 'company']
+            );
+        });
+
+        // A list that does not name every definition exactly once is rejected rather
+        // than partly applied. This is also what makes a stale client safe: if a
+        // colleague added a field since this client loaded, its list no longer names
+        // every definition and the reorder bounces instead of silently demoting the
+        // new field.
+        it('rejects a list that leaves a definition out', async function () {
+            await createField({name: 'Company'});
+            await createField({name: 'Shirt size'});
+
+            await reorder(['shirt_size'], 422);
+
+            assert.deepEqual(await browseKeys(), ['company', 'shirt_size']);
+        });
+
+        it('rejects a list naming a field that does not exist', async function () {
+            await createField({name: 'Company'});
+
+            await reorder(['company', 'nonexistent'], 422);
+
+            assert.deepEqual(await browseKeys(), ['company']);
+        });
+
+        it('rejects a list naming the same field twice', async function () {
+            await createField({name: 'Company'});
+            await createField({name: 'Shirt size'});
+
+            await reorder(['company', 'company'], 422);
+
+            assert.deepEqual(await browseKeys(), ['company', 'shirt_size']);
+        });
+
+
+
+        // A member's values are an object keyed by field, and an object cannot carry an
+        // order: JSON says nothing about member order, and JavaScript hoists any key
+        // that looks like an array index — a field named "2024" enumerates first however
+        // it was inserted. The definition list is the array that carries the order, and
+        // it is what every surface renders from. All this pins is that reordering does
+        // not disturb the values themselves.
+        it('leaves a member\'s values untouched when the list is reordered', async function () {
+            await createField({name: 'Company'});
+            await createField({name: 'Shirt size'});
+            const memberId = await createMember();
+            await setValues(memberId, {company: 'Ghost', 'shirt_size': 'M'});
+
+            await reorder(['shirt_size', 'company']);
+
+            assert.deepEqual(await readValues(memberId), {company: 'Ghost', 'shirt_size': 'M'});
+        });
+
+        // `updated_at` says when the definition changed, and a definition does not change
+        // when the list around it is reordered. Left alone so one drag does not read as
+        // an edit to every field on the site.
+        it('does not mark the fields as edited', async function () {
+            await createField({name: 'Company'});
+            await createField({name: 'Shirt size'});
+
+            await reorder(['shirt_size', 'company']);
+
+            const {body} = await agent.get('members/custom_fields/').expectStatus(200);
+            for (const field of body.members_custom_fields) {
+                assert.equal(field.updated_at, null, `${field.key} should not have been touched`);
+            }
+        });
+
+        it('never exposes a sort order on a field', async function () {
+            await createField({name: 'Company'});
+            await createField({name: 'Shirt size'});
+            const {members_custom_fields: reordered} = await reorder(['shirt_size', 'company']);
+
+            for (const field of reordered) {
+                assert.equal(field.sort_order, undefined);
+                assert.equal(field.sortOrder, undefined);
+            }
+
+            const {body} = await agent.get('members/custom_fields/shirt_size/').expectStatus(200);
+            assert.equal(body.members_custom_fields[0].sort_order, undefined);
+        });
+    });
+
     describe('Operational limit on the number of definitions', function () {
         // The cap is an operator setting, not a release constant. Ghost containers
         // are stateless, so it is read from config on every create: these tests set
@@ -1534,7 +1746,7 @@ describe('Member Custom Fields Admin API', function () {
         // context rather than in resource_id, which holds the row id.
         const contextOf = (a: {context: unknown}) =>
             (typeof a.context === 'string' ? JSON.parse(a.context) : a.context) as
-                {primary_name?: string; key?: string; previous_name?: string};
+                {primary_name?: string; key?: string; previous_name?: string; action_name?: string; count?: number};
 
         beforeAll(async function () {
             actorId = (await agent.get('users/me/').expectStatus(200)).body.users[0].id;
@@ -1565,6 +1777,28 @@ describe('Member Custom Fields Admin API', function () {
 
             const row = await models.Base.knex('members_custom_fields').where('key', field.key).first();
             assert.equal(actions[0].resource_id, row.id);
+        });
+
+        // A reorder is one act by the publisher, so it is one entry — not one per
+        // field whose position happened to shift. It belongs to no single field, so
+        // it carries no resource_id, and the count is what lets the activity feed
+        // read it as "3 custom fields reordered".
+        it('records a single action when the list is reordered', async function () {
+            await createField({name: 'Company'});
+            await createField({name: 'Shirt size'});
+            await createField({name: 'Address'});
+
+            await agent
+                .put('members/custom_fields/')
+                .body({members_custom_fields: [{key: 'address'}, {key: 'company'}, {key: 'shirt_size'}]})
+                .expectStatus(200);
+
+            const edited = (await customFieldActions()).filter((a: {event: string}) => a.event === 'edited');
+            assert.equal(edited.length, 1, 'a reorder records one action, not one per field');
+            assert.equal(edited[0].resource_id, null);
+            assert.equal(contextOf(edited[0]).action_name, 'reordered');
+            assert.equal(contextOf(edited[0]).count, 3);
+            assert.equal(edited[0].actor_id, actorId);
         });
 
         it('records an "edited" action when a field is renamed', async function () {
@@ -1779,6 +2013,13 @@ describe('Member Custom Fields Admin API', function () {
                 .body({members_custom_fields: [{name: 'Topic', type: 'short_text'}]})
                 .expectStatus(403);
         });
+
+        it('forbids a role without permission from reordering', async function () {
+            await agent
+                .put('members/custom_fields/')
+                .body({members_custom_fields: [{key: 'topic'}]})
+                .expectStatus(403);
+        });
     });
 
     describe('Flag disabled', function () {
@@ -1789,6 +2030,13 @@ describe('Member Custom Fields Admin API', function () {
 
         it('404s the definitions endpoint', async function () {
             await agent.get('members/custom_fields/').expectStatus(404);
+        });
+
+        it('404s the reorder endpoint', async function () {
+            await agent
+                .put('members/custom_fields/')
+                .body({members_custom_fields: [{key: 'company'}]})
+                .expectStatus(404);
         });
     });
 });

--- a/ghost/core/test/e2e-api/admin/members-exporter-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/members-exporter-custom-fields.test.ts
@@ -221,6 +221,31 @@ describe('Members API — exportCSV with custom fields', function () {
         assert.deepEqual(columns, [...CORE_COLUMNS, columnFor(numeric.key)]);
     });
 
+    // The export builds its columns from the definition list, so the publisher's order
+    // reaches the spreadsheet without the exporter knowing anything about ordering.
+    // Pinned here because it is the consumer that would regress most quietly.
+    it('writes the custom field columns in the publisher\'s order', async function () {
+        const nickname = await createField('Nickname', 'short_text');
+        const address = await createField('Shipping Address', 'address');
+        const bio = await createField('Bio', 'long_text');
+
+        await agent
+            .put('members/custom_fields/')
+            .body({members_custom_fields: [{key: address.key}, {key: bio.key}, {key: nickname.key}]})
+            .expectStatus(200);
+
+        await createMember();
+
+        const {columns} = await exportCSV();
+
+        assert.deepEqual(columns, [
+            ...CORE_COLUMNS,
+            ...addressColumnsFor(address.key),
+            columnFor(bio.key),
+            columnFor(nickname.key)
+        ]);
+    });
+
     it('escapes values that would otherwise break the CSV', async function () {
         const notes = await createField('Notes', 'short_text');
 

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const parseYaml = require('../../../../../core/server/services/route-settings/ya
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '8078d6e15d88dccf19ebd1ab9b205677';
+    const currentSchemaHash = 'bb0b6f2ab291417ad87e0e7bc49c2310';
     const currentFixturesHash = '4e0c7b4fe3c1593e9d1fae1a891389ca';
     const currentSettingsHash = '8650db85b9a61afe4797ad6333066c62';
     const currentRoutesHash = 'd8c25fa01bf6d22a2bcb05ba0de70dc1';


### PR DESCRIPTION
## Problem

Custom field definitions came back in the order they happened to be created, and every surface reads that one list: the settings list, a member's details, the import mapping's targets and the export's columns. A publisher who wants an address near the top has no way to say so, and because one list feeds every screen, a bad order is repeated everywhere rather than being one screen's problem.

## Solution

A publisher drags their custom fields into the order they want in Settings, and that order is the order everywhere else.

Order is a property of the list rather than of any one field, so no definition carries a rank anywhere in the API. It is stated by sending the whole collection in the order it should have, applied in one go, and that list has to name every field the site has — a client working from a stale list is told to reload rather than writing an order that was never true of the whole list.

Sites that never reorder keep exactly what they have today. The column is added with no backfill, and reads fall back to creation order until a publisher states one of their own.

Behind the `membersCustomFields` flag.

ref BER-3850