### PR TITLE
Forced UTC for automation timestamps

### DIFF
--- a/ghost/core/core/server/services/automations/database-automations-repository.ts
+++ b/ghost/core/core/server/services/automations/database-automations-repository.ts
@@ -21,7 +21,7 @@ import type {
     EditAutomationData,
     Page
 } from './automations-repository';
-import {toDatabaseDate} from './database-date';
+import {toDatabaseDate, type DatabaseDate} from './database-date';
 import {getStaleLockCutoff} from './stale-lock-cutoff';
 import type {ExclusifyUnion, ReadonlyDeep} from 'type-fest';
 
@@ -48,8 +48,8 @@ interface AutomationRow {
     slug: string;
     name: string;
     status: string;
-    created_at: string;
-    updated_at: string;
+    created_at: DatabaseDate;
+    updated_at: DatabaseDate;
 }
 
 
@@ -76,7 +76,7 @@ type ActionLinkRow = {
 
 type ActionRevisionRow = {
     action_id: string;
-    created_at: string;
+    created_at: DatabaseDate;
     wait_hours: number | null;
     email_subject: string | null;
     email_lexical: string | null;
@@ -108,7 +108,7 @@ type StepToRunRow = {
     action_id: string;
     automation_action_revision_id: string;
     type: string;
-    ready_at: string;
+    ready_at: DatabaseDate;
     step_attempts: number;
     wait_hours: number | null;
     email_subject: string | null;

--- a/ghost/core/core/server/services/automations/database-automations-repository.ts
+++ b/ghost/core/core/server/services/automations/database-automations-repository.ts
@@ -21,7 +21,7 @@ import type {
     EditAutomationData,
     Page
 } from './automations-repository';
-import {toDatabaseDate, type DatabaseDate} from './database-date';
+import {fromDatabaseDate, toDatabaseDate, type DatabaseDate} from './database-date';
 import {getStaleLockCutoff} from './stale-lock-cutoff';
 import type {ExclusifyUnion, ReadonlyDeep} from 'type-fest';
 
@@ -709,14 +709,14 @@ async function findNextPendingReadyAt(trx: Knex.Transaction, staleLockCutoff: Re
         })
         .orderBy('ready_at')
         .first();
-    return row?.next_ready_at ? new Date(row.next_ready_at) : null;
+    return row?.next_ready_at ? fromDatabaseDate(row.next_ready_at) : null;
 }
 
 function buildStepToRun(row: ReadonlyDeep<StepToRunRow>): AutomationStepToRun {
     const base = {
         id: row.id,
         step_attempts: row.step_attempts,
-        ready_at: new Date(row.ready_at),
+        ready_at: fromDatabaseDate(row.ready_at),
         locked_by: row.locked_by,
         automation_run_id: row.automation_run_id,
         automation_id: row.automation_id,
@@ -1259,13 +1259,13 @@ async function insertActionRevisions(
     );
 }
 
-function getNextRevisionCreatedAt(latestCreatedAt: string | null, requestedCreatedAt: string) {
+function getNextRevisionCreatedAt(latestCreatedAt: DatabaseDate | null, requestedCreatedAt: string) {
     if (!latestCreatedAt) {
         return toDatabaseDate(requestedCreatedAt);
     }
 
-    const requestedTime = new Date(requestedCreatedAt).getTime();
-    const latestTime = new Date(latestCreatedAt).getTime();
+    const requestedTime = fromDatabaseDate(requestedCreatedAt).getTime();
+    const latestTime = fromDatabaseDate(latestCreatedAt).getTime();
 
     if (requestedTime > latestTime) {
         return toDatabaseDate(requestedCreatedAt);
@@ -1355,8 +1355,8 @@ function buildAutomationSummary(automation: AutomationRow): AutomationSummary {
     };
 }
 
-function serializeDate(date: string) {
-    const normalizedDate = new Date(date);
+function serializeDate(date: DatabaseDate) {
+    const normalizedDate = fromDatabaseDate(date);
     normalizedDate.setMilliseconds(0);
     return normalizedDate.toISOString();
 }

--- a/ghost/core/core/server/services/automations/database-date.ts
+++ b/ghost/core/core/server/services/automations/database-date.ts
@@ -1,5 +1,26 @@
 import moment from 'moment';
+import * as errors from '@tryghost/errors';
 
 const DATABASE_DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss';
 
+export type DatabaseDate = Date | string | number;
+
 export const toDatabaseDate = (date: Date | string): string => moment(date).format(DATABASE_DATE_FORMAT);
+
+export const fromDatabaseDate = (date: DatabaseDate): Date => {
+    if (date instanceof Date) {
+        return new Date(date);
+    }
+
+    if (typeof date === 'string') {
+        return moment.utc(date, DATABASE_DATE_FORMAT).toDate();
+    }
+
+    // Defense-in-depth for legacy SQLite rows stored as epoch milliseconds.
+    if (typeof date === 'number') {
+        return moment.utc(date).toDate();
+    }
+
+    const exhaustive: never = date;
+    throw new errors.InternalServerError({message: `Unexpected type for database date: ${exhaustive}`});
+};

--- a/ghost/core/core/server/services/automations/database-date.ts
+++ b/ghost/core/core/server/services/automations/database-date.ts
@@ -5,7 +5,7 @@ const DATABASE_DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss';
 
 export type DatabaseDate = Date | string | number;
 
-export const toDatabaseDate = (date: Date | string): string => moment(date).format(DATABASE_DATE_FORMAT);
+export const toDatabaseDate = (date: Date | string): string => moment.utc(date).format(DATABASE_DATE_FORMAT);
 
 export const fromDatabaseDate = (date: DatabaseDate): Date => {
     if (date instanceof Date) {

--- a/ghost/core/core/server/services/automations/database-date.ts
+++ b/ghost/core/core/server/services/automations/database-date.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 import * as errors from '@tryghost/errors';
 
-const DATABASE_DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss';
+export const DATABASE_DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss';
 
 export type DatabaseDate = Date | string | number;
 

--- a/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
+++ b/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
@@ -8,11 +8,10 @@ import {NON_EMPTY_EMAIL_LEXICAL} from '../../../../utils/automations-fixtures';
 import ghostConfig from '../../../../../core/shared/config';
 import {createDatabaseAutomationsRepository} from '../../../../../core/server/services/automations/database-automations-repository';
 import type {AutomatedEmailEvents, AutomationAction, AutomationsRepository, AutomationStepToRun} from '../../../../../core/server/services/automations/automations-repository';
-import {fromDatabaseDate, toDatabaseDate} from '../../../../../core/server/services/automations/database-date';
+import {DATABASE_DATE_FORMAT, fromDatabaseDate, toDatabaseDate} from '../../../../../core/server/services/automations/database-date';
 
 const HOUR_MS = 60 * 60 * 1000;
 const FAKE_WAIT_HOURS_MULTIPLIER = 2500;
-const DATABASE_DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss';
 
 const toRepositoryDateISOString = (date: Date | string): string => fromDatabaseDate(toDatabaseDate(date)).toISOString();
 const linkLexical = (url: string): string => JSON.stringify({

--- a/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
+++ b/ghost/core/test/unit/server/services/automations/automations-repository.test.ts
@@ -8,13 +8,13 @@ import {NON_EMPTY_EMAIL_LEXICAL} from '../../../../utils/automations-fixtures';
 import ghostConfig from '../../../../../core/shared/config';
 import {createDatabaseAutomationsRepository} from '../../../../../core/server/services/automations/database-automations-repository';
 import type {AutomatedEmailEvents, AutomationAction, AutomationsRepository, AutomationStepToRun} from '../../../../../core/server/services/automations/automations-repository';
+import {fromDatabaseDate, toDatabaseDate} from '../../../../../core/server/services/automations/database-date';
 
 const HOUR_MS = 60 * 60 * 1000;
 const FAKE_WAIT_HOURS_MULTIPLIER = 2500;
 const DATABASE_DATE_FORMAT = 'YYYY-MM-DD HH:mm:ss';
 
-const toDatabaseDate = (date: Date | string): string => moment(date).format(DATABASE_DATE_FORMAT);
-const toRepositoryDateISOString = (date: Date | string): string => new Date(toDatabaseDate(date)).toISOString();
+const toRepositoryDateISOString = (date: Date | string): string => fromDatabaseDate(toDatabaseDate(date)).toISOString();
 const linkLexical = (url: string): string => JSON.stringify({
     root: {
         children: [{
@@ -30,7 +30,7 @@ const hashRedirectDestination = (url: string): Buffer => createHash('sha256').up
 
 const addHours = (dateCol: unknown, hours: number): Date => {
     assert(typeof dateCol === 'string', 'Expected date column to be a string');
-    return moment(dateCol, DATABASE_DATE_FORMAT).add(hours, 'hours').toDate();
+    return moment(fromDatabaseDate(dateCol)).add(hours, 'hours').toDate();
 };
 
 const createDatabase = async (): Promise<Knex> => {

--- a/ghost/core/test/unit/server/services/automations/database-date.test.ts
+++ b/ghost/core/test/unit/server/services/automations/database-date.test.ts
@@ -59,6 +59,18 @@ describe('database date utilities', function () {
             const result = toDatabaseDate(input);
             assert.strictEqual(result, '2024-06-01 16:34:56');
         });
+
+        it('converts unzoned strings to UTC date strings in your system timezone', function () {
+            const input = '2020-01-01 12:34:56';
+            const result = toDatabaseDate(input);
+            assert.strictEqual(result, '2020-01-01 12:34:56');
+        });
+
+        it('converts unzoned strings to UTC date strings in other system timezones', async function () {
+            await runInOtherTimezones(`
+                assert.deepEqual(toDatabaseDate('2020-01-01 12:34:56'), '2020-01-01 12:34:56');
+            `);
+        });
     });
 
     describe('fromDatabaseDate', function () {

--- a/ghost/core/test/unit/server/services/automations/database-date.test.ts
+++ b/ghost/core/test/unit/server/services/automations/database-date.test.ts
@@ -34,7 +34,7 @@ describe('database date utilities', function () {
             const child = spawn(
                 process.execPath,
                 ['-e', source],
-                {stdio: 'inherit', env: {TZ: tz}}
+                {stdio: 'inherit', env: {...process.env, TZ: tz}}
             );
             const [code] = await once(child, 'exit');
             assert.equal(code, 0, `Child process exited with code ${code}. 0 was expected`);

--- a/ghost/core/test/unit/server/services/automations/database-date.test.ts
+++ b/ghost/core/test/unit/server/services/automations/database-date.test.ts
@@ -1,7 +1,46 @@
 import assert from 'node:assert/strict';
-import {toDatabaseDate} from '../../../../../core/server/services/automations/database-date';
+import {spawn} from 'node:child_process';
+import {once} from 'node:events';
+import {fromDatabaseDate, toDatabaseDate} from '../../../../../core/server/services/automations/database-date';
 
 describe('database date utilities', function () {
+    const timezones = [
+        {tz: 'UTC', expectedNaive: '2020-01-01T12:34:56.000Z'},
+        {tz: 'Africa/Cairo', expectedNaive: '2020-01-01T10:34:56.000Z'},
+        {tz: 'Europe/London', expectedNaive: '2020-01-01T12:34:56.000Z'},
+        {tz: 'Pacific/Auckland', expectedNaive: '2019-12-31T23:34:56.000Z'}
+    ];
+
+    /**
+     * Run some code in another timezone.
+     *
+     * We need to do this in a separate process in order to change the system timezone.
+     */
+    const runInOtherTimezones = async (toRun: string) => {
+        // JSON.stringify does a good job wrapping strings in quotes and escaping.
+        const s = JSON.stringify;
+        const modulePath = require.resolve('../../../../../core/server/services/automations/database-date');
+
+        await Promise.all(timezones.map(async ({tz, expectedNaive}) => {
+            const source = `
+            const assert = require('node:assert/strict');
+            const {fromDatabaseDate, toDatabaseDate} = require(${s(modulePath)});
+
+            assert.deepEqual(new Date('2020-01-01 12:34:56'), new Date(${s(expectedNaive)}), 'test setup');
+
+            ${toRun}
+            `;
+
+            const child = spawn(
+                process.execPath,
+                ['-e', source],
+                {stdio: 'inherit', env: {TZ: tz}}
+            );
+            const [code] = await once(child, 'exit');
+            assert.equal(code, 0, `Child process exited with code ${code}. 0 was expected`);
+        }));
+    };
+
     describe('toDatabaseDate', function () {
         it('converts Dates to database date strings', function () {
             const input = new Date('2024-06-01T12:34:56Z');
@@ -19,6 +58,29 @@ describe('database date utilities', function () {
             const input = '2024-06-01T12:34:56-04:00';
             const result = toDatabaseDate(input);
             assert.strictEqual(result, '2024-06-01 16:34:56');
+        });
+    });
+
+    describe('fromDatabaseDate', function () {
+        it('clones Date objects', function () {
+            const input = new Date('2020-01-01T12:34:56Z');
+            const result = fromDatabaseDate(input);
+            assert.deepEqual(result, input, 'they are deep equal');
+            assert.notEqual(result, input, 'they are not the same object');
+        });
+
+        it('converts strings to Date objects, parsing as UTC, in your system timezone', async function () {
+            assert.deepEqual(fromDatabaseDate('2020-01-01T12:34:56.000Z'), new Date('2020-01-01T12:34:56.000Z'));
+        });
+
+        it('converts strings to Date objects, parsing as UTC, in other system timezones', async function () {
+            await runInOtherTimezones(`
+                assert.deepEqual(fromDatabaseDate('2020-01-01 12:34:56'), new Date('2020-01-01T12:34:56.000Z'));
+            `);
+        });
+
+        it('converts numbers to Date objects', function () {
+            assert.deepEqual(fromDatabaseDate(1577882096000), new Date('2020-01-01T12:34:56.000Z'));
         });
     });
 });


### PR DESCRIPTION
closes https://linear.app/ghost/issue/NY-1404

_I recommend [reviewing this one commit at a time](https://github.com/TryGhost/Ghost/pull/29811/commits)._

Most of the time, Ghost runs in a UTC environment where this change has no effect. But if you:

- self-host
- use SQLite
- use a time other than UTC

Automation timezones might have been messed up for you.

This fixes that by forcing everything to use UTC.

In addition to automated tests, I manually tested this by making sure scheduled automations still worked:

https://github.com/user-attachments/assets/aff984ce-0249-4d43-8844-e3a0fcae193f