### PR TITLE
Changed parse-email-address build to ESM

### DIFF
--- a/packages/parse-email-address/README.md
+++ b/packages/parse-email-address/README.md
@@ -5,8 +5,6 @@ Extract the local and domain parts of email address strings.
 ## Usage
 
 ```javascript
-import {parseEmailAddress} from '@tryghost/parse-email-address';
-
 parseEmailAddress('foo@example.com');
 // => {local: 'foo', domain: 'example.com'}
 
@@ -26,11 +24,13 @@ parseEmailAddress('foo@中文.example');
 
 ## Develop
 
-This is a private workspace package in the Ghost monorepo. From the repository
-root:
+This is a monorepo package.
 
-```bash
-pnpm --filter @tryghost/parse-email-address build
-pnpm --filter @tryghost/parse-email-address test
-pnpm --filter @tryghost/parse-email-address lint
-```
+Follow the instructions for the top-level repo.
+1. `git clone` this repo & `cd` into it as usual
+2. Run `pnpm` to install top-level dependencies.
+
+## Test
+
+- `pnpm lint` run just eslint
+- `pnpm test` run lint and tests

--- a/packages/parse-email-address/README.md
+++ b/packages/parse-email-address/README.md
@@ -5,6 +5,8 @@ Extract the local and domain parts of email address strings.
 ## Usage
 
 ```javascript
+import {parseEmailAddress} from '@tryghost/parse-email-address';
+
 parseEmailAddress('foo@example.com');
 // => {local: 'foo', domain: 'example.com'}
 
@@ -24,13 +26,11 @@ parseEmailAddress('foo@中文.example');
 
 ## Develop
 
-This is a monorepo package.
+This is a private workspace package in the Ghost monorepo. From the repository
+root:
 
-Follow the instructions for the top-level repo.
-1. `git clone` this repo & `cd` into it as usual
-2. Run `pnpm` to install top-level dependencies.
-
-## Test
-
-- `pnpm lint` run just eslint
-- `pnpm test` run lint and tests
+```bash
+pnpm --filter @tryghost/parse-email-address build
+pnpm --filter @tryghost/parse-email-address test
+pnpm --filter @tryghost/parse-email-address lint
+```

--- a/packages/parse-email-address/package.json
+++ b/packages/parse-email-address/package.json
@@ -2,6 +2,7 @@
   "name": "@tryghost/parse-email-address",
   "version": "0.0.0",
   "private": true,
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/TryGhost/Ghost.git",
@@ -19,10 +20,9 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {
-    "build": "pnpm build:tsc",
-    "build:tsc": "tsc",
+    "build": "tsc",
     "test:unit": "NODE_ENV=testing vitest run --coverage",
-    "test:types": "tsc --noEmit",
+    "test:types": "tsc --noEmit -p test/tsconfig.json",
     "test": "pnpm run '/^test:/'",
     "lint:code": "eslint src/ --cache",
     "lint:test": "eslint test/ --cache",
@@ -31,9 +31,6 @@
   "files": [
     "build"
   ],
-  "publishConfig": {
-    "access": "public"
-  },
   "devDependencies": {
     "@internal/cfg-eslint": "workspace:*",
     "@internal/cfg-typescript": "workspace:*",

--- a/packages/parse-email-address/test/index.test.ts
+++ b/packages/parse-email-address/test/index.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import {describe, it} from 'vitest';
-import {parseEmailAddress} from '../src';
+import {parseEmailAddress} from '../src/index.ts';
 
 describe('parseEmailAddress', function () {
     it('returns null for invalid email addresses', function () {


### PR DESCRIPTION
## Summary

- Changes `@tryghost/parse-email-address` from CommonJS output to the standard internal TypeScript/ESM package shape.
- Adds `type: module`, uses the standard direct `tsc` build, removes obsolete publishing metadata and makes the typecheck include the existing test configuration.
- Updates the test import for NodeNext ESM resolution.

The runtime implementation and exported API are unchanged. Ghost Core's CommonJS consumer continues to load the compiled ESM package through Node 22's `require(esm)` support.

## Testing

- [x] `pnpm --filter @tryghost/parse-email-address build`
- [x] `pnpm --filter @tryghost/parse-email-address test`
- [x] `pnpm --filter @tryghost/parse-email-address lint`
- [x] `pnpm --dir ghost/core test:single test/unit/server/services/members/members-api/utils/normalize-email.test.js`
- [x] `pnpm --dir ghost/core test:single test/unit/server/lib/get-inbox-links.test.ts`
- [x] Verified CommonJS `require()` against both compiled ESM and `--conditions=source`
- [x] `pnpm --filter @tryghost/parse-email-address pack --dry-run`
- [x] `pnpm build`
- [x] `pnpm --filter ghost archive`
- [x] Verified the release component contains ESM, declarations and package metadata without `src/`
- [x] `git diff --check`
