### PR TITLE
Added creating a custom field while mapping a members import

### DIFF
--- a/apps/admin-x-framework/src/api/member-custom-fields.ts
+++ b/apps/admin-x-framework/src/api/member-custom-fields.ts
@@ -105,7 +105,10 @@ export const userTypeForField = (field: MemberCustomField): MemberCustomFieldUse
 
 // A custom field CSV column offered as an import mapping target: the column name the
 // backend reads (`value`) and a human label for the picker.
-export type MemberCustomFieldCsvColumn = {label: string; value: string};
+// The field's type rides along so a picker can show what kind of thing the column holds
+// without being handed the fields as well. Every column of a composite carries the
+// composite's own type, which is what its icon is drawn from.
+export type MemberCustomFieldCsvColumn = {label: string; value: string; type: FieldType};
 
 /**
  * The CSV import mapping targets for a set of custom fields: one per column the export
@@ -118,7 +121,8 @@ export const memberCustomFieldCsvColumns = (fields: MemberCustomField[]): Member
         const labels = partLabelsFor(field.type);
         return csvColumnsForField({key: field.key, type: field.type}).map(({column, subField}) => ({
             label: subField === null ? field.name : `${field.name} (${labels[subField]})`,
-            value: column
+            value: column,
+            type: field.type
         }));
     });
 };

--- a/apps/admin-x-framework/src/api/member-custom-fields.ts
+++ b/apps/admin-x-framework/src/api/member-custom-fields.ts
@@ -173,7 +173,30 @@ export const useCreateMemberCustomField = createMutation<MemberCustomFieldsRespo
     method: 'POST',
     path: () => '/members/custom_fields/',
     body: field => ({members_custom_fields: [field]}),
-    invalidateQueries: {dataType}
+    invalidateQueries: {dataType},
+    // The created field is put into the cached lists as well as refetched, so a screen that
+    // has just made one can use it in the same breath instead of waiting for a round trip or
+    // keeping its own copy until one arrives. The refetch above remains the truth; this only
+    // decides what is on screen until it lands.
+    //
+    // Appended, because the API assigns a new field the last position. Keyed de-dup because
+    // the refetch may already have landed, and a list that does not hold the created field is
+    // left alone: a browse filtered to active fields should not be handed an archived one, and
+    // by the same token no list here is asked to take a field it did not ask for.
+    updateQueries: {
+        dataType,
+        emberUpdateType: 'skip',
+        update: (newData, currentData) => {
+            const current = currentData as MemberCustomFieldsResponseType | undefined;
+            if (!current?.members_custom_fields) {
+                return currentData;
+            }
+            const created = newData.members_custom_fields.filter(
+                field => !current.members_custom_fields.some(existing => existing.key === field.key)
+            );
+            return {...current, members_custom_fields: [...current.members_custom_fields, ...created]};
+        }
+    }
 });
 
 // Keys are immutable after creation (the API rejects changes); `name` and

--- a/apps/admin-x-framework/src/api/members.ts
+++ b/apps/admin-x-framework/src/api/members.ts
@@ -259,8 +259,11 @@ function buildImportMembersFormData({file, labels = [], mapping = {}}: ImportMem
         formData.append('labels', label);
     }
 
+    // An empty target is the caller naming a column to leave out of the import, and the
+    // importer only honours a column it is told about — so it has to survive to the wire.
+    // Null and undefined stay dropped: they are a column with nothing said about it.
     for (const [key, val] of Object.entries(mapping)) {
-        if (val) {
+        if (typeof val === 'string') {
             formData.append(`mapping[${key}]`, val);
         }
     }

--- a/apps/admin-x-framework/src/utils/errors.ts
+++ b/apps/admin-x-framework/src/utils/errors.ts
@@ -118,14 +118,19 @@ export class ValidationError extends JSONError {
 
 export const errorsWithMessage = [ValidationError, ThemeValidationError, HostLimitError, EmailError];
 
-// The API error serializer puts the human-readable text in `context`;
-// `message` is only a generic summary
+/**
+ * What the server said went wrong, for showing to a person.
+ *
+ * The API serializer rewrites `message` to a generic summary and leaves the sentence that
+ * explains the failure — and usually what to do about it — in `context`, so that is read
+ * first. Any error carrying an API body is read the same way: a caller should not have to
+ * know which class it got back to find the text, and reading only one class left every
+ * other one showing "Could not save…" while the reason sat unread in the payload.
+ */
 export function getErrorMessage(error: unknown, fallback: string): string {
-    if (error instanceof ValidationError && error.data?.errors[0]) {
-        return error.data.errors[0].context || error.data.errors[0].message;
-    }
+    const apiError = error instanceof JSONError ? error.data?.errors?.[0] : undefined;
 
-    return fallback;
+    return apiError?.context || apiError?.message || fallback;
 }
 
 // Frontend errors

--- a/apps/admin-x-framework/test/unit/api/member-custom-fields.test.ts
+++ b/apps/admin-x-framework/test/unit/api/member-custom-fields.test.ts
@@ -35,7 +35,7 @@ describe('member custom fields api helpers', () => {
     describe('memberCustomFieldCsvColumns', () => {
         it('gives a scalar field one target labelled by its name', () => {
             expect(memberCustomFieldCsvColumns([field({key: 'nickname', name: 'Nickname'})])).toEqual([
-                {label: 'Nickname', value: 'custom_fields.nickname'}
+                {label: 'Nickname', value: 'custom_fields.nickname', type: 'short_text'}
             ]);
         });
 
@@ -43,12 +43,12 @@ describe('member custom fields api helpers', () => {
             const columns = memberCustomFieldCsvColumns([field({key: 'shipping_address', name: 'Shipping Address', type: 'address'})]);
 
             expect(columns).toEqual([
-                {label: 'Shipping Address (Address line 1)', value: 'custom_fields.shipping_address.line1'},
-                {label: 'Shipping Address (Address line 2)', value: 'custom_fields.shipping_address.line2'},
-                {label: 'Shipping Address (City)', value: 'custom_fields.shipping_address.city'},
-                {label: 'Shipping Address (State)', value: 'custom_fields.shipping_address.state'},
-                {label: 'Shipping Address (Postal code)', value: 'custom_fields.shipping_address.postal_code'},
-                {label: 'Shipping Address (Country)', value: 'custom_fields.shipping_address.country'}
+                {label: 'Shipping Address (Address line 1)', value: 'custom_fields.shipping_address.line1', type: 'address'},
+                {label: 'Shipping Address (Address line 2)', value: 'custom_fields.shipping_address.line2', type: 'address'},
+                {label: 'Shipping Address (City)', value: 'custom_fields.shipping_address.city', type: 'address'},
+                {label: 'Shipping Address (State)', value: 'custom_fields.shipping_address.state', type: 'address'},
+                {label: 'Shipping Address (Postal code)', value: 'custom_fields.shipping_address.postal_code', type: 'address'},
+                {label: 'Shipping Address (Country)', value: 'custom_fields.shipping_address.country', type: 'address'}
             ]);
         });
 
@@ -62,7 +62,7 @@ describe('member custom fields api helpers', () => {
             const future = field({key: 'mystery', name: 'Mystery', type: 'a_type_from_the_future' as MemberCustomField['type']});
 
             expect(memberCustomFieldCsvColumns([future])).toEqual([
-                {label: 'Mystery', value: 'custom_fields.mystery'}
+                {label: 'Mystery', value: 'custom_fields.mystery', type: 'a_type_from_the_future'}
             ]);
         });
     });

--- a/apps/admin-x-framework/test/unit/utils/errors.test.ts
+++ b/apps/admin-x-framework/test/unit/utils/errors.test.ts
@@ -337,6 +337,34 @@ describe('errors utils', () => {
             expect(getErrorMessage(error, 'Fallback message')).toBe('Validation error, cannot edit label.');
         });
 
+        // Not just validation: the serializer treats every error the same way, so a caller
+        // should not have to know which class came back to find the sentence it carries.
+        const makeHostLimitError = (context: string | null) => {
+            const data: ErrorResponse = {
+                errors: [{
+                    code: 'CUSTOM_FIELDS_LIMIT_REACHED',
+                    context,
+                    details: null,
+                    ghostErrorCode: null,
+                    help: 'Help text',
+                    id: 'error-id',
+                    message: 'Cannot create custom field.',
+                    property: null,
+                    type: 'HostLimitError'
+                }]
+            };
+            return new HostLimitError({} as Response, data);
+        };
+
+        it('returns the context of any error carrying an API body, not only a validation one', () => {
+            const error = makeHostLimitError('Custom fields are limited to 20 per site.');
+            expect(getErrorMessage(error, 'Fallback message')).toBe('Custom fields are limited to 20 per site.');
+        });
+
+        it('falls back to the API message for a non-validation error with no context', () => {
+            expect(getErrorMessage(makeHostLimitError(null), 'Fallback message')).toBe('Cannot create custom field.');
+        });
+
         it('returns the fallback for other errors', () => {
             expect(getErrorMessage(new Error('boom'), 'Fallback message')).toBe('Fallback message');
             expect(getErrorMessage(undefined, 'Fallback message')).toBe('Fallback message');

--- a/apps/admin/src/members/components/bulk-action-modals/import-members-gate.tsx
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members-gate.tsx
@@ -1,0 +1,35 @@
+import {ImportMembersModal as BaselineImportMembersModal} from '@/members/components/bulk-action-modals/import-members-modal';
+import {ImportMembersModal as CustomFieldsImportMembersModal} from '@/members/components/bulk-action-modals/import-members/custom-fields/import-members-modal';
+import {useFeatureFlag} from '@tryghost/admin-x-framework/hooks';
+import type {ImportResponse} from '@/members/components/bulk-action-modals/import-members/state';
+
+interface ImportMembersGateProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    onComplete?: (importResponse?: ImportResponse) => void;
+    onClose?: (importResponse?: ImportResponse) => void;
+}
+
+/**
+ * Serves the members CSV import from the custom fields experience when the `membersCustomFields`
+ * Labs flag is on, and from the import as it shipped otherwise.
+ *
+ * Two whole implementations rather than one with the flag threaded through it. The mapping step
+ * diverges in almost every part — what a row offers, what a row means, what the request carries —
+ * and while both lived in one file every change was opt-out: five reached the flag-off path
+ * before anyone noticed. Here the baseline is a file this feature never edits, so it cannot
+ * regress by being forgotten about.
+ *
+ * The cost is real and worth stating: a fix to the import has to be applied to both, or knowingly
+ * to one, until the flag goes and the baseline is deleted.
+ */
+export function ImportMembersGate(props: ImportMembersGateProps) {
+    const customFieldsEnabled = useFeatureFlag('membersCustomFields');
+
+    if (customFieldsEnabled) {
+        return <CustomFieldsImportMembersModal {...props} />;
+    }
+    return <BaselineImportMembersModal {...props} />;
+}
+
+export default ImportMembersGate;

--- a/apps/admin/src/members/components/bulk-action-modals/import-members-modal.tsx
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members-modal.tsx
@@ -307,14 +307,14 @@ export function ImportMembersModal({
 
     return (
         <Dialog open={open} onOpenChange={handleOpenChange}>
-            {/* While mapping, the dialog is bounded to the viewport and laid out as a column,
-                    so the table takes the leftover height and the footer stays reachable on a
-                    short screen. 8vmin matches the dialog's own top offset. */}
-                <DialogContent className={cn(
-                    'gap-0',
-                    isWide && 'max-w-2xl',
-                    isWide && 'flex max-h-[calc(100vh-16vmin)] flex-col'
-                )}>
+            {/* While mapping, the dialog is bounded to the viewport and laid out as a column, so
+                the table takes the leftover height and the footer stays reachable on a short
+                screen. 8vmin matches the dialog's own top offset. */}
+            <DialogContent className={cn(
+                'gap-0',
+                isWide && 'max-w-2xl',
+                isWide && 'flex max-h-[calc(100vh-16vmin)] flex-col'
+            )}>
                 <DialogHeader>
                     <DialogTitle>{title}</DialogTitle>
                     <DialogDescription className="sr-only">

--- a/apps/admin/src/members/components/bulk-action-modals/import-members-modal.tsx
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members-modal.tsx
@@ -307,7 +307,14 @@ export function ImportMembersModal({
 
     return (
         <Dialog open={open} onOpenChange={handleOpenChange}>
-            <DialogContent className={cn('gap-0', isWide && 'max-w-2xl')}>
+            {/* While mapping, the dialog is bounded to the viewport and laid out as a column,
+                    so the table takes the leftover height and the footer stays reachable on a
+                    short screen. 8vmin matches the dialog's own top offset. */}
+                <DialogContent className={cn(
+                    'gap-0',
+                    isWide && 'max-w-2xl',
+                    isWide && 'flex max-h-[calc(100vh-16vmin)] flex-col'
+                )}>
                 <DialogHeader>
                     <DialogTitle>{title}</DialogTitle>
                     <DialogDescription className="sr-only">

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/components/mapping-step.tsx
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/components/mapping-step.tsx
@@ -55,7 +55,10 @@ export function MappingStep({
 
     return (
         <>
-            <div className="mt-5 space-y-5">
+            {/* A flex column inside the height-bounded dialog: the table box below grows into
+                whatever room is left, so a short file keeps a small modal and a long one
+                fills the viewport rather than scrolling inside a fixed height. */}
+            <div className="mt-5 flex min-h-0 flex-1 flex-col space-y-5">
                 {fileData === null ? (
                     <div className="flex items-center justify-center rounded-md border bg-muted p-10">
                         <LoadingIndicator size="md" />
@@ -63,10 +66,10 @@ export function MappingStep({
                 ) : (
                     <>
                         <div className={cn(
-                            'overflow-hidden rounded-md border',
+                            'flex min-h-0 flex-1 flex-col overflow-hidden rounded-md border',
                             showMappingErrors && mappingError && 'border-red-500'
                         )}>
-                            <div className="max-h-[400px] overflow-auto">
+                            <div className="min-h-0 flex-1 overflow-auto">
                                 <Table className="table-fixed">
                                     <TableHeader>
                                         <TableRow>

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/create-field-form.tsx
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/create-field-form.tsx
@@ -1,0 +1,123 @@
+import {Button, Field, FieldError, FieldGroup, FieldLabel, Input, Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from '@tryghost/shade/components';
+import {CustomFieldTypeOption} from '@/shared/member-custom-fields/custom-field-type-option';
+import {memberCustomFieldUserTypes} from '@tryghost/admin-x-framework/api/member-custom-fields';
+import {suggestedFieldName} from '@/members/components/bulk-action-modals/import-members/custom-fields/mapping';
+import {useEffect, useRef, useState} from 'react';
+import type {MemberCustomField} from '@tryghost/admin-x-framework/api/member-custom-fields';
+
+interface CreateFieldFormProps {
+    // The CSV column this field is being created for. Seeds the name, since a header is
+    // usually close to what the publisher would have called the field anyway.
+    columnKey: string;
+    // The request in flight and what came back of it. Owned by the step, which runs the
+    // create: this asks for a field and shows what it is told, and knows nothing about how
+    // either happens.
+    isSaving: boolean;
+    // On the name input, for a refusal the publisher can fix by typing.
+    nameError: string | null;
+    // Below the form, for one they cannot.
+    saveError: string | null;
+    // False once a refusal cannot be argued with — a site at its field ceiling — so the
+    // button stops inviting the same doomed request.
+    canRetry: boolean;
+    onSubmit: (name: string, type: MemberCustomField['type']) => void;
+    // Editing answers the last refusal: it was about what was there before.
+    onEdit: () => void;
+    onCancel: () => void;
+}
+
+/**
+ * Name and type for a field being created mid-mapping.
+ *
+ * Holds only what is being typed. Whether a name is acceptable is the server's answer — it
+ * owns the rule and the sentence for breaking it, and a copy here would be a second opinion
+ * that could disagree.
+ */
+export function CreateFieldForm({columnKey, isSaving, nameError, saveError, canRetry, onSubmit, onEdit, onCancel}: CreateFieldFormProps) {
+    const [name, setName] = useState(() => suggestedFieldName(columnKey));
+    const [typeId, setTypeId] = useState(memberCustomFieldUserTypes[0].id);
+
+    // Opened from a row that may sit at the bottom edge of the scroll area, in which case the
+    // form lands below the fold and its buttons are out of reach. `nearest` scrolls only when
+    // some of it is actually hidden, so a form that already fits doesn't move the table, and
+    // the scroll margin below carries it clear of the edge rather than flush against it.
+    const formRef = useRef<HTMLDivElement>(null);
+    useEffect(() => {
+        formRef.current?.scrollIntoView({block: 'nearest'});
+    }, []);
+
+    const submit = () => onSubmit(name, typeId);
+
+    return (
+        <div
+            ref={formRef}
+            className="scroll-mb-8 space-y-3"
+            data-testid="import-create-custom-field"
+            // The control this replaced was a Select, which ate Escape itself. Left to travel,
+            // Escape reaches the import dialog and closes the whole thing from inside a form the
+            // publisher was only trying to back out of.
+            onKeyDown={(event) => {
+                if (event.key === 'Escape') {
+                    event.stopPropagation();
+                    // Swallowed but not acted on mid-save, matching the Cancel button beside it:
+                    // backing out of a create already in flight would leave its answer nowhere.
+                    if (!isSaving) {
+                        onCancel();
+                    }
+                    return;
+                }
+                // Enter submits, as it would in a form — there is no form element here because
+                // this sits inside the import dialog's own, and nesting one is invalid.
+                if (event.key === 'Enter' && !isSaving && canRetry) {
+                    event.preventDefault();
+                    submit();
+                }
+            }}
+        >
+            <FieldGroup className="flex-row flex-wrap items-start gap-3">
+                    <Field className="min-w-56 flex-1" data-invalid={Boolean(nameError) || undefined}>
+                        <FieldLabel className="text-sm!" htmlFor="import-custom-field-name">Name</FieldLabel>
+                        <Input
+                            aria-invalid={Boolean(nameError) || undefined}
+                            autoComplete="off"
+                            className="h-8 text-sm!"
+                            id="import-custom-field-name"
+                            placeholder="Enter custom field name"
+                            value={name}
+                            autoFocus
+                            onChange={(e) => {
+                                setName(e.target.value);
+                                onEdit();
+                            }}
+                        />
+                        {nameError && <FieldError>{nameError}</FieldError>}
+                    </Field>
+                    <Field className="w-44">
+                        <FieldLabel className="text-sm!">Type</FieldLabel>
+                        <Select value={typeId} onValueChange={value => setTypeId(value as MemberCustomField['type'])}>
+                            <SelectTrigger aria-label="Type" className="h-8 text-sm!">
+                                <SelectValue><CustomFieldTypeOption type={typeId} /></SelectValue>
+                            </SelectTrigger>
+                            <SelectContent>
+                                {memberCustomFieldUserTypes.map(userType => (
+                                    <SelectItem key={userType.id} value={userType.id}>
+                                        <CustomFieldTypeOption type={userType.id} />
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </Field>
+                <div className="flex items-center gap-2 self-end pb-0.5">
+                    <Button disabled={isSaving} size="sm" variant="outline" onClick={onCancel}>
+                        Cancel
+                    </Button>
+                    <Button disabled={isSaving || !canRetry} size="sm" onClick={submit}>
+                        {isSaving ? 'Saving' : 'Save'}
+                    </Button>
+                </div>
+            </FieldGroup>
+
+            {saveError && <p className="text-sm text-destructive" role="alert">{saveError}</p>}
+        </div>
+    );
+}

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/field-picker.tsx
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/field-picker.tsx
@@ -1,0 +1,260 @@
+import CustomFieldIcon from '@/shared/member-custom-fields/custom-field-icon';
+import {Button, Command, CommandCheck, CommandGroup, CommandInput, CommandItem, CommandList, Popover, PopoverContent, PopoverTrigger, inputSurfaceClasses} from '@tryghost/shade/components';
+import {LucideIcon, cn} from '@tryghost/shade/utils';
+import {useRef} from 'react';
+import {type MemberCustomFieldCsvColumn} from '@tryghost/admin-x-framework/api/member-custom-fields';
+
+// One list, two sections, so what a column can be imported as is answered by reading rather
+// than by trying each kind in turn. The section a field sits in is what tells a native "Name"
+// apart from a custom field someone called "Name", so the trigger repeats it once chosen.
+const NATIVE_GROUP = 'Membership field';
+const CUSTOM_GROUP = 'Custom field';
+
+// Icons for the native targets. Written here rather than taken from somewhere shared because
+// nothing shared exists: the members filter picker hand-writes its own switch, and analytics
+// its own inline. Custom fields do have a registry, which is why they use CustomFieldIcon
+// below instead of appearing here — a new field type gets its icon from that one place.
+const NATIVE_ICONS: Record<string, typeof LucideIcon.Type> = {
+    email: LucideIcon.Mail,
+    name: LucideIcon.User,
+    note: LucideIcon.StickyNote,
+    subscribed_to_emails: LucideIcon.Send,
+    stripe_customer_id: LucideIcon.CreditCard,
+    // A comp, in the sense a venue means it: paid access granted rather than bought. Gift is
+    // taken, and would be the wrong reading anyway — gift_id is an actual gift someone sent.
+    complimentary_plan: LucideIcon.Ticket,
+    labels: LucideIcon.Tag,
+    created_at: LucideIcon.Calendar,
+    gift_id: LucideIcon.Gift,
+    import_tier: LucideIcon.Star
+};
+
+function NativeIcon({value, className}: {value: string; className?: string}) {
+    const Icon = NATIVE_ICONS[value] ?? LucideIcon.Type;
+    return <Icon className={className} />;
+}
+
+interface FieldPickerProps {
+    className?: string;
+    columnKey: string;
+    value: string | null;
+    disabled?: boolean;
+    invalid?: boolean;
+    fieldMappings: {label: string; value: string}[];
+    customFieldMappings: MemberCustomFieldCsvColumn[];
+    // Open and search are the caller's, not this component's: creating a composite has to
+    // reopen this row's picker filtered to the field it just made, so which picker is open and
+    // what it is filtered by have to be sayable from outside.
+    open: boolean;
+    search: string;
+    onOpenChange: (open: boolean) => void;
+    onSearchChange: (search: string) => void;
+    onSelect: (target: string) => void;
+    onCreateField: () => void;
+    triggerRef: (node: HTMLElement | null) => void;
+}
+
+export function FieldPicker({
+    className,
+    columnKey,
+    value,
+    disabled,
+    invalid,
+    fieldMappings,
+    customFieldMappings,
+    open,
+    search,
+    onOpenChange,
+    onSearchChange,
+    onSelect,
+    onCreateField,
+    triggerRef
+}: FieldPickerProps) {
+    // Choosing to add a field replaces this list with a form, and the form's first input should
+    // hold the focus rather than the button that opened the list. Two things are in the way, and
+    // both are the modal popover doing its job: it hands focus back to the trigger on close, and
+    // its focus trap stays alive through the exit animation — so a form mounted alongside it has
+    // its autoFocus pulled straight back inside. Both are dealt with at teardown, below.
+    const openingCreateForm = useRef(false);
+
+    const selectedCustom = customFieldMappings.find(field => field.value === value);
+    const selectedNative = fieldMappings.find(field => field.value === value);
+    const selected = selectedCustom ?? selectedNative;
+
+    const choose = (target: string) => {
+        onOpenChange(false);
+        onSelect(target);
+    };
+
+    return (
+        <Popover
+            open={open}
+            // The table lives in a Dialog, whose react-remove-scroll only lets its own subtree
+            // scroll — and this content is portalled to the body, outside it, so the wheel was
+            // being swallowed while clicks still worked. Modal gives the popover its own scroll
+            // manager, which allows the list it owns.
+            modal
+            onOpenChange={(next) => {
+                // aria-disabled leaves the trigger live, so the refusal happens here rather
+                // than in the DOM: it can be hovered and focused, and it does not open.
+                if (disabled) {
+                    return;
+                }
+                onOpenChange(next);
+            }}
+        >
+            <PopoverTrigger asChild>
+                {/* aria-disabled rather than the disabled attribute, which Shade pairs with
+                    pointer-events-none — and an element taking no pointer events can show no
+                    cursor, so there was nothing to say "not this row" on hover. Live, it keeps
+                    the cursor and stays reachable by keyboard; onOpenChange does the refusing.
+
+                    The fade is gentler than the button's own 50% because the border has to
+                    survive it: at 50% on a greyed row the control read as absent. */}
+                <Button
+                    ref={triggerRef}
+                    aria-disabled={disabled || undefined}
+                    aria-invalid={invalid || undefined}
+                    // Names the column and what it is mapped to. A bare "Field for <column>"
+                    // would replace the trigger's own text in the accessible name, so the
+                    // selection — the whole point of the two lines below — would never be read.
+                    aria-label={selected ? `Field for ${columnKey}, ${selected.label}` : `Field for ${columnKey}, not chosen`}
+                    className={cn(
+                        'h-auto w-full scroll-my-8 justify-start gap-2 px-2.5 py-1.5 font-normal',
+                        className,
+                        // Button's outline hover (bg-button-hover) is what the Select trigger this
+                        // replaced used too, so hovering weighs what it always did. Only the text
+                        // shift is dropped: Button tints it on hover and the Select trigger did
+                        // not.
+                        'hover:text-current',
+                        // Button has no invalid state of its own — the recipe the Select trigger
+                        // this replaced was built from does, and a row the import was refused
+                        // over has to look refused. Ring included, since the border alone is a
+                        // hairline on a greyed row.
+                        inputSurfaceClasses.invalidSelf,
+                        'aria-[invalid=true]:ring-2',
+                        // Not opacity on the control: that fades the border with everything else,
+                        // and the border is the one part that has to stay drawn. The contents
+                        // carry the fade instead, just below.
+                        // Nothing to point at on a row that is out of the import, so no hover.
+                        disabled && 'cursor-not-allowed hover:bg-transparent'
+                    )}
+                    role="combobox"
+                    variant="outline"
+                >
+                    {/* Blocked rather than bare, the way the font pickers show a chosen face: next
+                        to two lines of text a loose glyph reads as debris, and the tile gives it
+                        somewhere to sit. Only here — inside the list the icons sit against a
+                        single line and stay flat, as the filter picker has them.
+
+                        The tile is what sets the control's height, so an empty row is exactly as
+                        tall as a chosen one without a blank line held open to do it. Empty is an
+                        outline: a slot still to fill, not a thing with no icon. */}
+                    <span className={cn(
+                        'flex size-8 shrink-0 items-center justify-center rounded-md',
+                        // Filled is the font picker's tile exactly (global-settings.tsx:53), at the
+                        // size a table row can carry rather than its 48px: same border token, same
+                        // elevated surface, same shadow.
+                        selected && 'border border-border-default bg-surface-elevated shadow-xs',
+                        disabled && 'opacity-60'
+                    )}>
+                        {selectedCustom && <CustomFieldIcon className="size-4 text-foreground" type={selectedCustom.type} />}
+                        {selectedNative && <NativeIcon className="size-4 text-foreground" value={selectedNative.value} />}
+                        {/* Inside the slot rather than filling it: an empty dashed outline reads
+                            larger than a filled tile of the same size, since the border is the
+                            whole shape and there is nothing inside to give it a middle. Drawn
+                            smaller, the two look the same size — and the slot around it keeps its
+                            32px, so a row does not change height as columns go in and out. */}
+                        {!selected && <span className="size-7 rounded-md border border-dashed border-border-strong" />}
+                    </span>
+                    {selected ? (
+                        // The field first, then which list it came from — without that second line
+                        // a custom field named like a native one is indistinguishable once the
+                        // list is closed.
+                        <span className={cn('flex min-w-0 flex-col items-start text-left leading-tight', disabled && 'opacity-60')}>
+                            <span className="w-full truncate text-sm font-medium">{selected.label}</span>
+                            <span className="text-2xs text-muted-foreground">{selectedCustom ? CUSTOM_GROUP : NATIVE_GROUP}</span>
+                        </span>
+                    ) : (
+                        <span className={cn('min-w-0 truncate text-sm text-muted-foreground', disabled && 'opacity-60')}>Select field</span>
+                    )}
+                    <LucideIcon.ChevronDown className="ms-auto size-4 shrink-0 opacity-50" />
+                </Button>
+            </PopoverTrigger>
+            {/* Sized and spaced as the members filter picker is (members-filters.tsx:156,
+                filters.tsx:2636), rather than to its own taste: it is the same control doing the
+                same job a few screens away, and two dialects of it is one too many.
+
+                Bounded to the room Radix says it has rather than to a number of its own: a row
+                near the bottom of a tall table has little of it, and a fixed height there runs
+                off the screen with the list still scrolling inside. A column so the search box
+                keeps its height and the list takes what is left. */}
+            <PopoverContent
+                align="start"
+                className="flex max-h-(--radix-popover-content-available-height) w-(--radix-popover-trigger-width) min-w-64 flex-col p-0"
+                collisionPadding={16}
+                onCloseAutoFocus={(event) => {
+                    if (!openingCreateForm.current) {
+                        return;
+                    }
+                    openingCreateForm.current = false;
+                    // Don't return focus to the trigger, and only now open the form: this fires
+                    // as the trap releases, so the form mounts with nothing left to fight.
+                    event.preventDefault();
+                    onCreateField();
+                }}
+            >
+                <Command className="min-h-0">
+                    <CommandInput className="h-(--control-height) shrink-0" placeholder="Search fields..." value={search} onValueChange={onSearchChange} />
+                    {/* Shade's own max-height stands; only the shrinking is added. flex-1 with
+                        min-h-0 lets the list give up height to the available-height cap on the
+                        content above, which is what keeps a row near the bottom of the dialog
+                        from opening a list that runs off the screen. */}
+                    <CommandList className="min-h-0 flex-1">
+                        <CommandGroup heading={`${NATIVE_GROUP}s`}>
+                            {fieldMappings.map(field => (
+                                <CommandItem key={field.value} value={field.label} onSelect={() => choose(field.value)}>
+                                    <NativeIcon value={field.value} />
+                                    <span className="truncate">{field.label}</span>
+                                    {value === field.value && <CommandCheck />}
+                                </CommandItem>
+                            ))}
+                        </CommandGroup>
+                        <CommandGroup heading={`${CUSTOM_GROUP}s`}>
+                            {customFieldMappings.map(field => (
+                                <CommandItem key={field.value} value={field.label} onSelect={() => choose(field.value)}>
+                                    <CustomFieldIcon type={field.type} />
+                                    <span className="truncate">{field.label}</span>
+                                    {value === field.value && <CommandCheck />}
+                                </CommandItem>
+                            ))}
+                        </CommandGroup>
+                        {/* Its own group so it is the one thing search cannot take away: cmdk
+                            hands a group's forceMount down to every item in it, so leaving this
+                            among the fields would have pinned all of them too. A search matching
+                            no field is the strongest signal there is that the field wanted does
+                            not exist yet, and the answer to that is the way to make one — which
+                            is why there is no empty state behind it. */}
+                        <CommandGroup forceMount>
+                            {/* With a plus, mirroring the label picker below this table. A
+                                publisher can name a field something like "New field", so the
+                                colour is what sets this apart from one. */}
+                            <CommandItem
+                                className="font-semibold text-green"
+                                value="Add custom field"
+                                forceMount
+                                onSelect={() => {
+                                    openingCreateForm.current = true;
+                                    onOpenChange(false);
+                                }}
+                            >
+                                <LucideIcon.Plus />
+                                <span>Add custom field</span>
+                            </CommandItem>
+                        </CommandGroup>
+                    </CommandList>
+                </Command>
+            </PopoverContent>
+        </Popover>
+    );
+}

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/import-members-modal.tsx
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/import-members-modal.tsx
@@ -1,0 +1,479 @@
+// Every step but the mapping one is shared with the baseline modal: they are the same file
+// upload, progress and result screens, and nothing about custom fields reaches them.
+import {CompleteStep, ErrorStep, InitStep, ProcessingStep} from '@/members/components/bulk-action-modals/import-members/components';
+import {MappingStep} from '@/members/components/bulk-action-modals/import-members/custom-fields/mapping-step';
+import {AlertDialog, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, Button, LoadingIndicator} from '@tryghost/shade/components';
+import {useDirtyConfirmation} from '@tryghost/shade/patterns';
+import {Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle} from '@tryghost/shade/components';
+import {HostLimitError, JSONError, RequestEntityTooLargeError, ValidationError, getErrorMessage} from '@tryghost/admin-x-framework/errors';
+import {type ImportResponse} from '@/members/components/bulk-action-modals/import-members/state';
+import {MembersFieldMapping, detectFieldTypes, getFieldMappings} from '@/members/components/bulk-action-modals/import-members/custom-fields/mapping';
+import {buildImportResponse} from '@/members/components/bulk-action-modals/import-members/upload';
+import {cn} from '@tryghost/shade/utils';
+import {createInitialImportState, importReducer} from '@/members/components/bulk-action-modals/import-members/reducer';
+import {isImportMembersCompleteResponse, useImportMembers} from '@tryghost/admin-x-framework/api/members';
+import {memberCustomFieldCsvColumns, useBrowseMemberCustomFields} from '@tryghost/admin-x-framework/api/member-custom-fields';
+import {parseCSV} from '@/members/components/bulk-action-modals/import-members/csv';
+import {useCallback, useEffect, useLayoutEffect, useMemo, useReducer, useRef, useState} from 'react';
+import {useFeatureFlag} from '@tryghost/admin-x-framework/hooks';
+import {useLabelPicker} from '@/members/hooks/use-label-picker';
+
+interface ImportMembersModalProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    onComplete?: (importResponse?: ImportResponse) => void;
+    onClose?: (importResponse?: ImportResponse) => void;
+}
+
+export function ImportMembersModal({
+    open,
+    onOpenChange,
+    onComplete,
+    onClose
+}: ImportMembersModalProps) {
+    const [state, dispatch] = useReducer(importReducer, undefined, createInitialImportState);
+    const errorCsvUrlRef = useRef<string | null>(null);
+    const {mutateAsync: importMembers} = useImportMembers();
+    const importMemberTier = useFeatureFlag('importMemberTier');
+
+    // Defined custom fields become mapping targets. Browse returns active fields only, which
+    // are the ones the importer writes to. No flag check anywhere in this file: the gate does
+    // not render it unless membersCustomFields is on.
+    const {data: customFieldsData, isError: customFieldsFailed} = useBrowseMemberCustomFields();
+    // A field created from the mapping step is in here the moment it is created: the create
+    // mutation puts it into the cached list, so there is no window where a row points at a
+    // column the picker cannot name yet.
+    const customFieldColumns = useMemo(
+        () => memberCustomFieldCsvColumns(customFieldsData?.members_custom_fields ?? []),
+        [customFieldsData]
+    );
+    // The file-reader effect waits for this before its first parse: the custom field
+    // definitions must be loaded or auto-detection would miss custom_fields.* columns on a
+    // fast upload. It flips false -> true once and stays true (a refetch keeps data defined),
+    // so readiness never re-triggers the read.
+    // Ready, or never going to be. A failure has no representation in `data`, so waiting on it
+    // alone leaves the file unparsed and the step on a spinner with nothing said — for a query
+    // whose only job is to add targets to a list. Failing it costs the custom fields; blocking
+    // on it costs the import.
+    const customFieldsReady = customFieldsData !== undefined || customFieldsFailed;
+    // Detection options are read inside the effect through this ref rather than as deps, so
+    // a later refetch of the options can't re-run the read and overwrite a mapping the user
+    // has begun editing.
+    const detectOptionsRef = useRef({importMemberTier, customFieldColumns});
+    // Assigned in an effect rather than during render: a ref written while rendering can tear
+    // if a render is thrown away, and the read below happens after paint either way.
+    useLayoutEffect(() => {
+        detectOptionsRef.current = {importMemberTier, customFieldColumns};
+    }, [importMemberTier, customFieldColumns]);
+    // Native targets only. Each row's kind decides which list its picker shows, and custom
+    // targets reach it through customFieldColumns. Auto-detection still sees both, via
+    // detectOptionsRef above.
+    const fieldMappings = useMemo(
+        () => getFieldMappings({importMemberTier}),
+        [importMemberTier]
+    );
+
+    // Whether email is mapped is the mapping step's to answer, because it is the only thing
+    // that knows which columns are actually in the import — a second answer here could
+    // disagree, which is how a mapped-but-deselected email column would pass.
+    const labelPicker = useLabelPicker({
+        selectedSlugs: state.selectedLabelSlugs,
+        onSelectionChange: (slugs: string[]) => {
+            setHasEdits(true);
+            dispatch({type: 'SET_SELECTED_LABEL_SLUGS', selectedLabelSlugs: slugs});
+        }
+    });
+
+    const revokeErrorCsvUrl = useCallback(() => {
+        if (errorCsvUrlRef.current && typeof URL.revokeObjectURL === 'function') {
+            URL.revokeObjectURL(errorCsvUrlRef.current);
+            errorCsvUrlRef.current = null;
+        } else if (errorCsvUrlRef.current) {
+            errorCsvUrlRef.current = null;
+        }
+    }, []);
+
+    const reset = useCallback(() => {
+        revokeErrorCsvUrl();
+        // The modal is never unmounted (members-actions keeps it mounted and toggles `open`),
+        // so anything held outside the reducer outlives Start over unless it is cleared here.
+        setHasEdits(false);
+        dispatch({type: 'RESET'});
+    }, [revokeErrorCsvUrl]);
+
+    useEffect(() => {
+        return () => {
+            revokeErrorCsvUrl();
+        };
+    }, [revokeErrorCsvUrl]);
+
+    // Escape and a click on the backdrop stay as they are — they are how a dialog is dismissed
+    // and taking them away costs more than it saves. What they must not do is silently discard
+    // a mapped file: which columns are in, what each fills, the labels chosen. So dismissal
+    // asks first, using the same confirmation the settings modals use.
+    const {confirm, dialogProps} = useDirtyConfirmation();
+    // Whether anything would actually be lost by leaving. A file that has only been parsed is
+    // not worth asking about: re-uploading it reproduces the same detected mapping. What cannot
+    // be reproduced is what the publisher changed since, so that is what this tracks.
+    const [hasEdits, setHasEdits] = useState(false);
+
+    const handleOpenChange = useCallback((isOpen: boolean) => {
+        if (!isOpen && state.status === 'UPLOADING') {
+            return;
+        }
+        if (!isOpen) {
+            // Only the mapping step holds anything: every other one is either empty or shows a
+            // result that closing is the natural end of.
+            confirm(state.status === 'MAPPING' && hasEdits, () => {
+                const importResponse = state.importResponse ?? undefined;
+                reset();
+                onClose?.(importResponse);
+                onOpenChange(false);
+            });
+            return;
+        }
+        onOpenChange(isOpen);
+    }, [confirm, hasEdits, onClose, onOpenChange, reset, state.importResponse, state.status]);
+
+    useEffect(() => {
+        if (!state.file || !customFieldsReady) {
+            return;
+        }
+
+        let ignoreReaderEvents = false;
+        const reader = new FileReader();
+        reader.onload = (e) => {
+            if (ignoreReaderEvents) {
+                return;
+            }
+            try {
+                const text = e.target?.result as string;
+                const data = parseCSV(text);
+
+                if (data.length > 0) {
+                    const detectedMapping = detectFieldTypes(data, detectOptionsRef.current);
+                    const fieldMapping = new MembersFieldMapping(detectedMapping);
+
+                    dispatch({
+                        type: 'PARSE_SUCCESS',
+                        fileData: data,
+                        mapping: fieldMapping,
+                        mappingError: null
+                    });
+                } else {
+                    dispatch({
+                        type: 'PARSE_SUCCESS',
+                        fileData: [],
+                        mapping: null,
+                        mappingError: 'File is empty, nothing to import. Please select a different file.'
+                    });
+                }
+            } catch {
+                dispatch({
+                    type: 'PARSE_FAILURE',
+                    mappingError: 'Failed to parse this file. Please try another CSV file.'
+                });
+            }
+        };
+        reader.onerror = () => {
+            if (ignoreReaderEvents) {
+                return;
+            }
+            dispatch({
+                type: 'PARSE_FAILURE',
+                mappingError: `Failed to read file${reader.error?.message ? `: ${reader.error.message}` : ''}`
+            });
+        };
+        reader.onabort = () => {
+            if (ignoreReaderEvents) {
+                return;
+            }
+            dispatch({
+                type: 'PARSE_FAILURE',
+                mappingError: 'File read was interrupted. Please try again.'
+            });
+        };
+        reader.readAsText(state.file);
+
+        return () => {
+            ignoreReaderEvents = true;
+            if (reader.readyState === FileReader.LOADING) {
+                reader.abort();
+            }
+        };
+    }, [state.file, customFieldsReady]);
+
+    const validateFile = useCallback((file: File): boolean => {
+        const match = /(?:\.([^.]+))?$/.exec(file.name);
+        const extension = match?.[1];
+        if (!extension || extension.toLowerCase() !== 'csv') {
+            dispatch({
+                type: 'SET_FILE_ERROR',
+                fileError: 'The file type you uploaded is not supported'
+            });
+            return false;
+        }
+        dispatch({type: 'SET_FILE_ERROR', fileError: null});
+        return true;
+    }, []);
+
+    const handleFileSelected = useCallback((file: File) => {
+        if (validateFile(file)) {
+            dispatch({type: 'SELECT_FILE', file});
+        }
+    }, [validateFile]);
+
+    const handleUpdateMapping = useCallback((from: string, to: string | null) => {
+        if (!state.mapping) {
+            return;
+        }
+
+        setHasEdits(true);
+
+        const nextMapping = state.mapping.updateMapping(from, to);
+        const nextError = state.fileData && state.fileData.length === 0
+            ? 'File is empty, nothing to import. Please select a different file.'
+            : null;
+
+        dispatch({
+            type: 'UPDATE_MAPPING',
+            mapping: nextMapping,
+            mappingError: nextError
+        });
+    }, [state.fileData, state.mapping]);
+
+    // The row maps onto the column the form resolved — or onto nothing yet, for a composite,
+    // whose parts are all candidates and whose choice the mapping step asks in the picker.
+    // Either way the field joins the targets, so the other columns of a composite can be
+    // mapped by hand: guessing which of them holds a postcode is how data ends up in the
+    // wrong part.
+    //
+    // Nothing else is re-detected: a mapping already edited stays as they left it.
+    const handleFieldCreated = useCallback((columnKey: string, column: string | null) => {
+        if (column) {
+            handleUpdateMapping(columnKey, column);
+        }
+    }, [handleUpdateMapping]);
+
+    const handleUpload = useCallback(async (importMapping: Record<string, string | null>) => {
+        if (!state.file || state.mappingError) {
+            dispatch({type: 'SET_SHOW_MAPPING_ERRORS', showMappingErrors: true});
+            return;
+        }
+
+        dispatch({type: 'UPLOAD_START'});
+
+        const selectedLabelNames: string[] = [];
+        for (const slug of state.selectedLabelSlugs) {
+            const label = labelPicker.labels.find(l => l.slug === slug);
+            if (label) {
+                selectedLabelNames.push(label.name);
+            }
+        }
+
+        try {
+            // Sent as given. The mapping step composes it from the mapping and what is in the
+            // import, which is knowledge this modal does not have and must not second-guess.
+            const importData = await importMembers({
+                file: state.file,
+                labels: selectedLabelNames,
+                mapping: importMapping
+            });
+
+            if (isImportMembersCompleteResponse(importData)) {
+                const importResponse = buildImportResponse(importData);
+                revokeErrorCsvUrl();
+                errorCsvUrlRef.current = importResponse.errorCsvUrl;
+
+                dispatch({
+                    type: 'UPLOAD_COMPLETE',
+                    importResponse
+                });
+                onComplete?.(importResponse);
+                return;
+            }
+
+            // Per the upload API contract a 2xx response is either complete (handled
+            // above) or accepted for background processing; importMembers() has already
+            // thrown for any error status.
+            dispatch({type: 'UPLOAD_ACCEPTED'});
+            onComplete?.();
+        } catch (error) {
+            if (error instanceof RequestEntityTooLargeError) {
+                dispatch({
+                    type: 'UPLOAD_ERROR',
+                    errorMessage: 'The file you uploaded was larger than the maximum file size your server allows.'
+                });
+                return;
+            }
+
+            const apiError = error instanceof JSONError ? error.data?.errors?.[0] : null;
+
+            if (error instanceof HostLimitError && apiError?.code === 'EMAIL_VERIFICATION_NEEDED') {
+                dispatch({
+                    type: 'UPLOAD_ERROR',
+                    errorMessage: getErrorMessage(error, error.message),
+                    errorHeader: 'Woah there cowboy, that\'s a big list',
+                    showTryAgainButton: false
+                });
+                onComplete?.();
+                return;
+            }
+
+            if (error instanceof ValidationError || apiError?.type === 'DataImportError') {
+                dispatch({
+                    type: 'UPLOAD_ERROR',
+                    errorMessage: getErrorMessage(error, error instanceof Error ? error.message : 'An unexpected error occurred, please try again')
+                });
+                return;
+            }
+
+            dispatch({
+                type: 'UPLOAD_ERROR',
+                errorMessage: 'An unexpected error occurred, please try again'
+            });
+        }
+    }, [
+        state.file,
+        state.mappingError,
+        state.selectedLabelSlugs,
+        labelPicker.labels,
+        importMembers,
+        revokeErrorCsvUrl,
+        onComplete
+    ]);
+
+    const isWide = state.status === 'MAPPING' || state.status === 'UPLOADING';
+
+    const title = useMemo(() => {
+        switch (state.status) {
+        case 'PROCESSING':
+            return 'Import in progress';
+        case 'COMPLETE':
+            return 'Import complete';
+        case 'ERROR':
+            return state.errorHeader;
+        default:
+            return 'Import members';
+        }
+    }, [state.errorHeader, state.status]);
+
+    return (
+        <Dialog open={open} onOpenChange={handleOpenChange}>
+            {/* The mapping table needs the extra width only when it carries the kind
+                column; without it the dialog stays the size it has always been.
+                While mapping, the dialog is also bounded to the viewport and laid out
+                as a column, so the table can take the leftover height and the footer
+                is always reachable. 8vmin matches the dialog's own top offset. */}
+            <DialogContent className={cn(
+                'gap-0',
+                isWide && 'max-w-4xl',
+                isWide && 'flex max-h-[calc(100vh-16vmin)] flex-col'
+            )}>
+            <DialogHeader>
+                <DialogTitle>{title}</DialogTitle>
+                <DialogDescription className="sr-only">
+                    Import members from a CSV file.
+                </DialogDescription>
+            </DialogHeader>
+
+            {state.status === 'INIT' && (
+                <InitStep
+                    fileError={state.fileError}
+                    onClose={() => handleOpenChange(false)}
+                    onDropAccepted={handleFileSelected}
+                    onDropRejected={() => dispatch({
+                        type: 'SET_FILE_ERROR',
+                        fileError: 'The file type you uploaded is not supported'
+                    })}
+                />
+            )}
+
+            {/* Still parsing: the step is handed a file that has been read, so waiting for one
+                is the container's business and never reaches the table. A parse that failed
+                gives an empty set rather than none, so the step still renders to say so. */}
+            {(state.status === 'MAPPING' || state.status === 'UPLOADING') && state.fileData === null && (
+                <div className="flex items-center justify-center rounded-md border bg-muted p-10">
+                    <LoadingIndicator size="md" />
+                </div>
+            )}
+
+            {(state.status === 'MAPPING' || state.status === 'UPLOADING') && state.fileData !== null && (
+                <MappingStep
+                    customFieldMappings={customFieldColumns}
+                    dataPreviewIndex={state.dataPreviewIndex}
+                    fieldMappings={fieldMappings}
+                    fileData={state.fileData}
+                    labelPicker={labelPicker}
+                    mapping={state.mapping}
+                    mappingError={state.mappingError}
+                    showMappingErrors={state.showMappingErrors}
+                    status={state.status}
+                    onColumnsChanged={() => setHasEdits(true)}
+                    onDataPreviewIndexChange={(nextIndex) => {
+                        dispatch({
+                            type: 'SET_DATA_PREVIEW_INDEX',
+                            dataPreviewIndex: nextIndex
+                        });
+                    }}
+                    onFieldCreated={handleFieldCreated}
+                    onStartOver={reset}
+                    onUpdateMapping={handleUpdateMapping}
+                    onUpload={importMapping => void handleUpload(importMapping)}
+                />
+            )}
+
+            {state.status === 'PROCESSING' && (
+                <ProcessingStep
+                    onClose={() => handleOpenChange(false)}
+                    onUploadAnotherFile={reset}
+                />
+            )}
+
+            {state.status === 'COMPLETE' && state.importResponse && (
+                <CompleteStep
+                    importResponse={state.importResponse}
+                    onClose={() => handleOpenChange(false)}
+                    onReset={reset}
+                />
+            )}
+
+            {state.status === 'ERROR' && (
+                <ErrorStep
+                    errorMessage={state.errorMessage}
+                    showTryAgainButton={state.showTryAgainButton}
+                    onClose={() => handleOpenChange(false)}
+                    onTryAgain={reset}
+                />
+            )}
+        </DialogContent>
+        {/* Worded and shaped as the member detail's leave guard is (member-detail.tsx:480-494),
+            which is the same question a screen away: Shade's DirtyConfirmDialog says Stay/Leave
+            and talks about saving, and neither fits a members screen or an import that has
+            nothing to save. Its controller is still what decides whether to ask.
+
+            The cancel label names what the publisher goes back to, as the member detail's "Keep
+            editing" and the automations editor's "Keep working" do — which here is mapping.
+
+            Raised above the import dialog it interrupts, which owns z-50. */}
+        <AlertDialog open={dialogProps.open} onOpenChange={dialogProps.onOpenChange}>
+            {/* Escape closes the guard and nothing else: without this it reaches the import
+                dialog underneath and closes the very thing the guard is asking about. */}
+            <AlertDialogContent className="z-[1100]" data-testid="import-members-leave-guard" overlayClassName="z-[1100]" onEscapeKeyDown={event => event.stopPropagation()}>
+                <AlertDialogHeader>
+                    {/* Not "unsaved changes": nothing here is saved or savable, so there is no
+                        such state to be in. Nor "discard this import" — no import exists yet to
+                        be discarded. The title names the act the buttons perform, and the line
+                        below says what it costs without repeating it. */}
+                    <AlertDialogTitle>Leave without importing?</AlertDialogTitle>
+                    <AlertDialogDescription>The columns you have mapped will be lost.</AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                    <AlertDialogCancel>Keep mapping</AlertDialogCancel>
+                    <Button variant="destructive" onClick={dialogProps.onConfirm}>Leave</Button>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
+        </Dialog>
+    );
+}

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/mapping-step.tsx
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/mapping-step.tsx
@@ -1,0 +1,594 @@
+import {Button, Checkbox, DialogFooter, LoadingIndicator, Table, TableBody, TableCell, TableHead, TableHeader, TableRow} from '@tryghost/shade/components';
+import {CreateFieldForm} from '@/members/components/bulk-action-modals/import-members/custom-fields/create-field-form';
+import {APIError, HostLimitError, JSONError, ValidationError, getErrorMessage} from '@tryghost/admin-x-framework/errors';
+import {memberCustomFieldCsvColumns, memberCustomFieldParts, useCreateMemberCustomField} from '@tryghost/admin-x-framework/api/member-custom-fields';
+import {useHandleError} from '@tryghost/admin-x-framework/hooks';
+import {FieldPicker} from '@/members/components/bulk-action-modals/import-members/custom-fields/field-picker';
+import {LabelPicker} from '@/members/label-picker';
+import {LucideIcon, cn, formatNumber} from '@tryghost/shade/utils';
+import {MembersFieldMapping, columnsOf} from '@/members/components/bulk-action-modals/import-members/custom-fields/mapping';
+import {Fragment, useCallback, useLayoutEffect, useMemo, useRef, useState} from 'react';
+import {type MemberCustomField, type MemberCustomFieldCsvColumn} from '@tryghost/admin-x-framework/api/member-custom-fields';
+import {type UseLabelPickerResult} from '@/members/hooks/use-label-picker';
+
+interface MappingPreviewRow {
+    key: string;
+    value: string;
+    mapTo: string | null;
+}
+
+// An import the table refuses to send: why, and which columns are to blame. One value rather
+// than two, because a message shown with the wrong rows marked is worse than either alone.
+interface IncompleteImport {
+    message: string;
+    columns: ReadonlySet<string>;
+}
+
+interface MappingStepProps {
+    status: 'MAPPING' | 'UPLOADING';
+    fileData: Record<string, string>[];
+    mapping: MembersFieldMapping | null;
+    mappingError: string | null;
+    showMappingErrors: boolean;
+    dataPreviewIndex: number;
+    fieldMappings: {label: string; value: string}[];
+    customFieldMappings: MemberCustomFieldCsvColumn[];
+    labelPicker: UseLabelPickerResult;
+    onUpdateMapping: (from: string, to: string | null) => void;
+    onFieldCreated: (columnKey: string, column: string | null) => void;
+    onDataPreviewIndexChange: (next: number) => void;
+    onStartOver: () => void;
+    // Whether a column has been switched in or out of the import, which is the one decision
+    // this table keeps to itself. Everything else the publisher changes goes through
+    // onUpdateMapping, so between them the modal knows if there is anything to lose.
+    onColumnsChanged: () => void;
+    // Carries what the import should write, column by column. The table is the only thing
+    // that knows both the mapping and which columns are in the import, so it says the whole
+    // of it rather than handing over a correction to apply.
+    onUpload: (importMapping: Record<string, string | null>) => void;
+}
+
+// A set with one member added or removed, since both halves of the in-or-out decision below
+// are held as memberships.
+function toggled(set: ReadonlySet<string>, key: string, present: boolean): ReadonlySet<string> {
+    const next = new Set(set);
+    if (present) {
+        next.add(key);
+    } else {
+        next.delete(key);
+    }
+    return next;
+}
+
+/**
+ * The CSV column a row should map onto, resolved from the field the server actually created
+ * rather than from the type that was asked for.
+ *
+ * Null for a composite, which spans several columns and so has no single answer. Which of them
+ * this column holds is asked in the field picker afterwards, not here: it is the same question
+ * as any other mapping, and the picker already knows how to ask it.
+ */
+function columnFor(field: MemberCustomField): string | null {
+    if (memberCustomFieldParts(field.type)) {
+        return null;
+    }
+    return memberCustomFieldCsvColumns([field])[0]?.value ?? null;
+}
+
+export function MappingStep({
+    status,
+    fileData,
+    mapping,
+    mappingError,
+    showMappingErrors,
+    dataPreviewIndex,
+    fieldMappings,
+    customFieldMappings,
+    labelPicker,
+    onUpdateMapping,
+    onFieldCreated,
+    onDataPreviewIndexChange,
+    onStartOver,
+    onColumnsChanged,
+    onUpload
+}: MappingStepProps) {
+    // Columns switched on without a target yet, and columns switched off that still have one.
+    // Between them and the mapping, a column is either in the import or out of it — and what it
+    // was mapped to survives being switched off, because that is a different decision.
+    const [pendingColumns, setPendingColumns] = useState<ReadonlySet<string>>(new Set());
+    const [excludedColumns, setExcludedColumns] = useState<ReadonlySet<string>>(new Set());
+    // Raised when Import is pressed on a table that cannot be imported, and cleared by any
+    // answer to it. Set afresh on every press, so pressing Import again scrolls back to the
+    // first offender below rather than sitting inert.
+    const [incomplete, setIncomplete] = useState<IncompleteImport | null>(null);
+
+    // Each row's field picker, so a refusal can bring the column it names into view. A long
+    // file scrolls, and naming a column the publisher would have to go looking for is barely
+    // better than not naming it.
+    const fieldTriggers = useRef(new Map<string, HTMLElement>());
+
+    // After the refusal has rendered rather than while handling the click: the message appears
+    // below the table and takes its height from it, so scrolling first would aim at a table
+    // that is about to get shorter and leave the row half under the new bottom edge. Layout,
+    // not effect, so it lands before the frame the message arrives in is painted.
+    useLayoutEffect(() => {
+        const [firstUndecided] = incomplete?.columns ?? [];
+        if (!firstUndecided) {
+            return;
+        }
+        // 'nearest' scrolls only as far as it has to, leaving a column already in view where
+        // it was; scroll-my on the trigger keeps it off the edge it arrives at.
+        fieldTriggers.current.get(firstUndecided)?.scrollIntoView({
+            block: 'nearest',
+            behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth'
+        });
+    }, [incomplete]);
+
+    // The column whose create form is open, shown as a row beneath that column's own. Held
+    // here rather than by the modal, which only ever forwarded it, so it clears with the
+    // table on Start over instead of outliving the file it belonged to.
+    const [createFieldForColumn, setCreateFieldForColumn] = useState<string | null>(null);
+
+    // Which row's field picker is open, and what it is filtered by. Held here rather than in
+    // each picker because creating a composite has to reopen the picker it was launched from,
+    // filtered to the field just made — and only one can be open at a time regardless.
+    const [openPicker, setOpenPicker] = useState<{columnKey: string; search: string} | null>(null);
+
+    // A row other than the one being answered is faded out, and is inert to match: reading as
+    // disabled while still taking clicks is a mixed signal, and it is also what kept the create
+    // form reachable for unmounting while its own request was still in flight.
+    // The create lives here rather than in the form because its outcome is this step's
+    // business: a scalar finishes a row's mapping, a composite reopens the picker, and a
+    // refusal has to keep the form on screen to be shown in. The form asks; this answers.
+    const {mutateAsync: createField, isPending: isCreating} = useCreateMemberCustomField();
+    const [nameError, setNameError] = useState<string | null>(null);
+    const [saveError, setSaveError] = useState<string | null>(null);
+    const [canRetry, setCanRetry] = useState(true);
+    const handleError = useHandleError();
+
+    const clearCreateErrors = useCallback(() => {
+        setNameError(null);
+        setSaveError(null);
+        setCanRetry(true);
+    }, []);
+
+    const reportCreateFailure = (error: unknown) => {
+        const apiError = error instanceof JSONError ? error.data?.errors?.[0] : null;
+
+        // A refusal the publisher can answer by typing belongs on the input they would change.
+        if (error instanceof ValidationError && apiError?.property === 'name') {
+            setNameError(getErrorMessage(error, 'Invalid name'));
+            return;
+        }
+
+        // The server's own sentence wherever there is one — for the site's field ceiling it is
+        // the only thing that explains the refusal. The fallback covers the errors carrying no
+        // API body at all (maintenance, timeout, unreachable), whose class message is the text.
+        setSaveError(getErrorMessage(error, error instanceof APIError ? error.message : 'Could not create the custom field, please try again.'));
+        // Nothing they can type changes a ceiling or a permission.
+        setCanRetry(!(error instanceof HostLimitError) && apiError?.type !== 'NoPermissionError');
+
+        // The ceiling is an expected answer rather than a fault; everything else reaching here
+        // (a 500, a timeout, an expired session) should be visible to us. No toast: the form is
+        // still on screen saying it, an inch above the button they pressed.
+        if (!(error instanceof HostLimitError)) {
+            handleError(error, {withToast: false});
+        }
+    };
+
+    // The whole create, from asking to what its answer means for the row. Named rather than
+    // inlined into the form's prop: it is the step's business end, not markup.
+    const createFieldForRow = async (rowKey: string, name: string, type: MemberCustomField['type']) => {
+        clearCreateErrors();
+
+        let field;
+        try {
+            const response = await createField({name, type});
+            field = response.members_custom_fields?.[0];
+        } catch (error) {
+            reportCreateFailure(error);
+            return;
+        }
+
+        if (!field) {
+            // A success carrying nothing. The field may well have been made, so saying it could
+            // not be would have them make a second one; this says what is true and leaves the
+            // row to be mapped by hand from the list.
+            setSaveError('The field was created, but this column could not be mapped to it. Choose it from the list.');
+            setCanRetry(false);
+            handleError(new Error('Custom field create returned no field'));
+            return;
+        }
+
+        const column = columnFor(field);
+        onFieldCreated(rowKey, column);
+        setCreateFieldForColumn(null);
+        // Creating a field for a column the import was refused over is an answer to that
+        // refusal, so it clears with the others. A composite is not answered yet — its part is
+        // still to choose — but the message named a column, not a part, and leaving it up would
+        // keep pointing at a row that has moved on.
+        setIncomplete(null);
+
+        if (column) {
+            // A scalar is fully mapped now, so the form just goes; focus returns to the row
+            // rather than to the body.
+            fieldTriggers.current.get(rowKey)?.focus();
+            return;
+        }
+        // A composite spans several columns, so which of them this one holds is still open.
+        // Asked in the picker, filtered to the new field: the same question as any other
+        // mapping, rather than a third control on the form for the one type that needs it.
+        showPicker(rowKey, field.name);
+    };
+
+    const isDimmed = (row: MappingPreviewRow) => Boolean(createFieldForColumn) && createFieldForColumn !== row.key;
+    // Locked only while a create is actually in flight — long enough that the form cannot be
+    // taken away before its own request settles, and no longer, so moving on to another column
+    // still puts a form the publisher has finished with away.
+    const isRowLocked = (_row: MappingPreviewRow) => status === 'UPLOADING' || isCreating;
+
+    // Opening a row's picker puts the create form away: the publisher has moved on to another
+    // decision, and leaving it open would strand a half-filled form under someone else's
+    // dropdown. The form's own selects live inside it and are unaffected.
+    const showPicker = (columnKey: string, search: string) => {
+        // The refusal belonged to the form being put away. Left standing it would greet the
+        // next form, under an input nobody has touched, and a ceiling refusal would arrive
+        // with its Save already disabled.
+        clearCreateErrors();
+        setCreateFieldForColumn(null);
+        setOpenPicker({columnKey, search});
+    };
+
+    const showCreateForm = (columnKey: string) => {
+        clearCreateErrors();
+        setCreateFieldForColumn(columnKey);
+    };
+
+    // A target belongs to one column, so mapping it here takes it from whichever column held
+    // it. That column keeps its place in the import with the field still to answer: it did not
+    // ask to lose anything, and should not silently drop out of the import with nothing said.
+    const claimTarget = (row: MappingPreviewRow, target: string) => {
+        const previousHolder = mapping?.getKeyByValue(target);
+        if (previousHolder && previousHolder !== row.key) {
+            setPendingColumns(previous => toggled(previous, previousHolder, true));
+        }
+        onUpdateMapping(row.key, target);
+    };
+
+    const isImported = (row: MappingPreviewRow) => !excludedColumns.has(row.key)
+        && (Boolean(row.mapTo) || pendingColumns.has(row.key));
+
+    // Switching a column off leaves its field alone: excluding a column from this import and
+    // choosing what it holds are different answers, and switching it back on should not make
+    // the publisher pick again.
+    const setImported = (row: MappingPreviewRow, imported: boolean) => {
+        setIncomplete(null);
+        onColumnsChanged();
+        setExcludedColumns(previous => toggled(previous, row.key, !imported));
+        setPendingColumns(previous => toggled(previous, row.key, imported && !row.mapTo));
+        if (!imported && createFieldForColumn === row.key) {
+            setCreateFieldForColumn(null);
+        }
+    };
+
+    // Both refusals read the same way, and the mapping error wins: a file with no email column
+    // cannot be imported at all, whereas an undecided column is one answer away.
+    // Gated as the shipped step gates it, deliberately. The gate is dead — it only opens when
+    // Import is pressed, and that button is disabled in the one state that sets a mapping error
+    // — but opening it changes nothing a publisher can reach: papaparse does not throw, so the
+    // parse and read messages behind it cannot fire, and the empty-file case the table already
+    // reports in its own body. Left matching the shipped import until csv.ts stops discarding
+    // papaparse's errors, which is what would make any of these reachable. See BER ticket.
+    const visibleError = (showMappingErrors && mappingError) || incomplete?.message;
+    // A refusal that names columns is marked on their own selects, so the table is left alone:
+    // reddening the whole of it would point at every row for the sake of one. Every other
+    // refusal is about the file rather than a row anyone can be sent to, so the table carries it.
+    const tableError = Boolean(visibleError) && !incomplete?.columns.size;
+
+    const columnCount = 4;
+
+    // Every column the file has, not the ones the previewed row happens to carry. Papaparse
+    // omits keys for a row with fewer cells than the header, so reading columns off a single row
+    // lets a ragged CSV hide one from the table entirely — and a column the mapping never names
+    // is carried through by the importer rather than left out, which is the opposite of what a
+    // publisher who never saw it would expect. The preview index chooses which values are shown;
+    // it must never decide which columns exist.
+    // Derived rather than passed: all three are facts about the file and where the preview
+    // sits in it, both of which are already here. Sent down as well, they could only ever
+    // differ from their source by a bug.
+    const membersCount = fileData.length;
+    const hasPrevRecord = dataPreviewIndex > 0;
+    const hasNextRecord = Boolean(fileData[dataPreviewIndex + 1]);
+
+    const columnKeys = useMemo(() => columnsOf(fileData), [fileData]);
+
+    const currentlyDisplayedData: MappingPreviewRow[] = mapping
+        ? columnKeys.map(key => ({
+            key,
+            value: fileData[dataPreviewIndex]?.[key] ?? '',
+            mapTo: mapping.get(key)
+        }))
+        : [];
+
+    // What this import writes: one entry per column in the file — the field it fills, empty for
+    // a column left out, or null for a column in the import with no field chosen yet.
+    // Everything asking what is being imported reads this one value, so the checks below and
+    // the request itself cannot disagree.
+    //
+    // Empty rather than omitted, because the importer carries a column the mapping does not
+    // name through under its own header — which is how an unnamed custom_fields.* column
+    // survives to be read. Leaving a column out of the mapping is the opposite of leaving it
+    // out of the import.
+    const importMapping: Record<string, string | null> = Object.fromEntries(
+        currentlyDisplayedData.map(row => [row.key, isImported(row) ? row.mapTo : ''])
+    );
+
+    // What refuses this import, read off the mapping actually being sent. With custom fields
+    // on it is answered here, because this is the only place that knows both the mapping and
+    // which columns are in the import. A file-level problem (empty, unreadable) is the modal's
+    // to report and it refuses the upload itself, so nothing about the mapping is worth saying
+    // ahead of it.
+    //
+    // Off, both checks belong to the modal exactly as they always did.
+    const importRefusal = (): IncompleteImport | null => {
+        if (mappingError) {
+            return null;
+        }
+
+        if (!Object.values(importMapping).includes('email')) {
+            return {
+                message: 'Please map "Email" to one of the fields in the CSV, and make sure it is selected.',
+                columns: new Set()
+            };
+        }
+
+        // Null is a column in the import with nothing chosen for it, which is the one state
+        // the table can hold that cannot be sent.
+        const undecided = Object.keys(importMapping).filter(column => importMapping[column] === null);
+        if (undecided.length === 0) {
+            return null;
+        }
+
+        return {
+            message: `Choose a field for ${undecided.map(column => `"${column}"`).join(', ')}, or deselect ${undecided.length === 1 ? 'it' : 'them'}.`,
+            columns: new Set(undecided)
+        };
+    };
+
+    const handleImport = () => {
+        const refusal = importRefusal();
+        if (refusal) {
+            setIncomplete(refusal);
+            return;
+        }
+        onUpload(importMapping);
+    };
+
+    return (
+        <>
+            {/* A flex column inside the height-bounded dialog: the table box below grows into
+                whatever room is left, so a short file keeps a small modal and a long one
+                fills the viewport rather than scrolling inside a fixed 400px. */}
+            <div className="mt-5 flex min-h-0 flex-1 flex-col space-y-5">
+                {(
+                    <>
+                        <div className={cn(
+                            'flex min-h-0 flex-1 flex-col overflow-hidden rounded-md border',
+                            tableError && 'border-destructive'
+                        )}>
+                            <div className="min-h-0 flex-1 overflow-auto">
+                                <Table className="table-fixed">
+                                    <TableHeader>
+                                        <TableRow>
+                                            <TableHead className="w-10">
+                                                <span className="sr-only">Import this column</span>
+                                            </TableHead>
+                                            <TableHead className="w-[26%]">Field</TableHead>
+                                            <TableHead className="w-[30%]">
+                                                <div className="flex items-center justify-between">
+                                                    <span>
+                                                        Sample data <span className="text-muted-foreground">(#{formatNumber(dataPreviewIndex + 1)})</span>
+                                                    </span>
+                                                    <div className="flex items-center">
+                                                        <button
+                                                            aria-label="Show previous sample row"
+                                                            className={cn(
+                                                                'rounded p-0.5 hover:bg-muted',
+                                                                !hasPrevRecord && 'cursor-default opacity-30'
+                                                            )}
+                                                            disabled={!hasPrevRecord || status === 'UPLOADING'}
+                                                            type="button"
+                                                            onClick={() => onDataPreviewIndexChange(dataPreviewIndex - 1)}
+                                                        >
+                                                            <LucideIcon.ChevronLeft className="size-4" />
+                                                        </button>
+                                                        <button
+                                                            aria-label="Show next sample row"
+                                                            className={cn(
+                                                                'rounded p-0.5 hover:bg-muted',
+                                                                !hasNextRecord && 'cursor-default opacity-30'
+                                                            )}
+                                                            disabled={!hasNextRecord || status === 'UPLOADING'}
+                                                            type="button"
+                                                            onClick={() => onDataPreviewIndexChange(dataPreviewIndex + 1)}
+                                                        >
+                                                            <LucideIcon.ChevronRight className="size-4" />
+                                                        </button>
+                                                    </div>
+                                                </div>
+                                            </TableHead>
+                                            <TableHead className="w-[38%]">Import as</TableHead>
+                                        </TableRow>
+                                    </TableHeader>
+                                    <TableBody>
+                                        {currentlyDisplayedData.length > 0 ? (
+                                            currentlyDisplayedData.map(row => (
+                                                <Fragment key={row.key}>
+                                                {/* While a create form is open, the rows it doesn't concern step back, so
+                                                    the pair being worked on reads as the foreground without anything being
+                                                    covered. Opacity on the rows themselves, not a layer over them. */}
+                                                {/* A row that is out of the import is tinted rather than
+                                                    faded. Alpha on the token, not opacity on the row: at
+                                                    full strength it read as heavier than the rows that
+                                                    matter, and fading the row instead took the field
+                                                    control's border down with it. Fading is left for the
+                                                    create form, where dropping everything back is the
+                                                    point.
+
+                                                    No row hover: Shade paints it onto each cell through
+                                                    group-hover, so it is turned off there. Nothing here
+                                                    responds to a row being pointed at — the controls in
+                                                    it have their own hover — and the hover token is
+                                                    lighter than the tint above, so on a row out of the
+                                                    import it read as the row coming back to life. */}
+                                                <TableRow className={cn(
+                                                    'transition-opacity [&>td]:group-hover:bg-transparent',
+                                                    !isImported(row) && 'bg-muted/50',
+                                                    isDimmed(row) && 'opacity-40'
+                                                )}>
+                                                    <TableCell>
+                                                        <Checkbox
+                                                            aria-label={`Import ${row.key}`}
+                                                            checked={isImported(row)}
+                                                            disabled={isRowLocked(row)}
+                                                            onCheckedChange={checked => setImported(row, checked === true)}
+                                                        />
+                                                    </TableCell>
+                                                    <TableCell className={cn('text-sm font-medium break-all', !isImported(row) && 'text-muted-foreground')}>{row.key}</TableCell>
+                                                    <TableCell className={cn('text-sm break-all', (!row.value || !isImported(row)) && 'text-muted-foreground')}>
+                                                        {row.value || '\u00A0'}
+                                                    </TableCell>
+                                                    <TableCell>
+                                                    {/* Hidden rather than unmounted for a column out of the
+                                                        import: the control it would offer cannot be used, and a
+                                                        disabled one has to be styled, faded and explained.
+                                                        visibility keeps its box, so the row does not change
+                                                        height as columns go in and out, and takes it out of the
+                                                        tab order and out of reach of the pointer without a
+                                                        second mechanism. The mapping is not lost either way —
+                                                        it comes back with the row when it is selected again. */}
+                                                        <FieldPicker
+                                                            className={cn(!isImported(row) && 'invisible')}
+                                                            columnKey={row.key}
+                                                            customFieldMappings={customFieldMappings}
+                                                            disabled={isRowLocked(row)}
+                                                            fieldMappings={fieldMappings}
+                                                            invalid={incomplete?.columns.has(row.key)}
+                                                            open={openPicker?.columnKey === row.key}
+                                                            search={openPicker?.columnKey === row.key ? openPicker.search : ''}
+                                                            triggerRef={(node) => {
+                                                                if (node) {
+                                                                    fieldTriggers.current.set(row.key, node);
+                                                                } else {
+                                                                    fieldTriggers.current.delete(row.key);
+                                                                }
+                                                            }}
+                                                            value={row.mapTo}
+                                                            onCreateField={() => showCreateForm(row.key)}
+                                                            onOpenChange={next => (next ? showPicker(row.key, '') : setOpenPicker(null))}
+                                                            onSearchChange={search => setOpenPicker({columnKey: row.key, search})}
+                                                            onSelect={(target) => {
+                                                                setIncomplete(null);
+                                                                claimTarget(row, target);
+                                                            }}
+                                                        />
+                                                    </TableCell>
+                                                </TableRow>
+                                                {/* The create form is a row of the table rather than a layer over it, so it
+                                                    scrolls with the rows, needs no anchoring or collision handling, and can't
+                                                    be scrolled out from under itself. It follows the row it belongs to, which
+                                                    keeps that column's name and sample value in view while deciding. */}
+                                                {createFieldForColumn === row.key && (
+                                                    <TableRow className="bg-transparent hover:bg-transparent">
+                                                        <TableCell className="p-2" colSpan={columnCount}>
+                                                            {/* Raised rather than floating: it reads as a surface above the table
+                                                                while remaining a row of it, so nothing has to be anchored to the
+                                                                row or repositioned when the table scrolls. */}
+                                                            <div className="rounded-lg border bg-surface-elevated-2 p-3 shadow-lg">
+                                                            <CreateFieldForm
+                                                                canRetry={canRetry}
+                                                                columnKey={row.key}
+                                                                isSaving={isCreating}
+                                                                nameError={nameError}
+                                                                saveError={saveError}
+                                                                onCancel={() => {
+                                                                    clearCreateErrors();
+                                                                    setCreateFieldForColumn(null);
+                                                                    // Unmounting the form drops focus to the body, leaving a
+                                                                    // keyboard publisher to tab back from the top of the table.
+                                                                    fieldTriggers.current.get(row.key)?.focus();
+                                                                }}
+                                                                onEdit={clearCreateErrors}
+                                                                onSubmit={(name, type) => void createFieldForRow(row.key, name, type)}
+                                                            />
+                                                            </div>
+                                                        </TableCell>
+                                                    </TableRow>
+                                                )}
+                                            </Fragment>
+                                            ))
+                                        ) : (
+                                            <TableRow>
+                                                <TableCell className="text-muted-foreground" colSpan={columnCount}>
+                                                    No data found in the uploaded CSV.
+                                                </TableCell>
+                                            </TableRow>
+                                        )}
+                                    </TableBody>
+                                </Table>
+                            </div>
+                        </div>
+
+                        {visibleError && <p className="text-sm text-destructive" role="alert">{visibleError}</p>}
+
+                        {membersCount > 0 && (
+                            <p className="text-sm text-muted-foreground">
+                                If an email address in your CSV matches an existing member, they will be updated with the mapped values.
+                            </p>
+                        )}
+
+                        <div className="mt-5">
+                            <label className="mb-1 block text-sm font-semibold">Label these members</label>
+                            <LabelPicker
+                                isCreating={labelPicker.isCreating}
+                                labels={labelPicker.labels}
+                                optionSource={labelPicker.optionSource}
+                                resolvedSelectedLabels={labelPicker.resolvedSelectedLabels}
+                                selectedSlugs={labelPicker.selectedSlugs}
+                                onCreate={labelPicker.createLabel}
+                                onDelete={labelPicker.deleteLabel}
+                                onEdit={labelPicker.editLabel}
+                                onToggle={labelPicker.toggleLabel}
+                            />
+                        </div>
+                    </>
+                )}
+            </div>
+
+            <DialogFooter className="mt-5">
+                <Button
+                    disabled={status === 'UPLOADING'}
+                    variant="outline"
+                    onClick={onStartOver}
+                >
+                    Start over
+                </Button>
+                <Button
+                    disabled={status === 'UPLOADING' || membersCount === 0}
+                    onClick={handleImport}
+                >
+                    {status === 'UPLOADING' ? (
+                        <span className="flex items-center gap-2">
+                            <LoadingIndicator color="light" size="sm" />
+                            Uploading
+                        </span>
+                    ) : membersCount > 0 ? (
+                        `Import ${formatNumber(membersCount)} ${membersCount === 1 ? 'member' : 'members'}`
+                    ) : (
+                        'Import members'
+                    )}
+                </Button>
+            </DialogFooter>
+        </>
+    );
+}

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/mapping.test.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/mapping.test.ts
@@ -1,0 +1,78 @@
+import {detectFieldTypes, getFieldMappings, suggestedFieldName} from '@/members/components/bulk-action-modals/import-members/custom-fields/mapping';
+import {describe, expect, it} from 'vitest';
+import {type MemberCustomFieldCsvColumn} from '@tryghost/admin-x-framework/api/member-custom-fields';
+
+// Only what this modal's mapping module adds. Column detection, sampling, the mapping class and
+// the error wording are the shared module's, and are covered by its own tests — the custom field
+// cases below stay here because they are the reason this modal narrows what it offers.
+describe('custom fields mapping helpers', () => {
+
+    it('adds tier as an available field mapping when enabled', () => {
+        const fieldMappings = getFieldMappings({importMemberTier: true});
+
+        expect(fieldMappings).toContainEqual({label: 'Tier', value: 'import_tier'});
+    });
+
+    const customFieldColumns: MemberCustomFieldCsvColumn[] = [
+        {label: 'Nickname', value: 'custom_fields.nickname', type: 'short_text'},
+        {label: 'Shipping Address (Line 1)', value: 'custom_fields.shipping_address.line1', type: 'address'},
+        {label: 'Shipping Address (First name)', value: 'custom_fields.shipping_address.first_name', type: 'address'}
+    ];
+
+    it('auto-detects a custom field column by its namespaced header', () => {
+        const mapping = detectFieldTypes([
+            {email: 'user@example.com', 'custom_fields.nickname': 'Bex'}
+        ], {customFieldColumns});
+
+        expect(mapping['custom_fields.nickname']).toBe('custom_fields.nickname');
+    });
+
+    // The /name/i heuristic must not claim a custom field column containing "name".
+    it('does not map a name-like custom field column to the member name', () => {
+        const mapping = detectFieldTypes([
+            {email: 'user@example.com', 'custom_fields.shipping_address.first_name': 'Bex'}
+        ], {customFieldColumns});
+
+        expect(mapping.name).toBeUndefined();
+        expect(mapping['custom_fields.shipping_address.first_name']).toBe('custom_fields.shipping_address.first_name');
+    });
+
+    // Even a namespaced column with no offered target (its field archived after export,
+    // or a hand-built file) must not be claimed as the member name.
+    it('does not map a name-like namespaced column that has no offered target', () => {
+        const mapping = detectFieldTypes([
+            {email: 'user@example.com', 'custom_fields.former_field.last_name': 'Bex'}
+        ]);
+
+        expect(mapping.name).toBeUndefined();
+    });
+
+    // An email-typed custom field must not be bound to the member email (and thereby
+    // dropped) just because its values look like email addresses.
+    it('does not bind an email-valued custom field column to the member email', () => {
+        const mapping = detectFieldTypes([
+            {'custom_fields.contact_email': 'contact@example.com', email: 'member@example.com'}
+        ], {customFieldColumns: [{label: 'Contact email', value: 'custom_fields.contact_email', type: 'short_text'}]});
+
+        expect(mapping.email).toBe('email');
+        expect(mapping['custom_fields.contact_email']).toBe('custom_fields.contact_email');
+    });
+
+    describe('suggestedFieldName', () => {
+        it('strips the namespace and un-slugs a column from a Ghost export', () => {
+            expect(suggestedFieldName('custom_fields.nickname')).toBe('Nickname');
+            expect(suggestedFieldName('custom_fields.favorite-animal')).toBe('Favorite animal');
+        });
+
+        // The part is a separate question the form asks, so it must not end up in the name.
+        it('names the field, not the part, for a composite column', () => {
+            expect(suggestedFieldName('custom_fields.home-address.city')).toBe('Home address');
+            expect(suggestedFieldName('custom_fields.home-address.postal_code')).toBe('Home address');
+        });
+
+        it('keeps a column from anywhere else as the publisher wrote it', () => {
+            expect(suggestedFieldName('Job Title')).toBe('Job Title');
+            expect(suggestedFieldName('job_title')).toBe('Job title');
+        });
+    });
+});

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/mapping.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/custom-fields/mapping.ts
@@ -1,0 +1,43 @@
+import {FIELD_MAPPINGS, IMPORT_TIER_FIELD_MAPPING} from '@/members/components/bulk-action-modals/import-members/mapping';
+import {isCustomFieldColumn} from '@tryghost/admin-x-framework/api/member-custom-fields';
+
+/**
+ * What this modal adds to the shipped mapping vocabulary, and nothing it already says.
+ *
+ * Column detection, sampling, the mapping class and the error wording are the same questions
+ * with the same answers on both sides of the flag, so they are re-exported rather than copied:
+ * a fix to one is a fix to both, and there is no version of them that can drift.
+ *
+ * The class in particular has to come from there rather than be redeclared — it carries a
+ * private field, so a second declaration is a distinct type to TypeScript however identical
+ * its shape, and this modal could not hand its own mapping to the reducer it shares.
+ */
+export {MembersFieldMapping, columnsOf, detectFieldTypes, formatImportError, sampleData} from '@/members/components/bulk-action-modals/import-members/mapping';
+
+// The native targets only. Custom fields are offered from their own list, chosen by kind, so
+// they are not folded in here — auto-detection still sees both, through the shared detection.
+export function getFieldMappings({importMemberTier = false}: {importMemberTier?: boolean} = {}) {
+    return [
+        ...FIELD_MAPPINGS,
+        ...(importMemberTier ? [IMPORT_TIER_FIELD_MAPPING] : [])
+    ];
+}
+
+/**
+ * The field name to suggest for a column no defined field matches.
+ *
+ * A namespaced column comes from a Ghost export, so it carries a namespace that is noise
+ * to a publisher and a key that was machine-minted from a name in the first place: both
+ * are stripped back towards what someone would have typed. A column from anywhere else is
+ * already the publisher's own wording, so only its separators and first letter are
+ * touched. It is a starting point either way, and the form lets them edit it.
+ */
+export function suggestedFieldName(column: string): string {
+    // A custom field column is `custom_fields.<key>` or `custom_fields.<key>.<part>`. The name
+    // being suggested is the field's, so the part is dropped: `custom_fields.home-address.city`
+    // names a field called "Home address" whose City part this column holds, and the part is
+    // asked for separately. A bare `custom_fields` column has no key, so it suggests the namespace itself.
+    const segments = isCustomFieldColumn(column) ? column.split('.').slice(1, 2) : [column];
+    const words = (segments[0] ?? column).replace(/[._-]+/g, ' ').trim();
+    return words.charAt(0).toUpperCase() + words.slice(1);
+}

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/mapping.test.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/mapping.test.ts
@@ -1,5 +1,6 @@
 import {MembersFieldMapping, columnsOf, detectFieldTypes, formatImportError, getFieldMappings, sampleData} from '@/members/components/bulk-action-modals/import-members/mapping';
 import {describe, expect, it} from 'vitest';
+import type {MemberCustomFieldCsvColumn} from '@tryghost/admin-x-framework/api/member-custom-fields';
 
 describe('mapping helpers', () => {
     // Papaparse omits keys for a row with fewer cells than the header rather than padding it,
@@ -111,17 +112,17 @@ describe('mapping helpers', () => {
         expect(mapping.gift_id).toBe('gift_id');
     });
 
-    const customFieldColumns = [
-        {label: 'Nickname', value: 'custom_fields.nickname'},
-        {label: 'Shipping Address (Line 1)', value: 'custom_fields.shipping_address.line1'},
-        {label: 'Shipping Address (First name)', value: 'custom_fields.shipping_address.first_name'}
+    const customFieldColumns: MemberCustomFieldCsvColumn[] = [
+        {label: 'Nickname', value: 'custom_fields.nickname', type: 'short_text'},
+        {label: 'Shipping Address (Line 1)', value: 'custom_fields.shipping_address.line1', type: 'address'},
+        {label: 'Shipping Address (First name)', value: 'custom_fields.shipping_address.first_name', type: 'address'}
     ];
 
     it('offers the custom field columns as mapping targets', () => {
         const mappings = getFieldMappings({customFieldColumns});
 
-        expect(mappings).toContainEqual({label: 'Nickname', value: 'custom_fields.nickname'});
-        expect(mappings).toContainEqual({label: 'Shipping Address (Line 1)', value: 'custom_fields.shipping_address.line1'});
+        expect(mappings).toContainEqual(expect.objectContaining({label: 'Nickname', value: 'custom_fields.nickname'}));
+        expect(mappings).toContainEqual(expect.objectContaining({label: 'Shipping Address (Line 1)', value: 'custom_fields.shipping_address.line1'}));
     });
 
     it('auto-detects a custom field column by its namespaced header', () => {
@@ -157,7 +158,7 @@ describe('mapping helpers', () => {
     it('does not bind an email-valued custom field column to the member email', () => {
         const mapping = detectFieldTypes([
             {'custom_fields.contact_email': 'contact@example.com', email: 'member@example.com'}
-        ], {customFieldColumns: [{label: 'Contact email', value: 'custom_fields.contact_email'}]});
+        ], {customFieldColumns: [{label: 'Contact email', value: 'custom_fields.contact_email', type: 'short_text'}]});
 
         expect(mapping.email).toBe('email');
         expect(mapping['custom_fields.contact_email']).toBe('custom_fields.contact_email');

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/mapping.test.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/mapping.test.ts
@@ -1,7 +1,29 @@
-import {MembersFieldMapping, detectFieldTypes, formatImportError, getFieldMappings, sampleData} from '@/members/components/bulk-action-modals/import-members/mapping';
+import {MembersFieldMapping, columnsOf, detectFieldTypes, formatImportError, getFieldMappings, sampleData} from '@/members/components/bulk-action-modals/import-members/mapping';
 import {describe, expect, it} from 'vitest';
 
 describe('mapping helpers', () => {
+    // Papaparse omits keys for a row with fewer cells than the header rather than padding it,
+    // so reading the first row alone loses every column a short first row does not reach — and
+    // a column nothing names is carried through by the importer, imported without ever being
+    // shown to the publisher.
+    it('finds every column even when the first row is short', () => {
+        const ragged = [
+            {email: 'one@example.com'},
+            {email: 'two@example.com', name: 'Two', note: 'hello'}
+        ] as unknown as Record<string, string>[];
+
+        expect(columnsOf(ragged)).toEqual(['email', 'name', 'note']);
+        expect(Object.keys(detectFieldTypes(ragged))).toContain('note');
+    });
+
+    it('does not offer papaparse overflow as a column', () => {
+        const overflowing = [
+            {email: 'one@example.com', __parsed_extra: 'spare'}
+        ] as unknown as Record<string, string>[];
+
+        expect(columnsOf(overflowing)).toEqual(['email']);
+    });
+
     it('samples non-empty entries per column', () => {
         const sampled = sampleData([
             {email: '', name: 'A'},

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/mapping.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/mapping.ts
@@ -1,12 +1,10 @@
-import {isCustomFieldColumn} from '@tryghost/admin-x-framework/api/member-custom-fields';
-
-type CustomFieldColumn = {label: string; value: string};
+import {isCustomFieldColumn, type MemberCustomFieldCsvColumn} from '@tryghost/admin-x-framework/api/member-custom-fields';
 
 type FieldMappingOptions = {
     importMemberTier?: boolean;
     // Custom field CSV columns offered as mapping targets (see memberCustomFieldCsvColumns);
     // empty when the feature is off.
-    customFieldColumns?: CustomFieldColumn[];
+    customFieldColumns?: MemberCustomFieldCsvColumn[];
 };
 
 export const FIELD_MAPPINGS = [

--- a/apps/admin/src/members/components/bulk-action-modals/import-members/mapping.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/import-members/mapping.ts
@@ -21,7 +21,7 @@ export const FIELD_MAPPINGS = [
     {label: 'Gift ID', value: 'gift_id'}
 ];
 
-const IMPORT_TIER_FIELD_MAPPING = {label: 'Tier', value: 'import_tier'};
+export const IMPORT_TIER_FIELD_MAPPING = {label: 'Tier', value: 'import_tier'};
 
 const SUPPORTED_TYPES = [
     'email',
@@ -105,13 +105,37 @@ export class MembersFieldMapping {
  * Locate 10 non-empty cells from the start/middle(ish)/end of each column (30 non-empty values in total).
  * If the data contains 30 rows or fewer, all rows should be validated.
  */
+/**
+ * Every column the file has.
+ *
+ * Papaparse omits keys for a row carrying fewer cells than the header rather than padding it
+ * out, so the first row is only the full set for a rectangular file. A hand-edited or partly
+ * exported CSV whose first row is short would otherwise have its remaining columns go
+ * undetected — and a column nothing names is carried through by the importer, so it would be
+ * imported without ever appearing to the publisher.
+ *
+ * `__parsed_extra` is where papaparse collects the overflow of a row with more cells than
+ * headers. It is not a column and no mapping can name it.
+ */
+export function columnsOf(data: Record<string, string>[]): string[] {
+    const keys = new Set<string>();
+    for (const row of data) {
+        for (const key of Object.keys(row)) {
+            if (key !== '__parsed_extra') {
+                keys.add(key);
+            }
+        }
+    }
+    return [...keys];
+}
+
 export function sampleData(data: Record<string, string>[], validationSampleSize = 30): Record<string, string>[] {
     if (!data || data.length <= validationSampleSize) {
         return data;
     }
 
     const validatedSet: Record<string, string>[] = [];
-    const sampleKeys = Object.keys(data[0]);
+    const sampleKeys = columnsOf(data);
 
     sampleKeys.forEach((key) => {
         const nonEmptyKeyEntries = data.filter(entry => entry[key] && entry[key].trim() !== '');
@@ -159,7 +183,7 @@ export function detectFieldTypes(data: Record<string, string>[], options: FieldM
     // we only checked sampled entries. A custom field column auto-maps to itself here;
     // isCustomFieldColumn holds it apart from the fuzzy core-field heuristics below.
     if (data.length > 0) {
-        for (const key of Object.keys(data[0])) {
+        for (const key of columnsOf(data)) {
             if (!mapping.name && /name/i.test(key) && !isCustomFieldColumn(key)) {
                 mapping.name = key;
                 continue;

--- a/apps/admin/src/members/components/bulk-action-modals/index.ts
+++ b/apps/admin/src/members/components/bulk-action-modals/index.ts
@@ -2,4 +2,6 @@ export {AddLabelModal} from './add-label-modal';
 export {RemoveLabelModal} from './remove-label-modal';
 export {UnsubscribeModal} from './unsubscribe-modal';
 export {DeleteModal} from './delete-modal';
-export {ImportMembersModal} from './import-members-modal';
+// The gate picks between the import as it shipped and the custom fields experience, so
+// members-actions goes on importing one name and knowing nothing about the flag.
+export {ImportMembersGate as ImportMembersModal} from './import-members-gate';

--- a/apps/admin/src/members/import-members-custom-fields.acceptance.test.tsx
+++ b/apps/admin/src/members/import-members-custom-fields.acceptance.test.tsx
@@ -1,0 +1,558 @@
+import {describe, expect, it} from 'vitest';
+import {page, userEvent} from 'vitest/browser';
+
+import {fakeAdminEndpoint, fakeMembers, member, renderAdminApp} from '@test-utils/acceptance';
+import {membersScreen} from './members.screen';
+
+const FLAGS = {labs: {membersCustomFields: true}};
+
+// A `nickname` column no defined field matches, alongside the columns auto-detection claims.
+// `name` is present deliberately: it takes the /name/i heuristic, which would otherwise map
+// `nickname` to the member's name and leave nothing unmatched to create.
+const CSV = 'email,name,nickname,city,postcode\nada@example.com,Ada Lovelace,Countess,London,E1 6AN\n';
+
+// A hand-edited or partially-exported file: row 1 carries fewer cells than the header, which
+// papaparse reports as a row with fewer keys rather than padding it out.
+const RAGGED_CSV = 'email,name,note\nada@example.com\ngrace@example.com,Grace Hopper,Hi\n';
+
+// A Ghost export re-imported somewhere its field no longer exists: archived since, or a
+// different site. The header says what the column is even though nothing matches it.
+const EXPORTED_CSV = 'email,custom_fields.nickname\nada@example.com,Countess\n';
+
+/**
+ * The world the import modal reads: no custom fields defined yet, a create that mints a
+ * key from the name the way the service does, and a browse reflecting what has been
+ * created, so the picker behaves as it would against a real site.
+ */
+function fakeCustomFieldsWorld() {
+    const fields: Array<Record<string, unknown>> = [];
+    fakeMembers([member({name: 'Ada Lovelace'})]);
+    fakeAdminEndpoint('GET', '/members/custom_fields/', () => ({members_custom_fields: fields}));
+    const uploadApi = fakeAdminEndpoint('POST', '/members/upload/', {
+        meta: {stats: {imported: 1, invalid: []}, import_label: {name: 'Import', slug: 'import'}}
+    });
+    const createApi = fakeAdminEndpoint('POST', '/members/custom_fields/', ({body}) => {
+        const [input] = (body as {members_custom_fields: Array<{name: string; type: string}>}).members_custom_fields;
+        const field = {
+            key: input.name.trim().toLowerCase().replace(/\s+/g, '-'),
+            name: input.name.trim(),
+            type: input.type,
+            status: 'active',
+            created_at: '2026-08-05T00:00:00.000Z',
+            updated_at: null
+        };
+        fields.push(field);
+        return {members_custom_fields: [field]};
+    });
+    return {createApi, uploadApi};
+}
+
+/**
+ * The mapping as it went over the wire: the upload is multipart, carrying one
+ * `mapping[<column>]` field per column the request names.
+ */
+function sentMapping(body: unknown): Record<string, string> {
+    return Object.fromEntries(
+        Object.entries(body as Record<string, string>)
+            .filter(([key]) => key.startsWith('mapping['))
+            .map(([key, value]) => [key.slice('mapping['.length, -1), value])
+    );
+}
+
+async function openMappingStep(csv: string = CSV) {
+    await membersScreen.openActionsMenu();
+    await membersScreen.menuItem(/Import members/).click();
+
+    const dropzone = page.getByRole('button', {name: /select or drop a csv file/i});
+    await expect.element(dropzone).toBeVisible();
+    const input = dropzone.element().querySelector('input[type=file]');
+    if (!(input instanceof HTMLInputElement)) {
+        throw new Error('CSV upload input was not rendered');
+    }
+    await page.elementLocator(input).upload(new File([csv], 'members.csv', {type: 'text/csv'}));
+}
+
+const fieldSelect = (column: string) => page.getByRole('combobox', {name: `Field for ${column}`});
+const createForm = () => page.getByTestId('import-create-custom-field');
+const importToggle = (column: string) => page.getByRole('checkbox', {name: `Import ${column}`});
+
+async function openCreateForm(column: string) {
+    await importToggle(column).click();
+    await fieldSelect(column).click();
+    await page.getByRole('option', {name: 'Add custom field'}).click();
+}
+
+describe('Import members custom fields', () => {
+    it('creates a custom field for an unmatched column and maps the column onto it', async () => {
+        const {createApi} = fakeCustomFieldsWorld();
+        await renderAdminApp('/members', FLAGS);
+        await openMappingStep();
+
+        await importToggle('nickname').click();
+        await expect.element(fieldSelect('nickname')).toHaveTextContent('Select field');
+
+        await fieldSelect('nickname').click();
+        await page.getByRole('option', {name: 'Add custom field'}).click();
+
+        const dialog = page.getByTestId('import-create-custom-field');
+        await expect.element(dialog).toBeVisible();
+        // Suggested from the column, so the common case is nothing to type — and focused, so
+        // the uncommon case is typing over it. The picker is a modal popover whose focus trap
+        // outlives its exit animation, and has twice pulled the focus back out of this form.
+        await expect.element(dialog.getByLabelText('Name')).toHaveValue('Nickname');
+        await expect.element(dialog.getByLabelText('Name')).toHaveFocus();
+        await dialog.getByRole('button', {name: 'Save'}).click();
+
+        await expect.poll(() => createApi.lastRequest?.body).toEqual({
+            members_custom_fields: [{name: 'Nickname', type: 'short_text'}]
+        });
+
+        // The row carries the new field immediately, from the create response: the browse query
+        // is invalidated but not awaited, so waiting for the refetch would leave the picker
+        // blank in between. And the trigger names the list it came from, so a custom field
+        // called "Name" could not be read as the member's own name once the list is closed.
+        await expect.element(fieldSelect('nickname')).toHaveTextContent('Nickname');
+        await expect.element(fieldSelect('nickname')).toHaveTextContent('Custom field');
+    });
+
+    it('puts the create form away when another picker is opened', async () => {
+        fakeCustomFieldsWorld();
+        await renderAdminApp('/members', FLAGS);
+        await openMappingStep();
+
+        await openCreateForm('nickname');
+        await expect.element(createForm()).toBeVisible();
+
+        // The publisher has moved on to another decision, and a half-filled form stranded
+        // under someone else's dropdown helps nobody. `email` because a column out of the
+        // import has no control to open.
+        await fieldSelect('email').click();
+
+        await expect.element(createForm()).not.toBeInTheDocument();
+    });
+
+    it('keeps its field when a column is deselected', async () => {
+        fakeCustomFieldsWorld();
+        await renderAdminApp('/members', FLAGS);
+        await openMappingStep();
+
+        await openCreateForm('nickname');
+        await page.getByTestId('import-create-custom-field').getByRole('button', {name: 'Save'}).click();
+        await expect.element(fieldSelect('nickname')).toHaveTextContent('Nickname');
+
+        // Excluding a column from this import and choosing what it holds are different answers,
+        // so switching it back on must not make the publisher pick again.
+        await importToggle('nickname').click();
+        await importToggle('nickname').click();
+
+        await expect.element(fieldSelect('nickname')).toHaveTextContent('Nickname');
+    });
+
+    // A composite spans several columns, so the form has nothing to say about which one this
+    // is. It creates the field and hands the question back to the picker, filtered to what it
+    // just made — the same question as any other mapping, asked where the others are.
+    it('creates a composite field and asks which part the column holds', async () => {
+        const {createApi} = fakeCustomFieldsWorld();
+        await renderAdminApp('/members', FLAGS);
+        await openMappingStep();
+
+        await openCreateForm('city');
+
+        const dialog = page.getByTestId('import-create-custom-field');
+        await expect.element(dialog).toBeVisible();
+        await userEvent.fill(dialog.getByLabelText('Name'), 'Shipping address');
+
+        await dialog.getByRole('combobox', {name: 'Type'}).click();
+        await page.getByRole('option', {name: 'Address'}).click();
+        await dialog.getByRole('button', {name: 'Save'}).click();
+
+        await expect.poll(() => createApi.lastRequest?.body).toEqual({
+            members_custom_fields: [{name: 'Shipping address', type: 'address'}]
+        });
+
+        // The form is gone and its row's picker is open in its place, showing that field's
+        // parts and nothing else — the search is what narrows it, so it can still be cleared.
+        await expect.element(createForm()).not.toBeInTheDocument();
+        await expect.element(page.getByRole('option', {name: 'Shipping address (City)'})).toBeVisible();
+        await expect.element(page.getByRole('option', {name: 'Email', exact: true})).not.toBeInTheDocument();
+
+        await page.getByRole('option', {name: 'Shipping address (City)'}).click();
+
+        // Mapped onto the part chosen, not the field's first column.
+        await expect.element(fieldSelect('city')).toHaveTextContent('Shipping address (City)');
+    });
+
+    it('pins a name the site already uses to the name input', async () => {
+        fakeCustomFieldsWorld();
+        fakeAdminEndpoint('POST', '/members/custom_fields/', {
+            errors: [{message: 'A custom field with this name already exists.', property: 'name', type: 'ValidationError'}]
+        }, {status: 422});
+        await renderAdminApp('/members', FLAGS);
+        await openMappingStep();
+
+        await openCreateForm('nickname');
+        await createForm().getByRole('button', {name: 'Save'}).click();
+
+        // On the input they would fix, not in a corner: the clashing field may be archived,
+        // which they cannot see from here.
+        await expect.element(createForm().getByText('A custom field with this name already exists.')).toBeVisible();
+        await expect.element(fieldSelect('nickname')).toHaveTextContent('Select field');
+    });
+
+    it('shows why the site cannot take another field, and stops offering to retry', async () => {
+        fakeCustomFieldsWorld();
+        fakeAdminEndpoint('POST', '/members/custom_fields/', {
+            errors: [{
+                // As Ghost serialises a host limit: a generic summary in `message`, the sentence
+                // that explains the refusal in `context`.
+                message: 'Cannot create custom field.',
+                context: 'Custom fields are limited to 20 per site. Delete a field you no longer need to make room.',
+                code: 'CUSTOM_FIELDS_LIMIT_REACHED',
+                type: 'HostLimitError'
+            }]
+        }, {status: 403});
+        await renderAdminApp('/members', FLAGS);
+        await openMappingStep();
+
+        await openCreateForm('nickname');
+        await createForm().getByRole('button', {name: 'Save'}).click();
+
+        // The server's own sentence, because it is the only thing that explains the refusal.
+        await expect.element(createForm().getByText(/limited to 20 per site/)).toBeVisible();
+        // Retrying cannot succeed, so the button that invites it is disabled until they change
+        // something.
+        await expect.element(createForm().getByRole('button', {name: 'Save'})).toBeDisabled();
+    });
+
+    it('says the field exists when the response carries nothing to map onto', async () => {
+        fakeCustomFieldsWorld();
+        // A 2xx the client cannot use: an older bundle against a newer server, a proxy that
+        // reshapes the envelope. The field is created either way, so the form must not claim
+        // otherwise and send them to create a second one.
+        fakeAdminEndpoint('POST', '/members/custom_fields/', {members_custom_fields: []});
+        await renderAdminApp('/members', FLAGS);
+        await openMappingStep();
+
+        await openCreateForm('nickname');
+        await createForm().getByRole('button', {name: 'Save'}).click();
+
+        await expect.element(createForm().getByText(/was created, but this column could not be mapped/)).toBeVisible();
+        await expect.element(fieldSelect('nickname')).toHaveTextContent('Select field');
+    });
+
+    // Leaving a column out of the mapping is how the importer is told to carry it through
+    // under its own header, which for a custom_fields.* column means importing it. So a
+    // deselected column has to be named with an empty target, not omitted.
+    it('names every column it is not importing rather than omitting it', async () => {
+        const {uploadApi} = fakeCustomFieldsWorld();
+        await renderAdminApp('/members', FLAGS);
+        await openMappingStep();
+
+        // `name` is auto-detected, so this deselects a column that has a field; the three
+        // undetected columns are already out, having nothing to import them as.
+        await importToggle('name').click();
+        await page.getByRole('button', {name: 'Import 1 member'}).click();
+
+        await expect.poll(() => uploadApi.lastRequest && sentMapping(uploadApi.lastRequest.body)).toEqual({
+            email: 'email',
+            name: '',
+            nickname: '',
+            city: '',
+            postcode: ''
+        });
+    });
+
+    // Being deselected and having lost a target are separate facts, and the first outranks the
+    // second. Losing a target puts a column back in the import so it cannot silently vanish
+    // with nothing said — but a column the publisher already switched off asked to be out, and
+    // it stays out. Collapsing the two into one in-or-out decision would resurrect it here.
+    it('keeps a deselected column out when another column takes the field it held', async () => {
+        const {uploadApi} = fakeCustomFieldsWorld();
+        await renderAdminApp('/members', FLAGS);
+        await openMappingStep();
+
+        await importToggle('name').click();
+        await expect.element(importToggle('name')).not.toBeChecked();
+
+        // `nickname` claims Name, which `name` was auto-detected onto — so `name` loses its
+        // target the way a switched-off column never asked to.
+        await importToggle('nickname').click();
+        await fieldSelect('nickname').click();
+        await page.getByRole('option', {name: 'Name', exact: true}).click();
+
+        // Still out, and with nothing to show for it: a column out of the import has no field
+        // control at all, so the target it lost cannot be read off the row either.
+        await expect.element(importToggle('name')).not.toBeChecked();
+        await expect.element(fieldSelect('name')).not.toBeInTheDocument();
+
+        await page.getByRole('button', {name: 'Import 1 member'}).click();
+        await expect.poll(() => uploadApi.lastRequest && sentMapping(uploadApi.lastRequest.body)).toEqual({
+            email: 'email',
+            name: '',
+            nickname: 'name',
+            city: '',
+            postcode: ''
+        });
+    });
+
+    // The columns a publisher can see are the columns they can exclude, and a column the mapping
+    // never names is carried through by the importer rather than left out. So a short row must
+    // not be able to hide one: everything the header declares has to reach the table and the
+    // request, whichever sample happens to be on screen.
+    it('shows every column the file has, not just the previewed row', async () => {
+        const {uploadApi} = fakeCustomFieldsWorld();
+        await renderAdminApp('/members', FLAGS);
+        await openMappingStep(RAGGED_CSV);
+
+        // Row 1 holds only an email, so reading columns off it would leave these two off the
+        // table with no way to say anything about them.
+        await expect.element(importToggle('name')).toBeVisible();
+        await expect.element(importToggle('note')).toBeVisible();
+
+        // Detected too, not merely displayed: a column the publisher has to map by hand because
+        // an earlier row was short is barely better than one they never saw.
+        await expect.element(fieldSelect('name')).toHaveTextContent('Name');
+        await expect.element(fieldSelect('note')).toHaveTextContent('Note');
+
+        await importToggle('note').click();
+        await page.getByRole('button', {name: 'Import 2 members'}).click();
+
+        // Named and emptied, not omitted — omitting it is how the importer is told to keep it.
+        await expect.poll(() => uploadApi.lastRequest && sentMapping(uploadApi.lastRequest.body)).toEqual({
+            email: 'email',
+            name: 'name',
+            note: ''
+        });
+    });
+
+    // The upload result and its refusals are re-implemented in this modal, so they are asserted
+    // here rather than inherited: the shipped modal's own suite covers the file the gate no
+    // longer serves when the flag is on.
+    describe('after the upload', () => {
+        async function importAll() {
+            await renderAdminApp('/members', FLAGS);
+            await openMappingStep();
+            await page.getByRole('button', {name: 'Import 1 member'}).click();
+        }
+
+        it('shows the result when the import completes', async () => {
+            fakeCustomFieldsWorld();
+            await importAll();
+
+            await expect.element(page.getByText('Import complete')).toBeVisible();
+        });
+
+        it('says the file was too large rather than blaming the data', async () => {
+            fakeCustomFieldsWorld();
+            fakeAdminEndpoint('POST', '/members/upload/', {errors: [{message: 'too big'}]}, {status: 413});
+            await importAll();
+
+            await expect.element(page.getByText(/larger than the maximum file size/)).toBeVisible();
+        });
+
+        it('shows the host limit refusal and does not offer to try again', async () => {
+            fakeCustomFieldsWorld();
+            fakeAdminEndpoint('POST', '/members/upload/', {
+                errors: [{
+                    // As Ghost serialises it: generic summary in `message`, the sentence that
+                    // explains the refusal in `context`.
+                    message: 'Cannot import members.',
+                    context: 'Woah there, that is a lot of members.',
+                    code: 'EMAIL_VERIFICATION_NEEDED',
+                    type: 'HostLimitError'
+                }]
+            }, {status: 403});
+            await importAll();
+
+            // The server's own sentence, and no retry: nothing the publisher can do here changes
+            // a limit, so a button inviting them to repeat the request would only mislead.
+            await expect.element(page.getByText(/that is a lot of members/)).toBeVisible();
+            await expect.element(page.getByRole('button', {name: /Try again/})).not.toBeInTheDocument();
+        });
+
+        it('shows what the server refused about the data', async () => {
+            fakeCustomFieldsWorld();
+            fakeAdminEndpoint('POST', '/members/upload/', {
+                errors: [{message: 'The file has no email column.', type: 'DataImportError'}]
+            }, {status: 422});
+            await importAll();
+
+            await expect.element(page.getByText('The file has no email column.')).toBeVisible();
+        });
+    });
+
+    // A query whose only job is to add targets to a list must not be able to stop the import.
+    it('imports with membership fields when custom fields cannot be loaded', async () => {
+        fakeMembers([member({name: 'Ada Lovelace'})]);
+        fakeAdminEndpoint('GET', '/members/custom_fields/', {errors: [{message: 'nope'}]}, {status: 500});
+        const uploadApi = fakeAdminEndpoint('POST', '/members/upload/', {
+            meta: {stats: {imported: 1, invalid: []}, import_label: {name: 'Import', slug: 'import'}}
+        });
+        await renderAdminApp('/members', FLAGS);
+        await openMappingStep();
+
+        // The table is reached at all — waiting on a failed query would leave it on a spinner.
+        await expect.element(fieldSelect('email')).toHaveTextContent('Email');
+        await page.getByRole('button', {name: 'Import 1 member'}).click();
+
+        await expect.poll(() => uploadApi.lastRequest && sentMapping(uploadApi.lastRequest.body)).toMatchObject({
+            email: 'email'
+        });
+    });
+
+    it('clears a refusal when the column it named is answered by creating a field', async () => {
+        fakeCustomFieldsWorld();
+        await renderAdminApp('/members', FLAGS);
+        await openMappingStep();
+
+        // Refused: in the import with nothing chosen for it.
+        await importToggle('nickname').click();
+        await page.getByRole('button', {name: 'Import 1 member'}).click();
+        await expect.element(page.getByText(/Choose a field for "nickname"/)).toBeVisible();
+        await expect.element(fieldSelect('nickname')).toHaveAttribute('aria-invalid', 'true');
+
+        // Creating one is that question answered, so the refusal goes with it.
+        await fieldSelect('nickname').click();
+        await page.getByRole('option', {name: 'Add custom field'}).click();
+        await createForm().getByRole('button', {name: 'Save'}).click();
+
+        await expect.element(page.getByText(/Choose a field for/)).not.toBeInTheDocument();
+        await expect.element(fieldSelect('nickname')).not.toHaveAttribute('aria-invalid');
+    });
+
+    it('will not import a file whose email column is deselected', async () => {
+        const {uploadApi} = fakeCustomFieldsWorld();
+        await renderAdminApp('/members', FLAGS);
+        await openMappingStep();
+
+        // Mapped, but out of the import. The request would go without an email column and
+        // every row would come back missing one.
+        await importToggle('email').click();
+        await page.getByRole('button', {name: 'Import 1 member'}).click();
+
+        await expect.element(page.getByText(/make sure it is selected/)).toBeVisible();
+        expect(uploadApi.requests).toHaveLength(0);
+    });
+
+    it('marks the column it cannot import a selected row as, and lets it through once answered', async () => {
+        const {uploadApi} = fakeCustomFieldsWorld();
+        await renderAdminApp('/members', FLAGS);
+        await openMappingStep();
+
+        await importToggle('nickname').click();
+        await page.getByRole('button', {name: 'Import 1 member'}).click();
+
+        // On the row that has to change, not only in prose: the offending column may have
+        // scrolled out of view by the time the message is read.
+        await expect.element(page.getByText(/Choose a field for "nickname"/)).toBeVisible();
+        await expect.element(fieldSelect('nickname')).toHaveAttribute('aria-invalid', 'true');
+        expect(uploadApi.requests).toHaveLength(0);
+
+        await fieldSelect('nickname').click();
+        await page.getByRole('option', {name: 'Note'}).click();
+        await expect.element(fieldSelect('nickname')).not.toHaveAttribute('aria-invalid');
+
+        await page.getByRole('button', {name: 'Import 1 member'}).click();
+        await expect.poll(() => uploadApi.lastRequest && sentMapping(uploadApi.lastRequest.body)).toMatchObject({
+            nickname: 'note'
+        });
+    });
+
+    // The whole point of one list: what a column can be imported as is answered by reading it,
+    // not by switching a kind picker to find out what is behind each setting.
+    it('offers membership and custom fields in one searchable list', async () => {
+        fakeCustomFieldsWorld();
+        await renderAdminApp('/members', FLAGS);
+        await openMappingStep(EXPORTED_CSV);
+
+        // A Ghost export re-imported where its field no longer exists: nothing matches, so it
+        // starts out of the import with nothing chosen for it.
+        await importToggle('custom_fields.nickname').click();
+        await expect.element(fieldSelect('custom_fields.nickname')).toHaveTextContent('Select field');
+        await fieldSelect('custom_fields.nickname').click();
+
+        // Both kinds are reachable from the one list, without choosing between them first.
+        // Exact, or "Email" also matches "Subscribed to emails".
+        await expect.element(page.getByRole('option', {name: 'Email', exact: true})).toBeVisible();
+        await expect.element(page.getByRole('option', {name: 'Add custom field'})).toBeVisible();
+
+        // And searchable, which is what makes the member fields usable as one list rather than
+        // two — there are ten of them before a site defines a single custom field.
+        await userEvent.fill(page.getByPlaceholder('Search fields...'), 'stripe');
+        await expect.element(page.getByRole('option', {name: 'Stripe Customer ID'})).toBeVisible();
+        await expect.element(page.getByRole('option', {name: 'Email', exact: true})).not.toBeInTheDocument();
+    });
+
+    // A search matching no field is the strongest signal there is that the field wanted does not
+    // exist yet, so the way to make one has to survive the search that proves it.
+    it('offers to add a field when the search matches none', async () => {
+        fakeCustomFieldsWorld();
+        await renderAdminApp('/members', FLAGS);
+        await openMappingStep();
+
+        await importToggle('nickname').click();
+        await fieldSelect('nickname').click();
+        await userEvent.fill(page.getByPlaceholder('Search fields...'), 'zzzz');
+
+        await expect.element(page.getByRole('option', {name: 'Email', exact: true})).not.toBeInTheDocument();
+        await page.getByRole('option', {name: 'Add custom field'}).click();
+
+        await expect.element(createForm()).toBeVisible();
+    });
+
+    // The part is chosen in the picker now, so it can be left unchosen — which the form's old
+    // guard made impossible. The column is in the import with nothing to fill, and Import says so.
+    it('refuses the import when a composite is created and no part is chosen', async () => {
+        const {uploadApi} = fakeCustomFieldsWorld();
+        await renderAdminApp('/members', FLAGS);
+        await openMappingStep();
+
+        await openCreateForm('city');
+        await userEvent.fill(createForm().getByLabelText('Name'), 'Shipping address');
+        await createForm().getByRole('combobox', {name: 'Type'}).click();
+        await page.getByRole('option', {name: 'Address'}).click();
+        await createForm().getByRole('button', {name: 'Save'}).click();
+
+        // Dismissed without answering which part the column holds.
+        await expect.element(page.getByRole('option', {name: 'Shipping address (City)'})).toBeVisible();
+        await userEvent.keyboard('{Escape}');
+
+        await page.getByRole('button', {name: 'Import 1 member'}).click();
+        await expect.element(page.getByText(/Choose a field for "city"/)).toBeVisible();
+        expect(uploadApi.requests).toHaveLength(0);
+    });
+
+    // Dismissing is left alone — it is how a dialog is closed — but it must not silently discard
+    // a mapping. Nothing has been changed here, so there is nothing to lose and nothing to ask.
+    it('closes without asking when nothing has been changed', async () => {
+        fakeCustomFieldsWorld();
+        await renderAdminApp('/members', FLAGS);
+        await openMappingStep();
+        await expect.element(fieldSelect('email')).toBeVisible();
+
+        await userEvent.keyboard('{Escape}');
+
+        await expect.element(page.getByText('Leave without importing?')).not.toBeInTheDocument();
+        await expect.element(fieldSelect('email')).not.toBeInTheDocument();
+    });
+
+    it('asks before discarding a mapping that has been changed', async () => {
+        fakeCustomFieldsWorld();
+        await renderAdminApp('/members', FLAGS);
+        await openMappingStep();
+
+        await importToggle('nickname').click();
+        await userEvent.keyboard('{Escape}');
+
+        // Keeping goes back to exactly where they were, with the change intact.
+        await expect.element(page.getByText('Leave without importing?')).toBeVisible();
+        await page.getByRole('button', {name: 'Keep mapping'}).click();
+        await expect.element(fieldSelect('email')).toBeVisible();
+        await expect.element(importToggle('nickname')).toBeChecked();
+
+        await userEvent.keyboard('{Escape}');
+        await page.getByRole('button', {name: 'Leave'}).click();
+        await expect.element(fieldSelect('email')).not.toBeInTheDocument();
+    });
+
+});

--- a/apps/admin/src/members/import-members-gate.acceptance.test.tsx
+++ b/apps/admin/src/members/import-members-gate.acceptance.test.tsx
@@ -1,0 +1,54 @@
+import {describe, expect, it} from 'vitest';
+import {page} from 'vitest/browser';
+
+import {fakeAdminEndpoint, fakeMembers, member, renderAdminApp} from '@test-utils/acceptance';
+import {membersScreen} from './members.screen';
+
+const CSV = 'email,name\nada@example.com,Ada Lovelace\n';
+
+/**
+ * The one thing the split can break.
+ *
+ * Both implementations have their own tests: the import as it shipped is covered by
+ * import-members/modal.test.tsx, and the custom fields experience by
+ * import-members-custom-fields.acceptance.test.tsx. Neither can regress from the other's
+ * changes, because they share no file. What is left is whether the gate hands over to the
+ * right one, which is what this asserts — by a marker only that implementation renders.
+ */
+async function openMappingStep(labs: Record<string, boolean>) {
+    fakeMembers([member({name: 'Ada Lovelace'})]);
+    fakeAdminEndpoint('GET', '/members/custom_fields/', {members_custom_fields: []});
+    await renderAdminApp('/members', {labs});
+
+    await membersScreen.openActionsMenu();
+    await membersScreen.menuItem(/Import members/).click();
+
+    const dropzone = page.getByRole('button', {name: /select or drop a csv file/i});
+    await expect.element(dropzone).toBeVisible();
+    const input = dropzone.element().querySelector('input[type=file]');
+    if (!(input instanceof HTMLInputElement)) {
+        throw new Error('CSV upload input was not rendered');
+    }
+    await page.elementLocator(input).upload(new File([CSV], 'members.csv', {type: 'text/csv'}));
+}
+
+describe('Import members gate', () => {
+    it('serves the custom fields import when the flag is on', async () => {
+        await openMappingStep({membersCustomFields: true});
+
+        // A checkbox per column exists only in the custom fields experience: it is what decides
+        // whether a column is imported there, a job the select does in the import as it shipped.
+        await expect.element(page.getByRole('checkbox', {name: 'Import name'})).toBeVisible();
+    });
+
+    it('serves the import as it shipped when the flag is off', async () => {
+        await openMappingStep({});
+
+        // No checkbox, and the selects carry no accessible name — the shipped import never gave
+        // them one, which is itself a marker that this is that file and not ours.
+        await expect.element(page.getByRole('checkbox', {name: 'Import name'})).not.toBeInTheDocument();
+        await expect.element(page.getByRole('combobox').first()).toBeVisible();
+        await page.getByRole('combobox').first().click();
+        await expect.element(page.getByRole('option', {name: 'Not imported'})).toBeVisible();
+    });
+});

--- a/apps/admin/src/members/label-picker/label-picker.tsx
+++ b/apps/admin/src/members/label-picker/label-picker.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useLayoutEffect, useRef, useState} from 'react';
 import {
     Badge,
     type ComboboxOptionSource,
@@ -12,6 +12,16 @@ import {EditRow} from './edit-row';
 import {type Label} from '@tryghost/admin-x-framework/api/labels';
 import {LucideIcon} from '@tryghost/shade/utils';
 import {canCreateLabel} from './can-create-label';
+
+// What the list used to be capped at (max-h-64), and the least worth showing rather than
+// collapsing to a sliver. Between them it takes whatever room is below the field.
+const PREFERRED_HEIGHT = 256;
+const MIN_HEIGHT = 120;
+// Between the field and the scrollable list: the dropdown's mt-1 offset and its border. The
+// space is measured from the field, so this is spent before the list gets any of it.
+const DROPDOWN_CHROME = 6;
+// Kept clear of the viewport edge so the list never sits flush against it.
+const GUTTER = 16;
 
 export interface LabelPickerProps {
     labels: Label[];
@@ -264,6 +274,19 @@ const ComboboxPicker: React.FC<ComboboxPickerProps> = ({
     const [search, setSearch] = useState('');
     const inputRef = useRef<HTMLInputElement>(null);
     const containerRef = useRef<HTMLDivElement>(null);
+    const [maxHeight, setMaxHeight] = useState(PREFERRED_HEIGHT);
+
+    // No portal here (see the click-outside note below), so nothing anchors this for us: at a
+    // fixed height the list runs off-screen when the field sits low in a tall dialog. Opens
+    // downward as it always has and takes whatever room is below, scrolling inside it.
+    // Selecting labels wraps the field to another row and moves it, so that counts too.
+    useLayoutEffect(() => {
+        if (!open || !containerRef.current) {
+            return;
+        }
+        const spaceBelow = window.innerHeight - containerRef.current.getBoundingClientRect().bottom - DROPDOWN_CHROME - GUTTER;
+        setMaxHeight(Math.max(MIN_HEIGHT, Math.min(PREFERRED_HEIGHT, spaceBelow)));
+    }, [open, selectedSlugs.length]);
 
     const handleSearchChange = useCallback((value: string) => {
         setSearch(value);
@@ -330,7 +353,7 @@ const ComboboxPicker: React.FC<ComboboxPickerProps> = ({
                         </div>
                     ) : (
                         <Command shouldFilter={false}>
-                            <CommandList className="max-h-64 overflow-y-auto">
+                            <CommandList className="overflow-y-auto" style={{maxHeight}}>
                                 <LabelListItems
                                     isCreating={isCreating}
                                     labels={labels}

--- a/apps/admin/test-utils/acceptance/worker.ts
+++ b/apps/admin/test-utils/acceptance/worker.ts
@@ -211,6 +211,42 @@ export interface FakeEndpointOptions {
  * to resource fakes / boot overrides / `fakeAdminEndpoint`. Returns a
  * capture of every matched request for payload assertions.
  */
+/**
+ * A request body as something a test can assert against.
+ *
+ * JSON where the request is JSON. Multipart bodies are read as an object too, keyed by field
+ * name, with files reduced to their name and type — otherwise a file upload's body is invisible
+ * to tests and the only assertable thing about it is that it happened. Repeated fields (labels,
+ * `mapping[column]`) collect into arrays. Anything else stays undefined, including a request
+ * with no body at all.
+ */
+async function parseRequestBody(request: Request): Promise<unknown> {
+    const contentType = request.headers.get('content-type') ?? '';
+
+    if (!contentType.includes('multipart/form-data') && !contentType.includes('application/x-www-form-urlencoded')) {
+        try {
+            return await request.clone().json();
+        } catch {
+            return undefined;
+        }
+    }
+
+    try {
+        const form = await request.clone().formData();
+        // Collected as a Map so a field named after a prototype method cannot read as one
+        // already seen, then collapsed: a field that appeared once is worth asserting against
+        // as its own value rather than as a one-element array.
+        const fields = new Map<string, unknown[]>();
+        form.forEach((value, key) => {
+            const parsed = value instanceof File ? {filename: value.name, type: value.type} : value;
+            fields.set(key, [...(fields.get(key) ?? []), parsed]);
+        });
+        return Object.fromEntries([...fields].map(([key, values]) => [key, values.length === 1 ? values[0] : values]));
+    } catch {
+        return undefined;
+    }
+}
+
 export function fakeEndpoint(method: string, url: string, response: unknown, { status = 200 }: FakeEndpointOptions = {}): EndpointCapture {
     const expectedMethod = method.toUpperCase();
     const requests: CapturedEndpointRequest[] = [];
@@ -221,13 +257,7 @@ export function fakeEndpoint(method: string, url: string, response: unknown, { s
                 return undefined;
             }
 
-            let body: unknown;
-            try {
-                body = await request.clone().json();
-            } catch {
-                body = undefined;
-            }
-            requests.push({ url: request.url, body });
+            requests.push({ url: request.url, body: await parseRequestBody(request) });
 
             return HttpResponse.json(response as Record<string, unknown>, { status });
         })
@@ -322,14 +352,7 @@ export function fakeAdminEndpoint(
             return undefined;
         }
 
-        let body: unknown;
-        try {
-            body = await request.clone().json();
-        } catch {
-            body = undefined;
-        }
-
-        const captured: CapturedEndpointRequest = { url: request.url, body };
+        const captured: CapturedEndpointRequest = { url: request.url, body: await parseRequestBody(request) };
         requests.push(captured);
 
         const responseBody: unknown =

--- a/e2e/helpers/pages/admin/members/members-import-modal.ts
+++ b/e2e/helpers/pages/admin/members/members-import-modal.ts
@@ -28,9 +28,23 @@ export class MembersImportModal {
         return this.getMappingRow(fieldName).getByRole('combobox');
     }
 
+    // Whether a column is part of the import. Behind the custom fields flag this is a
+    // checkbox of its own; the control that names the target says nothing about it.
+    getIncludeCheckbox(csvColumn: string): Locator {
+        return this.getMappingRow(csvColumn).getByRole('checkbox');
+    }
+
     // Point a CSV column at a target field: open its "Import as" select and pick an option
     // (a core field or a defined custom field, by its label).
+    //
+    // A column no field matched starts out of the import behind the custom fields flag, and
+    // its target control appears only once it is brought in — so bring it in first if it is
+    // not already. Without the flag the checkbox is absent and the control is always there.
     async setMappingTarget(csvColumn: string, targetLabel: string): Promise<void> {
+        const include = this.getIncludeCheckbox(csvColumn);
+        if (await include.count() > 0 && !(await include.isChecked())) {
+            await include.check();
+        }
         await this.getMappingValue(csvColumn).click();
         await this.page.getByRole('option', {name: targetLabel, exact: true}).click();
     }

--- a/e2e/tests/admin/members/import-custom-fields.test.ts
+++ b/e2e/tests/admin/members/import-custom-fields.test.ts
@@ -65,7 +65,10 @@ test.describe('Ghost Admin - Members import with custom fields', () => {
 
         await expect(importModal.importButton).toBeVisible();
         // Default mapping: the exported column auto-detects to its field, no manual step.
-        await expect(importModal.getMappingValue(customColumn as string)).toHaveText(fieldName);
+        // Contains rather than equals: with custom fields on, the mapping control names the
+        // field and the list it came from on a second line, so the field name is part of the
+        // trigger's text rather than all of it.
+        await expect(importModal.getMappingValue(customColumn as string)).toContainText(fieldName);
 
         await importModal.importButton.click();
         await expect(importModal.importHeading).toBeVisible({timeout: 15000});
@@ -103,9 +106,12 @@ test.describe('Ghost Admin - Members import with custom fields', () => {
         await importModal.fileInput.setInputFiles(csvPath);
         await expect(importModal.importButton).toBeVisible();
 
-        await expect(importModal.getMappingValue('Their Job')).toHaveText('Not imported');
+        // A column no field matched is out of the import to begin with, said by its checkbox
+        // rather than by a value in the control that names the target — the two are separate
+        // answers here, so there is no control to read until the column is brought in.
+        await expect(importModal.getIncludeCheckbox('Their Job')).not.toBeChecked();
         await importModal.setMappingTarget('Their Job', fieldName);
-        await expect(importModal.getMappingValue('Their Job')).toHaveText(fieldName);
+        await expect(importModal.getMappingValue('Their Job')).toContainText(fieldName);
 
         await importModal.importButton.click();
         await expect(importModal.importHeading).toBeVisible({timeout: 15000});

--- a/ghost/core/core/server/services/members/import-export/csv/parse.ts
+++ b/ghost/core/core/server/services/members/import-export/csv/parse.ts
@@ -14,7 +14,8 @@ function isSafeColumnName(name: string): boolean {
 }
 
 // headerMapping renames the CSV's headers to the columns they emit under; unmapped
-// columns carry through under their own name.
+// columns carry through under their own name, and one mapped to an empty target is
+// dropped.
 export default function parse(path: string, headerMapping?: Record<string, string>): Promise<Row[]> {
     return new Promise(function (resolve, reject) {
         const csvFileStream = fs.createReadStream(path);
@@ -47,6 +48,13 @@ export default function parse(path: string, headerMapping?: Record<string, strin
                     // hasOwn, not `in`: a prototype-named header would otherwise match an
                     // inherited method on the mapping and take a function as its mapped name.
                     if (headerMapping && Object.hasOwn(headerMapping, header)) {
+                        // An empty target is the caller naming a column to leave out, which
+                        // it has to name: an unnamed column carries through below, and for a
+                        // custom_fields.* column carrying through means being imported. So
+                        // omitting a column from the mapping is the opposite of excluding it.
+                        if (!headerMapping[header]) {
+                            continue;
+                        }
                         row[headerMapping[header]] = value;
                     } else if (isSafeColumnName(header)) {
                         // Carry any unmapped column through untouched, so the import is not

--- a/ghost/core/test/e2e-api/admin/members-import-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/members-import-custom-fields.test.ts
@@ -121,6 +121,44 @@ describe('Members import — custom fields', function () {
         assert.equal(member.custom_fields?.[key], 'Bex');
     });
 
+    // The mapping step's deselected column. It has to name the column with an empty target
+    // rather than omit it: an omitted column carries through under its own header, and a
+    // custom_fields.* header is exactly what the importer reads a value from — so omitting
+    // it would import the very column the publisher switched off.
+    it('imports nothing from a namespaced column the mapping empties', async function () {
+        const key = await createField('Nickname', 'short_text');
+        const email = 'cf-deselected@example.com';
+
+        const res = await importCSV(
+            `email,custom_fields.${key}\n${email},Bex\n`,
+            {email: 'email', [`custom_fields.${key}`]: ''}
+        );
+        assert.equal(res.status, 201);
+        assert.equal(res.body.meta.stats.imported, 1, 'the member still imports, without that column');
+
+        const member = await findMember(email);
+        assert.equal(member.custom_fields?.[key], undefined);
+        assert.deepEqual(await storedLeaves(email), [], 'nothing was written for the emptied column');
+    });
+
+    // The same column, deselected after being pointed at a field: the target it was given is
+    // no reason to import it, and the request carries the emptied target rather than that one.
+    it('imports nothing from a column the mapping empties after it had a field', async function () {
+        const key = await createField('Nickname', 'short_text');
+        const email = 'cf-deselected-mapped@example.com';
+
+        const res = await importCSV(
+            `Email Address,Preferred Name\n${email},Bex\n`,
+            {'Email Address': 'email', 'Preferred Name': ''}
+        );
+        assert.equal(res.status, 201);
+        assert.equal(res.body.meta.stats.imported, 1);
+
+        const member = await findMember(email);
+        assert.equal(member.custom_fields?.[key], undefined);
+        assert.deepEqual(await storedLeaves(email), []);
+    });
+
     it('reads an address from its sub-field columns', async function () {
         const key = await createField('Shipping Address', 'address');
         const email = 'cf-address@example.com';

--- a/ghost/core/test/e2e-api/admin/members-import-custom-fields.test.ts
+++ b/ghost/core/test/e2e-api/admin/members-import-custom-fields.test.ts
@@ -125,6 +125,11 @@ describe('Members import — custom fields', function () {
     // rather than omit it: an omitted column carries through under its own header, and a
     // custom_fields.* header is exactly what the importer reads a value from — so omitting
     // it would import the very column the publisher switched off.
+    //
+    // What these two prove is that the API accepts an empty mapping value and that nothing is
+    // written for the column. They do not prove the parser *drops* it — before the change it
+    // renamed the column to the empty string instead, which nothing downstream reads either.
+    // That distinction is pinned where it is observable, in csv/parse.test.ts.
     it('imports nothing from a namespaced column the mapping empties', async function () {
         const key = await createField('Nickname', 'short_text');
         const email = 'cf-deselected@example.com';
@@ -141,22 +146,21 @@ describe('Members import — custom fields', function () {
         assert.deepEqual(await storedLeaves(email), [], 'nothing was written for the emptied column');
     });
 
-    // The same column, deselected after being pointed at a field: the target it was given is
-    // no reason to import it, and the request carries the emptied target rather than that one.
-    it('imports nothing from a column the mapping empties after it had a field', async function () {
+    // The same column mapped and then emptied, so the emptying is what changes the outcome
+    // rather than the column never having had anywhere to go.
+    it('stops importing a column once the mapping empties it', async function () {
         const key = await createField('Nickname', 'short_text');
         const email = 'cf-deselected-mapped@example.com';
+        const csv = `Email Address,Preferred Name\n${email},Bex\n`;
 
-        const res = await importCSV(
-            `Email Address,Preferred Name\n${email},Bex\n`,
-            {'Email Address': 'email', 'Preferred Name': ''}
-        );
+        await importCSV(csv, {'Email Address': 'email', 'Preferred Name': `custom_fields.${key}`});
+        assert.equal((await findMember(email)).custom_fields?.[key], 'Bex', 'the column imports while it is mapped');
+
+        const res = await importCSV(`Email Address,Preferred Name\n${email},Changed\n`, {'Email Address': 'email', 'Preferred Name': ''});
         assert.equal(res.status, 201);
         assert.equal(res.body.meta.stats.imported, 1);
 
-        const member = await findMember(email);
-        assert.equal(member.custom_fields?.[key], undefined);
-        assert.deepEqual(await storedLeaves(email), []);
+        assert.equal((await findMember(email)).custom_fields?.[key], 'Bex', 'and stops once it is emptied');
     });
 
     it('reads an address from its sub-field columns', async function () {

--- a/ghost/core/test/e2e-api/admin/members-import.test.js
+++ b/ghost/core/test/e2e-api/admin/members-import.test.js
@@ -1,4 +1,6 @@
 const path = require('path');
+const os = require('node:os');
+const fs = require('node:fs');
 const assert = require('node:assert/strict');
 const supertest = require('supertest');
 const testUtils = require('../../utils');
@@ -193,6 +195,41 @@ describe('Members import', function () {
         assertExists(member);
         assert.equal(member.name, 'Hannah');
         assert.equal(member.note, 'do map me');
+    });
+
+    // A column the mapping names with an empty target is one the caller is leaving out, and
+    // it stays out even though the file has it and the importer has a field of that name to
+    // put it in. Naming it is the point: an unnamed column carries through under its own
+    // header instead, which is the opposite of excluding it.
+    //
+    // Its own file and its own address, because the members this suite imports outlive the
+    // test that made them -- a shared one would already have the name under test.
+    it('imports nothing from a column the mapping empties', async function () {
+        const email = 'member+emptied-column@example.com';
+        const csvPath = path.join(os.tmpdir(), `members-emptied-column-${process.pid}.csv`);
+        fs.writeFileSync(csvPath, `correo_electrpnico,nombre,note\n${email},Hannah,do map me\n`);
+
+        let res;
+        try {
+            res = await request
+                .post(localUtils.API.getApiQuery('members/upload/'))
+                .field('mapping[correo_electrpnico]', 'email')
+                .field('mapping[nombre]', '')
+                .field('mapping[note]', 'note')
+                .attach('membersfile', csvPath)
+                .set('Origin', config.get('url'))
+                .expect('Content-Type', /json/);
+        } finally {
+            fs.unlinkSync(csvPath);
+        }
+
+        assert.equal(res.status, 201);
+        assert.equal(res.body.meta.stats.imported, 1);
+
+        const member = await findMember(email);
+        assertExists(member);
+        assert.ok(!member.name, `the emptied column did not fill the name, got ${JSON.stringify(member.name)}`);
+        assert.equal(member.note, 'do map me', 'the columns that kept a target are unaffected');
     });
 
     // A form label containing a comma is one label, while a row label containing a

--- a/ghost/core/test/unit/server/services/members/import-export/csv/parse.test.ts
+++ b/ghost/core/test/unit/server/services/members/import-export/csv/parse.test.ts
@@ -87,6 +87,21 @@ describe('parse', function () {
         assert.deepEqual(result[1], {id: '2', email: 'test@example.com', nombre: 'test'});
     });
 
+    // The only way a caller can exclude a column: leaving it out of the mapping carries it
+    // through under its own header instead, which for a custom_fields.* column means
+    // importing it. Admin's import mapping relies on this to honour a deselected column.
+    it('drops a column the mapping gives an empty target', async function () {
+        const result = await parse(csvPath + 'two-columns-mapping-header.csv', {
+            id: 'id',
+            correo_electronico: 'email',
+            nombre: ''
+        });
+
+        assert.equal(result.length, 2);
+        assert.deepEqual(result[0], {id: '1', email: 'jbloggs@example.com'});
+        assert.deepEqual(result[1], {id: '2', email: 'test@example.com'});
+    });
+
     it('leaves cell values as raw strings -- coercion is the schema\'s job', async function () {
         const result = await parse(csvPath + 'subscribed-to-emails-header.csv', {
             email: 'email',


### PR DESCRIPTION
## Problem

A CSV column with no matching custom field could only be left out. To import it a publisher had to abandon the import, go to Settings, create the field, and upload the file again. Custom fields are most needed during a migration, which is exactly the moment the product sent people away.

The mapping step also asked one control to answer two different questions at once: what a column should be imported as, and whether it should be imported at all.

## Solution

A column can be mapped to a field that does not exist yet, created from the mapping step. Each row gets one searchable picker listing membership and custom fields under their own headings, so what a column can hold is answered by reading rather than by opening a control to find out what is behind it. A separate checkbox decides whether a column is imported at all, and clearing it keeps the chosen field, because excluding a column and saying what it holds are separate answers.

A composite field has no single column, so creating one reopens the picker filtered to that field rather than adding a third control asking which part.

Columns are read from the whole file rather than the previewed row. A row with fewer cells than the header omits keys, so a ragged file could otherwise hide a column from the table entirely.

The new mapping step is served through a gate rather than woven into the shipped one. The two diverge in almost every part, and while they shared a file every change was opt-out — several reached the flag-off path unnoticed. The shipped files are untouched, so this cannot regress them by being forgotten. The cost is duplication until the flag goes and the old version is deleted.

## Also in this branch

Three changes that are not part of this feature and are not gated, kept at the base of the branch so they can be split out if preferred.

Two are layout fixes. The import dialog is now bounded to the viewport, so its footer stays reachable on a short screen instead of being pushed off. The label picker's list takes the room actually below the field rather than a fixed height, which was surfaced by the first fix and also affects the add-label, remove-label and member-detail surfaces.

The third is a data fix. The mapping table read its columns from the first parsed row, and a row with fewer cells than the header omits keys, so a file whose first row was short lost every column that row did not reach. Those columns never appeared in the table, so nobody was asked what they held — and the importer carries a column the mapping does not name, so they were imported anyway.

## Reviewer note: one change reaches beyond this feature

The helper that reads what the server said went wrong only understood validation errors, so every other kind surfaced as a generic summary while the reason sat unread in the payload. It now reads any error carrying an API body. That is what let this feature stop hand-rolling the same unwrapping at each call site, but it also means **every API error toast in admin** now prefers the server's own sentence over a generic class message. The shipped import modal is deliberately left reading the old way, so the flag-off path is unchanged.

ref https://linear.app/ghost/issue/BER-3846/
