### PR TITLE
Changed settings confirmations to a context provider

### DIFF
--- a/apps/admin/src/settings/app/app.tsx
+++ b/apps/admin/src/settings/app/app.tsx
@@ -1,6 +1,7 @@
 import MainContent from './main-content';
 import NiceModal from '@ebay/nice-modal-react';
 import SettingsAppProvider, {type UpgradeStatusType} from './components/providers/settings-app-provider';
+import {ConfirmationProvider} from './components/providers/confirmation-provider';
 import {Outlet, useLocation} from '@tryghost/admin-x-framework';
 import {useEffect} from 'react';
 import {useScrollSectionContext} from './hooks/use-scroll-section';
@@ -27,11 +28,13 @@ export function App({upgradeStatus}: AppProps) {
     return (
         <SettingsAppProvider upgradeStatus={upgradeStatus}>
             <div className='admin-x-base admin-x-settings [--color-focus-ring:var(--color-green-500)] [--focus-ring:var(--color-green-500)]'>
-                <NiceModal.Provider>
-                    <SettingsLocationSync />
-                    <MainContent />
-                    <Outlet />
-                </NiceModal.Provider>
+                <ConfirmationProvider>
+                    <NiceModal.Provider>
+                        <SettingsLocationSync />
+                        <MainContent />
+                        <Outlet />
+                    </NiceModal.Provider>
+                </ConfirmationProvider>
             </div>
         </SettingsAppProvider>
     );

--- a/apps/admin/src/settings/app/components/confirmation-modal.test.tsx
+++ b/apps/admin/src/settings/app/components/confirmation-modal.test.tsx
@@ -1,18 +1,19 @@
-import ConfirmationModal, {type ConfirmationModalProps} from '@/settings/app/components/confirmation-modal';
-import NiceModal from '@ebay/nice-modal-react';
-import {act, fireEvent, render, screen, waitFor} from '@testing-library/react';
+import {type ConfirmationModalProps} from '@/settings/app/components/confirmation-modal';
+import {useEffect} from 'react';
+import {ConfirmationProvider, useConfirmation} from '@/settings/app/components/providers/confirmation-provider';
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
 
 describe('ConfirmationModal', () => {
-    afterEach(() => {
-        void NiceModal.remove(ConfirmationModal);
-    });
-
     const showModal = (props: ConfirmationModalProps) => {
-        render(<NiceModal.Provider />);
-
-        act(() => {
-            void NiceModal.show(ConfirmationModal, props);
-        });
+        const Trigger = () => {
+            const {confirm} = useConfirmation();
+            useEffect(() => {
+                confirm(props);
+                 
+            }, [confirm]);
+            return null;
+        };
+        render(<ConfirmationProvider><Trigger /></ConfirmationProvider>);
     };
 
     it('renders the supplied content and confirms without closing implicitly', async () => {

--- a/apps/admin/src/settings/app/components/confirmation-modal.tsx
+++ b/apps/admin/src/settings/app/components/confirmation-modal.tsx
@@ -1,4 +1,3 @@
-import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import React, {useState} from 'react';
 import {
     AlertDialog,
@@ -31,7 +30,14 @@ export interface ConfirmationModalProps {
     testId?: string;
 }
 
-export const ConfirmationModalContent: React.FC<ConfirmationModalProps> = ({
+export type ConfirmationHostProps = {
+    visible?: boolean;
+    onRemove: () => void;
+};
+
+export const ConfirmationModalContent: React.FC<ConfirmationModalProps & ConfirmationHostProps> = ({
+    visible = true,
+    onRemove,
     title = 'Are you sure?',
     prompt,
     cancelLabel = 'Cancel',
@@ -45,7 +51,6 @@ export const ConfirmationModalContent: React.FC<ConfirmationModalProps> = ({
     stickyFooter = false,
     testId = 'confirmation-modal'
 }) => {
-    const modal = useModal();
     const [taskState, setTaskState] = useState<'running' | ''>('');
     const isRunning = taskState === 'running';
     const runningLabel = okRunningLabel || okLabel;
@@ -58,7 +63,7 @@ export const ConfirmationModalContent: React.FC<ConfirmationModalProps> = ({
         if (onCancel) {
             onCancel();
         } else {
-            modal.remove();
+            onRemove();
         }
     };
 
@@ -66,7 +71,7 @@ export const ConfirmationModalContent: React.FC<ConfirmationModalProps> = ({
         setTaskState('running');
 
         try {
-            await onOk?.(modal);
+            await onOk?.({remove: onRemove});
         } catch (error) {
             // eslint-disable-next-line no-console
             console.error('Unhandled Promise Rejection. Make sure you catch errors in your onOk handler.', error);
@@ -94,7 +99,7 @@ export const ConfirmationModalContent: React.FC<ConfirmationModalProps> = ({
     const footer = customFooter === undefined ? defaultFooter : customFooter;
 
     return (
-        <AlertDialog open={modal.visible} onOpenChange={open => !open && handleCancel()}>
+        <AlertDialog open={visible} onOpenChange={open => !open && handleCancel()}>
             <AlertDialogContent
                 className={cn(
                     'z-[1100] max-h-[calc(100dvh-4rem)] w-[calc(100%-2rem)] overflow-y-auto bg-background'
@@ -121,5 +126,3 @@ export const ConfirmationModalContent: React.FC<ConfirmationModalProps> = ({
         </AlertDialog>
     );
 };
-
-export default NiceModal.create(ConfirmationModalContent);

--- a/apps/admin/src/settings/app/components/limit-modal.test.tsx
+++ b/apps/admin/src/settings/app/components/limit-modal.test.tsx
@@ -1,18 +1,19 @@
-import LimitModal, {type LimitModalProps} from '@/settings/app/components/limit-modal';
-import NiceModal from '@ebay/nice-modal-react';
-import {act, fireEvent, render, screen, waitFor} from '@testing-library/react';
+import {type LimitModalProps} from '@/settings/app/components/limit-modal';
+import {useEffect} from 'react';
+import {ConfirmationProvider, useConfirmation} from '@/settings/app/components/providers/confirmation-provider';
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
 
 describe('LimitModal', () => {
-    afterEach(() => {
-        void NiceModal.remove(LimitModal);
-    });
-
     const showModal = (props: LimitModalProps) => {
-        render(<NiceModal.Provider />);
-
-        act(() => {
-            void NiceModal.show(LimitModal, props);
-        });
+        const Trigger = () => {
+            const {showLimit} = useConfirmation();
+            useEffect(() => {
+                showLimit(props);
+                 
+            }, [showLimit]);
+            return null;
+        };
+        render(<ConfirmationProvider><Trigger /></ConfirmationProvider>);
     };
 
     it('preserves the upgrade defaults and renders HTML prompts', async () => {

--- a/apps/admin/src/settings/app/components/limit-modal.tsx
+++ b/apps/admin/src/settings/app/components/limit-modal.tsx
@@ -1,7 +1,6 @@
-import NiceModal from '@ebay/nice-modal-react';
 import React from 'react';
 
-import {ConfirmationModalContent} from './confirmation-modal';
+import {type ConfirmationHostProps, ConfirmationModalContent} from './confirmation-modal';
 
 export interface LimitModalProps {
     title?: string;
@@ -13,7 +12,9 @@ export interface LimitModalProps {
     }) => void | Promise<void>;
 }
 
-export const LimitModalContent: React.FC<LimitModalProps> = ({
+export const LimitModalContent: React.FC<LimitModalProps & ConfirmationHostProps> = ({
+    visible = true,
+    onRemove,
     title = 'Upgrade your plan',
     prompt,
     okLabel = 'Upgrade',
@@ -31,9 +32,9 @@ export const LimitModalContent: React.FC<LimitModalProps> = ({
             prompt={<div className='w-full'>{promptContent}</div>}
             testId='limit-modal'
             title={title}
+            visible={visible}
             onOk={onOk}
+            onRemove={onRemove}
         />
     );
 };
-
-export default NiceModal.create(LimitModalContent);

--- a/apps/admin/src/settings/app/components/providers/confirmation-provider.tsx
+++ b/apps/admin/src/settings/app/components/providers/confirmation-provider.tsx
@@ -1,0 +1,56 @@
+import React, {createContext, useCallback, useContext, useRef, useState} from 'react';
+import {type ConfirmationModalProps, ConfirmationModalContent} from '@/settings/app/components/confirmation-modal';
+import {type LimitModalProps, LimitModalContent} from '@/settings/app/components/limit-modal';
+
+export type ConfirmationHandle = {remove: () => void};
+
+type ConfirmationRequest =
+    | {id: number; kind: 'confirm'; props: ConfirmationModalProps}
+    | {id: number; kind: 'limit'; props: LimitModalProps};
+
+type ConfirmationContextType = {
+    confirm: (props: ConfirmationModalProps) => ConfirmationHandle;
+    showLimit: (props: LimitModalProps) => ConfirmationHandle;
+};
+
+const ConfirmationContext = createContext<ConfirmationContextType | null>(null);
+
+export function useConfirmation(): ConfirmationContextType {
+    const context = useContext(ConfirmationContext);
+    if (!context) {
+        throw new Error('useConfirmation must be used inside ConfirmationProvider');
+    }
+    return context;
+}
+
+export const ConfirmationProvider: React.FC<{children: React.ReactNode}> = ({children}) => {
+    const [requests, setRequests] = useState<ConfirmationRequest[]>([]);
+    const nextId = useRef(0);
+
+    const show = useCallback((request: Omit<ConfirmationRequest, 'id'>): ConfirmationHandle => {
+        nextId.current += 1;
+        const id = nextId.current;
+        // One request per kind, matching NiceModal's per-component keying: a
+        // second show replaces the first instead of stacking (StrictMode
+        // double-effects depend on this).
+        setRequests(current => [...current.filter(r => r.kind !== request.kind), {...request, id} as ConfirmationRequest]);
+        return {remove: () => setRequests(current => current.filter(r => r.id !== id))};
+    }, []);
+
+    const confirm = useCallback((props: ConfirmationModalProps) => show({kind: 'confirm', props}), [show]);
+    const showLimit = useCallback((props: LimitModalProps) => show({kind: 'limit', props}), [show]);
+
+    const contextValue = React.useMemo(() => ({confirm, showLimit}), [confirm, showLimit]);
+
+    return (
+        <ConfirmationContext.Provider value={contextValue}>
+            {children}
+            {requests.map((request) => {
+                const remove = () => setRequests(current => current.filter(r => r.id !== request.id));
+                return request.kind === 'confirm' ?
+                    <ConfirmationModalContent key={request.id} {...request.props} onRemove={remove} /> :
+                    <LimitModalContent key={request.id} {...request.props} onRemove={remove} />;
+            })}
+        </ConfirmationContext.Provider>
+    );
+};

--- a/apps/admin/src/settings/app/components/settings/advanced/danger-zone.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/danger-zone.tsx
@@ -1,5 +1,3 @@
-import ConfirmationModal from '@/settings/app/components/confirmation-modal';
-import NiceModal from '@ebay/nice-modal-react';
 import React from 'react';
 import TopLevelGroup from '@/settings/app/components/top-level-group';
 import trackEvent from '@/settings/app/utils/analytics';
@@ -8,6 +6,7 @@ import {ActionList, ActionListItem, ActionListItemActions, ActionListItemContent
 import {formatNumber} from '@tryghost/shade/utils';
 import {getGhostPaths} from '@tryghost/admin-x-framework/helpers';
 import {toast} from 'sonner';
+import {useConfirmation} from '@/settings/app/components/providers/confirmation-provider';
 import {useDeleteAllContent} from '@tryghost/admin-x-framework/api/db';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
@@ -24,6 +23,7 @@ const DangerZone: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const handleError = useHandleError();
     const {config} = useGlobalData();
     const {totalUsers} = useStaffUsers();
+    const {confirm} = useConfirmation();
 
     const resetAuthEnabled = Boolean(config?.labs?.dangerZoneResetAuth);
 
@@ -34,7 +34,7 @@ const DangerZone: React.FC<{ keywords: string[] }> = ({keywords}) => {
             : 'All staff users, including you, will be signed out and must reset their password before signing back in.';
 
     const handleDeleteAllContent = () => {
-        NiceModal.show(ConfirmationModal, {
+        confirm({
             title: 'Would you really like to delete all content from your blog?',
             prompt: 'This is permanent! No backups, no restores, no magic undo button. We warned you, k?',
             okVariant: 'destructive',
@@ -53,7 +53,7 @@ const DangerZone: React.FC<{ keywords: string[] }> = ({keywords}) => {
     };
 
     const handleResetAuth = () => {
-        NiceModal.show(ConfirmationModal, {
+        confirm({
             title: 'Reset all authentication?',
             prompt: (
                 <>
@@ -85,7 +85,7 @@ const DangerZone: React.FC<{ keywords: string[] }> = ({keywords}) => {
     };
 
     const handleRemoveAllGiftLinks = () => {
-        NiceModal.show(ConfirmationModal, {
+        confirm({
             title: 'Reset all gift links?',
             prompt: 'This immediately invalidates every active gift link across your site. Anyone holding one will lose access. New gift links can still be created afterwards.',
             okLabel: 'Reset all gift links',

--- a/apps/admin/src/settings/app/components/settings/advanced/integrations.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/integrations.tsx
@@ -1,7 +1,5 @@
 import BrandIcon from '@/settings/app/components/icons/brand-icon';
-import ConfirmationModal from '@/settings/app/components/confirmation-modal';
 import IntegrationsSettingsImg from '@/settings/app/assets/images/integrations-settings.png';
-import NiceModal from '@ebay/nice-modal-react';
 import React, {useState} from 'react';
 import TopLevelGroup from '@/settings/app/components/top-level-group';
 import usePinturaEditor from '@/settings/app/hooks/use-pintura-editor';
@@ -11,6 +9,7 @@ import {LucideIcon} from '@tryghost/shade/utils';
 import {Plug} from 'lucide-react';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {toast} from 'sonner';
+import {useConfirmation} from '@/settings/app/components/providers/confirmation-provider';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
@@ -201,6 +200,7 @@ const CustomIntegrations: React.FC<{integrations: Integration[]}> = ({integratio
     const {updateRoute} = useSettingsNavigation();
     const {mutateAsync: deleteIntegration} = useDeleteIntegration();
     const handleError = useHandleError();
+    const {confirm} = useConfirmation();
 
     if (integrations.length) {
         return (
@@ -220,7 +220,7 @@ const CustomIntegrations: React.FC<{integrations: Integration[]}> = ({integratio
                         title={integration.name}
                         custom
                         onDelete={() => {
-                            NiceModal.show(ConfirmationModal, {
+                            confirm({
                                 title: 'Are you sure?',
                                 prompt: 'Deleting this integration will remove all webhooks and api keys associated with it.',
                                 okVariant: 'destructive',

--- a/apps/admin/src/settings/app/components/settings/advanced/integrations/add-integration-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/integrations/add-integration-modal.tsx
@@ -1,8 +1,7 @@
-import LimitModal from '@/settings/app/components/limit-modal';
-import NiceModal from '@ebay/nice-modal-react';
 import {useEffect, useState} from 'react';
 import {Field, FieldError, FieldGroup, FieldLabel, Input} from '@tryghost/shade/components';
 import {HostLimitError, useLimiter} from '@/settings/app/hooks/use-limiter';
+import {useConfirmation} from '@/settings/app/components/providers/confirmation-provider';
 import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {SettingsModal} from '@tryghost/shade/patterns';
 import {useCreateIntegration} from '@tryghost/admin-x-framework/api/integrations';
@@ -15,12 +14,13 @@ function AddIntegrationModal() {
     const {mutateAsync: createIntegration} = useCreateIntegration();
     const limiter = useLimiter();
     const handleError = useHandleError();
+    const {showLimit} = useConfirmation();
 
     useEffect(() => {
         if (limiter?.isLimited('customIntegrations')) {
             limiter.errorIfWouldGoOverLimit('customIntegrations').catch((error) => {
                 if (error instanceof HostLimitError) {
-                    NiceModal.show(LimitModal, {
+                    showLimit({
                         prompt: error.message || `Your current plan doesn't support more custom integrations.`,
                         onOk: () => updateRoute({route: '/pro', isExternal: true})
                     });
@@ -28,7 +28,7 @@ function AddIntegrationModal() {
                 }
             });
         }
-    }, [limiter, updateRoute]);
+    }, [limiter, showLimit, updateRoute]);
 
     return <SettingsModal
         okLabel='Add'

--- a/apps/admin/src/settings/app/components/settings/advanced/integrations/custom-integration-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/integrations/custom-integration-modal.tsx
@@ -1,6 +1,4 @@
 import APIKeys from './api-keys';
-import ConfirmationModal from '@/settings/app/components/confirmation-modal';
-import NiceModal from '@ebay/nice-modal-react';
 import React, {useEffect, useState} from 'react';
 import WebhooksTable from './webhooks-table';
 import {APIError} from '@tryghost/admin-x-framework/errors';
@@ -9,6 +7,7 @@ import {Box, Stack} from '@tryghost/shade/primitives';
 import {Field, FieldError, FieldLabel, Input} from '@tryghost/shade/components';
 import {ImageUpload, ImageUploadAction, ImageUploadActions, ImageUploadDropzone, ImageUploadImage, ImageUploadPreview} from '@tryghost/shade/patterns';
 import {type Integration, useBrowseIntegrations, useEditIntegration} from '@tryghost/admin-x-framework/api/integrations';
+import {useConfirmation} from '@/settings/app/components/providers/confirmation-provider';
 import {useParams} from '@tryghost/admin-x-framework';
 import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {SettingsModal} from '@tryghost/shade/patterns';
@@ -24,6 +23,7 @@ const CustomIntegrationModalContent: React.FC<{integration: Integration}> = ({in
     const {mutateAsync: refreshAPIKey} = useRefreshAPIKey();
     const {mutateAsync: uploadImage} = useUploadImage();
     const handleError = useHandleError();
+    const {confirm} = useConfirmation();
 
     const {formState, updateForm, handleSave, saveState, errors, clearError, okProps} = useForm({
         initialState: integration,
@@ -64,7 +64,7 @@ const CustomIntegrationModalContent: React.FC<{integration: Integration}> = ({in
 
         const name = apiKey.type === 'content' ? 'Content' : 'Admin';
 
-        NiceModal.show(ConfirmationModal, {
+        confirm({
             title: `Regenerate ${name} API Key`,
             prompt: `You can regenerate ${name} API Key any time, but any scripts or applications using it will need to be updated.`,
             okLabel: `Regenerate ${name} API Key`,

--- a/apps/admin/src/settings/app/components/settings/advanced/integrations/transistor-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/integrations/transistor-modal.tsx
@@ -1,14 +1,13 @@
 import APIKeys from './api-keys';
 import BookmarkThumb from '@/settings/app/assets/images/integrations/ghost-transistor.png';
 import BrandIcon from '@/settings/app/components/icons/brand-icon';
-import ConfirmationModal from '@/settings/app/components/confirmation-modal';
 import IntegrationHeader from './integration-header';
-import NiceModal from '@ebay/nice-modal-react';
 import {Field, FieldContent, FieldDescription, FieldGroup, FieldLabel, FieldSet, Switch} from '@tryghost/shade/components';
 import {type Setting, getSettingValues, useEditSettings} from '@tryghost/admin-x-framework/api/settings';
 import {SettingsModal} from '@tryghost/shade/patterns';
 import {getGhostPaths} from '@tryghost/admin-x-framework/helpers';
 import {useBrowseIntegrations} from '@tryghost/admin-x-framework/api/integrations';
+import {useConfirmation} from '@/settings/app/components/providers/confirmation-provider';
 import {useEffect, useState} from 'react';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
@@ -23,6 +22,7 @@ function TransistorModal() {
 
     const {mutateAsync: refreshAPIKey} = useRefreshAPIKey();
     const handleError = useHandleError();
+    const {confirm} = useConfirmation();
     const [regenerated, setRegenerated] = useState(false);
 
     const builtInApiIntegrationsDisabled = config.hostSettings?.limits?.customIntegrations?.disabled;
@@ -50,7 +50,7 @@ function TransistorModal() {
 
         setRegenerated(false);
 
-        NiceModal.show(ConfirmationModal, {
+        confirm({
             title: 'Regenerate Admin API Key',
             prompt: 'You will need to update the API key in your Transistor account settings after regenerating.',
             okLabel: 'Regenerate Admin API Key',

--- a/apps/admin/src/settings/app/components/settings/advanced/integrations/webhooks-table.test.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/integrations/webhooks-table.test.tsx
@@ -1,4 +1,5 @@
 import WebhooksTable from '@/settings/app/components/settings/advanced/integrations/webhooks-table';
+import {ConfirmationProvider} from '@/settings/app/components/providers/confirmation-provider';
 import {type Integration} from '@tryghost/admin-x-framework/api/integrations';
 import {render, screen} from '@testing-library/react';
 
@@ -17,7 +18,7 @@ describe('WebhooksTable', () => {
             webhooks: []
         } as unknown as Integration;
 
-        const {container} = render(<WebhooksTable integration={integration} />);
+        const {container} = render(<ConfirmationProvider><WebhooksTable integration={integration} /></ConfirmationProvider>);
 
         expect(screen.getByRole('heading', {name: 'No webhooks'})).toBeInTheDocument();
         expect(screen.getByText('Add a webhook to send Ghost events to another service.')).toBeInTheDocument();
@@ -40,7 +41,7 @@ describe('WebhooksTable', () => {
             }]
         } as unknown as Integration;
 
-        const {container} = render(<WebhooksTable integration={integration} />);
+        const {container} = render(<ConfirmationProvider><WebhooksTable integration={integration} /></ConfirmationProvider>);
 
         const table = screen.getByRole('table');
         const addButton = screen.getByRole('button', {name: 'Add webhook'});

--- a/apps/admin/src/settings/app/components/settings/advanced/integrations/webhooks-table.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/integrations/webhooks-table.tsx
@@ -1,4 +1,3 @@
-import ConfirmationModal from '@/settings/app/components/confirmation-modal';
 import NiceModal from '@ebay/nice-modal-react';
 import WebhookModal from './webhook-modal';
 import {Button, EmptyIndicator, Separator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow} from '@tryghost/shade/components';
@@ -7,12 +6,14 @@ import {type Integration} from '@tryghost/admin-x-framework/api/integrations';
 import {LucideIcon, formatNumber} from '@tryghost/shade/utils';
 import {getWebhookEventLabel} from './webhook-event-options';
 import {toast} from 'sonner';
+import {useConfirmation} from '@/settings/app/components/providers/confirmation-provider';
 import {useDeleteWebhook} from '@tryghost/admin-x-framework/api/webhooks';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 
 const WebhooksTable: React.FC<{integration: Integration}> = ({integration}) => {
     const {mutateAsync: deleteWebhook} = useDeleteWebhook();
     const handleError = useHandleError();
+    const {confirm} = useConfirmation();
     const webhooks = integration.webhooks || [];
 
     const showAddWebhookModal = () => {
@@ -22,7 +23,7 @@ const WebhooksTable: React.FC<{integration: Integration}> = ({integration}) => {
     };
 
     const handleDelete = (id: string) => {
-        NiceModal.show(ConfirmationModal, {
+        confirm({
             title: 'Are you sure?',
             prompt: 'Deleting this webhook may prevent the integration from functioning.',
             okVariant: 'destructive',

--- a/apps/admin/src/settings/app/components/settings/advanced/integrations/zapier-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/integrations/zapier-modal.tsx
@@ -1,14 +1,13 @@
 import APIKeys from './api-keys';
 import BrandIcon from '@/settings/app/components/icons/brand-icon';
-import ConfirmationModal from '@/settings/app/components/confirmation-modal';
 import IntegrationHeader from './integration-header';
-import NiceModal from '@ebay/nice-modal-react';
 import ZapierLogo from '@/settings/app/assets/images/zapier-logo.svg';
 import {ActionList, ActionListItem, ActionListItemActions, ActionListItemContent, Button} from '@tryghost/shade/components';
 import {LucideIcon} from '@tryghost/shade/utils';
 import {SettingsModal} from '@tryghost/shade/patterns';
 import {getGhostPaths} from '@tryghost/admin-x-framework/helpers';
 import {useBrowseIntegrations} from '@tryghost/admin-x-framework/api/integrations';
+import {useConfirmation} from '@/settings/app/components/providers/confirmation-provider';
 import {useEffect, useState} from 'react';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
@@ -31,6 +30,7 @@ function ZapierModal() {
 
     const {mutateAsync: refreshAPIKey} = useRefreshAPIKey();
     const handleError = useHandleError();
+    const {confirm} = useConfirmation();
     const [regenerated, setRegenerated] = useState(false);
 
     const zapierDisabled = config.hostSettings?.limits?.customIntegrations?.disabled;
@@ -50,7 +50,7 @@ function ZapierModal() {
 
         setRegenerated(false);
 
-        NiceModal.show(ConfirmationModal, {
+        confirm({
             title: 'Regenerate Admin API Key',
             prompt: 'You will need to locate the Ghost App within your Zapier account and click on "Reconnect" to enter the new Admin API Key.',
             okLabel: 'Regenerate Admin API Key',

--- a/apps/admin/src/settings/app/components/settings/advanced/migration-tools/universal-import-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/migration-tools/universal-import-modal.tsx
@@ -1,10 +1,10 @@
-import ConfirmationModal from '@/settings/app/components/confirmation-modal';
 import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import React, {useState} from 'react';
 import {Button, Dropzone} from '@tryghost/shade/components';
 import {ExternalLink} from 'lucide-react';
 import {Inline} from '@tryghost/shade/primitives';
 import {SettingsModal} from '@tryghost/shade/patterns';
+import {useConfirmation} from '@/settings/app/components/providers/confirmation-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useImportContent} from '@tryghost/admin-x-framework/api/db';
 
@@ -13,6 +13,7 @@ const UniversalImportModal: React.FC = () => {
     const {mutateAsync: importContent} = useImportContent();
     const [uploading, setUploading] = useState(false);
     const handleError = useHandleError();
+    const {confirm} = useConfirmation();
 
     return (
         <SettingsModal
@@ -40,7 +41,7 @@ const UniversalImportModal: React.FC = () => {
                         try {
                             await importContent(file);
                             modal.remove();
-                            NiceModal.show(ConfirmationModal, {
+                            confirm({
                                 title: 'Import in progress',
                                 prompt: `Your import is being processed, and you'll receive a confirmation email as soon as it’s complete. Usually this only takes a few minutes, but larger imports may take longer.`,
                                 cancelLabel: '',

--- a/apps/admin/src/settings/app/components/settings/email/emails.tsx
+++ b/apps/admin/src/settings/app/components/settings/email/emails.tsx
@@ -1,4 +1,3 @@
-import ConfirmationModal from '@/settings/app/components/confirmation-modal';
 import DefaultRecipients from './default-recipients';
 import EnableNewsletters from './enable-newsletters';
 import MailGun from './mailgun';
@@ -13,6 +12,7 @@ import {APIError} from '@tryghost/admin-x-framework/errors';
 import {ActionList, ActionListItem, ActionListItemActions, ActionListItemContent, Button, Select, SelectContent, SelectItem, SelectTrigger, SelectValue, Tabs, TabsContent, TabsList, TabsTrigger} from '@tryghost/shade/components';
 import {LucideIcon} from '@tryghost/shade/utils';
 import {getSettingValues} from '@tryghost/admin-x-framework/api/settings';
+import {useConfirmation} from '@/settings/app/components/providers/confirmation-provider';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
@@ -68,6 +68,7 @@ const EmailsGroup: React.FC<{ keywords: string[]; newslettersEnabled: boolean }>
     const verifyEmailToken = useQueryParams().getParam('verifyEmail');
     const {mutateAsync: verifySenderUpdate} = useVerifyAutomatedEmailSender();
     const handleError = useHandleError();
+    const {confirm} = useConfirmation();
     const submittedTokenRef = useRef<string | null>(null);
     const [selectedTab, setSelectedTab] = useState<'newsletters' | 'transactional'>(newslettersEnabled ? 'newsletters' : 'transactional');
     const [newslettersFilter, setNewslettersFilter] = useState<NewslettersFilter>('active');
@@ -102,7 +103,7 @@ const EmailsGroup: React.FC<{ keywords: string[]; newslettersEnabled: boolean }>
                 }
 
                 updateRoute('emails');
-                NiceModal.show(ConfirmationModal, {
+                confirm({
                     title,
                     prompt,
                     okLabel: 'Close',
@@ -117,7 +118,7 @@ const EmailsGroup: React.FC<{ keywords: string[]; newslettersEnabled: boolean }>
                 }
 
                 updateRoute('emails');
-                NiceModal.show(ConfirmationModal, {
+                confirm({
                     title: 'Error verifying email address',
                     prompt,
                     okLabel: 'Close',
@@ -129,7 +130,7 @@ const EmailsGroup: React.FC<{ keywords: string[]; newslettersEnabled: boolean }>
         };
 
         verify();
-    }, [handleError, updateRoute, verifyEmailToken, verifySenderUpdate]);
+    }, [confirm, handleError, updateRoute, verifyEmailToken, verifySenderUpdate]);
 
     const openNewNewsletter = () => {
         updateRoute('newsletters/new');

--- a/apps/admin/src/settings/app/components/settings/email/newsletters.tsx
+++ b/apps/admin/src/settings/app/components/settings/email/newsletters.tsx
@@ -1,6 +1,4 @@
-import ConfirmationModal from '@/settings/app/components/confirmation-modal';
 import NewslettersList from './newsletters/newsletters-list';
-import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import React, {type ReactNode, useEffect, useState} from 'react';
 import TopLevelGroup from '@/settings/app/components/top-level-group';
 import useQueryParams from '@/settings/app/hooks/use-query-params';
@@ -10,17 +8,17 @@ import {type InfiniteData, useQueryClient} from '@tryghost/admin-x-framework';
 import {type Newsletter, type NewslettersResponseType, newslettersDataType, useBrowseNewsletters, useEditNewsletter, useVerifyNewsletterEmail} from '@tryghost/admin-x-framework/api/newsletters';
 import {arrayMove} from '@dnd-kit/sortable';
 import {formatNumber} from '@tryghost/shade/utils';
+import {type ConfirmationHandle, useConfirmation} from '@/settings/app/components/providers/confirmation-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {withErrorBoundary} from '@/settings/app/components/error-boundary';
 
-const NavigateToNewsletter = ({id, children}: {id: string; children: ReactNode}) => {
-    const modal = useModal();
+const NavigateToNewsletter = ({id, onNavigate, children}: {id: string; onNavigate: () => void; children: ReactNode}) => {
     const {updateRoute} = useSettingsNavigation();
 
     return <Button className='h-auto p-0 text-green hover:text-green' type='button' variant='link' onClick={() => {
         updateRoute(`newsletters/${id}`);
-        modal.remove();
+        onNavigate();
     }}>{children}</Button>;
 };
 
@@ -37,6 +35,7 @@ const Newsletters: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const verifyEmailToken = useQueryParams().getParam('verifyEmail');
     const {mutateAsync: verifyEmail} = useVerifyNewsletterEmail();
     const handleError = useHandleError();
+    const {confirm} = useConfirmation();
 
     const [newsletters, setNewsletters] = useState<Newsletter[]>(apiNewsletters || []);
 
@@ -52,21 +51,23 @@ const Newsletters: React.FC<{ keywords: string[] }> = ({keywords}) => {
         const verify = async () => {
             try {
                 const {newsletters: [updatedNewsletter], meta: {email_verified: emailVerified} = {}} = await verifyEmail({token: verifyEmailToken});
+                const handleRef: {current: ConfirmationHandle | null} = {current: null};
+                const closeConfirmation = () => handleRef.current?.remove();
                 let title;
                 let prompt;
 
                 if (emailVerified && emailVerified === 'sender_email') {
                     title = 'Newsletter email verified';
-                    prompt = <>Newsletter <NavigateToNewsletter id={updatedNewsletter.id}>{updatedNewsletter.name}</NavigateToNewsletter> will now be sent from <strong>{updatedNewsletter.sender_email}</strong>.</>;
+                    prompt = <>Newsletter <NavigateToNewsletter id={updatedNewsletter.id} onNavigate={closeConfirmation}>{updatedNewsletter.name}</NavigateToNewsletter> will now be sent from <strong>{updatedNewsletter.sender_email}</strong>.</>;
                 } else if (emailVerified && emailVerified === 'sender_reply_to') {
                     title = 'Reply-to address verified';
-                    prompt = <>Newsletter <NavigateToNewsletter id={updatedNewsletter.id}>{updatedNewsletter.name}</NavigateToNewsletter> will now use <strong>{updatedNewsletter.sender_reply_to}</strong> as the reply-to address.</>;
+                    prompt = <>Newsletter <NavigateToNewsletter id={updatedNewsletter.id} onNavigate={closeConfirmation}>{updatedNewsletter.name}</NavigateToNewsletter> will now use <strong>{updatedNewsletter.sender_reply_to}</strong> as the reply-to address.</>;
                 } else {
                     title = 'Email address verified';
-                    prompt = <>Email address for newsletter <NavigateToNewsletter id={updatedNewsletter.id}>{updatedNewsletter.name}</NavigateToNewsletter> has been changed.</>;
+                    prompt = <>Email address for newsletter <NavigateToNewsletter id={updatedNewsletter.id} onNavigate={closeConfirmation}>{updatedNewsletter.name}</NavigateToNewsletter> has been changed.</>;
                 }
 
-                NiceModal.show(ConfirmationModal, {
+                handleRef.current = confirm({
                     title,
                     prompt,
                     okLabel: 'Close',
@@ -79,7 +80,7 @@ const Newsletters: React.FC<{ keywords: string[] }> = ({keywords}) => {
                 if (e instanceof APIError && e.message === 'Token expired') {
                     prompt = 'Verification link has expired.';
                 }
-                NiceModal.show(ConfirmationModal, {
+                confirm({
                     title: 'Error verifying email address',
                     prompt: prompt,
                     okLabel: 'Close',
@@ -90,7 +91,7 @@ const Newsletters: React.FC<{ keywords: string[] }> = ({keywords}) => {
             }
         };
         verify();
-    }, [verifyEmailToken, handleError, verifyEmail]);
+    }, [verifyEmailToken, handleError, verifyEmail, confirm]);
 
     const buttons = (
         <Button className='mt-[-5px]' size='sm' type='button' variant='ghost' onClick={() => {

--- a/apps/admin/src/settings/app/components/settings/email/newsletters/add-newsletter-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/email/newsletters/add-newsletter-modal.tsx
@@ -1,9 +1,8 @@
-import LimitModal from '@/settings/app/components/limit-modal';
-import NiceModal from '@ebay/nice-modal-react';
 import React, {useEffect, useState} from 'react';
 import useFeatureFlag from '@/settings/app/hooks/use-feature-flag';
 import {Field, FieldContent, FieldDescription, FieldError, FieldGroup, FieldLabel, Input, Switch, Textarea} from '@tryghost/shade/components';
 import {HostLimitError, useLimiter} from '@/settings/app/hooks/use-limiter';
+import {useConfirmation} from '@/settings/app/components/providers/confirmation-provider';
 import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {SettingsModal} from '@tryghost/shade/patterns';
 import {formatNumber} from '@tryghost/shade/utils';
@@ -15,6 +14,7 @@ const AddNewsletterModal: React.FC = () => {
     const {updateRoute} = useSettingsNavigation();
     const returnRoute = useFeatureFlag('automations') ? 'emails' : 'newsletters';
     const handleError = useHandleError();
+    const {showLimit} = useConfirmation();
     const [isCheckingLimit, setIsCheckingLimit] = useState(true);
     const [limitError, setLimitError] = useState<HostLimitError | null>(null);
 
@@ -75,13 +75,13 @@ const AddNewsletterModal: React.FC = () => {
 
     useEffect(() => {
         if (limitError) {
-            NiceModal.show(LimitModal, {
+            showLimit({
                 prompt: limitError.message || `Your current plan doesn't support more newsletters.`,
                 onOk: () => updateRoute({route: '/pro', isExternal: true})
             });
             updateRoute(returnRoute);
         }
-    }, [limitError, returnRoute, updateRoute]);
+    }, [limitError, returnRoute, updateRoute, showLimit]);
 
     if (isCheckingLimit || limitError) {
         return null;

--- a/apps/admin/src/settings/app/components/settings/email/newsletters/newsletter-detail-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/email/newsletters/newsletter-detail-modal.tsx
@@ -1,10 +1,7 @@
 import ColorPickerField from '@/settings/app/components/color-picker-field';
-import ConfirmationModal from '@/settings/app/components/confirmation-modal';
 import HeaderImageField from '@/settings/app/components/settings/email-design/header-image-field';
 import HtmlField from '@/settings/app/components/html-field';
-import LimitModal from '@/settings/app/components/limit-modal';
 import NewsletterPreview from './newsletter-preview';
-import NiceModal from '@ebay/nice-modal-react';
 import React, {useCallback, useEffect, useState} from 'react';
 import useFeatureFlag from '@/settings/app/hooks/use-feature-flag';
 import useSettingGroup from '@/settings/app/hooks/use-setting-group';
@@ -16,6 +13,7 @@ import {Inline, Stack} from '@tryghost/shade/primitives';
 import {LucideIcon} from '@tryghost/shade/utils';
 import {type Newsletter, useBrowseNewsletters, useEditNewsletter} from '@tryghost/admin-x-framework/api/newsletters';
 import {PreviewModalContent} from '@/settings/app/components/settings/preview-modal';
+import {useConfirmation} from '@/settings/app/components/providers/confirmation-provider';
 import {useParams} from '@tryghost/admin-x-framework';
 import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {getSettingValue, getSettingValues} from '@tryghost/admin-x-framework/api/settings';
@@ -107,6 +105,7 @@ const Sidebar: React.FC<{
     const {localSettings} = useSettingGroup();
     const [siteTitle] = getSettingValues(localSettings, ['title']) as string[];
     const handleError = useHandleError();
+    const {confirm, showLimit} = useConfirmation();
     const {data: {newsletters: apiNewsletters} = {}} = useBrowseNewsletters();
     const commentsEnabled = ['all', 'paid'].includes(getSettingValue(settings, 'comments_enabled') || '');
 
@@ -153,7 +152,7 @@ const Sidebar: React.FC<{
 
     const confirmStatusChange = async () => {
         if (newsletter.status === 'active') {
-            NiceModal.show(ConfirmationModal, {
+            confirm({
                 title: 'Archive newsletter',
                 prompt: <>
                     <div className="mb-6">Your newsletter <strong>{newsletter.name}</strong> will no longer be visible to members or available as an option when publishing new posts.</div>
@@ -176,7 +175,7 @@ const Sidebar: React.FC<{
                 await limiter?.errorIfWouldGoOverLimit('newsletters');
             } catch (error) {
                 if (error instanceof HostLimitError) {
-                    NiceModal.show(LimitModal, {
+                    showLimit({
                         prompt: error.message || `Your current plan doesn't support more newsletters.`,
                         onOk: () => updateRoute({route: '/pro', isExternal: true})
                     });
@@ -186,7 +185,7 @@ const Sidebar: React.FC<{
                 }
             }
 
-            NiceModal.show(ConfirmationModal, {
+            confirm({
                 title: 'Reactivate newsletter',
                 prompt: <>
                         Reactivating <strong>{newsletter.name}</strong> will immediately make it visible to members and re-enable it as an option when publishing new posts.

--- a/apps/admin/src/settings/app/components/settings/email/newsletters/newsletters-tab-content.tsx
+++ b/apps/admin/src/settings/app/components/settings/email/newsletters/newsletters-tab-content.tsx
@@ -1,6 +1,4 @@
-import ConfirmationModal from '@/settings/app/components/confirmation-modal';
 import NewslettersList from './newsletters-list';
-import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import React, {type ReactNode, useEffect, useState} from 'react';
 import useQueryParams from '@/settings/app/hooks/use-query-params';
 import {APIError} from '@tryghost/admin-x-framework/errors';
@@ -9,17 +7,17 @@ import {type InfiniteData, useQueryClient} from '@tryghost/admin-x-framework';
 import {type Newsletter, type NewslettersResponseType, newslettersDataType, useBrowseNewsletters, useEditNewsletter, useVerifyNewsletterEmail} from '@tryghost/admin-x-framework/api/newsletters';
 import {arrayMove} from '@dnd-kit/sortable';
 import {formatNumber} from '@tryghost/shade/utils';
+import {type ConfirmationHandle, useConfirmation} from '@/settings/app/components/providers/confirmation-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {withErrorBoundary} from '@/settings/app/components/error-boundary';
 
-const NavigateToNewsletter = ({id, children}: {id: string; children: ReactNode}) => {
-    const modal = useModal();
+const NavigateToNewsletter = ({id, onNavigate, children}: {id: string; onNavigate: () => void; children: ReactNode}) => {
     const {updateRoute} = useSettingsNavigation();
 
     return <Button className='h-auto p-0 text-green hover:text-green' type='button' variant='link' onClick={() => {
         updateRoute(`newsletters/${id}`);
-        modal.remove();
+        onNavigate();
     }}>{children}</Button>;
 };
 
@@ -44,6 +42,7 @@ const NewslettersTabContent: React.FC<NewslettersTabContentProps> = ({filter}) =
     const verifyEmailToken = useQueryParams().getParam('verifyEmail');
     const {mutateAsync: verifyEmail} = useVerifyNewsletterEmail();
     const handleError = useHandleError();
+    const {confirm} = useConfirmation();
 
     const [newsletters, setNewsletters] = useState<Newsletter[]>(apiNewsletters || []);
 
@@ -59,21 +58,23 @@ const NewslettersTabContent: React.FC<NewslettersTabContentProps> = ({filter}) =
         const verify = async () => {
             try {
                 const {newsletters: [updatedNewsletter], meta: {email_verified: emailVerified} = {}} = await verifyEmail({token: verifyEmailToken});
+                const handleRef: {current: ConfirmationHandle | null} = {current: null};
+                const closeConfirmation = () => handleRef.current?.remove();
                 let title;
                 let prompt;
 
                 if (emailVerified && emailVerified === 'sender_email') {
                     title = 'Newsletter email verified';
-                    prompt = <>Newsletter <NavigateToNewsletter id={updatedNewsletter.id}>{updatedNewsletter.name}</NavigateToNewsletter> will now be sent from <strong>{updatedNewsletter.sender_email}</strong>.</>;
+                    prompt = <>Newsletter <NavigateToNewsletter id={updatedNewsletter.id} onNavigate={closeConfirmation}>{updatedNewsletter.name}</NavigateToNewsletter> will now be sent from <strong>{updatedNewsletter.sender_email}</strong>.</>;
                 } else if (emailVerified && emailVerified === 'sender_reply_to') {
                     title = 'Reply-to address verified';
-                    prompt = <>Newsletter <NavigateToNewsletter id={updatedNewsletter.id}>{updatedNewsletter.name}</NavigateToNewsletter> will now use <strong>{updatedNewsletter.sender_reply_to}</strong> as the reply-to address.</>;
+                    prompt = <>Newsletter <NavigateToNewsletter id={updatedNewsletter.id} onNavigate={closeConfirmation}>{updatedNewsletter.name}</NavigateToNewsletter> will now use <strong>{updatedNewsletter.sender_reply_to}</strong> as the reply-to address.</>;
                 } else {
                     title = 'Email address verified';
-                    prompt = <>Email address for newsletter <NavigateToNewsletter id={updatedNewsletter.id}>{updatedNewsletter.name}</NavigateToNewsletter> has been changed.</>;
+                    prompt = <>Email address for newsletter <NavigateToNewsletter id={updatedNewsletter.id} onNavigate={closeConfirmation}>{updatedNewsletter.name}</NavigateToNewsletter> has been changed.</>;
                 }
 
-                NiceModal.show(ConfirmationModal, {
+                handleRef.current = confirm({
                     title,
                     prompt,
                     okLabel: 'Close',
@@ -86,7 +87,7 @@ const NewslettersTabContent: React.FC<NewslettersTabContentProps> = ({filter}) =
                 if (e instanceof APIError && e.message === 'Token expired') {
                     prompt = 'Verification link has expired.';
                 }
-                NiceModal.show(ConfirmationModal, {
+                confirm({
                     title: 'Error verifying email address',
                     prompt: prompt,
                     okLabel: 'Close',
@@ -97,7 +98,7 @@ const NewslettersTabContent: React.FC<NewslettersTabContentProps> = ({filter}) =
             }
         };
         verify();
-    }, [verifyEmailToken, handleError, verifyEmail]);
+    }, [verifyEmailToken, handleError, verifyEmail, confirm]);
 
     const sortedActiveNewsletters = newsletters.filter(n => n.status === 'active').sort((a, b) => a.sort_order - b.sort_order) || [];
     const archivedNewsletters = newsletters.filter(newsletter => newsletter.status !== 'active');

--- a/apps/admin/src/settings/app/components/settings/general/user-detail-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/general/user-detail-modal.tsx
@@ -1,7 +1,4 @@
-import ConfirmationModal from '@/settings/app/components/confirmation-modal';
 import EmailNotificationsTab from './users/email-notifications-tab';
-import LimitModal from '@/settings/app/components/limit-modal';
-import NiceModal from '@ebay/nice-modal-react';
 import ProfileTab from './users/profile-tab';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 import SocialLinksTab from './users/social-links-tab';
@@ -24,6 +21,7 @@ import {Text} from '@tryghost/shade/primitives';
 import {type User, canAccessSettings, hasAdminAccess, isAdminUser, isAuthorOrContributor, isEditorUser, isOwnerUser, useDeleteUser, useEditUser, useGetUserBySlug, useMakeOwner} from '@tryghost/admin-x-framework/api/users';
 import {getImageUrl, useUploadImage} from '@tryghost/admin-x-framework/api/images';
 import {toast} from 'sonner';
+import {useConfirmation} from '@/settings/app/components/providers/confirmation-provider';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
 
 const validators: Record<string, (u: Partial<User>) => string> = {
@@ -91,6 +89,7 @@ const UserDetailModalContent: React.FC<{user: User; onDeletingUserChange: (isDel
     const {ownerUser} = useStaffUsers();
     const {currentUser} = useGlobalData();
     const handleError = useHandleError();
+    const {confirm, showLimit} = useConfirmation();
     const {formState, setFormState, saveState, handleSave, updateForm, errors, setErrors, clearError, okProps} = useForm({
         initialState: user,
         savingDelay: 500,
@@ -172,7 +171,7 @@ const UserDetailModalContent: React.FC<{user: User; onDeletingUserChange: (isDel
                 await limiter?.errorIfWouldGoOverLimit('staff');
             } catch (error) {
                 if (error instanceof HostLimitError) {
-                    NiceModal.show(LimitModal, {
+                    showLimit({
                         formSheet: true,
                         prompt: error.message || `Your current plan doesn't support more users.`,
                         onOk: () => updateRoute({route: '/pro', isExternal: true})
@@ -188,7 +187,7 @@ const UserDetailModalContent: React.FC<{user: User; onDeletingUserChange: (isDel
         if (_user.status === 'inactive') {
             warningText = 'This user will be able to log in again and will have the same permissions they had previously.';
         }
-        NiceModal.show(ConfirmationModal, {
+        confirm({
             title: 'Are you sure you want to suspend this user?',
             prompt: (
                 <>
@@ -216,7 +215,7 @@ const UserDetailModalContent: React.FC<{user: User; onDeletingUserChange: (isDel
     };
 
     const confirmDelete = (_user: User, {owner}: {owner: User}) => {
-        NiceModal.show(ConfirmationModal, {
+        confirm({
             title: 'Are you sure you want to delete this user?',
             prompt: (
                 <>
@@ -243,7 +242,7 @@ const UserDetailModalContent: React.FC<{user: User; onDeletingUserChange: (isDel
     };
 
     const confirmMakeOwner = () => {
-        NiceModal.show(ConfirmationModal, {
+        confirm({
             title: 'Transfer Ownership',
             prompt: 'Are you sure you want to transfer the ownership of this blog? You will not be able to undo this action.',
             okLabel: 'Yep — I\'m sure',

--- a/apps/admin/src/settings/app/components/settings/general/users/staff-token.tsx
+++ b/apps/admin/src/settings/app/components/settings/general/users/staff-token.tsx
@@ -1,8 +1,7 @@
 import APIKeys from '@/settings/app/components/settings/advanced/integrations/api-keys';
-import ConfirmationModal from '@/settings/app/components/confirmation-modal';
-import NiceModal from '@ebay/nice-modal-react';
 import {Text} from '@tryghost/shade/primitives';
 import {genStaffToken, getStaffToken} from '@tryghost/admin-x-framework/api/staff-token';
+import {useConfirmation} from '@/settings/app/components/providers/confirmation-provider';
 import {useEffect, useState} from 'react';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 
@@ -11,6 +10,7 @@ const StaffToken: React.FC = () => {
         enabled: false
     });
     const handleError = useHandleError();
+    const {confirm} = useConfirmation();
     const [token, setToken] = useState('');
     const {mutateAsync: newApiKey} = genStaffToken();
 
@@ -25,7 +25,7 @@ const StaffToken: React.FC = () => {
     } , [apiKey]);
 
     const genConfirmation = () => {
-        NiceModal.show(ConfirmationModal, {
+        confirm({
             title: 'Regenerate your Staff Access Token',
             prompt: 'You can regenerate your Staff Access Token any time, but any scripts or applications using it will need to be updated.',
             okLabel: 'Regenerate your Staff Access Token',

--- a/apps/admin/src/settings/app/components/settings/growth/offers/edit-offer-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/growth/offers/edit-offer-modal.tsx
@@ -1,5 +1,3 @@
-import ConfirmationModal from '@/settings/app/components/confirmation-modal';
-import NiceModal from '@ebay/nice-modal-react';
 import PortalFrame from '@/settings/app/components/settings/membership/portal/portal-frame';
 import SettingsBreadcrumbs from '@/settings/app/components/settings/settings-breadcrumbs';
 import {Button, Field, FieldDescription, FieldError, FieldGroup, FieldLabel, Input, InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput, Textarea} from '@tryghost/shade/components';
@@ -12,6 +10,7 @@ import {formatNumber} from '@tryghost/shade/utils';
 import {getHomepageUrl} from '@tryghost/admin-x-framework/api/site';
 import {getOfferPortalPreviewUrl, type offerPortalPreviewUrlTypes} from '@/settings/app/utils/get-offers-portal-preview-url';
 import {toast} from 'sonner';
+import {useConfirmation} from '@/settings/app/components/providers/confirmation-provider';
 import {useEffect, useState} from 'react';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
 import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
@@ -34,6 +33,7 @@ const Sidebar: React.FC<{
             const {siteData} = useGlobalData();
             const [isCopied, setIsCopied] = useState(false);
             const handleError = useHandleError();
+            const {confirm} = useConfirmation();
             const {mutateAsync: editOffer} = useEditOffer();
 
             const [nameLength, setNameLength] = useState(offer?.name.length || 0);
@@ -57,7 +57,7 @@ const Sidebar: React.FC<{
 
             const confirmStatusChange = async () => {
                 if (offer?.status === 'active') {
-                    NiceModal.show(ConfirmationModal, {
+                    confirm({
                         title: 'Archive offer',
                         prompt: <>
                             <p>New members will no longer be able to subscribe using this offer.</p>
@@ -77,7 +77,7 @@ const Sidebar: React.FC<{
                         }
                     });
                 } else {
-                    NiceModal.show(ConfirmationModal, {
+                    confirm({
                         title: 'Reactivate offer',
                         prompt: <>
                             <p>Reactivating <strong>{offer?.name}</strong> will allow new members to subscribe using this offer. Existing members will remain unchanged.</p>

--- a/apps/admin/src/settings/app/components/settings/growth/recommendations/edit-recommendation-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/growth/recommendations/edit-recommendation-modal.tsx
@@ -1,11 +1,10 @@
-import ConfirmationModal from '@/settings/app/components/confirmation-modal';
-import NiceModal from '@ebay/nice-modal-react';
 import React from 'react';
 import RecommendationDescriptionForm, {validateDescriptionForm} from './recommendation-description-form';
 import {Button} from '@tryghost/shade/components';
 import {type Recommendation, useDeleteRecommendation, useEditRecommendation} from '@tryghost/admin-x-framework/api/recommendations';
 import {SettingsModal} from '@tryghost/shade/patterns';
 import {toast} from 'sonner';
+import {useConfirmation} from '@/settings/app/components/providers/confirmation-provider';
 import {useForm, useHandleError} from '@tryghost/admin-x-framework/hooks';
 
 interface EditRecommendationModalProps {
@@ -17,6 +16,7 @@ const EditRecommendationModal: React.FC<EditRecommendationModalProps> = ({recomm
     const {mutateAsync: editRecommendation} = useEditRecommendation();
     const {mutateAsync: deleteRecommendation} = useDeleteRecommendation();
     const handleError = useHandleError();
+    const {confirm} = useConfirmation();
 
     const {formState, updateForm, handleSave, errors, clearError, setErrors, okProps} = useForm({
         initialState: {
@@ -37,7 +37,7 @@ const EditRecommendationModal: React.FC<EditRecommendationModalProps> = ({recomm
     const leftButton = (
         <Button className='text-destructive hover:text-destructive' size='sm' type='button' variant='ghost' onClick={() => {
             onClose();
-            NiceModal.show(ConfirmationModal, {
+            confirm({
                 title: 'Delete recommendation',
                 prompt: <>
                     <p>Your recommendation <strong>{recommendation.title}</strong> will no longer be visible to your audience.</p>

--- a/apps/admin/src/settings/app/components/settings/membership/custom-fields/custom-field-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/membership/custom-fields/custom-field-modal.tsx
@@ -1,4 +1,3 @@
-import ConfirmationModal from '@/settings/app/components/confirmation-modal';
 import CustomFieldIcon from './custom-field-icon';
 import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import React from 'react';
@@ -8,6 +7,7 @@ import {SettingsModal} from '@tryghost/shade/patterns';
 import {ValidationError, getErrorMessage} from '@tryghost/admin-x-framework/errors';
 import {memberCustomFieldUserTypes, useCreateMemberCustomField, useDeleteMemberCustomField, useEditMemberCustomField, userTypeForField} from '@tryghost/admin-x-framework/api/member-custom-fields';
 import {toast} from 'sonner';
+import {useConfirmation} from '@/settings/app/components/providers/confirmation-provider';
 import {useForm, useHandleError} from '@tryghost/admin-x-framework/hooks';
 import type {MemberCustomField} from '@tryghost/admin-x-framework/api/member-custom-fields';
 
@@ -31,6 +31,7 @@ const renderTypeOption = (option: {label: string; value: string}) => (
 
 const CustomFieldModal = NiceModal.create<{field?: MemberCustomField}>(({field}) => {
     const modal = useModal();
+    const {confirm} = useConfirmation();
     const {mutateAsync: createField} = useCreateMemberCustomField();
     const {mutateAsync: editField} = useEditMemberCustomField();
     const {mutateAsync: deleteField} = useDeleteMemberCustomField();
@@ -85,7 +86,7 @@ const CustomFieldModal = NiceModal.create<{field?: MemberCustomField}>(({field})
     const archiveButton = (
         <Button className='text-destructive hover:text-destructive' size='sm' type='button' variant='ghost' onClick={() => {
             modal.remove();
-            NiceModal.show(ConfirmationModal, {
+            confirm({
                 title: 'Archive custom field',
                 prompt: <>
                     <div className='mb-6'>Your custom field <strong>{field!.name}</strong> will no longer show up on your members, collect new information, or appear in filters.</div>
@@ -113,7 +114,7 @@ const CustomFieldModal = NiceModal.create<{field?: MemberCustomField}>(({field})
     const reactivateButton = (
         <Button className='text-green hover:text-green' size='sm' type='button' variant='ghost' onClick={() => {
             modal.remove();
-            NiceModal.show(ConfirmationModal, {
+            confirm({
                 title: 'Reactivate custom field',
                 prompt: <>
                     <div className='mb-6'>Reactivating <strong>{field!.name}</strong> will immediately make it available again on your members, for collecting, and in filters.</div>
@@ -145,7 +146,7 @@ const CustomFieldModal = NiceModal.create<{field?: MemberCustomField}>(({field})
     // would put irreversible data loss on equal footing with Save.
     const confirmDeleteField = () => {
         modal.remove();
-        NiceModal.show(ConfirmationModal, {
+        confirm({
             title: 'Delete custom field',
             prompt: <><strong>{field!.name}</strong> and every value collected from your members will be permanently deleted from the database. This can&rsquo;t be undone.</>,
             okLabel: 'Delete',

--- a/apps/admin/src/settings/app/components/settings/membership/member-emails.tsx
+++ b/apps/admin/src/settings/app/components/settings/membership/member-emails.tsx
@@ -1,4 +1,3 @@
-import ConfirmationModal from '@/settings/app/components/confirmation-modal';
 import NiceModal from '@ebay/nice-modal-react';
 import React, {useEffect, useRef} from 'react';
 import TopLevelGroup from '@/settings/app/components/top-level-group';
@@ -13,6 +12,7 @@ import {WELCOME_EMAIL_SLUGS, type WelcomeEmailType, getDefaultWelcomeEmailRecord
 import {checkStripeEnabled, getSettingValues} from '@tryghost/admin-x-framework/api/settings';
 import {toast} from 'sonner';
 import {useAddAutomatedEmail, useBrowseAutomatedEmails, useEditAutomatedEmail, useVerifyAutomatedEmailSender} from '@tryghost/admin-x-framework/api/automated-emails';
+import {useConfirmation} from '@/settings/app/components/providers/confirmation-provider';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {withErrorBoundary} from '@/settings/app/components/error-boundary';
@@ -145,6 +145,7 @@ const MemberEmails: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {mutateAsync: editAutomatedEmail, isPending: isEditingAutomatedEmail} = useEditAutomatedEmail();
     const {mutateAsync: verifySenderUpdate} = useVerifyAutomatedEmailSender();
     const handleError = useHandleError();
+    const {confirm} = useConfirmation();
 
     const automatedEmails = automatedEmailsData?.automated_emails || [];
     const isMutating = isAddingAutomatedEmail || isEditingAutomatedEmail;
@@ -196,7 +197,7 @@ const MemberEmails: React.FC<{ keywords: string[] }> = ({keywords}) => {
                     prompt = <>Welcome email reply-to address has been verified and updated.</>;
                 }
 
-                NiceModal.show(ConfirmationModal, {
+                confirm({
                     title,
                     prompt,
                     okLabel: 'Close',
@@ -212,7 +213,7 @@ const MemberEmails: React.FC<{ keywords: string[] }> = ({keywords}) => {
 
                 clearVerifyEmailFromRoute();
 
-                NiceModal.show(ConfirmationModal, {
+                confirm({
                     title: 'Error verifying email address',
                     prompt,
                     okLabel: 'Close',
@@ -224,7 +225,7 @@ const MemberEmails: React.FC<{ keywords: string[] }> = ({keywords}) => {
         };
 
         verify();
-    }, [handleError, verifyEmailToken, verifySenderUpdate]);
+    }, [confirm, handleError, verifyEmailToken, verifySenderUpdate]);
 
     const handleToggle = async (emailType: 'free' | 'paid') => {
         const existing = automatedEmails.find(email => email.slug === WELCOME_EMAIL_SLUGS[emailType]);

--- a/apps/admin/src/settings/app/components/settings/membership/portal/portal-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/membership/portal/portal-modal.tsx
@@ -1,7 +1,5 @@
 import AccountPage from './account-page';
-import ConfirmationModal from '@/settings/app/components/confirmation-modal';
 import LookAndFeel from './look-and-feel';
-import NiceModal from '@ebay/nice-modal-react';
 import PortalPreview from './portal-preview';
 import React, {useEffect, useState} from 'react';
 import SignupOptions from './signup-options';
@@ -12,6 +10,7 @@ import {type Setting, type SettingValue, getSettingValues, useEditSettings} from
 import {Tabs, TabsContent, TabsList, TabsTrigger} from '@tryghost/shade/components';
 import {type Tier, useBrowseTiers, useEditTier} from '@tryghost/admin-x-framework/api/tiers';
 import {fullEmailAddress} from '@tryghost/admin-x-framework/api/site';
+import {useConfirmation} from '@/settings/app/components/providers/confirmation-provider';
 import {useFocusContext} from '@tryghost/shade/app';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
 import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
@@ -71,6 +70,7 @@ const PortalModal: React.FC = () => {
     const [selectedSidebarTab, setSelectedSidebarTab] = useState<SidebarTab>('signupOptions');
 
     const handleError = useHandleError();
+    const {confirm} = useConfirmation();
     const {settings, siteData, config} = useGlobalData();
     const {mutateAsync: editSettings} = useEditSettings();
     const {data: {tiers: allTiers} = {}} = useBrowseTiers();
@@ -88,7 +88,7 @@ const PortalModal: React.FC = () => {
             try {
                 const {settings: verifiedSettings} = await verifyToken({token});
                 const [supportEmail] = getSettingValues<string>(verifiedSettings, ['members_support_address']);
-                NiceModal.show(ConfirmationModal, {
+                confirm({
                     title: 'Support address verified',
                     prompt: <>Your support email address has been changed to <strong>{supportEmail}</strong>.</>,
                     okLabel: 'Close',
@@ -102,7 +102,7 @@ const PortalModal: React.FC = () => {
                 if (e?.message === 'Token expired') {
                     prompt = 'Verification link has expired.';
                 }
-                NiceModal.show(ConfirmationModal, {
+                confirm({
                     title: 'Error verifying support address',
                     prompt: prompt,
                     okLabel: 'Close',
@@ -115,7 +115,7 @@ const PortalModal: React.FC = () => {
         if (verifyEmail) {
             checkToken({token: verifyEmail});
         }
-    }, [handleError, verifyEmail, verifyToken]);
+    }, [confirm, handleError, verifyEmail, verifyToken]);
 
     const {formState, setFormState, saveState, handleSave, updateForm, okProps} = useForm({
         initialState: {
@@ -143,7 +143,7 @@ const PortalModal: React.FC = () => {
                 const currentEmail = currentSettings.find(setting => setting.key === 'support_email_address')?.value ||
                     fullEmailAddress(currentSettings.find(setting => setting.key === 'members_support_address')?.value?.toString() || 'noreply', siteData, config);
 
-                NiceModal.show(ConfirmationModal, {
+                confirm({
                     title: 'Confirm email address',
                     prompt: <>
                         We&apos;ve sent a confirmation email to <strong>{newEmail}</strong>.

--- a/apps/admin/src/settings/app/components/settings/membership/stripe/stripe-connect-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/membership/stripe/stripe-connect-modal.tsx
@@ -1,9 +1,6 @@
 import BookmarkThumb from '@/settings/app/assets/images/stripe-thumb.jpg';
-import ConfirmationModal from '@/settings/app/components/confirmation-modal';
 import GhostLogo from '@/settings/app/assets/images/orb-squircle.png';
 import GhostLogoPink from '@/settings/app/assets/images/orb-pink.png';
-import LimitModal from '@/settings/app/components/limit-modal';
-import NiceModal from '@ebay/nice-modal-react';
 import React, {useEffect, useState} from 'react';
 import StripeButton from '@/settings/app/components/stripe-button';
 import StripeLogo from '@/settings/app/assets/images/stripe-emblem.svg';
@@ -20,6 +17,7 @@ import {getGhostPaths} from '@tryghost/admin-x-framework/helpers';
 import {toast} from 'sonner';
 import {useBrowseMembers} from '@tryghost/admin-x-framework/api/members';
 import {useBrowseTiers, useEditTier} from '@tryghost/admin-x-framework/api/tiers';
+import {useConfirmation} from '@/settings/app/components/providers/confirmation-provider';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
@@ -161,6 +159,7 @@ const Connected: React.FC<{onClose?: () => void}> = ({onClose}) => {
 
     const {mutateAsync: deleteStripeSettings} = useDeleteStripeSettings();
     const handleError = useHandleError();
+    const {confirm} = useConfirmation();
 
     const openDisconnectStripeModal = async () => {
         const {data} = await fetchMembers();
@@ -168,7 +167,7 @@ const Connected: React.FC<{onClose?: () => void}> = ({onClose}) => {
 
         // const hasActiveStripeSubscriptions = false; //...
         // this.ghostPaths.url.api('/members/') + '?filter=status:paid&limit=0';
-        NiceModal.show(ConfirmationModal, {
+        confirm({
             title: 'Disconnect Stripe',
             prompt: (hasActiveStripeSubscriptions ? 'Cannot disconnect while there are members with active Stripe subscriptions.' : <>You&lsquo;re about to disconnect your Stripe account {stripeConnectAccountName} from this site. This will automatically turn off paid memberships on this site.</>),
             okLabel: hasActiveStripeSubscriptions ? '' : 'Disconnect',
@@ -260,6 +259,7 @@ const StripeConnectModal: React.FC = () => {
     const {updateRoute} = useSettingsNavigation();
     const [step, setStep] = useState<'start' | 'connect'>('start');
     const limiter = useLimiter();
+    const {showLimit} = useConfirmation();
 
     // Extract specific values needed for checkStripeEnabled, so not to
     // cause unnecessary re-renders by passing the whole settings object
@@ -276,7 +276,7 @@ const StripeConnectModal: React.FC = () => {
                 } catch (error) {
                     if (error instanceof HostLimitError) {
                         updateRoute('tiers');
-                        NiceModal.show(LimitModal, {
+                        showLimit({
                             prompt: error.message || `Your current plan doesn't support Stripe Connect.`,
                             onOk: () => updateRoute({route: '/pro', isExternal: true})
                         });
@@ -286,7 +286,7 @@ const StripeConnectModal: React.FC = () => {
         };
 
         checkLimit();
-    }, [limiter, updateRoute, stripeEnabled, hasStripeConnectLimit]);
+    }, [limiter, updateRoute, stripeEnabled, hasStripeConnectLimit, showLimit]);
 
     const startFlow = () => {
         setStep('connect');

--- a/apps/admin/src/settings/app/components/settings/membership/tiers.tsx
+++ b/apps/admin/src/settings/app/components/settings/membership/tiers.tsx
@@ -1,5 +1,3 @@
-import LimitModal from '@/settings/app/components/limit-modal';
-import NiceModal from '@ebay/nice-modal-react';
 import React, {useState} from 'react';
 import StripeButton from '@/settings/app/components/stripe-button';
 import TiersList from './tiers/tiers-list';
@@ -10,6 +8,7 @@ import {HostLimitError, useLimiter} from '@/settings/app/hooks/use-limiter';
 import {type Tier, getActiveTiers, getArchivedTiers, useBrowseTiers} from '@tryghost/admin-x-framework/api/tiers';
 import {checkStripeEnabled} from '@tryghost/admin-x-framework/api/settings';
 import {formatNumber} from '@tryghost/shade/utils';
+import {useConfirmation} from '@/settings/app/components/providers/confirmation-provider';
 import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
 import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {withErrorBoundary} from '@/settings/app/components/error-boundary';
@@ -35,6 +34,7 @@ const Tiers: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const archivedTiers = getArchivedTiers(tiers || []);
     const {updateRoute} = useSettingsNavigation();
     const limiter = useLimiter();
+    const {showLimit} = useConfirmation();
 
     const openConnectModal = async () => {
         // Allow Stripe despite the limit when it's already connected, so it's
@@ -44,7 +44,7 @@ const Tiers: React.FC<{ keywords: string[] }> = ({keywords}) => {
                 await limiter.errorIfWouldGoOverLimit('limitStripeConnect');
             } catch (error) {
                 if (error instanceof HostLimitError) {
-                    NiceModal.show(LimitModal, {
+                    showLimit({
                         prompt: error.message || `Your current plan doesn't support Stripe Connect.`,
                         onOk: () => updateRoute({route: '/pro', isExternal: true})
                     });

--- a/apps/admin/src/settings/app/components/settings/membership/tiers/tier-detail-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/membership/tiers/tier-detail-modal.tsx
@@ -1,5 +1,3 @@
-import ConfirmationModal from '@/settings/app/components/confirmation-modal';
-import NiceModal from '@ebay/nice-modal-react';
 import React, {useEffect, useRef} from 'react';
 import TierDetailPreview from './tier-detail-preview';
 import useCurrencyInput from '@/settings/app/hooks/use-currency-input';
@@ -17,6 +15,7 @@ import {type Tier, useAddTier, useBrowseTiers, useEditTier} from '@tryghost/admi
 import {currencies, currencySelectGroups, validateCurrencyAmount} from '@/settings/app/utils/currency';
 import {getSettingValues, useEditSettings} from '@tryghost/admin-x-framework/api/settings';
 import {toast} from 'sonner';
+import {useConfirmation} from '@/settings/app/components/providers/confirmation-provider';
 
 export type TierFormState = Partial<Omit<Tier, 'trial_days'>> & {
     trial_days: string;
@@ -32,6 +31,7 @@ const TierDetailModalContent: React.FC<{tier?: Tier}> = ({tier}) => {
     const {mutateAsync: editSettings} = useEditSettings();
     const [hasFreeTrial, setHasFreeTrial] = React.useState(!!tier?.trial_days);
     const handleError = useHandleError();
+    const {confirm} = useConfirmation();
     const {localSettings, siteData} = useSettingGroup();
     const [portalPlansJson] = getSettingValues(localSettings, ['portal_plans']) as string[];
     const portalPlans = JSON.parse(portalPlansJson?.toString() || '[]') as string[];
@@ -181,7 +181,7 @@ const TierDetailModalContent: React.FC<{tier?: Tier}> = ({tier}) => {
                 <div>Existing members will remain unchanged.</div>
             </>;
             const okLabel = tier.active ? 'Archive' : 'Reactivate';
-            NiceModal.show(ConfirmationModal, {
+            confirm({
                 title: promptTitle,
                 prompt: prompt,
                 okLabel: okLabel,

--- a/apps/admin/src/settings/app/components/settings/site/change-theme.tsx
+++ b/apps/admin/src/settings/app/components/settings/site/change-theme.tsx
@@ -1,5 +1,3 @@
-import LimitModal from '@/settings/app/components/limit-modal';
-import NiceModal from '@ebay/nice-modal-react';
 import React, {useEffect, useState} from 'react';
 import TopLevelGroup from '@/settings/app/components/top-level-group';
 import {Button, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger} from '@tryghost/shade/components';
@@ -9,6 +7,7 @@ import {Text} from '@tryghost/shade/primitives';
 import {type Theme, useBrowseThemes} from '@tryghost/admin-x-framework/api/themes';
 import {downloadFile, getGhostPaths} from '@tryghost/admin-x-framework/helpers';
 import {useCheckThemeLimitError} from '@/settings/app/hooks/use-check-theme-limit-error';
+import {useConfirmation} from '@/settings/app/components/providers/confirmation-provider';
 import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {withErrorBoundary} from '@/settings/app/components/error-boundary';
 
@@ -17,6 +16,7 @@ const ChangeTheme: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const [isCheckingLimit, setIsCheckingLimit] = useState(false);
     const {checkThemeLimitError} = useCheckThemeLimitError();
     const {route, updateRoute} = useSettingsNavigation();
+    const {showLimit} = useConfirmation();
     const {data: themesData} = useBrowseThemes();
     const activeTheme = themesData?.themes.find((theme: Theme) => theme.active);
 
@@ -38,7 +38,7 @@ const ChangeTheme: React.FC<{ keywords: string[] }> = ({keywords}) => {
         }
 
         if (themeLimitError) {
-            NiceModal.show(LimitModal, {
+            showLimit({
                 prompt: themeLimitError,
                 onOk: () => updateRoute({route: '/pro', isExternal: true})
             });
@@ -55,7 +55,7 @@ const ChangeTheme: React.FC<{ keywords: string[] }> = ({keywords}) => {
         const limitError = await checkThemeLimitError('.');
 
         if (limitError) {
-            NiceModal.show(LimitModal, {
+            showLimit({
                 prompt: limitError,
                 onOk: () => updateRoute({route: '/pro', isExternal: true})
             });

--- a/apps/admin/src/settings/app/components/settings/site/design-and-theme-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/site/design-and-theme-modal.tsx
@@ -1,9 +1,8 @@
 import ChangeThemeModal from './theme-modal';
 import DesignModal from './design-modal';
-import LimitModal from '@/settings/app/components/limit-modal';
-import NiceModal from '@ebay/nice-modal-react';
 import React, {useCallback, useEffect, useState} from 'react';
 import ThemeCodeEditorModal from './theme/theme-code-editor-modal';
+import {useConfirmation} from '@/settings/app/components/providers/confirmation-provider';
 import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 import {parseEditingThemeRoute} from './theme/theme-editor-utils';
 import {useCheckThemeLimitError} from '@/settings/app/hooks/use-check-theme-limit-error';
@@ -20,13 +19,14 @@ const DesignAndThemeModal: React.FC = () => {
     const [installationAllowed, setInstallationAllowed] = useState<boolean | null>(null);
     const [hasCheckedInstallation, setHasCheckedInstallation] = useState(false);
     const {themeName: editingThemeName, isInvalid: hasInvalidEditingThemeRoute} = parseEditingThemeRoute(currentPath);
+    const {showLimit} = useConfirmation();
 
     const showThemeLimitModal = useCallback((error: string) => {
-        NiceModal.show(LimitModal, {
+        showLimit({
             prompt: error,
             onOk: () => updateRoute({route: '/pro', isExternal: true})
         });
-    }, [updateRoute]);
+    }, [showLimit, updateRoute]);
 
     useEffect(() => {
         const checkIfThemeChangeAllowed = async () => {

--- a/apps/admin/src/settings/app/components/settings/site/theme-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/site/theme-modal.tsx
@@ -1,8 +1,6 @@
 import AdvancedThemeSettings from './theme/advanced-theme-settings';
-import ConfirmationModal from '@/settings/app/components/confirmation-modal';
 import InvalidThemeModal, {type FatalErrors} from './theme/invalid-theme-modal';
-import LimitModal from '@/settings/app/components/limit-modal';
-import NiceModal, {useModal} from '@ebay/nice-modal-react';
+import NiceModal from '@ebay/nice-modal-react';
 import OfficialThemes from './theme/official-themes';
 import React, {useEffect, useState} from 'react';
 import ThemeInstalledModal from './theme/theme-installed-modal';
@@ -14,6 +12,7 @@ import {type OfficialTheme} from '@/settings/app/components/providers/settings-a
 import {PageHeader, SettingsModal} from '@tryghost/shade/patterns';
 import {toast} from 'sonner';
 import {useCheckThemeLimitError} from '@/settings/app/hooks/use-check-theme-limit-error';
+import {type ConfirmationHandle, useConfirmation} from '@/settings/app/components/providers/confirmation-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 
@@ -34,14 +33,11 @@ interface ThemeModalContentProps {
 }
 
 const UploadModalContent: React.FC<{onUpload: (file: File) => void}> = ({onUpload}) => {
-    const modal = useModal();
-
     return (
         <Dropzone
             accept={{'application/zip': ['.zip']}}
             inputId="theme-upload"
             onDropAccepted={([file]) => {
-                modal.remove();
                 onUpload(file);
             }}
         >
@@ -59,6 +55,7 @@ const ThemeToolbar: React.FC<ThemeToolbarProps> = ({
     const {mutateAsync: uploadTheme} = useUploadTheme();
     const {checkThemeLimitError, isThemeLimited} = useCheckThemeLimitError();
     const handleError = useHandleError();
+    const {confirm, showLimit} = useConfirmation();
 
     const [uploadConfig, setUploadConfig] = useState<{enabled: boolean; error?: string} | undefined>();
     const [isUploading, setUploading] = useState(false);
@@ -86,7 +83,7 @@ const ThemeToolbar: React.FC<ThemeToolbarProps> = ({
         const themeFileName = file?.name.replace(/\.zip$/, '');
         const existingThemeNames = themes.map(t => t.name);
         if (isDefaultOrLegacyTheme({name: themeFileName})) {
-            NiceModal.show(ConfirmationModal, {
+            confirm({
                 title: 'Upload failed',
                 cancelLabel: 'Cancel',
                 okLabel: '',
@@ -101,7 +98,7 @@ const ThemeToolbar: React.FC<ThemeToolbarProps> = ({
                 }
             });
         } else if (existingThemeNames.includes(themeFileName)) {
-            NiceModal.show(ConfirmationModal, {
+            confirm({
                 title: 'Overwrite theme',
                 prompt: (
                     <>
@@ -228,14 +225,18 @@ const ThemeToolbar: React.FC<ThemeToolbarProps> = ({
         }
 
         if (uploadConfig.enabled) {
-            NiceModal.show(ConfirmationModal, {
+            const handleRef: {current: ConfirmationHandle | null} = {current: null};
+            handleRef.current = confirm({
                 title: 'Upload theme',
-                prompt: <UploadModalContent onUpload={onThemeUpload} />,
+                prompt: <UploadModalContent onUpload={(file) => {
+                    handleRef.current?.remove();
+                    onThemeUpload(file);
+                }} />,
                 okLabel: '',
                 formSheet: false
             });
         } else {
-            NiceModal.show(LimitModal, {
+            showLimit({
                 title: 'Upgrade to enable custom themes',
                 prompt: uploadConfig.error || <>Your current plan only supports official themes. You can install them from the <a href="https://ghost.org/marketplace/">Ghost theme marketplace</a>.</>,
                 onOk: () => updateRoute({route: '/pro', isExternal: true})
@@ -308,6 +309,7 @@ const ChangeThemeModal: React.FC<ChangeThemeModalProps> = ({source, themeRef}) =
     const {mutateAsync: activateTheme} = useActivateTheme();
     const {checkThemeLimitError} = useCheckThemeLimitError();
     const handleError = useHandleError();
+    const {confirm, showLimit} = useConfirmation();
 
     const onSelectTheme = (theme: OfficialTheme|null) => {
         setSelectedTheme(theme);
@@ -353,7 +355,7 @@ const ChangeThemeModal: React.FC<ChangeThemeModalProps> = ({source, themeRef}) =
                     </>
                     }
                 </>;
-                NiceModal.show(ConfirmationModal, {
+                confirm({
                     title: titleText,
                     prompt,
                     okLabel: 'Install',
@@ -388,7 +390,7 @@ const ChangeThemeModal: React.FC<ChangeThemeModalProps> = ({source, themeRef}) =
         };
 
         handleUrlInstallation();
-    }, [themeRef, source, installTheme, handleError, activateTheme, updateRoute, themes, installedFromMarketplace, checkThemeLimitError, isMounted]);
+    }, [themeRef, source, installTheme, handleError, activateTheme, updateRoute, themes, installedFromMarketplace, checkThemeLimitError, confirm, isMounted]);
 
     if (!themes) {
         return;
@@ -402,7 +404,7 @@ const ChangeThemeModal: React.FC<ChangeThemeModalProps> = ({source, themeRef}) =
             // Check theme limit FIRST, before any confirmation modals
             const limitError = await checkThemeLimitError(selectedTheme.name);
             if (limitError) {
-                NiceModal.show(LimitModal, {
+                showLimit({
                     prompt: limitError,
                     onOk: () => updateRoute({route: '/pro', isExternal: true})
                 });
@@ -412,7 +414,7 @@ const ChangeThemeModal: React.FC<ChangeThemeModalProps> = ({source, themeRef}) =
             // Handle the overwrite confirmation if needed
             if (installedTheme && !isDefaultOrLegacyTheme(selectedTheme)) {
                 return new Promise<void>((resolve) => {
-                    NiceModal.show(ConfirmationModal, {
+                    confirm({
                         title: 'Overwrite theme',
                         prompt: (
                             <>

--- a/apps/admin/src/settings/app/components/settings/site/theme/advanced-theme-settings.tsx
+++ b/apps/admin/src/settings/app/components/settings/site/theme/advanced-theme-settings.tsx
@@ -1,6 +1,4 @@
-import ConfirmationModal from '@/settings/app/components/confirmation-modal';
 import InvalidThemeModal, {type FatalErrors} from './invalid-theme-modal';
-import LimitModal from '@/settings/app/components/limit-modal';
 import NiceModal from '@ebay/nice-modal-react';
 import React from 'react';
 import useCustomFonts from '@/settings/app/hooks/use-custom-fonts';
@@ -12,6 +10,7 @@ import {type Theme, isActiveTheme, isDefaultTheme, isDeletableTheme, isLegacyThe
 import {downloadFile, getGhostPaths} from '@tryghost/admin-x-framework/helpers';
 import {toast} from 'sonner';
 import {useCheckThemeLimitError} from '@/settings/app/hooks/use-check-theme-limit-error';
+import {useConfirmation} from '@/settings/app/components/providers/confirmation-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useSettingsNavigation} from '@/settings/app/hooks/use-settings-navigation';
 
@@ -60,6 +59,7 @@ const ThemeActions: React.FC<ThemeActionProps> = ({
     const handleError = useHandleError();
     const {route, updateRoute} = useSettingsNavigation();
     const {checkThemeLimitError} = useCheckThemeLimitError();
+    const {confirm, showLimit} = useConfirmation();
 
     const handleActivate = async () => {
         try {
@@ -96,7 +96,7 @@ const ThemeActions: React.FC<ThemeActionProps> = ({
     };
 
     const handleDelete = async () => {
-        NiceModal.show(ConfirmationModal, {
+        confirm({
             title: 'Are you sure you want to delete this?',
             prompt: (
                 <>
@@ -131,7 +131,7 @@ const ThemeActions: React.FC<ThemeActionProps> = ({
         const limitError = await checkThemeLimitError('.');
 
         if (limitError) {
-            NiceModal.show(LimitModal, {
+            showLimit({
                 prompt: limitError,
                 onOk: () => updateRoute({route: '/pro', isExternal: true})
             });

--- a/apps/admin/src/settings/app/components/settings/site/theme/invalid-theme-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/site/theme/invalid-theme-modal.tsx
@@ -1,4 +1,4 @@
-import NiceModal from '@ebay/nice-modal-react';
+import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import React, {type ReactNode} from 'react';
 import {ConfirmationModalContent} from '@/settings/app/components/confirmation-modal';
 import {ErrorTextCard, type FatalErrors, ThemeValidationDetailsDisclosure, ValidationProblemCard, getIssuesFromFatalErrors} from './theme-validation-details';
@@ -20,6 +20,8 @@ const InvalidThemeModal: React.FC<{
     const {blockingProblems, secondaryProblems, stringErrors} = getIssuesFromFatalErrors(fatalErrors);
     const blockingIssueCount = blockingProblems.length + stringErrors.length;
     const promptText = prompt ?? <>Ghost found {blockingIssueCount === 1 ? 'a blocking validation error' : `${blockingIssueCount} blocking validation errors`} and did not save your theme. Fix {blockingIssueCount === 1 ? 'the issue' : 'the issues'} below and try again.</>;
+
+    const modal = useModal();
 
     return <ConfirmationModalContent
         cancelLabel='Close'
@@ -46,7 +48,9 @@ const InvalidThemeModal: React.FC<{
         </>}
         stickyFooter={true}
         title={title}
+        visible={modal.visible}
         onOk={onRetry}
+        onRemove={() => modal.remove()}
     />;
 };
 

--- a/apps/admin/src/settings/app/components/settings/site/theme/theme-installed-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/site/theme/theme-installed-modal.tsx
@@ -1,4 +1,4 @@
-import NiceModal from '@ebay/nice-modal-react';
+import NiceModal, {useModal} from '@ebay/nice-modal-react';
 import React, {type ReactNode} from 'react';
 import useCustomFonts from '@/settings/app/hooks/use-custom-fonts';
 import {ConfirmationModalContent} from '@/settings/app/components/confirmation-modal';
@@ -46,6 +46,8 @@ const ThemeInstalledModal: React.FC<{
         </>
     );
 
+    const modal = useModal();
+
     return <ConfirmationModalContent
         cancelLabel='Close'
         okLabel={okLabel}
@@ -73,6 +75,7 @@ const ThemeInstalledModal: React.FC<{
         </>}
         stickyFooter={true}
         title={modalTitle}
+        visible={modal.visible}
         onOk={async (activateModal) => {
             if (!installedTheme.active) {
                 try {
@@ -88,6 +91,7 @@ const ThemeInstalledModal: React.FC<{
             onActivate?.();
             activateModal?.remove();
         }}
+        onRemove={() => modal.remove()}
     />;
 };
 


### PR DESCRIPTION
First slice of the settings NiceModal burn-down (follows the router swap #29780 and un-portal #29789).

`ConfirmationModal` and `LimitModal` were NiceModal-shown from **54 call sites across 27 files** — the bulk of settings' remaining NiceModal usage. They now go through a settings-local `ConfirmationProvider`:

## What changed

- **`ConfirmationProvider`** (`app/components/providers/confirmation-provider.tsx`): `useConfirmation()` → `confirm(props)` / `showLimit(props)`, each returning a `{remove()}` handle. The request types are the existing `ConfirmationModalProps`/`LimitModalProps`, testids stay `confirmation-modal`/`limit-modal`, and `onOk` still receives the close handle — so all 54 sites converted as a pure `NiceModal.show(X, props)` → `confirm(props)` substitution with prop objects verbatim.
- **One request per kind**, matching NiceModal's per-component keying: a second show replaces the first instead of stacking — StrictMode double-effects (the verification-token flows) depend on this, caught by the suite during integration.
- **`ConfirmationModalContent`/`LimitModalContent`** take `visible`/`onRemove` host props instead of `useModal()`; their NiceModal.create default exports are gone. The two direct renderers (theme-installed / invalid-theme dialogs) pass their own handles.
- **Prompt-closes-confirmation flows** (the legacy `useModal().remove()`-from-inside-the-prompt trick): newsletter verification links and the theme upload picker now close via a handle closure passed from the `confirm()` caller — same UX, no NiceModal context needed. (This preserves behavior the earlier spike had documented as a lost capability.)
- Provider wraps the NiceModal provider so the modals still shown imperatively (custom fields, welcome-email, theme/editor dialogs — the next burn-down slices) can confirm from inside their own flows.

## Verification

- Acceptance: 57 files / 433 tests pass (confirmation-heavy suites — custom fields, danger zone, staff, tiers, offers, newsletters verification — all green)
- Unit: 128 files / 1374 pass, including the confirmation/limit tests rewritten onto the provider
- `tsc -b`, full lint, boundaries clean

Remaining NiceModal in settings after this: 12 imperative dialog components (webhook, code, yaml, universal-import, feature-toggle, theme cluster, welcome-email pair, email-design, custom-field) — they convert to controlled Shade dialogs in follow-up slices, then the provider mount and the dependency go.