### PR TITLE
Removed the Featurebase Feedback labs flag

### DIFF
--- a/apps/admin-x-framework/src/hooks/use-featurebase.ts
+++ b/apps/admin-x-framework/src/hooks/use-featurebase.ts
@@ -93,8 +93,8 @@ function initFeaturebaseWidget(organization: string, theme: 'light' | 'dark', to
  * Lazy-loads the Featurebase SDK and opens the feedback widget.
  *
  * `isAvailable` reflects whether Featurebase is enabled for the current site.
- * The server only exposes `config.featurebase` when the `featurebaseFeedback`
- * lab is on AND the org config is set, so checking it here is sufficient.
+ * The server only exposes `config.featurebase` when the org config is set,
+ * so checking it here is sufficient.
  * Callers still need to gate by user role (e.g. exclude contributors) if
  * relevant to their surface.
  *

--- a/apps/admin/src/settings/app/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/labs/private-features.tsx
@@ -52,10 +52,6 @@ const features: Feature[] = [{
     description: 'Enable theme translation using i18next instead of the old translation package.',
     flag: 'themeTranslation'
 }, {
-    title: 'Featurebase Feedback',
-    description: 'Display a Feedback menu item in the admin sidebar. Requires the new admin experience.',
-    flag: 'featurebaseFeedback'
-}, {
     title: 'Picture Element',
     description: 'Use the HTML picture element to serve modern image formats (AVIF, WebP) with automatic fallbacks',
     flag: 'pictureImageFormats'

--- a/ghost/core/core/server/services/public-config/config.js
+++ b/ghost/core/core/server/services/public-config/config.js
@@ -75,7 +75,7 @@ module.exports = function getConfigProperties() {
         configProperties.stats = getTinybirdStatsPayload(statsConfig, siteUuid);
     }
 
-    if (labs.isSet('featurebaseFeedback') && config.get('featurebase')) {
+    if (config.get('featurebase')) {
         // Expose only the public featurebase config properties
         configProperties.featurebase = {
             enabled: config.get('featurebase:enabled'),

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -31,7 +31,6 @@ const GA_FEATURES = [
     'customFonts',
     'commentsThreads',
     'commentsPinning',
-    'featurebaseFeedback',
     'dangerZoneResetAuth'
 ];
 

--- a/ghost/core/test/unit/server/services/public-config/config.test.js
+++ b/ghost/core/test/unit/server/services/public-config/config.test.js
@@ -211,9 +211,6 @@ describe('Public-config Service', function () {
         });
 
         it('should return featurebase config with enabled=false when configured but disabled', function () {
-            configUtils.set('labs', {
-                featurebaseFeedback: true
-            });
             configUtils.set('featurebase', {
                 enabled: false,
                 organization: 'test-org',
@@ -227,9 +224,6 @@ describe('Public-config Service', function () {
         });
 
         it('should return only public featurebase config properties, not sensitive ones', function () {
-            configUtils.set('labs', {
-                featurebaseFeedback: true
-            });
             configUtils.set('featurebase', {
                 enabled: true,
                 organization: 'test-org',


### PR DESCRIPTION
no issue

The `featurebaseFeedback` flag has been permanently enabled via `GA_FEATURES` for a while, so the labs conditional it gated was dead in practice. This removes the flag and its only remaining conditional in the public-config service, where the Featurebase widget config exposure is now gated solely by the `featurebase` org config — the same switch the token endpoint and config serializer were already using.