### PR TITLE
Cleaned up stale routing comments, dead code and two domain-model type holes

### DIFF
--- a/ghost/core/core/frontend/services/data/fetch-data.js
+++ b/ghost/core/core/frontend/services/data/fetch-data.js
@@ -3,15 +3,7 @@
  * Dynamically build and execute queries on the API
  */
 const _ = require('lodash');
-const {resolveRouteData} = require('../routing/api-adapter');
-
-// The default settings for a default post query
-const queryDefaults = {
-    type: 'browse',
-    resource: 'posts',
-    controller: 'postsPublic',
-    options: {}
-};
+const {resolveApiCall, resolveRouteData} = require('../routing/api-adapter');
 
 /**
  * The theme expects to have access to the relations by default e.g. {{post.authors}}
@@ -29,13 +21,16 @@ const defaultDataQueryOptions = {
     author: null
 };
 
-const defaultPostQuery = _.cloneDeep(queryDefaults);
-defaultPostQuery.options = defaultQueryOptions.options;
+const defaultPostQuery = {
+    ...resolveApiCall({type: 'browse', resource: 'posts'}),
+    options: _.cloneDeep(defaultQueryOptions.options)
+};
 
 /**
  * Process query request.
  *
- * Takes a 'query' object, ensures that type, resource and options are set
+ * Takes a resolved query spec, which already carries type, resource,
+ * controller and options.
  * Replaces occurrences of `%s` in options with slugParam
  * Converts the query config to a promise for the result
  *
@@ -47,8 +42,6 @@ function processQuery(query, slugParam, locals) {
     const api = require('../proxy').api;
 
     query = _.cloneDeep(query);
-
-    _.defaultsDeep(query, queryDefaults);
 
     // Replace any slugs, see TaxonomyRouter. We replace any '%s' by the slug
     _.each(query.options, function (option, name) {

--- a/ghost/core/core/frontend/services/routing/api-adapter.ts
+++ b/ghost/core/core/frontend/services/routing/api-adapter.ts
@@ -30,7 +30,7 @@ interface ResourceConfig {
     options?: Record<string, unknown>;
 }
 
-// A domain resource with no entry here would only fail per request.
+// Without this, a domain resource with no entry here would only fail per request.
 QUERY satisfies Record<DataShortFormResource, ResourceConfig>;
 
 /**

--- a/ghost/core/core/frontend/services/routing/api-adapter.ts
+++ b/ghost/core/core/frontend/services/routing/api-adapter.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import errors from '@tryghost/errors';
 import {QUERY} from './config';
-import type {RouteData, DataEntry, DataShortForm, DataLongFormEntry} from '@tryghost/adapter-base-route-settings';
+import type {RouteData, DataEntry, DataShortForm, DataShortFormResource, DataLongFormEntry} from '@tryghost/adapter-base-route-settings';
 
 /**
  * A resolved Content API call: which controller to reach for, which method to
@@ -30,9 +30,13 @@ interface ResourceConfig {
     options?: Record<string, unknown>;
 }
 
+// A domain resource with no entry here would only fail per request.
+QUERY satisfies Record<DataShortFormResource, ResourceConfig>;
+
 /**
- * Not every entry in QUERY is reachable from route data — `previews` and `email`
- * are internal routers with no `type`, so they resolve to no API call.
+ * A superset: `previews` and `email` are internal routers with no `type`, so
+ * nothing here resolves them — but the preview and email routers hand their
+ * QUERY entry straight to a controller, so removing one still breaks them.
  */
 const RESOURCE_CONFIGS: Record<string, ResourceConfig | undefined> = QUERY;
 
@@ -101,9 +105,12 @@ function resolveLongForm(entry: DataLongFormEntry): ApiCallSpec {
 /**
  * Resolve a single route data entry into a Content API call.
  *
- * This is the one place that knows how a domain `resource` maps onto a Ghost API
- * controller — routes.yaml talks about `tags`, the API is reached via
- * `tagsPublic`. Callers work with the domain model and never name a controller.
+ * Resolves how a domain `resource` maps onto a Ghost API controller — routes.yaml
+ * talks about `tags`, the API is reached via `tagsPublic`. Callers work with the
+ * domain model and never name a controller.
+ *
+ * Not the only such place yet: four routers still put a raw QUERY entry on
+ * `res.routerOptions.query` for their controllers to index directly.
  *
  * @example resolveApiCall('tag.food')
  *   // => {controller: 'tagsPublic', type: 'read', resource: 'tags', options: {slug: 'food', visibility: 'public'}}

--- a/ghost/core/core/frontend/services/routing/collection-router.js
+++ b/ghost/core/core/frontend/services/routing/collection-router.js
@@ -138,8 +138,7 @@ class CollectionRouter extends ParentRouter {
      * @returns {string}
      */
     getResourceType() {
-        // @TODO: resourceAlias can be removed? We removed it. Looks like a last left over. Needs double checking.
-        return this.RESOURCE_CONFIG.resourceAlias || this.RESOURCE_CONFIG.resource;
+        return this.RESOURCE_CONFIG.resource;
     }
 
     /**

--- a/ghost/core/core/frontend/services/routing/controllers/previews.js
+++ b/ghost/core/core/frontend/services/routing/controllers/previews.js
@@ -38,9 +38,6 @@ module.exports = function previewController(req, res, next) {
                     return next();
                 }
 
-                // @TODO: we don't know which resource type it is, because it's a generic preview handler and the
-                //        preview API returns {previews: []}
-                // @TODO: figure out how to solve better
                 const resourceType = post.type;
 
                 // CASE: last param of the url is /edit, redirect to admin

--- a/ghost/core/core/frontend/services/routing/events.js
+++ b/ghost/core/core/frontend/services/routing/events.js
@@ -1,7 +1,8 @@
 const EventEmitter = require('events').EventEmitter;
 
 /**
- * Raised for each router mounted during activation.
+ * Raised by the four routers given a routerCreated callback: static routes,
+ * collections, static pages and taxonomies.
  *
  * @typedef {Object} RouteRegistered
  * @property {string|null} path - route in domain notation, e.g. `/about/`.

--- a/ghost/core/core/frontend/services/routing/parent-router.js
+++ b/ghost/core/core/frontend/services/routing/parent-router.js
@@ -10,7 +10,6 @@
 const debug = require('@tryghost/debug')('routing:parent-router');
 
 const express = require('../../../shared/express');
-const _ = require('lodash');
 const url = require('url');
 const security = require('@tryghost/security');
 const {resolveResourceRead} = require('./api-adapter');
@@ -142,27 +141,6 @@ class ParentRouter {
         registry.setRoute(this.name, path);
         this._router.post(path, controller);
         this._router.get(path, controller);
-    }
-
-    /**
-     * @description Unmount route.
-     *
-     * Not used at the moment, but useful to keep for e.g. deregister routes on runtime.
-     *
-     * @param {string} path
-     */
-    unmountRoute(path) {
-        let indexToRemove = null;
-
-        _.each(this._router.stack, (item, index) => {
-            if (item.path === path) {
-                indexToRemove = index;
-            }
-        });
-
-        if (indexToRemove !== null) {
-            this._router.stack.splice(indexToRemove, 1);
-        }
     }
 
     /**

--- a/ghost/core/core/frontend/services/routing/router-manager.js
+++ b/ghost/core/core/frontend/services/routing/router-manager.js
@@ -53,8 +53,8 @@ class RouterManager {
     }
 
     /**
-     * The `init` function will return the wrapped parent express router and will start creating all
-     * routers if you pass the option "start: true".
+     * The `init` function will return the wrapped parent express router, and will start creating
+     * all routers if you pass `routeSettings`.
      *
      * CASES:
      *   - if Ghost starts, it will first init the site app with the wrapper router and then call `start`

--- a/ghost/core/core/frontend/services/routing/static-pages-router.js
+++ b/ghost/core/core/frontend/services/routing/static-pages-router.js
@@ -68,7 +68,6 @@ class StaticPagesRouter extends ParentRouter {
     _prepareContext(req, res, next) {
         res.routerOptions = {
             type: 'entry',
-            filter: this.filter,
             permalinks: this.permalinks.getValue({withUrlOptions: true}),
             resourceType: this.getResourceType(),
             query: this.RESOURCE_CONFIG,

--- a/ghost/core/core/frontend/services/sitemap/handler.js
+++ b/ghost/core/core/frontend/services/sitemap/handler.js
@@ -26,10 +26,9 @@ module.exports = function handler(siteApp) {
         res.send(content);
     };
 
-    // The XML reads are async: with a lazy URL backend the manager builds
-    // its index on first read. Express 4 does not forward async handler
-    // rejections, so each body is fully wrapped — a failed build or render
-    // becomes an error response instead of a hung socket.
+    // Express 4 does not forward async handler rejections, so each body is
+    // fully wrapped — a failed index build or render becomes an error
+    // response instead of a hung socket.
     siteApp.get('/sitemap.xml', async function sitemapXML(req, res, next) {
         try {
             sendXml(res, await manager.getIndexXml());

--- a/ghost/core/core/frontend/services/sitemap/site-map-manager.js
+++ b/ghost/core/core/frontend/services/sitemap/site-map-manager.js
@@ -67,8 +67,7 @@ class SiteMapManager {
             };
             this._routerEntries.push(entry);
             this.pages.addUrl(entry.url, entry.datum);
-            // A router registering after a build (routes reload re-registers
-            // them one macrotask after RoutesReset) must not leave a
+            // A router registering after a build must not leave a
             // zero-router index marked built — the CDN would pin it.
             this._invalidateIndex();
         });

--- a/ghost/core/core/server/services/route-settings/dynamic-routing-service.js
+++ b/ghost/core/core/server/services/route-settings/dynamic-routing-service.js
@@ -81,6 +81,8 @@ class DynamicRoutingService {
         const parseYaml = require('./yaml-parser');
         const {parseRouteSettings} = require('./route-settings-parser');
         const urlService = require('../url');
+        // Deferred: bridge reaches back here via api/endpoints/settings.js,
+        // so hoisting this would resolve to a half-initialised export.
         const bridge = require('../../../bridge');
 
         // Parse and validate before anything is persisted — an invalid

--- a/ghost/core/core/server/services/route-settings/route-settings-parser.ts
+++ b/ghost/core/core/server/services/route-settings/route-settings-parser.ts
@@ -15,6 +15,9 @@ import tpl from '@tryghost/tpl';
 import type {PathSegment, RouteSettingsErrorCode} from './validation-errors';
 import {describeValue, formatLocation, humanList, ROUTE_SETTINGS_ERROR_CODES, toValidationError, validationError} from './validation-errors';
 
+// Omit over a union collapses to the shared keys; map over the members instead.
+type DistributiveOmit<T, K extends PropertyKey> = T extends unknown ? Omit<T, K> : never;
+
 const messages = {
     badDataError: '"{key}" is a reserved key. Please wrap the data definition into a custom name.',
     badDataHelp: 'Example:\n data:\n  my-tag:\n    resource: tags\n    ...\n',
@@ -192,7 +195,7 @@ const routeObjectSchema = (path: PathSegment[]) => z.object({
     order: OptionalStringField,
     limit: LimitField,
     rss: OptionalBooleanField
-}).transform((val): Omit<Route, 'path'> => {
+}).transform((val): DistributiveOmit<Route, 'path'> => {
     const templates = val.template;
     const data = val.data !== undefined ? parseRouteData(val.data, [...path, 'data']) : undefined;
 
@@ -331,11 +334,11 @@ export function parseRouteSettings(raw: unknown, yamlSource: string): RouteSetti
             }
 
             const route = routeResult.data;
-            if (route.type === 'template' && (!route.templates || route.templates.length === 0) && !route.data && !(route as Omit<TemplateRoute, 'path'>).contentType) {
+            if (route.type === 'template' && (!route.templates || route.templates.length === 0) && !route.data && !route.contentType) {
                 throw validationError(formatLocation(routeLocation), 'Please define a template, e.g. /about/: about.', {code: ROUTE_SETTINGS_ERROR_CODES.INVALID_TEMPLATE});
             }
 
-            routes.push({...route, path} as Route);
+            routes.push({...route, path});
         }
     }
 
@@ -388,7 +391,7 @@ export function serializeRouteSettings(settings: Omit<RouteSettings, 'yamlSource
 
     const routes: Record<string, unknown> = {};
     for (const route of settings.routes) {
-        if (route.type === 'template' && route.templates?.length === 1 && !route.data && !(route as TemplateRoute).contentType) {
+        if (route.type === 'template' && route.templates?.length === 1 && !route.data && !route.contentType) {
             routes[route.path] = route.templates[0];
         } else {
             const entry: Record<string, unknown> = {};
@@ -399,7 +402,7 @@ export function serializeRouteSettings(settings: Omit<RouteSettings, 'yamlSource
                 entry.data = route.data;
             }
             if (route.type === 'channel') {
-                const channel = route as ChannelRoute;
+                const channel = route;
                 entry.controller = 'channel';
                 if (channel.filter !== undefined) {
                     entry.filter = channel.filter;
@@ -414,7 +417,7 @@ export function serializeRouteSettings(settings: Omit<RouteSettings, 'yamlSource
                     entry.rss = channel.rss;
                 }
             } else {
-                const tmpl = route as TemplateRoute;
+                const tmpl = route;
                 if (tmpl.contentType !== undefined) {
                     entry.content_type = tmpl.contentType;
                 }

--- a/ghost/core/core/server/services/route-settings/yaml-parser.d.ts
+++ b/ghost/core/core/server/services/route-settings/yaml-parser.d.ts
@@ -1,4 +1,4 @@
-// Declaration shim so the TS FileStore adapter can reuse the legacy YAML
-// parser (and its error semantics) until it's deleted in HKG-1898.
+// Declaration shim so the TS store adapters can reuse the YAML parser
+// (and its error semantics).
 declare function parseYaml(file: string): unknown;
 export = parseYaml;

--- a/ghost/core/test/e2e-frontend/sitemap-slug-rename.test.js
+++ b/ghost/core/test/e2e-frontend/sitemap-slug-rename.test.js
@@ -1,4 +1,4 @@
-// A tag or author slug rename has to refresh the sitemap on its own, with no
+// A slug rename has to refresh the sitemap on its own, with no
 // unrelated edit to nudge it. The chain: the edit handler sets
 // `X-Cache-Invalidate: /*` dynamically (the endpoints' static `cacheInvalidate`
 // config is `false`, so it covers none of this) → the emit-events middleware
@@ -56,6 +56,29 @@ describe('Sitemap freshness', function () {
         const sitemap = await getSitemap('/sitemap-tags.xml');
         assert.ok(sitemap.includes(`/tag/${newSlug}/`), 'sitemap should serve the renamed tag URL');
         assert.ok(!sitemap.includes(`/tag/${oldSlug}/`), 'sitemap should not still serve the old tag URL');
+    });
+
+    // Posts reach the sitemap through the collection router's permalink, the
+    // other two through the taxonomy router and the author permalink.
+    it('serves the new URL in /sitemap-posts.xml after a post slug rename', async function () {
+        const {body: {posts: [post]}} = await adminAgent
+            .get('posts/?filter=status:published&limit=1')
+            .expectStatus(200);
+        const newSlug = `${post.slug}-renamed`;
+
+        assert.ok(
+            (await getSitemap('/sitemap-posts.xml')).includes(`/${post.slug}/`),
+            'precondition: sitemap should serve the original post URL'
+        );
+
+        await adminAgent.put(`posts/${post.id}/`)
+            .body({posts: [{slug: newSlug, updated_at: post.updated_at}]})
+            .expectStatus(200)
+            .expect(cacheInvalidateHeaderSetToWildcard());
+
+        const sitemap = await getSitemap('/sitemap-posts.xml');
+        assert.ok(sitemap.includes(`/${newSlug}/`), 'sitemap should serve the renamed post URL');
+        assert.ok(!sitemap.includes(`/${post.slug}/`), 'sitemap should not still serve the old post URL');
     });
 
     it('serves the new URL in /sitemap-authors.xml after an author slug rename', async function () {

--- a/ghost/core/test/unit/frontend/services/data/entry-lookup.test.js
+++ b/ghost/core/test/unit/frontend/services/data/entry-lookup.test.js
@@ -37,7 +37,7 @@ describe('Unit - frontend/data/entry-lookup', function () {
                     pages: pages
                 });
 
-            sinon.stub(api, 'posts').get(() => {
+            sinon.stub(api, 'postsPublic').get(() => {
                 return {
                     read: postsReadStub
                 };
@@ -68,7 +68,7 @@ describe('Unit - frontend/data/entry-lookup', function () {
     describe('posts', function () {
         const routerOptions = {
             permalinks: '/:slug/:options(edit)?/',
-            query: {controller: 'posts', resource: 'posts'}
+            query: {controller: 'postsPublic', resource: 'posts'}
         };
 
         let posts;
@@ -88,7 +88,7 @@ describe('Unit - frontend/data/entry-lookup', function () {
                     posts: posts
                 });
 
-            sinon.stub(api, 'posts').get(() => {
+            sinon.stub(api, 'postsPublic').get(() => {
                 return {
                     read: postsReadStub
                 };
@@ -130,7 +130,7 @@ describe('Unit - frontend/data/entry-lookup', function () {
         it('matches hyphen-separated date permalinks with hyphenated slugs', function () {
             const datedRouterOptions = {
                 permalinks: '/articles/:year-:month-:day-:slug/:options(edit)?/',
-                query: {controller: 'posts', resource: 'posts'}
+                query: {controller: 'postsPublic', resource: 'posts'}
             };
 
             postsReadStub.resolves({
@@ -153,7 +153,7 @@ describe('Unit - frontend/data/entry-lookup', function () {
         it('matches edit URLs for hyphen-separated date permalinks with hyphenated slugs', function () {
             const datedRouterOptions = {
                 permalinks: '/articles/:year-:month-:day-:slug/:options(edit)?/',
-                query: {controller: 'posts', resource: 'posts'}
+                query: {controller: 'postsPublic', resource: 'posts'}
             };
 
             postsReadStub.resolves({
@@ -177,7 +177,7 @@ describe('Unit - frontend/data/entry-lookup', function () {
         it('matches generic hyphen-separated params with hyphenated slugs', function () {
             const sectionRouterOptions = {
                 permalinks: '/articles/:section-:slug/:options(edit)?/',
-                query: {controller: 'posts', resource: 'posts'}
+                query: {controller: 'postsPublic', resource: 'posts'}
             };
 
             postsReadStub.resolves({

--- a/ghost/core/test/unit/frontend/services/routing/api-adapter.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/api-adapter.test.js
@@ -76,6 +76,16 @@ describe('UNIT - services/routing/api-adapter', function () {
     });
 
     describe('resolveApiCall - long form browse', function () {
+        it('resolves the posts browse a collection route runs by default', function () {
+            // fetch-data's default post query is built from this spec.
+            assert.deepEqual(resolveApiCall({type: 'browse', resource: 'posts'}), {
+                controller: 'postsPublic',
+                type: 'browse',
+                resource: 'posts',
+                options: {}
+            });
+        });
+
         it('does not apply read defaults to a browse entry', function () {
             assert.deepEqual(resolveApiCall({type: 'browse', resource: 'tags'}), {
                 controller: 'tagsPublic',

--- a/ghost/core/test/unit/frontend/services/routing/bootstrap.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/bootstrap.test.js
@@ -3,7 +3,7 @@ const CollectionRouter = require('../../../../../core/frontend/services/routing/
 const RouterManager = require('../../../../../core/frontend/services/routing/router-manager');
 const registry = require('../../../../../core/frontend/services/routing/registry');
 
-const RESOURCE_CONFIG = {QUERY: {post: {controller: 'posts', resource: 'posts'}}};
+const RESOURCE_CONFIG = {QUERY: {post: {controller: 'postsPublic', resource: 'posts'}}};
 
 describe('UNIT: services/routing/router-manager', function () {
     let routerUpdatedSpy;

--- a/ghost/core/test/unit/frontend/services/routing/collection-router.test.js
+++ b/ghost/core/test/unit/frontend/services/routing/collection-router.test.js
@@ -5,7 +5,7 @@ const express = require('../../../../../core/shared/express')._express;
 const events = require('../../../../../core/server/lib/common/events');
 const controllers = require('../../../../../core/frontend/services/routing/controllers');
 const CollectionRouter = require('../../../../../core/frontend/services/routing/collection-router');
-const RESOURCE_CONFIG = {QUERY: {post: {controller: 'posts', resource: 'posts'}}};
+const RESOURCE_CONFIG = {QUERY: {post: {controller: 'postsPublic', resource: 'posts'}}};
 
 describe('UNIT - services/routing/CollectionRouter', function () {
     let req;
@@ -22,7 +22,6 @@ describe('UNIT - services/routing/CollectionRouter', function () {
 
         mountRouteSpy = sinon.spy(CollectionRouter.prototype, 'mountRoute');
         mountRouterSpy = sinon.spy(CollectionRouter.prototype, 'mountRouter');
-        sinon.spy(CollectionRouter.prototype, 'unmountRoute');
         sinon.spy(express.Router, 'param');
 
         req = sinon.stub();
@@ -158,7 +157,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
                 type: 'collection',
                 filter: undefined,
                 permalinks: '/:slug/:options(edit)?/',
-                query: {controller: 'posts', resource: 'posts'},
+                query: {controller: 'postsPublic', resource: 'posts'},
                 frontPageTemplate: 'home',
                 templates: [],
                 identifier: collectionRouter.identifier,
@@ -186,7 +185,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
                 type: 'collection',
                 filter: undefined,
                 permalinks: '/:slug/:options(edit)?/',
-                query: {controller: 'posts', resource: 'posts'},
+                query: {controller: 'postsPublic', resource: 'posts'},
                 frontPageTemplate: 'home',
                 templates: ['index', 'home'],
                 identifier: collectionRouter.identifier,

--- a/ghost/core/test/unit/server/adapters/route-settings/file-store.test.ts
+++ b/ghost/core/test/unit/server/adapters/route-settings/file-store.test.ts
@@ -11,6 +11,7 @@ import FileStore from '../../../../../core/server/adapters/route-settings/FileSt
 import parseYaml from '../../../../../core/server/services/route-settings/yaml-parser';
 import {parseRouteSettings} from '../../../../../core/server/services/route-settings/route-settings-parser';
 import {buildRouteSettings} from '../../services/route-settings/route-settings-fixture';
+import {runStoreContract} from './helpers/store-contract';
 
 const REAL_DEFAULTS_PATH = path.join(__dirname, '../../../../../core/server/services/route-settings');
 
@@ -66,6 +67,8 @@ describe('UNIT: route-settings FileStore', function () {
         await fs.remove(basePath);
         await fs.remove(defaultsPath);
     });
+
+    runStoreContract({createStore: () => createStore()});
 
     describe('adapter contract', function () {
         it('extends RouteSettingsStoreBase and declares get/replace as required', function () {

--- a/ghost/core/test/unit/server/services/url/lazy-url-service.test.js
+++ b/ghost/core/test/unit/server/services/url/lazy-url-service.test.js
@@ -7,9 +7,9 @@ function makeUrlUtils() {
     // Just enough of url-utils to satisfy the service. createUrl returns the
     // path verbatim so tests can assert on the relative form; replacePermalink
     // does the same substitution Ghost's url-utils does for our limited fields.
-    // Permalinks use the `:field` syntax that Ghost's RouteSettings validator
-    // rewrites all `{field}` placeholders into before they reach the URL
-    // service.
+    // Permalinks use the `:field` syntax: the routers convert the domain
+    // model's `{field}` placeholders via toExpressNotation before handing
+    // them to the URL service.
     return {
         replacePermalink(permalink, resource) {
             const datePart = resource.published_at ? new Date(resource.published_at) : null;
@@ -97,7 +97,7 @@ describe('LazyUrlService', function () {
             const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
             service.onRouterAddedType('default', null, 'posts', '/:slug/');
 
-            // Eager only maps status:published posts, so a draft has no URL.
+            // Only status:published posts are routable, so a draft has no URL.
             const url = service.getUrlForResource({type: 'posts', id: 'p', slug: 'hello', status: 'draft'});
             assert.equal(url, '/404/');
         });
@@ -229,11 +229,11 @@ describe('LazyUrlService', function () {
         });
 
         it('matches page:false against the singular DB type field', function () {
-            // The legacy transformer rewrites `page:false` to `type:post` and
+            // The page transformer rewrites `page:false` to `type:post` and
             // evaluates it against the resource's singular DB-style `type`
             // field. The negative half (a record whose `type` is 'page'
             // failing the filter) is not directly expressible through this
-            // public API: `_routerTypeOf('page')` returns 'pages', so a
+            // public API: `routerTypeOf('page')` returns 'pages', so a
             // type:'page' resource is routed to the pages collection rather
             // than reaching this posts router's filter at all. That's why
             // only the positive match is asserted here.
@@ -268,8 +268,8 @@ describe('LazyUrlService', function () {
             const service = new LazyUrlService({urlUtils, findResource: noopFindResource});
             service.onRouterAddedType('tagsRouter', null, 'tags', '/tag/:slug/');
 
-            // Eager filters its tag resources to visibility:public, so an
-            // internal tag (#hash) has no URL there and must 404 here too.
+            // Tag resources are filtered to visibility:public, so an
+            // internal tag (#hash) has no URL.
             assert.equal(
                 service.getUrlForResource({type: 'tags', id: 't1', slug: 'hash-internal', visibility: 'internal'}),
                 '/404/'

--- a/ghost/core/test/unit/server/services/webhooks/serialize.test.js
+++ b/ghost/core/test/unit/server/services/webhooks/serialize.test.js
@@ -6,8 +6,6 @@ const {Member} = require('../../../../../core/server/models/member');
 
 const createSerialize = require('../../../../../core/server/services/webhooks/serialize');
 
-// Eager routing needs no relations; getRequiredRelations returns [] there, so
-// this is the default for tests that don't exercise relation loading.
 const noRelationsUrlService = {getRequiredRelations: () => []};
 const serialize = createSerialize({urlService: noRelationsUrlService});
 


### PR DESCRIPTION
ref https://linear.app/ghost/project/moving-routesyaml-off-of-disk-9887873946a1/

Tidying PR

**No production behaviour changes.** Every non-comment change is argued below, and I verified the type-only ones mechanically by diffing the esbuild-emitted JS for each changed file against `main` — `api-adapter.ts` and `route-settings-parser.ts` emit byte-identical output.

## Comments that were describing code we removed

- The sitemap said routers re-register *"one macrotask after RoutesReset"*. `RouterManager` emits and calls `start()` in the same synchronous tick, so this sent a reader hunting for a queue that doesn't exist. The defensive `_invalidateIndex()` below it is still correct — only the false reason is gone.
- `RouterManager.init`'s JSDoc named a `start: true` option that has never existed.
- The `RouteRegistered` typedef claimed the event fires "for each router mounted". It fires for the four routers given a `routerCreated` callback; unsubscribe, preview, email, apps and site mount silently.
- Four comments justified live assertions by reference to the eager URL service deleted in #29792, so the stated reason could no longer be checked. One was also **wrong** about where `{field}` placeholders are rewritten — the parser deliberately leaves them alone, and the routers convert via `toExpressNotation`.
- The preview controller carried a `@TODO` saying we can't know the resource type, which the code fifteen lines below it disproves.
- The yaml-parser shim named HKG-1898 as its deletion ticket. That shipped in #29744 and the file is still load-bearing for both store adapters.

Deliberately **not** touched: the `eager` references in `e2e-api/admin/{users,tags}.test.js`, which cite HKG-1920 as the ticket that accepted a behaviour change. That's history the code can't say, and a naive `grep -i eager` would have eaten it.

## Two type holes

**`Omit` over a union collapses to its shared keys.** `Route` is `ChannelRoute | TemplateRoute`, so `Omit<Route, 'path'>` resolved to `{type, templates?, data?}` — silently dropping `filter`, `order`, `limit`, `rss` and `contentType`. The parser builds routes against that type, so it could emit a route missing a field its own variant declares and nothing would fail to compile. Proven before fixing:

```
route-settings-parser.ts(334,122): error TS2339: Property 'contentType' does not exist on type 'Omit<Route, "path">'.
```

`DistributiveOmit` restores the discriminant and takes five casts with it — including the `as Route` on the push, the one place an arbitrary object could enter the domain model unchecked. No regression test needed: the casts are gone, so reverting the type stops the file compiling under `lint:types`.

**The resource vocabulary is declared three times** — `DataShortFormResource`, the frontend `QUERY` table, and the parser's own literal lists — and only reconciled at runtime. Adding a resource to the domain model without a `QUERY` entry compiled fine and surfaced as an `IncorrectUsageError` on every request that routed through it. A `satisfies` makes it a compile error; verified by adding a fifth resource and watching the build fail with *"Property 'newsletter' is missing"*.

## Dead code

- `ParentRouter.unmountRoute` had no callers **and would not have worked**: it matches `item.path` against the express router stack, where a mounted route's path lives at `layer.route.path`, so it silently removed nothing — while its own comment invited a future caller. Deleting it takes the file's only lodash use with it.
- `CollectionRouter.getResourceType` read `RESOURCE_CONFIG.resourceAlias` behind a `@TODO` asking whether it could go. It can — the key exists nowhere in the repo and `QUERY` is `as const`, so the branch was always taken.
- `StaticPagesRouter` put `filter: this.filter` on `routerOptions`, but only the collection and static-routes routers assign that field. Static pages route through `controllers.entry`, which never reads it, and the one reader anywhere is a truthiness check — so an always-undefined key and an absent one behave identically.
- `_.defaultsDeep(query, queryDefaults)` in `fetch-data`: `processQuery` has exactly two callers and both already supply `type`, `resource`, `controller` and `options`.

## The default post query

`fetch-data` restated `controller: 'postsPublic'` as a literal, duplicating the mapping the API adapter exists to own. That mattered more than tidiness: `processQuery` falls back to `api[query.resource]`, so a rename in `config.ts` would have silently repointed the frontend at the **Admin** posts endpoint rather than throwing. `resolveApiCall` already returns exactly that spec — pinned with a test first, then asked the adapter for it.

One consequence worth stating: it now resolves at module load, so a malformed `QUERY` fails at boot instead of per request. `QUERY` is a static `as const`, so this is unreachable today.

I also corrected the adapter's claim to be *"the one place"* that maps a resource to a controller. It isn't yet — four routers still hand a raw `QUERY` entry to their controllers. Reshaping that was considered and cut: all four read the same `config.ts` object the adapter reads, so the "rename and miss a router" hazard doesn't exist, and it would mean touching the hot post/page render path for no behaviour change.

## Tests

- **Post slug rename → sitemap.** #29802 covered tags and authors. Posts reach the sitemap through the collection router rather than the taxonomy router. Verified non-vacuous: disabling the `site.changed` listener fails it on *"sitemap should serve the renamed post URL"*.
- **FileStore against `runStoreContract`.** It ran against the in-memory store and, in integration, the S3 store — but not the FileStore, so the store every self-hosted Ghost runs was the only one not held to the shared contract. It passes all six cases unchanged, which is the point.
- **Three fixtures pinned `controller: 'posts'`** and stubbed `api.posts` — the Admin endpoint — where production always passes `postsPublic`. They passed because they stubbed whichever name they'd invented, so the only unit coverage of collection entry lookup exercised a controller the frontend never reaches.