### PR TITLE
Excluded GitHub docs from Core CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,10 @@ jobs:
               - 'scripts/test/check-agent-skill-links.test.js'
             core:
               - *shared
+              # Repository documentation and ownership metadata do not affect
+              # Ghost runtime behaviour, even though they live in .github.
+              - '!.github/**/*.md'
+              - '!.github/CODEOWNERS'
               - 'ghost/**'
               - '!ghost/core/core/server/data/tinybird/**'
               # Unit tests + vitest config are exercised only by job_unit-tests;


### PR DESCRIPTION
## Summary

- Prevents repository documentation under `.github` from marking Ghost Core as changed.
- Excludes `.github/**/*.md` and `.github/CODEOWNERS` from the Core path filter while leaving workflow, action, and script changes covered.
- Keeps Markdown changes covered by the dedicated docs filter.

## Testing

- [x] Parsed `.github/workflows/ci.yml` with Ruby YAML
- [x] `git diff --check`
- [x] Verified the include/exclude cases directly with `picomatch`

## Context

Documentation-only changes to `.github/CONTRIBUTING.md` currently trigger the MySQL and SQLite acceptance and legacy test matrices because `.github/**` is shared by the Core filter. Those files cannot affect Ghost runtime behaviour.
