### PR TITLE
Fixed internal package documentation examples

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -134,12 +134,12 @@ packed package or Ghost release component.
 
 ## Verification
 
-For package changes, run at least:
+For package changes, run at least from the package directory:
 
 ```bash
-pnpm --filter @tryghost/<name> build
-pnpm --filter @tryghost/<name> test
-pnpm --filter @tryghost/<name> lint
+pnpm build
+pnpm test
+pnpm lint
 ```
 
 Also verify:

--- a/packages/_template/README.md
+++ b/packages/_template/README.md
@@ -8,10 +8,10 @@ maintenance rules.
 
 ## Develop
 
-This is a workspace package in the Ghost monorepo. From the repo root:
+This is a workspace package in the Ghost monorepo. From the package directory:
 
 ```bash
-pnpm --filter @tryghost/{{NAME}} build   # compile to build/ with tsc (ESM)
-pnpm --filter @tryghost/{{NAME}} test    # type-check + unit tests
-pnpm --filter @tryghost/{{NAME}} lint    # lint source and tests
+pnpm build   # compile to build/ with tsc (ESM)
+pnpm test    # type-check + unit tests
+pnpm lint    # lint source and tests
 ```

--- a/packages/_template/test/index.test.ts
+++ b/packages/_template/test/index.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import {describe, it} from 'vitest';
-import {greeting} from '../src/index';
+import {greeting} from '../src/index.ts';
 
 describe('{{NAME}}', function () {
     it('returns a greeting', function () {


### PR DESCRIPTION
## Summary

- Use the repository's conventional package-local commands in the internal package golden path and template.
- Make the template's relative TypeScript import explicit so it matches the documented NodeNext configuration.

## Testing

- [x] `pnpm lint:docs`
- [x] Commit hook: ESLint for `packages/_template/test/index.test.ts`
- [x] `git diff --check`
