### PR TITLE
Removed the dangerZoneResetAuth labs flag

### DIFF
--- a/apps/admin/src/settings/advanced/advanced.acceptance.test.tsx
+++ b/apps/admin/src/settings/advanced/advanced.acceptance.test.tsx
@@ -52,12 +52,12 @@ describe("Advanced settings", () => {
         await expect.poll(() => api.requests.length).toBe(1);
     });
 
-    it("resets authentication when the feature is enabled", async () => {
+    it("resets authentication after confirmation", async () => {
         fakeSettingsScreens();
         // Success intentionally navigates to /ghost/ after locking users;
         // the isolated E2E danger-zone test covers that successful mutation.
         const api = fakeAdminEndpoint("POST", "/authentication/reset/", {errors: [{message: "stop after request"}]}, {status: 400});
-        await renderAdminApp("/settings/advanced", {labs: {dangerZoneResetAuth: true}});
+        await renderAdminApp("/settings/advanced");
 
         await settingsScreen.section("dangerzone").getByRole("button", {name: "Reset all authentication"}).click();
         await settingsScreen.confirmationModal().getByRole("button", {name: "Reset all authentication"}).click();

--- a/apps/admin/src/settings/app/components/settings/advanced/danger-zone.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/danger-zone.tsx
@@ -8,7 +8,6 @@ import {getGhostPaths} from '@tryghost/admin-x-framework/helpers';
 import {toast} from 'sonner';
 import {useConfirmation} from '@/settings/app/components/providers/confirmation-provider';
 import {useDeleteAllContent} from '@tryghost/admin-x-framework/api/db';
-import {useGlobalData} from '@/settings/app/components/providers/global-data-provider';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 import {useQueryClient} from '@tryghost/admin-x-framework';
 import {useRemoveAllGiftLinks} from '@tryghost/admin-x-framework/api/gift-links';
@@ -21,11 +20,8 @@ const DangerZone: React.FC<{ keywords: string[] }> = ({keywords}) => {
     const {mutateAsync: removeAllGiftLinks} = useRemoveAllGiftLinks();
     const client = useQueryClient();
     const handleError = useHandleError();
-    const {config} = useGlobalData();
     const {totalUsers} = useStaffUsers();
     const {confirm} = useConfirmation();
-
-    const resetAuthEnabled = Boolean(config?.labs?.dangerZoneResetAuth);
 
     const resetAuthStaffSentence = totalUsers === 1
         ? 'You will be signed out and must reset your password before signing back in.'
@@ -121,15 +117,13 @@ const DangerZone: React.FC<{ keywords: string[] }> = ({keywords}) => {
                     </ActionListItemContent>
                     <ActionListItemActions><Button aria-label='Delete all content' size='sm' type='button' variant='destructive' onClick={handleDeleteAllContent}>Delete</Button></ActionListItemActions>
                 </ActionListItem>
-                {resetAuthEnabled && (
-                    <ActionListItem data-testid='reset-all-authentication' hover={false}>
-                        <ActionListItemContent className='py-3 pr-6'>
-                            <div>Reset all authentication</div>
-                            <div className='text-sm text-muted-foreground'>Rotate every API key, sign out every staff user, and require a password reset. Use after a suspected credential compromise.</div>
-                        </ActionListItemContent>
-                        <ActionListItemActions><Button aria-label='Reset all authentication' size='sm' type='button' variant='destructive' onClick={handleResetAuth}>Reset</Button></ActionListItemActions>
-                    </ActionListItem>
-                )}
+                <ActionListItem data-testid='reset-all-authentication' hover={false}>
+                    <ActionListItemContent className='py-3 pr-6'>
+                        <div>Reset all authentication</div>
+                        <div className='text-sm text-muted-foreground'>Rotate every API key, sign out every staff user, and require a password reset. Use after a suspected credential compromise.</div>
+                    </ActionListItemContent>
+                    <ActionListItemActions><Button aria-label='Reset all authentication' size='sm' type='button' variant='destructive' onClick={handleResetAuth}>Reset</Button></ActionListItemActions>
+                </ActionListItem>
                 <ActionListItem data-testid='reset-all-gift-links' hover={false}>
                     <ActionListItemContent className='py-3 pr-6'>
                         <div>Reset all gift links</div>

--- a/e2e/tests/admin/settings/danger-zone.test.ts
+++ b/e2e/tests/admin/settings/danger-zone.test.ts
@@ -24,8 +24,6 @@ async function snapshotApiKeys(page: SettingsPage['page'], baseURL: string): Pro
 }
 
 test.describe('Ghost Admin - Danger Zone security actions', () => {
-    test.use({labs: {dangerZoneResetAuth: true}});
-
     test('reset all authentication - rotates every visible key, locks owner, kills session', async ({page, ghostAccountOwner, baseURL}) => {
         const url = baseURL ?? '';
         const settingsPage = new SettingsPage(page);

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -30,8 +30,7 @@ const GA_FEATURES = [
     'automationAnalytics',
     'customFonts',
     'commentsThreads',
-    'commentsPinning',
-    'dangerZoneResetAuth'
+    'commentsPinning'
 ];
 
 // These features are considered publicly available and can be enabled/disabled by users


### PR DESCRIPTION
## Problem

The "reset all authentication" action in Danger Zone shipped behind the `dangerZoneResetAuth` labs flag in May. The flag went out permanently enabled, so every site has always seen the action and there was never a toggle for it in settings. All the flag does today is gate the UI behind a condition that can only ever be true, and force both the acceptance and end-to-end tests to opt in before they can exercise the feature.

## Solution

Removed the flag and its guard, so the Danger Zone action renders unconditionally, and dropped the flag setup from the two test suites that were opting in. The config snapshot loses the flag key along with it.

Nothing changes for users, since the flag was already on everywhere. This follows the same pattern as the recent Explore and llms.txt flag removals.