### PR TITLE
Added regression coverage for tag/author slug rename to sitemap

### DIFF
--- a/ghost/core/test/e2e-frontend/sitemap-slug-rename.test.js
+++ b/ghost/core/test/e2e-frontend/sitemap-slug-rename.test.js
@@ -1,0 +1,80 @@
+// A tag or author slug rename has to refresh the sitemap on its own, with no
+// unrelated edit to nudge it. The chain: the edit handler sets
+// `X-Cache-Invalidate: /*` dynamically (the endpoints' static `cacheInvalidate`
+// config is `false`, so it covers none of this) → the emit-events middleware
+// turns that header into `site.changed` → the sitemap index is invalidated and
+// the next read rebuilds. Both ends are asserted, so a break at either one fails
+// here rather than silently serving a stale sitemap.
+const assert = require('node:assert/strict');
+const {agentProvider, assertions, fixtureManager} = require('../utils/e2e-framework');
+const {cacheInvalidateHeaderSetToWildcard} = assertions;
+
+describe('Sitemap freshness', function () {
+    let adminAgent;
+    let frontendAgent;
+    let ghostServer;
+
+    async function getSitemap(path) {
+        const res = await frontendAgent.get(path).expect(200);
+        return res.text;
+    }
+
+    beforeAll(async function () {
+        const agents = await agentProvider.getAgentsWithFrontend();
+        adminAgent = agents.adminAgent;
+        frontendAgent = agents.frontendAgent;
+        ghostServer = agents.ghostServer;
+
+        await fixtureManager.init('posts');
+        await adminAgent.loginAsOwner();
+    });
+
+    afterAll(async function () {
+        // Optional-chained: a `beforeAll` that failed before the boot returned
+        // would otherwise throw here and mask the real error, and the bound port
+        // would leak to the next file sharing this fork.
+        await ghostServer?.stop();
+    });
+
+    // The old-URL assertions below rely on the trailing slash: the renamed URL
+    // still contains the old slug as a prefix, and only the `/` after it tells
+    // `/tag/kitchen-sink/` apart from `/tag/kitchen-sink-renamed/`.
+    it('serves the new URL in /sitemap-tags.xml after a tag slug rename', async function () {
+        const {id, slug: oldSlug} = fixtureManager.get('tags', 0);
+        const newSlug = `${oldSlug}-renamed`;
+
+        assert.ok(
+            (await getSitemap('/sitemap-tags.xml')).includes(`/tag/${oldSlug}/`),
+            'precondition: sitemap should serve the original tag URL'
+        );
+
+        await adminAgent.put(`tags/${id}/`)
+            .body({tags: [{slug: newSlug}]})
+            .expectStatus(200)
+            .expect(cacheInvalidateHeaderSetToWildcard());
+
+        const sitemap = await getSitemap('/sitemap-tags.xml');
+        assert.ok(sitemap.includes(`/tag/${newSlug}/`), 'sitemap should serve the renamed tag URL');
+        assert.ok(!sitemap.includes(`/tag/${oldSlug}/`), 'sitemap should not still serve the old tag URL');
+    });
+
+    it('serves the new URL in /sitemap-authors.xml after an author slug rename', async function () {
+        // users[0] is the owner — the same user the suite authenticated as above.
+        const {id, slug: oldSlug} = fixtureManager.get('users', 0);
+        const newSlug = `${oldSlug}-renamed`;
+
+        assert.ok(
+            (await getSitemap('/sitemap-authors.xml')).includes(`/author/${oldSlug}/`),
+            'precondition: sitemap should serve the original author URL'
+        );
+
+        await adminAgent.put(`users/${id}/`)
+            .body({users: [{slug: newSlug}]})
+            .expectStatus(200)
+            .expect(cacheInvalidateHeaderSetToWildcard());
+
+        const sitemap = await getSitemap('/sitemap-authors.xml');
+        assert.ok(sitemap.includes(`/author/${newSlug}/`), 'sitemap should serve the renamed author URL');
+        assert.ok(!sitemap.includes(`/author/${oldSlug}/`), 'sitemap should not still serve the old author URL');
+    });
+});


### PR DESCRIPTION
ref https://linear.app/ghost/issue/HKG-1958/add-regression-coverage-for-tagauthor-slug-rename-sitemap-original

Test-only. No production code is touched.

## What the test covers

`ghost/core/test/e2e-frontend/sitemap-slug-rename.test.js` — boots a full Ghost with a frontend, renames a fixture tag slug and a fixture author slug through the Admin API, and asserts both ends of the chain:

1. `X-Cache-Invalidate: /*` on the edit response
2. `/sitemap-tags.xml` serves the new tag URL and no longer the old one, with no unrelated edit in between
3. Same for `/sitemap-authors.xml`

The chain under test:

`handler sets header` → `res.set()` → response finish → `web/parent/middleware/emit-events.js` sees `/*` → `events.emit('site.changed')` → `frontend/services/proxy.js` → `site-map-manager.js` `_invalidateIndex()` → next read rebuilds from the DB.

Two links in that chain can each break silently, so both are asserted rather than just the end result. Verified by breaking each one independently and confirming the test goes red for the right reason:

| Break introduced | Failure |
| --- | --- |
| Remove `frame.setHeader('X-Cache-Invalidate', '/*')` from both endpoints | `AssertionError: x-cache-invalidate header should be set to /*` ×2 |
| No-op the `site.changed` handler in `site-map-manager.js` | `AssertionError: sitemap should serve the renamed tag URL` / `... renamed author URL` |

### Why this file rather than `tags.test.js` / `users.test.js`

Those suites use `getAdminAPIAgent()` / legacy `localUtils`, neither of which yields a frontend agent that can request `/sitemap-*.xml`. Only `getAgentsWithFrontend()` gives both agents against a single boot — which is what lets the header and the served XML be asserted on the *same* edit. `users.test.js` already asserts the wildcard header on `website` / `roles` / `mastodon` edits, but none on a `slug` change; `tags.test.js` has no `X-Cache-Invalidate` coverage at all.

### Post-lazy correctness

The test asserts observable output — the URL present in the served XML — not any per-URL event. It has no reference to the removed eager service's `url.added` / `url.removed`, and no dependency on the `/404/` sentinel behaviour either way (HKG-1920): both fixture resources have published posts, so they get real URLs under the old rule and the new one.
