### PR TITLE
Removed unused lexicalIndicators labs flag

### DIFF
--- a/apps/ember-admin/app/components/posts-list/list-item-analytics.hbs
+++ b/apps/ember-admin/app/components/posts-list/list-item-analytics.hbs
@@ -72,16 +72,6 @@
                         {{svg-jar "star-fill" class="gh-featured-post"}}
                     {{/if}}
                     {{@post.title}}
-
-                    {{! Display lexical/mobiledoc indicators for easier testing of the feature --}}
-                    {{#if (feature 'lexicalIndicators')}}
-                        {{#if @post.lexical}}
-                            <span class="gh-lexical-indicator">L</span>
-                        {{else if @post.mobiledoc}}
-                            <span class="gh-lexical-indicator">M</span>
-                        {{/if}}
-                    {{/if}}
-
                 </h3>
                 {{#unless @hideAuthor }}
                     <p class="gh-content-entry-meta">

--- a/apps/ember-admin/app/components/posts-list/list-item.hbs
+++ b/apps/ember-admin/app/components/posts-list/list-item.hbs
@@ -53,16 +53,6 @@
                     {{svg-jar "star-fill" class="gh-featured-post"}}
                 {{/if}}
                 {{@post.title}}
-
-                {{! Display lexical/mobiledoc indicators for easier testing of the feature --}}
-                {{#if (feature 'lexicalIndicators')}}
-                    {{#if @post.lexical}}
-                        <span class="gh-lexical-indicator">L</span>
-                    {{else if @post.mobiledoc}}
-                        <span class="gh-lexical-indicator">M</span>
-                    {{/if}}
-                {{/if}}
-
             </h3>
             {{#unless @hideAuthor }}
                 <p class="gh-content-entry-meta">

--- a/apps/ember-admin/app/services/feature.js
+++ b/apps/ember-admin/app/services/feature.js
@@ -80,7 +80,6 @@ export default class FeatureService extends Service {
     @feature('emailCustomization') emailCustomization;
     @feature('importMemberTier') importMemberTier;
     @feature('adminUIRefresh') adminUIRefresh;
-    @feature('lexicalIndicators') lexicalIndicators;
     @feature('editorExcerpt') editorExcerpt;
     @feature('memberDetailsReact') memberDetailsReact;
     @feature('tagDetailsReact') tagDetailsReact;

--- a/apps/ember-admin/app/styles/layouts/content.css
+++ b/apps/ember-admin/app/styles/layouts/content.css
@@ -357,12 +357,6 @@
     overflow: hidden;
 }
 
-.gh-post-list-title .gh-lexical-indicator {
-    margin: 2px 8px 0;
-    padding: 0 8px;
-    font-size: 1.2rem;
-}
-
 .gh-post-list-title .gh-featured-post {
     flex-shrink: 0;
     width: 11px;

--- a/apps/ember-admin/app/styles/layouts/editor.css
+++ b/apps/ember-admin/app/styles/layouts/editor.css
@@ -1093,18 +1093,6 @@ body[data-user-is-dragging] .gh-editor-feature-image-dropzone {
     }
 }
 
-.gh-lexical-indicator {
-    margin: 1px 0 0 8px;
-    padding: 1px 8px;
-    background: var(--whitegrey-d1);
-    color: var(--black);
-    font-family: var(--font-family-mono);
-    font-size: 1.25rem;
-    border-radius: var(--border-radius);
-}
-
-
-
 .gh-editor-preview-trigger {
     height: 34px;
     background: var(--white);

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -46,7 +46,6 @@ const PRIVATE_FEATURES = [
     'stripeAutomaticTax',
     'importMemberTier',
     'csvContentImporter',
-    'lexicalIndicators',
     'adminUIRefresh',
     'emailCustomization',
     'tagsX',


### PR DESCRIPTION
no issue

The `lexicalIndicators` private labs flag only existed to overlay L/M badges on the posts list so we could spot lexical vs mobiledoc posts while testing the editor migration. That migration testing is long finished and nothing reads the flag any more, so this removes the flag registration, the Ember feature property, the posts-list template blocks, and the orphaned `gh-lexical-indicator` CSS rules.