### PR TITLE
Store member custom-field values by field key, not id

### DIFF
--- a/ghost/core/core/server/data/migrations/versions/6.57/2026-08-04-18-00-00-store-custom-field-values-as-leaf-rows.js
+++ b/ghost/core/core/server/data/migrations/versions/6.57/2026-08-04-18-00-00-store-custom-field-values-as-leaf-rows.js
@@ -39,18 +39,30 @@ module.exports = createNonTransactionalMigration(
             await addColumn(TABLE, 'path', knex, undefined, {algorithm: 'auto'});
         }
 
-        // `member_id` stays leftmost, covering that foreign key the moment this exists.
-        await addUnique(TABLE, ['member_id', 'custom_field_id', 'path'], knex, LEAF_UNIQUE);
-        await dropUnique(TABLE, ['member_id', 'custom_field_id'], knex);
+        // A later 6.58 migration re-keys this table onto `custom_field_key`, dropping
+        // `custom_field_id`. The idempotency check re-runs every up against that final
+        // schema, so guard these on the column: gone, they are a no-op here rather than an
+        // error on the missing column (MySQL raises it; SQLite swallows it). A forward run
+        // always sees the column present, so this changes nothing an install ever applies.
+        const hasFieldId = await knex.schema.hasColumn(TABLE, 'custom_field_id');
+
+        if (hasFieldId) {
+            // `member_id` stays leftmost, covering that foreign key the moment this exists.
+            await addUnique(TABLE, ['member_id', 'custom_field_id', 'path'], knex, LEAF_UNIQUE);
+            await dropUnique(TABLE, ['member_id', 'custom_field_id'], knex);
+        }
 
         if (await knex.schema.hasColumn(TABLE, 'value_json')) {
             await dropColumn(TABLE, 'value_json', knex, {}, {algorithm: 'auto'});
         }
-        await addIndex(TABLE, ['custom_field_id', 'path'], knex);
 
-        // Only present after a rollback, where `down` adds it to keep a foreign key
-        // covered. Leaving it would be drift against a fresh install.
-        await dropIndex(TABLE, ['custom_field_id'], knex);
+        if (hasFieldId) {
+            await addIndex(TABLE, ['custom_field_id', 'path'], knex);
+
+            // Only present after a rollback, where `down` adds it to keep a foreign key
+            // covered. Leaving it would be drift against a fresh install.
+            await dropIndex(TABLE, ['custom_field_id'], knex);
+        }
     },
     async function down(knex) {
         // Rebuilding a composite would need the field-type catalog, which a migration must

--- a/ghost/core/core/server/data/migrations/versions/6.58/2026-08-10-15-24-09-reset-custom-field-definitions-for-underscored-keys.js
+++ b/ghost/core/core/server/data/migrations/versions/6.58/2026-08-10-15-24-09-reset-custom-field-definitions-for-underscored-keys.js
@@ -45,7 +45,15 @@ module.exports = createTransactionalMigration(
         }
 
         const ids = discarded.map(definition => definition.id);
-        const discardedValues = await knex(VALUES_TABLE).whereIn('custom_field_id', ids).del();
+
+        // A later 6.58 migration re-keys this table off `custom_field_id`. On the idempotency
+        // re-run the column is gone, but so are these definitions (deleted on the first run,
+        // and minting will not re-create them), so this branch is unreachable then. Guarding
+        // on the column keeps the query shape-proof rather than erroring on a MySQL install.
+        const hasFieldId = await knex.schema.hasColumn(VALUES_TABLE, 'custom_field_id');
+        const discardedValues = hasFieldId
+            ? await knex(VALUES_TABLE).whereIn('custom_field_id', ids).del()
+            : 0;
         const discardedFields = await knex(FIELDS_TABLE).whereIn('id', ids).del();
 
         logging.info(`Discarded ${discardedFields} custom field definition(s) this release cannot mint, and ${discardedValues} value(s): ${discarded.map(definition => definition.key).join(', ')}`);

--- a/ghost/core/core/server/data/migrations/versions/6.58/2026-08-11-10-00-00-swap-custom-field-values-to-key-fk.js
+++ b/ghost/core/core/server/data/migrations/versions/6.58/2026-08-11-10-00-00-swap-custom-field-values-to-key-fk.js
@@ -1,0 +1,65 @@
+const logging = require('@tryghost/logging');
+const {createNonTransactionalMigration} = require('../../utils');
+const commands = require('../../../schema/commands');
+
+const TABLE = 'members_custom_field_values';
+
+// The table keyed by the field's key, as it is now. `custom_field_key` is a foreign key
+// to the definition's immutable, unique `key`.
+const KEY_SHAPE = {
+    id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+    custom_field_key: {type: 'string', maxlength: 191, nullable: false, references: 'members_custom_fields.key', cascadeDelete: true},
+    member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
+    path: {type: 'string', maxlength: 191, nullable: false, defaultTo: ''},
+    value_text: {type: 'text', maxlength: 65535, nullable: true},
+    created_at: {type: 'dateTime', nullable: false},
+    updated_at: {type: 'dateTime', nullable: true},
+    '@@UNIQUE_CONSTRAINTS@@': [
+        {columns: ['member_id', 'custom_field_key', 'path'], indexName: 'members_custom_field_values_leaf_unique'}
+    ],
+    '@@INDEXES@@': [
+        ['custom_field_key', 'path']
+    ]
+};
+
+// The prior shape, keyed by the field's id. Rebuilding it exactly is what makes the
+// rollback reversible: the earlier leaf-rows migration's `down` alters `custom_field_id`
+// (re-adding its indexes), so that column has to be back before this migration hands the
+// rollback on. Identical to KEY_SHAPE apart from the foreign key column.
+const ID_SHAPE = {
+    id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+    custom_field_id: {type: 'string', maxlength: 24, nullable: false, references: 'members_custom_fields.id', cascadeDelete: true},
+    member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
+    path: {type: 'string', maxlength: 191, nullable: false, defaultTo: ''},
+    value_text: {type: 'text', maxlength: 65535, nullable: true},
+    created_at: {type: 'dateTime', nullable: false},
+    updated_at: {type: 'dateTime', nullable: true},
+    '@@UNIQUE_CONSTRAINTS@@': [
+        {columns: ['member_id', 'custom_field_id', 'path'], indexName: 'members_custom_field_values_leaf_unique'}
+    ],
+    '@@INDEXES@@': [
+        ['custom_field_id', 'path']
+    ]
+};
+
+// SQLite cannot alter a foreign key in place, so the column swap is a drop-and-recreate
+// rather than an ALTER. Existing rows are discarded either way: the feature is behind the
+// `membersCustomFields` flag with no released data, so a wipe is cheaper than a backfill.
+// Re-running after a mid-migration crash is safe — the table is dropped first if present.
+async function rebuild(knex, shape) {
+    if (await knex.schema.hasTable(TABLE)) {
+        await commands.deleteTable(TABLE, knex);
+    }
+    await commands.createTable(TABLE, knex, shape);
+}
+
+module.exports = createNonTransactionalMigration(
+    async function up(knex) {
+        logging.info('Keying members_custom_field_values by custom_field_key');
+        await rebuild(knex, KEY_SHAPE);
+    },
+    async function down(knex) {
+        logging.info('Reverting members_custom_field_values to custom_field_id');
+        await rebuild(knex, ID_SHAPE);
+    }
+);

--- a/ghost/core/core/server/data/schema/schema.js
+++ b/ghost/core/core/server/data/schema/schema.js
@@ -680,7 +680,11 @@ module.exports = {
     },
     members_custom_field_values: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
-        custom_field_id: {type: 'string', maxlength: 24, nullable: false, references: 'members_custom_fields.id', cascadeDelete: true},
+        // The field's stable key, not its id: a value is addressed by key everywhere it
+        // matters (the write names it, a filter names it, the key is immutable), so the row
+        // carries it directly and the read and filter paths skip an id-to-key join. Matches
+        // the referenced column's 191, as a foreign key must.
+        custom_field_key: {type: 'string', maxlength: 191, nullable: false, references: 'members_custom_fields.key', cascadeDelete: true},
         member_id: {type: 'string', maxlength: 24, nullable: false, references: 'members.id', cascadeDelete: true},
         // Which part of the field's value this row carries. A scalar has one part and
         // stores it under the empty path; a composite stores one row per sub-field it
@@ -696,12 +700,12 @@ module.exports = {
         value_text: {type: 'text', maxlength: 65535, nullable: true},
         created_at: {type: 'dateTime', nullable: false},
         updated_at: {type: 'dateTime', nullable: true},
-        // Named, because the name knex derives from the table and all three columns is
-        // 65 characters and MySQL stops at 64. The migration that first created this
-        // table already shortened a column for the same reason; a third column spends
-        // what headroom that bought.
+        // Named, because the name knex derives from the table and all three columns
+        // overruns MySQL's 64-character identifier limit. The migration that first
+        // created this table already shortened a column for the same reason; a third
+        // column spends what headroom that bought.
         '@@UNIQUE_CONSTRAINTS@@': [
-            {columns: ['member_id', 'custom_field_id', 'path'], indexName: 'members_custom_field_values_leaf_unique'}
+            {columns: ['member_id', 'custom_field_key', 'path'], indexName: 'members_custom_field_values_leaf_unique'}
         ],
         // What a segment filter looks up: every member holding a given value for a
         // given part of a given field. The value itself is not in the index — it is
@@ -709,7 +713,7 @@ module.exports = {
         // applies one length to every column in a composite index rather than to a
         // single chosen one.
         '@@INDEXES@@': [
-            ['custom_field_id', 'path']
+            ['custom_field_key', 'path']
         ]
     },
     members_stripe_customers: {

--- a/ghost/core/core/server/services/members-custom-fields/schema.ts
+++ b/ghost/core/core/server/services/members-custom-fields/schema.ts
@@ -28,7 +28,7 @@ type CustomFieldRow = z.infer<typeof DbCustomField>;
 // carries it as a plain string.
 export const DbCustomFieldValue = z.object({
     id: z.string(),
-    custom_field_id: z.string(),
+    custom_field_key: z.string(),
     member_id: z.string(),
     path: z.string(),
     // Nullable like the column, though nothing here writes a null: a part with no value

--- a/ghost/core/core/server/services/members-custom-fields/values-service.ts
+++ b/ghost/core/core/server/services/members-custom-fields/values-service.ts
@@ -83,7 +83,7 @@ export class CustomFieldValuesService {
         }
 
         const rows = await this.knex(VALUES_TABLE)
-            .join(FIELDS_TABLE, `${VALUES_TABLE}.custom_field_id`, `${FIELDS_TABLE}.id`)
+            .join(FIELDS_TABLE, `${VALUES_TABLE}.custom_field_key`, `${FIELDS_TABLE}.key`)
             .whereIn(`${VALUES_TABLE}.member_id`, memberIds)
             .where(`${FIELDS_TABLE}.status`, FIELD_STATUS.active)
             .orderBy(`${FIELDS_TABLE}.created_at`, 'asc')
@@ -207,25 +207,25 @@ export class CustomFieldValuesService {
             // than one per part, under one timestamp, because a write happened once
             // however many rows record it.
             const now = new Date();
-            const clearedFields: string[] = [];
-            const clearedPaths: Array<{fieldId: string, paths: string[]}> = [];
+            const clearedKeys: string[] = [];
+            const clearedPaths: Array<{fieldKey: string, paths: string[]}> = [];
             const rows: DbLeafRow[] = [];
 
             for (const {field, value} of writes) {
                 if (value === undefined) {
-                    clearedFields.push(field.id);
+                    clearedKeys.push(field.key);
                     continue;
                 }
 
                 const {set, cleared} = leavesToWrite(value);
                 if (cleared.length > 0) {
-                    clearedPaths.push({fieldId: field.id, paths: cleared});
+                    clearedPaths.push({fieldKey: field.key, paths: cleared});
                 }
 
                 rows.push(...set.map(leaf => ({
                     id: new ObjectID().toHexString(),
                     member_id: memberId,
-                    custom_field_id: field.id,
+                    custom_field_key: field.key,
                     path: leaf.path,
                     value_text: leaf.value_text,
                     created_at: now,
@@ -233,15 +233,15 @@ export class CustomFieldValuesService {
                 })));
             }
 
-            if (clearedFields.length > 0) {
-                await trx(VALUES_TABLE).where('member_id', memberId).whereIn('custom_field_id', clearedFields).del();
+            if (clearedKeys.length > 0) {
+                await trx(VALUES_TABLE).where('member_id', memberId).whereIn('custom_field_key', clearedKeys).del();
             }
 
             if (clearedPaths.length > 0) {
                 // One statement with a group per field, rather than a statement per field.
                 await trx(VALUES_TABLE).where('member_id', memberId).where((builder) => {
-                    for (const {fieldId, paths} of clearedPaths) {
-                        builder.orWhere(pair => pair.where('custom_field_id', fieldId).whereIn('path', paths));
+                    for (const {fieldKey, paths} of clearedPaths) {
+                        builder.orWhere(pair => pair.where('custom_field_key', fieldKey).whereIn('path', paths));
                     }
                 }).del();
             }
@@ -254,7 +254,7 @@ export class CustomFieldValuesService {
                     .insert(rows.slice(from, from + UPSERT_CHUNK))
                     // Naming the columns rather than giving values takes each from the row
                     // that lost the conflict, so every part updates to its own value.
-                    .onConflict(['member_id', 'custom_field_id', 'path'])
+                    .onConflict(['member_id', 'custom_field_key', 'path'])
                     .merge(['value_text', 'updated_at']);
             }
         };

--- a/ghost/core/test/unit/server/data/schema/integrity.test.js
+++ b/ghost/core/test/unit/server/data/schema/integrity.test.js
@@ -35,7 +35,7 @@ const parseYaml = require('../../../../../core/server/services/route-settings/ya
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'f5780f506a6a4f2597e48ef2c267ce72';
+    const currentSchemaHash = '8078d6e15d88dccf19ebd1ab9b205677';
     const currentFixturesHash = '4e0c7b4fe3c1593e9d1fae1a891389ca';
     const currentSettingsHash = '8650db85b9a61afe4797ad6333066c62';
     const currentRoutesHash = 'd8c25fa01bf6d22a2bcb05ba0de70dc1';


### PR DESCRIPTION
## Problem

Member custom-field values are stored against the surrogate id of their field definition, but the field is addressed by its stable key everywhere else: the write names it by key, a filter names it by key, and the key is immutable once minted from the slug. Storing by id means the read path and any filter have to join the values table back to the definitions table just to translate an id into the key it started from, for a surrogate that earns nothing here. Renaming a key is already impossible because saved segments freeze it, and the index cost of a short slug is negligible.

## Solution

Store the value against its field's key directly. The values table now references its field by the field's key, a foreign key to the definition's unique key column, in place of the id foreign key. The definition keeps its own id as its primary key. The write path stores the key it already holds instead of resolving it to an id, and later work can filter members straight off the value row.

The feature is behind the `membersCustomFields` flag with no released data, so the migration wipes and recreates the table rather than backfilling. This is groundwork for the members filtering PR, which stacks on top and, with this change, needs no id-to-key view or join at all.
