### PR TITLE
Fixed test:types failures in kg-converters and adapter-base-scheduling

### DIFF
--- a/.changeset/tidy-types-check.md
+++ b/.changeset/tidy-types-check.md
@@ -1,0 +1,5 @@
+---
+"@tryghost/kg-converters": patch
+---
+
+Fixed the test suite type-check failing under TypeScript 7.

--- a/.changeset/typed-logging-args.md
+++ b/.changeset/typed-logging-args.md
@@ -1,0 +1,5 @@
+---
+"@tryghost/adapter-base-scheduling": patch
+---
+
+Fixed the test suite type-check against the typed @tryghost/logging error signature.

--- a/koenig/kg-converters/tsconfig.test.json
+++ b/koenig/kg-converters/tsconfig.test.json
@@ -2,6 +2,7 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "rootDir": ".",
+        "types": ["node"],
         "outDir": null,
         "noEmit": true,
         "declaration": false,

--- a/packages/adapters/scheduling-base/test/base.test.ts
+++ b/packages/adapters/scheduling-base/test/base.test.ts
@@ -90,13 +90,14 @@ describe('SchedulingBase', function () {
                 await base.rescheduleAll({});
 
                 assert.equal(errorStub.callCount, 2, 'only the failing reschedulers are logged');
-                const [meta, message] = errorStub.firstCall.args;
+                type FailureLogArgs = [{event: {name: string}; err: Error; rescheduler: string}, string];
+                const [meta, message] = errorStub.firstCall.args as FailureLogArgs;
                 assert.equal(meta.event.name, 'scheduler.reschedule_all.failed');
                 assert.equal(meta.rescheduler, 'PostScheduling');
                 assert.equal(meta.err.message, 'post failed');
                 assert.equal(message, 'Rescheduler failed');
 
-                const [meta2, message2] = errorStub.secondCall.args;
+                const [meta2, message2] = errorStub.secondCall.args as FailureLogArgs;
                 assert.equal(meta2.event.name, 'scheduler.reschedule_all.failed');
                 assert.equal(meta2.rescheduler, 'unknown');
                 assert.equal(meta2.err.message, 'anonymous failed');


### PR DESCRIPTION
## Summary

Two packages fail their `test:types` target on a fresh local `pnpm test` run. CI only runs the `test:unit` target for workspace packages, so these type-check failures never surfaced there — but every local full test run hits them.

### @tryghost/kg-converters

TypeScript 6/7 no longer auto-includes `node_modules/@types`, so the test tsconfig could not resolve the `assert/strict` import:

```
test/exports.test.ts(1,20): error TS2591: Cannot find name 'assert/strict'.
```

Fixed by adding an explicit `"types": ["node"]` to `tsconfig.test.json`, matching the shared config in `configs/typescript/esm.json` which already declares it.

### @tryghost/adapter-base-scheduling

`@tryghost/logging` 5.3.0 ships type definitions declaring `error(...args: unknown[])`, so the sinon stub's call args destructure to `unknown` and property access fails:

```
test/base.test.ts(94,30): error TS18046: 'meta' is of type 'unknown'.
```

Fixed by asserting the known log payload tuple shape in the test.

## Verification

- `pnpm run '/^test:/'` (test:types + test:unit) passes in both packages
- `lint` passes for both packages
- `scripts/change-check.js` passes with the included changesets