### PR TITLE
Fixed feedback api to omit member relation for less privileged staff

### DIFF
--- a/ghost/core/core/server/services/audience-feedback/audience-feedback-controller.js
+++ b/ghost/core/core/server/services/audience-feedback/audience-feedback-controller.js
@@ -1,5 +1,6 @@
 const Feedback = require('./feedback');
 const errors = require('@tryghost/errors');
+const permissions = require('../../services/permissions');
 const tpl = require('@tryghost/tpl');
 
 const messages = {
@@ -118,12 +119,20 @@ class AudienceFeedbackController {
         const postId = frame.data.id;
         const options = {
             limit: frame.options.limit || 10,
-            page: frame.options.page || 1
+            page: frame.options.page || 1,
+            withMember: false
         };
 
         // Add score filter if specified
         if (frame.options.score !== undefined) {
             options.score = parseInt(frame.options.score);
+        }
+
+        try {
+            await permissions.canThis(frame.options.context).browse.member();
+            options.withMember = true;
+        } catch {
+            // permissions throws; we want to return data but without member info
         }
 
         const result = await this.#repository.getForPost(postId, options);

--- a/ghost/core/core/server/services/audience-feedback/feedback-repository.js
+++ b/ghost/core/core/server/services/audience-feedback/feedback-repository.js
@@ -76,9 +76,12 @@ module.exports = class FeedbackRepository {
             limit: options.limit || 10,
             page: options.page || 1,
             order: 'created_at DESC',
-            withRelated: ['member'],
             filter: filter
         };
+
+        if (options.withMember) {
+            findOptions.withRelated = ['member'];
+        }
 
         // Use findPage with filter
         const results = await this.#MemberFeedback.findPage(findOptions);

--- a/ghost/core/test/unit/server/services/audience-feedback/audience-feedback-controller.test.js
+++ b/ghost/core/test/unit/server/services/audience-feedback/audience-feedback-controller.test.js
@@ -1,7 +1,12 @@
 const sinon = require('sinon');
+const permissions = require('../../../../../core/server/services/permissions');
 const AudienceFeedbackController = require('../../../../../core/server/services/audience-feedback/audience-feedback-controller');
 
 describe('AudienceFeedbackController', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
     describe('redirectToPost', function () {
         const postId = '634fc3901e0a291855d8b135';
         const uuid = '7b11de3c-dff9-4563-82ae-a281122d201d';
@@ -81,6 +86,68 @@ describe('AudienceFeedbackController', function () {
 
             sinon.assert.notCalled(res.redirect);
             sinon.assert.calledOnceWithExactly(next, error);
+        });
+    });
+
+    describe('browse', function () {
+        const postId = '634fc3901e0a291855d8b135';
+        const context = {user: 'user-id'};
+
+        function createController(getForPost) {
+            return new AudienceFeedbackController({
+                repository: {getForPost},
+                audienceFeedbackService: {}
+            });
+        }
+
+        it('includes member data when the user can browse members', async function () {
+            const browseMember = sinon.stub().resolves();
+            sinon.stub(permissions, 'canThis').withArgs(context).returns({
+                browse: {
+                    member: browseMember
+                }
+            });
+            const result = {data: [], meta: {}};
+            const getForPost = sinon.stub().resolves(result);
+            const controller = createController(getForPost);
+
+            const response = await controller.browse({
+                data: {id: postId},
+                options: {context}
+            });
+
+            sinon.assert.calledOnce(browseMember);
+            sinon.assert.calledOnceWithExactly(getForPost, postId, {
+                limit: 10,
+                page: 1,
+                withMember: true
+            });
+            sinon.assert.match(response, result);
+        });
+
+        it('excludes member data when the user cannot browse members', async function () {
+            const browseMember = sinon.stub().rejects();
+            sinon.stub(permissions, 'canThis').withArgs(context).returns({
+                browse: {
+                    member: browseMember
+                }
+            });
+            const result = {data: [], meta: {}};
+            const getForPost = sinon.stub().resolves(result);
+            const controller = createController(getForPost);
+
+            const response = await controller.browse({
+                data: {id: postId},
+                options: {context}
+            });
+
+            sinon.assert.calledOnce(browseMember);
+            sinon.assert.calledOnceWithExactly(getForPost, postId, {
+                limit: 10,
+                page: 1,
+                withMember: false
+            });
+            sinon.assert.match(response, result);
         });
     });
 });

--- a/ghost/core/test/unit/server/services/audience-feedback/feedback-repository.test.js
+++ b/ghost/core/test/unit/server/services/audience-feedback/feedback-repository.test.js
@@ -1,0 +1,44 @@
+const sinon = require('sinon');
+const FeedbackRepository = require('../../../../../core/server/services/audience-feedback/feedback-repository');
+
+describe('FeedbackRepository', function () {
+    const postId = '634fc3901e0a291855d8b135';
+
+    function createRepository(findPage) {
+        return new FeedbackRepository({
+            Member: {},
+            Post: {},
+            MemberFeedback: {findPage},
+            Feedback: class Feedback {}
+        });
+    }
+
+    it('loads the related member when requested', async function () {
+        const findPage = sinon.stub().resolves({data: [], meta: {}});
+        const repository = createRepository(findPage);
+
+        await repository.getForPost(postId, {withMember: true});
+
+        sinon.assert.calledOnceWithExactly(findPage, {
+            limit: 10,
+            page: 1,
+            order: 'created_at DESC',
+            filter: `post_id:'${postId}'`,
+            withRelated: ['member']
+        });
+    });
+
+    it('does not load the related member by default', async function () {
+        const findPage = sinon.stub().resolves({data: [], meta: {}});
+        const repository = createRepository(findPage);
+
+        await repository.getForPost(postId);
+
+        sinon.assert.calledOnceWithExactly(findPage, {
+            limit: 10,
+            page: 1,
+            order: 'created_at DESC',
+            filter: `post_id:'${postId}'`
+        });
+    });
+});


### PR DESCRIPTION
fixes https://linear.app/ghost/issue/SC-41/
- this limits which staff users can view member data in feedback.