### PR TITLE
Replaced nrwl/nx-set-shas action with in-repo script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,12 +78,30 @@ jobs:
           echo "GITHUB_EVENT_NAME: ${{ github.event_name }}"
           echo "GITHUB_CONTEXT: ${{ toJson(github.event) }}"
 
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - name: Set up Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        env:
+          FORCE_COLOR: 0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      # Replaced nrwl/nx-set-shas, which verified each candidate commit over the
+      # API and hid the errors — see scripts/nx-set-shas.js.
       - name: Set SHAs for Nx Commands
         if: env.IS_TAG != 'true'
-        uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
-        with:
-          main-branch-name: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}
-          error-on-no-successful-workflow: ${{ env.IS_MAIN == 'true' && github.repository == 'TryGhost/Ghost' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}
+          # Canonical main is the one branch where too narrow a base means
+          # untested commits land, so there a lookup that comes up empty fails
+          # the run rather than falling back to the previous commit.
+          ON_MISSING: ${{ (env.IS_MAIN == 'true' && github.repository == 'TryGhost/Ghost') && 'error' || 'previous-commit' }}
+        run: node scripts/nx-set-shas.js --branch "$BRANCH" --head "$HEAD_COMMIT" --on-missing "$ON_MISSING"
 
       - name: Check user org membership
         id: check_user_org_membership
@@ -199,18 +217,6 @@ jobs:
         id: node_matrix
         run: |
           echo 'matrix=["22.23.1"]' >> $GITHUB_OUTPUT
-
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - name: Set up Node
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
-        env:
-          FORCE_COLOR: 0
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Start Nx Cloud CI run
         run: pnpm nx start-ci-run

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,15 @@ catalogs:
     '@faker-js/faker':
       specifier: 10.5.0
       version: 10.5.0
+    '@octokit/core':
+      specifier: 7.0.7
+      version: 7.0.7
+    '@octokit/plugin-retry':
+      specifier: 8.1.1
+      version: 8.1.1
+    '@octokit/plugin-throttling':
+      specifier: 11.0.5
+      version: 11.0.5
     '@playwright/test':
       specifier: 1.61.1
       version: 1.61.1
@@ -4046,6 +4055,15 @@ importers:
 
   scripts:
     dependencies:
+      '@octokit/core':
+        specifier: 'catalog:'
+        version: 7.0.7
+      '@octokit/plugin-retry':
+        specifier: 'catalog:'
+        version: 8.1.1(@octokit/core@7.0.7)
+      '@octokit/plugin-throttling':
+        specifier: 'catalog:'
+        version: 11.0.5(@octokit/core@7.0.7)
       '@pnpm/releasing.versioning':
         specifier: 1100.1.0
         version: 1100.1.0(@pnpm/logger@1100.0.0)
@@ -6596,6 +6614,48 @@ packages:
     resolution: {integrity: sha512-TE/wvBa2cpkVXmk/AXUQAneong4JReS2hyNpAUONKG1yXU7TDKe0wvn1xQXxAbyspudT9NuCnVtpVuEkRz8S+Q==}
     cpu: [x64]
     os: [win32]
+
+  '@octokit/auth-token@6.0.0':
+    resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
+    engines: {node: '>= 20'}
+
+  '@octokit/core@7.0.7':
+    resolution: {integrity: sha512-DcB0M3KFgr9ECI328lhBMVsyFT2DnmNucSBTqEN3exyNKUzkkpUSCHmTRcunF41Eou2TIQKW4seewri8ON9bSA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/endpoint@11.0.4':
+    resolution: {integrity: sha512-f1cOWoHPmxryJFknxbtDdjODWfV8A9tc8Aae6ermXPNgHFZ/x91AtHIz4gicEjL8hkJiip+u21QHJORfBv/qiA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/graphql@9.0.4':
+    resolution: {integrity: sha512-5s15CCiY8XXQ+FG+b1YQcl6Z2FA++nwAz/tg2VUrTmnMncP+2nnGUEYANImdnxsA2Fnq+Mbl7hDjUTw7cFAwcg==}
+    engines: {node: '>= 20'}
+
+  '@octokit/openapi-types@28.0.0':
+    resolution: {integrity: sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==}
+
+  '@octokit/plugin-retry@8.1.1':
+    resolution: {integrity: sha512-VCVvZ/R1+u3WuiBWpNavZ0mY4aaJNAsENrpBP9aLSR2QyOpQgd7DhM5j4AW7z4MQpnJYgwBPf0XqPQoNBRdQwg==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=7'
+
+  '@octokit/plugin-throttling@11.0.5':
+    resolution: {integrity: sha512-LIdrkrUv+DWbKeg/49rGuFJ3SU0d3hUS+B4MhNZLepBoNUFXms8Ic9edJjrlx+zycqJHjrMRudVpVb/bAXM2Lw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': ^7.0.0
+
+  '@octokit/request-error@7.1.1':
+    resolution: {integrity: sha512-+eaY7G2VVpSf2pc5Gn1+mph837V/d/TYTJAgWL9Tb0ogGYcpN3IlAVFgjL+Vv93F/sevrxkvsYCedtpLdcFLzA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/request@10.0.13':
+    resolution: {integrity: sha512-v2269YxL9Yf+x3d+gRI63FP0vFQEiWgLyBzxe/Y+0yFDg2B/Tzf5dhh9VNfccVAQnfcfwQWyk/y6Bn7rUXXs7A==}
+    engines: {node: '>= 20'}
+
+  '@octokit/types@17.0.0':
+    resolution: {integrity: sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==}
 
   '@one-ini/wasm@0.1.1':
     resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
@@ -10997,6 +11057,9 @@ packages:
     resolution: {integrity: sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==}
     hasBin: true
 
+  before-after-hook@4.0.0:
+    resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
@@ -11083,6 +11146,9 @@ packages:
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
+  bottleneck@2.19.5:
+    resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
 
   boundary@2.0.0:
     resolution: {integrity: sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==}
@@ -16379,6 +16445,9 @@ packages:
 
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
+  json-with-bigint@3.5.10:
+    resolution: {integrity: sha512-Vcx+JVNEBts/xfcoCS69sKrOhOk/3TVlvlT+XzUOefVKnnrbYSCKpDCm10pohsJFtsJVYnwa/cXRZ4eElzaM6w==}
 
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
@@ -21804,6 +21873,9 @@ packages:
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
+  universal-user-agent@7.0.3:
+    resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
+
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
@@ -25919,6 +25991,61 @@ snapshots:
 
   '@nx/nx-win32-x64-msvc@23.0.1':
     optional: true
+
+  '@octokit/auth-token@6.0.0': {}
+
+  '@octokit/core@7.0.7':
+    dependencies:
+      '@octokit/auth-token': 6.0.0
+      '@octokit/graphql': 9.0.4
+      '@octokit/request': 10.0.13
+      '@octokit/request-error': 7.1.1
+      '@octokit/types': 17.0.0
+      before-after-hook: 4.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/endpoint@11.0.4':
+    dependencies:
+      '@octokit/types': 17.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/graphql@9.0.4':
+    dependencies:
+      '@octokit/request': 10.0.13
+      '@octokit/types': 17.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/openapi-types@28.0.0': {}
+
+  '@octokit/plugin-retry@8.1.1(@octokit/core@7.0.7)':
+    dependencies:
+      '@octokit/core': 7.0.7
+      '@octokit/request-error': 7.1.1
+      '@octokit/types': 17.0.0
+      bottleneck: 2.19.5
+
+  '@octokit/plugin-throttling@11.0.5(@octokit/core@7.0.7)':
+    dependencies:
+      '@octokit/core': 7.0.7
+      '@octokit/types': 17.0.0
+      bottleneck: 2.19.5
+
+  '@octokit/request-error@7.1.1':
+    dependencies:
+      '@octokit/types': 17.0.0
+
+  '@octokit/request@10.0.13':
+    dependencies:
+      '@octokit/endpoint': 11.0.4
+      '@octokit/request-error': 7.1.1
+      '@octokit/types': 17.0.0
+      content-type: 2.0.0
+      json-with-bigint: 3.5.10
+      universal-user-agent: 7.0.3
+
+  '@octokit/types@17.0.0':
+    dependencies:
+      '@octokit/openapi-types': 28.0.0
 
   '@one-ini/wasm@0.1.1':
     optional: true
@@ -31464,6 +31591,8 @@ snapshots:
 
   bcryptjs@3.0.3: {}
 
+  before-after-hook@4.0.0: {}
+
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
@@ -31582,6 +31711,8 @@ snapshots:
   boolbase@1.0.0: {}
 
   boolean@3.2.0: {}
+
+  bottleneck@2.19.5: {}
 
   boundary@2.0.0: {}
 
@@ -39260,6 +39391,8 @@ snapshots:
 
   json-stringify-safe@5.0.1: {}
 
+  json-with-bigint@3.5.10: {}
+
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
@@ -46056,6 +46189,8 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
+
+  universal-user-agent@7.0.3: {}
 
   universalify@0.1.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -184,6 +184,9 @@ catalog:
   '@dnd-kit/utilities': 3.2.2
   shell-quote: 1.10.0
   unidecode: 1.1.0
+  '@octokit/core': 7.0.7
+  '@octokit/plugin-retry': 8.1.1
+  '@octokit/plugin-throttling': 11.0.5
 
 catalogs:
   react17:

--- a/scripts/nx-set-shas.js
+++ b/scripts/nx-set-shas.js
@@ -1,0 +1,225 @@
+// Resolves NX_BASE / NX_HEAD — the commit window `nx affected` and the CI path
+// filters diff against.
+//
+// Replaces nrwl/nx-set-shas, which re-verified every candidate commit over the
+// GitHub API (two calls per candidate, up to 60 a run) and swallowed every
+// error, so a transient API failure was indistinguishable from a rewritten
+// branch and hard-failed the run. Ancestry is answerable locally — job_setup
+// checks out with fetch-depth 0 — so the API is only asked which runs passed:
+// one request, with the retry/throttling plugins handling rate limits.
+
+import {appendFileSync} from 'node:fs';
+import {spawnSync} from 'node:child_process';
+import {parseArgs} from 'node:util';
+
+import {Octokit} from '@octokit/core';
+import {retry} from '@octokit/plugin-retry';
+import {throttling} from '@octokit/plugin-throttling';
+
+// Hash of git's empty tree — diffing against it marks everything as changed.
+const EMPTY_TREE_SHA = '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
+const PULL_REQUEST_EVENTS = new Set(['pull_request', 'pull_request_target']);
+const ON_MISSING_MODES = new Set(['error', 'previous-commit']);
+// A primary rate limit can reset an hour out; waiting that long would just burn
+// the job's timeout, so past this we fail with the real status instead.
+const MAX_THROTTLE_WAIT_SECONDS = 60;
+const MAX_THROTTLE_RETRIES = 2;
+
+function git(args) {
+    const {status, stdout} = spawnSync('git', args, {encoding: 'utf8'});
+
+    return {ok: status === 0, stdout: (stdout ?? '').trim()};
+}
+
+function isAncestor(sha, headSha) {
+    // Exits 128 rather than 1 when the commit isn't in the local history, which
+    // for our purposes is the same answer: not a usable base.
+    return git(['merge-base', '--is-ancestor', sha, headSha]).ok;
+}
+
+export function createOctokit({token, baseUrl = process.env.GITHUB_API_URL} = {}) {
+    const CiOctokit = Octokit.plugin(retry, throttling);
+    const onLimit = (retryAfter, options, octokit, retryCount) => {
+        octokit.log.warn(`Rate limited on ${options.method} ${options.url}, waiting ${retryAfter}s`);
+
+        return retryAfter <= MAX_THROTTLE_WAIT_SECONDS && retryCount < MAX_THROTTLE_RETRIES;
+    };
+
+    return new CiOctokit({
+        auth: token,
+        ...(baseUrl ? {baseUrl} : {}),
+        throttle: {onRateLimit: onLimit, onSecondaryRateLimit: onLimit}
+    });
+}
+
+/**
+ * The head SHAs of the workflow's successful runs on a branch, newest first.
+ *
+ * @param {object} options
+ * @param {object} options.octokit
+ * @param {string} options.repo - owner/name
+ * @param {string} options.workflow - workflow file name, e.g. ci.yml
+ * @param {string} options.branch
+ * @param {string} [options.event] - the trigger to match, defaults to push
+ * @returns {Promise<string[]>}
+ */
+export async function fetchSuccessfulRunShas({octokit, repo, workflow, branch, event = 'push'}) {
+    const [owner, name] = repo.split('/');
+    const {data} = await octokit.request('GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs', {
+        owner,
+        repo: name,
+        workflow_id: workflow,
+        branch,
+        event,
+        status: 'success',
+        per_page: 100,
+        exclude_pull_requests: true
+    });
+
+    return data.workflow_runs.map(run => run.head_sha);
+}
+
+/**
+ * The newest run SHA usable as a base: still in this branch's history, and not
+ * the commit under test — re-running a commit that already passed should
+ * re-test it, not diff it against itself. Commits whose run was cancelled by a
+ * faster follow-up push have no successful run, so they're skipped over and
+ * their changes stay inside the window rather than going untested.
+ *
+ * @param {string[]} shas - candidate SHAs, newest first
+ * @param {object} options
+ * @param {string} options.headSha
+ * @param {Function} [options.ancestorCheck] - injectable for tests
+ * @returns {string|null}
+ */
+export function selectBaseSha(shas, {headSha, ancestorCheck = isAncestor}) {
+    for (const sha of shas) {
+        if (sha !== headSha && ancestorCheck(sha, headSha)) {
+            return sha;
+        }
+    }
+
+    return null;
+}
+
+function previousCommit(headSha) {
+    const previous = git(['rev-parse', `${headSha}~1`]);
+
+    if (previous.ok && previous.stdout) {
+        return previous.stdout;
+    }
+
+    console.log(`${headSha}~1 does not exist, using the empty tree as base`);
+    return EMPTY_TREE_SHA;
+}
+
+function exportShas(base, head) {
+    console.log(`NX_BASE=${base}`);
+    console.log(`NX_HEAD=${head}`);
+
+    if (process.env.GITHUB_ENV) {
+        appendFileSync(process.env.GITHUB_ENV, `NX_BASE=${base}\nNX_HEAD=${head}\n`);
+    }
+}
+
+/**
+ * @param {object} options
+ * @param {object} options.octokit
+ * @param {string} options.branch - the PR's base branch, or the pushed branch
+ * @param {string} options.headSha
+ * @param {string} options.event - GITHUB_EVENT_NAME
+ * @param {string} options.workflow
+ * @param {string} options.repo
+ * @param {string} options.onMissing - error | previous-commit
+ * @param {Function} [options.ancestorCheck] - injectable for tests
+ * @returns {Promise<string>}
+ */
+export async function resolveBase({octokit, branch, headSha, event, workflow, repo, onMissing, ancestorCheck}) {
+    if (PULL_REQUEST_EVENTS.has(event)) {
+        const mergeBase = git(['merge-base', `origin/${branch}`, headSha]);
+
+        if (!mergeBase.ok || !mergeBase.stdout) {
+            throw new Error(`Could not find the merge base of origin/${branch} and ${headSha}`);
+        }
+
+        return mergeBase.stdout;
+    }
+
+    const shas = await fetchSuccessfulRunShas({octokit, repo, workflow, branch});
+    const base = selectBaseSha(shas, {headSha, ancestorCheck});
+
+    if (base) {
+        console.log(`Last successful ${workflow} run on ${branch}: ${base}`);
+        return base;
+    }
+
+    if (onMissing === 'error') {
+        throw new Error(shas.length === 0 ?
+            `No successful ${workflow} run found on ${branch}` :
+            `None of the ${shas.length} successful ${workflow} runs on ${branch} point at a commit in this ` +
+            `branch's history — was ${branch} rebased?`
+        );
+    }
+
+    console.log(`No successful ${workflow} run found on ${branch}, falling back to the previous commit`);
+    return previousCommit(headSha);
+}
+
+export async function main(argv = process.argv.slice(2)) {
+    const {values} = parseArgs({
+        args: argv,
+        options: {
+            branch: {type: 'string'},
+            head: {type: 'string'},
+            event: {type: 'string', default: process.env.GITHUB_EVENT_NAME ?? 'push'},
+            workflow: {type: 'string', default: 'ci.yml'},
+            repo: {type: 'string', default: process.env.GITHUB_REPOSITORY},
+            // What to do when no successful run can be found: fail, for a
+            // canonical branch where too narrow a base means untested commits
+            // land, or fall back to HEAD~1 for forks, which may have no run
+            // history at all.
+            'on-missing': {type: 'string', default: 'previous-commit'}
+        }
+    });
+
+    const onMissing = values['on-missing'];
+
+    if (!ON_MISSING_MODES.has(onMissing)) {
+        throw new Error(`--on-missing must be one of: ${[...ON_MISSING_MODES].join(', ')}`);
+    }
+
+    if (!values.branch) {
+        throw new Error('--branch is required');
+    }
+
+    if (!values.repo) {
+        throw new Error('--repo is required when GITHUB_REPOSITORY is unset');
+    }
+
+    const headSha = values.head || git(['rev-parse', 'HEAD']).stdout;
+
+    if (!headSha) {
+        throw new Error('Could not resolve HEAD');
+    }
+
+    const base = await resolveBase({
+        octokit: createOctokit({token: process.env.GITHUB_TOKEN || process.env.GH_TOKEN}),
+        branch: values.branch,
+        headSha,
+        event: values.event,
+        workflow: values.workflow,
+        repo: values.repo,
+        onMissing
+    });
+
+    exportShas(base, headSha);
+}
+
+if (import.meta.main) {
+    try {
+        await main();
+    } catch (error) {
+        console.error(error.message);
+        process.exit(1);
+    }
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -11,6 +11,9 @@
     "test": "pnpm run '/^test:/'"
   },
   "dependencies": {
+    "@octokit/core": "catalog:",
+    "@octokit/plugin-retry": "catalog:",
+    "@octokit/plugin-throttling": "catalog:",
     "@pnpm/releasing.versioning": "1100.1.0",
     "@pnpm/workspace.workspace-manifest-reader": "1100.1.0",
     "camelcase-keys": "10.0.2",

--- a/scripts/test/nx-set-shas.test.js
+++ b/scripts/test/nx-set-shas.test.js
@@ -1,0 +1,110 @@
+import {describe, it} from 'node:test';
+import assert from 'node:assert';
+import {fetchSuccessfulRunShas, resolveBase, selectBaseSha} from '../nx-set-shas.js';
+
+const HEAD = 'head0000000000000000000000000000000000000';
+const GREEN = 'green000000000000000000000000000000000000';
+const OLDER = 'older000000000000000000000000000000000000';
+const REBASED = 'gone0000000000000000000000000000000000000';
+
+// The branch as CI sees it: HEAD plus the two commits behind it.
+const ancestors = new Set([HEAD, GREEN, OLDER]);
+const ancestorCheck = sha => ancestors.has(sha);
+
+function octokitReturning(shas) {
+    const calls = [];
+
+    return {
+        calls,
+        request: async (route, params) => {
+            calls.push({route, params});
+            return {data: {workflow_runs: shas.map(sha => ({head_sha: sha}))}};
+        }
+    };
+}
+
+describe('selectBaseSha', () => {
+    it('takes the newest successful run still on the branch', () => {
+        assert.strictEqual(selectBaseSha([GREEN, OLDER], {headSha: HEAD, ancestorCheck}), GREEN);
+    });
+
+    it('skips commits that are no longer on the branch', () => {
+        assert.strictEqual(selectBaseSha([REBASED, GREEN], {headSha: HEAD, ancestorCheck}), GREEN);
+    });
+
+    it('skips a successful run of the commit under test so a re-run re-tests it', () => {
+        assert.strictEqual(selectBaseSha([HEAD, GREEN], {headSha: HEAD, ancestorCheck}), GREEN);
+    });
+
+    it('returns null when nothing is usable', () => {
+        assert.strictEqual(selectBaseSha([REBASED], {headSha: HEAD, ancestorCheck}), null);
+        assert.strictEqual(selectBaseSha([], {headSha: HEAD, ancestorCheck}), null);
+    });
+});
+
+describe('fetchSuccessfulRunShas', () => {
+    it('asks for successful runs of the workflow on the branch', async () => {
+        const octokit = octokitReturning([GREEN, OLDER]);
+        const shas = await fetchSuccessfulRunShas({
+            octokit,
+            repo: 'TryGhost/Ghost',
+            workflow: 'ci.yml',
+            branch: 'main'
+        });
+
+        assert.deepStrictEqual(shas, [GREEN, OLDER]);
+        assert.strictEqual(octokit.calls.length, 1);
+        assert.deepStrictEqual(octokit.calls[0].params, {
+            owner: 'TryGhost',
+            repo: 'Ghost',
+            workflow_id: 'ci.yml',
+            branch: 'main',
+            event: 'push',
+            status: 'success',
+            per_page: 100,
+            exclude_pull_requests: true
+        });
+    });
+});
+
+describe('resolveBase', () => {
+    const pushRun = {
+        branch: 'main',
+        headSha: HEAD,
+        event: 'push',
+        workflow: 'ci.yml',
+        repo: 'TryGhost/Ghost',
+        onMissing: 'error',
+        ancestorCheck
+    };
+
+    it('resolves to the last successful run on the branch', async () => {
+        const base = await resolveBase({...pushRun, octokit: octokitReturning([GREEN])});
+
+        assert.strictEqual(base, GREEN);
+    });
+
+    it('errors rather than narrowing the window when nothing is usable', async () => {
+        await assert.rejects(
+            resolveBase({...pushRun, octokit: octokitReturning([REBASED])}),
+            /was main rebased/
+        );
+    });
+
+    it('errors when the branch has no successful runs at all', async () => {
+        await assert.rejects(
+            resolveBase({...pushRun, octokit: octokitReturning([])}),
+            /No successful ci.yml run found on main/
+        );
+    });
+
+    it('surfaces an API failure instead of treating it as no successful run', async () => {
+        const octokit = {
+            request: async () => {
+                throw new Error('GitHub API responded 403');
+            }
+        };
+
+        await assert.rejects(resolveBase({...pushRun, octokit}), /403/);
+    });
+});


### PR DESCRIPTION
no ref
- nx-set-shas makes a high number of calls to the Github API - transient issues or rate limiting errors are masked as a failure to lookup a workflow
- adding a custom script that only needs one call to the Github API simplifies the setup and leverages the local git checkout more