### PR TITLE
Fixed flaky tag code injection acceptance test

### DIFF
--- a/apps/admin/src/tags/detail/tag-detail.acceptance.test.tsx
+++ b/apps/admin/src/tags/detail/tag-detail.acceptance.test.tsx
@@ -55,15 +55,19 @@ describe('Tag detail (tagDetailsReact on)', () => {
         const updatedHead = '<script>updatedHead();</script>';
         const updatedFoot = '<style>.footer { display: grid; }</style>';
 
-        // Let CodeMirror commit the clear before inserting replacement text.
-        // A single fill can race its async mutation observer and append the
-        // original document after the replacement.
-        await headerEditor.clear();
+        // Playwright manipulates contenteditable DOM directly when clearing,
+        // which can race CodeMirror's document reconciliation. Clear through
+        // CodeMirror's keyboard handling before filling the empty editor.
+        await headerEditor.click();
+        await userEvent.keyboard('{ControlOrMeta>}a{/ControlOrMeta}');
+        await userEvent.keyboard('{Backspace}');
         await expect.poll(() => headerEditor.element().textContent).toBe('');
         await headerEditor.fill(updatedHead);
         await expect.poll(() => (headerEditor.element() as HTMLElement).innerText).toBe(updatedHead);
 
-        await footerEditor.clear();
+        await footerEditor.click();
+        await userEvent.keyboard('{ControlOrMeta>}a{/ControlOrMeta}');
+        await userEvent.keyboard('{Backspace}');
         await expect.poll(() => footerEditor.element().textContent).toBe('');
         await footerEditor.fill(updatedFoot);
         await expect.poll(() => (footerEditor.element() as HTMLElement).innerText).toBe(updatedFoot);

--- a/apps/admin/src/tags/detail/tag-detail.acceptance.test.tsx
+++ b/apps/admin/src/tags/detail/tag-detail.acceptance.test.tsx
@@ -52,14 +52,27 @@ describe('Tag detail (tagDetailsReact on)', () => {
         await expect.poll(() => (headerEditor.element() as HTMLElement).innerText).toBe(head);
         await expect.poll(() => (footerEditor.element() as HTMLElement).innerText).toBe(foot);
 
-        await headerEditor.fill('<script>updatedHead();</script>');
-        await footerEditor.fill('<style>.footer { display: grid; }</style>');
+        const updatedHead = '<script>updatedHead();</script>';
+        const updatedFoot = '<style>.footer { display: grid; }</style>';
+
+        // Let CodeMirror commit the clear before inserting replacement text.
+        // A single fill can race its async mutation observer and append the
+        // original document after the replacement.
+        await headerEditor.clear();
+        await expect.poll(() => headerEditor.element().textContent).toBe('');
+        await headerEditor.fill(updatedHead);
+        await expect.poll(() => (headerEditor.element() as HTMLElement).innerText).toBe(updatedHead);
+
+        await footerEditor.clear();
+        await expect.poll(() => footerEditor.element().textContent).toBe('');
+        await footerEditor.fill(updatedFoot);
+        await expect.poll(() => (footerEditor.element() as HTMLElement).innerText).toBe(updatedFoot);
         await page.getByRole('button', {name: 'Save'}).click();
 
         await expect.element(page.getByRole('button', {name: 'Saved'})).toBeVisible();
         const saved = (saveApi.lastRequest?.body as {tags: Array<Record<string, unknown>>}).tags[0];
-        expect(saved.codeinjection_head).toBe('<script>updatedHead();</script>');
-        expect(saved.codeinjection_foot).toBe('<style>.footer { display: grid; }</style>');
+        expect(saved.codeinjection_head).toBe(updatedHead);
+        expect(saved.codeinjection_foot).toBe(updatedFoot);
     });
 
     it('keeps CodeMirror autocomplete outside the clipped editor surface', async () => {


### PR DESCRIPTION
## What changed

- Clear populated CodeMirror fields through their own `ControlOrMeta+A` and Backspace key handling.
- Wait for the empty document before filling each replacement, then verify the rendered value before saving.
- Reuse the expected replacement values in the exact request-body assertions.

## Why

The Admin acceptance job in [CI run 31439933242](https://github.com/TryGhost/Ghost/actions/runs/31439933242/job/93622571053) intermittently saved the new header followed by its original content. Playwright's `fill()` and `clear()` manipulate a contenteditable DOM selection outside CodeMirror's state; CodeMirror can reconcile that DOM between the selection and insertion/deletion steps, leaving stale content in place.

The test now lets CodeMirror process select-all and deletion as editor-state transactions, then uses `fill()` only after the document is observably empty. This is a test synchronization fix; product behavior is unchanged.

## Verification

- The superseded `clear()` approach failed on repetition 6 of a focused stress loop.
- Revised keyboard path: 20/20 consecutive focused runs passed (25 tests each).
- `CI=true pnpm nx run @tryghost/admin:test:acceptance --skip-nx-cache` — 57 files, 435/435 tests passed.
- `pnpm nx run @tryghost/admin:lint --skip-nx-cache` passed.
- Three independent review agents completed reliability, adversarial, and conventions reviews; no actionable findings remain.