### PR TITLE
Removed unused emailCustomization labs flag

### DIFF
--- a/.changeset/clean-flags-retire.md
+++ b/.changeset/clean-flags-retire.md
@@ -1,0 +1,5 @@
+---
+"@tryghost/kg-default-nodes": patch
+---
+
+Removed the unused emailCustomization and emailCustomizationAlpha feature options.

--- a/apps/admin/src/settings/app/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/labs/private-features.tsx
@@ -24,10 +24,6 @@ const features: Feature[] = [{
     description: 'Use Stripe Automatic Tax at Stripe Checkout. Needs to be enabled in Stripe',
     flag: 'stripeAutomaticTax'
 }, {
-    title: 'Email customization (internal beta)',
-    description: 'Newsletter customization settings that have been released to Ghost\'s own production sites',
-    flag: 'emailCustomization'
-}, {
     title: 'Import Member Tier',
     description: 'Enables tier to be specified when importing members',
     flag: 'importMemberTier'

--- a/apps/ember-admin/app/services/feature.js
+++ b/apps/ember-admin/app/services/feature.js
@@ -77,7 +77,6 @@ export default class FeatureService extends Service {
 
     // labs flags
     @feature('stripeAutomaticTax') stripeAutomaticTax;
-    @feature('emailCustomization') emailCustomization;
     @feature('importMemberTier') importMemberTier;
     @feature('adminUIRefresh') adminUIRefresh;
     @feature('lexicalIndicators') lexicalIndicators;

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -48,7 +48,6 @@ const PRIVATE_FEATURES = [
     'csvContentImporter',
     'lexicalIndicators',
     'adminUIRefresh',
-    'emailCustomization',
     'tagsX',
     'emailUniqueid',
     'themeTranslation',

--- a/koenig/kg-default-nodes/src/export-dom.ts
+++ b/koenig/kg-default-nodes/src/export-dom.ts
@@ -10,8 +10,6 @@ export type ExportDOMOutput<
 };
 
 export interface ExportDOMFeatureOptions {
-    emailCustomization?: boolean;
-    emailCustomizationAlpha?: boolean;
     [key: string]: unknown;
 }
 

--- a/koenig/kg-default-nodes/test/generate-decorator-node.test.ts
+++ b/koenig/kg-default-nodes/test/generate-decorator-node.test.ts
@@ -177,27 +177,21 @@ describe('Utils: generateDecoratorNode', function () {
             expect(() => node.exportDOM(editor)).toThrow('[generateDecoratorNode] versioned-render-test: "defaultRenderFn" for version 2 is required');
         }));
 
-        ['emailCustomizationAlpha', 'emailCustomization'].forEach((feature) => {
-            it(`uses custom renderer if passed in (${feature})`, editorTest(function () {
-                const node = $createNodeWithRender();
-                const customRenderer = () => createRenderResult('span', 'custom render');
+        it('uses custom renderer if passed in', editorTest(function () {
+            const node = $createNodeWithRender();
+            const customRenderer = () => createRenderResult('span', 'custom render');
 
-                const featureOption: Record<string, boolean> = {};
-                featureOption[feature] = true;
+            const result = node.exportDOM(editor, {
+                nodeRenderers: {
+                    'render-test': customRenderer
+                }
+            });
 
-                const result = node.exportDOM(editor, {
-                    feature: featureOption,
-                    nodeRenderers: {
-                        'render-test': customRenderer
-                    }
-                });
+            expect(result.type).toBe('inner');
+            expect(expectHtmlElement(result).outerHTML).toBe('<span>custom render</span>');
+        }));
 
-                expect(result.type).toBe('inner');
-                expect(expectHtmlElement(result).outerHTML).toBe('<span>custom render</span>');
-            }));
-        });
-
-        it('throws error when custom versioned renderer is missing for node version (emailCustomizationAlpha)', editorTest(function () {
+        it('throws error when custom versioned renderer is missing for node version', editorTest(function () {
             const VersionedNode = utils.generateDecoratorNode({
                 nodeType: 'versioned-render-test',
                 properties: {version: {default: 1}},
@@ -211,9 +205,6 @@ describe('Utils: generateDecoratorNode', function () {
             const node = new VersionedNode({version: 2});
 
             expect(() => node.exportDOM(editor, {
-                feature: {
-                    emailCustomizationAlpha: true
-                },
                 nodeRenderers: {
                     'versioned-render-test': {
                         1: () => createRenderResult('div', 'version 1')

--- a/koenig/kg-default-nodes/test/renderers/call-to-action-renderer.test.ts
+++ b/koenig/kg-default-nodes/test/renderers/call-to-action-renderer.test.ts
@@ -310,45 +310,36 @@ describe('renderers/call-to-action-renderer', function () {
         it('skips link to image when button is not shown (email, minimal)', testSkippedImageLink('email', 'minimal'));
         it('skips link to image when button is not shown (email, immersive)', testSkippedImageLink('email', 'immersive'));
 
-        ['emailCustomization', 'emailCustomizationAlpha'].forEach((flag) => {
-            it(`can render email with ${flag}`, function () {
-                const result = renderForEmail(getTestData(), {feature: {[flag]: true}});
-
-                assert.equal(result.element.tagName, 'TABLE');
-                assert.ok(result.element.querySelector('table.btn'), 'table.btn element should exist');
+        it('can render outline accent buttons', function () {
+            const result = renderForEmail(getTestData({buttonColor: 'accent'}), {
+                feature: {},
+                design: {buttonStyle: 'outline'}
             });
 
-            it(`can render outline accent buttons (${flag})`, function () {
-                const result = renderForEmail(getTestData({buttonColor: 'accent'}), {
-                    feature: {[flag]: true},
-                    design: {buttonStyle: 'outline'}
-                });
+            // accent buttons are fully styled by the main email template CSS
+            assert.equal(result.element.querySelector('table.btn td').getAttribute('style'), null);
+            assert.equal(result.element.querySelector('table.btn a').getAttribute('style'), null);
+        });
 
-                // accent buttons are fully styled by the main email template CSS
-                assert.equal(result.element.querySelector('table.btn td').getAttribute('style'), null);
-                assert.equal(result.element.querySelector('table.btn a').getAttribute('style'), null);
+        it('can render outline custom buttons', function () {
+            const result = renderForEmail(getTestData({buttonColor: '#F0F0F0'}), {
+                feature: {},
+                design: {buttonStyle: 'outline'}
             });
 
-            it(`can render outline custom buttons (${flag})`, function () {
-                const result = renderForEmail(getTestData({buttonColor: '#F0F0F0'}), {
-                    feature: {[flag]: true},
-                    design: {buttonStyle: 'outline'}
-                });
-
-                assertPrettifiedIncludes(result.html, html`
-                    <table class="btn" border="0" cellspacing="0" cellpadding="0">
-                        <tbody>
-                            <tr>
-                                <td align="center" style="color: #F0F0F0 !important; border: 1px solid #F0F0F0; border-color: currentColor; background-color: transparent;">
-                                    <a href="http://blog.com/post1" style="color: #F0F0F0 !important;">
-                                        click me
-                                    </a>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                `);
-            });
+            assertPrettifiedIncludes(result.html, html`
+                <table class="btn" border="0" cellspacing="0" cellpadding="0">
+                    <tbody>
+                        <tr>
+                            <td align="center" style="color: #F0F0F0 !important; border: 1px solid #F0F0F0; border-color: currentColor; background-color: transparent;">
+                                <a href="http://blog.com/post1" style="color: #F0F0F0 !important;">
+                                    click me
+                                </a>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            `);
         });
 
         it('handles accent button color', function () {

--- a/koenig/kg-default-nodes/test/renderers/product-renderer.test.ts
+++ b/koenig/kg-default-nodes/test/renderers/product-renderer.test.ts
@@ -243,67 +243,6 @@ describe('renderers/product-renderer', function () {
             `);
         });
 
-        it('renders with emailCustomization feature flag', function () {
-            const result = renderForEmail({
-                productButton: 'Click me',
-                productButtonEnabled: true,
-                productDescription: 'This product is ok',
-                productImageSrc: 'https://example.com/images/ok.jpg',
-                productImageWidth: null,
-                productImageHeight: null,
-                productRatingEnabled: true,
-                productStarRating: 3,
-                productTitle: 'Product title!',
-                productUrl: 'https://example.com/product/ok'
-            }, {feature: {emailCustomization: true}});
-
-            assertPrettifiesTo(result.html, html`
-                <table class="kg-product-card" cellspacing="0" cellpadding="0" border="0">
-                    <tbody>
-                        <tr>
-                            <td class="kg-product-card-container">
-                                <table cellspacing="0" cellpadding="0" border="0">
-                                    <tbody>
-                                        <tr>
-                                            <td class="kg-product-image" align="center">
-                                                <img src="https://example.com/images/ok.jpg" border="0" />
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td valign="top">
-                                                <h4 class="kg-product-title">Product title!</h4>
-                                            </td>
-                                        </tr>
-                                        <tr class="kg-product-rating">
-                                            <td valign="top">
-                                                <img src="https://static.ghost.org/v4.0.0/images/star-rating-3.png" border="0" />
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td class="kg-product-description-wrapper">This product is ok</td>
-                                        </tr>
-                                        <tr>
-                                            <td class="kg-product-button-wrapper">
-                                                <table class="btn" border="0" cellspacing="0" cellpadding="0">
-                                                    <tbody>
-                                                        <tr>
-                                                            <td align="center" width="100%">
-                                                                <a href="https://example.com/product/ok">Click me</a>
-                                                            </td>
-                                                        </tr>
-                                                    </tbody>
-                                                </table>
-                                            </td>
-                                        </tr>
-                                    </tbody>
-                                </table>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            `);
-        });
-
         it('renders without rating when star-rating is disabled', function () {
             const result = renderForEmail({
                 productButton: 'Click me',


### PR DESCRIPTION
no ref

The `emailCustomization` labs flag has fully shipped its behaviour and nothing reads it at runtime any more — there are no `labs.isSet`/feature conditionals left anywhere, and `kg-default-nodes`' `exportDOM` never consults `options.feature` when selecting renderers. The same is true of the older `emailCustomizationAlpha` variant, which only survived in type definitions and tests. Keeping the registrations around just left a dead toggle in the private labs settings UI and misleading test names implying the flags still changed rendering output.

- Removed the flag from `PRIVATE_FEATURES` in `labs.js`, the "Email customization (internal beta)" toggle from the admin labs settings, and the `emailCustomization` property from the Ember feature service
- Dropped both flags from `ExportDOMFeatureOptions` in `kg-default-nodes` (the interface keeps its index signature for the flags that are still read)
- De-flagged the `kg-default-nodes` tests that passed the flags as inert options, collapsing the per-flag test loops, and removed the flag-specific tests whose coverage already exists in unflagged tests
- The only remaining mentions are historical comments in two shipped 5.126 migrations, left untouched