### PR TITLE
Version-pin pnpm dependency build approvals

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,23 +15,25 @@ minimumReleaseAge: 4320 # 3 days in minutes; matches Renovate's minimumReleaseAg
 blockExoticSubdeps: true
 
 allowBuilds:
+  # Permitted builds are version-scoped. Adding or updating a permitted version
+  # requires an explicit Platform security review.
   # sentry-cli's postinstall downloads its binary, which is only used for
   # sourcemap upload — that was gated on the old Koenig repo's IS_SHIPPING
   # publish flow and isn't part of dev or CI builds here.
   '@sentry/cli': false
-  '@swc/core': true
-  better-sqlite3: true
-  core-js: true
+  '@swc/core@1.15.43': true
+  'better-sqlite3@12.11.1': true
+  'core-js@2.6.12': true
   cpu-features: false
-  dtrace-provider: true
-  esbuild: true
-  fsevents: true
-  msw: true
-  nx: true
-  protobufjs: true
-  re2: true
-  sharp: true
-  sqlite3: true
+  'dtrace-provider@0.8.8': true
+  'esbuild@0.25.12 || 0.28.1': true
+  'fsevents@1.2.13 || 2.3.2 || 2.3.3': true
+  'msw@2.14.6': true
+  'nx@23.0.1': true
+  'protobufjs@7.6.4': true
+  're2@1.25.0': true
+  'sharp@0.35.3': true
+  'sqlite3@5.1.7': true
   ssh2: false
 
 catalog:


### PR DESCRIPTION
## What changed

- Version-scoped every `allowBuilds: true` entry in `pnpm-workspace.yaml` to the exact version or versions currently resolved in `pnpm-lock.yaml`.
- Kept the existing package-wide denials unchanged.
- Documented that adding or updating a permitted version requires explicit Platform security review.

## Why

Package-wide build approval lets a future release of an approved dependency inherit permission to run lifecycle scripts automatically. Because install scripts are a supply-chain trust boundary, each newly resolved version should require an intentional configuration change and review before it can execute.

This addresses [PLA-308](https://linear.app/ghost/issue/PLA-308/version-scope-pnpm-allowbuilds-and-document-the-required-security).

## Impact

There is no runtime or user-facing behavior change. A dependency update that introduces a new version of one of the 12 permitted build packages will now fail closed until the version is explicitly added to `allowBuilds` and receives Platform security review.

## Validation

- `pnpm install --frozen-lockfile`
- Static check that all 12 permitted selectors are version-scoped and every approved version exists in `pnpm-lock.yaml`
- `git diff --check`