### PR TITLE
Fixed docker build to upload core image as artifact in forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -534,7 +534,8 @@ jobs:
     name: Performance tests (production image)
     runs-on: blacksmith-2vcpu-ubuntu-2404
     needs: [job_setup, job_docker]
-    # Registry path only: the core image is pushed to GHCR, never saved as an artifact.
+    # Registry path only: benchmarks are a canonical-repo series, so this pulls the
+    # core image from GHCR rather than loading the artifact-path tarball.
     if: |
       needs.job_docker.result == 'success' &&
       needs.job_docker.outputs.use-artifact == 'false' &&
@@ -1398,6 +1399,29 @@ jobs:
           labels: ${{ steps.meta-core.outputs.labels }}
           cache-from: type=registry,ref=${{ steps.strategy.outputs.image-core-name }}:cache-main
           cache-to: ${{ steps.strategy.outputs.should-push == 'true' && format('type=registry,ref={0}:cache-{1},mode=max', steps.strategy.outputs.image-core-name, github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'main') || '' }}
+
+      # Uploaded here, before the full image is even built: on the artifact path
+      # consumers (Ghost-Moya CD) need the core image — server only, no admin —
+      # and would otherwise have to fall back to `docker-image-production`.
+      - name: Save core image as artifact
+        if: steps.strategy.outputs.use-artifact == 'true'
+        run: |
+          IMAGE_TAG=$(echo "${{ steps.meta-core.outputs.tags }}" | head -n1)
+          echo "Saving image: $IMAGE_TAG"
+          # Written outside the repo root: a stray tarball there would change the
+          # `.` context between the core and full builds and bust the deploy-stage
+          # COPY cache (same reason the admin artifact lands in RUNNER_TEMP below).
+          docker save "$IMAGE_TAG" | gzip > "${RUNNER_TEMP}/docker-image-core.tar.gz"
+          ls -lh "${RUNNER_TEMP}/docker-image-core.tar.gz"
+
+      - name: Upload core image artifact
+        if: steps.strategy.outputs.use-artifact == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: docker-image-core
+          path: ${{ runner.temp }}/docker-image-core.tar.gz
+          retention-days: 1
+          if-no-files-found: error
 
       # Synchronise with job_build_admin only now, after core is built: the full
       # image is core + admin. No `needs` edge, so the two jobs run concurrently


### PR DESCRIPTION
no ref
- makes the core build consistent with admin/e2e builds