### PR TITLE
Tested email analytics initializer

### DIFF
--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -356,6 +356,7 @@ async function initServices({ghostServer} = {}) {
     const adapterManager = require('./server/services/adapter-manager').default;
     const {withErrorCapture} = require('./server/adapters/scheduling/error-capture');
 
+    const db = require('./server/data/db');
     const urlUtils = require('./shared/url-utils').default;
     const settingsCache = require('./shared/settings-cache');
     const internalKeys = require('./server/services/internal-keys').default;
@@ -383,6 +384,7 @@ async function initServices({ghostServer} = {}) {
         audienceFeedback.init(),
         emailService.init({ghostServer}),
         emailAnalytics.init({
+            db,
             domainEvents
         }),
         webhooks.listen(),

--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -390,6 +390,7 @@ async function initServices({ghostServer, config, prometheusClient}) {
             config,
             db,
             domainEvents,
+            emailSuppressionList,
             membersRepository: members.api.members,
             models,
             prometheusClient

--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -353,6 +353,7 @@ async function initServices({ghostServer} = {}) {
     const explorePingService = require('./server/services/explore-ping');
     const domainEvents = require('@tryghost/domain-events');
     const automations = require('./server/services/automations');
+    const automationsApi = require('./server/services/automations/automations-api');
     const adapterManager = require('./server/services/adapter-manager').default;
     const {withErrorCapture} = require('./server/adapters/scheduling/error-capture');
 
@@ -384,6 +385,7 @@ async function initServices({ghostServer} = {}) {
         audienceFeedback.init(),
         emailService.init({ghostServer}),
         emailAnalytics.init({
+            automationsApi,
             db,
             domainEvents
         }),

--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -358,6 +358,7 @@ async function initServices({ghostServer, config, prometheusClient}) {
     const {withErrorCapture} = require('./server/adapters/scheduling/error-capture');
 
     const db = require('./server/data/db');
+    const models = require('./server/models');
     const urlUtils = require('./shared/url-utils').default;
     const settingsCache = require('./shared/settings-cache');
     const internalKeys = require('./server/services/internal-keys').default;
@@ -389,6 +390,7 @@ async function initServices({ghostServer, config, prometheusClient}) {
             config,
             db,
             domainEvents,
+            models,
             prometheusClient
         }),
         webhooks.listen(),

--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -390,6 +390,7 @@ async function initServices({ghostServer, config, prometheusClient}) {
             config,
             db,
             domainEvents,
+            membersRepository: members.api.members,
             models,
             prometheusClient
         }),

--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -317,7 +317,7 @@ async function initAppService() {
  * These services should all be part of core, frontend services should be loaded with the frontend
  * We are working towards this being a service loader, with the ability to make certain services optional
  */
-async function initServices({ghostServer} = {}) {
+async function initServices({ghostServer, config}) {
     debug('Begin: initServices');
 
     debug('Begin: Services');
@@ -386,6 +386,7 @@ async function initServices({ghostServer} = {}) {
         emailService.init({ghostServer}),
         emailAnalytics.init({
             automationsApi,
+            config,
             db,
             domainEvents
         }),
@@ -600,7 +601,7 @@ async function bootGhost({backend = true, frontend = true, server = true} = {}) 
             await initAppService();
         }
 
-        await initServices({ghostServer});
+        await initServices({ghostServer, config});
         debug('End: Load Ghost Services & Apps');
 
         // Step 5 - Mount the full Ghost app onto the minimal root app & disable maintenance mode

--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -357,6 +357,7 @@ async function initServices({ghostServer, config, prometheusClient}) {
     const adapterManager = require('./server/services/adapter-manager').default;
     const {withErrorCapture} = require('./server/adapters/scheduling/error-capture');
 
+    const metrics = require('@tryghost/metrics');
     const db = require('./server/data/db');
     const models = require('./server/models');
     const urlUtils = require('./shared/url-utils').default;
@@ -393,7 +394,9 @@ async function initServices({ghostServer, config, prometheusClient}) {
             emailSuppressionList,
             membersRepository: members.api.members,
             models,
-            prometheusClient
+            metrics,
+            prometheusClient,
+            settingsCache
         }),
         webhooks.listen(),
         comments.init(),

--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -382,7 +382,9 @@ async function initServices({ghostServer} = {}) {
         slack.init(),
         audienceFeedback.init(),
         emailService.init({ghostServer}),
-        emailAnalytics.init(),
+        emailAnalytics.init({
+            domainEvents
+        }),
         webhooks.listen(),
         comments.init(),
         linkTracking.init(),

--- a/ghost/core/core/boot.js
+++ b/ghost/core/core/boot.js
@@ -317,7 +317,7 @@ async function initAppService() {
  * These services should all be part of core, frontend services should be loaded with the frontend
  * We are working towards this being a service loader, with the ability to make certain services optional
  */
-async function initServices({ghostServer, config}) {
+async function initServices({ghostServer, config, prometheusClient}) {
     debug('Begin: initServices');
 
     debug('Begin: Services');
@@ -388,7 +388,8 @@ async function initServices({ghostServer, config}) {
             automationsApi,
             config,
             db,
-            domainEvents
+            domainEvents,
+            prometheusClient
         }),
         webhooks.listen(),
         comments.init(),
@@ -601,7 +602,7 @@ async function bootGhost({backend = true, frontend = true, server = true} = {}) 
             await initAppService();
         }
 
-        await initServices({ghostServer, config});
+        await initServices({ghostServer, config, prometheusClient});
         debug('End: Load Ghost Services & Apps');
 
         // Step 5 - Mount the full Ghost app onto the minimal root app & disable maintenance mode

--- a/ghost/core/core/server/services/email-analytics/email-analytics-service-wrapper.js
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-service-wrapper.js
@@ -1,14 +1,17 @@
+const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
-const metrics = require('@tryghost/metrics');
-const config = require('../../../shared/config');
-const domainEvents = require('@tryghost/domain-events');
+/** @import {ConfigInstance} from '../../../shared/config/loader' */
+/** @import DomainEvents from '@tryghost/domain-events' */
 /** @import {Queries} from './lib/queries' */
+/** @import Metrics from '@tryghost/metrics' */
 /** @import {PrometheusClient} from '@tryghost/prometheus-metrics' */
 /** @import {BatchEventProcessor} from './batch-event-processor' */
 /** @import {JobNames, CursorSeed, EmailAnalyticsFetchResult} from './email-analytics-service' */
 
 class EmailAnalyticsServiceWrapper {
     /** @type {string} */ #logName;
+    /** @type {Pick<ConfigInstance, 'get'> | undefined} */ #config;
+    /** @type {Pick<Metrics, 'metric'> | undefined} */ #metrics;
     #fetching = false;
     #restoredSchedule = false;
 
@@ -28,33 +31,43 @@ class EmailAnalyticsServiceWrapper {
 
     /**
      * @param {object} options
-     * @param {Parameters<typeof domainEvents.subscribe>[0]} options.event
+     * @param {Pick<ConfigInstance, 'get'>} options.config
+     * @param {Pick<DomainEvents, 'subscribe'>} options.domainEvents
+     * @param {Parameters<DomainEvents['subscribe']>[0]} options.event
      * @param {Queries} options.queries
      * @param {string[]} options.mailgunTags
      * @param {JobNames} options.jobNames
      * @param {CursorSeed} options.cursorSeed
      * @param {() => BatchEventProcessor} options.createEventProcessor
+     * @param {Pick<Metrics, 'metric'>} options.metrics
      * @param {PrometheusClient | null} options.prometheusClient
+     * @param {{get: (key: string) => unknown}} options.settingsCache
      */
     init({
+        config,
+        domainEvents,
         event,
         queries,
         mailgunTags,
         jobNames,
         cursorSeed,
         createEventProcessor,
-        prometheusClient
+        metrics,
+        prometheusClient,
+        settingsCache
     }) {
         if (this.service) {
             return;
         }
 
+        this.#config = config;
+        this.#metrics = metrics;
+
         const {EmailAnalyticsService} = require('./email-analytics-service');
         const {fetchMailgunEvents} = require('./fetch-mailgun-events');
-        const settings = require('../../../shared/settings-cache');
 
         this.service = new EmailAnalyticsService({
-            fetchEvents: (options) => fetchMailgunEvents({...options, config, settings, tags: mailgunTags}),
+            fetchEvents: (options) => fetchMailgunEvents({...options, config, settings: settingsCache, tags: mailgunTags}),
             queries,
             jobNames,
             cursorSeed,
@@ -63,7 +76,7 @@ class EmailAnalyticsServiceWrapper {
         });
 
         // Log the processing mode on initialization
-        const batchProcessingEnabled = config.get('emailAnalytics:batchProcessing');
+        const batchProcessingEnabled = this.#config.get('emailAnalytics:batchProcessing');
         logging.info(`${this.#logPrefix} Initialized with ${batchProcessingEnabled ? 'BATCHED' : 'SEQUENTIAL'} processing mode`);
 
         // We currently cannot trigger a non-offloaded job from the job manager
@@ -73,6 +86,14 @@ class EmailAnalyticsServiceWrapper {
         });
     }
 
+    #getConfig() {
+        const result = this.#config;
+        if (!result) {
+            throw new errors.InternalServerError({message: "EmailAnalyticsServiceWrapper is not initialized with config"});
+        }
+        return result;
+    }
+
     /**
      * Log comprehensive job completion with timing metrics
      * @param {string} jobType - Type of job (e.g., 'latest-opened', 'latest', 'missing', 'scheduled')
@@ -80,6 +101,8 @@ class EmailAnalyticsServiceWrapper {
      * @param {number} totalDurationMs - Total duration in milliseconds
      */
     _logJobCompletion(jobType, fetchResult, totalDurationMs) {
+        const config = this.#getConfig();
+
         const {eventCount, apiPollingTimeMs, processingTimeMs, aggregationTimeMs, emailAggregationTimeMs, memberAggregationTimeMs, result} = fetchResult;
 
         if (eventCount === 0) {
@@ -110,6 +133,13 @@ class EmailAnalyticsServiceWrapper {
                 const metricName = this.#logName === 'newsletters'
                     ? 'email-analytics-open-throughput'
                     : `email-${this.#logName}-analytics-open-throughput`;
+
+                const metrics = this.#metrics;
+                if (!metrics) {
+                    throw new errors.InternalServerError({
+                        message: 'EmailAnalyticsServiceWrapper is not initialized with metrics'
+                    });
+                }
                 metrics.metric(metricName, {
                     value: throughput,
                     events: eventCount,
@@ -120,6 +150,8 @@ class EmailAnalyticsServiceWrapper {
     }
 
     async fetchLatestOpenedEvents({maxEvents} = {maxEvents: Infinity}) {
+        const config = this.#getConfig();
+
         const beginTimestamp = await this.service.getLastOpenedEventTimestamp();
         const lagMinutes = (Date.now() - beginTimestamp.getTime()) / 60000;
         const lagThreshold = config.get('emailAnalytics:openedJobLagWarningMinutes');

--- a/ghost/core/core/server/services/email-analytics/email-analytics-service-wrapper.js
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-service-wrapper.js
@@ -34,7 +34,7 @@ class EmailAnalyticsServiceWrapper {
      * @param {JobNames} options.jobNames
      * @param {CursorSeed} options.cursorSeed
      * @param {() => BatchEventProcessor} options.createEventProcessor
-     * @param {PrometheusClient} [options.prometheusClient]
+     * @param {PrometheusClient | null} options.prometheusClient
      */
     init({
         event,
@@ -56,10 +56,10 @@ class EmailAnalyticsServiceWrapper {
         this.service = new EmailAnalyticsService({
             fetchEvents: (options) => fetchMailgunEvents({...options, config, settings, tags: mailgunTags}),
             queries,
-            prometheusClient,
             jobNames,
             cursorSeed,
-            createEventProcessor
+            createEventProcessor,
+            ...(prometheusClient ? {prometheusClient} : {})
         });
 
         // Log the processing mode on initialization

--- a/ghost/core/core/server/services/email-analytics/index.ts
+++ b/ghost/core/core/server/services/email-analytics/index.ts
@@ -11,7 +11,7 @@ import NewsletterEmailEventStorage from '../email-service/newsletter-email-event
 import EmailEventProcessor from '../email-service/email-event-processor';
 import type membersService from '../members';
 // @ts-expect-error This module lacks type definitions.
-import emailSuppressionList from '../email-suppression-list';
+import type EmailSuppressionList from '../email-suppression-list';
 // @ts-expect-error This module lacks type definitions.
 import type {EmailRecipientFailure, EmailSpamComplaintEvent, Email} from '../../models';
 // @ts-expect-error This module lacks type definitions.
@@ -36,6 +36,7 @@ export const init = ({
     config,
     db,
     domainEvents,
+    emailSuppressionList,
     membersRepository,
     models: {
         Email,
@@ -48,6 +49,7 @@ export const init = ({
     config: Pick<ConfigInstance, 'get'>;
     db: {knex: Knex},
     domainEvents: Pick<DomainEvents, 'subscribe'>;
+    emailSuppressionList: Pick<typeof EmailSuppressionList, 'removeComplaint' | 'removeUnsubscribe'>;
     membersRepository: Pick<typeof membersService.api.members, 'get' | 'update'>;
     models: {
         Email: Email;

--- a/ghost/core/core/server/services/email-analytics/index.ts
+++ b/ghost/core/core/server/services/email-analytics/index.ts
@@ -9,7 +9,7 @@ import {NewsletterEmailAnalyticsBatchProcessor} from './newsletter-email-analyti
 import NewsletterEmailEventStorage from '../email-service/newsletter-email-event-storage';
 // @ts-expect-error This module lacks type definitions.
 import EmailEventProcessor from '../email-service/email-event-processor';
-import membersService from '../members';
+import type membersService from '../members';
 // @ts-expect-error This module lacks type definitions.
 import emailSuppressionList from '../email-suppression-list';
 // @ts-expect-error This module lacks type definitions.
@@ -36,6 +36,7 @@ export const init = ({
     config,
     db,
     domainEvents,
+    membersRepository,
     models: {
         Email,
         EmailRecipientFailure,
@@ -47,6 +48,7 @@ export const init = ({
     config: Pick<ConfigInstance, 'get'>;
     db: {knex: Knex},
     domainEvents: Pick<DomainEvents, 'subscribe'>;
+    membersRepository: Pick<typeof membersService.api.members, 'get' | 'update'>;
     models: {
         Email: Email;
         EmailRecipientFailure: EmailRecipientFailure;
@@ -61,7 +63,7 @@ export const init = ({
         db,
         eventStorage: new NewsletterEmailEventStorage({
             db,
-            membersRepository: membersService.api.members,
+            membersRepository,
             models: {
                 Email,
                 EmailRecipientFailure,

--- a/ghost/core/core/server/services/email-analytics/index.ts
+++ b/ghost/core/core/server/services/email-analytics/index.ts
@@ -2,6 +2,10 @@ import type {Knex} from 'knex';
 import type {PrometheusClient} from '@tryghost/prometheus-metrics';
 import type {ConfigInstance} from '../../../shared/config/loader';
 // @ts-expect-error This module lacks type definitions.
+import type Metrics from '@tryghost/metrics';
+// @ts-expect-error This module lacks type definitions.
+import type SettingsCache from '../../../shared/settings-cache';
+// @ts-expect-error This module lacks type definitions.
 import EmailAnalyticsServiceWrapper from './email-analytics-service-wrapper';
 // @ts-expect-error This module lacks type definitions.
 import {NewsletterEmailAnalyticsBatchProcessor} from './newsletter-email-analytics-batch-processor';
@@ -43,7 +47,9 @@ export const init = ({
         EmailRecipientFailure,
         EmailSpamComplaintEvent
     },
-    prometheusClient
+    metrics,
+    prometheusClient,
+    settingsCache
 }: {
     automationsApi: Pick<typeof AutomationsApi, 'getAutomatedEmailRecipientsByMailgunIds' | 'trackEmailDeliveredAndOpened'>;
     config: Pick<ConfigInstance, 'get'>;
@@ -56,7 +62,9 @@ export const init = ({
         EmailRecipientFailure: EmailRecipientFailure;
         EmailSpamComplaintEvent: EmailSpamComplaintEvent;
     };
+    metrics: Pick<Metrics, 'metric'>;
     prometheusClient: PrometheusClient | null;
+    settingsCache: Pick<typeof SettingsCache, 'get'>;
 }) => {
     const queries = new Queries(db.knex);
 
@@ -64,6 +72,7 @@ export const init = ({
         domainEvents,
         db,
         eventStorage: new NewsletterEmailEventStorage({
+            config,
             db,
             membersRepository,
             models: {
@@ -83,6 +92,8 @@ export const init = ({
     }
 
     newsletters.init({
+        config,
+        domainEvents,
         event: StartEmailAnalyticsJobEvent,
         queries,
         mailgunTags: newsletterMailgunTags,
@@ -100,7 +111,9 @@ export const init = ({
                 failed: 'failed_at'
             }
         },
+        metrics,
         prometheusClient,
+        settingsCache,
         createEventProcessor: () => (
             new NewsletterEmailAnalyticsBatchProcessor({
                 config,
@@ -112,6 +125,8 @@ export const init = ({
     });
 
     automations.init({
+        config,
+        domainEvents,
         event: StartAutomationEmailAnalyticsJobEvent,
         queries,
         mailgunTags: [AUTOMATION_EMAIL_TAG],
@@ -128,6 +143,8 @@ export const init = ({
                 opened: 'opened_at'
             }
         },
+        metrics,
+        settingsCache,
         createEventProcessor: () => (
             new AutomationEmailAnalyticsBatchProcessor({
                 automationsApi

--- a/ghost/core/core/server/services/email-analytics/index.ts
+++ b/ghost/core/core/server/services/email-analytics/index.ts
@@ -1,3 +1,4 @@
+import type {Knex} from 'knex';
 // @ts-expect-error This module lacks type definitions.
 import EmailAnalyticsServiceWrapper from './email-analytics-service-wrapper';
 import config from '../../../shared/config';
@@ -7,7 +8,6 @@ import {NewsletterEmailAnalyticsBatchProcessor} from './newsletter-email-analyti
 import NewsletterEmailEventStorage from '../email-service/newsletter-email-event-storage';
 // @ts-expect-error This module lacks type definitions.
 import EmailEventProcessor from '../email-service/email-event-processor';
-import * as db from '../../data/db';
 import membersService from '../members';
 // @ts-expect-error This module lacks type definitions.
 import emailSuppressionList from '../email-suppression-list';
@@ -33,8 +33,10 @@ export const automations = new EmailAnalyticsServiceWrapper({
 });
 
 export const init = ({
+    db,
     domainEvents
 }: {
+    db: {knex: Knex},
     domainEvents: Pick<DomainEvents, 'subscribe'>;
 }) => {
     const queries = new Queries(db.knex);

--- a/ghost/core/core/server/services/email-analytics/index.ts
+++ b/ghost/core/core/server/services/email-analytics/index.ts
@@ -1,7 +1,7 @@
 import type {Knex} from 'knex';
+import type {ConfigInstance} from '../../../shared/config/loader';
 // @ts-expect-error This module lacks type definitions.
 import EmailAnalyticsServiceWrapper from './email-analytics-service-wrapper';
-import config from '../../../shared/config';
 // @ts-expect-error This module lacks type definitions.
 import {NewsletterEmailAnalyticsBatchProcessor} from './newsletter-email-analytics-batch-processor';
 // @ts-expect-error This module lacks type definitions.
@@ -34,10 +34,12 @@ export const automations = new EmailAnalyticsServiceWrapper({
 
 export const init = ({
     automationsApi,
+    config,
     db,
     domainEvents
 }: {
     automationsApi: Pick<typeof AutomationsApi, 'getAutomatedEmailRecipientsByMailgunIds' | 'trackEmailDeliveredAndOpened'>;
+    config: Pick<ConfigInstance, 'get'>;
     db: {knex: Knex},
     domainEvents: Pick<DomainEvents, 'subscribe'>;
 }) => {

--- a/ghost/core/core/server/services/email-analytics/index.ts
+++ b/ghost/core/core/server/services/email-analytics/index.ts
@@ -14,7 +14,7 @@ import emailSuppressionList from '../email-suppression-list';
 // @ts-expect-error This module lacks type definitions.
 import {EmailRecipientFailure, EmailSpamComplaintEvent, Email} from '../../models';
 // @ts-expect-error This module lacks type definitions.
-import domainEvents from '@tryghost/domain-events';
+import type DomainEvents from '@tryghost/domain-events';
 // @ts-expect-error This module lacks type definitions.
 import prometheusClient from '../../../shared/prometheus-client';
 import {Queries} from './lib/queries';
@@ -32,7 +32,11 @@ export const automations = new EmailAnalyticsServiceWrapper({
     logName: 'automations',
 });
 
-export const init = () => {
+export const init = ({
+    domainEvents
+}: {
+    domainEvents: Pick<DomainEvents, 'subscribe'>;
+}) => {
     const queries = new Queries(db.knex);
 
     const newsletterEmailEventProcessor = new EmailEventProcessor({

--- a/ghost/core/core/server/services/email-analytics/index.ts
+++ b/ghost/core/core/server/services/email-analytics/index.ts
@@ -1,4 +1,5 @@
 import type {Knex} from 'knex';
+import type {PrometheusClient} from '@tryghost/prometheus-metrics';
 import type {ConfigInstance} from '../../../shared/config/loader';
 // @ts-expect-error This module lacks type definitions.
 import EmailAnalyticsServiceWrapper from './email-analytics-service-wrapper';
@@ -15,8 +16,6 @@ import emailSuppressionList from '../email-suppression-list';
 import {EmailRecipientFailure, EmailSpamComplaintEvent, Email} from '../../models';
 // @ts-expect-error This module lacks type definitions.
 import type DomainEvents from '@tryghost/domain-events';
-// @ts-expect-error This module lacks type definitions.
-import prometheusClient from '../../../shared/prometheus-client';
 import {Queries} from './lib/queries';
 import {StartEmailAnalyticsJobEvent} from './events/start-email-analytics-job-event';
 import {StartAutomationEmailAnalyticsJobEvent} from './events/start-automation-email-analytics-job-event';
@@ -36,12 +35,14 @@ export const init = ({
     automationsApi,
     config,
     db,
-    domainEvents
+    domainEvents,
+    prometheusClient
 }: {
     automationsApi: Pick<typeof AutomationsApi, 'getAutomatedEmailRecipientsByMailgunIds' | 'trackEmailDeliveredAndOpened'>;
     config: Pick<ConfigInstance, 'get'>;
     db: {knex: Knex},
     domainEvents: Pick<DomainEvents, 'subscribe'>;
+    prometheusClient: PrometheusClient | null;
 }) => {
     const queries = new Queries(db.knex);
 

--- a/ghost/core/core/server/services/email-analytics/index.ts
+++ b/ghost/core/core/server/services/email-analytics/index.ts
@@ -21,7 +21,7 @@ import {Queries} from './lib/queries';
 import {StartEmailAnalyticsJobEvent} from './events/start-email-analytics-job-event';
 import {StartAutomationEmailAnalyticsJobEvent} from './events/start-automation-email-analytics-job-event';
 import {AUTOMATION_EMAIL_TAG} from '../member-welcome-emails/constants';
-import * as automationsApi from '../automations/automations-api';
+import type * as AutomationsApi from '../automations/automations-api';
 import {AutomationEmailAnalyticsBatchProcessor} from './automation-email-analytics-batch-processor';
 
 export const newsletters = new EmailAnalyticsServiceWrapper({
@@ -33,9 +33,11 @@ export const automations = new EmailAnalyticsServiceWrapper({
 });
 
 export const init = ({
+    automationsApi,
     db,
     domainEvents
 }: {
+    automationsApi: Pick<typeof AutomationsApi, 'getAutomatedEmailRecipientsByMailgunIds' | 'trackEmailDeliveredAndOpened'>;
     db: {knex: Knex},
     domainEvents: Pick<DomainEvents, 'subscribe'>;
 }) => {

--- a/ghost/core/core/server/services/email-analytics/index.ts
+++ b/ghost/core/core/server/services/email-analytics/index.ts
@@ -13,7 +13,7 @@ import membersService from '../members';
 // @ts-expect-error This module lacks type definitions.
 import emailSuppressionList from '../email-suppression-list';
 // @ts-expect-error This module lacks type definitions.
-import {EmailRecipientFailure, EmailSpamComplaintEvent, Email} from '../../models';
+import type {EmailRecipientFailure, EmailSpamComplaintEvent, Email} from '../../models';
 // @ts-expect-error This module lacks type definitions.
 import type DomainEvents from '@tryghost/domain-events';
 import {Queries} from './lib/queries';
@@ -36,12 +36,22 @@ export const init = ({
     config,
     db,
     domainEvents,
+    models: {
+        Email,
+        EmailRecipientFailure,
+        EmailSpamComplaintEvent
+    },
     prometheusClient
 }: {
     automationsApi: Pick<typeof AutomationsApi, 'getAutomatedEmailRecipientsByMailgunIds' | 'trackEmailDeliveredAndOpened'>;
     config: Pick<ConfigInstance, 'get'>;
     db: {knex: Knex},
     domainEvents: Pick<DomainEvents, 'subscribe'>;
+    models: {
+        Email: Email;
+        EmailRecipientFailure: EmailRecipientFailure;
+        EmailSpamComplaintEvent: EmailSpamComplaintEvent;
+    };
     prometheusClient: PrometheusClient | null;
 }) => {
     const queries = new Queries(db.knex);

--- a/ghost/core/core/server/services/email-service/newsletter-email-event-storage.js
+++ b/ghost/core/core/server/services/email-service/newsletter-email-event-storage.js
@@ -1,9 +1,9 @@
 const moment = require('moment-timezone');
 const errors = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
-const config = require('../../../shared/config');
 
 class NewsletterEmailEventStorage {
+    #config;
     #db;
     #membersRepository;
     #models;
@@ -11,7 +11,8 @@ class NewsletterEmailEventStorage {
     #prometheusClient;
     #pendingUpdates;
 
-    constructor({db, models, membersRepository, emailSuppressionList, prometheusClient}) {
+    constructor({config, db, models, membersRepository, emailSuppressionList, prometheusClient}) {
+        this.#config = config;
         this.#db = db;
         this.#models = models;
         this.#membersRepository = membersRepository;
@@ -35,7 +36,7 @@ class NewsletterEmailEventStorage {
     }
 
     async handleDelivered(event) {
-        const useBatchProcessing = config.get('emailAnalytics:batchProcessing');
+        const useBatchProcessing = this.#config.get('emailAnalytics:batchProcessing');
 
         if (useBatchProcessing) {
             // Accumulate update for batch processing
@@ -61,7 +62,7 @@ class NewsletterEmailEventStorage {
     }
 
     async handleOpened(event) {
-        const useBatchProcessing = config.get('emailAnalytics:batchProcessing');
+        const useBatchProcessing = this.#config.get('emailAnalytics:batchProcessing');
 
         if (useBatchProcessing) {
             // Accumulate update for batch processing
@@ -87,7 +88,7 @@ class NewsletterEmailEventStorage {
     }
 
     async handlePermanentFailed(event) {
-        const useBatchProcessing = config.get('emailAnalytics:batchProcessing');
+        const useBatchProcessing = this.#config.get('emailAnalytics:batchProcessing');
 
         if (useBatchProcessing) {
             // Accumulate update for batch processing

--- a/ghost/core/test/unit/server/services/email-analytics/email-analytics-service-wrapper.test.js
+++ b/ghost/core/test/unit/server/services/email-analytics/email-analytics-service-wrapper.test.js
@@ -1,5 +1,4 @@
 const sinon = require('sinon');
-const createKnex = require('knex');
 const EmailAnalyticsServiceWrapper = require('../../../../../core/server/services/email-analytics/email-analytics-service-wrapper');
 const {Queries} = require('../../../../../core/server/services/email-analytics/lib/queries');
 
@@ -39,13 +38,7 @@ describe('EmailAnalyticsServiceWrapper', function () {
                 subscribe: sinon.stub(),
             },
             event: FakeEvent,
-            queries: new Queries(createKnex({
-                client: 'better-sqlite3',
-                connection: {
-                    filename: ':memory:'
-                },
-                useNullAsDefault: true
-            })),
+            queries: sinon.createStubInstance(Queries),
             mailgunTags: [],
             jobNames: {
                 latestNonOpened: 'email-analytics-latest-others',

--- a/ghost/core/test/unit/server/services/email-analytics/email-analytics-service-wrapper.test.js
+++ b/ghost/core/test/unit/server/services/email-analytics/email-analytics-service-wrapper.test.js
@@ -1,25 +1,79 @@
 const sinon = require('sinon');
-const metrics = require('@tryghost/metrics');
-
-const configUtils = require('../../../../utils/config-utils');
+const createKnex = require('knex');
 const EmailAnalyticsServiceWrapper = require('../../../../../core/server/services/email-analytics/email-analytics-service-wrapper');
+const {Queries} = require('../../../../../core/server/services/email-analytics/lib/queries');
+
+class FakeEvent {
+    timestamp = new Date();
+    data = null;
+}
 
 describe('EmailAnalyticsServiceWrapper', function () {
+    /** @type {sinon.SinonStub} */
     let metricStub;
 
     beforeEach(function () {
-        configUtils.set('emailAnalytics:metrics:openThroughput:enabled', true);
-        configUtils.set('emailAnalytics:metrics:openThroughput:threshold', 0);
-        metricStub = sinon.stub(metrics, 'metric');
+        metricStub = sinon.stub();
     });
 
     afterEach(async function () {
         sinon.restore();
-        await configUtils.restore();
     });
 
     function logLatestOpenedJob(logName) {
         const wrapper = new EmailAnalyticsServiceWrapper({logName});
+        wrapper.init({
+            config: {
+                get: (key) => {
+                    switch (key) {
+                    case 'emailAnalytics:metrics:openThroughput:enabled':
+                        return true;
+                    case 'emailAnalytics:metrics:openThroughput:threshold':
+                        return 0;
+                    default:
+                        return undefined;
+                    }
+                }
+            },
+            domainEvents: {
+                subscribe: sinon.stub(),
+            },
+            event: FakeEvent,
+            queries: new Queries(createKnex({
+                client: 'better-sqlite3',
+                connection: {
+                    filename: ':memory:'
+                },
+                useNullAsDefault: true
+            })),
+            mailgunTags: [],
+            jobNames: {
+                latestNonOpened: 'email-analytics-latest-others',
+                missing: 'email-analytics-missing',
+                latestOpened: 'email-analytics-latest-opened',
+                scheduled: 'email-analytics-scheduled'
+            },
+            cursorSeed: {
+                tableName: 'email_recipients',
+                eventColumns: {
+                    delivered: 'delivered_at',
+                    opened: 'opened_at',
+                    failed: 'failed_at'
+                }
+            },
+            settingsCache: {
+                get: sinon.stub()
+            },
+            createEventProcessor: sinon.stub().returns({
+                process: sinon.stub().resolves()
+            }),
+            metrics: {
+                metric: metricStub
+            },
+            prometheusClient: {
+                registerCounter: sinon.stub()
+            },
+        });
         wrapper._logJobCompletion('latest-opened', {
             eventCount: 10,
             apiPollingTimeMs: 500,

--- a/ghost/core/test/unit/server/services/email-analytics/index.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/index.test.ts
@@ -1,0 +1,117 @@
+import sinon from 'sinon';
+import createKnex from 'knex';
+
+import {automations, init, newsletters} from '../../../../../core/server/services/email-analytics';
+import {AUTOMATION_EMAIL_TAG} from '../../../../../core/server/services/member-welcome-emails/constants';
+
+describe('email analytics service', function () {
+    const automationsApi = {
+        getAutomatedEmailRecipientsByMailgunIds: sinon.stub(),
+        trackEmailDeliveredAndOpened: sinon.stub()
+    };
+    const config = {get: sinon.stub()};
+    config.get.withArgs('bulkEmail:mailgun:tag').returns('custom-mailgun-tag');
+    const domainEvents = {subscribe: sinon.stub()};
+    const metrics = {metric: sinon.stub()};
+    const settingsCache = {get: sinon.stub()};
+
+    let newslettersInit: sinon.SinonStub;
+    let automationsInit: sinon.SinonStub;
+
+    let dependencies: Parameters<typeof init>[0];
+
+    beforeEach(function () {
+        newslettersInit = sinon.stub(newsletters, 'init');
+        automationsInit = sinon.stub(automations, 'init');
+
+        dependencies = {
+            automationsApi,
+            config,
+            db: {
+                knex: createKnex({
+                    client: 'better-sqlite3',
+                    connection: {
+                        filename: ':memory:'
+                    },
+                    useNullAsDefault: true
+                })
+            },
+            domainEvents,
+            emailSuppressionList: {
+                removeComplaint: sinon.stub(),
+                removeUnsubscribe: sinon.stub()
+            },
+            membersRepository: {
+                get: sinon.stub(),
+                update: sinon.stub()
+            },
+            models: {
+                Email: {},
+                EmailRecipientFailure: {},
+                EmailSpamComplaintEvent: {}
+            },
+            metrics,
+            prometheusClient: null,
+            settingsCache
+        };
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it('initializes newsletter and automation analytics', function () {
+        init(dependencies);
+
+        sinon.assert.calledOnceWithExactly(newslettersInit, sinon.match({
+            config,
+            domainEvents,
+            event: {
+                name: 'StartEmailAnalyticsJobEvent',
+            },
+            mailgunTags: ['bulk-email', 'custom-mailgun-tag'],
+            jobNames: {
+                latestNonOpened: 'email-analytics-latest-others',
+                missing: 'email-analytics-missing',
+                latestOpened: 'email-analytics-latest-opened',
+                scheduled: 'email-analytics-scheduled'
+            },
+            cursorSeed: {
+                tableName: 'email_recipients',
+                eventColumns: {
+                    delivered: 'delivered_at',
+                    opened: 'opened_at',
+                    failed: 'failed_at'
+                }
+            },
+            metrics,
+            settingsCache,
+            createEventProcessor: sinon.match.func
+        }));
+
+        sinon.assert.calledOnceWithExactly(automationsInit, sinon.match({
+            config,
+            domainEvents,
+            event: {
+                name: 'StartAutomationEmailAnalyticsJobEvent',
+            },
+            mailgunTags: [AUTOMATION_EMAIL_TAG],
+            jobNames: {
+                latestNonOpened: 'email-analytics-automation-latest-others',
+                missing: 'email-analytics-automation-missing',
+                latestOpened: 'email-analytics-automation-latest-opened',
+                scheduled: 'email-analytics-automation-scheduled'
+            },
+            cursorSeed: {
+                tableName: 'automated_email_recipients',
+                eventColumns: {
+                    delivered: 'delivered_at',
+                    opened: 'opened_at'
+                }
+            },
+            metrics,
+            settingsCache,
+            createEventProcessor: sinon.match.func
+        }));
+    });
+});

--- a/ghost/core/test/unit/server/services/email-service/newsletter-email-event-storage.test.js
+++ b/ghost/core/test/unit/server/services/email-service/newsletter-email-event-storage.test.js
@@ -4,6 +4,7 @@ const sinon = require('sinon');
 const assert = require('node:assert/strict');
 const logging = require('@tryghost/logging');
 const {createDb, createPrometheusClient} = require('./utils');
+const config = require('../../../../../core/shared/config');
 
 const EmailDeliveredEvent = require('../../../../../core/server/services/email-service/events/email-delivered-event');
 const EmailOpenedEvent = require('../../../../../core/server/services/email-service/events/email-opened-event');
@@ -11,6 +12,8 @@ const EmailBouncedEvent = require('../../../../../core/server/services/email-ser
 const EmailTemporaryBouncedEvent = require('../../../../../core/server/services/email-service/events/email-temporary-bounced-event');
 const EmailUnsubscribedEvent = require('../../../../../core/server/services/email-service/events/email-unsubscribed-event');
 const SpamComplaintEvent = require('../../../../../core/server/services/email-service/events/spam-complaint-event');
+
+const createEventStorage = (dependencies = {}) => new NewsletterEmailEventStorage({config, ...dependencies});
 
 describe('Email Event Storage', function () {
     let logError;
@@ -26,12 +29,12 @@ describe('Email Event Storage', function () {
 
     describe('Constructor', function () {
         it('doesn\'t throw', function () {
-            new NewsletterEmailEventStorage({});
+            createEventStorage({});
         });
 
         it('sets up metrics if prometheusClient is provided', function () {
             const prometheusClient = createPrometheusClient();
-            new NewsletterEmailEventStorage({prometheusClient});
+            createEventStorage({prometheusClient});
             sinon.assert.calledOnce(prometheusClient.registerCounter);
         });
     });
@@ -46,7 +49,7 @@ describe('Email Event Storage', function () {
         });
 
         const db = createDb();
-        const eventHandler = new NewsletterEmailEventStorage({db});
+        const eventHandler = createEventStorage({db});
         await eventHandler.handleDelivered(event);
         sinon.assert.calledOnce(db.update);
         assert(!!db.update.firstCall.args[0].delivered_at);
@@ -56,7 +59,7 @@ describe('Email Event Storage', function () {
         const event = EmailDeliveredEvent.create({});
         const db = createDb();
         const prometheusClient = createPrometheusClient();
-        const eventHandler = new NewsletterEmailEventStorage({db, prometheusClient});
+        const eventHandler = createEventStorage({db, prometheusClient});
         sinon.stub(eventHandler, 'recordEventStored').resolves();
         await eventHandler.handleDelivered(event);
         sinon.assert.calledOnce(eventHandler.recordEventStored);
@@ -72,7 +75,7 @@ describe('Email Event Storage', function () {
         });
 
         const db = createDb();
-        const eventHandler = new NewsletterEmailEventStorage({db});
+        const eventHandler = createEventStorage({db});
         await eventHandler.handleOpened(event);
         sinon.assert.calledOnce(db.update);
         assert(!!db.update.firstCall.args[0].opened_at);
@@ -82,7 +85,7 @@ describe('Email Event Storage', function () {
         const event = EmailOpenedEvent.create({});
         const db = createDb();
         const prometheusClient = createPrometheusClient();
-        const eventHandler = new NewsletterEmailEventStorage({db, prometheusClient});
+        const eventHandler = createEventStorage({db, prometheusClient});
         sinon.stub(eventHandler, 'recordEventStored').resolves();
         await eventHandler.handleOpened(event);
         sinon.assert.calledOnce(eventHandler.recordEventStored);
@@ -122,7 +125,7 @@ describe('Email Event Storage', function () {
             findOne: sinon.stub().resolves(existing)
         };
 
-        const eventHandler = new NewsletterEmailEventStorage({
+        const eventHandler = createEventStorage({
             db,
             models: {
                 EmailRecipientFailure
@@ -168,7 +171,7 @@ describe('Email Event Storage', function () {
             findOne: sinon.stub().resolves(existing)
         };
 
-        const eventHandler = new NewsletterEmailEventStorage({
+        const eventHandler = createEventStorage({
             db,
             models: {
                 EmailRecipientFailure
@@ -213,7 +216,7 @@ describe('Email Event Storage', function () {
             findOne: sinon.stub().resolves(existing)
         };
 
-        const eventHandler = new NewsletterEmailEventStorage({
+        const eventHandler = createEventStorage({
             db,
             models: {
                 EmailRecipientFailure
@@ -248,7 +251,7 @@ describe('Email Event Storage', function () {
             add: sinon.stub().resolves()
         };
 
-        const eventHandler = new NewsletterEmailEventStorage({
+        const eventHandler = createEventStorage({
             db,
             models: {
                 EmailRecipientFailure
@@ -283,7 +286,7 @@ describe('Email Event Storage', function () {
             add: sinon.stub().resolves()
         };
 
-        const eventHandler = new NewsletterEmailEventStorage({
+        const eventHandler = createEventStorage({
             db,
             models: {
                 EmailRecipientFailure
@@ -317,7 +320,7 @@ describe('Email Event Storage', function () {
             add: sinon.stub().resolves()
         };
 
-        const eventHandler = new NewsletterEmailEventStorage({
+        const eventHandler = createEventStorage({
             db,
             models: {
                 EmailRecipientFailure
@@ -340,7 +343,7 @@ describe('Email Event Storage', function () {
         });
 
         const db = createDb();
-        const eventHandler = new NewsletterEmailEventStorage({
+        const eventHandler = createEventStorage({
             db,
             models: {}
         });
@@ -382,7 +385,7 @@ describe('Email Event Storage', function () {
             findOne: sinon.stub().resolves(existing)
         };
 
-        const eventHandler = new NewsletterEmailEventStorage({
+        const eventHandler = createEventStorage({
             db,
             models: {
                 EmailRecipientFailure
@@ -428,7 +431,7 @@ describe('Email Event Storage', function () {
             findOne: sinon.stub().resolves(existing)
         };
 
-        const eventHandler = new NewsletterEmailEventStorage({
+        const eventHandler = createEventStorage({
             models: {
                 EmailRecipientFailure
             }
@@ -470,7 +473,7 @@ describe('Email Event Storage', function () {
             findOne: sinon.stub().resolves(existing)
         };
 
-        const eventHandler = new NewsletterEmailEventStorage({
+        const eventHandler = createEventStorage({
             models: {
                 EmailRecipientFailure
             }
@@ -509,7 +512,7 @@ describe('Email Event Storage', function () {
             })
         };
 
-        const eventHandler = new NewsletterEmailEventStorage({
+        const eventHandler = createEventStorage({
             membersRepository: {
                 get,
                 update
@@ -557,7 +560,7 @@ describe('Email Event Storage', function () {
             })
         };
 
-        const eventHandler = new NewsletterEmailEventStorage({
+        const eventHandler = createEventStorage({
             membersRepository: {
                 get,
                 update
@@ -590,7 +593,7 @@ describe('Email Event Storage', function () {
             removeUnsubscribe: sinon.stub().resolves()
         };
 
-        const eventHandler = new NewsletterEmailEventStorage({
+        const eventHandler = createEventStorage({
             membersRepository: {
                 get,
                 update
@@ -625,7 +628,7 @@ describe('Email Event Storage', function () {
             removeUnsubscribe: sinon.stub().resolves()
         };
 
-        const eventHandler = new NewsletterEmailEventStorage({
+        const eventHandler = createEventStorage({
             membersRepository: {
                 get,
                 update
@@ -663,7 +666,7 @@ describe('Email Event Storage', function () {
             removeUnsubscribe: sinon.stub().resolves()
         };
 
-        const eventHandler = new NewsletterEmailEventStorage({
+        const eventHandler = createEventStorage({
             membersRepository: {
                 get,
                 update
@@ -705,7 +708,7 @@ describe('Email Event Storage', function () {
             })
         };
 
-        const eventHandler = new NewsletterEmailEventStorage({
+        const eventHandler = createEventStorage({
             membersRepository,
             models: {
                 Email
@@ -734,7 +737,7 @@ describe('Email Event Storage', function () {
             removeComplaint: sinon.stub().resolves()
         };
 
-        const eventHandler = new NewsletterEmailEventStorage({
+        const eventHandler = createEventStorage({
             models: {
                 EmailSpamComplaintEvent
             },
@@ -762,7 +765,7 @@ describe('Email Event Storage', function () {
             removeComplaint: sinon.stub().resolves()
         };
 
-        const eventHandler = new NewsletterEmailEventStorage({
+        const eventHandler = createEventStorage({
             models: {
                 EmailSpamComplaintEvent
             },
@@ -789,7 +792,7 @@ describe('Email Event Storage', function () {
             removeComplaint: sinon.stub().resolves()
         };
 
-        const eventHandler = new NewsletterEmailEventStorage({
+        const eventHandler = createEventStorage({
             models: {
                 EmailSpamComplaintEvent
             },
@@ -809,7 +812,7 @@ describe('Email Event Storage', function () {
                     inc: incStub
                 })
             };
-            const eventHandler = new NewsletterEmailEventStorage({prometheusClient});
+            const eventHandler = createEventStorage({prometheusClient});
             eventHandler.recordEventStored('delivered');
             sinon.assert.calledOnce(incStub);
         });
@@ -819,7 +822,7 @@ describe('Email Event Storage', function () {
                 registerCounter: sinon.stub(),
                 getMetric: sinon.stub().throws(new Error('Metric not found'))
             };
-            const eventHandler = new NewsletterEmailEventStorage({prometheusClient});
+            const eventHandler = createEventStorage({prometheusClient});
             assert.doesNotThrow(() => eventHandler.recordEventStored('delivered'));
         });
     });


### PR DESCRIPTION
no ref

_I recommend reviewing this [one commit at a time](https://github.com/TryGhost/Ghost/pull/29892/commits)._

This change should have no user impact.

This change:

- tests the email analytics initializer
- stops using global references and injects the dependencies (DI)

In addition to automated testing, I also manually tested this. I sent a newsletter, opened it in Gmail, and verified that I saw the open appear in the newsletter's analytics.