### PR TITLE
Changed routing events to carry domain data instead of Express routers

### DIFF
--- a/ghost/core/core/frontend/services/routing/events.js
+++ b/ghost/core/core/frontend/services/routing/events.js
@@ -1,12 +1,26 @@
 const EventEmitter = require('events').EventEmitter;
 
 /**
- * Frontend-internal routing events.
+ * Raised for each router mounted during activation.
  *
- * Carries `router.created` and `routers.reset`, which are emitted by the
- * router manager and consumed only inside the frontend (the sitemap keeps
- * its route entries in sync from them). They used to ride the server's
- * shared event bus purely for historical reasons — nothing server-side
- * listens to them.
+ * @typedef {Object} RouteRegistered
+ * @property {string|null} path - route in domain notation, e.g. `/about/`.
+ *   Null for routers with no route of their own: the static pages router,
+ *   and taxonomies, which have no index route (`/tag/` does not exist).
+ * @property {string} type - the kind of router, e.g. `CollectionRouter`
+ * @property {string} id - the router's identifier
+ */
+
+/**
+ * Frontend-internal routing domain events.
+ *
+ * Carries `RouteRegistered` and `RoutesReset` — the latter has no payload and
+ * is raised before a reload clears the routers. Both are emitted by the router
+ * manager and consumed only inside the frontend (the sitemap keeps its route
+ * entries in sync from them). They used to ride the server's shared event bus
+ * purely for historical reasons — nothing server-side listens to them.
+ *
+ * The payloads are plain data, so a consumer never depends on the internals
+ * of the Express-backed router that happened to raise the event.
  */
 module.exports = new EventEmitter();

--- a/ghost/core/core/frontend/services/routing/permalink-adapter.ts
+++ b/ghost/core/core/frontend/services/routing/permalink-adapter.ts
@@ -8,16 +8,3 @@
 export function toExpressNotation(permalink: string): string {
     return permalink.replace(/{(\w+)}/g, ':$1');
 }
-
-/**
- * Convert an Express / URL-service permalink back into domain-model notation.
- * Will be used on the download path when serialising the canonical shape back
- * to YAML — no production caller yet.
- *
- * @example toDomainNotation('/:slug/')               // => '/{slug}/'
- * @example toDomainNotation('/:primary_tag/:slug/')  // => '/{primary_tag}/{slug}/'
- * @example toDomainNotation('/{slug}/')              // => '/{slug}/' (idempotent)
- */
-export function toDomainNotation(permalink: string): string {
-    return permalink.replace(/:(\w+)/g, '{$1}');
-}

--- a/ghost/core/core/frontend/services/routing/router-manager.js
+++ b/ghost/core/core/frontend/services/routing/router-manager.js
@@ -39,7 +39,7 @@ class RouterManager {
         });
 
         // CASE: there are router types which do not generate resource urls
-        //       e.g. static route router, in this case we don't want ot notify the URL service
+        //       e.g. static route router, in this case we don't want to notify the URL service
         if (!router.getPermalinks()) {
             return;
         }

--- a/ghost/core/core/frontend/services/routing/router-manager.js
+++ b/ghost/core/core/frontend/services/routing/router-manager.js
@@ -8,7 +8,7 @@ const ParentRouter = require('./parent-router');
 const EmailRouter = require('./email-router');
 const UnsubscribeRouter = require('./unsubscribe-router');
 
-// Frontend-internal routing events (router.created / routers.reset)
+// Frontend-internal routing domain events (RouteRegistered / RoutesReset)
 const routingEvents = require('./events');
 
 class RouterManager {
@@ -30,11 +30,17 @@ class RouterManager {
     }
 
     routerCreated(router) {
-        routingEvents.emit('router.created', router);
+        routingEvents.emit('RouteRegistered', {
+            // Not every router owns a route: the static pages router has none,
+            // and taxonomies have no index route (`/tag/` does not exist).
+            path: router.route ? router.route.value : null,
+            type: router.name,
+            id: router.identifier
+        });
 
         // CASE: there are router types which do not generate resource urls
         //       e.g. static route router, in this case we don't want ot notify the URL service
-        if (!router || !router.getPermalinks()) {
+        if (!router.getPermalinks()) {
             return;
         }
 
@@ -65,7 +71,7 @@ class RouterManager {
         this.registry.resetAllRouters();
         this.registry.resetAllRoutes();
 
-        routingEvents.emit('routers.reset');
+        routingEvents.emit('RoutesReset');
 
         this.siteRouter = new ParentRouter('SiteRouter');
         this.registry.setRouter('siteRouter', this.siteRouter);

--- a/ghost/core/core/frontend/services/sitemap/site-map-manager.js
+++ b/ghost/core/core/frontend/services/sitemap/site-map-manager.js
@@ -6,7 +6,7 @@ const PostsMapGenerator = require('./post-map-generator');
 const UsersMapGenerator = require('./user-map-generator');
 const TagsMapGenerator = require('./tags-map-generator');
 
-// Frontend-internal routing events (router.created / routers.reset)
+// Frontend-internal routing domain events (RouteRegistered / RoutesReset)
 const routingEvents = require('../routing/events');
 
 // What the sitemap XML reads off each resource, beyond the columns URL
@@ -52,23 +52,23 @@ class SiteMapManager {
         this._indexBuilt = false;
         this._buildInFlight = null;
         this._indexEpoch = 0;
-        // Static/collection route entries only arrive via router.created,
+        // Static/collection route entries only arrive via RouteRegistered,
         // which fires at boot and routes reload. They are recorded here so
         // every rebuild can replay them after resetting the generators.
         this._routerEntries = [];
 
-        routingEvents.on('router.created', (router) => {
-            if (router.name !== 'StaticRoutesRouter' && router.name !== 'CollectionRouter') {
+        routingEvents.on('RouteRegistered', ({path, type, id}) => {
+            if (type !== 'StaticRoutesRouter' && type !== 'CollectionRouter') {
                 return;
             }
             const entry = {
-                url: router.getRoute({absolute: true}),
-                datum: {id: router.identifier, staticRoute: router.name === 'StaticRoutesRouter'}
+                url: urlUtils.createUrl(path, true),
+                datum: {id, staticRoute: type === 'StaticRoutesRouter'}
             };
             this._routerEntries.push(entry);
             this.pages.addUrl(entry.url, entry.datum);
             // A router registering after a build (routes reload re-registers
-            // them one macrotask after routers.reset) must not leave a
+            // them one macrotask after RoutesReset) must not leave a
             // zero-router index marked built — the CDN would pin it.
             this._invalidateIndex();
         });
@@ -79,7 +79,7 @@ class SiteMapManager {
             this._invalidateIndex();
         });
 
-        routingEvents.on('routers.reset', () => {
+        routingEvents.on('RoutesReset', () => {
             this.pages && this.pages.reset();
             this.posts && this.posts.reset();
             this.users && this.users.reset();

--- a/ghost/core/test/unit/frontend/services/routing/permalink-adapter.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/permalink-adapter.test.js
@@ -1,5 +1,5 @@
 const assert = require('node:assert/strict');
-const {toExpressNotation, toDomainNotation} = require('../../../../../core/frontend/services/routing/permalink-adapter');
+const {toExpressNotation} = require('../../../../../core/frontend/services/routing/permalink-adapter');
 
 describe('UNIT - services/routing/permalink-adapter', function () {
     describe('toExpressNotation', function () {
@@ -26,41 +26,6 @@ describe('UNIT - services/routing/permalink-adapter', function () {
         it('is idempotent — already-converted :slug notation is unchanged', function () {
             assert.equal(toExpressNotation('/:slug/'), '/:slug/');
             assert.equal(toExpressNotation('/:primary_tag/:slug/'), '/:primary_tag/:slug/');
-        });
-    });
-
-    describe('toDomainNotation', function () {
-        it('converts a single :slug placeholder to {slug}', function () {
-            assert.equal(toDomainNotation('/:slug/'), '/{slug}/');
-        });
-
-        it('converts every placeholder in a multi-segment permalink', function () {
-            assert.equal(toDomainNotation('/:primary_tag/:slug/'), '/{primary_tag}/{slug}/');
-        });
-
-        it('converts placeholders adjacent to non-slash separators', function () {
-            assert.equal(toDomainNotation('/:year-:month-:day-:slug/'), '/{year}-{month}-{day}-{slug}/');
-        });
-
-        it('leaves a permalink with no placeholder untouched', function () {
-            assert.equal(toDomainNotation('/about/'), '/about/');
-        });
-
-        it('is idempotent — already-converted {slug} notation is unchanged', function () {
-            assert.equal(toDomainNotation('/{slug}/'), '/{slug}/');
-            assert.equal(toDomainNotation('/{primary_tag}/{slug}/'), '/{primary_tag}/{slug}/');
-        });
-    });
-
-    describe('round-trip', function () {
-        it('domain → express → domain returns the original', function () {
-            const domain = '/{primary_tag}/{slug}/';
-            assert.equal(toDomainNotation(toExpressNotation(domain)), domain);
-        });
-
-        it('express → domain → express returns the original', function () {
-            const express = '/:primary_tag/:slug/';
-            assert.equal(toExpressNotation(toDomainNotation(express)), express);
         });
     });
 });

--- a/ghost/core/test/unit/frontend/services/routing/router-manager.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/router-manager.test.js
@@ -3,6 +3,7 @@ const sinon = require('sinon');
 
 const RouterManager = require('../../../../../core/frontend/services/routing/router-manager');
 const registry = require('../../../../../core/frontend/services/routing/registry');
+const routingEvents = require('../../../../../core/frontend/services/routing/events');
 
 // The routers RouterManager mounts unconditionally (previews, unsubscribe,
 // static pages, apps); only the settings-driven ones are asserted on here.
@@ -52,6 +53,88 @@ describe('UNIT: services/routing/RouterManager', function () {
 
             assert.ok(taxonomyRouters.includes('/categories/:slug/'));
             assert.ok(!taxonomyRouters.some(route => route.includes('author')));
+        });
+    });
+
+    describe('domain events', function () {
+        let registered;
+        let resetsBeforeEachRegistration;
+        let resetCount;
+        let onRegistered;
+        let onReset;
+
+        // Fails the assertion rather than throwing a TypeError when the router
+        // never registered, which is the more likely regression.
+        const eventFor = (type) => {
+            const event = registered.find(candidate => candidate.type === type);
+            assert.ok(event, `${type} emitted RouteRegistered`);
+            return event;
+        };
+
+        beforeEach(function () {
+            registered = [];
+            resetsBeforeEachRegistration = [];
+            resetCount = 0;
+            onRegistered = (event) => {
+                registered.push(event);
+                resetsBeforeEachRegistration.push(resetCount);
+            };
+            onReset = () => {
+                resetCount += 1;
+            };
+            routingEvents.on('RouteRegistered', onRegistered);
+            routingEvents.on('RoutesReset', onReset);
+        });
+
+        afterEach(function () {
+            routingEvents.off('RouteRegistered', onRegistered);
+            routingEvents.off('RoutesReset', onReset);
+        });
+
+        it('emits RoutesReset once per init, before any router registers', function () {
+            start({...emptySettings, taxonomies: {tag: '/tag/{slug}/'}});
+
+            assert.equal(resetCount, 1);
+            // The sitemap empties its recorded entries on RoutesReset and
+            // refills them from the registrations that follow; a router
+            // registering before the reset would be dropped.
+            assert.deepEqual([...new Set(resetsBeforeEachRegistration)], [1]);
+        });
+
+        it('emits RouteRegistered with the domain path, router type and identifier', function () {
+            start({
+                ...emptySettings,
+                routes: [{path: '/about/', type: 'template', contentType: 'page', templates: ['about']}]
+            });
+
+            const event = eventFor('StaticRoutesRouter');
+
+            assert.equal(event.path, '/about/', 'carries the domain path, not an absolute URL');
+            assert.equal(typeof event.id, 'string');
+            assert.ok(event.id.length > 0, 'carries the router identifier');
+        });
+
+        it('emits a null path for routers that have no index route', function () {
+            start({...emptySettings, taxonomies: {tag: '/tag/{slug}/'}});
+
+            // StaticPagesRouter has no route at all and the taxonomy router has
+            // no index route (/tag/ does not exist), so neither can report a path.
+            for (const type of ['StaticPagesRouter', 'Taxonomy']) {
+                assert.equal(eventFor(type).path, null, type);
+            }
+        });
+
+        it('carries data only — never an Express router instance', function () {
+            start({
+                ...emptySettings,
+                collections: [{path: '/', permalink: '/{slug}/', templates: [], data: {}}]
+            });
+
+            assert.ok(registered.length > 0, 'sanity: routers registered');
+            for (const event of registered) {
+                assert.deepEqual(Object.keys(event).sort(), ['id', 'path', 'type'], event.type);
+                assert.ok(event.path === null || typeof event.path === 'string', event.type);
+            }
         });
     });
 });

--- a/ghost/core/test/unit/frontend/services/sitemap/manager.test.js
+++ b/ghost/core/test/unit/frontend/services/sitemap/manager.test.js
@@ -52,7 +52,7 @@ describe('Unit: sitemap/manager', function () {
         eventsToRemember = {};
 
         // @NOTE: the pattern of faking event call is not great, we should be
-        //        ideally tasting on real events instead of faking them
+        //        ideally testing on real events instead of faking them
         // RouteRegistered / RoutesReset are frontend-internal routing events
         sinon.stub(routingEvents, 'on').callsFake(function (eventName, callback) {
             eventsToRemember[eventName] = callback;

--- a/ghost/core/test/unit/frontend/services/sitemap/manager.test.js
+++ b/ghost/core/test/unit/frontend/services/sitemap/manager.test.js
@@ -53,7 +53,7 @@ describe('Unit: sitemap/manager', function () {
 
         // @NOTE: the pattern of faking event call is not great, we should be
         //        ideally tasting on real events instead of faking them
-        // router.created / routers.reset are frontend-internal routing events
+        // RouteRegistered / RoutesReset are frontend-internal routing events
         sinon.stub(routingEvents, 'on').callsFake(function (eventName, callback) {
             eventsToRemember[eventName] = callback;
         });
@@ -77,8 +77,8 @@ describe('Unit: sitemap/manager', function () {
         it('can create a SiteMapManager instance', function () {
             assertExists(manager);
             assert.equal(Object.keys(eventsToRemember).length, 3);
-            assertExists(eventsToRemember['router.created']);
-            assertExists(eventsToRemember['routers.reset']);
+            assertExists(eventsToRemember.RouteRegistered);
+            assertExists(eventsToRemember.RoutesReset);
             assertExists(eventsToRemember['site.changed']);
         });
 
@@ -103,11 +103,15 @@ describe('Unit: sitemap/manager', function () {
                 });
             }
 
+            // The absolute URL is derived from the domain path the event
+            // carries, so the expectation is computed the same way.
+            const aboutUrl = urlUtils.createUrl('/about/', true);
+
             function emitAboutRouter() {
-                eventsToRemember['router.created']({
-                    name: 'StaticRoutesRouter',
-                    identifier: 'sr1',
-                    getRoute: () => 'http://example.com/about/'
+                eventsToRemember.RouteRegistered({
+                    type: 'StaticRoutesRouter',
+                    id: 'sr1',
+                    path: '/about/'
                 });
             }
 
@@ -224,9 +228,13 @@ describe('Unit: sitemap/manager', function () {
 
                 await siteMapManager.getSiteMapXml('posts');
 
-                // router.created only fires at boot and routes reload; the entry
+                // The expectation is computed the same way the subscriber
+                // computes it, so anchor its shape: the domain path the event
+                // carries has to reach the sitemap absolutised.
+                assert.match(aboutUrl, /^https?:\/\/.+\/about\/$/);
+                // RouteRegistered only fires at boot and routes reload; the entry
                 // must survive the apply-phase generator reset.
-                sinon.assert.calledWith(PageGenerator.prototype.addUrl, 'http://example.com/about/', sinon.match({id: 'sr1'}));
+                sinon.assert.calledWith(PageGenerator.prototype.addUrl, aboutUrl, sinon.match({id: 'sr1'}));
             });
 
             it('rebuilds after a router registers, so a reload window cannot pin a routerless index', async function () {
@@ -240,17 +248,17 @@ describe('Unit: sitemap/manager', function () {
                 sinon.assert.callCount(fetchStub, 8);
             });
 
-            it('forgets recorded route entries when routers.reset fires', async function () {
+            it('forgets recorded route entries when RoutesReset fires', async function () {
                 const siteMapManager = makeManager();
                 emitAboutRouter();
 
-                eventsToRemember['routers.reset']();
+                eventsToRemember.RoutesReset();
                 PageGenerator.prototype.addUrl.resetHistory();
                 await siteMapManager.getSiteMapXml('posts');
 
                 // The routers re-register right after a reset and refill the
                 // list; a stale entry here would resurrect a deleted route.
-                sinon.assert.neverCalledWith(PageGenerator.prototype.addUrl, 'http://example.com/about/', sinon.match({id: 'sr1'}));
+                sinon.assert.neverCalledWith(PageGenerator.prototype.addUrl, aboutUrl, sinon.match({id: 'sr1'}));
             });
 
             it('fails a read with a 503 when the build is invalidated mid-flight, and rebuilds on the next read', async function () {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1899

The last piece of code in the **DDD Architecture Cleanup** milestone (design step 3.8).

## The problem

`RouterManager.routerCreated()` broadcast a live Express-backed router instance:

```js
routingEvents.emit('router.created', router);
```

The sitemap — the only listener — then reached into that object for three things:

```js
if (router.name !== 'StaticRoutesRouter' && router.name !== 'CollectionRouter') return;
const entry = {
    url: router.getRoute({absolute: true}),
    datum: {id: router.identifier, staticRoute: router.name === 'StaticRoutesRouter'}
};
```

Two frontend subsystems coupled through an infrastructure handle rather than a message. Change a router's method surface and static/collection routes silently stop appearing in the sitemap, with nothing to catch it.

## The change

```
RouteRegistered { path, type, id }   // path in domain notation, e.g. '/about/'
RoutesReset                          // no payload
```

`RouterManager` emits data; the sitemap filters on `type` and absolutises `path` itself.

## Three decisions worth reviewing

**1. `path` (domain notation), not a pre-rendered absolute URL.**
This matches the issue spec and the design doc's Layer-2 table (`RouteRegistered { path, type, id }`). Our internal plan doc had argued for an emitter-computed absolute `url` on the grounds that the sitemap would otherwise "have to reach back for `urlUtils`" — that premise was wrong: `site-map-manager.js:2` already imported `urlUtils` for its `/404/` sentinel. So `path` costs nothing and keeps the event domain-level instead of carrying rendered output.

The conversion is provably lossless. `ParentRouter.getRoute()` and `CollectionRouter.getRoute()` (the only two emitting types) are both exactly `urlUtils.createUrl(this.route.value, options.absolute)`, and the subscriber now calls `urlUtils.createUrl(path, true)` on that same value. Verified identical by instantiating the real router classes under three configs — root, `http://localhost/blog/`, `https://example.com/blog/` — across `/`, `/about/`, `/feed/`, `/podcast/`, `/hello/world/`. **Subdirectory installs included.**

**2. Kept the frontend-internal `EventEmitter` rather than `@tryghost/domain-events`.**
The issue allows either. Two reasons for local:
- `729891bc00` deliberately created `frontend/services/routing/events.js` to move these events *off* the server's shared bus, as part of taking these modules off the dependency-cruiser allowlist. Adopting `DomainEvents` — a process-wide static singleton — reverses that.
- `DomainEvents.subscribe` wraps every handler in `try/catch` and only logs (`DomainEvents.js:33-39`). The sitemap's handler mutates `_routerEntries` and invalidates the index; a swallowed throw there is a silently stale sitemap.

**3. `path` is `null` for routers that own no route.**
`StaticPagesRouter` has no `this.route` and `TaxonomyRouter` has no index route (`/tag/` doesn't exist). Previously invisible because the subscriber's name filter ran *before* it ever called `getRoute()`; the `type` filter still runs before `path` is used, so `createUrl(null, …)` is unreachable for the two live types.

`type` deliberately carries the router's `name` — a hand-passed `super()` string literal, not `constructor.name`, so it's already decoupled from the class name. Re-vocabularising it to `static-route`/`collection` would add exactly the mapping layer the design doc's "Keeping it lean" section warns against, for no behavioural gain.

## No backwards-compat shim

The issue offers keeping `router.created` "if other consumers exist". None do — repo-wide search across `.js/.ts/.tsx/.json/.hbs` (including `apps/`, `packages/`, `e2e/`, and computed event names) found only the two emitters, the one consumer, and their tests. `grep -rn "router.created\|routers.reset" ghost/core/core ghost/core/test` now returns nothing.

## Second commit — `toDomainNotation()`

A pure deletion, split into its own commit for blame. It's the milestone's documented last loose end. It never had a production caller, and its docstring's promise of one on the download path is provably obsolete: `DynamicRoutingService.download()` returns `settings.yamlSource` verbatim and never re-serialises.

## Testing

Behaviour is intended to be byte-identical; the tests were written first.

- `router-manager.test.js` — new `domain events` block (5 → 7 tests): payload shape pinned by `Object.keys(event).sort()`, the null-path case, and the ordering the sitemap depends on (`RoutesReset` always precedes every registration that refills the entries it emptied).
- `manager.test.js` — the hand-built fake router becomes a plain payload.
- Full `pnpm test:unit`: **matches pristine `main` exactly** (same 2 pre-existing failures in `automations-repository` and `email-renderer`, both unrelated and reproducing on `main`).
- `test/e2e-frontend/` — 18 files / 259 tests green. This is the real safety net: `default-routes.test.js` and `custom-routes.test.js` render actual sitemap XML through the real emit→subscribe path, and `advanced-url-config.test.js` covers the subdirectory install.
- `--project legacy` — 35 files / 451 tests green.
- `pnpm lint:boundaries` — 0 violations across 5,137 modules; no new cross-context coupling.

The one `tsc` error locally (`values-service.ts` / `subFieldsOf`) reproduces on pristine `main` — a stale local workspace-package build, not this branch.

Reviewed before opening by three independent agents (clean code, production safety, scope/design alignment); their actionable findings are already folded in.
