### PR TITLE
Read the address editor's parts from the shared catalog

### DIFF
--- a/apps/admin-x-framework/src/api/member-custom-fields.ts
+++ b/apps/admin-x-framework/src/api/member-custom-fields.ts
@@ -1,4 +1,4 @@
-import {FIELD_TYPES, FIELD_TYPE_IDS, subFieldsOf, type FieldType} from '@tryghost/custom-field-types';
+import {FIELD_TYPE_IDS, subFieldsOf, type FieldType, type PartsOf} from '@tryghost/custom-field-types';
 import {csvColumnsForField} from '@tryghost/custom-field-types/csv';
 import {Meta, createMutation, createQuery, createQueryWithId} from '../utils/api/hooks';
 
@@ -46,10 +46,6 @@ export type MemberCustomFieldUserType = {
     subFields?: Record<string, string>;
 };
 
-/** The parts a type's value schema declares, or never for a type whose value is one thing. */
-type PartKeys<T extends FieldType> =
-    typeof FIELD_TYPES[T] extends {fields: infer F} ? Extract<keyof F, string> : never;
-
 /**
  * How one field type is presented, constrained by what its value is: a composite names
  * every part its schema declares and no others, a scalar names none.
@@ -62,7 +58,7 @@ type PartKeys<T extends FieldType> =
 export type FieldTypePresentation<T extends FieldType> = {
     label: string;
     input: MemberCustomFieldUserType['input'];
-} & ([PartKeys<T>] extends [never] ? {subFields?: never} : {subFields: Record<PartKeys<T>, string>});
+} & ([PartsOf<T>] extends [never] ? {subFields?: never} : {subFields: Record<PartsOf<T>, string>});
 
 // Presentation for every field type in the shared catalog. The mapped type keeps this
 // exhaustive: adding a field type upstream fails to compile here until it has one.
@@ -126,7 +122,7 @@ export const memberCustomFieldCsvColumns = (fields: MemberCustomField[]): Member
 };
 
 /** One part of a composite field type: the key the value schema declares, and its label. */
-export type MemberCustomFieldPart = {key: string; label: string};
+export type MemberCustomFieldPart<T extends FieldType = FieldType> = {key: PartsOf<T>; label: string};
 
 /**
  * The parts of a composite field type, or null for a scalar.
@@ -134,7 +130,7 @@ export type MemberCustomFieldPart = {key: string; label: string};
  * Which parts exist, and in what order, comes from the value schema; naming them is this
  * catalog's job.
  */
-export const memberCustomFieldParts = (type: FieldType): MemberCustomFieldPart[] | null => {
+export const memberCustomFieldParts = <T extends FieldType>(type: T): MemberCustomFieldPart<T>[] | null => {
     const partKeys = subFieldsOf(type);
     if (!partKeys) {
         return null;

--- a/apps/admin/src/members/detail/member-custom-fields-field.tsx
+++ b/apps/admin/src/members/detail/member-custom-fields-field.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import {Button, Card, CardContent, Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, Input, Label, LoadingIndicator, Textarea} from '@tryghost/shade/components';
 import {LucideIcon} from '@tryghost/shade/utils';
 import {dequal} from 'dequal';
-import {ADDRESS_SUBFIELD_KEYS, buildCustomFieldSavePayload, getCustomFieldValidationErrors, getEditableCustomFieldValues, parseCustomFieldServerErrors} from './member-detail-edit';
+import {ADDRESS_PARTS, buildCustomFieldSavePayload, getCustomFieldValidationErrors, getEditableCustomFieldValues, parseCustomFieldServerErrors} from './member-detail-edit';
 import {formatAddressValue} from './member-detail-format';
 import {toast} from 'sonner';
-import {useBrowseMemberCustomFields, userTypeForField, userTypeForFieldType} from '@tryghost/admin-x-framework/api/member-custom-fields';
+import {useBrowseMemberCustomFields, userTypeForField} from '@tryghost/admin-x-framework/api/member-custom-fields';
 import {useEditMember} from '@tryghost/admin-x-framework/api/members';
 import type {EditableAddressValue, EditableCustomFieldValue} from './member-detail-edit';
 import type {MemberCustomField} from '@tryghost/admin-x-framework/api/member-custom-fields';
@@ -18,9 +18,6 @@ interface MemberCustomFieldsFieldProps {
     customFields: Record<string, unknown> | undefined;
     disabled?: boolean;
 }
-
-// Shared with the CSV import mapping so a sub-field reads the same on every surface.
-const ADDRESS_SUBFIELD_LABELS = userTypeForFieldType('address').subFields ?? {};
 
 // role='alert': after a save-attempt these render while focus stays on the Save
 // button, so an assertive live region is the only way a screen reader hears the
@@ -43,12 +40,12 @@ const AddressInput: React.FC<{
 }> = ({inputId, value, errors, disabled, onChange}) => {
     return (
         <div className='grid gap-x-4 gap-y-3 md:grid-cols-2'>
-            {ADDRESS_SUBFIELD_KEYS.map((subfield) => {
+            {ADDRESS_PARTS.map(({key: subfield, label}) => {
                 const subfieldId = `${inputId}-${subfield}`;
                 const error = errors?.[subfield];
                 return (
                     <div key={subfield} className='flex flex-col gap-1.5'>
-                        <Label htmlFor={subfieldId}>{ADDRESS_SUBFIELD_LABELS[subfield] ?? subfield}</Label>
+                        <Label htmlFor={subfieldId}>{label}</Label>
                         <Input
                             aria-invalid={error ? true : undefined}
                             disabled={disabled}

--- a/apps/admin/src/members/detail/member-detail-edit.ts
+++ b/apps/admin/src/members/detail/member-detail-edit.ts
@@ -1,14 +1,16 @@
 import moment from 'moment-timezone';
-import {MEMBER_CUSTOM_FIELD_TYPES} from '@tryghost/admin-x-framework/api/member-custom-fields';
+import {MEMBER_CUSTOM_FIELD_TYPES, memberCustomFieldParts} from '@tryghost/admin-x-framework/api/member-custom-fields';
 import {dequal} from 'dequal';
 import type {EditMemberData, Member} from '@tryghost/admin-x-framework/api/members';
 import type {MemberCustomField, MemberCustomFieldAddress} from '@tryghost/admin-x-framework/api/member-custom-fields';
 
-// The sub-fields of the address composite, in display order. Partial because a
-// draft mid-edit (or a normalized sparse value) may hold any subset; the shared
-// AddressValue schema — enforced by the server — decides completeness.
-export const ADDRESS_SUBFIELD_KEYS = ['line1', 'line2', 'city', 'state', 'postal_code', 'country'] as const;
-export type EditableAddressValue = Partial<Pick<MemberCustomFieldAddress, typeof ADDRESS_SUBFIELD_KEYS[number]>>;
+// The parts of the address composite, in the order its value schema declares them, each
+// with the label every other surface shows it under.
+export const ADDRESS_PARTS = memberCustomFieldParts('address') ?? [];
+
+// Partial because a draft mid-edit (or a normalized sparse value) may hold any subset; the
+// shared AddressValue schema — enforced by the server — decides completeness.
+export type EditableAddressValue = Partial<MemberCustomFieldAddress>;
 export type EditableCustomFieldValue = string | EditableAddressValue;
 
 export interface MemberEditableLabel {
@@ -99,10 +101,10 @@ export function getEditableCustomFieldValues(customFields: Record<string, unknow
  */
 function addressToSave(value: Record<string, unknown>): EditableAddressValue | undefined {
     const address: EditableAddressValue = {};
-    for (const subfield of ADDRESS_SUBFIELD_KEYS) {
-        const subvalue = value[subfield];
+    for (const {key} of ADDRESS_PARTS) {
+        const subvalue = value[key];
         if (typeof subvalue === 'string') {
-            address[subfield] = subvalue.trim();
+            address[key] = subvalue.trim();
         }
     }
     return Object.values(address).some(part => part !== '') ? address : undefined;
@@ -115,10 +117,10 @@ function addressToSave(value: Record<string, unknown>): EditableAddressValue | u
  */
 function normalizeAddressValue(value: Record<string, unknown>): EditableAddressValue | undefined {
     const address: EditableAddressValue = {};
-    for (const subfield of ADDRESS_SUBFIELD_KEYS) {
-        const subvalue = value[subfield];
+    for (const {key} of ADDRESS_PARTS) {
+        const subvalue = value[key];
         if (typeof subvalue === 'string' && subvalue.trim() !== '') {
-            address[subfield] = subvalue.trim();
+            address[key] = subvalue.trim();
         }
     }
     return Object.keys(address).length ? address : undefined;

--- a/apps/admin/src/members/detail/member-detail-format.ts
+++ b/apps/admin/src/members/detail/member-detail-format.ts
@@ -1,3 +1,5 @@
+import type {MemberCustomFieldAddress} from '@tryghost/admin-x-framework/api/member-custom-fields';
+
 export interface MemberGeolocation {
     country_code?: string;
     country?: string;
@@ -54,8 +56,12 @@ export function formatMemberLocation(rawGeolocation: string | null | undefined):
  * "1 Main St, 12 apt B, New York, NY 00001, US". State and postal code pair
  * up the way people write them; whatever sub-fields are missing simply drop
  * out, so a partial address still reads naturally.
+ *
+ * The parts are named one by one rather than walked, because where each sits in the
+ * sentence is a fact about how an address reads, not one the value schema can supply. A
+ * part added upstream will not appear here until someone decides where it belongs.
  */
-export function formatAddressValue(address: Partial<Record<'line1' | 'line2' | 'city' | 'state' | 'postal_code' | 'country', string>>): string {
+export function formatAddressValue(address: Partial<MemberCustomFieldAddress>): string {
     const statePostal = [address.state, address.postal_code].filter(Boolean).join(' ');
     return [address.line1, address.line2, address.city, statePostal, address.country]
         .filter(Boolean)

--- a/packages/custom-field-types/src/index.ts
+++ b/packages/custom-field-types/src/index.ts
@@ -185,9 +185,25 @@ export const FIELD_TYPES = defineFieldTypes({
 export const AddressValue = FIELD_TYPES.address.value;
 export type Address = z.infer<typeof AddressValue>;
 
-/** The parts of a record type in declaration order, or null for a type with none. */
-export function subFieldsOf(type: FieldType): string[] | null {
+/**
+ * The parts a record type declares, or never for a type whose value is a single thing.
+ *
+ * Distributed over `T`, so a caller holding a type it only knows as `FieldType` gets every
+ * part any type declares rather than the empty intersection of all of them.
+ */
+export type PartsOf<T extends FieldType> = T extends FieldType
+    ? typeof FIELD_TYPES[T] extends {fields: infer F} ? Extract<keyof F, string> : never
+    : never;
+
+/**
+ * The parts of a record type in declaration order, or null for a type with none.
+ *
+ * Typed to the parts the caller's type declares, so a caller holding one of these can
+ * index a value of that type without restating which parts exist.
+ */
+export function subFieldsOf<T extends FieldType>(type: T): PartsOf<T>[] | null {
     // Through the interface, not the literal: a type with no parts has no `fields` key.
     const {fields}: FieldTypeDefinition = FIELD_TYPES[type];
-    return fields ? Object.keys(fields) : null;
+    // The keys are `PartsOf<T>` by construction: `fields` is the object it reads `keyof` from.
+    return fields ? Object.keys(fields) as PartsOf<T>[] : null;
 }


### PR DESCRIPTION
Stacked on #29904. Review that one first; this branch contains its commit.

## Problem

The member detail editor kept its own list of the address composite's parts, so the parts existed in three places: the value schema that declares them, the catalog that labels them, and a tuple in the editor.

That tuple also typed the editable value through a `Pick`, which catches a part being removed or renamed upstream but not one being added. A part added to the address would have been quietly missing from the editor, and from the trimming that both the draft and the save run over a value, while everything still compiled.

The editor also carried its own copy of the part labels, falling back to the raw key when one was missing.

## Solution

The editor takes the parts from the same accessor the import mapping reads, in the order the value schema declares them and under the labels every other surface shows. The tuple and the local label map are gone, and so is the fallback to a raw key.

Part keys now carry their own type out of the shared catalog, so a consumer can index a value by one without restating which parts exist. That is what let the editor drop its list rather than swap it for a cast.

The formatted address line still names its parts one by one. Where each sits in the sentence is a fact about how an address reads, not one the schema can supply, so a part added upstream becomes editable before it becomes printable. The comment there says so.

ref https://linear.app/ghost/issue/BER-3859/
