### PR TITLE
Bumped bookshelf-plugins and removed smarterCounts labs flag

### DIFF
--- a/apps/admin/src/settings/app/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/labs/private-features.tsx
@@ -52,10 +52,6 @@ const features: Feature[] = [{
     description: 'Use the HTML picture element to serve modern image formats (AVIF, WebP) with automatic fallbacks',
     flag: 'pictureImageFormats'
 }, {
-    title: 'Smarter Counts',
-    description: 'Use optimized COUNT queries for API pagination when safe',
-    flag: 'smarterCounts'
-}, {
     title: 'Get helper deduplication',
     description: 'Deduplicate identical {{#get}} helper queries within a single request to avoid redundant database calls',
     flag: 'getHelperDeduplication'

--- a/ghost/core/core/server/models/base/plugins/crud.js
+++ b/ghost/core/core/server/models/base/plugins/crud.js
@@ -2,7 +2,6 @@ const _ = require('lodash');
 const errors = require('@tryghost/errors');
 
 const tpl = require('@tryghost/tpl');
-const labs = require('../../../../shared/labs');
 
 const messages = {
     couldNotUnderstandRequest: 'Could not understand request.'
@@ -178,10 +177,6 @@ module.exports = function (Bookshelf) {
             //option param to skip distinct from count query, distinct adds a lot of latency and in this case the result set will always be unique.
             if (unfilteredOptions.useBasicCount) {
                 options.useBasicCount = unfilteredOptions.useBasicCount;
-            }
-
-            if (labs.isSet('smarterCounts')) {
-                options.useSmartCount = true;
             }
 
             if (skipPagination) {

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -51,7 +51,6 @@ const PRIVATE_FEATURES = [
     'emailUniqueid',
     'themeTranslation',
     'pictureImageFormats',
-    'smarterCounts',
     'getHelperDeduplication',
     'memberDetailsReact',
     'membersCustomFields',

--- a/ghost/core/package.json
+++ b/ghost/core/package.json
@@ -92,7 +92,7 @@
         "@tryghost/adapter-base-sso": "workspace:*",
         "@tryghost/admin-api-schema": "workspace:*",
         "@tryghost/api-framework": "catalog:",
-        "@tryghost/bookshelf-plugins": "2.3.2",
+        "@tryghost/bookshelf-plugins": "2.3.8",
         "@tryghost/brute-knex": "catalog:",
         "@tryghost/color-utils": "catalog:",
         "@tryghost/config-url-helpers": "1.0.27",

--- a/ghost/core/test/unit/server/models/post.test.js
+++ b/ghost/core/test/unit/server/models/post.test.js
@@ -41,7 +41,7 @@ describe('Unit: models/post', function () {
                 withRelated: ['tags']
             }).then(() => {
                 assert.equal(queries.length, 2);
-                assert.equal(queries[0].sql, 'select count(distinct posts.id) as aggregate from `posts` where ((`posts`.`id` != ? and `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`slug` in (?, ?))) and (`posts`.`type` = ? and `posts`.`status` = ?))');
+                assert.equal(queries[0].sql, 'select count(*) as aggregate from `posts` where ((`posts`.`id` != ? and `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`slug` in (?, ?))) and (`posts`.`type` = ? and `posts`.`status` = ?))');
                 assert.deepEqual(queries[0].bindings, [
                     testUtils.filterData.data.posts[3].id,
                     'photo',
@@ -76,7 +76,7 @@ describe('Unit: models/post', function () {
                 withRelated: ['authors', 'tags']
             }).then(() => {
                 assert.equal(queries.length, 2);
-                assert.equal(queries[0].sql, 'select count(distinct posts.id) as aggregate from `posts` where (((`posts`.`feature_image` is not null or `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`slug` = ?)) and `posts`.`id` in (select `posts_authors`.`post_id` from `posts_authors` inner join `users` as `authors` on `authors`.`id` = `posts_authors`.`author_id` where `authors`.`slug` in (?, ?))) and (`posts`.`type` = ? and `posts`.`status` = ?))');
+                assert.equal(queries[0].sql, 'select count(*) as aggregate from `posts` where (((`posts`.`feature_image` is not null or `posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` where `tags`.`slug` = ?)) and `posts`.`id` in (select `posts_authors`.`post_id` from `posts_authors` inner join `users` as `authors` on `authors`.`id` = `posts_authors`.`author_id` where `authors`.`slug` in (?, ?))) and (`posts`.`type` = ? and `posts`.`status` = ?))');
                 assert.deepEqual(queries[0].bindings, [
                     'hash-audio',
                     'leslie',
@@ -112,7 +112,7 @@ describe('Unit: models/post', function () {
                 withRelated: ['tags']
             }).then(() => {
                 assert.equal(queries.length, 2);
-                assert.equal(queries[0].sql, 'select count(distinct posts.id) as aggregate from `posts` where (`posts`.`published_at` > ? and (`posts`.`type` = ? and `posts`.`status` = ?))');
+                assert.equal(queries[0].sql, 'select count(*) as aggregate from `posts` where (`posts`.`published_at` > ? and (`posts`.`type` = ? and `posts`.`status` = ?))');
                 assert.deepEqual(queries[0].bindings, [
                     '2015-07-20',
                     'post',
@@ -199,7 +199,7 @@ describe('Unit: models/post', function () {
                     withRelated: ['tags']
                 }).then(() => {
                     assert.equal(queries.length, 2);
-                    assert.equal(queries[0].sql, 'select count(distinct posts.id) as aggregate from `posts` where ((`posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` and `posts_tags`.`sort_order` = 0 where `tags`.`slug` = ? and `tags`.`visibility` = ?)) and (`posts`.`type` = ? and `posts`.`status` = ?))');
+                    assert.equal(queries[0].sql, 'select count(*) as aggregate from `posts` where ((`posts`.`id` in (select `posts_tags`.`post_id` from `posts_tags` inner join `tags` on `tags`.`id` = `posts_tags`.`tag_id` and `posts_tags`.`sort_order` = 0 where `tags`.`slug` = ? and `tags`.`visibility` = ?)) and (`posts`.`type` = ? and `posts`.`status` = ?))');
                     assert.deepEqual(queries[0].bindings, [
                         'photo',
                         'public',
@@ -232,7 +232,7 @@ describe('Unit: models/post', function () {
                     withRelated: ['authors']
                 }).then(() => {
                     assert.equal(queries.length, 2);
-                    assert.equal(queries[0].sql, 'select count(distinct posts.id) as aggregate from `posts` where ((`posts`.`id` in (select `posts_authors`.`post_id` from `posts_authors` inner join `users` as `authors` on `authors`.`id` = `posts_authors`.`author_id` and `posts_authors`.`sort_order` = 0 where `authors`.`slug` = ? and `authors`.`visibility` = ?)) and (`posts`.`type` = ? and `posts`.`status` = ?))');
+                    assert.equal(queries[0].sql, 'select count(*) as aggregate from `posts` where ((`posts`.`id` in (select `posts_authors`.`post_id` from `posts_authors` inner join `users` as `authors` on `authors`.`id` = `posts_authors`.`author_id` and `posts_authors`.`sort_order` = 0 where `authors`.`slug` = ? and `authors`.`visibility` = ?)) and (`posts`.`type` = ? and `posts`.`status` = ?))');
                     assert.deepEqual(queries[0].bindings, [
                         'leslie',
                         'public',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2163,8 +2163,8 @@ importers:
         specifier: 'catalog:'
         version: 3.3.5(supports-color@10.2.2)
       '@tryghost/bookshelf-plugins':
-        specifier: 2.3.2
-        version: 2.3.2(supports-color@10.2.2)
+        specifier: 2.3.8
+        version: 2.3.8(supports-color@10.2.2)
       '@tryghost/brute-knex':
         specifier: 'catalog:'
         version: 3.2.1(better-sqlite3@12.11.1)(express@4.22.2(supports-color@10.2.2))(mysql2@3.22.5(@types/node@22.20.0))(sqlite3@5.1.7(bluebird@3.7.2)(supports-color@10.2.2))(supports-color@10.2.2)
@@ -8917,38 +8917,38 @@ packages:
   '@tryghost/api-framework@3.3.5':
     resolution: {integrity: sha512-6bDBLtKAHPG82P3ZdY0gT0ZcfpfLbRiK5uwcJhLbr4CfhhH8IWvrecvjkKUskQldL18Tdr2Ct+rfbj2SOYGXog==}
 
-  '@tryghost/bookshelf-collision@2.3.2':
-    resolution: {integrity: sha512-9OQvpAU3Xo/rwlsJGyxe1NmbTpMuu3SZl3A2QF2Q3xy8yvxZOlWsX8JmDmPmK433cAkLW/G5qt21cVq+fxG/bQ==}
+  '@tryghost/bookshelf-collision@2.3.7':
+    resolution: {integrity: sha512-CIrIW1BhzyBaybKTKF7Ly6jcnx/AOzCmH1rrLlLhxUjW/5tRZt7qHfXgH7r/SbYbzR8+CVuljq1jGA4vqjM9SA==}
 
-  '@tryghost/bookshelf-custom-query@2.3.2':
-    resolution: {integrity: sha512-uLj8mqaudNyRx6MFO9wXcjDl7PEuoOP9Zi0rJBbdByjHmJfmf5Jc83DIcMH3A7C+s9XS5xHLqIZCLW1fB0qKSw==}
+  '@tryghost/bookshelf-custom-query@2.3.7':
+    resolution: {integrity: sha512-i9P24QcI4SadAkFfIwRr5RfK8c0EFOhRlGka0gkXecAOOsnRLJEK36/+f+7eOfVbhdOZq2drOg6zVBAkBjv4HQ==}
 
-  '@tryghost/bookshelf-eager-load@2.3.2':
-    resolution: {integrity: sha512-nb0NdNhkPrbY1wVGD9W5IkXm1FNvfltLuonR7MW5xDQMWdlHZQ2QXOHXjzFvfG8wG7D8G0zXn9o91YF0EXmuKw==}
+  '@tryghost/bookshelf-eager-load@2.3.7':
+    resolution: {integrity: sha512-k3eB8Xe665PpZxx+t/ycIh0rqQt9XhV1BtnqCyNWRzgIvnTEcrIx0vQqxUQMOOAEtMoZ0s5rFAqGVzDo1H4KjQ==}
 
-  '@tryghost/bookshelf-filter@2.3.2':
-    resolution: {integrity: sha512-C1sNBp5HfrAm7g+M+LS4kgbrQVcpSrQarXFch3KCnLpJDeEm4Qhrn6lLIYTMmAG4y3KF2NHXv1qhtlcG02mVLA==}
+  '@tryghost/bookshelf-filter@2.3.7':
+    resolution: {integrity: sha512-lR51ryZO4NCNvzVcWv6b4CHDpp41XhflbltwdvJZdXgEej5dIf9kYSZ8km7Mrw8CEbZrGqoPUdiAdCxTgeKUZg==}
 
-  '@tryghost/bookshelf-has-posts@2.4.2':
-    resolution: {integrity: sha512-RT+QFPn+qWqXQv3QUjetuYyXhdFynKG+nUT6HmHQqA/hgRbeRVHEsARMdqxIQntZyja2PLg4SXv1I166Tbqz5A==}
+  '@tryghost/bookshelf-has-posts@2.4.7':
+    resolution: {integrity: sha512-uWdsQKosBvKhMZnKLArBmK791qH13o6oNnTMcpM9dDRBNWDW3IJBW3XYnZUTJmjDg9HnJ7t5zm7wZxOnKwwP9Q==}
 
-  '@tryghost/bookshelf-include-count@2.3.2':
-    resolution: {integrity: sha512-X1xeAnbOxmZE8HEKL06/JtCC5/h2Gn35zL9HnHCeIUwfnfPPRUgTi6+HKAG4aala1JHjsJgDnCNhXQtHHr2SyA==}
+  '@tryghost/bookshelf-include-count@2.3.7':
+    resolution: {integrity: sha512-opncKLBLPtc4/lLgMx+fIhXdjDX34V+4a2OYp259eDsKyFOnrm4H1vYdyxy/VIw8d/WnRy7KpdYA9xlJgZhDsQ==}
 
-  '@tryghost/bookshelf-order@2.3.2':
-    resolution: {integrity: sha512-ZGLoygYHfGCYUrar8qiwsvQo1xX8DzpZretf8nNG/V5RQpkmmXqOBh5bOSqkxyFFr3b3FMLgqOq6MUQ1ekzaqA==}
+  '@tryghost/bookshelf-order@2.3.7':
+    resolution: {integrity: sha512-pX4+8ne1W0oo5Kw98gvvgWL7RgzeywywnydnvGe6B48QuSt0NheFqKQ30g9VKZiCanEI7vkyKs9NZkoRTbY9Sw==}
 
-  '@tryghost/bookshelf-pagination@2.3.2':
-    resolution: {integrity: sha512-5CN7fW3xFmvpm+zODM6V+xT+pH8xdKn3ufe2HxoEdEHaKJnzenrQLrJEKmdD6zDkg/I1b9QNIj0B8dFKGKNMOQ==}
+  '@tryghost/bookshelf-pagination@2.4.1':
+    resolution: {integrity: sha512-oEFuybdPkEhpadvOBUXM83BgVKyKaiFpdALOUqFHR4fk1xHA4vWgOE75ajntXcDUBUmmTSRW8k/4XZDofFWTxA==}
 
-  '@tryghost/bookshelf-plugins@2.3.2':
-    resolution: {integrity: sha512-4gF429NmprYpxzJiJ+G+nhhsBJ0MceGZSofUTvzOQTmvOf+Stkmz5bzB0+qiRcTyPwqUqraBJ/ucDuECTcqTGw==}
+  '@tryghost/bookshelf-plugins@2.3.8':
+    resolution: {integrity: sha512-CSEMOYJtBqXOxE1JccvYcktPDiC1xAXrYQAYSGGoUPXj/5zIRgU0Lr9z5WfmX4AmxEnpTPpFQl1O/9EoDrsxXA==}
 
-  '@tryghost/bookshelf-search@2.3.2':
-    resolution: {integrity: sha512-I9VdWjtnIXAVrVvVkY1TpuTQPTNkPrCuNr0p+IxvwLR6eTy+4MmHdXlcHEsITvWU521Jf2hz1qkFpQV7WGn4Mw==}
+  '@tryghost/bookshelf-search@2.3.7':
+    resolution: {integrity: sha512-MAy/aLA72BGIJ7lYoBkCooJMpXGcnCRWI1+QwPDtszNdC4lawDOgBANyEmBzUFH+YveCkK0RAzDPCV4UO0xyPA==}
 
-  '@tryghost/bookshelf-transaction-events@2.3.2':
-    resolution: {integrity: sha512-j1lHAxVp+AZzTM9JlOTiKB5RS0SwbkpFam7aUzzp71DwceKNb6JXhxA7zJhqG1lQS8c71DuG7IRbgQTppFsBSQ==}
+  '@tryghost/bookshelf-transaction-events@2.3.7':
+    resolution: {integrity: sha512-m9SP1f999C+pO0HU6wzEVhGAIijXWcv4A4EFooHwTqyYszJTXxSwyzyw3u2dXMaMLHLKO9+iFotlaOBPLZN65g==}
 
   '@tryghost/brute-knex@3.2.1':
     resolution: {integrity: sha512-1Q1CzpDuWNRrejD4sbSZF4CAJ9RTuZWLuQH1BjcC1U6+5sTY3cbnRv4w6mmxGHbUxWJ0kwbP10UM+ODheGaL7A==}
@@ -8981,11 +8981,11 @@ packages:
   '@tryghost/debug@2.3.1':
     resolution: {integrity: sha512-m35yRGwmmmvHWzs42qJnf0duCvi5Yd456bPa436Gcldv/rxK5YMPehtGDrwjHstJ4K2If0oguXsdHJf3tjgAjw==}
 
-  '@tryghost/debug@2.3.2':
-    resolution: {integrity: sha512-+ux9DG8GapSubq8JRLNVnWYxzou2oga66jM2bit7pq7zCGsNKnmGPV6YMWFbn8xKD22dG1isAUAgLwi3UAHr9A==}
-
   '@tryghost/debug@2.3.5':
     resolution: {integrity: sha512-t08spG/+SXLb7x1C2zJ0ATw/sM3CC5ssaeCHm/Ew2zPaIF+4SaFzNMynGRxKjzlIb+bxUoWPMJlW0EQaveOPeg==}
+
+  '@tryghost/debug@2.3.7':
+    resolution: {integrity: sha512-qS8QrBLNdDTu1DBgx/RwnNeF/7abDvT1iRZ+bDJ95TIj6gKcHbQN2gQs0rLhZLsnxQs2aC4arb0QjHRy8JyazA==}
 
   '@tryghost/domain-events@3.3.5':
     resolution: {integrity: sha512-mflHTxYQxZ8j7veZqrLQfhqiBbn17NpvCKX+8gzAYvX3jOAJTZOY1KgsJ6GRDuLrxMrAuT80enuhIjFxfWGcKw==}
@@ -9044,8 +9044,14 @@ packages:
   '@tryghost/mongo-knex@0.10.1':
     resolution: {integrity: sha512-6LRA4zVpNvCrVrA9hOhs8N4iylAiafGssiKuD8yML/13xg2PvKw6dzOZj6hg0CKQwG7tVp8TA+7Nw3iDOzy/jQ==}
 
+  '@tryghost/mongo-knex@0.11.0':
+    resolution: {integrity: sha512-OWNRZLAqgRDgW3FFFhsZksiDaUMcjgBQVAWM+PzZEB3JpamdqLq+60MWrbkDiI5WynrFHtYI/5rAOxDaz7HY/g==}
+
   '@tryghost/mongo-utils@0.6.5':
     resolution: {integrity: sha512-fMEfdlVaVkr7SJwVxBxVDfUQ+x4DVF4PMet698PLzabqSnGsaWcruBaQlOuNvtf8ITNXKFUAqZMdmSUTIAHU+Q==}
+
+  '@tryghost/mongo-utils@0.6.6':
+    resolution: {integrity: sha512-CeWSgFKfUhFqD/dk22zEugawFdzVpa9avRgzFExbogiIFmNOfMOuD4G12/GUwFYOGjyCRAdQyKp8xgWSF97SRg==}
 
   '@tryghost/mw-error-handler@1.0.13':
     resolution: {integrity: sha512-qDRjyiOkF5UNGgMHUDdFKTY0Mcwnxo5N9m71pliwVI+HfYvw77k/GxEIGc8mgikxjCuZkgC+IUnJjWCLuzCvKQ==}
@@ -9059,8 +9065,14 @@ packages:
   '@tryghost/nql-lang@0.6.6':
     resolution: {integrity: sha512-ZWEUN92fVnxavf+matwASvi7pom0i1jhAtNCuoCN9f3ShtyrVm92m1SfvY+x/XuEvbefXAzCGzSEMcaQ4cqoXw==}
 
+  '@tryghost/nql-lang@0.6.7':
+    resolution: {integrity: sha512-quholb52aCqHWCskYp1ZC2hY/E+BD8XmZtgsrp1TcTHm0si9O3DBV9NGX2GB1GEE1V+QHFL24gdp0j98TrhFIQ==}
+
   '@tryghost/nql@0.13.1':
     resolution: {integrity: sha512-TQRDur1miWd2ORa3XOhtw8Na8AUj/8h+epNMDgiutOyAH/RTw+d+ksLndMnm/Z9MhnKg7kFy7398peKZ7nF8bQ==}
+
+  '@tryghost/nql@0.13.2':
+    resolution: {integrity: sha512-nlG3xMNJYUO5MvOtnSaYltFKRaSeBTalIAUbIyeGplY4YXlIPVH/KUzCIpM8HyJ5uncR8bXkUey0a29RqCFaeA==}
 
   '@tryghost/pretty-cli@3.3.1':
     resolution: {integrity: sha512-P7/GffeBG0grjmFxMWEeVFONL6HGt1mWUZvI5G36mhlxC/AXSWCSS6+qiQU91ZfenTwBrP6LZRC9Pyt0gqfzLg==}
@@ -9111,6 +9123,9 @@ packages:
   '@tryghost/root-utils@2.3.5':
     resolution: {integrity: sha512-7OnoEPEAAaT9LFgR0WNxHUeehC1VSits1k3KuW5FpqitE6NznieiSK9Cpo8v0489Xq7d0Xbkc9qsDytWCCRGCg==}
 
+  '@tryghost/root-utils@2.3.7':
+    resolution: {integrity: sha512-8HR0W95it+s+ERkRI3syWHDLyYcinBFexpVlmLBhMMf8yEcL7r6tio6H3sUAj09L/YE8Kk5uGhvjAZAT3TU77Q==}
+
   '@tryghost/security@1.0.6':
     resolution: {integrity: sha512-h4FiUK4ndHezlXeuRzfwTZrX/a8ZdCS/FRqmZWCHcMUiBH6lewHv8eIjsPemN6e6Gn9jtsWZsKnuYM2mD0meSQ==}
 
@@ -9136,14 +9151,14 @@ packages:
   '@tryghost/tpl@2.3.1':
     resolution: {integrity: sha512-qqa2SvhnBVKFYN+G4hfj2cYZuZXINBDyJ9cTzNBtev/FRNUKniyGarPKAkyb6ZBtvp3Nqlmyvrqe+SFoqHcfrQ==}
 
-  '@tryghost/tpl@2.3.2':
-    resolution: {integrity: sha512-CXx7JCqyTFtsZENp4Bc3Af0cFD6QmQAtoLnM0BL4kTZkPFsPkvJPIhE55JmV3sL8rj9NA0kyz7w8614ViMugiA==}
-
   '@tryghost/tpl@2.3.4':
     resolution: {integrity: sha512-/sPmwPuTcu1noY5PGwTwDmlE8wZuttl2r1IORMF5vxRKYUC7iWQnyKNstXtYfgh3bgBTYcq0kkfoPdz3B4GEKQ==}
 
   '@tryghost/tpl@2.3.5':
     resolution: {integrity: sha512-wexPVuAfF+k/Ysy1uTLTHPznQVsKe5kImlvhKd3IQU1eA4ZYGwymtD7GaSvJxHvyaS6zRB8FXzbgXl2dpAUyVg==}
+
+  '@tryghost/tpl@2.3.7':
+    resolution: {integrity: sha512-TIDQF9tj4MaQKrIxNB8CxpElShAwLfyByozggIBnuzIVkGudX07gy/o9oWGRYslRselrvdByf+NpYonQ9j3Y0Q==}
 
   '@tryghost/url-utils@5.2.6':
     resolution: {integrity: sha512-3TQRcseZW/rq3UsSMP94n6WgKYZJqufreNdv9wJT5P4Fm5bNQ04rEHvL8i1AggXWa2kUPmwt2ed7KzNY6xx7zA==}
@@ -28231,72 +28246,72 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tryghost/bookshelf-collision@2.3.2':
+  '@tryghost/bookshelf-collision@2.3.7':
     dependencies:
       '@tryghost/errors': 3.3.5
       lodash: 4.18.1
       moment-timezone: 0.5.45
 
-  '@tryghost/bookshelf-custom-query@2.3.2': {}
+  '@tryghost/bookshelf-custom-query@2.3.7': {}
 
-  '@tryghost/bookshelf-eager-load@2.3.2(supports-color@10.2.2)':
+  '@tryghost/bookshelf-eager-load@2.3.7(supports-color@10.2.2)':
     dependencies:
-      '@tryghost/debug': 2.3.2(supports-color@10.2.2)
+      '@tryghost/debug': 2.3.7(supports-color@10.2.2)
       lodash: 4.18.1
     transitivePeerDependencies:
       - supports-color
 
-  '@tryghost/bookshelf-filter@2.3.2(supports-color@10.2.2)':
+  '@tryghost/bookshelf-filter@2.3.7(supports-color@10.2.2)':
     dependencies:
-      '@tryghost/debug': 2.3.2(supports-color@10.2.2)
+      '@tryghost/debug': 2.3.7(supports-color@10.2.2)
       '@tryghost/errors': 3.3.5
-      '@tryghost/nql': 0.13.1(supports-color@10.2.2)
-      '@tryghost/tpl': 2.3.2
+      '@tryghost/nql': 0.13.2(supports-color@10.2.2)
+      '@tryghost/tpl': 2.3.7
     transitivePeerDependencies:
       - supports-color
 
-  '@tryghost/bookshelf-has-posts@2.4.2(supports-color@10.2.2)':
+  '@tryghost/bookshelf-has-posts@2.4.7(supports-color@10.2.2)':
     dependencies:
-      '@tryghost/debug': 2.3.2(supports-color@10.2.2)
+      '@tryghost/debug': 2.3.7(supports-color@10.2.2)
       lodash: 4.18.1
     transitivePeerDependencies:
       - supports-color
 
-  '@tryghost/bookshelf-include-count@2.3.2(supports-color@10.2.2)':
+  '@tryghost/bookshelf-include-count@2.3.7(supports-color@10.2.2)':
     dependencies:
-      '@tryghost/debug': 2.3.2(supports-color@10.2.2)
+      '@tryghost/debug': 2.3.7(supports-color@10.2.2)
       lodash: 4.18.1
     transitivePeerDependencies:
       - supports-color
 
-  '@tryghost/bookshelf-order@2.3.2':
+  '@tryghost/bookshelf-order@2.3.7':
     dependencies:
       lodash: 4.18.1
 
-  '@tryghost/bookshelf-pagination@2.3.2':
+  '@tryghost/bookshelf-pagination@2.4.1':
     dependencies:
       '@tryghost/errors': 3.3.5
-      '@tryghost/tpl': 2.3.2
+      '@tryghost/tpl': 2.3.7
       lodash: 4.18.1
 
-  '@tryghost/bookshelf-plugins@2.3.2(supports-color@10.2.2)':
+  '@tryghost/bookshelf-plugins@2.3.8(supports-color@10.2.2)':
     dependencies:
-      '@tryghost/bookshelf-collision': 2.3.2
-      '@tryghost/bookshelf-custom-query': 2.3.2
-      '@tryghost/bookshelf-eager-load': 2.3.2(supports-color@10.2.2)
-      '@tryghost/bookshelf-filter': 2.3.2(supports-color@10.2.2)
-      '@tryghost/bookshelf-has-posts': 2.4.2(supports-color@10.2.2)
-      '@tryghost/bookshelf-include-count': 2.3.2(supports-color@10.2.2)
-      '@tryghost/bookshelf-order': 2.3.2
-      '@tryghost/bookshelf-pagination': 2.3.2
-      '@tryghost/bookshelf-search': 2.3.2
-      '@tryghost/bookshelf-transaction-events': 2.3.2
+      '@tryghost/bookshelf-collision': 2.3.7
+      '@tryghost/bookshelf-custom-query': 2.3.7
+      '@tryghost/bookshelf-eager-load': 2.3.7(supports-color@10.2.2)
+      '@tryghost/bookshelf-filter': 2.3.7(supports-color@10.2.2)
+      '@tryghost/bookshelf-has-posts': 2.4.7(supports-color@10.2.2)
+      '@tryghost/bookshelf-include-count': 2.3.7(supports-color@10.2.2)
+      '@tryghost/bookshelf-order': 2.3.7
+      '@tryghost/bookshelf-pagination': 2.4.1
+      '@tryghost/bookshelf-search': 2.3.7
+      '@tryghost/bookshelf-transaction-events': 2.3.7
     transitivePeerDependencies:
       - supports-color
 
-  '@tryghost/bookshelf-search@2.3.2': {}
+  '@tryghost/bookshelf-search@2.3.7': {}
 
-  '@tryghost/bookshelf-transaction-events@2.3.2': {}
+  '@tryghost/bookshelf-transaction-events@2.3.7': {}
 
   '@tryghost/brute-knex@3.2.1(better-sqlite3@12.11.1)(express@4.22.2(supports-color@10.2.2))(mysql2@3.22.5(@types/node@22.20.0))(sqlite3@5.1.7(bluebird@3.7.2)(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
@@ -28349,16 +28364,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tryghost/debug@2.3.2(supports-color@10.2.2)':
+  '@tryghost/debug@2.3.5(supports-color@10.2.2)':
     dependencies:
-      '@tryghost/root-utils': 2.3.2
+      '@tryghost/root-utils': 2.3.5
       debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@tryghost/debug@2.3.5(supports-color@10.2.2)':
+  '@tryghost/debug@2.3.7(supports-color@10.2.2)':
     dependencies:
-      '@tryghost/root-utils': 2.3.5
+      '@tryghost/root-utils': 2.3.7
       debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
@@ -28508,7 +28523,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@tryghost/mongo-knex@0.11.0(supports-color@10.2.2)':
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      lodash: 4.18.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@tryghost/mongo-utils@0.6.5':
+    dependencies:
+      lodash: 4.18.1
+
+  '@tryghost/mongo-utils@0.6.6':
     dependencies:
       lodash: 4.18.1
 
@@ -28594,11 +28620,25 @@ snapshots:
     dependencies:
       date-fns: 2.30.0
 
+  '@tryghost/nql-lang@0.6.7':
+    dependencies:
+      date-fns: 2.30.0
+
   '@tryghost/nql@0.13.1(supports-color@10.2.2)':
     dependencies:
       '@tryghost/mongo-knex': 0.10.1(supports-color@10.2.2)
       '@tryghost/mongo-utils': 0.6.5
       '@tryghost/nql-lang': 0.6.6
+      lodash: 4.18.1
+      mingo: 2.5.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tryghost/nql@0.13.2(supports-color@10.2.2)':
+    dependencies:
+      '@tryghost/mongo-knex': 0.11.0(supports-color@10.2.2)
+      '@tryghost/mongo-utils': 0.6.6
+      '@tryghost/nql-lang': 0.6.7
       lodash: 4.18.1
       mingo: 2.5.3
     transitivePeerDependencies:
@@ -28687,6 +28727,11 @@ snapshots:
       caller: 1.1.0
       find-root: 1.1.0
 
+  '@tryghost/root-utils@2.3.7':
+    dependencies:
+      caller: 1.1.0
+      find-root: 1.1.0
+
   '@tryghost/security@1.0.6':
     dependencies:
       '@tryghost/string': 0.2.21
@@ -28718,11 +28763,11 @@ snapshots:
 
   '@tryghost/tpl@2.3.1': {}
 
-  '@tryghost/tpl@2.3.2': {}
-
   '@tryghost/tpl@2.3.4': {}
 
   '@tryghost/tpl@2.3.5': {}
+
+  '@tryghost/tpl@2.3.7': {}
 
   '@tryghost/url-utils@5.2.6':
     dependencies:


### PR DESCRIPTION
no ref

The `smarterCounts` labs flag gated an optimized `count(*)` pagination query in `@tryghost/bookshelf-pagination`, opted into via a `useSmartCount` option. That behaviour has now been promoted to the default upstream — `@tryghost/bookshelf-pagination` 2.4.1 uses the optimized count for single-table queries automatically and no longer has a `useSmartCount` option — so the flag no longer does anything useful and just adds noise to the labs UI and model code.

- Bumped `@tryghost/bookshelf-plugins` to 2.3.8, which pulls in `@tryghost/bookshelf-pagination` 2.4.1
- Removed the `smarterCounts` labs flag, its gating in the model crud plugin, and the labs UI toggle
- The `useBasicCount` force-override for multi-table queries is unchanged and still supported upstream