### PR TITLE
Removed the llms.txt labs flag

### DIFF
--- a/apps/admin/src/settings/app/components/settings/general/seo-meta.tsx
+++ b/apps/admin/src/settings/app/components/settings/general/seo-meta.tsx
@@ -1,6 +1,5 @@
 import React, {useState} from 'react';
 import TopLevelGroup from '@/settings/app/components/top-level-group';
-import useFeatureFlag from '@/settings/app/hooks/use-feature-flag';
 import usePinturaEditor from '@/settings/app/hooks/use-pintura-editor';
 import useSettingGroup from '@/settings/app/hooks/use-setting-group';
 import {APIError} from '@tryghost/admin-x-framework/errors';
@@ -82,7 +81,6 @@ const SEOMeta: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const handleError = useHandleError();
     const {mutateAsync: uploadImage} = useUploadImage();
     const editor = usePinturaEditor();
-    const hasLlmsTxt = useFeatureFlag('llmsTxt');
 
     // Get all settings needed for all tabs
     const [
@@ -171,12 +169,10 @@ const SEOMeta: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const metadataTabContent = (
         <>
             <SettingGroupContent className="my-6 gap-3">
-                {hasLlmsTxt && (
-                    <Field orientation='horizontal'>
-                        <FieldLabel htmlFor='llms-enabled'>Enable structured data for LLMs and AI search engines</FieldLabel>
-                        <Switch checked={llmsEnabled} id='llms-enabled' onCheckedChange={handleLlmsToggleChange} />
-                    </Field>
-                )}
+                <Field orientation='horizontal'>
+                    <FieldLabel htmlFor='llms-enabled'>Enable structured data for LLMs and AI search engines</FieldLabel>
+                    <Switch checked={llmsEnabled} id='llms-enabled' onCheckedChange={handleLlmsToggleChange} />
+                </Field>
                 <Field><FieldLabel htmlFor='meta-title'>Meta title</FieldLabel><Input ref={focusRef} id='meta-title' maxLength={300} placeholder={siteTitle} value={metaTitle} onChange={handleMetaTitleChange} /><FieldDescription>Recommended: 70 characters</FieldDescription></Field>
                 <Field><FieldLabel htmlFor='meta-description'>Meta description</FieldLabel><Input id='meta-description' maxLength={500} placeholder={siteDescription} value={metaDescription} onChange={handleMetaDescriptionChange} /><FieldDescription>Recommended: 156 characters</FieldDescription></Field>
             </SettingGroupContent>

--- a/apps/admin/src/settings/general/seo-meta.acceptance.test.tsx
+++ b/apps/admin/src/settings/general/seo-meta.acceptance.test.tsx
@@ -12,12 +12,10 @@ function fakeImageUpload(url: string): void {
 }
 
 describe("SEO meta settings", () => {
-    it("toggles LLM structured data when the feature flag is on", async () => {
+    it("toggles LLM structured data", async () => {
         fakeSettingsScreens();
         const settingsApi = fakeEditSettings();
-        await renderAdminApp("/settings", {
-            labs: { llmsTxt: true },
-        });
+        await renderAdminApp("/settings");
 
         const section = settingsScreen.seoMeta();
         const toggle = section.getByLabelText("Enable structured data for LLMs and AI search engines");
@@ -33,8 +31,7 @@ describe("SEO meta settings", () => {
         fakeSettingsScreens();
         const settingsApi = fakeEditSettings();
         await renderAdminApp("/settings", {
-            labs: { llmsTxt: true },
-            boot: { browseSettings: { response: settingsResponse({ labs: { llmsTxt: true }, settings: { llms_enabled: false } }) } },
+            boot: { browseSettings: { response: settingsResponse({ settings: { llms_enabled: false } }) } },
         });
 
         const section = settingsScreen.seoMeta();
@@ -44,15 +41,6 @@ describe("SEO meta settings", () => {
         await section.getByRole("button", { name: "Save" }).click();
 
         await expect(settingsApi).toHaveEditedSettings([{ key: "llms_enabled", value: true }]);
-    });
-
-    it("hides LLM structured data when the feature flag is off", async () => {
-        fakeSettingsScreens();
-        await renderAdminApp("/settings");
-
-        const section = settingsScreen.seoMeta();
-        await expect.element(section.getByLabelText("Meta title")).toBeVisible();
-        await expect(section.getByLabelText("Enable structured data for LLMs and AI search engines")).toHaveCount(0);
     });
 
     it("edits search metadata", async () => {

--- a/ghost/core/core/frontend/services/llms/service.js
+++ b/ghost/core/core/frontend/services/llms/service.js
@@ -25,7 +25,7 @@ const LLMS_FULL_TXT_RECENT_POSTS_FOOTER = '\n_Includes the latest 500 public pos
 const LLMS_TXT_FIELDS = 'id,title,slug,custom_excerpt,featured,published_at,url';
 const LLMS_FULL_TXT_FIELDS = 'id,title,slug,featured,published_at,updated_at,created_at,url,visibility,custom_excerpt';
 
-function createLlmsService({settingsCache, labs, config, urlUtils, routing, api, fullTxtBudget}) {
+function createLlmsService({settingsCache, config, urlUtils, routing, api, fullTxtBudget}) {
     const footerBudget = Math.max(
         Buffer.byteLength(LLMS_FULL_TXT_TRUNCATION_FOOTER, 'utf8'),
         Buffer.byteLength(LLMS_FULL_TXT_RECENT_POSTS_FOOTER, 'utf8')
@@ -33,7 +33,7 @@ function createLlmsService({settingsCache, labs, config, urlUtils, routing, api,
     const BUDGET = (fullTxtBudget || LLMS_FULL_TXT_BUDGET) - footerBudget;
 
     function isEnabled() {
-        return labs.isSet('llmsTxt') && !settingsCache.get('is_private') && settingsCache.get('llms_enabled') !== false;
+        return !settingsCache.get('is_private') && settingsCache.get('llms_enabled') !== false;
     }
 
     async function fetchPublicEntry(resourceType, id, member = null) {

--- a/ghost/core/core/frontend/web/middleware/llms-discovery.js
+++ b/ghost/core/core/frontend/web/middleware/llms-discovery.js
@@ -15,9 +15,9 @@ function appendHeaderValue(existingValue, newValue) {
     return raw.concat(newValue).join(', ');
 }
 
-function createLlmsDiscovery({settingsCache, labs}) {
+function createLlmsDiscovery({settingsCache}) {
     function isDiscoveryEnabled() {
-        return labs.isSet('llmsTxt') && !settingsCache.get('is_private') && settingsCache.get('llms_enabled') !== false;
+        return !settingsCache.get('is_private') && settingsCache.get('llms_enabled') !== false;
     }
 
     return function llmsDiscovery(req, res, next) {

--- a/ghost/core/core/frontend/web/site.js
+++ b/ghost/core/core/frontend/web/site.js
@@ -69,7 +69,6 @@ module.exports = function setupSiteApp(routerConfig) {
     servePublicFiles(siteApp);
 
     const settingsCache = require('../../shared/settings-cache');
-    const labs = require('../../shared/labs');
     const routing = require('../services/routing');
     const {api} = require('../services/proxy');
     const {createLlmsService} = require('../services/llms/service');
@@ -78,7 +77,6 @@ module.exports = function setupSiteApp(routerConfig) {
 
     const llmsService = createLlmsService({
         settingsCache,
-        labs,
         config,
         urlUtils,
         routing,
@@ -93,7 +91,7 @@ module.exports = function setupSiteApp(routerConfig) {
         settingsCache
     });
 
-    siteApp.use(createLlmsDiscovery({settingsCache, labs}));
+    siteApp.use(createLlmsDiscovery({settingsCache}));
 
     // Serve site images using the storage adapter
     siteApp.use(STATIC_IMAGE_URL_PREFIX, mw.handleImageSizes, adapterManager.getAdapter('storage:images').serve());

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -33,8 +33,7 @@ const GA_FEATURES = [
     'commentsThreads',
     'commentsPinning',
     'featurebaseFeedback',
-    'dangerZoneResetAuth',
-    'llmsTxt'
+    'dangerZoneResetAuth'
 ];
 
 // These features are considered publicly available and can be enabled/disabled by users

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -32,7 +32,6 @@ Object {
       "giftSubCustomization": true,
       "importMemberTier": true,
       "lexicalIndicators": true,
-      "llmsTxt": true,
       "memberDetailsReact": true,
       "members": true,
       "membersCustomFields": true,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -2253,7 +2253,7 @@ exports[`Settings API Edit can edit Stripe settings when Stripe Connect limit is
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "5477",
+  "content-length": "5460",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/e2e-frontend/gift-links.test.ts
+++ b/ghost/core/test/e2e-frontend/gift-links.test.ts
@@ -41,9 +41,7 @@ describe('Front-end gift links', function () {
         const originalSettingsCacheGetFn = settingsCache.get;
         sinon.stub(settingsCache, 'get').callsFake(function (key: any, options: any) {
             if (key === 'labs') {
-                // llmsTxt enables the markdown variants (`.md` URLs and Accept
-                // negotiation) so the suite can pin their gift-link behaviour.
-                return {members: true, llmsTxt: true};
+                return {members: true};
             }
             if (key === 'active_theme') {
                 return 'members-test-theme';

--- a/ghost/core/test/e2e-frontend/llms-routes.test.js
+++ b/ghost/core/test/e2e-frontend/llms-routes.test.js
@@ -4,11 +4,9 @@
 // instance so the request runs through the real controllers and serializers,
 // covering the fields/formats/url interaction the unit tests mock away.
 const assert = require('node:assert/strict');
-const sinon = require('sinon');
 const supertest = require('supertest');
 const testUtils = require('../utils');
 const configUtils = require('../utils/config-utils');
-const settingsCache = require('../../core/shared/settings-cache');
 
 describe('llms.txt routing', function () {
     let request;
@@ -18,21 +16,6 @@ describe('llms.txt routing', function () {
         await testUtils.startGhost();
         siteUrl = configUtils.config.get('url').replace(/\/$/, '');
         request = supertest.agent(configUtils.config.get('url'));
-    });
-
-    beforeEach(function () {
-        const originalGet = settingsCache.get;
-        sinon.stub(settingsCache, 'get').callsFake(function (key, options) {
-            if (key === 'labs') {
-                return {llmsTxt: true};
-            }
-
-            return originalGet(key, options);
-        });
-    });
-
-    afterEach(function () {
-        sinon.restore();
     });
 
     it('serves llms.txt with published public entries and absolute urls', async function () {

--- a/ghost/core/test/unit/frontend/services/llms/service.test.js
+++ b/ghost/core/test/unit/frontend/services/llms/service.test.js
@@ -89,14 +89,6 @@ describe('Unit: frontend/services/llms/service', function () {
         };
     }
 
-    function createFakeLabs(flags = {llmsTxt: true}) {
-        return {
-            isSet(flag) {
-                return !!flags[flag];
-            }
-        };
-    }
-
     function createService(opts = {}) {
         const pages = opts.pages || [];
         const posts = opts.posts || [];
@@ -104,7 +96,6 @@ describe('Unit: frontend/services/llms/service', function () {
 
         return createLlmsService({
             settingsCache: opts.settingsCache || createFakeSettingsCache(opts.settingsOverrides),
-            labs: opts.labs || createFakeLabs(opts.labsFlags),
             config: opts.config || createFakeConfig(),
             urlUtils: opts.urlUtils || createFakeUrlUtils(),
             routing: opts.routing || createFakeRouting(),
@@ -141,18 +132,6 @@ describe('Unit: frontend/services/llms/service', function () {
         assert.match(llmsTxt, /\[Recent Post\]\(https:\/\/example\.com\/2026\/04\/recent-post\.md\) - A{299}…/);
         assert.match(llmsTxt, /## Optional[\s\S]*\[RSS Feed\]\(https:\/\/example\.com\/rss\/\)/m);
         assert.match(llmsTxt, /\[Sitemap\]\(http:\/\/127\.0\.0\.1:\d+\/sitemap\.xml\)/);
-    });
-
-    it('returns null when labs flag is off', async function () {
-        const service = createService({
-            labsFlags: {llmsTxt: false},
-            pages: [],
-            posts: [],
-            urlMap: {}
-        });
-
-        const result = await service.getLlmsTxt();
-        assert.equal(result, null);
     });
 
     it('returns null when site is private', async function () {


### PR DESCRIPTION
## Description

Removes the permanently enabled `llmsTxt` labs flag now that llms.txt support is generally available.

- serves llms.txt and its discovery headers without a Labs dependency
- always shows the existing Admin setting
- retains the `llms_enabled` opt-out and private-site checks
- removes obsolete flag-specific test setup and updates API snapshots

## Testing

- `pnpm test:single test/unit/frontend/services/llms/service.test.js`
- `pnpm test:single test/e2e-frontend/llms-routes.test.js`
- `pnpm test:single test/e2e-frontend/gift-links.test.ts`
- `UPDATE_SNAPSHOT=1 pnpm test:single test/e2e-api/admin/config.test.js`
- `UPDATE_SNAPSHOT=1 pnpm test:single test/e2e-api/admin/settings.test.js`
- `pnpm test:acceptance src/settings/general/seo-meta.acceptance.test.tsx`
- focused ESLint checks for changed Admin and core files
- `pnpm nx run ghost:build:tsc`