### PR TITLE
Added a scoped Shade code editor for tag details

### DIFF
--- a/apps/admin/src/tags/detail/tag-detail-form.tsx
+++ b/apps/admin/src/tags/detail/tag-detail-form.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, {useMemo} from 'react';
 import TagColorField from './tag-color-field';
 import TagImageField from './tag-image-field';
-import {Accordion, AccordionContent, AccordionItem, AccordionTrigger, Card, CardContent, FieldError, Input, Label, Textarea} from '@tryghost/shade/components';
+import {Accordion, AccordionContent, AccordionItem, AccordionTrigger, Card, CardContent, CodeEditor, FieldError, Input, Label, Textarea} from '@tryghost/shade/components';
+import {Stack} from '@tryghost/shade/primitives';
 import {DESCRIPTION_MAX_LENGTH, FACEBOOK_DESCRIPTION_RECOMMENDED_LENGTH, FACEBOOK_TITLE_RECOMMENDED_LENGTH, META_DESCRIPTION_RECOMMENDED_LENGTH, META_TITLE_RECOMMENDED_LENGTH, X_DESCRIPTION_RECOMMENDED_LENGTH, X_TITLE_RECOMMENDED_LENGTH, charLength, getBlogDomain, getSeoDescription, getSeoTitle, getSeoUrl, getSlugUrlPreview, validateTagField} from './tag-detail-edit';
 import {FacebookCardPreview, SeoPreview, XCardPreview} from './tag-detail-previews';
 import {cn, formatNumber} from '@tryghost/shade/utils';
@@ -47,6 +48,7 @@ const TagDetailForm: React.FC<TagDetailFormProps> = ({draft, errors, blogUrl, di
     const siteMetaTitle = getSettingValue<string>(settingsData?.settings ?? [], 'meta_title') ?? '';
     const siteMetaDescription = getSettingValue<string>(settingsData?.settings ?? [], 'meta_description') ?? '';
     const unsplashEnabled = getSettingValue<boolean>(settingsData?.settings ?? [], 'unsplash') ?? false;
+    const htmlExtensions = useMemo(() => [import('@codemirror/lang-html').then(module => module.html())], []);
 
     const validateOnBlur = (field: TagFieldName) => {
         onFieldError(field, validateTagField(field, draft));
@@ -315,30 +317,28 @@ const TagDetailForm: React.FC<TagDetailFormProps> = ({draft, errors, blogUrl, di
                         <AccordionItem className='last:border-b-0' value='code-injection'>
                             <SectionTrigger description='Add styles/scripts to the header and footer.' title='Code injection' />
                             <AccordionContent>
-                                <div className='flex flex-col gap-5 pt-2'>
-                                    <div className='flex flex-col gap-1.5'>
-                                        <Label htmlFor='codeinjection-head'>Tag header <code className='ml-1 font-normal'>{'{{ghost_head}}'}</code></Label>
-                                        <Textarea
-                                            className='min-h-32 font-mono text-sm'
-                                            disabled={disabled}
-                                            id='codeinjection-head'
-                                            spellCheck={false}
-                                            value={draft.codeinjectionHead}
-                                            onChange={e => onChange({codeinjectionHead: e.target.value})}
-                                        />
-                                    </div>
-                                    <div className='flex flex-col gap-1.5'>
-                                        <Label htmlFor='codeinjection-foot'>Tag footer <code className='ml-1 font-normal'>{'{{ghost_foot}}'}</code></Label>
-                                        <Textarea
-                                            className='min-h-32 font-mono text-sm'
-                                            disabled={disabled}
-                                            id='codeinjection-foot'
-                                            spellCheck={false}
-                                            value={draft.codeinjectionFoot}
-                                            onChange={e => onChange({codeinjectionFoot: e.target.value})}
-                                        />
-                                    </div>
-                                </div>
+                                <Stack className='pt-2' gap='lg'>
+                                    <CodeEditor
+                                        ariaLabel='Tag header'
+                                        data-testid='codeinjection-head'
+                                        editable={!disabled}
+                                        extensions={htmlExtensions}
+                                        height='128px'
+                                        title={<>Tag header <code className='ml-1 font-normal'>{'{{ghost_head}}'}</code></>}
+                                        value={draft.codeinjectionHead}
+                                        onChange={value => onChange({codeinjectionHead: value})}
+                                    />
+                                    <CodeEditor
+                                        ariaLabel='Tag footer'
+                                        data-testid='codeinjection-foot'
+                                        editable={!disabled}
+                                        extensions={htmlExtensions}
+                                        height='128px'
+                                        title={<>Tag footer <code className='ml-1 font-normal'>{'{{ghost_foot}}'}</code></>}
+                                        value={draft.codeinjectionFoot}
+                                        onChange={value => onChange({codeinjectionFoot: value})}
+                                    />
+                                </Stack>
                             </AccordionContent>
                         </AccordionItem>
                     </Accordion>

--- a/apps/admin/src/tags/detail/tag-detail-form.tsx
+++ b/apps/admin/src/tags/detail/tag-detail-form.tsx
@@ -1,4 +1,4 @@
-import React, {useMemo} from 'react';
+import React from 'react';
 import TagColorField from './tag-color-field';
 import TagImageField from './tag-image-field';
 import {Accordion, AccordionContent, AccordionItem, AccordionTrigger, Card, CardContent, CodeEditor, FieldError, Input, Label, Textarea} from '@tryghost/shade/components';
@@ -21,6 +21,7 @@ interface TagDetailFormProps {
 }
 
 const errorId = (field: TagFieldName) => `tag-${field}-error`;
+const htmlExtensions = [() => import('@codemirror/lang-html').then(module => module.html())];
 
 /** Ember's `gh-count-down-characters`: the used count, red once past the limit. */
 const UsedCharacters: React.FC<{value: string; limit: number; prefix: 'Maximum' | 'Recommended'}> = ({value, limit, prefix}) => {
@@ -48,7 +49,6 @@ const TagDetailForm: React.FC<TagDetailFormProps> = ({draft, errors, blogUrl, di
     const siteMetaTitle = getSettingValue<string>(settingsData?.settings ?? [], 'meta_title') ?? '';
     const siteMetaDescription = getSettingValue<string>(settingsData?.settings ?? [], 'meta_description') ?? '';
     const unsplashEnabled = getSettingValue<boolean>(settingsData?.settings ?? [], 'unsplash') ?? false;
-    const htmlExtensions = useMemo(() => [import('@codemirror/lang-html').then(module => module.html())], []);
 
     const validateOnBlur = (field: TagFieldName) => {
         onFieldError(field, validateTagField(field, draft));
@@ -319,7 +319,6 @@ const TagDetailForm: React.FC<TagDetailFormProps> = ({draft, errors, blogUrl, di
                             <AccordionContent>
                                 <Stack className='pt-2' gap='lg'>
                                     <CodeEditor
-                                        ariaLabel='Tag header'
                                         data-testid='codeinjection-head'
                                         editable={!disabled}
                                         extensions={htmlExtensions}
@@ -329,7 +328,6 @@ const TagDetailForm: React.FC<TagDetailFormProps> = ({draft, errors, blogUrl, di
                                         onChange={value => onChange({codeinjectionHead: value})}
                                     />
                                     <CodeEditor
-                                        ariaLabel='Tag footer'
                                         data-testid='codeinjection-foot'
                                         editable={!disabled}
                                         extensions={htmlExtensions}

--- a/apps/admin/src/tags/detail/tag-detail.acceptance.test.tsx
+++ b/apps/admin/src/tags/detail/tag-detail.acceptance.test.tsx
@@ -62,6 +62,38 @@ describe('Tag detail (tagDetailsReact on)', () => {
         expect(saved.codeinjection_foot).toBe('<style>.footer { display: grid; }</style>');
     });
 
+    it('keeps CodeMirror autocomplete outside the clipped editor surface', async () => {
+        const t = tag({name: 'News', slug: 'news'});
+        fakeTagWorld(t);
+        await renderAdminApp(`/tags/${t.slug}`, FLAGS);
+
+        await page.getByRole('button', {name: /Code injection/}).click();
+        const headerEditor = page.getByRole('textbox', {name: 'Tag header'});
+        await headerEditor.fill('<');
+
+        await expect.poll(() => {
+            const tooltip = document.querySelector<HTMLElement>('.cm-tooltip-autocomplete');
+            const tooltipParent = tooltip?.closest<HTMLElement>('.cm-tooltip-parent');
+            const container = tooltipParent?.firstElementChild as HTMLElement | null;
+
+            if (!tooltip || !tooltipParent || !container) {
+                return null;
+            }
+
+            return {
+                containerBackground: getComputedStyle(container).backgroundColor,
+                containerHeight: container.getBoundingClientRect().height,
+                hostParent: tooltipParent.parentElement?.tagName,
+                tooltipVisible: tooltip.getBoundingClientRect().height > 0
+            };
+        }).toEqual({
+            containerBackground: 'rgba(0, 0, 0, 0)',
+            containerHeight: 0,
+            hostParent: 'BODY',
+            tooltipVisible: true
+        });
+    });
+
     it('redirects to billing during a force upgrade', async () => {
         const config = configResponse(FLAGS);
         config.config.hostSettings = {forceUpgrade: true};

--- a/apps/admin/src/tags/detail/tag-detail.acceptance.test.tsx
+++ b/apps/admin/src/tags/detail/tag-detail.acceptance.test.tsx
@@ -45,8 +45,8 @@ describe('Tag detail (tagDetailsReact on)', () => {
         await renderAdminApp(`/tags/${t.slug}`, FLAGS);
 
         await page.getByRole('button', {name: /Code injection/}).click();
-        const headerEditor = page.getByRole('textbox', {name: 'Tag header'});
-        const footerEditor = page.getByRole('textbox', {name: 'Tag footer'});
+        const headerEditor = page.getByRole('textbox', {name: /^Tag header/});
+        const footerEditor = page.getByRole('textbox', {name: /^Tag footer/});
         await expect.element(headerEditor).toBeVisible();
         await expect.element(footerEditor).toBeVisible();
         await expect.poll(() => (headerEditor.element() as HTMLElement).innerText).toBe(head);
@@ -71,7 +71,7 @@ describe('Tag detail (tagDetailsReact on)', () => {
         await new Promise((resolve) => {
             window.setTimeout(resolve, 250);
         });
-        const headerEditor = page.getByRole('textbox', {name: 'Tag header'});
+        const headerEditor = page.getByRole('textbox', {name: /^Tag header/});
         await headerEditor.fill('<');
 
         await new Promise((resolve) => {

--- a/apps/admin/src/tags/detail/tag-detail.acceptance.test.tsx
+++ b/apps/admin/src/tags/detail/tag-detail.acceptance.test.tsx
@@ -37,6 +37,31 @@ describe('Tag detail (tagDetailsReact on)', () => {
         await expect.element(page.getByRole('button', {name: 'Delete tag', exact: true})).toBeVisible();
     });
 
+    it('edits and saves tag code injection with CodeMirror', async () => {
+        const head = '<script>\n    head();\n</script>';
+        const foot = '<style>\n    .footer { display: block; }\n</style>';
+        const t = tag({name: 'News', slug: 'news', codeinjection_head: head, codeinjection_foot: foot});
+        const saveApi = fakeTagWorld(t);
+        await renderAdminApp(`/tags/${t.slug}`, FLAGS);
+
+        await page.getByRole('button', {name: /Code injection/}).click();
+        const headerEditor = page.getByRole('textbox', {name: 'Tag header'});
+        const footerEditor = page.getByRole('textbox', {name: 'Tag footer'});
+        await expect.element(headerEditor).toBeVisible();
+        await expect.element(footerEditor).toBeVisible();
+        await expect.poll(() => (headerEditor.element() as HTMLElement).innerText).toBe(head);
+        await expect.poll(() => (footerEditor.element() as HTMLElement).innerText).toBe(foot);
+
+        await headerEditor.fill('<script>updatedHead();</script>');
+        await footerEditor.fill('<style>.footer { display: grid; }</style>');
+        await page.getByRole('button', {name: 'Save'}).click();
+
+        await expect.element(page.getByRole('button', {name: 'Saved'})).toBeVisible();
+        const saved = (saveApi.lastRequest?.body as {tags: Array<Record<string, unknown>>}).tags[0];
+        expect(saved.codeinjection_head).toBe('<script>updatedHead();</script>');
+        expect(saved.codeinjection_foot).toBe('<style>.footer { display: grid; }</style>');
+    });
+
     it('redirects to billing during a force upgrade', async () => {
         const config = configResponse(FLAGS);
         config.config.hostSettings = {forceUpgrade: true};

--- a/apps/admin/src/tags/detail/tag-detail.acceptance.test.tsx
+++ b/apps/admin/src/tags/detail/tag-detail.acceptance.test.tsx
@@ -68,29 +68,47 @@ describe('Tag detail (tagDetailsReact on)', () => {
         await renderAdminApp(`/tags/${t.slug}`, FLAGS);
 
         await page.getByRole('button', {name: /Code injection/}).click();
+        await new Promise((resolve) => {
+            window.setTimeout(resolve, 250);
+        });
         const headerEditor = page.getByRole('textbox', {name: 'Tag header'});
         await headerEditor.fill('<');
+
+        await new Promise((resolve) => {
+            window.setTimeout(resolve, 75);
+        });
 
         await expect.poll(() => {
             const tooltip = document.querySelector<HTMLElement>('.cm-tooltip-autocomplete');
             const tooltipParent = tooltip?.closest<HTMLElement>('.cm-tooltip-parent');
             const container = tooltipParent?.firstElementChild as HTMLElement | null;
+            const editor = headerEditor.element().closest<HTMLElement>('[data-testid="codeinjection-head"]');
 
-            if (!tooltip || !tooltipParent || !container) {
+            if (!tooltip || !tooltipParent || !container || !editor) {
                 return null;
             }
+
+            const tooltipRect = tooltip.getBoundingClientRect();
+            const editorRect = editor.getBoundingClientRect();
 
             return {
                 containerBackground: getComputedStyle(container).backgroundColor,
                 containerHeight: container.getBoundingClientRect().height,
+                escapesEditor: tooltipRect.bottom > editorRect.bottom || tooltipRect.top < editorRect.top,
                 hostParent: tooltipParent.parentElement?.tagName,
-                tooltipVisible: tooltip.getBoundingClientRect().height > 0
+                tooltipOnscreen: tooltipRect.bottom > 0
+                    && tooltipRect.right > 0
+                    && tooltipRect.top < window.innerHeight
+                    && tooltipRect.left < window.innerWidth,
+                tooltipPosition: getComputedStyle(tooltip).position
             };
         }).toEqual({
             containerBackground: 'rgba(0, 0, 0, 0)',
             containerHeight: 0,
+            escapesEditor: true,
             hostParent: 'BODY',
-            tooltipVisible: true
+            tooltipOnscreen: true,
+            tooltipPosition: 'fixed'
         });
     });
 

--- a/apps/shade/package.json
+++ b/apps/shade/package.json
@@ -103,10 +103,11 @@
         "vitest": "catalog:"
     },
     "dependencies": {
-        "@ebay/nice-modal-react": "catalog:",
+        "@codemirror/state": "catalog:",
         "@dnd-kit/core": "catalog:",
         "@dnd-kit/sortable": "catalog:",
         "@dnd-kit/utilities": "catalog:",
+        "@ebay/nice-modal-react": "catalog:",
         "@hookform/resolvers": "5.4.0",
         "@number-flow/react": "0.6.2",
         "@radix-ui/react-accordion": "1.2.15",
@@ -132,6 +133,7 @@
         "@types/react": "catalog:",
         "@types/react-dom": "catalog:",
         "@types/validator": "catalog:",
+        "@uiw/react-codemirror": "catalog:",
         "class-variance-authority": "0.7.1",
         "clsx": "catalog:",
         "cmdk": "1.1.1",

--- a/apps/shade/src/components.ts
+++ b/apps/shade/src/components.ts
@@ -12,6 +12,7 @@ export * from './components/ui/calendar';
 export * from './components/ui/card';
 export * from './components/ui/chart';
 export * from './components/ui/checkbox';
+export * from './components/ui/code-editor';
 export * from './components/ui/command';
 export * from './components/ui/combobox';
 export * from './components/ui/context-menu';

--- a/apps/shade/src/components/ui/code-editor-view.tsx
+++ b/apps/shade/src/components/ui/code-editor-view.tsx
@@ -1,4 +1,4 @@
-import CodeMirror, {EditorView, type BasicSetupOptions, type ReactCodeMirrorProps, type ReactCodeMirrorRef} from '@uiw/react-codemirror';
+import CodeMirror, {EditorView, tooltips, type BasicSetupOptions, type ReactCodeMirrorProps, type ReactCodeMirrorRef} from '@uiw/react-codemirror';
 import React, {type FocusEventHandler, forwardRef, useEffect, useId, useMemo, useRef, useState} from 'react';
 
 import {FieldDescription, FieldLabel} from '@/components/ui/field';
@@ -30,8 +30,7 @@ const codeMirrorClasses = [
     '[&_.cm-gutters]:bg-muted',
     '[&_.cm-gutters]:text-muted-foreground',
     '[&_.cm-gutters]:border-border',
-    '[&_.cm-cursor]:border-foreground',
-    '[&_.cm-tooltip-autocomplete.cm-tooltip_ul_li:not([aria-selected])]:bg-background'
+    '[&_.cm-cursor]:border-foreground'
 ].join(' ');
 
 // Imported asynchronously by CodeEditor so CodeMirror stays out of the main bundle.
@@ -57,6 +56,21 @@ const CodeEditorView = forwardRef<ReactCodeMirrorRef, CodeEditorProps>(function 
     const [resolvedExtensions, setResolvedExtensions] = useState<Extension[]>([]);
     const {darkMode, setFocusState} = useFocusContext();
 
+    // Keep autocomplete outside the editor and accordion overflow boundaries.
+    // CodeMirror can switch fixed tooltips to absolute after its first layout
+    // measurement. A viewport-sized body host gives both positioning modes the
+    // same coordinate space, preventing the visible first-frame jump.
+    const [tooltipParent] = useState(() => document.createElement('div'));
+
+    useEffect(() => {
+        tooltipParent.className = 'shade cm-tooltip-parent pointer-events-none fixed inset-0 z-[60]';
+        document.body.appendChild(tooltipParent);
+
+        return () => {
+            tooltipParent.remove();
+        };
+    }, [tooltipParent]);
+
     const basicSetup = useMemo<BasicSetupOptions>(() => ({
         crosshairCursor: false,
         searchKeymap: false
@@ -75,8 +89,12 @@ const CodeEditorView = forwardRef<ReactCodeMirrorRef, CodeEditorProps>(function 
             contentAttributes['aria-disabled'] = 'true';
         }
 
-        return [...resolvedExtensions, EditorView.contentAttributes.of(contentAttributes)];
-    }, [ariaLabel, editable, error, id, resolvedExtensions]);
+        return [
+            ...resolvedExtensions,
+            tooltips({position: 'fixed', parent: tooltipParent}),
+            EditorView.contentAttributes.of(contentAttributes)
+        ];
+    }, [ariaLabel, editable, error, id, resolvedExtensions, tooltipParent]);
 
     const handleFocus: FocusEventHandler<HTMLDivElement> = (event) => {
         onFocus?.(event);

--- a/apps/shade/src/components/ui/code-editor-view.tsx
+++ b/apps/shade/src/components/ui/code-editor-view.tsx
@@ -51,10 +51,15 @@ const CodeEditorView = forwardRef<ReactCodeMirrorRef, CodeEditorProps>(function 
     ...props
 }, ref) {
     const id = useId();
+    const hintId = `${id}-description`;
     const sizeRef = useRef<HTMLDivElement>(null);
+    const {darkMode, setFocusState} = useFocusContext();
+    const focusedRef = useRef(false);
+    const setFocusStateRef = useRef(setFocusState);
     const [width, setWidth] = useState(100);
     const [resolvedExtensions, setResolvedExtensions] = useState<Extension[]>([]);
-    const {darkMode, setFocusState} = useFocusContext();
+
+    setFocusStateRef.current = setFocusState;
 
     // Keep autocomplete outside the editor and accordion overflow boundaries.
     // CodeMirror can switch fixed tooltips to absolute after its first layout
@@ -85,6 +90,9 @@ const CodeEditorView = forwardRef<ReactCodeMirrorRef, CodeEditorProps>(function 
         if (error) {
             contentAttributes['aria-invalid'] = 'true';
         }
+        if (hint) {
+            contentAttributes['aria-describedby'] = hintId;
+        }
         if (!editable) {
             contentAttributes['aria-disabled'] = 'true';
         }
@@ -94,17 +102,27 @@ const CodeEditorView = forwardRef<ReactCodeMirrorRef, CodeEditorProps>(function 
             tooltips({position: 'fixed', parent: tooltipParent}),
             EditorView.contentAttributes.of(contentAttributes)
         ];
-    }, [ariaLabel, editable, error, id, resolvedExtensions, tooltipParent]);
+    }, [ariaLabel, editable, error, hint, hintId, id, resolvedExtensions, tooltipParent]);
 
     const handleFocus: FocusEventHandler<HTMLDivElement> = (event) => {
         onFocus?.(event);
+        focusedRef.current = true;
         setFocusState(true);
     };
 
     const handleBlur: FocusEventHandler<HTMLDivElement> = (event) => {
         onBlur?.(event);
+        focusedRef.current = false;
         setFocusState(false);
     };
+
+    useEffect(() => {
+        return () => {
+            if (focusedRef.current) {
+                setFocusStateRef.current(false);
+            }
+        };
+    }, []);
 
     useEffect(() => {
         let cancelled = false;
@@ -163,7 +181,7 @@ const CodeEditorView = forwardRef<ReactCodeMirrorRef, CodeEditorProps>(function 
                     onFocus={handleFocus}
                     {...props}
                 />
-                {hint && <FieldDescription className={cn(error && 'text-destructive')}>{hint}</FieldDescription>}
+                {hint && <FieldDescription className={cn(error && 'text-destructive')} id={hintId}>{hint}</FieldDescription>}
             </Stack>
         </>
     );

--- a/apps/shade/src/components/ui/code-editor-view.tsx
+++ b/apps/shade/src/components/ui/code-editor-view.tsx
@@ -15,7 +15,7 @@ export interface CodeEditorProps extends Omit<ReactCodeMirrorProps, 'value' | 'o
     error?: boolean;
     hint?: React.ReactNode;
     clearBg?: boolean;
-    extensions: Array<Extension | Promise<Extension>>;
+    extensions: Array<Extension | Promise<Extension> | (() => Extension | Promise<Extension>)>;
     ariaLabel?: string;
     onChange?: (value: string) => void;
 }
@@ -51,7 +51,9 @@ const CodeEditorView = forwardRef<ReactCodeMirrorRef, CodeEditorProps>(function 
     ...props
 }, ref) {
     const id = useId();
+    const labelId = `${id}-label`;
     const hintId = `${id}-description`;
+    const hasTitle = Boolean(title);
     const sizeRef = useRef<HTMLDivElement>(null);
     const {darkMode, setFocusState} = useFocusContext();
     const focusedRef = useRef(false);
@@ -84,7 +86,9 @@ const CodeEditorView = forwardRef<ReactCodeMirrorRef, CodeEditorProps>(function 
     const editorExtensions = useMemo(() => {
         const contentAttributes: Record<string, string> = {id};
 
-        if (ariaLabel) {
+        if (hasTitle) {
+            contentAttributes['aria-labelledby'] = labelId;
+        } else if (ariaLabel) {
             contentAttributes['aria-label'] = ariaLabel;
         }
         if (error) {
@@ -102,7 +106,7 @@ const CodeEditorView = forwardRef<ReactCodeMirrorRef, CodeEditorProps>(function 
             tooltips({position: 'fixed', parent: tooltipParent}),
             EditorView.contentAttributes.of(contentAttributes)
         ];
-    }, [ariaLabel, editable, error, hint, hintId, id, resolvedExtensions, tooltipParent]);
+    }, [ariaLabel, editable, error, hasTitle, hint, hintId, id, labelId, resolvedExtensions, tooltipParent]);
 
     const handleFocus: FocusEventHandler<HTMLDivElement> = (event) => {
         onFocus?.(event);
@@ -116,6 +120,12 @@ const CodeEditorView = forwardRef<ReactCodeMirrorRef, CodeEditorProps>(function 
         setFocusState(false);
     };
 
+    const handleLabelClick = () => {
+        if (editable) {
+            document.getElementById(id)?.focus();
+        }
+    };
+
     useEffect(() => {
         return () => {
             if (focusedRef.current) {
@@ -127,7 +137,11 @@ const CodeEditorView = forwardRef<ReactCodeMirrorRef, CodeEditorProps>(function 
     useEffect(() => {
         let cancelled = false;
 
-        Promise.all(extensions).then((nextExtensions) => {
+        const pendingExtensions = extensions.map(extension => (
+            typeof extension === 'function' ? extension() : extension
+        ));
+
+        Promise.all(pendingExtensions).then((nextExtensions) => {
             if (!cancelled) {
                 setResolvedExtensions(nextExtensions);
             }
@@ -163,10 +177,10 @@ const CodeEditorView = forwardRef<ReactCodeMirrorRef, CodeEditorProps>(function 
     );
 
     return (
-        <>
+        <div className={cn('w-full', height === 'full' && 'h-full')}>
             <div ref={sizeRef} />
             <Stack className={height === 'full' ? 'h-full' : ''} gap='xs' style={{width}}>
-                {title && <FieldLabel htmlFor={id}>{title}</FieldLabel>}
+                {title && <FieldLabel id={labelId} onClick={handleLabelClick}>{title}</FieldLabel>}
                 <CodeMirror
                     ref={ref}
                     basicSetup={basicSetup}
@@ -183,7 +197,7 @@ const CodeEditorView = forwardRef<ReactCodeMirrorRef, CodeEditorProps>(function 
                 />
                 {hint && <FieldDescription className={cn(error && 'text-destructive')} id={hintId}>{hint}</FieldDescription>}
             </Stack>
-        </>
+        </div>
     );
 });
 

--- a/apps/shade/src/components/ui/code-editor-view.tsx
+++ b/apps/shade/src/components/ui/code-editor-view.tsx
@@ -1,0 +1,156 @@
+import CodeMirror, {EditorView, type BasicSetupOptions, type ReactCodeMirrorProps, type ReactCodeMirrorRef} from '@uiw/react-codemirror';
+import React, {type FocusEventHandler, forwardRef, useEffect, useId, useMemo, useRef, useState} from 'react';
+
+import {FieldDescription, FieldLabel} from '@/components/ui/field';
+import {inputSurface} from '@/components/ui/input-surface';
+import {Stack} from '@/components/primitives/stack';
+import {cn} from '@/lib/utils';
+import {useFocusContext} from '@/providers/shade-provider';
+import type {Extension} from '@codemirror/state';
+
+export interface CodeEditorProps extends Omit<ReactCodeMirrorProps, 'value' | 'onChange' | 'extensions' | 'title'> {
+    title?: React.ReactNode;
+    value?: string;
+    height?: string;
+    error?: boolean;
+    hint?: React.ReactNode;
+    clearBg?: boolean;
+    extensions: Array<Extension | Promise<Extension>>;
+    ariaLabel?: string;
+    onChange?: (value: string) => void;
+}
+
+const codeMirrorClasses = [
+    '[&_.cm-editor]:bg-transparent',
+    '[&_.cm-editor]:border-transparent',
+    '[&_.cm-scroller]:font-mono',
+    '[&_.cm-scroller]:border-transparent',
+    '[&_.cm-activeLine]:bg-transparent',
+    '[&_.cm-activeLineGutter]:bg-transparent',
+    '[&_.cm-gutters]:bg-muted',
+    '[&_.cm-gutters]:text-muted-foreground',
+    '[&_.cm-gutters]:border-border',
+    '[&_.cm-cursor]:border-foreground',
+    '[&_.cm-tooltip-autocomplete.cm-tooltip_ul_li:not([aria-selected])]:bg-background'
+].join(' ');
+
+// Imported asynchronously by CodeEditor so CodeMirror stays out of the main bundle.
+const CodeEditorView = forwardRef<ReactCodeMirrorRef, CodeEditorProps>(function CodeEditorView({
+    title,
+    value,
+    height = '200px',
+    error,
+    hint,
+    clearBg = true,
+    extensions,
+    ariaLabel,
+    editable = true,
+    onChange,
+    onFocus,
+    onBlur,
+    className,
+    ...props
+}, ref) {
+    const id = useId();
+    const sizeRef = useRef<HTMLDivElement>(null);
+    const [width, setWidth] = useState(100);
+    const [resolvedExtensions, setResolvedExtensions] = useState<Extension[]>([]);
+    const {darkMode, setFocusState} = useFocusContext();
+
+    const basicSetup = useMemo<BasicSetupOptions>(() => ({
+        crosshairCursor: false,
+        searchKeymap: false
+    }), []);
+
+    const editorExtensions = useMemo(() => {
+        const contentAttributes: Record<string, string> = {id};
+
+        if (ariaLabel) {
+            contentAttributes['aria-label'] = ariaLabel;
+        }
+        if (error) {
+            contentAttributes['aria-invalid'] = 'true';
+        }
+        if (!editable) {
+            contentAttributes['aria-disabled'] = 'true';
+        }
+
+        return [...resolvedExtensions, EditorView.contentAttributes.of(contentAttributes)];
+    }, [ariaLabel, editable, error, id, resolvedExtensions]);
+
+    const handleFocus: FocusEventHandler<HTMLDivElement> = (event) => {
+        onFocus?.(event);
+        setFocusState(true);
+    };
+
+    const handleBlur: FocusEventHandler<HTMLDivElement> = (event) => {
+        onBlur?.(event);
+        setFocusState(false);
+    };
+
+    useEffect(() => {
+        let cancelled = false;
+
+        Promise.all(extensions).then((nextExtensions) => {
+            if (!cancelled) {
+                setResolvedExtensions(nextExtensions);
+            }
+        }, () => {
+            if (!cancelled) {
+                setResolvedExtensions([]);
+            }
+        });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [extensions]);
+
+    useEffect(() => {
+        const resizeObserver = new ResizeObserver(([entry]) => {
+            setWidth(entry.contentRect.width);
+        });
+
+        resizeObserver.observe(sizeRef.current!);
+
+        return () => resizeObserver.disconnect();
+    }, []);
+
+    const styles = cn(
+        inputSurface('within'),
+        'peer order-2 w-full max-w-full overflow-hidden',
+        clearBg && 'bg-transparent',
+        height === 'full' && 'h-full',
+        !editable && 'cursor-not-allowed opacity-50',
+        codeMirrorClasses,
+        className
+    );
+
+    return (
+        <>
+            <div ref={sizeRef} />
+            <Stack className={height === 'full' ? 'h-full' : ''} gap='xs' style={{width}}>
+                {title && <FieldLabel htmlFor={id}>{title}</FieldLabel>}
+                <CodeMirror
+                    ref={ref}
+                    basicSetup={basicSetup}
+                    className={styles}
+                    editable={editable}
+                    extensions={editorExtensions}
+                    height={height === 'full' ? '100%' : height}
+                    theme={darkMode ? 'dark' : 'light'}
+                    value={value}
+                    onBlur={handleBlur}
+                    onChange={onChange}
+                    onFocus={handleFocus}
+                    {...props}
+                />
+                {hint && <FieldDescription className={cn(error && 'text-destructive')}>{hint}</FieldDescription>}
+            </Stack>
+        </>
+    );
+});
+
+CodeEditorView.displayName = 'CodeEditorView';
+
+export default CodeEditorView;

--- a/apps/shade/src/components/ui/code-editor.stories.tsx
+++ b/apps/shade/src/components/ui/code-editor.stories.tsx
@@ -1,0 +1,95 @@
+import type {Meta, StoryObj} from '@storybook/react-vite';
+
+import {CodeEditor} from '@/components/ui/code-editor';
+
+const meta = {
+    title: 'Components / CodeEditor',
+    component: CodeEditor,
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component: 'CodeMirror-backed input for editing code with consumer-provided language support.'
+            }
+        }
+    },
+    decorators: [
+        Story => (
+            <div style={{maxWidth: '640px', padding: '24px'}}>
+                <Story />
+            </div>
+        )
+    ]
+} satisfies Meta<typeof CodeEditor>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    args: {
+        ariaLabel: 'Code injection',
+        extensions: [],
+        hint: 'Injected into {{ghost_head}}',
+        title: 'Code injection',
+        value: '<script>\n    console.log("hello");\n</script>'
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: 'Use for editable code with a visible label and supporting hint.'
+            }
+        }
+    }
+};
+
+export const Focused: Story = {
+    args: {
+        ariaLabel: 'Focused code editor',
+        autoFocus: true,
+        extensions: [],
+        title: 'Focused editor',
+        value: 'body { color: currentColor; }'
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: 'Shows the focus-visible treatment used while editing code.'
+            }
+        }
+    }
+};
+
+export const WithError: Story = {
+    args: {
+        ariaLabel: 'Invalid code injection',
+        error: true,
+        extensions: [],
+        hint: 'Something is wrong with this code.',
+        title: 'Code injection',
+        value: '<script>broken(</script>'
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: 'Use the error state to associate invalid editor chrome with a corrective hint.'
+            }
+        }
+    }
+};
+
+export const Disabled: Story = {
+    args: {
+        ariaLabel: 'Read-only code injection',
+        editable: false,
+        extensions: [],
+        title: 'Code injection',
+        value: '<style>body { color: currentColor; }</style>'
+    },
+    parameters: {
+        docs: {
+            description: {
+                story: 'Use when code should remain visible but cannot be changed.'
+            }
+        }
+    }
+};

--- a/apps/shade/src/components/ui/code-editor.stories.tsx
+++ b/apps/shade/src/components/ui/code-editor.stories.tsx
@@ -27,7 +27,6 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
     args: {
-        ariaLabel: 'Code injection',
         extensions: [],
         hint: 'Injected into {{ghost_head}}',
         title: 'Code injection',
@@ -44,7 +43,6 @@ export const Default: Story = {
 
 export const Focused: Story = {
     args: {
-        ariaLabel: 'Focused code editor',
         autoFocus: true,
         extensions: [],
         title: 'Focused editor',
@@ -61,7 +59,6 @@ export const Focused: Story = {
 
 export const WithError: Story = {
     args: {
-        ariaLabel: 'Invalid code injection',
         error: true,
         extensions: [],
         hint: 'Something is wrong with this code.',
@@ -79,7 +76,6 @@ export const WithError: Story = {
 
 export const Disabled: Story = {
     args: {
-        ariaLabel: 'Read-only code injection',
         editable: false,
         extensions: [],
         title: 'Code injection',

--- a/apps/shade/src/components/ui/code-editor.tsx
+++ b/apps/shade/src/components/ui/code-editor.tsx
@@ -1,0 +1,20 @@
+import React, {Suspense, forwardRef} from 'react';
+
+import type {CodeEditorProps} from '@/components/ui/code-editor-view';
+import type {ReactCodeMirrorRef} from '@uiw/react-codemirror';
+
+export type {CodeEditorProps};
+
+const CodeEditorView = React.lazy(() => import('@/components/ui/code-editor-view'));
+
+const CodeEditor = forwardRef<ReactCodeMirrorRef, CodeEditorProps>(function CodeEditor(props, ref) {
+    return (
+        <Suspense fallback={null}>
+            <CodeEditorView ref={ref} {...props} />
+        </Suspense>
+    );
+});
+
+CodeEditor.displayName = 'CodeEditor';
+
+export {CodeEditor};

--- a/apps/shade/styles.css
+++ b/apps/shade/styles.css
@@ -107,6 +107,23 @@ html.theme-switching *::after {
     scrollbar-width: none; /* Firefox */
 }
 
+/* CodeEditor autocomplete is portalled to a viewport-sized body child so it
+   can escape form-control and accordion overflow boundaries. CodeMirror adds
+   an intermediate container carrying the editor theme classes; collapse and
+   clear that container so those classes cannot paint a full-screen surface. */
+.cm-tooltip-parent > * {
+    height: 0 !important;
+    background: none !important;
+}
+
+.cm-tooltip {
+    pointer-events: auto;
+}
+
+.cm-tooltip-autocomplete.cm-tooltip ul li:not([aria-selected]) {
+    background: var(--background);
+}
+
 /* Prose classes are for formatting arbitrary HTML that comes from the API */
 .gh-prose-links a {
     color: #30cf43;

--- a/apps/shade/styles.css
+++ b/apps/shade/styles.css
@@ -116,11 +116,11 @@ html.theme-switching *::after {
     background: none !important;
 }
 
-.cm-tooltip {
+.cm-tooltip-parent .cm-tooltip {
     pointer-events: auto;
 }
 
-.cm-tooltip-autocomplete.cm-tooltip ul li:not([aria-selected]) {
+.cm-tooltip-parent .cm-tooltip-autocomplete.cm-tooltip ul li:not([aria-selected]) {
     background: var(--background);
 }
 

--- a/apps/shade/test/unit/components/ui/code-editor.test.tsx
+++ b/apps/shade/test/unit/components/ui/code-editor.test.tsx
@@ -46,6 +46,30 @@ describe('CodeEditor', () => {
         assert.equal(document.getElementById(descriptionId)?.textContent, 'Add valid HTML.');
     });
 
+    it('associates the visible title and renders as one layout item', async () => {
+        render(
+            <ShadeProvider darkMode={false} fetchKoenigLexical={null}>
+                <div data-testid='editor-layout'>
+                    <CodeEditor
+                        extensions={[]}
+                        title='HTML editor'
+                        value='<p>Hello</p>'
+                    />
+                </div>
+            </ShadeProvider>
+        );
+
+        const editor = await screen.findByRole('textbox', {name: 'HTML editor'});
+        const labelId = editor.getAttribute('aria-labelledby');
+
+        assert.ok(labelId);
+        assert.equal(document.getElementById(labelId)?.textContent, 'HTML editor');
+        assert.equal(screen.getByTestId('editor-layout').childElementCount, 1);
+
+        fireEvent.click(document.getElementById(labelId)!);
+        assert.equal(document.activeElement, editor);
+    });
+
     it('clears the shared focus state when a focused editor unmounts', async () => {
         const {rerender} = render(<Harness />);
         const editor = await screen.findByRole('textbox', {name: 'Code editor'});

--- a/apps/shade/test/unit/components/ui/code-editor.test.tsx
+++ b/apps/shade/test/unit/components/ui/code-editor.test.tsx
@@ -1,0 +1,59 @@
+import assert from 'assert/strict';
+import {beforeEach, describe, it} from 'vitest';
+import {fireEvent, screen} from '@testing-library/react';
+
+import ShadeProvider, {useFocusContext} from '../../../../src/providers/shade-provider';
+import {CodeEditor} from '../../../../src/components/ui/code-editor';
+import {render} from '../../utils/test-utils';
+
+class ResizeObserverMock implements ResizeObserver {
+    disconnect() {}
+    observe() {}
+    unobserve() {}
+}
+
+const FocusState = () => {
+    const {isAnyTextFieldFocused} = useFocusContext();
+    return <output data-testid='focus-state'>{String(isAnyTextFieldFocused)}</output>;
+};
+
+const Harness = ({showEditor = true}: {showEditor?: boolean}) => (
+    <ShadeProvider darkMode={false} fetchKoenigLexical={null}>
+        {showEditor && (
+            <CodeEditor
+                ariaLabel='Code editor'
+                extensions={[]}
+                hint='Add valid HTML.'
+                value='<p>Hello</p>'
+            />
+        )}
+        <FocusState />
+    </ShadeProvider>
+);
+
+describe('CodeEditor', () => {
+    beforeEach(() => {
+        global.ResizeObserver = ResizeObserverMock;
+    });
+
+    it('associates hint text with the editable content', async () => {
+        render(<Harness />);
+
+        const editor = await screen.findByRole('textbox', {name: 'Code editor'});
+        const descriptionId = editor.getAttribute('aria-describedby');
+
+        assert.ok(descriptionId);
+        assert.equal(document.getElementById(descriptionId)?.textContent, 'Add valid HTML.');
+    });
+
+    it('clears the shared focus state when a focused editor unmounts', async () => {
+        const {rerender} = render(<Harness />);
+        const editor = await screen.findByRole('textbox', {name: 'Code editor'});
+
+        fireEvent.focus(editor);
+        assert.equal(screen.getByTestId('focus-state').textContent, 'true');
+
+        rerender(<Harness showEditor={false} />);
+        assert.equal(screen.getByTestId('focus-state').textContent, 'false');
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1629,6 +1629,9 @@ importers:
 
   apps/shade:
     dependencies:
+      '@codemirror/state':
+        specifier: 'catalog:'
+        version: 6.7.1
       '@dnd-kit/core':
         specifier: 'catalog:'
         version: 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1716,6 +1719,9 @@ importers:
       '@types/validator':
         specifier: 'catalog:'
         version: 13.15.10
+      '@uiw/react-codemirror':
+        specifier: 'catalog:'
+        version: 4.25.11(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.1)(@codemirror/state@6.7.1)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.6)(codemirror@6.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1


### PR DESCRIPTION
## What changed

- Added an additive Shade `CodeEditor` with lazy CodeMirror loading.
- Adopted it only for the header and footer fields on the flagged React tag-details screen.
- Added Storybook states for default, focused, error, and disabled behavior.
- Portalled Shade autocomplete into a transparent body-level host so suggestions escape clipped editor and accordion containers.
- Connected hint and error copy to the editable element and reset shared focus state when a focused editor unmounts.
- Added real-browser coverage for editing, saving, autocomplete visibility, positioning stability, and portal paint safety.

## Scope

This deliberately does **not** migrate established Admin consumers:

- Global Code Injection still imports `settings/app/components/code-editor`.
- Labs routes and redirects still import `settings/app/components/code-editor`.
- The theme editor is untouched.
- The tooltip host belongs only to the new Shade component, and its CSS is scoped beneath `.cm-tooltip-parent`.

The only product adoption remains behind `tagDetailsReact`.

## Why

#29764 combined the flagged tag-details enhancement with a migration of existing full-height editors. That expanded the blast radius and allowed new tooltip behavior to regress unflagged Admin settings.

This PR keeps the new Shade implementation available for design review without changing existing editor behavior. Its body-level tooltip host keeps CodeMirror fixed and absolute positioning in the same coordinate space, preventing autocomplete from flashing above the page before snapping behind clipped content.

A broader editor migration can happen separately after the component has been reviewed and its interaction design has settled.

## Verification

- Shade lint passed.
- Shade unit and type tests passed: 294 tests.
- Shade build passed.
- Admin lint and typecheck passed.
- Tag-details browser acceptance tests passed: 25 tests.
- The autocomplete regression passed three repeated isolated browser runs.
- Autocomplete is verified onscreen, outside the clipped editor surface, and fixed after CodeMirror measurement.
- The CodeMirror portal container remains zero-height and transparent.
- No established Settings editor files are present in the diff.

## Review

Two independent reviews covered architecture and blast radius, plus CodeMirror positioning and browser-test reliability. Their actionable accessibility, focus lifecycle, and regression-coverage feedback has been incorporated; both reviewers approved the final patch.

## Design review

The candidate component is available in Storybook under **Components / CodeEditor**, including its primary interaction states.
