### PR TITLE
Tied a composite custom field's part labels to its value schema

### DIFF
--- a/apps/admin-x-framework/src/api/member-custom-fields.ts
+++ b/apps/admin-x-framework/src/api/member-custom-fields.ts
@@ -1,4 +1,4 @@
-import {FIELD_TYPE_IDS, type Address, type FieldType} from '@tryghost/custom-field-types';
+import {FIELD_TYPES, FIELD_TYPE_IDS, subFieldsOf, type FieldType} from '@tryghost/custom-field-types';
 import {csvColumnsForField} from '@tryghost/custom-field-types/csv';
 import {Meta, createMutation, createQuery, createQueryWithId} from '../utils/api/hooks';
 
@@ -41,21 +41,37 @@ export type MemberCustomFieldUserType = {
     // Which control collects/edits a value of this type
     input: 'text' | 'textarea' | 'address';
     // Composite types only: label per sub-field, keyed by the sub-field key the shared
-    // value schema defines. Kept with the type's other presentation, not a parallel map.
+    // value schema defines. Widened from the catalog below, which is exact, because a
+    // caller resolving a type at runtime cannot know which one it holds.
     subFields?: Record<string, string>;
 };
 
-// Presentation for every field type in the shared catalog. The explicit
-// Record<FieldType, ...> annotation keeps this exhaustive: adding a field type
-// upstream fails to compile here until it has a presentation.
-const fieldTypePresentation: Record<FieldType, Omit<MemberCustomFieldUserType, 'id'>> = {
+/** The parts a type's value schema declares, or never for a type whose value is one thing. */
+type PartKeys<T extends FieldType> =
+    typeof FIELD_TYPES[T] extends {fields: infer F} ? Extract<keyof F, string> : never;
+
+/**
+ * How one field type is presented, constrained by what its value is: a composite names
+ * every part its schema declares and no others, a scalar names none.
+ *
+ * The shared catalog owns which parts exist; this one owns what they are called, so adding,
+ * removing or renaming a part upstream fails the build here rather than reaching a publisher
+ * as a raw key. Enforced against a literal, which is how the catalog below is written; a
+ * pre-widened `Record<string, string>` would satisfy it.
+ */
+export type FieldTypePresentation<T extends FieldType> = {
+    label: string;
+    input: MemberCustomFieldUserType['input'];
+} & ([PartKeys<T>] extends [never] ? {subFields?: never} : {subFields: Record<PartKeys<T>, string>});
+
+// Presentation for every field type in the shared catalog. The mapped type keeps this
+// exhaustive: adding a field type upstream fails to compile here until it has one.
+const fieldTypePresentation: {[T in FieldType]: FieldTypePresentation<T>} = {
     short_text: {label: 'Short text', input: 'text'},
     long_text: {label: 'Long text', input: 'textarea'},
     address: {
         label: 'Address',
         input: 'address',
-        // Keyed to the shared value schema's parts (`satisfies`), so a part added, removed,
-        // or mistyped upstream is a compile error here rather than a silently missing label.
         subFields: {
             line1: 'Address line 1',
             line2: 'Address line 2',
@@ -63,9 +79,17 @@ const fieldTypePresentation: Record<FieldType, Omit<MemberCustomFieldUserType, '
             state: 'State',
             postal_code: 'Postal code',
             country: 'Country'
-        } satisfies Record<keyof Address, string>
+        }
     }
 };
+
+/**
+ * A type's part labels, keyed by part; empty for a type with no parts.
+ *
+ * Total for every key the value schema declares, which is the only kind of key that
+ * reaches it: `FieldTypePresentation` refuses to compile a catalog missing one.
+ */
+const partLabelsFor = (type: FieldType): Record<string, string> => fieldTypePresentation[type].subFields ?? {};
 
 // The catalog in the shared catalog's declared order, so every admin surface
 // offers and renders the field types in the same order.
@@ -93,16 +117,30 @@ export type MemberCustomFieldCsvColumn = {label: string; value: string};
  */
 export const memberCustomFieldCsvColumns = (fields: MemberCustomField[]): MemberCustomFieldCsvColumn[] => {
     return fields.flatMap((field) => {
-        const columns = csvColumnsForField({key: field.key, type: field.type});
-        return columns.map((column) => {
-            if (columns.length === 1) {
-                return {label: field.name, value: column};
-            }
-            const sub = column.slice(column.lastIndexOf('.') + 1);
-            const subLabel = userTypeForFieldType(field.type).subFields?.[sub] ?? sub;
-            return {label: `${field.name} (${subLabel})`, value: column};
-        });
+        const labels = partLabelsFor(field.type);
+        return csvColumnsForField({key: field.key, type: field.type}).map(({column, subField}) => ({
+            label: subField === null ? field.name : `${field.name} (${labels[subField]})`,
+            value: column
+        }));
     });
+};
+
+/** One part of a composite field type: the key the value schema declares, and its label. */
+export type MemberCustomFieldPart = {key: string; label: string};
+
+/**
+ * The parts of a composite field type, or null for a scalar.
+ *
+ * Which parts exist, and in what order, comes from the value schema; naming them is this
+ * catalog's job.
+ */
+export const memberCustomFieldParts = (type: FieldType): MemberCustomFieldPart[] | null => {
+    const partKeys = subFieldsOf(type);
+    if (!partKeys) {
+        return null;
+    }
+    const labels = partLabelsFor(type);
+    return partKeys.map(key => ({key, label: labels[key]}));
 };
 
 export interface MemberCustomFieldsResponseType {

--- a/apps/admin-x-framework/test/unit/api/member-custom-fields.test.ts
+++ b/apps/admin-x-framework/test/unit/api/member-custom-fields.test.ts
@@ -1,4 +1,25 @@
-import {type MemberCustomField, memberCustomFieldCsvColumns} from '../../../src/api/member-custom-fields';
+import {type FieldTypePresentation, type MemberCustomField, memberCustomFieldCsvColumns, memberCustomFieldParts} from '../../../src/api/member-custom-fields';
+
+// Compile-time cases: the build failing is the assertion. Each `@ts-expect-error` fails the
+// build if the case it names stops being an error. Declared on one line each, because the
+// directive only covers the line below it and a spread literal reports on its inner line.
+const composite = {line1: 'a', line2: 'b', city: 'c', state: 'd', postal_code: 'e', country: 'f'};
+
+const labelled: FieldTypePresentation<'address'> = {label: 'Address', input: 'address', subFields: composite};
+
+// @ts-expect-error a composite missing one of the parts its value schema declares
+const missingPart: FieldTypePresentation<'address'> = {label: 'Address', input: 'address', subFields: {line1: 'a', line2: 'b', city: 'c', state: 'd', country: 'f'}};
+
+// @ts-expect-error a composite naming a part its value schema does not declare
+const unknownPart: FieldTypePresentation<'address'> = {label: 'Address', input: 'address', subFields: {...composite, county: 'g'}};
+
+// @ts-expect-error a composite with no part labels at all
+const unlabelled: FieldTypePresentation<'address'> = {label: 'Address', input: 'address'};
+
+// @ts-expect-error a type whose value is one thing has no parts to name
+const scalarWithParts: FieldTypePresentation<'short_text'> = {label: 'Short text', input: 'text', subFields: {line1: 'a'}};
+
+export {labelled, missingPart, unknownPart, unlabelled, scalarWithParts};
 
 const field = (overrides: Partial<MemberCustomField>): MemberCustomField => ({
     key: 'nickname',
@@ -33,6 +54,26 @@ describe('member custom fields api helpers', () => {
 
         it('returns no targets for an empty field set', () => {
             expect(memberCustomFieldCsvColumns([])).toEqual([]);
+        });
+    });
+
+    describe('memberCustomFieldParts', () => {
+        // The null is the contract a caller branches on to tell a composite from a
+        // scalar, so it is pinned by name rather than only through the CSV columns.
+        it('has no parts for a scalar type', () => {
+            expect(memberCustomFieldParts('short_text')).toBeNull();
+            expect(memberCustomFieldParts('long_text')).toBeNull();
+        });
+
+        it('names a composite type\'s parts in the order its value schema declares them', () => {
+            expect(memberCustomFieldParts('address')).toEqual([
+                {key: 'line1', label: 'Address line 1'},
+                {key: 'line2', label: 'Address line 2'},
+                {key: 'city', label: 'City'},
+                {key: 'state', label: 'State'},
+                {key: 'postal_code', label: 'Postal code'},
+                {key: 'country', label: 'Country'}
+            ]);
         });
     });
 });

--- a/packages/custom-field-types/src/csv.ts
+++ b/packages/custom-field-types/src/csv.ts
@@ -45,12 +45,21 @@ function isBlank(cell: string): boolean {
     return cell.trim() === '';
 }
 
+/** A column a field occupies, and which part of the field's value it holds. */
+export interface CsvFieldColumn {
+    column: string;
+    /** The part this column holds, or null where the field's whole value is one column. */
+    subField: string | null;
+}
+
 // Shares csvCellsForFields' column derivation, so a field is written, read, and offered
 // as a mapping target under one set of column names.
-export function csvColumnsForField(field: CsvField): string[] {
+export function csvColumnsForField(field: CsvField): CsvFieldColumn[] {
     const column = `${NAMESPACE}${SEPARATOR}${field.key}`;
     const subFields = subFieldsOf(field.type);
-    return subFields ? subFields.map(sub => `${column}${SEPARATOR}${sub}`) : [column];
+    return subFields
+        ? subFields.map(sub => ({column: `${column}${SEPARATOR}${sub}`, subField: sub}))
+        : [{column, subField: null}];
 }
 
 export function isCustomFieldColumn(column: string): boolean {

--- a/packages/custom-field-types/test/csv.test.ts
+++ b/packages/custom-field-types/test/csv.test.ts
@@ -80,18 +80,20 @@ describe('custom field CSV cells', function () {
 // The column names are the vocabulary the admin offers as import mapping targets and
 // the error report echoes, so they are derived from the same primitives the cells are.
 describe('custom field CSV columns', function () {
-    it('gives a scalar field one namespaced column', function () {
-        assert.deepEqual(csvColumnsForField({key: 'nickname', type: 'short_text'}), ['custom_fields.nickname']);
+    it('gives a scalar field one namespaced column holding no particular part', function () {
+        assert.deepEqual(csvColumnsForField({key: 'nickname', type: 'short_text'}), [
+            {column: 'custom_fields.nickname', subField: null}
+        ]);
     });
 
-    it('gives a composite field one column per sub-field', function () {
+    it('gives a composite field one column per sub-field, each naming the part it holds', function () {
         assert.deepEqual(csvColumnsForField({key: 'shipping_address', type: 'address'}), [
-            'custom_fields.shipping_address.line1',
-            'custom_fields.shipping_address.line2',
-            'custom_fields.shipping_address.city',
-            'custom_fields.shipping_address.state',
-            'custom_fields.shipping_address.postal_code',
-            'custom_fields.shipping_address.country'
+            {column: 'custom_fields.shipping_address.line1', subField: 'line1'},
+            {column: 'custom_fields.shipping_address.line2', subField: 'line2'},
+            {column: 'custom_fields.shipping_address.city', subField: 'city'},
+            {column: 'custom_fields.shipping_address.state', subField: 'state'},
+            {column: 'custom_fields.shipping_address.postal_code', subField: 'postal_code'},
+            {column: 'custom_fields.shipping_address.country', subField: 'country'}
         ]);
     });
 


### PR DESCRIPTION
## Problem

A composite custom field's parts are described in two places and nothing held them together. The shared field-type catalog derives them from the type's own value schema; admin hand-writes the label for each one. The only check that the two still agreed was a constraint applied by hand to the address type alone.

So a part added upstream reached a publisher as its raw key, looking like a bug. Worse, a composite nobody had labelled at all read as a scalar, and a caller would never think to ask which part it was holding, quietly taking the first.

Admin also recovered which part a CSV column held by slicing apart the column name it had just built, then paired labels to columns by their position in two separately built lists.

## Solution

Presentation is compile-forced against the value schema for every type, not just address. A composite must name every part its schema declares and no others; a type whose value is a single thing must name none. Adding, removing or renaming a part upstream now fails the build in admin rather than reaching a publisher, so the fallback to a raw key is gone.

Columns carry the part they hold, so a label is looked up by that part instead of by position, and nothing takes a column apart to work out what it is.

The type constraint is pinned by compile-time cases that fail the build if it ever stops biting.

ref https://linear.app/ghost/issue/BER-3859/
