### PR TITLE
Removed ability to cancel in-progress email analytics jobs

### DIFF
--- a/apps/ember-admin/app/components/posts/debug.hbs
+++ b/apps/ember-admin/app/components/posts/debug.hbs
@@ -401,13 +401,11 @@
                             <td>Last event time:</td>
                             <td>{{ this.analyticsStatus.scheduled.lastEventTimestamp }}</td>
                         </tr>
-                        {{#unless this.analyticsStatus.scheduled.canceled}}
-                            <tr>
-                                <td colspan="2">
-                                    <button type="button" class="gh-email-debug-schedule-analytics" {{on "click" this.cancelScheduleAnalytics }}>{{svg-jar "trash"}}Cancel scheduled refetch</button>
-                                </td>
-                            </tr>
-                        {{/unless}}
+                        <tr>
+                            <td colspan="2">
+                                <button type="button" class="gh-email-debug-schedule-analytics" {{on "click" this.cancelScheduleAnalytics }}>{{svg-jar "trash"}}Cancel scheduled refetch</button>
+                            </td>
+                        </tr>
                     {{else}}
                         {{#if this.showCustomSchedule}}
                             <tr>

--- a/ghost/core/core/server/services/email-analytics/email-analytics-service.ts
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-service.ts
@@ -16,8 +16,6 @@ export type FetchData = {
     /** The begin time used during the last fetch */
     lastBegin?: Date;
     lastEventTimestamp?: Date;
-    /** Set to quit the job early */
-    canceled?: boolean;
 };
 
 type FetchDataScheduled = FetchData & {schedule?: {begin: Date; end: Date}};
@@ -134,14 +132,6 @@ export class EmailAnalyticsService {
         };
     }
 
-    #clearScheduledData() {
-        this.#fetchScheduledData = {
-            running: false,
-            jobName: this.#jobNames.scheduled
-        };
-        this.queries.setJobMetadata(this.#jobNames.scheduled, null);
-    }
-
     getStatus() {
         return {
             latest: this.#fetchLatestNonOpenedData,
@@ -255,19 +245,18 @@ export class EmailAnalyticsService {
 
     /**
      * Cancels the scheduled fetch of email analytics events.
-     * If a fetch is currently running, it marks it for cancellation.
-     * If no fetch is running, it clears the scheduled fetch data.
+     * An in-progress fetch completes its current pass after its schedule is cleared.
      */
     cancelScheduled() {
-        if (this.#fetchScheduledData) {
-            if (this.#fetchScheduledData.running) {
-                this.#fetchScheduledData.canceled = true;
-                // Clear metadata eagerly; fetchScheduled() will clear in-memory state next cycle
-                this.queries.setJobMetadata(this.#jobNames.scheduled, null);
-            } else {
-                this.#clearScheduledData();
-            }
+        if (this.#fetchScheduledData.running) {
+            delete this.#fetchScheduledData.schedule;
+        } else {
+            this.#fetchScheduledData = {
+                running: false,
+                jobName: this.#jobNames.scheduled
+            };
         }
+        this.queries.setJobMetadata(this.#jobNames.scheduled, null);
     }
 
     /**
@@ -313,11 +302,6 @@ export class EmailAnalyticsService {
             return createEmptyResult();
         }
 
-        if (this.#fetchScheduledData.canceled) {
-            this.#clearScheduledData();
-            return createEmptyResult();
-        }
-
         let begin = this.#fetchScheduledData.schedule.begin;
         const end = this.#fetchScheduledData.schedule.end;
 
@@ -328,16 +312,17 @@ export class EmailAnalyticsService {
 
         if (end <= begin) {
             logging.info('[EmailAnalytics] Ending fetchScheduled because end is before begin');
-            this.#clearScheduledData();
+            this.cancelScheduled();
             return createEmptyResult();
         }
 
-        const fetchResult = await this.#fetchEventsForJob(this.#fetchScheduledData, {begin, end, maxEvents});
-        if (fetchResult.eventCount === 0 || this.#fetchScheduledData.canceled) {
-            this.#clearScheduledData();
+        const fetchData = this.#fetchScheduledData;
+        const fetchResult = await this.#fetchEventsForJob(fetchData, {begin, end, maxEvents});
+        if (fetchResult.eventCount === 0 && this.#fetchScheduledData === fetchData) {
+            this.cancelScheduled();
         }
 
-        this.queries.setJobTimestamp(this.#fetchScheduledData.jobName, 'finished', this.#fetchScheduledData.lastEventTimestamp!);
+        this.queries.setJobTimestamp(fetchData.jobName, 'finished', fetchData.lastEventTimestamp!);
         return fetchResult;
     }
     /**
@@ -435,24 +420,14 @@ export class EmailAnalyticsService {
                 logging.error('[EmailAnalytics] Error while aggregating stats');
                 logging.error(err);
             }
-
-            if (fetchData.canceled) {
-                throw new errors.InternalServerError({
-                    message: 'Fetching canceled'
-                });
-            }
         };
 
         try {
             await this.#fetchEvents({batchHandler: processBatch, begin, end, maxEvents, events: eventTypes});
         } catch (err) {
-            if (!(err instanceof Error) || err.message !== 'Fetching canceled') {
-                logging.error('[EmailAnalytics] Error while fetching');
-                logging.error(err);
-                error = err;
-            } else {
-                logging.error('[EmailAnalytics] Canceled fetching');
-            }
+            logging.error('[EmailAnalytics] Error while fetching');
+            logging.error(err);
+            error = err;
         }
 
         // Final aggregation.

--- a/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.ts
@@ -374,7 +374,7 @@ describe('EmailAnalyticsService', function () {
                 sinon.assert.notCalled(eventProcessor.aggregate);
             });
 
-            it('returns 0 when fetch is canceled', async function () {
+            it('returns 0 when scheduled fetch is canceled before it starts', async function () {
                 await service.schedule({
                     begin: new Date(2023, 0, 1),
                     end: new Date(2023, 0, 2)
@@ -398,6 +398,65 @@ describe('EmailAnalyticsService', function () {
                 sinon.assert.calledOnce(setJobStatusStub);
                 sinon.assert.calledOnce(eventProcessor.processBatch);
                 assert.deepEqual(eventProcessor.processBatch.getCall(0).args[0], [1,2,3,4,5,6,7,8,9,10]);
+            });
+
+            it('finishes an in-progress fetch when its schedule is canceled', async function () {
+                let startFetch = () => {};
+                const fetchStarted = new Promise<void>((resolve) => {
+                    startFetch = resolve;
+                });
+                let continueFetch = () => {};
+                const fetchCanContinue = new Promise<void>((resolve) => {
+                    continueFetch = resolve;
+                });
+
+                service = createService({
+                    queries: {
+                        setJobTimestamp: setJobTimestampStub,
+                        setJobStatus: setJobStatusStub,
+                        setJobMetadata: setJobMetadataStub
+                    },
+                    fetchEvents: async ({batchHandler}) => {
+                        startFetch();
+                        await fetchCanContinue;
+                        await batchHandler([1,2,3,4,5,6,7,8,9,10]);
+                    },
+                    createEventProcessor: () => eventProcessor
+                });
+                await service.schedule({
+                    begin: new Date(2023, 0, 1),
+                    end: new Date(2023, 0, 2)
+                });
+                setJobMetadataStub.resetHistory();
+
+                const fetch = service.fetchScheduled({maxEvents: 100});
+                await fetchStarted;
+                service.cancelScheduled();
+
+                sinon.assert.calledOnceWithExactly(setJobMetadataStub, 'email-analytics-scheduled', null);
+                assert.equal(service.getStatus().scheduled.running, true);
+                assert.equal(service.getStatus().scheduled.schedule, undefined);
+                await assert.rejects(service.schedule({
+                    begin: new Date(2023, 0, 3),
+                    end: new Date(2023, 0, 4)
+                }), /Already fetching scheduled events/);
+
+                continueFetch();
+                const result = await fetch;
+
+                assert.equal(result.eventCount, 10);
+                sinon.assert.calledOnce(eventProcessor.processBatch);
+                assert.equal(service.getStatus().scheduled.running, false);
+                assert.equal(service.getStatus().scheduled.schedule, undefined);
+
+                await service.schedule({
+                    begin: new Date(2023, 0, 3),
+                    end: new Date(2023, 0, 4)
+                });
+                assert.deepEqual(service.getStatus().scheduled.schedule, {
+                    begin: new Date(2023, 0, 3),
+                    end: new Date(2023, 0, 4)
+                });
             });
 
             it('bails when end date is before begin date', async function () {


### PR DESCRIPTION
towards https://linear.app/ghost/issue/NY-1473

*I recommend [reviewing this with whitespace changes disabled](https://github.com/TryGhost/Ghost/pull/29869/changes?w=1).*

Scheduled email analytics jobs can be canceled from a hidden debug screen. Not only does this cancel future jobs, it also stops processing existing jobs.

This has two disadvantages:

- It makes the code more complex.
- It relies on in-memory data, which we want to remove for statelessness purposes.

Given that this can only be canceled from a debug view, let's remove this small but troublesome feature.

I think this is a useful change on its own, but it'll make [an upcoming change][0] easier.

[0]: https://linear.app/ghost/issue/NY-1473