### PR TITLE
Removed unused parameter for Mailgun client init

### DIFF
--- a/ghost/core/core/server/services/email-suppression-list/service.js
+++ b/ghost/core/core/server/services/email-suppression-list/service.js
@@ -1,7 +1,6 @@
 const models = require('../../models');
 const configService = require('../../../shared/config');
 const settingsCache = require('../../../shared/settings-cache');
-const labs = require('../../../shared/labs');
 const MailgunClient = require('../lib/mailgun-client');
 const MailgunEmailSuppressionList = require('./mailgun-email-suppression-list');
 

--- a/ghost/core/core/server/services/email-suppression-list/service.js
+++ b/ghost/core/core/server/services/email-suppression-list/service.js
@@ -7,8 +7,7 @@ const MailgunEmailSuppressionList = require('./mailgun-email-suppression-list');
 
 const mailgunClient = new MailgunClient({
     config: configService,
-    settings: settingsCache,
-    labs
+    settings: settingsCache
 });
 
 module.exports = new MailgunEmailSuppressionList({


### PR DESCRIPTION
no ref

This change should have no user impact.

Just something small I noticed.