### PR TITLE
Make the member.edited webhook fire on cancellation and reinstatement of paid plans

### DIFF
--- a/ghost/core/core/server/models/base/plugins/overrides.js
+++ b/ghost/core/core/server/models/base/plugins/overrides.js
@@ -96,11 +96,13 @@ module.exports = function (Bookshelf) {
                     (value, key) => key.startsWith(PIVOT_PREFIX)
                 );
 
-                if (this.relationships) {
-                    this.relationships.forEach((relation) => {
-                        if (this._previousRelations && Object.prototype.hasOwnProperty.call(this._previousRelations, relation)) {
-                            clonedModel.related(relation).models = this._previousRelations[relation].models;
-                        }
+                // Iterate `_previousRelations` rather than `relationships` — a relation
+                // can carry previous state without being managed by bookshelf-relations
+                // (e.g. a member's stripeSubscriptions). Behaviour is unchanged for
+                // relations that are in both.
+                if (this._previousRelations) {
+                    Object.keys(this._previousRelations).forEach((relation) => {
+                        clonedModel.related(relation).models = this._previousRelations[relation].models;
                     });
                 }
 

--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -1256,6 +1256,11 @@ module.exports = class MemberRepository {
         };
         let eventData = {};
 
+        // A cancellation (or reactivation) changes no `members` column, so the member
+        // model event would be suppressed by `wasChanged()`. Remember the pre-update
+        // subscription so the event can be marked and carry its prior state.
+        let subscriptionBeforeCancelFlagChange = null;
+
         const stripeCustomerSubscriptionModelShouldBeDeleted = stripeSubscriptionData.metadata && !!stripeSubscriptionData.metadata.ghost_migrated_to && stripeSubscriptionData.status === 'canceled';
         if (stripeCustomerSubscriptionModelShouldBeDeleted) {
             logging.warn(`Subscription ${subscriptionData.subscription_id} is marked for deletion, skipping linking.`);
@@ -1298,6 +1303,10 @@ module.exports = class MemberRepository {
                     subscriptionId: updatedStripeCustomerSubscriptionModel.id
                 }, redemptionTimestamp);
                 this.dispatchEvent(offerRedemptionEvent, options);
+            }
+
+            if (stripeCustomerSubscriptionModel.get('cancel_at_period_end') !== updatedStripeCustomerSubscriptionModel.get('cancel_at_period_end')) {
+                subscriptionBeforeCancelFlagChange = stripeCustomerSubscriptionModel;
             }
 
             if (stripeCustomerSubscriptionModel.get('mrr') !== updatedStripeCustomerSubscriptionModel.get('mrr') || stripeCustomerSubscriptionModel.get('plan_id') !== updatedStripeCustomerSubscriptionModel.get('plan_id') || stripeCustomerSubscriptionModel.get('status') !== updatedStripeCustomerSubscriptionModel.get('status') || stripeCustomerSubscriptionModel.get('cancel_at_period_end') !== updatedStripeCustomerSubscriptionModel.get('cancel_at_period_end')) {
@@ -1548,6 +1557,30 @@ module.exports = class MemberRepository {
             logging.error(`Failed to update member - ${data.id} - with related products`);
             logging.error(e);
             updatedMember = await this._Member.edit({status: status}, {...options, id: data.id});
+        }
+
+        // Cancelling (or reactivating) touches no `members` column, so mark the
+        // subscription relation as the change and carry its prior state. This lets the
+        // webhook payload express before/after — see `services/webhooks/serialize.js`.
+        //
+        // No explicit `emitChange` is needed, and adding one would emit twice: inside a
+        // transaction `emitChange` queues onto the `committed` handler and defers its
+        // `wasChanged()` check to commit time (see `models/base/plugins/events.js`), so
+        // the event already queued by `_Member.edit` above is still pending and setting
+        // `_changed` here is what lets it through. The e2e test asserting exactly one
+        // `member.edited` per cancellation guards this.
+        if (subscriptionBeforeCancelFlagChange && updatedMember) {
+            await updatedMember.load(['stripeSubscriptions'], options);
+            updatedMember._changed = {
+                ...updatedMember._changed,
+                stripeSubscriptions: {
+                    cancel_at_period_end: subscriptionBeforeCancelFlagChange.get('cancel_at_period_end')
+                }
+            };
+            updatedMember._previousRelations = {
+                ...updatedMember._previousRelations,
+                stripeSubscriptions: {models: [subscriptionBeforeCancelFlagChange]}
+            };
         }
 
         const newMemberProductIds = memberProducts.map(product => product.id);

--- a/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
+++ b/ghost/core/core/server/services/members/members-api/repositories/member-repository.js
@@ -1570,16 +1570,34 @@ module.exports = class MemberRepository {
         // `_changed` here is what lets it through. The e2e test asserting exactly one
         // `member.edited` per cancellation guards this.
         if (subscriptionBeforeCancelFlagChange && updatedMember) {
-            await updatedMember.load(['stripeSubscriptions'], options);
+            // Price/tier relations are needed for the serialized subscription shape
+            // to match the Admin API member resource (price, tier, plan)
+            await updatedMember.load([
+                'stripeSubscriptions',
+                'stripeSubscriptions.stripePrice',
+                'stripeSubscriptions.stripePrice.stripeProduct',
+                'stripeSubscriptions.stripePrice.stripeProduct.product'
+            ], options);
+            await subscriptionBeforeCancelFlagChange.load([
+                'stripePrice',
+                'stripePrice.stripeProduct',
+                'stripePrice.stripeProduct.product'
+            ], options);
             updatedMember._changed = {
                 ...updatedMember._changed,
                 stripeSubscriptions: {
                     cancel_at_period_end: subscriptionBeforeCancelFlagChange.get('cancel_at_period_end')
                 }
             };
+            // `previous` must be the full collection — a member can have multiple
+            // subscriptions — with only the changed one swapped for its prior state
             updatedMember._previousRelations = {
                 ...updatedMember._previousRelations,
-                stripeSubscriptions: {models: [subscriptionBeforeCancelFlagChange]}
+                stripeSubscriptions: {
+                    models: updatedMember.related('stripeSubscriptions').models.map((subscription) => {
+                        return subscription.id === subscriptionBeforeCancelFlagChange.id ? subscriptionBeforeCancelFlagChange : subscription;
+                    })
+                }
             };
         }
 

--- a/ghost/core/core/server/services/webhooks/serialize.js
+++ b/ghost/core/core/server/services/webhooks/serialize.js
@@ -9,7 +9,8 @@
 // API-serialized payload, where some keys are renamed (members `products` → `tiers`).
 const SERIALIZED_KEYS = {
     members: {
-        products: 'tiers'
+        products: 'tiers',
+        stripeSubscriptions: 'subscriptions'
     }
 };
 

--- a/ghost/core/test/e2e-api/members/webhooks.test.js
+++ b/ghost/core/test/e2e-api/members/webhooks.test.js
@@ -6,6 +6,8 @@ const stripe = require('stripe');
 const {Product} = require('../../../core/server/models/product');
 const {agentProvider, mockManager, fixtureManager, matchers} = require('../../utils/e2e-framework');
 const models = require('../../../core/server/models');
+const modelEvents = require('../../../core/server/lib/common/events');
+const createWebhookSerializer = require('../../../core/server/services/webhooks/serialize');
 const urlServiceUtils = require('../../utils/url-service-utils');
 const urlUtils = require('../../../core/shared/url-utils').default;
 const DomainEvents = require('@tryghost/domain-events');
@@ -366,11 +368,32 @@ describe('Members API', function () {
                 secret: process.env.WEBHOOK_SECRET
             });
 
+            // A cancellation changes no members column, so the model event is only
+            // emitted if the subscription relation is explicitly marked as the change.
+            // Counting matters: `emitChange` defers its `wasChanged()` check to commit
+            // time inside a transaction, so it is possible to emit twice by accident.
+            const memberEditedEvents = [];
+            const captureMemberEdited = model => memberEditedEvents.push(model);
+            modelEvents.on('member.edited', captureMemberEdited);
+
             await membersAgent.post('/webhooks/stripe/')
                 .body(webhookPayload)
                 .header('content-type', 'application/json')
                 .header('stripe-signature', webhookSignature)
                 .expectStatus(200);
+
+            modelEvents.removeListener('member.edited', captureMemberEdited);
+            assert.equal(memberEditedEvents.length, 1, 'A cancellation should emit exactly one member.edited');
+            assert.ok(memberEditedEvents[0]._changed.stripeSubscriptions, 'The event should be marked as a subscription change');
+
+            // The payload a webhook subscriber actually receives must show both states
+            const webhookBody = await createWebhookSerializer({getRequiredRelations: () => []})(
+                'member.edited', memberEditedEvents[0]
+            );
+            assert.equal(webhookBody.member.current.subscriptions[0].cancel_at_period_end, true,
+                'The webhook payload should show the subscription now cancelling');
+            assert.equal(webhookBody.member.previous.subscriptions[0].cancel_at_period_end, false,
+                'The webhook payload should show the subscription was not cancelling before');
 
             // Check that the subscription has been set to cancel and has saved the cancellation reason
             const {body: body2} = await adminAgent.get('/members/' + initialMember.id + '/');
@@ -416,6 +439,108 @@ describe('Members API', function () {
                 subject: /Cancellation: Cancel me at the end of the billing cycle/,
                 to: 'jbloggs@example.com'
             });
+        });
+
+        it('Handles reinstating a subscription that was set to cancel at period end', async function () {
+            const customer_id = createStripeID('cust');
+            const subscription_id = createStripeID('sub');
+
+            set(subscription, {
+                id: subscription_id,
+                customer: customer_id,
+                status: 'active',
+                items: {
+                    type: 'list',
+                    data: [{
+                        id: 'item_123',
+                        price: {
+                            id: 'price_123',
+                            product: 'product_123',
+                            active: true,
+                            nickname: 'Monthly',
+                            currency: 'usd',
+                            recurring: {
+                                interval: 'month'
+                            },
+                            unit_amount: 500,
+                            type: 'recurring'
+                        }
+                    }]
+                },
+                start_date: Date.now() / 1000,
+                current_period_end: Date.now() / 1000 + (60 * 60 * 24 * 31),
+                cancel_at_period_end: false
+            });
+
+            set(customer, {
+                id: customer_id,
+                name: 'Reinstate me before the cycle ends',
+                email: 'reinstate-me@test.com',
+                subscriptions: {
+                    type: 'list',
+                    data: [subscription]
+                }
+            });
+
+            await createMemberFromStripe();
+
+            const sendSubscriptionUpdated = async () => {
+                const payload = JSON.stringify({
+                    type: 'customer.subscription.updated',
+                    data: {
+                        object: subscription
+                    }
+                });
+                const signature = stripe.webhooks.generateTestHeaderString({
+                    payload,
+                    secret: process.env.WEBHOOK_SECRET
+                });
+
+                const captured = [];
+                const capture = model => captured.push(model);
+                modelEvents.on('member.edited', capture);
+
+                await membersAgent.post('/webhooks/stripe/')
+                    .body(payload)
+                    .header('content-type', 'application/json')
+                    .header('stripe-signature', signature)
+                    .expectStatus(200);
+
+                modelEvents.removeListener('member.edited', capture);
+
+                // Cancelling dispatches a staff-notification domain event; drain it so
+                // it does not outlive the test and stall teardown
+                await DomainEvents.allSettled();
+
+                return captured;
+            };
+
+            // Setup: cancel first, since a subscription can only be reinstated from
+            // a cancelling state
+            set(subscription, {
+                ...subscription,
+                canceled_at: Date.now() / 1000,
+                cancel_at_period_end: true
+            });
+            await sendSubscriptionUpdated();
+
+            // The change under test: flip the flag back
+            set(subscription, {
+                ...subscription,
+                canceled_at: null,
+                cancel_at_period_end: false
+            });
+            const reinstateEvents = await sendSubscriptionUpdated();
+
+            assert.equal(reinstateEvents.length, 1, 'Reinstating should emit exactly one member.edited');
+
+            const webhookBody = await createWebhookSerializer({getRequiredRelations: () => []})(
+                'member.edited', reinstateEvents[0]
+            );
+            assert.equal(webhookBody.member.current.subscriptions[0].cancel_at_period_end, false,
+                'The webhook payload should show the subscription is no longer cancelling');
+            assert.equal(webhookBody.member.previous.subscriptions[0].cancel_at_period_end, true,
+                'The webhook payload should show the subscription was cancelling before');
         });
 
         it('Handles immediate cancellation of paid subscriptions', async function () {

--- a/ghost/core/test/e2e-api/members/webhooks.test.js
+++ b/ghost/core/test/e2e-api/members/webhooks.test.js
@@ -394,6 +394,12 @@ describe('Members API', function () {
                 'The webhook payload should show the subscription now cancelling');
             assert.equal(webhookBody.member.previous.subscriptions[0].cancel_at_period_end, false,
                 'The webhook payload should show the subscription was not cancelling before');
+            // The subscription shape must match the Admin API member resource —
+            // price and tier only serialize when their relations are loaded
+            assert.equal(webhookBody.member.current.subscriptions[0].price.amount, 500,
+                'The webhook payload subscriptions should include the price');
+            assert.equal(webhookBody.member.previous.subscriptions[0].price.amount, 500,
+                'The previous subscriptions should include the price');
 
             // Check that the subscription has been set to cancel and has saved the cancellation reason
             const {body: body2} = await adminAgent.get('/members/' + initialMember.id + '/');

--- a/ghost/core/test/e2e-api/members/webhooks.test.js
+++ b/ghost/core/test/e2e-api/members/webhooks.test.js
@@ -549,6 +549,199 @@ describe('Members API', function () {
                 'The webhook payload should show the subscription was cancelling before');
         });
 
+        it('Includes every subscription in the previous payload when one of several is cancelled', async function () {
+            const customer_id = createStripeID('cust');
+            const first_subscription_id = createStripeID('sub');
+            const second_subscription_id = createStripeID('sub');
+
+            const buildSubscription = (id, itemId) => ({
+                id,
+                customer: customer_id,
+                status: 'active',
+                items: {
+                    type: 'list',
+                    data: [{
+                        id: itemId,
+                        price: {
+                            id: 'price_123',
+                            product: 'product_123',
+                            active: true,
+                            nickname: 'Monthly',
+                            currency: 'usd',
+                            recurring: {
+                                interval: 'month'
+                            },
+                            unit_amount: 500,
+                            type: 'recurring'
+                        }
+                    }]
+                },
+                start_date: Date.now() / 1000,
+                current_period_end: Date.now() / 1000 + (60 * 60 * 24 * 31),
+                cancel_at_period_end: false
+            });
+
+            set(subscription, buildSubscription(first_subscription_id, 'item_first'));
+            const secondSubscription = buildSubscription(second_subscription_id, 'item_second');
+            subscriptionOverrides[second_subscription_id] = secondSubscription;
+
+            set(customer, {
+                id: customer_id,
+                name: 'Two subscriptions, cancel only one',
+                email: 'cancel-one-of-two@test.com',
+                subscriptions: {
+                    type: 'list',
+                    data: [subscription, secondSubscription]
+                }
+            });
+
+            const initialMember = await createMemberFromStripe();
+            assert.equal(initialMember.subscriptions.length, 2, 'The member should start with two subscriptions');
+
+            // Cancel only the second subscription
+            Object.assign(secondSubscription, {
+                canceled_at: Date.now() / 1000,
+                cancel_at_period_end: true
+            });
+
+            const payload = JSON.stringify({
+                type: 'customer.subscription.updated',
+                data: {
+                    object: secondSubscription
+                }
+            });
+            const signature = stripe.webhooks.generateTestHeaderString({
+                payload,
+                secret: process.env.WEBHOOK_SECRET
+            });
+
+            const captured = [];
+            const capture = model => captured.push(model);
+            modelEvents.on('member.edited', capture);
+
+            await membersAgent.post('/webhooks/stripe/')
+                .body(payload)
+                .header('content-type', 'application/json')
+                .header('stripe-signature', signature)
+                .expectStatus(200);
+
+            modelEvents.removeListener('member.edited', capture);
+            await DomainEvents.allSettled();
+
+            assert.equal(captured.length, 1, 'Cancelling one of two subscriptions should emit exactly one member.edited');
+
+            const webhookBody = await createWebhookSerializer({getRequiredRelations: () => []})(
+                'member.edited', captured[0]
+            );
+            const currentSubs = webhookBody.member.current.subscriptions;
+            const previousSubs = webhookBody.member.previous.subscriptions;
+
+            assert.equal(currentSubs.length, 2, 'current must carry both subscriptions');
+            assert.equal(previousSubs.length, 2,
+                'previous must carry the full collection, not only the changed subscription');
+            assert.deepEqual(previousSubs.map(s => s.id).sort(), currentSubs.map(s => s.id).sort(),
+                'previous and current must describe the same set of subscriptions');
+
+            assert.equal(currentSubs.find(s => s.id === second_subscription_id).cancel_at_period_end, true,
+                'current must show the cancelled subscription as cancelling');
+            assert.equal(currentSubs.find(s => s.id === first_subscription_id).cancel_at_period_end, false,
+                'current must show the untouched subscription unchanged');
+            assert.equal(previousSubs.find(s => s.id === second_subscription_id).cancel_at_period_end, false,
+                'previous must show the changed subscription in its prior state');
+            assert.equal(previousSubs.find(s => s.id === first_subscription_id).cancel_at_period_end, false,
+                'previous must show the untouched subscription unchanged');
+        });
+
+        it('Does not emit member.edited when a subscription update leaves cancel_at_period_end unchanged', async function () {
+            const customer_id = createStripeID('cust');
+            const subscription_id = createStripeID('sub');
+
+            set(subscription, {
+                id: subscription_id,
+                customer: customer_id,
+                status: 'active',
+                items: {
+                    type: 'list',
+                    data: [{
+                        id: 'item_123',
+                        price: {
+                            id: 'price_123',
+                            product: 'product_123',
+                            active: true,
+                            nickname: 'Monthly',
+                            currency: 'usd',
+                            recurring: {
+                                interval: 'month'
+                            },
+                            unit_amount: 500,
+                            type: 'recurring'
+                        }
+                    }]
+                },
+                start_date: Date.now() / 1000,
+                current_period_end: Date.now() / 1000 + (60 * 60 * 24 * 31),
+                cancel_at_period_end: false
+            });
+
+            set(customer, {
+                id: customer_id,
+                name: 'Renew me quietly',
+                email: 'renew-me-quietly@test.com',
+                subscriptions: {
+                    type: 'list',
+                    data: [subscription]
+                }
+            });
+
+            const initialMember = await createMemberFromStripe();
+            // Anchor: the webhook path under test is only reached for a linked paid
+            // member — without this a broken fixture would make the test pass vacuously
+            assert.equal(initialMember.status, 'paid', 'The member must start paid');
+            assert.equal(initialMember.subscriptions.length, 1, 'The member must start with one linked subscription');
+
+            // A renewal-style update: the billing period moves, the cancel flag does not.
+            // This must stay silent — otherwise every Stripe sync becomes webhook spam.
+            const renewedPeriodEnd = Math.floor(Date.now() / 1000) + (60 * 60 * 24 * 62);
+            set(subscription, {
+                ...subscription,
+                current_period_end: renewedPeriodEnd
+            });
+
+            const payload = JSON.stringify({
+                type: 'customer.subscription.updated',
+                data: {
+                    object: subscription
+                }
+            });
+            const signature = stripe.webhooks.generateTestHeaderString({
+                payload,
+                secret: process.env.WEBHOOK_SECRET
+            });
+
+            const captured = [];
+            const capture = model => captured.push(model);
+            modelEvents.on('member.edited', capture);
+
+            await membersAgent.post('/webhooks/stripe/')
+                .body(payload)
+                .header('content-type', 'application/json')
+                .header('stripe-signature', signature)
+                .expectStatus(200);
+
+            modelEvents.removeListener('member.edited', capture);
+            await DomainEvents.allSettled();
+
+            // Anchor: the update must have been fully processed — proving the silence
+            // comes from the wasChanged() suppression, not from the webhook
+            // short-circuiting before linkSubscription
+            const subscriptionRow = await getSubscription(subscription_id);
+            assert.equal(Math.floor(subscriptionRow.get('current_period_end').getTime() / 1000), renewedPeriodEnd,
+                'The renewal must have been persisted by linkSubscription');
+
+            assert.equal(captured.length, 0,
+                'A subscription update without a cancel_at_period_end change must not emit member.edited');
+        });
+
         it('Handles immediate cancellation of paid subscriptions', async function () {
             const customer_id = createStripeID('cust');
             const subscription_id = createStripeID('sub');

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
@@ -457,7 +457,8 @@ describe('MemberRepository', function () {
                     _previousAttributes: {},
                     // The real _Member.edit resolves a bookshelf model; linkSubscription
                     // loads relations off it when a subscription cancel flag changes
-                    load: sinon.stub().resolvesThis()
+                    load: sinon.stub().resolvesThis(),
+                    related: sinon.stub().returns({models: []})
                 })
             };
 
@@ -567,7 +568,8 @@ describe('MemberRepository', function () {
                     _previousAttributes: {},
                     // The real _Member.edit resolves a bookshelf model; linkSubscription
                     // loads relations off it when a subscription cancel flag changes
-                    load: sinon.stub().resolvesThis()
+                    load: sinon.stub().resolvesThis(),
+                    related: sinon.stub().returns({models: []})
                 })
             };
             MemberPaidSubscriptionEvent = {
@@ -702,6 +704,7 @@ describe('MemberRepository', function () {
             });
 
             sinon.stub(repo, 'getSubscriptionByStripeID').resolves({
+                load: sinon.stub().resolvesThis(),
                 get: sinon.stub().withArgs('offer_id').returns(null)
             });
 
@@ -1042,6 +1045,7 @@ describe('MemberRepository', function () {
 
             // Existing subscription
             sinon.stub(repo, 'getSubscriptionByStripeID').resolves({
+                load: sinon.stub().resolvesThis(),
                 get: sinon.stub().withArgs('offer_id').returns(null)
             });
 
@@ -1339,6 +1343,7 @@ describe('MemberRepository', function () {
             });
 
             sinon.stub(repo, 'getSubscriptionByStripeID').resolves({
+                load: sinon.stub().resolvesThis(),
                 id: 'sub_db_id',
                 get: sinon.stub().callsFake((key) => {
                     if (key === 'offer_id') {
@@ -1386,6 +1391,7 @@ describe('MemberRepository', function () {
             });
 
             sinon.stub(repo, 'getSubscriptionByStripeID').resolves({
+                load: sinon.stub().resolvesThis(),
                 id: 'sub_db_id',
                 get: sinon.stub().callsFake((key) => {
                     if (key === 'offer_id') {
@@ -1432,6 +1438,7 @@ describe('MemberRepository', function () {
             });
 
             sinon.stub(repo, 'getSubscriptionByStripeID').resolves({
+                load: sinon.stub().resolvesThis(),
                 id: 'sub_db_id',
                 get: sinon.stub().callsFake((key) => {
                     if (key === 'offer_id') {
@@ -1496,6 +1503,7 @@ describe('MemberRepository', function () {
             });
 
             sinon.stub(repo, 'getSubscriptionByStripeID').resolves({
+                load: sinon.stub().resolvesThis(),
                 id: 'sub_db_id',
                 get: sinon.stub().callsFake((key) => {
                     if (key === 'offer_id') {
@@ -1558,6 +1566,7 @@ describe('MemberRepository', function () {
             });
 
             sinon.stub(repo, 'getSubscriptionByStripeID').resolves({
+                load: sinon.stub().resolvesThis(),
                 id: 'sub_db_id',
                 get: sinon.stub().callsFake((key) => {
                     if (key === 'offer_id') {
@@ -1626,6 +1635,7 @@ describe('MemberRepository', function () {
             });
 
             sinon.stub(repo, 'getSubscriptionByStripeID').resolves({
+                load: sinon.stub().resolvesThis(),
                 id: 'sub_db_id',
                 get: sinon.stub().callsFake((key) => {
                     if (key === 'offer_id') {
@@ -1693,6 +1703,7 @@ describe('MemberRepository', function () {
             });
 
             sinon.stub(repo, 'getSubscriptionByStripeID').resolves({
+                load: sinon.stub().resolvesThis(),
                 id: 'sub_db_id',
                 get: sinon.stub().callsFake((key) => {
                     if (key === 'offer_id') {
@@ -1962,7 +1973,8 @@ describe('MemberRepository', function () {
                     _previousAttributes: {},
                     // The real _Member.edit resolves a bookshelf model; linkSubscription
                     // loads relations off it when a subscription cancel flag changes
-                    load: sinon.stub().resolvesThis()
+                    load: sinon.stub().resolvesThis(),
+                    related: sinon.stub().returns({models: []})
                 })
             };
 

--- a/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/repositories/member-repository.test.js
@@ -454,7 +454,10 @@ describe('MemberRepository', function () {
                 }),
                 edit: sinon.stub().resolves({
                     attributes: {},
-                    _previousAttributes: {}
+                    _previousAttributes: {},
+                    // The real _Member.edit resolves a bookshelf model; linkSubscription
+                    // loads relations off it when a subscription cancel flag changes
+                    load: sinon.stub().resolvesThis()
                 })
             };
 
@@ -561,7 +564,10 @@ describe('MemberRepository', function () {
                 }),
                 edit: sinon.stub().resolves({
                     attributes: {},
-                    _previousAttributes: {}
+                    _previousAttributes: {},
+                    // The real _Member.edit resolves a bookshelf model; linkSubscription
+                    // loads relations off it when a subscription cancel flag changes
+                    load: sinon.stub().resolvesThis()
                 })
             };
             MemberPaidSubscriptionEvent = {
@@ -1953,7 +1959,10 @@ describe('MemberRepository', function () {
                 }),
                 edit: sinon.stub().resolves({
                     attributes: {},
-                    _previousAttributes: {}
+                    _previousAttributes: {},
+                    // The real _Member.edit resolves a bookshelf model; linkSubscription
+                    // loads relations off it when a subscription cancel flag changes
+                    load: sinon.stub().resolvesThis()
                 })
             };
 

--- a/ghost/core/test/unit/server/services/webhooks/serialize.test.js
+++ b/ghost/core/test/unit/server/services/webhooks/serialize.test.js
@@ -4,6 +4,7 @@ const sinon = require('sinon');
 const {Post} = require('../../../../../core/server/models/post');
 const {Member} = require('../../../../../core/server/models/member');
 const {Product} = require('../../../../../core/server/models/product');
+const {StripeCustomerSubscription} = require('../../../../../core/server/models/stripe-customer-subscription');
 
 const createSerialize = require('../../../../../core/server/services/webhooks/serialize');
 
@@ -195,5 +196,58 @@ describe('WebhookService - Serialize', function () {
 
         assert.deepEqual(result.member.current.tiers.map(tier => tier.slug), ['gold']);
         assert.deepEqual(result.member.previous.tiers.map(tier => tier.slug), ['bronze']);
+    });
+
+    it('includes the previous subscriptions when a cancellation flips cancel_at_period_end', async function () {
+        // bookshelf only populates _previousAttributes on fetch, and `previous: true`
+        // cascades into related models — so these have to look fetched, not constructed.
+        const asFetched = (model) => {
+            model._previousAttributes = {...model.attributes};
+            return model;
+        };
+        const activeSub = asFetched(new StripeCustomerSubscription({
+            id: 'sub-1',
+            subscription_id: 'sub_123',
+            status: 'active',
+            cancel_at_period_end: false,
+            plan_id: 'price_123',
+            plan_nickname: 'Monthly',
+            plan_amount: 500,
+            plan_interval: 'month',
+            plan_currency: 'usd'
+        }));
+        const cancellingSub = asFetched(new StripeCustomerSubscription({
+            id: 'sub-1',
+            subscription_id: 'sub_123',
+            status: 'active',
+            cancel_at_period_end: true,
+            plan_id: 'price_123',
+            plan_nickname: 'Monthly',
+            plan_amount: 500,
+            plan_interval: 'month',
+            plan_currency: 'usd'
+        }));
+
+        const memberModel = new Member({
+            id: 'member-id',
+            uuid: 'member-uuid',
+            email: 'member@example.com',
+            status: 'paid',
+            created_at: new Date('2026-01-01T00:00:00.000Z'),
+            updated_at: new Date('2026-01-01T00:00:00.000Z')
+        });
+
+        // Cancelling touches no members column — the subscription relation is the only change
+        memberModel._previousAttributes = {...memberModel.attributes};
+        memberModel._changed = {stripeSubscriptions: {cancel_at_period_end: true}};
+        memberModel._previousRelations = {stripeSubscriptions: {models: [activeSub]}};
+        memberModel.related('stripeSubscriptions').models = [cancellingSub];
+
+        sinon.stub(memberModel, 'load').resolves(memberModel);
+
+        const result = await serialize('member.edited', memberModel);
+
+        assert.equal(result.member.current.subscriptions[0].cancel_at_period_end, true);
+        assert.equal(result.member.previous.subscriptions[0].cancel_at_period_end, false);
     });
 });


### PR DESCRIPTION
closes #29806 

stacked on #29810 

Currently, if a user clicks 'cancel subscription' or while in cancel_at_period_end: true state clicks 'resume', Ghost does not fire a webhook, which makes it hard for integrations to run retention flows.

This PR causes the member.edited webhook to fire, and causes the webhook to include the subscription field in current and previous.


