### PR TITLE
Added types for database connection object

### DIFF
--- a/ghost/core/core/server/data/db/index.d.ts
+++ b/ghost/core/core/server/data/db/index.d.ts
@@ -1,0 +1,3 @@
+import type { Knex } from 'knex';
+
+export const knex: Knex;

--- a/ghost/core/core/server/services/email-analytics/index.ts
+++ b/ghost/core/core/server/services/email-analytics/index.ts
@@ -7,8 +7,7 @@ import {NewsletterEmailAnalyticsBatchProcessor} from './newsletter-email-analyti
 import NewsletterEmailEventStorage from '../email-service/newsletter-email-event-storage';
 // @ts-expect-error This module lacks type definitions.
 import EmailEventProcessor from '../email-service/email-event-processor';
-// @ts-expect-error This module lacks type definitions.
-import db from '../../data/db';
+import * as db from '../../data/db';
 import membersService from '../members';
 // @ts-expect-error This module lacks type definitions.
 import emailSuppressionList from '../email-suppression-list';

--- a/ghost/core/test/utils/automations-fixtures.ts
+++ b/ghost/core/test/utils/automations-fixtures.ts
@@ -1,7 +1,6 @@
 import ObjectId from 'bson-objectid';
 import moment from 'moment';
 import {MEMBER_WELCOME_EMAIL_SLUGS} from '../../core/server/services/member-welcome-emails/constants';
-// @ts-expect-error Database has not been converted to TypeScript yet.
 import * as db from '../../core/server/data/db';
 
 export const TEST_EMAIL_DESIGN_SETTING_ID = '64b6f7b7c8f1a2b3c4d5e6f7';


### PR DESCRIPTION
no ref

This change should have no user impact. It adds a type declaration for `core/server/data/index.js`.