### PR TITLE
Fixed the IndexNow development unit test

### DIFF
--- a/ghost/core/test/unit/server/services/indexnow-ping/indexnow-ping-service.test.js
+++ b/ghost/core/test/unit/server/services/indexnow-ping/indexnow-ping-service.test.js
@@ -270,7 +270,7 @@ describe('IndexNow', function () {
 
             await service.ping(testPost);
 
-            sinon.assert.notCalled(deps.urlService.facade.getUrlForResource);
+            sinon.assert.notCalled(deps.urlService.getUrlForResource);
         });
 
         it('with a post should execute ping', async function () {


### PR DESCRIPTION
## Summary

- Fixes the IndexNow development guard test on `main`.
- Updates the assertion to use the current direct URL-service dependency rather than the removed `facade` shape.
- Contains no runtime behavior changes.

## Context

The stale assertion was introduced when #29781 merged after #29792 changed the URL-service dependency shape. The `main` CI run for #29781 was cancelled by the following merge, so the interaction surfaced in [the next `main` run](https://github.com/TryGhost/Ghost/actions/runs/31405973089/job/93513219875).

## Testing

- [x] `pnpm test:single test/unit/server/services/indexnow-ping/indexnow-ping-service.test.js` — 28 passed
- [x] ESLint pre-commit check