### PR TITLE
🐛 Fixed sitemap reporting a stale last-modified date after content changes

### DIFF
--- a/ghost/core/core/frontend/services/sitemap/base-site-map-generator.js
+++ b/ghost/core/core/frontend/services/sitemap/base-site-map-generator.js
@@ -200,11 +200,6 @@ class BaseSiteMapGenerator {
         this.nodeLookup = {};
         this.nodeTimeLookup = {};
         this.siteMapContent.clear();
-        // updateLastModified only ever raises this, so it has to be cleared
-        // with the nodes it was derived from. The index rebuild resets every
-        // generator and replays the surviving resources, which restores the
-        // correct value; keeping the old one would report the timestamp of a
-        // resource that is no longer in the sitemap.
         this.lastModified = 0;
     }
 }

--- a/ghost/core/core/frontend/services/sitemap/base-site-map-generator.js
+++ b/ghost/core/core/frontend/services/sitemap/base-site-map-generator.js
@@ -200,6 +200,12 @@ class BaseSiteMapGenerator {
         this.nodeLookup = {};
         this.nodeTimeLookup = {};
         this.siteMapContent.clear();
+        // updateLastModified only ever raises this, so it has to be cleared
+        // with the nodes it was derived from. The index rebuild resets every
+        // generator and replays the surviving resources, which restores the
+        // correct value; keeping the old one would report the timestamp of a
+        // resource that is no longer in the sitemap.
+        this.lastModified = 0;
     }
 }
 

--- a/ghost/core/test/unit/frontend/services/sitemap/generator.test.js
+++ b/ghost/core/test/unit/frontend/services/sitemap/generator.test.js
@@ -43,6 +43,46 @@ describe('Generators', function () {
         assert.equal(generator.maxPerPage, 50000);
     });
 
+    describe('fn: reset', function () {
+        const addPostAt = (gen, slug, updatedAt) => gen.addUrl(
+            `http://my-ghost-blog.com/${slug}/`,
+            testUtils.DataGenerator.forKnex.createPost({
+                slug,
+                updated_at: updatedAt,
+                created_at: updatedAt,
+                published_at: updatedAt
+            })
+        );
+
+        it('clears lastModified so a rebuild cannot report a removed resource', function () {
+            generator = new PostGenerator();
+
+            addPostAt(generator, 'older', '2024-01-01T00:00:00.000Z');
+            addPostAt(generator, 'newer', '2024-06-01T00:00:00.000Z');
+            assert.equal(generator.lastModified.toISOString(), '2024-06-01T00:00:00.000Z');
+
+            // The index rebuild resets every generator and replays only the
+            // resources that are still routable — here "newer" was deleted.
+            generator.reset();
+            addPostAt(generator, 'older', '2024-01-01T00:00:00.000Z');
+
+            assert.equal(
+                generator.lastModified.toISOString(),
+                '2024-01-01T00:00:00.000Z',
+                'lastModified must fall back to the newest surviving resource'
+            );
+        });
+
+        it('leaves lastModified at zero when nothing is replayed', function () {
+            generator = new PostGenerator();
+
+            addPostAt(generator, 'only', '2024-06-01T00:00:00.000Z');
+            generator.reset();
+
+            assert.equal(generator.lastModified, 0);
+        });
+    });
+
     describe('IndexGenerator', function () {
         beforeEach(function () {
             generator = new IndexGenerator({
@@ -80,6 +120,27 @@ describe('Generators', function () {
                 assert.doesNotMatch(xml, /sitemap-posts.xml/);
                 assert.doesNotMatch(xml, /sitemap-pages.xml/);
                 assert.doesNotMatch(xml, /sitemap-authors.xml/);
+            });
+
+            it('reports the newest surviving resource after a rebuild', function () {
+                const addPostAt = (slug, updatedAt) => generator.types.posts.addUrl(
+                    `http://my-ghost-blog.com/${slug}/`,
+                    testUtils.DataGenerator.forKnex.createPost({
+                        slug,
+                        updated_at: updatedAt,
+                        created_at: updatedAt,
+                        published_at: updatedAt
+                    })
+                );
+
+                addPostAt('older', '2024-01-01T00:00:00.000Z');
+                addPostAt('newer', '2024-06-01T00:00:00.000Z');
+                assert.match(generator.getXml(), /<lastmod>2024-06-01T00:00:00.000Z<\/lastmod>/);
+
+                generator.types.posts.reset();
+                addPostAt('older', '2024-01-01T00:00:00.000Z');
+
+                assert.match(generator.getXml(), /<lastmod>2024-01-01T00:00:00.000Z<\/lastmod>/);
             });
 
             it('creates multiple pages when there are too many posts', function () {


### PR DESCRIPTION
ref https://linear.app/ghost/project/moving-routesyaml-off-of-disk-9887873946a1/

## Problem

`sitemap.xml` can advertise a `<lastmod>` for a resource that is no longer in the sitemap — and keep advertising it until Ghost restarts.

`BaseSiteMapGenerator.reset()` cleared `nodeLookup`, `nodeTimeLookup` and the cached XML, but left `this.lastModified` alone. Since `updateLastModified()` only ever raises the value:

```js
updateLastModified(datum, lastModified = this.getLastModifiedForDatum(datum)) {
    if (lastModified > this.lastModified) {
        this.lastModified = lastModified;
    }
}
```

…it behaves as a permanent high-water mark. `SiteMapIndexGenerator` reads it for the `<lastmod>` of every `<sitemap>` entry in the index, so:

1. Publish a post dated June 1st → index reports `2024-06-01`
2. Delete or unpublish it → index still reports `2024-06-01`, forever

## Why now

This was always latent, but harmless in practice: the sitemap index used to be maintained incrementally from URL-service events, so `reset()` effectively only ran at boot.

The move to a DB-driven rebuild changed that. `SiteMapManager._buildIndex()` now resets every generator and replays the surviving resources, and `_invalidateIndex()` fires on every `site.changed` — i.e. on every publish, edit, delete and import. So a method that used to run once per process now runs on every content change, and the stale value is reachable constantly.

Search engines consume this field to decide whether to refetch a sitemap section, so a section pinned to the timestamp of a deleted post can suppress recrawls of the posts that are still there.

## Solution

Clear `lastModified` in `reset()`. Nothing else is needed: the rebuild replays the surviving resources immediately afterwards, and each `addUrl()` raises the value back to the newest one that is genuinely still in the sitemap.

## Tests

Three regression tests, all of which fail on `main` for the right reason (the index XML literally contains the deleted post's timestamp):

- `fn: reset` › clears `lastModified` so a rebuild reports the newest **surviving** resource
- `fn: reset` › leaves `lastModified` at zero when nothing is replayed
- `IndexGenerator` › `fn: getXml` › the user-visible symptom — `<lastmod>` in the index falls back after a rebuild

```
test/unit/frontend/services/sitemap/                    42 passed
test/e2e-frontend/{sitemap-slug-rename,default-routes}  44 passed
test/e2e-frontend/custom-routes                          7 passed
eslint                                                   clean
```

No other test in the repo referenced `lastModified`, so nothing depended on the old behaviour.

## Scope

Deliberately just this one line plus coverage. Two adjacent sitemap items came up while looking at it and are **not** included:

- `SITEMAP_BUILD_SUPERSEDED` returns a 503 with deliberately no retry — reasonable as a decision, but it assumes someone is alerting on it, and nobody is yet
- the DB-driven rebuild re-enumerates all posts/pages/tags/authors and recomputes every URL on each `site.changed`, where the old path was incremental. Unbenchmarked on a large site
