### PR TITLE
Added configuration and development practice guides

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -58,6 +58,12 @@ detail, see the [monorepo structure guide](codebase/monorepo-structure.md). The
 [configuration guide](codebase/configuration.md) explains how Ghost Core loads
 defaults, local overrides, and environment variables.
 
+## Development Practices
+
+The [internationalization guide](practices/internationalization.md) explains
+how to write translatable copy, update locale files, and validate translation
+changes.
+
 ## Contributing a change
 
 Before contributing, please read:

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,7 +62,8 @@ defaults, local overrides, and environment variables.
 
 The [internationalization guide](practices/internationalization.md) explains
 how to write translatable copy, update locale files, and validate translation
-changes.
+changes. The [error handling guide](practices/error-handling.md) covers server
+errors, API responses, safe user messages, and tests.
 
 ## Contributing a change
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,7 +54,9 @@ Ghost/
 ```
 
 pnpm links the workspaces and Nx runs their tasks in dependency order. For more
-detail, see the [monorepo structure guide](codebase/monorepo-structure.md).
+detail, see the [monorepo structure guide](codebase/monorepo-structure.md). The
+[configuration guide](codebase/configuration.md) explains how Ghost Core loads
+defaults, local overrides, and environment variables.
 
 ## Contributing a change
 

--- a/docs/codebase/configuration.md
+++ b/docs/codebase/configuration.md
@@ -1,0 +1,132 @@
+# Configuration
+
+Ghost Core loads configuration through `nconf`. This guide explains the
+configuration contract for people changing or running the codebase. For the
+supported self-hosting options, see the
+[public configuration reference](https://docs.ghost.org/config).
+
+The loader lives in
+[`ghost/core/core/shared/config/`](../../ghost/core/core/shared/config/). Ghost
+reads configuration when the process starts, so restart the development server
+after changing a configuration file or environment variable.
+
+## Configuration precedence
+
+When the same key appears in more than one place, Ghost uses the first value in
+this list:
+
+1. Internal overrides in `core/shared/config/overrides.json`
+2. Command-line arguments
+3. Environment variables
+4. `config.<NODE_ENV>.json` in `ghost/core/`
+5. Docker development defaults when `GHOST_DEV_IS_DOCKER=true`
+6. `config.local.json` in `ghost/core/`
+7. `config.local.jsonc` in `ghost/core/`
+8. Environment defaults in `core/shared/config/env/config.<NODE_ENV>.json`
+9. Global defaults in `core/shared/config/defaults.json`
+
+Internal overrides cannot be replaced by another configuration source. Avoid
+using command-line arguments for persistent configuration; files and environment
+variables are easier to reproduce.
+
+`NODE_ENV` defaults to `development`. The test environments do not load the
+local JSON or JSONC files.
+
+## Local development
+
+Create `ghost/core/config.local.json` for local overrides:
+
+```json
+{
+    "logging": {
+        "level": "debug"
+    }
+}
+```
+
+The repository ignores `config.*.json` and `config.*.jsonc` files in
+`ghost/core/` unless they are already tracked. Do not commit local credentials
+or overrides.
+
+Use `config.local.jsonc` instead when comments are useful. If both local files
+define the same key, `config.local.json` takes precedence.
+
+The standard `pnpm dev` environment supplies container connection values as
+environment variables and also loads
+`core/shared/config/env/config.development.docker.json`. Because environment
+variables have higher precedence, a value supplied by Docker Compose cannot be
+replaced in a local configuration file.
+
+## Environment variables
+
+Environment variable names match configuration keys exactly, including case.
+Use two underscores to represent a nested key:
+
+```bash
+logging__level=debug pnpm dev
+```
+
+Values are parsed rather than treated only as strings. Use valid JSON syntax for
+arrays and objects:
+
+```bash
+logging__transports='["stdout"]' pnpm dev
+```
+
+Prefer environment variables for values supplied by the runtime, especially
+secrets. Never commit secrets to a configuration file.
+
+## Reading configuration in code
+
+Import the shared configuration instance and use colon-separated paths for
+nested values:
+
+```javascript
+const config = require('../../shared/config');
+
+const port = config.get('server:port');
+const server = config.get('server');
+```
+
+`config.get('server')` returns a plain object, so read `server.port` rather than
+calling `server.get('port')`.
+
+Use the existing configuration instance rather than creating another `nconf`
+provider. This preserves the repository's precedence, path normalization, URL
+validation, and database normalization behavior.
+
+## Adding a configuration key
+
+Before adding a key, search the defaults, environment files, and call sites for
+an existing setting with the same purpose. New shared defaults belong in
+[`defaults.json`](../../ghost/core/core/shared/config/defaults.json) so the
+available configuration remains discoverable.
+
+Use `camelCase` for new keys. Add focused tests when the change affects loading,
+precedence, parsing, validation, or environment-specific behavior. The loader
+tests live in
+[`ghost/core/test/unit/shared/config/`](../../ghost/core/test/unit/shared/config/).
+
+Keep private deployment mechanics out of this repository. This guide documents
+the public, code-visible configuration contract; environment-specific operations
+belong in the system that owns that deployment.
+
+## Debugging
+
+To print the resolved configuration while starting Ghost Core, enable the
+configuration debug namespace:
+
+```bash
+DEBUG=ghost:*,ghost-config pnpm dev
+```
+
+The resolved output can contain secrets. Use it only in a local environment and
+do not paste unredacted output into issues, pull requests, or logs.
+
+If Ghost rejects a configuration change, check that:
+
+- `url` includes `http://` or `https://`
+- `paths.contentPath` exists
+- nested environment variables use `__`
+- environment-variable names use the same case as their configuration keys
+- JSON files contain valid JSON, or comments are placed in the JSONC file

--- a/docs/practices/error-handling.md
+++ b/docs/practices/error-handling.md
@@ -1,0 +1,97 @@
+# Error Handling
+
+An error has three audiences: developers investigating it, code responding to
+it, and the person using Ghost. Handle each audience deliberately. Keep the
+technical detail needed for diagnosis, return a stable API error, and show a
+clear message with a useful next step.
+
+## Ghost Core
+
+Use the error classes from `@tryghost/errors` at server boundaries. Choose the
+class that represents the failure; its type and HTTP status become part of the
+API contract.
+
+```js
+const errors = require('@tryghost/errors');
+
+throw new errors.ValidationError({
+    message: 'Please enter a valid email address.',
+    property: 'email',
+    code: 'INVALID_EMAIL'
+});
+```
+
+Ghost errors support these fields:
+
+| Field | Purpose |
+| --- | --- |
+| `message` | Short, user-readable description of the failure |
+| `context` | Extra information about what failed |
+| `help` | A useful next step |
+| `code` | Stable identifier for code that needs to handle this case |
+| `property` | Input field associated with a validation failure |
+| `errorDetails` | Structured details needed by a specific API consumer |
+| `err` | Original error, retained for diagnosis |
+
+Pass the original error as `err` when wrapping a dependency or lower-level
+failure. Do not expose database errors, stack traces, secrets, or raw responses
+from another service in user-facing fields. Unexpected errors are converted to
+a generic internal server error before they reach the API.
+
+## API responses
+
+Ghost API errors use an `errors` array:
+
+```json
+{
+    "errors": [{
+        "message": "Please enter a valid email address.",
+        "context": null,
+        "type": "ValidationError",
+        "details": null,
+        "property": "email",
+        "help": null,
+        "code": "INVALID_EMAIL",
+        "id": "..."
+    }]
+}
+```
+
+The HTTP status and error `type` describe the general failure. Use `code` when
+a caller needs to distinguish a specific case. Messages explain the problem to
+people and can change, so do not use message text as a programmatic identifier.
+
+When changing an API error, consider existing callers. Changing its status,
+type, code, or field shape can be a compatibility change even when the success
+response is unchanged.
+
+## User interfaces
+
+Handle expected failures close to the action that caused them. A useful error
+message says what happened and, where possible, what the person can do next.
+Translate user-facing copy using the
+[internationalization guide](internationalization.md).
+
+Only display a server message when that endpoint deliberately returns copy that
+is safe for the user. Do not show raw JavaScript errors or unknown dependency
+messages. Use the established generic fallback when there is no trusted message:
+
+> An unexpected error occurred, please try again.
+
+Preserve the original error for diagnostics even when the UI shows a simpler
+message. Known global cases such as maintenance or a version mismatch should use
+their dedicated UI rather than a generic notification.
+
+## Testing errors
+
+Test both sides of an error boundary:
+
+- Server tests should assert the error type, HTTP status, code, and any fields
+  the caller relies on.
+- UI tests should cover the expected recovery path and the generic fallback for
+  an unknown error.
+- Do not only assert message text when the behavior depends on a stable code or
+  type.
+
+Keep tests focused on the contract that matters to the caller. Internal stack
+traces and logging metadata are diagnostic details, not API contracts.

--- a/docs/practices/internationalization.md
+++ b/docs/practices/internationalization.md
@@ -1,0 +1,91 @@
+# Internationalization
+
+Ghost keeps translatable product copy in `packages/i18n`. English strings are
+the source for every supported locale, and the translation tooling extracts
+those strings from the apps and Ghost Core.
+
+## Translation namespaces
+
+Translation files live at
+`packages/i18n/locales/<locale>/<namespace>.json`. Each part of Ghost uses its
+own namespace:
+
+| Namespace | Source |
+| --- | --- |
+| `ghost` | Ghost Core, including server and frontend email templates |
+| `portal` | Portal |
+| `signup-form` | Signup form |
+| `comments` | Comments |
+| `search` | Search |
+
+The list of supported locales is in
+`packages/i18n/lib/locale-data.json`. Each namespace has the same set of locale
+files.
+
+## Adding or changing copy
+
+Write the English message in the source code using that app's `t()` helper,
+then update the translation files from the repository root:
+
+```bash
+pnpm --filter @tryghost/i18n translate
+```
+
+The command extracts source messages, updates every locale file, and updates
+`packages/i18n/locales/context.json`. Add a useful description for every new
+entry in `context.json` so translators know where the message appears and what
+it means. CI rejects missing messages and empty context descriptions.
+
+Commit the source change, generated locale changes, and context changes
+together.
+
+## Writing translatable messages
+
+Keep a complete sentence in one translation call. Translators need the whole
+message so they can change its word order.
+
+```jsx
+// Do
+t('Could not sign in. Please try again.')
+
+// Do not split one sentence across calls
+t('Could not sign in.') + ' ' + t('Please try again.')
+```
+
+Use named variables for dynamic values:
+
+```jsx
+t('Welcome back, {name}!', {name: member.name})
+```
+
+When a message contains a link, button, or other element, keep the full message
+in one string and use `@doist/react-interpolate`:
+
+```jsx
+import Interpolate from '@doist/react-interpolate';
+
+<Interpolate
+    mapping={{a: <a href={helpUrl} />}}
+    string={t('Having trouble? <a>Read the help guide</a>.')}
+/>
+```
+
+Do not build a sentence from translated fragments. Apart from making word order
+fixed, fragments make the translator's context unclear.
+
+When editing translated values directly, preserve every `{variable}` and
+`<tag>` from the English message. Their names and spelling are part of the
+runtime contract.
+
+## Checking changes
+
+Run the translation checks from the repository root:
+
+```bash
+pnpm --filter @tryghost/i18n lint:translations
+pnpm --filter @tryghost/i18n test
+```
+
+The linter checks that translations use the variables defined by their English
+message. The package tests also run extraction, so check the resulting diff and
+commit any expected generated changes.


### PR DESCRIPTION
## Summary

- add a configuration guide covering Ghost Core's defaults, local overrides, environment variables, and reload behavior
- add practice guides for the current internationalization workflow and error-handling contracts across Core, APIs, and user interfaces
- link all three guides from the codebase documentation index; private deployment and operational details remain out of scope

## Testing

- [x] `cd ghost/core && pnpm test:single test/unit/shared/config/loader.test.js`
- [x] `pnpm --filter @tryghost/i18n lint:translations`
- [x] `pnpm --filter @tryghost/i18n test`
- [x] `pnpm --filter @tryghost/portal test -- errors.test.js`
- [x] `pnpm nx run ghost-admin:test -- 1 --file-path=tests/unit/services/notifications-test.js`
- [x] `pnpm lint:docs`
- [x] `git diff --check`
