### PR TITLE
Added filter segment primitives and a read-only filter to Shade

### DIFF
--- a/apps/shade/src/components/patterns/filters.stories.tsx
+++ b/apps/shade/src/components/patterns/filters.stories.tsx
@@ -1,6 +1,6 @@
 import type {Meta, StoryObj} from '@storybook/react-vite';
 import {useState} from 'react';
-import {Filters, type Filter, type FilterFieldConfig, createFilter} from './filters';
+import {Filters, FilterSegmentSelect, FilterSegmentInput, FilterEmptyHint, type CustomRendererProps, type Filter, type FilterFieldConfig, createFilter} from './filters';
 import {
     User,
     Mail,
@@ -15,7 +15,9 @@ import {
     CheckCircle,
     XCircle,
     Circle,
-    X
+    X,
+    Archive,
+    SlidersHorizontal
 } from 'lucide-react';
 
 const meta = {
@@ -822,6 +824,142 @@ export const ClearButtonCustomHandler: Story = {
         docs: {
             description: {
                 story: 'Custom clear handler using the `onClear` prop. This allows you to perform additional actions when filters are cleared, such as analytics tracking or side effects.'
+            }
+        }
+    }
+};
+
+// A customRenderer composing FilterSegmentSelect + FilterSegmentInput into a cascade
+// (part -> operator -> value) that reads as native filter segments.
+const CascadeRenderer = ({values, onChange, operator, onOperatorChange, readOnly}: CustomRendererProps<string>) => {
+    const [part = '', value = ''] = values;
+
+    return (
+        <>
+            <FilterSegmentSelect
+                ariaLabel="Part"
+                options={[{value: '', label: 'Any'}, {value: 'city', label: 'City'}, {value: 'country', label: 'Country'}]}
+                readOnly={readOnly}
+                value={part}
+                onChange={next => onChange([next, value])}
+            />
+            {onOperatorChange && (
+                <FilterSegmentSelect
+                    ariaLabel="Operator"
+                    options={[{value: 'contains', label: 'contains'}, {value: 'is', label: 'is'}]}
+                    readOnly={readOnly}
+                    value={operator}
+                    onChange={onOperatorChange}
+                />
+            )}
+            <FilterSegmentInput
+                ariaLabel="Value"
+                placeholder="Enter value..."
+                readOnly={readOnly}
+                value={value}
+                onChange={next => onChange([part, next])}
+            />
+        </>
+    );
+};
+
+const segmentFields: FilterFieldConfig[] = [
+    {
+        key: 'address',
+        label: 'Address',
+        type: 'custom',
+        icon: <SlidersHorizontal className="size-4" />,
+        renderOperatorInValue: true,
+        operators: [{value: 'contains', label: 'contains'}, {value: 'is', label: 'is'}],
+        customRenderer: props => <CascadeRenderer {...(props as CustomRendererProps<string>)} />
+    }
+];
+
+export const ComposedSegments: Story = {
+    render: () => <FilterDemo fields={segmentFields} initialFilters={[createFilter('address', 'contains', ['city', 'York'])]} />,
+    parameters: {
+        docs: {
+            description: {
+                story: 'FilterSegmentSelect and FilterSegmentInput composed by a customRenderer (with `renderOperatorInValue`) into a cascade that reads as native filter segments rather than standalone selects.'
+            }
+        }
+    }
+};
+
+const readOnlyFields: FilterFieldConfig[] = [
+    {
+        key: 'archived_field',
+        label: 'Archived field',
+        type: 'text',
+        icon: <Archive className="size-4" />,
+        readOnly: true,
+        operators: [{value: 'is', label: 'is'}]
+    },
+    {
+        key: 'name',
+        label: 'Name',
+        type: 'text',
+        icon: <User className="size-4" />
+    }
+];
+
+export const ReadOnlyFilter: Story = {
+    render: () => <FilterDemo fields={readOnlyFields} initialFilters={[createFilter('archived_field', 'is', ['London'])]} />,
+    parameters: {
+        docs: {
+            description: {
+                story: 'A read-only filter keeps its operator and value visible as static text and can only be removed — for a filter on a source no longer offered, such as an archived field.'
+            }
+        }
+    }
+};
+
+const previewLimitFields: FilterFieldConfig[] = [
+    {
+        group: 'Basic',
+        fields: [{key: 'name', label: 'Name', type: 'text', icon: <User className="size-4" />}]
+    },
+    {
+        group: 'Custom fields',
+        previewLimit: 3,
+        fields: Array.from({length: 8}, (_, index): FilterFieldConfig => ({
+            key: `custom_field.field_${index + 1}`,
+            label: `Field ${index + 1}`,
+            type: 'text',
+            icon: <SlidersHorizontal className="size-4" />
+        }))
+    }
+];
+
+export const GroupPreviewLimit: Story = {
+    render: () => <FilterDemo fields={previewLimitFields} />,
+    parameters: {
+        docs: {
+            description: {
+                story: 'A group can preview a subset of its fields with `previewLimit`, revealing the rest behind "Show more". Every field stays resolvable and findable by search.'
+            }
+        }
+    }
+};
+
+const emptyStateFields: FilterFieldConfig[] = [
+    {
+        group: 'Basic',
+        fields: [{key: 'name', label: 'Name', type: 'text', icon: <User className="size-4" />}]
+    },
+    {
+        group: 'Custom fields',
+        fields: [],
+        emptyState: <FilterEmptyHint>No custom fields yet</FilterEmptyHint>
+    }
+];
+
+export const GroupEmptyState: Story = {
+    render: () => <FilterDemo fields={emptyStateFields} />,
+    parameters: {
+        docs: {
+            description: {
+                story: 'A group with no addable fields can render an `emptyState` (via FilterEmptyHint) to point at where those fields are configured, instead of vanishing from the picker.'
             }
         }
     }

--- a/apps/shade/src/components/patterns/filters.tsx
+++ b/apps/shade/src/components/patterns/filters.tsx
@@ -35,6 +35,7 @@ export interface FilterI18nConfig {
     noResultsFound: string;
     loading: string;
     loadMore: string;
+    showMore: (count: number) => string;
     select: string;
     true: string;
     false: string;
@@ -112,6 +113,7 @@ export const DEFAULT_I18N: FilterI18nConfig = {
     noResultsFound: 'No results found.',
     loading: 'Loading...',
     loadMore: 'Load more',
+    showMore: count => `Show ${count} more`,
     select: 'Select...',
     true: 'True',
     false: 'False',
@@ -346,12 +348,19 @@ const filterOperatorVariants = cva(
             cursorPointer: {
                 true: 'cursor-pointer',
                 false: ''
+            },
+            // A read-only segment keeps its chrome but reads as static: muted, no
+            // hover, no pointer. Used for an applied-but-not-editable filter.
+            readOnly: {
+                true: 'pointer-events-none text-muted-foreground hover:text-muted-foreground',
+                false: ''
             }
         },
         defaultVariants: {
             variant: 'outline',
             size: 'md',
-            cursorPointer: true
+            cursorPointer: true,
+            readOnly: false
         }
     }
 );
@@ -414,12 +423,19 @@ const filterFieldValueVariants = cva(
             cursorPointer: {
                 true: 'cursor-pointer has-[[data-slot=switch]]:cursor-default has-[>[data-slot=filters-input-wrapper]]:cursor-text',
                 false: ''
+            },
+            // A read-only value keeps its chrome but reads as static: muted, no hover,
+            // no pointer. Mirrors the operator segment's read-only treatment.
+            readOnly: {
+                true: 'pointer-events-none text-muted-foreground hover:bg-background',
+                false: ''
             }
         },
         defaultVariants: {
             variant: 'outline',
             size: 'md',
-            cursorPointer: true
+            cursorPointer: true,
+            readOnly: false
         }
     }
 );
@@ -915,12 +931,28 @@ export interface CustomRendererProps<T = unknown> {
     values: T[];
     onChange: (values: T[]) => void;
     operator: string;
+    // Set the predicate's operator from inside the renderer. Provided when the
+    // field opts into `renderOperatorInValue`, so a renderer whose operator set
+    // depends on a choice made in the value area (e.g. a custom field whose type
+    // is picked here) can own the operator control itself.
+    onOperatorChange?: (operator: string) => void;
+    // Render the composed segments as static, non-editable text (an applied filter
+    // that can't be changed, e.g. one on an archived source). The renderer should
+    // pass this through to its FilterSegment* children.
+    readOnly?: boolean;
 }
 
 // Grouped field configuration interface
 export interface FilterFieldGroup<T = unknown> {
     group?: string;
     fields: FilterFieldConfig<T>[];
+    // Show only the first `previewLimit` fields in the picker, with a "Show more"
+    // to reveal the rest. Every field stays resolvable regardless — this caps
+    // presentation, not the config map. Absent = show all.
+    previewLimit?: number;
+    // Content shown in the picker when the group has no addable fields — e.g. a
+    // pointer to where those fields are configured.
+    emptyState?: React.ReactNode;
 }
 
 // Union type for both flat and grouped field configurations
@@ -970,6 +1002,14 @@ export interface FilterFieldConfig<T = unknown> {
     // Group-level configuration
     group?: string;
     fields?: FilterFieldConfig<T>[];
+    previewLimit?: number;
+    // Group-level: content shown in the picker when the group has no addable fields,
+    // e.g. a pointer to where those fields are configured.
+    emptyState?: React.ReactNode;
+    // Renders an existing pill as read-only: its operator and value stay visible but
+    // static, and it can only be removed — for a filter on a source no longer offered
+    // in the picker (e.g. an archived field).
+    readOnly?: boolean;
     // Field-specific options
     options?: FilterOption<T>[];
     isLoading?: boolean;
@@ -1006,6 +1046,12 @@ export interface FilterFieldConfig<T = unknown> {
     defaultValue?: T;
     // Hide the operator dropdown and only show the operator as text
     hideOperatorSelect?: boolean;
+    // Suppress the framework's operator control entirely and let a customRenderer
+    // render its own, positioned after the value area's own selections. Used when
+    // the valid operator set depends on a choice made inside the renderer (e.g. a
+    // custom field whose type is picked there). The renderer receives
+    // `onOperatorChange` to drive the predicate operator.
+    renderOperatorInValue?: boolean;
     // Controlled values support for this field
     value?: T[];
     onValueChange?: (values: T[]) => void;
@@ -1196,6 +1242,66 @@ interface FilterOperatorDropdownProps<T = unknown> {
     onChange: (operator: string) => void;
 }
 
+// The operator-style dropdown chrome, shared by the built-in operator control and the
+// composable FilterSegmentSelect: a trigger styled with `filterOperatorVariants` over a
+// checked option list. `readOnly` renders the trigger as static text with no menu, so an
+// applied-but-not-editable filter still shows its value.
+function SegmentDropdown({
+    trigger,
+    options,
+    value,
+    onChange,
+    readOnly,
+    ariaLabel,
+    testId
+}: {
+    trigger: React.ReactNode;
+    options: FilterSegmentOption[];
+    value: string;
+    onChange: (value: string) => void;
+    readOnly?: boolean;
+    ariaLabel?: string;
+    testId?: string;
+}) {
+    const context = useFilterContext();
+
+    if (readOnly) {
+        return (
+            <div
+                aria-label={ariaLabel}
+                className={filterOperatorVariants({variant: context.variant, size: context.size, readOnly: true})}
+                data-testid={testId}
+            >
+                {trigger}
+            </div>
+        );
+    }
+
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger
+                aria-label={ariaLabel}
+                className={filterOperatorVariants({variant: context.variant, size: context.size})}
+                data-testid={testId}
+            >
+                {trigger}
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="w-fit min-w-fit">
+                {options.map(option => (
+                    <DropdownMenuItem
+                        key={option.value}
+                        className="flex items-center justify-between"
+                        onClick={() => onChange(option.value)}
+                    >
+                        <span>{option.label}</span>
+                        <Check className={`ms-auto text-primary ${option.value === value ? 'opacity-100' : 'opacity-0'}`} />
+                    </DropdownMenuItem>
+                ))}
+            </DropdownMenuContent>
+        </DropdownMenu>
+    );
+}
+
 function FilterOperatorDropdown<T = unknown>({field, operator, values, onChange}: FilterOperatorDropdownProps<T>) {
     const context = useFilterContext();
     const operators = getOperatorsForField(field, values, context.i18n);
@@ -1204,33 +1310,115 @@ function FilterOperatorDropdown<T = unknown>({field, operator, values, onChange}
     const operatorLabel =
     operators.find(op => op.value === operator)?.label || context.i18n.helpers.formatOperator(operator);
 
-    // If hideOperatorSelect is true, just render the operator as plain text
-    if (field.hideOperatorSelect) {
-        return (
-            <div className="flex items-center self-stretch border border-r-0 px-2.5 whitespace-nowrap text-muted-foreground">
-                {operatorLabel}
-            </div>
-        );
-    }
+    // Both `hideOperatorSelect` and a read-only field render the operator as static
+    // text through the shared chrome, rather than a live menu.
+    return (
+        <SegmentDropdown
+            options={operators}
+            readOnly={field.readOnly || field.hideOperatorSelect}
+            trigger={operatorLabel}
+            value={operator}
+            onChange={onChange}
+        />
+    );
+}
+
+export interface FilterSegmentOption {
+    value: string;
+    label: string;
+}
+
+export interface FilterSegmentSelectProps {
+    value: string;
+    options: FilterSegmentOption[];
+    onChange: (value: string) => void;
+    placeholder?: string;
+    ariaLabel?: string;
+    className?: string;
+    testId?: string;
+    // Render the selection as static text (no menu) — for an applied filter that
+    // should stay legible but not editable.
+    readOnly?: boolean;
+}
+
+// A dropdown segment styled like the built-in operator control, so a custom
+// renderer can compose its own choices (e.g. a custom field's field / sub-field /
+// operator) that read as native filter segments rather than standalone selects.
+export function FilterSegmentSelect({value, options, onChange, placeholder, ariaLabel, className, testId, readOnly}: FilterSegmentSelectProps) {
+    const selected = options.find(option => option.value === value);
 
     return (
-        <DropdownMenu>
-            <DropdownMenuTrigger className={filterOperatorVariants({variant: context.variant, size: context.size})}>
-                {operatorLabel}
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" className="w-fit min-w-fit">
-                {operators.map(op => (
-                    <DropdownMenuItem
-                        key={op.value}
-                        className="flex items-center justify-between"
-                        onClick={() => onChange(op.value)}
-                    >
-                        <span>{op.label}</span>
-                        <Check className={`ms-auto text-primary ${op.value === operator ? 'opacity-100' : 'opacity-0'}`} />
-                    </DropdownMenuItem>
-                ))}
-            </DropdownMenuContent>
-        </DropdownMenu>
+        <SegmentDropdown
+            ariaLabel={ariaLabel}
+            options={options}
+            readOnly={readOnly}
+            testId={testId}
+            trigger={
+                <span className={cn(selected ? undefined : 'text-muted-foreground', className)}>
+                    {selected ? selected.label : placeholder}
+                </span>
+            }
+            value={value}
+            onChange={onChange}
+        />
+    );
+}
+
+export interface FilterSegmentInputProps {
+    value: string;
+    onChange: (value: string) => void;
+    placeholder?: string;
+    ariaLabel?: string;
+    className?: string;
+    testId?: string;
+    // Render the value as static text (no input) — for an applied filter that should
+    // stay legible but not editable.
+    readOnly?: boolean;
+}
+
+// A text-input segment styled like the built-in value input, for the value part
+// of a custom renderer composed from segments.
+export function FilterSegmentInput({value, onChange, placeholder, ariaLabel, className, testId, readOnly}: FilterSegmentInputProps) {
+    const context = useFilterContext();
+
+    return (
+        <div
+            className={cn('w-36', filterInputVariants({variant: context.variant, size: context.size}), className)}
+            data-slot="filters-input-wrapper"
+        >
+            {readOnly ? (
+                <span
+                    aria-label={ariaLabel}
+                    className="block w-full truncate text-muted-foreground"
+                    data-slot="filters-input"
+                    data-testid={testId}
+                >
+                    {value || placeholder}
+                </span>
+            ) : (
+                <input
+                    aria-label={ariaLabel}
+                    autoComplete="off"
+                    className="w-full bg-transparent outline-hidden"
+                    data-slot="filters-input"
+                    data-testid={testId}
+                    placeholder={placeholder}
+                    value={value}
+                    onChange={event => onChange(event.target.value)}
+                />
+            )}
+        </div>
+    );
+}
+
+// A hint row for a filter group's `emptyState`: command-item metrics and muted text so a
+// "nothing here yet, set it up over there" pointer aligns with the picker's own rows. The
+// consumer supplies the copy (and any link) in the picker.
+export function FilterEmptyHint({children, className}: {children: React.ReactNode; className?: string}) {
+    return (
+        <div className={cn('px-2 py-1.5 text-(length:--text-control) text-muted-foreground', className)}>
+            {children}
+        </div>
     );
 }
 
@@ -1239,6 +1427,8 @@ interface FilterValueSelectorProps<T = unknown> {
     values: T[];
     onChange: (values: T[]) => void;
     operator: string;
+    onOperatorChange?: (operator: string) => void;
+    readOnly?: boolean;
 }
 
 interface SelectOptionsPopoverProps<T = unknown> {
@@ -1750,7 +1940,7 @@ function SelectOptionsPopover<T = unknown>({
     );
 }
 
-function FilterValueSelector<T = unknown>({field, values, onChange, operator}: FilterValueSelectorProps<T>) {
+function FilterValueSelector<T = unknown>({field, values, onChange, operator, onOperatorChange, readOnly}: FilterValueSelectorProps<T>) {
     const [open, setOpen] = useState(false);
     const [searchInput, setSearchInput] = useState('');
     const context = useFilterContext();
@@ -1775,15 +1965,49 @@ function FilterValueSelector<T = unknown>({field, values, onChange, operator}: F
 
     // Use custom renderer if provided
     if (field.customRenderer) {
+        // A field that renders its own operator also composes its own segments, so
+        // it sits directly in the filter item rather than inside a single value box
+        // — otherwise its segments would nest inside one bordered value pill.
+        if (field.renderOperatorInValue) {
+            return <>{field.customRenderer({field, values, onChange, operator, onOperatorChange, readOnly})}</>;
+        }
+
         return (
             <div
                 className={filterFieldValueVariants({
                     variant: context.variant,
                     size: context.size,
-                    cursorPointer: context.cursorPointer
+                    cursorPointer: context.cursorPointer,
+                    readOnly
                 })}
             >
-                {field.customRenderer({field, values, onChange, operator})}
+                {field.customRenderer({field, values, onChange, operator, onOperatorChange, readOnly})}
+            </div>
+        );
+    }
+
+    // A read-only field with no custom renderer shows its value as static text.
+    if (readOnly) {
+        return (
+            <div
+                className={filterFieldValueVariants({
+                    variant: context.variant,
+                    size: context.size,
+                    cursorPointer: context.cursorPointer,
+                    readOnly: true
+                })}
+            >
+                {field.customValueRenderer
+                    ? field.customValueRenderer(values, field.options ?? [])
+                    : values
+                        .map((currentValue) => {
+                            // Through the options, as the editable path does: a field that
+                            // reads "Gold" while editable must not read "t1" once frozen.
+                            const option = field.options?.find(candidate => candidate.value === currentValue);
+                            return option ? option.label : String(currentValue);
+                        })
+                        .filter(Boolean)
+                        .join(', ')}
             </div>
         );
     }
@@ -2250,19 +2474,23 @@ export const FiltersContent = <T = unknown,>({filters, fields, onChange}: Filter
                         </div>
 
                         {/* Operator Dropdown */}
-                        <FilterOperatorDropdown<T>
-                            field={field}
-                            operator={filter.operator}
-                            values={filter.values}
-                            onChange={operator => updateFilter(filter.id, {operator})}
-                        />
+                        {!field.renderOperatorInValue && (
+                            <FilterOperatorDropdown<T>
+                                field={field}
+                                operator={filter.operator}
+                                values={filter.values}
+                                onChange={operator => updateFilter(filter.id, {operator})}
+                            />
+                        )}
 
                         {/* Value Selector */}
                         <FilterValueSelector<T>
                             field={field}
                             operator={filter.operator}
+                            readOnly={field.readOnly}
                             values={filter.values}
                             onChange={values => updateFilter(filter.id, {values})}
+                            onOperatorChange={operator => updateFilter(filter.id, {operator})}
                         />
 
                         {/* Remove Button */}
@@ -2336,6 +2564,11 @@ export function Filters<T = unknown>({
     const [addFilterOpen, setAddFilterOpen] = useState(false);
     const [selectedFieldKeyForOptions, setSelectedFieldKeyForOptions] = useState<string | null>(null);
     const [tempSelectedValues, setTempSelectedValues] = useState<unknown[]>([]);
+    // The field-picker search, controlled so a `previewLimit` group can uncap while
+    // the user is searching. `expandedGroups` holds the groups whose "Show more" was
+    // clicked. Both reset when the picker closes.
+    const [fieldSearch, setFieldSearch] = useState('');
+    const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
 
     // Notify parent when active field changes
     useEffect(() => {
@@ -2439,6 +2672,8 @@ export function Filters<T = unknown>({
         setAddFilterOpen(false);
         setSelectedFieldKeyForOptions(null);
         setTempSelectedValues([]);
+        setFieldSearch('');
+        setExpandedGroups(new Set());
     }, []);
 
     const addFilter = useCallback(
@@ -2495,6 +2730,19 @@ export function Filters<T = unknown>({
         [closeFilterPopover, filters, onChange]
     );
 
+    // A read-only field is never offered: it exists so a filter already applied against it
+    // stays readable and removable. Checked before allowMultiple, which otherwise lets a
+    // field be picked again while it is applied — minting a second, uneditable, empty one.
+    const isOfferable = useCallback((field: FilterFieldConfig<T>) => {
+        if (field.readOnly) {
+            return false;
+        }
+        if (allowMultiple) {
+            return true;
+        }
+        return !filters.some(filter => filter.field === field.key);
+    }, [allowMultiple, filters]);
+
     const selectableFields = useMemo(() => {
         const flatFields = flattenFields(fields);
         return flatFields.filter((field) => {
@@ -2502,14 +2750,73 @@ export function Filters<T = unknown>({
             if (!field.key || field.type === 'separator') {
                 return false;
             }
-            // If allowMultiple is true, don't filter out fields that already have filters
-            if (allowMultiple) {
-                return true;
-            }
-            // Filter out fields that already have filters (default behavior)
-            return !filters.some(filter => filter.field === field.key);
+            return isOfferable(field);
         });
-    }, [fields, filters, allowMultiple]);
+    }, [fields, isOfferable]);
+
+    // A group can preview a subset in the picker (previewLimit) while every field
+    // stays resolvable — getFieldsMap flattens all of them, so named pills and saved
+    // segments never depend on a field being listed here. "Show more" reveals the
+    // rest; an active search reveals the whole group so a capped-out field is still
+    // findable by name.
+    const renderPickerGroup = (
+        groupKey: string,
+        heading: string,
+        groupFields: FilterFieldConfig<T>[],
+        previewLimit?: number,
+        emptyState?: React.ReactNode
+    ) => {
+        if (groupFields.length === 0) {
+            // A group with nothing to add still shows its heading + pointer when it
+            // supplies an empty state (e.g. no custom fields defined yet); otherwise
+            // it collapses away.
+            return emptyState
+                ? <CommandGroup key={groupKey} heading={heading}>{emptyState}</CommandGroup>
+                : null;
+        }
+
+        const searching = fieldSearch.trim().length > 0;
+        const capped = previewLimit !== undefined
+            && !searching
+            && !expandedGroups.has(groupKey)
+            && groupFields.length > previewLimit;
+        const visibleFields = capped ? groupFields.slice(0, previewLimit) : groupFields;
+        const hiddenCount = groupFields.length - visibleFields.length;
+
+        return (
+            <CommandGroup key={groupKey} heading={heading}>
+                {visibleFields.map((field, fieldIndex) => {
+                    if (field.type === 'separator') {
+                        return <CommandSeparator key={field.key ?? `${groupKey}-separator-${fieldIndex}`} />;
+                    }
+
+                    return (
+                        <CommandItem
+                            key={field.key ?? `${groupKey}-field-${fieldIndex}`}
+                            className="min-w-0"
+                            onSelect={() => field.key && addFilter(field.key)}
+                        >
+                            {field.icon}
+                            <span className="truncate">{field.label}</span>
+                        </CommandItem>
+                    );
+                })}
+                {capped && (
+                    <CommandItem
+                        className="min-w-0 text-muted-foreground"
+                        value={`${groupKey}-show-more`}
+                        onSelect={() => setExpandedGroups((prev) => {
+                            const next = new Set(prev);
+                            next.add(groupKey);
+                            return next;
+                        })}
+                    >
+                        <span className="truncate">{mergedI18n.showMore(hiddenCount)}</span>
+                    </CommandItem>
+                )}
+            </CommandGroup>
+        );
+    };
 
     return (
         <FilterContext.Provider
@@ -2551,19 +2858,26 @@ export function Filters<T = unknown>({
                             </div>
 
                             {/* Operator Dropdown */}
-                            <FilterOperatorDropdown<T>
-                                field={field}
-                                operator={filter.operator}
-                                values={filter.values}
-                                onChange={operator => updateFilter(filter.id, {operator})}
-                            />
+                            {!field.renderOperatorInValue && (
+                                <FilterOperatorDropdown<T>
+                                    field={field}
+                                    operator={filter.operator}
+                                    values={filter.values}
+                                    onChange={operator => updateFilter(filter.id, {operator})}
+                                />
+                            )}
 
-                            {/* Value Selector */}
+                            {/* Value Selector. A read-only field (e.g. an archived
+                                source) still renders its operator and value, but as
+                                static segments, so the filter stays legible while only
+                                the remove control acts. */}
                             <FilterValueSelector<T>
                                 field={field}
                                 operator={filter.operator}
+                                readOnly={field.readOnly}
                                 values={filter.values}
                                 onChange={values => updateFilter(filter.id, {values})}
+                                onOperatorChange={operator => updateFilter(filter.id, {operator})}
                             />
 
                             {/* Remove Button */}
@@ -2580,6 +2894,8 @@ export function Filters<T = unknown>({
                             if (!open) {
                                 setSelectedFieldKeyForOptions(null);
                                 setTempSelectedValues([]);
+                                setFieldSearch('');
+                                setExpandedGroups(new Set());
                             }
                         }}
                     >
@@ -2633,7 +2949,7 @@ export function Filters<T = unknown>({
                             ) : (
                                 // Show field selection - needs Command wrapper for search/list
                                 <Command className='outline-hidden' tabIndex={showSearchInput ? undefined : 0}>
-                                    {showSearchInput && <CommandInput className="h-(--control-height)" placeholder={mergedI18n.searchFields} />}
+                                    {showSearchInput && <CommandInput className="h-(--control-height)" placeholder={mergedI18n.searchFields} value={fieldSearch} onValueChange={setFieldSearch} />}
                                     <CommandList className="outline-hidden">
                                         <CommandEmpty>{mergedI18n.noFieldsFound}</CommandEmpty>
                                         {fields.map((item, index) => {
@@ -2644,41 +2960,10 @@ export function Filters<T = unknown>({
                                                     if (field.type === 'separator') {
                                                         return true;
                                                     }
-                                                    // If allowMultiple is true, don't filter out fields that already have filters
-                                                    if (allowMultiple) {
-                                                        return true;
-                                                    }
-                                                    // Filter out fields that already have filters (default behavior)
-                                                    return !filters.some(filter => filter.field === field.key);
+                                                    return isOfferable(field);
                                                 });
 
-                                                if (groupFields.length === 0) {
-                                                    return null;
-                                                }
-
-                                                return (
-                                                    <CommandGroup key={item.group || `group-${index}`} heading={item.group || 'Fields'}>
-                                                        {groupFields.map((field, fieldIndex) => {
-                                                            // Handle separator - use field.key if available, or generate stable key
-                                                            if (field.type === 'separator') {
-                                                                const sepKey = field.key ?? `${item.group ?? `group-${index}`}-separator-${fieldIndex}`;
-                                                                return <CommandSeparator key={sepKey} />;
-                                                            }
-
-                                                            // Regular field
-                                                            return (
-                                                                <CommandItem
-                                                                    key={field.key ?? `${item.group ?? `group-${index}`}-field-${fieldIndex}`}
-                                                                    className="min-w-0"
-                                                                    onSelect={() => field.key && addFilter(field.key)}
-                                                                >
-                                                                    {field.icon}
-                                                                    <span className="truncate">{field.label}</span>
-                                                                </CommandItem>
-                                                            );
-                                                        })}
-                                                    </CommandGroup>
-                                                );
+                                                return renderPickerGroup(item.group || `group-${index}`, item.group || 'Fields', groupFields, item.previewLimit, item.emptyState);
                                             }
 
                                             // Handle group-level fields (new FilterFieldConfig structure with group property)
@@ -2688,37 +2973,10 @@ export function Filters<T = unknown>({
                                                     if (field.type === 'separator') {
                                                         return true;
                                                     }
-                                                    // If allowMultiple is true, don't filter out fields that already have filters
-                                                    if (allowMultiple) {
-                                                        return true;
-                                                    }
-                                                    // Filter out fields that already have filters (default behavior)
-                                                    return !filters.some(filter => filter.field === field.key);
+                                                    return isOfferable(field);
                                                 });
 
-                                                if (groupFields.length === 0) {
-                                                    return null;
-                                                }
-
-                                                return (
-                                                    <CommandGroup key={item.group || `group-${index}`} heading={item.group || 'Fields'}>
-                                                        {groupFields.map((field) => {
-                                                            // Handle separator - use field.key if available, or generate stable key
-                                                            if (field.type === 'separator') {
-                                                                const sepKey = field.key || `${item.group || `group-${index}`}-separator-${field.label || Math.random()}`;
-                                                                return <CommandSeparator key={sepKey} />;
-                                                            }
-
-                                                            // Regular field
-                                                            return (
-                                                                <CommandItem key={field.key} className="min-w-0" onSelect={() => field.key && addFilter(field.key)}>
-                                                                    {field.icon}
-                                                                    <span className="truncate">{field.label}</span>
-                                                                </CommandItem>
-                                                            );
-                                                        })}
-                                                    </CommandGroup>
-                                                );
+                                                return renderPickerGroup(item.group || `group-${index}`, item.group || 'Fields', groupFields, item.previewLimit, item.emptyState);
                                             }
 
                                             // Handle flat field configuration (backward compatibility)
@@ -2730,8 +2988,7 @@ export function Filters<T = unknown>({
                                                 return <CommandSeparator key={sepKey} />;
                                             }
 
-                                            // If allowMultiple is false, filter out fields that already have filters
-                                            if (!allowMultiple && filters.some(filter => filter.field === field.key)) {
+                                            if (!isOfferable(field)) {
                                                 return null;
                                             }
 

--- a/apps/shade/test/unit/components/patterns/filters.test.tsx
+++ b/apps/shade/test/unit/components/patterns/filters.test.tsx
@@ -1,6 +1,6 @@
 import {useMemo, useState} from 'react';
 import {act, fireEvent, render, screen, waitFor} from '../../utils/test-utils';
-import {afterEach, beforeAll, describe, expect, it, vi} from 'vitest';
+import {afterAll, afterEach, beforeAll, describe, expect, it, vi} from 'vitest';
 import {createFilter, Filter, FilterFieldConfig, Filters, ValueSource} from '../../../../src/components/patterns/filters';
 
 vi.mock('@/components/ui/calendar', () => ({
@@ -434,6 +434,234 @@ describe('Filters', () => {
 
             // Picker should have closed — no more option role elements visible.
             expect(screen.queryByRole('option', {name: 'Gold'})).toBeNull();
+        });
+    });
+
+    describe('group previewLimit', () => {
+        const originalResizeObserver = global.ResizeObserver;
+        const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+
+        beforeAll(() => {
+            global.ResizeObserver = class {
+                observe() {
+                    return undefined;
+                }
+
+                unobserve() {
+                    return undefined;
+                }
+
+                disconnect() {
+                    return undefined;
+                }
+            } as unknown as typeof ResizeObserver;
+            HTMLElement.prototype.scrollIntoView = vi.fn();
+        });
+
+        afterAll(() => {
+            global.ResizeObserver = originalResizeObserver;
+            HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+        });
+
+        function PreviewLimitFilters({previewLimit}: Readonly<{previewLimit?: number}>) {
+            const [filters, setFilters] = useState<Filter<string>[]>([]);
+            const fields = useMemo(() => ([
+                {
+                    group: 'Custom fields',
+                    previewLimit,
+                    fields: Array.from({length: 8}, (_, index) => ({
+                        key: `custom_field.field_${index + 1}`,
+                        label: `Field ${index + 1}`,
+                        type: 'text' as const,
+                        operators: [{value: 'is', label: 'is'}]
+                    }))
+                }
+            ]), [previewLimit]);
+
+            return (
+                <Filters
+                    addButtonText="Add filter"
+                    allowMultiple={true}
+                    fields={fields}
+                    filters={filters}
+                    showSearchInput={true}
+                    onChange={setFilters}
+                />
+            );
+        }
+
+        it('previews only the first previewLimit fields behind a "Show more"', async () => {
+            render(<PreviewLimitFilters previewLimit={5} />);
+            fireEvent.click(screen.getByRole('button', {name: 'Add filter'}));
+
+            expect(await screen.findByRole('option', {name: 'Field 5'})).toBeDefined();
+            expect(screen.queryByRole('option', {name: 'Field 6'})).toBeNull();
+            expect(screen.getByRole('option', {name: 'Show 3 more'})).toBeDefined();
+        });
+
+        it('reveals the rest of the group when "Show more" is clicked', async () => {
+            render(<PreviewLimitFilters previewLimit={5} />);
+            fireEvent.click(screen.getByRole('button', {name: 'Add filter'}));
+
+            fireEvent.click(await screen.findByRole('option', {name: 'Show 3 more'}));
+
+            expect(await screen.findByRole('option', {name: 'Field 8'})).toBeDefined();
+            expect(screen.queryByRole('option', {name: /Show \d+ more/})).toBeNull();
+        });
+
+        it('uncaps the group while searching so a capped-out field is findable by name', async () => {
+            render(<PreviewLimitFilters previewLimit={5} />);
+            fireEvent.click(screen.getByRole('button', {name: 'Add filter'}));
+
+            const search = await screen.findByPlaceholderText('Search fields...');
+            fireEvent.change(search, {target: {value: 'Field 8'}});
+
+            expect(await screen.findByRole('option', {name: 'Field 8'})).toBeDefined();
+            // "Show more" is a capping affordance, never part of a search result.
+            expect(screen.queryByRole('option', {name: /Show \d+ more/})).toBeNull();
+        });
+
+        it('shows every field when no previewLimit is set', async () => {
+            render(<PreviewLimitFilters />);
+            fireEvent.click(screen.getByRole('button', {name: 'Add filter'}));
+
+            expect(await screen.findByRole('option', {name: 'Field 8'})).toBeDefined();
+            expect(screen.queryByRole('option', {name: /Show \d+ more/})).toBeNull();
+        });
+    });
+
+    describe('disabled fields and group empty state', () => {
+        const originalResizeObserver = global.ResizeObserver;
+        const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+
+        beforeAll(() => {
+            global.ResizeObserver = class {
+                observe() {
+                    return undefined;
+                }
+
+                unobserve() {
+                    return undefined;
+                }
+
+                disconnect() {
+                    return undefined;
+                }
+            } as unknown as typeof ResizeObserver;
+            HTMLElement.prototype.scrollIntoView = vi.fn();
+        });
+
+        afterAll(() => {
+            global.ResizeObserver = originalResizeObserver;
+            HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+        });
+
+        function ReadOnlyFieldFilters() {
+            const [filters, setFilters] = useState<Filter<string>[]>([createFilter('custom_field.archived', 'is', ['London'])]);
+            const fields = useMemo(() => ([
+                {
+                    group: 'Custom fields',
+                    fields: [{
+                        key: 'custom_field.archived',
+                        label: 'Archived field',
+                        type: 'text' as const,
+                        readOnly: true,
+                        operators: [{value: 'is', label: 'is'}]
+                    }]
+                }
+            ]), []);
+
+            return <Filters fields={fields} filters={filters} showSearchInput={true} onChange={setFilters} />;
+        }
+
+        function ReadOnlyPickerFilters() {
+            const [filters, setFilters] = useState<Filter<string>[]>([createFilter('custom_field.archived', 'is', ['London'])]);
+            const fields = useMemo(() => ([
+                {
+                    group: 'Custom fields',
+                    fields: [
+                        {
+                            key: 'custom_field.archived',
+                            label: 'Archived field',
+                            type: 'text' as const,
+                            readOnly: true,
+                            operators: [{value: 'is', label: 'is'}]
+                        },
+                        {
+                            key: 'custom_field.active',
+                            label: 'Active field',
+                            type: 'text' as const,
+                            operators: [{value: 'is', label: 'is'}]
+                        }
+                    ]
+                }
+            ]), []);
+
+            // allowMultiple is what a caller passes to let one field carry several filters.
+            // It skips the applied-field de-dup, so it is the case where a read-only field
+            // would otherwise reappear in the picker while its own pill is on screen.
+            return <Filters addButtonText="Add filter" allowMultiple={true} fields={fields} filters={filters} showSearchInput={true} onChange={setFilters} />;
+        }
+
+        it('never offers a read-only field in the picker, even where a field may repeat', () => {
+            render(<ReadOnlyPickerFilters />);
+            fireEvent.click(screen.getByRole('button', {name: 'Add filter'}));
+
+            // The one that can be filtered on is offered...
+            expect(screen.getByRole('option', {name: 'Active field'})).toBeDefined();
+            // ...the read-only one is not: picking it would mint a second filter that could
+            // never be edited. Its existing pill is still on screen.
+            expect(screen.queryByRole('option', {name: 'Archived field'})).toBeNull();
+        });
+
+        function ReadOnlyOptionLabelFilters() {
+            const [filters, setFilters] = useState<Filter<string>[]>([createFilter('tier', 'is', ['t1'])]);
+            const fields = useMemo(() => ([{
+                key: 'tier',
+                label: 'Tier',
+                type: 'select' as const,
+                readOnly: true,
+                operators: [{value: 'is', label: 'is'}],
+                options: [{value: 't1', label: 'Gold'}]
+            }]), []);
+
+            return <Filters fields={fields} filters={filters} onChange={setFilters} />;
+        }
+
+        it('reads a read-only value through its option label, as the editable one does', () => {
+            render(<ReadOnlyOptionLabelFilters />);
+
+            expect(screen.getByText('Gold')).toBeDefined();
+            expect(screen.queryByText('t1')).toBeNull();
+        });
+
+        it('renders a read-only field showing its operator and value as static, non-editable text', () => {
+            render(<ReadOnlyFieldFilters />);
+
+            expect(screen.getByText('Archived field')).toBeDefined();
+            // Operator and value stay visible so the filter reads clearly...
+            expect(screen.getByText('is')).toBeDefined();
+            expect(screen.getByText('London')).toBeDefined();
+            // ...but there is nothing to edit: no input and no operator menu button.
+            expect(screen.queryByRole('textbox')).toBeNull();
+            expect(screen.queryByRole('button', {name: 'is'})).toBeNull();
+        });
+
+        function EmptyStateFilters() {
+            const [filters, setFilters] = useState<Filter<string>[]>([]);
+            const fields = useMemo(() => ([
+                {group: 'Basic', fields: [{key: 'name', label: 'Name', type: 'text' as const, operators: [{value: 'is', label: 'is'}]}]},
+                {group: 'Custom fields', fields: [], emptyState: <div>Configure custom fields in Settings</div>}
+            ]), []);
+
+            return <Filters addButtonText="Add filter" fields={fields} filters={filters} showSearchInput={true} onChange={setFilters} />;
+        }
+
+        it('shows a group empty state in the picker when the group has no fields', async () => {
+            render(<EmptyStateFilters />);
+            fireEvent.click(screen.getByRole('button', {name: 'Add filter'}));
+
+            expect(await screen.findByText('Configure custom fields in Settings')).toBeDefined();
         });
     });
 });


### PR DESCRIPTION
Prerequisite extracted from the members custom-field filtering branch, where this design-system work was spread across three commits alongside its consumer. Lifted out so it lands and is reviewed as a change to the filter pattern, with the feature branch keeping only the consumer code.

## Problem

A filter pill could already take a custom renderer, but the renderer had nothing to draw with. Its choices came out as standalone selects sitting beside the filter segments rather than reading as part of the pill, and the operator was always drawn by the pattern, so a renderer whose valid operators depend on a choice it makes itself had no way to say so.

Two other gaps show up as soon as a filter list is built from data a publisher controls. A filter applied against something they can no longer choose had to be either fully editable or gone. And a group with many fields flooded the picker, while a group with none simply vanished rather than saying why.

## Solution

The pattern offers the segments themselves, so a renderer composes a pill from the same pieces the built-in controls are made of, and can take the operator over where it owns the choice that decides which operators are valid.

A filter can be read-only: it stays legible and removable, but is never offered in the picker again. That last part matters where a caller lets one field carry several filters, because the usual de-duplication is skipped there, and without it a read-only field would be offered while its own pill was on screen and would mint a second filter that could never be edited.

A group can cap how many fields the picker previews, with a search or a Show more revealing the rest, and can say something useful when it has none.

Everything is additive: every new prop is optional and absent behaviour is unchanged. One deliberate visual change for existing callers, noted below.

## Reviewer notes

The read-only value now reads through its option labels, matching the editable path, so a field showing "Gold" while editable no longer shows "t1" once frozen.

`hideOperatorSelect` callers get slightly different chrome: the bespoke static element it used is now the shared operator styling with a read-only variant, so it picks up the surrounding background and tracks the size variant instead of hardcoding one. Sixteen call sites across comments, members and analytics, all on the default variant and size, where the difference is small and arguably a correction. Worth an eyeball in Storybook.

ref https://linear.app/ghost/issue/BER-3792/
