### PR TITLE
Single-source duplicated custom-field facts

### DIFF
--- a/apps/admin-x-framework/src/api/member-custom-fields.ts
+++ b/apps/admin-x-framework/src/api/member-custom-fields.ts
@@ -1,4 +1,4 @@
-import {FIELD_TYPE_IDS, type FieldType} from '@tryghost/custom-field-types';
+import {FIELD_TYPE_IDS, type Address, type FieldType} from '@tryghost/custom-field-types';
 import {csvColumnsForField} from '@tryghost/custom-field-types/csv';
 import {Meta, createMutation, createQuery, createQueryWithId} from '../utils/api/hooks';
 
@@ -54,6 +54,8 @@ const fieldTypePresentation: Record<FieldType, Omit<MemberCustomFieldUserType, '
     address: {
         label: 'Address',
         input: 'address',
+        // Keyed to the shared value schema's parts (`satisfies`), so a part added, removed,
+        // or mistyped upstream is a compile error here rather than a silently missing label.
         subFields: {
             line1: 'Address line 1',
             line2: 'Address line 2',
@@ -61,7 +63,7 @@ const fieldTypePresentation: Record<FieldType, Omit<MemberCustomFieldUserType, '
             state: 'State',
             postal_code: 'Postal code',
             country: 'Country'
-        }
+        } satisfies Record<keyof Address, string>
     }
 };
 

--- a/ghost/core/core/server/services/members-custom-fields/values-service.ts
+++ b/ghost/core/core/server/services/members-custom-fields/values-service.ts
@@ -11,8 +11,11 @@ import {leavesToWrite, valuesFromLeaves, type StoredLeaf} from './storage';
 const FIELDS_TABLE = 'members_custom_fields';
 const VALUES_TABLE = 'members_custom_field_values';
 
-/** Matches the `members_custom_fields.key` column, so no key a site could hold is refused. */
-const MAX_KEY_LENGTH = 191;
+/**
+ * From the canonical schema, the same source definitions-service reads, so no key a site
+ * could hold is refused and this cannot drift from the `members_custom_fields.key` column.
+ */
+const MAX_KEY_LENGTH: number = require('../../data/schema').tables[FIELDS_TABLE].key.maxlength;
 
 /**
  * Rows per insert statement, bounded by knex rather than by either database. SQLite takes

--- a/ghost/core/test/unit/server/data/schema/custom-fields-schema.test.js
+++ b/ghost/core/test/unit/server/data/schema/custom-fields-schema.test.js
@@ -1,0 +1,19 @@
+const assert = require('node:assert/strict');
+const {FIELD_TYPE_IDS} = require('@tryghost/custom-field-types');
+const {FIELD_STATUS} = require('../../../../../core/server/services/members-custom-fields/schema');
+
+const schema = require('../../../../../core/server/data/schema/schema');
+
+// The static schema restates the field-type and status lists because it cannot import them:
+// it feeds the schema-hash integrity check and is read before the TS build. A "keep in sync"
+// comment guards each restatement; these pin them to the source of truth so a divergence
+// fails the build rather than shipping a schema that accepts or rejects the wrong values.
+describe('members_custom_fields schema mirrors the source of truth', function () {
+    it('type validation matches FIELD_TYPE_IDS', function () {
+        assert.deepEqual(schema.members_custom_fields.type.validations.isIn[0], [...FIELD_TYPE_IDS]);
+    });
+
+    it('status validation matches FIELD_STATUS', function () {
+        assert.deepEqual(schema.members_custom_fields.status.validations.isIn[0], Object.values(FIELD_STATUS));
+    });
+});


### PR DESCRIPTION
## Problem

A coupling/cohesion review of the members custom-field feature found several facts restated in more than one place and kept in sync by hand, where a divergence would compile or ship silently:

- the `members_custom_fields.key` length, derived from the schema in one service but hardcoded as `191` in its sibling;
- the field-type and status lists in the static schema, mirrored from the shared catalog with only a "keep in sync" comment to guard them;
- an address's sub-field labels in the presentation catalog, typed loosely enough that a mistyped or omitted part compiles and silently loses its label.

## Solution

Single-source each one:

- values-service reads the key cap from the canonical schema, the same source definitions-service already uses;
- a unit test pins the schema's field-type and status lists to `FIELD_TYPE_IDS` and `FIELD_STATUS`, so a divergence fails the build;
- the presentation catalog's address parts are typed against the shared `Address` value schema, so a part added, removed, or renamed upstream is a compile error rather than a missing label at runtime.

Found during the custom-field filter review; independent of the filtering work.
