### PR TITLE
Added internal package TypeScript conversion skill

### DIFF
--- a/.agents/skills/convert-internal-package-to-typescript/SKILL.md
+++ b/.agents/skills/convert-internal-package-to-typescript/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: convert-internal-package-to-typescript
+description: Convert a legacy internal Ghost workspace package from JavaScript or CommonJS to the repository's TypeScript and ESM golden path while preserving file history and runtime compatibility. Use when modernizing an existing or newly migrated private package, including staged lib-to-src moves, JS-to-TS renames, consumer analysis, and package or archive verification.
+---
+
+# Convert an internal package to TypeScript
+
+Modernize an internal package without mixing mechanical moves with semantic
+changes or obscuring file history. Treat `packages/README.md` as the authority
+for the package's lifetime architecture; this skill owns only the conversion
+workflow.
+
+## Confirm this workflow applies
+
+Read `packages/README.md` completely, then inspect the package, its consumers,
+and comparable current packages. Confirm that the package is internal-only and
+can adopt the documented single-build TypeScript and ESM contract.
+
+Before editing:
+
+1. Find every import, `require()`, export, runtime asset and path reference.
+2. Inspect package metadata, build and test configuration, release/archive
+   inclusion, and any dynamic module loading.
+3. Run the package's existing tests and representative consumer checks to
+   establish a baseline.
+4. Identify supported consumers that cannot load the golden-path ESM output.
+
+If the package is independently published, supports third-party consumers, or
+requires a format that conflicts with the golden path, stop and establish its
+support contract instead of applying this workflow mechanically.
+
+Read
+[`references/history-and-verification.md`](references/history-and-verification.md)
+completely before planning the commits.
+
+## Preserve lineage with three focused commits
+
+Keep each commit independently valid and verify rename detection before moving
+on. Avoid formatting or opportunistic cleanup in the mechanical commits.
+
+### 1. Move sources from `lib` to `src`
+
+Use `git mv` to move the source tree. Update only references that must change
+for the new path, such as test imports, build inputs and package metadata. Do
+not change module syntax, file extensions or implementation in this commit.
+
+Use the subject `Moved <package> sources from lib to src` when that accurately
+describes the change.
+
+### 2. Change file extensions to TypeScript
+
+Use `git mv` for `.js` to `.ts` renames. Add only the minimum configuration and
+syntax adjustments needed for the renamed sources to parse and for this commit
+to remain coherent. Preserve behavior and defer meaningful typing and ESM
+conversion to the next commit.
+
+Use the subject `Changed <package> file extensions to TypeScript`.
+
+### 3. Convert the implementation to TypeScript and ESM
+
+Apply the package contract from `packages/README.md`: shared config packages,
+minimal package-local config, ESM metadata and exports, standard scripts, and a
+single compiled output unless a verified consumer requires an exception.
+
+Use the subject `Converted <package> to TypeScript`.
+
+## Hold the conversion to production standards
+
+- Model real input, output and registry shapes; do not replace missing types
+  with `any`.
+- Use `unknown` only at genuine untrusted boundaries and narrow it promptly.
+- Do not use broad casts, non-null assertions, `@ts-ignore`, or lint disables
+  merely to silence the compiler.
+- Preserve the package's runtime API unless an API change is explicitly in
+  scope and all consumers are updated.
+- Use explicit `.ts` extensions for relative TypeScript imports under the
+  repository's NodeNext configuration.
+- Replace dynamic CommonJS discovery with explicit typed registries when ESM
+  cannot express the old loading pattern safely.
+- Ensure JSON and other runtime assets are emitted and available from `build/`.
+- Avoid top-level `await` so supported CommonJS consumers can use Node's
+  `require(esm)` interoperability.
+- Do not weaken shared TypeScript, ESLint or Vitest rules to make the conversion
+  pass.
+
+## Verify the result
+
+Run the build, tests and lint commands required by `packages/README.md`. Also:
+
+- exercise representative consumers using their real `import` or `require()`
+  path;
+- test raw `source` resolution and compiled output where both are used;
+- inspect the packed package or Ghost release component when exports, runtime
+  assets or archive inclusion changed;
+- run the repository build when the workspace build graph changed;
+- run `git diff --summary` for each mechanical commit and `git log --follow` on
+  representative files to confirm the lineage remains readable.
+
+The modernization PR may be rebase-merged when these commits are independently
+valid and intentionally ordered. This does not change the merge-commit
+requirement for a preceding subtree history import.

--- a/.agents/skills/convert-internal-package-to-typescript/SKILL.md
+++ b/.agents/skills/convert-internal-package-to-typescript/SKILL.md
@@ -25,9 +25,10 @@ Before editing:
    establish a baseline.
 4. Identify supported consumers that cannot load the golden-path ESM output.
 
-If the package is independently published, supports third-party consumers, or
-requires a format that conflicts with the golden path, stop and establish its
-support contract instead of applying this workflow mechanically.
+If the package has an active independent release or third-party support
+contract, or requires a format that conflicts with the golden path, stop and
+establish its support contract instead of applying this workflow mechanically.
+Deprecated historical npm versions do not by themselves block conversion.
 
 Read
 [`references/history-and-verification.md`](references/history-and-verification.md)

--- a/.agents/skills/convert-internal-package-to-typescript/references/history-and-verification.md
+++ b/.agents/skills/convert-internal-package-to-typescript/references/history-and-verification.md
@@ -1,0 +1,69 @@
+# History and verification reference
+
+## Known-good commit shape
+
+The `admin-api-schema` conversion used three deliberately separate commits:
+
+1. `688807ca052 Moved Admin API schema sources from lib to src`
+2. `be31b36ffab Changed Admin API schema file extensions to TypeScript`
+3. `b825dafdc19 Converted Admin API schemas to TypeScript`
+
+This ordering lets Git and reviewers distinguish relocation, mechanical
+renaming and semantic conversion. It is an example of the shape, not a reason
+to copy package-specific implementation.
+
+## History checks
+
+Use `git mv` for every move or extension change. After each mechanical commit,
+inspect the summary and a representative file:
+
+```bash
+git diff --summary HEAD^
+git log --follow -- packages/<name>/src/index.ts
+```
+
+Git records snapshots rather than an explicit rename operation, so rename
+detection depends on similarity. A file that is both moved and substantially
+rewritten in one commit can appear as a deletion and addition. Separate those
+operations so history remains intelligible.
+
+A small CommonJS forwarding file may legitimately appear as deleted when the
+new ESM entry point replaces it; verify the implementation's lineage rather
+than forcing a misleading rename.
+
+## Compatibility checks
+
+Inspect actual consumers before choosing output formats. For the normal
+internal-package contract, verify at least:
+
+- a source-condition consumer can load raw TypeScript in development/tests;
+- plain Node can import the compiled ESM entry point;
+- any existing CommonJS consumer can `require()` the compiled entry point on
+  Ghost's supported Node versions;
+- the compiled module graph contains no top-level `await`;
+- all declared export paths exist after build.
+
+Do not add a second CommonJS build speculatively. Record and test any required
+exception in the package README and configuration.
+
+## Assets and packaging checks
+
+Build from a clean package output and inspect `build/` for every runtime file.
+When JSON schemas or similar assets are required, import them from TypeScript
+when the compiler can emit them; otherwise use an explicit portable copy step.
+
+Use the repository's existing pack or release-archive checks where available.
+Confirm that:
+
+- production execution does not read from `src/`;
+- `files` includes the built output and excludes authored source unless the
+  package contract explicitly says otherwise;
+- package exports, `main` and `types` resolve to files in the artifact;
+- consumer behavior is tested against the artifact, not only the worktree.
+
+## Review the final diff
+
+Before opening the PR, inspect each commit independently as well as the total
+diff. Look specifically for accidental formatting churn, weakened compiler or
+lint rules, unexplained `unknown` or casts, stale CommonJS configuration,
+missing assets, and consumers that still bypass the package exports.

--- a/.agents/skills/convert-internal-package-to-typescript/references/history-and-verification.md
+++ b/.agents/skills/convert-internal-package-to-typescript/references/history-and-verification.md
@@ -19,7 +19,7 @@ inspect the summary and a representative file:
 
 ```bash
 git diff --summary HEAD^
-git log --follow -- packages/<name>/src/index.ts
+git log --follow -- packages/<name>/src/<representative-file>.ts
 ```
 
 Git records snapshots rather than an explicit rename operation, so rename

--- a/.agents/skills/convert-internal-package-to-typescript/references/history-and-verification.md
+++ b/.agents/skills/convert-internal-package-to-typescript/references/history-and-verification.md
@@ -34,14 +34,17 @@ than forcing a misleading rename.
 ## Compatibility checks
 
 Inspect actual consumers before choosing output formats. For the normal
-internal-package contract, verify at least:
+internal-package contract, first verify from the worktree that a consumer using
+the `source` condition resolves and loads raw TypeScript in development/tests.
 
-- a source-condition consumer can load raw TypeScript in development/tests;
+Then build and pack the package. Verify against the packed artifact that:
+
 - plain Node can import the compiled ESM entry point;
 - any existing CommonJS consumer can `require()` the compiled entry point on
   Ghost's supported Node versions;
 - the compiled module graph contains no top-level `await`;
-- all declared export paths exist after build.
+- the shipped `types`, `default` and `main` targets resolve to files in the
+  artifact.
 
 Do not add a second CommonJS build speculatively. Record and test any required
 exception in the package README and configuration.
@@ -58,7 +61,6 @@ Confirm that:
 - production execution does not read from `src/`;
 - `files` includes the built output and excludes authored source unless the
   package contract explicitly says otherwise;
-- package exports, `main` and `types` resolve to files in the artifact;
 - consumer behavior is tested against the artifact, not only the worktree.
 
 ## Review the final diff

--- a/.agents/skills/migrate-internal-package/SKILL.md
+++ b/.agents/skills/migrate-internal-package/SKILL.md
@@ -139,25 +139,15 @@ standalone cleanup PR so the later conversion remains focused.
 
 ## 6. Hand off to the package golden path
 
-Compare the package against `packages/_template`, current comparable internal
-packages, and any canonical package guidance in the repository. Do not turn
-this one-time migration skill into the source of lifetime package standards.
+Read `packages/README.md` completely and compare the package against the
+template and current comparable internal packages. Do not turn this one-time
+migration skill into the source of lifetime package standards.
 
-For a legacy `lib/*.js` package, preserve file lineage with three focused
-commits:
-
-1. `Moved ... sources from lib to src` — paths and path references only.
-2. `Changed ... file extensions to TypeScript` — mechanical renames and the
-   minimum compilation scaffolding.
-3. `Converted ... to TypeScript` — types, ESM semantics and cleanup.
-
-Use `git diff --summary` after mechanical commits and confirm Git recognizes
-the files as renames. A small CommonJS forwarding shim may correctly appear as
-a deletion when a real ESM export replaces it.
-
-This modernization PR may be rebase-merged when the commits are independently
-valid and intentionally ordered. That does not alter the merge-commit
-requirement for the earlier subtree import.
+If the package needs conversion from legacy JavaScript or CommonJS, use the
+`convert-internal-package-to-typescript` skill in a separate modernization PR.
+That skill owns commit staging, file-lineage checks, TypeScript quality and
+runtime verification. This does not alter the merge-commit requirement for the
+earlier subtree history import.
 
 ## Completion criteria
 

--- a/.claude/skills/convert-internal-package-to-typescript
+++ b/.claude/skills/convert-internal-package-to-typescript
@@ -1,0 +1,1 @@
+../../.agents/skills/convert-internal-package-to-typescript


### PR DESCRIPTION
## Summary

- Add a reusable workflow for converting legacy internal packages to Ghost's TypeScript and ESM golden path while preserving readable file history.
- Keep lifetime package rules in `packages/README.md`; the new skill covers conversion sequencing, type quality, compatibility and artifact verification.
- Replace duplicated modernization detail in the migration skill with a handoff, and expose the new skill to Claude through the required symlink.

## Testing

- [x] `pnpm lint:docs`
- [x] `uv run --with pyyaml /Users/hannah/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/convert-internal-package-to-typescript`
- [x] `git diff --check`
