### PR TITLE
Removed the Explore labs flag

### DIFF
--- a/apps/admin/src/settings/app/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/labs/private-features.tsx
@@ -40,10 +40,6 @@ const features: Feature[] = [{
     description: 'Enable Admin UI refresh (exploration)',
     flag: 'adminUIRefresh'
 }, {
-    title: 'Explore',
-    description: 'Enables keeping in touch with the new Explore API',
-    flag: 'explore'
-}, {
     title: 'Tags X',
     description: 'Enables the new Tags UI',
     flag: 'tagsX'

--- a/ghost/core/core/server/services/explore-ping/explore-ping-service.ts
+++ b/ghost/core/core/server/services/explore-ping/explore-ping-service.ts
@@ -6,10 +6,6 @@ type Config = {
     get(key: string): unknown;
 };
 
-type Labs = {
-    isSet(flag: string): boolean;
-};
-
 type Logging = {
     info(...args: unknown[]): void;
     warn(...args: unknown[]): void;
@@ -65,7 +61,6 @@ type ExplorePayload = {
 export type ExplorePingServiceDeps = {
     settingsCache: SettingsCache;
     config: Config;
-    labs: Labs;
     logging: Logging;
     ghostVersion: GhostVersion;
     request: RequestFn;
@@ -77,7 +72,6 @@ export type ExplorePingServiceDeps = {
 export class ExplorePingService {
     settingsCache: SettingsCache;
     config: Config;
-    labs: Labs;
     logging: Logging;
     ghostVersion: GhostVersion;
     request: RequestFn;
@@ -85,10 +79,9 @@ export class ExplorePingService {
     members: MembersService;
     statsService: StatsService;
 
-    constructor({settingsCache, config, labs, logging, ghostVersion, request, posts, members, statsService}: ExplorePingServiceDeps) {
+    constructor({settingsCache, config, logging, ghostVersion, request, posts, members, statsService}: ExplorePingServiceDeps) {
         this.settingsCache = settingsCache;
         this.config = config;
-        this.labs = labs;
         this.logging = logging;
         this.ghostVersion = ghostVersion;
         this.request = request;
@@ -177,10 +170,6 @@ export class ExplorePingService {
     }
 
     async ping(): Promise<void> {
-        if (!this.labs.isSet('explore')) {
-            return;
-        }
-
         const exploreUrl = this.config.get('explore:update_url') as string | undefined;
         if (!exploreUrl) {
             this.logging.warn('Explore URL not set');

--- a/ghost/core/core/server/services/explore-ping/index.ts
+++ b/ghost/core/core/server/services/explore-ping/index.ts
@@ -1,7 +1,6 @@
 import {ExplorePingService} from './explore-ping-service';
 
 const config = require('../../../shared/config');
-const labs = require('../../../shared/labs');
 const logging = require('@tryghost/logging');
 const ghostVersion = require('@tryghost/version');
 const request = require('@tryghost/request');
@@ -15,7 +14,6 @@ export function createService(): ExplorePingService {
     return new ExplorePingService({
         settingsCache,
         config,
-        labs,
         logging,
         ghostVersion,
         request,

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -29,7 +29,6 @@ const messages = {
 const GA_FEATURES = [
     'automationAnalytics',
     'customFonts',
-    'explore',
     'commentsThreads',
     'commentsPinning',
     'featurebaseFeedback',

--- a/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/config.test.js.snap
@@ -26,7 +26,6 @@ Object {
       "editorExcerpt": true,
       "emailCustomization": true,
       "emailUniqueid": true,
-      "explore": true,
       "featurebaseFeedback": true,
       "getHelperDeduplication": true,
       "giftSubCustomization": true,

--- a/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
+++ b/ghost/core/test/e2e-api/admin/__snapshots__/settings.test.js.snap
@@ -2253,7 +2253,7 @@ exports[`Settings API Edit can edit Stripe settings when Stripe Connect limit is
 Object {
   "access-control-allow-origin": "http://127.0.0.1:2369",
   "cache-control": "no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0",
-  "content-length": "5477",
+  "content-length": "5460",
   "content-type": "application/json; charset=utf-8",
   "content-version": StringMatching /v\\\\d\\+\\\\\\.\\\\d\\+/,
   "etag": StringMatching /\\(\\?:W\\\\/\\)\\?"\\(\\?:\\[ !#-\\\\x7E\\\\x80-\\\\xFF\\]\\*\\|\\\\r\\\\n\\[\\\\t \\]\\|\\\\\\\\\\.\\)\\*"/,

--- a/ghost/core/test/unit/server/services/explore-ping/explore-ping-service.test.js
+++ b/ghost/core/test/unit/server/services/explore-ping/explore-ping-service.test.js
@@ -6,7 +6,6 @@ describe('ExplorePingService', function () {
     let explorePingService;
     let settingsCacheStub;
     let configStub;
-    let labsStub;
     let loggingStub;
     let ghostVersionStub;
     let requestStub;
@@ -34,10 +33,6 @@ describe('ExplorePingService', function () {
 
         configStub.get.withArgs('url').returns('https://example.com');
         configStub.get.withArgs('explore:update_url').returns('https://explore.testing.com');
-
-        labsStub = {
-            isSet: sinon.stub().returns(true)
-        };
 
         loggingStub = {
             info: sinon.stub(),
@@ -77,7 +72,6 @@ describe('ExplorePingService', function () {
         explorePingService = new ExplorePingService({
             settingsCache: settingsCacheStub,
             config: configStub,
-            labs: labsStub,
             logging: loggingStub,
             ghostVersion: ghostVersionStub,
             request: requestStub,
@@ -216,7 +210,6 @@ describe('ExplorePingService', function () {
             explorePingService = new ExplorePingService({
                 settingsCache: settingsCacheStub,
                 config: configStub,
-                labs: labsStub,
                 logging: loggingStub,
                 ghostVersion: ghostVersionStub,
                 request: requestStub,
@@ -263,14 +256,6 @@ describe('ExplorePingService', function () {
     });
 
     describe('ping', function () {
-        it('does not ping if labs flag is not set', async function () {
-            labsStub.isSet.returns(false);
-
-            await explorePingService.ping();
-
-            sinon.assert.notCalled(requestStub);
-        });
-
         it('does not ping if explore URL is not set', async function () {
             configStub.get.withArgs('explore:update_url').returns(null);
 


### PR DESCRIPTION
## Description

Removes the permanently enabled `explore` Labs flag from Explore Ping now that the feature is generally available.

- removes the Labs check and dependency from Explore Ping
- removes the obsolete private Labs toggle
- retains the publisher-controlled `explore_ping` opt-out
- retains the separate `explore_ping_growth` opt-in for member and revenue data
- updates the API snapshots and focused unit coverage

This intentionally does not remove the legacy Explore iframe and pull-based Admin API integration; that cleanup will follow separately.

## Testing

- `pnpm test:single test/unit/server/services/explore-ping/explore-ping-service.test.js`
- `pnpm nx run ghost:build:tsc`
- `UPDATE_SNAPSHOT=1 pnpm test:single test/e2e-api/admin/config.test.js`
- `UPDATE_SNAPSHOT=1 pnpm test:single test/e2e-api/admin/settings.test.js`
- focused ESLint checks for changed Admin and core files