### PR TITLE
Added per-role first-login smoke tests for Ghost Admin

### DIFF
--- a/e2e/helpers/pages/admin/sidebar/contributor-user-menu.ts
+++ b/e2e/helpers/pages/admin/sidebar/contributor-user-menu.ts
@@ -1,0 +1,26 @@
+import * as sidebarSel from '@tryghost/test-data/selectors/sidebar';
+import {AdminPage} from '@/admin-pages';
+import {Locator, Page} from '@playwright/test';
+
+/**
+ * Contributors get a floating avatar menu instead of the admin sidebar
+ * (apps/admin/src/layout/admin-layout.tsx).
+ */
+export class ContributorUserMenu extends AdminPage {
+    public readonly trigger: Locator;
+    public readonly postsMenuItem: Locator;
+    public readonly viewSiteMenuItem: Locator;
+    public readonly profileMenuItem: Locator;
+
+    constructor(page: Page) {
+        super(page);
+        this.trigger = page.getByRole('button', {name: sidebarSel.contributorMenuTrigger});
+        this.postsMenuItem = page.getByRole('menuitem', {name: sidebarSel.contributorPostsMenuItem});
+        this.viewSiteMenuItem = page.getByRole('menuitem', {name: sidebarSel.contributorViewSiteMenuItem});
+        this.profileMenuItem = page.getByRole('menuitem', {name: sidebarSel.profileMenuItem});
+    }
+
+    async open(): Promise<void> {
+        await this.trigger.click();
+    }
+}

--- a/e2e/helpers/pages/admin/sidebar/index.ts
+++ b/e2e/helpers/pages/admin/sidebar/index.ts
@@ -1,1 +1,2 @@
+export * from './contributor-user-menu';
 export * from './sidebar-page';

--- a/e2e/helpers/pages/admin/sidebar/sidebar-page.ts
+++ b/e2e/helpers/pages/admin/sidebar/sidebar-page.ts
@@ -3,7 +3,7 @@ import {AdminPage} from '@/admin-pages';
 import {Locator, Page} from '@playwright/test';
 import {whatsNewMenuItem} from '@tryghost/test-data/selectors/whats-new';
 
-export type UserRole = 'Administrator' | 'Editor' | 'Author' | 'Contributor';
+export type UserRole = 'Administrator' | 'Editor' | 'Super Editor' | 'Author' | 'Contributor';
 
 export interface NavItem {
     name: string;
@@ -15,15 +15,20 @@ export interface NavItem {
 /**
  * Navigation items in the sidebar with their expected paths and role visibility.
  * Used for navigation tests and force upgrade redirect validation.
+ *
+ * `roles` = roles whose sidebar shows the item (Owner sees everything
+ * Administrator does; Contributors have no sidebar at all — they get a
+ * floating user menu instead). Gating source:
+ * apps/admin/src/layout/app-sidebar/{nav-main,nav-content}.tsx.
  */
 export const NAV_ITEMS: NavItem[] = [
     {name: 'Analytics', path: /\/ghost\/#\/analytics\/?$/, directUrl: '/ghost/#/analytics', roles: ['Administrator']},
     {name: 'Network', path: /\/ghost\/#\/(network|activitypub)\/?/, directUrl: '/ghost/#/activitypub', roles: ['Administrator']},
-    {name: 'View site', path: /\/ghost\/#\/site\/?$/, directUrl: '/ghost/#/site', roles: ['Administrator', 'Editor']},
-    {name: 'Posts', path: /\/ghost\/#\/posts\/?$/, directUrl: '/ghost/#/posts', roles: ['Administrator', 'Editor', 'Author', 'Contributor']},
-    {name: 'Pages', path: /\/ghost\/#\/pages\/?$/, directUrl: '/ghost/#/pages', roles: ['Administrator', 'Editor']},
-    {name: 'Tags', path: /\/ghost\/#\/tags\/?$/, directUrl: '/ghost/#/tags', roles: ['Administrator', 'Editor']},
-    {name: 'Members', path: /\/ghost\/#\/members\/?$/, directUrl: '/ghost/#/members', roles: ['Administrator', 'Editor']}
+    {name: 'View site', path: /\/ghost\/#\/site\/?$/, directUrl: '/ghost/#/site', roles: ['Administrator']},
+    {name: 'Posts', path: /\/ghost\/#\/posts\/?$/, directUrl: '/ghost/#/posts', roles: ['Administrator', 'Editor', 'Super Editor', 'Author']},
+    {name: 'Pages', path: /\/ghost\/#\/pages\/?$/, directUrl: '/ghost/#/pages', roles: ['Administrator', 'Editor', 'Super Editor', 'Author']},
+    {name: 'Tags', path: /\/ghost\/#\/tags\/?$/, directUrl: '/ghost/#/tags', roles: ['Administrator', 'Editor', 'Super Editor']},
+    {name: 'Members', path: /\/ghost\/#\/members\/?$/, directUrl: '/ghost/#/members', roles: ['Administrator', 'Super Editor']}
 ];
 
 /**
@@ -36,6 +41,7 @@ export const NAV_ITEMS: NavItem[] = [
  */
 export class SidebarPage extends AdminPage {
     public readonly sidebar: Locator;
+    public readonly adminSidebar: Locator;
     public readonly postsToggle: Locator;
     public readonly userDropdownTrigger: Locator;
     public readonly appearanceMenuItem: Locator;
@@ -57,6 +63,9 @@ export class SidebarPage extends AdminPage {
         // carry a breadcrumb <nav aria-label="breadcrumb"> too), so anchor on
         // the site search control, which only the sidebar contains.
         this.sidebar = page.getByRole('navigation').filter({has: page.getByRole('button', {name: /Search site/})});
+        // Container testid — for asserting the sidebar's absence (contributors
+        // get a floating avatar menu instead of the sidebar).
+        this.adminSidebar = page.getByTestId(sidebarSel.adminSidebar);
         this.postsToggle = this.sidebar.getByRole('button', {name: sidebarSel.postsToggle});
         this.userDropdownTrigger = page.getByRole('button', {name: sidebarSel.userMenuTrigger});
         this.appearanceMenuItem = page.getByRole('menuitem', {name: sidebarSel.appearanceMenuItem});

--- a/e2e/helpers/playwright/fixture.ts
+++ b/e2e/helpers/playwright/fixture.ts
@@ -107,6 +107,9 @@ export interface GhostInstanceFixture {
     ghostAccountOwner: User;
     ghostAccountAuthor: StaffAccount;
     ghostAccountContributor: StaffAccount;
+    ghostAccountEditor: StaffAccount;
+    ghostAccountSuperEditor: StaffAccount;
+    ghostAccountAdministrator: StaffAccount;
     pageWithAuthenticatedUser: {
         page: Page;
         context: BrowserContext;
@@ -568,6 +571,18 @@ export const test = base.extend<GhostInstanceFixture & InternalFixtures, WorkerF
 
     ghostAccountContributor: async ({pageWithAuthenticatedUser, emailClient}, use) => {
         await use(await createStaffAccount(pageWithAuthenticatedUser.page, emailClient, 'Contributor'));
+    },
+
+    ghostAccountEditor: async ({pageWithAuthenticatedUser, emailClient}, use) => {
+        await use(await createStaffAccount(pageWithAuthenticatedUser.page, emailClient, 'Editor'));
+    },
+
+    ghostAccountSuperEditor: async ({pageWithAuthenticatedUser, emailClient}, use) => {
+        await use(await createStaffAccount(pageWithAuthenticatedUser.page, emailClient, 'Super Editor'));
+    },
+
+    ghostAccountAdministrator: async ({pageWithAuthenticatedUser, emailClient}, use) => {
+        await use(await createStaffAccount(pageWithAuthenticatedUser.page, emailClient, 'Administrator'));
     },
 
     // Intermediate fixture that sets up the page and returns all setup data

--- a/e2e/tests/admin/staff-role-smoke.test.ts
+++ b/e2e/tests/admin/staff-role-smoke.test.ts
@@ -2,22 +2,13 @@ import {AnalyticsOverviewPage, ContributorUserMenu, LoginPage, PostsPage, Sideba
 import {Page} from '@playwright/test';
 import {expect, test, withIsolatedPage} from '@/helpers/playwright';
 
-// Each role signs in for the first time in a fresh browser context and must
-// land on its default view with its navigation available (incident-315:
-// Ember/React router desync blanked non-admin landing views after login).
 test.describe('Ghost Admin - Staff role smoke', () => {
-    // A user's first-ever login skips staff device verification (the session
-    // endpoint checks user.hasLoggedIn()); signing in again with the same
-    // account would stall on the emailed-code screen.
     async function signInFirstTime(page: Page, account: {email: string; password: string}) {
         const loginPage = new LoginPage(page);
         await loginPage.goto();
         await loginPage.signIn(account.email, account.password);
     }
 
-    // The sidebar locator anchors on the search button, which only renders
-    // once the current user has resolved — so the hidden checks cannot run
-    // before role gating has been applied.
     async function expectNavigation(sidebarPage: SidebarPage, {visible, hidden}: {visible: string[]; hidden: string[]}) {
         await expect(sidebarPage.sidebar).toBeVisible();
         for (const name of visible) {
@@ -36,8 +27,6 @@ test.describe('Ghost Admin - Staff role smoke', () => {
             await expect(analyticsPage.header).toBeVisible();
 
             const sidebarPage = new SidebarPage(page);
-            // Positive control for the contributor test's absence assertion:
-            // if the admin-sidebar testid disappears, this fails first.
             await expect(sidebarPage.adminSidebar).toBeVisible();
             await expectNavigation(sidebarPage, {
                 visible: ['Analytics', 'View site', 'Posts', 'Pages', 'Tags', 'Members', 'Settings'],

--- a/e2e/tests/admin/staff-role-smoke.test.ts
+++ b/e2e/tests/admin/staff-role-smoke.test.ts
@@ -1,0 +1,108 @@
+import {AnalyticsOverviewPage, ContributorUserMenu, LoginPage, PostsPage, SidebarPage, SitePage} from '@/admin-pages';
+import {Page} from '@playwright/test';
+import {expect, test, withIsolatedPage} from '@/helpers/playwright';
+
+// Each role signs in for the first time in a fresh browser context and must
+// land on its default view with its navigation available (incident-315:
+// Ember/React router desync blanked non-admin landing views after login).
+test.describe('Ghost Admin - Staff role smoke', () => {
+    // A user's first-ever login skips staff device verification (the session
+    // endpoint checks user.hasLoggedIn()); signing in again with the same
+    // account would stall on the emailed-code screen.
+    async function signInFirstTime(page: Page, account: {email: string; password: string}) {
+        const loginPage = new LoginPage(page);
+        await loginPage.goto();
+        await loginPage.signIn(account.email, account.password);
+    }
+
+    // The sidebar locator anchors on the search button, which only renders
+    // once the current user has resolved — so the hidden checks cannot run
+    // before role gating has been applied.
+    async function expectNavigation(sidebarPage: SidebarPage, {visible, hidden}: {visible: string[]; hidden: string[]}) {
+        await expect(sidebarPage.sidebar).toBeVisible();
+        for (const name of visible) {
+            await expect(sidebarPage.getNavLink(name)).toBeVisible();
+        }
+        for (const name of hidden) {
+            await expect(sidebarPage.getNavLink(name)).toHaveCount(0);
+        }
+    }
+
+    test('administrator first login - lands on analytics with full navigation', async ({browser, baseURL, ghostAccountAdministrator}) => {
+        await withIsolatedPage(browser, {baseURL}, async ({page}) => {
+            await signInFirstTime(page, ghostAccountAdministrator);
+
+            const analyticsPage = new AnalyticsOverviewPage(page);
+            await expect(analyticsPage.header).toBeVisible();
+
+            const sidebarPage = new SidebarPage(page);
+            // Positive control for the contributor test's absence assertion:
+            // if the admin-sidebar testid disappears, this fails first.
+            await expect(sidebarPage.adminSidebar).toBeVisible();
+            await expectNavigation(sidebarPage, {
+                visible: ['Analytics', 'View site', 'Posts', 'Pages', 'Tags', 'Members', 'Settings'],
+                hidden: []
+            });
+        });
+    });
+
+    test('editor first login - lands on site view with content navigation', async ({browser, baseURL, ghostAccountEditor}) => {
+        await withIsolatedPage(browser, {baseURL}, async ({page}) => {
+            await signInFirstTime(page, ghostAccountEditor);
+
+            const sitePage = new SitePage(page);
+            await sitePage.waitForPageToFullyLoad();
+
+            await expectNavigation(new SidebarPage(page), {
+                visible: ['Posts', 'Pages', 'Tags', 'Settings'],
+                hidden: ['Analytics', 'View site', 'Members']
+            });
+        });
+    });
+
+    test('super editor first login - lands on site view with members navigation', async ({browser, baseURL, ghostAccountSuperEditor}) => {
+        await withIsolatedPage(browser, {baseURL}, async ({page}) => {
+            await signInFirstTime(page, ghostAccountSuperEditor);
+
+            const sitePage = new SitePage(page);
+            await sitePage.waitForPageToFullyLoad();
+
+            await expectNavigation(new SidebarPage(page), {
+                visible: ['Posts', 'Pages', 'Tags', 'Members', 'Settings'],
+                hidden: ['Analytics', 'View site']
+            });
+        });
+    });
+
+    test('author first login - lands on site view with posts and pages navigation', async ({browser, baseURL, ghostAccountAuthor}) => {
+        await withIsolatedPage(browser, {baseURL}, async ({page}) => {
+            await signInFirstTime(page, ghostAccountAuthor);
+
+            const sitePage = new SitePage(page);
+            await sitePage.waitForPageToFullyLoad();
+
+            await expectNavigation(new SidebarPage(page), {
+                visible: ['Posts', 'Pages'],
+                hidden: ['Analytics', 'View site', 'Tags', 'Members', 'Settings']
+            });
+        });
+    });
+
+    test('contributor first login - lands on posts list with floating user menu instead of sidebar', async ({browser, baseURL, ghostAccountContributor}) => {
+        await withIsolatedPage(browser, {baseURL}, async ({page}) => {
+            await signInFirstTime(page, ghostAccountContributor);
+
+            const postsPage = new PostsPage(page);
+            await postsPage.waitForPageToFullyLoad();
+
+            const sidebarPage = new SidebarPage(page);
+            await expect(sidebarPage.adminSidebar).toHaveCount(0);
+
+            const contributorMenu = new ContributorUserMenu(page);
+            await contributorMenu.open();
+            await expect(contributorMenu.postsMenuItem).toBeVisible();
+            await expect(contributorMenu.viewSiteMenuItem).toBeVisible();
+            await expect(contributorMenu.profileMenuItem).toBeVisible();
+        });
+    });
+});

--- a/packages/testing/test-data/src/selectors/sidebar.ts
+++ b/packages/testing/test-data/src/selectors/sidebar.ts
@@ -10,6 +10,10 @@ export const networkNotificationBadge = "network-notification-badge";
 // accessible names
 export const postsToggle = "Toggle post views";
 export const userMenuTrigger = "User menu";
+/** Contributors get a floating avatar menu instead of the sidebar. */
+export const contributorMenuTrigger = "Open user menu";
+export const contributorPostsMenuItem = "Posts";
+export const contributorViewSiteMenuItem = "View site";
 export const profileMenuItem = "Your profile";
 export const signOutMenuItem = "Sign out";
 /** The appearance item's accessible name includes the current choice ("Appearance Light"). */


### PR DESCRIPTION
## What

- New e2e spec `e2e/tests/admin/staff-role-smoke.test.ts`: every staff role performs a real first login in a fresh browser context and the test asserts the role's landing view plus the navigation it should (and should not) have:
  - **Administrator** → `/analytics`, full sidebar (Analytics, View site, Posts, Pages, Tags, Members, Settings)
  - **Editor** → `/site`, sidebar with Posts, Pages, Tags, Settings (no Analytics/View site/Members)
  - **Super Editor** → `/site`, Editor set plus Members
  - **Author** → `/site`, Posts and Pages only
  - **Contributor** → `/posts`, no sidebar at all — floating avatar menu with Posts / View site / Your profile
- New Playwright fixtures `ghostAccountEditor`, `ghostAccountSuperEditor`, `ghostAccountAdministrator`, reusing the existing StaffAccountFactory invite + MailPit flow (Author/Contributor already existed).
- New `ContributorUserMenu` page object backed by new selector constants in `@tryghost/test-data`.
- Corrected the stale `NAV_ITEMS` role-visibility metadata in the sidebar page object (it claimed Editors see View site and Members, contradicting the shipped gating) and added `Super Editor` to its `UserRole` union.

## Why

A recent production regression left non-admin staff with blank or wrong landing views immediately after login — only a hard refresh recovered — and nothing in the suite walked a non-admin role through a real first login, so it shipped unnoticed. The four non-admin tests anchor their landing waits on Ember-rendered content (site preview iframe, posts list), which is exactly what fails to render when the React and Ember routers desync, so this class of regression now fails loudly. First-ever logins skip staff device verification (the session endpoint checks `user.hasLoggedIn()`), which is what makes fresh-context signin deterministic here.

A console-error tripwire was considered and deliberately deferred — the admin console is currently too noisy to fail on. Tracked in PLA-314.

## Verification

- Spec green across three full local runs (dev mode), including one after the final revision; first test ~13s (instance boot), ~5s per test after.
- `pnpm lint` (0 errors) and `pnpm test:types` in `e2e/`; lint + typecheck in `packages/testing/test-data`.
- Every asserted expectation traced to product source (`home-redirect.tsx`, sidebar gating in `nav-main`/`nav-content`/`nav-settings`, `admin-layout.tsx`, role predicates in `admin-x-framework`).
- Three independent review passes (mechanical, e2e-conventions/flakiness, adversarial correctness); all findings addressed. The adversarial pass traced the pre-regression code path and confirmed each non-admin test would have caught it.