### PR TITLE
Minted custom field keys with underscores in place of hyphens

### DIFF
--- a/apps/admin/src/members/components/bulk-action-modals/import-members/upload.test.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/upload.test.ts
@@ -114,7 +114,7 @@ describe('buildImportResponse', () => {
     it('keeps a reason whole however it is punctuated', () => {
         // A reason may quote a cell the publisher wrote, and a CSV cell legally holds
         // both a comma and a newline.
-        const punctuated = 'custom_fields.home-address.country: Enter a 2-letter country code, like US.';
+        const punctuated = 'custom_fields.home_address.country: Enter a 2-letter country code, like US.';
         const multiline = '"Gold\nPlan" is not a valid tier.';
         const result = buildImportResponse({
             meta: {
@@ -197,9 +197,9 @@ describe('buildImportResponse', () => {
                     imported: 0,
                     invalid: [{
                         email: 'a@test.com',
-                        'custom_fields.home-address.country': 'IRL',
-                        errors: ['Missing email address', 'custom_fields.home-address.country: Enter a 2-letter country code, like US.'],
-                        error: 'Missing email address\ncustom_fields.home-address.country: Enter a 2-letter country code, like US.'
+                        'custom_fields.home_address.country': 'IRL',
+                        errors: ['Missing email address', 'custom_fields.home_address.country: Enter a 2-letter country code, like US.'],
+                        error: 'Missing email address\ncustom_fields.home_address.country: Enter a 2-letter country code, like US.'
                     }]
                 },
                 import_label: {name: 'Test', slug: 'test'}
@@ -210,7 +210,7 @@ describe('buildImportResponse', () => {
         // CRLF between rows; a reason may itself contain a bare newline.
         const [header] = csv.split('\r\n');
 
-        expect(header).toBe('"email","custom_fields.home-address.country","error"');
-        expect(csv).toContain('"Missing email address\ncustom_fields.home-address.country: Enter a 2-letter country code, like US."');
+        expect(header).toBe('"email","custom_fields.home_address.country","error"');
+        expect(csv).toContain('"Missing email address\ncustom_fields.home_address.country: Enter a 2-letter country code, like US."');
     });
 });

--- a/ghost/core/core/server/data/migrations/versions/6.58/2026-08-10-15-24-09-reset-custom-field-definitions-for-underscored-keys.js
+++ b/ghost/core/core/server/data/migrations/versions/6.58/2026-08-10-15-24-09-reset-custom-field-definitions-for-underscored-keys.js
@@ -4,31 +4,51 @@ const {createTransactionalMigration} = require('../../utils');
 const FIELDS_TABLE = 'members_custom_fields';
 const VALUES_TABLE = 'members_custom_field_values';
 
+// The shape this release mints: alphanumeric runs joined by single underscores, with no
+// separator at either end. Written out here rather than imported from the service, so a
+// later change to how keys are minted cannot change what this migration did.
+const MINTED_KEY_SHAPE = /^[a-z0-9]+(?:_[a-z0-9]+)*$/;
+
+// A key naming an inherited property reads back as that property wherever a member's
+// values are indexed, so it goes too, whatever its shape. Minting has refused these
+// since 6.53, but the definitions endpoint shipped four days before that guard did.
+const INHERITED_PROPERTY_NAMES = Object.getOwnPropertyNames(Object.prototype);
+
+function isUnmintable(key) {
+    return !MINTED_KEY_SHAPE.test(key) || INHERITED_PROPERTY_NAMES.includes(key);
+}
+
 // A key is minted once and never changes, so a definition created before this release
-// keeps its hyphens for good. Those definitions are discarded rather than rewritten:
-// custom fields sit behind a private flag and have never been released, so only a site
-// deliberately opted in can hold one, and re-creating a field re-mints its key.
+// keeps whatever shape it was given. Those definitions are discarded rather than
+// rewritten: custom fields sit behind a private flag and have never been released, so
+// only a site deliberately opted in can hold one, and re-creating a field re-mints it.
 //
-// Only hyphenated keys go. A single-word key was already what this release would mint,
-// so it and its values are left alone.
+// Only the keys this release could not produce go. Hyphens are what changed, but they
+// are not the whole set: the previous minting passed underscores through untouched, so
+// a leading, trailing or doubled one survived it too.
+//
+// Every definition is read rather than filtered in SQL. The table is small, the rule is
+// a regular expression neither engine agrees on, and `_` is a wildcard in LIKE, so the
+// pattern that looks obvious is not the one that runs.
 //
 // Values are deleted explicitly rather than left to the foreign key: it cascades on
 // MySQL, but SQLite only enforces one when `foreign_keys` is on, which knex-migrator
 // does not guarantee.
 module.exports = createTransactionalMigration(
     async function up(knex) {
-        // `-` carries no special meaning in a LIKE pattern, unlike `_` and `%`.
-        const ids = await knex(FIELDS_TABLE).where('key', 'like', '%-%').pluck('id');
+        const definitions = await knex(FIELDS_TABLE).select('id', 'key');
+        const discarded = definitions.filter(definition => isUnmintable(definition.key));
 
-        if (ids.length === 0) {
-            logging.info('No custom field definitions with hyphenated keys to discard');
+        if (discarded.length === 0) {
+            logging.info('No custom field definitions to discard: every key is one this release can mint');
             return;
         }
 
+        const ids = discarded.map(definition => definition.id);
         const discardedValues = await knex(VALUES_TABLE).whereIn('custom_field_id', ids).del();
         const discardedFields = await knex(FIELDS_TABLE).whereIn('id', ids).del();
 
-        logging.info(`Discarded ${discardedFields} custom field definition(s) with hyphenated keys, and ${discardedValues} value(s)`);
+        logging.info(`Discarded ${discardedFields} custom field definition(s) this release cannot mint, and ${discardedValues} value(s): ${discarded.map(definition => definition.key).join(', ')}`);
     },
     async function down() {
         // Nothing to undo: an underscored key is a key the previous release can read and

--- a/ghost/core/core/server/data/migrations/versions/6.58/2026-08-10-15-24-09-reset-custom-field-definitions-for-underscored-keys.js
+++ b/ghost/core/core/server/data/migrations/versions/6.58/2026-08-10-15-24-09-reset-custom-field-definitions-for-underscored-keys.js
@@ -1,0 +1,38 @@
+const logging = require('@tryghost/logging');
+const {createTransactionalMigration} = require('../../utils');
+
+const FIELDS_TABLE = 'members_custom_fields';
+const VALUES_TABLE = 'members_custom_field_values';
+
+// A key is minted once and never changes, so a definition created before this release
+// keeps its hyphens for good. Those definitions are discarded rather than rewritten:
+// custom fields sit behind a private flag and have never been released, so only a site
+// deliberately opted in can hold one, and re-creating a field re-mints its key.
+//
+// Only hyphenated keys go. A single-word key was already what this release would mint,
+// so it and its values are left alone.
+//
+// Values are deleted explicitly rather than left to the foreign key: it cascades on
+// MySQL, but SQLite only enforces one when `foreign_keys` is on, which knex-migrator
+// does not guarantee.
+module.exports = createTransactionalMigration(
+    async function up(knex) {
+        // `-` carries no special meaning in a LIKE pattern, unlike `_` and `%`.
+        const ids = await knex(FIELDS_TABLE).where('key', 'like', '%-%').pluck('id');
+
+        if (ids.length === 0) {
+            logging.info('No custom field definitions with hyphenated keys to discard');
+            return;
+        }
+
+        const discardedValues = await knex(VALUES_TABLE).whereIn('custom_field_id', ids).del();
+        const discardedFields = await knex(FIELDS_TABLE).whereIn('id', ids).del();
+
+        logging.info(`Discarded ${discardedFields} custom field definition(s) with hyphenated keys, and ${discardedValues} value(s)`);
+    },
+    async function down() {
+        // Nothing to undo: an underscored key is a key the previous release can read and
+        // address, it is only one it would not have minted.
+        logging.info('Leaving underscored custom field keys in place: the previous release reads them unchanged');
+    }
+);

--- a/ghost/core/core/server/services/members-custom-fields/definitions-service.ts
+++ b/ghost/core/core/server/services/members-custom-fields/definitions-service.ts
@@ -241,7 +241,10 @@ export class CustomFieldDefinitionsService {
      * key is never reused once minted.
      */
     private async mintKey(db: Knex, base: string): Promise<string> {
-        const safeBase = base.slice(0, MAX_KEY_BASE_LENGTH);
+        // Trimmed again after cutting, because the cut can land mid-separator and
+        // a key that ends in one is not a shape minting is allowed to produce. The
+        // base starts with an alphanumeric, so something always survives.
+        const safeBase = base.slice(0, MAX_KEY_BASE_LENGTH).replace(/_+$/, '');
         const taken = new Set([
             ...RESERVED_KEYS,
             ...await db(TABLE).where('key', 'like', `${safeBase}%`).pluck('key')

--- a/ghost/core/core/server/services/members-custom-fields/definitions-service.ts
+++ b/ghost/core/core/server/services/members-custom-fields/definitions-service.ts
@@ -12,6 +12,13 @@ import {type RecordCustomFieldAction, type RequestContext} from './actions';
 // @tryghost/string ships no types; slugify is the same helper tags/labels use.
 const {slugify} = require('@tryghost/string') as {slugify(input: string): string};
 
+// A key is typed by hand into member filters, CSV columns, email replacement strings
+// and themes, and the hyphen a slug separates with is the character those disagree
+// about: NQL will not parse one in a property path, and a replacement string matches
+// word characters only. Slugify still does the transliteration and lowercasing, so
+// only the separator changes, and it changes for hyphens the publisher typed too.
+const mintableKey = (name: string): string => slugify(name).replace(/-/g, '_');
+
 // The same NQL -> knex bridge Bookshelf's filter plugin uses, applied directly to
 // our raw-knex query: nql parses the `filter` string to a Mongo query, mongo-knex
 // turns that into parametrised WHERE clauses. Neither needs a Bookshelf model.
@@ -29,7 +36,7 @@ const columns = require('../../data/schema').tables[TABLE];
 const MAX_NAME_LENGTH: number = columns.name.maxlength;
 const MAX_KEY_LENGTH: number = columns.key.maxlength;
 const MAX_SLUG_ITERATIONS = 1000;
-// Reserve room for a `-<n>` suffix (n up to MAX_SLUG_ITERATIONS).
+// Reserve room for a `_<n>` suffix (n up to MAX_SLUG_ITERATIONS).
 const MAX_KEY_BASE_LENGTH = MAX_KEY_LENGTH - (String(MAX_SLUG_ITERATIONS).length + 1);
 
 // A key becomes a property name on the plain objects that carry a member's values —
@@ -40,10 +47,10 @@ const MAX_KEY_BASE_LENGTH = MAX_KEY_LENGTH - (String(MAX_SLUG_ITERATIONS).length
 // assigning it sets a prototype rather than a property.
 //
 // Derived rather than listed, because the set is a consequence of how keys are
-// minted: slugifying lowercases, so only an already-lowercase prototype name can
+// minted: minting lowercases, so only an already-lowercase prototype name can
 // survive to become a key. Currently `constructor` and `__proto__`.
 const RESERVED_KEYS = Object.getOwnPropertyNames(Object.prototype)
-    .filter(name => slugify(name) === name);
+    .filter(name => mintableKey(name) === name);
 
 const FieldName = z.string().trim().min(1, {message: 'Custom field name is required.'}).max(MAX_NAME_LENGTH, {message: 'Custom field name is too long.'});
 
@@ -141,10 +148,10 @@ export class CustomFieldDefinitionsService {
         }
         const fields = parsed.data;
 
-        // Slugify before opening the transaction: it needs no database access, and
+        // Mint before opening the transaction: it needs no database access, and
         // an unusable name is a payload problem worth reporting on its own terms.
         const bases = fields.map((field, index) => {
-            const base = slugify(field.name);
+            const base = mintableKey(field.name);
             if (!base) {
                 throw new errors.ValidationError({
                     message: 'Custom field name must contain at least one usable character.',
@@ -240,9 +247,9 @@ export class CustomFieldDefinitionsService {
     }
 
     /**
-     * Pick a free key from the name's slug: `base`, then `base-2`, `base-3`, ...
+     * Pick a free key from the name's base: `base`, then `base_2`, `base_3`, ...
      * Reads the keys already taken by that base — including archived fields, so a
-     * slug is never reused once minted. Mirrors how tags/labels generate slugs.
+     * key is never reused once minted.
      */
     private async mintKey(db: Knex, base: string): Promise<string> {
         const safeBase = base.slice(0, MAX_KEY_BASE_LENGTH);
@@ -254,7 +261,7 @@ export class CustomFieldDefinitionsService {
             return safeBase;
         }
         for (let suffix = 2; suffix <= MAX_SLUG_ITERATIONS; suffix += 1) {
-            const candidate = `${safeBase}-${suffix}`;
+            const candidate = `${safeBase}_${suffix}`;
             if (!taken.has(candidate)) {
                 return candidate;
             }

--- a/ghost/core/core/server/services/members-custom-fields/definitions-service.ts
+++ b/ghost/core/core/server/services/members-custom-fields/definitions-service.ts
@@ -7,17 +7,8 @@ import {FieldTypeSchema} from '@tryghost/custom-field-types';
 import {customFieldCodec} from './codec';
 import {FIELD_STATUS, FieldStatusSchema} from './schema';
 import {activeFields} from './queries';
+import {mintableKey} from './key';
 import {type RecordCustomFieldAction, type RequestContext} from './actions';
-
-// @tryghost/string ships no types; slugify is the same helper tags/labels use.
-const {slugify} = require('@tryghost/string') as {slugify(input: string): string};
-
-// A key is typed by hand into member filters, CSV columns, email replacement strings
-// and themes, and the hyphen a slug separates with is the character those disagree
-// about: NQL will not parse one in a property path, and a replacement string matches
-// word characters only. Slugify still does the transliteration and lowercasing, so
-// only the separator changes, and it changes for hyphens the publisher typed too.
-const mintableKey = (name: string): string => slugify(name).replace(/-/g, '_');
 
 // The same NQL -> knex bridge Bookshelf's filter plugin uses, applied directly to
 // our raw-knex query: nql parses the `filter` string to a Mongo query, mongo-knex
@@ -35,20 +26,18 @@ const TABLE = 'members_custom_fields';
 const columns = require('../../data/schema').tables[TABLE];
 const MAX_NAME_LENGTH: number = columns.name.maxlength;
 const MAX_KEY_LENGTH: number = columns.key.maxlength;
-const MAX_SLUG_ITERATIONS = 1000;
-// Reserve room for a `_<n>` suffix (n up to MAX_SLUG_ITERATIONS).
-const MAX_KEY_BASE_LENGTH = MAX_KEY_LENGTH - (String(MAX_SLUG_ITERATIONS).length + 1);
+const MAX_KEY_ITERATIONS = 1000;
+// Reserve room for a `_<n>` suffix (n up to MAX_KEY_ITERATIONS).
+const MAX_KEY_BASE_LENGTH = MAX_KEY_LENGTH - (String(MAX_KEY_ITERATIONS).length + 1);
 
 // A key becomes a property name on the plain objects that carry a member's values —
 // on both sides of the wire, since `custom_fields` is JSON and a client gets a plain
 // object from JSON.parse. A key naming a member of Object.prototype reads back as
-// inherited rather than absent wherever one of those objects is indexed, and
-// `__proto__` holds no value at all: the values schema drops it during parse, and
-// assigning it sets a prototype rather than a property.
+// inherited rather than absent wherever one of those objects is indexed.
 //
 // Derived rather than listed, because the set is a consequence of how keys are
-// minted: minting lowercases, so only an already-lowercase prototype name can
-// survive to become a key. Currently `constructor` and `__proto__`.
+// minted: minting lowercases and trims leading underscores, so a prototype name
+// survives only if it has neither. `constructor` is the only one.
 const RESERVED_KEYS = Object.getOwnPropertyNames(Object.prototype)
     .filter(name => mintableKey(name) === name);
 
@@ -131,8 +120,8 @@ export class CustomFieldDefinitionsService {
      *
      * Running inside the transaction also makes a batch self-consistent for free —
      * `assertNameAvailable` and `mintKey` see the rows inserted earlier in the same
-     * batch, so two items sharing a name are caught and two items sharing a slug
-     * get distinct keys, exactly as if they had arrived as separate requests.
+     * batch, so two items sharing a name are caught and two items deriving the same
+     * key get distinct ones, exactly as if they had arrived as separate requests.
      */
     async add(context: RequestContext, input: unknown): Promise<CustomField[]> {
         const requestedCount = Array.isArray(input) ? input.length : 0;
@@ -260,7 +249,7 @@ export class CustomFieldDefinitionsService {
         if (!taken.has(safeBase)) {
             return safeBase;
         }
-        for (let suffix = 2; suffix <= MAX_SLUG_ITERATIONS; suffix += 1) {
+        for (let suffix = 2; suffix <= MAX_KEY_ITERATIONS; suffix += 1) {
             const candidate = `${safeBase}_${suffix}`;
             if (!taken.has(candidate)) {
                 return candidate;

--- a/ghost/core/core/server/services/members-custom-fields/key.ts
+++ b/ghost/core/core/server/services/members-custom-fields/key.ts
@@ -1,0 +1,35 @@
+// Neither package ships types.
+const {stripInvisibleChars} = require('@tryghost/string') as {stripInvisibleChars(input: string): string};
+const unidecode = require('unidecode') as (input: string) => string;
+
+/** Every character a key may contain. Nothing else survives minting. */
+export const KEY_CHARACTERS = /^[a-z0-9_]+$/;
+
+/**
+ * Mint the key a field is addressed by, from the name a publisher chose.
+ *
+ * A key is typed by hand into member filters, CSV columns, email replacement strings
+ * and, later, themes. Those agree on letters, digits and the underscore, and disagree
+ * about everything else, so what a key may contain is stated here as an allowlist
+ * rather than inherited from slugify, whose separator and reserved characters answer
+ * to URLs. The two formats happen to be near-identical today; they are not the same
+ * rule, and this one belongs where its consumers are known.
+ *
+ * Transliteration and invisible-character stripping stay with the libraries that own
+ * them. Only the policy is local.
+ *
+ * Runs collapse and the ends are trimmed, so no key can lead or trail with a
+ * separator. `__proto__` is unmintable as a result, which is worth more than
+ * reserving it would be.
+ *
+ * Returns an empty string for a name with nothing usable in it; the caller decides
+ * what to do about that.
+ */
+export function mintableKey(name: string): string {
+    return unidecode(stripInvisibleChars(name))
+        .toLowerCase()
+        // Dropped rather than separated, so a possessive reads as one word.
+        .replace(/'/g, '')
+        .replace(/[^a-z0-9]+/g, '_')
+        .replace(/^_+|_+$/g, '');
+}

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ghost",
-    "version": "6.57.2-rc.0",
+    "version": "6.58.0-rc.0",
     "description": "The professional publishing platform",
     "author": "Ghost Foundation",
     "homepage": "https://ghost.org",

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -238,6 +238,7 @@
         "tldts": "catalog:",
         "type-fest": "catalog:",
         "ua-parser-js": "1.0.41",
+        "unidecode": "catalog:",
         "xml": "1.0.1",
         "zod": "catalog:"
     },

--- a/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
@@ -208,6 +208,20 @@ describe('Member Custom Fields Admin API', function () {
             assert.deepEqual(await readValues(memberId), {constructor_role: 'Foreman'});
         });
 
+        // The key column is shorter than the name column, so a long name is cut to
+        // fit. The cut can land mid-separator, and a key ending in one is a shape
+        // minting is not allowed to produce.
+        it('mints a key that fits the column without ending in a separator', async function () {
+            const created = await createField({name: `${'a'.repeat(185)} bcdef`});
+
+            assert.ok(created.key.length <= 191, `key was ${created.key.length} characters`);
+            assert.doesNotMatch(created.key, /_$/);
+
+            // And the suffix a collision adds lands against that trimmed base.
+            const second = await createField({name: `${'a'.repeat(185)} bcdeg`});
+            assert.doesNotMatch(second.key, /__/);
+        });
+
         it('rejects a name that exceeds the maximum length', async function () {
             await agent
                 .post('members/custom_fields/')

--- a/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
@@ -135,16 +135,12 @@ describe('Member Custom Fields Admin API', function () {
 
         // A key names a property on the plain objects carrying a member's values, so
         // one naming a member of Object.prototype reads back as inherited rather than
-        // absent wherever it is indexed. Those keys are already taken, so the
-        // publisher keeps the name and the key takes a suffix. The match is on the
-        // key rather than the name, which is what catches every spelling that
-        // collapses onto it.
+        // absent wherever it is indexed. That key is already taken, so the publisher
+        // keeps the name and the key takes a suffix. The match is on the key rather
+        // than the name, which is what catches every spelling that collapses onto it.
         const reservedSpellings = [
             {name: 'Constructor', key: 'constructor_2'},
-            {name: 'constructor', key: 'constructor_2'},
-            {name: '__proto__', key: '__proto___2'},
-            {name: '__PROTO__', key: '__proto___2'},
-            {name: '＿＿ｐｒｏｔｏ＿＿', key: '__proto___2'}
+            {name: 'constructor', key: 'constructor_2'}
         ];
         for (const {name, key} of reservedSpellings) {
             it(`mints ${key} for the name ${name}, and the value round-trips`, async function () {
@@ -155,6 +151,21 @@ describe('Member Custom Fields Admin API', function () {
                 await setValues(memberId, {[key]: 'Bex'});
 
                 assert.deepEqual(await readValues(memberId), {[key]: 'Bex'});
+            });
+        }
+
+        // The other prototype name a publisher could reach for needs no reserving:
+        // minting trims leading and trailing separators, so no spelling of it can
+        // produce the key itself.
+        for (const name of ['__proto__', '__PROTO__', '＿＿ｐｒｏｔｏ＿＿']) {
+            it(`cannot mint __proto__ from the name ${name}`, async function () {
+                const field = await createField({name});
+                assert.equal(field.key, 'proto');
+
+                const memberId = await createMember();
+                await setValues(memberId, {proto: 'Bex'});
+
+                assert.deepEqual(await readValues(memberId), {proto: 'Bex'});
             });
         }
 

--- a/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/member-custom-fields.test.ts
@@ -81,9 +81,9 @@ describe('Member Custom Fields Admin API', function () {
             assert.deepEqual(body.members_custom_fields, []);
         });
 
-        it('creates a field, minting a slug key from the name', async function () {
+        it('creates a field, minting an underscored key from the name', async function () {
             const created = await createField({name: 'Favourite topic'});
-            assert.equal(created.key, 'favourite-topic');
+            assert.equal(created.key, 'favourite_topic');
             assert.equal(created.name, 'Favourite topic');
             assert.equal(created.type, 'short_text');
             // A new field is active; status travels with the definition so the UI
@@ -96,16 +96,24 @@ describe('Member Custom Fields Admin API', function () {
             assert.equal(list.members_custom_fields.length, 1);
 
             const read = (await agent.get(`members/custom_fields/${created.key}/`).expectStatus(200)).body;
-            assert.equal(read.members_custom_fields[0].key, 'favourite-topic');
+            assert.equal(read.members_custom_fields[0].key, 'favourite_topic');
         });
 
-        it('mints a suffixed key when the derived slug collides', async function () {
-            // Two distinct names can derive the same slug ("!" is stripped), so
+        // A key is referenced from filters, CSV columns, replacement strings and
+        // themes, and the hyphen is the character those disagree about. Nothing a
+        // publisher can type may put one in a key, including typing one themselves.
+        it('mints underscores for a name that already contains hyphens', async function () {
+            const created = await createField({name: 'T-Shirt size'});
+            assert.equal(created.key, 't_shirt_size');
+        });
+
+        it('mints a suffixed key when the derived base collides', async function () {
+            // Two distinct names can derive the same base ("!" is stripped), so
             // the key is suffixed even though the names stay unique.
             const first = await createField({name: 'Favourite topic'});
             const second = await createField({name: 'Favourite topic!'});
-            assert.equal(first.key, 'favourite-topic');
-            assert.equal(second.key, 'favourite-topic-2');
+            assert.equal(first.key, 'favourite_topic');
+            assert.equal(second.key, 'favourite_topic_2');
         });
 
         it('rejects a duplicate name, case-insensitively', async function () {
@@ -118,7 +126,7 @@ describe('Member Custom Fields Admin API', function () {
                 .expectStatus(422);
         });
 
-        it('rejects a name with no sluggable characters', async function () {
+        it('rejects a name with no usable characters', async function () {
             await agent
                 .post('members/custom_fields/')
                 .body({members_custom_fields: [{name: '!!!', type: 'short_text'}]})
@@ -129,14 +137,14 @@ describe('Member Custom Fields Admin API', function () {
         // one naming a member of Object.prototype reads back as inherited rather than
         // absent wherever it is indexed. Those keys are already taken, so the
         // publisher keeps the name and the key takes a suffix. The match is on the
-        // slug rather than the name, which is what catches every spelling that
+        // key rather than the name, which is what catches every spelling that
         // collapses onto it.
         const reservedSpellings = [
-            {name: 'Constructor', key: 'constructor-2'},
-            {name: 'constructor', key: 'constructor-2'},
-            {name: '__proto__', key: '__proto__-2'},
-            {name: '__PROTO__', key: '__proto__-2'},
-            {name: '＿＿ｐｒｏｔｏ＿＿', key: '__proto__-2'}
+            {name: 'Constructor', key: 'constructor_2'},
+            {name: 'constructor', key: 'constructor_2'},
+            {name: '__proto__', key: '__proto___2'},
+            {name: '__PROTO__', key: '__proto___2'},
+            {name: '＿＿ｐｒｏｔｏ＿＿', key: '__proto___2'}
         ];
         for (const {name, key} of reservedSpellings) {
             it(`mints ${key} for the name ${name}, and the value round-trips`, async function () {
@@ -156,14 +164,14 @@ describe('Member Custom Fields Admin API', function () {
             const first = await createField({name: 'Constructor'});
             const second = await createField({name: 'Constructor!'});
 
-            assert.equal(first.key, 'constructor-2');
-            assert.equal(second.key, 'constructor-3');
+            assert.equal(first.key, 'constructor_2');
+            assert.equal(second.key, 'constructor_3');
         });
 
         // The batch runs in one transaction, so mintKey sees the rows minted earlier
         // in the same request — reserving a key must hold within a batch too, not
         // just across separate requests.
-        it('mints distinct keys when two definitions in one batch both slug onto a reserved key', async function () {
+        it('mints distinct keys when two definitions in one batch both derive a reserved key', async function () {
             const {body} = await agent
                 .post('members/custom_fields/')
                 .body({members_custom_fields: [
@@ -174,19 +182,19 @@ describe('Member Custom Fields Admin API', function () {
 
             assert.deepEqual(
                 body.members_custom_fields.map((f: {key: string}) => f.key),
-                ['constructor-2', 'constructor-3']
+                ['constructor_2', 'constructor_3']
             );
         });
 
-        // A reserved slug must not take a whole prefix with it — only the exact key.
+        // A reserved key must not take a whole prefix with it, only the exact key.
         it('leaves a name that merely starts with a reserved word unsuffixed', async function () {
             const field = await createField({name: 'Constructor role'});
-            assert.equal(field.key, 'constructor-role');
+            assert.equal(field.key, 'constructor_role');
 
             const memberId = await createMember();
             await setValues(memberId, {[field.key]: 'Foreman'});
 
-            assert.deepEqual(await readValues(memberId), {'constructor-role': 'Foreman'});
+            assert.deepEqual(await readValues(memberId), {constructor_role: 'Foreman'});
         });
 
         it('rejects a name that exceeds the maximum length', async function () {
@@ -301,7 +309,7 @@ describe('Member Custom Fields Admin API', function () {
             await agent.get('members/custom_fields/?filter=' + encodeURIComponent('status:')).expectStatus(400);
         });
 
-        it('archives a field, keeping its name and slug reserved', async function () {
+        it('archives a field, keeping its name and key reserved', async function () {
             const first = await createField({name: 'Favourite topic'});
 
             const archived = await setStatus(first.key, 'archived');
@@ -318,10 +326,10 @@ describe('Member Custom Fields Admin API', function () {
                 .body({members_custom_fields: [{name: 'Favourite topic', type: 'short_text'}]})
                 .expectStatus(422);
 
-            // ...and so does its slug: a different name deriving the same slug is
+            // ...and so does its key: a different name deriving the same base is
             // suffixed rather than reusing (and resurrecting) the old key.
             const second = await createField({name: 'Favourite topic!'});
-            assert.equal(second.key, 'favourite-topic-2');
+            assert.equal(second.key, 'favourite_topic_2');
         });
 
         it('restores an archived field', async function () {
@@ -362,7 +370,7 @@ describe('Member Custom Fields Admin API', function () {
             assert.equal(list.length, 1);
         });
 
-        it('permanently deletes an archived field, freeing its name and slug', async function () {
+        it('permanently deletes an archived field, freeing its name and key', async function () {
             const original = await createField({name: 'Favourite topic'});
             await setStatus(original.key, 'archived');
 
@@ -373,10 +381,10 @@ describe('Member Custom Fields Admin API', function () {
             assert.deepEqual(list, []);
             await agent.get(`members/custom_fields/${original.key}/`).expectStatus(404);
 
-            // The row is gone, so the name and its base slug are free again: a
+            // The row is gone, so the name and its base key are free again: a
             // fresh field with the same name reclaims the original (unsuffixed) key.
             const fresh = await createField({name: 'Favourite topic'});
-            assert.equal(fresh.key, 'favourite-topic');
+            assert.equal(fresh.key, 'favourite_topic');
         });
     });
 
@@ -401,8 +409,8 @@ describe('Member Custom Fields Admin API', function () {
             assert.equal(list.members_custom_fields.length, 3);
         });
 
-        it('mints distinct keys when two definitions in the batch derive the same slug', async function () {
-            // Within a batch each insert is visible to the next, so slug collision
+        it('mints distinct keys when two definitions in the batch derive the same base', async function () {
+            // Within a batch each insert is visible to the next, so a collision
             // resolves exactly as it would across two separate requests.
             const {body} = await agent
                 .post('members/custom_fields/')
@@ -414,7 +422,7 @@ describe('Member Custom Fields Admin API', function () {
 
             assert.deepEqual(
                 body.members_custom_fields.map((field: {key: string}) => field.key),
-                ['favourite-topic', 'favourite-topic-2']
+                ['favourite_topic', 'favourite_topic_2']
             );
         });
 

--- a/ghost/core/test/unit/server/services/members-custom-fields/key.test.ts
+++ b/ghost/core/test/unit/server/services/members-custom-fields/key.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import {KEY_CHARACTERS, mintableKey} from '../../../../../core/server/services/members-custom-fields/key';
+
+describe('Custom field key minting', function () {
+    it('separates words with underscores', function () {
+        assert.equal(mintableKey('Shipping address'), 'shipping_address');
+    });
+
+    it('replaces a hyphen the publisher typed', function () {
+        assert.equal(mintableKey('T-Shirt size'), 't_shirt_size');
+    });
+
+    it('transliterates to ASCII', function () {
+        assert.equal(mintableKey('Ünïcødé Field'), 'unicode_field');
+        assert.equal(mintableKey('Привет мир'), 'privet_mir');
+    });
+
+    it('drops apostrophes rather than separating on them', function () {
+        assert.equal(mintableKey("Sam's Field"), 'sams_field');
+        assert.equal(mintableKey('Sam’s Field'), 'sams_field');
+    });
+
+    it('collapses runs and trims the ends', function () {
+        assert.equal(mintableKey('  lots   of   space  '), 'lots_of_space');
+        assert.equal(mintableKey('---leading---trailing---'), 'leading_trailing');
+        assert.equal(mintableKey('a__b'), 'a_b');
+    });
+
+    // Leading and trailing separators are trimmed, so the one prototype name that
+    // would otherwise survive minting cannot be spelled at all.
+    it('cannot mint __proto__ under any spelling', function () {
+        for (const spelling of ['__proto__', '__PROTO__', '＿＿ｐｒｏｔｏ＿＿']) {
+            assert.equal(mintableKey(spelling), 'proto');
+        }
+    });
+
+    it('returns empty for a name with nothing usable in it', function () {
+        assert.equal(mintableKey('!!!'), '');
+        assert.equal(mintableKey('🎉'), '');
+        assert.equal(mintableKey(''), '');
+    });
+
+    // The charset is the contract every consumer reads a key through: NQL will not
+    // parse a hyphen in a property path, an email replacement string matches word
+    // characters only, and a dot would be indistinguishable from the separator in a
+    // `custom_fields.<key>.<part>` CSV column. A transliteration library widening
+    // what it emits has to fail here rather than downstream.
+    it('mints only characters every consumer accepts', function () {
+        const names = [
+            'Shipping address', 'T-Shirt size', "Sam's Field", 'Ünïcødé Field',
+            '½ measure', 'Привет мир', '日本語のフィールド', 'emoji 🎉 field',
+            'café_naïve', '100% Sure', '£5 tier', 'A/B test',
+            'a@b:c/d?e#f[g]h!i$j&k(l)m*n+o,p;q=r', 'Ω omega', 'naïve—dash', 'x​y'
+        ];
+
+        for (const name of names) {
+            const key = mintableKey(name);
+            assert.match(key, KEY_CHARACTERS, `minted ${JSON.stringify(key)} from ${JSON.stringify(name)}`);
+        }
+    });
+});

--- a/ghost/core/test/unit/server/services/members-custom-fields/values-service.test.ts
+++ b/ghost/core/test/unit/server/services/members-custom-fields/values-service.test.ts
@@ -19,7 +19,7 @@ describe('CustomFieldValuesService', function () {
         });
 
         it('answers yes for a body that names a value', function () {
-            assert.equal(service().namesValues({'favourite-topic': 'Ghosts'}), true);
+            assert.equal(service().namesValues({favourite_topic: 'Ghosts'}), true);
         });
 
         it('rejects a body that is present but is not a values object', function () {

--- a/ghost/core/test/unit/server/services/members/members-api/services/members-bread-service.test.js
+++ b/ghost/core/test/unit/server/services/members/members-api/services/members-bread-service.test.js
@@ -97,7 +97,7 @@ describe('MemberBreadService', function () {
             const {service, createStub} = createService({}, customFieldValues);
 
             await assert.rejects(
-                () => service.add({email: 'test@example.com', custom_fields: {'favourite-topic': 'Ghosts'}}, {}),
+                () => service.add({email: 'test@example.com', custom_fields: {favourite_topic: 'Ghosts'}}, {}),
                 (error) => {
                     assert.equal(error.errorType, 'ValidationError');
                     assert.equal(error.property, 'custom_fields');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -384,6 +384,9 @@ catalogs:
     typescript-eslint:
       specifier: 8.62.1
       version: 8.62.1
+    unidecode:
+      specifier: 1.1.0
+      version: 1.1.0
     validator:
       specifier: 13.12.0
       version: 13.12.0
@@ -2591,6 +2594,9 @@ importers:
       ua-parser-js:
         specifier: 1.0.41
         version: 1.0.41
+      unidecode:
+        specifier: 'catalog:'
+        version: 1.1.0
       xml:
         specifier: 1.0.1
         version: 1.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -183,6 +183,7 @@ catalog:
   '@dnd-kit/sortable': 7.0.2
   '@dnd-kit/utilities': 3.2.2
   shell-quote: 1.10.0
+  unidecode: 1.1.0
 
 catalogs:
   react17:


### PR DESCRIPTION
## Problem

A custom field's key is derived from the name a publisher gives it, so "Shipping address" became a hyphenated key. That key is not an internal identifier. It is what a publisher types wherever they reference the field, and the surfaces where they can do that keep growing: member filters and saved segments, CSV import and export columns, replacement strings in email cards, and soon theme helpers and editor cards.

Each of those surfaces has its own rules about what an identifier may contain, and the hyphen is the character they disagree on. Filters cannot name a hyphenated field directly, which is why filtering one today takes a more roundabout form than it should. Email replacement strings recognise word characters only, so a hyphenated field is never treated as a replacement at all: it reaches the reader as literal text, with nothing to warn the publisher it was never substituted. Every surface we add pays this again, and works around it differently.

The convention already contradicts itself, too. The parts of a composite field are underscored, and a name typed with underscores keeps them, so a single export column can carry both conventions at once.

Underneath that sat a second problem. The key format was not defined anywhere. It was whatever the slug helper happened to produce, so the rule a growing number of surfaces depend on lived in a shared helper whose job is building URLs, and could change out from under them on a version bump.

## Solution

Keys are now minted with underscores, and the field domain owns what a key may contain rather than inheriting it. A slug and a key are different things: a slug is a URL segment that a publisher can edit and that answers to web conventions, while a key is an identifier nobody types by hand, referenced from filters, CSV columns and email templates, and it answers to whatever those grammars accept. They overlap heavily today and have already diverged once, which is what this change is fixing.

So the format is now stated as what a key may contain rather than as a list of characters to strip out, and it is stated where the surfaces that depend on it are known. The genuinely hard parts stay where they belong: names are still transliterated to ASCII and stripped of invisible characters by the libraries that own that work. Only the policy is local, and the character set is pinned by a test, so a transliteration library widening what it emits fails loudly here rather than producing a key that quietly breaks a filter or a CSV column much later.

Two things follow from it. A hyphen a publisher types into the name themselves now lands as an underscore, so there is no longer any way to end up with a key that a filter or a replacement string cannot address. And because a key can no longer begin or end with a separator, the one name that would previously have shadowed an inherited object property can no longer be spelled at all, which is a better guarantee than the reservation it used to need.

A key is minted once and never changes, so a field created before this would keep its hyphens for good. Rather than rewrite those keys, a migration discards the affected definitions along with the values stored against them. Custom fields sit behind a private flag and have never been released, so only a site that deliberately opted in can be holding one, and re-creating the field mints a fresh key. Definitions whose keys never contained a hyphen are left alone, since they already match what this release would mint.

Doing this now costs a key format nobody outside developer experiments has seen. After release it would cost a migration of live publisher data, plus every saved segment and template that had frozen the old key.
