### PR TITLE
Improved internal package migration safeguards

### DIFF
--- a/.agents/skills/migrate-internal-package/SKILL.md
+++ b/.agents/skills/migrate-internal-package/SKILL.md
@@ -19,6 +19,20 @@ Explain every cross-repository or administrative action before it happens.
   PR, deprecating npm versions, or force-pushing.
 - Never ask for, display, or store credentials or OTPs.
 
+## Work in isolated checkouts
+
+Never manipulate history in a checkout containing unrelated work. Fetch both
+repositories, confirm the source checkout is clean, and create a dedicated
+Ghost worktree from the freshly fetched `origin/main`.
+
+Run history-changing commands individually or in a fail-fast shell. A failed
+`git worktree add` must not be followed by `git subtree add` in whichever
+checkout happens to be current. Stop if the destination branch or path already
+exists and inspect that state rather than reusing it implicitly.
+
+Before importing, record and compare the destination `HEAD` and `origin/main`;
+they must match. Recheck the first parent immediately after the subtree commit.
+
 ## Confirm this workflow applies
 
 Before changing either repository, record the source repository, its default
@@ -35,6 +49,14 @@ the package has been published to npm. Then:
 Publication or download counts alone do not prove that a package must remain a
 supported public API. If supported external consumers still need new releases,
 stop: this internal-only workflow is the wrong publishing model.
+
+For the public-consumer audit, check npm metadata, first-party repositories and
+documentation, plus GitHub code search for package dependencies and runtime
+imports. Classify results as first-party consumers, independent integrations,
+Ghost forks, or deployed Ghost installation snapshots. Forks and installation
+snapshots demonstrate continued installation needs, but do not establish an
+independently supported API. Record the evidence and confidence behind the
+ownership decision; stop and ask if support expectations remain unclear.
 
 ## Produce these work products in order
 
@@ -68,8 +90,32 @@ After the subtree commit, add focused integration commits that:
 - minimally adapt configuration and tests to work in Ghost;
 - retain runtime behavior for the later modernization PR.
 
+Before editing package metadata, map each source `workspace:*` dependency to
+its destination state:
+
+- use `workspace:*` when the dependency already exists in Ghost;
+- use `catalog:` when Ghost's catalog version satisfies the imported package;
+- add a named migration catalog with the exact published version when changing
+  the shared catalog would broaden the migration or alter runtime behavior;
+- stop if a required dependency is unpublished or exists only in the source
+  workspace.
+
+Document temporary named-catalog entries for the modernization follow-up. Never
+inline dependency versions; Ghost's strict catalog policy still applies. Do not
+import additional packages implicitly.
+
+If the package is legacy JavaScript or CommonJS, read
+[`references/legacy-integration.md`](references/legacy-integration.md)
+completely before creating integration commits.
+
 Verify that the subtree commit has two parents and that representative file
 history crosses into the source repository before opening the PR.
+
+Before opening the PR, also verify the source split is reachable from the branch
+tip, the consumer resolves the workspace package through its production import
+path, package lint and tests pass through Nx, relevant consumer tests pass, the
+full build passes, and the Ghost archive contains the internal package. Record
+the exact commit IDs and commands in the handoff.
 
 ## 2. Merge the import without rewriting history
 

--- a/.agents/skills/migrate-internal-package/SKILL.md
+++ b/.agents/skills/migrate-internal-package/SKILL.md
@@ -54,9 +54,12 @@ For the public-consumer audit, check npm metadata, first-party repositories and
 documentation, plus GitHub code search for package dependencies and runtime
 imports. Classify results as first-party consumers, independent integrations,
 Ghost forks, or deployed Ghost installation snapshots. Forks and installation
-snapshots demonstrate continued installation needs, but do not establish an
-independently supported API. Record the evidence and confidence behind the
-ownership decision; stop and ask if support expectations remain unclear.
+snapshots show historical presence only. Require a recent update, current
+deployment, active dependency or another freshness signal before treating them
+as evidence of continued installation needs; even then, they do not establish
+an independently supported API. Record the evidence and confidence behind the
+ownership decision; stop and ask if current support expectations remain
+unclear.
 
 ## Produce these work products in order
 

--- a/.agents/skills/migrate-internal-package/references/history-and-merge.md
+++ b/.agents/skills/migrate-internal-package/references/history-and-merge.md
@@ -15,8 +15,11 @@ until it returns an exit status, and do not mistake an output timeout for
 completion. For example, when the default branch is `main`:
 
 ```bash
+set -euo pipefail
+
 git fetch origin
 git switch --detach origin/main
+test -z "$(git status --porcelain)"
 git subtree split \
   --quiet \
   --prefix=<source-package-path> \
@@ -42,6 +45,9 @@ Create or enter a dedicated Ghost worktree, then verify its branch, cleanliness,
 base and empty destination before attaching history:
 
 ```bash
+set -euo pipefail
+
+test "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)"
 test "$(git branch --show-current)" = "codex/import-<package>"
 test -z "$(git status --porcelain)"
 test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"
@@ -69,6 +75,9 @@ git-subtree-split: <source-split-tip>
 Verify the topology before adding integration commits:
 
 ```bash
+set -euo pipefail
+
+source_split_tip="<recorded-source-split-tip>"
 subtree_commit=$(git rev-parse HEAD)
 ghost_parent=$(git rev-parse HEAD^1)
 imported_parent=$(git rev-parse HEAD^2)

--- a/.agents/skills/migrate-internal-package/references/history-and-merge.md
+++ b/.agents/skills/migrate-internal-package/references/history-and-merge.md
@@ -4,23 +4,33 @@ Read this reference before creating the Ghost import PR.
 
 ## Create package-only source history
 
-Work from an up-to-date clone of the source repository. Use its actual default
-branch and a temporary branch name that cannot be confused with a product
-branch. For example, when the default branch is `main`:
+Work from an up-to-date, clean clone of the source repository. Use its actual
+default branch and a temporary branch name that cannot be confused with a
+product branch.
+
+`git subtree split` may inspect thousands of commits and run for several
+minutes. Use `--quiet` in agent or CI-style runners so its progress stream does
+not flood or interrupt the runner. Run it on its own, keep the process alive
+until it returns an exit status, and do not mistake an output timeout for
+completion. For example, when the default branch is `main`:
 
 ```bash
 git fetch origin
 git switch --detach origin/main
 git subtree split \
+  --quiet \
   --prefix=<source-package-path> \
-  -b migrate-<package>-history
+  -b migrate-<package>-history \
+  origin/main
 ```
 
-Record the split tip and inspect the resulting package-only history:
+Confirm the branch was actually created, then record the split tip and inspect
+the resulting package-only history:
 
 ```bash
-git rev-parse migrate-<package>-history
-git log --oneline --reverse migrate-<package>-history
+git show-ref --verify refs/heads/migrate-<package>-history
+source_split_tip=$(git rev-parse migrate-<package>-history)
+git log --oneline --reverse "$source_split_tip"
 ```
 
 `git subtree split` retains the relevant commit authorship and chronology while
@@ -28,8 +38,18 @@ excluding unrelated source-repository paths.
 
 ## Attach the history to Ghost
 
-From a branch based on freshly fetched Ghost `origin/main`, fetch the local
-source split and add it without `--squash`:
+Create or enter a dedicated Ghost worktree, then verify its branch, cleanliness,
+base and empty destination before attaching history:
+
+```bash
+test "$(git branch --show-current)" = "codex/import-<package>"
+test -z "$(git status --porcelain)"
+test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"
+test ! -e "packages/<ghost-directory>"
+```
+
+Fetch the local source split and add it without `--squash`. Run these as
+separate checked operations and stop immediately if either fails:
 
 ```bash
 git fetch /absolute/path/to/source-repository migrate-<package>-history
@@ -49,13 +69,24 @@ git-subtree-split: <source-split-tip>
 Verify the topology before adding integration commits:
 
 ```bash
-git show --no-patch --format='%H%nparents: %P%n%B' HEAD
+subtree_commit=$(git rev-parse HEAD)
+ghost_parent=$(git rev-parse HEAD^1)
+imported_parent=$(git rev-parse HEAD^2)
+
+test "$ghost_parent" = "$(git rev-parse origin/main)"
+test "$imported_parent" = "$source_split_tip"
+git merge-base --is-ancestor "$source_split_tip" HEAD
+
+git show --no-patch --format='%H%nparents: %P%n%B' "$subtree_commit"
 git log --graph --oneline --decorate --all --max-count=40
-git log --follow -- packages/<ghost-directory>/path/to/representative-file
+git log --oneline -- packages/<ghost-directory>/path/to/representative-file
+git log --oneline "$source_split_tip" -- path/to/representative-file
 ```
 
-The subtree commit must have two parents, and its second parent must equal the
-recorded split tip.
+The subtree commit must have two parents: its first parent must equal the
+recorded Ghost base and its second parent must equal the recorded split tip.
+Checking the prefixed destination path and unprefixed split path separately is
+more reliable around merge boundaries than relying only on `--follow`.
 
 The Admin API schema migration from TryGhost/SDK is a known-good example:
 

--- a/.agents/skills/migrate-internal-package/references/legacy-integration.md
+++ b/.agents/skills/migrate-internal-package/references/legacy-integration.md
@@ -1,0 +1,105 @@
+# Integrate a legacy JavaScript package
+
+Read this reference when the imported package is JavaScript or CommonJS. The
+import PR establishes ownership and a green workspace package; it does not
+modernize the implementation.
+
+## Keep the integration narrow
+
+Change only what Ghost needs to consume and verify the package:
+
+- set `"private": true` and the internal placeholder version;
+- point repository metadata at Ghost;
+- remove public publishing configuration;
+- switch Ghost consumers to `workspace:*`;
+- translate source-workspace dependencies deliberately;
+- adapt lint and test configuration to Ghost's shared tools.
+
+Do not rename source files, change module format, introduce TypeScript, redesign
+exports or clean up implementation details. Use the
+`convert-internal-package-to-typescript` skill for that later work.
+
+## ESLint configuration
+
+Use the shared Node library factory in CommonJS mode and declare
+`@internal/cfg-eslint` plus `eslint` as package dev dependencies:
+
+```js
+import {nodeLibConfig} from '@internal/cfg-eslint';
+
+export default nodeLibConfig({
+    typescript: false,
+    commonjs: true,
+    legacyLocalFilenames: true,
+    srcGlobs: ['index.js', 'lib/**/*.js'],
+    testGlobs: ['test/**/*.js']
+});
+```
+
+Prefer fixing trivial configuration drift. When a Ghost rule conflicts with a
+test that intentionally exercises legacy behavior, use a narrow, documented
+`extraTestRules` exception instead of changing runtime semantics. Rules must be
+`'error'` or `'off'`, never warnings.
+
+## Vitest configuration
+
+The shared default targets TypeScript, so override its globs for JavaScript.
+Preserve the source repository's coverage thresholds where practical:
+
+```ts
+import {createVitestConfig} from '@internal/cfg-vitest';
+
+export default createVitestConfig({
+    test: {
+        globals: true,
+        include: ['test/**/*.test.js'],
+        coverage: {
+            include: ['lib/**/*.js'],
+            thresholds: {
+                lines: 90,
+                functions: 90,
+                branches: 80,
+                statements: 90
+            }
+        }
+    }
+});
+```
+
+Declare `@internal/cfg-vitest`, `@vitest/coverage-v8` and `vitest` in the
+package's dev dependencies. Match the actual source and test layout rather than
+copying these example globs blindly.
+
+## Dependency mapping
+
+Source `workspace:*` ranges cannot be copied blindly when their packages are
+not also Ghost workspaces. For each dependency:
+
+1. Prefer `workspace:*` for an existing Ghost package.
+2. Prefer Ghost's catalog when it provides a compatible version.
+3. Add the source release's exact published version to a named migration
+   catalog when changing the shared catalog would affect unrelated consumers or
+   alter behavior. Reference it with `catalog:<name>`; never inline the version.
+4. Stop if no published or destination-workspace dependency can satisfy it.
+
+Record temporary named-catalog entries in the PR and reassess them during
+modernization.
+
+## Verification
+
+Run the package through its Nx surface and exercise a real consumer:
+
+```bash
+pnpm nx run @tryghost/<package>:lint
+pnpm nx run @tryghost/<package>:test
+pnpm build
+```
+
+Also verify:
+
+- the package resolves through the consumer's production `require()` or import;
+- relevant consumer tests pass;
+- `pnpm archive` succeeds from `ghost/core`;
+- the resulting Ghost archive contains the package component.
+
+Generated archives are verification artifacts, not files to commit.


### PR DESCRIPTION
## Summary

- hardens the internal-package migration workflow after its first cold-start use
- requires isolated, freshly based worktrees and machine-checkable subtree topology verification
- documents public-consumer assessment, strict-catalog dependency mapping, and minimal legacy JavaScript integration
- keeps CommonJS configuration details in a conditional reference so the core workflow remains concise

## Testing

- [x] `git diff --check`
- [x] `pnpm lint:agent-skills`

## Context

The first end-to-end use of the migration skill exposed gaps around long-running `git subtree split` commands, partially created worktrees, destination-base verification, source `workspace:*` dependencies, and adapting a legacy CommonJS package without prematurely modernizing it.

This PR updates the reusable workflow only. It does not migrate or modernize a package.
