### PR TITLE
Added 1-click export mockup behind a labs flag

### DIFF
--- a/apps/admin/src/settings/advanced/migration-tools-export.acceptance.test.tsx
+++ b/apps/admin/src/settings/advanced/migration-tools-export.acceptance.test.tsx
@@ -1,0 +1,62 @@
+import {describe, expect, it} from "vitest";
+import {page} from "vitest/browser";
+
+import {configResponse, fakeSettingsScreens, renderAdminApp} from "@test-utils/acceptance";
+import {settingsScreen} from "@/settings/settings.screen";
+
+async function openExportTab() {
+    const section = settingsScreen.section("migrationtools");
+    await section.getByRole("tab", {name: "Export"}).click();
+    return section;
+}
+
+describe("Migration tools export", () => {
+    it("keeps the individual export buttons without the selfServeArchives flag", async () => {
+        fakeSettingsScreens();
+        await renderAdminApp("/settings/advanced");
+
+        const section = await openExportTab();
+        await expect.element(section.getByRole("button", {name: "Content & settings"})).toBeVisible();
+        await expect.element(section.getByRole("button", {name: "Post analytics"})).toBeVisible();
+        await expect.element(section.getByRole("button", {name: "Export data"})).not.toBeInTheDocument();
+    });
+
+    it("offers the sync export dialog without media when no archive host is configured", async () => {
+        fakeSettingsScreens();
+        await renderAdminApp("/settings/advanced", {labs: {selfServeArchives: true}});
+
+        const section = await openExportTab();
+        await section.getByRole("button", {name: "Export data"}).click();
+
+        const dialog = page.getByRole("dialog");
+        await expect.element(dialog.getByText("downloaded as a single zip", {exact: false})).toBeVisible();
+        await expect.element(dialog.getByText("Members", {exact: true})).toBeVisible();
+        await expect.element(dialog.getByText("Media files", {exact: true})).not.toBeInTheDocument();
+
+        await dialog.getByRole("button", {name: "Export", exact: true}).click();
+        await expect.element(dialog.getByText("Preparing your export", {exact: false})).toBeVisible();
+    });
+
+    it("offers media and email delivery when an archive host is configured", async () => {
+        fakeSettingsScreens();
+        const config = configResponse({labs: {selfServeArchives: true}});
+        (config.config as {hostSettings?: object}).hostSettings = {
+            ...(config.config as {hostSettings?: object}).hostSettings,
+            export: {generate_archive_url: "https://archives.example.com/generate"},
+        };
+        await renderAdminApp("/settings/advanced", {
+            labs: {selfServeArchives: true},
+            boot: {browseConfig: {response: config}},
+        });
+
+        const section = await openExportTab();
+        await section.getByRole("button", {name: "Export data"}).click();
+
+        const dialog = page.getByRole("dialog");
+        await expect.element(dialog.getByText("sent to you by email", {exact: false})).toBeVisible();
+        await expect.element(dialog.getByText("Media files", {exact: true})).toBeVisible();
+
+        await dialog.getByRole("button", {name: "Export", exact: true}).click();
+        await expect.element(dialog.getByText("Exporting data", {exact: false})).toBeVisible();
+    });
+});

--- a/apps/admin/src/settings/app/components/settings/advanced/labs/private-features.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/labs/private-features.tsx
@@ -75,6 +75,10 @@ const features: Feature[] = [{
     title: 'Gift subscription customization',
     description: 'Enables fixed-duration gift subscription purchases before publisher configuration is available',
     flag: 'giftSubCustomization'
+}, {
+    title: 'Self-serve archives',
+    description: 'Replaces the individual export buttons with a single "Export data" flow for downloading a full site archive',
+    flag: 'selfServeArchives'
 }];
 
 const AlphaFeatures: React.FC = () => {

--- a/apps/admin/src/settings/app/components/settings/advanced/migration-tools/export-all-modal.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/migration-tools/export-all-modal.tsx
@@ -1,0 +1,205 @@
+import React, {useEffect, useRef, useState} from 'react';
+import {
+    Button,
+    Checkbox,
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    LoadingIndicator
+} from '@tryghost/shade/components';
+import {LucideIcon} from '@tryghost/shade/utils';
+import {useCurrentUser} from '@tryghost/admin-x-framework/api/current-user';
+
+export type ExportMode = 'sync' | 'async';
+
+type ExportComponentKey = 'content' | 'members' | 'analytics' | 'themes' | 'routes' | 'media';
+
+type ExportComponent = {
+    key: ExportComponentKey;
+    label: string;
+    description: string;
+    defaultChecked: boolean;
+    asyncOnly?: boolean;
+};
+
+const EXPORT_COMPONENTS: ExportComponent[] = [
+    {key: 'content', label: 'Content & settings', description: 'Posts, pages, tags, tiers and settings (JSON)', defaultChecked: true},
+    {key: 'members', label: 'Members', description: 'All members with labels and subscription status (CSV)', defaultChecked: true},
+    {key: 'analytics', label: 'Post analytics', description: 'Sends, opens, clicks and conversions per post (CSV)', defaultChecked: true},
+    {key: 'themes', label: 'Themes', description: 'All installed themes, including custom code', defaultChecked: true},
+    {key: 'routes', label: 'Redirects & routes', description: 'routes.yaml and redirects configuration', defaultChecked: true},
+    {key: 'media', label: 'Media files', description: 'All images, video and audio files. May significantly increase export size and duration', defaultChecked: false, asyncOnly: true}
+];
+
+type ExportPhase = 'select' | 'confirmed' | 'preparing' | 'done';
+
+const ExportAllModal: React.FC<{open: boolean; onOpenChange: (open: boolean) => void; mode: ExportMode}> = ({open, onOpenChange, mode}) => {
+    const {data: currentUser} = useCurrentUser();
+    const [phase, setPhase] = useState<ExportPhase>('select');
+    const [selected, setSelected] = useState<Record<ExportComponentKey, boolean>>(() => {
+        const initial = {} as Record<ExportComponentKey, boolean>;
+        EXPORT_COMPONENTS.forEach((component) => {
+            initial[component.key] = component.defaultChecked;
+        });
+        return initial;
+    });
+    const mockTimerRef = useRef<ReturnType<typeof setTimeout>>();
+    const resetTimerRef = useRef<ReturnType<typeof setTimeout>>();
+
+    const email = currentUser?.email;
+    const visibleComponents = EXPORT_COMPONENTS.filter(component => mode === 'async' || !component.asyncOnly);
+    const noneSelected = visibleComponents.every(component => !selected[component.key]);
+
+    const handleOpenChange = (next: boolean) => {
+        onOpenChange(next);
+        if (next) {
+            clearTimeout(resetTimerRef.current);
+            setPhase('select');
+            return;
+        }
+        clearTimeout(mockTimerRef.current);
+        clearTimeout(resetTimerRef.current);
+        // Reset for the next open, after the close animation
+        resetTimerRef.current = setTimeout(() => setPhase('select'), 200);
+    };
+
+    // Static UX/UI mockup, nothing is wired to a backend
+    const startExport = () => {
+        if (mode === 'async') {
+            setPhase('confirmed');
+            return;
+        }
+        setPhase('preparing');
+        mockTimerRef.current = setTimeout(() => {
+            triggerMockDownload();
+            setPhase('done');
+        }, 10000);
+    };
+
+    const triggerMockDownload = () => {
+        const emptyZip = new Uint8Array([0x50, 0x4b, 0x05, 0x06, ...new Array(18).fill(0)]);
+        const url = URL.createObjectURL(new Blob([emptyZip], {type: 'application/zip'}));
+        const anchor = document.createElement('a');
+        anchor.href = url;
+        anchor.download = 'ghost-export.zip';
+        document.body.appendChild(anchor);
+        anchor.click();
+        anchor.remove();
+        URL.revokeObjectURL(url);
+    };
+
+    useEffect(() => {
+        return () => {
+            clearTimeout(mockTimerRef.current);
+            clearTimeout(resetTimerRef.current);
+        };
+    }, []);
+
+    return (
+        <Dialog open={open} onOpenChange={handleOpenChange}>
+            <DialogContent className='max-h-[85vh] max-w-md overflow-y-auto'>
+                {phase === 'select' && (
+                    <>
+                        <DialogHeader>
+                            <DialogTitle>Export data</DialogTitle>
+                            <DialogDescription>
+                                {mode === 'async'
+                                    ? 'Choose what to include. Your export will be prepared in the background and a download link sent to you by email.'
+                                    : <>
+                                        Your export will be downloaded as a single zip file.{' '}
+                                        Images, videos and files are not included.{' '}
+                                        <a
+                                            className='font-medium whitespace-nowrap text-foreground hover:underline'
+                                            href='https://docs.ghost.org/migration/ghost#images'
+                                            rel='noopener noreferrer'
+                                            target='_blank'
+                                        >Learn more &rarr;</a>
+                                    </>}
+                            </DialogDescription>
+                        </DialogHeader>
+                        <div className='flex flex-col gap-1 py-1'>
+                            {visibleComponents.map(component => (
+                                <label
+                                    key={component.key}
+                                    className='flex cursor-pointer items-start gap-3 rounded-md px-2 py-1.5 hover:bg-muted/60'
+                                    htmlFor={`export-${component.key}`}
+                                >
+                                    <Checkbox
+                                        checked={selected[component.key]}
+                                        className='mt-0.5'
+                                        id={`export-${component.key}`}
+                                        onCheckedChange={checked => setSelected(current => ({...current, [component.key]: checked === true}))}
+                                    />
+                                    <span className='flex flex-col'>
+                                        <span className='text-sm font-medium text-foreground'>{component.label}</span>
+                                        <span className='text-xs text-muted-foreground'>{component.description}</span>
+                                    </span>
+                                </label>
+                            ))}
+                        </div>
+                        <DialogFooter className='gap-2 sm:justify-end'>
+                            <Button variant='outline' onClick={() => handleOpenChange(false)}>Cancel</Button>
+                            <Button disabled={noneSelected} onClick={startExport}>
+                                <LucideIcon.Download /> Export
+                            </Button>
+                        </DialogFooter>
+                    </>
+                )}
+
+                {phase === 'confirmed' && (
+                    <>
+                        <DialogHeader>
+                            <DialogTitle className='flex items-center gap-2'>
+                                <LucideIcon.CircleCheck className='size-5 text-green-600' /> Exporting data&hellip;
+                            </DialogTitle>
+                        </DialogHeader>
+                        <DialogDescription>
+                            A link to download your data will be sent to your email <span className='font-medium text-foreground'>{email}</span> once
+                            the export is complete. The link will be valid for 7 days. You can now close this window.
+                        </DialogDescription>
+                        <DialogFooter className='sm:justify-end'>
+                            <Button onClick={() => handleOpenChange(false)}>Close</Button>
+                        </DialogFooter>
+                    </>
+                )}
+
+                {phase === 'preparing' && (
+                    <>
+                        <DialogHeader>
+                            <DialogTitle className='flex items-center gap-2'>
+                                <LoadingIndicator size='sm' /> Preparing your export&hellip;
+                            </DialogTitle>
+                        </DialogHeader>
+                        <DialogDescription>
+                            Your download will start automatically when it&rsquo;s ready. Keep this window open.
+                        </DialogDescription>
+                        <DialogFooter className='sm:justify-end'>
+                            <Button variant='outline' onClick={() => handleOpenChange(false)}>Cancel</Button>
+                        </DialogFooter>
+                    </>
+                )}
+
+                {phase === 'done' && (
+                    <>
+                        <DialogHeader>
+                            <DialogTitle className='flex items-center gap-2'>
+                                <LucideIcon.CircleCheck className='size-5 text-green-600' /> Export downloaded
+                            </DialogTitle>
+                        </DialogHeader>
+                        <DialogDescription>
+                            Your export has been downloaded as a zip file.
+                        </DialogDescription>
+                        <DialogFooter className='sm:justify-end'>
+                            <Button onClick={() => handleOpenChange(false)}>Close</Button>
+                        </DialogFooter>
+                    </>
+                )}
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+export default ExportAllModal;

--- a/apps/admin/src/settings/app/components/settings/advanced/migration-tools/migration-tools-export.tsx
+++ b/apps/admin/src/settings/app/components/settings/advanced/migration-tools/migration-tools-export.tsx
@@ -1,13 +1,22 @@
+import ExportAllModal, {type ExportMode} from './export-all-modal';
 import React from 'react';
+import useFeatureFlag from '@/settings/app/hooks/use-feature-flag';
 import {Button, LoadingIndicator} from '@tryghost/shade/components';
 import {LucideIcon} from '@tryghost/shade/utils';
 import {blobDownloadFromEndpoint} from '@tryghost/admin-x-framework/helpers';
 import {downloadAllContent} from '@tryghost/admin-x-framework/api/db';
+import {useBrowseConfig} from '@tryghost/admin-x-framework/api/config';
 import {useHandleError} from '@tryghost/admin-x-framework/hooks';
 
 const MigrationToolsExport: React.FC = () => {
     const [isExportingPosts, setIsExportingPosts] = React.useState(false);
+    const [exportAllOpen, setExportAllOpen] = React.useState(false);
     const handleError = useHandleError();
+
+    const hasSelfServeArchives = useFeatureFlag('selfServeArchives');
+    const {data: configData} = useBrowseConfig();
+    const hostSettings = configData?.config?.hostSettings as {export?: {generate_archive_url?: string}} | undefined;
+    const mode: ExportMode = hostSettings?.export?.generate_archive_url ? 'async' : 'sync';
 
     const exportPosts = async () => {
         if (isExportingPosts) {
@@ -24,6 +33,19 @@ const MigrationToolsExport: React.FC = () => {
             setIsExportingPosts(false);
         }
     };
+
+    if (hasSelfServeArchives) {
+        return (
+            <>
+                <div className='grid grid-cols-1 gap-4 pt-4 md:grid-cols-2 lg:grid-cols-3'>
+                    <Button className='h-9 font-semibold' data-testid='export-all-button' type='button' variant='secondary' onClick={() => setExportAllOpen(true)}>
+                        <LucideIcon.PackageOpen />Export data
+                    </Button>
+                </div>
+                <ExportAllModal mode={mode} open={exportAllOpen} onOpenChange={setExportAllOpen} />
+            </>
+        );
+    }
 
     return (
         <div className='grid grid-cols-1 gap-4 pt-4 md:grid-cols-2 lg:grid-cols-3'>

--- a/ghost/core/core/shared/labs.js
+++ b/ghost/core/core/shared/labs.js
@@ -55,7 +55,8 @@ const PRIVATE_FEATURES = [
     'membersCustomFields',
     'paywallImprovements',
     'giftSubCustomization',
-    'tagDetailsReact'
+    'tagDetailsReact',
+    'selfServeArchives'
 ];
 
 module.exports.GA_KEYS = [...GA_FEATURES];


### PR DESCRIPTION
closes https://linear.app/ghost/issue/GVA-921/
ref https://linear.app/ghost/project/self-serve-archives-bd3a8920c136

Static UX/UI mockup of the one-click data export flow, behind a new private labs flag (`selfServeArchives`). Will be wired up in follow-up PRs

### Async flow (includes media assets)
<img width="2978" height="3150" alt="image" src="https://github.com/user-attachments/assets/e5f4068d-6ee3-4b1f-bd71-7b1a9ad0cfdf" />
<img width="2978" height="3150" alt="image" src="https://github.com/user-attachments/assets/591421c0-b567-4144-bec8-a2c579d6516d" />
<img width="2978" height="3150" alt="image" src="https://github.com/user-attachments/assets/a5709984-f3ad-4887-8c44-ff3958b99830" />


### Sync flow (no media assets)
<img width="3068" height="3154" alt="image" src="https://github.com/user-attachments/assets/4296d4c5-2619-4489-9dab-0f691c80d2c3" />
<img width="3068" height="3154" alt="image" src="https://github.com/user-attachments/assets/2e6e649e-b99d-4dcf-b1dc-6abf3157ddcd" />
<img width="3068" height="3152" alt="image" src="https://github.com/user-attachments/assets/a2d5f95b-b105-4c54-acd3-49fc79e9bbc6" />
<img width="3056" height="3140" alt="image" src="https://github.com/user-attachments/assets/21409a12-f3b3-498a-af96-eb39a91b4ecd" />
<img width="3068" height="3154" alt="image" src="https://github.com/user-attachments/assets/e073c6d0-0768-4f54-a199-3f4d730dc7ca" />
