### PR TITLE
Fixed flaky tag detail acceptance test

### DIFF
--- a/apps/admin/src/tags/detail/tag-detail.acceptance.test.tsx
+++ b/apps/admin/src/tags/detail/tag-detail.acceptance.test.tsx
@@ -133,6 +133,7 @@ describe('Tag detail (tagDetailsReact on)', () => {
 
         await expect.element(page.getByTestId('tag-detail-title')).toHaveTextContent('New tag');
         const nameInput = page.getByLabelText('Name', {exact: true});
+        await expect.element(nameInput).toBeVisible();
         await userEvent.type(nameInput.element(), 'Weekly News');
         await expect.element(page.getByLabelText('Slug', {exact: true})).toHaveValue('weekly-news');
 


### PR DESCRIPTION
## What changed

- Wait for the tag name input to be visible before passing its element to `userEvent.type`.

## Why

The `/tags/new` title renders before the form is ready because the form also waits for asynchronous site data. The test used the title as its readiness signal and then synchronously dereferenced the name input, which could fail when the form had not mounted yet.

This only affects test reliability; there is no user-facing behavior change.

Original failure: https://github.com/TryGhost/Ghost/actions/runs/31425087803/job/93575289305

## Validation

- `pnpm --dir apps/admin exec vitest run -c vitest.acceptance.config.ts src/tags/detail/tag-detail.acceptance.test.tsx` — 23 passed
- `pnpm --dir apps/admin exec eslint src/tags/detail/tag-detail.acceptance.test.tsx`