### PR TITLE
Removed the IndexNow labs flag

### DIFF
--- a/ghost/core/core/frontend/web/middleware/serve-indexnow-key.js
+++ b/ghost/core/core/frontend/web/middleware/serve-indexnow-key.js
@@ -10,7 +10,7 @@
  * Security considerations:
  * - Only serves keys that exactly match the configured key
  * - Only responds to 32-character hex patterns (valid IndexNow key format)
- * - Returns 404 (via next()) if IndexNow is disabled or no key configured
+ * - Returns 404 (via next()) if no key is configured
  *
  * Route collision note:
  * The pattern /[a-f0-9]{32}.txt is unlikely to collide with user content
@@ -23,7 +23,6 @@
  */
 
 const settingsCache = require('../../../shared/settings-cache');
-const labs = require('../../../shared/labs');
 
 /**
  * Middleware to serve the IndexNow API key verification file
@@ -31,11 +30,6 @@ const labs = require('../../../shared/labs');
 function serveIndexNowKey(req, res, next) {
     // Only handle requests for .txt files at the root
     if (!req.path.match(/^\/[a-f0-9]{32}\.txt$/)) {
-        return next();
-    }
-
-    // Check if IndexNow is enabled
-    if (!labs.isSet('indexnow')) {
         return next();
     }
 

--- a/ghost/core/core/server/services/indexnow-ping/index.ts
+++ b/ghost/core/core/server/services/indexnow-ping/index.ts
@@ -12,7 +12,6 @@ class IndexNowPingServiceWrapper {
         // Wire up all the dependencies
         const settingsCache = require('../../../shared/settings-cache');
         const config = require('../../../shared/config');
-        const labs = require('../../../shared/labs');
         const urlService = require('../url');
         const urlUtils = require('../../../shared/url-utils').default;
         const request = require('@tryghost/request');
@@ -22,7 +21,6 @@ class IndexNowPingServiceWrapper {
         this.service = new IndexNowPingService({
             settingsCache,
             config,
-            labs,
             urlService,
             urlUtils,
             request,

--- a/ghost/core/core/server/services/indexnow-ping/indexnow-ping-service.ts
+++ b/ghost/core/core/server/services/indexnow-ping/indexnow-ping-service.ts
@@ -39,10 +39,6 @@ type Config = {
     isPrivacyDisabled(key: string): boolean;
 };
 
-type Labs = {
-    isSet(flag: string): boolean;
-};
-
 type UrlService = {
     getUrlForResource(resource: Record<string, unknown>, options: {absolute: boolean}): string | null;
 };
@@ -84,7 +80,6 @@ type Post = {
 export type IndexNowPingServiceDeps = {
     settingsCache: SettingsCache;
     config: Config;
-    labs: Labs;
     urlService: UrlService;
     urlUtils: UrlUtils;
     request: RequestFn;
@@ -95,7 +90,6 @@ export type IndexNowPingServiceDeps = {
 export class IndexNowPingService {
     settingsCache: SettingsCache;
     config: Config;
-    labs: Labs;
     urlService: UrlService;
     urlUtils: UrlUtils;
     request: RequestFn;
@@ -103,10 +97,9 @@ export class IndexNowPingService {
     events: ModelEvents;
     listener: ModelEventListener;
 
-    constructor({settingsCache, config, labs, urlService, urlUtils, request, logging, events}: IndexNowPingServiceDeps) {
+    constructor({settingsCache, config, urlService, urlUtils, request, logging, events}: IndexNowPingServiceDeps) {
         this.settingsCache = settingsCache;
         this.config = config;
-        this.labs = labs;
         this.urlService = urlService;
         this.urlUtils = urlUtils;
         this.request = request;
@@ -149,11 +142,6 @@ export class IndexNowPingService {
 
         // Skip if IndexNow pings are disabled via privacy config
         if (this.config.isPrivacyDisabled('useIndexNow')) {
-            return;
-        }
-
-        // Skip if IndexNow is not enabled in labs
-        if (!this.labs.isSet('indexnow')) {
             return;
         }
 

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -34,7 +34,6 @@ const GA_FEATURES = [
     'commentsPinning',
     'featurebaseFeedback',
     'dangerZoneResetAuth',
-    'indexnow',
     'llmsTxt'
 ];
 

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -30,7 +30,6 @@ Object {
       "getHelperDeduplication": true,
       "giftSubCustomization": true,
       "importMemberTier": true,
-      "indexnow": true,
       "lexicalIndicators": true,
       "llmsTxt": true,
       "memberDetailsReact": true,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -2253,7 +2253,7 @@ exports[`Settings API Edit can edit Stripe settings when Stripe Connect limit is
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "5495",
+  "content-length": "5477",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/unit/server/services/indexnow-ping/indexnow-ping-service.test.js
+++ b/ghost/core/test/unit/server/services/indexnow-ping/indexnow-ping-service.test.js
@@ -19,9 +19,6 @@ function createService() {
     const config = {isPrivacyDisabled: sinon.stub()};
     config.isPrivacyDisabled.withArgs('useIndexNow').returns(false);
 
-    const labs = {isSet: sinon.stub()};
-    labs.isSet.withArgs('indexnow').returns(true);
-
     const urlService = {
         getUrlForResource: sinon.stub().returns('https://example.com/my-post/')
     };
@@ -36,7 +33,7 @@ function createService() {
     // Chainable so `events.removeListener(...).on(...)` works.
     const events = {removeListener: sinon.stub().returnsThis(), on: sinon.stub().returnsThis()};
 
-    const deps = {settingsCache, config, labs, urlService, urlUtils, request, logging, events};
+    const deps = {settingsCache, config, urlService, urlUtils, request, logging, events};
     const service = new IndexNowPingService(deps);
 
     return {service, deps};
@@ -321,20 +318,6 @@ describe('IndexNow', function () {
             const testPage = _.clone(testUtils.DataGenerator.Content.posts[5]);
 
             await service.ping(testPage);
-
-            assert.equal(pingRequest.isDone(), false);
-        });
-
-        it('when labs.indexnow is false should not execute ping', async function () {
-            const {service, deps} = createService();
-            deps.labs.isSet.withArgs('indexnow').returns(false);
-
-            const pingRequest = nock('https://api.indexnow.org')
-                .get(/\/indexnow/)
-                .reply(200);
-            const testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
-
-            await service.ping(testPost);
 
             assert.equal(pingRequest.isDone(), false);
         });


### PR DESCRIPTION
## Summary

- Removes the generally available `indexnow` Labs flag.
- Makes IndexNow pings and API-key verification serving unconditional instead of checking an always-enabled flag.
- Keeps `privacy.useIndexNow` as the supported way to disable outbound IndexNow requests.

## Testing

- [x] `pnpm --dir ghost/core test:single test/unit/server/services/indexnow-ping/indexnow-ping-service.test.js`
- [x] `pnpm --dir ghost/core test:single test/e2e-api/admin/config.test.js`
- [x] `pnpm nx run ghost:build:tsc`
- [x] ESLint and dependency-cruiser pre-commit checks