### PR TITLE
Removed unused events map from member count history

### DIFF
--- a/ghost/core/core/server/services/stats/members-stats-service.js
+++ b/ghost/core/core/server/services/stats/members-stats-service.js
@@ -111,13 +111,6 @@ class MembersStatsService {
         const startDateMoment = moment.utc(startDate).startOf('day');
         const endDateMoment = moment.utc(today).startOf('day');
         
-        // Create a map of events by date for fast lookup
-        const eventsMap = new Map();
-        rows.forEach((row) => {
-            const date = moment(row.date).format('YYYY-MM-DD');
-            eventsMap.set(date, row);
-        });
-
         // Sort rows chronologically to calculate historical totals
         rows.sort((a, b) => moment(a.date).valueOf() - moment(b.date).valueOf());
 


### PR DESCRIPTION
### Why

`_generateCompleteRange` in `members-stats-service.js` builds a `Map` of events by date and then never reads it.

```js
// Create a map of events by date for fast lookup
const eventsMap = new Map();
rows.forEach((row) => {
    const date = moment(row.date).format('YYYY-MM-DD');
    eventsMap.set(date, row);
});
```

`eventsMap` appears exactly twice in the repository — the two lines above. Every lookup in that method goes through `historicalTotalsMap`, which is built by the loop right below and keyed the same way. The comment says "for fast lookup", so this reads like a leftover from when something did consume it.

### What

Removes those lines. Nothing else changes.

The loop immediately below already computes `moment(row.date).format('YYYY-MM-DD')` for every row, so the deleted `forEach` was a second walk over the same rows, doing the same date formatting, and discarding the result. For a one-year range that is ~365 redundant `moment().format()` calls per request to member count history.

### Why this matters to Ghost

No behaviour change and no new API — it is dead work removed from a request path, and one less thing to reason about in a method that is already doing careful running-total arithmetic.

### Tests

No test change. The removed value had no consumer, so behaviour is identical and the existing `MembersStatsService > getCountHistory` unit tests cover the method.

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [ ] I've written an automated test to prove my change works — this is a deletion of an unread value, so there is no new behaviour to assert. Happy to add a test if you would like one.
