### PR TITLE
✨ Added support for Docker secrets to config loading

### DIFF
--- a/ghost/core/core/shared/config/loader.ts
+++ b/ghost/core/core/shared/config/loader.ts
@@ -2,6 +2,7 @@ import Nconf from 'nconf';
 import path from 'node:path';
 import {bindAll as bindUrlHelpers, type BoundHelpers} from '@tryghost/config-url-helpers';
 import * as localUtils from './utils';
+import {loadSecretsFromEnv, isSecretFileRef} from './secrets';
 import {bindAll as bindHelpers, type ConfigHelpers} from './helpers';
 
 const _debug = require('@tryghost/debug')._base;
@@ -28,9 +29,17 @@ function loadNconf(options?: LoadNconfOptions): ConfigInstance {
     // no channel can override the overrides
     nconf.file('overrides', path.join(baseConfigPath, 'overrides.json'));
 
-    // command line arguments take precedence, then environment variables
+    // command line arguments take precedence, then secret files, then environment variables
     nconf.argv();
-    nconf.env({separator: '__', parseValues: true});
+    // secrets are not parsed - a password like `01234` must stay a string
+    nconf.add('secrets', {type: 'literal', store: loadSecretsFromEnv()});
+    nconf.env({
+        separator: '__',
+        parseValues: true,
+        // the secrets store has already resolved these, so keep the file paths themselves
+        // out of config - otherwise e.g. `database:connection` gains a bogus `password_FILE` key
+        transform: ({key, value}: {key: string, value: string}) => (isSecretFileRef(key) ? false : {key, value})
+    });
 
     // Now load various config json files
     nconf.file('custom-env', path.join(customConfigPath, 'config.' + env + '.json'));

--- a/ghost/core/core/shared/config/secrets.ts
+++ b/ghost/core/core/shared/config/secrets.ts
@@ -1,0 +1,83 @@
+import fs from 'node:fs';
+import {setWith} from 'lodash';
+
+const SUFFIX = '_file';
+
+type SecretStore = Record<string, unknown>;
+
+/**
+ * Whether an env var name is a reference to a secret file rather than a config value itself.
+ */
+function isSecretFileRef(name: string, separator: string = '__'): boolean {
+    if (!name.toLowerCase().endsWith(SUFFIX)) {
+        return false;
+    }
+
+    const keyPath = name.slice(0, -SUFFIX.length).split(separator);
+
+    // the key must be nested, which keeps unrelated env vars such as SSL_CERT_FILE out
+    return keyPath.length >= 2 && keyPath.every(segment => !!segment);
+}
+
+/**
+ * Resolve `<config_key>_FILE` env vars into config values by reading the file they point at,
+ * so secrets can be mounted (Docker/Swarm secrets, k8s projected volumes, systemd LoadCredential)
+ * instead of being passed as plaintext env vars.
+ *
+ *   database__connection__password_FILE=/run/secrets/db_password
+ *
+ * The suffix is matched case-insensitively.
+ *
+ * Returns a plain object suitable for an nconf `literal` store.
+ */
+function loadSecretsFromEnv(env: NodeJS.ProcessEnv = process.env, separator: string = '__'): SecretStore {
+    const store: SecretStore = {};
+    const seen = new Map<string, {name: string, filePath: string}>();
+
+    for (const [name, filePath] of Object.entries(env)) {
+        if (!isSecretFileRef(name, separator) || !filePath) {
+            continue;
+        }
+
+        const varName = name.slice(0, -SUFFIX.length);
+
+        if (env[varName] !== undefined) {
+            // new Error is allowed here, as we do not want config to depend on @tryghost/error
+            // eslint-disable-next-line ghost/ghost-custom/no-native-error
+            throw new Error(`Cannot set both ${varName} and ${name} - use one or the other.`);
+        }
+
+        const duplicate = seen.get(varName);
+
+        if (duplicate) {
+            // env var names are case-sensitive on POSIX, so the same key can be set twice —
+            // only a conflict if they disagree about which file to read
+            if (duplicate.filePath !== filePath) {
+                // eslint-disable-next-line ghost/ghost-custom/no-native-error
+                throw new Error(`Cannot set both ${duplicate.name} and ${name} to different files - they resolve to the same config key.`);
+            }
+
+            continue;
+        }
+
+        seen.set(varName, {name, filePath});
+
+        let contents: string;
+
+        try {
+            contents = fs.readFileSync(filePath, 'utf8');
+        } catch (err) {
+            // eslint-disable-next-line ghost/ghost-custom/no-native-error
+            throw new Error(`Could not read the secret file referenced by ${name}: ${filePath}`, {cause: err});
+        }
+
+        // strip a single trailing newline, matching `$(cat file)` behaviour, but leave
+        // any other surrounding whitespace alone in case it is part of the secret
+        // setWith with Object keeps numeric key segments as plain objects rather than arrays
+        setWith(store, varName.split(separator), contents.replace(/\r?\n$/, ''), Object);
+    }
+
+    return store;
+}
+
+export {loadSecretsFromEnv, isSecretFileRef};

--- a/ghost/core/test/unit/shared/config/loader.test.js
+++ b/ghost/core/test/unit/shared/config/loader.test.js
@@ -1,4 +1,6 @@
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
 const path = require('path');
 const _ = require('lodash');
 const configUtils = require('../../../utils/config-utils');
@@ -17,10 +19,18 @@ describe('Config Loader', function () {
         let originalArgv;
         let customConfig;
         let loader;
+        let tmpDir;
+
+        function writeSecret(contents) {
+            const filePath = path.join(tmpDir, 'secret');
+            fs.writeFileSync(filePath, contents);
+            return filePath;
+        }
 
         beforeEach(function () {
             originalEnv = _.clone(process.env);
             originalArgv = _.clone(process.argv);
+            tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ghost-loader-'));
             loader = require('../../../../core/shared/config/loader');
             // getNodeEnv() reads process.env.NODE_ENV, so drive that directly
             process.env.NODE_ENV = 'testing';
@@ -35,6 +45,7 @@ describe('Config Loader', function () {
         afterEach(function () {
             process.env = originalEnv;
             process.argv = originalArgv;
+            fs.rmSync(tmpDir, {recursive: true, force: true});
             sinon.restore();
         });
 
@@ -59,6 +70,50 @@ describe('Config Loader', function () {
             });
 
             assert.equal(customConfig.get('database:client'), 'stronger');
+        });
+
+        it('secret file is stronger than file', function () {
+            process.env.logging__level_FILE = writeSecret('warn\n');
+
+            customConfig = loader.loadNconf({
+                baseConfigPath: path.join(__dirname, '../../../utils/fixtures/config'),
+                customConfigPath: path.join(__dirname, '../../../utils/fixtures/config')
+            });
+
+            assert.equal(customConfig.get('logging:level'), 'warn');
+        });
+
+        it('argv is stronger than a secret file', function () {
+            process.env.logging__level_FILE = writeSecret('warn\n');
+            process.argv[2] = '--logging:level=stronger';
+
+            customConfig = loader.loadNconf({
+                baseConfigPath: path.join(__dirname, '../../../utils/fixtures/config'),
+                customConfigPath: path.join(__dirname, '../../../utils/fixtures/config')
+            });
+
+            assert.equal(customConfig.get('logging:level'), 'stronger');
+        });
+
+        it('does not leak the secret file path into config', function () {
+            process.env.database__connection__password_FILE = writeSecret('hunter2\n');
+
+            customConfig = loader.loadNconf({
+                baseConfigPath: path.join(__dirname, '../../../utils/fixtures/config'),
+                customConfigPath: path.join(__dirname, '../../../utils/fixtures/config')
+            });
+
+            assert.equal(customConfig.get('database:connection:password_FILE'), undefined);
+        });
+
+        it('throws if a value and its secret file are both set', function () {
+            process.env.logging__level = 'warn';
+            process.env.logging__level_FILE = writeSecret('error\n');
+
+            assert.throws(() => loader.loadNconf({
+                baseConfigPath: path.join(__dirname, '../../../utils/fixtures/config'),
+                customConfigPath: path.join(__dirname, '../../../utils/fixtures/config')
+            }), /Cannot set both logging__level and logging__level_FILE/);
         });
 
         it('argv or env is NOT stronger than overrides', function () {

--- a/ghost/core/test/unit/shared/config/secrets.test.ts
+++ b/ghost/core/test/unit/shared/config/secrets.test.ts
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {loadSecretsFromEnv} from '../../../../core/shared/config/secrets';
+
+describe('Config Secrets', function () {
+    let tmpDir: string;
+
+    function writeSecret(name: string, contents: string): string {
+        const filePath = path.join(tmpDir, name);
+        fs.writeFileSync(filePath, contents);
+        return filePath;
+    }
+
+    beforeEach(function () {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ghost-secrets-'));
+    });
+
+    afterEach(function () {
+        fs.rmSync(tmpDir, {recursive: true, force: true});
+    });
+
+    it('resolves a nested key from a file', function () {
+        const filePath = writeSecret('db', 'hunter2');
+
+        assert.deepEqual(loadSecretsFromEnv({database__connection__password_FILE: filePath}), {
+            database: {connection: {password: 'hunter2'}}
+        });
+    });
+
+    it('matches the suffix case-insensitively', function () {
+        const filePath = writeSecret('db', 'hunter2');
+
+        assert.deepEqual(loadSecretsFromEnv({database__connection__password_file: filePath}), {
+            database: {connection: {password: 'hunter2'}}
+        });
+    });
+
+    it('does not parse values', function () {
+        const filePath = writeSecret('db', '01234');
+
+        assert.deepEqual(loadSecretsFromEnv({database__connection__password_FILE: filePath}), {
+            database: {connection: {password: '01234'}}
+        });
+    });
+
+    it('strips a single trailing newline but keeps other whitespace', function () {
+        const trailing = writeSecret('trailing', 'hunter2\n');
+        const surrounding = writeSecret('surrounding', '  hunter2  ');
+        const multiple = writeSecret('multiple', 'hunter2\n\n');
+
+        assert.deepEqual(loadSecretsFromEnv({a__b_FILE: trailing}), {a: {b: 'hunter2'}});
+        assert.deepEqual(loadSecretsFromEnv({a__b_FILE: surrounding}), {a: {b: '  hunter2  '}});
+        assert.deepEqual(loadSecretsFromEnv({a__b_FILE: multiple}), {a: {b: 'hunter2\n'}});
+    });
+
+    it('merges multiple secrets under a shared parent', function () {
+        const user = writeSecret('user', 'ghost');
+        const pass = writeSecret('pass', 'hunter2');
+
+        assert.deepEqual(loadSecretsFromEnv({
+            mail__options__auth__user_FILE: user,
+            mail__options__auth__pass_FILE: pass
+        }), {
+            mail: {options: {auth: {user: 'ghost', pass: 'hunter2'}}}
+        });
+    });
+
+    it('ignores env vars that are not nested config keys', function () {
+        const filePath = writeSecret('ca', 'not-a-secret');
+
+        assert.deepEqual(loadSecretsFromEnv({
+            SSL_CERT_FILE: filePath,
+            CURL_CA_BUNDLE: filePath,
+            _FILE: filePath,
+            database____password_FILE: filePath
+        }), {});
+    });
+
+    it('ignores env vars with an empty value', function () {
+        assert.deepEqual(loadSecretsFromEnv({database__connection__password_FILE: ''}), {});
+    });
+
+    it('keeps numeric key segments as plain objects', function () {
+        const filePath = writeSecret('token', 'abc');
+        const store = loadSecretsFromEnv({adapters__0__token_FILE: filePath});
+
+        assert.deepEqual(store, {adapters: {0: {token: 'abc'}}});
+        assert.equal(Array.isArray(store.adapters), false);
+    });
+
+    it('throws if the value and its file reference are both set', function () {
+        const filePath = writeSecret('db', 'hunter2');
+
+        assert.throws(() => loadSecretsFromEnv({
+            database__connection__password: 'hunter2',
+            database__connection__password_FILE: filePath
+        }), /Cannot set both database__connection__password and database__connection__password_FILE/);
+    });
+
+    it('allows the same key set twice if both point at the same file', function () {
+        const filePath = writeSecret('db', 'hunter2');
+
+        assert.deepEqual(loadSecretsFromEnv({
+            database__connection__password_FILE: filePath,
+            database__connection__password_file: filePath
+        }), {
+            database: {connection: {password: 'hunter2'}}
+        });
+    });
+
+    it('throws if the same key is set twice pointing at different files', function () {
+        assert.throws(() => loadSecretsFromEnv({
+            database__connection__password_FILE: writeSecret('one', 'hunter2'),
+            database__connection__password_file: writeSecret('two', 'hunter3')
+        }), /to different files/);
+    });
+
+    it('throws if the file cannot be read', function () {
+        const filePath = path.join(tmpDir, 'nope');
+
+        assert.throws(() => loadSecretsFromEnv({database__connection__password_FILE: filePath}), (err: Error) => {
+            assert.match(err.message, /Could not read the secret file referenced by database__connection__password_FILE/);
+            assert.equal((err.cause as NodeJS.ErrnoException).code, 'ENOENT');
+            return true;
+        });
+    });
+
+    it('supports a custom separator', function () {
+        const filePath = writeSecret('db', 'hunter2');
+
+        assert.deepEqual(loadSecretsFromEnv({'database.connection.password_FILE': filePath}, '.'), {
+            database: {connection: {password: 'hunter2'}}
+        });
+    });
+});


### PR DESCRIPTION
ref https://github.com/TryGhost/docker-library-ghost/issues/429
- add support for _FILE-suffixed environment variables pointing to local files for secrets loading, in keeping with existing Docker conventions