### PR TITLE
fix missing tiers in previous part of webhook

### DIFF
--- a/ghost/core/core/server/services/webhooks/serialize.js
+++ b/ghost/core/core/server/services/webhooks/serialize.js
@@ -29,6 +29,17 @@ module.exports = ({urlService}) => async (event, model) => {
         'newsletters'
     ];
 
+    // `model._changed` carries raw model keys, but `previous` is picked off the
+    // API-serialized payload, where some of them are renamed. Without the
+    // mapping a change to a renamed key is silently dropped from `previous` —
+    // e.g. a switch between two paid tiers touches no members column at all, so
+    // `products` (renamed to `tiers`) is the only thing that changed.
+    const SERIALIZED_KEYS = {
+        members: {
+            products: 'tiers'
+        }
+    };
+
     let current = {};
     let previous = {};
 
@@ -80,7 +91,7 @@ module.exports = ({urlService}) => async (event, model) => {
             .serializers
             .handle
             .output(model, {docName: docName, method: 'read'}, api.serializers.output, frame);
-        previous = _.pick(frame.response[docName][0], changed);
+        previous = _.pick(frame.response[docName][0], changed.map(key => SERIALIZED_KEYS[docName]?.[key] ?? key));
     }
 
 

--- a/ghost/core/core/server/services/webhooks/serialize.js
+++ b/ghost/core/core/server/services/webhooks/serialize.js
@@ -5,6 +5,14 @@
 // already carries (e.g. authors) would strip its nested roles from the
 // payload. `getRequiredRelations()` is [] when the routing config reads
 // none, so this is a no-op on a default routes.yaml.
+// `model._changed` carries raw model keys, but `previous` is picked off the
+// API-serialized payload, where some keys are renamed (members `products` → `tiers`).
+const SERIALIZED_KEYS = {
+    members: {
+        products: 'tiers'
+    }
+};
+
 const loadRequiredUrlRelations = async (model, urlService) => {
     const required = urlService.getRequiredRelations();
     const missing = required.filter(relation => !model.relations[relation]);
@@ -28,17 +36,6 @@ module.exports = ({urlService}) => async (event, model) => {
         'products',
         'newsletters'
     ];
-
-    // `model._changed` carries raw model keys, but `previous` is picked off the
-    // API-serialized payload, where some of them are renamed. Without the
-    // mapping a change to a renamed key is silently dropped from `previous` —
-    // e.g. a switch between two paid tiers touches no members column at all, so
-    // `products` (renamed to `tiers`) is the only thing that changed.
-    const SERIALIZED_KEYS = {
-        members: {
-            products: 'tiers'
-        }
-    };
 
     let current = {};
     let previous = {};

--- a/ghost/core/test/unit/server/services/webhooks/serialize.test.js
+++ b/ghost/core/test/unit/server/services/webhooks/serialize.test.js
@@ -163,9 +163,7 @@ describe('WebhookService - Serialize', function () {
     });
 
     it('includes the previous tiers when a member switches between paid tiers', async function () {
-        // `previous: true` cascades into related models, so the tiers have to look
-        // like the fetched models they are in the real event — bookshelf only
-        // populates `_previousAttributes` on fetch, not on construction.
+        // bookshelf only populates `_previousAttributes` on fetch, not construction
         const asFetched = (model) => {
             model._previousAttributes = {...model.attributes};
             return model;
@@ -182,10 +180,8 @@ describe('WebhookService - Serialize', function () {
             updated_at: new Date('2026-01-01T00:00:00.000Z')
         });
 
-        // A paid -> paid tier switch leaves every members column untouched, so the
-        // only change bookshelf-relations records is on the products relation:
-        // the change itself on `_changed` (extendChanged) and the pre-change
-        // targets on `_previousRelations` (attachPreviousRelations).
+        // mirrors bookshelf-relations' extendChanged + attachPreviousRelations output
+        // for a tier switch that touches no members column
         memberModel._previousAttributes = {...memberModel.attributes};
         memberModel._changed = {
             products: {attached: [newTier], detached: [oldTier]}

--- a/ghost/core/test/unit/server/services/webhooks/serialize.test.js
+++ b/ghost/core/test/unit/server/services/webhooks/serialize.test.js
@@ -3,6 +3,7 @@ const sinon = require('sinon');
 
 const {Post} = require('../../../../../core/server/models/post');
 const {Member} = require('../../../../../core/server/models/member');
+const {Product} = require('../../../../../core/server/models/product');
 
 const createSerialize = require('../../../../../core/server/services/webhooks/serialize');
 
@@ -159,5 +160,44 @@ describe('WebhookService - Serialize', function () {
         assert.equal(result.member.previous.status, 'comped');
         assert.deepEqual(result.member.previous.updated_at, previousUpdatedAt);
         assert.deepEqual(Object.keys(result.member.previous).sort(), ['status', 'updated_at']);
+    });
+
+    it('includes the previous tiers when a member switches between paid tiers', async function () {
+        // `previous: true` cascades into related models, so the tiers have to look
+        // like the fetched models they are in the real event — bookshelf only
+        // populates `_previousAttributes` on fetch, not on construction.
+        const asFetched = (model) => {
+            model._previousAttributes = {...model.attributes};
+            return model;
+        };
+        const oldTier = asFetched(new Product({id: 'tier-old', name: 'Bronze', slug: 'bronze', type: 'paid', active: true}));
+        const newTier = asFetched(new Product({id: 'tier-new', name: 'Gold', slug: 'gold', type: 'paid', active: true}));
+
+        const memberModel = new Member({
+            id: 'member-id',
+            uuid: 'member-uuid',
+            email: 'member@example.com',
+            status: 'paid',
+            created_at: new Date('2026-01-01T00:00:00.000Z'),
+            updated_at: new Date('2026-01-01T00:00:00.000Z')
+        });
+
+        // A paid -> paid tier switch leaves every members column untouched, so the
+        // only change bookshelf-relations records is on the products relation:
+        // the change itself on `_changed` (extendChanged) and the pre-change
+        // targets on `_previousRelations` (attachPreviousRelations).
+        memberModel._previousAttributes = {...memberModel.attributes};
+        memberModel._changed = {
+            products: {attached: [newTier], detached: [oldTier]}
+        };
+        memberModel._previousRelations = {products: {models: [oldTier]}};
+        memberModel.related('products').models = [newTier];
+
+        sinon.stub(memberModel, 'load').resolves(memberModel);
+
+        const result = await serialize('member.edited', memberModel);
+
+        assert.deepEqual(result.member.current.tiers.map(tier => tier.slug), ['gold']);
+        assert.deepEqual(result.member.previous.tiers.map(tier => tier.slug), ['bronze']);
     });
 });


### PR DESCRIPTION
closes #29805 

Currently, switching between tiers does not cause a webhook to fire.  This makes it hard for an integration to detect plan changes without doing a full scan of members.

This PR makes sure that tiers are emitted, and provides a test for the corrected behavior.

AI disclosure:  Fable helped find the code responsible for the bug and fix it.
