### PR TITLE
Initialize email analytics Prometheus metrics in proper spot

### DIFF
--- a/ghost/core/core/server/services/email-analytics/email-analytics-service-wrapper.js
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-service-wrapper.js
@@ -4,7 +4,6 @@ const logging = require('@tryghost/logging');
 /** @import DomainEvents from '@tryghost/domain-events' */
 /** @import {Queries} from './lib/queries' */
 /** @import Metrics from '@tryghost/metrics' */
-/** @import {PrometheusClient} from '@tryghost/prometheus-metrics' */
 /** @import {BatchEventProcessor} from './batch-event-processor' */
 /** @import {JobNames, CursorSeed, EmailAnalyticsFetchResult} from './email-analytics-service' */
 
@@ -40,7 +39,6 @@ class EmailAnalyticsServiceWrapper {
      * @param {CursorSeed} options.cursorSeed
      * @param {() => BatchEventProcessor} options.createEventProcessor
      * @param {Pick<Metrics, 'metric'>} options.metrics
-     * @param {PrometheusClient | null} options.prometheusClient
      * @param {{get: (key: string) => unknown}} options.settingsCache
      */
     init({
@@ -53,7 +51,6 @@ class EmailAnalyticsServiceWrapper {
         cursorSeed,
         createEventProcessor,
         metrics,
-        prometheusClient,
         settingsCache
     }) {
         if (this.service) {
@@ -71,8 +68,7 @@ class EmailAnalyticsServiceWrapper {
             queries,
             jobNames,
             cursorSeed,
-            createEventProcessor,
-            ...(prometheusClient ? {prometheusClient} : {})
+            createEventProcessor
         });
 
         // Log the processing mode on initialization

--- a/ghost/core/core/server/services/email-analytics/email-analytics-service.ts
+++ b/ghost/core/core/server/services/email-analytics/email-analytics-service.ts
@@ -1,7 +1,6 @@
 import {EventProcessingResult} from './event-processing-result';
 import logging from '@tryghost/logging';
 import errors from '@tryghost/errors';
-import type {PrometheusClient} from '@tryghost/prometheus-metrics';
 import type {BatchEventProcessor} from './batch-event-processor';
 import type {Queries} from './lib/queries';
 
@@ -74,7 +73,6 @@ type FetchEvents = (options: {
 
 const TRUST_THRESHOLD_MS = 30 * 60 * 1000; // 30 minutes
 const FETCH_LATEST_END_MARGIN_MS = 1 * 60 * 1000; // Do not fetch events newer than 1 minute (yet). Reduces the chance of having missed events in fetchLatest.
-const AGGREGATE_MEMBER_STATS_METRIC_NAME = 'email_analytics_aggregate_member_stats_count';
 
 /**
  * Helper function to create an empty fetch result
@@ -95,7 +93,6 @@ function createEmptyResult(): EmailAnalyticsFetchResult {
 export class EmailAnalyticsService {
     queries: Queries;
     #fetchEvents: FetchEvents;
-    prometheusClient?: PrometheusClient;
     #createEventProcessor: () => BatchEventProcessor;
 
     #jobNames: JobNames;
@@ -106,17 +103,15 @@ export class EmailAnalyticsService {
     #fetchLatestOpenedData: FetchData;
     #fetchScheduledData: FetchDataScheduled;
 
-    constructor({queries, fetchEvents, prometheusClient, createEventProcessor, jobNames, cursorSeed}: {
+    constructor({queries, fetchEvents, createEventProcessor, jobNames, cursorSeed}: {
         queries: Queries;
         fetchEvents: FetchEvents;
-        prometheusClient?: PrometheusClient;
         createEventProcessor: () => BatchEventProcessor;
         jobNames: JobNames;
         cursorSeed: CursorSeed;
     }) {
         this.queries = queries;
         this.#fetchEvents = fetchEvents;
-        this.prometheusClient = prometheusClient;
         this.#createEventProcessor = createEventProcessor;
         this.#jobNames = jobNames;
         this.#cursorSeed = cursorSeed;
@@ -137,10 +132,6 @@ export class EmailAnalyticsService {
             running: false,
             jobName: jobNames.scheduled
         };
-
-        if (prometheusClient) {
-            prometheusClient.registerCounter({name: AGGREGATE_MEMBER_STATS_METRIC_NAME, help: 'Count of member stats aggregations'});
-        }
     }
 
     #clearScheduledData() {

--- a/ghost/core/core/server/services/email-analytics/index.ts
+++ b/ghost/core/core/server/services/email-analytics/index.ts
@@ -8,7 +8,7 @@ import type SettingsCache from '../../../shared/settings-cache';
 // @ts-expect-error This module lacks type definitions.
 import EmailAnalyticsServiceWrapper from './email-analytics-service-wrapper';
 // @ts-expect-error This module lacks type definitions.
-import {NewsletterEmailAnalyticsBatchProcessor} from './newsletter-email-analytics-batch-processor';
+import {AGGREGATE_MEMBER_STATS_METRIC_NAME, NewsletterEmailAnalyticsBatchProcessor} from './newsletter-email-analytics-batch-processor';
 // @ts-expect-error This module lacks type definitions.
 import NewsletterEmailEventStorage from '../email-service/newsletter-email-event-storage';
 // @ts-expect-error This module lacks type definitions.
@@ -63,7 +63,7 @@ export const init = ({
         EmailSpamComplaintEvent: EmailSpamComplaintEvent;
     };
     metrics: Pick<Metrics, 'metric'>;
-    prometheusClient: PrometheusClient | null;
+    prometheusClient: Pick<PrometheusClient, 'registerCounter'> | null;
     settingsCache: Pick<typeof SettingsCache, 'get'>;
 }) => {
     const queries = new Queries(db.knex);
@@ -90,6 +90,11 @@ export const init = ({
     if (config.get('bulkEmail:mailgun:tag')) {
         newsletterMailgunTags.push(config.get('bulkEmail:mailgun:tag'));
     }
+
+    prometheusClient?.registerCounter({
+        name: AGGREGATE_MEMBER_STATS_METRIC_NAME,
+        help: 'Count of member stats aggregations'
+    });
 
     newsletters.init({
         config,

--- a/ghost/core/core/server/services/email-analytics/index.ts
+++ b/ghost/core/core/server/services/email-analytics/index.ts
@@ -63,7 +63,7 @@ export const init = ({
         EmailSpamComplaintEvent: EmailSpamComplaintEvent;
     };
     metrics: Pick<Metrics, 'metric'>;
-    prometheusClient: Pick<PrometheusClient, 'registerCounter'> | null;
+    prometheusClient: Pick<PrometheusClient, 'registerCounter' | 'getMetric'> | null;
     settingsCache: Pick<typeof SettingsCache, 'get'>;
 }) => {
     const queries = new Queries(db.knex);

--- a/ghost/core/core/server/services/email-analytics/newsletter-email-analytics-batch-processor.js
+++ b/ghost/core/core/server/services/email-analytics/newsletter-email-analytics-batch-processor.js
@@ -3,6 +3,9 @@ const logging = require('@tryghost/logging');
 /** @import {BatchEventProcessor} from './batch-event-processor' */
 /** @import {FetchData} from './email-analytics-service' */
 
+const AGGREGATE_MEMBER_STATS_METRIC_NAME = 'email_analytics_aggregate_member_stats_count';
+exports.AGGREGATE_MEMBER_STATS_METRIC_NAME = AGGREGATE_MEMBER_STATS_METRIC_NAME;
+
 /**
  * @implements {BatchEventProcessor}
  */
@@ -222,7 +225,7 @@ class NewsletterEmailAnalyticsBatchProcessor {
         }
         const emailAggregationTimeMs = Date.now() - emailAggregationStart;
 
-        const memberMetric = this.#prometheusClient?.getMetric('email_analytics_aggregate_member_stats_count');
+        const memberMetric = this.#prometheusClient?.getMetric(AGGREGATE_MEMBER_STATS_METRIC_NAME);
 
         const memberAggregationStart = Date.now();
         if (useBatchProcessing) {

--- a/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.js
+++ b/ghost/core/test/unit/server/services/email-analytics/email-analytics-service.test.js
@@ -49,29 +49,6 @@ describe('EmailAnalyticsService', function () {
         clock.restore();
     });
 
-    describe('constructor', function () {
-        it('registers Prometheus metrics only for services given a client', function () {
-            const prometheusClient = {
-                registerCounter: sinon.stub()
-            };
-
-            createService({prometheusClient});
-            createService({
-                jobNames: {
-                    latestNonOpened: 'email-analytics-automation-latest-others',
-                    missing: 'email-analytics-automation-missing',
-                    latestOpened: 'email-analytics-automation-latest-opened',
-                    scheduled: 'email-analytics-automation-scheduled'
-                }
-            });
-
-            sinon.assert.calledOnceWithExactly(prometheusClient.registerCounter, {
-                name: 'email_analytics_aggregate_member_stats_count',
-                help: 'Count of member stats aggregations'
-            });
-        });
-    });
-
     describe('getStatus', function () {
         it('returns status object', function () {
             // these are null because we're not running them before calling this

--- a/ghost/core/test/unit/server/services/email-analytics/index.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/index.test.ts
@@ -120,7 +120,10 @@ describe('email analytics service', function () {
 
         init({
             ...dependencies,
-            prometheusClient: {registerCounter}
+            prometheusClient: {
+                registerCounter,
+                getMetric: sinon.stub()
+            }
         });
 
         sinon.assert.calledWith(registerCounter, sinon.match({

--- a/ghost/core/test/unit/server/services/email-analytics/index.test.ts
+++ b/ghost/core/test/unit/server/services/email-analytics/index.test.ts
@@ -114,4 +114,18 @@ describe('email analytics service', function () {
             createEventProcessor: sinon.match.func
         }));
     });
+
+    it('registers Prometheus metrics for member stat aggregation', function () {
+        const registerCounter = sinon.stub();
+
+        init({
+            ...dependencies,
+            prometheusClient: {registerCounter}
+        });
+
+        sinon.assert.calledWith(registerCounter, sinon.match({
+            name: 'email_analytics_aggregate_member_stats_count',
+            help: 'Count of member stats aggregations'
+        }));
+    });
 });


### PR DESCRIPTION
no ref

This change should have no impact on functionality.

Before this change, we initialized newsletter-specific metrics in `EmailAnalyticsService`, which should be unaware of newsletters.

Now, it's moved higher up. I think this is a useful cleanup.

_(Note: this PR's branch name is a misnomer, left over from a previous direction.)_